### PR TITLE
Remove ext/random backwards-compatibility headers

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -30,6 +30,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
   int(*)(zend_object_iterator *) to zend_result(*)(zend_object_iterator *) to
   be more in line with what callbacks are returning.
 
+* The backwards compatibility headers ext/standard/{php_lcg.h,php_mt_rand.h,
+  php_rand.h,php_random.h} have been removed. Include ext/random/php_random.h
+  directly.
+
 ========================
 2. Build system changes
 ========================

--- a/ext/standard/php_lcg.h
+++ b/ext/standard/php_lcg.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_mt_rand.h
+++ b/ext/standard/php_mt_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"


### PR DESCRIPTION
When ext/random was initially added in PHP 8.2, these headers started “forwarding” to the new ext/random/php_random.h to reduce the impact on existing extensions.

As master already contains some breaking changes of the internal API of ext/random and as the last PHP version without ext/random will be EOL once master is released, it appears appropriate to drop these headers now.

-------------------

see also: https://github.com/php/php-src/pull/8094#discussion_r917308676