### PR TITLE
zend_ssa minor struct changes.

### DIFF
--- a/Zend/Optimizer/zend_ssa.h
+++ b/Zend/Optimizer/zend_ssa.h
@@ -67,7 +67,7 @@ struct _zend_ssa_phi {
 	int                    var;           /* Original CV, VAR or TMP variable index */
 	int                    ssa_var;       /* SSA variable index */
 	int                    block;         /* current BB index */
-	bool                   has_range_constraint : 1;
+	bool                   has_range_constraint;
 	zend_ssa_phi         **use_chains;
 	zend_ssa_phi          *sym_use_chain;
 	int                   *sources;       /* Array of SSA IDs that produce this var.
@@ -112,8 +112,8 @@ typedef struct _zend_ssa_var {
 	zend_ssa_phi          *definition_phi; /* phi that defines this value */
 	zend_ssa_phi          *phi_use_chain;  /* uses of this value in Phi, linked through use_chain */
 	zend_ssa_phi          *sym_use_chain;  /* uses of this value in Pi constraints */
-	unsigned int           no_val : 1;     /* value doesn't matter (used as op1 in ZEND_ASSIGN) */
-	unsigned int           scc_entry : 1;
+	bool                   no_val : 1;     /* value doesn't matter (used as op1 in ZEND_ASSIGN) */
+	bool                   scc_entry : 1;
 	unsigned int           alias : 2;  /* value may be changed indirectly */
 	unsigned int           escape_state : 2;
 } zend_ssa_var;


### PR DESCRIPTION
_zend_ssa_pid::has_range_constraint being the only bool, the bitfield would not bring any benefit.