### PR TITLE
Remove obsolescent AC_C_INLINE Autoconf macro

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -225,8 +225,6 @@ if test "$ZEND_ZTS" = "yes"; then
   CFLAGS="$CFLAGS -DZTS"
 fi
 
-AC_C_INLINE
-
 dnl Test and set the alignment define for ZEND_MM. This also does the
 dnl logarithmic test for ZEND_MM.
 AC_MSG_CHECKING(for MM alignment and log values)


### PR DESCRIPTION
This macro defines the inline keyword to be `__inline__`, `__inline`, or empty, based on the compiler inline support in main/php_config.h:

```c
/* Define to '__inline__' or '__inline' if that's what the C compiler
   calls it, or to nothing if 'inline' is not supported under any name.  */
#ifndef __cplusplus
/* #undef inline */
#endif
```

Since PHP requires C99, which has the inline keyword definition and all current compilers support it, this check is redundant and not needed anymore.