### PR TITLE
Remove properties field from php_libxml_node_object

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -55,6 +55,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
  d. ext/libxml
    - Added php_libxml_pretend_ctx_error_ex() to emit errors as if they had come
      from libxml.
+   - Removed the "properties" HashTable field from php_libxml_node_object.
 
  e. ext/date
    - Added the php_format_date_ex() API to format instances of php_date_obj.

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -152,15 +152,6 @@ static void php_libxml_unlink_entity(void *data, void *table, xmlChar *name)
 }
 
 /* {{{ internal functions for interoperability */
-static int php_libxml_clear_object(php_libxml_node_object *object)
-{
-	if (object->properties) {
-		object->properties = NULL;
-	}
-	php_libxml_decrement_node_ptr(object);
-	return php_libxml_decrement_doc_ref(object);
-}
-
 static void php_libxml_unregister_node(xmlNodePtr nodep)
 {
 	php_libxml_node_object *wrapper;
@@ -170,7 +161,8 @@ static void php_libxml_unregister_node(xmlNodePtr nodep)
 	if (nodeptr != NULL) {
 		wrapper = nodeptr->_private;
 		if (wrapper) {
-			php_libxml_clear_object(wrapper);
+			php_libxml_decrement_node_ptr(wrapper);
+			php_libxml_decrement_doc_ref(wrapper);
 		} else {
 			if (nodeptr->node != NULL && nodeptr->node->type != XML_DOCUMENT_NODE) {
 				nodeptr->node->_private = NULL;

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -79,7 +79,6 @@ typedef struct _php_libxml_node_ptr {
 typedef struct _php_libxml_node_object {
 	php_libxml_node_ptr *node;
 	php_libxml_ref_obj *document;
-	HashTable *properties;
 	zend_object  std;
 } php_libxml_node_object;
 


### PR DESCRIPTION
This shrinks the struct from 80 bytes to 72 bytes. This was unused internally, I did not find users externally via GitHub search.
The intention for this was that it could be used for attaching extra data as a 3rd party to a node. However, there are better mechanisms for that like using actual objects.