### PR TITLE
Sync Zend/Optimizer headers installation

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -323,7 +323,7 @@ if (VS_TOOLSET && VCVERS >= 1914) {
 }
 
 PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/streams/ win32/");
-PHP_INSTALL_HEADERS("Zend/Optimizer", "zend_call_graph.h zend_cfg.h zend_dump.h zend_func_info.h zend_inference.h zend_optimizer.h zend_ssa.h zend_worklist.h");
+PHP_INSTALL_HEADERS("Zend/Optimizer", "zend_call_graph.h zend_cfg.h zend_dfg.h zend_dump.h zend_func_info.h zend_inference.h zend_optimizer.h zend_ssa.h zend_worklist.h");
 
 STDOUT.WriteBlankLines(1);
 


### PR DESCRIPTION
On *nix installation there is zend_dfg.h installed as part of the bug fix #81136, but it wasn't synced with Windows yet. This now syncs Zend headers on both builds.