### PR TITLE
Remove HAVE_SYSCONF check

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -337,18 +337,6 @@ AC_DEFUN([AC_FPM_LQ],
   fi
 ])
 
-AC_DEFUN([AC_FPM_SYSCONF],
-[
-	AC_MSG_CHECKING([for sysconf])
-
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[sysconf(_SC_CLK_TCK);]])],[
-		AC_DEFINE([HAVE_SYSCONF], 1, [do we have sysconf?])
-		AC_MSG_RESULT([yes])
-	], [
-		AC_MSG_RESULT([no])
-	])
-])
-
 AC_DEFUN([AC_FPM_TIMES],
 [
 	AC_MSG_CHECKING([for times])
@@ -499,7 +487,6 @@ if test "$PHP_FPM" != "no"; then
   AC_FPM_TRACE
   AC_FPM_BUILTIN_ATOMIC
   AC_FPM_LQ
-  AC_FPM_SYSCONF
   AC_FPM_TIMES
   AC_FPM_KQUEUE
   AC_FPM_PORT

--- a/sapi/fpm/fpm/fpm_scoreboard.c
+++ b/sapi/fpm/fpm/fpm_scoreboard.c
@@ -26,7 +26,7 @@ int fpm_scoreboard_init_main(void)
 	struct fpm_worker_pool_s *wp;
 
 #ifdef HAVE_TIMES
-#if (defined(HAVE_SYSCONF) && defined(_SC_CLK_TCK))
+#ifdef _SC_CLK_TCK
 	fpm_scoreboard_tick = sysconf(_SC_CLK_TCK);
 #else /* _SC_CLK_TCK */
 #ifdef HZ


### PR DESCRIPTION
The sysconf can be assumed to be present on current systems, when checking for the _SC_CLK_TCK symbol.