### PR TITLE
CI: Remove ext/imap dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
               `#snmp-mibs-downloader` \
               freetds-dev \
               `#unixodbc-dev` \
-              libc-client-dev \
               dovecot-core \
               dovecot-pop3d \
               dovecot-imapd \

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -59,7 +59,6 @@ runs:
           unixodbc-dev \
           llvm \
           clang \
-          libc-client-dev \
           dovecot-core \
           dovecot-pop3d \
           dovecot-imapd \


### PR DESCRIPTION
Now that ext/imap is unbundled, `libc-client-dev*` packages are no longer necessary.