### PR TITLE
Mark ob_start's callback parameter nullable

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1533,8 +1533,7 @@ function header_register_callback(callable $callback): bool {}
 
 /* main/output.c */
 
-/** @param callable $callback */
-function ob_start($callback = null, int $chunk_size = 0, int $flags = PHP_OUTPUT_HANDLER_STDFLAGS): bool {}
+function ob_start(?callable $callback = null, int $chunk_size = 0, int $flags = PHP_OUTPUT_HANDLER_STDFLAGS): bool {}
 
 function ob_flush(): bool {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b14f7e9eb57bc1f2aff20097fddd14d1fe0494e */
+ * Stub hash: b8adb95a797d1041b285f3182b9b0991ee88df70 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -10,7 +10,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_header_register_callback, 0, 1, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ob_start, 0, 0, _IS_BOOL, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, callback, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, chunk_size, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "PHP_OUTPUT_HANDLER_STDFLAGS")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
Mark `ob_start()`'s callable `$callback` parameter nullable in the stub file. 

This parameter has intentionally been nullable so that user-defined `$chunk_size` and `$flags` can be set while still using the default output handler. This PR doesn't change the acceptable type of the callable or the current behavior of `ob_start()`, it just makes the type declaration explicit.

This code
```php
var_dump(ob_start(null));
```
results in this output (with or without this PR)
```
bool(true)
```