### PR TITLE
Remove unused <extension>_SHARED_LIBADD variables

### DIFF
--- a/ext/filter/config.m4
+++ b/ext/filter/config.m4
@@ -6,7 +6,6 @@ PHP_ARG_ENABLE([filter],
 
 if test "$PHP_FILTER" != "no"; then
   PHP_NEW_EXTENSION(filter, filter.c sanitizing_filters.c logical_filters.c callback_filter.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_SUBST(FILTER_SHARED_LIBADD)
 
   PHP_INSTALL_HEADERS([ext/filter], [php_filter.h])
   PHP_ADD_EXTENSION_DEP(filter, pcre)

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -64,7 +64,6 @@ if test "$PHP_MYSQLI" != "no"; then
                   mysqli_report.c mysqli_driver.c mysqli_warning.c \
                   mysqli_exception.c mysqli_result_iterator.c"
   PHP_NEW_EXTENSION(mysqli, $mysqli_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_SUBST(MYSQLI_SHARED_LIBADD)
   PHP_INSTALL_HEADERS([ext/mysqli], [php_mysqli_structs.h mysqli_mysqlnd.h])
   PHP_ADD_EXTENSION_DEP(mysqli, mysqlnd)
 fi


### PR DESCRIPTION
These are used to store libraries needed to link when extension is shared and needs libraries linked to it. Since other similar types of extensions don't have these variables substituted in Makefile, these can be also removed. The filter and mysqli don't need any libraries for linking here.