### PR TITLE
Sync CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,62 @@
+# The following volunteers have self-identified as subject matter experts
+# or interested parties over a particular area of the php-src source code.
+# While requesting a review from someone does not obligate that person to
+# review a pull request, these reviewers might have valuable knowledge of
+# the problem area and could aid in deciding whether a pull request is ready
+# for merging.
+#
+# For more information, see the GitHub CODEOWNERS documentation:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/.github @iluuu1994 @TimWolla
+/build/gen_stub.php @kocsismate
+/ext/bcmath @Girgias
+/ext/curl @adoy
+/ext/date @derickr
+/ext/dba @Girgias
+/ext/dom @nielsdos
+/ext/ffi @dstogov
+/ext/gettext @devnexen
+/ext/gmp @Girgias
+/ext/imap @Girgias
+/ext/intl @devnexen
+/ext/json @bukka
+/ext/libxml @nielsdos
+/ext/mbstring @alexdowad
+/ext/opcache @dstogov @iluuu1994
+/ext/openssl @bukka
+/ext/odbc @NattyNarwhal
+/ext/pdo_odbc @NattyNarwhal
+/ext/pdo_pgsql @devnexen
+/ext/pgsql @devnexen
+/ext/random @TimWolla @zeriyoshi
+/ext/session @Girgias
+/ext/sockets @devnexen
+/ext/spl @Girgias
+/ext/standard @bukka
+/ext/xmlreader @nielsdos
+/ext/xsl @nielsdos
+/main @bukka
+/sapi/fpm @bukka
+/Zend @iluuu1994
+/Zend/Optimizer @dstogov
+/Zend/zend.* @dstogov
+/Zend/zend_alloc.* @dstogov
+/Zend/zend_API.* @dstogov
+/Zend/zend_call_stack.* @arnaud-lb
+/Zend/zend_closures.* @dstogov
+/Zend/zend_execute.* @dstogov
+/Zend/zend_execute_API.c @dstogov
+/Zend/zend_gc.* @dstogov @arnaud-lb
+/Zend/zend_hash.* @dstogov
+/Zend/zend_inheritance.* @dstogov
+/Zend/zend_max_execution_timer.* @arnaud-lb
+/Zend/zend_object_handlers.* @dstogov
+/Zend/zend_objects.* @dstogov
+/Zend/zend_objects_API.* @dstogov
+/Zend/zend_opcode.* @dstogov
+/Zend/zend_string.* @dstogov
+/Zend/zend_type*.h @dstogov
+/Zend/zend_variables.* @dstogov
+/Zend/zend_vm* @dstogov
+*.stub.php @kocsismate


### PR DESCRIPTION
This adds CODEOWNERS also to PHP-8.2 branch. See #13591 

This is a combination of master and PHP-8.3 branches:
ext/imap @Girgias (for PHP-8.2 and PHP-8.3)
ext/pdo_odbc @NattyNarwhal as noted here https://github.com/php/php-src/commit/af80cba8a377df6b5bb70bcd90ae94bd27ac9eae#comments
