### PR TITLE
ext/sockets: enabling multicast group for ipv4 on freebsd.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -117,6 +117,9 @@ SimpleXML:
   . Fixed bug #55098 (SimpleXML iteration produces infinite loop). (nielsdos)
   . Fix signature of simplexml_import_dom(). (nielsdos)
 
+Sockets:
+  . Added multicast group support for ipv4 on FreeBSD. (jonathan@tangential.ca)
+
 SNMP:
   . Removed the deprecated inet_ntoa call support. (David Carlier)
 

--- a/ext/sockets/multicast.h
+++ b/ext/sockets/multicast.h
@@ -14,7 +14,8 @@
    +----------------------------------------------------------------------+
  */
 
-#if defined(MCAST_JOIN_GROUP) && !defined(__APPLE__)
+// TODO using setsourcefilter api on freebsd to support both ipv4/ipv6.
+#if defined(MCAST_JOIN_GROUP) && !defined(__APPLE__) && !defined(__FreeBSD__)
 # define RFC3678_API 1
 /* has block/unblock and source membership, in this case for both IPv4 and IPv6 */
 # define HAS_MCAST_EXT 1

--- a/ext/sockets/tests/bug63000.phpt
+++ b/ext/sockets/tests/bug63000.phpt
@@ -2,13 +2,6 @@
 Bug #63000: Multicast on OSX
 --EXTENSIONS--
 sockets
---SKIPIF--
-<?php
-
-if (str_contains(PHP_OS, 'FreeBSD')) {
-    die('skip option not supported on FreeBSD');
-}
-?>
 --FILE--
 <?php
 $socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);


### PR DESCRIPTION
bug#75721 patch from jonathan@tangential.ca.

MCAST_JOIN_GROUP/MCAST_LEAVE_GROUP socket option for the RFC 3678 support does not work on freebsd, using IP_ADD_MEMBERSHIP instead.