### PR TITLE
Simplify strcasestr check in fileinfo

### DIFF
--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -14,40 +14,10 @@ if test "$PHP_FILEINFO" != "no"; then
     libmagic/readcdf.c libmagic/softmagic.c libmagic/der.c \
     libmagic/buffer.c libmagic/is_csv.c"
 
-  AC_MSG_CHECKING([for strcasestr])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-#include <strings.h>
-#include <stdlib.h>
-
-int main(void)
-{
-        char *s0, *s1, *ret;
-
-        s0 = (char *) malloc(42);
-        s1 = (char *) malloc(8);
-
-        memset(s0, 'X', 42);
-        s0[24] = 'Y';
-        s0[26] = 'Z';
-        s0[41] = '\0';
-        memset(s1, 'x', 8);
-        s1[0] = 'y';
-        s1[2] = 'Z';
-        s1[7] = '\0';
-
-        ret = strcasestr(s0, s1);
-
-        return !(NULL != ret);
-}
-  ]])],[
-    dnl using the platform implementation
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
+  AC_CHECK_FUNCS([strcasestr],,[
     AC_MSG_NOTICE(using libmagic strcasestr implementation)
     libmagic_sources="$libmagic_sources libmagic/strcasestr.c"
-  ],[AC_MSG_RESULT([skipped, cross-compiling])])
+  ])
 
   PHP_NEW_EXTENSION(fileinfo, fileinfo.c php_libmagic.c $libmagic_sources, $ext_shared,,-I@ext_srcdir@/libmagic)
   PHP_ADD_BUILD_DIR($ext_builddir/libmagic)


### PR DESCRIPTION
The strcasestr is not present on Windows and on Solaris 10 until Solaris 11 implementation in string.h.

At this point strcasestr is not used in the bundled libmagic (file) library due to patch removing the strcasestr usage in file.c, however future libmagic version bump might need it again. This simplifies the strcasestr check if available on the system without running the test code and avoiding the unknown issue when cross-compiling. If found, the HAVE_STRCASESTR is defined, otherwise the strcasestr.c is added to the build sources.