### PR TITLE
Fix GH-13612: Corrupted memory in destructor with weak references

### DIFF
--- a/Zend/tests/weakrefs/gh13612.phpt
+++ b/Zend/tests/weakrefs/gh13612.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-13612 (Corrupted memory in destructor with weak references)
+--FILE--
+<?php
+
+class WeakAnalysingMapRepro
+{
+    public array $destroyed = [];
+    public array $ownerDestructorHandlers = [];
+
+    public function __construct()
+    {
+        $handler = new class($this) {
+            private \WeakReference $weakAnalysingMap;
+
+            public function __construct(WeakAnalysingMapRepro $analysingMap)
+            {
+                $this->weakAnalysingMap = \WeakReference::create($analysingMap);
+            }
+
+            public function __destruct()
+            {
+                var_dump($this->weakAnalysingMap->get());
+            }
+        };
+
+        $this->destroyed[] = 1;
+        $this->ownerDestructorHandlers[] = $handler;
+    }
+}
+
+new WeakAnalysingMapRepro();
+
+echo "Done\n";
+
+?>
+--EXPECT--
+NULL
+Done

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -47,6 +47,10 @@ ZEND_API void zend_object_std_dtor(zend_object *object)
 {
 	zval *p, *end;
 
+	if (UNEXPECTED(GC_FLAGS(object) & IS_OBJ_WEAKLY_REFERENCED)) {
+		zend_weakrefs_notify(object);
+	}
+
 	if (object->properties) {
 		if (EXPECTED(!(GC_FLAGS(object->properties) & IS_ARRAY_IMMUTABLE))) {
 			if (EXPECTED(GC_DELREF(object->properties) == 0)
@@ -84,10 +88,6 @@ ZEND_API void zend_object_std_dtor(zend_object *object)
 			zend_hash_destroy(guards);
 			FREE_HASHTABLE(guards);
 		}
-	}
-
-	if (UNEXPECTED(GC_FLAGS(object) & IS_OBJ_WEAKLY_REFERENCED)) {
-		zend_weakrefs_notify(object);
 	}
 }
 


### PR DESCRIPTION
Inside `zend_object_std_dtor` the weakrefs are notified after the destruction of properties already took place. In this test case, the destructor of an anon class will be invoked due to the property destruction. That class has a weak reference to its parent. This means that the destructor can access parent properties that already have been destroyed, resulting in a UAF. Fix this by notifying the weakrefs at the start of the object's destruction.