### PR TITLE
Clear output handler status flags during handler initialization

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -237,6 +237,10 @@ PHP 8.4 UPGRADE NOTES
   . New serial_hex parameter added to openssl_csr_sign to allow setting serial
     number in the hexadecimal format.
 
+- Output Buffering Control:
+  . Output handler status flags passed to the flags parameter of ob_start
+    are now cleared.
+
 - PDO:
   . getAttribute, enabled to get the value of ATTR_STRINGIFY_FETCHES.
 

--- a/main/output.c
+++ b/main/output.c
@@ -478,7 +478,7 @@ PHPAPI php_output_handler *php_output_handler_create_user(zval *output_handler, 
 		default:
 			user = ecalloc(1, sizeof(php_output_handler_user_func_t));
 			if (SUCCESS == zend_fcall_info_init(output_handler, 0, &user->fci, &user->fcc, &handler_name, &error)) {
-				handler = php_output_handler_init(handler_name, chunk_size, (flags & ~0xf00f) | PHP_OUTPUT_HANDLER_USER);
+				handler = php_output_handler_init(handler_name, chunk_size, PHP_OUTPUT_HANDLER_ABILITY_FLAGS(flags) | PHP_OUTPUT_HANDLER_USER);
 				ZVAL_COPY(&user->zoh, output_handler);
 				handler->func.user = user;
 			} else {
@@ -504,7 +504,7 @@ PHPAPI php_output_handler *php_output_handler_create_internal(const char *name, 
 	php_output_handler *handler;
 	zend_string *str = zend_string_init(name, name_len, 0);
 
-	handler = php_output_handler_init(str, chunk_size, (flags & ~0xf00f) | PHP_OUTPUT_HANDLER_INTERNAL);
+	handler = php_output_handler_init(str, chunk_size, PHP_OUTPUT_HANDLER_ABILITY_FLAGS(flags) | PHP_OUTPUT_HANDLER_INTERNAL);
 	handler->func.internal = output_handler;
 	zend_string_release_ex(str, 0);
 

--- a/main/output.c
+++ b/main/output.c
@@ -478,7 +478,7 @@ PHPAPI php_output_handler *php_output_handler_create_user(zval *output_handler, 
 		default:
 			user = ecalloc(1, sizeof(php_output_handler_user_func_t));
 			if (SUCCESS == zend_fcall_info_init(output_handler, 0, &user->fci, &user->fcc, &handler_name, &error)) {
-				handler = php_output_handler_init(handler_name, chunk_size, (flags & ~0xf) | PHP_OUTPUT_HANDLER_USER);
+				handler = php_output_handler_init(handler_name, chunk_size, (flags & ~0xf00f) | PHP_OUTPUT_HANDLER_USER);
 				ZVAL_COPY(&user->zoh, output_handler);
 				handler->func.user = user;
 			} else {
@@ -504,7 +504,7 @@ PHPAPI php_output_handler *php_output_handler_create_internal(const char *name, 
 	php_output_handler *handler;
 	zend_string *str = zend_string_init(name, name_len, 0);
 
-	handler = php_output_handler_init(str, chunk_size, (flags & ~0xf) | PHP_OUTPUT_HANDLER_INTERNAL);
+	handler = php_output_handler_init(str, chunk_size, (flags & ~0xf00f) | PHP_OUTPUT_HANDLER_INTERNAL);
 	handler->func.internal = output_handler;
 	zend_string_release_ex(str, 0);
 

--- a/main/php_output.h
+++ b/main/php_output.h
@@ -43,6 +43,8 @@
 #define PHP_OUTPUT_HANDLER_DISABLED		0x2000
 #define PHP_OUTPUT_HANDLER_PROCESSED	0x4000
 
+#define PHP_OUTPUT_HANDLER_ABILITY_FLAGS(bitmask) ((bitmask) & ~0xf00f)
+
 /* handler op return values */
 typedef enum _php_output_handler_status_t {
 	PHP_OUTPUT_HANDLER_FAILURE,

--- a/tests/output/ob_start_flags.phpt
+++ b/tests/output/ob_start_flags.phpt
@@ -2,13 +2,14 @@
 ob_start(): Ensure that user supplied handler type and status flags are erased
 --FILE--
 <?php
-define('PHP_OUTOPUT_HANDLER_TYPE_INTERNAL', 0);
+define('PHP_OUTPUT_HANDLER_TYPE_INTERNAL', 0);
+define('PHP_OUTPUT_HANDLER_TYPE_USER', 1);
 
 ob_start(
-    null,
+    fn ($s) => $s,
     0,
     PHP_OUTPUT_HANDLER_STDFLAGS |
-    PHP_OUTOPUT_HANDLER_TYPE_INTERNAL |
+    PHP_OUTPUT_HANDLER_TYPE_INTERNAL |
     PHP_OUTPUT_HANDLER_STARTED |
     PHP_OUTPUT_HANDLER_DISABLED |
     PHP_OUTPUT_HANDLER_PROCESSED
@@ -17,14 +18,14 @@ ob_start(
 $bitmask = ob_get_status()['flags'];
 
 var_dump($bitmask & PHP_OUTPUT_HANDLER_STDFLAGS);
-var_dump($bitmask & PHP_OUTOPUT_HANDLER_TYPE_INTERNAL);
+var_dump($bitmask & PHP_OUTPUT_HANDLER_TYPE_USER);
 var_dump($bitmask & PHP_OUTPUT_HANDLER_STARTED);
 var_dump($bitmask & PHP_OUTPUT_HANDLER_DISABLED);
 var_dump($bitmask & PHP_OUTPUT_HANDLER_PROCESSED);
 ?>
 --EXPECT--
 int(112)
-int(0)
+int(1)
 int(0)
 int(0)
 int(0)

--- a/tests/output/ob_start_flags.phpt
+++ b/tests/output/ob_start_flags.phpt
@@ -1,0 +1,30 @@
+--TEST--
+ob_start(): Ensure that user supplied handler type and status flags are erased
+--FILE--
+<?php
+define('PHP_OUTOPUT_HANDLER_TYPE_INTERNAL', 0);
+
+ob_start(
+    null,
+    0,
+    PHP_OUTPUT_HANDLER_STDFLAGS |
+    PHP_OUTOPUT_HANDLER_TYPE_INTERNAL |
+    PHP_OUTPUT_HANDLER_STARTED |
+    PHP_OUTPUT_HANDLER_DISABLED |
+    PHP_OUTPUT_HANDLER_PROCESSED
+);
+
+$bitmask = ob_get_status()['flags'];
+
+var_dump($bitmask & PHP_OUTPUT_HANDLER_STDFLAGS);
+var_dump($bitmask & PHP_OUTOPUT_HANDLER_TYPE_INTERNAL);
+var_dump($bitmask & PHP_OUTPUT_HANDLER_STARTED);
+var_dump($bitmask & PHP_OUTPUT_HANDLER_DISABLED);
+var_dump($bitmask & PHP_OUTPUT_HANDLER_PROCESSED);
+?>
+--EXPECT--
+int(112)
+int(0)
+int(0)
+int(0)
+int(0)


### PR DESCRIPTION
When initializing output handlers, clears user supplied handler status flags (see all flags listed below).

Output buffers accept a bitflag for setting the operations allowed on the buffer (see `handler ability flags` below). These flags, along with the flags for handler type (see `handler types` below) and handler status (see `handler status flags` below) are stored in one bitmask internally. When initializing the buffer, the bits that represent handler type are cleared and set internally ([here](https://github.com/php/php-src/blob/73722df4390b4fb467062815ccc426e990b517a1/main/output.c#L481) and [here](https://github.com/php/php-src/blob/73722df4390b4fb467062815ccc426e990b517a1/main/output.c#L507)), and the rest of the user supplied bitmask is left unchanged. This has the (IMO unintended) side effect that the handler processing status can be set by the code starting the buffer.

Setting the `PHP_OUTPUT_HANDLER_STARTED` status flag manually will prevent the passing of the `PHP_OUTPUT_HANDLER_START` flag to the output handler function which can be used by user defined functions to identify the first time the output buffer calls the handler function. Internally, this flag cannot be set as it will only be set after the handler function first gets called.

Setting the `PHP_OUTPUT_HANDLER_DISABLED` status flag manually will prevent ob_end_clean, ob_get_clean, ob_end_flush and ob_get_flush from calling the handler function. Internally, this flag will only be set when a handler function fails or when `php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_DISABLE, NULL)` is called.


https://github.com/php/php-src/blob/73722df4390b4fb467062815ccc426e990b517a1/main/php_output.h#L31-L44