### PR TITLE
Do not allow zend.script_encoding to be set to 'pass'

### DIFF
--- a/Zend/tests/multibyte/multibyte_encoding_007.phpt
+++ b/Zend/tests/multibyte/multibyte_encoding_007.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Don't segfault when zend.script_encoding=pass
+--EXTENSIONS--
+mbstring
+--INI--
+zend.multibyte=1
+zend.script_encoding=pass
+internal_encoding=UTF-8
+--FILE--
+<?php
+	print "Done!\n";
+?>
+--EXPECT--
+Warning: PHP Startup: INI setting contains invalid encoding "pass" in Unknown on line 0
+Done!

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -478,7 +478,7 @@ static zend_result php_mb_zend_encoding_list_parser(const char *encoding_list, s
 	return php_mb_parse_encoding_list(
 		encoding_list, encoding_list_len,
 		(const mbfl_encoding ***)return_list, return_size,
-		persistent, /* arg_num */ 0, /* allow_pass_encoding */ 1);
+		persistent, /* arg_num */ 0, /* allow_pass_encoding */ 0);
 }
 
 static const zend_encoding *php_mb_zend_internal_encoding_getter(void)


### PR DESCRIPTION
When investigating another bug reported by GitHub user 'tstangner', I discovered that PHP segfaults when the INI parameter zend.script_encoding is set to "pass". This bug dates back to December 2022 (caused by yours truly in 953864661a).

If any PHP users in the wild were actually setting zend.script_encoding to "pass" (which would be an utterly useless thing to do), I expect that someone would have filed a bug report by now. The absence of such bug reports is evidence that nobody is doing this.

Hence, it seems that the best fix is simply to disallow "pass" as a choice for zend.script_encoding. The internal function 'php_mb_zend_encoding_list_parser' which I am modifying to accomplish this has no other in-tree callers, aside from the 'exif' extension. Further, exif only calls the function with a few hard-coded values, and none of them are the string "pass", so this change will not have any impact on exif.

Any comments? @Girgias @iluuu1994 @nielsdos @youkidearitai @kamil-tekiela