### PR TITLE
Fix segfault caused by use of 'pass' encoding when mbstring is converting multipart form POST data

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter_pass.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter_pass.c
@@ -27,12 +27,24 @@
  *
  */
 
-#include <stddef.h>
-
 #include "mbfilter.h"
 #include "mbfilter_pass.h"
 
 static const char *mbfl_encoding_pass_aliases[] = {"none", NULL};
+
+static size_t mb_pass_to_wchar(unsigned char **in, size_t *in_len, uint32_t *buf, size_t bufsize, unsigned int *state)
+{
+	unsigned char *p = *in, *e = p + *in_len;
+	uint32_t *out = buf, *limit = buf + bufsize;
+
+	while (p < e && out < limit) {
+		*out++ = *p++;
+	}
+
+	*in_len = e - p;
+	*in = p;
+	return out - buf;
+}
 
 const mbfl_encoding mbfl_encoding_pass = {
 	mbfl_no_encoding_pass,
@@ -43,11 +55,16 @@ const mbfl_encoding mbfl_encoding_pass = {
 	0,
 	NULL,
 	NULL,
-	NULL,
+	mb_pass_to_wchar,
 	NULL,
 	NULL,
 	NULL,
 };
+
+static int mbfl_filt_conv_pass(int c, mbfl_convert_filter *filter)
+{
+	return (*filter->output_function)(c, filter->data);
+}
 
 const struct mbfl_convert_vtbl vtbl_pass = {
 	mbfl_no_encoding_pass,
@@ -58,8 +75,3 @@ const struct mbfl_convert_vtbl vtbl_pass = {
 	mbfl_filt_conv_common_flush,
 	NULL,
 };
-
-int mbfl_filt_conv_pass(int c, mbfl_convert_filter *filter)
-{
-	return (*filter->output_function)(c, filter->data);
-}

--- a/ext/mbstring/libmbfl/mbfl/mbfilter_pass.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter_pass.h
@@ -36,6 +36,4 @@
 MBFLAPI extern const mbfl_encoding mbfl_encoding_pass;
 MBFLAPI extern const struct mbfl_convert_vtbl vtbl_pass;
 
-MBFLAPI extern int mbfl_filt_conv_pass(int c, mbfl_convert_filter *filter);
-
 #endif /* MBFL_MBFILTER_PASS_H */

--- a/ext/mbstring/tests/gh13123.phpt
+++ b/ext/mbstring/tests/gh13123.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Segfault in mb_fast_convert() when mbstring.encoding_translation is enabled (GH-13123)
+--EXTENSIONS--
+mbstring
+--POST_RAW--
+Content-Type: multipart/form-data, boundary=Blah
+
+--Blah
+Content-Disposition: form-data; name="file"; filename="file.txt"
+Content-Type: text/plain
+
+foo
+--Blah
+
+--INI--
+mbstring.encoding_translation=On
+mbstring.http_input=pass
+--FILE--
+<?php
+print "Done!\n";
+?>
+--EXPECT--
+Done!
+
+Deprecated: PHP Startup: Use of mbstring.http_input is deprecated in Unknown on line 0


### PR DESCRIPTION
FYA @nielsdos @tstangner

Fixes #13123 