### PR TITLE
Fix GH-13309: array hashes comparison, wrong buffer len calculation.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.2.17
 
+- Core:
+  . Fixed array key as string (case insensitive) comparison typo
+    for the second operand buffer size. (A. Slepykh)
+
 - Curl:
   . Fix failing tests due to string changes in libcurl 8.6.0. (Ayesh)
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -188,7 +188,7 @@ static zend_always_inline int php_array_key_compare_string_case_unstable_i(Bucke
 		l2 = s->key->len;
 	} else {
 		s2 = zend_print_long_to_buf(buf2 + sizeof(buf2) - 1, s->h);
-		l2 = buf2 + sizeof(buf2) - 1 - s1;
+		l2 = buf2 + sizeof(buf2) - 1 - s2;
 	}
 	return zend_binary_strcasecmp_l(s1, l1, s2, l2);
 }


### PR DESCRIPTION
php_array_key_compare_string_case_unstable_i has a typo for the second operand resulting in a wrong buffer size calculation.

Issue reported by @AlexRudyuk