### PR TITLE
ext/curl: Update `sync_constants.php` const matching to uncover more constants

### DIFF
--- a/ext/curl/sync-constants.php
+++ b/ext/curl/sync-constants.php
@@ -25,7 +25,7 @@ const IGNORED_PHP_CONSTANTS = [
     'CURLOPT_SAFE_UPLOAD',
 ];
 
-const CONSTANTS_REGEX_PATTERN = '~^CURL(?:OPT|_VERSION|_HTTP)_[A-Z0-9_]+$~';
+const CONSTANTS_REGEX_PATTERN = '~^CURL(?:E|INFO|OPT|_VERSION|_HTTP)_[A-Z0-9_]+$~';
 
 /**
  * A simple helper to create ASCII tables.


### PR DESCRIPTION
The `sync_constants.php` file uncovers constants present in libcurl source, but not present in PHP ext/curl source. There is a regular expression to match Curl constants, but to it did not previously include `CURLE_*` and `CURLINFO_*` constants, which PHP should expose as constants.

This updates the `sync_constants.php` file's constant filter regex to expose those constants patterns as well. The new missing constants will be added in a later PR.