### PR TITLE
Fix phpdbg local console mode when using libedit/readline

### DIFF
--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -23,6 +23,10 @@
 #include "phpdbg_prompt.h"
 #include "phpdbg_io.h"
 
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
 ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 
 static inline const char *phpdbg_command_name(const phpdbg_command_t *command, char *buffer) {
@@ -745,17 +749,29 @@ PHPDBG_API char *phpdbg_read_input(const char *buffered) /* {{{ */
 	if ((PHPDBG_G(flags) & (PHPDBG_IS_STOPPING | PHPDBG_IS_RUNNING)) != PHPDBG_IS_STOPPING) {
 		if (buffered == NULL) {
 #ifdef HAVE_PHPDBG_READLINE
-			char *cmd = readline(phpdbg_get_prompt());
-			PHPDBG_G(last_was_newline) = 1;
+#ifdef HAVE_UNISTD_H
+			/* EOF makes readline write prompt again in local console mode and
+			ignored if compiled without readline integration. */
+			if (!isatty(PHPDBG_G(io)[PHPDBG_STDIN].fd)) {
+				char buf[PHPDBG_MAX_CMD];
+				phpdbg_write("%s", phpdbg_get_prompt());
+				phpdbg_consume_stdin_line(buf);
+				buffer = estrdup(buf);
+			} else
+#endif
+			{
+				char *cmd = readline(phpdbg_get_prompt());
+				PHPDBG_G(last_was_newline) = 1;
 
-			if (!cmd) {
-				PHPDBG_G(flags) |= PHPDBG_IS_QUITTING;
-				zend_bailout();
+				if (!cmd) {
+					PHPDBG_G(flags) |= PHPDBG_IS_QUITTING;
+					zend_bailout();
+				}
+
+				add_history(cmd);
+				buffer = estrdup(cmd);
+				free(cmd);
 			}
-
-			add_history(cmd);
-			buffer = estrdup(cmd);
-			free(cmd);
 #else
 			char buf[PHPDBG_MAX_CMD];
 			phpdbg_write("%s", phpdbg_get_prompt());


### PR DESCRIPTION
When using libedit/readline integration in phpdbg, EOF makes editline write prompt again in local console mode. For example, this can be noticed when reading phpt test files from STDIN and running phpdbg.

How to reproduce the issue:

```sh
./configure --with-readline --enable-phpdbg-readline
make
./sapi/cli/php run-tests.php sapi/phpdbg
# here tests fail with prompt being repeated in the output
```

After this patch, phpdbg tests pass.