### PR TITLE
Add DateInterval subclasses

### DIFF
--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -135,6 +135,8 @@ PHPAPI zend_class_entry *php_date_get_immutable_ce(void);
 PHPAPI zend_class_entry *php_date_get_interface_ce(void);
 PHPAPI zend_class_entry *php_date_get_timezone_ce(void);
 PHPAPI zend_class_entry *php_date_get_interval_ce(void);
+PHPAPI zend_class_entry *php_date_get_date_time_interval_ce(void);
+PHPAPI zend_class_entry *php_date_get_date_time_string_interval_ce(void);
 PHPAPI zend_class_entry *php_date_get_period_ce(void);
 
 /* Functions for creating DateTime objects, and initializing them from a string */

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -247,8 +247,7 @@ function timezone_abbreviations_list(): array {}
 /** @refcount 1 */
 function timezone_version_get(): string {}
 
-/** @refcount 1 */
-function date_interval_create_from_date_string(string $datetime): DateInterval|false {}
+function date_interval_create_from_date_string(string $datetime): DateTimeStringInterval|false {}
 
 /** @refcount 1 */
 function date_interval_format(DateInterval $object, string $format): string {}
@@ -668,12 +667,14 @@ class DateTimeZone
 
 class DateInterval
 {
+    public readonly bool $from_string;
+
     public function __construct(string $duration) {}
 
     /**
      * @tentative-return-type
      */
-    public static function createFromDateString(string $datetime): DateInterval|false {}
+    public static function createFromDateString(string $datetime): DateTimeStringInterval|false {}
 
     /**
      * @tentative-return-type
@@ -690,6 +691,26 @@ class DateInterval
 
     /** @tentative-return-type */
     public static function __set_state(array $array): DateInterval {}
+}
+
+final class DateTimeStringInterval extends DateInterval
+{
+    public readonly ?string $date_string;
+
+    public function __construct(string $datetime) {}
+}
+
+final class DateTimeInterval extends DateInterval
+{
+    public readonly int $y;
+    public readonly int $m;
+    public readonly int $d;
+    public readonly int $h;
+    public readonly int $i;
+    public readonly int $s;
+    public readonly float $f;
+    public readonly int $invert;
+    public readonly int|false $days;
 }
 
 class DatePeriod implements IteratorAggregate

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1445f6053da5ca9dc7bb618f2eadc4a8ea56a15f */
+ * Stub hash: f24ce09b1f759e78f9cc2002252751cb92d5630e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -193,7 +193,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_timezone_version_get, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_date_interval_create_from_date_string, 0, 1, DateInterval, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_date_interval_create_from_date_string, 0, 1, DateTimeStringInterval, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -451,7 +451,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateInterval___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, duration, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, DateInterval, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateInterval_createFromDateString, 0, 1, DateTimeStringInterval, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -465,6 +465,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateInterval___set_state, 0, 1, DateInterval, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateTimeStringInterval___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DatePeriod_createFromISO8601String, 0, 1, IS_STATIC, 0)
@@ -590,6 +594,7 @@ ZEND_METHOD(DateInterval, __serialize);
 ZEND_METHOD(DateInterval, __unserialize);
 ZEND_METHOD(DateInterval, __wakeup);
 ZEND_METHOD(DateInterval, __set_state);
+ZEND_METHOD(DateTimeStringInterval, __construct);
 ZEND_METHOD(DatePeriod, createFromISO8601String);
 ZEND_METHOD(DatePeriod, __construct);
 ZEND_METHOD(DatePeriod, getStartDate);
