### PR TITLE
ext/intl: Timezone::getIanaID method addition.

### DIFF
--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -616,6 +616,10 @@ function intltz_to_date_time_zone(IntlTimeZone $timezone): DateTimeZone|false {}
 
 function intltz_use_daylight_time(IntlTimeZone $timezone): bool {}
 
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+function intltz_get_iana_id(string $timezoneId): string|false {}
+#endif
+
 /* transliterator */
 
 function transliterator_create(string $id, int $direction = Transliterator::FORWARD): ?Transliterator {}

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 893419f59d38566a8f6a766829250c18663e339c */
+ * Stub hash: 50cc9edef7f40e6885be38be25a71f66d7405a50 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -753,6 +753,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_intltz_use_daylight_time, 0, 1, 
 	ZEND_ARG_OBJ_INFO(0, timezone, IntlTimeZone, 0)
 ZEND_END_ARG_INFO()
 
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_intltz_get_iana_id, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_transliterator_create, 0, 1, Transliterator, 1)
 	ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, direction, IS_LONG, 0, "Transliterator::FORWARD")
@@ -965,6 +971,9 @@ ZEND_FUNCTION(intltz_get_id_for_windows_id);
 ZEND_FUNCTION(intltz_has_same_rules);
 ZEND_FUNCTION(intltz_to_date_time_zone);
 ZEND_FUNCTION(intltz_use_daylight_time);
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+ZEND_FUNCTION(intltz_get_iana_id);
+#endif
 ZEND_FUNCTION(transliterator_create);
 ZEND_FUNCTION(transliterator_create_from_rules);
 ZEND_FUNCTION(transliterator_list_ids);
@@ -1154,6 +1163,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(intltz_has_same_rules, arginfo_intltz_has_same_rules)
 	ZEND_FE(intltz_to_date_time_zone, arginfo_intltz_to_date_time_zone)
 	ZEND_FE(intltz_use_daylight_time, arginfo_intltz_use_daylight_time)
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+	ZEND_FE(intltz_get_iana_id, arginfo_intltz_get_iana_id)
+#endif
 	ZEND_FE(transliterator_create, arginfo_transliterator_create)
 	ZEND_FE(transliterator_create_from_rules, arginfo_transliterator_create_from_rules)
 	ZEND_FE(transliterator_list_ids, arginfo_transliterator_list_ids)

--- a/ext/intl/tests/timezone_getIanaID.phpt
+++ b/ext/intl/tests/timezone_getIanaID.phpt
@@ -1,0 +1,25 @@
+--TEST--
+IntlTimeZone::getIanaID
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (version_compare(INTL_ICU_VERSION, '74.0') < 0) die('skip for ICU >= 74.0'); ?>
+--FILE--
+<?php
+ini_set("intl.error_level", E_WARNING);
+
+var_dump(IntlTimeZone::getIanaID("php\x81"));
+var_dump(IntlTimeZone::getIanaID("Galaxy/Pluto"));
+var_dump(IntlTimeZone::getIanaID('Europe/Dublin'));
+var_dump(IntlTimeZone::getIanaID('Asia/Calcutta'));
+var_dump(intltz_get_iana_id('Asia/Calcutta') === IntlTimeZone::getIanaID('Asia/Calcutta'));
+?>
+--EXPECTF--
+Warning: IntlTimeZone::getIanaID(): could not convert time zone id to UTF-16 in %s on line %d
+bool(false)
+
+Warning: IntlTimeZone::getIanaID(): error obtaining IANA ID in %s on line %d
+bool(false)
+string(13) "Europe/Dublin"
+string(12) "Asia/Kolkata"
+bool(true)

--- a/ext/intl/timezone/timezone.stub.php
+++ b/ext/intl/timezone/timezone.stub.php
@@ -112,6 +112,13 @@ class IntlTimeZone
      */
     public static function getGMT(): IntlTimeZone {}
 
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+    /**
+     * @alias intltz_get_iana_id
+     */
+    public static function getIanaID(string $timezoneId): string|false {}
+#endif
+
     /**
      * @tentative-return-type
      * @alias intltz_get_id

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: be6841ed5e1bc6ef9b3b8d4236d3708b4c74cd2b */
+ * Stub hash: ff6d6bb0789c719625f4271bf9ce1c12eea5c95e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlTimeZone___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -55,6 +55,12 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_IntlTimeZone_get
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_IntlTimeZone_getGMT arginfo_class_IntlTimeZone_createDefault
+
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_IntlTimeZone_getIanaID, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_IntlTimeZone_getID arginfo_class_IntlTimeZone_getErrorMessage
 
@@ -112,6 +118,9 @@ ZEND_FUNCTION(intltz_get_equivalent_id);
 ZEND_FUNCTION(intltz_get_error_code);
 ZEND_FUNCTION(intltz_get_error_message);
 ZEND_FUNCTION(intltz_get_gmt);
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+ZEND_FUNCTION(intltz_get_iana_id);
+#endif
 ZEND_FUNCTION(intltz_get_id);
 ZEND_FUNCTION(intltz_get_offset);
 ZEND_FUNCTION(intltz_get_raw_offset);
@@ -143,6 +152,9 @@ static const zend_function_entry class_IntlTimeZone_methods[] = {
 	ZEND_ME_MAPPING(getErrorCode, intltz_get_error_code, arginfo_class_IntlTimeZone_getErrorCode, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getErrorMessage, intltz_get_error_message, arginfo_class_IntlTimeZone_getErrorMessage, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getGMT, intltz_get_gmt, arginfo_class_IntlTimeZone_getGMT, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+	ZEND_ME_MAPPING(getIanaID, intltz_get_iana_id, arginfo_class_IntlTimeZone_getIanaID, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#endif
 	ZEND_ME_MAPPING(getID, intltz_get_id, arginfo_class_IntlTimeZone_getID, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getOffset, intltz_get_offset, arginfo_class_IntlTimeZone_getOffset, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getRawOffset, intltz_get_raw_offset, arginfo_class_IntlTimeZone_getRawOffset, ZEND_ACC_PUBLIC)

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -371,6 +371,37 @@ U_CFUNC PHP_FUNCTION(intltz_get_equivalent_id)
 	RETVAL_NEW_STR(u8str);
 }
 
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+U_CFUNC PHP_FUNCTION(intltz_get_iana_id)
+{
+	char	*str_id;
+	size_t	 str_id_len;
+	intl_error_reset(NULL);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s",
+			&str_id, &str_id_len) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	UErrorCode status = UErrorCode();
+	UnicodeString id;
+	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
+		intl_error_set(NULL, status,
+			"could not convert time zone id to UTF-16", 0);
+		RETURN_FALSE;
+	}
+
+	UnicodeString result;
+	TimeZone::getIanaID(id, result, status);
+	INTL_CHECK_STATUS(status, "error obtaining IANA ID");
+
+	zend_string *u8str = intl_convert_utf16_to_utf8(result.getBuffer(), result.length(), &status);
+	INTL_CHECK_STATUS(status,
+		"could not convert time zone id to UTF-16");
+	RETVAL_NEW_STR(u8str);
+}
+#endif
+
 U_CFUNC PHP_FUNCTION(intltz_get_id)
 {
 	TIMEZONE_METHOD_INIT_VARS;


### PR DESCRIPTION
returns the primary IANA zone ID from the provided timezone ID. Most of the time, timezone ID==IANA ID.
available from icu >= 74.