### PR TITLE
Fix JIT QM_ASSIGN may be optimized out when op1 is null

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -5070,8 +5070,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 						CHECK_OP1_TRACE_TYPE();
 						res_info = RES_INFO();
 						res_use_info = zend_jit_trace_type_to_info(
-							STACK_MEM_TYPE(stack, EX_VAR_TO_NUM(opline->result.var)))
-								& (MAY_BE_UNDEF|MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG|MAY_BE_DOUBLE);
+							STACK_MEM_TYPE(stack, EX_VAR_TO_NUM(opline->result.var)));
 						res_addr = RES_REG_ADDR();
 						if (Z_MODE(res_addr) != IS_REG &&
 								STACK_TYPE(stack, EX_VAR_TO_NUM(opline->result.var)) !=

--- a/ext/opcache/tests/jit/qm_assign_004.phpt
+++ b/ext/opcache/tests/jit/qm_assign_004.phpt
@@ -1,0 +1,39 @@
+--TEST--
+JIT QM_ASSIGN: 004 missing type store
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+--FILE--
+<?php
+
+function getPropertyScopes($props, $flags): array
+{
+    $propertyScopes = [];
+    foreach ($props as $prop) {
+        $tmp = 'x'.$flags;
+        $propertyScopes[] = $propertyScopes[] = ($flags & 1 ? false : null) . '';
+    }
+
+    return $propertyScopes;
+}
+
+var_dump(getPropertyScopes(['a'], 0));
+var_dump(getPropertyScopes(['a'], 0));
+?>
+DONE
+--EXPECT--
+array(2) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+}
+array(2) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+}
+DONE


### PR DESCRIPTION
`ZVAL_COPY_CONST` and its variations avoid updating `Z_TYPE_P(dst_addr)` when it's known to have the right value already, based on `dst_info`. However, when emitting code for `ZEND_QM_ASSIGN`, we add `MAY_BE_NULL` to `dst_info` when the SSA type and stack types disagree. I'm assuming this is done to force a type store here:

https://github.com/php/php-src/blob/88e90c6f839d4daa2306d13cf90748f908510f5d/ext/opcache/jit/zend_jit_x86.dasc#L959-L963

Both of these conditions will be true unless `Z_TYPE_P(zv)` is NULL, in which case the type store is erroneously eliminated.

In this change I set `res_use_info` (`dst_info`) to `0` to force a type store. `MAY_BE_ANY` would also work.

This fixes #13508, but I'm not 100% confident this is correct.

`ZEND_ASSIGN` may have the same issue and I will look at it later.