### PR TITLE
Fix GH-13215 GCC 14 build

### DIFF
--- a/Zend/zend_atomic.h
+++ b/Zend/zend_atomic.h
@@ -23,7 +23,7 @@
 	((__GNUC__ == (x) && __GNUC_MINOR__ >= (y)) || (__GNUC__ > (x)))
 
 /* Builtins are used to avoid library linkage */
-#if __has_feature(c_atomic)
+#if __has_feature(c_atomic) && defined(__clang__)
 #define	HAVE_C11_ATOMICS 1
 #elif ZEND_GCC_PREREQ(4, 7)
 #define	HAVE_GNUC_ATOMICS 1


### PR DESCRIPTION
GCC 14 has the feature but with different function name (HAVE_GNUC_ATOMICS will be used)


