### PR TITLE
Workaround ZTS persistent resource crashes (PHP 8.3 and lower)

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1091,33 +1091,8 @@ zend_result zend_post_startup(void) /* {{{ */
 }
 /* }}} */
 
-/* Returns a NULL-terminated array of module entries that were dynamically loaded. */
-static zend_module_entry **zend_collect_dl_loaded_module_entries(void)
-{
-	zend_module_entry **modules = malloc(sizeof(zend_module_entry *) * (zend_hash_num_elements(&module_registry) + 1));
-	zend_module_entry *module;
-	unsigned int index = 0;
-	ZEND_HASH_MAP_REVERSE_FOREACH_PTR(&module_registry, module) {
-		if (module->handle) {
-			modules[index++] = module;
-		}
-	} ZEND_HASH_FOREACH_END();
-	modules[index] = NULL;
-	return modules;
-}
-
-static void zend_unload_modules(zend_module_entry **modules)
-{
-	while (*modules) {
-		module_registry_unload(*modules);
-		modules++;
-	}
-}
-
 void zend_shutdown(void) /* {{{ */
 {
-	zend_module_entry **modules = zend_collect_dl_loaded_module_entries();
-
 	zend_vm_dtor();
 
 	zend_destroy_rsrc_list(&EG(persistent_list));
@@ -1166,8 +1141,7 @@ void zend_shutdown(void) /* {{{ */
 #endif
 	zend_destroy_rsrc_list_dtors();
 
-	zend_unload_modules(modules);
-	free(modules);
+	zend_unload_modules();
 
 	zend_optimizer_shutdown();
 	startup_done = false;

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -277,6 +277,7 @@ void zend_shutdown(void);
 void zend_register_standard_ini_entries(void);
 zend_result zend_post_startup(void);
 void zend_set_utility_values(zend_utility_values *utility_values);
+void zend_unload_modules(void);
 
 ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno);
 ZEND_API size_t zend_get_page_size(void);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3153,6 +3153,7 @@ void zend_unload_modules(void) /* {{{ */
 		modules++;
 	}
 	free(modules_dl_loaded);
+	modules_dl_loaded = NULL;
 }
 /* }}} */
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3073,17 +3073,22 @@ void module_destructor(zend_module_entry *module) /* {{{ */
 		clean_module_functions(module);
 	}
 
-#if HAVE_LIBDL
-	if (module->handle && !getenv("ZEND_DONT_UNLOAD_MODULES")) {
-		DL_UNLOAD(module->handle);
-	}
-#endif
-
 #if ZEND_RC_DEBUG
 	zend_rc_debug = orig_rc_debug;
 #endif
 }
 /* }}} */
+
+void module_registry_unload(const zend_module_entry *module)
+{
+#if HAVE_LIBDL
+	if (module->handle && !getenv("ZEND_DONT_UNLOAD_MODULES")) {
+		DL_UNLOAD(module->handle);
+	}
+#else
+	ZEND_IGNORE_VALUE(module);
+#endif
+}
 
 ZEND_API void zend_activate_modules(void) /* {{{ */
 {
@@ -3147,6 +3152,7 @@ ZEND_API void zend_post_deactivate_modules(void) /* {{{ */
 				break;
 			}
 			module_destructor(module);
+			module_registry_unload(module);
 			zend_string_release_ex(key, 0);
 		} ZEND_HASH_MAP_FOREACH_END_DEL();
 	} else {

--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -125,7 +125,7 @@ extern ZEND_API HashTable module_registry;
 
 void module_destructor(zend_module_entry *module);
 int module_registry_request_startup(zend_module_entry *module);
-int module_registry_unload_temp(const zend_module_entry *module);
+void module_registry_unload(const zend_module_entry *module);
 END_EXTERN_C()
 
 #endif


### PR DESCRIPTION
For master (8.4-dev) I merged GH-13381. But that PR changes public API of TSRM, so cannot be used on lower branches.

This patch is a safe workaround for the issue with dynamic loaded modules, in combination with a existing fix using [`ifdef ZTS + if (module_started)` inside pgsql and odbc](https://github.com/php/php-src/blob/c2b671cb1bc61305013aa449e3cd04253f32f52a/ext/pgsql/pgsql.c#L317-L324). The idea is to delay unloading modules until the persistent resources are destroyed. This will keep the destructor code accessible in memory.

This is not a proper fix on its own, because we still need the workaround of not accessing globals after module destruction. The proper fix is in master.

Note: `module_registry_unload_temp` does not exist.