### PR TITLE
missing SKIP_SLOW_TESTS

### DIFF
--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -1,5 +1,9 @@
 --TEST--
 proc_open() with output socketpairs
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("SKIP_SLOW_TESTS");
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -2,7 +2,7 @@
 proc_open() with output socketpairs
 --SKIPIF--
 <?php
-if (getenv("SKIP_SLOW_TESTS")) die("SKIP_SLOW_TESTS");
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
this test took 2 seconds to execute on a 5GHz AMD Ryzen 9 7950x (one of AMD's fastest single-thread-performance CPUs), it should have SKIP_SLOW_TESTS