### PR TITLE
Create modules directory in a centralized location

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -128,6 +128,16 @@ AC_DEFUN([PHP_INIT_BUILD_SYSTEM],[
 AC_REQUIRE([PHP_CANONICAL_HOST_TARGET])dnl
 > Makefile.objects
 > Makefile.fragments
+dnl Run at the end of the configuration, before creating the config.status.
+AC_CONFIG_COMMANDS_PRE([dnl
+dnl Directory for storing shared objects of extensions.
+PHP_ADD_BUILD_DIR([modules])dnl
+phplibdir="$(pwd)/modules"
+PHP_SUBST([phplibdir])dnl
+dnl Create build directories and generate global Makefile.
+PHP_GEN_BUILD_DIRS[]dnl
+PHP_GEN_GLOBAL_MAKEFILE[]dnl
+])dnl
 ])
 
 dnl
@@ -136,6 +146,7 @@ dnl
 dnl Generates the global makefile.
 dnl
 AC_DEFUN([PHP_GEN_GLOBAL_MAKEFILE],[
+  AC_MSG_NOTICE([creating Makefile])
   cat >Makefile <<EOF
 srcdir = $abs_srcdir
 builddir = $abs_builddir
@@ -881,6 +892,7 @@ dnl
 dnl PHP_GEN_BUILD_DIRS
 dnl
 AC_DEFUN([PHP_GEN_BUILD_DIRS],[
+  AC_MSG_NOTICE([creating build directories])
   $php_shtool mkdir -p $BUILD_DIR
 ])
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -129,14 +129,13 @@ AC_REQUIRE([PHP_CANONICAL_HOST_TARGET])dnl
 > Makefile.objects
 > Makefile.fragments
 dnl Run at the end of the configuration, before creating the config.status.
-AC_CONFIG_COMMANDS_PRE([dnl
-dnl Directory for storing shared objects of extensions.
-PHP_ADD_BUILD_DIR([modules])dnl
+AC_CONFIG_COMMANDS_PRE(
+[dnl Directory for storing shared objects of extensions.
+PHP_ADD_BUILD_DIR([modules])
 phplibdir="$(pwd)/modules"
-PHP_SUBST([phplibdir])dnl
-dnl Create build directories and generate global Makefile.
-PHP_GEN_BUILD_DIRS[]dnl
-PHP_GEN_GLOBAL_MAKEFILE[]dnl
+PHP_SUBST([phplibdir])
+PHP_GEN_BUILD_DIRS
+PHP_GEN_GLOBAL_MAKEFILE
 ])dnl
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1380,8 +1380,6 @@ case `eval echo $datadir` in
     ;;
 esac
 
-phplibdir=`pwd`/modules
-$php_shtool mkdir -p $phplibdir
 phptempdir=`pwd`/libs
 
 old_exec_prefix=$exec_prefix
@@ -1508,7 +1506,6 @@ PHP_SUBST_OLD(program_suffix)
 PHP_SUBST(includedir)
 PHP_SUBST(libdir)
 PHP_SUBST(mandir)
-PHP_SUBST(phplibdir)
 PHP_SUBST(phptempdir)
 PHP_SUBST(prefix)
 PHP_SUBST(localstatedir)
@@ -1749,9 +1746,6 @@ PHP_ADD_BUILD_DIR(Zend Zend/asm Zend/Optimizer)
 
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/scripts/Makefile.frag,$abs_srcdir/scripts,scripts)
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Zend/Makefile.frag,$abs_srcdir/Zend,Zend)
-
-PHP_GEN_BUILD_DIRS
-PHP_GEN_GLOBAL_MAKEFILE
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -162,7 +162,6 @@ AC_PROG_LIBTOOL
 
 all_targets='$(PHP_MODULES) $(PHP_ZEND_EX)'
 install_targets="install-modules install-headers"
-phplibdir="`pwd`/modules"
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CFLAGS_CLEAN='$(CFLAGS) -D_GNU_SOURCE'
 CXXFLAGS_CLEAN='$(CXXFLAGS)'
@@ -188,7 +187,6 @@ PHP_SUBST(prefix)
 PHP_SUBST(exec_prefix)
 PHP_SUBST(libdir)
 PHP_SUBST(prefix)
-PHP_SUBST(phplibdir)
 PHP_SUBST(phpincludedir)
 
 PHP_SUBST(CC)
@@ -209,11 +207,6 @@ PHP_SUBST(LIBTOOL)
 PHP_SUBST(SHELL)
 PHP_SUBST(INSTALL_HEADERS)
 PHP_SUBST(BUILD_CC)
-
-PHP_GEN_BUILD_DIRS
-PHP_GEN_GLOBAL_MAKEFILE
-
-test -d modules || $php_shtool mkdir modules
 
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Shared objects of extensions during the build are copied to the `modules` directory. It is a practice established since the early days of the PHP build system. This change ensures that the directory is consistently created in a single location, for both the primary PHP build process and when utilizing `phpize` within extensions. For now, the shtool is still utilized, until it can be clear that it is obsolete on current systems and their shells in favor of the native mkdir.