### PR TITLE
Sync ext/hash installed headers

### DIFF
--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -32,7 +32,6 @@ else
 fi
 
 PHP_ADD_BUILD_DIR(ext/hash/murmur, 1)
-PHP_HASH_CFLAGS="$PHP_HASH_CFLAGS -I@ext_srcdir@/xxhash"
 
 EXT_HASH_SOURCES="hash.c hash_md.c hash_sha.c hash_ripemd.c hash_haval.c \
   hash_tiger.c hash_gost.c hash_snefru.c hash_whirlpool.c hash_adler32.c \
@@ -42,7 +41,7 @@ EXT_HASH_HEADERS="php_hash.h php_hash_md.h php_hash_sha.h php_hash_ripemd.h \
   php_hash_haval.h php_hash_tiger.h php_hash_gost.h php_hash_snefru.h \
   php_hash_whirlpool.h php_hash_adler32.h php_hash_crc32.h \
   php_hash_fnv.h php_hash_joaat.h php_hash_sha3.h php_hash_murmur.h \
-  php_hash_xxhash.h"
+  php_hash_xxhash.h xxhash/xxhash.h"
 
 PHP_NEW_EXTENSION(hash, $EXT_HASH_SOURCES, 0,,$PHP_HASH_CFLAGS)
 PHP_INSTALL_HEADERS(ext/hash, $EXT_HASH_HEADERS)

--- a/ext/hash/config.w32
+++ b/ext/hash/config.w32
@@ -35,13 +35,9 @@ if (!CHECK_HEADER_ADD_INCLUDE('PMurHash.h', 'CFLAGS_HASH', hash_murmur_dir)) {
 }
 ADD_SOURCES(hash_murmur_dir, 'PMurHash.c PMurHash128.c', 'hash');
 
-var hash_xxhash_dir = 'ext/hash/xxhash';
-if (!CHECK_HEADER_ADD_INCLUDE('xxhash.h', 'CFLAGS_HASH', hash_xxhash_dir)) {
-	ERROR('Unable to locate xxhash headers');
-}
-
 PHP_INSTALL_HEADERS('ext/hash/',	'php_hash.h php_hash_md.h php_hash_sha.h ' +
 									'php_hash_ripemd.h php_hash_haval.h php_hash_tiger.h ' +
 									'php_hash_gost.h php_hash_snefru.h php_hash_whirlpool.h ' +
 									'php_hash_adler32.h php_hash_crc32.h php_hash_sha3.h ' +
-									'php_hash_murmur.h php_hash_xxhash.h');
+									'php_hash_murmur.h php_hash_xxhash.h php_hash_fnv.h ' +
+									'php_hash_joaat.h xxhash/xxhash.h');

--- a/ext/hash/php_hash_xxhash.h
+++ b/ext/hash/php_hash_xxhash.h
@@ -17,8 +17,11 @@
 #ifndef PHP_HASH_XXHASH_H
 #define PHP_HASH_XXHASH_H
 
+/* Undefined, if xxhash namespace was already set elsewhere. */
+#undef XXH_NAMESPACE
+#define XXH_NAMESPACE PHP_NAMESPACE
 #define XXH_INLINE_ALL 1
-#include "xxhash.h"
+#include "xxhash/xxhash.h"
 
 typedef struct {
 	XXH32_state_t s;


### PR DESCRIPTION
This syncs ext/hash headers installation on *nix and Windows:
- php_hash_joaat.h and php_hash_fnv.h added also on Windows installation
- xxhash/xxhash.h added on both installations as it is included in php_hash_xxhash.h
- Include path for xxhash.h changed to relative so the php_hash_xxhash.h can be included outside of php-src
- Redundant include flags removed

This looks ok or have I misses something perhaps?