### PR TITLE
sapi/fpm: setting backlog default to -1 for DragonFlyBSD.

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.h
+++ b/sapi/fpm/fpm/fpm_sockets.h
@@ -15,9 +15,10 @@
 #include "fpm_worker_pool.h"
 
 /*
-  On Linux, FreeBSD, OpenBSD and macOS, backlog negative values are truncated to SOMAXCONN
+  On Linux, FreeBSD, OpenBSD, DragonFlyBSD and macOS, backlog negative values are truncated to SOMAXCONN
 */
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__) || \
+    defined(__DragonFly__) || defined(__APPLE__)
 #define FPM_BACKLOG_DEFAULT -1
 #else
 #define FPM_BACKLOG_DEFAULT 511


### PR DESCRIPTION
like most of BSD, when negative the syscall sets it internally to SOMAXCONN.