### PR TITLE
Fix GH-13519: PGSQL_CONNECT_FORCE_RENEW with persistent connections.

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -591,6 +591,12 @@ newpconn:
 			PGG(num_links)++;
 			PGG(num_persistent)++;
 		} else {  /* we do */
+			if ((connect_type & PGSQL_CONNECT_FORCE_NEW)) {
+				if (zend_hash_del(&EG(persistent_list), str.s) != SUCCESS) {
+					goto err;
+				}
+				goto newpconn;
+			}
 			if (le->type != le_plink) {
 				goto err;
 			}
@@ -620,12 +626,6 @@ newpconn:
 			if (PQprotocolVersion(pgsql) >= 3 && zend_strtod(PQparameterStatus(pgsql, "server_version"), NULL) >= 7.2) {
 				pg_result = PQexec(pgsql, "RESET ALL;");
 				PQclear(pg_result);
-			}
-			if ((connect_type & PGSQL_CONNECT_FORCE_NEW)) {
-				if (zend_hash_del(&EG(persistent_list), str.s) != SUCCESS) {
-					goto err;
-				}
-				goto newpconn;
 			}
 		}
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -562,6 +562,7 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 
 		/* try to find if we already have this link in our persistent list */
 		if ((le = zend_hash_find_ptr(&EG(persistent_list), str.s)) == NULL) {  /* we don't */
+newpconn:
 			if (PGG(max_links) != -1 && PGG(num_links) >= PGG(max_links)) {
 				php_error_docref(NULL, E_WARNING,
 								 "Cannot create new link. Too many open links (" ZEND_LONG_FMT ")", PGG(num_links));
@@ -619,6 +620,12 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 			if (PQprotocolVersion(pgsql) >= 3 && zend_strtod(PQparameterStatus(pgsql, "server_version"), NULL) >= 7.2) {
 				pg_result = PQexec(pgsql, "RESET ALL;");
 				PQclear(pg_result);
+			}
+			if ((connect_type & PGSQL_CONNECT_FORCE_NEW)) {
+				if (zend_hash_del(&EG(persistent_list), str.s) != SUCCESS) {
+					goto err;
+				}
+				goto newpconn;
 			}
 		}
 

--- a/ext/pgsql/tests/gh13519.phpt
+++ b/ext/pgsql/tests/gh13519.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-13519 - PGSQL_CONNECT_FORCE_NEW with persistent connections.
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+include 'config.inc';
+
+$db1 = pg_pconnect($conn_str);
+$pid1 = pg_get_pid($db1);
+for ($i = 0; $i < 3; $i ++) {
+	$db2 = pg_pconnect($conn_str);
+	var_dump($pid1 === pg_get_pid($db2));
+}
+for ($i = 0; $i < 3; $i ++) {
+	$db2 = pg_pconnect($conn_str, PGSQL_CONNECT_FORCE_NEW);
+	var_dump($pid1 === pg_get_pid($db2));
+	pg_close($db2);
+}
+pg_close($db1);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
persistent connections did not take in account this flag, after the usual link sanity checks, we remove its entry.