### PR TITLE
Fix defined but not used warnings

### DIFF
--- a/sapi/litespeed/lscriu.c
+++ b/sapi/litespeed/lscriu.c
@@ -99,7 +99,9 @@ static int (*s_lscapi_dump_me)(void) = NULL;
 static int (*s_lscapi_prepare_me)(void) = NULL;
 static int s_native = 0;
 static int s_tried_checkpoint = 0;
+#ifdef LSAPILIB_DEBUG_CRIU
 static int s_criu_debug = 0;
+#endif
 static int s_fd_native = -1;
 static char *s_criu_image_path = NULL;
 static int s_pid = 0;
@@ -309,6 +311,7 @@ static void LSCRIU_Wink_Server_is_Ready(void)
 }
 
 
+#ifdef LSAPILIB_DEBUG_CRIU
 static char *LSCRIU_Error_File_Name(char *pchFile, int max_len)
 {
     const char *pchDefaultSocketPath = "/tmp/";
@@ -319,7 +322,6 @@ static char *LSCRIU_Error_File_Name(char *pchFile, int max_len)
 }
 
 
-#ifdef LSAPILIB_DEBUG_CRIU
 static void LSCRIU_Debugging(void) {
     char *pchCRIUDebug;
     pchCRIUDebug = getenv("LSAPI_CRIU_DEBUG");


### PR DESCRIPTION
This fixes two warnings when building litespeed SAPI:

```
.../php-src/sapi/litespeed/lscriu.c:312:14: warning:
'LSCRIU_Error_File_Name' defined but not used
[-Wunused-function]
  312 | static char *LSCRIU_Error_File_Name(char *pchFile, int max_len)
      |              ^~~~~~~~~~~~~~~~~~~~~~
.../php-src/sapi/litespeed/lscriu.c:102:12: warning:
's_criu_debug' defined but not used [-Wunused-variable]
  102 | static int s_criu_debug = 0;
      |            ^~~~~~~~~~~~
```