### PR TITLE
random: Clean up integer seeding when constructing engines

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -282,7 +282,7 @@ PHP_METHOD(Random_Engine_Mt19937, __construct)
 		}
 	}
 
-	engine->algo->seed(engine->status, seed);
+	mt19937_seed_state(state, seed);
 }
 /* }}} */
 

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -177,7 +177,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 				RETURN_THROWS();
 			}
 		} else {
-			engine->algo->seed(engine->status, int_seed);
+			seed128(state, php_random_uint128_constant(0ULL, (uint64_t) int_seed));
 		}
 	}
 }

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -34,9 +34,8 @@ static inline void step(php_random_status_state_pcgoneseq128xslrr64 *s)
 	);
 }
 
-static inline void seed128(php_random_status *status, php_random_uint128_t seed)
+static inline void seed128(php_random_status_state_pcgoneseq128xslrr64 *s, php_random_uint128_t seed)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status->state;
 	s->state = php_random_uint128_constant(0ULL, 0ULL);
 	step(s);
 	s->state = php_random_uint128_add(s->state, seed);
@@ -45,7 +44,7 @@ static inline void seed128(php_random_status *status, php_random_uint128_t seed)
 
 static void seed(php_random_status *status, uint64_t seed)
 {
-	seed128(status, php_random_uint128_constant(0ULL, seed));
+	seed128(status->state, php_random_uint128_constant(0ULL, seed));
 }
 
 static php_random_result generate(php_random_status *status)
@@ -172,7 +171,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 					}
 				}
 
-				seed128(engine->status, php_random_uint128_constant(t[0], t[1]));
+				seed128(state, php_random_uint128_constant(t[0], t[1]));
 			} else {
 				zend_argument_value_error(1, "must be a 16 byte (128 bit) string");
 				RETURN_THROWS();

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -89,7 +89,7 @@ static inline void seed256(php_random_status_state_xoshiro256starstar *s, uint64
 	s->state[3] = s3;
 }
 
-static void seed(php_random_status *status, uint64_t seed)
+static inline void seed64(php_random_status_state_xoshiro256starstar *state, uint64_t seed)
 {
 	uint64_t s[4];
 
@@ -98,7 +98,12 @@ static void seed(php_random_status *status, uint64_t seed)
 	s[2] = splitmix64(&seed);
 	s[3] = splitmix64(&seed);
 
-	seed256(status->state, s[0], s[1], s[2], s[3]);
+	seed256(state, s[0], s[1], s[2], s[3]);
+}
+
+static void seed(php_random_status *status, uint64_t seed)
+{
+	seed64(status->state, seed);
 }
 
 static php_random_result generate(php_random_status *status)

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -81,10 +81,8 @@ static inline void jump(php_random_status_state_xoshiro256starstar *state, const
 	state->state[3] = s3;
 }
 
-static inline void seed256(php_random_status *status, uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3)
+static inline void seed256(php_random_status_state_xoshiro256starstar *s, uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3)
 {
-	php_random_status_state_xoshiro256starstar *s = status->state;
-
 	s->state[0] = s0;
 	s->state[1] = s1;
 	s->state[2] = s2;
@@ -100,7 +98,7 @@ static void seed(php_random_status *status, uint64_t seed)
 	s[2] = splitmix64(&seed);
 	s[3] = splitmix64(&seed);
 
-	seed256(status, s[0], s[1], s[2], s[3]);
+	seed256(status->state, s[0], s[1], s[2], s[3]);
 }
 
 static php_random_result generate(php_random_status *status)
@@ -237,7 +235,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 					RETURN_THROWS();
 				}
 
-				seed256(engine->status, t[0], t[1], t[2], t[3]);
+				seed256(state, t[0], t[1], t[2], t[3]);
 			} else {
 				zend_argument_value_error(1, "must be a 32 byte (256 bit) string");
 				RETURN_THROWS();

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -246,7 +246,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 				RETURN_THROWS();
 			}
 		} else {
-			engine->algo->seed(engine->status, (uint64_t) int_seed);
+			seed64(state, (uint64_t) int_seed);
 		}
 	}
 }


### PR DESCRIPTION
I plan to merge this using “rebase and merge” to preserve the original commits.