### PR TITLE
ext/curl: Fix `sync-constants` script

### DIFF
--- a/ext/curl/sync-constants.php
+++ b/ext/curl/sync-constants.php
@@ -208,7 +208,7 @@ function getCurlConstants() : array
     $html = file_get_contents(CURL_DOC_FILE);
 
     // Extract the constant list from the HTML file (located in the only <pre> tag in the page)
-    preg_match('~<pre>([^<]+)</pre>~', $html, $matches);
+    preg_match('~<table>(.*?)</table>~s', $html, $matches);
     $constantList = $matches[1];
 
     /**
@@ -220,16 +220,16 @@ function getCurlConstants() : array
      * CURLOPT_FTPASCII                7.1           7.11.1      7.15.5
      * CURLOPT_HTTPREQUEST             7.1           -           7.15.5
      */
-    $regexp = '/^([A-Za-z0-9_]+) +([0-9\.]+)(?: +([0-9\.\-]+))?(?: +([0-9\.]+))?/m';
+    $regexp = '@<tr><td>(?:<a href=".*?">)?(?<const>[A-Za-z0-9_]+)(?:</a>)?</td><td>(?:<a href=".*?">)?(?<added>[\d\.]+)(?:</a>)?</td><td>(?:<a href=".*?">)?(?<deprecated>[\d\.]+)?(?:</a>)?</td><td>(<a href=".*?">)?(?<removed>[\d\.]+)?(</a>)?</td></tr>@m';
     preg_match_all($regexp, $constantList, $matches, PREG_SET_ORDER);
 
     $constants = [];
 
     foreach ($matches as $match) {
-        $name       = $match[1];
-        $introduced = $match[2];
-        $deprecated = $match[3] ?? null;
-        $removed    = $match[4] ?? null;
+        $name       = $match['const'];
+        $introduced = $match['added'];
+        $deprecated = $match['deprecated'] ?? null;
+        $removed    = $match['removed'] ?? null;
 
         if (in_array($name, IGNORED_CURL_CONSTANTS, true) || !preg_match(CONSTANTS_REGEX_PATTERN, $name)) {
             // not a wanted constant


### PR DESCRIPTION
The Curl doc page that was used to check the constants was changed from `<pre></pre>` tags to an HTML page. This updates the regexps to account for the changes, the Cthulu way.

 - New: https://curl.se/libcurl/c/symbols-in-versions.html
 - Old: https://web.archive.org/web/20231201000000*/https://curl.se/libcurl/c/symbols-in-versions.html
 - Change in curl-www: https://github.com/curl/curl-www/commit/2baba5ed45