### PR TITLE
Use strtoll() and atoll() unconditionally

### DIFF
--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -1,10 +1,8 @@
 dnl Check for headers needed by timelib
 AC_CHECK_HEADERS([io.h])
 
-dnl Check for strtoll, atoll
-AC_CHECK_FUNCS([strtoll atoll])
+PHP_DATE_CFLAGS="-Wno-implicit-fallthrough -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1 -DHAVE_STRTOLL"
 
-PHP_DATE_CFLAGS="-Wno-implicit-fallthrough -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 


### PR DESCRIPTION
The strtoll() and atoll() are [C99 standard functions](https://port70.net/~nsz/c/c99/n1256.html#7.20.1.2) and don't need checking. Since the upstream timelib library needs to be changed separately, this simplifies checking by using a compile definition.