### PR TITLE
Fix zend_test extension name

### DIFF
--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -1,5 +1,5 @@
 PHP_ARG_ENABLE([zend-test],
-  [whether to enable zend-test extension],
+  [whether to enable zend_test extension],
   [AS_HELP_STRING([--enable-zend-test],
     [Enable zend_test extension])])
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -1207,7 +1207,7 @@ PHP_MSHUTDOWN_FUNCTION(zend_test)
 	zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS_PASSTHRU);
 
 	if (ZT_G(print_stderr_mshutdown)) {
-		fprintf(stderr, "[zend-test] MSHUTDOWN\n");
+		fprintf(stderr, "[zend_test] MSHUTDOWN\n");
 	}
 
 	return SUCCESS;

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -10,4 +10,4 @@ zend_test.print_stderr_mshutdown=1
 ==DONE==
 --EXPECTF--
 ==DONE==
-[zend-test] MSHUTDOWN
+[zend_test] MSHUTDOWN


### PR DESCRIPTION
The zend_test extension was renamed from zend-test to zend_test in dbe5725ff3c89b61d14dea3e97bc77331830220e. This only syncs few minor remainings.