### PR TITLE
Fix GH-13603 ext/sockets: properly initialised address info data.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -917,7 +917,7 @@ PHP_FUNCTION(socket_read)
 PHP_FUNCTION(socket_getsockname)
 {
 	zval					*arg1, *addr, *port = NULL;
-	php_sockaddr_storage	sa_storage;
+	php_sockaddr_storage	sa_storage = {0};
 	php_socket				*php_sock;
 	struct sockaddr			*sa;
 	struct sockaddr_in		*sin;
@@ -994,7 +994,7 @@ PHP_FUNCTION(socket_getsockname)
 PHP_FUNCTION(socket_getpeername)
 {
 	zval					*arg1, *arg2, *arg3 = NULL;
-	php_sockaddr_storage	sa_storage;
+	php_sockaddr_storage	sa_storage = {0};
 	php_socket				*php_sock;
 	struct sockaddr			*sa;
 	struct sockaddr_in		*sin;

--- a/ext/sockets/tests/gh13603.phpt
+++ b/ext/sockets/tests/gh13603.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-13603 -  socket_getsockname - invalid characters
+--EXTENSIONS--
+sockets
+--FILE--
+<?php
+        $socket = socket_create(AF_UNIX, SOCK_STREAM, 0);
+        socket_bind($socket, 'sn.socp');
+        socket_listen($socket);
+        socket_getsockname($socket, $address);
+        var_dump($address);
+        socket_close($socket);
+        unlink($address);
+--EXPECT--
+string(7) "sn.socp"


### PR DESCRIPTION
Led to random characters visible on socket id on macOs.