### PR TITLE
ZEND_ELEMENT_COUNT usage reduction.

### DIFF
--- a/Zend/Optimizer/zend_call_graph.h
+++ b/Zend/Optimizer/zend_call_graph.h
@@ -39,7 +39,7 @@ struct _zend_call_info {
 	bool               named_args;   /* Function has named arguments */
 	bool               is_prototype; /* An overridden child method may be called */
 	int                     num_args;	/* Number of arguments, excluding named and variadic arguments */
-	zend_send_arg_info      arg_info[1] ZEND_ELEMENT_COUNT(num_args);
+	zend_send_arg_info      arg_info[1];
 };
 
 struct _zend_func_info {

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -95,7 +95,7 @@ typedef struct _zend_trait_method_reference {
 typedef struct _zend_trait_precedence {
 	zend_trait_method_reference trait_method;
 	uint32_t num_excludes;
-	zend_string *exclude_class_names[1] ZEND_ELEMENT_COUNT(num_excludes);
+	zend_string *exclude_class_names[1];
 } zend_trait_precedence;
 
 typedef struct _zend_trait_alias {

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -191,7 +191,7 @@ typedef struct _zend_ast_list {
 	zend_ast_attr attr;
 	uint32_t lineno;
 	uint32_t children;
-	zend_ast *child[1] ZEND_ELEMENT_COUNT(children);
+	zend_ast *child[1];
 } zend_ast_list;
 
 /* Lineno is stored in val.u2.lineno */

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -58,7 +58,7 @@ typedef struct _zend_attribute {
 	/* Parameter offsets start at 1, everything else uses 0. */
 	uint32_t offset;
 	uint32_t argc;
-	zend_attribute_arg args[1] ZEND_ELEMENT_COUNT(argc);
+	zend_attribute_arg args[1];
 } zend_attribute;
 
 typedef struct _zend_internal_attribute {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -139,7 +139,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t num_types;
-	zend_type types[1] ZEND_ELEMENT_COUNT(num_types);
+	zend_type types[1];
 } zend_type_list;
 
 #define _ZEND_TYPE_EXTRA_FLAGS_SHIFT 25
@@ -374,7 +374,7 @@ struct _zend_string {
 	zend_refcounted_h gc;
 	zend_ulong        h;                /* hash value */
 	size_t            len;
-	char              val[1] ZEND_ELEMENT_COUNT(len);
+	char              val[1];
 };
 
 typedef struct _Bucket {
@@ -572,7 +572,7 @@ struct _zend_resource {
 typedef struct {
 	size_t num;
 	size_t num_allocated;
-	struct _zend_property_info *ptr[1] ZEND_ELEMENT_COUNT(num);
+	struct _zend_property_info *ptr[1];
 } zend_property_info_list;
 
 typedef union {

--- a/ext/fileinfo/libmagic/cdf.h
+++ b/ext/fileinfo/libmagic/cdf.h
@@ -277,7 +277,7 @@ typedef struct {
 
 typedef struct {
 	size_t cat_num;
-	cdf_catalog_entry_t cat_e[1] ZEND_ELEMENT_COUNT(cat_num);
+	cdf_catalog_entry_t cat_e[1];
 } cdf_catalog_t;
 
 struct timespec;

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -540,7 +540,7 @@ struct _zend_jit_trace_stack_frame {
 	int                         used_stack;
 	int                         old_checked_stack;
 	int                         old_peek_checked_stack;
-	zend_jit_trace_stack        stack[1] ZEND_ELEMENT_COUNT(used_stack);
+	zend_jit_trace_stack        stack[1];
 };
 
 #define TRACE_FRAME_SHIFT_NUM_ARGS            16

--- a/sapi/phpdbg/phpdbg_list.h
+++ b/sapi/phpdbg/phpdbg_list.h
@@ -44,7 +44,7 @@ typedef struct {
 	size_t len;
 	zend_op_array op_array;
 	uint32_t lines;
-	uint32_t line[1] ZEND_ELEMENT_COUNT(lines);
+	uint32_t line[1];
 } phpdbg_file_source;
 
 #endif /* PHPDBG_LIST_H */


### PR DESCRIPTION
clang 18 is going to be released and in the meantime the counted_by attribute usage had been constrained to true flexible arrays, typical cases such as type name[1] ZEND_ELEMENT_COUNT(size) no longer build.