### PR TITLE
Fix url_rewriter.hosts not used for output_add_rewrite_var()

### DIFF
--- a/ext/standard/tests/general_functions/url_rewriting_basic1.phpt
+++ b/ext/standard/tests/general_functions/url_rewriting_basic1.phpt
@@ -1,0 +1,154 @@
+--TEST--
+Test session and output_add_rewrite_var() URL-Rewriting independently
+--EXTENSIONS--
+session
+--INI--
+session.trans_sid_tags="a=href,area=href,frame=src,form="
+url_rewriter.tags="a=href,area=href,frame=src,form="
+--FILE--
+<?php
+$testTags = <<<TEST
+
+<a href=""></a>
+<a href="./foo.php"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"> </form>
+<form action="./foo.php" method="get"></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+TEST;
+
+ob_start();
+
+ini_set('session.trans_sid_hosts', 'session-trans-sid.com');
+ini_set('url_rewriter.hosts', 'url-rewriter.com');
+
+ini_set('session.use_only_cookies', 1);
+ini_set('session.use_cookies', 1);
+ini_set('session.use_strict_mode', 1);
+ini_set('session.use_trans_sid', 0);
+
+output_add_rewrite_var('<name>', '<value>');
+
+echo "URL-Rewriting with output_add_rewrite_var() without transparent session id support\n";
+echo $testTags;
+
+ob_end_flush();
+
+
+ini_set('session.use_only_cookies', 0);
+ini_set('session.use_cookies', 0);
+ini_set('session.use_strict_mode', 0);
+ini_set('session.use_trans_sid', 1);
+
+session_id('testid');
+session_start();
+
+echo "\nURL-Rewriting with transparent session id support without output_add_rewrite_var()\n";
+echo $testTags;
+
+--EXPECT--
+URL-Rewriting with output_add_rewrite_var() without transparent session id support
+
+<a href="?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="./foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="http://url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="http://url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+URL-Rewriting with transparent session id support without output_add_rewrite_var()
+
+<a href="?PHPSESSID=testid"></a>
+<a href="./foo.php?PHPSESSID=testid"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="http://session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="PHPSESSID" value="testid" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>

--- a/ext/standard/tests/general_functions/url_rewriting_basic2.phpt
+++ b/ext/standard/tests/general_functions/url_rewriting_basic2.phpt
@@ -1,0 +1,203 @@
+--TEST--
+Test output_add_rewrite_var() with and without nested session URL-Rewriting
+--EXTENSIONS--
+session
+--INI--
+session.trans_sid_tags="a=href,area=href,frame=src,form="
+url_rewriter.tags="a=href,area=href,frame=src,form="
+--FILE--
+<?php
+$testTags = <<<TEST
+
+<a href=""></a>
+<a href="./foo.php"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"> </form>
+<form action="./foo.php" method="get"></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+TEST;
+
+ob_start();
+
+ini_set('session.trans_sid_hosts', 'session-trans-sid.com');
+ini_set('url_rewriter.hosts', 'url-rewriter.com');
+
+ini_set('session.use_only_cookies', 1);
+ini_set('session.use_cookies', 1);
+ini_set('session.use_strict_mode', 0);
+ini_set('session.use_trans_sid', 0);
+
+output_add_rewrite_var('<name>', '<value>');
+
+echo "URL-Rewriting with output_add_rewrite_var() without transparent session id support\n";
+echo $testTags;
+
+ob_flush();
+
+output_reset_rewrite_vars();
+
+ini_set('session.use_only_cookies', 0);
+ini_set('session.use_cookies', 0);
+ini_set('session.use_strict_mode', 0);
+ini_set('session.use_trans_sid', 1);
+
+session_id('testid');
+session_start();
+
+output_add_rewrite_var('<NAME>', '<VALUE>');
+
+echo "\nURL-Rewriting with transparent session id support without output_add_rewrite_var()\n";
+echo $testTags;
+
+ob_end_flush();
+
+
+output_add_rewrite_var('<name2>', '<value2>');
+
+echo "\nURL-Rewriting with output_add_rewrite_var() without transparent session id support\n";
+echo $testTags;
+
+--EXPECT--
+URL-Rewriting with output_add_rewrite_var() without transparent session id support
+
+<a href="?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="./foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="http://url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="http://url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+URL-Rewriting with transparent session id support without output_add_rewrite_var()
+
+<a href="?PHPSESSID=testid&%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="./foo.php?PHPSESSID=testid&%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="http://session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="http://url-rewriter.com/foo.php?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /><input type="hidden" name="PHPSESSID" value="testid" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /><input type="hidden" name="PHPSESSID" value="testid" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /></form>
+<form action="http://url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+URL-Rewriting with output_add_rewrite_var() without transparent session id support
+
+<a href="?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="./foo.php?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="http://url-rewriter.com/foo.php?%3CNAME%3E=%3CVALUE%3E&%3Cname2%3E=%3Cvalue2%3E"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /></form>
+<form action="http://url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;NAME&gt;" value="&lt;VALUE&gt;" /><input type="hidden" name="&lt;name2&gt;" value="&lt;value2&gt;" /></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>

