### PR TITLE
Fix "warning: conflicting types for ‘zend_multibyte_set_script_encoding’ due to enum/integer mismatch;"

### DIFF
--- a/Zend/zend_multibyte.h
+++ b/Zend/zend_multibyte.h
@@ -70,7 +70,7 @@ ZEND_API zend_result zend_multibyte_parse_encoding_list(const char *encoding_lis
 
 ZEND_API const zend_encoding *zend_multibyte_get_internal_encoding(void);
 ZEND_API const zend_encoding *zend_multibyte_get_script_encoding(void);
-ZEND_API int zend_multibyte_set_script_encoding(const zend_encoding **encoding_list, size_t encoding_list_size);
+ZEND_API zend_result zend_multibyte_set_script_encoding(const zend_encoding **encoding_list, size_t encoding_list_size);
 ZEND_API zend_result zend_multibyte_set_internal_encoding(const zend_encoding *encoding);
 ZEND_API zend_result zend_multibyte_set_script_encoding_by_string(const char *new_value, size_t new_value_length);
 


### PR DESCRIPTION
Related: #13122 

I found return type mismatch and displays warning when GCC 13 on Ubuntu 23.10.

```
/home/tekimen.linux/src/youkidearitai_php-src/Zend/zend_multibyte.c:173:22: warning: conflicting types for ‘zend_multibyte_set_script_encoding’ due to enum/integer mismatch; have ‘zend_result(const zend_encoding **, size_t)’ {aka ‘ZEND_RESULT_CODE(const struct _zend_encoding **, long unsigned int)’} [-Wenum-int-mismatch]
  173 | ZEND_API zend_result zend_multibyte_set_script_encoding(const zend_encoding **encoding_list, size_t encoding_list_size)
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/tekimen.linux/src/youkidearitai_php-src/Zend/zend_globals.h:39,
                 from /home/tekimen.linux/src/youkidearitai_php-src/Zend/zend_compile.h:773,
                 from /home/tekimen.linux/src/youkidearitai_php-src/Zend/zend_multibyte.c:21:
/home/tekimen.linux/src/youkidearitai_php-src/Zend/zend_multibyte.h:73:14: note: previous declaration of ‘zend_multibyte_set_script_encoding’ with type ‘int(const zend_encoding **, size_t)’ {aka ‘int(const struct _zend_encoding **, long unsigned int)’}
   73 | ZEND_API int zend_multibyte_set_script_encoding(const zend_encoding **encoding_list, size_t encoding_list_size);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```