### PR TITLE
Compress interned string table offsets and increase maximum supported buffer size

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -236,6 +236,11 @@ typedef struct _zend_string_table {
 	zend_string *saved_top;
 } zend_string_table;
 
+typedef uint32_t zend_string_table_pos_t;
+
+#define ZEND_STRING_TABLE_POS_MAX UINT32_MAX
+#define ZEND_STRING_TABLE_POS_ALIGNMENT 8
+
 typedef struct _zend_accel_shared_globals {
 	/* Cache Data Structures */
 	zend_ulong   hits;

--- a/ext/opcache/tests/gh9259_001.phpt
+++ b/ext/opcache/tests/gh9259_001.phpt
@@ -13,6 +13,6 @@ echo 'OK';
 
 ?>
 --EXPECTF--
-%sWarning opcache.interned_strings_buffer must be less than or equal to 4095, 131072 given%s
+%sWarning opcache.interned_strings_buffer must be less than or equal to 32767, 131072 given%s
 
 OK

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -49,7 +49,7 @@
 		/* nTableMask must not overflow (uint32_t) */ \
 		UINT32_MAX / (32 * 1024 * sizeof(zend_string_table_pos_t)) \
 	), \
-	/* SHM allocation must not overlow (size_t) */ \
+	/* SHM allocation must not overflow (size_t) */ \
 	(SIZE_MAX - sizeof(zend_accel_shared_globals)) / (1024 * 1024) \
 ))
 #define TOKENTOSTR(X) #X

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -41,7 +41,17 @@
 #define STRING_NOT_NULL(s) (NULL == (s)?"":s)
 #define MIN_ACCEL_FILES 200
 #define MAX_ACCEL_FILES 1000000
-#define MAX_INTERNED_STRINGS_BUFFER_SIZE ((zend_long)((UINT32_MAX-PLATFORM_ALIGNMENT-sizeof(zend_accel_shared_globals))/(1024*1024)))
+/* Max value of opcache.interned_strings_buffer */
+#define MAX_INTERNED_STRINGS_BUFFER_SIZE ((zend_long)MIN( \
+	MIN( \
+		/* STRTAB_STR_TO_POS() must not overflow (zend_string_table_pos_t) */ \
+		(ZEND_STRING_TABLE_POS_MAX - sizeof(zend_string_table)) / (1024 * 1024 / ZEND_STRING_TABLE_POS_ALIGNMENT), \
+		/* nTableMask must not overflow (uint32_t) */ \
+		UINT32_MAX / (32 * 1024 * sizeof(zend_string_table_pos_t)) \
+	), \
+	/* SHM allocation must not overlow (size_t) */ \
+	(SIZE_MAX - sizeof(zend_accel_shared_globals)) / (1024 * 1024) \
+))
 #define TOKENTOSTR(X) #X
 
 static zif_handler orig_file_exists = NULL;

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -369,11 +369,7 @@ void *zend_shared_alloc(size_t size)
 	ZEND_ASSERT(ZCG(locked));
 
 	int i;
-	unsigned int block_size = ZEND_ALIGNED_SIZE(size);
-
-	if (UNEXPECTED(block_size < size)) {
-		zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Possible integer overflow in shared memory allocation (%zu + %zu)", size, PLATFORM_ALIGNMENT);
-	}
+	size_t block_size = ZEND_ALIGNED_SIZE(size);
 
 	if (block_size > ZSMMG(shared_free)) { /* No hope to find a big-enough block */
 		SHARED_ALLOC_FAILED();


### PR DESCRIPTION
The interned string buffer is organized as a header + a hash table + a zend_string arena. Hash slots point to the arena, but are represented as 32bit offsets from the buffer, which limits the maximum buffer size to about 4GiB. However zend_strings are 8-byte aligned in the buffer, so we can compress the 3 lower bits. This allows to increase the maximum supported interned string buffer size from 4095 MiB to 32767 MiB.