### PR TITLE
Add bison -Wall flag to Windows build

### DIFF
--- a/ext/json/Makefile.frag.w32
+++ b/ext/json/Makefile.frag.w32
@@ -2,4 +2,4 @@ ext\json\json_scanner.c ext\json\php_json_scanner_defs.h: ext\json\json_scanner.
 	$(RE2C) $(RE2C_FLAGS) -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
 
 ext\json\json_parser.tab.c ext\json\json_parser.tab.h: ext\json\json_parser.y
-	$(BISON) --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c
+	$(BISON) $(BISON_FLAGS) --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -78,15 +78,15 @@ $(BUILD_DIR)\$(PHPDLL).def: $(PHP_DLL_DEF_SOURCES)
 	type $(PHP_DLL_DEF_SOURCES) > $(BUILD_DIR)\$(PHPDLL).def
 
 Zend\zend_ini_parser.c Zend\zend_ini_parser.h: Zend\zend_ini_parser.y
-	$(BISON) --output=Zend/zend_ini_parser.c -v -d Zend/zend_ini_parser.y
+	$(BISON) $(BISON_FLAGS) --output=Zend/zend_ini_parser.c -v -d Zend/zend_ini_parser.y
 
 Zend\zend_language_parser.c Zend\zend_language_parser.h: Zend\zend_language_parser.y
-	$(BISON) --output=Zend/zend_language_parser.c -v -d Zend/zend_language_parser.y
+	$(BISON) $(BISON_FLAGS) --output=Zend/zend_language_parser.c -v -d Zend/zend_language_parser.y
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.c
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.h
 
 sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_parser.h: sapi\phpdbg\phpdbg_parser.y
-	$(BISON) --output=sapi/phpdbg/phpdbg_parser.c -v -d sapi/phpdbg/phpdbg_parser.y
+	$(BISON) $(BISON_FLAGS) --output=sapi/phpdbg/phpdbg_parser.c -v -d sapi/phpdbg/phpdbg_parser.y
 
 !if $(RE2C) != ""
 Zend\zend_ini_scanner.c Zend\zend_ini_scanner_defs.h: Zend\zend_ini_scanner.l

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2978,6 +2978,7 @@ function toolset_setup_project_tools()
 	PATH_PROG('lib', null, 'MAKE_LIB');
 
 	var BISON = PATH_PROG('bison');
+	DEFINE('BISON_FLAGS', '-Wall');
 	if (BISON) {
 		var BISONVERS = probe_binary(BISON, "longversion");
 		STDOUT.WriteLine('  Detected bison version ' + BISONVERS);


### PR DESCRIPTION
Following the d7d3a1c66e090489779eb43ffba18297d22d4893, this adds bison flag `-Wall` also to Windows build system.

Flag has been added via 2127a37b833a863e28a4692e7394613b89c89290.