@@ -749,6 +754,17 @@ static const zend_function_entry class_DateInterval_methods[] = {
 	ZEND_ME(DateInterval, __unserialize, arginfo_class_DateInterval___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateInterval, __wakeup, arginfo_class_DateInterval___wakeup, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateInterval, __set_state, arginfo_class_DateInterval___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_DateTimeStringInterval_methods[] = {
+	ZEND_ME(DateTimeStringInterval, __construct, arginfo_class_DateTimeStringInterval___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_DateTimeInterval_methods[] = {
 	ZEND_FE_END
 };
 
@@ -1076,6 +1092,94 @@ static zend_class_entry *register_class_DateInterval(void)
 
 	INIT_CLASS_ENTRY(ce, "DateInterval", class_DateInterval_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	zval property_from_string_default_value;
+	ZVAL_UNDEF(&property_from_string_default_value);
+	zend_string *property_from_string_name = zend_string_init("from_string", sizeof("from_string") - 1, 1);
+	zend_declare_typed_property(class_entry, property_from_string_name, &property_from_string_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_from_string_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DateTimeStringInterval(zend_class_entry *class_entry_DateInterval)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DateTimeStringInterval", class_DateTimeStringInterval_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_DateInterval);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_date_string_default_value;
+	ZVAL_UNDEF(&property_date_string_default_value);
+	zend_string *property_date_string_name = zend_string_init("date_string", sizeof("date_string") - 1, 1);
+	zend_declare_typed_property(class_entry, property_date_string_name, &property_date_string_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_date_string_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DateTimeInterval(zend_class_entry *class_entry_DateInterval)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DateTimeInterval", class_DateTimeInterval_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_DateInterval);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_y_default_value;
+	ZVAL_UNDEF(&property_y_default_value);
+	zend_string *property_y_name = zend_string_init("y", sizeof("y") - 1, 1);
+	zend_declare_typed_property(class_entry, property_y_name, &property_y_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_y_name);
+
+	zval property_m_default_value;
+	ZVAL_UNDEF(&property_m_default_value);
+	zend_string *property_m_name = zend_string_init("m", sizeof("m") - 1, 1);
+	zend_declare_typed_property(class_entry, property_m_name, &property_m_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_m_name);
+
+	zval property_d_default_value;
+	ZVAL_UNDEF(&property_d_default_value);
+	zend_string *property_d_name = zend_string_init("d", sizeof("d") - 1, 1);
+	zend_declare_typed_property(class_entry, property_d_name, &property_d_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_d_name);
+
+	zval property_h_default_value;
+	ZVAL_UNDEF(&property_h_default_value);
+	zend_string *property_h_name = zend_string_init("h", sizeof("h") - 1, 1);
+	zend_declare_typed_property(class_entry, property_h_name, &property_h_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_h_name);
+
+	zval property_i_default_value;
+	ZVAL_UNDEF(&property_i_default_value);
+	zend_string *property_i_name = zend_string_init("i", sizeof("i") - 1, 1);
+	zend_declare_typed_property(class_entry, property_i_name, &property_i_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_i_name);
+
+	zval property_s_default_value;
+	ZVAL_UNDEF(&property_s_default_value);
+	zend_string *property_s_name = zend_string_init("s", sizeof("s") - 1, 1);
+	zend_declare_typed_property(class_entry, property_s_name, &property_s_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_s_name);
+
+	zval property_f_default_value;
+	ZVAL_UNDEF(&property_f_default_value);
+	zend_string *property_f_name = zend_string_init("f", sizeof("f") - 1, 1);
+	zend_declare_typed_property(class_entry, property_f_name, &property_f_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
+	zend_string_release(property_f_name);
+
+	zval property_invert_default_value;
+	ZVAL_UNDEF(&property_invert_default_value);
+	zend_string *property_invert_name = zend_string_init("invert", sizeof("invert") - 1, 1);
+	zend_declare_typed_property(class_entry, property_invert_name, &property_invert_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_invert_name);
+
+	zval property_days_default_value;
+	ZVAL_UNDEF(&property_days_default_value);
+	zend_string *property_days_name = zend_string_init("days", sizeof("days") - 1, 1);
+	zend_declare_typed_property(class_entry, property_days_name, &property_days_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_FALSE));
+	zend_string_release(property_days_name);
 
 	return class_entry;
 }

--- a/ext/date/tests/DateInterval_serialize-001.phpt
+++ b/ext/date/tests/DateInterval_serialize-001.phpt
@@ -26,7 +26,9 @@ var_dump($now->sub($e));
 ?>
 --EXPECTF--
 Original object:
-object(DateInterval)#1 (10) {
+object(DateInterval)#1 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -44,18 +46,18 @@ object(DateInterval)#1 (10) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }
 
 
 Serialised object:
-string(164) "O:12:"DateInterval":10:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}"
+string(164) "O:12:"DateInterval":10:{s:11:"from_string";b:0;s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}"
 
 
 Unserialised object:
-object(DateInterval)#2 (10) {
+object(DateInterval)#2 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -73,14 +75,14 @@ object(DateInterval)#2 (10) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }
 
 
 Calling __serialize manually:
 array(%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -99,13 +101,11 @@ array(%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["from_string"]=>
-  bool(false)
 }
 
 
 Used serialised interval:
-object(DateTimeImmutable)#4 (3) {
+object(DateTimeImmutable)#4 (%d) {
   ["date"]=>
   string(26) "2024-04-26 22:33:11.000000"
   ["timezone_type"]=>
@@ -113,7 +113,7 @@ object(DateTimeImmutable)#4 (3) {
   ["timezone"]=>
   string(3) "BST"
 }
-object(DateTimeImmutable)#4 (3) {
+object(DateTimeImmutable)#4 (%d) {
   ["date"]=>
   string(26) "2020-04-18 10:17:11.000000"
   ["timezone_type"]=>

--- a/ext/date/tests/DateInterval_serialize-002.phpt
+++ b/ext/date/tests/DateInterval_serialize-002.phpt
@@ -38,6 +38,22 @@ $d->__unserialize(
 );
 var_dump($d);
 
+echo "\n\nCalling __unserialize manually on DateTimeInterval:\n";
+$d = new DateTimeInterval('P2Y4DT6H8M');
+$d->__unserialize(
+	[
+		'y' => 43,
+		'm' =>  3,
+		'd' => 24,
+		'h' =>  1,
+		'i' => 12,
+		's' => 27,
+		'f' => 0.654321,
+		'days' => 15820,
+	]
+);
+var_dump($d);
+
 echo "\n\nUsed serialised interval:\n";
 $now = new DateTimeImmutable("2022-04-15 10:27:27 BST");
 var_dump($now->add($e));
@@ -45,7 +61,9 @@ var_dump($now->sub($e));
 ?>
 --EXPECTF--
 Original object:
-object(DateInterval)#3 (10) {
+object(DateTimeInterval)#3 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(43)
   ["m"]=>
@@ -64,17 +82,17 @@ object(DateInterval)#3 (10) {
   int(0)
   ["days"]=>
   int(15820)
-  ["from_string"]=>
-  bool(false)
 }
 
 
 Serialised object:
-string(172) "O:12:"DateInterval":10:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:15820;s:11:"from_string";b:0;}"
+string(176) "O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:15820;}"
 
 
 Unserialised object:
-object(DateInterval)#4 (10) {
+object(DateTimeInterval)#4 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(43)
   ["m"]=>
@@ -93,13 +111,13 @@ object(DateInterval)#4 (10) {
   int(0)
   ["days"]=>
   int(15820)
-  ["from_string"]=>
-  bool(false)
 }
 
 
 Calling __serialize manually:
 array(%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(43)
   ["m"]=>
@@ -118,13 +136,13 @@ array(%d) {
   int(0)
   ["days"]=>
   int(15820)
-  ["from_string"]=>
-  bool(false)
 }
 
 
 Calling __unserialize manually:
-object(DateInterval)#5 (10) {
+object(DateInterval)#5 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(43)
   ["m"]=>
@@ -143,13 +161,36 @@ object(DateInterval)#5 (10) {
   int(0)
   ["days"]=>
   int(15820)
+}
+
+
+Calling __unserialize manually on DateTimeInterval:
+object(DateTimeInterval)#3 (%d) {
   ["from_string"]=>
   bool(false)
+  ["y"]=>
+  int(43)
+  ["m"]=>
+  int(3)
+  ["d"]=>
+  int(24)
+  ["h"]=>
+  int(1)
+  ["i"]=>
+  int(12)
+  ["s"]=>
+  int(27)
+  ["f"]=>
+  float(0.654321)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
 }
 
 
 Used serialised interval:
-object(DateTimeImmutable)#6 (3) {
+object(DateTimeImmutable)#6 (%d) {
   ["date"]=>
   string(26) "2065-08-08 11:39:54.000000"
   ["timezone_type"]=>
@@ -157,7 +198,7 @@ object(DateTimeImmutable)#6 (3) {
   ["timezone"]=>
   string(3) "BST"
 }
-object(DateTimeImmutable)#6 (3) {
+object(DateTimeImmutable)#6 (%d) {
   ["date"]=>
   string(26) "1978-12-22 09:15:00.000000"
   ["timezone_type"]=>

--- a/ext/date/tests/DateInterval_serialize-003.phpt
+++ b/ext/date/tests/DateInterval_serialize-003.phpt
@@ -40,7 +40,7 @@ try {
 ?>
 --EXPECTF--
 Original object:
-object(DateInterval)#1 (%d) {
+object(DateTimeStringInterval)#1 (%d) {
   ["from_string"]=>
   bool(true)
   ["date_string"]=>
@@ -49,11 +49,11 @@ object(DateInterval)#1 (%d) {
 
 
 Serialised object:
-string(%d) "O:12:"DateInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:%d:"next weekday";}"
+string(96) "O:22:"DateTimeStringInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:12:"next weekday";}"
 
 
 Unserialised object:
-object(DateInterval)#2 (2) {
+object(DateTimeStringInterval)#2 (%d) {
   ["from_string"]=>
   bool(true)
   ["date_string"]=>
@@ -62,7 +62,7 @@ object(DateInterval)#2 (2) {
 
 
 Calling __serialize manually:
-array(2) {
+array(%d) {
   ["from_string"]=>
   bool(true)
   ["date_string"]=>
@@ -71,7 +71,7 @@ array(2) {
 
 
 Calling __unserialize manually:
-object(DateInterval)#3 (2) {
+object(DateInterval)#3 (%d) {
   ["from_string"]=>
   bool(true)
   ["date_string"]=>
@@ -80,7 +80,7 @@ object(DateInterval)#3 (2) {
 
 
 Used serialised interval:
-object(DateTimeImmutable)#4 (3) {
+object(DateTimeImmutable)#4 (%d) {
   ["date"]=>
   string(26) "2022-04-25 16:25:11.000000"
   ["timezone_type"]=>

--- a/ext/date/tests/DatePeriod_createFromISO8601String_static_return.phpt
+++ b/ext/date/tests/DatePeriod_createFromISO8601String_static_return.phpt
@@ -20,10 +20,10 @@ try {
 }
 
 ?>
---EXPECT--
-object(MyDatePeriod)#1 (7) {
+--EXPECTF--
+object(MyDatePeriod)#1 (%d) {
   ["start"]=>
-  object(DateTimeImmutable)#2 (3) {
+  object(DateTimeImmutable)#2 (%d) {
     ["date"]=>
     string(26) "2012-07-01 00:00:00.000000"
     ["timezone_type"]=>
@@ -36,7 +36,9 @@ object(MyDatePeriod)#1 (7) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#3 (10) {
+  object(DateTimeInterval)#3 (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -54,8 +56,6 @@ object(MyDatePeriod)#1 (7) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DatePeriod_serialize-001.phpt
+++ b/ext/date/tests/DatePeriod_serialize-001.phpt
@@ -37,7 +37,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -56,8 +58,6 @@ object(DatePeriod)#%d (%d) {
     int(0)
     ["days"]=>
     bool(false)
-    ["from_string"]=>
-    bool(false)
   }
   ["recurrences"]=>
   int(5)
@@ -69,7 +69,7 @@ object(DatePeriod)#%d (%d) {
 
 
 Serialised object:
-string(%d) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2012-07-01 00:00:00.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"current";N;s:3:"end";N;s:8:"interval";O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:7;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}s:11:"recurrences";i:5;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;}"
+string(453) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2012-07-01 00:00:00.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}s:7:"current";N;s:3:"end";N;s:8:"interval";O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:7;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}s:11:"recurrences";i:5;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;}"
 
 
 Unserialised object:
