### PR TITLE
random: Pass algorithm and state together as `php_random_algo_with_state`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -86,6 +86,11 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      the new php_random_result struct, replacing the last_generated_size
      member of the php_random_status struct and the generate_size member of
      the php_random_algo struct.
+   - The php_random_status struct has been removed, since the previous change
+     reduced it to a single void* member containing the actual state, resulting
+     in needless indirection. Any user of the php_random_status struct should
+     directly use (e.g. access or pass) what previously was the state member
+     of the php_random_status struct.
    - The CSPRNG API (php_random_(bytes|int)_*) is now provided by the new
      and much smaller php_random_csprng.h header. The new header is included
      in php_random.h for compatibility with existing users.

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -88,9 +88,11 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      the php_random_algo struct.
    - The php_random_status struct has been removed, since the previous change
      reduced it to a single void* member containing the actual state, resulting
-     in needless indirection. Any user of the php_random_status struct should
-     directly use (e.g. access or pass) what previously was the state member
-     of the php_random_status struct.
+     in needless indirection. Functions taking a php_random_algo struct pointer
+     and a php_random_status struct pointer as separate parameters now take a
+     single php_random_algo_with_state struct by value, making it easier to
+     pass around the state with its associated algorithm and thus reducing
+     the chance for mistakes.
    - The CSPRNG API (php_random_(bytes|int)_*) is now provided by the new
      and much smaller php_random_csprng.h header. The new header is included
      in php_random.h for compatibility with existing users.

--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -32,17 +32,17 @@
  */
 #define MODMULT(a, b, c, m, s) q = s / a; s = b * (s - a * q) - c * q; if (s < 0) s += m
 
-static void seed(php_random_status *status, uint64_t seed)
+static void seed(void *status, uint64_t seed)
 {
-	php_random_status_state_combinedlcg *s = status->state;
+	php_random_status_state_combinedlcg *s = status;
 
 	s->state[0] = seed & 0xffffffffU;
 	s->state[1] = seed >> 32;
 }
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
-	php_random_status_state_combinedlcg *s = status->state;
+	php_random_status_state_combinedlcg *s = status;
 	int32_t q, z;
 
 	MODMULT(53668, 40014, 12211, 2147483563L, s->state[0]);
@@ -59,14 +59,14 @@ static php_random_result generate(php_random_status *status)
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	return php_random_range(&php_random_algo_combinedlcg, status, min, max);
 }
 
