### PR TITLE
Update error handling when node cannot be added

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1285,8 +1285,7 @@ PHP_METHOD(DOMNode, appendChild)
 	DOM_RET_OBJ(new_child, &ret, intern);
 	return;
 cannot_add:
-	// TODO Convert to Error?
-	php_error_docref(NULL, E_WARNING, "Couldn't append node");
+	php_dom_throw_error(INVALID_STATE_ERR, stricterror);
 	RETURN_FALSE;
 }
 /* }}} end dom_node_append_child */


### PR DESCRIPTION
This can only fail on OOM, so be consistent with the other locations and throw an INVALID_STATE_ERR.