### PR TITLE
ext/openssl: Bump minimum required OpenSSL version to 1.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,6 @@ jobs:
               libsqlite3-dev \
               libwebp-dev \
               libonig-dev \
-              libkrb5-dev \
-              libgssapi-krb5-2 \
               libcurl4-openssl-dev \
               libxml2-dev \
               libxslt1-dev \
@@ -128,7 +126,6 @@ jobs:
               --enable-calendar \
               --enable-ftp \
               --with-enchant=/usr \
-              --with-kerberos \
               --enable-sysvmsg \
               --with-ffi \
               --enable-zend-test \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,10 +11,10 @@ freebsd_task:
     #- sed -i -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf
     #- pkg upgrade -y
     - kldload accf_http
-    - pkg install -y autoconf bison gmake re2c icu libiconv png freetype2 enchant2 bzip2 krb5 t1lib gmp tidyp libsodium libzip libxml2 libxslt openssl oniguruma pkgconf webp libavif
+    - pkg install -y autoconf bison gmake re2c icu libiconv png freetype2 enchant2 bzip2 t1lib gmp tidyp libsodium libzip libxml2 libxslt openssl oniguruma pkgconf webp libavif
   script:
     - ./buildconf -f
-    - ./configure --prefix=/usr/local --enable-debug --enable-option-checking=fatal --enable-fpm --with-pdo-sqlite --without-pear --with-bz2 --with-avif --with-jpeg --with-webp --with-freetype --enable-gd --enable-exif --with-zip --with-zlib --enable-soap --enable-xmlreader --with-xsl --with-libxml --enable-shmop --enable-pcntl --enable-mbstring --with-curl --enable-sockets --with-openssl --with-iconv=/usr/local --enable-bcmath --enable-calendar --enable-ftp --with-kerberos --with-ffi --enable-zend-test --enable-dl-test=shared --enable-intl --with-mhash --with-sodium --enable-werror --with-config-file-path=/etc --with-config-file-scan-dir=/etc/php.d
+    - ./configure --prefix=/usr/local --enable-debug --enable-option-checking=fatal --enable-fpm --with-pdo-sqlite --without-pear --with-bz2 --with-avif --with-jpeg --with-webp --with-freetype --enable-gd --enable-exif --with-zip --with-zlib --enable-soap --enable-xmlreader --with-xsl --with-libxml --enable-shmop --enable-pcntl --enable-mbstring --with-curl --enable-sockets --with-openssl --with-iconv=/usr/local --enable-bcmath --enable-calendar --enable-ftp --with-ffi --enable-zend-test --enable-dl-test=shared --enable-intl --with-mhash --with-sodium --enable-werror --with-config-file-path=/etc --with-config-file-scan-dir=/etc/php.d
     - gmake -j2
     - mkdir /etc/php.d
     - gmake install

--- a/.github/actions/apt-x32/action.yml
+++ b/.github/actions/apt-x32/action.yml
@@ -23,10 +23,8 @@ runs:
           libffi-dev:i386 \
           libfreetype6-dev:i386 \
           libgmp-dev:i386 \
-          libgssapi-krb5-2:i386 \
           libicu-dev:i386 \
           libjpeg-dev:i386 \
-          libkrb5-dev:i386 \
           libonig-dev:i386 \
           libpng-dev:i386 \
           libpq-dev:i386 \

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -40,8 +40,6 @@ runs:
           libsqlite3-mod-spatialite \
           libwebp-dev \
           libonig-dev \
-          libkrb5-dev \
-          libgssapi-krb5-2 \
           libcurl4-openssl-dev \
           libxml2-dev \
           libxslt1-dev \

--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -19,7 +19,6 @@ runs:
         brew install \
           openssl@1.1 \
           curl \
-          krb5 \
           bzip2 \
           enchant \
           libffi \

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -13,7 +13,6 @@ runs:
         export PATH="$BREW_OPT/bison/bin:$PATH"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/openssl@1.1/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/curl/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/krb5/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libffi/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libxml2/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libxslt/lib/pkgconfig"
@@ -58,7 +57,6 @@ runs:
           --enable-bcmath \
           --enable-calendar \
           --enable-ftp \
