### PR TITLE
Fix GH-13094: range(9.9, '0') causes segmentation fault

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2924,8 +2924,8 @@ PHP_FUNCTION(range)
 
 	/* If the range is given as strings, generate an array of characters. */
 	if (start_type >= IS_STRING || end_type >= IS_STRING) {
-		/* If one of the inputs is NOT a string */
-		if (UNEXPECTED(start_type + end_type < 2*IS_STRING)) {
+		/* If one of the inputs is NOT a string nor single-byte string */
+		if (UNEXPECTED(start_type < IS_STRING || end_type < IS_STRING)) {
 			if (start_type < IS_STRING) {
 				if (end_type != IS_ARRAY) {
 					php_error_docref(NULL, E_WARNING, "Argument #1 ($start) must be a single byte string if"


### PR DESCRIPTION
`start_type + end_type < 2*IS_STRING` is not right, in this test case the types are start_type==5 (IS_DOUBLE), end_type==7 (IS_ARRAY). The IS_ARRAY type is a sentinel to disambiguate single-byte strings. The path must be taken when one of the types is not a string nor a single-byte string. Therefore, use < IS_STRING with an OR condition.