### PR TITLE
Remove root library check for dlopen() and dlsym()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,8 +365,8 @@ PHP_CHECK_FUNC(socketpair, socket, network)
 PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
-PHP_CHECK_FUNC(dlopen, dl, root)
-PHP_CHECK_FUNC(dlsym, dl, root)
+PHP_CHECK_FUNC(dlopen, dl)
+PHP_CHECK_FUNC(dlsym, dl)
 if test "$ac_cv_func_dlopen" = "yes"; then
   AC_DEFINE(HAVE_LIBDL, 1, [ ])
 fi


### PR DESCRIPTION
The root library was added here for the Haiku system, to check dlopen() and dlsym(). However, the root library is already explicitly linked in the system, and it does not need to be checked neither linked anymore, since at least ~2013.

@devnexen if you perhaps remember this. Thanks...