### PR TITLE
Verify stub aliases in CI

### DIFF
--- a/.github/actions/verify-generated-files/action.yml
+++ b/.github/actions/verify-generated-files/action.yml
@@ -4,12 +4,11 @@ runs:
   steps:
     - shell: bash
       run: |
-        set -x
+        set -ex
         [[ "$OSTYPE" == "darwin"* ]] && export PATH="$(brew --prefix)/opt/bison/bin:$PATH"
         scripts/dev/credits
         scripts/dev/genfiles
         Zend/zend_vm_gen.php
         ext/tokenizer/tokenizer_data_gen.php
-        build/gen_stub.php -f
-        build/gen_stub.php --generate-optimizer-info
+        build/gen_stub.php -f --generate-optimizer-info --verify
         git add . -N && git diff --exit-code

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -5922,7 +5922,7 @@ if ($verify) {
     $errors = [];
 
     foreach ($funcMap as $aliasFunc) {
-        if (!$aliasFunc->alias) {
+        if (!$aliasFunc->alias || $aliasFunc->aliasType !== "alias") {
             continue;
         }
 

--- a/ext/bz2/bz2.stub.php
+++ b/ext/bz2/bz2.stub.php
@@ -14,21 +14,18 @@ function bzread($bz, int $length = 1024): string|false {}
 /**
  * @param resource $bz
  * @implementation-alias fwrite
- * @no-verify Uses different parameter name
  */
 function bzwrite($bz, string $data, ?int $length = null): int|false {}
 
 /**
  * @param resource $bz
  * @implementation-alias fflush
- * @no-verify Uses different parameter name
  */
 function bzflush($bz): bool {}
 
 /**
  * @param resource $bz
  * @implementation-alias fclose
- * @no-verify Uses different parameter name
  */
 function bzclose($bz): bool {}
 

--- a/ext/bz2/bz2_arginfo.h
+++ b/ext/bz2/bz2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ebd3dc9902075c276828c17dc7a1c3bdc5401f8e */
+ * Stub hash: c2c8e0fe1e3244c8cadafe60b65b7235c105b3c9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bzopen, 0, 0, 2)
 	ZEND_ARG_INFO(0, file)

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -776,7 +776,6 @@ class mysqli
     /**
      * @return true
      * @alias mysqli_close
-     * @no-verify
      */
     public function close() {} // TODO make return type void
 
@@ -989,7 +988,6 @@ class mysqli
     /**
      * @return true
      * @alias mysqli_ssl_set
-     * @no-verify
      */
     public function ssl_set(
         ?string $key,
@@ -1242,7 +1240,6 @@ class mysqli_stmt
     /**
      * @return true
      * @alias mysqli_stmt_close
-     * @no-verify
      */
     public function close() {} // TODO make return type void
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a54ef005e9535458e886b7845a25a1c742a114ac */
+ * Stub hash: a8822bd2d34cadfd7c7e166cb7be38271ea3ae6a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)

--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -245,10 +245,7 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 
 class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 {
-    /**
-     * @implementation-alias Phar::__construct
-     * @no-verify PharData constructor accepts extra $format argument
-     */
+    /** @implementation-alias Phar::__construct */
     public function __construct(string $filename, int $flags = FilesystemIterator::SKIP_DOTS|FilesystemIterator::UNIX_PATHS, ?string $alias = null, int $format = 0) {}
 
     /** @implementation-alias Phar::__destruct */
@@ -299,14 +296,12 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
     /**
      * @tentative-return-type
      * @implementation-alias Phar::compress
-     * @no-verify
      */
     public function compress(int $compression, ?string $extension = null): ?PharData {}
 
     /**
      * @tentative-return-type
      * @implementation-alias Phar::decompress
-     * @no-verify
      */
     public function decompress(?string $extension = null): ?PharData {}
 

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 00f5d4fc74e8b7dc67da6f12180c9fae343954cc */
+ * Stub hash: 03ae11b93de6df5cfb494662f96a1474ddc2fd28 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -800,10 +800,7 @@ class ReflectionEnumUnitCase extends ReflectionClassConstant
 
     public function getEnum(): ReflectionEnum {}
 
-    /**
-     * @implementation-alias ReflectionClassConstant::getValue
-     * @no-verify
-     */
+    /** @implementation-alias ReflectionClassConstant::getValue */
     public function getValue(): UnitEnum {}
 }
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0adb92be59fadce74bb12017fe64ffbccab2a060 */
+ * Stub hash: f787e43effbd114daddad5d3ffcaf9faf7821d64 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)

--- a/ext/spl/spl_observer.stub.php
+++ b/ext/spl/spl_observer.stub.php
@@ -88,7 +88,6 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @param object $object
      * @tentative-return-type
      * @implementation-alias SplObjectStorage::attach
-     * @no-verify Cannot specify arg type because ArrayAccess does not
      */
     public function offsetSet($object, mixed $info = null): void {}
 
@@ -96,7 +95,6 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @param object $object
      * @tentative-return-type
      * @implementation-alias SplObjectStorage::detach
-     * @no-verify Cannot specify arg type because ArrayAccess does not
      */
     public function offsetUnset($object): void {}
 
@@ -159,9 +157,6 @@ class MultipleIterator implements Iterator
     /** @tentative-return-type */
     public function next(): void {}
 
-    /**
-     * @tentative-return-type
-     * @implementation-alias SplObjectStorage::__debugInfo
-     */
+    /** @tentative-return-type */
     public function __debugInfo(): array {}
 }

