### PR TITLE
random: Fix unknown `mt_srand()` compatibility for unknown modes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-13354 (pg_execute/pg_send_query_params/pg_send_execute
     with null value passed by reference). (George Barbarosie)
 
+- Random:
+  . Fixed bug GH-13544 (Pre-PHP 8.2 compatibility for mt_srand with
+    unknown modes). (timwolla)
+
 - Standard:
   . Fixed array key as hash to string (case insensitive) comparison typo
     for the second operand buffer size (albeit unused for now). (A. Slepykh)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -688,7 +688,13 @@ PHP_FUNCTION(mt_srand)
 		Z_PARAM_LONG(mode)
 	ZEND_PARSE_PARAMETERS_END();
 
-	state->mode = mode;
+	switch (mode) {
+	case MT_RAND_PHP:
+		state->mode = MT_RAND_PHP;
+		break;
+	default:
+		state->mode = MT_RAND_MT19937;
+	}
 
 	if (ZEND_NUM_ARGS() == 0) {
 		php_random_mt19937_seed_default(status->state);

--- a/ext/random/tests/01_functions/mt_srand_unknown_mode.phpt
+++ b/ext/random/tests/01_functions/mt_srand_unknown_mode.phpt
@@ -1,0 +1,22 @@
+--TEST--
+mt_srand(): Test unknown modes
+--FILE--
+<?php
+// MT_RAND_MT19937
+mt_srand(1, 0);
+var_dump(mt_rand());
+// MT_RAND_PHP
+mt_srand(1, 1);
+var_dump(mt_rand());
+// Unknown
+mt_srand(1, 2);
+var_dump(mt_rand());
+// Equivalent to 0 when cast as unsigned 8-bit integer
+mt_srand(1, 256);
+var_dump(mt_rand());
+?>
+--EXPECT--
+int(895547922)
+int(1244335972)
+int(895547922)
+int(895547922)


### PR DESCRIPTION
see: https://3v4l.org/fOZbQ. Will need some adjustments when merging to PHP 8.3, due to the deprecation.

Found, because I wondered about the implicit downcast from `zend_long` to `uint8_t` during the assignment of `mode` and wondered about that, because I contemplated making the two mode constants and enum in PHP 8.4+.

-----------

PHP 8.1 and below interpreted unknown modes as `MT_RAND_MT19937`, but PHP 8.2+ interprets them as `MT_RAND_PHP`.

Align the behavior with PHP 8.1 and below, because folks should be steered towards the standard mode.