-          --with-kerberos \
           --enable-sysvmsg \
           --with-ffi \
           --enable-zend-test \

--- a/.github/actions/configure-x32/action.yml
+++ b/.github/actions/configure-x32/action.yml
@@ -54,7 +54,6 @@ runs:
             --enable-bcmath \
             --enable-calendar \
             --enable-ftp \
-            --with-kerberos \
             --enable-sysvmsg \
             --with-ffi \
             --enable-zend-test \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -53,7 +53,6 @@ runs:
           --enable-calendar \
           --enable-ftp \
           ${{ inputs.skipSlow == 'false' && '--with-enchant=/usr' || '' }} \
-          --with-kerberos \
           --enable-sysvmsg \
           --with-ffi \
           --enable-zend-test \

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
       - libgmp-dev
       - libicu-dev
       - libjpeg-dev
-      - libkrb5-dev
       - libonig-dev
       - libpng-dev
       - libpq-dev

--- a/NEWS
+++ b/NEWS
@@ -110,6 +110,7 @@ PHP                                                                        NEWS
     Florian Sowade)
   . Added X509_PURPOSE_OCSP_HELPER and X509_PURPOSE_TIMESTAMP_SIGN constants.
     (Vincent Jardin)
+  . Bumped minimum required OpenSSL version to 1.1.1. (Ayesh Karunaratne)
 
 - Output:
   . Clear output handler status flags during handler initialization. (haszi)

--- a/UPGRADING
+++ b/UPGRADING
@@ -494,6 +494,9 @@ PHP 8.4 UPGRADE NOTES
 - Intl:
   . The class constants are typed now.
 
+- Intl:
+  . The OpenSSL extension now requires at least OpenSSL 1.1.1.
+
 - PDO:
   . The class constants are typed now.
 

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -96,6 +96,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The configure option --with-imap-ssl has been removed.
    - The configure option --with-oci8 has been removed.
    - The configure option --with-zlib-dir has been removed.
+   - The configure option --with-kerberos has been removed.
    - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
    - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
    - HAVE_UTSNAME_DOMAINNAME symbol renamed to HAVE_STRUCT_UTSNAME_DOMAINNAME.

--- a/build/php.m4
+++ b/build/php.m4
@@ -1817,7 +1817,7 @@ dnl
 AC_DEFUN([PHP_SETUP_OPENSSL],[
   found_openssl=no
 
-  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.2], [found_openssl=yes])
+  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.1], [found_openssl=yes])
 
   if test "$found_openssl" = "yes"; then
     PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -293,9 +293,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 			return 0;
 		}
 
-#if OPENSSL_VERSION_NUMBER >= 0x0090605fL
 		ssl_ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
