### PR TITLE
Simplify Pgrab and proc library Autoconf check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -372,6 +372,9 @@ case $host_alias in
     ;;
 esac
 
+dnl Solaris/Illumos for process mapping.
+AC_SEARCH_LIBS([Pgrab], [proc])
+
 dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
@@ -643,9 +646,6 @@ PHP_CHECK_FUNC_LIB(nanosleep, rt)
 
 dnl Haiku does not have network api in libc.
 PHP_CHECK_FUNC_LIB(setsockopt, network)
-
-dnl Solaris/Illumos for process mapping.
-PHP_CHECK_FUNC_LIB(Pgrab, proc)
 
 dnl Check for getaddrinfo, should be a better way, but... Also check for working
 dnl getaddrinfo.


### PR DESCRIPTION
For Solaris/illumos systems, in this case, the check can be done using AC_SEARCH_LIBS, which avoids defining redundant symbols like HAVE_PGRAB and HAVE_LIBPROC.