### PR TITLE
Fix GH-10344: imagettfbbox(): Could not find/open font UNC path

### DIFF
--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -401,7 +401,17 @@ static void *fontFetch (char **error, void *key)
 #ifdef NETWARE
 		if (*name == '/' || (name[0] != 0 && strstr(name, ":/"))) {
 #else
-		if (*name == '/' || (name[0] != 0 && name[1] == ':' && (name[2] == '/' || name[2] == '\\'))) {
+		/* Actual length doesn't matter, just the minimum does up to length 2. */
+		unsigned int min_length = 0;
+		if (name[0] != '\0') {
+			if (name[1] != '\0') {
+				min_length = 2;
+			} else {
+				min_length = 1;
+			}
+		}
+		ZEND_IGNORE_VALUE(min_length); /* On Posix systems this may be unused */
+		if (IS_ABSOLUTE_PATH(name, min_length)) {
 #endif
 			snprintf(fullname, sizeof(fullname) - 1, "%s", name);
 			if (access(fullname, R_OK) == 0) {

--- a/ext/gd/tests/gh10344.phpt
+++ b/ext/gd/tests/gh10344.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-10344 (imagettfbbox(): Could not find/open font UNC path)
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY != 'Windows') {
+    die("skip windows only test");
+}
+if (!GD_BUNDLED) {
+    die("skip Not (yet) fixed in libgd itself");
+}
+if (!function_exists("imagettfbbox")) {
+    die("skip ttf support unavailable");
+}
+if (!is_readable("\\\\localhost\\c$\\Windows\\Fonts\\arial.ttf")) {
+    die("skip font not readable");
+}
+?>
+--FILE--
+<?php
+
+$font = '\\\\localhost\\c$\\Windows\\Fonts\\arial.ttf';
+var_dump(count(imagettfbbox(10, 0, $font, 'hello')));
+
+?>
+--EXPECT--
+int(8)


### PR DESCRIPTION
libgd uses an incorrect absolute path check in gdft.c. It checks if either the path starts with a '/' (only valid on Posix btw), or whether it contains something of the form C:\ or C:/. However, this overlooks the possibility of using UNC paths on Windows. As we already do PHP-specific stuff with VCWD_ macros, use IS_ABSOLUTE_PATH to check for an absolute path which will take into account UNC paths as well.