### PR TITLE
Call _exit(2) not exit(3) on fatal non-recoverable errors

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1215,7 +1215,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
 
 	if (!EG(bailout)) {
 		zend_output_debug_string(1, "%s(%d) : Bailed out without a bailout address!", filename, lineno);
-		exit(-1);
+		_exit(-1);
 	}
 	gc_protect(1);
 	CG(unclean_shutdown) = 1;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3276,7 +3276,7 @@ ZEND_API void zend_activate_modules(void) /* {{{ */
 
 		if (module->request_startup_func(module->type, module->module_number)==FAILURE) {
 			zend_error(E_WARNING, "request_startup() for %s module failed", module->name);
-			exit(1);
+			_exit(1);
 		}
 		p++;
 	}

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -388,7 +388,7 @@ static ZEND_COLD ZEND_NORETURN void zend_mm_safe_error(zend_mm_heap *heap,
 	}  zend_end_try();
 	heap->overflow = 0;
 	zend_bailout();
-	exit(1);
+	_exit(1);
 }
 
 #ifdef _WIN32
@@ -2770,7 +2770,7 @@ ZEND_API void shutdown_memory_manager(bool silent, bool full_shutdown)
 static ZEND_COLD ZEND_NORETURN void zend_out_of_memory(void)
 {
 	fprintf(stderr, "Out of memory\n");
-	exit(1);
+	_exit(1);
 }
 
 #if ZEND_MM_CUSTOM

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4716,15 +4716,15 @@ static zend_result accel_finish_startup_preload_subprocess(pid_t *pid)
 	if (*pid == 0) { /* children */
 		if (setgid(pw->pw_gid) < 0) {
 			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setgid(%d)", pw->pw_gid);
-			exit(1);
+			_exit(1);
 		}
 		if (initgroups(pw->pw_name, pw->pw_gid) < 0) {
 			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to initgroups(\"%s\", %d)", pw->pw_name, pw->pw_uid);
-			exit(1);
+			_exit(1);
 		}
 		if (setuid(pw->pw_uid) < 0) {
 			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setuid(%d)", pw->pw_uid);
-			exit(1);
+			_exit(1);
 		}
 	}
 
@@ -4775,7 +4775,7 @@ static zend_result accel_finish_startup(void)
 	} else if (pid == 0) { /* subprocess */
 		const zend_result ret = accel_finish_startup_preload(true);
 
-		exit(ret == SUCCESS ? 0 : 1);
+		_exit(ret == SUCCESS ? 0 : 1);
 	} else { /* parent */
 		int status;
 

--- a/ext/opcache/jit/ir/dynasm/dasm_proto.h
+++ b/ext/opcache/jit/ir/dynasm/dasm_proto.h
@@ -33,7 +33,7 @@
       if (_sz < 16) _sz = 16; \
       while (_sz < _need) _sz += _sz; \
       (p) = (t *)realloc((p), _sz); \
-      if ((p) == NULL) exit(1); \
+      if ((p) == NULL) _exit(1); \
       (sz) = _sz; \
     } \
   } while(0)

--- a/ext/opcache/jit/ir/ir_ra.c
+++ b/ext/opcache/jit/ir/ir_ra.c
@@ -3008,7 +3008,7 @@ static ir_reg ir_allocate_blocked_reg(ir_ctx *ctx, ir_live_interval *ival, ir_li
 	if (IR_REGSET_IS_EMPTY(available)) {
 		fprintf(stderr, "LSRA Internal Error: No registers available. Allocation is not possible\n");
 		IR_ASSERT(0);
-		exit(-1);
+		_exit(-1);
 	}
 
 	/* for each interval it in active */
@@ -3160,7 +3160,7 @@ try_next_available_register:
 			if (IR_REGSET_IS_EMPTY(available)) {
 				fprintf(stderr, "LSRA Internal Error: Unsolvable conflict. Allocation is not possible\n");
 				IR_ASSERT(0);
-				exit(-1);
+				_exit(-1);
 			}
 			IR_LOG_LSRA("      ---- Restart", ival, "");
 			goto select_register;

--- a/ext/opcache/zend_accelerator_debug.c
+++ b/ext/opcache/zend_accelerator_debug.c
@@ -90,7 +90,7 @@ static void zend_accel_error_va_args(int type, const char *format, va_list args)
 			zend_bailout();
 			break;
 		case ACCEL_LOG_FATAL:
-			exit(-2);
+			_exit(-2);
 			break;
 	}
 

