### PR TITLE
Add macos-14 to the push and nightly workflows

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -31,6 +31,7 @@ runs:
           tidy-html5 \
           libxml2 \
           libjpeg \
+          libsodium \
           libxslt \
           postgresql
         brew link icu4c gettext --force

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -9,15 +9,16 @@ runs:
     - shell: bash
       run: |
         set -x
-        export PATH="/usr/local/opt/bison/bin:$PATH"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/curl/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/krb5/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libffi/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxml2/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxslt/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
+        BREW_OPT="$(brew --prefix)"/opt
+        export PATH="$BREW_OPT/bison/bin:$PATH"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/openssl@1.1/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/curl/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/krb5/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libffi/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libxml2/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libxslt/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/zlib/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/icu4c/lib/pkgconfig"
         ./buildconf --force
         ./configure \
           --enable-option-checking=fatal \
@@ -25,8 +26,8 @@ runs:
           --enable-fpm \
           --with-pdo-mysql=mysqlnd \
           --with-mysqli=mysqlnd \
-          --with-pgsql=/usr/local/opt/libpq \
-          --with-pdo-pgsql=/usr/local/opt/libpq \
+          --with-pgsql="$BREW_OPT"/libpq \
+          --with-pdo-pgsql="$BREW_OPT"/libpq \
           --with-pdo-sqlite \
           --without-pear \
           --enable-gd \
@@ -39,21 +40,21 @@ runs:
           --enable-soap \
           --enable-xmlreader \
           --with-xsl \
-          --with-tidy=/usr/local/opt/tidy-html5 \
+          --with-tidy="$BREW_OPT"/tidy-html5 \
           --with-libxml \
           --enable-sysvsem \
           --enable-sysvshm \
           --enable-shmop \
           --enable-pcntl \
-          --with-readline=/usr/local/opt/readline \
+          --with-readline="$BREW_OPT"/readline \
           --enable-mbstring \
           --with-curl \
-          --with-gettext=/usr/local/opt/gettext \
+          --with-gettext="$BREW_OPT"/gettext \
           --enable-sockets \
-          --with-bz2=/usr/local/opt/bzip2 \
+          --with-bz2="$BREW_OPT"/bzip2 \
           --with-openssl \
-          --with-gmp=/usr/local/opt/gmp \
-          --with-iconv=/usr/local/opt/libiconv \
+          --with-gmp="$BREW_OPT"/gmp \
+          --with-iconv="$BREW_OPT"/libiconv \
           --enable-bcmath \
           --enable-calendar \
           --enable-ftp \

--- a/.github/actions/verify-generated-files/action.yml
+++ b/.github/actions/verify-generated-files/action.yml
@@ -5,7 +5,7 @@ runs:
     - shell: bash
       run: |
         set -x
-        [[ "$OSTYPE" == "darwin"* ]] && export PATH="/usr/local/opt/bison/bin:$PATH"
+        [[ "$OSTYPE" == "darwin"* ]] && export PATH="$(brew --prefix)/opt/bison/bin:$PATH"
         scripts/dev/credits
         scripts/dev/genfiles
         Zend/zend_vm_gen.php

--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -103,7 +103,7 @@ function get_macos_matrix_include(array $branches) {
                     'os' => $branch === 'master' ? '13' : '12',
                     'arch' => 'X64',
                 ];
