### PR TITLE
Fix the SO_LISTENQLEN check in FPM

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -343,8 +343,8 @@ AC_DEFUN([AC_FPM_LQ],
       AC_MSG_RESULT([no])
     ])
 
-    if test "$have_lq" = "tcp_info"; then
-      AC_DEFINE([HAVE_LQ_SO_LISTENQ], 1, [do we have SO_LISTENQxxx?])
+    if test "$have_lq" = "so_listenq"; then
+      AC_DEFINE([HAVE_LQ_SO_LISTENQ], 1, [do we have SO_LISTENQ?])
     fi
   fi
 ])

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -609,9 +609,8 @@ int fpm_socket_get_listening_queue(int sock, unsigned *cur_lq, unsigned *max_lq)
 
 	return 0;
 }
-#endif
 
-#ifdef HAVE_LQ_SO_LISTENQ
+#elif defined(HAVE_LQ_SO_LISTENQ)
 
 int fpm_socket_get_listening_queue(int sock, unsigned *cur_lq, unsigned *max_lq)
 {


### PR DESCRIPTION
This fixes the check and defines the `HAVE_LQ_SO_LISTENQ`. I'm not sure if this was intended here because it might not be fully integrated yet.