### PR TITLE
Fix GH-13517: Multiple test failures when building with --with-expat

### DIFF
--- a/ext/reflection/tests/016.phpt
+++ b/ext/reflection/tests/016.phpt
@@ -1,15 +1,17 @@
 --TEST--
 ReflectionExtension::getDependencies()
 --EXTENSIONS--
-xml
+dom
 --FILE--
 <?php
-$ext = new ReflectionExtension("xml");
+$ext = new ReflectionExtension("dom");
 $deps = $ext->getDependencies();
 var_dump($deps);
 ?>
 --EXPECT--
-array(1) {
+array(2) {
   ["libxml"]=>
   string(8) "Required"
+  ["domxml"]=>
+  string(9) "Conflicts"
 }

--- a/ext/xml/tests/bug26614.inc
+++ b/ext/xml/tests/bug26614.inc
@@ -1,0 +1,73 @@
+<?php
+/*
+this test has different output on libxml2 (even depending on the version) and Expat
+
+further investigation has shown that not only line count
+is skippet on CDATA sections but that libxml does also
+show different column numbers and byte positions depending
+on context and in opposition to what one would expect to
+see and what good old Expat reported just fine ...
+*/
+
+$xmls = array();
+
+// Case 1: CDATA Sections
+$xmls["CDATA"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
+<data>
+<![CDATA[
+multi
+line
+CDATA
+block
+]]>
+</data>';
+
+// Case 2: replace some characters so that we get comments instead
+$xmls["Comment"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
+<data>
+<!-- ATA[
+multi
+line
+CDATA
+block
+-->
+</data>';
+
+// Case 3: replace even more characters so that only textual data is left
+$xmls["Text"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
+<data>
+-!-- ATA[
+multi
+line
+CDATA
+block
+---
+</data>';
+
+function startElement($parser, $name, $attrs) {
+    printf("<$name> at line %d, col %d (byte %d)\n",
+               xml_get_current_line_number($parser),
+               xml_get_current_column_number($parser),
+               xml_get_current_byte_index($parser));
+}
+
+function endElement($parser, $name) {
+    printf("</$name> at line %d, col %d (byte %d)\n",
+               xml_get_current_line_number($parser),
+               xml_get_current_column_number($parser),
+               xml_get_current_byte_index($parser));
+}
+
+function characterData($parser, $data) {
+  // dummy
+}
+
+foreach ($xmls as $desc => $xml) {
+  echo "$desc\n";
+    $xml_parser = xml_parser_create();
+    xml_set_element_handler($xml_parser, "startElement", "endElement");
+    xml_set_character_data_handler($xml_parser, "characterData");
+    if (!xml_parse($xml_parser, $xml, true))
+        echo "Error: ".xml_error_string(xml_get_error_code($xml_parser))."\n";
+    xml_parser_free($xml_parser);
+}

--- a/ext/xml/tests/bug26614.phpt
+++ b/ext/xml/tests/bug26614.phpt
@@ -4,91 +4,20 @@ Bug #26614 (CDATA sections skipped on line count)
 xml
 --SKIPIF--
 <?php
-if (defined("LIBXML_VERSION")) die('skip expat test');
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: true);
 ?>
 --FILE--
 <?php
-/*
-this test works fine with Expat but fails with libxml
-which we now use as default
-
-further investigation has shown that not only line count
-is skippet on CDATA sections but that libxml does also
-show different column numbers and byte positions depending
-on context and in opposition to what one would expect to
-see and what good old Expat reported just fine ...
-*/
-
-$xmls = array();
-
-// Case 1: CDATA Sections
-$xmls["CDATA"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<![CDATA[
-multi
-line
-CDATA
-block
-]]>
-</data>';
-
-// Case 2: replace some characters so that we get comments instead
-$xmls["Comment"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<!-- ATA[
-multi
-line
-CDATA
-block
--->
-</data>';
-
-// Case 3: replace even more characters so that only textual data is left
-$xmls["Text"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
--!-- ATA[
-multi
-line
-CDATA
-block
----
-</data>';
-
-function startElement($parser, $name, $attrs) {
-    printf("<$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function endElement($parser, $name) {
-    printf("</$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function characterData($parser, $data) {
-  // dummy
-}
-
-foreach ($xmls as $desc => $xml) {
-  echo "$desc\n";
-    $xml_parser = xml_parser_create();
-    xml_set_element_handler($xml_parser, "startElement", "endElement");
-    xml_set_character_data_handler($xml_parser, "characterData");
-    if (!xml_parse($xml_parser, $xml, true))
-        echo "Error: ".xml_error_string(xml_get_error_code($xml_parser))."\n";
-    xml_parser_free($xml_parser);
-}
+require __DIR__ . '/bug26614.inc';
 ?>
 --EXPECT--
 CDATA
 <DATA> at line 2, col 0 (byte 45)
-</DATA> at line 9, col 0 (byte 90)
+</DATA> at line 9, col 0 (byte 89)
 Comment
 <DATA> at line 2, col 0 (byte 45)
-</DATA> at line 9, col 0 (byte 90)
+</DATA> at line 9, col 0 (byte 89)
 Text
 <DATA> at line 2, col 0 (byte 45)
-</DATA> at line 9, col 0 (byte 90)
+</DATA> at line 9, col 0 (byte 89)

--- a/ext/xml/tests/bug26614_libxml_gte2_11.phpt
+++ b/ext/xml/tests/bug26614_libxml_gte2_11.phpt
@@ -4,84 +4,13 @@ Bug #26614 (CDATA sections skipped on line count)
 xml
 --SKIPIF--
 <?php
-if (!defined("LIBXML_VERSION")) die('skip libxml2 test');
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: false);
 if (LIBXML_VERSION < 21100) die('skip libxml2 test variant for version >= 2.11');
 ?>
 --FILE--
 <?php
-/*
-this test works fine with Expat but fails with libxml
-which we now use as default
-
-further investigation has shown that not only line count
-is skipped on CDATA sections but that libxml does also
-show different column numbers and byte positions depending
-on context and in opposition to what one would expect to
-see and what good old Expat reported just fine ...
-*/
-
-$xmls = array();
-
-// Case 1: CDATA Sections
-$xmls["CDATA"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<![CDATA[
-multi
-line
-CDATA
-block
-]]>
-</data>';
-
-// Case 2: replace some characters so that we get comments instead
-$xmls["Comment"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<!-- ATA[
-multi
-line
-CDATA
-block
--->
-</data>';
-
-// Case 3: replace even more characters so that only textual data is left
-$xmls["Text"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
--!-- ATA[
-multi
-line
-CDATA
-block
----
-</data>';
-
-function startElement($parser, $name, $attrs) {
-    printf("<$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function endElement($parser, $name) {
-    printf("</$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function characterData($parser, $data) {
-  // dummy
-}
-
-foreach ($xmls as $desc => $xml) {
-  echo "$desc\n";
-    $xml_parser = xml_parser_create();
-    xml_set_element_handler($xml_parser, "startElement", "endElement");
-    xml_set_character_data_handler($xml_parser, "characterData");
-    if (!xml_parse($xml_parser, $xml, true))
-        echo "Error: ".xml_error_string(xml_get_error_code($xml_parser))."\n";
-    xml_parser_free($xml_parser);
-}
+require __DIR__ . '/bug26614.inc';
 ?>
 --EXPECTF--
 CDATA

--- a/ext/xml/tests/bug26614_libxml_pre2_11.phpt
+++ b/ext/xml/tests/bug26614_libxml_pre2_11.phpt
@@ -4,84 +4,13 @@ Bug #26614 (CDATA sections skipped on line count)
 xml
 --SKIPIF--
 <?php
-if (!defined("LIBXML_VERSION")) die('skip libxml2 test');
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: false);
 if (LIBXML_VERSION >= 21100) die('skip libxml2 test variant for version < 2.11');
 ?>
 --FILE--
 <?php
-/*
-this test works fine with Expat but fails with libxml
-which we now use as default
-
-further investigation has shown that not only line count
-is skipped on CDATA sections but that libxml does also
-show different column numbers and byte positions depending
-on context and in opposition to what one would expect to
-see and what good old Expat reported just fine ...
-*/
-
-$xmls = array();
-
-// Case 1: CDATA Sections
-$xmls["CDATA"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<![CDATA[
-multi
-line
-CDATA
-block
-]]>
-</data>';
-
-// Case 2: replace some characters so that we get comments instead
-$xmls["Comment"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
-<!-- ATA[
-multi
-line
-CDATA
-block
--->
-</data>';
-
-// Case 3: replace even more characters so that only textual data is left
-$xmls["Text"] ='<?xml version="1.0" encoding="iso-8859-1" ?>
-<data>
--!-- ATA[
-multi
-line
-CDATA
-block
----
-</data>';
-
-function startElement($parser, $name, $attrs) {
-    printf("<$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function endElement($parser, $name) {
-    printf("</$name> at line %d, col %d (byte %d)\n",
-               xml_get_current_line_number($parser),
-               xml_get_current_column_number($parser),
-               xml_get_current_byte_index($parser));
-}
-
-function characterData($parser, $data) {
-  // dummy
-}
-
-foreach ($xmls as $desc => $xml) {
-  echo "$desc\n";
-    $xml_parser = xml_parser_create();
-    xml_set_element_handler($xml_parser, "startElement", "endElement");
-    xml_set_character_data_handler($xml_parser, "characterData");
-    if (!xml_parse($xml_parser, $xml, true))
-        echo "Error: ".xml_error_string(xml_get_error_code($xml_parser))."\n";
-    xml_parser_free($xml_parser);
-}
+require __DIR__ . '/bug26614.inc';
 ?>
 --EXPECTF--
 CDATA

--- a/ext/xml/tests/bug46699.phpt
+++ b/ext/xml/tests/bug46699.phpt
@@ -27,8 +27,8 @@ xml_parser_set_option($parser,XML_OPTION_CASE_FOLDING,0);
 xml_parse($parser, $xml);
 xml_parser_free($parser);
 ?>
---EXPECT--
-<a xmlns="http://example.com/foo" xmlns:bar="http://example.com/bar">
+--EXPECTF--
+<a xmlns="http://example.com/foo"%axmlns:bar="http://example.com/bar">
   <bar:b foo="bar">1</bar:b>
   <bar:c bar:nix="null" foo="bar">2</bar:c>
 </a>

--- a/ext/xml/tests/bug81351.phpt
+++ b/ext/xml/tests/bug81351.phpt
@@ -22,5 +22,5 @@ $error = xml_error_string($code);
 echo "xml_parse returned $success, xml_get_error_code = $code, xml_error_string = $error\r\n";
 ?>
 --EXPECTF--
-xml_parse returned 1, xml_get_error_code = 0, xml_error_string = No error
-%rxml_parse returned 0, xml_get_error_code = 5, xml_error_string = Invalid document end|xml_parse returned 0, xml_get_error_code = 77, xml_error_string = Tag not finished%r
+xml_parse returned 1, xml_get_error_code = 0, xml_error_string = %S
+%rxml_parse returned 0, xml_get_error_code = 5, xml_error_string = Invalid document end|xml_parse returned 0, xml_get_error_code = 3, xml_error_string = no element found|xml_parse returned 0, xml_get_error_code = 77, xml_error_string = Tag not finished%r

--- a/ext/xml/tests/libxml_expat_skipif.inc
+++ b/ext/xml/tests/libxml_expat_skipif.inc
@@ -1,0 +1,9 @@
+<?php
+function skipif(bool $want_expat) {
+    ob_start();
+    echo phpinfo(INFO_MODULES);
+    $output = ob_get_clean();
+    if ($want_expat !== str_contains($output, 'EXPAT')) {
+        die('skip test is for ' . ($want_expat ? 'Expat' : 'libxml'));
+    }
+}

--- a/ext/xml/tests/xml_error_string_basic.inc
+++ b/ext/xml/tests/xml_error_string_basic.inc
@@ -1,8 +1,3 @@
---TEST--
-xml_error_string() - Basic test on 5 error codes
---EXTENSIONS--
-xml
---FILE--
 <?php
 $xmls = array(
     '<?xml version="1.0"?><element>',
@@ -20,15 +15,3 @@ foreach ($xmls as $xml) {
     }
     xml_parser_free($xml_parser);
 }
-?>
---EXPECTF--
-int(%r5|77%r)
-string(%d) %r"Invalid document end"|"Tag not finished"%r
-int(47)
-string(35) "Processing Instruction not finished"
-int(57)
-string(28) "XML declaration not finished"
-int(64)
-string(17) "Reserved XML Name"
-int(76)
-string(14) "Mismatched tag"

--- a/ext/xml/tests/xml_error_string_basic_expat.phpt
+++ b/ext/xml/tests/xml_error_string_basic_expat.phpt
@@ -1,0 +1,24 @@
+--TEST--
+xml_error_string() - Basic test on 5 error codes
+--EXTENSIONS--
+xml
+--SKIPIF--
+<?php
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: true);
+?>
+--FILE--
+<?php
+require __DIR__ . '/xml_error_string_basic.inc';
+?>
+--EXPECT--
+int(3)
+string(16) "no element found"
+int(4)
+string(31) "not well-formed (invalid token)"
+int(5)
+string(14) "unclosed token"
+int(30)
+string(31) "XML declaration not well-formed"
+int(7)
+string(14) "mismatched tag"

--- a/ext/xml/tests/xml_error_string_basic_libxml.phpt
+++ b/ext/xml/tests/xml_error_string_basic_libxml.phpt
@@ -1,0 +1,24 @@
+--TEST--
+xml_error_string() - Basic test on 5 error codes
+--EXTENSIONS--
+xml
+--SKIPIF--
+<?php
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: false);
+?>
+--FILE--
+<?php
+require __DIR__ . '/xml_error_string_basic.inc';
+?>
+--EXPECTF--
+int(%r5|77%r)
+string(%d) %r"Invalid document end"|"Tag not finished"%r
+int(47)
+string(35) "Processing Instruction not finished"
+int(57)
+string(28) "XML declaration not finished"
+int(64)
+string(17) "Reserved XML Name"
+int(76)
+string(14) "Mismatched tag"

--- a/ext/xml/tests/xml_set_start_namespace_decl_handler_basic.inc
+++ b/ext/xml/tests/xml_set_start_namespace_decl_handler_basic.inc
@@ -1,8 +1,3 @@
---TEST--
-Test xml_set_start_namespace_decl_handler function: basic
---EXTENSIONS--
-xml
---FILE--
 <?php
 $xml = <<<HERE
 <aw1:book xmlns:aw1="http://www.somewhere.com/namespace1"
@@ -37,14 +32,3 @@ function Namespace_End_Handler($parser, $prefix) {
 function DefaultHandler( $parser, $data ) {
    print( 'DefaultHandler Called<br/>' );
 }
-?>
---EXPECT--
-bool(true)
-bool(true)
-Namespace_Start_Handler called
-...Prefix: aw1
-...Uri: http://www.somewhere.com/namespace1
-Namespace_Start_Handler called
-...Prefix: aw2
-...Uri: file:/DTD/somewhere.dtd
-Done

--- a/ext/xml/tests/xml_set_start_namespace_decl_handler_basic_expat.phpt
+++ b/ext/xml/tests/xml_set_start_namespace_decl_handler_basic_expat.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test xml_set_start_namespace_decl_handler function: basic
+--EXTENSIONS--
+xml
+--SKIPIF--
+<?php
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: true);
+?>
+--FILE--
+<?php
+require __DIR__ . '/xml_set_start_namespace_decl_handler_basic.inc';
+?>
+--EXPECT--
+bool(true)
+bool(true)
+Namespace_Start_Handler called
+...Prefix: aw1
+...Uri: http://www.somewhere.com/namespace1
+Namespace_Start_Handler called
+...Prefix: aw2
+...Uri: file:/DTD/somewhere.dtd
+Namespace_End_Handler called
+...Prefix: aw2
+
+Namespace_End_Handler called
+...Prefix: aw1
+
+Done

--- a/ext/xml/tests/xml_set_start_namespace_decl_handler_basic_libxml.phpt
+++ b/ext/xml/tests/xml_set_start_namespace_decl_handler_basic_libxml.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test xml_set_start_namespace_decl_handler function: basic
+--EXTENSIONS--
+xml
+--SKIPIF--
+<?php
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: false);
+?>
+--FILE--
+<?php
+// Note: namespace end handlers are only supported on expat
+require __DIR__ . '/xml_set_start_namespace_decl_handler_basic.inc';
+?>
+--EXPECT--
+bool(true)
+bool(true)
+Namespace_Start_Handler called
+...Prefix: aw1
+...Uri: http://www.somewhere.com/namespace1
+Namespace_Start_Handler called
+...Prefix: aw2
+...Uri: file:/DTD/somewhere.dtd
+Done


### PR DESCRIPTION
The reflection failure is because the XML extension is used to check the module dependency information, but that extension can be configured to not depend on ext/libxml, resulting in a different output. The solution is to check another extension instead.

The test failures in ext/xml/tests are because of different behaviour between libxml2 and Expat error handling. These are expected differences and the solution is to split the tests.