### PR TITLE
Fix GH-10232 autoload during constant resolution.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.2.17
 
+- Core:
+  . Fixed bug GH-10232 (if autoloading occurs during constant resolution
+    filename and lineno are identified incorrectly). (ranvis)
+
 - Curl:
   . Fix failing tests due to string changes in libcurl 8.6.0. (Ayesh)
 

--- a/Zend/tests/gh10232.phpt
+++ b/Zend/tests/gh10232.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-10232 (Weird behaviour when a file is autoloaded in assignment of a constant)
+--FILE--
+<?php
+
+set_include_path('gh10232-nonexistent') or exit(1);
+chdir(__DIR__) or exit(1);
+
+spl_autoload_register(function () {
+    trigger_error(__LINE__);
+    $ex = new Exception();
+    echo 'Exception on line ', $ex->getLine(), "\n";
+    require_once __DIR__ . '/gh10232/constant_def.inc';
+}, true);
+
+
+class ConstantRef
+{
+    public const VALUE = ConstantDef::VALUE;
+}
+
+ConstantRef::VALUE;
+
+?>
+--EXPECTF--
+Notice: 7 in %sgh10232.php on line 7
+Exception on line 8
+
+Notice: constant_def.inc in %sconstant_def.inc on line 3
+Exception in constant_def.inc on line 4
+
+Notice: required.inc in %srequired.inc on line 3
+Exception in required.inc on line 4

--- a/Zend/tests/gh10232/constant_def.inc
+++ b/Zend/tests/gh10232/constant_def.inc
@@ -1,0 +1,12 @@
+<?php
+
+trigger_error(basename(__FILE__));
+$ex = new Exception();
+echo 'Exception in ', basename($ex->getFile()), ' on line ', $ex->getLine(), "\n";
+
+require_once 'required.inc'; // The script of the same directory.
+
+class ConstantDef
+{
+    const VALUE = true;
+}

--- a/Zend/tests/gh10232/required.inc
+++ b/Zend/tests/gh10232/required.inc
@@ -1,0 +1,5 @@
+<?php
+
+trigger_error(basename(__FILE__));
+$ex = new Exception();
+echo 'Exception in ', basename($ex->getFile()), ' on line ', $ex->getLine(), "\n";

--- a/Zend/tests/gh7771_3.phpt
+++ b/Zend/tests/gh7771_3.phpt
@@ -12,5 +12,5 @@ spl_autoload_register(function($class) use ($classlist) {
 var_dump(D::HW);
 ?>
 --EXPECTF--
-Fatal error: Constant expression contains invalid operations in %sgh7771_3.php(7) : eval()'d code(1) : eval()'d code on line 1
+Fatal error: Constant expression contains invalid operations in %sgh7771_3.php(7) : eval()'d code on line 1
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1205,9 +1205,15 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 		autoload_name = zend_string_copy(name);
 	}
 
+	zend_string *previous_filename = EG(filename_override);
+	zend_long previous_lineno = EG(lineno_override);
+	EG(filename_override) = NULL;
+	EG(lineno_override) = -1;
 	zend_exception_save();
 	ce = zend_autoload(autoload_name, lc_name);
 	zend_exception_restore();
+	EG(filename_override) = previous_filename;
+	EG(lineno_override) = previous_lineno;
 
 	zend_string_release_ex(autoload_name, 0);
 	zend_hash_del(EG(in_autoload), lc_name);


### PR DESCRIPTION
The fix and test for #10232.

The filename and line number are incorrect when userland code is executed during constant expression resolution, resulting in the failure of `include` functions.

https://3v4l.org/v4nl0