### PR TITLE
An uninitialized DateTime is UNEXPECTED

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -326,7 +326,7 @@ static void date_throw_uninitialized_error(zend_class_entry *ce)
 }
 
 #define DATE_CHECK_INITIALIZED(member, ce) \
-	if (!(member)) { \
+	if (UNEXPECTED(!member)) { \
 		date_throw_uninitialized_error(ce); \
 		RETURN_THROWS(); \
 	}


### PR DESCRIPTION
I wasn't able to bench any difference on my system but I don't have an idle system either - so I'm expecting to much noise on my system anyway.