### PR TITLE
Fix FG-13163 attempt imagecrop on transparent background.

### DIFF
--- a/ext/gd/libgd/gd_crop.c
+++ b/ext/gd/libgd/gd_crop.c
@@ -92,7 +92,7 @@ gdImagePtr gdImageCropAuto(gdImagePtr im, const unsigned int mode)
 
 	switch (mode) {
 		case GD_CROP_TRANSPARENT:
-			color = gdImageGetTransparent(im);
+			color = gdImageGetTransparent(im) & 0x7f000000;
 			break;
 
 		case GD_CROP_BLACK:

--- a/ext/gd/tests/gh13163.phpt
+++ b/ext/gd/tests/gh13163.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-13163 (imagecrop on transparent background)
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+$gdImage = imagecreatetruecolor(100,100);
+imagesavealpha($gdImage, true);
+imagefill($gdImage, 0, 0, imagecolorallocatealpha($gdImage, 0, 0, 0, 127));
+$result = imagecropauto($gdImage, IMG_CROP_TRANSPARENT);
+var_dump($result);
+--EXPECT--
+bool(false)


### PR DESCRIPTION
based on @nielsdos proposal.
patches on the embedded version of libgd. Fixing mismatch color model between imageallocatealpha using gdImageGetTransparent and gdImageCropAuto usage.

thankfully CI does not use external gd flag.