### PR TITLE
CI: Continue on error if Caddy download fails

### DIFF
--- a/.github/actions/setup-caddy/action.yml
+++ b/.github/actions/setup-caddy/action.yml
@@ -10,3 +10,4 @@ runs:
         gh release -R caddyserver/caddy download --pattern 'caddy_*_linux_amd64.tar.gz' -O - | sudo tar -xz -C /usr/bin caddy
         sudo chmod +x /usr/bin/caddy
         sudo caddy start --config ext/curl/tests/Caddyfile
+      continue-on-error: true


### PR DESCRIPTION
Download often fails so we just try to download it. It's not the end of the world if this test is skipped.