### PR TITLE
Rustify DOMXPath::quote

### DIFF
--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -34,7 +34,7 @@ if test "$PHP_DOM" != "no"; then
                             documenttype.c entity.c \
                             nodelist.c text.c comment.c \
                             entityreference.c \
-                            notation.c xpath.c dom_iterators.c \
+                            notation.c xpath.c xpath_rust.rs dom_iterators.c \
                             namednodemap.c xpath_callbacks.c \
                             $LEXBOR_SOURCES],
                             $ext_shared,,$PHP_LEXBOR_CFLAGS)

--- a/ext/dom/xpath_rust.h
+++ b/ext/dom/xpath_rust.h
@@ -1,0 +1,1 @@
+extern char* domxpath_quote_literal(const char *const input, uintptr_t *const len);

--- a/ext/dom/xpath_rust.rs
+++ b/ext/dom/xpath_rust.rs
@@ -1,0 +1,56 @@
+use std::ffi::{CString, c_char};
+
+
+#[no_mangle]
+pub extern "C" fn domxpath_quote_literal(input: *const c_char, len: *mut usize) -> *mut c_char {
+    let slice = unsafe { std::slice::from_raw_parts(input as *const u8, *len as usize) };
+
+    let single_quote_absent = !slice.contains(&b'\'');
+    let double_quote_absent = !slice.contains(&b'"');
+
+    let result = if single_quote_absent {
+        let mut res = Vec::with_capacity(slice.len() + 2);
+        res.push(b'\'');
+        res.extend_from_slice(slice);
+        res.push(b'\'');
+        res
+    } else if double_quote_absent {
+        let mut res = Vec::with_capacity(slice.len() + 2);
+        res.push(b'"');
+        res.extend_from_slice(slice);
+        res.push(b'"');
+        res
+    } else {
+        let mut res = Vec::from("concat(".as_bytes());
+        let mut temp_slice = slice;
+
+        while !temp_slice.is_empty() {
+            let bytes_until_single_quote = temp_slice.iter().position(|&x| x == b'\'').unwrap_or(temp_slice.len());
+            let bytes_until_double_quote = temp_slice.iter().position(|&x| x == b'"').unwrap_or(temp_slice.len());
+            
+            let (quote_method, bytes_until_quote) = if bytes_until_single_quote > bytes_until_double_quote {
+                (b'\'', bytes_until_single_quote)
+            } else {
+                (b'"', bytes_until_double_quote)
+            };
+
+            res.push(quote_method);
+            res.extend_from_slice(&temp_slice[..bytes_until_quote]);
+            res.push(quote_method);
+            res.push(b',');
+            temp_slice = &temp_slice[bytes_until_quote..];
+        }
+        let res_len = res.len();
+        res[res_len - 1] = b')';
+        res
+    };
+
+    // Update length
+    unsafe {
+        *len = result.len() as usize;
+    }
+
+    // Convert Vec<u8> to *mut c_char
+    let c_str = CString::new(result).expect("CString::new failed");
+    c_str.into_raw()
+}


### PR DESCRIPTION
I am fairly certain DOMXPath::quote is bug-free due to the extensive testing done by @nielsdos , quote:

>I've let it fuzz to search for crashes for a while now. It tried about 23 million cases and all seems good.
> If anyone is interested, here's the fuzz harness: https://gist.github.com/nielsdos/44981a753808129b0222f3ef28429c69
Compile & run with: clang tmp.c -O1 -g -o ./tmp -I./main -I./Zend -I. -I./TSRM -fsanitize=fuzzer,address && ./tmp

That is impressive, and made me think, what if we take it 1 step further and re-write it in Rust, with it's memory properties?

For those not in the know, [Rust](https://en.wikipedia.org/wiki/Rust_(programming_language)) is a memory-safe [high-performance](https://benchmarksgame-team.pages.debian.net/benchmarksgame/fastest/rust.html) language.

The Linux Kernel and the Windows kernel and Mozilla Firefox has adopted Rust for it's performance and safety, and the Chromium browser developers is looking into doing the same for Chromium,

Maybe PHP can adopt it too? 😄 