--- a/ext/spl/spl_observer.stub.php
+++ b/ext/spl/spl_observer.stub.php
@@ -157,6 +157,9 @@ class MultipleIterator implements Iterator
     /** @tentative-return-type */
     public function next(): void {}
 
-    /** @tentative-return-type */
+    /**
+     * @tentative-return-type
+     * @implementation-alias SplObjectStorage::__debugInfo
+     */
     public function __debugInfo(): array {}
 }

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3e17e99dffb3150685ae7c4724d6b8aad2f5db6e */
+ * Stub hash: 2d075036abecd043dbf5f3a2ab0c57f2d49e42f0 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObserver_update, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)
@@ -166,6 +166,7 @@ ZEND_METHOD(MultipleIterator, valid);
 ZEND_METHOD(MultipleIterator, key);
 ZEND_METHOD(MultipleIterator, current);
 ZEND_METHOD(MultipleIterator, next);
+ZEND_METHOD(MultipleIterator, __debugInfo);
 
 static const zend_function_entry class_SplObserver_methods[] = {
 	ZEND_RAW_FENTRY("update", NULL, arginfo_class_SplObserver_update, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
@@ -220,7 +221,7 @@ static const zend_function_entry class_MultipleIterator_methods[] = {
 	ZEND_ME(MultipleIterator, key, arginfo_class_MultipleIterator_key, ZEND_ACC_PUBLIC)
 	ZEND_ME(MultipleIterator, current, arginfo_class_MultipleIterator_current, ZEND_ACC_PUBLIC)
 	ZEND_ME(MultipleIterator, next, arginfo_class_MultipleIterator_next, ZEND_ACC_PUBLIC)
-	ZEND_RAW_FENTRY("__debugInfo", zim_SplObjectStorage___debugInfo, arginfo_class_MultipleIterator___debugInfo, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(MultipleIterator, __debugInfo, arginfo_class_MultipleIterator___debugInfo, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2d075036abecd043dbf5f3a2ab0c57f2d49e42f0 */
+ * Stub hash: 1fc23a91e7531eeb73729d4ad44addf0190c3a62 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObserver_update, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)
@@ -166,7 +166,6 @@ ZEND_METHOD(MultipleIterator, valid);
 ZEND_METHOD(MultipleIterator, key);
 ZEND_METHOD(MultipleIterator, current);
 ZEND_METHOD(MultipleIterator, next);
-ZEND_METHOD(MultipleIterator, __debugInfo);
 
 static const zend_function_entry class_SplObserver_methods[] = {
 	ZEND_RAW_FENTRY("update", NULL, arginfo_class_SplObserver_update, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
@@ -221,7 +220,7 @@ static const zend_function_entry class_MultipleIterator_methods[] = {
 	ZEND_ME(MultipleIterator, key, arginfo_class_MultipleIterator_key, ZEND_ACC_PUBLIC)
 	ZEND_ME(MultipleIterator, current, arginfo_class_MultipleIterator_current, ZEND_ACC_PUBLIC)
 	ZEND_ME(MultipleIterator, next, arginfo_class_MultipleIterator_next, ZEND_ACC_PUBLIC)
-	ZEND_ME(MultipleIterator, __debugInfo, arginfo_class_MultipleIterator___debugInfo, ZEND_ACC_PUBLIC)
+	ZEND_RAW_FENTRY("__debugInfo", zim_SplObjectStorage___debugInfo, arginfo_class_MultipleIterator___debugInfo, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_FE_END
 };
 

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -272,13 +272,13 @@ class SQLite3
     public const int RECURSIVE = UNKNOWN;
 #endif
 
-    /**
-     * @implementation-alias SQLite3::open
-     * @no-verify SQLite3::open should really be static
-     */
+    /** @implementation-alias SQLite3::open */
     public function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = "") {}
 
-    /** @tentative-return-type */
+    /**
+     * @tentative-return-type
+     * @todo SQLite3::open should really be static
+     */
     public function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = ""): void {}
 
     /** @return bool */

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6c5f8bc087baa56f40834f9745f3d0f22f60edba */
+ * Stub hash: ec304d7a3db5b3a50c0d95755691bc055dffe047 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)


### PR DESCRIPTION
In the same time, let's not verify implementation aliases since they may now legitimately differ from their aliased function/method counterpart (think about the ext/dom refactoring). Additionally, unncessary `@no-verify` tags are cleaned up.