### PR TITLE
Fix GH-13620: Failing openssl_private_decrypt tests

### DIFF
--- a/ext/openssl/tests/openssl_error_string_basic.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic.phpt
@@ -6,7 +6,6 @@ openssl
 <?php
 if (OPENSSL_VERSION_NUMBER >= 0x30000000) die('skip For OpenSSL < 3.0');
 ?>
---XFAIL--
 --FILE--
 <?php
 // helper function to check openssl errors
@@ -119,12 +118,12 @@ expect_openssl_errors('openssl_pkey_get_public', [$err_pem_no_start_line]);
 @openssl_private_encrypt("data", $crypted, $private_key_file, 1000);
 expect_openssl_errors('openssl_private_encrypt', ['0408F090']);
 // private decrypt with failed padding check
-@openssl_private_decrypt("data", $crypted, $private_key_file);
-expect_openssl_errors('openssl_private_decrypt', ['04065072']);
+@openssl_private_decrypt("data", $crypted, $private_key_file, OPENSSL_PKCS1_OAEP_PADDING);
+expect_openssl_errors('openssl_private_decrypt', ['04099079']);
 // public encrypt and decrypt with failed padding check and padding
 @openssl_public_encrypt("data", $crypted, $public_key_file, 1000);
-@openssl_public_decrypt("data", $crypted, $public_key_file);
-expect_openssl_errors('openssl_private_(en|de)crypt padding', [$err_pem_no_start_line, '0408F090', '04067072']);
+@openssl_public_decrypt("data", $crypted, $public_key_file, OPENSSL_PKCS1_OAEP_PADDING);
+expect_openssl_errors('openssl_private_(en|de)crypt padding', [$err_pem_no_start_line, '0408F090', '06089093']);
 
 // X509
 echo "X509 errors\n";

--- a/ext/openssl/tests/openssl_error_string_basic_openssl3.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic_openssl3.phpt
@@ -6,7 +6,6 @@ openssl
 <?php
 if (OPENSSL_VERSION_NUMBER < 0x30000000) die('skip For OpenSSL >= 3.0');
 ?>
---XFAIL--
 --FILE--
 <?php
 // helper function to check openssl errors
@@ -122,12 +121,12 @@ expect_openssl_errors('openssl_pkey_get_public', [$err_pem_no_start_line]);
 @openssl_private_encrypt("data", $crypted, $private_key_file, 1000);
 expect_openssl_errors('openssl_private_encrypt', ['1C8000A5']);
 // private decrypt with failed padding check
-@openssl_private_decrypt("data", $crypted, $private_key_file);
-expect_openssl_errors('openssl_private_decrypt', ['0200009F', '02000072']);
+@openssl_private_decrypt("data", $crypted, $private_key_file, OPENSSL_PKCS1_OAEP_PADDING);
+expect_openssl_errors('openssl_private_decrypt', ['02000079']);
 // public encrypt and decrypt with failed padding check and padding
 @openssl_public_encrypt("data", $crypted, $public_key_file, 1000);
-@openssl_public_decrypt("data", $crypted, $public_key_file);
-expect_openssl_errors('openssl_private_(en|de)crypt padding', [$err_pem_no_start_line, '02000076', '0200008A', '02000072', '1C880004']);
+@openssl_public_decrypt("data", $crypted, $public_key_file, OPENSSL_PKCS1_OAEP_PADDING);
+expect_openssl_errors('openssl_private_(en|de)crypt padding', [$err_pem_no_start_line, '1C8000A5']);
 
 // X509
 echo "X509 errors\n";

--- a/ext/openssl/tests/openssl_private_decrypt_basic.phpt
+++ b/ext/openssl/tests/openssl_private_decrypt_basic.phpt
@@ -2,7 +2,6 @@
 openssl_private_decrypt() tests
 --EXTENSIONS--
 openssl
---XFAIL--
 --FILE--
 <?php
 $data = "Testing openssl_public_decrypt()";
@@ -10,22 +9,22 @@ $privkey = "file://" . __DIR__ . "/private_rsa_1024.key";
 $pubkey = "file://" . __DIR__ . "/public.key";
 $wrong = "wrong";
 
-openssl_public_encrypt($data, $encrypted, $pubkey);
-var_dump(openssl_private_decrypt($encrypted, $output, $privkey));
+openssl_public_encrypt($data, $encrypted, $pubkey, OPENSSL_PKCS1_OAEP_PADDING);
+var_dump(openssl_private_decrypt($encrypted, $output, $privkey, OPENSSL_PKCS1_OAEP_PADDING));
 var_dump($output);
-var_dump(openssl_private_decrypt($encrypted, $output2, $wrong));
+var_dump(openssl_private_decrypt($encrypted, $output2, $wrong, OPENSSL_PKCS1_OAEP_PADDING));
 var_dump($output2);
-var_dump(openssl_private_decrypt($wrong, $output3, $privkey));
+var_dump(openssl_private_decrypt($wrong, $output3, $privkey, OPENSSL_PKCS1_OAEP_PADDING));
 var_dump($output3);
 
 try {
-    var_dump(openssl_private_decrypt($encrypted, $output4, array($privkey)));
+    var_dump(openssl_private_decrypt($encrypted, $output4, array($privkey), OPENSSL_PKCS1_OAEP_PADDING));
     var_dump($output4);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 
-var_dump(openssl_private_decrypt($encrypted, $output5, array($privkey, "")));
+var_dump(openssl_private_decrypt($encrypted, $output5, array($privkey, ""), OPENSSL_PKCS1_OAEP_PADDING));
 var_dump($output5);
 ?>
 --EXPECTF--


### PR DESCRIPTION
Use OPENSSL_PKCS1_OAEP_PADDING padding in tests