### PR TITLE
random: Adjust `status` to `state`

### DIFF
--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -63,7 +63,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_combinedlcg,
-		.status = state,
+		.state = state,
 	}, min, max);
 }
 

--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -32,17 +32,17 @@
  */
 #define MODMULT(a, b, c, m, s) q = s / a; s = b * (s - a * q) - c * q; if (s < 0) s += m
 
-static void seed(void *status, uint64_t seed)
+static void seed(void *state, uint64_t seed)
 {
-	php_random_status_state_combinedlcg *s = status;
+	php_random_status_state_combinedlcg *s = state;
 
 	s->state[0] = seed & 0xffffffffU;
 	s->state[1] = seed >> 32;
 }
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
-	php_random_status_state_combinedlcg *s = status;
+	php_random_status_state_combinedlcg *s = state;
 	int32_t q, z;
 
 	MODMULT(53668, 40014, 12211, 2147483563L, s->state[0]);
@@ -59,17 +59,17 @@ static php_random_result generate(void *status)
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_combinedlcg,
-		.status = status,
+		.status = state,
 	}, min, max);
 }
 
-static bool serialize(void *status, HashTable *data)
+static bool serialize(void *state, HashTable *data)
 {
-	php_random_status_state_combinedlcg *s = status;
+	php_random_status_state_combinedlcg *s = state;
 	zval t;
 
 	for (uint32_t i = 0; i < 2; i++) {
@@ -80,9 +80,9 @@ static bool serialize(void *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(void *status, HashTable *data)
+static bool unserialize(void *state, HashTable *data)
 {
-	php_random_status_state_combinedlcg *s = status;
+	php_random_status_state_combinedlcg *s = state;
 	zval *t;
 
 	for (uint32_t i = 0; i < 2; i++) {

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -139,14 +139,14 @@ static inline void mt19937_seed_state(php_random_status_state_mt19937 *state, ui
 	mt19937_reload(state);
 }
 
-static void seed(void *status, uint64_t seed)
+static void seed(void *state, uint64_t seed)
 {
-	mt19937_seed_state(status, seed);
+	mt19937_seed_state(state, seed);
 }
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
-	php_random_status_state_mt19937 *s = status;
+	php_random_status_state_mt19937 *s = state;
 	uint32_t s1;
 
 	if (s->count >= MT_N) {
@@ -164,17 +164,17 @@ static php_random_result generate(void *status)
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_mt19937,
-		.status = status,
+		.status = state,
 	}, min, max);
 }
 
-static bool serialize(void *status, HashTable *data)
+static bool serialize(void *state, HashTable *data)
 {
-	php_random_status_state_mt19937 *s = status;
+	php_random_status_state_mt19937 *s = state;
 	zval t;
 
 	for (uint32_t i = 0; i < MT_N; i++) {
@@ -189,9 +189,9 @@ static bool serialize(void *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(void *status, HashTable *data)
+static bool unserialize(void *state, HashTable *data)
 {
-	php_random_status_state_mt19937 *s = status;
+	php_random_status_state_mt19937 *s = state;
 	zval *t;
 
 	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -168,7 +168,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_mt19937,
-		.status = state,
+		.state = state,
 	}, min, max);
 }
 
@@ -255,7 +255,7 @@ PHPAPI void php_random_mt19937_seed_default(php_random_status_state_mt19937 *sta
 PHP_METHOD(Random_Engine_Mt19937, __construct)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_mt19937 *state = engine.status;
+	php_random_status_state_mt19937 *state = engine.state;
 	zend_long seed, mode = MT_RAND_MT19937;
 	bool seed_is_null = true;
 
@@ -298,7 +298,7 @@ PHP_METHOD(Random_Engine_Mt19937, generate)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	php_random_result generated = engine.algo->generate(engine.status);
+	php_random_result generated = engine.algo->generate(engine.state);
 	if (EG(exception)) {
 		RETURN_THROWS();
 	}
@@ -332,7 +332,7 @@ PHP_METHOD(Random_Engine_Mt19937, __serialize)
 
 	/* state */
 	array_init(&t);
-	if (!engine->engine.algo->serialize(engine->engine.status, Z_ARRVAL(t))) {
+	if (!engine->engine.algo->serialize(engine->engine.state, Z_ARRVAL(t))) {
 		zend_throw_exception(NULL, "Engine serialize failed", 0);
 		RETURN_THROWS();
 	}
@@ -375,7 +375,7 @@ PHP_METHOD(Random_Engine_Mt19937, __unserialize)
 		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(engine->std.ce->name));
 		RETURN_THROWS();
 	}
-	if (!engine->engine.algo->unserialize(engine->engine.status, Z_ARRVAL_P(t))) {
+	if (!engine->engine.algo->unserialize(engine->engine.state, Z_ARRVAL_P(t))) {
 		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(engine->std.ce->name));
 		RETURN_THROWS();
 	}
@@ -397,7 +397,7 @@ PHP_METHOD(Random_Engine_Mt19937, __debugInfo)
 
 	if (engine->engine.algo->serialize) {
 		array_init(&t);
-		if (!engine->engine.algo->serialize(engine->engine.status, Z_ARRVAL(t))) {
+		if (!engine->engine.algo->serialize(engine->engine.state, Z_ARRVAL(t))) {
 			zend_throw_exception(NULL, "Engine serialize failed", 0);
 			RETURN_THROWS();
 		}

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -43,14 +43,14 @@ static inline void seed128(php_random_status_state_pcgoneseq128xslrr64 *s, php_r
 	step(s);
 }
 
-static void seed(void *status, uint64_t seed)
+static void seed(void *state, uint64_t seed)
 {
-	seed128(status, php_random_uint128_constant(0ULL, seed));
+	seed128(state, php_random_uint128_constant(0ULL, seed));
 }
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status;
+	php_random_status_state_pcgoneseq128xslrr64 *s = state;
 
 	step(s);
 
@@ -60,17 +60,17 @@ static php_random_result generate(void *status)
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_pcgoneseq128xslrr64,
-		.status = status,
+		.status = state,
 	}, min, max);
 }
 
-static bool serialize(void *status, HashTable *data)
+static bool serialize(void *state, HashTable *data)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status;
+	php_random_status_state_pcgoneseq128xslrr64 *s = state;
 	uint64_t u;
 	zval z;
 
@@ -85,9 +85,9 @@ static bool serialize(void *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(void *status, HashTable *data)
+static bool unserialize(void *state, HashTable *data)
 {
-	php_random_status_state_pcgoneseq128xslrr64 *s = status;
+	php_random_status_state_pcgoneseq128xslrr64 *s = state;
 	uint64_t u[2];
 	zval *t;
 

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -64,7 +64,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_pcgoneseq128xslrr64,
-		.status = state,
+		.state = state,
 	}, min, max);
 }
 
@@ -146,7 +146,7 @@ PHPAPI void php_random_pcgoneseq128xslrr64_advance(php_random_status_state_pcgon
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine.status;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine.state;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;
@@ -195,7 +195,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, jump)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_pcgoneseq128xslrr64 *state = engine.status;
+	php_random_status_state_pcgoneseq128xslrr64 *state = engine.state;
 	zend_long advance = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -25,7 +25,7 @@
 
 #include "Zend/zend_exceptions.h"
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
 	zend_ulong r = 0;
 
@@ -37,7 +37,7 @@ static php_random_result generate(void *status)
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	zend_long result = 0;
 

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -69,7 +69,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_user,
-		.status = state,
+		.state = state,
 	}, min, max);
 }
 

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -21,9 +21,9 @@
 #include "php.h"
 #include "php_random.h"
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
-	php_random_status_state_user *s = status;
+	php_random_status_state_user *s = state;
 	uint64_t result = 0;
 	size_t size;
 	zval retval;
