### PR TITLE
Remove unused php.sym files

### DIFF
--- a/sapi/apache2handler/php.sym
+++ b/sapi/apache2handler/php.sym
@@ -1,1 +1,0 @@
-php_module


### PR DESCRIPTION
These were used with the --enable-versioning option and are no longer used like this.

Removed via b0ef04af84a0a2958b84d35865991be99b4d6a26

At this time, sapi/cgi, sapi/cli, and sapi/fpm create and use php.sym file at the build phase in the php-src project root directory only on AIX platform.