@@ -88,7 +88,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -106,8 +108,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -135,7 +135,9 @@ array(%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -153,8 +155,6 @@ array(%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DatePeriod_serialize-002.phpt
+++ b/ext/date/tests/DatePeriod_serialize-002.phpt
@@ -52,7 +52,9 @@ object(DatePeriod)#%d (%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -71,8 +73,6 @@ object(DatePeriod)#%d (%d) {
     int(0)
     ["days"]=>
     bool(false)
-    ["from_string"]=>
-    bool(false)
   }
   ["recurrences"]=>
   int(1)
@@ -84,7 +84,7 @@ object(DatePeriod)#%d (%d) {
 
 
 Serialised object:
-string(%d) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2022-04-29 15:51:56.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}s:8:"interval";O:12:"DateInterval":10:{s:1:"y";i:2;s:1:"m";i:6;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}s:11:"recurrences";i:1;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;}"
+string(597) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2022-04-29 15:51:56.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}s:8:"interval";O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:2;s:1:"m";i:6;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}s:11:"recurrences";i:1;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;}"
 
 
 Unserialised object:
@@ -110,7 +110,9 @@ object(DatePeriod)#%d (%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -128,8 +130,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -164,7 +164,9 @@ array(%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -182,8 +184,6 @@ array(%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DatePeriod_serialize-003.phpt
+++ b/ext/date/tests/DatePeriod_serialize-003.phpt
@@ -52,7 +52,9 @@ object(DatePeriod)#%d (%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -71,8 +73,6 @@ object(DatePeriod)#%d (%d) {
     int(0)
     ["days"]=>
     bool(false)
-    ["from_string"]=>
-    bool(false)
   }
   ["recurrences"]=>
   int(0)
@@ -84,7 +84,7 @@ object(DatePeriod)#%d (%d) {
 
 
 Serialised object:
