### PR TITLE
ext/intl: Refactor ResourceBundle get and dimension access

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,13 @@ PHP                                                                        NEWS
   . Added IntlDateFormatter::getIanaID/intltz_get_iana_id method/function.
     (David Carlier)
   . Set to C++17 standard for icu 74 and onwards. (David Carlier)
+  . resourcebundle_get(), ResourceBundle::get(), and accessing offsets on a
+    ResourceBundle object now throw:
+    - TypeError for invalid offset types
+    - ValueError for an empty string
+    - ValueError if the integer index does not fit in a signed 32 bit integer
+  . ResourceBundle::get() now has a tentative return type of:
+    ResourceBundle|array|string|int|null
 
 - LDAP:
   . Added LDAP_OPT_X_TLS_PROTOCOL_MAX/LDAP_OPT_X_TLS_PROTOCOL_TLS1_3

--- a/UPGRADING
+++ b/UPGRADING
@@ -45,6 +45,13 @@ PHP 8.4 UPGRADE NOTES
     object. This is no longer possible, and cloning a DOMXPath object now throws
     an error.
 
+- Intl:
+  . resourcebundle_get(), ResourceBundle::get(), and accessing offsets on a
+    ResourceBundle object now throw:
+    - TypeError for invalid offset types
+    - ValueError for an empty string
+    - ValueError if the integer index does not fit in a signed 32 bit integer
+
 - MBString:
   . mb_encode_numericentity() and mb_decode_numericentity() now check that
     the $map is only composed of integers, if not a ValueError is thrown.
@@ -321,6 +328,8 @@ PHP 8.4 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/new_rounding_modes_to_round_function
   . NumberFormatter::ROUND_HALFODD added to complement existing
     NumberFormatter::ROUND_HALFEVEN functionality.
