### PR TITLE
ext/intl: IntlDateFormatter class removing redundant error message info.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -60,7 +60,7 @@ PHP                                                                        NEWS
     aliases for ::ROUND_DOWN and ::ROUND_UP. (Jorg Sowa)
   . Added NumberFormatter::ROUND_HALFODD. (Ayesh Karunaratne)
   . Added PROPERTY_IDS_UNARY_OPERATOR, PROPERTY_ID_COMPAT_MATH_START and
-    PROPERTY_ID_COMPT_MATH_CONTINUE constants. (David Carlier)
+    PROPERTY_ID_COMPAT_MATH_CONTINUE constants. (David Carlier)
   . Added IntlDateFormatter::getIanaID/intltz_get_iana_id method/function.
     (David Carlier)
   . Set to C++17 standard for icu 74 and onwards. (David Carlier)

--- a/UPGRADING
+++ b/UPGRADING
@@ -467,8 +467,8 @@ PHP 8.4 UPGRADE NOTES
   . The IntlDateFormatter class exposes now the new PATTERN constant
     reflecting udat api's UDAT_PATTERN.
   . The IntlChar class exposes now the new PROPERTY_IDS_UNARY_OPERATOR (new
-    IDS binary operator), PROPERTY_ID_COMPT_MATH_START,
-    PROPERTY_ID_COMPT_MATH_CONTINUE (both for mathematical
+    IDS binary operator), PROPERTY_ID_COMPAT_MATH_START,
+    PROPERTY_ID_COMPAT_MATH_CONTINUE (both for mathematical
     identifier profiling purpose) constants.
 
 - LDAP:

--- a/ext/intl/tests/timezone_IDforWindowsID_basic2.phpt
+++ b/ext/intl/tests/timezone_IDforWindowsID_basic2.phpt
@@ -27,7 +27,7 @@ foreach ($tzs as $tz => $regions) {
 --EXPECT--
 ** Gnomeregan
 bool(false)
-Error: intltz_get_windows_id: Unknown windows timezone: U_ILLEGAL_ARGUMENT_ERROR
+Error: unknown windows timezone: U_ILLEGAL_ARGUMENT_ERROR
 ** India Standard Time
 string(13) "Asia/Calcutta"
 ** Pacific Standard Time

--- a/ext/intl/tests/timezone_countEquivalentIDs_error.phpt
+++ b/ext/intl/tests/timezone_countEquivalentIDs_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::countEquivalentIDs("foo\x80"));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::countEquivalentIDs(): intltz_count_equivalent_ids: could not convert time zone id to UTF-16 in %s on line %d
+Warning: IntlTimeZone::countEquivalentIDs(): could not convert time zone id to UTF-16 in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_createEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createEnumeration_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::createEnumeration(array()));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::createEnumeration(): intltz_create_enumeration: invalid argument type in %s on line %d
+Warning: IntlTimeZone::createEnumeration(): invalid argument type in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::createTimeZoneIDEnumeration(-1));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::createTimeZoneIDEnumeration(): intltz_create_time_zone_id_enumeration: bad zone type in %s on line %d
+Warning: IntlTimeZone::createTimeZoneIDEnumeration(): bad zone type in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_createTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_createTimeZone_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::createTimeZone("foo\x80"));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::createTimeZone(): intltz_create_time_zone: could not convert time zone id to UTF-16 in %s on line %d
+Warning: IntlTimeZone::createTimeZone(): could not convert time zone id to UTF-16 in %s on line %d
 NULL

--- a/ext/intl/tests/timezone_getCanonicalID_error.phpt
+++ b/ext/intl/tests/timezone_getCanonicalID_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::getCanonicalID("foo\x81"));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::getCanonicalID(): intltz_get_canonical_id: could not convert time zone id to UTF-16 in %s on line %d
+Warning: IntlTimeZone::getCanonicalID(): could not convert time zone id to UTF-16 in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_getCanonicalID_variant1_2.phpt
+++ b/ext/intl/tests/timezone_getCanonicalID_variant1_2.phpt
@@ -20,6 +20,6 @@ var_dump($isSystemId);
 string(13) "Europe/Lisbon"
 bool(true)
 
