### PR TITLE
Omit HAVE_INET_NTOP definition with AC_CHECK_FUNC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -643,7 +643,7 @@ memrchr \
 mempcpy \
 )
 
-AC_CHECK_FUNCS(inet_ntop,[],[
+AC_CHECK_FUNC(inet_ntop,[],[
     AC_MSG_ERROR([Cannot find inet_ntop which is required])
 ]
 )


### PR DESCRIPTION
Following the bb1109d9f1275866ce6664c897176c91d6f3baaa this now doesn't define the unused symbol HAVE_INET_NTOP also in the Autotools build system.

(I've missed this earlier).