--- a/ext/standard/tests/general_functions/url_rewriting_basic3.phpt
+++ b/ext/standard/tests/general_functions/url_rewriting_basic3.phpt
@@ -1,0 +1,196 @@
+--TEST--
+Test session URL-Rewriting with and without nested output_add_rewrite_var()
+--EXTENSIONS--
+session
+--INI--
+session.trans_sid_tags="a=href,area=href,frame=src,form="
+url_rewriter.tags="a=href,area=href,frame=src,form="
+--FILE--
+<?php
+$testTags = <<<TEST
+
+<a href=""></a>
+<a href="./foo.php"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php"></a>
+<a href="http://session-trans-sid.com/foo.php"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"> </form>
+<form action="./foo.php" method="get"></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+TEST;
+
+ob_start();
+
+ini_set('session.trans_sid_hosts', 'session-trans-sid.com');
+ini_set('url_rewriter.hosts', 'url-rewriter.com');
+
+ini_set('session.use_only_cookies', 0);
+ini_set('session.use_cookies', 0);
+ini_set('session.use_strict_mode', 0);
+ini_set('session.use_trans_sid', 1);
+
+session_id('testid');
+session_start();
+
+echo "URL-Rewriting with transparent session id support without output_add_rewrite_var()\n";
+echo $testTags;
+
+ob_flush();
+
+
+output_add_rewrite_var('<name>', '<value>');
+
+echo "\nURL-Rewriting with transparent session id support and output_add_rewrite_var()\n";
+echo $testTags;
+
+ob_end_flush();
+output_reset_rewrite_vars();
+
+
+output_add_rewrite_var('<name2>', '<value2>');
+
+echo "\nURL-Rewriting with transparent session id support without output_add_rewrite_var()\n";
+echo $testTags;
+
+--EXPECT--
+URL-Rewriting with transparent session id support without output_add_rewrite_var()
+
+<a href="?PHPSESSID=testid"></a>
+<a href="./foo.php?PHPSESSID=testid"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="http://session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="PHPSESSID" value="testid" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+URL-Rewriting with transparent session id support and output_add_rewrite_var()
+
+<a href="?%3Cname%3E=%3Cvalue%3E&PHPSESSID=testid"></a>
+<a href="./foo.php?%3Cname%3E=%3Cvalue%3E&PHPSESSID=testid"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="http://session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="http://url-rewriter.com/foo.php?%3Cname%3E=%3Cvalue%3E"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="PHPSESSID" value="testid" /><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="http://url-rewriter.com/bar.php" method="get"><input type="hidden" name="&lt;name&gt;" value="&lt;value&gt;" /></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>
+
+URL-Rewriting with transparent session id support without output_add_rewrite_var()
+
+<a href="?PHPSESSID=testid"></a>
+<a href="./foo.php?PHPSESSID=testid"></a>
+
+<a href="//php.net/foo.php"></a>
+<a href="http://php.net/foo.php"></a>
+<a href="bad://php.net/foo.php"></a>
+<a href="//www.php.net/foo.php"></a>
+
+<a href="//session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="http://session-trans-sid.com/foo.php?PHPSESSID=testid"></a>
+<a href="bad://session-trans-sid.com/foo.php"></a>
+<a href="//www.session-trans-sid.com/foo.php"></a>
+
+<a href="//url-rewriter.com/foo.php"></a>
+<a href="http://url-rewriter.com/foo.php"></a>
+<a href="bad://url-rewriter.com/foo.php"></a>
+<a href="//www.url-rewriter.com/foo.php"></a>
+
+<form action="" method="get"><input type="hidden" name="PHPSESSID" value="testid" /> </form>
+<form action="./foo.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+
+<form action="//php.net/foo.php" method="get"></form>
+<form action="http://php.net/foo.php" method="get"></form>
+<form action="bad://php.net/foo.php" method="get"></form>
+<form action="//www.php.net/foo.php" method="get"></form>
+
+<form action="//session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="http://session-trans-sid.com/bar.php" method="get"><input type="hidden" name="PHPSESSID" value="testid" /></form>
+<form action="bad://session-trans-sid.com/bar.php" method="get"></form>
+<form action="//www.session-trans-sid.com/bar.php" method="get"></form>
+
+<form action="//url-rewriter.com/bar.php" method="get"></form>
+<form action="http://url-rewriter.com/bar.php" method="get"></form>
+<form action="bad://url-rewriter.com/bar.php" method="get"></form>
+<form action="//www.url-rewriter.com/bar.php" method="get"></form>

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -180,7 +180,7 @@ alphadash = ([a-zA-Z] | "-");
 #define YYLIMIT q
 #define YYMARKER r
 
