### PR TITLE
Fix iterator position resetting

### DIFF
--- a/Zend/tests/gh13178_1.phpt
+++ b/Zend/tests/gh13178_1.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-13178: Packed to hash must reset iterator position
+--FILE--
+<?php
+$array = ['foo'];
+foreach ($array as $key => &$value) {
+    var_dump($key);
+    unset($array[$key]);
+    $array[] = 'foo';
+    if ($key === 10) {
+        break;
+    }
+}
+?>
+--EXPECT--
+int(0)
+int(1)
+int(2)
+int(3)
+int(4)
+int(5)
+int(6)
+int(7)
+int(8)
+int(9)
+int(10)

--- a/Zend/tests/gh13178_2.phpt
+++ b/Zend/tests/gh13178_2.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-13178: Unsetting last offset must floor iterator position
+--FILE--
+<?php
+$array = [100 => 'foo'];
+foreach ($array as $key => &$value) {
+    var_dump($key);
+    unset($array[$key]);
+    $array[] = 'foo';
+    if ($key === 110) {
+        break;
+    }
+}
+?>
+--EXPECT--
+int(100)
+int(101)
+int(102)
+int(103)
+int(104)
+int(105)
+int(106)
+int(107)
+int(108)
+int(109)
+int(110)

--- a/Zend/tests/gh13178_3.phpt
+++ b/Zend/tests/gh13178_3.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-13178: Unsetting last offset variation with hashed array
+--FILE--
+<?php
+
+$data = ['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'];
+
+foreach ($data as $key => &$value) {
+    var_dump($value);
+    if ($value === 'baz') {
+        unset($data['bar']);
+        unset($data['baz']);
+        $data['qux'] = 'qux';
+        $data['quux'] = 'quux';
+    }
+}
+
+?>
+--EXPECT--
+string(3) "foo"
+string(3) "bar"
+string(3) "baz"
+string(3) "qux"
+string(4) "quux"

--- a/Zend/tests/gh13178_4.phpt
+++ b/Zend/tests/gh13178_4.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-13178: Packed to hash must reset nInternalPointer
+--FILE--
+<?php
+$array = ['foo'];
+reset($array);
+while (true) {
+    $key = key($array);
+    next($array);
+    var_dump($key);
+    unset($array[$key]);
+    $array[] = 'foo';
+    if ($key === 10) {
+        break;
+    }
+}
+?>
+--EXPECT--
+int(0)
+int(1)
+int(2)
+int(3)
+int(4)
+int(5)
+int(6)
+int(7)
+int(8)
+int(9)
+int(10)

--- a/Zend/tests/gh13178_5.phpt
+++ b/Zend/tests/gh13178_5.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-13178: Packed array with last elements removed must reset iterator positions
+--FILE--
+<?php
+$array = [0, 1, 2];
+foreach ($array as &$value) {
+    var_dump($value);
+    if ($value === 2) {
+        unset($array[2]);
+        unset($array[1]);
+        $array[1] = 3;
+        $array[2] = 4;
+    }
+}
+?>
+--EXPECT--
+int(0)
+int(1)
+int(2)
+int(3)
+int(4)

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1332,6 +1332,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 			ht->nNumUsed = 0;
 			HT_HASH_RESET(ht);
 			/* Even if the array is empty, we still need to reset the iterator positions. */
+			ht->nInternalPointer = 0;
 			if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 				HashTableIterator *iter = EG(ht_iterators);
 				HashTableIterator *end  = iter + EG(ht_iterators_used);
@@ -1427,28 +1428,21 @@ static zend_always_inline void _zend_hash_packed_del_val(HashTable *ht, uint32_t
 {
 	idx = HT_HASH_TO_IDX(idx);
 	ht->nNumOfElements--;
-	if (ht->nInternalPointer == idx || UNEXPECTED(HT_HAS_ITERATORS(ht))) {
-		uint32_t new_idx;
-
-		new_idx = idx;
-		while (1) {
-			new_idx++;
-			if (new_idx >= ht->nNumUsed) {
-				break;
-			} else if (Z_TYPE(ht->arPacked[new_idx]) != IS_UNDEF) {
-				break;
-			}
-		}
-		if (ht->nInternalPointer == idx) {
-			ht->nInternalPointer = new_idx;
-		}
-		zend_hash_iterators_update(ht, idx, new_idx);
-	}
 	if (ht->nNumUsed - 1 == idx) {
 		do {
 			ht->nNumUsed--;
 		} while (ht->nNumUsed > 0 && (UNEXPECTED(Z_TYPE(ht->arPacked[ht->nNumUsed-1]) == IS_UNDEF)));
 		ht->nInternalPointer = MIN(ht->nInternalPointer, ht->nNumUsed);
+		if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
+			HashTableIterator *iter = EG(ht_iterators);
+			HashTableIterator *end  = iter + EG(ht_iterators_used);
+			while (iter != end) {
+				if (iter->ht == ht) {
+					iter->pos = MIN(iter->pos, ht->nNumUsed);
+				}
+				iter++;
+			}
+		}
 	}
 	if (ht->pDestructor) {
 		zval tmp;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3262,6 +3262,11 @@ static void php_splice(HashTable *in_hash, zend_long offset, zend_long length, H
 				Z_TRY_ADDREF_P(entry);
 				zend_hash_next_index_insert_new(removed, entry);
 				zend_hash_packed_del_val(in_hash, entry);
+				/* Bump iterator positions to the element after replacement. */
+				if (idx == iter_pos) {
+					zend_hash_iterators_update(in_hash, idx, offset + length);
+					iter_pos = zend_hash_iterators_lower_pos(in_hash, iter_pos + 1);
+				}
 			}
 		} else { /* otherwise just skip those entries */
 			int pos2 = pos;
@@ -3270,9 +3275,13 @@ static void php_splice(HashTable *in_hash, zend_long offset, zend_long length, H
 				if (Z_TYPE_P(entry) == IS_UNDEF) continue;
 				pos2++;
 				zend_hash_packed_del_val(in_hash, entry);
+				/* Bump iterator positions to the element after replacement. */
+				if (idx == iter_pos) {
+					zend_hash_iterators_update(in_hash, idx, offset + length);
+					iter_pos = zend_hash_iterators_lower_pos(in_hash, iter_pos + 1);
+				}
 			}
 		}
-		iter_pos = zend_hash_iterators_lower_pos(in_hash, iter_pos);
 
 		/* If there are entries to insert.. */
 		if (replace) {


### PR DESCRIPTION
Previously, when an array was converted from packed to hashed, iterators would not be correctly reset to 0. Similarly, removing the last element from an array would decrease nNumUsed but not actually fix the iterator position, causing the element to be skipped in the next iteration.

Some code was also removed that skips over IS_UNDEF elements for nInternalPointer and iterator positions. This is unnecessary, as this already happens during iteration.

Closes GH-13178