### PR TITLE
Remove malloc.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,6 @@ grp.h \
 ieeefp.h \
 langinfo.h \
 linux/sock_diag.h \
-malloc.h \
 os/signpost.h \
 poll.h \
 pty.h \

--- a/ext/gd/libgd/gdcache.h
+++ b/ext/gd/libgd/gdcache.h
@@ -41,9 +41,6 @@
 /*********************************************************/
 
 #include <stdlib.h>
-#if (!defined(__OpenBSD__)) && defined(HAVE_MALLOC_H)
- #include <malloc.h>
-#endif
 #ifndef NULL
 #define NULL (void *)0
 #endif


### PR DESCRIPTION
This removes the deprecated malloc.h header Autoconf check on *nix systems and its HAVE_MALLOC_H symbol. It can be replaced mostly with the stdlib.h. The libgd usptream also doesn't include it anymore.

On Windows, it is still used for some memory allocation functions, but can be replaced with stdlib.h in the future.