### PR TITLE
Avoid new SSA var for ASSIGN_OBJ_REF without RC inference

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -3157,7 +3157,7 @@ static zend_always_inline zend_result _zend_update_type_info(
 			}
 			break;
 		case ZEND_ASSIGN_OBJ_REF:
-			if (opline->op1_type == IS_CV) {
+			if (opline->op1_type == IS_CV && ssa_op->op1_def >= 0) {
 				tmp = t1;
 				if (tmp & MAY_BE_OBJECT) {
 					tmp |= MAY_BE_RC1 | MAY_BE_RCN;

--- a/Zend/Optimizer/zend_ssa.c
+++ b/Zend/Optimizer/zend_ssa.c
@@ -607,7 +607,7 @@ add_op1_def:
 			}
 			break;
 		case ZEND_ASSIGN_OBJ_REF:
-			if (opline->op1_type == IS_CV) {
+			if ((build_flags & ZEND_SSA_RC_INFERENCE) && opline->op1_type == IS_CV) {
 				ssa_ops[k].op1_def = ssa_vars_count;
 				var[EX_VAR_TO_NUM(opline->op1.var)] = ssa_vars_count;
 				ssa_vars_count++;


### PR DESCRIPTION
Previously, this variable was necessary because of auto-vivification on UNDEF/NULL/false. It's now only used for RC inference, as auto-vivification has been removed.

This implicitly solves an inference problem for $obj->bar &= $obj; where we get a new variable for both literal references to $obj, with the first one getting the RCn flag, and the second one getting the MAY_BE_REFERENCE flag. Thus, the first variable will be missing the reference type, causing a false-positive type inference warning.

If we want to verify RC inference at some point we'll need a better solution.

For reference: https://github.com/php/php-src/actions/runs/7619720239/job/20753304348