### PR TITLE
Add missing --ini-path and --ini-dir php-config options to man page

### DIFF
--- a/scripts/man1/php-config.1.in
+++ b/scripts/man1/php-config.1.in
@@ -51,6 +51,14 @@ Show all SAPI modules available
 Configure options to recreate configuration of current PHP installation
 .TP
 .PD 0
+.B \-\-ini-path
+Directory from which PHP reads its INI configuration file (php.ini)
+.TP
+.PD 0
+.B \-\-ini-dir
+Directory from which PHP scans for additional INI configuration files
+.TP
+.PD 0
 .B \-\-version
 PHP version
 .TP


### PR DESCRIPTION
This adds two missing php-config script options: --ini-path and --ini-dir to *nix man pages.