### PR TITLE
Remove HAVE_JSON symbol

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -53,6 +53,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - HAVE_ODBC2 symbol has been removed in ext/odbc.
    - Removed linking with obsolete dnet_stub library in ext/pdo_dblib.
    - Removed checking and linking with obsolete libbind for some functions.
+   - Symbol HAVE_JSON has been removed (ext/json is always available since PHP
+     8.0).
 
  c. Windows build system changes
    - Added Bison flag '-Wall' when generating lexer files as done in *nix build

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -1,6 +1,3 @@
-dnl HAVE_JSON is always 1 as of php 8.0 and the constant will be removed in the future.
-dnl Note that HAVE_JSON was never defined for Windows builds (see config.w32)
-AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])
 PHP_NEW_EXTENSION(json,
 	  json.c \
 	  json_encoder.c \


### PR DESCRIPTION
The json extension is always available as of php 8.0. HAVE_JSON was also never defined for Windows builds.

I'd simply remove this in PHP-8.4, otherwise I can wait with this PR for PHP-9.0 if it's too early for this...