### PR TITLE
wallet support with session pool

### DIFF
--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -1115,12 +1115,11 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 	}
 
 	/* {{{ Get the session pool that suits this connection request from the persistent list. This
-	 * step is only for non-persistent connections as persistent connections have private session
-	 * pools. Non-persistent conns use shared session pool to allow for optimizations such as
+	 * step is only for non-persistent connections as persistent connections have a private session
+	 * pools. Non-persistent conns use a shared session pool to allow for optimizations such as
 	 * caching the physical connection (for DRCP) even when the non-persistent php connection is
 	 * destroyed.
 	 *
-	 * TODO: Unconditionally do this once OCI provides extended OCISessionGet capability
 	 */
 	if (use_spool && !connection->is_persistent) {
 		if ((session_pool = php_oci_get_spool(username, username_len, password, password_len, dbname, dbname_len, charsetid ? charsetid:charsetid_nls_lang, session_mode))==NULL)
@@ -1895,7 +1894,7 @@ static php_oci_spool *php_oci_create_spool(char *username, int username_len, cha
    */
   if (mode & PHP_OCI_CRED_EXT)
     poolmode = OCI_DEFAULT;
-	else {
+  else {
     /* Disable RLB as we mostly have single-connection pools */
     poolmode = OCI_SPC_NO_RLB | OCI_SPC_HOMOGENEOUS;
   }
@@ -1943,7 +1942,7 @@ static php_oci_spool *php_oci_create_spool(char *username, int username_len, cha
 
 	/* Create the homogeneous session pool - We have different session pools for every different
 	 * username, password, charset and dbname. 
-   * Except for OCI_CRED_EXT mode
+     * Except for OCI_CRED_EXT mode
 	 */
 	PHP_OCI_CALL_RETURN(errstatus, OCISessionPoolCreate,(session_pool->env, OCI_G(err), session_pool->poolh, (OraText **)&session_pool->poolname, &session_pool->poolname_len, (OraText *)dbname, (ub4)dbname_len, 0, UB4MAXVAL, 1,(OraText *)username, (ub4)username_len, (OraText *)password,(ub4)password_len, poolmode));
 
@@ -2275,7 +2274,7 @@ static int php_oci_create_session(php_oci_connection *connection, php_oci_spool 
 	ub4 purity = -2;				/* Illegal value to initialize */
 	time_t timestamp = time(NULL);
 	ub4 statement_cache_size = 0;
-  int mode = OCI_DEFAULT;
+    int mode = OCI_DEFAULT;
 
 	if (OCI_G(statement_cache_size) > 0) {
 		if (OCI_G(statement_cache_size) > SB4MAXVAL)

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -851,8 +851,7 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 	}
 
 	/* We cannot use the new session create logic (OCISessionGet from
-	 * client-side session pool) when privileged connect or password
-	 * change is attempted is specified.
+	 * client-side session pool) when privileged connect or password change is attempted.
 	 * TODO: Re-enable this when OCI provides support.
 	 */
 	if ((session_mode & (OCI_SYSOPER | OCI_SYSDBA)) || (new_password_len)) {
@@ -1116,7 +1115,7 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 
 	/* {{{ Get the session pool that suits this connection request from the persistent list. This
 	 * step is only for non-persistent connections as persistent connections have a private session
-	 * pools. Non-persistent conns use a shared session pool to allow for optimizations such as
+	 * pool. Non-persistent conns use a shared session pool to allow for optimizations such as
 	 * caching the physical connection (for DRCP) even when the non-persistent php connection is
 	 * destroyed.
 	 *
@@ -1892,11 +1891,12 @@ static php_oci_spool *php_oci_create_spool(char *username, int username_len, cha
 
   /* if CRED_EXT mode poolcreate set to hetero(OCI_DEFAULT) 
    */
-  if (mode & PHP_OCI_CRED_EXT)
-    poolmode = OCI_DEFAULT;
+  if (mode & PHP_OCI_CRED_EXT) {
+      poolmode = OCI_DEFAULT;
+  }
   else {
-    /* Disable RLB as we mostly have single-connection pools */
-    poolmode = OCI_SPC_NO_RLB | OCI_SPC_HOMOGENEOUS;
+      /* Disable RLB as we mostly have single-connection pools */
+      poolmode = OCI_SPC_NO_RLB | OCI_SPC_HOMOGENEOUS;
   }
 	/* {{{ Allocate auth handle for session pool */
 	PHP_OCI_CALL_RETURN(errstatus, OCIHandleAlloc, (session_pool->env, (dvoid **)&(spoolAuth), OCI_HTYPE_AUTHINFO, 0, NULL));
@@ -2371,11 +2371,10 @@ static int php_oci_create_session(php_oci_connection *connection, php_oci_spool 
 		/* Continue to use the global error handle as the connection is closed when an error occurs */
     
   if (session_mode & PHP_OCI_CRED_EXT) {
-    mode = OCI_SESSGET_SPOOL|OCI_SESSGET_CREDEXT; 
+      mode = OCI_SESSGET_SPOOL|OCI_SESSGET_CREDEXT; 
+  }  else {
+      mode = OCI_SESSGET_SPOOL;
   }
-  else 
-    mode = OCI_SESSGET_SPOOL;
-
 		PHP_OCI_CALL_RETURN(OCI_G(errcode),OCISessionGet, (connection->env, OCI_G(err), &(connection->svc), (OCIAuthInfo *)connection->authinfo, (OraText *)actual_spool->poolname, (ub4)actual_spool->poolname_len, NULL, 0, NULL, NULL, NULL, mode));
 
 		if (OCI_G(errcode) != OCI_SUCCESS) {


### PR DESCRIPTION
oci8 driver currently does not support wallet authentication with oci_pconnect(). These changes enable it so that wallet authentication can be used with the session pool.
Tests for external authentications i.e. walltet authentications are already there under extauth_01.phpt to extauth_04.phpt. extauth_03.phpt calls oci_pconnect() with wallet authentication. The same test will be sufficient here. The only difference would be now the php will utilize the OCI Session Pool feature in case of ext auth also.