### PR TITLE
Implement GH-13609: Dump wrapped object in WeakReference class

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@ PHP                                                                        NEWS
   . Fixed zend call stack size for macOs/arm64. (David Carlier)
   . Added support for Zend Max Execution Timers on FreeBSD. (Kévin Dunglas)
   . Ensure fiber stack is not backed by THP. (crrodriguez)
+  . Implement GH-13609 (Dump wrapped object in WeakReference class). (nielsdos)
 
 - Curl:
   . Deprecated the CURLOPT_BINARYTRANSFER constant. (divinity76)

--- a/UPGRADING
+++ b/UPGRADING
@@ -164,6 +164,8 @@ PHP 8.4 UPGRADE NOTES
   . Added request_parse_body() function that allows parsing RFC1867 (multipart)
     requests in non-POST HTTP requests.
     RFC: https://wiki.php.net/rfc/rfc1867-non-post
+  . Getting the debug info for WeakReference will now also output the object
+    it references, or null if the reference is no longer valid.
 
 - Curl:
   . curl_version() returns an additional feature_list value, which is an

--- a/Zend/tests/weakrefs/weakrefs_001.phpt
+++ b/Zend/tests/weakrefs/weakrefs_001.phpt
@@ -26,9 +26,15 @@ object(stdClass)#1 (0) refcount(2){
 }
 object(stdClass)#1 (0) refcount(2){
 }
-object(WeakReference)#2 (0) {
+object(WeakReference)#2 (1) {
+  ["object"]=>
+  object(stdClass)#1 (0) {
+  }
 }
-object(WeakReference)#2 (0) {
+object(WeakReference)#2 (1) {
+  ["object"]=>
+  object(stdClass)#1 (0) {
+  }
 }
 object(stdClass)#1 (0) refcount(2){
 }
@@ -36,4 +42,3 @@ object(stdClass)#1 (0) refcount(2){
 }
 NULL
 NULL
-

--- a/Zend/tests/weakrefs/weakrefs_debug_dump.phpt
+++ b/Zend/tests/weakrefs/weakrefs_debug_dump.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Weakrefs debug dump
+--FILE--
+<?php
+
+$s = new stdClass;
+$s->hello = 'world';
+
+$weak = WeakReference::create($s);
+var_dump($weak);
+unset($s);
+var_dump($weak);
+
+?>
+--EXPECT--
+object(WeakReference)#2 (1) {
+  ["object"]=>
+  object(stdClass)#1 (1) {
+    ["hello"]=>
+    string(5) "world"
+  }
+}
+object(WeakReference)#2 (1) {
+  ["object"]=>
+  NULL
+}


### PR DESCRIPTION
I chose "object" as that's also the argument name in `WeakReference::create`.