-Warning: IntlTimeZone::getCanonicalID(): intltz_get_canonical_id: error obtaining canonical ID in %stimezone_getCanonicalID_variant1_2.php on line %d
+Warning: IntlTimeZone::getCanonicalID(): error obtaining canonical ID in %stimezone_getCanonicalID_variant1_2.php on line %d
 bool(false)
 bool(true)

--- a/ext/intl/tests/timezone_getDisplayName_error.phpt
+++ b/ext/intl/tests/timezone_getDisplayName_error.phpt
@@ -12,7 +12,7 @@ var_dump($tz->getDisplayName(false, -1));
 var_dump(intltz_get_display_name(null, IntlTimeZone::DISPLAY_SHORT, false, 'pt_PT'));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::getDisplayName(): intltz_get_display_name: wrong display type in %s on line %d
+Warning: IntlTimeZone::getDisplayName(): wrong display type in %s on line %d
 bool(false)
 
 Fatal error: Uncaught TypeError: intltz_get_display_name(): Argument #1 ($timezone) must be of type IntlTimeZone, null given in %s:%d

--- a/ext/intl/tests/timezone_getEquivalentID_error.phpt
+++ b/ext/intl/tests/timezone_getEquivalentID_error.phpt
@@ -9,5 +9,5 @@ ini_set("intl.error_level", E_WARNING);
 var_dump(IntlTimeZone::getEquivalentID("foo\x80", 0));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::getEquivalentID(): intltz_get_equivalent_id: could not convert time zone id to UTF-16 in %s on line %d
+Warning: IntlTimeZone::getEquivalentID(): could not convert time zone id to UTF-16 in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_getErrorCodeMessage_basic.phpt
+++ b/ext/intl/tests/timezone_getErrorCodeMessage_basic.phpt
@@ -28,7 +28,7 @@ var_dump($lsb->getErrorMessage());
 int(0)
 string(12) "U_ZERO_ERROR"
 
-Warning: IntlTimeZone::getOffset(): intltz_get_offset: error obtaining offset in %s on line %d
+Warning: IntlTimeZone::getOffset(): error obtaining offset in %s on line %d
 bool(false)
 int(1)
-string(67) "intltz_get_offset: error obtaining offset: U_ILLEGAL_ARGUMENT_ERROR"
+string(48) "error obtaining offset: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/timezone_getOffset_error.phpt
+++ b/ext/intl/tests/timezone_getOffset_error.phpt
@@ -19,7 +19,7 @@ var_dump($tz->getOffset(INF, true, $a, $a));
 intltz_get_offset(null, time()*1000, false, $a, $a);
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::getOffset(): intltz_get_offset: error obtaining offset in %s on line %d
+Warning: IntlTimeZone::getOffset(): error obtaining offset in %s on line %d
 bool(false)
 
 Fatal error: Uncaught TypeError: intltz_get_offset(): Argument #1 ($timezone) must be of type IntlTimeZone, null given in %s:%d

--- a/ext/intl/tests/timezone_getRegion_error.phpt
+++ b/ext/intl/tests/timezone_getRegion_error.phpt
@@ -10,8 +10,8 @@ var_dump(IntlTimeZone::getRegion("foo\x81"));
 var_dump(IntlTimeZone::getRegion("foo"));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::getRegion(): intltz_get_region: could not convert time zone id to UTF-16 in %s on line %d
+Warning: IntlTimeZone::getRegion(): could not convert time zone id to UTF-16 in %s on line %d
 bool(false)
 
-Warning: IntlTimeZone::getRegion(): intltz_get_region: Error obtaining region in %s on line %d
+Warning: IntlTimeZone::getRegion(): error obtaining region in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_windowsID_basic2.phpt
+++ b/ext/intl/tests/timezone_windowsID_basic2.phpt
@@ -33,7 +33,7 @@ string(18) "Cuba Standard Time"
 string(21) "Central Standard Time"
 string(21) "Pacific Standard Time"
 bool(false)
