### PR TITLE
Refactor union semun in ext/sysvsem

### DIFF
--- a/ext/sysvsem/config.m4
+++ b/ext/sysvsem/config.m4
@@ -4,22 +4,9 @@ PHP_ARG_ENABLE([sysvsem],
     [Enable System V semaphore support])])
 
 if test "$PHP_SYSVSEM" != "no"; then
- PHP_NEW_EXTENSION(sysvsem, sysvsem.c, $ext_shared)
- AC_DEFINE(HAVE_SYSVSEM, 1, [ ])
- AC_CACHE_CHECK(for union semun,php_cv_semun,
-   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/ipc.h>
-#include <sys/sem.h>
-   ]], [[union semun x;]])],[
-     php_cv_semun=yes
-   ],[
-     php_cv_semun=no
-   ])
- )
- if test "$php_cv_semun" = "yes"; then
-   AC_DEFINE(HAVE_SEMUN, 1, [ ])
- else
-   AC_DEFINE(HAVE_SEMUN, 0, [ ])
- fi
+  PHP_NEW_EXTENSION(sysvsem, sysvsem.c, $ext_shared)
+  AC_DEFINE(HAVE_SYSVSEM, 1, [ ])
+  AC_CHECK_TYPES([union semun],,,[#include <sys/types.h>
+    #include <sys/ipc.h>
+    #include <sys/sem.h>])
 fi


### PR DESCRIPTION
The union semun is always defined in php-src code. Current systems require user to define it manually as done in the ext/sysvsem/sysvsem.c. The conditional checks for `HAVE_SEMUN` were unused. The PHP 3.0.12 AIX bug bugs.php.net/2149 was fixed by the removal of `__GNU_LIBRARY__` check, so this now further simplifies the code. The Autoconf `AC_CHECK_TYPES` checks if system by any chance has the union semun, and by default defines the `HAVE_UNION_SEMUN`.