### PR TITLE
Use ZEND_API in zend_hrtime

### DIFF
--- a/Zend/zend_hrtime.c
+++ b/Zend/zend_hrtime.c
@@ -31,13 +31,13 @@
 
 # define WIN32_LEAN_AND_MEAN
 
-double zend_hrtime_timer_scale = .0;
+ZEND_API double zend_hrtime_timer_scale = .0;
 
 #elif ZEND_HRTIME_PLATFORM_APPLE
 
 # include <mach/mach_time.h>
 # include <string.h>
-mach_timebase_info_data_t zend_hrtime_timerlib_info = {
+ZEND_API mach_timebase_info_data_t zend_hrtime_timerlib_info = {
 	.numer = 0,
 	.denom = 1,
 };

--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -60,13 +60,13 @@ BEGIN_EXTERN_C()
 
 #if ZEND_HRTIME_PLATFORM_WINDOWS
 
-extern double zend_hrtime_timer_scale;
+ZEND_API extern double zend_hrtime_timer_scale;
 
 #elif ZEND_HRTIME_PLATFORM_APPLE
 
 # include <mach/mach_time.h>
 # include <string.h>
-extern mach_timebase_info_data_t zend_hrtime_timerlib_info;
+ZEND_API extern mach_timebase_info_data_t zend_hrtime_timerlib_info;
 
 #endif
 


### PR DESCRIPTION
This allows actually calling zend_hrtime() from extensions on Windows.

Otherwise zend_hrtime() can just be used on Linux... I suppose it's safe to include it in PHP-8.3 - that shouldn't change ABI, right?