-#endif
 		SSL_CTX_set_options(ctx, ssl_ctx_options);
 
 		/* Allow SSL to re-use sessions.

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -99,15 +99,13 @@ static void ftp_object_destroy(zend_object *zobj) {
 
 PHP_MINIT_FUNCTION(ftp)
 {
-#ifdef HAVE_FTP_SSL
-#if OPENSSL_VERSION_NUMBER < 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(HAVE_FTP_SSL) && !defined(LIBRESSL_VERSION_NUMBER)
 	SSL_library_init();
 	OpenSSL_add_all_ciphers();
 	OpenSSL_add_all_digests();
 	OpenSSL_add_all_algorithms();
 
 	SSL_load_error_strings();
-#endif
 #endif
 
 	php_ftp_ce = register_class_FTP_Connection();

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -3,13 +3,6 @@ PHP_ARG_WITH([openssl],
   [AS_HELP_STRING([--with-openssl],
     [Include OpenSSL support (requires OpenSSL >= 1.1.1)])])
 
-PHP_ARG_WITH([kerberos],
-  [for Kerberos support],
-  [AS_HELP_STRING([--with-kerberos],
-    [OPENSSL: Include Kerberos support])],
-  [no],
-  [no])
-
 PHP_ARG_WITH([system-ciphers],
   [whether to use system default cipher list instead of hardcoded value],
   [AS_HELP_STRING([--with-system-ciphers],
@@ -20,14 +13,6 @@ PHP_ARG_WITH([system-ciphers],
 if test "$PHP_OPENSSL" != "no"; then
   PHP_NEW_EXTENSION(openssl, openssl.c xp_ssl.c, $ext_shared)
   PHP_SUBST(OPENSSL_SHARED_LIBADD)
-
-  if test "$PHP_KERBEROS" != "no"; then
-    PKG_CHECK_MODULES([KERBEROS], [krb5-gssapi krb5])
-
-    PHP_EVAL_INCLINE($KERBEROS_CFLAGS)
-    PHP_EVAL_LIBLINE($KERBEROS_LIBS, OPENSSL_SHARED_LIBADD)
-  fi
-
   PHP_SETUP_OPENSSL(OPENSSL_SHARED_LIBADD,
   [
     AC_DEFINE(HAVE_OPENSSL_EXT,1,[ ])

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -1,7 +1,7 @@
 PHP_ARG_WITH([openssl],
   [for OpenSSL support],
   [AS_HELP_STRING([--with-openssl],
-    [Include OpenSSL support (requires OpenSSL >= 1.0.2)])])
+    [Include OpenSSL support (requires OpenSSL >= 1.1.1)])])
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -61,7 +61,7 @@
 #include <openssl/param_build.h>
 #endif
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)) && !defined(OPENSSL_NO_ENGINE)
+#if defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ENGINE)
 #include <openssl/engine.h>
 #endif
 
@@ -99,7 +99,7 @@
 #define HAVE_EVP_PKEY_EC 1
 
 /* the OPENSSL_EC_EXPLICIT_CURVE value was added
- * in OpenSSL 1.1.0; previous versions should 
+ * in OpenSSL 1.1.0; previous versions should
  * use 0 instead.
  */
 #ifndef OPENSSL_EC_EXPLICIT_CURVE
@@ -1269,7 +1269,7 @@ PHP_MINIT_FUNCTION(openssl)
 	php_openssl_pkey_object_handlers.clone_obj = NULL;
 	php_openssl_pkey_object_handlers.compare = zend_objects_not_comparable;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 	OPENSSL_config(NULL);
 	SSL_library_init();
 	OpenSSL_add_all_ciphers();
@@ -1309,9 +1309,7 @@ PHP_MINIT_FUNCTION(openssl)
 	php_stream_xport_register("tlsv1.0", php_openssl_ssl_socket_factory);
 	php_stream_xport_register("tlsv1.1", php_openssl_ssl_socket_factory);
 	php_stream_xport_register("tlsv1.2", php_openssl_ssl_socket_factory);
-#if OPENSSL_VERSION_NUMBER >= 0x10101000
 	php_stream_xport_register("tlsv1.3", php_openssl_ssl_socket_factory);
-#endif
 
 	/* override the default tcp socket provider */
 	php_stream_xport_register("tcp", php_openssl_ssl_socket_factory);
@@ -1364,7 +1362,7 @@ PHP_MINFO_FUNCTION(openssl)
 /* {{{ PHP_MSHUTDOWN_FUNCTION */
 PHP_MSHUTDOWN_FUNCTION(openssl)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 	EVP_cleanup();
 
 	/* prevent accessing locking callback from unloaded extension */
@@ -1391,9 +1389,7 @@ PHP_MSHUTDOWN_FUNCTION(openssl)
 	php_stream_xport_unregister("tlsv1.0");
 	php_stream_xport_unregister("tlsv1.1");
 	php_stream_xport_unregister("tlsv1.2");
-#if OPENSSL_VERSION_NUMBER >= 0x10101000
 	php_stream_xport_unregister("tlsv1.3");
-#endif
 
 	/* reinstate the default tcp handler */
 	php_stream_xport_register("tcp", php_stream_generic_socket_factory);
@@ -4609,7 +4605,7 @@ static EVP_PKEY *php_openssl_pkey_init_ec(zval *data, bool *is_private) {
 		EVP_PKEY_CTX_free(ctx);
 		ctx = EVP_PKEY_CTX_new(param_key, NULL);
 	}