-Error: intltz_get_windows_id: Unknown system timezone: U_ILLEGAL_ARGUMENT_ERROR
+Error: unknown system timezone: U_ILLEGAL_ARGUMENT_ERROR
 string(21) "Morocco Standard Time"
 string(23) "Singapore Standard Time"
 string(26) "W. Australia Standard Time"

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -60,7 +60,7 @@ U_CFUNC PHP_FUNCTION(intltz_create_time_zone)
 	UnicodeString id = UnicodeString();
 	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
 		intl_error_set(NULL, status,
-			"intltz_create_time_zone: could not convert time zone id to UTF-16", 0);
+			"could not convert time zone id to UTF-16", 0);
 		RETURN_NULL();
 	}
 
@@ -84,7 +84,7 @@ U_CFUNC PHP_FUNCTION(intltz_from_date_time_zone)
 	tzobj = Z_PHPTIMEZONE_P(zv_timezone);
 	if (!tzobj->initialized) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_from_date_time_zone: DateTimeZone object is unconstructed",
+			"DateTimeZone object is unconstructed",
 			0);
 		RETURN_NULL();
 	}
@@ -151,7 +151,7 @@ int_offset:
 		if (UNEXPECTED(Z_LVAL_P(arg) < (zend_long)INT32_MIN ||
 				Z_LVAL_P(arg) > (zend_long)INT32_MAX)) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-				"intltz_create_enumeration: value is out of range", 0);
+				"value is out of range", 0);
 			RETURN_FALSE;
 		} else {
 			se = TimeZone::createEnumeration((int32_t) Z_LVAL_P(arg));
@@ -180,7 +180,7 @@ double_offset:
 		se = TimeZone::createEnumeration(Z_STRVAL_P(arg));
 	} else {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_create_enumeration: invalid argument type", 0);
+			"invalid argument type", 0);
 		RETURN_FALSE;
 	}
 
@@ -188,7 +188,7 @@ double_offset:
 		IntlIterator_from_StringEnumeration(se, return_value);
 	} else {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_create_enumeration: error obtaining enumeration", 0);
+			"error obtaining enumeration", 0);
 		RETVAL_FALSE;
 	}
 }
@@ -208,7 +208,7 @@ U_CFUNC PHP_FUNCTION(intltz_count_equivalent_ids)
 	UnicodeString id = UnicodeString();
 	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
 		intl_error_set(NULL, status,
-			"intltz_count_equivalent_ids: could not convert time zone id to UTF-16", 0);
+			"could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
@@ -236,14 +236,14 @@ U_CFUNC PHP_FUNCTION(intltz_create_time_zone_id_enumeration)
 	if (zoneType != UCAL_ZONE_TYPE_ANY && zoneType != UCAL_ZONE_TYPE_CANONICAL
 			&& zoneType != UCAL_ZONE_TYPE_CANONICAL_LOCATION) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_create_time_zone_id_enumeration: bad zone type", 0);
+			"bad zone type", 0);
 		RETURN_FALSE;
 	}
 
 	if (!arg3isnull) {
 		if (UNEXPECTED(offset_arg < (zend_long)INT32_MIN || offset_arg > (zend_long)INT32_MAX)) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-				"intltz_create_time_zone_id_enumeration: offset out of bounds", 0);
+				"offset out of bounds", 0);
 			RETURN_FALSE;
 		}
 		offset = (int32_t)offset_arg;
@@ -254,8 +254,7 @@ U_CFUNC PHP_FUNCTION(intltz_create_time_zone_id_enumeration)
 	UErrorCode uec = UErrorCode();
 	se = TimeZone::createTimeZoneIDEnumeration((USystemTimeZoneType)zoneType,
 		region, offsetp, uec);
-	INTL_CHECK_STATUS(uec, "intltz_create_time_zone_id_enumeration: "
-		"Error obtaining time zone id enumeration")
+	INTL_CHECK_STATUS(uec, "error obtaining time zone id enumeration")
 
 	IntlIterator_from_StringEnumeration(se, return_value);
 }
