### PR TITLE
Singular DateTime::[get|set]Microsecond & no tentative return type

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,7 +23,7 @@ PHP                                                                        NEWS
 
 - Date:
   . Added DateTime[Immutable]::createFromTimestamp. (Marc Bennewitz)
-  . Added DateTime[Immutable]::[get|set]Microseconds. (Marc Bennewitz)
+  . Added DateTime[Immutable]::[get|set]Microsecond. (Marc Bennewitz)
 
 - DOM:
   . Added DOMNode::compareDocumentPosition(). (nielsdos)

--- a/UPGRADING
+++ b/UPGRADING
@@ -173,9 +173,9 @@ PHP 8.4 UPGRADE NOTES
 - Date:
   . Added static methods
     DateTime[Immutable]::createFromTimestamp(int|float $timestamp): static.
-  . Added method DateTime[Immutable]::getMicroseconds(): int.
+  . Added method DateTime[Immutable]::getMicrosecond(): int.
   . Added method
-    DateTime[Immutable]::setMicroseconds(int $microseconds): static.
+    DateTime[Immutable]::setMicrosecond(int $microsecond): static.
 
 - DOM:
   . Added constant DOMNode::DOCUMENT_POSITION_DISCONNECTED.

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2377,15 +2377,15 @@ static void update_errors_warnings(timelib_error_container **last_errors) /* {{{
 	*last_errors = NULL;
 } /* }}} */
 
