### PR TITLE
nitpick re2c "or newer"

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1841,7 +1841,7 @@ AC_DEFUN([PHP_PROG_RE2C],[
   case $php_re2c_check in
     ""|invalid[)]
       if test ! -f "$abs_srcdir/Zend/zend_language_scanner.c"; then
-        AC_MSG_ERROR([re2c $php_re2c_required_version is required to generate PHP lexers.])
+        AC_MSG_ERROR([re2c $php_re2c_required_version or newer is required to generate PHP lexers.])
       fi
 
       RE2C="exit 0;"

--- a/build/php.m4
+++ b/build/php.m4
@@ -1783,7 +1783,7 @@ AC_DEFUN([PHP_PROG_BISON], [
   case $php_bison_check in
     ""|invalid[)]
       if test ! -f "$abs_srcdir/Zend/zend_language_parser.h" || test ! -f "$abs_srcdir/Zend/zend_language_parser.c"; then
-        AC_MSG_ERROR([bison $php_bison_required_version is required to generate PHP parsers (excluded versions: $php_bison_excluded_versions).])
+        AC_MSG_ERROR([bison $php_bison_required_version or newer is required to generate PHP parsers (excluded versions: $php_bison_excluded_versions).])
       fi
 
       YACC="exit 0;"


### PR DESCRIPTION
just a nitpick,

The old message was
```
configure: error: re2c 1.0.3 is required to generate PHP lexers.
```
but re2c 3.0 is also accepted, thus it should be
```
configure: error: re2c 1.0.3 or newer is required to generate PHP lexers.
```