### PR TITLE
Remove unused includes of php_random.h

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -22,7 +22,6 @@
 
 #include "php.h"
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
-#include "ext/random/php_random.h"
 #include "php_dom.h"
 #include "php_dom_arginfo.h"
 #include "dom_properties.h"

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -27,9 +27,6 @@
 
 #include "url_scanner_ex.h"
 
-/* for MT_N */
-#include "ext/random/php_random.h"
-
 #if defined(_WIN32) && !defined(__clang__)
 #include <intrin.h>
 #endif

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -43,7 +43,6 @@
 #endif
 
 #include "php_crypt.h"
-#include "ext/random/php_random.h"
 
 /* Used to check DES salts to ensure that they contain only valid characters */
 #define IS_VALID_SALT_CHARACTER(c) (((c) >= '.' && (c) <= '9') || ((c) >= 'A' && (c) <= 'Z') || ((c) >= 'a' && (c) <= 'z'))

--- a/main/internal_functions_win32.c
+++ b/main/internal_functions_win32.c
@@ -39,7 +39,6 @@
 #include "ext/standard/php_array.h"
 #include "ext/standard/php_assert.h"
 #include "ext/reflection/php_reflection.h"
-#include "ext/random/php_random.h"
 #if HAVE_BCMATH
 #include "ext/bcmath/php_bcmath.h"
 #endif

--- a/main/reentrancy.c
+++ b/main/reentrancy.c
@@ -22,7 +22,6 @@
 #endif
 
 #include "php_reentrancy.h"
-#include "ext/random/php_random.h"                   /* for PHP_RAND_MAX */
 
 enum {
 	LOCALTIME_R,


### PR DESCRIPTION
Before this change php_random.h was listed in 146 different *.dep files for a

    env CC=clang ./configure --without-sqlite3 --without-pdo-sqlite

build, after this change it's only listed in 110 of them, preventing uselessly recompiling those files when working on ext/random, mostly caused by the include in ext/standard/basic_functions.h.