### PR TITLE
Remove unused PHP_DL_TEST_EXPORTS and PHP_ZEND_TEST_EXPORTS

### DIFF
--- a/ext/dl_test/config.w32
+++ b/ext/dl_test/config.w32
@@ -4,5 +4,4 @@ ARG_ENABLE("dl-test", "enable dl_test extension", "no");
 
 if (PHP_DL_TEST != "no") {
 	EXTENSION("dl_test", "dl_test.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-	ADD_FLAG("CFLAGS_DL_TEST", "/D PHP_DL_TEST_EXPORTS ");
 }

--- a/ext/zend_test/config.w32
+++ b/ext/zend_test/config.w32
@@ -4,5 +4,4 @@ ARG_ENABLE("zend-test", "enable zend_test extension", "no");
 
 if (PHP_ZEND_TEST != "no") {
 	EXTENSION("zend_test", "test.c observer.c fiber.c iterators.c object_handlers.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-	ADD_FLAG("CFLAGS_ZEND_TEST", "/D PHP_ZEND_TEST_EXPORTS ");
 }


### PR DESCRIPTION
In current code these aren't used on Windows build. The PHP_ZEND_TEST_EXPORTS was intended to fix MSVC level 1 (severe) warnings but it's not implemented yet.