### PR TITLE
Use Autoconf AC_CHECK_TYPE for checking siginfo_t

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -9,20 +9,7 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
   AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx])
 
-  AC_MSG_CHECKING([for siginfo_t])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #include <signal.h>
-    #ifdef HAVE_SIGINFO_H
-      #include <siginfo.h>
-    #endif
-  ]],[[
-    siginfo_t info;
-  ]])],[
-    AC_MSG_RESULT([yes])
-    PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"
-  ], [
-    AC_MSG_RESULT([no])
-  ])
+  AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
 
   PHP_NEW_EXTENSION(pcntl, pcntl.c php_signal.c, $ext_shared, cli, $PCNTL_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 fi


### PR DESCRIPTION
The siginfo_t is defined by including the signal.h. Some systems include the siginfo.h in the signal.h. Including it separately is obsolete on current systems.