### PR TITLE
Find and link network library as needed with AC_SEARCH_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,6 +375,9 @@ esac
 dnl Solaris/Illumos for process mapping.
 AC_SEARCH_LIBS([Pgrab], [proc])
 
+dnl Haiku does not have network api in libc.
+AC_SEARCH_LIBS([setsockopt], [network])
+
 dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
@@ -643,9 +646,6 @@ AX_FUNC_WHICH_GETHOSTBYNAME_R
 dnl Some systems (Solaris 10) do not have nanosleep in libc.
 AC_CHECK_FUNCS([nanosleep],,
   [AC_SEARCH_LIBS([nanosleep], [rt], [AC_DEFINE([HAVE_NANOSLEEP], [1])])])
-
-dnl Haiku does not have network api in libc.
-PHP_CHECK_FUNC_LIB(setsockopt, network)
 
 dnl Check for getaddrinfo, should be a better way, but... Also check for working
 dnl getaddrinfo.


### PR DESCRIPTION
This prepends -lnetwork as needed (Haiku) whether linker sees the setsockopt function and avoids defining redundant symbols, such as HAVE_LIBNETWORK and HAVE_SETSOCKOPT.