### PR TITLE
Fix bug #75712: getenv in php-fpm should not read $_ENV, $_SERVER

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -743,7 +743,7 @@ PHP_FUNCTION(getenv)
 
 	if (!str) {
 		array_init(return_value);
-		php_import_environment_variables(return_value);
+		php_load_environment_variables(return_value);
 		return;
 	}
 

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -28,7 +28,9 @@
 
 /* for systems that need to override reading of environment variables */
 void _php_import_environment_variables(zval *array_ptr);
+void _php_load_environment_variables(zval *array_ptr);
 PHPAPI void (*php_import_environment_variables)(zval *array_ptr) = _php_import_environment_variables;
+PHPAPI void (*php_load_environment_variables)(zval *array_ptr) = _php_load_environment_variables;
 
 PHPAPI void php_register_variable(const char *var, const char *strval, zval *track_vars_array)
 {
@@ -630,6 +632,11 @@ void _php_import_environment_variables(zval *array_ptr)
 #endif
 
 	tsrm_env_unlock();
+}
+
+void _php_load_environment_variables(zval *array_ptr)
+{
+	php_import_environment_variables(array_ptr);
 }
 
 bool php_std_auto_global_callback(char *name, uint32_t name_len)

--- a/main/php_variables.h
+++ b/main/php_variables.h
@@ -32,6 +32,7 @@
 BEGIN_EXTERN_C()
 void php_startup_auto_globals(void);
 extern PHPAPI void (*php_import_environment_variables)(zval *array_ptr);
+extern PHPAPI void (*php_load_environment_variables)(zval *array_ptr);
 PHPAPI void php_register_variable(const char *var, const char *val, zval *track_vars_array);
 /* binary-safe version */
 PHPAPI void php_register_variable_safe(const char *var, const char *val, size_t val_len, zval *track_vars_array);

--- a/sapi/fpm/tests/bug75712-getenv-server-vars.phpt
+++ b/sapi/fpm/tests/bug75712-getenv-server-vars.phpt
@@ -1,0 +1,62 @@
+--TEST--
+FPM: bug75712 - getenv should not read from $_ENV and $_SERVER
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+env[TEST] = test
+php_value[register_argc_argv] = on
+EOT;
+
+$code = <<<EOT
+<?php
+
+var_dump(isset(getenv()['argv']));
+var_dump(isset(getenv()['SERVER_NAME']));
+var_dump(getenv()['TEST']);
+var_dump(isset(getenv()['DTEST']));
+var_dump(getenv('DTEST'));
+putenv('DTEST=dt');
+var_dump(getenv()['DTEST']);
+var_dump(getenv('DTEST'));
+
+function notcalled()
+{
+    \$_SERVER['argv'];
+}
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody([
+    'bool(false)',
+    'bool(true)',
+    'string(4) "test"',
+    'bool(false)',
+    'bool(false)',
+    'string(2) "dt"',
+    'string(2) "dt"',
+]);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
Currently `getenv()` returned array contains different environment variables compare to environment variable search by single varaible return call (passing string argument like `getenv($env_name)`). The bigger problem is that the array does not even have to contain only string values. In case of the reported issue it copied argv array into it.

The reason for the above misbehaviour is that it uses logic used for `$_ENV` filling which does different thing in PHP-FPM (even though some of the logic is also questionable and should be changed) due to some historic reasons most likely. It also applies variable filtering which is not used for single value return.

The PR fixes the issue by introducing a different function for loading env vars which defaults to calling old import function. This is overwritten in FPM and different logic (matching single env return) is used.