### PR TITLE
Fix run-tests.php differ calculateCommonSubsequence for EXPECTF

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -4138,7 +4138,7 @@ final class Differ
         if ($cFrom === 1) {
             foreach ($to as $toV) {
                 if (($this->isEqual)($from[0], $toV)) {
-                    return [$from[0]];
+                    return [$toV];
                 }
             }
 


### PR DESCRIPTION
calculateCommonSubsequence should not contain regexes.

Fixes GH-13083

@jorgsowa Does this fix your issue?