### PR TITLE
Sync logical operators in shell scripting code

### DIFF
--- a/TSRM/threads.m4
+++ b/TSRM/threads.m4
@@ -126,7 +126,7 @@ if test "$pthreads_working" != "yes"; then
 fi
 ])
 
-if test "x$ac_cv_pthreads_cflags" != "x" -o "x$ac_cv_pthreads_lib" != "x"; then
+if test "x$ac_cv_pthreads_cflags" != "x" || test "x$ac_cv_pthreads_lib" != "x"; then
   pthreads_working="yes"
 fi
 ])

--- a/build/php.m4
+++ b/build/php.m4
@@ -2148,7 +2148,7 @@ crypt_r("passwd", "hash", &buffer);
   if test "$php_cv_crypt_r_style" = "cryptd"; then
     AC_DEFINE(CRYPT_R_CRYPTD, 1, [Define if crypt_r has uses CRYPTD])
   fi
-  if test "$php_cv_crypt_r_style" = "struct_crypt_data" -o "$php_cv_crypt_r_style" = "struct_crypt_data_gnu_source"; then
+  if test "$php_cv_crypt_r_style" = "struct_crypt_data" || test "$php_cv_crypt_r_style" = "struct_crypt_data_gnu_source"; then
     AC_DEFINE(CRYPT_R_STRUCT_CRYPT_DATA, 1, [Define if crypt_r uses struct crypt_data])
   fi
   if test "$php_cv_crypt_r_style" = "struct_crypt_data_gnu_source"; then

--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ PHP_TEST_WRITE_STDOUT
 
 dnl Check for /usr/pkg/{lib,include} which is where NetBSD puts binary and
 dnl source packages. This should be harmless on other OSs.
-if test -d /usr/pkg/include -a -d /usr/pkg/lib ; then
+if test -d /usr/pkg/include && test -d /usr/pkg/lib; then
    CPPFLAGS="$CPPFLAGS -I/usr/pkg/include"
    LDFLAGS="$LDFLAGS -L/usr/pkg/lib"
 fi

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -46,8 +46,8 @@ AC_DEFUN([PHP_ODBC_FIND_SOLID_LIBS],[
   fi
 
 dnl Check for the library files, and setup the ODBC_LIBS path.
-if test ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so -a \
-  ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a; then
+if test ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so && \
+  test ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a; then
   dnl we have an error and should bail out, as we can't find the libs!
   echo ""
   echo "*********************************************************************"
@@ -395,7 +395,7 @@ PHP_ARG_WITH([dbmaker],,
       dnl check DBMaker version (from 5.0 to 2.0)
       DBMAKER_VERSION=5.0
 
-      while test ! -d $DBMAKER_HOME/$DBMAKER_VERSION -a "$DBMAKER_VERSION" != "2.9"; do
+      while test ! -d $DBMAKER_HOME/$DBMAKER_VERSION && test "$DBMAKER_VERSION" != "2.9"; do
         DM_VER=`echo $DBMAKER_VERSION | sed -e 's/\.//' | $AWK '{ print $1-1;}'`
         MAJOR_V=`echo $DM_VER | $AWK '{ print $1/10; }'  | $AWK -F. '{ print $1; }'`
         MINOR_V=`echo $DM_VER | $AWK '{ print $1%10; }'`

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -56,7 +56,7 @@ if test "$PHP_PDO_PGSQL" != "no"; then
     AC_MSG_ERROR(Cannot find libpq.so. Please specify correct PostgreSQL installation path)
   fi
 
-  if test -z "$PGSQL_INCLUDE" -a -z "$PGSQL_LIBDIR" ; then
+  if test -z "$PGSQL_INCLUDE" && test -z "$PGSQL_LIBDIR"; then
     AC_MSG_ERROR([Unable to find libpq anywhere under $PGSQL_SEARCH_PATHS])
   fi
 

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -54,7 +54,7 @@ if test "$PHP_PGSQL" != "no"; then
     AC_MSG_ERROR(Cannot find libpq.so. Please specify correct PostgreSQL installation path)
   fi
 
-  if test -z "$PGSQL_INCLUDE" -a -z "$PGSQL_LIBDIR" ; then
+  if test -z "$PGSQL_INCLUDE" && test -z "$PGSQL_LIBDIR"; then
     AC_MSG_ERROR([Unable to find libpq anywhere under $PGSQL_SEARCH_PATHS])
   fi
 

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -577,13 +577,13 @@ if test "$PHP_FPM" != "no"; then
   PHP_SUBST_OLD(php_fpm_systemd)
   AC_DEFINE_UNQUOTED(PHP_FPM_SYSTEMD, "$php_fpm_systemd", [fpm systemd service type])
 
-  if test -z "$PHP_FPM_USER" -o "$PHP_FPM_USER" = "yes" -o "$PHP_FPM_USER" = "no"; then
+  if test -z "$PHP_FPM_USER" || test "$PHP_FPM_USER" = "yes" || test "$PHP_FPM_USER" = "no"; then
     php_fpm_user="nobody"
   else
     php_fpm_user="$PHP_FPM_USER"
   fi
 
-  if test -z "$PHP_FPM_GROUP" -o "$PHP_FPM_GROUP" = "yes" -o "$PHP_FPM_GROUP" = "no"; then
+  if test -z "$PHP_FPM_GROUP" || test "$PHP_FPM_GROUP" = "yes" || test "$PHP_FPM_GROUP" = "no"; then
     php_fpm_group="nobody"
   else
     php_fpm_group="$PHP_FPM_GROUP"

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -34,7 +34,7 @@ if test "$PHP_PHPDBG" != "no"; then
 
   AC_MSG_CHECKING([for phpdbg and readline integration])
   if test "$PHP_PHPDBG_READLINE" = "yes"; then
-    if test "$PHP_READLINE" != "no" -o  "$PHP_LIBEDIT" != "no"; then
+    if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then
   	  AC_DEFINE(HAVE_PHPDBG_READLINE, 1, [ ])
   	  PHPDBG_EXTRA_LIBS="$PHP_READLINE_LIBS"
   	  AC_MSG_RESULT([ok])


### PR DESCRIPTION
This updates the obsolescent `-a` and `-o` binary primaries to `&&` and `||`.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html