### PR TITLE
random: Initialize the `mode` field when seeding in `php_random_default_status()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,8 @@ PHP                                                                        NEWS
 - Random:
   . Fixed bug GH-13544 (Pre-PHP 8.2 compatibility for mt_srand with unknown
     modes). (timwolla)
+  . Fixed bug GH-13690 (Global Mt19937 is not properly reset in-between
+    requests when MT_RAND_PHP is used). (timwolla)
 
 - Sockets:
   . Fixed bug GH-13604 (socket_getsockname returns random characters in the end

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -334,6 +334,7 @@ PHPAPI php_random_status *php_random_default_status(void)
 	php_random_status *status = RANDOM_G(mt19937);
 
 	if (!RANDOM_G(mt19937_seeded)) {
+		((php_random_status_state_mt19937 *)status->state)->mode = MT_RAND_MT19937;
 		php_random_mt19937_seed_default(status->state);
 		RANDOM_G(mt19937_seeded) = true;
 	}


### PR DESCRIPTION
Unfortunately this is not really testable, as the used mode is not externally observable.

----------

This is not just an issue due to missing initialization since moving the state struct directly into the module globals. In earlier versions changing the mode to `MT_RAND_PHP` within a single request would also affect the mode for subsequent requests.

Original commit message follows:

This is a follow-up fix for GH-13579. The issue was detected in the nightly MSAN build.

(cherry picked from commit bf0abd1629291c193064a9cb95a2da3565decc38)