### PR TITLE
ext/xmlreader: Add class constant types to stub

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -481,6 +481,9 @@ PHP 8.4 UPGRADE NOTES
 - Sqlite:
   . The class constants are typed now.
 
+- XMLReader:
+  . The class constants are typed now.
+
 - XSL:
   . The typed properties XSLTProcessor::$cloneDocument and
     XSLTProcessor::$doXInclude are now declared.

--- a/ext/xmlreader/php_xmlreader.stub.php
+++ b/ext/xmlreader/php_xmlreader.stub.php
@@ -7,118 +7,96 @@ class XMLReader
     /* Constants for NodeType - cannot define common types to share with dom as there are differences in these types */
 
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_NONE
      */
-    public const NONE = UNKNOWN;
+    public const int NONE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_ELEMENT
      */
-    public const ELEMENT = UNKNOWN;
+    public const int ELEMENT = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_ATTRIBUTE
      */
-    public const ATTRIBUTE = UNKNOWN;
+    public const int ATTRIBUTE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_TEXT
      */
-    public const TEXT = UNKNOWN;
+    public const int TEXT = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_CDATA
      */
-    public const CDATA = UNKNOWN;
+    public const int CDATA = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_ENTITY_REFERENCE
      */
-    public const ENTITY_REF = UNKNOWN;
+    public const int ENTITY_REF = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_ENTITY
      */
-    public const ENTITY = UNKNOWN;
+    public const int ENTITY = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_PROCESSING_INSTRUCTION
      */
-    public const PI = UNKNOWN;
+    public const int PI = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_COMMENT
      */
-    public const COMMENT = UNKNOWN;
+    public const int COMMENT = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_DOCUMENT
      */
-    public const DOC = UNKNOWN;
+    public const int DOC = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_DOCUMENT_TYPE
      */
-    public const DOC_TYPE = UNKNOWN;
+    public const int DOC_TYPE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_DOCUMENT_FRAGMENT
      */
-    public const DOC_FRAGMENT = UNKNOWN;
+    public const int DOC_FRAGMENT = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_NOTATION
      */
-    public const NOTATION = UNKNOWN;
+    public const int NOTATION = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_WHITESPACE
      */
-    public const WHITESPACE = UNKNOWN;
+    public const int WHITESPACE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_SIGNIFICANT_WHITESPACE
      */
-    public const SIGNIFICANT_WHITESPACE = UNKNOWN;
+    public const int SIGNIFICANT_WHITESPACE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_END_ELEMENT
      */
-    public const END_ELEMENT = UNKNOWN;
+    public const int END_ELEMENT = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_END_ENTITY
      */
-    public const END_ENTITY = UNKNOWN;
+    public const int END_ENTITY = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_READER_TYPE_XML_DECLARATION
      */
-    public const XML_DECLARATION = UNKNOWN;
+    public const int XML_DECLARATION = UNKNOWN;
 
     /* Constants for Parser options */
 
     /**
-     * @var int
      * @cvalue XML_PARSER_LOADDTD
      */
-    public const LOADDTD = UNKNOWN;
+    public const int LOADDTD = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_PARSER_DEFAULTATTRS
      */
-    public const DEFAULTATTRS = UNKNOWN;
+    public const int DEFAULTATTRS = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_PARSER_VALIDATE
      */
-    public const VALIDATE = UNKNOWN;
+    public const int VALIDATE = UNKNOWN;
     /**
-     * @var int
      * @cvalue XML_PARSER_SUBST_ENTITIES
      */
-    public const SUBST_ENTITIES = UNKNOWN;
+    public const int SUBST_ENTITIES = UNKNOWN;
 
 
     public int $attributeCount;