-string(%d) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2022-04-29 15:51:56.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}s:8:"interval";O:12:"DateInterval":10:{s:1:"y";i:2;s:1:"m";i:6;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}s:11:"recurrences";i:0;s:18:"include_start_date";b:0;s:16:"include_end_date";b:0;}"
+string(597) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2022-04-29 15:51:56.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}s:8:"interval";O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:2;s:1:"m";i:6;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}s:11:"recurrences";i:0;s:18:"include_start_date";b:0;s:16:"include_end_date";b:0;}"
 
 
 Unserialised object:
@@ -110,7 +110,9 @@ object(DatePeriod)#%d (%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -128,8 +130,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -164,7 +164,9 @@ array(%d) {
     string(13) "Europe/London"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(2)
     ["m"]=>
@@ -182,8 +184,6 @@ array(%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DatePeriod_serialize-004.phpt
+++ b/ext/date/tests/DatePeriod_serialize-004.phpt
@@ -50,7 +50,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -68,8 +70,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -92,7 +92,7 @@ Iterate of object:
 
 
 Serialised object:
-string(%d) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1979-08-06 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:3:"end";N;s:8:"interval";O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}s:11:"recurrences";i:7;s:18:"include_start_date";b:0;s:16:"include_end_date";b:0;}"
+string(%d) "O:10:"DatePeriod":7:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1978-12-22 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:7:"current";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"1979-08-06 09:15:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:16:"Europe/Amsterdam";}s:3:"end";N;s:8:"interval";O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}s:11:"recurrences";i:7;s:18:"include_start_date";b:0;s:16:"include_end_date";b:0;}"
 
 
 Unserialised object:
@@ -118,7 +118,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -136,8 +138,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -172,7 +172,9 @@ array(%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -190,8 +192,6 @@ array(%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DatePeriod_set_state.phpt
+++ b/ext/date/tests/DatePeriod_set_state.phpt
@@ -34,7 +34,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -52,8 +54,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/DateTimeInterval_properties.phpt
+++ b/ext/date/tests/DateTimeInterval_properties.phpt
@@ -1,0 +1,103 @@
+--TEST--
+Test DateTimeInterval readonly properties
+--FILE--
+<?php
+
+$i = new DateTimeInterval("P1D");
+
+try {
+    $i->from_string = true;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->y = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->m = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->d = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->h = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->i = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->s = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->f = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->invert = true;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->days = 1;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+var_dump($i);
+
+?>
+--EXPECTF--
+Cannot modify readonly property DateTimeInterval::$from_string
+Cannot modify readonly property DateTimeInterval::$y
+Cannot modify readonly property DateTimeInterval::$m
+Cannot modify readonly property DateTimeInterval::$d
+Cannot modify readonly property DateTimeInterval::$h
+Cannot modify readonly property DateTimeInterval::$i
+Cannot modify readonly property DateTimeInterval::$s
+Cannot modify readonly property DateTimeInterval::$f
+Cannot modify readonly property DateTimeInterval::$invert
+Cannot modify readonly property DateTimeInterval::$days
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(1)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+}

--- a/ext/date/tests/DateTimeInterval_set_state.phpt
+++ b/ext/date/tests/DateTimeInterval_set_state.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test DateTimeInterval::__set_state()
+--FILE--
+<?php
+
+var_dump(DateTimeInterval::__set_state([
+    "y" => 2024,
+]));
+
+try {
+    DateTimeInterval::__set_state([
+        "date_string" => "yesterday"
+    ]);
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(2024)
+  ["m"]=>
+  int(-1)
+  ["d"]=>
+  int(-1)
+  ["h"]=>
+  int(-1)
+  ["i"]=>
+  int(-1)
+  ["s"]=>
+  int(-1)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(-1)
+}
+DateInterval::__set_state(): Argument #1 ($array) cannot contain a "date_string" key with a string value

--- a/ext/date/tests/DateTimeStringInterval_construct.phpt
+++ b/ext/date/tests/DateTimeStringInterval_construct.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test DateTimeStringInterval::__construct()
+--FILE--
+<?php
+
+var_dump(new DateTimeStringInterval("yesterday"));
+
+try {
+    new DateTimeStringInterval("");
+} catch (DateException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    new DateTimeStringInterval("P1D");
+} catch (DateException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+object(DateTimeStringInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(9) "yesterday"
+}
+Unknown or bad format () at position 0 ( ): Empty string
+Unknown or bad format (P1D) at position 1 (1): Unexpected character

--- a/ext/date/tests/DateTimeStringInterval_properties.phpt
+++ b/ext/date/tests/DateTimeStringInterval_properties.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test DateTimeStringInterval readonly properties
+--FILE--
+<?php
+
+$i = new DateTimeStringInterval("yesterday");
+
+try {
+    $i->from_string = false;
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $i->date_string = "";
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+var_dump($i);
+
+?>
+--EXPECTF--
+Cannot modify readonly property DateTimeStringInterval::$from_string
+Cannot modify readonly property DateTimeStringInterval::$date_string
+object(DateTimeStringInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(9) "yesterday"
+}

--- a/ext/date/tests/DateTimeStringInterval_set_state.phpt
+++ b/ext/date/tests/DateTimeStringInterval_set_state.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test DateTimeStringInterval::__set_state()
+--FILE--
+<?php
+
+var_dump(DateTimeStringInterval::__set_state([
+    "date_string" => "yesterday"
+]));
+
+try {
+    DateTimeStringInterval::__set_state([
+        "y" => 2024,
+    ]);
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+object(DateTimeStringInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(9) "yesterday"
+}
+DateInterval::__set_state(): Argument #1 ($array) must contain a "date_string" key with a string value

--- a/ext/date/tests/bug-gh11416.phpt
+++ b/ext/date/tests/bug-gh11416.phpt
@@ -6,6 +6,7 @@ date.timezone=UTC
 <?php
 $now = new DateTimeImmutable();
 $simpleInterval = new DateInterval("P2D");
+$simpleDateTimeInterval = new DateTimeInterval("P2D");
 
 $date = (new ReflectionClass(DateTime::class))->newInstanceWithoutConstructor();
 try {
@@ -57,6 +58,16 @@ try {
 } catch (Error $e) {
 	echo get_class($e), ': ', $e->getMessage(), "\n";
 }
+
+try {
+	$dateperiod->__unserialize([
+		'start' => $now, 'end' => $now, 'current' => $now, 'interval' => $simpleDateTimeInterval,
+		'recurrences' => 2, 'include_start_date' => true, 'include_end_date' => true,
+	]);
+	echo "DatePeriod::__unserialize: SUCCESS\n";
+} catch (Error $e) {
+	echo get_class($e), ': ', $e->getMessage(), "\n";
+}
 echo "OK\n";
 ?>
 --EXPECT--
@@ -66,5 +77,6 @@ Error: Invalid serialization data for DatePeriod object
 Error: Invalid serialization data for DatePeriod object
 Error: Invalid serialization data for DatePeriod object
 Error: Invalid serialization data for DatePeriod object
+DatePeriod::__unserialize: SUCCESS
 DatePeriod::__unserialize: SUCCESS
 OK

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -13,7 +13,9 @@ $diff = date_diff($date, $other);
 var_dump($diff);
 ?>
 --EXPECTF--
-object(DateInterval)#%d (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -32,6 +34,4 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(3)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -3,34 +3,52 @@ Bug #48678 (DateInterval segfaults when unserialising)
 --FILE--
 <?php
 $x = new DateInterval("P3Y6M4DT12H30M5S");
-print_r($x);
+var_dump($x);
 $y = unserialize(serialize($x));
-print_r($y);
+var_dump($y);
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 3
-    [m] => 6
-    [d] => 4
-    [h] => 12
-    [i] => 30
-    [s] => 5
-    [f] => 0
-    [invert] => 0
-    [days] => 
-    [from_string] => 
-)
-DateInterval Object
-(
-    [y] => 3
-    [m] => 6
-    [d] => 4
-    [h] => 12
-    [i] => 30
-    [s] => 5
-    [f] => 0
-    [invert] => 0
-    [days] => 
-    [from_string] => 
-)
+--EXPECTF--
+object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(3)
+  ["m"]=>
+  int(6)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(12)
+  ["i"]=>
+  int(30)
+  ["s"]=>
+  int(5)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+}
+object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(3)
+  ["m"]=>
+  int(6)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(12)
+  ["i"]=>
+  int(30)
+  ["s"]=>
+  int(5)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+}

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -2,23 +2,32 @@
 Bug #49081 (DateTime::diff() mistake if start in January and interval > 28 days)
 --FILE--
 <?php
-   date_default_timezone_set('Europe/Berlin');
-   $d1 = new DateTime('2010-01-01 06:00:00');
-   $d2 = new DateTime('2010-01-31 10:00:00');
-   $d  = $d1->diff($d2);
-   print_r($d);
+date_default_timezone_set('Europe/Berlin');
+$d1 = new DateTime('2010-01-01 06:00:00');
+$d2 = new DateTime('2010-01-31 10:00:00');
+$d  = $d1->diff($d2);
+var_dump($d);
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 30
-    [h] => 4
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 30
-    [from_string] => 
-)
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(30)
+  ["h"]=>
+  int(4)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(30)
+}

--- a/ext/date/tests/bug49778.phpt
+++ b/ext/date/tests/bug49778.phpt
@@ -9,6 +9,8 @@ echo $i->format("%a"), "\n";
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -26,8 +28,6 @@ object(DateInterval)#%d (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }
 7

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -11,6 +11,7 @@ $p = new DatePeriod($start, $diff, 2);
 $diff_s = serialize($diff);
 var_dump($diff, $diff_s);
 var_export($diff);
+echo "\n";
 
 $diff_un = unserialize($diff_s);
 $p = new DatePeriod($start, $diff_un, 2);
@@ -33,7 +34,9 @@ var_dump($unser, $p);
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -52,11 +55,10 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["from_string"]=>
-  bool(false)
 }
