### PR TITLE
Simplify clock_gettime Autoconf check

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -7,39 +7,14 @@ PHP_ARG_ENABLE([fpm],,
 dnl Configure checks.
 AC_DEFUN([AC_FPM_CLOCK],
 [
-  have_clock_gettime=no
-
-  AC_MSG_CHECKING([for clock_gettime])
-
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <time.h>]], [[struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);]])], [
-    have_clock_gettime=yes
-    AC_MSG_RESULT([yes])
-  ], [
-    AC_MSG_RESULT([no])
-  ])
-
-  if test "$have_clock_gettime" = "no"; then
-    AC_MSG_CHECKING([for clock_gettime in -lrt])
-
-    SAVED_LIBS="$LIBS"
-    LIBS="$LIBS -lrt"
-
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <time.h>]], [[struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);]])], [
-      have_clock_gettime=yes
-      AC_MSG_RESULT([yes])
-    ], [
-      LIBS="$SAVED_LIBS"
-      AC_MSG_RESULT([no])
-    ])
-  fi
-
-  if test "$have_clock_gettime" = "yes"; then
-    AC_DEFINE([HAVE_CLOCK_GETTIME], 1, [do we have clock_gettime?])
-  fi
+  AC_CHECK_FUNCS([clock_gettime],,
+    [AC_SEARCH_LIBS([clock_gettime], [rt],
+      [ac_cv_func_clock_gettime=yes
+      AC_DEFINE([HAVE_CLOCK_GETTIME], [1])])])
 
   have_clock_get_time=no
 
-  if test "$have_clock_gettime" = "no"; then
+  if test "$ac_cv_func_clock_gettime" = "no"; then
     AC_MSG_CHECKING([for clock_get_time])
 
     AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <mach/mach.h>


### PR DESCRIPTION
The clock_gettime() is found in libc on modern systems, except on Solaris <= 10 and possible similar systems, it is in the rt library.

This checks if clock_gettime() exists in the libc, then it checks if rt library has clock_gettime, prepends it to LIBS and defines the HAVE_CLOCK_GETTIME symbol with the template from the AC_CHECK_FUNCS.

The ac_cv_func_clock_gettime is a cache variable set by AC_CHECK_FUNCS.