### PR TITLE
Remove obsolete PHP_WITH_SHARED M4 macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -64,6 +64,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol MISSING_FCLOSE_DECL and M4 macro PHP_MISSING_FCLOSE_DECL removed.
    - Symbol HAVE_BSD_ICONV has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
+   - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -953,18 +953,6 @@ dnl ---------------------------
 ])
 
 dnl
-dnl PHP_WITH_SHARED
-dnl
-dnl Checks whether $withval is "shared" or starts with "shared,XXX" and sets
-dnl $shared to "yes" or "no", and removes "shared,?" stuff from $withval.
-dnl
-AC_DEFUN([PHP_WITH_SHARED],[
-  PHP_ARG_ANALYZE_EX(withval)
-  shared=$ext_shared
-  unset ext_shared ext_output
-])
-
-dnl
 dnl PHP_ADD_EXTENSION_DEP(extname, depends [, depconf])
 dnl
 dnl This macro is scanned by genif.sh when it builds the internal functions


### PR DESCRIPTION
This macro is obsolete in favor of the PHP_ARG_WITH macro. It was once used in combination with the AC_ARG_WITH macro to determine, whether the extension has been configured as shared.

New attempt after macOS caching issues: #13374