### PR TITLE
Give anonymous dom structs a name

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -418,7 +418,7 @@ PHP_METHOD(DOMElement, setAttribute)
 }
 /* }}} end dom_element_set_attribute */
 
-typedef struct {
+typedef struct _dom_deep_ns_redef_item {
 	xmlNodePtr current_node;
 	xmlNsPtr defined_ns;
 } dom_deep_ns_redef_item;

--- a/ext/dom/html5_parser.c
+++ b/ext/dom/html5_parser.c
@@ -33,7 +33,7 @@
 /* libxml2 reserves 2 pointer-sized words for interned strings */
 #define LXML_INTERNED_STRINGS_SIZE (sizeof(void *) * 2)
 
-typedef struct {
+typedef struct _work_list_item {
     lxb_dom_node_t *node;
     uintptr_t current_active_namespace;
     xmlNodePtr lxml_parent;

--- a/ext/dom/html5_parser.h
+++ b/ext/dom/html5_parser.h
@@ -42,13 +42,13 @@ typedef void (*lexbor_libxml2_bridge_tree_error_reporter)(
     size_t len
 );
 
-typedef struct {
+typedef struct _lexbor_libxml2_bridge_extracted_observations {
     bool has_explicit_html_tag;
     bool has_explicit_head_tag;
     bool has_explicit_body_tag;
 } lexbor_libxml2_bridge_extracted_observations;
 
-typedef struct {
+typedef struct _lexbor_libxml2_bridge_parse_context {
     /* Private fields */
     lexbor_libxml2_bridge_tokenizer_error_reporter tokenizer_error_reporter;
     lexbor_libxml2_bridge_tree_error_reporter tree_error_reporter;

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -32,13 +32,13 @@
 #define DOM_FALLBACK_ENCODING_NAME "UTF-8"
 #define DOM_FALLBACK_ENCODING_ID LXB_ENCODING_UTF_8
 
-typedef struct {
+typedef struct _dom_line_column_cache {
 	size_t last_line;
 	size_t last_column;
 	size_t last_offset;
 } dom_line_column_cache;
 
-typedef struct {
+typedef struct _dom_lexbor_libxml2_bridge_application_data {
 	const char *input_name;
 	const lxb_codepoint_t *current_input_codepoints;
 	const char *current_input_characters;
@@ -48,14 +48,14 @@ typedef struct {
 	bool html_no_implied;
 } dom_lexbor_libxml2_bridge_application_data;
 
-typedef struct {
+typedef struct _dom_character_encoding_data {
 	const lxb_encoding_data_t *encoding_data;
 	size_t bom_shift;
 } dom_character_encoding_data;
 
 typedef zend_result (*dom_write_output)(void*, const char *, size_t);
 
-typedef struct {
+typedef struct _dom_output_ctx {
 	const lxb_encoding_data_t *encoding_data;
 	const lxb_encoding_data_t *decoding_data;
 	lxb_encoding_encode_t *encode;
@@ -66,7 +66,7 @@ typedef struct {
 	dom_write_output write_output;
 } dom_output_ctx;
 
-typedef struct {
+typedef struct _dom_decoding_encoding_ctx {
 	/* We can skip some conversion if the input and output encoding are both UTF-8,
 	 * we only have to validate and substitute replacement characters */
 	bool fast_path; /* Put first, near the encode & decode structures, for cache locality */


### PR DESCRIPTION
Uses the convention of using the same name as the typedeffed name with an underscore in front.
As requested by @TimWolla 