### PR TITLE
ext/gettext: updating apis accepting domain behavior.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -324,7 +324,7 @@ PHP 8.4 UPGRADE NOTES
 
 - Gettext:
   . bind_textdomain_codeset, textdomain and d(*)gettext functions now throw an exception
-    if the domain's argument is empty.
+    if the domain argument is empty.
 
 - Hash:
   . Changed the return type of hash_update() to true. It was already the case that only

--- a/UPGRADING
+++ b/UPGRADING
@@ -323,7 +323,8 @@ PHP 8.4 UPGRADE NOTES
     Previously, the return type was bool but only true could be returned in practice.
 
 - Gettext:
-  . bind_textdomain_codeset now throws an exception if the domain's argument is empty.
+  . bind_textdomain_codeset, textdomain and d(*)gettext functions now throw an exception
+    if the domain's argument is empty.
 
 - Hash:
   . Changed the return type of hash_update() to true. It was already the case that only

--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -54,6 +54,9 @@ ZEND_GET_MODULE(php_gettext)
 	if (UNEXPECTED(domain_len > PHP_GETTEXT_MAX_DOMAIN_LENGTH)) { \
 		zend_argument_value_error(_arg_num, "is too long"); \
 		RETURN_THROWS(); \
+	} else if (domain_len == 0) { \
+		zend_argument_value_error(_arg_num, "cannot be empty"); \
+		RETURN_THROWS(); \
 	}
 
 #define PHP_GETTEXT_LENGTH_CHECK(_arg_num, check_len) \
@@ -179,11 +182,6 @@ PHP_FUNCTION(bindtextdomain)
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, domain_len)
 
-	if (!domain_len) {
-		zend_argument_value_error(1, "cannot be empty");
-		RETURN_THROWS();
-	}
-
 	if (dir == NULL) {
 		RETURN_STRING(bindtextdomain(domain, NULL));
 	}
@@ -291,11 +289,6 @@ PHP_FUNCTION(bind_textdomain_codeset)
 	}
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, domain_len)
-
-	if (!domain_len) {
-		zend_argument_value_error(1, "cannot be empty");
-		RETURN_THROWS();
-	}
 
 	retval = bind_textdomain_codeset(domain, codeset);
 

--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -88,8 +88,11 @@ PHP_FUNCTION(textdomain)
 		RETURN_THROWS();
 	}
 
-	if (domain != NULL && ZSTR_LEN(domain) != 0 && !zend_string_equals_literal(domain, "0")) {
+	if (domain != NULL) {
 		PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
+	}
+
+	if (domain != NULL && !zend_string_equals_literal(domain, "0")) {
 		domain_name = ZSTR_VAL(domain);
 	}
 

--- a/ext/gettext/tests/dcngettext.phpt
+++ b/ext/gettext/tests/dcngettext.phpt
@@ -13,8 +13,18 @@ var_dump(dcngettext(1,1,1,1,1));
 var_dump(dcngettext("test","test","test",1,1));
 var_dump(dcngettext("test","test","test",0,1));
 var_dump(dcngettext("test","test","test",-1,-1));
-var_dump(dcngettext("","","",1,1));
-var_dump(dcngettext("","","",0,1));
+
+try {
+    dcngettext("","","",1,1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    dcngettext("","","",0,1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
 
 echo "Done\n";
 ?>
@@ -23,6 +33,6 @@ string(1) "1"
 string(4) "test"
 string(4) "test"
 string(4) "test"
-string(0) ""
-string(0) ""
+dcngettext(): Argument #1 ($domain) cannot be empty
+dcngettext(): Argument #1 ($domain) cannot be empty
 Done

--- a/ext/gettext/tests/gettext_textdomain-retval.phpt
+++ b/ext/gettext/tests/gettext_textdomain-retval.phpt
@@ -18,11 +18,18 @@ bindtextdomain ("messages", "./locale");
 echo textdomain('test'), "\n";
 echo textdomain(null), "\n";
 echo textdomain('foo'), "\n";
+
+try {
+	textdomain('');
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
 ?>
 --EXPECT--
 test
 test
 foo
+textdomain(): Argument #1 ($domain) cannot be empty
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09


### PR DESCRIPTION
to be more in line with the proper usage ; normally domain should not be empty strings.