### PR TITLE
Add ReflectorWithAttributes interface with getFirstAttribute() and hasAttribute()

### DIFF
--- a/ext/reflection/php_reflection.h
+++ b/ext/reflection/php_reflection.h
@@ -28,6 +28,7 @@ BEGIN_EXTERN_C()
 
 /* Class entry pointers */
 extern PHPAPI zend_class_entry *reflector_ptr;
+extern PHPAPI zend_class_entry *reflector_with_attributes_ptr;
 extern PHPAPI zend_class_entry *reflection_exception_ptr;
 extern PHPAPI zend_class_entry *reflection_ptr;
 extern PHPAPI zend_class_entry *reflection_function_abstract_ptr;

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -16,8 +16,13 @@ interface Reflector extends Stringable
 {
 }
 
+interface ReflectorWithAttributes
+{
+    public function getAttributes(?string $name = null, int $flags = 0): array;
+}
+
 /** @not-serializable */
-abstract class ReflectionFunctionAbstract implements Reflector
+abstract class ReflectionFunctionAbstract implements Reflector, ReflectorWithAttributes
 {
     public string $name;
 
@@ -112,6 +117,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
     public function getTentativeReturnType(): ?ReflectionType {}
 
     public function getAttributes(?string $name = null, int $flags = 0): array {}
+
+    public function getAttribute(?string $name = null, int $flags = 0): ?ReflectionAttribute {}
 }
 
 class ReflectionFunction extends ReflectionFunctionAbstract
@@ -234,7 +241,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
 }
 
 /** @not-serializable */
