### PR TITLE
Fix GH-13531: Unable to resize SplfixedArray after being unserialized in PHP 8.2.15

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -91,6 +91,7 @@ static void spl_fixedarray_default_ctor(spl_fixedarray *array)
 {
 	array->size = 0;
 	array->elements = NULL;
+	array->cached_resize = -1;
 }
 
 /* Initializes the range [from, to) to null. Does not dtor existing elements. */
@@ -110,6 +111,7 @@ static void spl_fixedarray_init_non_empty_struct(spl_fixedarray *array, zend_lon
 	array->elements = size ? safe_emalloc(size, sizeof(zval), 0) : NULL;
 	array->size = size;
 	array->should_rebuild_properties = true;
+	array->cached_resize = -1;
 }
 
 static void spl_fixedarray_init(spl_fixedarray *array, zend_long size)
@@ -120,7 +122,6 @@ static void spl_fixedarray_init(spl_fixedarray *array, zend_long size)
 	} else {
 		spl_fixedarray_default_ctor(array);
 	}
-	array->cached_resize = -1;
 }
 
 /* Copies the range [begin, end) into the fixedarray, beginning at `offset`.

--- a/ext/spl/tests/gh13531.phpt
+++ b/ext/spl/tests/gh13531.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-13531 (Unable to resize SplfixedArray after being unserialized in PHP 8.2.15)
+--FILE--
+<?php
+
+$array = new SplFixedArray(5);
+$array[4] = 1;
+$serialized = serialize($array);
+$unserialized = unserialize($serialized);
+$unserialized->setSize(6);
+var_dump($unserialized);
+
+?>
+--EXPECT--
+object(SplFixedArray)#2 (6) {
+  [0]=>
+  NULL
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+  [3]=>
+  NULL
+  [4]=>
+  int(1)
+  [5]=>
+  NULL
+}


### PR DESCRIPTION
When unserializing, the cached_resize field was not reset to -1 correctly, causing the setSize() method to think we were inside of a resize operation.