### PR TITLE
Remove PHP_CHECK_GCC_ARG

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -116,6 +116,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
    - M4 macro PHP_SOCKADDR_CHECKS has been removed (use AC_CHECK_TYPES and
      AC_CHECK_MEMBERS).
+   - M4 macro PHP_CHECK_GCC_ARG has been removed since PHP 8.0 (use
+     AX_CHECK_COMPILE_FLAG).
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -295,10 +295,6 @@ if test "$PHP_RPATH" = "no"; then
 fi
 ])
 
-AC_DEFUN([PHP_CHECK_GCC_ARG],[
-  AC_MSG_ERROR([[Use AX_CHECK_COMPILE_FLAG instead]])
-])
-
 dnl
 dnl PHP_LIBGCC_LIBPATH(gcc)
 dnl


### PR DESCRIPTION
The PHP_CHECK_GCC_ARG has been already removed in PHP 8.0 and this also removes the error emitting wrapper.

Patches for the solr and vld extensions have been sent upstream.