### PR TITLE
Zend,fibers: Ensure fiber stack is not backed by THP.

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -244,6 +244,12 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
 		return NULL;
 	}
 
+#if defined(MADV_NOHUGEPAGE)
+	/* Multiple reasons to fail, ignore all errors only needed
+	 * for linux < 6.8 */
+	(void) madvise(pointer, alloc_size, MADV_NOHUGEPAGE);
+#endif
+
 	zend_mmap_set_name(pointer, alloc_size, "zend_fiber_stack");
 
 # if ZEND_FIBER_GUARD_PAGES


### PR DESCRIPTION
Ending with fiber stack mapped in hugepages will affect performance badly.
Until < Linux 6.8-rc2 MAP_STACK was a noop, now it implies no THP, older releases need madvise.