### PR TITLE
Fix EINPROGRESS very rarely occurring on synchronous php_network_connect_socket()

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -365,6 +365,11 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
 		if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char*)&error, &len) != 0) {
 			ret = -1;
 		}
+		if (error == EINPROGRESS) {
+			/* Is leftover from the earlier connect call, since php_socket_errno
+			 * does not clear it. */
+			error = 0;
+		}
 	} else {
 		/* whoops: sockfd has disappeared */
 		ret = -1;


### PR DESCRIPTION
`php_network_connect_socket()` in blocking mode does a `select()` to block on a `connect()` call that reported `EINPROGRESS`. However, it then checks for `select()` errors using `getsockopt(..., SO_ERROR, ...)`, which will return the earlier `EINPROGRESS` since it wasn't cleared by `php_socket_errno()`. I believe this is the cause of https://github.com/phpredis/phpredis/issues/1881 and possibly other issues.

Note that, since the issue only happens very sporadically, I'm unable to write a test that reproduces it, or to test that my fix works in practice. Also new to contributing to PHP, so apologies in advance if I've done something wrong. :-)