### PR TITLE
zend call stack fixing stack limit for macOs arm64.

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_010.phpt
+++ b/Zend/tests/stack_limit/stack_limit_010.phpt
@@ -15,7 +15,10 @@ $stack = zend_test_zend_call_stack_get();
 var_dump($stack);
 
 $expectedMaxSize = match(php_uname('s')) {
-    'Darwin' => 8*1024*1024,
+    'Darwin' => match(php_uname('m')) {
+        'x86_64' => 8*1024*1024,
+        'arm64' => 8372224,
+    },
     'FreeBSD' => match(php_uname('m')) {
         'amd64' => 512*1024*1024 - 4096,
         'i386' => 64*1024*1024 - 4096,

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -427,7 +427,9 @@ static bool zend_call_stack_get_macos(zend_call_stack *stack)
 	void *base = pthread_get_stackaddr_np(pthread_self());
 	size_t max_size;
 
-	if (pthread_main_np()) {
+#if !defined(__aarch64__)
+	if (pthread_main_np())
+	{
 		/* pthread_get_stacksize_np() returns a too low value for the main
 		 * thread in OSX 10.9, 10.10:
 		 * https://mail.openjdk.org/pipermail/hotspot-dev/2013-October/011353.html
@@ -437,7 +439,10 @@ static bool zend_call_stack_get_macos(zend_call_stack *stack)
 		/* Stack size is 8MiB by default for main threads
 		 * https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html */
 		max_size = 8 * 1024 * 1024;
-	} else {
+	}
+	else
+#endif
+	{
 		max_size = pthread_get_stacksize_np(pthread_self());
 	}
 


### PR DESCRIPTION
8MB sounded a prudent size for older 10.9 macOs release, however with newer mac with arm64, it triggers a stack overflow.