### PR TITLE
Remove unused config.w32.h.in symbols

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -129,6 +129,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - FIBER_ASSEMBLER and FIBER_ASM_ARCH Makefile variables removed in favor of
      PHP_ASSEMBLER and FIBER_ASM_ABI.
    - HAVE_PHP_SOAP symbol renamed to HAVE_SOAP.
+   - Unused symbols CONFIGURATION_FILE_PATH, DISCARD_PATH, HAVE_ERRMSG_H,
+     HAVE_REGCOMP, HAVE_RINT, NEED_ISBLANK, PHP_URL_FOPEN, REGEX, HSREGEX,
+     USE_CONFIG_FILE have been removed.
 
 ========================
 3. Module changes

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -10,7 +10,6 @@
 
 /* Default PHP / PEAR directories */
 #define PHP_CONFIG_FILE_PATH ""
-#define CONFIGURATION_FILE_PATH "php.ini"
 #define PEAR_INSTALLDIR "@PREFIX@\\pear"
 #define PHP_BINDIR "@PREFIX@"
 #define PHP_DATADIR "@PREFIX@"
@@ -22,8 +21,6 @@
 #define PHP_SYSCONFDIR "@PREFIX@"
 
 /* PHP Runtime Configuration */
-#define PHP_URL_FOPEN 1
-#define USE_CONFIG_FILE 1
 #define DEFAULT_SHORT_OPEN_TAG "1"
 
 /* Platform-Specific Configuration. Should not be changed. */
@@ -40,7 +37,6 @@
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
-#define HAVE_ERRMSG_H 0
 #undef HAVE_ADABAS
 #undef HAVE_SOLID
 #undef HAVE_SYMLINK
@@ -50,8 +46,6 @@
 #define HAVE_NANOSLEEP 1
 
 #define HAVE_GETCWD 1
-#define NEED_ISBLANK 1
-#define DISCARD_PATH 0
 #undef HAVE_SETITIMER
 #undef HAVE_SIGSETJMP
 #undef HAVE_IODBC
@@ -65,11 +59,8 @@
 #undef HAVE_STRUCT_STAT_ST_BLKSIZE
 #undef HAVE_STRUCT_STAT_ST_BLOCKS
 #define HAVE_STRUCT_STAT_ST_RDEV 1
-#define REGEX 1
-#define HSREGEX 1
 #define HAVE_GETLOGIN 1
 #define HAVE_MEMMOVE 1
-#define HAVE_REGCOMP 1
 #define HAVE_SHUTDOWN 1
 #define HAVE_STRCASECMP 1
 #define HAVE_UTIME 1
@@ -86,7 +77,6 @@
 #undef HAVE_ALLOCA_H
 #undef HAVE_KILL
 #define HAVE_GETPID 1
-#undef HAVE_RINT
 /* int and long are still 32bit in 64bit compiles */
 #define SIZEOF_INT 4
 #define SIZEOF_LONG 4


### PR DESCRIPTION
- CONFIGURATION_FILE_PATH
  Removed via 2cf1b8d3459736457b46c295eb2e8b87acb4f521.

- DISCARD_PATH
  Used for the --enable-discard-path CGI configure option and converted to INI configuration. Removed via 06f43b30c1c50ae8cafd35dd2207e3bbda7c3e3c.

- HAVE_ERRMSG_H
  Removed via fd1578c196575c7e120a84ee030bb87c14a199b0.

- HAVE_REGCOMP
  Used for regcomp function.

- HAVE_RINT
  Used for rint function.

- NEED_ISBLANK
  Windows ctype.h once didn't have C99 isblank() function. Cannot be found on current Windows systems anymore, neither was used in PHP at least since PHP 4.0.

- PHP_URL_FOPEN
  Removed via cae27179ce1f84d47de87c4efbbcbd814f3c7bc6.

- REGEX
  Not used in current code.

- HSREGEX
  Not used in current code.

- USE_CONFIG_FILE
  Symbol was once defined by the --with-config-file-path configure option.