--- a/ext/xmlreader/php_xmlreader_arginfo.h
+++ b/ext/xmlreader/php_xmlreader_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4751b68b857ffbf53cab6d1aa88fe8f6120d4fc6 */
+ * Stub hash: 6284a7b9f4477a9c0b2dd268d6229653bf66297c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLReader_close, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -156,133 +156,133 @@ static zend_class_entry *register_class_XMLReader(void)
 	zval const_NONE_value;
 	ZVAL_LONG(&const_NONE_value, XML_READER_TYPE_NONE);
 	zend_string *const_NONE_name = zend_string_init_interned("NONE", sizeof("NONE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_NONE_name, &const_NONE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_NONE_name, &const_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NONE_name);
 
 	zval const_ELEMENT_value;
 	ZVAL_LONG(&const_ELEMENT_value, XML_READER_TYPE_ELEMENT);
 	zend_string *const_ELEMENT_name = zend_string_init_interned("ELEMENT", sizeof("ELEMENT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ELEMENT_name, &const_ELEMENT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ELEMENT_name, &const_ELEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ELEMENT_name);
 
 	zval const_ATTRIBUTE_value;
 	ZVAL_LONG(&const_ATTRIBUTE_value, XML_READER_TYPE_ATTRIBUTE);
 	zend_string *const_ATTRIBUTE_name = zend_string_init_interned("ATTRIBUTE", sizeof("ATTRIBUTE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTRIBUTE_name, &const_ATTRIBUTE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTRIBUTE_name, &const_ATTRIBUTE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTRIBUTE_name);
 
 	zval const_TEXT_value;
 	ZVAL_LONG(&const_TEXT_value, XML_READER_TYPE_TEXT);
 	zend_string *const_TEXT_name = zend_string_init_interned("TEXT", sizeof("TEXT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TEXT_name, &const_TEXT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TEXT_name, &const_TEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TEXT_name);
 
 	zval const_CDATA_value;
 	ZVAL_LONG(&const_CDATA_value, XML_READER_TYPE_CDATA);
 	zend_string *const_CDATA_name = zend_string_init_interned("CDATA", sizeof("CDATA") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CDATA_name, &const_CDATA_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CDATA_name, &const_CDATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CDATA_name);
 
 	zval const_ENTITY_REF_value;
 	ZVAL_LONG(&const_ENTITY_REF_value, XML_READER_TYPE_ENTITY_REFERENCE);
 	zend_string *const_ENTITY_REF_name = zend_string_init_interned("ENTITY_REF", sizeof("ENTITY_REF") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ENTITY_REF_name, &const_ENTITY_REF_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ENTITY_REF_name, &const_ENTITY_REF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ENTITY_REF_name);
 
 	zval const_ENTITY_value;
 	ZVAL_LONG(&const_ENTITY_value, XML_READER_TYPE_ENTITY);
 	zend_string *const_ENTITY_name = zend_string_init_interned("ENTITY", sizeof("ENTITY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ENTITY_name, &const_ENTITY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ENTITY_name, &const_ENTITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ENTITY_name);
 
 	zval const_PI_value;
 	ZVAL_LONG(&const_PI_value, XML_READER_TYPE_PROCESSING_INSTRUCTION);
 	zend_string *const_PI_name = zend_string_init_interned("PI", sizeof("PI") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_PI_name, &const_PI_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_PI_name, &const_PI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PI_name);
 
 	zval const_COMMENT_value;
 	ZVAL_LONG(&const_COMMENT_value, XML_READER_TYPE_COMMENT);
 	zend_string *const_COMMENT_name = zend_string_init_interned("COMMENT", sizeof("COMMENT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_COMMENT_name, &const_COMMENT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_COMMENT_name, &const_COMMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_COMMENT_name);
 
 	zval const_DOC_value;
 	ZVAL_LONG(&const_DOC_value, XML_READER_TYPE_DOCUMENT);
 	zend_string *const_DOC_name = zend_string_init_interned("DOC", sizeof("DOC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_DOC_name, &const_DOC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_DOC_name, &const_DOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_name);
 
 	zval const_DOC_TYPE_value;
 	ZVAL_LONG(&const_DOC_TYPE_value, XML_READER_TYPE_DOCUMENT_TYPE);
 	zend_string *const_DOC_TYPE_name = zend_string_init_interned("DOC_TYPE", sizeof("DOC_TYPE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_DOC_TYPE_name, &const_DOC_TYPE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_DOC_TYPE_name, &const_DOC_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_TYPE_name);
 
 	zval const_DOC_FRAGMENT_value;
 	ZVAL_LONG(&const_DOC_FRAGMENT_value, XML_READER_TYPE_DOCUMENT_FRAGMENT);
 	zend_string *const_DOC_FRAGMENT_name = zend_string_init_interned("DOC_FRAGMENT", sizeof("DOC_FRAGMENT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_DOC_FRAGMENT_name, &const_DOC_FRAGMENT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_DOC_FRAGMENT_name, &const_DOC_FRAGMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_FRAGMENT_name);
 
 	zval const_NOTATION_value;
 	ZVAL_LONG(&const_NOTATION_value, XML_READER_TYPE_NOTATION);
 	zend_string *const_NOTATION_name = zend_string_init_interned("NOTATION", sizeof("NOTATION") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_NOTATION_name, &const_NOTATION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_NOTATION_name, &const_NOTATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NOTATION_name);
 
 	zval const_WHITESPACE_value;
 	ZVAL_LONG(&const_WHITESPACE_value, XML_READER_TYPE_WHITESPACE);
 	zend_string *const_WHITESPACE_name = zend_string_init_interned("WHITESPACE", sizeof("WHITESPACE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_WHITESPACE_name, &const_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_WHITESPACE_name, &const_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WHITESPACE_name);
 
 	zval const_SIGNIFICANT_WHITESPACE_value;
 	ZVAL_LONG(&const_SIGNIFICANT_WHITESPACE_value, XML_READER_TYPE_SIGNIFICANT_WHITESPACE);
 	zend_string *const_SIGNIFICANT_WHITESPACE_name = zend_string_init_interned("SIGNIFICANT_WHITESPACE", sizeof("SIGNIFICANT_WHITESPACE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_SIGNIFICANT_WHITESPACE_name, &const_SIGNIFICANT_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_SIGNIFICANT_WHITESPACE_name, &const_SIGNIFICANT_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SIGNIFICANT_WHITESPACE_name);
 
 	zval const_END_ELEMENT_value;
 	ZVAL_LONG(&const_END_ELEMENT_value, XML_READER_TYPE_END_ELEMENT);
 	zend_string *const_END_ELEMENT_name = zend_string_init_interned("END_ELEMENT", sizeof("END_ELEMENT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_END_ELEMENT_name, &const_END_ELEMENT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_END_ELEMENT_name, &const_END_ELEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_END_ELEMENT_name);
 
 	zval const_END_ENTITY_value;
 	ZVAL_LONG(&const_END_ENTITY_value, XML_READER_TYPE_END_ENTITY);
 	zend_string *const_END_ENTITY_name = zend_string_init_interned("END_ENTITY", sizeof("END_ENTITY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_END_ENTITY_name, &const_END_ENTITY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_END_ENTITY_name, &const_END_ENTITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_END_ENTITY_name);
 
 	zval const_XML_DECLARATION_value;
 	ZVAL_LONG(&const_XML_DECLARATION_value, XML_READER_TYPE_XML_DECLARATION);
 	zend_string *const_XML_DECLARATION_name = zend_string_init_interned("XML_DECLARATION", sizeof("XML_DECLARATION") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_XML_DECLARATION_name, &const_XML_DECLARATION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_XML_DECLARATION_name, &const_XML_DECLARATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_XML_DECLARATION_name);
 
 	zval const_LOADDTD_value;
 	ZVAL_LONG(&const_LOADDTD_value, XML_PARSER_LOADDTD);
 	zend_string *const_LOADDTD_name = zend_string_init_interned("LOADDTD", sizeof("LOADDTD") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LOADDTD_name, &const_LOADDTD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_LOADDTD_name, &const_LOADDTD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LOADDTD_name);
 
 	zval const_DEFAULTATTRS_value;
 	ZVAL_LONG(&const_DEFAULTATTRS_value, XML_PARSER_DEFAULTATTRS);
 	zend_string *const_DEFAULTATTRS_name = zend_string_init_interned("DEFAULTATTRS", sizeof("DEFAULTATTRS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_DEFAULTATTRS_name, &const_DEFAULTATTRS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_DEFAULTATTRS_name, &const_DEFAULTATTRS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULTATTRS_name);
 
 	zval const_VALIDATE_value;
 	ZVAL_LONG(&const_VALIDATE_value, XML_PARSER_VALIDATE);
 	zend_string *const_VALIDATE_name = zend_string_init_interned("VALIDATE", sizeof("VALIDATE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_VALIDATE_name, &const_VALIDATE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_VALIDATE_name, &const_VALIDATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VALIDATE_name);
 
 	zval const_SUBST_ENTITIES_value;
 	ZVAL_LONG(&const_SUBST_ENTITIES_value, XML_PARSER_SUBST_ENTITIES);
 	zend_string *const_SUBST_ENTITIES_name = zend_string_init_interned("SUBST_ENTITIES", sizeof("SUBST_ENTITIES") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_SUBST_ENTITIES_name, &const_SUBST_ENTITIES_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_SUBST_ENTITIES_name, &const_SUBST_ENTITIES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SUBST_ENTITIES_name);
 
 	zval property_attributeCount_default_value;


### PR DESCRIPTION
Declares class constant types for the `XMLReader` class.