### PR TITLE
Remove unused symbol ZEND_FIBER_ASM

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -66,6 +66,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol DARWIN has been removed (use __APPLE__ to target Darwin systems).
    - Symbol MISSING_FCLOSE_DECL and M4 macro PHP_MISSING_FCLOSE_DECL removed.
    - Symbol HAVE_BSD_ICONV has been removed.
+   - Symbol ZEND_FIBER_ASM has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/configure.ac
+++ b/configure.ac
@@ -1338,7 +1338,6 @@ fi
 
 if test "$fiber_asm" = 'yes'; then
   AC_MSG_CHECKING([for fiber switching context])
-  AC_DEFINE([ZEND_FIBER_ASM], 1, [ ])
   PHP_ADD_SOURCES(Zend/asm, make_${fiber_asm_file}.S jump_${fiber_asm_file}.S, "$fiber_asm_cflag")
   AC_MSG_RESULT([$fiber_asm_file])
 else


### PR DESCRIPTION
The symbol `ZEND_FIBER_ASM` is not defined on Windows and not used around the ecosystem.