### PR TITLE
Fix typedef redefinition warnings

### DIFF
--- a/Zend/zend_frameless_function.h
+++ b/Zend/zend_frameless_function.h
@@ -26,7 +26,7 @@
 # include <php_config.h>
 #endif
 
-#include "zend_portability.h"
+#include "zend_types.h"
 
 #define ZEND_FRAMELESS_FUNCTION_PARAMETERS_0 zval *return_value
 #define ZEND_FRAMELESS_FUNCTION_PARAMETERS_1 zval *return_value, zval *arg1
@@ -102,10 +102,6 @@
 	}
 
 BEGIN_EXTERN_C()
-
-typedef struct _zval_struct zval;
-typedef struct _zend_op zend_op;
-typedef union _zend_function zend_function;
 
 typedef void (*zend_frameless_function_0)(zval *return_value);
 typedef void (*zend_frameless_function_1)(zval *return_value, zval *op1);


### PR DESCRIPTION
This is more of a question, since PHP at this point still requires only C99 and this PR fixes warnings "redefinition of typedef '...' is a C11 feature [-Wtypedef-redefinition]" when building with Clang and -Wtypedef-redefinition.

This sounds good for now or should we bump to C11 at some point in the near future?

The issue can be noticed like this:

```sh
./buildconf
CC=clang CFLAGS=-Wtypedef-redefinition ./configure 
make
```