### PR TITLE
Fix phar/tests/bug77432.phpt

### DIFF
--- a/ext/phar/tests/bug77432.phpt
+++ b/ext/phar/tests/bug77432.phpt
@@ -1,14 +1,10 @@
 --TEST--
 Bug #77432 (Segmentation fault on including phar file)
---SKIPIF--
-<?php
-if (PHP_OS_FAMILY === "Windows") {
-    die('skip not for Windows');
-}
-?>
 --EXTENSIONS--
 phar
 --INI--
+opcache.enable=0
+error_reporting=-1
 phar.readonly=0
 --FILE--
 <?php


### PR DESCRIPTION
- For Windows we just have to set the right error_reporting value
- Test cannot be used repeatedly on Opcache because the unlink will have no effect because of caching.