### PR TITLE
ext/curl: Change UPGRADING file entry for curl_version-feature_list to correct section

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -165,6 +165,11 @@ PHP 8.4 UPGRADE NOTES
     requests in non-POST HTTP requests.
     RFC: https://wiki.php.net/rfc/rfc1867-non-post
 
+- Curl:
+  . curl_version() returns an additional feature_list value, which is an
+    associative array of all known Curl features, and whether they are
+    supported (true) or not (false).
+
 - Date:
   . Added static methods
     DateTime[Immutable]::createFromTimestamp(int|float $timestamp): static.
@@ -264,9 +269,6 @@ PHP 8.4 UPGRADE NOTES
 
 - Curl:
   . The CURLOPT_BINARYTRANSFER constant is deprecated.
-  . curl_version() returns an additional feature_list value, which is an
-    associative array of all known Curl features, and whether they are
-    supported (true) or not (false).
 
 - Date:
   . Calling DatePeriod::__construct(string $isostr, int $options = 0) is


### PR DESCRIPTION
Fixes mistakenly put `UPGRADING` note (in #13439) to the correct section (from Deprecated Functionality to New Features).