### PR TITLE
Add PHP_SBINDIR

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -638,6 +638,7 @@ PHP 8.4 UPGRADE NOTES
 
 - Core:
   . PHP_OUTPUT_HANDLER_PROCESSED.
+  . PHP_SBINDIR.
 
 - Intl:
   . The IntlDateFormatter class exposes now the new PATTERN constant

--- a/main/main.stub.php
+++ b/main/main.stub.php
@@ -84,6 +84,11 @@ const PHP_PREFIX = UNKNOWN;
  * @cvalue PHP_BINDIR
  */
 const PHP_BINDIR = UNKNOWN;
+/**
+ * @var string
+ * @cvalue PHP_SBINDIR
+ */
+const PHP_SBINDIR = UNKNOWN;
 #ifndef PHP_WIN32
 /**
  * @var string

--- a/main/main_arginfo.h
+++ b/main/main_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7ff3d7dc2636153044513390669cb46e9a5b5a0a */
+ * Stub hash: 793b455a47a0422cee767ef2f6a448a369520542 */
 
 static void register_main_symbols(int module_number)
 {
@@ -19,6 +19,7 @@ static void register_main_symbols(int module_number)
 	REGISTER_STRING_CONSTANT("PHP_EXTENSION_DIR", PHP_EXTENSION_DIR, CONST_PERSISTENT);
 	REGISTER_STRING_CONSTANT("PHP_PREFIX", PHP_PREFIX, CONST_PERSISTENT);
 	REGISTER_STRING_CONSTANT("PHP_BINDIR", PHP_BINDIR, CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("PHP_SBINDIR", PHP_SBINDIR, CONST_PERSISTENT);
 #if !defined(PHP_WIN32)
 	REGISTER_STRING_CONSTANT("PHP_MANDIR", PHP_MANDIR, CONST_PERSISTENT);
 #endif

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -12,6 +12,7 @@
 #define PHP_CONFIG_FILE_PATH ""
 #define PEAR_INSTALLDIR "@PREFIX@\\pear"
 #define PHP_BINDIR "@PREFIX@"
+#define PHP_SBINDIR "@PREFIX@"
 #define PHP_DATADIR "@PREFIX@"
 #define PHP_EXTENSION_DIR "@PREFIX@\\ext"
 #define PHP_INCLUDE_PATH	".;@PREFIX@\\pear"


### PR DESCRIPTION
The PHP_SBINDIR symbol was defined on *nix systems but never used. This adds the constant similar to PHP_BINDIR also to PHP. On Windows it is the value of prefix configuration when PHP was built (same value as PHP_BINDIR).