### PR TITLE
Fix GH-13680: Segfault with session_decode and compilation error

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -259,16 +259,17 @@ static zend_result php_session_decode(zend_string *data) /* {{{ */
 		php_error_docref(NULL, E_WARNING, "Unknown session.serialize_handler. Failed to decode session object");
 		return FAILURE;
 	}
+	zend_result result = SUCCESS;
 	zend_try {
 		if (PS(serializer)->decode(ZSTR_VAL(data), ZSTR_LEN(data)) == FAILURE) {
 			php_session_cancel_decode();
-			return FAILURE;
+			result = FAILURE;
 		}
 	} zend_catch {
 		php_session_cancel_decode();
 		zend_bailout();
 	} zend_end_try();
-	return SUCCESS;
+	return result;
 }
 /* }}} */
 

--- a/ext/session/tests/gh13680.phpt
+++ b/ext/session/tests/gh13680.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-13680 (Segfault with session_decode and compilation error)
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--INI--
+session.use_cookies=0
+session.use_strict_mode=0
+session.cache_limiter=
+session.serialize_handler=php_serialize
+session.save_handler=files
+error_reporting=E_ALL
+--FILE--
+<?php
+session_start();
+session_decode('foo');
+class Test extends DateTime {
+    public static function createFromFormat($format, $datetime, $timezone = null): Wrong {}
+}
+?>
+--EXPECTF--
+Warning: session_decode(): Failed to decode session object. Session has been destroyed in %s on line %d
+
+Fatal error: Could not check compatibility between Test::createFromFormat($format, $datetime, $timezone = null): Wrong and DateTime::createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): DateTime|false, because class Wrong is not available in %s on line %d


### PR DESCRIPTION
It's illegal to return from a bailout because that doesn't restore the original bailout data. Return outside of it.

Test by YuanchengJiang