### PR TITLE
Simplify prctl and procctl Autoconf checks

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2679,32 +2679,6 @@ AC_DEFUN([PHP_PATCH_CONFIG_HEADERS], [
     > $srcdir/$1.tmp && mv $srcdir/$1.tmp $srcdir/$1
 ])
 
-dnl Check if we have prctl
-AC_DEFUN([PHP_CHECK_PRCTL],
-[
-  AC_MSG_CHECKING([for prctl])
-
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/prctl.h>]], [[prctl(0, 0, 0, 0, 0);]])], [
-    AC_DEFINE([HAVE_PRCTL], 1, [do we have prctl?])
-    AC_MSG_RESULT([yes])
-  ], [
-    AC_MSG_RESULT([no])
-  ])
-])
-
-dnl Check if we have procctl
-AC_DEFUN([PHP_CHECK_PROCCTL],
-[
-  AC_MSG_CHECKING([for procctl])
-
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/procctl.h>]], [[procctl(0, 0, 0, 0);]])], [
-    AC_DEFINE([HAVE_PROCCTL], 1, [do we have procctl?])
-    AC_MSG_RESULT([yes])
-  ], [
-    AC_MSG_RESULT([no])
-  ])
-])
-
 dnl
 dnl PHP_CHECK_AVX512_SUPPORTS
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -410,7 +410,6 @@ sys/file.h \
 sys/mman.h \
 sys/mount.h \
 sys/poll.h \
-sys/procctl.h \
 sys/resource.h \
 sys/select.h \
 sys/socket.h \
@@ -515,10 +514,6 @@ dnl Check __builtin_cpu_supports
 PHP_CHECK_BUILTIN_CPU_SUPPORTS
 dnl Check __builtin_frame_address
 PHP_CHECK_BUILTIN_FRAME_ADDRESS
-dnl Check prctl
-PHP_CHECK_PRCTL
-dnl Check procctl
-PHP_CHECK_PROCCTL
 dnl Check AVX512
 PHP_CHECK_AVX512_SUPPORTS
 dnl Check AVX512 VBMI
@@ -642,6 +637,10 @@ AC_CHECK_FUNC([inet_pton],,[AC_MSG_ERROR([Required inet_pton not found.])])
 
 dnl Check for strerror_r, and if its a POSIX-compatible or a GNU specific version.
 AC_FUNC_STRERROR_R
+
+dnl Check for functions inside their belonging headers.
+AC_CHECK_HEADER([sys/prctl.h], [AC_CHECK_FUNCS([prctl])])
+AC_CHECK_HEADER([sys/procctl.h], [AC_CHECK_FUNCS([procctl])])
 
 AX_FUNC_WHICH_GETHOSTBYNAME_R
 

--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -34,7 +34,7 @@
 #endif
 
 #include "zend_execute.h"
-#ifdef HAVE_SYS_PROCCTL_H
+#ifdef HAVE_PROCCTL
 #include <sys/procctl.h>
 #endif
 


### PR DESCRIPTION
The AC_CHECK_FUNCS checks whether the linker sees the function in the usual libraries, in this case libc. This is a simple trick to also check existence of belonging headers, since the code uses HAVE_PRCTL and HAVE_PROCCTL to include headers and call functions.