### PR TITLE
random: Reuse the seed128/seed256 helpers when seeding using the CSPRNG

### DIFF
--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -154,10 +154,14 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (seed_is_null) {
-		if (php_random_bytes_throw(&state->state, sizeof(state->state)) == FAILURE) {
+		php_random_uint128_t s;
+
+		if (php_random_bytes_throw(&s, sizeof(s)) == FAILURE) {
 			zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 			RETURN_THROWS();
 		}
+
+		seed128(state, s);
 	} else {
 		if (str_seed) {
 			/* char (byte: 8 bit) * 16 = 128 bits */

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -216,12 +216,16 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (seed_is_null) {
+		uint64_t t[4];
+
 		do {
-			if (php_random_bytes_throw(&state->state, sizeof(state->state)) == FAILURE) {
+			if (php_random_bytes_throw(&t, sizeof(t)) == FAILURE) {
 				zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 				RETURN_THROWS();
 			}
-		} while (UNEXPECTED(state->state[0] == 0 && state->state[1] == 0 && state->state[2] == 0 && state->state[3] == 0));
+		} while (UNEXPECTED(t[0] == 0 && t[1] == 0 && t[2] == 0 && t[3] == 0));
+
+		seed256(state, t[0], t[1], t[2], t[3]);
 	} else {
 		if (str_seed) {
 			/* char (byte: 8 bit) * 32 = 256 bits */


### PR DESCRIPTION
Instead of writing to the engine's state struct directly, use the helpers for consistency.