### PR TITLE
fix GH-13203 file_put_contents fail on strings over 4GB on Windows

### DIFF
--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -37,9 +37,7 @@ unlink($tmpfile);
 if (disk_free_space(dirname($tmpfile)) < 10 * 1024 * 1024 * 1024) {
     die('skip Reason: Insufficient disk space (less than 10GB)');
 }
-
 ?>
-
 --INI--
 memory_limit=6G
 --CLEAN--
@@ -60,6 +58,5 @@ if ($result !== strlen($large_string)) {
     echo "File written successfully.";
 }
 ?>
-
 --EXPECT--
 File written successfully.

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -27,26 +27,29 @@ function get_system_memory(): int|float|false
 if (get_system_memory() < 10 * 1024 * 1024 * 1024) {
     die('skip Reason: Insufficient RAM (less than 10GB)');
 }
-$tmpfileh = tmpfile();
+$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";
+$tmpfileh = fopen($tmpfile, "wb");
 if ($tmpfileh === false) {
     die('skip Reason: Unable to create temporary file');
 }
-$tmpfile = stream_get_meta_data($tmpfileh)['uri'];
+fclose($tmpfileh);
+unlink($tmpfile);
 if (disk_free_space(dirname($tmpfile)) < 10 * 1024 * 1024 * 1024) {
     die('skip Reason: Insufficient disk space (less than 10GB)');
 }
-fclose($tmpfileh);
 
 ?>
 
 --INI--
 memory_limit=6G
-
+--CLEAN--
+<?php
+@unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin");
+?>
 --FILE--
 <?php
 
-$tmpfileh = tmpfile();
-$tmpfile = stream_get_meta_data($tmpfileh)['uri'];
+$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";
 $large_string = str_repeat('a', 5 * 1024 * 1024 * 1024);
 
 $result = file_put_contents($tmpfile, $large_string);
@@ -56,7 +59,6 @@ if ($result !== strlen($large_string)) {
 } else {
     echo "File written successfully.";
 }
-fclose($tmpfileh);
 ?>
 
 --EXPECT--

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -55,7 +55,7 @@ if ($result !== strlen($large_string)) {
     echo "File written successfully.";
 }
 clearstatcache(true, $tmpfile);
-if (file_exists($tmpfile))  {
+if (file_exists($tmpfile)) {
     unlink($tmpfile);
 }
 ?>

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -23,7 +23,7 @@ function get_system_memory(): int|float|false
     }
     return false;
 }
-if (get_system_memory() < 10 * 1024 * 1024 * 1024) {
+if (get_system_memory() < 10 * 1024 * 1024) {
     die('skip Reason: Insufficient RAM (less than 10GB)');
 }
 $tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -50,6 +50,10 @@ if ($result !== strlen($large_string)) {
 } else {
     echo "File written successfully.";
 }
+clearstatcache(true, $tmpfile);
+if(file_exists($tmpfile))  {
+    unlink($tmpfile);
+}
 ?>
 --CLEAN--
 <?php

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Test file_put_contents() function with 5GB string
+--SKIPIF--
+<?php
+if (getenv('SKIP_SLOW_TESTS')) {
+    die('skip slow test');
+}
+
+function get_system_memory(): int|float|false
+{
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        // Windows-based memory check
+        @exec('wmic ComputerSystem get AvailablePhysicalMemory', $output);
+        if (isset($output[1])) {
+            return (int)trim($output[1]);
+        }
+    } else {
+        // Unix/Linux-based memory check
+        $memInfo = @file_get_contents("/proc/meminfo");
+        if ($memInfo) {
+            preg_match('/MemFree:\s+(\d+) kB/', $memInfo, $matches);
+            return $matches[1] * 1024; // Convert to bytes
+        }
+    }
+    return false;
+}
+if (get_system_memory() < 10 * 1024 * 1024 * 1024) {
+    die('skip Reason: Insufficient RAM (less than 10GB)');
+}
+$tmpfileh = tmpfile();
+if ($tmpfileh === false) {
+    die('skip Reason: Unable to create temporary file');
+}
+$tmpfile = stream_get_meta_data($tmpfileh)['uri'];
+if (disk_free_space(dirname($tmpfile)) < 10 * 1024 * 1024 * 1024) {
+    die('skip Reason: Insufficient disk space (less than 10GB)');
+}
+fclose($tmpfileh);
+
+?>
+
+--INI--
+memory_limit=6G
+
+--FILE--
+<?php
+
+$tmpfileh = tmpfile();
+$tmpfile = stream_get_meta_data($tmpfileh)['uri'];
+$large_string = str_repeat('a', 5 * 1024 * 1024 * 1024);
+
+$result = file_put_contents($tmpfile, $large_string);
+if ($result !== strlen($large_string)) {
+    echo "Could only write $result bytes of " . strlen($large_string) . " bytes.";
+    var_dump(error_get_last());
+} else {
+    echo "File written successfully.";
+}
+fclose($tmpfileh);
+?>
+
+--EXPECT--
+File written successfully.

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -2,6 +2,10 @@
 Test file_put_contents() function with 5GB string
 --SKIPIF--
 <?php
+if (PHP_INT_SIZE < 5) {
+    // 4=4gb, 5=549gb, 8=9exabytes
+    skip("skip PHP_INT_SIZE<5 will not fit test string in RAM");
+}
 if (getenv('SKIP_SLOW_TESTS')) {
     die('skip slow test');
 }

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -11,7 +11,7 @@ function get_system_memory(): int|float|false
         // Windows-based memory check
         @exec('wmic OS get FreePhysicalMemory', $output);
         if (isset($output[1])) {
-            return (int)trim($output[1]);
+            return ((int)trim($output[1])) * 1024;
         }
     } else {
         // Unix/Linux-based memory check
@@ -23,7 +23,7 @@ function get_system_memory(): int|float|false
     }
     return false;
 }
