### PR TITLE
int|float for DateTime::setTimestamp

### DIFF
--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -204,7 +204,7 @@ function date_date_set(DateTime $object, int $year, int $month, int $day): DateT
 
 function date_isodate_set(DateTime $object, int $year, int $week, int $dayOfWeek = 1): DateTime {}
 
-function date_timestamp_set(DateTime $object, int $timestamp): DateTime {}
+function date_timestamp_set(DateTime $object, int|float $timestamp): DateTime {}
 
 function date_timestamp_get(DateTimeInterface $object): int {}
 
@@ -437,7 +437,7 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_timestamp_set
      */
-    public function setTimestamp(int $timestamp): DateTime {}
+    public function setTimestamp(int|float $timestamp): DateTime {}
 
     /** @tentative-return-type */
     public function setMicroseconds(int $microseconds): static {}
@@ -543,7 +543,7 @@ class DateTimeImmutable implements DateTimeInterface
     public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTimeImmutable {}
 
     /** @tentative-return-type */
-    public function setTimestamp(int $timestamp): DateTimeImmutable {}
+    public function setTimestamp(int|float $timestamp): DateTimeImmutable {}
 
     /** @tentative-return-type */
     public function setMicroseconds(int $microseconds): static {}

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6fb121a5992ae96d12dea6055d1b0f0d6534cf21 */
+ * Stub hash: 690e40e295b09ca44dbb6dfadd3cd350695b4c85 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -148,7 +148,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_timestamp_set, 0, 2, DateTime, 0)
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
-	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
+	ZEND_ARG_TYPE_MASK(0, timestamp, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_date_timestamp_get arginfo_date_offset_get
@@ -329,7 +329,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setISODa
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimestamp, 0, 1, DateTime, 0)
-	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
+	ZEND_ARG_TYPE_MASK(0, timestamp, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setMicroseconds, 0, 1, IS_STATIC, 0)
@@ -408,7 +408,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setTimestamp, 0, 1, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
+	ZEND_ARG_TYPE_MASK(0, timestamp, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_setMicroseconds arginfo_class_DateTime_setMicroseconds

--- a/ext/date/tests/date-set-timestamp.phpt
+++ b/ext/date/tests/date-set-timestamp.phpt
@@ -9,7 +9,12 @@ echo $d->format( "Y-m-d H:i e\n" );
 $d = new DateTime();
 $d->setTimestamp( 1217184864 );
 echo $d->format( "Y-m-d H:i e\n" );
+
+$d = new DateTime();
+$d->setTimestamp(0.123456789);
+echo $d->format( \DateTime::RFC3339_EXTENDED );
 ?>
 --EXPECT--
 2008-07-27 18:54 +00:00
 2008-07-27 20:54 Europe/Oslo
+1970-01-01T01:00:00.123+01:00

--- a/ext/date/tests/date_timestamp_set_nullparam2.phpt
+++ b/ext/date/tests/date_timestamp_set_nullparam2.phpt
@@ -14,7 +14,7 @@ $dtms021 = date_create();
 var_dump(date_timestamp_set($dtms021, null));
 ?>
 --EXPECTF--
-Deprecated: date_timestamp_set(): Passing null to parameter #2 ($timestamp) of type int is deprecated in %s on line %d
+Deprecated: date_timestamp_set(): Passing null to parameter #2 ($timestamp) of type int|float is deprecated in %s on line %d
 object(DateTime)#1 (3) {
   ["date"]=>
   string(26) "1970-01-01 00:00:00.000000"


### PR DESCRIPTION
just like the constructor accepts
```
new DateTime("@0.123456"); // 1970-01-01 00:00:00.123456
new DateTime("@".microtime(true));
```
now setTimestamp accepts it too:
```
$dt->setTimestamp(0.123456); // 1970-01-01 00:00:00.123456
$dt->setTimestamp(microtime(true));
```

resolves https://github.com/php/php-src/issues/13376
