### PR TITLE
script to format pull requests

### DIFF
--- a/scripts/dev/format_pull_request.php
+++ b/scripts/dev/format_pull_request.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+error_reporting(E_ALL);
+set_error_handler(function ($errno, $errstr, $errfile, $errline){
+    if(error_reporting() & $errno) {
+        throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+    }
+});
+$force = array_search('--force', $argv, true);
+if ($force !== false) {
+    unset($argv[$force]);
+    $force = true;
+    $argv = array_values($argv);
+    $argc = count($argv);
+}
+if ($argc !== 2) {
+    ob_start();
+    echo "Usage: php {$argv[0]} [diff-uri]\n";
+    echo "example:\nphp {$argv[0]} " . escapeshellarg('https://github.com/php/php-src/pull/13401.diff') . "\n";
+    fwrite(STDERR, ob_get_clean());
+    exit(1);
+}
+chdir(__DIR__ . '/../../'); // php-src root
+if(!$force){
+    $gitStatus = null;
+    system('git diff --quiet --exit-code', $gitStatus);
+    if($gitStatus !== 0){
+        fwrite(STDERR, "Error: Working directory is not clean according to 'git diff'\n");
+        fwrite(STDERR, "commit your stuff -or- run 'git reset --hard' and try again\n");
+        exit(1);
+    }
+    unset($gitStatus);
+}
+//
+$diff = file_get_contents($argv[1]);
+$diffFileHandle = tmpfile();
+fwrite($diffFileHandle, $diff);
+$diffFilePath = stream_get_meta_data($diffFileHandle)['uri'];
+passthru("git apply " . escapeshellarg($diffFilePath), $ret);
+if($ret !== 0){
+    fwrite(STDERR, "Error: git apply failed with exit code {$ret}\n");
+    passthru("git reset --hard");
+    exit(1);
+}
+$clangFormatOptions = array(
+    // tests on ext/standard/array.c indicate that the clang-format
+    // preset that most closely resembles the php-src coding style is WebKit
+    'BasedOnStyle' => 'WebKit',
+    'UseTab' => 'ForIndentation',
+    // clang-format's support for tabs isn't great, and we have to say "4 spaces" to get 1 tab
+    'IndentWidth' => 4, 
+    'TabWidth' => 4,
+);
+
+$cmd = array(
+    'git diff -U0 --no-color --relative  |',
+    'clang-format-diff -p1 -style=' . escapeshellarg(json_encode($clangFormatOptions)),
+    '-iregex=' . escapeshellarg('.*\.(c|cc|cpp|c\+\+|cxx|h|hh|hpp|h\+\+|h)$'),
+);
+$cmd = implode(' ', $cmd);
+passthru($cmd, $ret);
+if($ret !== 0){
+    fwrite(STDERR, "Error: clang-format-diff failed with exit code {$ret}\n");
+    fwrite(STDERR, "cmd:\n{$cmd}\n");
+    //passthru("git reset --hard");
+    exit(1);
+}
+shell_exec("git reset --hard");

--- a/scripts/dev/format_pull_request.php
+++ b/scripts/dev/format_pull_request.php
@@ -62,7 +62,7 @@ passthru($cmd, $ret);
 if($ret !== 0){
     fwrite(STDERR, "Error: clang-format-diff failed with exit code {$ret}\n");
     fwrite(STDERR, "cmd:\n{$cmd}\n");
-    //passthru("git reset --hard");
+    passthru("git reset --hard");
     exit(1);
 }
 shell_exec("git reset --hard");

--- a/scripts/dev/format_pull_request.php
+++ b/scripts/dev/format_pull_request.php
@@ -1,8 +1,9 @@
 <?php
+
 declare(strict_types=1);
 error_reporting(E_ALL);
