### PR TITLE
random: Move CSPRNG API into php_random_csprng.h

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -81,6 +81,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      the new php_random_result struct, replacing the last_generated_size
      member of the php_random_status struct and the generate_size member of
      the php_random_algo struct.
+   - The CSPRNG API (php_random_(bytes|int)_*) is now provided by the new
+     and much smaller php_random_csprng.h header. The new header is included
+     in php_random.h for compatibility with existing users.
 
  c. ext/xsl
    - The function php_xsl_create_object() was removed as it was not used

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -31,6 +31,7 @@
 
 /* Needed for gmp_random() */
 #include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 
 #define GMP_ROUND_ZERO      0
 #define GMP_ROUND_PLUSINF   1

--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -29,4 +29,4 @@ PHP_NEW_EXTENSION(random,
       gammasection.c \
       randomizer.c,
       no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-PHP_INSTALL_HEADERS([ext/random], [php_random.h php_random_uint128.h])
+PHP_INSTALL_HEADERS([ext/random], [php_random.h php_random_csprng.h php_random_uint128.h])

--- a/ext/random/config.w32
+++ b/ext/random/config.w32
@@ -1,4 +1,4 @@
 EXTENSION("random", "random.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 PHP_RANDOM="yes";
 ADD_SOURCES(configure_module_dirname, "csprng.c engine_combinedlcg.c engine_mt19937.c engine_pcgoneseq128xslrr64.c engine_xoshiro256starstar.c engine_secure.c engine_user.c gammasection.c randomizer.c", "random");
-PHP_INSTALL_HEADERS("ext/random", "php_random.h php_random_uint128.h");
+PHP_INSTALL_HEADERS("ext/random", "php_random.h php_random_csprng.h php_random_uint128.h");

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -28,6 +28,7 @@
 #include "Zend/zend_exceptions.h"
 
 #include "php_random.h"
+#include "php_random_csprng.h"
 
 #if HAVE_UNISTD_H
 # include <unistd.h>

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -29,6 +29,7 @@
 
 #include "php.h"
 #include "php_random.h"
+#include "php_random_csprng.h"
 
 #include "Zend/zend_exceptions.h"
 

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -22,6 +22,7 @@
 
 #include "php.h"
 #include "php_random.h"
+#include "php_random_csprng.h"
 #include "php_random_uint128.h"
 
 #include "Zend/zend_exceptions.h"

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -23,6 +23,7 @@
 
 #include "php.h"
 #include "php_random.h"
+#include "php_random_csprng.h"
 
 #include "Zend/zend_exceptions.h"
 

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -32,6 +32,7 @@
 # define PHP_RANDOM_H
 
 # include "php.h"
+# include "php_random_csprng.h"
 # include "php_random_uint128.h"
 
 PHPAPI double php_combined_lcg(void);
@@ -64,29 +65,6 @@ PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max);
 
 PHPAPI void php_srand(zend_long seed);
 PHPAPI zend_long php_rand(void);
-
-PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
-PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
-
-static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
-{
-	return php_random_bytes(bytes, size, true);
-}
-
-static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
-{
-	return php_random_bytes(bytes, size, false);
-}
-
-static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
-{
-	return php_random_int(min, max, result, true);
-}
-
-static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
-{
-	return php_random_int(min, max, result, false);
-}
 
 typedef struct _php_random_status_ {
 	void *state;

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -10,47 +10,37 @@
    | obtain it through the world-wide-web, please send a note to          |
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
-   | Authors: Sammy Kaye Powers <me@sammyk.me>                            |
+   | Authors: Tim Düsterhus <timwolla@php.net>                            |
    |          Go Kudo <zeriyoshi@php.net>                                 |
    +----------------------------------------------------------------------+
 */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#ifndef PHP_RANDOM_CSPRNG_H
+# define PHP_RANDOM_CSPRNG_H
 
-#include "php.h"
-#include "php_random.h"
-#include "php_random_csprng.h"
+# include "php.h"
 
-#include "Zend/zend_exceptions.h"
+PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 
-static php_random_result generate(php_random_status *status)
+static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
 {
-	zend_ulong r = 0;
-
-	php_random_bytes_throw(&r, sizeof(zend_ulong));
-
-	return (php_random_result){
-		.size = sizeof(zend_ulong),
-		.result = r,
-	};
+	return php_random_bytes(bytes, size, true);
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
 {
-	zend_long result = 0;
-
-	php_random_int_throw(min, max, &result);
-
-	return result;
+	return php_random_bytes(bytes, size, false);
 }
 
-const php_random_algo php_random_algo_secure = {
-	0,
-	NULL,
-	generate,
-	range,
-	NULL,
-	NULL
-};
+static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
+{
+	return php_random_int(min, max, result, true);
+}
+
+static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
+{
+	return php_random_int(min, max, result, false);
+}
+
+#endif	/* PHP_RANDOM_CSPRNG_H */

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -30,6 +30,7 @@
 #include "Zend/zend_exceptions.h"
 
 #include "php_random.h"
+#include "php_random_csprng.h"
 
 #if HAVE_UNISTD_H
 # include <unistd.h>

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -27,7 +27,7 @@
 #include "php_reflection.h"
 #include "ext/standard/info.h"
 #include "ext/standard/sha1.h"
-#include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 
 #include "zend.h"
 #include "zend_API.h"

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -46,6 +46,7 @@
 #include "ext/standard/basic_functions.h"
 #include "ext/standard/head.h"
 #include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 
 #include "mod_files.h"
 #include "mod_user.h"

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -19,7 +19,7 @@
 #include "php_soap.h"
 #include "ext/standard/base64.h"
 #include "ext/standard/md5.h"
-#include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 #include "ext/hash/php_hash.h"
 
 static char *get_http_header_value_nodup(char *headers, char *type, size_t *len);

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -25,7 +25,7 @@
 #include "base64.h"
 #include "zend_interfaces.h"
 #include "info.h"
-#include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 #ifdef HAVE_ARGON2LIB
 #include "argon2.h"
 #endif

--- a/ext/standard/uniqid.c
+++ b/ext/standard/uniqid.c
@@ -32,6 +32,7 @@
 #endif
 
 #include "ext/random/php_random.h"
+#include "ext/random/php_random_csprng.h"
 
 #ifdef HAVE_GETTIMEOFDAY
 ZEND_TLS struct timeval prev_tv = { 0, 0 };


### PR DESCRIPTION
This allows consumers of just the CSPRNG to include a much smaller header. It also allows to verify at a glance whether a source file might use non-secure randomness.

This commit includes the new header wherever the CSPRNG is used, possibly replacing the inclusion of php_random.h if nothing else is used, but also includes it in the main php_random.h header for compatibility.

Somewhat related to 45f8cfaf104f504340b0073b9736bb50a88d70a1, 2b30f18708b4f73d2c1d29d3a92a606ebdc5ac4c, and
b14dd85dca3b67a5462f5ed9b6aa0dc22beb615c.