### PR TITLE
Rename HAVE_PHP_SOAP symbol on Windows ext/soap

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -81,6 +81,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      in ext/mbstring/libmbfl removed.
    - FIBER_ASSEMBLER and FIBER_ASM_ARCH Makefile variables removed in favor of
      PHP_ASSEMBLER and FIBER_ASM_ABI.
+   - HAVE_PHP_SOAP symbol renamed to HAVE_SOAP.
 
 ========================
 3. Module changes

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -9,7 +9,7 @@ if (PHP_SOAP != "no") {
 		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2")
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE('HAVE_PHP_SOAP', 1, "SOAP support");
+		AC_DEFINE('HAVE_SOAP', 1, "SOAP support");
 
 		if (!PHP_SOAP_SHARED) {
 			ADD_FLAG('CFLAGS_SOAP', "/D LIBXML_STATIC ");


### PR DESCRIPTION
This syncs the symbol name with the *nix build, where HAVE_SOAP is defined.

Symbol is not used around the ecosystem, so it's not much of a compatibility break concern.