### PR TITLE
Check sockaddr_storage.ss_family with AC_CHECK_MEMBERS

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -10,19 +10,7 @@ if test "$PHP_SOCKETS" != "no"; then
   AC_DEFINE([HAVE_SOCKETS], 1, [ ])
 
   dnl Check for fied ss_family in sockaddr_storage (missing in AIX until 5.3)
-  AC_CACHE_CHECK([for field ss_family in struct sockaddr_storage], ac_cv_ss_family,
-  [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netdb.h>
-  ]], [[struct sockaddr_storage sa_store; sa_store.ss_family = AF_INET6;]])],
-    [ac_cv_ss_family=yes], [ac_cv_ss_family=no])
-  ])
-
-  if test "$ac_cv_ss_family" = yes; then
-    AC_DEFINE(HAVE_SA_SS_FAMILY,1,[Whether you have sockaddr_storage.ss_family])
-  fi
+  AC_CHECK_MEMBERS([struct sockaddr_storage.ss_family],,,[#include <sys/socket.h>])
 
   dnl Check for AI_V4MAPPED flag
   AC_CACHE_CHECK([if getaddrinfo supports AI_V4MAPPED],[ac_cv_gai_ai_v4mapped],

--- a/ext/sockets/php_sockets.h
+++ b/ext/sockets/php_sockets.h
@@ -132,7 +132,7 @@ PHP_SOCKETS_API bool socket_import_file_descriptor(PHP_SOCKET socket, php_socket
 #define phpext_sockets_ptr NULL
 #endif
 
-#if defined(_AIX) && !defined(HAVE_SA_SS_FAMILY)
+#if defined(_AIX) && !defined(HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY)
 # define ss_family __ss_family
 #endif
 


### PR DESCRIPTION
This simplifies the check. On AIX 6 and newer, the ss_family is available, if compiled without defining COMPAT_43 (BSD 4.3 compatibility).