### PR TITLE
Fix mysqli tests for MariaDB/MySQL versions exceeding 25 characters

### DIFF
--- a/ext/mysqli/tests/mysqli_stmt_execute_stored_proc.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_stored_proc.phpt
@@ -24,7 +24,7 @@ if (mysqli_get_server_version($link) <= 50000) {
     if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
         printf("[009] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
 
-    if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(25)) BEGIN SELECT VERSION() INTO ver_param; END;')) {
+    if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(50)) BEGIN SELECT VERSION() INTO ver_param; END;')) {
         /* no result set, one output parameter */
         if (!$stmt = mysqli_prepare($link, 'CALL p(@version)'))
             printf("[011] Cannot prepare CALL, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -68,7 +68,7 @@ if (mysqli_get_server_version($link) <= 50000) {
         if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
             printf("[019] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
 
-        if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(25)) BEGIN SELECT VERSION() INTO ver_param; END;')) {
+        if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(50)) BEGIN SELECT VERSION() INTO ver_param; END;')) {
             // no result set, one output parameter
             if (!$stmt = mysqli_prepare($link, 'CALL p(@version)'))
                 printf("[020] Cannot prepare CALL, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -105,7 +105,7 @@ if (mysqli_get_server_version($link) <= 50000) {
     if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
         printf("[028] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
 
-    if (mysqli_real_query($link, 'CREATE PROCEDURE p(IN ver_in VARCHAR(25), OUT ver_out VARCHAR(25)) BEGIN SELECT ver_in INTO ver_out; END;')) {
+    if (mysqli_real_query($link, 'CREATE PROCEDURE p(IN ver_in VARCHAR(50), OUT ver_out VARCHAR(50)) BEGIN SELECT ver_in INTO ver_out; END;')) {
         // no result set, one input parameter, output parameter
         // yes, I really do not want to bind input values...
         if (!$stmt = mysqli_prepare($link, "CALL p('myversion', @version)"))
@@ -143,7 +143,7 @@ if (mysqli_get_server_version($link) <= 50000) {
     if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
         printf("[037] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
 
-    if (mysqli_real_query($link, 'CREATE PROCEDURE p(IN ver_in VARCHAR(25), OUT ver_out VARCHAR(25)) BEGIN SELECT ver_in INTO ver_out; END;')) {
+    if (mysqli_real_query($link, 'CREATE PROCEDURE p(IN ver_in VARCHAR(50), OUT ver_out VARCHAR(50)) BEGIN SELECT ver_in INTO ver_out; END;')) {
         // no result set, one input parameter, output parameter
         // yes, I really do not want to bind input values...
         if (!$stmt = mysqli_prepare($link, 'CALL p(?, @version)'))

--- a/ext/mysqli/tests/mysqli_store_result_copy.phpt
+++ b/ext/mysqli/tests/mysqli_store_result_copy.phpt
@@ -164,7 +164,7 @@ mysqlnd.fetch_data_copy=0
     if (mysqli_get_server_version($link) > 50000) {
         // let's try to play with stored procedures
         mysqli_real_query($link, 'DROP PROCEDURE IF EXISTS p');
-        if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(25)) READS SQL DATA BEGIN SELECT id FROM test WHERE id >= 100 ORDER BY id; SELECT id + 1, label FROM test WHERE id > 0 AND id < 3 ORDER BY id; SELECT VERSION() INTO ver_param;
+        if (mysqli_real_query($link, 'CREATE PROCEDURE p(OUT ver_param VARCHAR(50)) READS SQL DATA BEGIN SELECT id FROM test WHERE id >= 100 ORDER BY id; SELECT id + 1, label FROM test WHERE id > 0 AND id < 3 ORDER BY id; SELECT VERSION() INTO ver_param;
 END;')) {
             mysqli_multi_query($link, "CALL p(@version)");
             do {


### PR DESCRIPTION
Due to an error, MariaDB Docker Official Images containers and MariaDB released Debian/Ubuntu packages ended up with a long version number:

```
select length(version()),version()'
+-------------------+-----------------------------------------+
| length(version()) | version()                               |
+-------------------+-----------------------------------------+
|                39 | 10.5.23-MariaDB-1:10.5.23+maria~ubu2004 |
```

https://jira.mariadb.org/browse/MDEV-33631

Even fixing this upstream down to 10.11.23-MariaDB-1~ubu2004 is 27 characters resulting in a truncate to NULL in the changed tests resulting in a test failure.

Example failure changing mysql to mariadb container in [test run](https://github.com/grooverdan/php-src/actions/runs/8183927946/job/22377535403)
```
========DIFF========
001+ [012] Cannot execute CALL, [1406] Data too long for column 'ver_param' at row 1
002+ [013] Cannot execute CALL, [1406] Data too long for column 'ver_param' at row 1
003+ [018] Results seem wrong, got , [0] 
004+ [021] Cannot execute CALL, [1406] Data too long for column 'ver_param' at row 1
005+ [026] Results seem wrong, got , [0] 
     done!
========DONE========
FAIL mysqli_stmt_execute() - Stored Procedures [ext/mysqli/tests/mysqli_stmt_execute_stored_proc.phpt] 

========DIFF========
--
         string(1) "b"
       }
     }
084+ [024] Expecting array [0] 
085+ array(1) {
086+   ["p_version"]=>
087+   NULL
088+ }
     done!
========DONE========
FAIL mysqli_store_result() [ext/mysqli/tests/mysqli_store_result_copy.phpt] 
=====================================================================
```