### PR TITLE
zend_call_stack sort of GH-13358 follow-up.

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_010.phpt
+++ b/Zend/tests/stack_limit/stack_limit_010.phpt
@@ -27,6 +27,7 @@ $expectedMaxSize = match(php_uname('s')) {
         'true' => 16*1024*1024, // https://github.com/actions/runner-images/pull/3328
         default => 8*1024*1024,
     },
+    'SunOS' => 10 * 1024 * 1024,
     'Windows NT' => 67108864 - 4*4096, // Set by sapi/cli/config.w32
 };
 


### PR DESCRIPTION
for threaded context, it solely uses a new api only available on illumos.
Here using a common older api to get the stack info for the current thread.
while at it, completing stack_limit_010 test for these platforms.