### PR TITLE
Simplify FPM ACL check

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -489,50 +489,24 @@ if test "$PHP_FPM" != "no"; then
   if test "$PHP_FPM_ACL" != "no" ; then
     AC_CHECK_HEADERS([sys/acl.h])
 
-    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <sys/acl.h>
-      int main(void)
-      {
-        acl_t acl;
+    dnl *BSD has acl_* built into libc, macOS doesn't have user/group support.
+    LIBS_save="$LIBS"
+    AC_SEARCH_LIBS([acl_free], [acl],
+      [AC_MSG_CHECKING([for acl user/group permissions support])
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <sys/acl.h>],
+        [acl_t acl;
         acl_entry_t user, group;
         acl = acl_init(1);
         acl_create_entry(&acl, &user);
         acl_set_tag_type(user, ACL_USER);
         acl_create_entry(&acl, &group);
         acl_set_tag_type(user, ACL_GROUP);
-        acl_free(acl);
-        return 0;
-      }
-    ]])], [
-      AC_CHECK_LIB(acl, acl_free,
-        [PHP_ADD_LIBRARY(acl)
-          have_fpm_acl=yes
-        ],[
-          AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/acl.h>
-            int main(void)
-            {
-              acl_t acl;
-              acl_entry_t user, group;
-              acl = acl_init(1);
-              acl_create_entry(&acl, &user);
-              acl_set_tag_type(user, ACL_USER);
-              acl_create_entry(&acl, &group);
-              acl_set_tag_type(user, ACL_GROUP);
-              acl_free(acl);
-              return 0;
-            }
-          ]])],[have_fpm_acl=yes],[have_fpm_acl=no],[have_fpm_acl=no])
-        ])
-    ], [
-      have_fpm_acl=no
-    ])
-
-    AC_MSG_CHECKING([for acl user/group permissions support])
-    if test "$have_fpm_acl" = "yes"; then
-      AC_MSG_RESULT([yes])
-      AC_DEFINE([HAVE_FPM_ACL], 1, [do we have acl support?])
-    else
-      AC_MSG_RESULT([no])
-    fi
+        acl_free(acl);])],
+        [AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_FPM_ACL], [1], [Whether FPM has acl support])],
+        [AC_MSG_RESULT([no])
+        LIBS="$LIBS_save"])],
+      [LIBS="$LIBS_save"])
   fi
 
   if test "x$PHP_FPM_APPARMOR" != "xno" ; then

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -491,22 +491,25 @@ if test "$PHP_FPM" != "no"; then
 
     dnl *BSD has acl_* built into libc, macOS doesn't have user/group support.
     LIBS_save="$LIBS"
-    AC_SEARCH_LIBS([acl_free], [acl],
-      [AC_MSG_CHECKING([for acl user/group permissions support])
-      AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <sys/acl.h>],
-        [acl_t acl;
+    AC_SEARCH_LIBS([acl_free], [acl], [
+      AC_MSG_CHECKING([for acl user/group permissions support])
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <sys/acl.h>], [
+        acl_t acl;
         acl_entry_t user, group;
         acl = acl_init(1);
         acl_create_entry(&acl, &user);
         acl_set_tag_type(user, ACL_USER);
         acl_create_entry(&acl, &group);
         acl_set_tag_type(user, ACL_GROUP);
-        acl_free(acl);])],
-        [AC_MSG_RESULT([yes])
-        AC_DEFINE([HAVE_FPM_ACL], [1], [Whether FPM has acl support])],
-        [AC_MSG_RESULT([no])
-        LIBS="$LIBS_save"])],
-      [LIBS="$LIBS_save"])
+        acl_free(acl);
+      ])], [
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_FPM_ACL], [1], [Whether FPM has acl support])
+      ], [
+        AC_MSG_RESULT([no])
+        LIBS="$LIBS_save"
+      ])
+    ])
   fi
 
   if test "x$PHP_FPM_APPARMOR" != "xno" ; then


### PR DESCRIPTION
Instead of running the user/group permissions check (unknown when cross-compiling), check with linking (AC_LINK_IFELSE) can be sufficient to test if ACL_USER and ACL_GROUP are available (missing on macOS). The AC_SEARCH_LIBS is used to test the ACL availability in c or acl library.