### PR TITLE
Fix GH-12996: Incorrect SCRIPT_NAME with ProxyPassMatch when + in path

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1165,7 +1165,7 @@ static void init_request_info(void)
 									size_t decoded_path_info_len = 0;
 									if (strchr(path_info, '%')) {
 										decoded_path_info = estrdup(path_info);
-										decoded_path_info_len = php_url_decode(decoded_path_info, strlen(path_info));
+										decoded_path_info_len = php_raw_url_decode(decoded_path_info, strlen(path_info));
 									}
 									size_t snlen = strlen(env_script_name);
 									size_t env_script_file_info_start = 0;

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded-plus.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded-plus.phpt
@@ -1,0 +1,54 @@
+--TEST--
+FPM: FastCGI env var path info fix for Apache ProxyPass SCRIPT_NAME encoded path and plush sign (GH-12996)
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[cgi.fix_pathinfo] = yes
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$_SERVER["SCRIPT_NAME"] . "\n";
+echo \$_SERVER["ORIG_SCRIPT_NAME"] . "\n";
+echo \$_SERVER["SCRIPT_FILENAME"] . "\n";
+echo \$_SERVER["PATH_INFO"] . "\n";
+echo \$_SERVER["PHP_SELF"];
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName();
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(
+        uri: $scriptName . '/1%202',
+        scriptFilename: "proxy:fcgi://" . $tester->getAddr() . $sourceFilePath . '/1%20+2',
+        scriptName: $scriptName . '/1 +2'
+    )
+    ->expectBody([$scriptName, $scriptName . '/1 +2', $sourceFilePath, '/1%20+2', $scriptName . '/1%20+2']);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
This fixes incorrect URL decoding with Apache ProxyPassMatch when percent and plus sign is in the path. The problem was that `php_url_decode` was used which replaces `+` with space. The fix is to use `php_raw_url_decode` which does not treat `+` specially.