-class ReflectionClass implements Reflector
+class ReflectionClass implements Reflector, ReflectorWithAttributes
 {
     /**
      * @cvalue ZEND_ACC_IMPLICIT_ABSTRACT_CLASS
@@ -422,7 +429,7 @@ class ReflectionObject extends ReflectionClass
 }
 
 /** @not-serializable */
-class ReflectionProperty implements Reflector
+class ReflectionProperty implements Reflector, ReflectorWithAttributes
 {
     /** @cvalue ZEND_ACC_STATIC */
     public const int IS_STATIC = UNKNOWN;
@@ -550,17 +557,17 @@ class ReflectionClassConstant implements Reflector
     /** @tentative-return-type */
     public function getDocComment(): string|false {}
 
-    public function getAttributes(?string $name = null, int $flags = 0): array {}
-
     public function isEnumCase(): bool {}
 
     public function hasType(): bool {}
 
     public function getType(): ?ReflectionType {}
+
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
 /** @not-serializable */
-class ReflectionParameter implements Reflector
+class ReflectionParameter implements Reflector, ReflectorWithAttributes
 {
     public string $name;
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,8 +1,13 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 11fcaa654fc0442e8338f6849b91aa2970b211b9 */
+ * Stub hash: 8891d0ac967da90383bcb8925e764e76ef6f0134 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectorWithAttributes_getAttributes, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFunctionAbstract___clone, 0, 0, IS_VOID, 0)
@@ -81,7 +86,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getTentativeReturnType, 0, 0, ReflectionType, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttributes, 0, 0, IS_ARRAY, 0)
+#define arginfo_class_ReflectionFunctionAbstract_getAttributes arginfo_class_ReflectorWithAttributes_getAttributes
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttribute, 0, 0, ReflectionAttribute, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -324,7 +331,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionClass_getShortName arginfo_class_ReflectionFunctionAbstract_getName
 
-#define arginfo_class_ReflectionClass_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+#define arginfo_class_ReflectionClass_getAttributes arginfo_class_ReflectorWithAttributes_getAttributes
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionObject___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
@@ -385,7 +392,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_getDefaultValue, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_ReflectionProperty_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+#define arginfo_class_ReflectionProperty_getAttributes arginfo_class_ReflectorWithAttributes_getAttributes
 
 #define arginfo_class_ReflectionClassConstant___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -414,13 +421,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionClassConstant_getDocComment arginfo_class_ReflectionFunctionAbstract_getDocComment
 
-#define arginfo_class_ReflectionClassConstant_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
-
 #define arginfo_class_ReflectionClassConstant_isEnumCase arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionClassConstant_hasType arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionClassConstant_getType arginfo_class_ReflectionFunctionAbstract_getTentativeReturnType
+
+#define arginfo_class_ReflectionClassConstant_getAttributes arginfo_class_ReflectorWithAttributes_getAttributes
 
 #define arginfo_class_ReflectionParameter___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -470,7 +477,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionParameter_isPromoted arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
-#define arginfo_class_ReflectionParameter_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+#define arginfo_class_ReflectionParameter_getAttributes arginfo_class_ReflectorWithAttributes_getAttributes
 
 #define arginfo_class_ReflectionType___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -647,6 +654,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, hasTentativeReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, getTentativeReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, getAttributes);
+ZEND_METHOD(ReflectionFunctionAbstract, getAttribute);
 ZEND_METHOD(ReflectionFunction, __construct);
 ZEND_METHOD(ReflectionFunction, __toString);
 ZEND_METHOD(ReflectionFunction, isAnonymous);
@@ -767,10 +775,10 @@ ZEND_METHOD(ReflectionClassConstant, isFinal);
 ZEND_METHOD(ReflectionClassConstant, getModifiers);
 ZEND_METHOD(ReflectionClassConstant, getDeclaringClass);
 ZEND_METHOD(ReflectionClassConstant, getDocComment);
-ZEND_METHOD(ReflectionClassConstant, getAttributes);
 ZEND_METHOD(ReflectionClassConstant, isEnumCase);
 ZEND_METHOD(ReflectionClassConstant, hasType);
 ZEND_METHOD(ReflectionClassConstant, getType);
+ZEND_METHOD(ReflectionClassConstant, getAttributes);
 ZEND_METHOD(ReflectionParameter, __construct);
 ZEND_METHOD(ReflectionParameter, __toString);
 ZEND_METHOD(ReflectionParameter, getName);
@@ -864,6 +872,12 @@ static const zend_function_entry class_Reflector_methods[] = {
 };
 
 
+static const zend_function_entry class_ReflectorWithAttributes_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(ReflectorWithAttributes, getAttributes, arginfo_class_ReflectorWithAttributes_getAttributes, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};
+
+
 static const zend_function_entry class_ReflectionFunctionAbstract_methods[] = {
 	ZEND_MALIAS(ReflectionClass, __clone, __clone, arginfo_class_ReflectionFunctionAbstract___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(ReflectionFunctionAbstract, inNamespace, arginfo_class_ReflectionFunctionAbstract_inNamespace, ZEND_ACC_PUBLIC)
@@ -897,6 +911,7 @@ static const zend_function_entry class_ReflectionFunctionAbstract_methods[] = {
 	ZEND_ME(ReflectionFunctionAbstract, hasTentativeReturnType, arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, getTentativeReturnType, arginfo_class_ReflectionFunctionAbstract_getTentativeReturnType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, getAttributes, arginfo_class_ReflectionFunctionAbstract_getAttributes, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionFunctionAbstract, getAttribute, arginfo_class_ReflectionFunctionAbstract_getAttribute, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -1056,10 +1071,10 @@ static const zend_function_entry class_ReflectionClassConstant_methods[] = {
 	ZEND_ME(ReflectionClassConstant, getModifiers, arginfo_class_ReflectionClassConstant_getModifiers, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDeclaringClass, arginfo_class_ReflectionClassConstant_getDeclaringClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDocComment, arginfo_class_ReflectionClassConstant_getDocComment, ZEND_ACC_PUBLIC)
-	ZEND_ME(ReflectionClassConstant, getAttributes, arginfo_class_ReflectionClassConstant_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, isEnumCase, arginfo_class_ReflectionClassConstant_isEnumCase, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, hasType, arginfo_class_ReflectionClassConstant_hasType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getType, arginfo_class_ReflectionClassConstant_getType, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClassConstant, getAttributes, arginfo_class_ReflectionClassConstant_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -1240,14 +1255,24 @@ static zend_class_entry *register_class_Reflector(zend_class_entry *class_entry_
 	return class_entry;
 }
 
-static zend_class_entry *register_class_ReflectionFunctionAbstract(zend_class_entry *class_entry_Reflector)
+static zend_class_entry *register_class_ReflectorWithAttributes(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "ReflectorWithAttributes", class_ReflectorWithAttributes_methods);
+	class_entry = zend_register_internal_interface(&ce);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ReflectionFunctionAbstract(zend_class_entry *class_entry_Reflector, zend_class_entry *class_entry_ReflectorWithAttributes)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionFunctionAbstract", class_ReflectionFunctionAbstract_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ABSTRACT|ZEND_ACC_NOT_SERIALIZABLE;
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
+	zend_class_implements(class_entry, 2, class_entry_Reflector, class_entry_ReflectorWithAttributes);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
@@ -1337,14 +1362,14 @@ static zend_class_entry *register_class_ReflectionMethod(zend_class_entry *class
 	return class_entry;
 }
 
-static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_entry_Reflector)
+static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_entry_Reflector, zend_class_entry *class_entry_ReflectorWithAttributes)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionClass", class_ReflectionClass_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
+	zend_class_implements(class_entry, 2, class_entry_Reflector, class_entry_ReflectorWithAttributes);
 
 	zval const_IS_IMPLICIT_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_IMPLICIT_ABSTRACT_value, ZEND_ACC_IMPLICIT_ABSTRACT_CLASS);
@@ -1389,14 +1414,14 @@ static zend_class_entry *register_class_ReflectionObject(zend_class_entry *class
 	return class_entry;
 }
 
-static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *class_entry_Reflector)
+static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *class_entry_Reflector, zend_class_entry *class_entry_ReflectorWithAttributes)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionProperty", class_ReflectionProperty_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
+	zend_class_implements(class_entry, 2, class_entry_Reflector, class_entry_ReflectorWithAttributes);
 
 	zval const_IS_STATIC_value;
 	ZVAL_LONG(&const_IS_STATIC_value, ZEND_ACC_STATIC);
@@ -1491,14 +1516,14 @@ static zend_class_entry *register_class_ReflectionClassConstant(zend_class_entry
 	return class_entry;
 }
 
-static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *class_entry_Reflector)
+static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *class_entry_Reflector, zend_class_entry *class_entry_ReflectorWithAttributes)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionParameter", class_ReflectionParameter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
+	zend_class_implements(class_entry, 2, class_entry_Reflector, class_entry_ReflectorWithAttributes);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);

