### PR TITLE
Check for struct ucred with AC_CHECK_TYPES

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -51,22 +51,12 @@ if test "$PHP_SOCKETS" != "no"; then
     AC_DEFINE(HAVE_AI_IDN,1,[Whether you have AI_IDN])
   fi
 
-  dnl Check for struct ucred
-  dnl checking the header is not enough	(eg DragonFlyBSD)
-  AC_CACHE_CHECK([if ancillary credentials uses ucred],[ac_cv_ucred],
-  [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <sys/socket.h>
-  ]], [[struct ucred u = {.gid = 0};]])],
-      [ac_cv_ucred=yes], [ac_cv_ucred=no])
-  ])
-
-  if test "$ac_cv_ucred" = yes; then
-    AC_DEFINE(ANC_CREDS_UCRED,1,[Uses ucred struct])
-  fi
+  dnl Check for struct ucred. Checking the header is not enough (DragonFlyBSD).
+  AC_CHECK_TYPES([struct ucred],,,
+    [#ifndef _GNU_SOURCE
+    # define _GNU_SOURCE
+    #endif
+    #include <sys/socket.h>])
 
   dnl Check for struct cmsgcred
   AC_CACHE_CHECK([if ancillary credentials uses cmsgcred],[ac_cv_cmsgcred],

--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -123,7 +123,7 @@ static void init_ancillary_registry(void)
 #endif
 
 #ifdef SO_PASSCRED
-#ifdef ANC_CREDS_UCRED
+#ifdef HAVE_STRUCT_UCRED
 	PUT_ENTRY(sizeof(struct ucred), 0, 0, from_zval_write_ucred,
 			to_zval_read_ucred, SOL_SOCKET, SCM_CREDENTIALS);
 #else


### PR DESCRIPTION
The AC_CHECK_TYPES can be used to check for the struct ucred. By default it defines the symbol HAVE_STRUCT_UCRED instead of ANC_CREDS_UCRED.