### PR TITLE
Add -Wno-implicit-fallthrough flags conditionally

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-15020 (Memory leak in Zend/Optimizer/escape_analysis.c).
     (nielsdos)
   . Fixed bug GH-15023 (Memory leak in Zend/zend_ini.c). (nielsdos)
+  . Fixed bug GH-13330 (Append -Wno-implicit-fallthrough flag conditionally).
+    (Peter Kokot)
 
 - Curl:
   . Fixed case when curl_error returns an empty string.

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -4,7 +4,11 @@ AC_CHECK_HEADERS([io.h])
 dnl Check for strtoll, atoll
 AC_CHECK_FUNCS(strtoll atoll)
 
-PHP_DATE_CFLAGS="-Wno-implicit-fallthrough -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
+AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
+  [PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -Wno-implicit-fallthrough"],,
+  [-Werror])
+
+PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -28,8 +28,13 @@ else
     SHA3_OPT_SRC="$SHA3_DIR/KeccakP-1600-opt64.c"
   ])
   EXT_HASH_SHA3_SOURCES="$SHA3_OPT_SRC $SHA3_DIR/KeccakHash.c $SHA3_DIR/KeccakSponge.c hash_sha3.c"
+
   dnl Add -Wno-implicit-fallthrough flag as it happens on 32 bit builds
-  PHP_HASH_CFLAGS="-Wno-implicit-fallthrough -I@ext_srcdir@/$SHA3_DIR -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
+    [PHP_HASH_CFLAGS="$PHP_HASH_CFLAGS -Wno-implicit-fallthrough"],,
+    [-Werror])
+
+  PHP_HASH_CFLAGS="$PHP_HASH_CFLAGS -I@ext_srcdir@/$SHA3_DIR -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
   PHP_ADD_BUILD_DIR(ext/hash/$SHA3_DIR, 1)
 fi

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -317,6 +317,10 @@ int main(void) {
   fi
   AC_MSG_RESULT([$have_shm_mmap_posix])
 
+  AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
+    [PHP_OPCACHE_CFLAGS="$PHP_OPCACHE_CFLAGS -Wno-implicit-fallthrough"],,
+    [-Werror])
+
   PHP_NEW_EXTENSION(opcache,
 	ZendAccelerator.c \
 	zend_accelerator_blacklist.c \
@@ -332,7 +336,7 @@ int main(void) {
 	shared_alloc_mmap.c \
 	shared_alloc_posix.c \
 	$ZEND_JIT_SRC,
-	shared,,"-Wno-implicit-fallthrough -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
+	shared,,"$PHP_OPCACHE_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
 
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -66,7 +66,12 @@ else
   pcre2lib/pcre2_string_utils.c pcre2lib/pcre2_study.c pcre2lib/pcre2_substitute.c  pcre2lib/pcre2_substring.c \
   pcre2lib/pcre2_tables.c pcre2lib/pcre2_ucd.c pcre2lib/pcre2_valid_utf.c pcre2lib/pcre2_xclass.c \
   pcre2lib/pcre2_find_bracket.c pcre2lib/pcre2_convert.c pcre2lib/pcre2_extuni.c pcre2lib/pcre2_script_run.c"
-  PHP_PCRE_CFLAGS="-Wno-implicit-fallthrough -DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+
+  AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
+    [PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -Wno-implicit-fallthrough"],,
+    [-Werror])
+
+  PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
   AC_DEFINE(HAVE_BUNDLED_PCRE, 1, [ ])
   AC_DEFINE(PCRE2_CODE_UNIT_WIDTH, 8, [ ])
 


### PR DESCRIPTION
Older GCC versions (< 7.0) don't support the -Wno-implicit-fallthrough compiler flag. This adds the flag conditionally in case some other compiler will run into same issue.

Fixes #13330