### PR TITLE
remove flag ZEND_DEBUG check for ZEND_ASSERT

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -1357,9 +1357,7 @@ static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint3
 }
 
 static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {
-#if ZEND_DEBUG
 	ZEND_ASSERT(Z_REFCOUNTED_P(pz) || Z_TYPE_P(pz) == IS_ARRAY);
-#endif
 	return GC_REFCOUNT(Z_COUNTED_P(pz));
 }
 


### PR DESCRIPTION
Flag `ZEND_DEBUG` is checked anyway in macro `ZEND_ASSERT`, so this code is redundant.