### PR TITLE
Use `ITIMER_REAL` for timeout handling on Apple Silicon systems

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1523,7 +1523,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
 # if defined(__CYGWIN__) || defined(__PASE__) || (defined(__aarch64__) && defined(__APPLE__))
-            // ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14
+			// ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}
 		signo = SIGALRM;
@@ -1587,7 +1587,7 @@ void zend_unset_timeout(void) /* {{{ */
 
 		no_timeout.it_value.tv_sec = no_timeout.it_value.tv_usec = no_timeout.it_interval.tv_sec = no_timeout.it_interval.tv_usec = 0;
 
-# if defined(__CYGWIN__) || defined(__PASE__)
+# if defined(__CYGWIN__) || defined(__PASE__) || (defined(__aarch64__) && defined(__APPLE__))
 		setitimer(ITIMER_REAL, &no_timeout, NULL);
 # else
 		setitimer(ITIMER_PROF, &no_timeout, NULL);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1523,7 +1523,8 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
 # if defined(__CYGWIN__) || defined(__PASE__) || (defined(__aarch64__) && defined(__APPLE__))
-			// ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14
+			// ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14. The SIGALRM signal is sent way too early
+			// when the process opens sockets.
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}
 		signo = SIGALRM;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1522,7 +1522,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_sec = seconds;
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
-# if defined(__CYGWIN__) || defined(__PASE__) || defined(__aarch64__)
+# if defined(__CYGWIN__) || defined(__PASE__) || (defined(__aarch64__) && defined(__APPLE__))
             // ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1522,7 +1522,8 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_sec = seconds;
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
-# if defined(__CYGWIN__) || defined(__PASE__)
+# if defined(__CYGWIN__) || defined(__PASE__) || defined(__aarch64__)
+            // ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}
 		signo = SIGALRM;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1523,7 +1523,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
 # if defined(__CYGWIN__) || defined(__PASE__) || (defined(__aarch64__) && defined(__APPLE__))
-			// ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14. The SIGALRM signal is sent way too early
+			// ITIMER_PROF is broken in Apple Silicon system with MacOS >= 14. The SIGPROF signal is sent way too early
 			// when the process opens sockets.
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}


### PR DESCRIPTION
This closes #12814