### PR TITLE
Update upgrading docs

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -371,6 +371,10 @@ PDO_SQLITE:
 8. Removed Extensions and SAPIs
 ========================================
 
+- PSpell:
+  . The pspell extension has been unbundled and moved to PECL.
+    RFC: https://wiki.php.net/rfc/unbundle_imap_pspell_oci8
+
 ========================================
 9. Other Changes to Extensions
 ========================================

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -38,9 +38,27 @@ PHP 8.4 INTERNALS UPGRADE NOTES
 2. Build system changes
 ========================
 
- a. Unix build system changes
+ a. Abstract
+   - SIZEOF_SHORT symbol removed (size of 2 on 32-bit and 64-bit platforms).
+   - DBA_CDB_MAKE symbol removed in ext/dba.
+   - The configure option --with-mhash emits deprecation warning.
+   - The configure option --with-pspell has been removed.
+
+ b. Unix build system changes
    - The configure option --with-zlib-dir has been removed.
-   - Symbol COOKIE_IO_FUNCTIONS_T has been removed (use cookie_io_functions_t).
+   - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
+   - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
+   - PHP_CHECK_IN_ADDR_T M4 macro and 'in_addr_t' fallback definition to 'u_int'
+     removed (use AC_CHECK_TYPES Autoconf macro instead).
+   - HAVE_ODBC2 symbol has been removed in ext/odbc.
+   - Removed linking with obsolete dnet_stub library in ext/pdo_dblib.
+   - Removed checking and linking with obsolete libbind for some functions.
+
+ c. Windows build system changes
+   - Added Bison flag '-Wall' when generating lexer files as done in *nix build
+     system.
+   - HAVE_WIN32_NATIVE_THREAD, USE_WIN32_NATIVE_THREAD, ENABLE_THREADS symbols
+     in ext/mbstring/libmbfl removed.
 
 ========================
 3. Module changes


### PR DESCRIPTION
This updates the UPGRADING documents with current build system changes done since the PHP-8.3 release to have this synced a bit more.