### PR TITLE
zend call stack fixing stack limit for macOs arm64.

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_010.phpt
+++ b/Zend/tests/stack_limit/stack_limit_010.phpt
@@ -15,7 +15,10 @@ $stack = zend_test_zend_call_stack_get();
 var_dump($stack);
 
 $expectedMaxSize = match(php_uname('s')) {
-    'Darwin' => 8*1024*1024,
+    'Darwin' => match(php_uname('m')) {
+        'x86_64' => 8*1024*1024,
+        'arm64' => 8372224,
+    },
     'FreeBSD' => match(php_uname('m')) {
         'amd64' => 512*1024*1024 - 4096,
         'i386' => 64*1024*1024 - 4096,

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -427,6 +427,13 @@ static bool zend_call_stack_get_macos(zend_call_stack *stack)
 	void *base = pthread_get_stackaddr_np(pthread_self());
 	size_t max_size;
 
+#if defined(__aarch64__)
+	/*
+	 * 8 mb for the main thread triggers a stack overflow.
+	 * instead we derive it from pthread_get_stacksize_np.
+	 */
+	max_size = pthread_get_stacksize_np(pthread_self());
+#else
 	if (pthread_main_np()) {
 		/* pthread_get_stacksize_np() returns a too low value for the main
 		 * thread in OSX 10.9, 10.10:
@@ -440,6 +447,7 @@ static bool zend_call_stack_get_macos(zend_call_stack *stack)
 	} else {
 		max_size = pthread_get_stacksize_np(pthread_self());
 	}
+#endif
 
 	stack->base = base;
 	stack->max_size = max_size;


### PR DESCRIPTION
8MB sounded a prudent size for older 10.9 macOs release, however with newer mac with arm64, it triggers a stack overflow.