### PR TITLE
Remove Autoconf check for C99 header stdint.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,6 @@ dnl ----------------------------------------------------------------------------
 
 dnl QNX requires unix.h to allow functions in libunix to work properly.
 AC_CHECK_HEADERS([ \
-stdint.h \
 dirent.h \
 sys/param.h \
 sys/types.h \


### PR DESCRIPTION
This removes the redundant check that defines the HAVE_STDINT_H symbol, which is used in the ext/date/lib and ext/fileinfo/libmagic but on both places patches and other header files take care of this so it is always included unconditionally in php-src.

Autoconf by default still automatically checks for stdint.h internally in current versions, so for now the HAVE_STDINT_H symbol is still defined in php_config.h and will be made redundant along the way.