### PR TITLE
Fix GC buffer unnecessarily growing up to GC_MAX_BUF_SIZE when scanning WeakMaps

### DIFF
--- a/Zend/tests/gh13569.phpt
+++ b/Zend/tests/gh13569.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-13569: GC buffer grows up to GC_MAX_BUF_SIZE when scanning WeakMaps
+--FILE--
+<?php
+
+$wm = new WeakMap();
+$objs = [];
+for ($i = 0; $i < 30_000; $i++) {
+    $objs[] = $obj = new stdClass;
+    $wm[$obj] = $obj;
+}
+
+gc_collect_cycles();
+
+$tmp = $wm;
+$tmp = null;
+
+gc_collect_cycles();
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -718,7 +718,7 @@ static void ZEND_FASTCALL gc_extra_root(zend_refcounted *ref)
 
 	if (EXPECTED(GC_HAS_UNUSED())) {
 		idx = GC_FETCH_UNUSED();
-	} else if (EXPECTED(GC_HAS_NEXT_UNUSED_UNDER_THRESHOLD())) {
+	} else if (EXPECTED(GC_HAS_NEXT_UNUSED())) {
 		idx = GC_FETCH_NEXT_UNUSED();
 	} else {
 		gc_grow_root_buffer();


### PR DESCRIPTION
This should fix #13569.

This is caused by a wrong condition in `gc_extra_root()` causing it to grow the root buffer when it's not necessary: It grows the buffer when the `first_unused` slot is higher or equal to `gc_threshold`. Additionally, this condition applies repeatedly because the threshold is (legitimately) not updated in this case, thus the buffer size quickly grows towards `GC_MAX_BUF_SIZE`, after which an `E_WARNING` is triggered and the GC is disabled.

The fix is to compare `first_unused` to `buf_size` instead.