### PR TITLE
ci: update caddy job to use GitHub Releases

### DIFF
--- a/.github/actions/setup-caddy/action.yml
+++ b/.github/actions/setup-caddy/action.yml
@@ -3,8 +3,10 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -x
-        sudo curl 'https://caddyserver.com/api/download?os=linux&arch=amd64' -o /usr/bin/caddy
+        gh release -R caddyserver/caddy download --pattern 'caddy_*_linux_amd64.tar.gz' -O - | sudo tar -xz -C /usr/bin caddy
         sudo chmod +x /usr/bin/caddy
         sudo caddy start --config ext/curl/tests/Caddyfile


### PR DESCRIPTION
The caddyserver.com download page is unreliable, and it also recommends to use GitHub releases instead.
Replaces #13295.