### PR TITLE
Use __attribute__((assume())) in ZEND_ASSUME when available

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -89,6 +89,9 @@
 
 #if defined(ZEND_WIN32) && !defined(__clang__)
 # define ZEND_ASSUME(c)	__assume(c)
+#elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
+/* GCC emits a warning when __attribute__ appears directly after a label, so we need a do-while loop. */
+# define ZEND_ASSUME(c)	do { __attribute__((assume(c))); } while (0)
 #elif defined(__clang__) && __has_builtin(__builtin_assume)
 # pragma clang diagnostic ignored "-Wassume"
 # define ZEND_ASSUME(c)	__builtin_assume(c)


### PR DESCRIPTION
On GCC, with this patch, I can see a reduction of assembly lines from 1134787 to 1132912 (-0.17%), and reduction of the sapi/cli/php binary size from 47974048 to 47897952 (-0.16%).

Prompted by https://github.com/php/php-src/pull/13159.

/cc @jorgsowa @dstogov