### PR TITLE
Fix instable array during in-place modification in uksort

### DIFF
--- a/Zend/tests/gh13279.phpt
+++ b/Zend/tests/gh13279.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-13279: Instable array during in-place modification in uksort
+--FILE--
+<?php
+
+// Make sure the array is not const
+$array = [];
+$array['a'] = 1;
+$array['b'] = 2;
+
+uksort($array, function ($a, $b) use (&$array) {
+    return $array[$a] - $array[$b];
+});
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -901,18 +901,10 @@ static void php_usort(INTERNAL_FUNCTION_PARAMETERS, bucket_compare_func_t compar
 		RETURN_TRUE;
 	}
 
-	/* Copy array, so the in-place modifications will not be visible to the callback function.
-	 * Unless there are no other references since we know for sure it won't be visible. */
-	bool in_place = zend_may_modify_arg_in_place(array);
-	if (!in_place) {
-		arr = zend_array_dup(arr);
-	}
+	/* Copy array, so the in-place modifications will not be visible to the callback function */
+	arr = zend_array_dup(arr);
 
 	zend_hash_sort(arr, compare_func, renumber);
-
-	if (in_place) {
-		GC_ADDREF(arr);
-	}
 
 	zval garbage;
 	ZVAL_COPY_VALUE(&garbage, array);


### PR DESCRIPTION
The array isn't just observable if the array has RCn, but also if it is inside a reference that is RCn. By-ref parameters are always RCn and as such always observable.

Fixes GH-13279