### PR TITLE
Fix argument type of simplexml_import_dom

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -108,6 +108,7 @@ SimpleXML:
   . Fixed bug GH-12208 (SimpleXML infinite loop when a cast is used inside a
     foreach). (nielsdos)
   . Fixed bug #55098 (SimpleXML iteration produces infinite loop). (nielsdos)
+  . Fix signature of simplexml_import_dom(). (nielsdos)
 
 SNMP:
   . Removed the deprecated inet_ntoa call support. (David Carlier)

--- a/UPGRADING
+++ b/UPGRADING
@@ -102,6 +102,8 @@ PHP 8.4 UPGRADE NOTES
     cause an infinite loop because it destroyed the current iterator data.
     This is no longer the case as a consequence of the bugfixes for GH-12192,
     GH-12208, #55098.
+  . Calling simplexml_import_dom() with a non-XML object now throws a TypeError
+    instead of a ValueError.
 
 - SPL:
   . Out of bounds accesses in SplFixedArray now throw an exception of type
@@ -134,6 +136,8 @@ PHP 8.4 UPGRADE NOTES
   . Failure to call a PHP function callback during evaluation now throws
     instead of emitting a warning.
     RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl
+  . Calling XSLTProcessor::importStyleSheet() with a non-XML object now throws
+    a TypeError instead of a ValueError.
 
 ========================================
 2. New Features

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2567,7 +2567,7 @@ PHP_FUNCTION(simplexml_import_dom)
 	nodep = php_libxml_import_node(node);
 
 	if (!nodep) {
-		zend_argument_type_error(1, "must be of type SimpleXMLElement|DOMNode, %s given", zend_zval_value_name(node));
+		zend_argument_value_error(1, "must be a valid XML node");
 		RETURN_THROWS();
 	}
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2567,7 +2567,7 @@ PHP_FUNCTION(simplexml_import_dom)
 	nodep = php_libxml_import_node(node);
 
 	if (!nodep) {
-		zend_argument_value_error(1, "must be a valid XML node");
+		zend_argument_type_error(1, "must be a valid XML node");
 		RETURN_THROWS();
 	}
 

--- a/ext/simplexml/simplexml.stub.php
+++ b/ext/simplexml/simplexml.stub.php
@@ -6,7 +6,7 @@ function simplexml_load_file(string $filename, ?string $class_name = SimpleXMLEl
 
 function simplexml_load_string(string $data, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $namespace_or_prefix = "", bool $is_prefix = false): SimpleXMLElement|false {}
 
-function simplexml_import_dom(SimpleXMLElement|DOMNode $node, ?string $class_name = SimpleXMLElement::class): ?SimpleXMLElement {}
+function simplexml_import_dom(object $node, ?string $class_name = SimpleXMLElement::class): ?SimpleXMLElement {}
 
 /** @not-serializable */
 class SimpleXMLElement implements Stringable, Countable, RecursiveIterator

--- a/ext/simplexml/simplexml_arginfo.h
+++ b/ext/simplexml/simplexml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 06c88dc2fb5582a6d21c11aee6ac0a0538e70cbc */
+ * Stub hash: 36eac2dee86bcc386c24e2cc14caa7bd3d709e82 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_simplexml_load_file, 0, 1, SimpleXMLElement, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -18,7 +18,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_simplexml_load_string, 0, 1,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_simplexml_import_dom, 0, 1, SimpleXMLElement, 1)
-	ZEND_ARG_OBJ_TYPE_MASK(0, node, SimpleXMLElement|DOMNode, 0, NULL)
+	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 1, "SimpleXMLElement::class")
 ZEND_END_ARG_INFO()
 

--- a/ext/xsl/tests/xsltprocessor_importStylesheet-invalidparam.phpt
+++ b/ext/xsl/tests/xsltprocessor_importStylesheet-invalidparam.phpt
@@ -9,7 +9,7 @@ $xslt = new XSLTProcessor();
 $dummy = new stdClass();
 try {
     var_dump($xslt->importStylesheet($dummy));
-} catch (ValueError $e) {
+} catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -147,7 +147,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 		doc = nodep->doc;
 	}
 	if (doc == NULL) {
-		zend_argument_value_error(1, "must be a valid XML node");
+		zend_argument_type_error(1, "must be a valid XML node");
 		RETURN_THROWS();
 	}
 
@@ -232,7 +232,7 @@ static xmlDocPtr php_xsl_apply_stylesheet(zval *id, xsl_object *intern, xsltStyl
 	}
 
 	if (doc == NULL) {
-		zend_argument_value_error(1, "must be a valid XML node");
+		zend_argument_type_error(1, "must be a valid XML node");
 		return NULL;
 	}
 


### PR DESCRIPTION
It needs to be "object".
This is because first- and third-party extension can register custom node types using `php_libxml_register_export`. So we don't know upfront what types can be expected.

This also changes the error to a ValueError, which is consistent with ext/xsl.

Sending this fix to master because of potential BC breaks.