### PR TITLE
GH-12940 ext/pdo_pgsql: using PQclosePrepared to free statement resou…

### DIFF
--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -19,6 +19,12 @@ if test "$PHP_PDO_PGSQL" != "no"; then
       or later).])],,
     [$PGSQL_LIBS])
 
+  PHP_CHECK_LIBRARY([pq], [PQclosePrepared],
+    [AC_DEFINE([HAVE_PQCLOSEPREPARED], [1],
+      [Define to 1 if libpq has the 'PQclosePrepared' function (PostgreSQL 17
+      or later).])],,
+    [$PGSQL_LIBS])
+
   PHP_CHECK_PDO_INCLUDES
 
   PHP_NEW_EXTENSION([pdo_pgsql],


### PR DESCRIPTION
…rces.

PQclosePrepared allows the statement's name to be reused thus allowing cache solutions to work properly ; whereas, for now, the `DEALLOCATE <statement>` query is used frees entirely the statement's resources.