-string(164) "O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;s:11:"from_string";b:0;}"
-\DateInterval::__set_state(array(
+string(168) "O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;}"
+\DateTimeInterval::__set_state(array(
+   'from_string' => false,
    'y' => 0,
    'm' => 0,
    'd' => 0,
@@ -66,8 +68,10 @@ string(164) "O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
    'f' => 0.0,
    'invert' => 0,
    'days' => 0,
-   'from_string' => false,
-))object(DateInterval)#%d (%d) {
+))
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -86,8 +90,6 @@ string(164) "O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
   int(0)
   ["days"]=>
   int(0)
-  ["from_string"]=>
-  bool(false)
 }
 object(DatePeriod)#%d (%d) {
   ["start"]=>
@@ -104,7 +106,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -123,8 +127,6 @@ object(DatePeriod)#%d (%d) {
     int(0)
     ["days"]=>
     int(0)
-    ["from_string"]=>
-    bool(false)
   }
   ["recurrences"]=>
   int(3)
@@ -134,6 +136,8 @@ object(DatePeriod)#%d (%d) {
   bool(false)
 }
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(7)
   ["m"]=>
@@ -152,8 +156,6 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(2400)
-  ["from_string"]=>
-  bool(false)
 }
 object(DatePeriod)#%d (%d) {
   ["start"]=>
@@ -170,7 +172,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -189,8 +193,6 @@ object(DatePeriod)#%d (%d) {
     int(0)
     ["days"]=>
     int(0)
-    ["from_string"]=>
-    bool(false)
   }
   ["recurrences"]=>
   int(3)

--- a/ext/date/tests/bug52738.phpt
+++ b/ext/date/tests/bug52738.phpt
@@ -13,23 +13,33 @@ echo $I->unit."\n";
 $I->unit = 42;
 echo $I->unit."\n";
 $I->d++;
-print_r($I);
+var_dump($I);
 ?>
---EXPECT--
+--EXPECTF--
 1
 2
 42
-di Object
-(
-    [unit] => 42
-    [y] => 0
-    [m] => 0
-    [d] => 11
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 
-    [from_string] => 
-)
+object(di)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["unit"]=>
+  int(42)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(11)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+}

--- a/ext/date/tests/bug52808.phpt
+++ b/ext/date/tests/bug52808.phpt
@@ -28,6 +28,8 @@ echo "==DONE==\n";
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(1)
   ["m"]=>
