### PR TITLE
Refactor utsname.domainname struct member Autoconf check

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -50,6 +50,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The configure option --with-zlib-dir has been removed.
    - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
    - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
+   - HAVE_UTSNAME_DOMAINNAME symbol renamed to HAVE_STRUCT_UTSNAME_DOMAINNAME.
    - PHP_CHECK_IN_ADDR_T M4 macro and 'in_addr_t' fallback definition to 'u_int'
      removed (use AC_CHECK_TYPES Autoconf macro instead).
    - HAVE_ODBC2 symbol has been removed in ext/odbc.

--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -36,21 +36,10 @@ int main(int argc, char *argv[])
     AC_MSG_RESULT([no, cannot detect working ttyname_r() when cross compiling. posix_ttyname() will be thread-unsafe])
   ])
 
-  AC_CACHE_CHECK([for utsname.domainname], ac_cv_have_utsname_domainname, [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      #ifndef _GNU_SOURCE
-      #define _GNU_SOURCE
-      #endif
-      #include <sys/utsname.h>
-    ]],[[
-      return sizeof(((struct utsname *)0)->domainname);
-    ]])],[
-      ac_cv_have_utsname_domainname=yes
-    ],[
-      ac_cv_have_utsname_domainname=no
-    ])
+  AC_CHECK_MEMBERS([struct utsname.domainname],,,[
+    #ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+    #endif
+    #include <sys/utsname.h>
   ])
-  if test "$ac_cv_have_utsname_domainname" = yes; then
-    AC_DEFINE(HAVE_UTSNAME_DOMAINNAME, 1, [Whether struct utsname has domainname])
-  fi
 fi

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -358,7 +358,7 @@ PHP_FUNCTION(posix_uname)
 	add_assoc_string(return_value, "version",  u.version);
 	add_assoc_string(return_value, "machine",  u.machine);
 
-#if defined(_GNU_SOURCE) && !defined(DARWIN) && defined(HAVE_UTSNAME_DOMAINNAME)
+#if defined(_GNU_SOURCE) && !defined(DARWIN) && defined(HAVE_STRUCT_UTSNAME_DOMAINNAME)
 	add_assoc_string(return_value, "domainname", u.domainname);
 #endif
 }

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -358,7 +358,7 @@ PHP_FUNCTION(posix_uname)
 	add_assoc_string(return_value, "version",  u.version);
 	add_assoc_string(return_value, "machine",  u.machine);
 
-#if defined(_GNU_SOURCE) && !defined(DARWIN) && defined(HAVE_STRUCT_UTSNAME_DOMAINNAME)
+#if defined(_GNU_SOURCE) && defined(HAVE_STRUCT_UTSNAME_DOMAINNAME)
 	add_assoc_string(return_value, "domainname", u.domainname);
 #endif
 }


### PR DESCRIPTION
Autoconf's AC_CHECK_MEMBERS macro (available since Autoconf 2.50) can be used instead of the compile check. This was originally implemented for IRIX compatibility, when Autoconf 2.13 didn't have the struct members checking macro yet.

Macro by default here defines the HAVE_STRUCT_UTSNAME_DOMAINNAME symbol.