-static void php_date_set_time_fraction(timelib_time *time, int microseconds)
+static void php_date_set_time_fraction(timelib_time *time, int microsecond)
 {
-	time->us = microseconds;
+	time->us = microsecond;
 }
 
 static void php_date_get_current_time_with_fraction(time_t *sec, suseconds_t *usec)
 {
 #if HAVE_GETTIMEOFDAY
-	struct timeval tp = {0}; /* For setting microseconds */
+	struct timeval tp = {0}; /* For setting microsecond */
 
 	gettimeofday(&tp, NULL);
 	*sec = tp.tv_sec;
@@ -3855,7 +3855,7 @@ PHP_METHOD(DateTimeImmutable, setTimestamp)
 /* }}} */
 
 /* {{{ */
-PHP_METHOD(DateTimeImmutable, setMicroseconds)
+PHP_METHOD(DateTimeImmutable, setMicrosecond)
 {
 	zval *object, new_object;
 	php_date_obj *dateobj, *new_dateobj;
@@ -3889,7 +3889,7 @@ PHP_METHOD(DateTimeImmutable, setMicroseconds)
 /* }}} */
 
 /* {{{ */
-PHP_METHOD(DateTime, setMicroseconds)
+PHP_METHOD(DateTime, setMicrosecond)
 {
 	zval *object;
 	php_date_obj *dateobj;
@@ -3947,7 +3947,7 @@ PHP_FUNCTION(date_timestamp_get)
 }
 /* }}} */
 
-PHP_METHOD(DateTime, getMicroseconds) /* {{{ */
+PHP_METHOD(DateTime, getMicrosecond) /* {{{ */
 {
 	zval *object;
 	php_date_obj *dateobj;

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -412,8 +412,7 @@ class DateTime implements DateTimeInterface
      */
     public function getOffset(): int {}
 
-    /** @tentative-return-type */
-    public function getMicroseconds(): int {}
+    public function getMicrosecond(): int {}
 
     /**
      * @tentative-return-type
@@ -439,8 +438,7 @@ class DateTime implements DateTimeInterface
      */
     public function setTimestamp(int $timestamp): DateTime {}
 
-    /** @tentative-return-type */
-    public function setMicroseconds(int $microseconds): static {}
+    public function setMicrosecond(int $microsecond): static {}
 
     /**
      * @tentative-return-type
@@ -510,10 +508,9 @@ class DateTimeImmutable implements DateTimeInterface
     public function getTimestamp(): int {}
 
     /**
-     * @alias DateTime::getMicroseconds
-     * @tentative-return-type
+     * @alias DateTime::getMicrosecond
      */
-    public function getMicroseconds(): int {}
+    public function getMicrosecond(): int {}
 
     /**
      * @tentative-return-type
@@ -545,8 +542,7 @@ class DateTimeImmutable implements DateTimeInterface
     /** @tentative-return-type */
     public function setTimestamp(int $timestamp): DateTimeImmutable {}
 
-    /** @tentative-return-type */
-    public function setMicroseconds(int $microseconds): static {}
+    public function setMicrosecond(int $microsecond): static {}
 
     /** @tentative-return-type */
     public static function createFromMutable(DateTime $object): static {}

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -325,6 +325,8 @@ interface DateTimeInterface
     /** @tentative-return-type */
     public function getTimestamp(): int;
 
+    public function getMicrosecond(): int;
+
     /** @tentative-return-type */
     public function diff(DateTimeInterface $targetObject, bool $absolute = false): DateInterval;
 

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 418128002b5d1ce129f18fb86e1903955a5cc1c5 */
+ * Stub hash: 199789cfbbb53ead5c5418ae30935ffdd7c9685f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -236,6 +236,8 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeInterfac
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeInterface_getTimestamp arginfo_class_DateTimeInterface_getOffset
+
+#define arginfo_class_DateTimeInterface_getMicrosecond arginfo_time
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_diff, 0, 1, DateInterval, 0)
 	ZEND_ARG_OBJ_INFO(0, targetObject, DateTimeInterface, 0)
@@ -671,6 +673,7 @@ static const zend_function_entry class_DateTimeInterface_methods[] = {
 	ZEND_RAW_FENTRY("getTimezone", NULL, arginfo_class_DateTimeInterface_getTimezone, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("getOffset", NULL, arginfo_class_DateTimeInterface_getOffset, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_DateTimeInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+	ZEND_RAW_FENTRY("getMicrosecond", NULL, arginfo_class_DateTimeInterface_getMicrosecond, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("diff", NULL, arginfo_class_DateTimeInterface_diff, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("__wakeup", NULL, arginfo_class_DateTimeInterface___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_RAW_FENTRY("__serialize", NULL, arginfo_class_DateTimeInterface___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6fb121a5992ae96d12dea6055d1b0f0d6534cf21 */
+ * Stub hash: 418128002b5d1ce129f18fb86e1903955a5cc1c5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -307,7 +307,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getOffset arginfo_class_DateTimeInterface_getOffset
 
-#define arginfo_class_DateTime_getMicroseconds arginfo_class_DateTimeInterface_getOffset
+#define arginfo_class_DateTime_getMicrosecond arginfo_time
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTime, 0, 2, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
@@ -332,8 +332,8 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimes
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setMicroseconds, 0, 1, IS_STATIC, 0)
-	ZEND_ARG_TYPE_INFO(0, microseconds, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setMicrosecond, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, microsecond, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTime_getTimestamp arginfo_class_DateTimeInterface_getOffset
@@ -370,7 +370,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_getTimestamp arginfo_class_DateTimeInterface_getOffset
 
-#define arginfo_class_DateTimeImmutable_getMicroseconds arginfo_class_DateTimeInterface_getOffset
+#define arginfo_class_DateTimeImmutable_getMicrosecond arginfo_time
 
 #define arginfo_class_DateTimeImmutable_diff arginfo_class_DateTimeInterface_diff
 
@@ -411,7 +411,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setMicroseconds arginfo_class_DateTime_setMicroseconds
+#define arginfo_class_DateTimeImmutable_setMicrosecond arginfo_class_DateTime_setMicrosecond
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_createFromMutable, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
@@ -572,8 +572,8 @@ ZEND_METHOD(DateTime, createFromInterface);
 ZEND_METHOD(DateTime, createFromTimestamp);
 ZEND_METHOD(DateTime, modify);
 ZEND_METHOD(DateTime, sub);
-ZEND_METHOD(DateTime, getMicroseconds);
-ZEND_METHOD(DateTime, setMicroseconds);
+ZEND_METHOD(DateTime, getMicrosecond);
+ZEND_METHOD(DateTime, setMicrosecond);
 ZEND_METHOD(DateTimeImmutable, __construct);
 ZEND_METHOD(DateTimeImmutable, __serialize);
 ZEND_METHOD(DateTimeImmutable, __unserialize);
@@ -588,7 +588,7 @@ ZEND_METHOD(DateTimeImmutable, setTime);
 ZEND_METHOD(DateTimeImmutable, setDate);
 ZEND_METHOD(DateTimeImmutable, setISODate);
 ZEND_METHOD(DateTimeImmutable, setTimestamp);
-ZEND_METHOD(DateTimeImmutable, setMicroseconds);
+ZEND_METHOD(DateTimeImmutable, setMicrosecond);
 ZEND_METHOD(DateTimeImmutable, createFromMutable);
 ZEND_METHOD(DateTimeImmutable, createFromInterface);
 ZEND_METHOD(DateTimeZone, __construct);
@@ -696,12 +696,12 @@ static const zend_function_entry class_DateTime_methods[] = {
 	ZEND_RAW_FENTRY("getTimezone", zif_date_timezone_get, arginfo_class_DateTime_getTimezone, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("setTimezone", zif_date_timezone_set, arginfo_class_DateTime_setTimezone, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getOffset", zif_date_offset_get, arginfo_class_DateTime_getOffset, ZEND_ACC_PUBLIC, NULL, NULL)
-	ZEND_ME(DateTime, getMicroseconds, arginfo_class_DateTime_getMicroseconds, ZEND_ACC_PUBLIC)
+	ZEND_ME(DateTime, getMicrosecond, arginfo_class_DateTime_getMicrosecond, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("setTime", zif_date_time_set, arginfo_class_DateTime_setTime, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("setDate", zif_date_date_set, arginfo_class_DateTime_setDate, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("setISODate", zif_date_isodate_set, arginfo_class_DateTime_setISODate, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("setTimestamp", zif_date_timestamp_set, arginfo_class_DateTime_setTimestamp, ZEND_ACC_PUBLIC, NULL, NULL)
-	ZEND_ME(DateTime, setMicroseconds, arginfo_class_DateTime_setMicroseconds, ZEND_ACC_PUBLIC)
+	ZEND_ME(DateTime, setMicrosecond, arginfo_class_DateTime_setMicrosecond, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("getTimestamp", zif_date_timestamp_get, arginfo_class_DateTime_getTimestamp, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("diff", zif_date_diff, arginfo_class_DateTime_diff, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_FE_END
@@ -720,7 +720,7 @@ static const zend_function_entry class_DateTimeImmutable_methods[] = {
 	ZEND_RAW_FENTRY("getTimezone", zif_date_timezone_get, arginfo_class_DateTimeImmutable_getTimezone, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getOffset", zif_date_offset_get, arginfo_class_DateTimeImmutable_getOffset, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getTimestamp", zif_date_timestamp_get, arginfo_class_DateTimeImmutable_getTimestamp, ZEND_ACC_PUBLIC, NULL, NULL)
-	ZEND_RAW_FENTRY("getMicroseconds", zim_DateTime_getMicroseconds, arginfo_class_DateTimeImmutable_getMicroseconds, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_RAW_FENTRY("getMicrosecond", zim_DateTime_getMicrosecond, arginfo_class_DateTimeImmutable_getMicrosecond, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("diff", zif_date_diff, arginfo_class_DateTimeImmutable_diff, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(DateTimeImmutable, modify, arginfo_class_DateTimeImmutable_modify, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateTimeImmutable, add, arginfo_class_DateTimeImmutable_add, ZEND_ACC_PUBLIC)
@@ -730,7 +730,7 @@ static const zend_function_entry class_DateTimeImmutable_methods[] = {
 	ZEND_ME(DateTimeImmutable, setDate, arginfo_class_DateTimeImmutable_setDate, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateTimeImmutable, setISODate, arginfo_class_DateTimeImmutable_setISODate, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateTimeImmutable, setTimestamp, arginfo_class_DateTimeImmutable_setTimestamp, ZEND_ACC_PUBLIC)
-	ZEND_ME(DateTimeImmutable, setMicroseconds, arginfo_class_DateTimeImmutable_setMicroseconds, ZEND_ACC_PUBLIC)
+	ZEND_ME(DateTimeImmutable, setMicrosecond, arginfo_class_DateTimeImmutable_setMicrosecond, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateTimeImmutable, createFromMutable, arginfo_class_DateTimeImmutable_createFromMutable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(DateTimeImmutable, createFromInterface, arginfo_class_DateTimeImmutable_createFromInterface, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END

--- a/ext/date/tests/getSetMicroseconds.phpt
+++ b/ext/date/tests/getSetMicroseconds.phpt
@@ -6,7 +6,7 @@ Tests for DateTime[Immutable]::[get|set]Microseconds
 class MyDateTime extends DateTime {};
 class MyDateTimeImmutable extends DateTimeImmutable {};
 
-$microsecondsList = array(
+$microsecondList = array(
     0,
     999999,
     -1,
@@ -18,56 +18,56 @@ $dti = new DateTimeImmutable('2023-04-05T06:07:08.901234+00:00');
 $myDt = new MyDateTime('2023-04-05T06:07:08.901234+00:00');
 $myDti = new MyDateTimeImmutable('2023-04-05T06:07:08.901234+00:00');
 
-echo 'DateTime::getMicroseconds(): ' . var_export($dt->getMicroseconds(), true) . "\n";
+echo 'DateTime::getMicrosecond(): ' . var_export($dt->getMicrosecond(), true) . "\n";
 var_dump($dt);
 
-echo 'DateTimeImmutable::getMicroseconds(): ' . var_export($dti->getMicroseconds(), true) . "\n";
+echo 'DateTimeImmutable::getMicrosecond(): ' . var_export($dti->getMicrosecond(), true) . "\n";
 var_dump($dti);
 
-echo 'MyDateTime::getMicroseconds(): ' . var_export($myDt->getMicroseconds(), true) . "\n";
+echo 'MyDateTime::getMicrosecond(): ' . var_export($myDt->getMicrosecond(), true) . "\n";
 var_dump($myDt);
 
-echo 'MyDateTimeImmutable::getMicroseconds(): ' . var_export($myDti->getMicroseconds(), true) . "\n";
+echo 'MyDateTimeImmutable::getMicrosecond(): ' . var_export($myDti->getMicrosecond(), true) . "\n";
 var_dump($myDti);
 
-foreach ($microsecondsList as $microseconds) {
+foreach ($microsecondList as $microsecond) {
     echo "##################################\n";
 
-    echo 'DateTime::setMicroseconds('.var_export($microseconds, true).'): ';
+    echo 'DateTime::setMicrosecond('.var_export($microsecond, true).'): ';
     try {
-        var_dump($dt->setMicroseconds($microseconds));
+        var_dump($dt->setMicrosecond($microsecond));
     } catch (Throwable $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
-    echo 'DateTime::getMicroseconds(): ' . var_export($dt->getMicroseconds(), true) . "\n";
+    echo 'DateTime::getMicrosecond(): ' . var_export($dt->getMicrosecond(), true) . "\n";
 
-    echo 'DateTimeImmutable::setMicroseconds('.var_export($microseconds, true).'): ';
+    echo 'DateTimeImmutable::setMicrosecond('.var_export($microsecond, true).'): ';
     try {
-        var_dump($dti->setMicroseconds($microseconds));
+        var_dump($dti->setMicrosecond($microsecond));
     } catch (Throwable $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
-    echo 'DateTimeImmutable::getMicroseconds(): ' . var_export($dti->getMicroseconds(), true) . "\n";
+    echo 'DateTimeImmutable::getMicrosecond(): ' . var_export($dti->getMicrosecond(), true) . "\n";
 
-    echo 'MyDateTime::setMicroseconds('.var_export($microseconds, true).'): ';
+    echo 'MyDateTime::setMicrosecond('.var_export($microsecond, true).'): ';
     try {
-        var_dump($myDt->setMicroseconds($microseconds));
+        var_dump($myDt->setMicrosecond($microsecond));
     } catch (Throwable $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
-    echo 'MyDateTime::getMicroseconds(): ' . var_export($myDt->getMicroseconds(), true) . "\n";
+    echo 'MyDateTime::getMicrosecond(): ' . var_export($myDt->getMicrosecond(), true) . "\n";
 
-    echo 'MyDateTimeImmutable::setMicroseconds('.var_export($microseconds, true).'): ';
+    echo 'MyDateTimeImmutable::setMicrosecond('.var_export($microsecond, true).'): ';
     try {
-        var_dump($myDti->setMicroseconds($microseconds));
+        var_dump($myDti->setMicrosecond($microsecond));
     } catch (Throwable $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
-    echo 'MyDateTimeImmutable::getMicroseconds(): ' . var_export($myDti->getMicroseconds(), true) . "\n";
+    echo 'MyDateTimeImmutable::getMicrosecond(): ' . var_export($myDti->getMicrosecond(), true) . "\n";
 }
 ?>
 --EXPECTF--
-DateTime::getMicroseconds(): 901234
+DateTime::getMicrosecond(): 901234
 object(DateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.901234"
@@ -76,7 +76,7 @@ object(DateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTimeImmutable::getMicroseconds(): 901234
+DateTimeImmutable::getMicrosecond(): 901234
 object(DateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.901234"
@@ -85,7 +85,7 @@ object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTime::getMicroseconds(): 901234
+MyDateTime::getMicrosecond(): 901234
 object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.901234"
@@ -94,7 +94,7 @@ object(MyDateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTimeImmutable::getMicroseconds(): 901234
+MyDateTimeImmutable::getMicrosecond(): 901234
 object(MyDateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.901234"
@@ -104,7 +104,7 @@ object(MyDateTimeImmutable)#%d (3) {
   string(6) "+00:00"
 }
 ##################################
-DateTime::setMicroseconds(0): object(DateTime)#%d (3) {
+DateTime::setMicrosecond(0): object(DateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.000000"
   ["timezone_type"]=>
@@ -112,8 +112,8 @@ DateTime::setMicroseconds(0): object(DateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::getMicroseconds(): 0
-DateTimeImmutable::setMicroseconds(0): object(DateTimeImmutable)#%d (3) {
+DateTime::getMicrosecond(): 0
+DateTimeImmutable::setMicrosecond(0): object(DateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.000000"
   ["timezone_type"]=>
@@ -121,8 +121,8 @@ DateTimeImmutable::setMicroseconds(0): object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTimeImmutable::getMicroseconds(): 901234
-MyDateTime::setMicroseconds(0): object(MyDateTime)#%d (3) {
+DateTimeImmutable::getMicrosecond(): 901234
+MyDateTime::setMicrosecond(0): object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.000000"
   ["timezone_type"]=>
@@ -130,8 +130,8 @@ MyDateTime::setMicroseconds(0): object(MyDateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTime::getMicroseconds(): 0
-MyDateTimeImmutable::setMicroseconds(0): object(MyDateTimeImmutable)#%d (3) {
+MyDateTime::getMicrosecond(): 0
+MyDateTimeImmutable::setMicrosecond(0): object(MyDateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.000000"
   ["timezone_type"]=>
@@ -139,9 +139,9 @@ MyDateTimeImmutable::setMicroseconds(0): object(MyDateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTimeImmutable::getMicroseconds(): 901234
+MyDateTimeImmutable::getMicrosecond(): 901234
 ##################################
-DateTime::setMicroseconds(999999): object(DateTime)#%d (3) {
+DateTime::setMicrosecond(999999): object(DateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.999999"
   ["timezone_type"]=>
@@ -149,8 +149,8 @@ DateTime::setMicroseconds(999999): object(DateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::getMicroseconds(): 999999
-DateTimeImmutable::setMicroseconds(999999): object(DateTimeImmutable)#%d (3) {
+DateTime::getMicrosecond(): 999999
+DateTimeImmutable::setMicrosecond(999999): object(DateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.999999"
   ["timezone_type"]=>
@@ -158,8 +158,8 @@ DateTimeImmutable::setMicroseconds(999999): object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTimeImmutable::getMicroseconds(): 901234
-MyDateTime::setMicroseconds(999999): object(MyDateTime)#%d (3) {
+DateTimeImmutable::getMicrosecond(): 901234
+MyDateTime::setMicrosecond(999999): object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.999999"
   ["timezone_type"]=>
@@ -167,8 +167,8 @@ MyDateTime::setMicroseconds(999999): object(MyDateTime)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTime::getMicroseconds(): 999999
-MyDateTimeImmutable::setMicroseconds(999999): object(MyDateTimeImmutable)#%d (3) {
+MyDateTime::getMicrosecond(): 999999
+MyDateTimeImmutable::setMicrosecond(999999): object(MyDateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "2023-04-05 06:07:08.999999"
   ["timezone_type"]=>
@@ -176,22 +176,22 @@ MyDateTimeImmutable::setMicroseconds(999999): object(MyDateTimeImmutable)#%d (3)
   ["timezone"]=>
   string(6) "+00:00"
 }
-MyDateTimeImmutable::getMicroseconds(): 901234
+MyDateTimeImmutable::getMicrosecond(): 901234
 ##################################
-DateTime::setMicroseconds(-1): DateRangeError: DateTime::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, -1 given
-DateTime::getMicroseconds(): 999999
-DateTimeImmutable::setMicroseconds(-1): DateRangeError: DateTimeImmutable::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, -1 given
-DateTimeImmutable::getMicroseconds(): 901234
-MyDateTime::setMicroseconds(-1): DateRangeError: DateTime::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, -1 given
-MyDateTime::getMicroseconds(): 999999
-MyDateTimeImmutable::setMicroseconds(-1): DateRangeError: DateTimeImmutable::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, -1 given
-MyDateTimeImmutable::getMicroseconds(): 901234
+DateTime::setMicrosecond(-1): DateRangeError: DateTime::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, -1 given
+DateTime::getMicrosecond(): 999999
+DateTimeImmutable::setMicrosecond(-1): DateRangeError: DateTimeImmutable::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, -1 given
+DateTimeImmutable::getMicrosecond(): 901234
+MyDateTime::setMicrosecond(-1): DateRangeError: DateTime::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, -1 given
+MyDateTime::getMicrosecond(): 999999
+MyDateTimeImmutable::setMicrosecond(-1): DateRangeError: DateTimeImmutable::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, -1 given
+MyDateTimeImmutable::getMicrosecond(): 901234
 ##################################
-DateTime::setMicroseconds(1000000): DateRangeError: DateTime::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, 1000000 given
-DateTime::getMicroseconds(): 999999
-DateTimeImmutable::setMicroseconds(1000000): DateRangeError: DateTimeImmutable::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, 1000000 given
-DateTimeImmutable::getMicroseconds(): 901234
-MyDateTime::setMicroseconds(1000000): DateRangeError: DateTime::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, 1000000 given
-MyDateTime::getMicroseconds(): 999999
-MyDateTimeImmutable::setMicroseconds(1000000): DateRangeError: DateTimeImmutable::setMicroseconds(): Argument #1 ($microseconds) must be between 0 and 999999, 1000000 given
-MyDateTimeImmutable::getMicroseconds(): 901234
+DateTime::setMicrosecond(1000000): DateRangeError: DateTime::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given
+DateTime::getMicrosecond(): 999999
+DateTimeImmutable::setMicrosecond(1000000): DateRangeError: DateTimeImmutable::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given
+DateTimeImmutable::getMicrosecond(): 901234
+MyDateTime::setMicrosecond(1000000): DateRangeError: DateTime::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given
+MyDateTime::getMicrosecond(): 999999
+MyDateTimeImmutable::setMicrosecond(1000000): DateRangeError: DateTimeImmutable::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given
+MyDateTimeImmutable::getMicrosecond(): 901234


### PR DESCRIPTION
Renamed `DateTime[Immutable]::[get|set]Microseconds()` to `DateTime[Immutable]::[get|set]Microsecond()`
* This is a getter/setter of the microsecond part of the time and not a multiple microseconds
* If you think of hour this gets more clear as it would be `[get|set]Hour` and not hours

Removed tentative return type as noted here https://github.com/php/php-src/pull/12557#discussion_r1483964579

Added `getMicrosecond` to `DateTimeInterface` as discussed in #13491

As this hasn't been added to any stable/beta branch it's not a BC break.