### PR TITLE
Use AC_CHECK_TYPES for checking struct flock

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -68,6 +68,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_BSD_ICONV has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
+   - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -1243,25 +1243,6 @@ AC_DEFUN([PHP_MISSING_TIME_R_DECL],[
 ])
 
 dnl
-dnl PHP_STRUCT_FLOCK
-dnl
-AC_DEFUN([PHP_STRUCT_FLOCK],[
-AC_CACHE_CHECK(for struct flock,ac_cv_struct_flock,
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <unistd.h>
-#include <fcntl.h>
-        ]], [[struct flock x;]])],[
-          ac_cv_struct_flock=yes
-        ],[
-          ac_cv_struct_flock=no
-        ])
-)
-if test "$ac_cv_struct_flock" = "yes" ; then
-    AC_DEFINE(HAVE_STRUCT_FLOCK, 1,[whether you have struct flock])
-fi
-])
-
-dnl
 dnl PHP_SOCKADDR_CHECKS
 dnl
 AC_DEFUN([PHP_SOCKADDR_CHECKS], [

--- a/configure.ac
+++ b/configure.ac
@@ -464,8 +464,8 @@ dnl ----------------------------------------------------------------------------
 AC_STRUCT_TIMEZONE
 
 PHP_MISSING_TIME_R_DECL
-PHP_STRUCT_FLOCK
 
+AC_CHECK_TYPES([struct flock],,,[#include <fcntl.h>])
 AC_CHECK_TYPES(socklen_t, [], [], [
   #ifdef HAVE_SYS_TYPES_H
   # include <sys/types.h>


### PR DESCRIPTION
The struct flock is defined in fcntl.h, if system has it. This removes redundant PHP_STRUCT_FLOCK M4 macro in favor of the AC_CHECK_TYPES, which by default defines symbol HAVE_STRUCT_FLOCK.