### PR TITLE
missing SKIP_ONLINE_TESTS

### DIFF
--- a/ext/curl/tests/curl_error_basic.phpt
+++ b/ext/curl/tests/curl_error_basic.phpt
@@ -7,7 +7,8 @@ Mattijs Hoitink mattijshoitink@gmail.com
 curl
 --SKIPIF--
 <?php
-
+if(getenv("SKIP_ONLINE_TESTS")) die("SKIP_ONLINE_TESTS");
+if(getenv("SKIP_SLOW_TESTS")) die("SKIP_SLOW_TESTS");
 $url = "fakeURL";
 $ip = gethostbyname($url);
 if ($ip != $url) die("skip 'fakeURL' resolves to $ip\n");

--- a/ext/curl/tests/curl_error_basic.phpt
+++ b/ext/curl/tests/curl_error_basic.phpt
@@ -7,8 +7,8 @@ Mattijs Hoitink mattijshoitink@gmail.com
 curl
 --SKIPIF--
 <?php
-if(getenv("SKIP_ONLINE_TESTS")) die("SKIP_ONLINE_TESTS");
-if(getenv("SKIP_SLOW_TESTS")) die("SKIP_SLOW_TESTS");
+if(getenv("SKIP_ONLINE_TESTS")) die("skip online test");
+if(getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 $url = "fakeURL";
 $ip = gethostbyname($url);
 if ($ip != $url) die("skip 'fakeURL' resolves to $ip\n");


### PR DESCRIPTION
gethostbynamel may contact DNS servers, so it should be skipped if SKIP_ONLINE_TESTS , and on a AMD Ryzen 9 7950x WSL Ubuntu this test took ~2 seconds (some DNS timeout i guess?) so it should also have SKIP_SLOW_TESTS