### PR TITLE
Fix parameter hints in php_xsl.stub.php

### DIFF
--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -76,25 +76,25 @@ class XSLTProcessor
     public bool $cloneDocument = false;
 
     /**
-     * @param DOM\Document|SimpleXMLElement $stylesheet
+     * @param DOMDocument|DOM\Document|SimpleXMLElement $stylesheet
      * @tentative-return-type
      */
     public function importStylesheet(object $stylesheet): bool {}
 
     /**
-     * @param DOM\Document|SimpleXMLElement $document
+     * @param DOMDocument|DOM\Document|SimpleXMLElement $document
      * @tentative-return-type
      */
     public function transformToDoc(object $document, ?string $returnClass = null): object|false {}
 
     /**
-     * @param DOM\Document|SimpleXMLElement $document
+     * @param DOMDocument|DOM\Document|SimpleXMLElement $document
      * @tentative-return-type
      */
     public function transformToUri(object $document, string $uri): int {}
 
     /**
-     * @param DOM\Document|SimpleXMLElement $document
+     * @param DOMDocument|DOM\Document|SimpleXMLElement $document
      * @tentative-return-type
      */
     public function transformToXml(object $document): string|null|false {}

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0d12e04d92a3f0cc70179814aab0491d1d3fd2f7 */
+ * Stub hash: 855b4db5fd6a8f99ee0580008ecca2a747174b02 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)


### PR DESCRIPTION
After the spec compliance PR landed, DOMDocument no longer inherits from DOM\Document, and so the type hint needs to be updated.