@@ -46,10 +48,10 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(437)
-  ["from_string"]=>
-  bool(false)
 }
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -68,10 +70,10 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
-  ["from_string"]=>
-  bool(false)
 }
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -90,8 +92,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
-  ["from_string"]=>
-  bool(false)
 }
 DateMalformedIntervalStringException: Failed to parse interval (2007-05-11T15:30:00Z/)
 DateMalformedIntervalStringException: Failed to parse interval (2007-05-11T15:30:00Z)

--- a/ext/date/tests/bug53437_var0.phpt
+++ b/ext/date/tests/bug53437_var0.phpt
@@ -50,7 +50,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -68,8 +70,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -101,7 +101,9 @@ object(DatePeriod)#%d (%d) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -119,8 +121,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/bug53437_var2.phpt
+++ b/ext/date/tests/bug53437_var2.phpt
@@ -13,6 +13,8 @@ var_dump($di0, $di1);
 ?>
 --EXPECTF--
 object(DateInterval)#1 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -30,11 +32,11 @@ object(DateInterval)#1 (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }
 object(DateInterval)#2 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -52,7 +54,5 @@ object(DateInterval)#2 (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }

--- a/ext/date/tests/bug53437_var4.phpt
+++ b/ext/date/tests/bug53437_var4.phpt
@@ -21,7 +21,9 @@ var_dump($df,
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -40,8 +42,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(2)
-  ["from_string"]=>
-  bool(false)
 }
 int(0)
 int(0)

--- a/ext/date/tests/bug53437_var5.phpt
+++ b/ext/date/tests/bug53437_var5.phpt
@@ -12,6 +12,8 @@ var_dump($di);
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -30,6 +32,4 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug53437_var6.phpt
+++ b/ext/date/tests/bug53437_var6.phpt
@@ -12,6 +12,8 @@ var_dump($di);
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(2)
   ["m"]=>
@@ -30,6 +32,4 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug60774.phpt
+++ b/ext/date/tests/bug60774.phpt
@@ -8,7 +8,7 @@ echo $i->format("%d"), "\n";
 echo $i->format("%a"), "\n";
 ?>
 --EXPECTF--
-object(DateInterval)#1 (%d) {
+object(DateTimeStringInterval)#1 (%d) {
   ["from_string"]=>
   bool(true)
   ["date_string"]=>

--- a/ext/date/tests/bug66545.phpt
+++ b/ext/date/tests/bug66545.phpt
@@ -13,19 +13,28 @@ $d2 = new DateTime('now',new DateTimeZone('Europe/Paris'));
 $d1->setTimestamp($debut);
 $d2->setTimestamp($fin);
 $diff = $d1->diff($d2);
-print_r($diff);
+var_dump($diff);
 ?>
 --EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 14
-    [h] => 23
-    [i] => 59
-    [s] => 59
-    [f] => 0
-    [invert] => 0
-    [days] => 14
-    [from_string] => 
-)
+object(DateTimeInterval)#3 (10) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(14)
+  ["h"]=>
+  int(23)
+  ["i"]=>
+  int(59)
+  ["s"]=>
+  int(59)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(14)
+}

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -16,13 +16,13 @@ print_r($i2);
 var_dump($i1->days, $i2->days);
 ?>
 --EXPECT--
-DateInterval Object
+DateTimeStringInterval Object
 (
     [from_string] => 1
     [date_string] => +1 month
 )
-O:12:"DateInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:8:"+1 month";}
-DateInterval Object
+O:22:"DateTimeStringInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:8:"+1 month";}
+DateTimeStringInterval Object
 (
     [from_string] => 1
     [date_string] => +1 month

--- a/ext/date/tests/bug71700.phpt
+++ b/ext/date/tests/bug71700.phpt
@@ -12,7 +12,9 @@ $diff = date_diff($date1, $date2, true);
 var_dump($diff);
 ?>
 --EXPECTF--
-object(DateInterval)#3 (%d) {
+object(DateTimeInterval)#3 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -31,6 +33,4 @@ object(DateInterval)#3 (%d) {
   int(0)
   ["days"]=>
   int(30)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug73091.phpt
+++ b/ext/date/tests/bug73091.phpt
@@ -13,6 +13,8 @@ var_dump(unserialize('O:12:"DateInterval":1:{s:4:"days";O:3:"foo":0:{}}'));
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(-1)
   ["m"]=>
@@ -31,6 +33,4 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(-1)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug74274.phpt
+++ b/ext/date/tests/bug74274.phpt
@@ -6,19 +6,28 @@ $tz = new DateTimeZone("Europe/Paris");
 $startDate = new \DateTime('2018-10-28 00:00:00', $tz);
 $endDateBuggy = new \DateTime('2018-10-29 23:00:00', $tz);
 
-print_r($startDate->diff($endDateBuggy));
+var_dump($startDate->diff($endDateBuggy));
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 1
-    [h] => 23
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 1
-    [from_string] => 
-)
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(1)
+  ["h"]=>
+  int(23)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(1)
+}

--- a/ext/date/tests/bug74524.phpt
+++ b/ext/date/tests/bug74524.phpt
@@ -8,19 +8,28 @@ $a = new DateTime("2017-11-17 22:05:26.000000");
 $b = new DateTime("2017-04-03 22:29:15.079459");
 
 $diff = $a->diff($b);
-print_r($diff);
+var_dump($diff);
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 7
-    [d] => 13
-    [h] => 23
-    [i] => 36
-    [s] => 10
-    [f] => 0.920541
-    [invert] => 1
-    [days] => 227
-    [from_string] => 
-)
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(7)
+  ["d"]=>
+  int(13)
+  ["h"]=>
+  int(23)
+  ["i"]=>
+  int(36)
+  ["s"]=>
+  int(10)
+  ["f"]=>
+  float(0.920541)
+  ["invert"]=>
+  int(1)
+  ["days"]=>
+  int(227)
+}

