### PR TITLE
ext/curl: Fix failing tests due to string changes in libcurl 8.6.0

### DIFF
--- a/ext/curl/tests/bug77946.phpt
+++ b/ext/curl/tests/bug77946.phpt
@@ -34,4 +34,4 @@ curl_multi_close($mh);
 --EXPECTF--
 int(1)
 int(1)
-string(%d) "Protocol %Sunknown%S not supported or disabled in libcurl"
+string(%d) "Protocol %Sunknown%S %rnot supported( or disabled in libcurl)?%r"


### PR DESCRIPTION
Upstream libcurl 8.6.0 contains a change[^1] that caused a test failure. This fixes it by updating the test's `EXPECTF` to use a regex to account for both string patterns.

Replaces #13292.

[^1]: https://github.com/curl/curl/commit/45cf4755e71f#diff-a8a54563608f8155973318f4ddb61d7328dab512b8ff2b5cc48cc76979d4204cL1683