### PR TITLE
Improve optimizer support for class constants

### DIFF
--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -156,30 +156,36 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 			break;
 
 		case ZEND_FETCH_CLASS_CONSTANT:
-			if (opline->op2_type == IS_CONST &&
-				Z_TYPE(ZEND_OP2_LITERAL(opline)) == IS_STRING) {
+			{
+				const zend_class_constant *cc = zend_fetch_class_const_info(ctx->script, op_array, opline);
+				if (!cc) {
+					break;
+				}
 
-				zend_class_entry *ce = zend_optimizer_get_class_entry_from_op1(
-					ctx->script, op_array, opline);
-				if (ce) {
-					zend_class_constant *cc = zend_hash_find_ptr(
-						&ce->constants_table, Z_STR(ZEND_OP2_LITERAL(opline)));
-					if (cc && !(ZEND_CLASS_CONST_FLAGS(cc) & ZEND_ACC_DEPRECATED) && (ZEND_CLASS_CONST_FLAGS(cc) & ZEND_ACC_PPP_MASK) == ZEND_ACC_PUBLIC && !(ce->ce_flags & ZEND_ACC_TRAIT)) {
-						zval *c = &cc->value;
-						if (Z_TYPE_P(c) == IS_CONSTANT_AST) {
-							zend_ast *ast = Z_ASTVAL_P(c);
-							if (ast->kind != ZEND_AST_CONSTANT
-							 || !zend_optimizer_get_persistent_constant(zend_ast_get_constant_name(ast), &result, 1)
-							 || Z_TYPE(result) == IS_CONSTANT_AST) {
-								break;
-							}
-						} else {
-							ZVAL_COPY_OR_DUP(&result, c);
-						}
+				if (opline->op1_type == IS_UNUSED) {
+					int fetch_mask = (int) (opline->op1.num & ZEND_FETCH_CLASS_MASK);
 
-						replace_by_const_or_qm_assign(op_array, opline, &result);
+					if (
+						(fetch_mask == ZEND_FETCH_CLASS_STATIC || fetch_mask == ZEND_FETCH_CLASS_PARENT) &&
+						!(cc->ce->ce_flags & ZEND_ACC_FINAL) && !(ZEND_CLASS_CONST_FLAGS(cc) & ZEND_ACC_FINAL)
+					) {
+						break;
 					}
 				}
+
+				const zval *c = &cc->value;
+				if (Z_TYPE_P(c) == IS_CONSTANT_AST) {
+					zend_ast *ast = Z_ASTVAL_P(c);
+					if (ast->kind != ZEND_AST_CONSTANT
+					 || !zend_optimizer_get_persistent_constant(zend_ast_get_constant_name(ast), &result, 1)
+					 || Z_TYPE(result) == IS_CONSTANT_AST) {
+						break;
+					}
+				} else {
+					ZVAL_COPY_OR_DUP(&result, c);
+				}
+
+				replace_by_const_or_qm_assign(op_array, opline, &result);
 			}
 			break;
 

--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -158,10 +158,7 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 		case ZEND_FETCH_CLASS_CONSTANT: {
 			bool is_prototype;
 			const zend_class_constant *cc = zend_fetch_class_const_info(ctx->script, op_array, opline, &is_prototype);
-			if (!cc) {
-				break;
-			}
-			if (!is_prototype) {
+			if (!cc || is_prototype) {
 				break;
 			}
 			const zval *c = &cc->value;

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -3917,12 +3917,12 @@ static zend_always_inline zend_result _zend_update_type_info(
 			bool is_prototype;
 			const zend_class_constant *cc = zend_fetch_class_const_info(script, op_array, opline, &is_prototype);
 			if (!cc || !ZEND_TYPE_IS_SET(cc->type)) {
-				UPDATE_SSA_TYPE(MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY, ssa_op->result_def);
+				UPDATE_SSA_TYPE(MAY_BE_RC1|MAY_BE_RCN|MAY_BE_ANY|MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY, ssa_op->result_def);
 				break;
 			}
 			UPDATE_SSA_TYPE(zend_convert_type(script, cc->type, &ce), ssa_op->result_def);
 			if (ce) {
-				UPDATE_SSA_OBJ_TYPE(ce, 1, ssa_op->result_def);
+				UPDATE_SSA_OBJ_TYPE(ce, is_prototype, ssa_op->result_def);
 			}
 			break;
 		}

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -3922,7 +3922,7 @@ static zend_always_inline zend_result _zend_update_type_info(
 			}
 			UPDATE_SSA_TYPE(zend_convert_type(script, cc->type, &ce), ssa_op->result_def);
 			if (ce) {
-				UPDATE_SSA_OBJ_TYPE(ce, is_prototype, ssa_op->result_def);
+				UPDATE_SSA_OBJ_TYPE(ce, /* is_instanceof */ true, ssa_op->result_def);
 			}
 			break;
 		}

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -2409,11 +2409,6 @@ ZEND_API uint32_t zend_fetch_arg_info_type(const zend_script *script, const zend
 	return zend_convert_type(script, arg_info->type, pce);
 }
 
-static uint32_t zend_fetch_class_const_type(const zend_script *script, const zend_class_constant *class_const, zend_class_entry **pce)
-{
-	return zend_convert_type(script, class_const->type, pce);
-}
-
 static const zend_property_info *lookup_prop_info(const zend_class_entry *ce, zend_string *name, zend_class_entry *scope) {
 	const zend_property_info *prop_info;
 
@@ -3921,21 +3916,16 @@ static zend_always_inline zend_result _zend_update_type_info(
 		case ZEND_FETCH_CLASS_CONSTANT: {
 			bool is_prototype;
 			const zend_class_constant *cc = zend_fetch_class_const_info(script, op_array, opline, &is_prototype);
-			if (!cc) {
-				goto fetch_class_constant_generic;
+			if (!cc || !ZEND_TYPE_IS_SET(cc->type)) {
+				UPDATE_SSA_TYPE(MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY, ssa_op->result_def);
+				break;
 			}
-			if (!ZEND_TYPE_IS_SET(cc->type)) {
-				goto fetch_class_constant_generic;
-			}
-			UPDATE_SSA_TYPE(zend_fetch_class_const_type(script, cc, &ce), ssa_op->result_def);
+			UPDATE_SSA_TYPE(zend_convert_type(script, cc->type, &ce), ssa_op->result_def);
 			if (ce) {
 				UPDATE_SSA_OBJ_TYPE(ce, 1, ssa_op->result_def);
 			}
 			break;
-fetch_class_constant_generic:
-			UPDATE_SSA_TYPE(MAY_BE_RC1 | MAY_BE_RCN | MAY_BE_ANY | MAY_BE_ARRAY_KEY_ANY | MAY_BE_ARRAY_OF_ANY, ssa_op->result_def);
-			break;
-			}
+		}
 		case ZEND_STRLEN:
 		case ZEND_COUNT:
 		case ZEND_FUNC_NUM_ARGS:

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -831,14 +831,14 @@ zend_class_entry *zend_optimizer_get_class_entry_from_op1(
 	return NULL;
 }
 
-const zend_class_constant *zend_fetch_class_const_info(const zend_script *script, const zend_op_array *op_array, const zend_op *opline)
-{
+const zend_class_constant *zend_fetch_class_const_info(
+	const zend_script *script, const zend_op_array *op_array, const zend_op *opline, bool *is_prototype) {
 	const zend_class_entry *ce = NULL;
+	bool is_static_or_parent_reference = false;
 
 	if (opline->op2_type != IS_CONST || Z_TYPE(ZEND_OP2_LITERAL(opline)) != IS_STRING) {
 		return NULL;
 	}
-
 	if (opline->op1_type == IS_CONST) {
 		zval *op1 = CRT_CONSTANT(opline->op1);
 		if (Z_TYPE_P(op1) == IS_STRING) {
@@ -846,38 +846,31 @@ const zend_class_constant *zend_fetch_class_const_info(const zend_script *script
 		}
 	} else if (opline->op1_type == IS_UNUSED && op_array->scope && !(op_array->scope->ce_flags & ZEND_ACC_TRAIT)) {
 		int fetch_type = (int) opline->op1.num & ZEND_FETCH_CLASS_MASK;
-		switch (fetch_type) {
-			case ZEND_FETCH_CLASS_SELF:
-			case ZEND_FETCH_CLASS_STATIC:
-				/* We enforce that static property types cannot change during inheritance, so
-				 * handling static the same way as self here is legal. */
-				ce = op_array->scope;
-				break;
-			case ZEND_FETCH_CLASS_PARENT:
-				if (op_array->scope->ce_flags & ZEND_ACC_LINKED) {
-					ce = op_array->scope->parent;
-				}
-				break;
-			default:
-				break;
+		if (fetch_type == ZEND_FETCH_CLASS_SELF) {
+			ce = op_array->scope;
+		} else if (fetch_type == ZEND_FETCH_CLASS_STATIC) {
+			ce = op_array->scope;
+			is_static_or_parent_reference = true;
+		} else if (fetch_type == ZEND_FETCH_CLASS_PARENT) {
+			if (op_array->scope->ce_flags & ZEND_ACC_LINKED) {
+				ce = op_array->scope->parent;
+			}
+			is_static_or_parent_reference = true;
 		}
 	}
-
-	if (!ce) {
+	if (!ce || (ce->ce_flags & ZEND_ACC_TRAIT)) {
 		return NULL;
 	}
-
 	zend_class_constant *const_info = zend_hash_find_ptr(&ce->constants_table, Z_STR(ZEND_OP2_LITERAL(opline)));
 	if (!const_info) {
 		return NULL;
 	}
-
-	if ((ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_DEPRECATED) ||
-		(ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_PPP_MASK) != ZEND_ACC_PUBLIC ||
-		(ce->ce_flags & ZEND_ACC_TRAIT)
-	) {
+	if ((ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_DEPRECATED)
+		|| ((ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_PPP_MASK) != ZEND_ACC_PUBLIC && const_info->ce != op_array->scope)) {
 		return NULL;
 	}
+	*is_prototype = !is_static_or_parent_reference
+		|| (const_info->ce->ce_flags & ZEND_ACC_FINAL) || (ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_FINAL);
 
 	return const_info;
 }

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -836,7 +836,7 @@ const zend_class_constant *zend_fetch_class_const_info(
 	const zend_class_entry *ce = NULL;
 	bool is_static_reference = false;
 
-	if (opline->op2_type != IS_CONST || Z_TYPE(ZEND_OP2_LITERAL(opline)) != IS_STRING) {
+	if (!opline || !op_array || !script || opline->op2_type != IS_CONST || Z_TYPE(ZEND_OP2_LITERAL(opline)) != IS_STRING) {
 		return NULL;
 	}
 	if (opline->op1_type == IS_CONST) {

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -834,7 +834,7 @@ zend_class_entry *zend_optimizer_get_class_entry_from_op1(
 const zend_class_constant *zend_fetch_class_const_info(
 	const zend_script *script, const zend_op_array *op_array, const zend_op *opline, bool *is_prototype) {
 	const zend_class_entry *ce = NULL;
-	bool is_static_or_parent_reference = false;
+	bool is_static_reference = false;
 
 	if (opline->op2_type != IS_CONST || Z_TYPE(ZEND_OP2_LITERAL(opline)) != IS_STRING) {
 		return NULL;
@@ -850,12 +850,11 @@ const zend_class_constant *zend_fetch_class_const_info(
 			ce = op_array->scope;
 		} else if (fetch_type == ZEND_FETCH_CLASS_STATIC) {
 			ce = op_array->scope;
-			is_static_or_parent_reference = true;
+			is_static_reference = true;
 		} else if (fetch_type == ZEND_FETCH_CLASS_PARENT) {
 			if (op_array->scope->ce_flags & ZEND_ACC_LINKED) {
 				ce = op_array->scope->parent;
 			}
-			is_static_or_parent_reference = true;
 		}
 	}
 	if (!ce || (ce->ce_flags & ZEND_ACC_TRAIT)) {
@@ -869,8 +868,8 @@ const zend_class_constant *zend_fetch_class_const_info(
 		|| ((ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_PPP_MASK) != ZEND_ACC_PUBLIC && const_info->ce != op_array->scope)) {
 		return NULL;
 	}
-	*is_prototype = !is_static_or_parent_reference
-		|| (const_info->ce->ce_flags & ZEND_ACC_FINAL) || (ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_FINAL);
+	*is_prototype = is_static_reference
+		&& !(const_info->ce->ce_flags & ZEND_ACC_FINAL) && !(ZEND_CLASS_CONST_FLAGS(const_info) & ZEND_ACC_FINAL);
 
 	return const_info;
 }

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -836,7 +836,7 @@ const zend_class_constant *zend_fetch_class_const_info(
 	const zend_class_entry *ce = NULL;
 	bool is_static_reference = false;
 
-	if (!opline || !op_array || !script || opline->op2_type != IS_CONST || Z_TYPE(ZEND_OP2_LITERAL(opline)) != IS_STRING) {
+	if (!opline || !op_array || !script || opline->op2_type != IS_CONST || Z_TYPE_P(CRT_CONSTANT(opline->op2)) != IS_STRING) {
 		return NULL;
 	}
 	if (opline->op1_type == IS_CONST) {
@@ -845,7 +845,7 @@ const zend_class_constant *zend_fetch_class_const_info(
 			ce = zend_optimizer_get_class_entry(script, op_array, Z_STR_P(op1 + 1));
 		}
 	} else if (opline->op1_type == IS_UNUSED && op_array->scope && !(op_array->scope->ce_flags & ZEND_ACC_TRAIT)) {
-		int fetch_type = (int) opline->op1.num & ZEND_FETCH_CLASS_MASK;
+		int fetch_type = opline->op1.num & ZEND_FETCH_CLASS_MASK;
 		if (fetch_type == ZEND_FETCH_CLASS_SELF) {
 			ce = op_array->scope;
 		} else if (fetch_type == ZEND_FETCH_CLASS_STATIC) {

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -860,7 +860,7 @@ const zend_class_constant *zend_fetch_class_const_info(
 	if (!ce || (ce->ce_flags & ZEND_ACC_TRAIT)) {
 		return NULL;
 	}
-	zend_class_constant *const_info = zend_hash_find_ptr(&ce->constants_table, Z_STR(ZEND_OP2_LITERAL(opline)));
+	zend_class_constant *const_info = zend_hash_find_ptr(&ce->constants_table, Z_STR_P(CRT_CONSTANT(opline->op2)));
 	if (!const_info) {
 		return NULL;
 	}

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -844,7 +844,9 @@ const zend_class_constant *zend_fetch_class_const_info(
 		if (Z_TYPE_P(op1) == IS_STRING) {
 			ce = zend_optimizer_get_class_entry(script, op_array, Z_STR_P(op1 + 1));
 		}
-	} else if (opline->op1_type == IS_UNUSED && op_array->scope && !(op_array->scope->ce_flags & ZEND_ACC_TRAIT)) {
+	} else if (opline->op1_type == IS_UNUSED
+		&& op_array->scope && !(op_array->scope->ce_flags & ZEND_ACC_TRAIT)
+		&& !(op_array->fn_flags & ZEND_ACC_TRAIT_CLONE)) {
 		int fetch_type = opline->op1.num & ZEND_FETCH_CLASS_MASK;
 		if (fetch_type == ZEND_FETCH_CLASS_SELF) {
 			ce = op_array->scope;

--- a/Zend/Optimizer/zend_optimizer_internal.h
+++ b/Zend/Optimizer/zend_optimizer_internal.h
@@ -105,6 +105,8 @@ zend_class_entry *zend_optimizer_get_class_entry(
 		const zend_script *script, const zend_op_array *op_array, zend_string *lcname);
 zend_class_entry *zend_optimizer_get_class_entry_from_op1(
 		const zend_script *script, const zend_op_array *op_array, const zend_op *opline);
+const zend_class_constant *zend_fetch_class_const_info(
+		const zend_script *script, const zend_op_array *op_array, const zend_op *opline);
 
 void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimizer_pass3(zend_op_array *op_array, zend_optimizer_ctx *ctx);

--- a/Zend/Optimizer/zend_optimizer_internal.h
+++ b/Zend/Optimizer/zend_optimizer_internal.h
@@ -106,7 +106,7 @@ zend_class_entry *zend_optimizer_get_class_entry(
 zend_class_entry *zend_optimizer_get_class_entry_from_op1(
 		const zend_script *script, const zend_op_array *op_array, const zend_op *opline);
 const zend_class_constant *zend_fetch_class_const_info(
-		const zend_script *script, const zend_op_array *op_array, const zend_op *opline);
+		const zend_script *script, const zend_op_array *op_array, const zend_op *opline, bool *is_prototype);
 
 void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimizer_pass3(zend_op_array *op_array, zend_optimizer_ctx *ctx);

--- a/ext/opcache/tests/opt/type_inference_class_consts.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts.phpt
@@ -133,14 +133,10 @@ LIVE RANGES:
      0: 0001 - 0002 (tmp/var)
 
 Test2::getParentFoo:
-     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (lines=1, args=0, vars=0, tmps=0)
      ; (after optimizer)
      ; %s
-0000 T0 = FETCH_CLASS_CONSTANT (parent) (exception) string("FOO")
-0001 VERIFY_RETURN_TYPE T0
-0002 RETURN T0
-LIVE RANGES:
-     0: 0001 - 0002 (tmp/var)
+0000 RETURN int(42)
 
 Test2::getParentBar:
      ; (lines=1, args=0, vars=0, tmps=0)
@@ -149,11 +145,10 @@ Test2::getParentBar:
 0000 RETURN int(42)
 
 Test2::getParentBaz:
-     ; (lines=2, args=0, vars=0, tmps=1)
+     ; (lines=1, args=0, vars=0, tmps=0)
      ; (after optimizer)
      ; %s
-0000 T0 = FETCH_CLASS_CONSTANT (parent) (exception) string("BAZ")
-0001 RETURN T0
+0000 RETURN int(42)
 
 Test3::getTestFoo:
      ; (lines=1, args=0, vars=0, tmps=0)

--- a/ext/opcache/tests/opt/type_inference_class_consts.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts.phpt
@@ -1,0 +1,174 @@
+--TEST--
+Test type inference of class consts
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+class Test1 {
+    public const FOO = 42;
+    public final const BAR = 42;
+    public const int BAZ = 42;
+
+    public function getSelfFoo(): int {
+        return self::FOO;
+    }
+
+    public function getSelfBar(): int {
+        return self::BAR;
+    }
+
+    public function getSelfBaz(): int {
+        return self::BAZ;
+    }
+
+    public function getStaticFoo(): int {
+        return static::FOO;
+    }
+
+    public function getStaticBar(): int {
+        return static::BAR;
+    }
+
+    public function getStaticBaz(): int {
+        return static::BAZ;
+    }
+}
+
+final class Test2 extends Test1 {
+    public function getStaticFoo(): int {
+        return static::FOO;
+    }
+
+    public function getParentFoo(): int {
+        return parent::FOO;
+    }
+
+    public function getParentBar(): int {
+        return parent::BAR;
+    }
+
+    public function getParentBaz(): int {
+        return parent::BAZ;
+    }
+}
+
+class Test3 {
+    public function getTestFoo(): int {
+        return Test1::FOO;
+    }
+
+    public function getTestBar(): int {
+        return Test1::BAR;
+    }
+
+    public function getTestBaz(): int {
+        return Test1::BAZ;
+    }
+}
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(1)
+
+Test1::getSelfFoo:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test1::getSelfBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test1::getSelfBaz:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test1::getStaticFoo:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("FOO")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test1::getStaticBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test1::getStaticBaz:
+     ; (lines=2, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("BAZ")
+0001 RETURN T0
+
+Test2::getStaticFoo:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("FOO")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test2::getParentFoo:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (parent) (exception) string("FOO")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test2::getParentBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test2::getParentBaz:
+     ; (lines=2, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (parent) (exception) string("BAZ")
+0001 RETURN T0
+
+Test3::getTestFoo:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test3::getTestBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test3::getTestBaz:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)

--- a/ext/opcache/tests/opt/type_inference_class_consts1.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test type inference of class consts
+Test type inference of class consts - reference by static and self
 --INI--
 opcache.enable=1
 opcache.enable_cli=1
@@ -38,38 +38,6 @@ class Test1 {
 
     public function getStaticBaz(): int {
         return static::BAZ;
-    }
-}
-
-final class Test2 extends Test1 {
-    public function getStaticFoo(): int {
-        return static::FOO;
-    }
-
-    public function getParentFoo(): int {
-        return parent::FOO;
-    }
-
-    public function getParentBar(): int {
-        return parent::BAR;
-    }
-
-    public function getParentBaz(): int {
-        return parent::BAZ;
-    }
-}
-
-class Test3 {
-    public function getTestFoo(): int {
-        return Test1::FOO;
-    }
-
-    public function getTestBar(): int {
-        return Test1::BAR;
-    }
-
-    public function getTestBaz(): int {
-        return Test1::BAZ;
     }
 }
 
@@ -121,49 +89,3 @@ Test1::getStaticBaz:
      ; %s
 0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("BAZ")
 0001 RETURN T0
-
-Test2::getStaticFoo:
-     ; (lines=3, args=0, vars=0, tmps=1)
-     ; (after optimizer)
-     ; %s
-0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("FOO")
-0001 VERIFY_RETURN_TYPE T0
-0002 RETURN T0
-LIVE RANGES:
-     0: 0001 - 0002 (tmp/var)
-
-Test2::getParentFoo:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)
-
-Test2::getParentBar:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)
-
-Test2::getParentBaz:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)
-
-Test3::getTestFoo:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)
-
-Test3::getTestBar:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)
-
-Test3::getTestBaz:
-     ; (lines=1, args=0, vars=0, tmps=0)
-     ; (after optimizer)
-     ; %s
-0000 RETURN int(42)

--- a/ext/opcache/tests/opt/type_inference_class_consts2.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts2.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test type inference of class consts - reference by parent
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+class Test1 {
+    public const FOO = 42;
+    public final const BAR = 42;
+    public const int BAZ = 42;
+}
+
+final class Test2 extends Test1 {
+    public function getParentFoo(): int {
+        return parent::FOO;
+    }
+
+    public function getParentBar(): int {
+        return parent::BAR;
+    }
+
+    public function getParentBaz(): int {
+        return parent::BAZ;
+    }
+}
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(1)
+
+Test2::getParentFoo:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test2::getParentBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test2::getParentBaz:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)

--- a/ext/opcache/tests/opt/type_inference_class_consts3.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts3.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test type inference of class consts - reference by class name
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+class Test1 {
+    public const FOO = 42;
+    public final const BAR = 42;
+    public const int BAZ = 42;
+}
+
+class Test3 {
+    public function getTestFoo(): int {
+        return Test1::FOO;
+    }
+
+    public function getTestBar(): int {
+        return Test1::BAR;
+    }
+
+    public function getTestBaz(): int {
+        return Test1::BAZ;
+    }
+}
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(1)
+
+Test3::getTestFoo:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test3::getTestBar:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test3::getTestBaz:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)

--- a/ext/opcache/tests/opt/type_inference_class_consts4.phpt
+++ b/ext/opcache/tests/opt/type_inference_class_consts4.phpt
@@ -1,0 +1,104 @@
+--TEST--
+Test type inference of class consts - interface consts
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+interface TestI {
+    public const int A = 42;
+    public final const B = 42;
+}
+
+class Test4 implements TestI {
+    public function getSelfA(): int {
+        return self::A;
+    }
+
+    public function getSelfB(): int {
+        return self::B;
+    }
+
+    public function getStaticA(): int {
+        return static::A;
+    }
+
+    public function getStaticB(): int {
+        return static::B;
+    }
+
+    public function getTestIA(): int {
+        return TestI::A;
+    }
+
+    public function getTestIB(): int {
+        return TestI::B;
+    }
+}
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=2, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 DECLARE_CLASS string("test4")
+0001 RETURN int(1)
+
+Test4::getSelfA:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (self) (exception) string("A")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test4::getSelfB:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (self) (exception) string("B")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test4::getStaticA:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("A")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test4::getStaticB:
+     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T0 = FETCH_CLASS_CONSTANT (static) (exception) string("B")
+0001 VERIFY_RETURN_TYPE T0
+0002 RETURN T0
+LIVE RANGES:
+     0: 0001 - 0002 (tmp/var)
+
+Test4::getTestIA:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test4::getTestIB:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)


### PR DESCRIPTION
The following optimizations are added:
- Constant folding of (public) final class constant when they are referenced via `static::` or `parent::`
- Type inference of typed class constants

This is my first (attempted) contribution to the optimizer, so I'm not absolutely sure that my changes are correct. Locally, a couple of JIT tests fail.

It seems to me that non-public class constants could also be optimized, so I plan to do so in a followup, if it's a good idea indeed.