### PR TITLE
Use EXTENSIONS instead of SKIPIF sections in *.phpt

### DIFF
--- a/ext/bz2/tests/bzerr_functions_on_invalid_stream.phpt
+++ b/ext/bz2/tests/bzerr_functions_on_invalid_stream.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Calling bzerr* functions on non-bz2 streams
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $f = fopen(__FILE__, 'r');

--- a/ext/com_dotnet/tests/gh8778.phpt
+++ b/ext/com_dotnet/tests/gh8778.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug GH-8778 (Integer arithmethic with large number variants fails)
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")) die("skip com_dotnet extension not available");
 if (PHP_INT_SIZE < 8) die("skip for 64bit only");
 ?>
 --FILE--

--- a/ext/dom/tests/bug79971_2.phpt
+++ b/ext/dom/tests/bug79971_2.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #79971 (special character is breaking the path in xml function)
---SKIPIF--
-<?php
-if (!extension_loaded('dom')) die('skip dom extension not available');
-?>
+--EXTENSIONS--
+dom
 --FILE--
 <?php
 $imp = new DOMImplementation;

--- a/ext/dom/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/dom/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -1,10 +1,11 @@
 --TEST--
 GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
+--EXTENSIONS--
+dom
+libxml
+zend_test
 --SKIPIF--
 <?php
-if (!extension_loaded('libxml')) die('skip libxml extension not available');
-if (!extension_loaded('dom')) die('skip dom extension not available');
-if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
 if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--

--- a/ext/filter/tests/bug77221.phpt
+++ b/ext/filter/tests/bug77221.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #77221 (Request IP address filter flag to exclude non-global IP addresses)
---SKIPIF--
-<?php
-if (!extension_loaded('filter')) die("skip filter extension not available");
-?>
+--EXTENSIONS--
+filter
 --FILE--
 <?php
 

