### PR TITLE
random: Embed the Mt19937 and CombinedLCG state within the module globals

### DIFF
--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -203,11 +203,11 @@ PHP_MSHUTDOWN_FUNCTION(random);
 PHP_RINIT_FUNCTION(random);
 
 ZEND_BEGIN_MODULE_GLOBALS(random)
-	php_random_status_state_combinedlcg *combined_lcg;
-	bool combined_lcg_seeded;
-	php_random_status_state_mt19937 *mt19937;
-	bool mt19937_seeded;
 	int random_fd;
+	bool combined_lcg_seeded;
+	bool mt19937_seeded;
+	php_random_status_state_combinedlcg combined_lcg;
+	php_random_status_state_mt19937 mt19937;
 ZEND_END_MODULE_GLOBALS(random)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(random)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -309,7 +309,7 @@ PHPAPI const php_random_algo *php_random_default_algo(void)
 /* {{{ php_random_default_status */
 PHPAPI void *php_random_default_status(void)
 {
-	php_random_status_state_mt19937 *state = RANDOM_G(mt19937);
+	php_random_status_state_mt19937 *state = &RANDOM_G(mt19937);
 
 	if (!RANDOM_G(mt19937_seeded)) {
 		php_random_mt19937_seed_default(state);
@@ -390,7 +390,7 @@ PHPAPI bool php_random_hex2bin_le(zend_string *hexstr, void *dest)
 /* {{{ php_combined_lcg */
 PHPAPI double php_combined_lcg(void)
 {
-	php_random_status_state_combinedlcg *state = RANDOM_G(combined_lcg);
+	php_random_status_state_combinedlcg *state = &RANDOM_G(combined_lcg);
 
 	if (!RANDOM_G(combined_lcg_seeded)) {
 		php_random_combinedlcg_seed_default(state);
@@ -472,7 +472,7 @@ PHP_FUNCTION(mt_srand)
 	zend_long seed = 0;
 	bool seed_is_null = true;
 	zend_long mode = MT_RAND_MT19937;
-	php_random_status_state_mt19937 *state = RANDOM_G(mt19937);
+	php_random_status_state_mt19937 *state = &RANDOM_G(mt19937);
 
 	ZEND_PARSE_PARAMETERS_START(0, 2)
 		Z_PARAM_OPTIONAL
@@ -615,12 +615,6 @@ PHP_FUNCTION(random_int)
 static PHP_GINIT_FUNCTION(random)
 {
 	random_globals->random_fd = -1;
-
-	random_globals->combined_lcg = php_random_status_alloc(&php_random_algo_combinedlcg, true);
-	random_globals->combined_lcg_seeded = false;
-
-	random_globals->mt19937 = php_random_status_alloc(&php_random_algo_mt19937, true);
-	random_globals->mt19937_seeded = false;
 }
 /* }}} */
 
@@ -631,12 +625,6 @@ static PHP_GSHUTDOWN_FUNCTION(random)
 		close(random_globals->random_fd);
 		random_globals->random_fd = -1;
 	}
-
-	php_random_status_free(random_globals->combined_lcg, true);
-	random_globals->combined_lcg = NULL;
-
-	php_random_status_free(random_globals->mt19937, true);
-	random_globals->mt19937 = NULL;
 }
 /* }}} */
 


### PR DESCRIPTION
Somewhat related to #13577

------------

These are always dynamically allocated in GINIT, thus always take up memory. By embedding them here we can avoid the dynamic allocation and additional pointer indirection accessing them.

The test script:

    <?php
    for ($i = 0; $i < 9999999; $i++) mt_rand(1, 100);

Appears to run slightly faster with this change applied: Before this change it always ran in just over 3 seconds, after this change I was also seeing times below 3 seconds. Howver results are too close and too jittery to state this performance improvement as a fact.