### PR TITLE
ext/curl: Cleanup `config.w32` to remove superfluous checks and outdated comments

### DIFF
--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -21,16 +21,14 @@ if (PHP_CURL != "no") {
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "curl", PHP_CURL))) ||
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "curl", PHP_CURL)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))) &&
 		!isNaN(ver_num) &&
-		(ver_num <= parseInt("0x073b00") || ver_num > parseInt("0x073b00") &&
-			CHECK_LIB("normaliz.lib", "curl", PHP_CURL) &&
-			CHECK_LIB("libssh2.lib", "curl", PHP_CURL) &&
-			CHECK_LIB("nghttp2.lib", "curl", PHP_CURL))
+		(CHECK_LIB("normaliz.lib", "curl", PHP_CURL) &&
+		 CHECK_LIB("libssh2.lib", "curl", PHP_CURL) &&
+		 CHECK_LIB("nghttp2.lib", "curl", PHP_CURL))
 		) {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
 		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB /D PHP_CURL_EXPORTS=1");
 		PHP_INSTALL_HEADERS("ext/curl", "php_curl.h");
-		// TODO: check for curl_version_info
 	} else {
 		WARNING("curl not enabled; libraries and headers not found");
 	}


### PR DESCRIPTION

 - Remove a check for an always-true curl version check
 - Remove a `TODO` comment for curl_version_info check that should be always available since libcurl 7.10