### PR TITLE
Find and link math library as needed with AC_SEARCH_LIBS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -68,6 +68,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_BSD_ICONV has been removed.
    - Symbol ZEND_FIBER_ASM has been removed.
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
+   - Symbol HAVE_LIBM has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/configure.ac
+++ b/configure.ac
@@ -364,7 +364,7 @@ PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
 AC_SEARCH_LIBS([dlopen], [dl],
   [AC_DEFINE([HAVE_LIBDL], [1], [Define to 1 if the dl library is available.])])
-AC_CHECK_LIB(m, sin)
+AC_SEARCH_LIBS([sin], [m])
 
 case $host_alias in
   riscv64*)

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -86,7 +86,6 @@
 #undef HAVE_ALLOCA_H
 #undef HAVE_KILL
 #define HAVE_GETPID 1
-#define HAVE_LIBM 1
 #undef HAVE_RINT
 /* int and long are still 32bit in 64bit compiles */
 #define SIZEOF_INT 4


### PR DESCRIPTION
On some systems (Haiku) the math library is part of the C library and it doesn't need to be explicitly prepended to LIBS. The redundant HAVE_LIBM symbol defined by the AC_CHECK_LIB has been removed.