### PR TITLE
Remove unused variables FIBER_ASSEMBLER and FIBER_ASM_ARCH

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -252,14 +252,6 @@ if (!PHP_ASSEMBLER) {
 	ERROR("No assembler found, fiber cannot be built");
 }
 DEFINE('PHP_ASSEMBLER', PHP_ASSEMBLER);
-DEFINE('FIBER_ASSEMBLER', PHP_ASSEMBLER);// for compatible
-
-var FIBER_ASM_ARCH = {
-	'x64': 'x86_64',
-	'x86': 'i386',
-	'arm64': 'arm64'
-}[TARGET_ARCH];
-DEFINE('FIBER_ASM_ARCH', FIBER_ASM_ARCH); // for compatible only
 
 var FIBER_ASM_ABI = {
 	'x64': 'x86_64_ms_pe_masm',


### PR DESCRIPTION
In Windows build system these were replaced with common PHP_ASSEMBLER and FIBER_ASM_ABI when adjusting for the arm64.