### PR TITLE
Fix DragonFly build

### DIFF
--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -8,7 +8,7 @@ $(builddir)/jit/ir/ir_emit.lo: \
 	$(srcdir)/jit/ir/ir_emit.c $(builddir)/jit/ir/ir_emit_$(DASM_ARCH).h
 
 $(builddir)/jit/ir/gen_ir_fold_hash: $(srcdir)/jit/ir/gen_ir_fold_hash.c $(srcdir)/jit/ir/ir_strtab.c
-	$(BUILD_CC) -D${IR_TARGET} -DIR_PHP -DIR_PHP_MM=0 -o $@ $<
+	$(BUILD_CC) -D${IR_TARGET} -DIR_PHP -DIR_PHP_MM=0 -o $@ $(srcdir)/jit/ir/gen_ir_fold_hash.c
 
 $(builddir)/jit/ir/ir_fold_hash.h: $(builddir)/jit/ir/gen_ir_fold_hash $(srcdir)/jit/ir/ir_fold.h $(srcdir)/jit/ir/ir.h
 	$(builddir)/jit/ir/gen_ir_fold_hash < $(srcdir)/jit/ir/ir_fold.h > $(builddir)/jit/ir/ir_fold_hash.h


### PR DESCRIPTION
On DragonFly by default the BSD make is used with the CSH shell and the first prerequisite variable `$<` in Makefile doesn't work there. So, we can simplify this by simply repeating the filename here.

```
--- ext/opcache/jit/ir/gen_ir_fold_hash ---
cc -DIR_TARGET_X64 -DIR_PHP -DIR_PHP_MM=0 -o ext/opcache/jit/ir/gen_ir_fold_hash 
cc: fatal error: no input files
compilation terminated.
*** [ext/opcache/jit/ir/gen_ir_fold_hash] Error code 1
```

OS: DragonFly 6.4 and everything installed by default.

P.S.: The `$<` variable might work with patterns or in some other cases. And tests all pass ok so far.