### PR TITLE
Fix GH-13688: Test curl_basic_008 can fail

### DIFF
--- a/ext/curl/tests/curl_basic_008.phpt
+++ b/ext/curl/tests/curl_basic_008.phpt
@@ -6,7 +6,7 @@ TestFest 2009 - AFUP - Perrick Penet <perrick@noparking.net>
 curl
 --SKIPIF--
 <?php
-    $addr = "www.".uniqid().".".uniqid();
+    $addr = "www.".uniqid().".invalid";
     if (gethostbyname($addr) != $addr) {
         print "skip catch all dns";
     }
@@ -14,7 +14,7 @@ curl
 --FILE--
 <?php
 
-$url = "http://www.".uniqid().".".uniqid();
+$url = "http://www.".uniqid().".invalid";
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $url);
 


### PR DESCRIPTION
I'd say: just point it to a domain PHP controls and we should be fine?