### PR TITLE
[Intl] Add `NumberFormatter::ROUND_HALFODD`

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -281,8 +281,9 @@ PDO_SQLITE:
   . NumberFormatter::ROUND_TOWARD_ZERO and NumberFormatter::ROUND_AWAY_FROM_ZERO
     have been added as aliases for NumberFormatter::ROUND_DOWN and
     NumberFormatter::ROUND_UP to be consistent with the new PHP_ROUND_* modes.
-
     RFC: https://wiki.php.net/rfc/new_rounding_modes_to_round_function
+  . NumberFormatter::ROUND_HALFODD added to complement existing
+    NumberFormatter::ROUND_HALFEVEN functionality.
 
 - MBString:
   . The behavior of mb_strcut is more consistent now on invalid UTF-8 and UTF-16

--- a/ext/intl/formatter/formatter.stub.php
+++ b/ext/intl/formatter/formatter.stub.php
@@ -50,6 +50,8 @@ class NumberFormatter
     public const int ROUND_AWAY_FROM_ZERO = UNKNOWN;
     /** @cvalue UNUM_ROUND_HALFEVEN */
     public const int ROUND_HALFEVEN = UNKNOWN;
+    /** @cvalue UNUM_ROUND_HALF_ODD */
+    public const int ROUND_HALFODD = UNKNOWN;
     /** @cvalue UNUM_ROUND_HALFDOWN */
     public const int ROUND_HALFDOWN = UNKNOWN;
     /** @cvalue UNUM_ROUND_HALFUP */

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5d5421c72894a77894872efdf060ec058d275c13 */
+ * Stub hash: dcd5c897c37ec1e0729736dedada2a6aac4cb673 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumberFormatter___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -243,6 +243,12 @@ static zend_class_entry *register_class_NumberFormatter(void)
 	zend_string *const_ROUND_HALFEVEN_name = zend_string_init_interned("ROUND_HALFEVEN", sizeof("ROUND_HALFEVEN") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFEVEN_name, &const_ROUND_HALFEVEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_HALFEVEN_name);
+
+	zval const_ROUND_HALFODD_value;
+	ZVAL_LONG(&const_ROUND_HALFODD_value, UNUM_ROUND_HALF_ODD);
+	zend_string *const_ROUND_HALFODD_name = zend_string_init_interned("ROUND_HALFODD", sizeof("ROUND_HALFODD") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFODD_name, &const_ROUND_HALFODD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_ROUND_HALFODD_name);
 
 	zval const_ROUND_HALFDOWN_value;
 	ZVAL_LONG(&const_ROUND_HALFDOWN_value, UNUM_ROUND_HALFDOWN);

--- a/ext/intl/tests/formatter/rounding_modes.phpt
+++ b/ext/intl/tests/formatter/rounding_modes.phpt
@@ -13,6 +13,7 @@ var_dump(NumberFormatter::ROUND_TOWARD_ZERO);
 var_dump(NumberFormatter::ROUND_UP);
 var_dump(NumberFormatter::ROUND_AWAY_FROM_ZERO);
 var_dump(NumberFormatter::ROUND_HALFEVEN);
+var_dump(NumberFormatter::ROUND_HALFODD);
 var_dump(NumberFormatter::ROUND_HALFDOWN);
 var_dump(NumberFormatter::ROUND_HALFUP);
 
@@ -27,6 +28,7 @@ int(2)
 int(3)
 int(3)
 int(4)
+int(8)
 int(5)
 int(6)
 bool(true)


### PR DESCRIPTION
The `NumberFormatter::ROUND_HALFEVEN` constant exists in PHP already, but its counterpart `ROUND_HALFODD` was missing. This adds it, using `UNUM_ROUND_HALF_ODD`.