-if (get_system_memory() < 10 * 1024 * 1024) {
+if (get_system_memory() < 10 * 1024 * 1024 * 1024) {
     die('skip Reason: Insufficient RAM (less than 10GB)');
 }
 $tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -10,7 +10,7 @@ function get_system_memory(): int|float|false
 {
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
         // Windows-based memory check
-        @exec('wmic ComputerSystem get AvailablePhysicalMemory', $output);
+        @exec('wmic OS get FreePhysicalMemory', $output);
         if (isset($output[1])) {
             return (int)trim($output[1]);
         }

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -5,7 +5,6 @@ Test file_put_contents() function with 5GB string
 if (getenv('SKIP_SLOW_TESTS')) {
     die('skip slow test');
 }
-
 function get_system_memory(): int|float|false
 {
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
@@ -40,16 +39,10 @@ if (disk_free_space(dirname($tmpfile)) < 10 * 1024 * 1024 * 1024) {
 ?>
 --INI--
 memory_limit=6G
---CLEAN--
-<?php
-@unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin");
-?>
 --FILE--
 <?php
-
 $tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";
 $large_string = str_repeat('a', 5 * 1024 * 1024 * 1024);
-
 $result = file_put_contents($tmpfile, $large_string);
 if ($result !== strlen($large_string)) {
     echo "Could only write $result bytes of " . strlen($large_string) . " bytes.";
@@ -57,6 +50,10 @@ if ($result !== strlen($large_string)) {
 } else {
     echo "File written successfully.";
 }
+?>
+--CLEAN--
+<?php
+@unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin");
 ?>
 --EXPECT--
 File written successfully.

--- a/ext/standard/tests/file/file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_put_contents_5gb.phpt
@@ -55,7 +55,7 @@ if ($result !== strlen($large_string)) {
     echo "File written successfully.";
 }
 clearstatcache(true, $tmpfile);
-if(file_exists($tmpfile))  {
+if (file_exists($tmpfile))  {
     unlink($tmpfile);
 }
 ?>

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -357,7 +357,7 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 		if (ZEND_SIZE_T_UINT_OVFL(count)) {
 			count = UINT_MAX;
 		}
-		bytes_written = _write(data->fd, buf, (unsigned int)count);
+		bytes_written = _write(data->fd, buf, (unsigned int)((count > UINT_MAX) ? UINT_MAX : count));
 #else
 		ssize_t bytes_written = write(data->fd, buf, count);
 #endif

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -354,8 +354,7 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 
 	if (data->fd >= 0) {
 #ifdef PHP_WIN32
-		ssize_t bytes_written;
-		bytes_written = _write(data->fd, buf, (unsigned int)(count > INT_MAX ? INT_MAX : count));
+		ssize_t bytes_written = _write(data->fd, buf, (unsigned int)(count > INT_MAX ? INT_MAX : count));
 #else
 		ssize_t bytes_written = write(data->fd, buf, count);
 #endif

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -358,7 +358,7 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 		if (ZEND_SIZE_T_UINT_OVFL(count)) {
 			count = UINT_MAX;
 		}
-		bytes_written = _write(data->fd, buf, (unsigned int)((count > UINT_MAX) ? UINT_MAX : count));
+		bytes_written = _write(data->fd, buf, PLAIN_WRAP_BUF_SIZE(count));
 #else
 		ssize_t bytes_written = write(data->fd, buf, count);
 #endif

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -40,7 +40,7 @@
 # include "win32/time.h"
 # include "win32/ioutil.h"
 # include "win32/readdir.h"
-#include <limits.h>
+# include <limits.h>
 #endif
 
 #define php_stream_fopen_from_fd_int(fd, mode, persistent_id)	_php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_CC)

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -40,6 +40,7 @@
 # include "win32/time.h"
 # include "win32/ioutil.h"
 # include "win32/readdir.h"
+#include <limits.h>
 #endif
 
 #define php_stream_fopen_from_fd_int(fd, mode, persistent_id)	_php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_CC)

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -355,10 +355,7 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 	if (data->fd >= 0) {
 #ifdef PHP_WIN32
 		ssize_t bytes_written;
-		if (ZEND_SIZE_T_UINT_OVFL(count)) {
-			count = UINT_MAX;
-		}
-		bytes_written = _write(data->fd, buf, PLAIN_WRAP_BUF_SIZE(count));
+		bytes_written = _write(data->fd, buf, (int)(count > INT_MAX ? INT_MAX : count));
 #else
 		ssize_t bytes_written = write(data->fd, buf, count);
 #endif

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -355,7 +355,7 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 	if (data->fd >= 0) {
 #ifdef PHP_WIN32
 		ssize_t bytes_written;
-		bytes_written = _write(data->fd, buf, (int)(count > INT_MAX ? INT_MAX : count));
+		bytes_written = _write(data->fd, buf, (unsigned int)(count > INT_MAX ? INT_MAX : count));
 #else
 		ssize_t bytes_written = write(data->fd, buf, count);
 #endif


### PR DESCRIPTION
fix GH-13203
- used 10GB in SKIPIF to account for people running run-tests.php in parallel; i want there to be a comfortable amount of system resources, don't want to run if it's just barely enough.