### PR TITLE
Fix linking ext/curl against OpenSSL

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -28,6 +28,7 @@ if test "$PHP_CURL" != "no"; then
 
     AC_MSG_CHECKING([for libcurl linked against old openssl])
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdio.h>
 #include <strings.h>
 #include <curl/curl.h>
 
@@ -39,9 +40,18 @@ int main(int argc, char *argv[])
     const char *ptr = data->ssl_version;
 
     while(*ptr == ' ') ++ptr;
-    if (strncasecmp(ptr, "OpenSSL/1.1", sizeof("OpenSSL/1.1")-1) == 0) {
-      /* New OpenSSL version */
-      return 3;
+    int major, minor;
+    if (sscanf(ptr, "OpenSSL/%d", &major) == 1) {
+      if (major >= 3) {
+        /* OpenSSL version 3 or later */
+        return 4;
+      }
+    }
+    if (sscanf(ptr, "OpenSSL/%d.%d", &major, &minor) == 2) {
+      if (major > 1 || (major == 1 && minor >= 1)) {
+        /* OpenSSL version 1.1 or later */
+        return 3;
+      }
     }
     if (strncasecmp(ptr, "OpenSSL", sizeof("OpenSSL")-1) == 0) {
       /* Old OpenSSL version */
@@ -56,11 +66,7 @@ int main(int argc, char *argv[])
     ]])],[
       AC_MSG_RESULT([yes])
       AC_DEFINE([HAVE_CURL_OLD_OPENSSL], [1], [Have cURL with old OpenSSL])
-      PKG_CHECK_MODULES([OPENSSL], [openssl], [
-        PHP_EVAL_LIBLINE($OPENSSL_LIBS, CURL_SHARED_LIBADD)
-        PHP_EVAL_INCLINE($OPENSSL_CFLAGS)
-        AC_CHECK_HEADERS([openssl/crypto.h])
-      ], [])
+      PHP_SETUP_OPENSSL(CURL_SHARED_LIBADD,[AC_CHECK_HEADERS([openssl/crypto.h])],[])
     ], [
       AC_MSG_RESULT([no])
     ], [


### PR DESCRIPTION
Following 68f6ab711323678382d2746e57358d3f57a3446b, the ext/curl doesn't need to be linked against OpenSSL anymore, if curl_version_info_data ssl_version is OpenSSL/1.1 or later.

With OpenSSL 3 and later the check for old SSL crypto locking callbacks was detected here.

This also uses a common PHP_SETUP_OPENSSL macro for checking OpenSSL and syncs the minimum OpenSSL version (currently 1.0.2 or later) across the PHP build system.