### PR TITLE
Find SELinux library with pkgconf

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -525,7 +525,7 @@ if test "$PHP_FPM" != "no"; then
   fi
 
   if test "x$PHP_FPM_SELINUX" != "xno" ; then
-    PKG_CHECK_MODULES([SELINUX], [selinux], [
+    PKG_CHECK_MODULES([SELINUX], [libselinux], [
       PHP_EVAL_LIBLINE([$SELINUX_LIBS])
       PHP_EVAL_INCLINE([$SELINUX_CFLAGS])
     ],


### PR DESCRIPTION
The SELinux library has had pkg-config/pkgconf integration since ~2009. To ease this change, the check without pkgconf is executed in case the libselinux.pc file is not found on the system.

A sanity check also covers cases where the library path is overriden:
  /configure --enable-fpm --with-fpm-selinux \
    SELINUX_CFLAGS=-I/path/to/libselinux \
    SELINUX_LIBS="-L/path/to/libselinux -lselinux"

This also removes the redundant symbol HAVE_SELINUX_SELINUX_H since the selinux/selinux.h header is considered a required part of the SELinux library package.