### PR TITLE
Fix external pcre2 build

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -723,7 +723,9 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, bo
 			/* PCRE specific options */
 			case 'A':	coptions |= PCRE2_ANCHORED;		break;
 			case 'D':	coptions |= PCRE2_DOLLAR_ENDONLY;break;
+#ifdef PCRE2_EXTRA_CASELESS_RESTRICT
 			case 'r':	eoptions |= PCRE2_EXTRA_CASELESS_RESTRICT; break;
+#endif
 			case 'S':	/* Pass. */					break;
 			case 'X':	/* Pass. */					break;
 			case 'U':	coptions |= PCRE2_UNGREEDY;		break;

--- a/ext/pcre/tests/preg_match_caseless_restrict.phpt
+++ b/ext/pcre/tests/preg_match_caseless_restrict.phpt
@@ -1,5 +1,11 @@
 --TEST--
 testing /r modifier in preg_* functions
+--SKIPIF--
+<?php
+if (PCRE_VERSION_MAJOR == 10 && PCRE_VERSION_MINOR < 43) {
+    die("skip old pcre version");
+}
+?>
 --FILE--
 <?php
 echo "SK substitute matching" . PHP_EOL;


### PR DESCRIPTION
PCRE2_EXTRA_CASELESS_RESTRICT is only available as of pcre2 10.43. Note: no check is necessary for pcre2_set_compile_extra_options because it is available since pcre2 10.30, which is the minimum version PHP requires.