-	
+
 	if (EVP_PKEY_check(ctx) || EVP_PKEY_public_check_quick(ctx)) {
 		*is_private = d != NULL;
 		EVP_PKEY_up_ref(param_key);

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -26,7 +26,7 @@ extern zend_module_entry openssl_module_entry;
 #define PHP_OPENSSL_VERSION PHP_VERSION
 
 #include <openssl/opensslv.h>
-#if defined(LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 /* LibreSSL version check */
 #if LIBRESSL_VERSION_NUMBER < 0x20700000L
 #define PHP_OPENSSL_API_VERSION 0x10001
@@ -35,9 +35,7 @@ extern zend_module_entry openssl_module_entry;
 #endif
 #else
 /* OpenSSL version check */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define PHP_OPENSSL_API_VERSION 0x10002
-#elif OPENSSL_VERSION_NUMBER < 0x30000000L
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 #define PHP_OPENSSL_API_VERSION 0x10100
 #else
 #define PHP_OPENSSL_API_VERSION 0x30000

--- a/ext/openssl/tests/bug80747.phpt
+++ b/ext/openssl/tests/bug80747.phpt
@@ -2,10 +2,6 @@
 Bug #80747: Providing RSA key size < 512 generates key that crash PHP
 --EXTENSIONS--
 openssl
---SKIPIF--
-<?php
-if (OPENSSL_VERSION_NUMBER < 0x10100000) die("skip OpenSSL >= v1.1.0 required");
-?>
 --FILE--
 <?php
 

--- a/ext/openssl/tests/openssl_error_string_basic.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic.phpt
@@ -95,8 +95,7 @@ while (($enc_error_new = openssl_error_string()) !== false) {
 var_dump($error_queue_size);
 echo "\n";
 
-$is_111 = OPENSSL_VERSION_NUMBER >= 0x10101000;
-$err_pem_no_start_line = $is_111 ? '0909006C': '0906D06C';
+$err_pem_no_start_line = '0909006C';
 
 // PKEY
 echo "PKEY errors\n";

--- a/ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
+++ b/ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
@@ -4,9 +4,6 @@ int openssl_x509_checkpurpose ( mixed $x509cert , int $purpose [, array $cainfo 
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 openssl
---SKIPIF--
-<?php if (OPENSSL_VERSION_NUMBER < 0x10000000) die("skip Output requires OpenSSL 1.0");
-?>
 --FILE--
 <?php
 include 'CertificateGenerator.inc';

--- a/ext/openssl/tests/session_meta_capture_tlsv13.phpt
+++ b/ext/openssl/tests/session_meta_capture_tlsv13.phpt
@@ -5,7 +5,6 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (OPENSSL_VERSION_NUMBER < 0x10101000) die("skip OpenSSL v1.1.1 required");
 ?>
 --FILE--
 <?php

--- a/ext/openssl/tests/stream_crypto_flags_003.phpt
+++ b/ext/openssl/tests/stream_crypto_flags_003.phpt
@@ -5,7 +5,6 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (OPENSSL_VERSION_NUMBER < 0x10001001) die("skip OpenSSLv1.0.1 required");
 ?>
 --FILE--
 <?php

--- a/ext/openssl/tests/stream_security_level.phpt
+++ b/ext/openssl/tests/stream_security_level.phpt
@@ -4,7 +4,6 @@ security_level setting to prohibit cert
 openssl
 --SKIPIF--
 <?php
-if (OPENSSL_VERSION_NUMBER < 0x10100000) die("skip OpenSSL >= v1.1.0 required");
 if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --FILE--

--- a/ext/openssl/tests/tls_wrapper.phpt
+++ b/ext/openssl/tests/tls_wrapper.phpt
@@ -5,7 +5,6 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (OPENSSL_VERSION_NUMBER < 0x10101000) die("skip OpenSSL v1.1.1 required");
 ?>
 --FILE--
 <?php

--- a/ext/openssl/tests/tls_wrapper_with_tls_v1.3.phpt
+++ b/ext/openssl/tests/tls_wrapper_with_tls_v1.3.phpt
@@ -5,7 +5,6 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (OPENSSL_VERSION_NUMBER < 0x10101000) die("skip OpenSSL v1.1.1 required");
 ?>
 --FILE--
 <?php

--- a/ext/openssl/tests/tlsv1.3_wrapper.phpt
+++ b/ext/openssl/tests/tlsv1.3_wrapper.phpt
@@ -5,7 +5,6 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (OPENSSL_VERSION_NUMBER < 0x10101000) die("skip OpenSSL v1.1.1 required");
 ?>
 --FILE--
 <?php

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -76,7 +76,7 @@
 #define HAVE_TLS12 1
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(OPENSSL_NO_TLS1_3)
+#ifndef OPENSSL_NO_TLS1_3
 #define HAVE_TLS13 1
 #endif
 
@@ -89,7 +89,7 @@
 #define HAVE_TLS_ALPN 1
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#ifndef LIBRESSL_VERSION_NUMBER
 #define HAVE_SEC_LEVEL 1
 #endif
 
@@ -676,11 +676,7 @@ static int php_openssl_win_cert_verify_callback(X509_STORE_CTX *x509_store_ctx, 
 {
 	PCCERT_CONTEXT cert_ctx = NULL;
 	PCCERT_CHAIN_CONTEXT cert_chain_ctx = NULL;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	X509 *cert = x509_store_ctx->cert;
-#else
 	X509 *cert = X509_STORE_CTX_get0_cert(x509_store_ctx);
-#endif
 
 	php_stream *stream;
 	php_openssl_netstream_data_t *sslsock;

--- a/php.ini-development
+++ b/php.ini-development
@@ -928,12 +928,6 @@ default_socket_timeout = 60
 ;   Be sure to appropriately set the extension_dir directive.
 ;
 ;extension=bz2
-
-; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
-; otherwise it results in segfault when unloading after using SASL.
-; See https://github.com/php/php-src/issues/8620 for more info.
-;extension=ldap
-
 ;extension=curl
 ;extension=ffi
 ;extension=ftp
@@ -942,6 +936,7 @@ default_socket_timeout = 60
 ;extension=gettext
 ;extension=gmp
 ;extension=intl
+;extension=ldap
 ;extension=mbstring
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli

--- a/php.ini-production
+++ b/php.ini-production
@@ -930,12 +930,6 @@ default_socket_timeout = 60
 ;   Be sure to appropriately set the extension_dir directive.
 ;
 ;extension=bz2
-
-; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
-; otherwise it results in segfault when unloading after using SASL.
-; See https://github.com/php/php-src/issues/8620 for more info.
-;extension=ldap
-
 ;extension=curl
 ;extension=ffi
 ;extension=ftp
@@ -944,6 +938,7 @@ default_socket_timeout = 60
 ;extension=gettext
 ;extension=gmp
 ;extension=intl
+;extension=ldap
 ;extension=mbstring
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -61,7 +61,6 @@ $S390X_CONFIG \
 --enable-calendar \
 --enable-ftp \
 --with-enchant=/usr \
---with-kerberos \
 --enable-sysvmsg \
 --with-ffi \
 --with-sodium \


### PR DESCRIPTION
Bumps the minimum required OpenSSL version from 1.0.2 to 1.1.1.

OpenSSL 1.1.1 is an LTS release, but has reached[^1] EOL from upstream. However, Linux distro/OS vendors continue to ship OpenSSL 1.1.1, so 1.1.1 was picked as the minimum.

Bumping the minimum required OpenSSL version makes it possible for ext-openssl to remove a bunch of conditional code, and assume that TLS 1.3 (shipped with OpenSSL 1.1.1) will be supported everywhere.

 - Debian buster: 1.1.1[^2]
 - Ubuntu 20.04: 1.1.1[^3]
 - CentOS/RHEL 7: 1.0.2
 - RHEL 8/Rocky 8/EL 8: 1.1.1
 - Fedora 38: 3.0.9 (`openssl11` provides OpenSSL 1.1 as well)

RHEL/CentOS 7 reaches EOL mid 2024, so for PHP 8.4 scheduled towards the end of this year, we can safely bump the minimum OpenSSL version.

[^1]: https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/index.html
[^2]: https://packages.debian.org/buster/libssl-dev
[^3]: https://packages.ubuntu.com/focal/libssl-dev