-set_error_handler(function ($errno, $errstr, $errfile, $errline){
-    if(error_reporting() & $errno) {
+set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+    if (error_reporting() & $errno) {
         throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
     }
 });
@@ -21,10 +22,10 @@ if ($argc !== 2) {
     exit(1);
 }
 chdir(__DIR__ . '/../../'); // php-src root
-if(!$force){
+if (!$force) {
     $gitStatus = null;
     system('git diff --quiet --exit-code', $gitStatus);
-    if($gitStatus !== 0){
+    if ($gitStatus !== 0) {
         fwrite(STDERR, "Error: Working directory is not clean according to 'git diff'\n");
         fwrite(STDERR, "commit your stuff -or- run 'git reset --hard' and try again\n");
         exit(1);
@@ -37,9 +38,20 @@ $diffFileHandle = tmpfile();
 fwrite($diffFileHandle, $diff);
 $diffFilePath = stream_get_meta_data($diffFileHandle)['uri'];
 passthru("git apply " . escapeshellarg($diffFilePath), $ret);
-if($ret !== 0){
+if ($ret !== 0) {
     fwrite(STDERR, "Error: git apply failed with exit code {$ret}\n");
-    passthru("git reset --hard");
+    if (!$force) {
+        passthru('git reset --hard');
+    }
+    exit(1);
+}
+// commit
+passthru('git commit -a --message=clangformat --quiet', $ret);
+if ($ret !== 0) {
+    fwrite(STDERR, "Error: git commit failed with exit code {$ret}\n");
+    if (!$force) {
+        passthru('git reset --hard');
+    }
     exit(1);
 }
 $clangFormatOptions = array(
@@ -48,21 +60,27 @@ $clangFormatOptions = array(
     'BasedOnStyle' => 'WebKit',
     'UseTab' => 'ForIndentation',
     // clang-format's support for tabs isn't great, and we have to say "4 spaces" to get 1 tab
-    'IndentWidth' => 4, 
+    'IndentWidth' => 4,
     'TabWidth' => 4,
 );
-
 $cmd = array(
-    'git diff -U0 --no-color --relative  |',
-    'clang-format-diff -p1 -style=' . escapeshellarg(json_encode($clangFormatOptions)),
+    'git diff -U0 --no-color --relative HEAD^ |',
+    'clang-format-diff -i -p1 -style=' . escapeshellarg(json_encode($clangFormatOptions)),
     '-iregex=' . escapeshellarg('.*\.(c|cc|cpp|c\+\+|cxx|h|hh|hpp|h\+\+|h)$'),
 );
 $cmd = implode(' ', $cmd);
 passthru($cmd, $ret);
-if($ret !== 0){
+if ($ret !== 0) {
     fwrite(STDERR, "Error: clang-format-diff failed with exit code {$ret}\n");
     fwrite(STDERR, "cmd:\n{$cmd}\n");
-    passthru("git reset --hard");
+    if (!$force) {
+        // remove last commit and reset
+        passthru('git reset --hard HEAD^ --quiet');
+    }
     exit(1);
 }
-shell_exec("git reset --hard");
+passthru('git diff');
+if (!$force) {
+    // remove last commit and reset
+    passthru('git reset --hard HEAD^ --quiet');
+}


### PR DESCRIPTION
a script to format pull requests.
related conversation: https://github.com/php/php-src/pull/13401/files/d64a8ccdc1d21576827059ee86c0fa073c95ffcc#r1492699756

requirements: git, clang-format, php-cli.
usage: make sure your git working dir is clean (like "git reset --hard" clean) and run 
```
php scripts/dev/format_pull_request.php 'https://github.com/php/php-src/pull/13401.diff'
```
and if the pull request is not properly formatted, you should get a diff like
```diff
diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
index 320cbcc743..db68b727e5 100644
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1128,58 +1128,58 @@ PHP_FUNCTION(flush)
 /* }}} */
 
 /* {{{ Delay for a given number of seconds */
-PHP_FUNCTION(sleep) {
-  zval *num;
-
-  ZEND_PARSE_PARAMETERS_START(1, 1)
-  Z_PARAM_NUMBER(num)
-  ZEND_PARSE_PARAMETERS_END();
-  if (Z_TYPE_P(num) == IS_DOUBLE) {
-    const double seconds = Z_DVAL_P(num);
-    if (UNEXPECTED(seconds < 0)) {
-      zend_argument_value_error(1, "must be greater than or equal to 0");
-      RETURN_THROWS();
-    }
+PHP_FUNCTION(sleep)
+{
+	zval* num;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_NUMBER(num)
+	ZEND_PARSE_PARAMETERS_END();
+	if (Z_TYPE_P(num) == IS_DOUBLE) {
+		const double seconds = Z_DVAL_P(num);
+		if (UNEXPECTED(seconds < 0)) {
+			zend_argument_value_error(1, "must be greater than or equal to 0");
+			RETURN_THROWS();
+		}
 #ifdef HAVE_NANOSLEEP
-	time_t seconds_long = (time_t)seconds;
-	zend_long fraction_nanoseconds = (zend_long)((seconds - seconds_long) * 1000000000);
-	if(fraction_nanoseconds > 999999999) {
-		// for this to happen, you have to request to sleep for longer than
-		// 0.999999999 seconds and yet less than 1 second..
-		// nanosleep() has a documented limit of 999999999 nanoseconds, so let's just round it up to 1 second.
-		// that means we'll be off by <=0.9 nanoseconds in this edge-case, probably close enough.
-		fraction_nanoseconds = 0;
-		seconds_long += 1;
-	}
-	  struct timespec php_req, php_rem;
-	  php_req.tv_sec = (time_t)seconds_long;
-	  php_req.tv_nsec = fraction_nanoseconds;
-	  const int result = nanosleep(&php_req, &php_rem);
-	  if(UNEXPECTED(result == -1)) {
-		ZEND_ASSERT(errno != EINVAL); // this should be impossible, we carefully checked the input above
-		// it's probably EINTR
-		RETURN_DOUBLE(php_rem.tv_sec + (((double)php_rem.tv_nsec) / 1000000000.0));
-	  }
-	  RETURN_LONG(0);
+		time_t seconds_long = (time_t)seconds;
+		zend_long fraction_nanoseconds = (zend_long)((seconds - seconds_long) * 1000000000);
+		if (fraction_nanoseconds > 999999999) {
+			// for this to happen, you have to request to sleep for longer than
+			// 0.999999999 seconds and yet less than 1 second..
+			// nanosleep() has a documented limit of 999999999 nanoseconds, so let's just round it up to 1 second.
+			// that means we'll be off by <=0.9 nanoseconds in this edge-case, probably close enough.
+			fraction_nanoseconds = 0;
+			seconds_long += 1;
+		}
+		struct timespec php_req, php_rem;
+		php_req.tv_sec = (time_t)seconds_long;
+		php_req.tv_nsec = fraction_nanoseconds;
+		const int result = nanosleep(&php_req, &php_rem);
+		if (UNEXPECTED(result == -1)) {
+			ZEND_ASSERT(errno != EINVAL); // this should be impossible, we carefully checked the input above
+			// it's probably EINTR
+			RETURN_DOUBLE(php_rem.tv_sec + (((double)php_rem.tv_nsec) / 1000000000.0));
+		}
+		RETURN_LONG(0);
 #elif defined(HAVE_USLEEP)
-    const unsigned int fraction_microseconds =
-        (unsigned int)((seconds - (unsigned int)seconds) * 1000000);
-    if (fraction_microseconds > 0) {
-      usleep(fraction_microseconds);
-    }
-    RETURN_LONG(php_sleep((unsigned int)seconds));
+		const unsigned int fraction_microseconds = (unsigned int)((seconds - (unsigned int)seconds) * 1000000);
+		if (fraction_microseconds > 0) {
+			usleep(fraction_microseconds);
+		}
+		RETURN_LONG(php_sleep((unsigned int)seconds));
 #else
-	// avoid -Werror=unreachable-code
-    RETURN_LONG(php_sleep((unsigned int)seconds));
+		// avoid -Werror=unreachable-code
+		RETURN_LONG(php_sleep((unsigned int)seconds));
 #endif
-  }
-  ZEND_ASSERT(Z_TYPE_P(num) == IS_LONG); // Z_PARAM_NUMBER(num) above guarantee that it's double or float or throw :)
-  zend_long seconds = Z_LVAL_P(num);
-  if (UNEXPECTED(seconds < 0)) {
-    zend_argument_value_error(1, "must be greater than or equal to 0");
-    RETURN_THROWS();
-  }
-  RETURN_LONG(php_sleep((unsigned int)seconds));
+	}
+	ZEND_ASSERT(Z_TYPE_P(num) == IS_LONG); // Z_PARAM_NUMBER(num) above guarantee that it's double or float or throw :)
+	zend_long seconds = Z_LVAL_P(num);
+	if (UNEXPECTED(seconds < 0)) {
+		zend_argument_value_error(1, "must be greater than or equal to 0");
+		RETURN_THROWS();
+	}
+	RETURN_LONG(php_sleep((unsigned int)seconds));
 }
 /* }}} */

```
huh look at that, seems PR #13401 isn't properly formatted, i should do something about that.

This script is manual right now, but ideally it should be an automated part of a CI test, where a failed test can give a link to a diff file, so people can fix it by just running
```
curl 'link-to-diff-file' | git apply -
```
fwiw StyleCI does something similar (but does not support C): https://styleci.io/