### PR TITLE
Remove unused zend_shutdown_constants()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -77,6 +77,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
   void(*)(void *, size_t) to
   void(*)(void *, size_t ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 
+* The function zend_shutdown_constants() has been removed.
 
 ========================
 2. Build system changes

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -116,13 +116,6 @@ void zend_register_standard_constants(void)
 	null_const = zend_hash_str_find_ptr(EG(zend_constants), "NULL", sizeof("NULL")-1);
 }
 
-
-void zend_shutdown_constants(void)
-{
-	zend_hash_destroy(EG(zend_constants));
-	free(EG(zend_constants));
-}
-
 ZEND_API void zend_register_null_constant(const char *name, size_t name_len, int flags, int module_number)
 {
 	zend_constant c;

--- a/Zend/zend_constants.h
+++ b/Zend/zend_constants.h
@@ -71,7 +71,6 @@ BEGIN_EXTERN_C()
 void clean_module_constants(int module_number);
 void free_zend_constant(zval *zv);
 void zend_startup_constants(void);
-void zend_shutdown_constants(void);
 void zend_register_standard_constants(void);
 ZEND_API bool zend_verify_const_access(zend_class_constant *c, zend_class_entry *ce);
 ZEND_API zval *zend_get_constant(zend_string *name);


### PR DESCRIPTION
The zend_shutdown_constants() usage was removed in 21698c12fefc21acc7b2de2c54aa2b19cfaf3678 (memory leak) and in b80cb7bd2f721dad13a97a1300c6dc56934daaf7 (unicode support). I might be wrong but this isn't used in current code and can be removed also.