### PR TITLE
Optimize strpbrk()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -6144,7 +6144,6 @@ PHP_FUNCTION(str_split)
 PHP_FUNCTION(strpbrk)
 {
 	zend_string *haystack, *char_list;
-	const char *haystack_ptr, *cl_ptr;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR(haystack)
@@ -6156,12 +6155,14 @@ PHP_FUNCTION(strpbrk)
 		RETURN_THROWS();
 	}
 
-	for (haystack_ptr = ZSTR_VAL(haystack); haystack_ptr < (ZSTR_VAL(haystack) + ZSTR_LEN(haystack)); ++haystack_ptr) {
-		for (cl_ptr = ZSTR_VAL(char_list); cl_ptr < (ZSTR_VAL(char_list) + ZSTR_LEN(char_list)); ++cl_ptr) {
-			if (*cl_ptr == *haystack_ptr) {
-				RETURN_STRINGL(haystack_ptr, (ZSTR_VAL(haystack) + ZSTR_LEN(haystack) - haystack_ptr));
-			}
-		}
+	size_t shift = php_strcspn(
+		ZSTR_VAL(haystack),
+		ZSTR_VAL(char_list),
+		ZSTR_VAL(haystack) + ZSTR_LEN(haystack),
+		ZSTR_VAL(char_list) + ZSTR_LEN(char_list)
+	);
+	if (shift < ZSTR_LEN(haystack)) {
+		RETURN_STRINGL(ZSTR_VAL(haystack) + shift, ZSTR_LEN(haystack) - shift);
 	}
 
 	RETURN_FALSE;


### PR DESCRIPTION
strpbrk() can be implemented using strcspn(). As we have an optimized strcspn() implementation, we can do better than a nested for-loop. This is especially beneficial when the second argument contains more than one character.

When testing the following PHP code, I compared the run time in ms:
```php
$in = str_repeat('a', (int)$argv[1]) . ' ';
for ($i = 0; $i < 3000**2; $i++) {
    strpbrk($in, ' ');
}
```
![image](https://github.com/php/php-src/assets/7771979/74c956f5-c72b-48aa-a80d-9eb4dcc07f20)

Similarly, I have a test variant with multiple characters in the second argument:
```php
$in = str_repeat('a', (int)$argv[1]) . ' ';
for ($i = 0; $i < 3000**2; $i++) {
    strpbrk($in, 'qwerty ');
}
```
![image](https://github.com/php/php-src/assets/7771979/71d649b1-4e6f-4fcc-af25-20f65164fd1e)
