### PR TITLE
round: Abolished the CPU rounding mode change and modified it to a different logic.

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -163,8 +163,7 @@ static inline double php_round_helper(double integral, double value, double expo
  * mode. For the specifics of the algorithm, see http://wiki.php.net/rfc/rounding
  */
 PHPAPI double _php_math_round(double value, int places, int mode) {
-	double exponent;
-	double tmp_value;
+	double exponent, tmp_value, adjusted_value;
 	int cpu_round_mode;
 
 	if (!zend_finite(value) || value == 0.0) {
@@ -187,14 +186,23 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 	 * e.g.
 	 * 0.285 * 10000000000 => 2850000000.0
 	 * floor(0.285 * 10000000000) => 2850000000
+	 *
+	 * Using `if` twice to prevent accidental optimization with llvm 15.0.0.
 	 */
+	bool val_is_positive_or_zero = value >= 0.0;
 	cpu_round_mode = fegetround();
-	if (value >= 0.0) {
+	if (val_is_positive_or_zero) {
 		fesetround(FE_UPWARD);
-		tmp_value = floor(places > 0  ? value * exponent : value / exponent);
 	} else {
 		fesetround(FE_DOWNWARD);
-		tmp_value = ceil(places > 0  ? value * exponent : value / exponent);
+	}
+
+	adjusted_value = places > 0  ? value * exponent : value / exponent;
+
+	if (val_is_positive_or_zero) {
+		tmp_value = floor(adjusted_value);
+	} else {
+		tmp_value = ceil(adjusted_value);
 	}
 	fesetround(cpu_round_mode);
 


### PR DESCRIPTION
~~This doesn't happen with llvm 15.0.7, but I expect there are many users using 15.0.0, so I fixed it.
The llvm that comes with MacOS from the beginning may be 15.0.0, and to use 15.0.7 we need to install it from homebrew.~~

~~When I compared the assembly code, the one using llvm 15.0.0 was calculating `places > 0  ? value * exponent : value / exponent` before the CPU round mode change, so I made fix like this.~~

failed test:
https://github.com/php/php-src/actions/runs/7945635002/job/21692533874

~~testing in my repo:~~
~~https://github.com/SakiTakamachi/php-src/actions/runs/7968042924/job/21751687740~~

----

`#pragma STDC FENV_ACCESS ON` is included in C99, but many compilers do not support it.
Based on that, I decided that the CPU rounding mode change feature should not be used even if it existed, and I modified it to a different logic that does not use it.