### PR TITLE
Mark ob_start() callback parameter nullable

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1533,7 +1533,7 @@ function header_register_callback(callable $callback): bool {}
 
 /* main/output.c */
 
-/** @param callable $callback */
+/** @param callable|null $callback */
 function ob_start($callback = null, int $chunk_size = 0, int $flags = PHP_OUTPUT_HANDLER_STDFLAGS): bool {}
 
 function ob_flush(): bool {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b14f7e9eb57bc1f2aff20097fddd14d1fe0494e */
+ * Stub hash: a9603577b33f1a20150c9da6251c69d26686cf0b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)


### PR DESCRIPTION
Mark the `$callback` callable parameter of `ob_start()` as nullable. The parameter is already nullable and is needed for using the default output handler with user-defined `chunk_size` and/or `flags`.