@@ -276,18 +275,18 @@ U_CFUNC PHP_FUNCTION(intltz_get_canonical_id)
 	UnicodeString id;
 	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
 		intl_error_set(NULL, status,
-			"intltz_get_canonical_id: could not convert time zone id to UTF-16", 0);
+			"could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
 	UnicodeString result;
 	UBool isSystemID;
 	TimeZone::getCanonicalID(id, result, isSystemID, status);
-	INTL_CHECK_STATUS(status, "intltz_get_canonical_id: error obtaining canonical ID");
+	INTL_CHECK_STATUS(status, "error obtaining canonical ID");
 
 	zend_string *u8str =intl_convert_utf16_to_utf8(result.getBuffer(), result.length(), &status);
 	INTL_CHECK_STATUS(status,
-		"intltz_get_canonical_id: could not convert time zone id to UTF-16");
+		"could not convert time zone id to UTF-16");
 	RETVAL_NEW_STR(u8str);
 
 	if (is_systemid) { /* by-ref argument passed */
@@ -313,12 +312,12 @@ U_CFUNC PHP_FUNCTION(intltz_get_region)
 	UnicodeString id;
 	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
 		intl_error_set(NULL, status,
-			"intltz_get_region: could not convert time zone id to UTF-16", 0);
+			"could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
 	int32_t region_len = TimeZone::getRegion(id, outbuf, sizeof(outbuf), status);
-	INTL_CHECK_STATUS(status, "intltz_get_region: Error obtaining region");
+	INTL_CHECK_STATUS(status, "error obtaining region");
 
 	RETURN_STRINGL(outbuf, region_len);
 }
@@ -333,8 +332,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_tz_data_version)
 
 	UErrorCode status = UErrorCode();
 	const char *res = TimeZone::getTZDataVersion(status);
-	INTL_CHECK_STATUS(status, "intltz_get_tz_data_version: "
-		"Error obtaining time zone data version");
+	INTL_CHECK_STATUS(status, "error obtaining time zone data version");
 
 	RETURN_STRING(res);
 }
@@ -358,7 +356,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_equivalent_id)
 	UnicodeString id;
 	if (intl_stringFromChar(id, str_id, str_id_len, &status) == FAILURE) {
 		intl_error_set(NULL, status,
-			"intltz_get_equivalent_id: could not convert time zone id to UTF-16", 0);
+			"could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
@@ -366,8 +364,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_equivalent_id)
 	zend_string *u8str;
 
 	u8str = intl_convert_utf16_to_utf8(result.getBuffer(), result.length(), &status);
-	INTL_CHECK_STATUS(status, "intltz_get_equivalent_id: "
-		"could not convert resulting time zone id to UTF-16");
+	INTL_CHECK_STATUS(status, "could not convert resulting time zone id to UTF-16");
 	RETVAL_NEW_STR(u8str);
 }
 
@@ -420,7 +417,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_id)
 
 	u8str = intl_convert_utf16_to_utf8(
 		id_us.getBuffer(), id_us.length(), TIMEZONE_ERROR_CODE_P(to));
-	INTL_METHOD_CHECK_STATUS(to, "intltz_get_id: Could not convert id to UTF-8");
+	INTL_METHOD_CHECK_STATUS(to, "could not convert id to UTF-8");
 
 	RETVAL_NEW_STR(u8str);
 }
@@ -460,7 +457,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_offset)
 	to->utimezone->getOffset((UDate) date, (UBool) local, rawOffset, dstOffset,
 		TIMEZONE_ERROR_CODE(to));
 
-	INTL_METHOD_CHECK_STATUS(to, "intltz_get_offset: error obtaining offset");
+	INTL_METHOD_CHECK_STATUS(to, "error obtaining offset");
 
 	zval_ptr_dtor(rawOffsetArg);
 	ZVAL_LONG(rawOffsetArg, rawOffset);
