### PR TITLE
ext/gettext: bind_textdomain_codeset should not accept empty domains.

### DIFF
--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -171,7 +171,7 @@ PHP_FUNCTION(bindtextdomain)
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, domain_len)
 
-	if (domain[0] == '\0') {
+	if (!domain_len) {
 		zend_argument_value_error(1, "cannot be empty");
 		RETURN_THROWS();
 	}
@@ -282,6 +282,11 @@ PHP_FUNCTION(bind_textdomain_codeset)
 	}
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, domain_len)
+
+	if (!domain_len) {
+		zend_argument_value_error(1, "cannot be empty");
+		RETURN_THROWS();
+	}
 
 	retval = bind_textdomain_codeset(domain, codeset);
 

--- a/ext/gettext/tests/gettext_bind_textdomain_codeset-retval.phpt
+++ b/ext/gettext/tests/gettext_bind_textdomain_codeset-retval.phpt
@@ -4,13 +4,24 @@ test if bind_textdomain_codeset() returns correct value
 gettext
 --FILE--
 <?php
-    var_dump(bind_textdomain_codeset(false,false));
+    try {
+    	bind_textdomain_codeset(false,false);
+    } catch (ValueError $e) {
+	    echo $e->getMessage() . PHP_EOL;
+    }
+
+    try {
+    	bind_textdomain_codeset("", "UTF-8");
+    } catch (ValueError $e) {
+	    echo $e->getMessage() . PHP_EOL;
+    }
     var_dump(bind_textdomain_codeset('messages', "UTF-8"));
 
     echo "Done\n";
 ?>
 --EXPECT--
-bool(false)
+bind_textdomain_codeset(): Argument #1 ($domain) cannot be empty
+bind_textdomain_codeset(): Argument #1 ($domain) cannot be empty
 string(5) "UTF-8"
 Done
 --CREDITS--


### PR DESCRIPTION
the man page specifies that for bind_textdomain_codeset, like bindtextdomain, the domain should not be an empty string.