### PR TITLE
Explicitly initialize object variables passed to Z_PARAM_OBJ_OF_CLASS_OR_LONG

### DIFF
--- a/ext/intl/dateformat/dateformat_attrcpp.cpp
+++ b/ext/intl/dateformat/dateformat_attrcpp.cpp
@@ -158,8 +158,8 @@ U_CFUNC PHP_FUNCTION(datefmt_get_calendar_object)
 /* {{{ Set formatter's calendar. */
 U_CFUNC PHP_FUNCTION(datefmt_set_calendar)
 {
-	zend_object *calendar_obj;
-	zend_long calendar_long;
+	zend_object *calendar_obj = NULL;
+	zend_long calendar_long = 0;
 	bool calendar_is_null;
 	DATE_FORMAT_METHOD_INIT_VARS;
 


### PR DESCRIPTION
I'm wondering whether we should explicitly initialize other similar variables passed to union type ZPP checks in order to prevent compiler miscompilations like the one for `imagefontwidth`? E.g. there are quite a few `Z_PARAM_OBJ_OF_CLASS_OR_STR`  ZPP checks where an uninitialized object is passed.