### PR TITLE
Change return type of DOM\HTMLDocument::saveHTML()

### DIFF
--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1294,8 +1294,8 @@ PHP_METHOD(DOM_HTMLDocument, saveHTML)
 	if (nodep != NULL) {
 		DOM_GET_OBJ(node, nodep, xmlNodePtr, nodeobj);
 		if (node->doc != docp) {
-			php_dom_throw_error(WRONG_DOCUMENT_ERR, dom_get_strict_error(intern->document));
-			RETURN_FALSE;
+			php_dom_throw_error(WRONG_DOCUMENT_ERR, true);
+			RETURN_THROWS();
 		}
 	} else {
 		node = (const xmlNode *) docp;

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1599,7 +1599,7 @@ namespace DOM
         /** @implementation-alias DOMDocument::save */
         public function saveXMLFile(string $filename, int $options = 0): int|false {}
 
-        public function saveHTML(?Node $node = null): string|false {}
+        public function saveHTML(?Node $node = null): string {}
 
         public function saveHTMLFile(string $filename): int|false {}
     }

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bca273cb7255e24536575922505d3cce7488b32d */
+ * Stub hash: 59b592b969e62100af3e3d73212cf513ab8d3ab8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -1007,7 +1007,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_DOM_HTMLDocument_saveXMLFi
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_DOM_HTMLDocument_saveHTML, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DOM_HTMLDocument_saveHTML, 0, 0, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, node, DOM\\\116ode, 1, "null")
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Strict error checking is always true for classes in "new DOM". This means that we always throw an error when calling `php_dom_throw_error`, and therefore the false return value is not actually possible.
Also change the stub to reflect this.