### PR TITLE
random: Do not hardcode the target type when invoking the CSPRNG

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -240,7 +240,7 @@ PHPAPI void php_random_mt19937_seed_default(php_random_status_state_mt19937 *sta
 {
 	zend_long seed = 0;
 
-	if (php_random_bytes_silent(&seed, sizeof(zend_long)) == FAILURE) {
+	if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
 		seed = GENERATE_SEED();
 	}
 
@@ -277,7 +277,7 @@ PHP_METHOD(Random_Engine_Mt19937, __construct)
 
 	if (seed_is_null) {
 		/* MT19937 has a very large state, uses CSPRNG for seeding only */
-		if (php_random_bytes_throw(&seed, sizeof(zend_long)) == FAILURE) {
+		if (php_random_bytes_throw(&seed, sizeof(seed)) == FAILURE) {
 			zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 			RETURN_THROWS();
 		}

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -29,7 +29,7 @@ static php_random_result generate(php_random_status *status)
 {
 	zend_ulong r = 0;
 
-	php_random_bytes_throw(&r, sizeof(zend_ulong));
+	php_random_bytes_throw(&r, sizeof(r));
 
 	return (php_random_result){
 		.size = sizeof(zend_ulong),


### PR DESCRIPTION
Instead derive the number of bytes to retrieve from the variable that is being filled.