### PR TITLE
Remove htonl() Autoconf check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,7 +359,6 @@ dnl uClibc will bark at linking with glibc's libnsl.
 
 PHP_CHECK_FUNC(socket, socket, network)
 PHP_CHECK_FUNC(socketpair, socket, network)
-PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
 AC_SEARCH_LIBS([dlopen], [dl],


### PR DESCRIPTION
The htonl() function is available in libc on current *nix systems. On Solaris versions around 2.5.1 it was located in the socket library. Haiku has it in libc and Windows in ws2_32, which is linked as part of the common libraries. This removes the redundant HAVE_HTONL symbol.