### PR TITLE
Check struct stat.st_blocks with AC_CHECK_MEMBERS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -111,6 +111,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_BSD_ICONV has been removed.
    - Symbol ZEND_FIBER_ASM has been removed.
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
+   - Symbol HAVE_ST_BLOCKS has been removed (use HAVE_STRUCT_STAT_ST_BLOCKS).
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/configure.ac
+++ b/configure.ac
@@ -535,11 +535,7 @@ fi
 
 dnl Check for structure members.
 AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[#include <time.h>])
-AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev])
-dnl AC_STRUCT_ST_BLOCKS will screw QNX because fileblocks.o does not exist.
-if test "`uname -s 2>/dev/null`" != "QNX"; then
-  AC_STRUCT_ST_BLOCKS
-fi
+AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_blocks, struct stat.st_rdev])
 
 dnl Checks for types.
 AC_TYPE_UID_T


### PR DESCRIPTION
The AC_STRUCT_ST_BLOCKS expects fileblocks object to be compiled using AC_LIBOBJ in case stat.st_blocks is missing on some system. This can be simplified with the usual AC_CHECK_MEMBERS since PHP is using the stat.st_blocks (and stat.st_blksize) conditionally.

This also removes the obsolete HAVE_ST_BLOCKS symbol.

https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/types.m4?h=v2.72#n1055