### PR TITLE
Mark sapi/embed as non experimental

### DIFF
--- a/sapi/embed/EXPERIMENTAL
+++ b/sapi/embed/EXPERIMENTAL
@@ -1,5 +1,0 @@
-this module is experimental,
-its functions may change their names
-or move to extension all together
-so do not rely to much on them
-you have been warned!

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_ENABLE([embed],,
   [AS_HELP_STRING([[--enable-embed[=TYPE]]],
-    [EXPERIMENTAL: Enable building of embedded SAPI library TYPE is either
+    [Enable building of embedded SAPI library TYPE is either
     'shared' or 'static'. [TYPE=shared]])],
   [no],
   [no])


### PR DESCRIPTION
The embed SAPI has been around for quite a while now, and many apps already use it in production. It can be marked as non experimental to avoid confusion.