### PR TITLE
Fix GH-11086: FPM: config test runs twice in daemonised mode

### DIFF
--- a/sapi/fpm/fpm/zlog.c
+++ b/sapi/fpm/fpm/zlog.c
@@ -25,6 +25,7 @@
 #define EXTRA_SPACE_FOR_PREFIX 128
 
 static int zlog_fd = -1;
+static bool zlog_fd_is_stderr = false;
 static int zlog_level = ZLOG_NOTICE;
 static int zlog_limit = ZLOG_DEFAULT_LIMIT;
 static zlog_bool zlog_buffering = ZLOG_DEFAULT_BUFFERING;
@@ -88,11 +89,13 @@ size_t zlog_print_time(struct timeval *tv, char *timebuf, size_t timebuf_len) /*
 }
 /* }}} */
 
-int zlog_set_fd(int new_fd) /* {{{ */
+int zlog_set_fd(int new_fd, zlog_bool is_stderr) /* {{{ */
 {
 	int old_fd = zlog_fd;
 
 	zlog_fd = new_fd;
+	zlog_fd_is_stderr = is_stderr;
+
 	return old_fd;
 }
 /* }}} */
@@ -244,7 +247,7 @@ void vzlog(const char *function, int line, int flags, const char *fmt, va_list a
 		zend_quiet_write(zlog_fd > -1 ? zlog_fd : STDERR_FILENO, buf, len);
 	}
 
-	if (zlog_fd != STDERR_FILENO && zlog_fd != -1 &&
+	if (!zlog_fd_is_stderr && zlog_fd != -1 &&
 			!launched && (flags & ZLOG_LEVEL_MASK) >= ZLOG_NOTICE) {
 		zend_quiet_write(STDERR_FILENO, buf, len);
 	}

--- a/sapi/fpm/fpm/zlog.h
+++ b/sapi/fpm/fpm/zlog.h
@@ -17,7 +17,7 @@ typedef unsigned char zlog_bool;
 #define ZLOG_FALSE 0
 
 void zlog_set_external_logger(void (*logger)(int, char *, size_t));
-int zlog_set_fd(int new_fd);
+int zlog_set_fd(int new_fd, zlog_bool is_stderr);
 int zlog_set_level(int new_value);
 int zlog_set_limit(int new_value);
 int zlog_set_buffering(zlog_bool buffering);

--- a/sapi/fpm/tests/gh-11086-daemonized-logs-duplicated.phpt
+++ b/sapi/fpm/tests/gh-11086-daemonized-logs-duplicated.phpt
@@ -1,0 +1,34 @@
+--TEST--
+FPM: gh68591 - daemonized mode duplicated logs
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = /dev/stderr
+daemonize = true
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->testConfig(dumpConfig: false, printOutput: true);
+
+?>
+Done
+--EXPECTF--
+%sNOTICE: configuration file %s test is successful
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -440,12 +440,22 @@ class Tester
      * @return null|array
      * @throws \Exception
      */
-    public function testConfig($silent = false, array|string|null $expectedPattern = null): ?array
-    {
-        $configFile = $this->createConfig();
-        $cmd        = self::findExecutable() . ' -n -tt -y ' . $configFile . ' 2>&1';
+    public function testConfig(
+        $silent = false,
+        array|string|null $expectedPattern = null,
+        $dumpConfig = true,
+        $printOutput = false
+    ): ?array {
+        $configFile    = $this->createConfig();
+        $configTestArg = $dumpConfig ? '-tt' : '-t';
+        $cmd           = self::findExecutable() . " -n $configTestArg -y $configFile 2>&1";
         $this->trace('Testing config using command', $cmd, true);
         exec($cmd, $output, $code);
+        if ($printOutput) {
+            foreach ($output as $outputLine) {
+                echo $outputLine . "\n";
+            }
+        }
         $found = 0;
         if ($expectedPattern !== null) {
             $expectedPatterns = is_array($expectedPattern) ? $expectedPattern : [$expectedPattern];


### PR DESCRIPTION
The previous check for STDERR did not work because it never actually gets `STDERR_FILENO` but new file descriptor which is greater than 2. Unfortunately I did not come up with a better way than checking the source file name which might not be always reliable and cover all case - specifically when there is a link to stderr. We could probably check a link (readlink) in such case and compare but it seems quite unlikely that anyone would use that - we can do it if anyone complains. I have been also trying `isatty` but that does not work if FPM is executed by script (specifically it does not work in our test env).