+  . ResourceBundle::get() now has a tentative return type of:
+    ResourceBundle|array|string|int|null
 
 - MBString:
   . The behavior of mb_strcut is more consistent now on invalid UTF-8 and UTF-16

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -543,8 +543,7 @@ function normalizer_get_raw_decomposition(string $string, int $form = Normalizer
 
 function resourcebundle_create(?string $locale, ?string $bundle, bool $fallback = true): ?ResourceBundle {}
 
-/** @param string|int $index */
-function resourcebundle_get(ResourceBundle $bundle, $index, bool $fallback = true): mixed {}
+function resourcebundle_get(ResourceBundle $bundle, string|int $index, bool $fallback = true): ResourceBundle|array|string|int|null {}
 
 function resourcebundle_count(ResourceBundle $bundle): int {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 50cc9edef7f40e6885be38be25a71f66d7405a50 */
+ * Stub hash: c1adcd8a928af82766ee8c0cd6b20c2f2e9afcc1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -630,9 +630,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_resourcebundle_create, 0, 2, Reso
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fallback, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_resourcebundle_get, 0, 2, IS_MIXED, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_resourcebundle_get, 0, 2, ResourceBundle, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL)
 	ZEND_ARG_OBJ_INFO(0, bundle, ResourceBundle, 0)
-	ZEND_ARG_INFO(0, index)
+	ZEND_ARG_TYPE_MASK(0, index, MAY_BE_STRING|MAY_BE_LONG, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fallback, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/resourcebundle/resourcebundle.c
+++ b/ext/intl/resourcebundle/resourcebundle.c
@@ -71,11 +71,7 @@ void resourcebundle_extract_value( zval *return_value, ResourceBundle_object *so
 			source->child = NULL;
 			intl_errors_reset(INTL_DATA_ERROR_P(source));
 			break;
-
-		default:
-			intl_errors_set(INTL_DATA_ERROR_P(source), U_ILLEGAL_ARGUMENT_ERROR, "Unknown resource type", 0);
-			RETURN_FALSE;
-			break;
+		EMPTY_SWITCH_DEFAULT_CASE();
 	}
 }
 /* }}} */

--- a/ext/intl/resourcebundle/resourcebundle.stub.php
+++ b/ext/intl/resourcebundle/resourcebundle.stub.php
@@ -13,12 +13,8 @@ class ResourceBundle implements IteratorAggregate, Countable
      */
     public static function create(?string $locale, ?string $bundle, bool $fallback = true): ?ResourceBundle {}
 
-    /**
-     * @param string|int $index
-     * @tentative-return-type
-     * @alias resourcebundle_get
-     */
-    public function get($index, bool $fallback = true): mixed {}
+    /** @tentative-return-type */
+    public function get(string|int $index, bool $fallback = true): ResourceBundle|array|string|int|null {}
 
     /**
      * @tentative-return-type

--- a/ext/intl/resourcebundle/resourcebundle_arginfo.h
+++ b/ext/intl/resourcebundle/resourcebundle_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7816536650d8513ef6998233096b0bf6a29d7af4 */
+ * Stub hash: e302e5ca1abcb9b52e3c14abbd38b9e8f1461390 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ResourceBundle___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
@@ -13,8 +13,8 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_ResourceBundle_cr
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fallback, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ResourceBundle_get, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_INFO(0, index)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_ResourceBundle_get, 0, 1, ResourceBundle, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL)
+	ZEND_ARG_TYPE_MASK(0, index, MAY_BE_STRING|MAY_BE_LONG, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fallback, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
@@ -35,7 +35,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_METHOD(ResourceBundle, __construct);
 ZEND_FUNCTION(resourcebundle_create);
-ZEND_FUNCTION(resourcebundle_get);
+ZEND_METHOD(ResourceBundle, get);
 ZEND_FUNCTION(resourcebundle_count);
 ZEND_FUNCTION(resourcebundle_locales);
 ZEND_FUNCTION(resourcebundle_get_error_code);
@@ -45,7 +45,7 @@ ZEND_METHOD(ResourceBundle, getIterator);
 static const zend_function_entry class_ResourceBundle_methods[] = {
 	ZEND_ME(ResourceBundle, __construct, arginfo_class_ResourceBundle___construct, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("create", zif_resourcebundle_create, arginfo_class_ResourceBundle_create, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, NULL)
-	ZEND_RAW_FENTRY("get", zif_resourcebundle_get, arginfo_class_ResourceBundle_get, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(ResourceBundle, get, arginfo_class_ResourceBundle_get, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("count", zif_resourcebundle_count, arginfo_class_ResourceBundle_count, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getLocales", zif_resourcebundle_locales, arginfo_class_ResourceBundle_getLocales, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getErrorCode", zif_resourcebundle_get_error_code, arginfo_class_ResourceBundle_getErrorCode, ZEND_ACC_PUBLIC, NULL, NULL)

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -239,6 +239,7 @@ zval *resourcebundle_array_get(zend_object *object, zval *offset, int type, zval
 		return NULL;
 	}
 
+	ZVAL_DEREF(offset);
 	if (Z_TYPE_P(offset) == IS_LONG) {
 		return resource_bundle_array_fetch(object, /* offset_str */ NULL, Z_LVAL_P(offset), rv, /* fallback */ true, /* arg_num */ 0);
 	} else if (Z_TYPE_P(offset) == IS_STRING) {

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -183,7 +183,14 @@ static zval *resource_bundle_array_fetch(
 	intl_error_reset(INTL_DATA_ERROR_P(rb));
 
 	if (offset_str) {
-		// TODO Check is not empty?
+		if (UNEXPECTED(ZSTR_LEN(offset_str) == 0)) {
+			if (offset_arg_num) {
+				zend_argument_value_error(offset_arg_num, "cannot be empty");
+			} else {
+				zend_value_error("Offset cannot be empty");
+			}
+			return NULL;
+		}
 		key = ZSTR_VAL(offset_str);
 		rb->child = ures_getByKey(rb->me, key, rb->child, &INTL_DATA_ERROR_CODE(rb) );
 	} else {

--- a/ext/intl/tests/resourcebundle_arrayaccess.phpt
+++ b/ext/intl/tests/resourcebundle_arrayaccess.phpt
@@ -23,6 +23,11 @@ intl
     $r2 = $r['testarray'];
     printf( "testarray: %s\n", $r2[2] );
 
+    echo "Using a reference as an offset:\n";
+    $offset = 'teststring';
+    $ref = &$offset;
+    var_dump($r[$ref]);
+
     $t = $r['nonexisting'];
     echo debug( $t );
 ?>
@@ -46,5 +51,7 @@ Array
 testbin: a1b2c3d4e5f67890
 testtable: 3
 testarray: string 3
+Using a reference as an offset:
+string(12) "Hello World!"
 NULL
     2: Cannot load resource element 'nonexisting': U_MISSING_RESOURCE_ERROR

--- a/ext/intl/tests/resourcebundle_dimension_errors.phpt
+++ b/ext/intl/tests/resourcebundle_dimension_errors.phpt
@@ -35,6 +35,11 @@ try {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 try {
+    var_dump($r['']);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
     /* This can only happen on 64bit */
     if (PHP_INT_SIZE > 4) {
         var_dump($r[0xFFFFFFFFF]);
@@ -52,4 +57,5 @@ Error: Cannot use object of type ResourceBundle as array
 string(7) "default"
 TypeError: Cannot access offset of type float on ResourceBundle
 TypeError: Cannot access offset of type stdClass on ResourceBundle
+ValueError: Offset cannot be empty
 ValueError: Index must be between -2147483648 and 2147483647

--- a/ext/intl/tests/resourcebundle_dimension_errors.phpt
+++ b/ext/intl/tests/resourcebundle_dimension_errors.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test ResourceBundle errors with []
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+include "resourcebundle.inc";
+
+// fall back
+$r = new ResourceBundle( 'en_US', BUNDLE );
+
+try {
+    $ref = &$r[];
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(isset($r['non-existent']));
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($r['non-existent'] ?? "default");
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($r[12.5]);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($r[new stdClass()]);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    /* This can only happen on 64bit */
+    if (PHP_INT_SIZE > 4) {
+        var_dump($r[0xFFFFFFFFF]);
+    } else {
+        echo 'ValueError: Index must be between -2147483648 and 2147483647', PHP_EOL;
+    }
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Error: Cannot apply [] to ResourceBundle object
+Error: Cannot use object of type ResourceBundle as array
+string(7) "default"
+TypeError: Cannot access offset of type float on ResourceBundle
+TypeError: Cannot access offset of type stdClass on ResourceBundle
+ValueError: Index must be between -2147483648 and 2147483647


### PR DESCRIPTION
So it turns out ResourceBundle's overloading of the dimension handlers is totally dumb...