### PR TITLE
Remove PHP 4 PDO headers installation

### DIFF
--- a/ext/pdo/Makefile.frag
+++ b/ext/pdo/Makefile.frag
@@ -1,11 +1,3 @@
-phpincludedir=$(prefix)/include/php
-
-PDO_HEADER_FILES= \
-	php_pdo.h \
-	php_pdo_driver.h \
-	php_pdo_error.h
-
-
 $(srcdir)/pdo_sql_parser.c: $(srcdir)/pdo_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./pdo_sql_parser.re; then \
@@ -13,23 +5,3 @@ $(srcdir)/pdo_sql_parser.c: $(srcdir)/pdo_sql_parser.re
 	else \
 		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re; \
 	fi)
-
-install-pdo-headers:
-	@echo "Installing PDO headers:           $(INSTALL_ROOT)$(phpincludedir)/ext/pdo/"
-	@$(mkinstalldirs) $(INSTALL_ROOT)$(phpincludedir)/ext/pdo
-	@for f in $(PDO_HEADER_FILES); do \
-		if test -f "$(top_srcdir)/$$f"; then \
-			$(INSTALL_DATA) $(top_srcdir)/$$f $(INSTALL_ROOT)$(phpincludedir)/ext/pdo; \
-		elif test -f "$(top_builddir)/$$f"; then \
-			$(INSTALL_DATA) $(top_builddir)/$$f $(INSTALL_ROOT)$(phpincludedir)/ext/pdo; \
-		elif test -f "$(top_srcdir)/ext/pdo/$$f"; then \
-			$(INSTALL_DATA) $(top_srcdir)/ext/pdo/$$f $(INSTALL_ROOT)$(phpincludedir)/ext/pdo; \
-		elif test -f "$(top_builddir)/ext/pdo/$$f"; then \
-			$(INSTALL_DATA) $(top_builddir)/ext/pdo/$$f $(INSTALL_ROOT)$(phpincludedir)/ext/pdo; \
-		else \
-			echo "hmmm"; \
-		fi \
-	done;
-
-# mini hack
-install: $(all_targets) $(install_targets) install-pdo-headers


### PR DESCRIPTION
This was once used before the PHP_INSTALL_HEADERS macro became available in PHP 5.1.