### PR TITLE
Sync headers installation for extensions

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -19,5 +19,5 @@ tl_config.WriteLine("#define timelib_strndup estrndup");
 tl_config.WriteLine("#define timelib_free    efree");
 tl_config.Close();
 
-PHP_INSTALL_HEADERS("ext/date/", "php_date.h lib/timelib.h lib/timelib_config.h");
+PHP_INSTALL_HEADERS("ext/date", "php_date.h lib/timelib.h lib/timelib_config.h");
 AC_DEFINE('HAVE_TIMELIB_CONFIG_H', 1, 'Have timelib_config.h')

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -49,7 +49,7 @@ if test "$PHP_DOM" != "no"; then
     PHP_ADD_BUILD_DIR($ext_builddir/$LEXBOR_DIR/ns)
     PHP_ADD_BUILD_DIR($ext_builddir/$LEXBOR_DIR/tag)
     PHP_SUBST(DOM_SHARED_LIBADD)
-    PHP_INSTALL_HEADERS([ext/dom/xml_common.h ext/dom/xpath_callbacks.h])
+    PHP_INSTALL_HEADERS([ext/dom], [xml_common.h xpath_callbacks.h])
     PHP_ADD_EXTENSION_DEP(dom, libxml)
   ])
 fi

--- a/ext/filter/config.m4
+++ b/ext/filter/config.m4
@@ -8,6 +8,6 @@ if test "$PHP_FILTER" != "no"; then
   PHP_NEW_EXTENSION(filter, filter.c sanitizing_filters.c logical_filters.c callback_filter.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(FILTER_SHARED_LIBADD)
 
-  PHP_INSTALL_HEADERS([ext/filter/php_filter.h])
+  PHP_INSTALL_HEADERS([ext/filter], [php_filter.h])
   PHP_ADD_EXTENSION_DEP(filter, pcre)
 fi

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -235,7 +235,7 @@ dnl Various checks for GD features
     PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GD_CFLAGS))
     PHP_ADD_BUILD_DIR($ext_builddir/libgd)
     GD_CFLAGS="-Wno-strict-prototypes -I$ext_srcdir/libgd $GD_CFLAGS"
-    GD_HEADER_DIRS="ext/gd/ ext/gd/libgd/"
+    PHP_INSTALL_HEADERS([ext/gd], [php_gd.h libgd/])
 
     PHP_TEST_BUILD(foobar, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
@@ -250,13 +250,12 @@ dnl Various checks for GD features
     PHP_GD_CHECK_VERSION
 
     PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared)
-    GD_HEADER_DIRS="ext/gd/"
+    PHP_INSTALL_HEADERS([ext/gd], [php_gd.h])
     PHP_CHECK_LIBRARY(gd, gdImageCreate, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
     ], [ $GD_SHARED_LIBADD ])
   fi
 
-  PHP_INSTALL_HEADERS([$GD_HEADER_DIRS])
   PHP_SUBST(GD_CFLAGS)
   PHP_SUBST(GDLIB_CFLAGS)
   PHP_SUBST(GDLIB_LIBS)

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -75,7 +75,7 @@ if (PHP_GD != "no") {
 			ADD_FLAG("LDFLAGS_GD", "/nodefaultlib:libcmt");
 		}
 
-		PHP_INSTALL_HEADERS("", "ext/gd ext/gd/libgd" );
+		PHP_INSTALL_HEADERS("ext/gd", "php_gd.h libgd/");
 	} else {
 		WARNING("gd not enabled; libraries and headers not found");
 	}

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -27,7 +27,7 @@ if test "$PHP_GMP" != "no"; then
     PHP_ADD_INCLUDE($PHP_GMP/include)
   fi
 
