### PR TITLE
GitHub Actions: Add a timeout to Caddy server download

### DIFF
--- a/.github/actions/setup-caddy/action.yml
+++ b/.github/actions/setup-caddy/action.yml
@@ -5,6 +5,6 @@ runs:
     - shell: bash
       run: |
         set -x
-        sudo curl 'https://caddyserver.com/api/download?os=linux&arch=amd64' -o /usr/bin/caddy
+        sudo curl 'https://caddyserver.com/api/download?os=linux&arch=amd64' --max-time 120 --retry-delay 10 --retry 3 -o /usr/bin/caddy
         sudo chmod +x /usr/bin/caddy
         sudo caddy start --config ext/curl/tests/Caddyfile


### PR DESCRIPTION
Currently, `caddyserver.com/api/download` times out, which causes all our CI runs on Linux to fail after trying for 30 seconds.

Further, the caddy website also mentions the site is experiencing issues and there is no SLA.

Ideally, we are probably better off using Caddy's GitHub Releases page, but the URL patterns are difficult to build, so this timeout tries to avoid the CI jobs waiting nearly 30 minutes before giving up. This change adds 120 second hard timeout, and adds three retries 10 seconds apart. 