### PR TITLE
Added missing obj methods to DateTimeInterface

### DIFF
--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -317,10 +317,41 @@ interface DateTimeInterface
     public function format(string $format): string;
 
     /** @tentative-return-type */
+    public function modify(string $modifier): DateTimeInterface|false;
+
+
+    /** @tentative-return-type */
+    public function add(DateInterval $interval): DateTimeInterface;
+
+    /** @tentative-return-type */
+    public function sub(DateInterval $interval): DateTimeInterface;
+
+    /** @tentative-return-type */
     public function getTimezone(): DateTimeZone|false;
 
     /** @tentative-return-type */
+    public function setTimezone(DateTimeZone $timezone): DateTimeInterface;
+
+    /** @tentative-return-type */
     public function getOffset(): int;
+
+    /** @tentative-return-type */
+    public function getMicroseconds(): int; // TODO: Rename https://github.com/php/php-src/pull/13486
+
+    /** @tentative-return-type */
+    public function setMicroseconds(int $microseconds): static; // TODO: Rename https://github.com/php/php-src/pull/13486
+
+    /** @tentative-return-type */
+    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTimeInterface;
+
+    /** @tentative-return-type */
+    public function setDate(int $year, int $month, int $day): DateTimeInterface;
+
+    /** @tentative-return-type */
+    public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTimeInterface;
+
+    /** @tentative-return-type */
+    public function setTimestamp(int $timestamp): DateTimeInterface;
 
     /** @tentative-return-type */
     public function getTimestamp(): int;

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6fb121a5992ae96d12dea6055d1b0f0d6534cf21 */
+ * Stub hash: a0358c4ac3db3299d1ec286a144d2a6f45e903a1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -229,10 +229,53 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeInterfac
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateTimeInterface_modify, 0, 1, DateTimeInterface, MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, modifier, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_add, 0, 1, DateTimeInterface, 0)
+	ZEND_ARG_OBJ_INFO(0, interval, DateInterval, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_DateTimeInterface_sub arginfo_class_DateTimeInterface_add
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_DateTimeInterface_getTimezone, 0, 0, DateTimeZone, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_setTimezone, 0, 1, DateTimeInterface, 0)
+	ZEND_ARG_OBJ_INFO(0, timezone, DateTimeZone, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeInterface_getOffset, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_DateTimeInterface_getMicroseconds arginfo_class_DateTimeInterface_getOffset
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeInterface_setMicroseconds, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, microseconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_setTime, 0, 2, DateTimeInterface, 0)
+	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, minute, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_setDate, 0, 3, DateTimeInterface, 0)
+	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_setISODate, 0, 2, DateTimeInterface, 0)
+	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeInterface_setTimestamp, 0, 1, DateTimeInterface, 0)
+	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeInterface_getTimestamp arginfo_class_DateTimeInterface_getOffset
@@ -332,9 +375,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTimes
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTime_setMicroseconds, 0, 1, IS_STATIC, 0)
-	ZEND_ARG_TYPE_INFO(0, microseconds, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTime_setMicroseconds arginfo_class_DateTimeInterface_setMicroseconds
 
 #define arginfo_class_DateTime_getTimestamp arginfo_class_DateTimeInterface_getOffset
 
@@ -411,7 +452,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DateTimeImmutable_setMicroseconds arginfo_class_DateTime_setMicroseconds
+#define arginfo_class_DateTimeImmutable_setMicroseconds arginfo_class_DateTimeInterface_setMicroseconds
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DateTimeImmutable_createFromMutable, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
@@ -668,8 +709,18 @@ static const zend_function_entry ext_functions[] = {
 
 static const zend_function_entry class_DateTimeInterface_methods[] = {
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, format, arginfo_class_DateTimeInterface_format, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, modify, arginfo_class_DateTimeInterface_modify, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, add, arginfo_class_DateTimeInterface_add, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, sub, arginfo_class_DateTimeInterface_sub, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getTimezone, arginfo_class_DateTimeInterface_getTimezone, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setTimezone, arginfo_class_DateTimeInterface_setTimezone, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getOffset, arginfo_class_DateTimeInterface_getOffset, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getMicroseconds, arginfo_class_DateTimeInterface_getMicroseconds, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setMicroseconds, arginfo_class_DateTimeInterface_setMicroseconds, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setTime, arginfo_class_DateTimeInterface_setTime, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setDate, arginfo_class_DateTimeInterface_setDate, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setISODate, arginfo_class_DateTimeInterface_setISODate, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, setTimestamp, arginfo_class_DateTimeInterface_setTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, getTimestamp, arginfo_class_DateTimeInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, diff, arginfo_class_DateTimeInterface_diff, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(DateTimeInterface, __wakeup, arginfo_class_DateTimeInterface___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)


### PR DESCRIPTION
`DateTimeInterface` can not be implemented by user land which limits the interface to `DateTime` and `DateTimeImmutable`
but it's missing a lot of object methods available in both `DateTime` and `DateTimeImmutable`.

This makes your static analyzers (IDE, PHPStan and friends, ...) know which methods to expect.

Question: The interface already has `__wakeup()`, `__serialize()`, `__unserialize()` but not `__set_state()` which I personally would not expect in an interface if there isb't a very good reason ...
* Is there actually a very good reason?
* Could these be removed without BC break? (again the interface isn't allowed for user land)
* Should `__set_state()` be added as well?

NOTE: This somehow depends on https://github.com/php/php-src/pull/13486 or vise versa.