### PR TITLE
Find and link dl library as needed with AC_SEARCH_LIBS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -67,6 +67,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol MISSING_FCLOSE_DECL and M4 macro PHP_MISSING_FCLOSE_DECL removed.
    - Symbol HAVE_BSD_ICONV has been removed.
    - Symbol ZEND_FIBER_ASM has been removed.
+   - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/configure.ac
+++ b/configure.ac
@@ -362,11 +362,8 @@ PHP_CHECK_FUNC(socketpair, socket, network)
 PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
-PHP_CHECK_FUNC(dlopen, dl)
-PHP_CHECK_FUNC(dlsym, dl)
-if test "$ac_cv_func_dlopen" = "yes"; then
-  AC_DEFINE(HAVE_LIBDL, 1, [ ])
-fi
+AC_SEARCH_LIBS([dlopen], [dl],
+  [AC_DEFINE([HAVE_LIBDL], [1], [Define to 1 if the dl library is available.])])
 AC_CHECK_LIB(m, sin)
 
 case $host_alias in


### PR DESCRIPTION
AC_SEARCH_LIBS can be used to check for dlopen and if dl library needs to be prepended to LIBS. The dlsym is available with the same scope as dlopen (if dlopen is present, also dlsym is). The redundant HAVE_DLOPEN and HAVE_DLSYM symbols have been removed.