### PR TITLE
Check for struct cmsgcred with AC_CHECK_TYPES

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -68,19 +68,7 @@ if test "$PHP_SOCKETS" != "no"; then
     AC_DEFINE(ANC_CREDS_UCRED,1,[Uses ucred struct])
   fi
 
-  dnl Check for struct cmsgcred
-  AC_CACHE_CHECK([if ancillary credentials uses cmsgcred],[ac_cv_cmsgcred],
-  [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/socket.h>
-  ]], [[struct cmsgcred c = {0};]])],
-      [ac_cv_cmsgcred=yes], [ac_cv_cmsgcred=no])
-  ])
-
-  if test "$ac_cv_cmsgcred" = yes; then
-    AC_DEFINE(ANC_CREDS_CMSGCRED,1,[Uses cmsgcred struct])
-  fi
-
+  AC_CHECK_TYPES([struct cmsgcred],,,[#include <sys/socket.h>])
 
   PHP_SOCKETS_CFLAGS=-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1
   case $host_alias in

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1330,7 +1330,7 @@ static const field_descriptor descriptors_ucred[] = {
 		{"uid", sizeof("uid"), 1, offsetof(struct sockcred, sc_euid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* the type gid_t is the same as uid_t: */
 		{"gid", sizeof("gid"), 1, offsetof(struct sockcred, sc_egid), from_zval_write_uid_t, to_zval_read_uid_t},
-#elif defined(ANC_CREDS_CMSGCRED)
+#elif defined(HAVE_STRUCT_CMSGCRED)
 		{"pid", sizeof("pid"), 1, offsetof(struct cmsgcred, cmcred_pid), from_zval_write_pid_t, to_zval_read_pid_t},
 		{"uid", sizeof("uid"), 1, offsetof(struct cmsgcred, cmcred_uid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* assume the type gid_t is the same as uid_t: */


### PR DESCRIPTION
The AC_CHECK_TYPES can be used to check for the struct cmsgcred. By default it defines the symbol HAVE_STRUCT_CMSGCRED instead of ANC_CREDS_CMSGCRED.