### PR TITLE
Remove skipping on Darwin for socket test

### DIFF
--- a/ext/sockets/tests/socket_set_option_error_socket_option.phpt
+++ b/ext/sockets/tests/socket_set_option_error_socket_option.phpt
@@ -5,9 +5,6 @@ sockets
 --SKIPIF--
 <?php
 
-if (PHP_OS == 'Darwin') {
-    die('skip Not for OSX');
-}
 $filename = __FILE__ . '.root_check.tmp';
 $fp = fopen($filename, 'w');
 fclose($fp);


### PR DESCRIPTION
The test passes on Apple.