### PR TITLE
CI: Cirrus CI - skip build on ignore-paths

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@ freebsd_task:
   name: FREEBSD_DEBUG_NTS
   freebsd_instance:
     image_family: freebsd-13-3
+  skip: "changesIncludeOnly('docs/**', 'NEWS', 'UPGRADING', 'UPGRADING.INTERNALS', '**/README.*', 'CONTRIBUTING.md', 'CODING_STANDARDS.md', '.circleci/**')"
   env:
     ARCH: amd64
   install_script:


### PR DESCRIPTION
Cirrus CI supports a `<job>.skip` key that skips the build if the expression evaluates to true. This adds the same list of on.pull_request.paths-ignore patterns from GitHub Actions workflows.

This should save several minutes of CI times on PRs when the changes are only in the README/doc files.