### PR TITLE
Follow-up fix for GH-13082

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2749,9 +2749,8 @@ static void php_imagechar(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	gdImagePtr im;
 	int ch = 0, col, x, y, i, l = 0;
 	unsigned char *str = NULL;
-	zend_object *font_obj;
+	zend_object *font_obj = NULL;
 	zend_long font_int = 0;
-	gdFontPtr font = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(6, 6)
 		Z_PARAM_OBJECT_OF_CLASS(IM, gd_image_ce)
@@ -2776,7 +2775,7 @@ static void php_imagechar(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	y = Y;
 	x = X;
 
-	font = php_find_gd_font(font_obj, font_int);
+	gdFontPtr font = php_find_gd_font(font_obj, font_int);
 
 	switch (mode) {
 		case 0:


### PR DESCRIPTION
The `font_obj` variable should actually be NULL initialised, not the `font` gd pointer.

I missed this in the original code review, but upon adapting a static analyser to find these kinds of issues I found this again.
The reason I missed this is because the variable names are a bit confusing, and they're using C89 style instead of C99 which is confusing because you can't easily see what's used where.
So I merged the declaration and assignment of `font` such that it's clear that `font` is always initialised while `font_obj` has to be NULL-initialised.