### PR TITLE
Remove DARWIN symbol

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -58,6 +58,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Removed checking and linking with obsolete libbind for some functions.
    - Symbol HAVE_JSON has been removed (ext/json is always available since PHP
      8.0).
+   - Symbol DARWIN has been removed (use __APPLE__ to target Darwin systems).
 
  c. Windows build system changes
    - Added Bison flag '-Wall' when generating lexer files as done in *nix build

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -227,14 +227,6 @@ fi
 
 AC_C_INLINE
 
-AC_MSG_CHECKING(target system is Darwin)
-if echo "$target" | grep "darwin" > /dev/null; then
-  AC_DEFINE([DARWIN], 1, [Define if the target system is darwin])
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
-fi
-
 dnl Test and set the alignment define for ZEND_MM. This also does the
 dnl logarithmic test for ZEND_MM.
 AC_MSG_CHECKING(for MM alignment and log values)

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -205,7 +205,7 @@ char *alloca();
 # endif
 #endif
 
-#if !ZEND_DEBUG && (defined(HAVE_ALLOCA) || (defined (__GNUC__) && __GNUC__ >= 2)) && !(defined(ZTS) && defined(HPUX)) && !defined(DARWIN)
+#if !ZEND_DEBUG && (defined(HAVE_ALLOCA) || (defined (__GNUC__) && __GNUC__ >= 2)) && !(defined(ZTS) && defined(HPUX)) && !defined(__APPLE__)
 # define ZEND_ALLOCA_MAX_SIZE (32 * 1024)
 # define ALLOCA_FLAG(name) \
 	bool name;
@@ -305,7 +305,7 @@ char *alloca();
 # define ZEND_FASTCALL
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(DARWIN) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__)) || __has_attribute(noreturn)
+#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__)) || __has_attribute(noreturn)
 # define HAVE_NORETURN
 # define ZEND_NORETURN __attribute__((noreturn))
 #elif defined(ZEND_WIN32)
@@ -321,7 +321,7 @@ char *alloca();
 # define ZEND_STACK_ALIGNED
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(DARWIN) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__))
+#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__))
 # define HAVE_NORETURN_ALIAS
 # define HAVE_ATTRIBUTE_WEAK
 #endif

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -40,7 +40,7 @@
 #undef T_UNSPEC
 #endif
 #ifdef HAVE_ARPA_NAMESER_H
-#ifdef DARWIN
+#ifdef __APPLE__
 # define BIND_8_COMPAT 1
 #endif
 #include <arpa/nameser.h>

--- a/sapi/cli/ps_title.c
+++ b/sapi/cli/ps_title.c
@@ -57,7 +57,7 @@ extern char** environ;
 #include <machine/vmparam.h> /* for old BSD */
 #include <sys/exec.h>
 #endif
-#if defined(DARWIN)
+#if defined(__APPLE__)
 #include <crt_externs.h>
 #endif
 
@@ -91,9 +91,9 @@ extern char** environ;
 #define PS_USE_PSTAT
 #elif defined(HAVE_PS_STRINGS)
 #define PS_USE_PS_STRINGS
-#elif defined(BSD) && !defined(DARWIN)
+#elif defined(BSD) && !defined(__APPLE__)
 #define PS_USE_CHANGE_ARGV
-#elif defined(__linux__) || defined(_AIX) || defined(__sgi) || (defined(sun) && !defined(BSD)) || defined(ultrix) || defined(__osf__) || defined(DARWIN)
+#elif defined(__linux__) || defined(_AIX) || defined(__sgi) || (defined(sun) && !defined(BSD)) || defined(ultrix) || defined(__osf__) || defined(__APPLE__)
 #define PS_USE_CLOBBER_ARGV
 #elif defined(PHP_WIN32)
 #define PS_USE_WIN32
@@ -102,7 +102,7 @@ extern char** environ;
 #endif
 
 /* Different systems want the buffer padded differently */
-#if defined(_AIX) || defined(__linux__) || defined(DARWIN)
+#if defined(_AIX) || defined(__linux__) || defined(__APPLE__)
 #define PS_PADDING '\0'
 #else
 #define PS_PADDING ' '
@@ -235,7 +235,7 @@ char** save_ps_args(int argc, char** argv)
         }
         new_argv[argc] = NULL;
 
-#if defined(DARWIN)
+#if defined(__APPLE__)
         /*
          * Darwin (and perhaps other NeXT-derived platforms?) has a static
          * copy of the argv pointer, which we may fix like so:


### PR DESCRIPTION
When targeting Darwin systems (macOS, etc.), the compiler defines the `__APPLE__` symbol, which should be sufficient and a more established detection method practice in these cases.