-static inline void append_modified_url(smart_str *url, smart_str *dest, smart_str *url_app, const char *separator)
+static inline void append_modified_url(smart_str *url, smart_str *dest, smart_str *url_app, const char *separator, int type)
 {
 	php_url *url_parts;
 
@@ -212,7 +212,8 @@ static inline void append_modified_url(smart_str *url, smart_str *dest, smart_st
 	/* Check host whitelist. If it's not listed, do nothing. */
 	if (url_parts->host) {
 		zend_string *tmp = zend_string_tolower(url_parts->host);
-		if (!zend_hash_exists(&BG(url_adapt_session_hosts_ht), tmp)) {
+		HashTable *allowed_hosts = type ? &BG(url_adapt_session_hosts_ht) : &BG(url_adapt_output_hosts_ht);
+		if (!zend_hash_exists(allowed_hosts, tmp)) {
 			zend_string_release_ex(tmp, 0);
 			smart_str_append_smart_str(dest, url);
 			php_url_free(url_parts);
@@ -305,7 +306,7 @@ static inline void tag_arg(url_adapt_state_ex_t *ctx, char quotes, char type)
 		smart_str_appendc(&ctx->result, type);
 	}
 	if (f) {
-		append_modified_url(&ctx->val, &ctx->result, &ctx->url_app, PG(arg_separator).output);
+		append_modified_url(&ctx->val, &ctx->result, &ctx->url_app, PG(arg_separator).output, ctx->type);
 	} else {
 		smart_str_append_smart_str(&ctx->result, &ctx->val);
 	}
@@ -606,7 +607,7 @@ PHPAPI char *php_url_scanner_adapt_single_url(const char *url, size_t urllen, co
 		smart_str_appends(&url_app, value);
 	}
 
-	append_modified_url(&surl, &buf, &url_app, PG(arg_separator).output);
+	append_modified_url(&surl, &buf, &url_app, PG(arg_separator).output, 1);
 
 	smart_str_0(&buf);
 	if (newlen) *newlen = ZSTR_LEN(buf.s);
@@ -747,6 +748,7 @@ static inline int php_url_scanner_add_var_impl(const char *name, size_t name_len
 		php_url_scanner_ex_activate(type);
 		php_output_start_internal(ZEND_STRL("URL-Rewriter"), handler, 0, PHP_OUTPUT_HANDLER_STDFLAGS);
 		url_state->active = 1;
+		url_state->type = type;
 	}
 
 	if (url_state->url_app.s && ZSTR_LEN(url_state->url_app.s) != 0) {


### PR DESCRIPTION
Fixes the bug where `output_add_rewrite_var()` is using the hosts set in `session.trans_sid_hosts` instead of the `url_rewriter.hosts` which was added specifically for this purpose.