### PR TITLE
Use fabsf() and floorf() unconditionally in bundled libgd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -213,9 +213,6 @@ if test "$PHP_GD" != "no"; then
                   libgd/gd_transform.c libgd/gd_crop.c libgd/gd_interpolation.c libgd/gd_matrix.c \
                   libgd/gd_bmp.c libgd/gd_tga.c"
 
-dnl check for fabsf and floorf which are available since C99
-    AC_CHECK_FUNCS(fabsf floorf)
-
 dnl These are always available with bundled library
     AC_DEFINE(HAVE_GD_BUNDLED,          1, [ ])
     AC_DEFINE(HAVE_GD_PNG,              1, [ ])

--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -8,36 +8,6 @@
 
 #include "php.h"
 
-#ifdef _MSC_VER
-# if _MSC_VER >= 1300
-/* in MSVC.NET these are available but only for __cplusplus and not _MSC_EXTENSIONS */
-#  if !defined(_MSC_EXTENSIONS) && defined(__cplusplus)
-#   define HAVE_FABSF 1
-extern float fabsf(float x);
-#   define HAVE_FLOORF 1
-extern float floorf(float x);
-#  endif /*MSVC.NET */
-# endif /* MSC */
-#endif
-#ifndef HAVE_FABSF
-# define HAVE_FABSF 0
-#endif
-#ifndef HAVE_FLOORF
-# define HAVE_FLOORF 0
-#endif
-#if HAVE_FABSF == 0
-/* float fabsf(float x); */
-# ifndef fabsf
-#  define fabsf(x) ((float)(fabs(x)))
-# endif
-#endif
-#if HAVE_FLOORF == 0
-# ifndef floorf
-/* float floorf(float x);*/
-#  define floorf(x) ((float)(floor(x)))
-# endif
-#endif
-
 #ifdef _OSD_POSIX		/* BS2000 uses the EBCDIC char set instead of ASCII */
 #define CHARSET_EBCDIC
 #define __attribute__(any)	/*nothing */

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -67,16 +67,6 @@ TODO:
 # include <emmintrin.h>
 #endif
 
-#ifndef HAVE_FLOORF
-# define HAVE_FLOORF 0
-#endif
-#if HAVE_FLOORF == 0
-# ifndef floorf
-/* float floorf(float x);*/
-#  define floorf(x) ((float)(floor(x)))
-# endif
-#endif
-
 #ifndef MIN
 #define MIN(a,b) ((a)<(b)?(a):(b))
 #endif


### PR DESCRIPTION
If I'm not mistaken, these are available since C99 with math.h also on Windows, without requiring checking. Upstream libgd uses floorf() unconditionally and doesn't use fabsf().