@@ -499,7 +496,7 @@ U_CFUNC PHP_FUNCTION(intltz_has_same_rules)
 	other_to = Z_INTL_TIMEZONE_P(other_object);
 	if (other_to->utimezone == NULL) {
 		intl_errors_set(&to->err, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_has_same_rules: The second IntlTimeZone is unconstructed", 0);
+			"The second IntlTimeZone is unconstructed", 0);
 		RETURN_FALSE;
 	}
 
@@ -534,7 +531,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_display_name)
 	}
 	if (!found) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intltz_get_display_name: wrong display type", 0);
+			"wrong display type", 0);
 		RETURN_FALSE;
 	}
 
@@ -549,8 +546,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_display_name)
 		Locale::createFromName(locale_str), result);
 
 	zend_string *u8str = intl_convert_utf16_to_utf8(result.getBuffer(), result.length(), TIMEZONE_ERROR_CODE_P(to));
-	INTL_METHOD_CHECK_STATUS(to, "intltz_get_display_name: "
-		"could not convert resulting time zone id to UTF-16");
+	INTL_METHOD_CHECK_STATUS(to, "could not convert resulting time zone id to UTF-16");
 
 	RETVAL_NEW_STR(u8str);
 }
@@ -646,7 +642,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_windows_id)
 	error = U_ZERO_ERROR;
 	if (intl_stringFromChar(uID, id->val, id->len, &error) == FAILURE) {
 		intl_error_set(NULL, error,
-		               "intltz_get_windows_id: could not convert time zone id to UTF-16", 0);
+		               "could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
@@ -655,13 +651,13 @@ U_CFUNC PHP_FUNCTION(intltz_get_windows_id)
 	INTL_CHECK_STATUS(error, "intltz_get_windows_id: Unable to get timezone from windows ID");
 	if (uWinID.length() == 0) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-		               "intltz_get_windows_id: Unknown system timezone", 0);
+		               "unknown system timezone", 0);
 		RETURN_FALSE;
 	}
 
 	error = U_ZERO_ERROR;
 	winID = intl_convert_utf16_to_utf8(uWinID.getBuffer(), uWinID.length(), &error);
-	INTL_CHECK_STATUS(error, "intltz_get_windows_id: could not convert time zone id to UTF-8");
+	INTL_CHECK_STATUS(error, "could not convert time zone id to UTF-8");
 	RETURN_STR(winID);
 }
 /* }}} */
@@ -682,22 +678,22 @@ U_CFUNC PHP_FUNCTION(intltz_get_id_for_windows_id)
 	error = U_ZERO_ERROR;
 	if (intl_stringFromChar(uWinID, winID->val, winID->len, &error) == FAILURE) {
 		intl_error_set(NULL, error,
-		               "intltz_get_id_for_windows_id: could not convert time zone id to UTF-16", 0);
+		               "could not convert time zone id to UTF-16", 0);
 		RETURN_FALSE;
 	}
 
 	error = U_ZERO_ERROR;
 	TimeZone::getIDForWindowsID(uWinID, region ? region->val : NULL, uID, error);
-	INTL_CHECK_STATUS(error, "intltz_get_id_for_windows_id: Unable to get windows ID for timezone");
+	INTL_CHECK_STATUS(error, "unable to get windows ID for timezone");
 	if (uID.length() == 0) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-		               "intltz_get_windows_id: Unknown windows timezone", 0);
+		               "unknown windows timezone", 0);
 		RETURN_FALSE;
 	}
 
 	error = U_ZERO_ERROR;
 	id = intl_convert_utf16_to_utf8(uID.getBuffer(), uID.length(), &error);
-	INTL_CHECK_STATUS(error, "intltz_get_id_for_windows_id: could not convert time zone id to UTF-8");
+	INTL_CHECK_STATUS(error, "could not convert time zone id to UTF-8");
 	RETURN_STR(id);
 }
 /* }}} */

