### PR TITLE
number_format: zero out until negative decimals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -185,6 +185,7 @@ PHP                                                                        NEWS
   . Removed the deprecated inet_ntoa call support. (David Carlier)
   . Cast large floats that are within int range to int in number_format so
     the precision is not lost. (Marc Bennewitz)
+  . Zero out until negative decimals in number_format (Marc Bennewitz)
   . Add support for 4 new rounding modes to the round() function. (Jorg Sowa)
   . debug_zval_dump() now indicates whether an array is packed. (Max Semenik)
   . Fix GH-12143 (Optimize round). (SakiTakamachi)

--- a/ext/standard/tests/math/number_format_basiclong_64bit.phpt
+++ b/ext/standard/tests/math/number_format_basiclong_64bit.phpt
@@ -179,8 +179,8 @@ foreach ($numbers as $number) {
 --- testing: float(9.223372036854776E+18)
 ... with precision 5: string(31) "9,223,372,036,854,775,808.00000"
 ... with precision 0: string(25) "9,223,372,036,854,775,808"
-... with precision -1: string(25) "9,223,372,036,854,775,808"
-... with precision -5: string(25) "9,223,372,036,854,800,384"
+... with precision -1: string(25) "9,223,372,036,854,775,800"
+... with precision -5: string(25) "9,223,372,036,854,800,000"
 ... with precision -10: string(25) "9,223,372,040,000,000,000"
 ... with precision -11: string(25) "9,223,372,000,000,000,000"
 ... with precision -17: string(25) "9,200,000,000,000,000,000"


### PR DESCRIPTION
On formatting big floating point numbers using `number_format` with negative decimal places the resulting number did not contain zeros for the decimal places requested to round due to how floating point numbers work.

This PR now explicitly zeros out these places so the resulting number is rounded for humans even so the closest floating point number would not. If you cast that back to floating point number you still get the same result.

Previously
```php
printf("%s", number_format(1234567897576501234567.0, -5, "", "")); // 1234567897576501149696
printf("%f", (float)number_format(1234567897576501234567.0, -5, "", "")); // 1234567897576501149696.000000
```

After this change:
```php
printf("%s", number_format(1234567897576501234567.0, -5, "", "")); // 1234567897576501100000
printf("%f", (float)number_format(1234567897576501234567.0, -5, "", "")); // 1234567897576501149696.000000
```