-  PHP_INSTALL_HEADERS([ext/gmp/php_gmp_int.h])
+  PHP_INSTALL_HEADERS([ext/gmp], [php_gmp_int.h])
 
   PHP_NEW_EXTENSION(gmp, gmp.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(GMP_SHARED_LIBADD)

--- a/ext/hash/config.w32
+++ b/ext/hash/config.w32
@@ -40,7 +40,7 @@ if (!CHECK_HEADER_ADD_INCLUDE('xxhash.h', 'CFLAGS_HASH', hash_xxhash_dir)) {
 	ERROR('Unable to locate xxhash headers');
 }
 
-PHP_INSTALL_HEADERS('ext/hash/',	'php_hash.h php_hash_md.h php_hash_sha.h ' +
+PHP_INSTALL_HEADERS('ext/hash',	'php_hash.h php_hash_md.h php_hash_sha.h ' +
 									'php_hash_ripemd.h php_hash_haval.h php_hash_tiger.h ' +
 									'php_hash_gost.h php_hash_snefru.h php_hash_whirlpool.h ' +
 									'php_hash_adler32.h php_hash_crc32.h php_hash_sha3.h ' +

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -149,7 +149,7 @@ int main(void) {
 
     PHP_NEW_EXTENSION(iconv, iconv.c, $ext_shared,, [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_SUBST(ICONV_SHARED_LIBADD)
-    PHP_INSTALL_HEADERS([ext/iconv/])
+    PHP_INSTALL_HEADERS([ext/iconv], [php_iconv.h])
   else
     AC_MSG_ERROR(Please reinstall the iconv library.)
   fi

--- a/ext/iconv/config.w32
+++ b/ext/iconv/config.w32
@@ -17,7 +17,7 @@ if (PHP_ICONV != "no") {
 		if (!PHP_ICONV_SHARED) {
 			ADD_DEF_FILE("ext\\iconv\\php_iconv.def");
 		}
-		PHP_INSTALL_HEADERS("", "ext/iconv");
+		PHP_INSTALL_HEADERS("ext/iconv", "php_iconv.h");
 	} else {
 		WARNING("iconv support can't be enabled, libraries or headers are missing")
 		PHP_ICONV = "no";

--- a/ext/json/config.w32
+++ b/ext/json/config.w32
@@ -6,4 +6,4 @@ ADD_SOURCES(configure_module_dirname, "json_encoder.c json_parser.tab.c json_sca
 
 ADD_MAKEFILE_FRAGMENT();
 
-PHP_INSTALL_HEADERS("ext/json/", "php_json.h php_json_parser.h php_json_scanner.h");
+PHP_INSTALL_HEADERS("ext/json", "php_json.h php_json_parser.h php_json_scanner.h");

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -15,7 +15,7 @@ if (PHP_LIBXML == "yes") {
 		if (!PHP_LIBXML_SHARED) {
 			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");
 		}
-		PHP_INSTALL_HEADERS("ext/libxml/", "php_libxml.h");
+		PHP_INSTALL_HEADERS("ext/libxml", "php_libxml.h");
 	} else {
 		WARNING("libxml support can't be enabled, iconv or libxml are missing")
 		PHP_LIBXML = "no"

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -12,6 +12,6 @@ if test "$PHP_LIBXML" != "no"; then
   PHP_SETUP_LIBXML(LIBXML_SHARED_LIBADD, [
     AC_DEFINE(HAVE_LIBXML,1,[ ])
     PHP_NEW_EXTENSION(libxml, [libxml.c mime_sniff.c], $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-    PHP_INSTALL_HEADERS([ext/libxml/php_libxml.h])
+    PHP_INSTALL_HEADERS([ext/libxml], [php_libxml.h])
   ])
 fi

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -65,10 +65,6 @@ if test "$PHP_MYSQLI" != "no"; then
                   mysqli_exception.c mysqli_result_iterator.c"
   PHP_NEW_EXTENSION(mysqli, $mysqli_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(MYSQLI_SHARED_LIBADD)
-  PHP_INSTALL_HEADERS([ext/mysqli/php_mysqli_structs.h])
-
-  if test "$PHP_MYSQLI" = "yes" || test "$PHP_MYSQLI" = "mysqlnd"; then
-    PHP_ADD_EXTENSION_DEP(mysqli, mysqlnd)
-    PHP_INSTALL_HEADERS([ext/mysqli/mysqli_mysqlnd.h])
-  fi
+  PHP_INSTALL_HEADERS([ext/mysqli], [php_mysqli_structs.h mysqli_mysqlnd.h])
+  PHP_ADD_EXTENSION_DEP(mysqli, mysqlnd)
 fi

--- a/ext/mysqli/config.w32
+++ b/ext/mysqli/config.w32
@@ -22,6 +22,6 @@ if (PHP_MYSQLI != "no") {
 	if (PHP_MYSQLI != "no") {
 		EXTENSION("mysqli", mysqli_source, PHP_MYSQLI_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		ADD_EXTENSION_DEP('mysqli', 'mysqlnd', true);
-		PHP_INSTALL_HEADERS("ext/mysqli", "php_mysqli_structs.h");
+		PHP_INSTALL_HEADERS("ext/mysqli", "php_mysqli_structs.h mysqli_mysqlnd.h");
 	}
 }

--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -11,7 +11,7 @@ if test "$PHP_PDO" != "no"; then
 
   PHP_NEW_EXTENSION(pdo, pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c, $ext_shared)
   PHP_ADD_EXTENSION_DEP(pdo, spl, true)
-  PHP_INSTALL_HEADERS(ext/pdo, [php_pdo.h php_pdo_driver.h php_pdo_error.h])
+  PHP_INSTALL_HEADERS([ext/pdo], [php_pdo.h php_pdo_driver.h php_pdo_error.h])
 
   dnl so we always include the known-good working hack.
   PHP_ADD_MAKEFILE_FRAGMENT

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -35,6 +35,7 @@ if (PHP_PHAR != "no") {
 		}
 	}
 	ADD_EXTENSION_DEP('phar', 'spl', true);
+	PHP_INSTALL_HEADERS("ext/phar", "php_phar.h");
 
 	ADD_MAKEFILE_FRAGMENT();
 }

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -18,7 +18,7 @@ if test "$PHP_SESSION" != "no"; then
   PHP_ADD_EXTENSION_DEP(session, hash, true)
   PHP_ADD_EXTENSION_DEP(session, spl)
   PHP_SUBST(SESSION_SHARED_LIBADD)
-  PHP_INSTALL_HEADERS(ext/session, [php_session.h mod_files.h mod_user.h])
+  PHP_INSTALL_HEADERS([ext/session], [php_session.h mod_files.h mod_user.h])
   AC_DEFINE(HAVE_PHP_SESSION,1,[ ])
 fi
 
@@ -38,6 +38,6 @@ if test "$PHP_MM" != "no"; then
 
   PHP_ADD_LIBRARY_WITH_PATH(mm, $MM_DIR/$PHP_LIBDIR, SESSION_SHARED_LIBADD)
   PHP_ADD_INCLUDE($MM_DIR/include)
-  PHP_INSTALL_HEADERS([ext/session/mod_mm.h])
+  PHP_INSTALL_HEADERS([ext/session], [mod_mm.h])
   AC_DEFINE(HAVE_LIBMM, 1, [Whether you have libmm])
 fi

--- a/ext/session/config.w32
+++ b/ext/session/config.w32
@@ -5,5 +5,5 @@ ARG_ENABLE("session", "session support", "yes");
 if (PHP_SESSION == "yes") {
 	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	AC_DEFINE("HAVE_PHP_SESSION", 1, "Session support");
-	PHP_INSTALL_HEADERS("ext/session/", "mod_mm.h php_session.h mod_files.h mod_user.h");
+	PHP_INSTALL_HEADERS("ext/session", "mod_mm.h php_session.h mod_files.h mod_user.h");
 }

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -13,7 +13,7 @@ if test "$PHP_SIMPLEXML" != "no"; then
   PHP_SETUP_LIBXML(SIMPLEXML_SHARED_LIBADD, [
     AC_DEFINE(HAVE_SIMPLEXML,1,[ ])
     PHP_NEW_EXTENSION(simplexml, simplexml.c, $ext_shared)
-    PHP_INSTALL_HEADERS([ext/simplexml/php_simplexml.h ext/simplexml/php_simplexml_exports.h])
+    PHP_INSTALL_HEADERS([ext/simplexml], [php_simplexml.h php_simplexml_exports.h])
     PHP_SUBST(SIMPLEXML_SHARED_LIBADD)
   ])
   PHP_ADD_EXTENSION_DEP(simplexml, libxml)

--- a/ext/simplexml/config.w32
+++ b/ext/simplexml/config.w32
@@ -21,7 +21,7 @@ if (PHP_SIMPLEXML == "yes") {
 			MESSAGE("\tSPL support in simplexml disabled");
 		}
 		ADD_FLAG("CFLAGS_SIMPLEXML", "/D PHP_SIMPLEXML_EXPORTS ");
-		PHP_INSTALL_HEADERS("ext/simplexml/", "php_simplexml.h php_simplexml_exports.h");
+		PHP_INSTALL_HEADERS("ext/simplexml", "php_simplexml.h php_simplexml_exports.h");
 	} else {
 		PHP_SIMPLEXML = "no";
 		WARNING("simplexml not enabled; libraries and headers not found");

--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -103,5 +103,5 @@ if test "$PHP_SOCKETS" != "no"; then
     [sockets.c multicast.c conversions.c sockaddr_conv.c sendrecvmsg.c],
     [$ext_shared],,
     $PHP_SOCKETS_CFLAGS)
-  PHP_INSTALL_HEADERS([ext/sockets/], [php_sockets.h])
+  PHP_INSTALL_HEADERS([ext/sockets], [php_sockets.h])
 fi

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -15,5 +15,6 @@ if test "$PHP_SODIUM" != "no"; then
   SODIUM_COMPILER_FLAGS="$LIBSODIUM_CFLAGS -Wno-type-limits"
   AX_CHECK_COMPILE_FLAG([-Wno-logical-op], SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op", , [-Werror])
   PHP_NEW_EXTENSION(sodium, libsodium.c sodium_pwhash.c, $ext_shared, , $SODIUM_COMPILER_FLAGS)
+  PHP_INSTALL_HEADERS([ext/sodium], [php_libsodium.h])
   PHP_SUBST(SODIUM_SHARED_LIBADD)
 fi

--- a/ext/sodium/config.w32
+++ b/ext/sodium/config.w32
@@ -6,7 +6,7 @@ if (PHP_SODIUM != "no") {
 	if (CHECK_LIB("libsodium.lib", "sodium", PHP_SODIUM) && CHECK_HEADER_ADD_INCLUDE("sodium.h", "CFLAGS_SODIUM")) {
 		EXTENSION("sodium", "libsodium.c sodium_pwhash.c");
 		AC_DEFINE('HAVE_LIBSODIUMLIB', 1 , 'Have the Sodium library');
-		PHP_INSTALL_HEADERS("ext/sodium/", "php_libsodium.h");
+		PHP_INSTALL_HEADERS("ext/sodium", "php_libsodium.h");
 	} else {
 		WARNING("libsodium not enabled; libraries and headers not found");
 	}

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -32,6 +32,6 @@ if test "$PHP_XML" != "no"; then
 
   PHP_NEW_EXTENSION(xml, xml.c $xml_extra_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(XML_SHARED_LIBADD)
-  PHP_INSTALL_HEADERS([ext/xml/])
+  PHP_INSTALL_HEADERS([ext/xml], [expat_compat.h php_xml.h])
   AC_DEFINE(HAVE_XML, 1, [ ])
 fi

--- a/ext/xml/config.w32
+++ b/ext/xml/config.w32
@@ -13,7 +13,7 @@ if (PHP_XML == "yes") {
 		if (!PHP_XML_SHARED) {
 			ADD_FLAG("CFLAGS_XML", "/D LIBXML_STATIC ");
 		}
-		PHP_INSTALL_HEADERS("", "ext/xml");
+		PHP_INSTALL_HEADERS("ext/xml", "expat_compat.h php_xml.h");
 	} else {
 		WARNING("xml support can't be enabled, libraries or headers are missing")
 		PHP_XML = "no"

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -56,6 +56,6 @@ if test "$PHP_CLI" != "no"; then
 
   PHP_OUTPUT(sapi/cli/php.1)
 
-  PHP_INSTALL_HEADERS([sapi/cli/cli.h])
+  PHP_INSTALL_HEADERS([sapi/cli], [cli.h])
 fi
 AC_MSG_RESULT($PHP_CLI)

--- a/sapi/cli/config.w32
+++ b/sapi/cli/config.w32
@@ -8,6 +8,7 @@ if (PHP_CLI == "yes") {
 	ADD_FLAG("LIBS_CLI", "ws2_32.lib");
 	ADD_FLAG("LIBS_CLI", "shell32.lib");
 	ADD_FLAG("LDFLAGS_CLI", "/stack:67108864");
+	PHP_INSTALL_HEADERS("sapi/cli", "cli.h");
 
 	if (CHECK_LIB("edit_a.lib;edit.lib", "cli", PHP_CLI) &&
 		CHECK_HEADER_ADD_INCLUDE("editline/readline.h", "CFLAGS_CLI")) {

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -26,7 +26,7 @@ if test "$PHP_EMBED" != "no"; then
   if test "$PHP_EMBED_TYPE" != "no"; then
     PHP_SUBST(LIBPHP_CFLAGS)
     PHP_SELECT_SAPI(embed, $PHP_EMBED_TYPE, php_embed.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-    PHP_INSTALL_HEADERS([sapi/embed/php_embed.h])
+    PHP_INSTALL_HEADERS([sapi/embed], [php_embed.h])
   fi
   AC_MSG_RESULT([$PHP_EMBED_TYPE])
 else


### PR DESCRIPTION
This syncs the installed headers on *nix and Windows systems and provides only what is intended to be used outside of php-src.

- ext/iconv (without iconv_arginfo.h)
- ext/gd: (without gd_arginfo.h and gd_compat.h)
- ext/mysqli (mysqli_mysqlnd.h was missing on Windows)
- ext/phar (php_phar.h was missing on Windows)
- ext/sodium (php_libsodium.h was missing on *nix)
- ext/xml (without xml_arginfo.h)
- sapi/cli (cli.h was missing on Windows)