### PR TITLE
Update GitHub Action workflows to `actions/upload-artifact@v4`

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -46,7 +46,7 @@ runs:
           --show-diff \
           --show-slow 1000 \
           --set-timeout 120
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always() && inputs.testArtifacts != null
       with:
         name: ${{ github.job }}_${{ inputs.testArtifacts }}

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -28,7 +28,7 @@ runs:
           --show-diff \
           --show-slow 1000 \
           --set-timeout 120
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always() && inputs.testArtifacts != null
       with:
         name: ${{ github.job }}_${{ inputs.testArtifacts }}


### PR DESCRIPTION
Primarily running this through a PR to check that the breaking changes do not affect us.

------------------

Keep this up to date in all non-security-only branches, because the node.js runtime for older versions might get deprecated in the future and fixing this for all branches at once is easier.