### PR TITLE
Remove unused php_std_auto_global_callback()

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -641,12 +641,6 @@ void _php_load_environment_variables(zval *array_ptr)
 	php_import_environment_variables(array_ptr);
 }
 
-bool php_std_auto_global_callback(char *name, uint32_t name_len)
-{
-	zend_printf("%s\n", name);
-	return 0; /* don't rearm */
-}
-
 /* {{{ php_build_argv */
 PHPAPI void php_build_argv(const char *s, zval *track_vars_array)
 {


### PR DESCRIPTION
Introduced in 4e55747a2b0fd481018bfd390e2aa50569f73c41 but not used in current code. There was previous removal attempt via afa4e41c2fdd676c428614ff67f6517e995bcbdf but looks like it didn't make it into the master branch at that point.