--- a/ext/date/tests/bug77571.phpt
+++ b/ext/date/tests/bug77571.phpt
@@ -9,19 +9,28 @@ $date3 = DateTime::createFromFormat('Y-m-d H:i:s', '2019-04-01 00:00:00'); //  2
 $date4 = clone $date3;
 $date4->modify('+5 week'); // 2019-05-06 00:00:00.0 Europe/London (+01:00)
 $differenceDateInterval2 = $date3->diff($date4); // interval: + 1m 4d; days 35
-print_r($differenceDateInterval2);
+var_dump($differenceDateInterval2);
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 1
-    [d] => 5
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 35
-    [from_string] => 
-)
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(1)
+  ["d"]=>
+  int(5)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(35)
+}

--- a/ext/date/tests/bug78452.phpt
+++ b/ext/date/tests/bug78452.phpt
@@ -8,7 +8,9 @@ $date2 = new \DateTime('2019-08-21 12:47:24');
 var_dump($date1->diff($date2));
 ?>
 --EXPECTF--
-object(DateInterval)#3 (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -27,6 +29,4 @@ object(DateInterval)#3 (%d) {
   int(1)
   ["days"]=>
   int(33)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/bug79015.phpt
+++ b/ext/date/tests/bug79015.phpt
@@ -7,6 +7,8 @@ var_dump(unserialize($payload));
 ?>
 --EXPECTF--
 object(DateInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(1)
   ["m"]=>
@@ -24,7 +26,5 @@ object(DateInterval)#%d (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }

--- a/ext/date/tests/bug81263.phpt
+++ b/ext/date/tests/bug81263.phpt
@@ -6,33 +6,51 @@ Bug #81263 (Wrong result from DateTimeImmutable::diff)
 $dt1 = new DateTimeImmutable('2020-07-19 18:30:00', new DateTimeZone('Europe/Berlin'));
 $dt2 = new DateTimeImmutable('2020-07-19 16:30:00', new DateTimeZone('UTC'));
 
-print_r($dt2->diff($dt1));
-print_r($dt1->diff($dt2));
+var_dump($dt2->diff($dt1));
+var_dump($dt1->diff($dt2));
 ?>
 --EXPECTF--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 0
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 0
-    [from_string] => 
-)
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 0
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 0
-    [from_string] => 
-)
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(0)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(0)
+}
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(0)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(0)
+}

--- a/ext/date/tests/date_diff1.phpt
+++ b/ext/date/tests/date_diff1.phpt
@@ -28,7 +28,9 @@ object(DateTime)#2 (3) {
   ["timezone"]=>
   string(3) "EDT"
 }
-object(DateInterval)#%d (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -47,6 +49,4 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(33)
-  ["from_string"]=>
-  bool(false)
 }

--- a/ext/date/tests/date_period_set_state1.phpt
+++ b/ext/date/tests/date_period_set_state1.phpt
@@ -41,7 +41,9 @@ object(DatePeriod)#%d (%d) {
     string(3) "UTC"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -59,8 +61,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/date_period_unserialize1.phpt
+++ b/ext/date/tests/date_period_unserialize1.phpt
@@ -46,7 +46,9 @@ object(DatePeriod)#%d (%d) {
     string(3) "UTC"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -64,8 +66,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/date_period_unserialize3.phpt
+++ b/ext/date/tests/date_period_unserialize3.phpt
@@ -51,7 +51,9 @@ object(DatePeriod)#%d (%d) {
     string(3) "UTC"
   }
   ["interval"]=>
-  object(DateInterval)#%d (%d) {
+  object(DateTimeInterval)#%d (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -69,8 +71,6 @@ object(DatePeriod)#%d (%d) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/date_time_fractions.phpt
+++ b/ext/date/tests/date_time_fractions.phpt
@@ -58,7 +58,9 @@ microseconds = true
 2016-10-02 00:00:00.000000
 2016-10-03 12:00:00.000000
 2016-10-17 12:47:18.081921
-object(DateInterval)#%d (%d) {
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
   ["y"]=>
   int(0)
   ["m"]=>
@@ -77,8 +79,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["from_string"]=>
-  bool(false)
 }
 2016-10-03 13:20:06.724934
 2016-10-03 13:20:07.103123

--- a/ext/date/tests/examine_diff.inc
+++ b/ext/date/tests/examine_diff.inc
@@ -47,9 +47,10 @@ function examine_diff($end_date, $start_date, $expect_spec, $expect_days, $absol
     }
     $end_date = $end->format('Y-m-d H:i:s T');
 