--- a/ext/reflection/tests/ReflectionFunction_getAttribute.phpt
+++ b/ext/reflection/tests/ReflectionFunction_getAttribute.phpt
@@ -1,0 +1,25 @@
+--TEST--
+ReflectionFunction::getAttribute()
+--FILE--
+<?php
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::IS_REPEATABLE)]
+class AnAttribute {
+    public function __construct(public readonly string $value) {}
+}
+
+#[AnAttribute('first'), AnAttribute('second')]
+function foo() {}
+
+$function = new ReflectionFunction('foo');
+$attribute = $function->getAttribute(AnAttribute::class);
+var_dump($attribute);
+var_dump($attribute->newInstance()->value);
+
+$function = new ReflectionFunction('foo');
+var_dump($function->getAttribute(Stringable::class));
+?>
+--EXPECT--
+object(ReflectionAttribute)#2 (0) {
+}
+string(5) "first"
+NULL


### PR DESCRIPTION
This is my first attempt at introducing the interface `ReflectorWithAttributes` which is implemented by the following classes:

* `ReflectionFunctionAbstract`
* `ReflectionParameter`
* `ReflectionClass`
* `ReflectionProperty`

The `getAttributes()` method present all of the above has been moved to this new interface, and the following methods have been added:

* `getFirstAttribute(?string $name = null, int $flags = 0): ?ReflectionAttribute`
* `hasAttribute(?string $name = null, int $flags = 0): bool`

I've tried to work with what is currently there, rather than replacing the current approach to attributes, but I can't speak for efficiency and such, so would appreciate any feedback.

This PR is an implementation of #8489, which was mentioned on the mailing list with little to no feedback.