@@ -65,11 +65,11 @@ static php_random_result generate(void *status)
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_user,
-		.status = status,
+		.status = state,
 	}, min, max);
 }
 

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -119,7 +119,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_xoshiro256starstar,
-		.status = state,
+		.state = state,
 	}, min, max);
 }
 
@@ -184,7 +184,7 @@ PHPAPI void php_random_xoshiro256starstar_jump_long(php_random_status_state_xosh
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_xoshiro256starstar *state = engine.status;
+	php_random_status_state_xoshiro256starstar *state = engine.state;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -196,7 +196,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jump)
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_xoshiro256starstar *state = engine.status;
+	php_random_status_state_xoshiro256starstar *state = engine.state;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
@@ -208,7 +208,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong)
 PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 {
 	php_random_algo_with_state engine = Z_RANDOM_ENGINE_P(ZEND_THIS)->engine;
-	php_random_status_state_xoshiro256starstar *state = engine.status;
+	php_random_status_state_xoshiro256starstar *state = engine.state;
 	zend_string *str_seed = NULL;
 	zend_long int_seed = 0;
 	bool seed_is_null = true;

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -102,30 +102,30 @@ static inline void seed64(php_random_status_state_xoshiro256starstar *state, uin
 	seed256(state, s[0], s[1], s[2], s[3]);
 }
 
-static void seed(void *status, uint64_t seed)
+static void seed(void *state, uint64_t seed)
 {
-	seed64(status, seed);
+	seed64(state, seed);
 }
 
-static php_random_result generate(void *status)
+static php_random_result generate(void *state)
 {
 	return (php_random_result){
 		.size = sizeof(uint64_t),
-		.result = generate_state(status),
+		.result = generate_state(state),
 	};
 }
 
-static zend_long range(void *status, zend_long min, zend_long max)
+static zend_long range(void *state, zend_long min, zend_long max)
 {
 	return php_random_range((php_random_algo_with_state){
 		.algo = &php_random_algo_xoshiro256starstar,
-		.status = status,
+		.status = state,
 	}, min, max);
 }
 
-static bool serialize(void *status, HashTable *data)
+static bool serialize(void *state, HashTable *data)
 {
-	php_random_status_state_xoshiro256starstar *s = status;
+	php_random_status_state_xoshiro256starstar *s = state;
 	zval t;
 
 	for (uint32_t i = 0; i < 4; i++) {
@@ -136,9 +136,9 @@ static bool serialize(void *status, HashTable *data)
 	return true;
 }
 
-static bool unserialize(void *status, HashTable *data)
+static bool unserialize(void *state, HashTable *data)
 {
-	php_random_status_state_xoshiro256starstar *s = status;
+	php_random_status_state_xoshiro256starstar *s = state;
 	zval *t;
 
 	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -105,7 +105,7 @@ typedef struct _php_random_algo {
 
 typedef struct _php_random_algo_with_state {
 	const php_random_algo *algo;
-	void *status;
+	void *state;
 } php_random_algo_with_state;
 
 extern PHPAPI const php_random_algo php_random_algo_combinedlcg;
@@ -170,7 +170,7 @@ static inline php_random_algo_with_state php_random_default_engine(void)
 {
 	return (php_random_algo_with_state){
 		.algo = php_random_default_algo(),
-		.status = php_random_default_status(),
+		.state = php_random_default_status(),
 	};
 }
 

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -96,11 +96,11 @@ typedef struct _php_random_result {
 
 typedef struct _php_random_algo {
 	const size_t state_size;
-	void (*seed)(void *status, uint64_t seed);
-	php_random_result (*generate)(void *status);
-	zend_long (*range)(void *status, zend_long min, zend_long max);
-	bool (*serialize)(void *status, HashTable *data);
-	bool (*unserialize)(void *status, HashTable *data);
+	void (*seed)(void *state, uint64_t seed);
+	php_random_result (*generate)(void *state);
+	zend_long (*range)(void *state, zend_long min, zend_long max);
+	bool (*serialize)(void *state, HashTable *data);
+	bool (*unserialize)(void *state, HashTable *data);
 } php_random_algo;
 
 typedef struct _php_random_algo_with_state {

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -77,7 +77,7 @@ static zend_object_handlers random_randomizer_object_handlers;
 PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t umax)
 {
 	const php_random_algo *algo = engine.algo;
-	void *status = engine.status;
+	void *state = engine.status;
 
 	uint32_t result, limit;
 	size_t total_size = 0;
@@ -86,7 +86,7 @@ PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t u
 	result = 0;
 	total_size = 0;
 	do {
-		php_random_result r = algo->generate(status);
+		php_random_result r = algo->generate(state);
 		result = result | (((uint32_t) r.result) << (total_size * 8));
 		total_size += r.size;
 		if (EG(exception)) {
@@ -121,7 +121,7 @@ PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t u
 		result = 0;
 		total_size = 0;
 		do {
-			php_random_result r = algo->generate(status);
+			php_random_result r = algo->generate(state);
 			result = result | (((uint32_t) r.result) << (total_size * 8));
 			total_size += r.size;
 			if (EG(exception)) {
@@ -136,7 +136,7 @@ PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t u
 PHPAPI uint64_t php_random_range64(php_random_algo_with_state engine, uint64_t umax)
 {
 	const php_random_algo *algo = engine.algo;
-	void *status = engine.status;
+	void *state = engine.status;
 
 	uint64_t result, limit;
 	size_t total_size = 0;
@@ -145,7 +145,7 @@ PHPAPI uint64_t php_random_range64(php_random_algo_with_state engine, uint64_t u
 	result = 0;
 	total_size = 0;
 	do {
-		php_random_result r = algo->generate(status);
+		php_random_result r = algo->generate(state);
 		result = result | (r.result << (total_size * 8));
 		total_size += r.size;
 		if (EG(exception)) {
@@ -180,7 +180,7 @@ PHPAPI uint64_t php_random_range64(php_random_algo_with_state engine, uint64_t u
 		result = 0;
 		total_size = 0;
 		do {
-			php_random_result r = algo->generate(status);
+			php_random_result r = algo->generate(state);
 			result = result | (r.result << (total_size * 8));
 			total_size += r.size;
 			if (EG(exception)) {
@@ -309,14 +309,14 @@ PHPAPI const php_random_algo *php_random_default_algo(void)
 /* {{{ php_random_default_status */
 PHPAPI void *php_random_default_status(void)
 {
-	php_random_status_state_mt19937 *status = RANDOM_G(mt19937);
+	php_random_status_state_mt19937 *state = RANDOM_G(mt19937);
 
 	if (!RANDOM_G(mt19937_seeded)) {
-		php_random_mt19937_seed_default(status);
+		php_random_mt19937_seed_default(state);
 		RANDOM_G(mt19937_seeded) = true;
 	}
 
-	return status;
+	return state;
 }
 /* }}} */
 
@@ -390,14 +390,14 @@ PHPAPI bool php_random_hex2bin_le(zend_string *hexstr, void *dest)
 /* {{{ php_combined_lcg */
 PHPAPI double php_combined_lcg(void)
 {
-	php_random_status_state_combinedlcg *status = RANDOM_G(combined_lcg);
+	php_random_status_state_combinedlcg *state = RANDOM_G(combined_lcg);
 
 	if (!RANDOM_G(combined_lcg_seeded)) {
-		php_random_combinedlcg_seed_default(status);
+		php_random_combinedlcg_seed_default(state);
 		RANDOM_G(combined_lcg_seeded) = true;
 	}
 
-	return php_random_algo_combinedlcg.generate(status).result * 4.656613e-10;
+	return php_random_algo_combinedlcg.generate(state).result * 4.656613e-10;
 }
 /* }}} */
 

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -77,7 +77,7 @@ static zend_object_handlers random_randomizer_object_handlers;
 PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t umax)
 {
 	const php_random_algo *algo = engine.algo;
-	void *state = engine.status;
+	void *state = engine.state;
 
 	uint32_t result, limit;
 	size_t total_size = 0;
@@ -136,7 +136,7 @@ PHPAPI uint32_t php_random_range32(php_random_algo_with_state engine, uint32_t u
 PHPAPI uint64_t php_random_range64(php_random_algo_with_state engine, uint64_t umax)
 {
 	const php_random_algo *algo = engine.algo;
-	void *state = engine.status;
+	void *state = engine.state;
 
 	uint64_t result, limit;
 	size_t total_size = 0;
@@ -226,7 +226,7 @@ static void randomizer_free_obj(zend_object *object) {
 	php_random_randomizer *randomizer = php_random_randomizer_from_obj(object);
 
 	if (randomizer->is_userland_algo) {
-		php_random_status_free(randomizer->engine.status, false);
+		php_random_status_free(randomizer->engine.state, false);
 	}
 
 	zend_object_std_dtor(&randomizer->std);
@@ -256,7 +256,7 @@ PHPAPI php_random_engine *php_random_engine_common_init(zend_class_entry *ce, ze
 
 	engine->engine = (php_random_algo_with_state){
 		.algo = algo,
-		.status = php_random_status_alloc(algo, false)
+		.state = php_random_status_alloc(algo, false)
 	};
 	engine->std.handlers = handlers;
 
@@ -267,7 +267,7 @@ PHPAPI void php_random_engine_common_free_object(zend_object *object)
 {
 	php_random_engine *engine = php_random_engine_from_obj(object);
 
-	php_random_status_free(engine->engine.status, false);
+	php_random_status_free(engine->engine.state, false);
 	zend_object_std_dtor(object);
 }
 
@@ -277,8 +277,8 @@ PHPAPI zend_object *php_random_engine_common_clone_object(zend_object *object)
 	php_random_engine *new_engine = php_random_engine_from_obj(old_engine->std.ce->create_object(old_engine->std.ce));
 
 	new_engine->engine.algo = old_engine->engine.algo;
-	if (old_engine->engine.status) {
-		new_engine->engine.status = php_random_status_copy(old_engine->engine.algo, old_engine->engine.status, new_engine->engine.status);
+	if (old_engine->engine.state) {
+		new_engine->engine.state = php_random_status_copy(old_engine->engine.algo, old_engine->engine.state, new_engine->engine.state);
 	}
 
 	zend_objects_clone_members(&new_engine->std, &old_engine->std);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3214,7 +3214,7 @@ boundary_error:
 PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *array) /* {{{ */
 {
 	const php_random_algo *algo = engine.algo;
-	void *status = engine.status;
+	void *state = engine.status;
 
 	int64_t idx, j, n_elems, rnd_idx, n_left;
 	zval *zv, temp;
@@ -3256,7 +3256,7 @@ PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *arra
 			}
 		}
 		while (--n_left) {
-			rnd_idx = algo->range(status, 0, n_left);
+			rnd_idx = algo->range(state, 0, n_left);
 			if (EG(exception)) {
 				return false;
 			}
@@ -3284,7 +3284,7 @@ PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *arra
 			}
 		}
 		while (--n_left) {
-			rnd_idx = algo->range(status, 0, n_left);
+			rnd_idx = algo->range(state, 0, n_left);
 			if (EG(exception)) {
 				return false;
 			}
@@ -6197,7 +6197,7 @@ clean_up:
 PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, zend_long num_req, zval *retval, bool silent)
 {
 	const php_random_algo *algo = engine.algo;
-	void *status = engine.status;
+	void *state = engine.status;
 
 	HashTable *ht = Z_ARRVAL_P(input);
 	uint32_t num_avail = zend_hash_num_elements(ht);
@@ -6223,7 +6223,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 			/* If less than 1/2 of elements are used, don't sample. Instead search for a
 			 * specific offset using linear scan. */
 			i = 0;
-			randval = algo->range(status, 0, num_avail - 1);
+			randval = algo->range(state, 0, num_avail - 1);
 			if (EG(exception)) {
 				return false;
 			}
@@ -6246,7 +6246,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 		 * For N=10 this becomes smaller than 0.1%. */
 		if (HT_IS_PACKED(ht)) {
 			do {
-				randval = algo->range(status, 0, ht->nNumUsed - 1);
+				randval = algo->range(state, 0, ht->nNumUsed - 1);
 				if (EG(exception)) {
 					return false;
 				}
@@ -6258,7 +6258,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 			} while (true);
 		} else {
 			do {
-				randval = algo->range(status, 0, ht->nNumUsed - 1);
+				randval = algo->range(state, 0, ht->nNumUsed - 1);
 				if (EG(exception)) {
 					return false;
 				}
@@ -6296,7 +6296,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 	i = num_req;
 	int failures = 0;
 	while (i) {
-		randval = algo->range(status, 0, num_avail - 1);
+		randval = algo->range(state, 0, num_avail - 1);
 		if (EG(exception)) {
 			goto fail;
 		}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3214,7 +3214,7 @@ boundary_error:
 PHPAPI bool php_array_data_shuffle(php_random_algo_with_state engine, zval *array) /* {{{ */
 {
 	const php_random_algo *algo = engine.algo;
-	void *state = engine.status;
+	void *state = engine.state;
 
 	int64_t idx, j, n_elems, rnd_idx, n_left;
 	zval *zv, temp;
@@ -6197,7 +6197,7 @@ clean_up:
 PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, zend_long num_req, zval *retval, bool silent)
 {
 	const php_random_algo *algo = engine.algo;
-	void *state = engine.status;
+	void *state = engine.state;
 
 	HashTable *ht = Z_ARRVAL_P(input);
 	uint32_t num_avail = zend_hash_num_elements(ht);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5956,7 +5956,7 @@ PHP_FUNCTION(str_rot13)
 PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *str, zend_long len) /* {{{ */
 {
 	const php_random_algo *algo = engine.algo;
-	void *status = engine.status;
+	void *state = engine.status;
 
 	int64_t n_elems, rnd_idx, n_left;
 	char temp;
@@ -5972,7 +5972,7 @@ PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *s
 	n_left = n_elems;
 
 	while (--n_left) {
-		rnd_idx = algo->range(status, 0, n_left);
+		rnd_idx = algo->range(state, 0, n_left);
 		if (EG(exception)) {
 			return false;
 		}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5956,7 +5956,7 @@ PHP_FUNCTION(str_rot13)
 PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *str, zend_long len) /* {{{ */
 {
 	const php_random_algo *algo = engine.algo;
-	void *state = engine.status;
+	void *state = engine.state;
 
 	int64_t n_elems, rnd_idx, n_left;
 	char temp;


### PR DESCRIPTION
As a follow-up for #13350:

> The names of the status variables have not yet been touched to keep the diff small. They will be renamed to the more appropriate state in a follow-up cleanup commit.

-------------

I do not expect a review and will merge this once CI passes. This is a purely non-breaking change, as the `php_random_algo_with_state` struct was freshly added in 8.4 and merged just yesterday. The split into two PRs was just to keep the diffs small.