### PR TITLE
Fix GH-13177: PHP 8.3.2: final private constructor not allowed when used in trait

### DIFF
--- a/Zend/tests/traits/bugs/gh13177.phpt
+++ b/Zend/tests/traits/bugs/gh13177.phpt
@@ -23,17 +23,26 @@ class Foo3 {
     }
 }
 
-for ($i = 1; $i <= 3; $i++) {
+trait TraitNonConstructor {
+    private final function test() {}
+}
+
+class Foo4 {
+    use TraitNonConstructor { test as __construct; }
+}
+
+for ($i = 1; $i <= 4; $i++) {
     $rc = new ReflectionClass("Foo$i");
     echo $rc->getMethod("__construct"), "\n";
 }
 
-class Foo4 extends Foo3 {
+class Foo5 extends Foo3 {
     private function __construct() {}
 }
 
 ?>
 --EXPECTF--
+Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
 Method [ <user, ctor> final private method __construct ] {
   @@ %sgh13177.php 4 - 4
 }
@@ -44,6 +53,10 @@ Method [ <user, ctor> final private method __construct ] {
 
 Method [ <user, ctor> final private method __construct ] {
   @@ %sgh13177.php 4 - 4
+}
+
+Method [ <user, ctor> final private method __construct ] {
+  @@ %sgh13177.php 24 - 24
 }
 
 

--- a/Zend/tests/traits/bugs/gh13177.phpt
+++ b/Zend/tests/traits/bugs/gh13177.phpt
@@ -1,0 +1,50 @@
+--TEST--
+GH-13177 (PHP 8.3.2: final private constructor not allowed when used in trait)
+--FILE--
+<?php
+
+trait Bar {
+    final private function __construct() {}
+}
+
+final class Foo1 {
+    use Bar;
+}
+
+final class Foo2 {
+    use Bar {
+        __construct as final;
+    }
+}
+
+class Foo3 {
+    use Bar {
+        __construct as final;
+    }
+}
+
+for ($i = 1; $i <= 3; $i++) {
+    $rc = new ReflectionClass("Foo$i");
+    echo $rc->getMethod("__construct"), "\n";
+}
+
+class Foo4 extends Foo3 {
+    private function __construct() {}
+}
+
+?>
+--EXPECTF--
+Method [ <user, ctor> final private method __construct ] {
+  @@ %sgh13177.php 4 - 4
+}
+
+Method [ <user, ctor> final private method __construct ] {
+  @@ %sgh13177.php 4 - 4
+}
+
+Method [ <user, ctor> final private method __construct ] {
+  @@ %sgh13177.php 4 - 4
+}
+
+
+Fatal error: Cannot override final method Foo3::__construct() in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1949,10 +1949,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 	zend_function *new_fn;
 	bool check_inheritance = false;
 
-	if ((fn->common.fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) == (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL) && !zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME)) {
-		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");
-	}
-
 	if ((existing_fn = zend_hash_find_ptr(&ce->function_table, key)) != NULL) {
 		/* if it is the same function with the same visibility and has not been assigned a class scope yet, regardless
 		 * of where it is coming from there is no conflict and we do not need to add it again */
@@ -2033,6 +2029,17 @@ static void zend_fixup_trait_method(zend_function *fn, zend_class_entry *ce) /* 
 }
 /* }}} */
 
+static void zend_traits_check_private_final_inheritance(uint32_t original_fn_flags, zend_function *fn_copy, zend_string *name)
+{
+	/* If the function was originally already private+final, then it will have already been warned about.
+	 * If the function became private+final only after applying modifiers, we need to emit the same warning. */
+	if ((original_fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) != (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
+		&& (fn_copy->common.fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) == (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
+		&& !zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME)) {
+		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");
+	}
+}
+
 static void zend_traits_copy_functions(zend_string *fnname, zend_function *fn, zend_class_entry *ce, HashTable *exclude_table, zend_class_entry **aliases) /* {{{ */
 {
 	zend_trait_alias  *alias, **alias_ptr;
@@ -2057,6 +2064,8 @@ static void zend_traits_copy_functions(zend_string *fnname, zend_function *fn, z
 				} else {
 					fn_copy.common.fn_flags = alias->modifiers | fn->common.fn_flags;
 				}
+
+				zend_traits_check_private_final_inheritance(fn->common.fn_flags, &fn_copy, alias->alias);
 
 				lcname = zend_string_tolower(alias->alias);
 				zend_add_trait_method(ce, alias->alias, lcname, &fn_copy);
@@ -2094,6 +2103,8 @@ static void zend_traits_copy_functions(zend_string *fnname, zend_function *fn, z
 				i++;
 			}
 		}
+
+		zend_traits_check_private_final_inheritance(fn->common.fn_flags, &fn_copy, fnname);
 
 		zend_add_trait_method(ce, fn->common.function_name, fnname, &fn_copy);
 	}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1949,7 +1949,7 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 	zend_function *new_fn;
 	bool check_inheritance = false;
 
-	if ((fn->common.fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) == (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) {
+	if ((fn->common.fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) == (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL) && !zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME)) {
 		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");
 	}
 


### PR DESCRIPTION
zend_compile has an exception to this rule for constructors using `zend_is_constructor`, which compares the function name to `__construct`. Sadly, `zend_is_constructor` is not a public API, but we can just do the string compare ourselves.