### PR TITLE
ext/gettext: dcgettext/dcngettext sigabrt on macOs.

### DIFF
--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -23,6 +23,7 @@
 #ifdef HAVE_LIBINTL
 
 #include <stdio.h>
+#include <locale.h>
 #include "ext/standard/info.h"
 #include "php_gettext.h"
 #include "gettext_arginfo.h"
@@ -58,6 +59,12 @@ ZEND_GET_MODULE(php_gettext)
 #define PHP_GETTEXT_LENGTH_CHECK(_arg_num, check_len) \
 	if (UNEXPECTED(check_len > PHP_GETTEXT_MAX_MSGID_LENGTH)) { \
 		zend_argument_value_error(_arg_num, "is too long"); \
+		RETURN_THROWS(); \
+	}
+
+#define PHP_DCGETTEXT_CATEGORY_CHECK(_arg_num, category) \
+	if (category == LC_ALL) { \
+		zend_argument_value_error(_arg_num, "cannot be LC_ALL"); \
 		RETURN_THROWS(); \
 	}
 
@@ -146,6 +153,7 @@ PHP_FUNCTION(dcgettext)
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
 	PHP_GETTEXT_LENGTH_CHECK(2, ZSTR_LEN(msgid))
+	PHP_DCGETTEXT_CATEGORY_CHECK(3, category)
 
 	msgstr = dcgettext(ZSTR_VAL(domain), ZSTR_VAL(msgid), category);
 
@@ -260,6 +268,7 @@ PHP_FUNCTION(dcngettext)
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, domain_len)
 	PHP_GETTEXT_LENGTH_CHECK(2, msgid1_len)
 	PHP_GETTEXT_LENGTH_CHECK(3, msgid2_len)
+	PHP_DCGETTEXT_CATEGORY_CHECK(5, category)
 
 	msgstr = dcngettext(domain, msgid1, msgid2, count, category);
 

--- a/ext/gettext/tests/dcgettext_lcall.phpt
+++ b/ext/gettext/tests/dcgettext_lcall.phpt
@@ -1,0 +1,21 @@
+--TEST--
+dcgettext with LC_ALL is undefined behavior.
+--EXTENSIONS--
+gettext
+--FILE--
+<?php
+try {
+	dcgettext('dngettextTest', 'item', LC_ALL);
+} catch (ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	dcngettext('dngettextTest', 'item', 'item2', 1, LC_ALL);
+} catch (ValueError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECTF--
+dcgettext(): Argument #3 ($category) cannot be LC_ALL
+dcngettext(): Argument #5 ($category) cannot be LC_ALL

--- a/ext/gettext/tests/dcngettext.phpt
+++ b/ext/gettext/tests/dcngettext.phpt
@@ -11,10 +11,10 @@ if (!function_exists("dcngettext")) die("skip dcngettext() doesn't exist");
 
 var_dump(dcngettext(1,1,1,1,1));
 var_dump(dcngettext("test","test","test",1,1));
-var_dump(dcngettext("test","test","test",0,0));
+var_dump(dcngettext("test","test","test",0,1));
 var_dump(dcngettext("test","test","test",-1,-1));
 var_dump(dcngettext("","","",1,1));
-var_dump(dcngettext("","","",0,0));
+var_dump(dcngettext("","","",0,1));
 
 echo "Done\n";
 ?>


### PR DESCRIPTION
the man page states `the locale facet is determined by the category argument,  which  should  be
 one of the LC_xxx constants defined in the <locale.h> header, excluding LC_ALL`,
since the 0.22.5 release, sanity checks had been strenghtened leading to an abort with the Zend/tests/arginfo_zpp_mismatch.phpt test setting the category to 0 which is LC_ALL on macOs.