### PR TITLE
Remove redundant libbcmath include definition

### DIFF
--- a/ext/bcmath/config.m4
+++ b/ext/bcmath/config.m4
@@ -9,7 +9,7 @@ libbcmath/src/add.c libbcmath/src/div.c libbcmath/src/init.c libbcmath/src/neg.c
 libbcmath/src/compare.c libbcmath/src/divmod.c libbcmath/src/int2num.c libbcmath/src/num2long.c libbcmath/src/output.c libbcmath/src/recmul.c \
 libbcmath/src/sqrt.c libbcmath/src/zero.c libbcmath/src/doaddsub.c libbcmath/src/nearzero.c libbcmath/src/num2str.c libbcmath/src/raise.c \
 libbcmath/src/rmzero.c libbcmath/src/str2num.c,
-          $ext_shared,,-I@ext_srcdir@/libbcmath/src -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+          $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_ADD_BUILD_DIR($ext_builddir/libbcmath/src)
   AC_DEFINE(HAVE_BCMATH, 1, [Whether you have bcmath])
 fi

--- a/ext/bcmath/config.w32
+++ b/ext/bcmath/config.w32
@@ -3,7 +3,7 @@
 ARG_ENABLE("bcmath", "bc style precision math functions", "yes");
 
 if (PHP_BCMATH == "yes") {
-	EXTENSION("bcmath", "bcmath.c",	null, "-Iext/bcmath/libbcmath/src /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	EXTENSION("bcmath", "bcmath.c",	null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_SOURCES("ext/bcmath/libbcmath/src", "add.c div.c init.c neg.c \
 		raisemod.c sub.c compare.c divmod.c int2num.c \
 		num2long.c output.c recmul.c sqrt.c zero.c doaddsub.c \


### PR DESCRIPTION
The libbcmath headers are included relatively.