### PR TITLE
Remove obsolete check for missing fclose declaration

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -61,6 +61,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_JSON has been removed (ext/json is always available since PHP
      8.0).
    - Symbol DARWIN has been removed (use __APPLE__ to target Darwin systems).
+   - Symbol MISSING_FCLOSE_DECL and M4 macro PHP_MISSING_FCLOSE_DECL removed.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -1287,22 +1287,6 @@ fi
 ])
 
 dnl
-dnl PHP_MISSING_FCLOSE_DECL
-dnl
-dnl See if we have broken header files like SunOS has.
-dnl
-AC_DEFUN([PHP_MISSING_FCLOSE_DECL],[
-  AC_MSG_CHECKING([for fclose declaration])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[int (*func)() = fclose]])],[
-    AC_DEFINE(MISSING_FCLOSE_DECL,0,[ ])
-    AC_MSG_RESULT([ok])
-  ],[
-    AC_DEFINE(MISSING_FCLOSE_DECL,1,[ ])
-    AC_MSG_RESULT([missing])
-  ])
-])
-
-dnl
 dnl PHP_SOCKADDR_CHECKS
 dnl
 AC_DEFUN([PHP_SOCKADDR_CHECKS], [

--- a/configure.ac
+++ b/configure.ac
@@ -464,7 +464,6 @@ dnl ----------------------------------------------------------------------------
 AC_STRUCT_TIMEZONE
 
 PHP_MISSING_TIME_R_DECL
-PHP_MISSING_FCLOSE_DECL
 PHP_STRUCT_FLOCK
 
 AC_CHECK_TYPES(socklen_t, [], [], [

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -86,10 +86,6 @@
 # include <sys/file.h>
 #endif
 
-#if MISSING_FCLOSE_DECL
-extern int fclose(FILE *);
-#endif
-
 #ifdef HAVE_SYS_MMAN_H
 # include <sys/mman.h>
 #endif


### PR DESCRIPTION
SunOS 4.1.4 from 1994 didn't have fclose declared in standard header stdio.h. This doesn't need to be checked anymore, as fclose is part of the C89+ standard and declaration is present on Solaris 10 (SunOS 5.10) and later.