### PR TITLE
ext/gd disable gh13082 test for travis.

### DIFF
--- a/ext/gd/tests/gh13082.phpt
+++ b/ext/gd/tests/gh13082.phpt
@@ -2,6 +2,8 @@
 GH-13082 - imagefontwidth/height unexpectedly throwing an exception on a valid GdFont object.
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php if (getenv('TRAVIS')) die('skip Currently fails on Travis'); ?>
 --FILE--
 <?php
     $font = imageloadfont(__DIR__ . "/gh13082.gdf");


### PR DESCRIPTION
The sample file is for little endian architectures.