### PR TITLE
Check FFI_* ABI with Autoconf AC_CHECK_DECL

### DIFF
--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -13,96 +13,19 @@ if test "$PHP_FFI" != "no"; then
 
   AC_CHECK_TYPES(long double)
 
-  AC_CACHE_CHECK([for fastcall calling convention], ac_cv_ffi_fastcall,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_FASTCALL]])
-    ],
-    [ac_cv_ffi_fastcall=yes], [ac_cv_ffi_fastcall=no])
-  ])
+  AC_DEFUN([PHP_FFI_CHECK_DECL],
+    [AC_CHECK_DECL([$1],
+      [AC_DEFINE(AS_TR_CPP([HAVE_$1]), [1],
+        [Whether libffi supports the '$1' calling convention.])],,
+      [#include <ffi.h>])])
 
-  if test "$ac_cv_ffi_fastcall" = yes; then
-    AC_DEFINE(HAVE_FFI_FASTCALL,1,[Whether libffi supports fastcall calling convention])
-  fi
-
-  AC_CACHE_CHECK([for thiscall calling convention], ac_cv_ffi_thiscall,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_THISCALL]])
-    ],
-    [ac_cv_ffi_thiscall=yes], [ac_cv_ffi_thiscall=no])
-  ])
-
-  if test "$ac_cv_ffi_thiscall" = yes; then
-    AC_DEFINE(HAVE_FFI_THISCALL,1,[Whether libffi supports thiscall calling convention])
-  fi
-
-  AC_CACHE_CHECK([for stdcall calling convention], ac_cv_ffi_stdcall,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_STDCALL]])
-    ],
-    [ac_cv_ffi_stdcall=yes], [ac_cv_ffi_stdcall=no])
-  ])
-
-  if test "$ac_cv_ffi_stdcall" = yes; then
-    AC_DEFINE(HAVE_FFI_STDCALL,1,[Whether libffi supports stdcall calling convention])
-  fi
-
-  AC_CACHE_CHECK([for pascal calling convention], ac_cv_ffi_pascal,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_PASCAL]])
-    ],
-    [ac_cv_ffi_pascal=yes], [ac_cv_ffi_pascal=no])
-  ])
-
-  if test "$ac_cv_ffi_pascal" = yes; then
-    AC_DEFINE(HAVE_FFI_PASCAL,1,[Whether libffi supports pascal calling convention])
-  fi
-
-  AC_CACHE_CHECK([for register calling convention], ac_cv_ffi_register,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_REGISTER]])
-    ],
-    [ac_cv_ffi_register=yes], [ac_cv_ffi_register=no])
-  ])
-
-  if test "$ac_cv_ffi_register" = yes; then
-    AC_DEFINE(HAVE_FFI_REGISTER,1,[Whether libffi supports register calling convention])
-  fi
-
-  AC_CACHE_CHECK([for ms_cdecl calling convention], ac_cv_ffi_ms_cdecl,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_MS_CDECL]])
-    ],
-    [ac_cv_ffi_ms_cdecl=yes], [ac_cv_ffi_ms_cdecl=no])
-  ])
-
-  if test "$ac_cv_ffi_ms_cdecl" = yes; then
-    AC_DEFINE(HAVE_FFI_MS_CDECL,1,[Whether libffi supports ms_cdecl calling convention])
-  fi
-
-  AC_CACHE_CHECK([for sysv calling convention], ac_cv_ffi_sysv,
-    [
-      AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[#include <ffi.h>]],
-        [[return FFI_SYSV]])
-    ],
-    [ac_cv_ffi_sysv=yes], [ac_cv_ffi_sysv=no])
-  ])
-
-  if test "$ac_cv_ffi_sysv" = yes; then
-    AC_DEFINE(HAVE_FFI_SYSV,1,[Whether libffi supports sysv calling convention])
-  fi
+  PHP_FFI_CHECK_DECL([FFI_FASTCALL])
+  PHP_FFI_CHECK_DECL([FFI_THISCALL])
+  PHP_FFI_CHECK_DECL([FFI_STDCALL])
+  PHP_FFI_CHECK_DECL([FFI_PASCAL])
+  PHP_FFI_CHECK_DECL([FFI_REGISTER])
+  PHP_FFI_CHECK_DECL([FFI_MS_CDECL])
+  PHP_FFI_CHECK_DECL([FFI_SYSV])
 
   PHP_NEW_EXTENSION(ffi, ffi.c ffi_parser.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(FFI_SHARED_LIBADD)

--- a/ext/ffi/config.w32
+++ b/ext/ffi/config.w32
@@ -12,6 +12,7 @@ if (PHP_FFI != 'no') {
 		    AC_DEFINE('HAVE_FFI_MS_CDECL', 1 ,'libffi supports ms_cdecl calling convention');
 		    AC_DEFINE('HAVE_FFI_SYSV', 1 ,'libffi supports sysv calling convention');
 		}
+		// Available in https://github.com/winlibs/libffi.
 		if (GREP_HEADER("ffitarget.h", "FFI_VECTORCALL_PARTIAL", PHP_PHP_BUILD + "\\include")) {
 			AC_DEFINE('HAVE_FFI_VECTORCALL_PARTIAL', 1 ,'libffi partially supports vectorcall calling convention');
 		}


### PR DESCRIPTION
The FFI_* calling conventions are enum constants and AC_CHECK_DECL(S) can be used to check for their existence in the ffi.h header. This simplifes the checks and adds a simple AC_CHECK_DECL macro wrapper which defines the HAVE_FFI_* belonging symbols.