+    $invert = false;
     $expect_interval = new DateInterval('P' . substr($expect_spec, 2));
     if (substr($expect_spec, 1, 1) == '-') {
-        $expect_interval->invert = true;
+        $invert = true;
     }
 
     if (PHPT_DATETIME_SHOW == PHPT_DATETIME_SHOW_DIFF) {
@@ -65,12 +66,12 @@ function examine_diff($end_date, $start_date, $expect_spec, $expect_days, $absol
         // echo "DAYS: **$expect_days**\n";
     }
     if (PHPT_DATETIME_SHOW == PHPT_DATETIME_SHOW_ADD) {
-        $start->add($expect_interval);
+        $invert ? $start->sub($expect_interval) : $start->add($expect_interval);
         $result_end_date = $start->format('Y-m-d H:i:s T');
         echo "ADD: $start_date + $expect_spec = **$result_end_date**\n";
     }
     if (PHPT_DATETIME_SHOW == PHPT_DATETIME_SHOW_SUB) {
-        $end->sub($expect_interval);
+        $invert ? $end->add($expect_interval) : $end->sub($expect_interval);
         $result_start_date = $end->format('Y-m-d H:i:s T');
         echo "SUB: $end_date - $expect_spec = **$result_start_date**\n";
         // echo "SUB: $end_date - $expect_spec = **$start_date**\n";

--- a/ext/date/tests/gh10747-3.phpt
+++ b/ext/date/tests/gh10747-3.phpt
@@ -24,7 +24,9 @@ $u = unserialize($s);
 var_dump($i, str_replace(chr(0), '!', $s), $u);
 ?>
 --EXPECTF--
-object(I)#1 (14) {
+object(I)#1 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["var1":"I":private]=>
   int(1)
   ["var2":"I":private]=>
@@ -50,12 +52,12 @@ object(I)#1 (14) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }
-string(224) "O:1:"I":14:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:3;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;s:7:"!I!var1";i:1;s:7:"!I!var2";i:2;s:7:"!*!var3";i:3;s:7:"!*!var4";i:4;}"
-object(I)#2 (14) {
+string(224) "O:1:"I":14:{s:11:"from_string";b:0;s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:3;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:7:"!I!var1";i:1;s:7:"!I!var2";i:2;s:7:"!*!var3";i:3;s:7:"!*!var4";i:4;}"
+object(I)#2 (%d) {
+  ["from_string"]=>
+  bool(false)
   ["var1":"I":private]=>
   int(1)
   ["var2":"I":private]=>
@@ -81,7 +83,5 @@ object(I)#2 (14) {
   ["invert"]=>
   int(0)
   ["days"]=>
-  bool(false)
-  ["from_string"]=>
   bool(false)
 }

--- a/ext/date/tests/gh10747-4.phpt
+++ b/ext/date/tests/gh10747-4.phpt
@@ -26,7 +26,7 @@ $u = unserialize($s);
 var_dump($i, str_replace(chr(0), '!', $s), $u);
 ?>
 --EXPECTF--
-object(I)#1 (11) {
+object(I)#1 (%d) {
   ["start"]=>
   object(DateTimeImmutable)#5 (3) {
     ["date"]=>
@@ -39,7 +39,7 @@ object(I)#1 (11) {
   ["current"]=>
   NULL
   ["end"]=>
-  object(DateTimeImmutable)#6 (3) {
+  object(DateTimeImmutable)#6 (%d) {
     ["date"]=>
     string(26) "2023-03-09 16:24:00.000000"
     ["timezone_type"]=>
@@ -48,7 +48,9 @@ object(I)#1 (11) {
     string(3) "UTC"
   }
   ["interval"]=>
-  object(DateInterval)#7 (10) {
+  object(DateTimeInterval)#7 (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -66,8 +68,6 @@ object(I)#1 (11) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>
@@ -85,10 +85,10 @@ object(I)#1 (11) {
   ["var4":protected]=>
   int(4)
 }
-string(631) "O:1:"I":11:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2023-03-03 16:24:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2023-03-09 16:24:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:8:"interval";O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:1;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}s:11:"recurrences";i:1;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;s:7:"!I!var1";i:1;s:7:"!I!var2";i:2;s:7:"!*!var3";i:3;s:7:"!*!var4";i:4;}"
-object(I)#2 (11) {
+string(635) "O:1:"I":11:{s:5:"start";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2023-03-03 16:24:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:7:"current";N;s:3:"end";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2023-03-09 16:24:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:8:"interval";O:16:"DateTimeInterval":10:{s:11:"from_string";b:0;s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:1;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;}s:11:"recurrences";i:1;s:18:"include_start_date";b:1;s:16:"include_end_date";b:0;s:7:"!I!var1";i:1;s:7:"!I!var2";i:2;s:7:"!*!var3";i:3;s:7:"!*!var4";i:4;}"
+object(I)#2 (%d) {
   ["start"]=>
-  object(DateTimeImmutable)#9 (3) {
+  object(DateTimeImmutable)#9 (%d) {
     ["date"]=>
     string(26) "2023-03-03 16:24:00.000000"
     ["timezone_type"]=>
@@ -99,7 +99,7 @@ object(I)#2 (11) {
   ["current"]=>
   NULL
   ["end"]=>
-  object(DateTimeImmutable)#10 (3) {
+  object(DateTimeImmutable)#10 (%d) {
     ["date"]=>
     string(26) "2023-03-09 16:24:00.000000"
     ["timezone_type"]=>
@@ -108,7 +108,9 @@ object(I)#2 (11) {
     string(3) "UTC"
   }
   ["interval"]=>
-  object(DateInterval)#11 (10) {
+  object(DateTimeInterval)#11 (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(0)
     ["m"]=>
@@ -126,8 +128,6 @@ object(I)#2 (11) {
     ["invert"]=>
     int(0)
     ["days"]=>
-    bool(false)
-    ["from_string"]=>
     bool(false)
   }
   ["recurrences"]=>

--- a/ext/date/tests/gh8730.phpt
+++ b/ext/date/tests/gh8730.phpt
@@ -4,19 +4,28 @@ Bug GH-8730 (DateTime::diff miscalculation is same time zone of different type)
 <?php
 $foo = new DateTime('2022-06-08 09:15:00', new DateTimeZone('-04:00'));
 $bar = new DateTime('2022-06-08 09:15:00', new DateTimeZone('US/Eastern'));
-print_r($foo->diff($bar));
+var_dump($foo->diff($bar));
 ?>
---EXPECT--
-DateInterval Object
-(
-    [y] => 0
-    [m] => 0
-    [d] => 0
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 0
-    [from_string] => 
-)
+--EXPECTF--
+object(DateTimeInterval)#%d (%d) {
+  ["from_string"]=>
+  bool(false)
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(0)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(0)
+}

--- a/ext/standard/tests/serialize/bug69425.phpt
+++ b/ext/standard/tests/serialize/bug69425.phpt
@@ -27,6 +27,8 @@ int(1)
 array(2) {
   [0]=>
   object(DateInterval)#1 (%d) {
+    ["from_string"]=>
+    bool(false)
     ["y"]=>
     int(-1)
     ["m"]=>
@@ -45,8 +47,6 @@ array(2) {
     int(0)
     ["days"]=>
     int(-1)
-    ["from_string"]=>
-    bool(false)
   }
   [1]=>
   int(2)


### PR DESCRIPTION
The idea here is to add 2 `DateInterval` subclasses:
- `DateTimeInterval`: represents an interval based on the regular interval specification
- `DateTimeStringInterval`: represents an interval based on a date time with relative parts

The advantage of this separation is to be able to properly declare properties (as readonly). The `DateInterval` class still works as before, and its properties are still not declared.

Later on, `DateInterval::$from_string` could be deprecated and removed, and the original `DateInterval` class could be made `abstract` or converted to an `interface`.