### PR TITLE
Add extra test for libxml_set_streams_context and remove useless code

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1054,7 +1054,6 @@ PHP_FUNCTION(libxml_set_streams_context)
 
 	if (!Z_ISUNDEF(LIBXML(stream_context))) {
 		zval_ptr_dtor(&LIBXML(stream_context));
-		ZVAL_UNDEF(&LIBXML(stream_context));
 	}
 	ZVAL_COPY(&LIBXML(stream_context), arg);
 }

--- a/ext/libxml/tests/libxml_set_streams_context_overwrite.phpt
+++ b/ext/libxml/tests/libxml_set_streams_context_overwrite.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Overwrite libxml_set_streams_context
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+
+// Based on bug54440.phpt
+
+class TestWrapper {
+    function stream_open($path, $mode, $options, &$opened_path)
+    {
+        print_r(stream_context_get_options($this->context));
+        return false;
+    }
+
+    function url_stat($path, $flags)
+    {
+        return array();
+    }
+}
+
+stream_wrapper_register("test", "TestWrapper");
+
+$ctx1 = stream_context_create(array('test'=>array('test'=>'test 1')));
+$ctx2 = stream_context_create(array('test'=>array('test'=>'test 2')));
+
+libxml_set_streams_context($ctx2);
+@simplexml_load_file('test://sdfsdf');
+
+libxml_set_streams_context($ctx1);
+@simplexml_load_file('test://sdfsdf');
+?>
+--EXPECT--
+Array
+(
+    [test] => Array
+        (
+            [test] => test 2
+        )
+
+)
+Array
+(
+    [test] => Array
+        (
+            [test] => test 1
+        )
+
+)


### PR DESCRIPTION
* Add test for overwriting an existing stream context using libxml_set_streams_context. This was previously untested and the branch was not covered according to codecov.

* Remove useless write to LIBXML(stream_context). The value will always be overwritten.