-static bool serialize(php_random_status *status, HashTable *data)
+static bool serialize(void *status, HashTable *data)
 {
-	php_random_status_state_combinedlcg *s = status->state;
+	php_random_status_state_combinedlcg *s = status;
 	zval t;
 
 	for (uint32_t i = 0; i < 2; i++) {
@@ -77,9 +77,9 @@ static bool serialize(php_random_status *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(php_random_status *status, HashTable *data)
+static bool unserialize(void *status, HashTable *data)
 {
-	php_random_status_state_combinedlcg *s = status->state;
+	php_random_status_state_combinedlcg *s = status;
 	zval *t;
 
 	for (uint32_t i = 0; i < 2; i++) {

--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -61,7 +61,10 @@ static php_random_result generate(void *status)
 
 static zend_long range(void *status, zend_long min, zend_long max)
 {
-	return php_random_range(&php_random_algo_combinedlcg, status, min, max);
+	return php_random_range((php_random_algo_with_state){
+		.algo = &php_random_algo_combinedlcg,
+		.status = status,
+	}, min, max);
 }
 
 static bool serialize(void *status, HashTable *data)

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -139,14 +139,14 @@ static inline void mt19937_seed_state(php_random_status_state_mt19937 *state, ui
 	mt19937_reload(state);
 }
 
-static void seed(php_random_status *status, uint64_t seed)
+static void seed(void *status, uint64_t seed)
 {
-	mt19937_seed_state(status->state, seed);
+	mt19937_seed_state(status, seed);
 }
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
-	php_random_status_state_mt19937 *s = status->state;
+	php_random_status_state_mt19937 *s = status;
 	uint32_t s1;
 
 	if (s->count >= MT_N) {
@@ -164,14 +164,14 @@ static php_random_result generate(php_random_status *status)
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	return php_random_range(&php_random_algo_mt19937, status, min, max);
 }
 
-static bool serialize(php_random_status *status, HashTable *data)
+static bool serialize(void *status, HashTable *data)
 {
-	php_random_status_state_mt19937 *s = status->state;
+	php_random_status_state_mt19937 *s = status;
 	zval t;
 
 	for (uint32_t i = 0; i < MT_N; i++) {
@@ -186,9 +186,9 @@ static bool serialize(php_random_status *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(php_random_status *status, HashTable *data)
+static bool unserialize(void *status, HashTable *data)
 {
-	php_random_status_state_mt19937 *s = status->state;
+	php_random_status_state_mt19937 *s = status;
 	zval *t;
 
 	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */
@@ -252,7 +252,7 @@ PHPAPI void php_random_mt19937_seed_default(php_random_status_state_mt19937 *sta
 PHP_METHOD(Random_Engine_Mt19937, __construct)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_mt19937 *state = engine->status->state;
+	php_random_status_state_mt19937 *state = engine->status;
 	zend_long seed, mode = MT_RAND_MT19937;
 	bool seed_is_null = true;
 

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -43,14 +43,14 @@ static inline void seed128(php_random_status_state_pcgoneseq128xslrr64 *s, php_r
 	step(s);
 }
 
-static void seed(php_random_status *status, uint64_t seed)
+static void seed(void *status, uint64_t seed)
 {
-	seed128(status->state, php_random_uint128_constant(0ULL, seed));
+	seed128(status, php_random_uint128_constant(0ULL, seed));
 }
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status->state;
+	php_random_status_state_pcgoneseq128xslrr64 *s = status;
 
 	step(s);
 
@@ -60,14 +60,14 @@ static php_random_result generate(php_random_status *status)
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	return php_random_range(&php_random_algo_pcgoneseq128xslrr64, status, min, max);
 }
 
-static bool serialize(php_random_status *status, HashTable *data)
+static bool serialize(void *status, HashTable *data)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status->state;
+	php_random_status_state_pcgoneseq128xslrr64 *s = status;
 	uint64_t u;
 	zval z;
 
@@ -82,9 +82,9 @@ static bool serialize(php_random_status *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(php_random_status *status, HashTable *data)
+static bool unserialize(void *status, HashTable *data)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status->state;
+	php_random_status_state_pcgoneseq128xslrr64 *s = status;
 	uint64_t u[2];
 	zval *t;
 
@@ -143,7 +143,7 @@ PHPAPI void php_random_pcgoneseq128xslrr64_advance(php_random_status_state_pcgon
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status->state;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;
@@ -192,7 +192,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, jump)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status->state;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status;
 	zend_long advance = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -62,7 +62,10 @@ static php_random_result generate(void *status)
 
 static zend_long range(void *status, zend_long min, zend_long max)
 {
-	return php_random_range(&php_random_algo_pcgoneseq128xslrr64, status, min, max);
+	return php_random_range((php_random_algo_with_state){
+		.algo = &php_random_algo_pcgoneseq128xslrr64,
+		.status = status,
+	}, min, max);
 }
 
 static bool serialize(void *status, HashTable *data)
@@ -142,8 +145,8 @@ PHPAPI void php_random_pcgoneseq128xslrr64_advance(php_random_status_state_pcgon
 /* {{{ Random\Engine\PcgOneseq128XslRr64::__construct */
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 {
-	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status;
+	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine.status;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;
@@ -191,8 +194,8 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 /* {{{ Random\Engine\PcgOneseq128XslRr64::jump() */
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, jump)
 {
-	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine->status;
+	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine.status;
 	zend_long advance = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -25,7 +25,7 @@
 
 #include "Zend/zend_exceptions.h"
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
 	zend_ulong r = 0;
 
@@ -37,7 +37,7 @@ static php_random_result generate(php_random_status *status)
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	zend_long result = 0;
 

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -21,9 +21,9 @@
 #include "php.h"
 #include "php_random.h"
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
-	php_random_status_state_user *s = status->state;
+	php_random_status_state_user *s = status;
 	uint64_t result = 0;
 	size_t size;
 	zval retval;
@@ -65,7 +65,7 @@ static php_random_result generate(php_random_status *status)
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	return php_random_range(&php_random_algo_user, status, min, max);
 }

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -67,7 +67,10 @@ static php_random_result generate(void *status)
 
 static zend_long range(void *status, zend_long min, zend_long max)
 {
-	return php_random_range(&php_random_algo_user, status, min, max);
+	return php_random_range((php_random_algo_with_state){
+		.algo = &php_random_algo_user,
+		.status = status,
+	}, min, max);
 }
 
 const php_random_algo php_random_algo_user = {

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -117,7 +117,10 @@ static php_random_result generate(void *status)
 
 static zend_long range(void *status, zend_long min, zend_long max)
 {
-	return php_random_range(&php_random_algo_xoshiro256starstar, status, min, max);
+	return php_random_range((php_random_algo_with_state){
+		.algo = &php_random_algo_xoshiro256starstar,
+		.status = status,
+	}, min, max);
 }
 
 static bool serialize(void *status, HashTable *data)
@@ -180,8 +183,8 @@ PHPAPI void php_random_xoshiro256starstar_jump_long(php_random_status_state_xosh
 /* {{{ Random\Engine\Xoshiro256StarStar::jump() */
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 {
-	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status;
+	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
+	php_random_status_state_xoshiro256starstar *state = engine.status;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -192,8 +195,8 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 /* {{{ Random\Engine\Xoshiro256StarStar::jumpLong() */
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 {
-	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status;
+	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
+	php_random_status_state_xoshiro256starstar *state = engine.status;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -204,8 +207,8 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 /* {{{ Random\Engine\Xoshiro256StarStar::__construct */
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 {
-	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status;
+	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
+	php_random_status_state_xoshiro256starstar *state = engine.status;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -102,27 +102,27 @@ static inline void seed64(php_random_status_state_xoshiro256starstar *state, uin
 	seed256(state, s[0], s[1], s[2], s[3]);
 }
 
-static void seed(php_random_status *status, uint64_t seed)
+static void seed(void *status, uint64_t seed)
 {
-	seed64(status->state, seed);
+	seed64(status, seed);
 }
 
-static php_random_result generate(php_random_status *status)
+static php_random_result generate(void *status)
 {
 	return (php_random_result){
 		.size = sizeof(uint64_t),
-		.result = generate_state(status->state),
+		.result = generate_state(status),
 	};
 }
 
-static zend_long range(php_random_status *status, zend_long min, zend_long max)
+static zend_long range(void *status, zend_long min, zend_long max)
 {
 	return php_random_range(&php_random_algo_xoshiro256starstar, status, min, max);
 }
 
-static bool serialize(php_random_status *status, HashTable *data)
+static bool serialize(void *status, HashTable *data)
 {
-	php_random_status_state_xoshiro256starstar *s = status->state;
+	php_random_status_state_xoshiro256starstar *s = status;
 	zval t;
 
 	for (uint32_t i = 0; i < 4; i++) {
@@ -133,9 +133,9 @@ static bool serialize(php_random_status *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(php_random_status *status, HashTable *data)
+static bool unserialize(void *status, HashTable *data)
 {
-	php_random_status_state_xoshiro256starstar *s = status->state;
+	php_random_status_state_xoshiro256starstar *s = status;
 	zval *t;
 
 	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */
@@ -181,7 +181,7 @@ PHPAPI void php_random_xoshiro256starstar_jump_long(php_random_status_state_xosh
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status->state;
+	php_random_status_state_xoshiro256starstar *state = engine->status;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -193,7 +193,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status->state;
+	php_random_status_state_xoshiro256starstar *state = engine->status;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -205,7 +205,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 {
 	php_random_engine *engine = Z_RANDOM_ENGINE_P(ZEND_THIS);
-	php_random_status_state_xoshiro256starstar *state = engine->status->state;
+	php_random_status_state_xoshiro256starstar *state = engine->status;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;

--- a/ext/random/gammasection.c
+++ b/ext/random/gammasection.c
@@ -71,7 +71,7 @@ static uint64_t ceilint(double a, double b, double g)
 	return (s != si) ? (uint64_t)si : (uint64_t)si + (e > 0);
 }
 
-PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, void *status, double min, double max)
+PHPAPI double php_random_gammasection_closed_open(php_random_algo_with_state engine, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -80,7 +80,7 @@ PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, v
 		return NAN;
 	}
 
-	uint64_t k = 1 + php_random_range64(algo, status, hi - 1); /* [1, hi] */
+	uint64_t k = 1 + php_random_range64(engine, hi - 1); /* [1, hi] */
 
 	if (fabs(min) <= fabs(max)) {
 		if (k == hi) {
@@ -99,7 +99,7 @@ PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, v
 	}
 }
 
-PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo, void *status, double min, double max)
+PHPAPI double php_random_gammasection_closed_closed(php_random_algo_with_state engine, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -108,7 +108,7 @@ PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo,
 		return NAN;
 	}
 
-	uint64_t k = php_random_range64(algo, status, hi); /* [0, hi] */
+	uint64_t k = php_random_range64(engine, hi); /* [0, hi] */
 
 	if (fabs(min) <= fabs(max)) {
 		if (k == hi) {
@@ -131,7 +131,7 @@ PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo,
 	}
 }
 
-PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, void *status, double min, double max)
+PHPAPI double php_random_gammasection_open_closed(php_random_algo_with_state engine, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -140,7 +140,7 @@ PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, v
 		return NAN;
 	}
 
-	uint64_t k = php_random_range64(algo, status, hi - 1); /* [0, hi - 1] */
+	uint64_t k = php_random_range64(engine, hi - 1); /* [0, hi - 1] */
 
 	if (fabs(min) <= fabs(max)) {
 		double k_hi, k_lo;
@@ -159,7 +159,7 @@ PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, v
 	}
 }
 
-PHPAPI double php_random_gammasection_open_open(const php_random_algo *algo, void *status, double min, double max)
+PHPAPI double php_random_gammasection_open_open(php_random_algo_with_state engine, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -168,7 +168,7 @@ PHPAPI double php_random_gammasection_open_open(const php_random_algo *algo, voi
 		return NAN;
 	}
 
-	uint64_t k = 1 + php_random_range64(algo, status, hi - 2); /* [1, hi - 1] */
+	uint64_t k = 1 + php_random_range64(engine, hi - 2); /* [1, hi - 1] */
 
 	if (fabs(min) <= fabs(max)) {
 		double k_hi, k_lo;

--- a/ext/random/gammasection.c
+++ b/ext/random/gammasection.c
@@ -71,7 +71,7 @@ static uint64_t ceilint(double a, double b, double g)
 	return (s != si) ? (uint64_t)si : (uint64_t)si + (e > 0);
 }
 
-PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, php_random_status *status, double min, double max)
+PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, void *status, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -99,7 +99,7 @@ PHPAPI double php_random_gammasection_closed_open(const php_random_algo *algo, p
 	}
 }
 
-PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo, php_random_status *status, double min, double max)
+PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo, void *status, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -131,7 +131,7 @@ PHPAPI double php_random_gammasection_closed_closed(const php_random_algo *algo,
 	}
 }
 
-PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, php_random_status *status, double min, double max)
+PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, void *status, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);
@@ -159,7 +159,7 @@ PHPAPI double php_random_gammasection_open_closed(const php_random_algo *algo, p
 	}
 }
 
-PHPAPI double php_random_gammasection_open_open(const php_random_algo *algo, php_random_status *status, double min, double max)
+PHPAPI double php_random_gammasection_open_open(const php_random_algo *algo, void *status, double min, double max)
 {
 	double g = gamma_max(min, max);
 	uint64_t hi = ceilint(min, max, g);

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -38,7 +38,7 @@ static inline void randomizer_common_init(php_random_randomizer *randomizer, zen
 	} else {
 		/* Self allocation */
 		randomizer->status = php_random_status_alloc(&php_random_algo_user, false);
-		php_random_status_state_user *state = randomizer->status->state;
+		php_random_status_state_user *state = randomizer->status;
 		zend_string *mname;
 		zend_function *generate_method;
 
@@ -243,7 +243,7 @@ PHP_METHOD(Random_Randomizer, getInt)
 
 	if (UNEXPECTED(
 		randomizer->algo->range == php_random_algo_mt19937.range
-		&& ((php_random_status_state_mt19937 *) randomizer->status->state)->mode != MT_RAND_MT19937
+		&& ((php_random_status_state_mt19937 *) randomizer->status)->mode != MT_RAND_MT19937
 	)) {
 		uint64_t r = php_random_algo_mt19937.generate(randomizer->status).result >> 1;
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3211,7 +3211,7 @@ boundary_error:
 #undef RANGE_CHECK_LONG_INIT_ARRAY
 
 /* {{{ php_array_data_shuffle */
-PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, php_random_status *status, zval *array) /* {{{ */
+PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, void *status, zval *array) /* {{{ */
 {
 	int64_t idx, j, n_elems, rnd_idx, n_left;
 	zval *zv, temp;
@@ -6191,7 +6191,7 @@ clean_up:
 /* }}} */
 
 /* {{{ php_array_pick_keys */
-PHPAPI bool php_array_pick_keys(const php_random_algo *algo, php_random_status *status, zval *input, zend_long num_req, zval *retval, bool silent)
+PHPAPI bool php_array_pick_keys(const php_random_algo *algo, void *status, zval *input, zend_long num_req, zval *retval, bool silent)
 {
 	HashTable *ht = Z_ARRVAL_P(input);
 	uint32_t num_avail = zend_hash_num_elements(ht);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3211,8 +3211,11 @@ boundary_error:
 #undef RANGE_CHECK_LONG_INIT_ARRAY
 
 /* {{{ php_array_data_shuffle */
-PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, void *status, zval *array) /* {{{ */
+PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *array) /* {{{ */
 {
+	const php_random_algo *algo = engine.algo;
+	void *status = engine.status;
+
 	int64_t idx, j, n_elems, rnd_idx, n_left;
 	zval *zv, temp;
 	HashTable *hash;
@@ -3310,7 +3313,7 @@ PHP_FUNCTION(shuffle)
 		Z_PARAM_ARRAY_EX(array, 0, 1)
 	ZEND_PARSE_PARAMETERS_END();
 
-	php_array_data_shuffle(php_random_default_algo(), php_random_default_status(), array);
+	php_array_data_shuffle(php_random_default_engine(), array);
 
 	RETURN_TRUE;
 }
@@ -6191,8 +6194,11 @@ clean_up:
 /* }}} */
 
 /* {{{ php_array_pick_keys */
-PHPAPI bool php_array_pick_keys(const php_random_algo *algo, void *status, zval *input, zend_long num_req, zval *retval, bool silent)
+PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, zend_long num_req, zval *retval, bool silent)
 {
+	const php_random_algo *algo = engine.algo;
+	void *status = engine.status;
+
 	HashTable *ht = Z_ARRVAL_P(input);
 	uint32_t num_avail = zend_hash_num_elements(ht);
 	zend_long i, randval;
@@ -6350,8 +6356,7 @@ PHP_FUNCTION(array_rand)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!php_array_pick_keys(
-			php_random_default_algo(),
-			php_random_default_status(),
+			php_random_default_engine(),
 			input,
 			num_req,
 			return_value,

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -31,8 +31,8 @@ PHPAPI int php_array_replace_recursive(HashTable *dest, HashTable *src);
 PHPAPI int php_multisort_compare(const void *a, const void *b);
 PHPAPI zend_long php_count_recursive(HashTable *ht);
 
-PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, php_random_status *status, zval *array);
-PHPAPI bool php_array_pick_keys(const php_random_algo *algo, php_random_status *status, zval *input, zend_long num_req, zval *retval, bool silent);
+PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, void *status, zval *array);
+PHPAPI bool php_array_pick_keys(const php_random_algo *algo, void *status, zval *input, zend_long num_req, zval *retval, bool silent);
 
 #define PHP_EXTR_OVERWRITE			0
 #define PHP_EXTR_SKIP				1

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -31,8 +31,8 @@ PHPAPI int php_array_replace_recursive(HashTable *dest, HashTable *src);
 PHPAPI int php_multisort_compare(const void *a, const void *b);
 PHPAPI zend_long php_count_recursive(HashTable *ht);
 
-PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, void *status, zval *array);
-PHPAPI bool php_array_pick_keys(const php_random_algo *algo, void *status, zval *input, zend_long num_req, zval *retval, bool silent);
+PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *array);
+PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, zend_long num_req, zval *retval, bool silent);
 
 #define PHP_EXTR_OVERWRITE			0
 #define PHP_EXTR_SKIP				1

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -62,7 +62,7 @@ PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2
 PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);
 PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
 
-PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, void *status, char *str, zend_long len);
+PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *str, zend_long len);
 
 #ifdef _REENTRANT
 # ifdef PHP_WIN32

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -62,7 +62,7 @@ PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2
 PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);
 PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
 
-PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, php_random_status *status, char *str, zend_long len);
+PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, void *status, char *str, zend_long len);
 
 #ifdef _REENTRANT
 # ifdef PHP_WIN32

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5953,7 +5953,7 @@ PHP_FUNCTION(str_rot13)
 /* }}} */
 
 /* {{{ php_binary_string_shuffle */
-PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, php_random_status *status, char *str, zend_long len) /* {{{ */
+PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, void *status, char *str, zend_long len) /* {{{ */
 {
 	int64_t n_elems, rnd_idx, n_left;
 	char temp;

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5953,8 +5953,11 @@ PHP_FUNCTION(str_rot13)
 /* }}} */
 
 /* {{{ php_binary_string_shuffle */
-PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, void *status, char *str, zend_long len) /* {{{ */
+PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *str, zend_long len) /* {{{ */
 {
+	const php_random_algo *algo = engine.algo;
+	void *status = engine.status;
+
 	int64_t n_elems, rnd_idx, n_left;
 	char temp;
 
@@ -5996,8 +5999,7 @@ PHP_FUNCTION(str_shuffle)
 	RETVAL_STRINGL(ZSTR_VAL(arg), ZSTR_LEN(arg));
 	if (Z_STRLEN_P(return_value) > 1) {
 		php_binary_string_shuffle(
-			php_random_default_algo(),
-			php_random_default_status(),
+			php_random_default_engine(),
 			Z_STRVAL_P(return_value),
 			Z_STRLEN_P(return_value)
 		);


### PR DESCRIPTION
Since 162e1dce9870168cb8c65c013f2b5a510b6536b1, the `php_random_status` struct contains just a single `void*`, resulting in needless indirection when accessing the engine state and thus decreasing readability because of the additional non-meaningful `->state` references / the local helper variables.

There is also a small, but measurable performance benefit:

    <?php
    $e = new Random\Engine\Xoshiro256StarStar(0);
    $r = new Random\Randomizer($e);

    for ($i = 0; $i < 15; $i++)
    	var_dump(strlen($r->getBytes(100000000)));

goes from roughly 3.85s down to 3.60s.

The names of the `status` variables have not yet been touched to keep the diff small. They will be renamed to the more appropriate `state` in a follow-up cleanup commit.