### PR TITLE
Add hosted docs link to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # php-src docs
 
 This is the home of the php-src internal documentation, hosted at
-[php.github.io/php-src/](https://php.github.io/php-src/). It is in very early stages, but is intended
-to become the primary place where new information about php-src is documented. Over time, it is
-expected to replace various mediums like:
+[php.github.io/php-src/](https://php.github.io/php-src/). It is in very early stages,
+but is intended to become the primary place where new information about php-src is documented.
+Over time, it is expected to replace various mediums like:
 
 * https://www.phpinternalsbook.com/
 * https://wiki.php.net/internals
@@ -22,7 +22,8 @@ That's it! You can view the documentation under `./build/html/index.html` in you
 
 ## Formatting
 
-The files in this documentation are formatted using the [``rstfmt``](https://github.com/dzhu/rstfmt) tool.
+The files in this documentation are formatted using the
+[``rstfmt``](https://github.com/dzhu/rstfmt) tool.
 
 ```bash
 rstfmt -w 100 source

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # php-src docs
 
-This is the home of the php-src internal documentation. It is in very early stages, but is intended
+This is the home of the php-src internal documentation hosted at [php.github.io/php-src/](https://php.github.io/php-src/). It is in very early stages, but is intended
 to become the primary place where new information about php-src is documented. Over time, it is
 expected to replace various mediums like:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # php-src docs
 
-This is the home of the php-src internal documentation hosted at [php.github.io/php-src/](https://php.github.io/php-src/). It is in very early stages, but is intended
+This is the home of the php-src internal documentation, hosted at
+[php.github.io/php-src/](https://php.github.io/php-src/). It is in very early stages, but is intended
 to become the primary place where new information about php-src is documented. Over time, it is
 expected to replace various mediums like:
 


### PR DESCRIPTION
I know the link is also in the main README, but for me, it is very logical to have a hosted link in docs/ which is the place I naturally open when I am looking for docs.