-                if($branch['name'] === 'master') {
+                if($branch['version']['minor'] === 4) {
                     $jobs[] = [
                         'branch' => $branch,
                         'debug' => $debug,

--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -101,7 +101,7 @@ function get_macos_matrix_include(array $branches) {
                     'debug' => $debug,
                     'zts' => $zts,
                     'os' => $branch === 'master' ? '13' : '12',
-                    'arch' => 'X32',
+                    'arch' => 'X64',
                 ];
                 if($branch['name'] === 'master') {
                     $jobs[] = [

--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -103,7 +103,7 @@ function get_macos_matrix_include(array $branches) {
                     'os' => $branch === 'master' ? '13' : '12',
                     'arch' => 'X64',
                 ];
-                if($branch['version']['minor'] === 4) {
+                if ($branch['version']['minor'] >= 4 || $branch['version']['major'] >= 9) {
                     $jobs[] = [
                         'branch' => $branch,
                         'debug' => $debug,

--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -91,6 +91,33 @@ function get_windows_matrix_include(array $branches) {
     return $jobs;
 }
 
+function get_macos_matrix_include(array $branches) {
+    $jobs = [];
+    foreach ($branches as $branch) {
+        foreach([true, false] as $debug) {
+            foreach([true, false] as $zts) {
+                $jobs[] = [
+                    'branch' => $branch,
+                    'debug' => $debug,
+                    'zts' => $zts,
+                    'os' => $branch === 'master' ? '13' : '12',
+                    'arch' => 'X32',
+                ];
+                if($branch['name'] === 'master') {
+                    $jobs[] = [
+                        'branch' => $branch,
+                        'debug' => $debug,
+                        'zts' => $zts,
+                        'os' => '14',
+                        'arch' => 'ARM64',
+                    ];
+                }
+            }
+        }
+    }
+    return $jobs;
+}
+
 function get_current_version(): array {
     $file = dirname(__DIR__) . '/main/php_version.h';
     $content = file_get_contents($file);
@@ -114,9 +141,11 @@ $branches = $branch === 'master'
     : [['name' => strtoupper($branch), 'ref' => $branch, 'version' => get_current_version()]];
 $matrix_include = get_matrix_include($branches);
 $windows_matrix_include = get_windows_matrix_include($branches);
+$macos_matrix_include = get_macos_matrix_include($branches);
 
 $f = fopen(getenv('GITHUB_OUTPUT'), 'a');
 fwrite($f, 'branches=' . json_encode($branches, JSON_UNESCAPED_SLASHES) . "\n");
 fwrite($f, 'matrix-include=' . json_encode($matrix_include, JSON_UNESCAPED_SLASHES) . "\n");
 fwrite($f, 'windows-matrix-include=' . json_encode($windows_matrix_include, JSON_UNESCAPED_SLASHES) . "\n");
+fwrite($f, 'macos-matrix-include=' . json_encode($macos_matrix_include, JSON_UNESCAPED_SLASHES) . "\n");
 fclose($f);

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -249,7 +249,7 @@ jobs:
             --${{ matrix.zts && 'enable' || 'disable' }}-zts
       - name: make
         run: |-
-          export PATH="/usr/local/opt/bison/bin:$PATH"
+          export PATH="$(brew --prefix)/opt/bison/bin:$PATH"
           make -j$(sysctl -n hw.logicalcpu) >/dev/null
       - name: make install
         run: sudo make install

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,7 @@ jobs:
       branches: ${{ steps.set-matrix.outputs.branches }}
       matrix-include: ${{ steps.set-matrix.outputs.matrix-include }}
       windows-matrix-include: ${{ steps.set-matrix.outputs.windows-matrix-include }}
+      macos-matrix-include: ${{ steps.set-matrix.outputs.macos-matrix-include }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -230,11 +231,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJson(needs.GENERATE_MATRIX.outputs.branches) }}
-        debug: [true, false]
-        zts: [true, false]
-    name: "${{ matrix.branch.name }}_MACOS_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: macos-${{ matrix.branch.version.minor >= 4 && '13' || '12' }}
+        include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.macos-matrix-include) }}
+    name: "${{ matrix.branch.name }}_MACOS_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
+    runs-on: macos-${{ matrix.os }}
     steps:
       - name: git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -256,11 +256,11 @@ jobs:
       - name: Test
         uses: ./.github/actions/test-macos
         with:
-          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}
+          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}
       - name: Test Tracing JIT
         uses: ./.github/actions/test-macos
         with:
-          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Tracing JIT
+          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Tracing JIT
           jitType: tracing
           runTestsParameters: >-
             -d zend_extension=opcache.so
@@ -268,14 +268,14 @@ jobs:
       - name: Test OpCache
         uses: ./.github/actions/test-macos
         with:
-          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} OpCache
+          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} OpCache
           runTestsParameters: >-
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
       - name: Test Function JIT
         uses: ./.github/actions/test-macos
         with:
-          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Function JIT
+          testArtifacts: ${{ matrix.branch.name }}_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Function JIT
           jitType: function
           runTestsParameters: >-
             -d zend_extension=opcache.so

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -150,8 +150,12 @@ jobs:
   MACOS_DEBUG_NTS:
     strategy:
       matrix:
-        os: [13, 14]
-    name: MACOS_DEBUG_NTS_${{ matrix.os }}
+        include:
+          - os: 13
+            arch: X32
+          - os: 14
+            arch: ARM64
+    name: MACOS_${{ matrix.arch }}_DEBUG_NTS
     runs-on: macos-${{ matrix.os }}
     steps:
       - name: git checkout

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -149,6 +149,7 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: 13

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Test Tracing JIT
         uses: ./.github/actions/test-macos
         with:
-          testArtifacts: ${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Tracing JIT
+          testArtifacts: ${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }} Tracing JIT
           jitType: tracing
           runTestsParameters: >-
             -d zend_extension=opcache.so

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -174,7 +174,7 @@ jobs:
           configurationParameters: --enable-debug --disable-zts
       - name: make
         run: |-
-          export PATH="/usr/local/opt/bison/bin:$PATH"
+          export PATH="$(brew --prefix)/opt/bison/bin:$PATH"
           make -j$(sysctl -n hw.logicalcpu) >/dev/null
       - name: make install
         run: sudo make install

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -165,7 +165,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "${{github.job}}-${{hashFiles('main/php_version.h')}}"
+          key: "${{github.job}}-${{matrix.os}}-${{hashFiles('main/php_version.h')}}"
           append-timestamp: false
       - name: ./configure
         uses: ./.github/actions/configure-macos

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -148,7 +148,11 @@ jobs:
         if: ${{ !matrix.asan }}
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
-    runs-on: macos-13
+    strategy:
+      matrix:
+        os: [13, 14]
+    name: MACOS_DEBUG_NTS_${{ matrix.os }}
+    runs-on: macos-${{ matrix.os }}
     steps:
       - name: git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -153,7 +153,7 @@ jobs:
       matrix:
         include:
           - os: 13
-            arch: X32
+            arch: X64
           - os: 14
             arch: ARM64
     name: MACOS_${{ matrix.arch }}_DEBUG_NTS


### PR DESCRIPTION
Adding `macos-14` to the push and nightly workflows to test with arm64 architecture.
Ref: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

------------------

This PR also does the following

- Added `libsodium` to the `brew` action as it is not installed on `macos-14` by default.
- Replaced hardcoded brew path in `configure-macos` action as brew's prefix is different in `macos-14`.