### PR TITLE
Fix undefined symbol pthread_attr_get_np on Solaris

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -664,6 +664,7 @@ static bool zend_call_stack_get_netbsd(zend_call_stack *stack)
 #endif /* defined(__NetBSD__) */
 
 #if defined(__sun)
+# if defined(HAVE_PTHREAD_ATTR_GET_NP) && defined(HAVE_PTHREAD_ATTR_GETSTACK)
 static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
 {
 	pthread_attr_t attr;
@@ -694,6 +695,12 @@ static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
 
 	return true;
 }
+# else /* defined(HAVE_PTHREAD_ATTR_GET_NP) && defined(HAVE_PTHREAD_ATTR_GETSTACK) */
+static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
+{
+	return false;
+}
+# endif /* defined(HAVE_PTHREAD_ATTR_GET_NP) && defined(HAVE_PTHREAD_ATTR_GETSTACK) */
 
 static bool zend_call_stack_get_solaris_proc_maps(zend_call_stack *stack)
 {


### PR DESCRIPTION
Solaris doesn't have pthread_attr_get_np().

Checked on Oracle Solaris 11.4.

```sh
...php-src/Zend/zend_call_stack.c:674:17: warning: implicit declaration of function ‘pthread_attr_get_np’; did you mean ‘pthread_attr_getname_np’? [-Wimplicit-function-declaration]
  674 |         error = pthread_attr_get_np(pthread_self(), &attr);
      |                 ^~~~~~~~~~~~~~~~~~~
      |                 pthread_attr_getname_np
```

```sh
Undefined                       first referenced
 symbol                             in file
pthread_attr_get_np                 Zend/zend_call_stack.o
ld: fatal: symbol referencing errors
collect2: error: ld returned 1 exit status
``` 