--- a/ext/intl/uchar/uchar.stub.php
+++ b/ext/intl/uchar/uchar.stub.php
@@ -59,9 +59,9 @@ class IntlChar
     /** @cvalue UCHAR_IDS_UNARY_OPERATOR */
     public const int PROPERTY_IDS_UNARY_OPERATOR = UNKNOWN;
     /** @cvalue UCHAR_ID_COMPAT_MATH_START */
-    public const int PROPERTY_ID_COMPT_MATH_START = UNKNOWN;
+    public const int PROPERTY_ID_COMPAT_MATH_START = UNKNOWN;
     /** @cvalue UCHAR_ID_COMPAT_MATH_CONTINUE */
-    public const int PROPERTY_ID_COMPT_MATH_CONTINUE = UNKNOWN;
+    public const int PROPERTY_ID_COMPAT_MATH_CONTINUE = UNKNOWN;
 #endif
     /** @cvalue UCHAR_JOIN_CONTROL */
     public const int PROPERTY_JOIN_CONTROL = UNKNOWN;

--- a/ext/intl/uchar/uchar_arginfo.h
+++ b/ext/intl/uchar/uchar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70f5e584df42040922a6641a6b619c89de2b101a */
+ * Stub hash: f0c67026b921d853e745fcc5d980bdb86f475c80 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlChar_hasBinaryProperty, 0, 2, _IS_BOOL, 1)
 	ZEND_ARG_TYPE_MASK(0, codepoint, MAY_BE_LONG|MAY_BE_STRING, NULL)
@@ -476,19 +476,19 @@ static zend_class_entry *register_class_IntlChar(void)
 #endif
 #if U_ICU_VERSION_MAJOR_NUM >= 74
 
-	zval const_PROPERTY_ID_COMPT_MATH_START_value;
-	ZVAL_LONG(&const_PROPERTY_ID_COMPT_MATH_START_value, UCHAR_ID_COMPAT_MATH_START);
-	zend_string *const_PROPERTY_ID_COMPT_MATH_START_name = zend_string_init_interned("PROPERTY_ID_COMPT_MATH_START", sizeof("PROPERTY_ID_COMPT_MATH_START") - 1, 1);
-	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPT_MATH_START_name, &const_PROPERTY_ID_COMPT_MATH_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(const_PROPERTY_ID_COMPT_MATH_START_name);
+	zval const_PROPERTY_ID_COMPAT_MATH_START_value;
+	ZVAL_LONG(&const_PROPERTY_ID_COMPAT_MATH_START_value, UCHAR_ID_COMPAT_MATH_START);
+	zend_string *const_PROPERTY_ID_COMPAT_MATH_START_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_START", sizeof("PROPERTY_ID_COMPAT_MATH_START") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPAT_MATH_START_name, &const_PROPERTY_ID_COMPAT_MATH_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_PROPERTY_ID_COMPAT_MATH_START_name);
 #endif
 #if U_ICU_VERSION_MAJOR_NUM >= 74
 
-	zval const_PROPERTY_ID_COMPT_MATH_CONTINUE_value;
-	ZVAL_LONG(&const_PROPERTY_ID_COMPT_MATH_CONTINUE_value, UCHAR_ID_COMPAT_MATH_CONTINUE);
-	zend_string *const_PROPERTY_ID_COMPT_MATH_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_COMPT_MATH_CONTINUE", sizeof("PROPERTY_ID_COMPT_MATH_CONTINUE") - 1, 1);
-	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPT_MATH_CONTINUE_name, &const_PROPERTY_ID_COMPT_MATH_CONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(const_PROPERTY_ID_COMPT_MATH_CONTINUE_name);
+	zval const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value;
+	ZVAL_LONG(&const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value, UCHAR_ID_COMPAT_MATH_CONTINUE);
+	zend_string *const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_CONTINUE", sizeof("PROPERTY_ID_COMPAT_MATH_CONTINUE") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name, &const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name);
 #endif
 
 	zval const_PROPERTY_JOIN_CONTROL_value;


### PR DESCRIPTION
Also correcting new IntlChar class constants typos.