### PR TITLE
Fix GH-13685: Unexpected null pointer in zend_string.h

### DIFF
--- a/ext/spl/tests/gh13685.phpt
+++ b/ext/spl/tests/gh13685.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-13685 (Unexpected null pointer in zend_string.h)
+--FILE--
+<?php
+
+$contents = <<<EOS
+"A", "B", "C"
+"D", "E", "F"
+EOS;
+
+echo "--- Directly call fgetcsv ---\n";
+
+$file = new SplTempFileObject;
+$file->fwrite($contents);
+$file->rewind();
+while (($data = $file->fgetcsv(',', '"', ''))) {
+    var_dump((string) $file);
+}
+try {
+    var_dump((string) $file);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Use csv control ---\n";
+
+$file = new SplTempFileObject;
+$file->fwrite($contents);
+$file->rewind();
+$file->setFlags(SplFileObject::READ_CSV);
+$file->setCsvControl(',', '"', '');
+foreach ($file as $row) {
+    var_dump((string) $file);
+}
+try {
+    var_dump((string) $file);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+--- Directly call fgetcsv ---
+string(14) ""A", "B", "C"
+"
+string(13) ""D", "E", "F""
+Cannot read from file php://temp
+--- Use csv control ---
+string(14) ""A", "B", "C"
+"
+string(13) ""D", "E", "F""
+Cannot read from file php://temp


### PR DESCRIPTION
Regressed in 6fbf81c.

There is a missing error check on spl_filesystem_file_read_line(), which means that if the line could not be read (e.g. because we're at the end of the file), it will not set intern->u.file.current_line, which will cause a NULL pointer deref later on.

Fix it by adding a check, and reintroducing the silent flag partially to be able to throw an exception like it did in the past.