--- a/ext/filter/tests/bug81122.phpt
+++ b/ext/filter/tests/bug81122.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #81122 (SSRF bypass in FILTER_VALIDATE_URL)
---SKIPIF--
-<?php
-if (!extension_loaded('filter')) die("skip filter extension not available");
-?>
+--EXTENSIONS--
+filter
 --FILE--
 <?php
 $urls = [

--- a/ext/intl/tests/gh10647.phpt
+++ b/ext/intl/tests/gh10647.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug GH-10647 (Spoofchecker::isSuspicious $errorCode always null)
---SKIPIF--
-<?php
-if (!extension_loaded("intl")) die("skip intl extension not available");
-?>
+--EXTENSIONS--
+intl
 --FILE--
 <?php
 $error = 123;

--- a/ext/intl/tests/gh8364.phpt
+++ b/ext/intl/tests/gh8364.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug GH-8364 (msgfmt_format $values may not support references)
---SKIPIF--
-<?php
-if (!extension_loaded("intl")) die("skip intl extension not available");
-?>
+--EXTENSIONS--
+intl
 --FILE--
 <?php
 $formatter = new MessageFormatter('en', 'translate {0}');

--- a/ext/intl/tests/locale/bug72809.phpt
+++ b/ext/intl/tests/locale/bug72809.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #72809 (Locale::lookup() wrong result with canonicalize option)
---SKIPIF--
-<?php
-if (!extension_loaded('intl')) die("skip intl extension not avaible");
-?>
+--EXTENSIONS--
+intl
 --FILE--
 <?php
 var_dump(

--- a/ext/mbstring/tests/gh8086.phpt
+++ b/ext/mbstring/tests/gh8086.phpt
@@ -1,9 +1,7 @@
 --TEST--
 GH-8086 (mb_send_mail() function not working correctly in PHP 8.x)
---SKIPIF--
-<?php
-if (!extension_loaded("mbstring")) die("skip mbstring extension not available");
-?>
+--EXTENSIONS--
+mbstring
 --INI--
 sendmail_path={MAIL:{PWD}/gh8086.eml}
 mail.mixed_lf_and_crlf=on

--- a/ext/openssl/tests/bug50293.phpt
+++ b/ext/openssl/tests/bug50293.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #50293 (Several openssl functions ignore the VCWD)
---SKIPIF--
-<?php
-if (!extension_loaded("openssl")) die("skip openssl not loaded");
-?>
+--EXTENSIONS--
+openssl
 --FILE--
 <?php
 $cert = "file://" . __DIR__ . "/cert.crt";

--- a/ext/openssl/tests/gh9339.phpt
+++ b/ext/openssl/tests/gh9339.phpt
@@ -1,9 +1,7 @@
 --TEST--
 GH-9339: oid_file path check warning contains uninitialized path
---SKIPIF--
-<?php
-if (!extension_loaded("openssl")) die("skip openssl not loaded");
-?>
+--EXTENSIONS--
+openssl
 --FILE--
 <?php
 $configCode = <<<CONFIG

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -1,8 +1,9 @@
 --TEST--
 GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect
+--EXTENSIONS--
+pdo
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';

--- a/ext/pdo_pgsql/tests/gh7723.phpt
+++ b/ext/pdo_pgsql/tests/gh7723.phpt
@@ -1,8 +1,10 @@
 --TEST--
 GitHub #7723 (Fix error message allocation of PDO PgSQL)
+--EXTENSIONS--
+pdo
+pdo_pgsql
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 require __DIR__ . '/config.inc';
 PDOTest::skip();

--- a/ext/pdo_pgsql/tests/gh9411.phpt
+++ b/ext/pdo_pgsql/tests/gh9411.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Bug GH-9411 (PgSQL large object resource is incorrectly closed)
+--EXTENSIONS--
+pdo
+pdo_pgsql
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
 require __DIR__ . '/config.inc';
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 PDOTest::skip();

--- a/ext/phar/tests/GHSA-jqcx-ccgc-xwhv.phpt
+++ b/ext/phar/tests/GHSA-jqcx-ccgc-xwhv.phpt
@@ -1,7 +1,7 @@
 --TEST--
 GHSA-jqcx-ccgc-xwhv (Buffer overflow and overread in phar_dir_read())
---SKIPIF--
-<?php if (!extension_loaded("phar")) die("skip"); ?>
+--EXTENSIONS--
+phar
 --INI--
 phar.readonly=0
 --FILE--

--- a/ext/phar/tests/bug81211.phpt
+++ b/ext/phar/tests/bug81211.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #81211 (Symlinks are followed when creating PHAR archive)
+--EXTENSIONS--
+phar
 --SKIPIF--
 <?php
-if (!extension_loaded('phar')) die('skip phar extension is not available');
 if (PHP_OS_FAMILY === 'Windows') {
     if (false === include __DIR__ . '/../../standard/tests/file/windows_links/common.inc') {
         die('skip windows_links/common.inc is not available');

--- a/ext/simplexml/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/simplexml/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -1,10 +1,11 @@
 --TEST--
 GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
+--EXTENSIONS--
+libxml
+simplexml
+zend_test
 --SKIPIF--
 <?php
-if (!extension_loaded('libxml')) die('skip libxml extension not available');
-if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
-if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
 if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--

--- a/ext/xmlreader/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/xmlreader/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -1,10 +1,11 @@
 --TEST--
 GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
+--EXTENSIONS--
+libxml
+xmlreader
+zend_test
 --SKIPIF--
 <?php
-if (!extension_loaded('libxml')) die('skip libxml extension not available');
-if (!extension_loaded('xmlreader')) die('skip xmlreader extension not available');
-if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
 if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--

--- a/ext/zend_test/tests/observer_sqlite_create_function.phpt
+++ b/ext/zend_test/tests/observer_sqlite_create_function.phpt
@@ -2,7 +2,7 @@
 Observer: PDO::sqliteCreateFunction() can be observed
 --EXTENSIONS--
 zend_test
-PDO
+pdo
 pdo_sqlite
 --INI--
 zend_test.observer.enabled=1

--- a/ext/zip/tests/bug77978.phpt
+++ b/ext/zip/tests/bug77978.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #77978 (Dirname ending in colon unzips to wrong dir)
---SKIPIF--
-<?php
-if (!extension_loaded("zip")) die("skip zip extension not available");
-?>
+--EXTENSIONS--
+zip
 --FILE--
 <?php
 $file = __DIR__ . "/bug77978.zip";

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #80833 (ZipArchive::getStream doesn't use setPassword)
+--EXTENSIONS--
+zip
 --SKIPIF--
 <?php
-if (!extension_loaded('zip')) die("skip zip extension not available");
 if (!method_exists('ZipArchive', 'setEncryptionName')) die('skip encryption not supported');
 ?>
 --FILE--

--- a/ext/zip/tests/bug81420.phpt
+++ b/ext/zip/tests/bug81420.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #81420 (ZipArchive::extractTo extracts outside of destination)
---SKIPIF--
-<?php
-if (!extension_loaded("zip")) die("skip zip extension not available");
-?>
+--EXTENSIONS--
+zip
 --FILE--
 <?php
 $zip = new ZipArchive();

--- a/ext/zip/tests/bug81490.phpt
+++ b/ext/zip/tests/bug81490.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #81490 (ZipArchive::extractTo() may leak memory)
---SKIPIF--
-<?php
-if (!extension_loaded("zip")) die("skip zip extension not available");
-?>
+--EXTENSIONS--
+zip
 --FILE--
 <?php
 $zip = new ZipArchive();

--- a/ext/zip/tests/bug_gh8781.phpt
+++ b/ext/zip/tests/bug_gh8781.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug GH-8781 (ZipArchive deletes zip file with no contents)
---SKIPIF--
-<?php
-if (!extension_loaded('zip')) die('skip zip extension not available');
-?>
+--EXTENSIONS--
+zip
 --FILE--
 <?php
 touch($file = __DIR__ . '/bug_gh8781.zip');


### PR DESCRIPTION
This changes the SKIPIF to EXTENSIONS in *.phpt.

There are some typos (PDO instead of pdo and zend-test instead of zend_test):
- ext/dom/tests/libxml_global_state_entity_loader_bypass.phpt
- ext/simplexml/tests/libxml_global_state_entity_loader_bypass.phpt
- ext/xmlreader/tests/libxml_global_state_entity_loader_bypass.phpt
- ext/zend_test/tests/observer_sqlite_create_function.phpt

Should PHP-8.2 branch be updated for these?