### PR TITLE
Let php-fpm -tt dump info regardless of log_level

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -1710,6 +1710,12 @@ static void fpm_conf_dump(void)
 {
 	struct fpm_worker_pool_s *wp;
 
+	// set level to at least NOTICE, so that the following output is visible regardless of configured log_level
+	int old_level = zlog_set_level(ZLOG_NOTICE);
+	if (old_level < ZLOG_NOTICE) {
+		zlog_set_level(old_level);
+	}
+
 	/*
 	 * Please keep the same order as in fpm_conf.h and in php-fpm.conf.in
 	 */
@@ -1815,6 +1821,8 @@ static void fpm_conf_dump(void)
 		}
 		zlog(ZLOG_NOTICE, " ");
 	}
+	// reset level
+	zlog_set_level(old_level);
 }
 
 int fpm_conf_init_main(int test_conf, int force_daemon) /* {{{ */

--- a/sapi/fpm/tests/config-dump-log-level.phpt
+++ b/sapi/fpm/tests/config-dump-log-level.phpt
@@ -1,0 +1,38 @@
+--TEST--
+FPM: -tt dumps config as NOTICEs regardless of log level
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+log_level = warning
+pid = {{FILE:PID}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 5
+php_admin_flag[log_errors] = 1
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start(['-tt']);
+$tester->expectLogConfigOptions([
+    'log_level = WARNING',
+    'php_admin_value[log_errors] = 1',
+]);
+// $tester->expectLogNotice('configuration file %s test is successful', null, 1, true, true);
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
When using `php-fpm -tt` to dump the configuration, and the input config has a `log_level` of warning or error, then nothing will be printed.

This change temporarily changes the `zlog` level to notice, if necessary, to allow the output to be printed.

Notably, the "configuration file %s test is successful" output is not affected by this; it still obeys the configured `log_level`.

Can't be tested, however, as `tester.inc`'s log helpers do not actually seem to work with the "invert" flag passed in.

N.b.: the dump probably really should a) not occur with any log decoration applied, and b) be printed to stdout like most other programs do it...