--- a/main/main.c
+++ b/main/main.c
@@ -1388,7 +1388,7 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 		case E_CORE_ERROR:
 			if(!module_initialized) {
 				/* bad error in module startup - no way we can live with this */
-				exit(-2);
+				_exit(-2);
 			}
 		ZEND_FALLTHROUGH;
 		case E_ERROR:

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2002,7 +2002,7 @@ consult the installation file that came with this distribution, or visit \n\
 				sigaction(SIGQUIT, &act, &old_quit)
 			) {
 				perror("Can't set signals");
-				exit(1);
+				_exit(1);
 			}
 
 			if (fcgi_in_shutdown()) {
@@ -2031,7 +2031,7 @@ consult the installation file that came with this distribution, or visit \n\
 						break;
 					case -1:
 						perror("php (pre-forking)");
-						exit(1);
+						_exit(1);
 						break;
 					default:
 						/* Fine */

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2473,7 +2473,7 @@ static void php_cli_server_worker_install_pdeathsig(void)
 
 	// Check if parent has exited just after the fork
 	if (getppid() != php_cli_server_master) {
-		exit(1);
+		_exit(1);
 	}
 }
 #endif

--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -200,7 +200,7 @@ static void fpm_child_init(struct fpm_worker_pool_s *wp) /* {{{ */
 	    0 > fpm_child_cloexec()) {
 
 		zlog(ZLOG_ERROR, "[pool %s] child failed to initialize", wp->config->name);
-		exit(FPM_EXIT_SOFTWARE);
+		_exit(FPM_EXIT_SOFTWARE);
 	}
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -105,7 +105,7 @@ static void fpm_pctl_exec(void)
 
 	execvp(saved_argv[0], saved_argv);
 	zlog(ZLOG_SYSERROR, "failed to reload: execvp() failed");
-	exit(FPM_EXIT_SOFTWARE);
+	_exit(FPM_EXIT_SOFTWARE);
 }
 
 static void fpm_pctl_action_last(void)

--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -643,34 +643,34 @@ int fpm_unix_init_main(void)
 				ret = select(fpm_globals.send_config_pipe[0] + 1, &rfds, NULL, NULL, &tv);
 				if (ret == -1) {
 					zlog(ZLOG_SYSERROR, "failed to select");
-					exit(FPM_EXIT_SOFTWARE);
+					_exit(FPM_EXIT_SOFTWARE);
 				}
 				if (ret) { /* data available */
 					int readval;
 					ret = read(fpm_globals.send_config_pipe[0], &readval, sizeof(readval));
 					if (ret == -1) {
 						zlog(ZLOG_SYSERROR, "failed to read from pipe");
-						exit(FPM_EXIT_SOFTWARE);
+						_exit(FPM_EXIT_SOFTWARE);
 					}
 
 					if (ret == 0) {
 						zlog(ZLOG_ERROR, "no data have been read from pipe");
-						exit(FPM_EXIT_SOFTWARE);
+						_exit(FPM_EXIT_SOFTWARE);
 					} else {
 						if (readval == 1) {
 							zlog(ZLOG_DEBUG, "I received a valid acknowledge from the master process, I can exit without error");
 							fpm_cleanups_run(FPM_CLEANUP_PARENT_EXIT);
-							exit(FPM_EXIT_OK);
+							_exit(FPM_EXIT_OK);
 						} else {
 							zlog(ZLOG_DEBUG, "The master process returned an error !");
-							exit(FPM_EXIT_SOFTWARE);
+							_exit(FPM_EXIT_SOFTWARE);
 						}
 					}
 				} else { /* no date sent ! */
 					zlog(ZLOG_ERROR, "the master process didn't send back its status (via the pipe to the calling process)");
-				  exit(FPM_EXIT_SOFTWARE);
+				  _exit(FPM_EXIT_SOFTWARE);
 				}
-				exit(FPM_EXIT_SOFTWARE);
+				_exit(FPM_EXIT_SOFTWARE);
 		}
 	}
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1068,7 +1068,7 @@ void phpdbg_signal_handler(int sig, siginfo_t *info, void *context) /* {{{ */
 
 void phpdbg_sighup_handler(int sig) /* {{{ */
 {
-	exit(0);
+	_exit(0);
 } /* }}} */
 #endif
 


### PR DESCRIPTION
On unrecoverable errors there is no point in trying to flush stdio buffers or run atexit handlers or perform any cleanup operation that may not even complete.
