### PR TITLE
Add missing memfd_create Autoconf check for bundled pcre2lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -599,6 +599,7 @@ glob \
 localtime_r \
 lchown \
 memcntl \
+memfd_create \
 memmove \
 mkstemp \
 mmap \

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -103,7 +103,7 @@ if test "$PHP_OPCACHE" != "no"; then
     fi
   fi
 
-  AC_CHECK_FUNCS([mprotect memfd_create shm_create_largepage])
+  AC_CHECK_FUNCS([mprotect shm_create_largepage])
 
   AC_MSG_CHECKING(for sysvipc shared memory support)
   AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
This moves memfd_create (HAVE_MEMFD_CREATE) to configure.ac. Since ext/pcre is always enabled and check can be done in this case for ext/pcre and ext/opcache at once.