### PR TITLE
ext/standard: Minor improvements to phpinfo() output

### DIFF
--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -939,7 +939,7 @@ ZEND_INI_DISP(zend_ini_color_displayer_cb) /* {{{ */
 	}
 	if (value) {
 		if (zend_uv.html_errors) {
-			zend_printf("<font style=\"color: %s\">%s</font>", value, value);
+			zend_printf("<span style=\"color: %s\">%s</span>", value, value);
 		} else {
 			ZEND_PUTS(value);
 		}

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -805,7 +805,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 	        the_time = time(NULL);
 	        ta = php_localtime_r(&the_time, &tmbuf);
 
-			php_info_print("<a href=\"http://www.php.net/\"><img border=\"0\" src=\"");
+			php_info_print("<a href=\"https://www.php.net/\"><img src=\"");
 	        if (ta && (ta->tm_mon==3) && (ta->tm_mday==1)) {
 		        php_info_print(PHP_EGG_LOGO_DATA_URI "\" alt=\"PHP logo\" /></a>");
 	        } else {
@@ -928,7 +928,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 		/* Zend Engine */
 		php_info_print_box_start(0);
 		if (!sapi_module.phpinfo_as_text) {
-			php_info_print("<a href=\"http://www.zend.com/\"><img border=\"0\" src=\"");
+			php_info_print("<a href=\"https://www.zend.com/\"><img src=\"");
 			php_info_print(ZEND_LOGO_DATA_URI "\" alt=\"Zend logo\" /></a>\n");
 		}
 		php_info_print("This program makes use of the Zend Scripting Language Engine:");


### PR DESCRIPTION
 - Change `http://` links to `https://` for php.net and zend.com
 - Remove `<img border=0` attributes as they are no longer in the HTML standard
 - Replace `<font>` tags with `<span>` tags (used for highlight.* INI color value display previews)