### PR TITLE
All FreeBSD do not implement the function sysconf with arguments

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -477,7 +477,11 @@ PHP_FUNCTION(posix_ttyname)
 #if defined(ZTS) && defined(HAVE_TTYNAME_R) && defined(_SC_TTY_NAME_MAX)
 	buflen = sysconf(_SC_TTY_NAME_MAX);
 	if (buflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+		buflen = sysconf(_SC_PAGESIZE);
+#else
 		RETURN_FALSE;
+#endif
 	}
 	p = emalloc(buflen);
 
@@ -784,7 +788,11 @@ PHP_FUNCTION(posix_getgrnam)
 #if defined(ZTS) && defined(HAVE_GETGRNAM_R) && defined(_SC_GETGR_R_SIZE_MAX)
 	buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
 	if (buflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+		buflen = sysconf(_SC_PAGESIZE);
+#else
 		RETURN_FALSE;
+#endif
 	}
 	buf = emalloc(buflen);
 try_again:
@@ -840,7 +848,11 @@ PHP_FUNCTION(posix_getgrgid)
 
 	grbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
 	if (grbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+		grbuflen = sysconf(_SC_PAGESIZE);
+#else
 		RETURN_FALSE;
+#endif
 	}
 
 	grbuf = emalloc(grbuflen);
@@ -914,7 +926,11 @@ PHP_FUNCTION(posix_getpwnam)
 #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWNAM_R)
 	buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
 	if (buflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+		buflen = sysconf(_SC_PAGESIZE);
+#else
 		RETURN_FALSE;
+#endif
 	}
 	buf = emalloc(buflen);
 	pw = &pwbuf;
@@ -969,7 +985,11 @@ PHP_FUNCTION(posix_getpwuid)
 #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
 	pwbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
 	if (pwbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+		pwbuflen = sysconf(_SC_PAGESIZE);
+#else
 		RETURN_FALSE;
+#endif
 	}
 	pwbuf = emalloc(pwbuflen);
 

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -281,7 +281,11 @@ PHPAPI zend_result php_get_gid_by_name(const char *name, gid_t *gid)
 		char *grbuf;
 
 		if (grbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+			grbuflen = sysconf(_SC_PAGESIZE);
+#else
 			return FAILURE;
+#endif
 		}
 
 		grbuf = emalloc(grbuflen);
@@ -407,7 +411,11 @@ PHPAPI zend_result php_get_uid_by_name(const char *name, uid_t *uid)
 		char *pwbuf;
 
 		if (pwbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+			pwbuflen = sysconf(_SC_PAGESIZE);
+#else
 			return FAILURE;
+#endif
 		}
 
 		pwbuf = emalloc(pwbuflen);

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -381,7 +381,11 @@ PHPAPI int php_fopen_primary_script(zend_file_handle *file_handle)
 			char *pwbuf;
 
 			if (pwbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+				pwbuflen = sysconf(_SC_PAGESIZE);
+#else
 				return FAILURE;
+#endif
 			}
 
 			pwbuf = emalloc(pwbuflen);

--- a/main/main.c
+++ b/main/main.c
@@ -1461,7 +1461,11 @@ PHPAPI char *php_get_current_user(void)
 		char *pwbuf;
 
 		if (pwbuflen < 1) {
+#if defined(__FreeBSD__) && defined(_SC_PAGESIZE)
+			pwbuflen = sysconf(_SC_PAGESIZE);
+#else
 			return "";
+#endif
 		}
 		pwbuf = emalloc(pwbuflen);
 		if (getpwuid_r(pstat->st_uid, &_pw, pwbuf, pwbuflen, &retpwptr) != 0) {


### PR DESCRIPTION
_SC_GETGR_R_SIZE_MAX , _SC_TTY_NAME_MAX:_SC_GETPW_R_SIZE_MAX.

php use this sysconf() in:

main/main.c php_get_current_user()
main/fopen_wrappers.c php_fopen_primary_script()
ext/posix/posix.c posix_getpwnam(), posix_getpwuid(), posix_getgrnam(), posix_getgrgid()
ext/standard/filestat.c php_get_uid_by_name(), php_get_gid_by_name()

Somehow I mistakenly rebased on the previous PR branch. This is just a fresh continuation of:
https://github.com/php/php-src/pull/12995/

@bukka Somehow I was not getting your comments until today I was rebasing the patches for php 8.3.2 and 8.2.15 in the FreeBSD ports tree. However I think this patch will answer that question.