### PR TITLE
Refactor PHP_SOCKADDR_CHECKS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -69,6 +69,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
+   - M4 macro PHP_SOCKADDR_CHECKS has been removed (use AC_CHECK_TYPES and
+     AC_CHECK_MEMBERS).
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -1243,31 +1243,6 @@ AC_DEFUN([PHP_MISSING_TIME_R_DECL],[
 ])
 
 dnl
-dnl PHP_SOCKADDR_CHECKS
-dnl
-AC_DEFUN([PHP_SOCKADDR_CHECKS], [
-  dnl Check for struct sockaddr_storage exists.
-  AC_CACHE_CHECK([for struct sockaddr_storage], ac_cv_sockaddr_storage,
-    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <sys/socket.h>]],
-    [[struct sockaddr_storage s; s]])],
-    [ac_cv_sockaddr_storage=yes], [ac_cv_sockaddr_storage=no])
-  ])
-  if test "$ac_cv_sockaddr_storage" = "yes"; then
-    AC_DEFINE(HAVE_SOCKADDR_STORAGE, 1, [Whether you have struct sockaddr_storage])
-  fi
-  dnl Check if field sa_len exists in struct sockaddr.
-  AC_CACHE_CHECK([for field sa_len in struct sockaddr],ac_cv_sockaddr_sa_len,[
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <sys/socket.h>]], [[static struct sockaddr sa; int n = (int) sa.sa_len; return n;]])],
-    [ac_cv_sockaddr_sa_len=yes], [ac_cv_sockaddr_sa_len=no])
-  ])
-  if test "$ac_cv_sockaddr_sa_len" = "yes"; then
-    AC_DEFINE(HAVE_SOCKADDR_SA_LEN, 1, [Whether struct sockaddr has field sa_len])
-  fi
-])
-
-dnl
 dnl PHP_EBCDIC
 dnl
 AC_DEFUN([PHP_EBCDIC], [

--- a/configure.ac
+++ b/configure.ac
@@ -552,7 +552,8 @@ dnl Checks for types.
 AC_TYPE_UID_T
 
 dnl Checks for sockaddr_storage and sockaddr.sa_len.
-PHP_SOCKADDR_CHECKS
+AC_CHECK_TYPES([struct sockaddr_storage],,,[#include <sys/socket.h>])
+AC_CHECK_MEMBERS([struct sockaddr.sa_len],,,[#include <sys/socket.h>])
 
 dnl Checks for GCC function attributes on all systems except ones without glibc
 dnl Fix for these systems is already included in GCC 7, but not on GCC 6.

--- a/ext/sockets/multicast.c
+++ b/ext/sockets/multicast.c
@@ -790,7 +790,7 @@ zend_result php_add4_to_if_index(struct in_addr *addr, php_socket *php_sock, uns
 		struct ifreq cur_req;
 		memcpy(&cur_req, p, sizeof(struct ifreq));
 
-#ifdef HAVE_SOCKADDR_SA_LEN
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 		entry_len = cur_req.ifr_addr.sa_len + sizeof(cur_req.ifr_name);
 #else
 		/* if there's no sa_len, assume the ifr_addr field is a sockaddr */

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -247,11 +247,11 @@ static inline bool _php_check_fd_setsize(php_socket_t *max_fd, int setsize)
 
 #define PHP_SOCK_CHUNK_SIZE	8192
 
-#ifdef HAVE_SOCKADDR_STORAGE
+#ifdef HAVE_STRUCT_SOCKADDR_STORAGE
 typedef struct sockaddr_storage php_sockaddr_storage;
 #else
 typedef struct {
-#ifdef HAVE_SOCKADDR_SA_LEN
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 		unsigned char ss_len;
 		unsigned char ss_family;
 #else


### PR DESCRIPTION
Instead of the project macro, the sockaddr_storage and sockaddr.sa_len can be checked with the AC_CHECK_TYPES and AC_CHECK_MEMBERS by including the sys/socket.h. Some systems (~1988) didn't include the sys/types.h in the socket.h (obsolete on current systems).

These macros by default define the HAVE_STRUCT_SOCKADDR_STORAGE and HAVE_STRUCT_SOCKADDR_SA_LEN.