### PR TITLE
Declare the missing true return types

### DIFF
--- a/ext/fileinfo/fileinfo.stub.php
+++ b/ext/fileinfo/fileinfo.stub.php
@@ -83,10 +83,10 @@ class finfo
     public function buffer(string $string, int $flags = FILEINFO_NONE, $context = null): string|false {}
 
     /**
-     * @return bool
      * @alias finfo_set_flags
+     * @tentative-return-type
      */
-    public function set_flags(int $flags) {} // TODO make return type void
+    public function set_flags(int $flags): true {}
 }
 
 /** @refcount 1 */
@@ -94,7 +94,7 @@ function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null):
 
 function finfo_close(finfo $finfo): bool {}
 
-function finfo_set_flags(finfo $finfo, int $flags): bool {} // TODO make return type void
+function finfo_set_flags(finfo $finfo, int $flags): true {}
 
 /**
  * @param resource|null $context

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 94697d59958fb55a431bfa4786158b5db3c1ae0e */
+ * Stub hash: 96d78126bc5af37c5d94fa160e509623e947de48 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_finfo_open, 0, 0, finfo, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
@@ -10,7 +10,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_finfo_close, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_finfo_set_flags, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_finfo_set_flags, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -50,7 +50,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_finfo_buffer, 0,
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_finfo_set_flags, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_finfo_set_flags, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/calendar/calendar.stub.php
+++ b/ext/intl/calendar/calendar.stub.php
@@ -127,10 +127,10 @@ class IntlCalendar
     public function before(IntlCalendar $other): bool {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_clear
      */
-    public function clear(?int $field = null) {} // TODO make return type void
+    public function clear(?int $field = null): true {}
 
     /**
      * @tentative-return-type
@@ -224,10 +224,10 @@ class IntlCalendar
     public function getMinimalDaysInFirstWeek(): int|false {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_set_minimal_days_in_first_week
      */
-    public function setMinimalDaysInFirstWeek(int $days) {} // TODO make return void
+    public function setMinimalDaysInFirstWeek(int $days): true {}
 
     /**
      * @tentative-return-type
@@ -315,38 +315,38 @@ class IntlCalendar
     public function isSet(int $field): bool {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @implementation-alias intlcal_set
      */
-    public function set(int $year, int $month, int $dayOfMonth = UNKNOWN, int $hour = UNKNOWN, int $minute = UNKNOWN, int $second = UNKNOWN) {} // TODO make return type void
+    public function set(int $year, int $month, int $dayOfMonth = UNKNOWN, int $hour = UNKNOWN, int $minute = UNKNOWN, int $second = UNKNOWN): true {}
 
     public function setDate(int $year, int $month, int $dayOfMonth): void {}
 
     public function setDateTime(int $year, int $month, int $dayOfMonth, int $hour, int $minute, ?int $second = null): void {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_set_first_day_of_week
      */
-    public function setFirstDayOfWeek(int $dayOfWeek) {} // TODO make return type void
+    public function setFirstDayOfWeek(int $dayOfWeek): true {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_set_lenient
      */
-    public function setLenient(bool $lenient) {} // TODO make return type void
+    public function setLenient(bool $lenient): true {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_set_repeated_wall_time_option
      */
-    public function setRepeatedWallTimeOption(int $option) {} // TODO make return type void
+    public function setRepeatedWallTimeOption(int $option): true {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias intlcal_set_skipped_wall_time_option
      */
-    public function setSkippedWallTimeOption(int $option) {} // TODO make return type void
+    public function setSkippedWallTimeOption(int $option): true {}
 
     /**
      * @tentative-return-type

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dbd7f8dd82cfdca04988aa791523b29b564347e0 */
+ * Stub hash: c014b88c9b6aa145ea20cc1f3fd719fe9f3d6966 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -27,7 +27,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_IntlCalendar_before arginfo_class_IntlCalendar_equals
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_clear, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_clear, 0, 0, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, field, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -77,7 +77,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_IntlCalendar_getMinimalDaysInFirstWeek arginfo_class_IntlCalendar_getErrorCode
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_setMinimalDaysInFirstWeek, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_setMinimalDaysInFirstWeek, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, days, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -122,7 +122,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_isS
 	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_set, 0, 0, 2)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_set, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, dayOfMonth, IS_LONG, 0)
@@ -146,15 +146,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_setDateTime, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_setFirstDayOfWeek, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_setFirstDayOfWeek, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, dayOfWeek, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_setLenient, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_setLenient, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, lenient, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_setRepeatedWallTimeOption, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlCalendar_setRepeatedWallTimeOption, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/collator/collator.stub.php
+++ b/ext/intl/collator/collator.stub.php
@@ -126,10 +126,10 @@ class Collator
     public function getStrength(): int {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @alias collator_set_strength
      */
-    public function setStrength(int $strength) {} // TODO make return type void
+    public function setStrength(int $strength): true {}
 
     /**
      * @tentative-return-type

--- a/ext/intl/collator/collator_arginfo.h
+++ b/ext/intl/collator/collator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e021fa414fee84d971ace20b7f9c903d1adc5560 */
+ * Stub hash: cbe3c5f4c35d93f90c3e7164bdfc4e2fefc88c83 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Collator___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -37,7 +37,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Collator_getStrength, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Collator_setStrength, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Collator_setStrength, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, strength, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/locale/locale.stub.php
+++ b/ext/intl/locale/locale.stub.php
@@ -32,10 +32,10 @@ class Locale
     public static function getDefault(): string {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @alias locale_set_default
      */
-    public static function setDefault(string $locale) {} // TODO make return type void
+    public static function setDefault(string $locale): true {}
 
     /**
      * @tentative-return-type

--- a/ext/intl/locale/locale_arginfo.h
+++ b/ext/intl/locale/locale_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e446ff14fc14d08a6ac225af78cde931e381ee5b */
+ * Stub hash: 59861342e0075231d2a576afb2d5df6973d70684 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_getDefault, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Locale_setDefault, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_setDefault, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -300,7 +300,7 @@ function collator_set_attribute(Collator $object, int $attribute, int $value): b
 
 function collator_get_strength(Collator $object): int {}
 
-function collator_set_strength(Collator $object, int $strength): bool {}
+function collator_set_strength(Collator $object, int $strength): true {}
 
 function collator_sort(Collator $object, array &$array, int $flags = Collator::SORT_REGULAR): bool {}
 
@@ -461,7 +461,7 @@ function idn_to_utf8(string $domain, int $flags = IDNA_DEFAULT, int $variant = I
 
 function locale_get_default(): string {}
 
-function locale_set_default(string $locale): bool {}
+function locale_set_default(string $locale): true {}
 
 function locale_get_primary_language(string $locale): ?string {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c1adcd8a928af82766ee8c0cd6b20c2f2e9afcc1 */
+ * Stub hash: 08c4caf706645f1afaa8d40c3887f01025ced930 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -226,7 +226,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collator_get_strength, 0, 1, IS_
 	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collator_set_strength, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collator_set_strength, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
 	ZEND_ARG_TYPE_INFO(0, strength, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -503,7 +503,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_locale_get_default arginfo_intl_get_error_message
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_set_default, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_set_default, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -774,10 +774,10 @@ class mysqli
     public function character_set_name(): string {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias mysqli_close
      */
-    public function close() {} // TODO make return type void
+    public function close(): true {}
 
     /**
      * @tentative-return-type
@@ -806,11 +806,11 @@ class mysqli
     public function dump_debug_info(): bool {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias mysqli_debug
      * @no-verify Should really be a static method
      */
-    public function debug(string $options) {} // TODO make return type void
+    public function debug(string $options): true {}
 
     /**
      * @tentative-return-type
@@ -986,7 +986,7 @@ class mysqli
     public function set_opt(int $option, $value): bool {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias mysqli_ssl_set
      */
     public function ssl_set(
@@ -995,7 +995,7 @@ class mysqli
         ?string $ca_certificate,
         ?string $ca_path,
         ?string $cipher_algos
-    ) {} // TODO make return type void
+    ): true {}
 
     /**
      * @tentative-return-type
@@ -1142,7 +1142,7 @@ class mysqli_result implements IteratorAggregate
      * @tentative-return-type
      * @alias mysqli_field_seek
      */
-    public function field_seek(int $index): true {} // TODO make return type void
+    public function field_seek(int $index): true {}
 
     /**
      * @tentative-return-type
@@ -1238,10 +1238,10 @@ class mysqli_stmt
     public function bind_result(mixed &...$vars): bool {}
 
     /**
-     * @return true
+     * @tentative-return-type
      * @alias mysqli_stmt_close
      */
-    public function close() {} // TODO make return type void
+    public function close(): true {}
 
     /**
      * @tentative-return-type
@@ -1360,7 +1360,7 @@ function mysqli_change_user(mysqli $mysql, string $username, #[\SensitiveParamet
 /** @refcount 1 */
 function mysqli_character_set_name(mysqli $mysql): string {}
 
-function mysqli_close(mysqli $mysql): true {} // TODO make return type void
+function mysqli_close(mysqli $mysql): true {}
 
 function mysqli_commit(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
@@ -1385,7 +1385,7 @@ function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
 function mysqli_dump_debug_info(mysqli $mysql): bool {}
 
-function mysqli_debug(string $options): true {} // TODO make return type void
+function mysqli_debug(string $options): true {}
 
 function mysqli_errno(mysqli $mysql): int {}
 
@@ -1454,7 +1454,7 @@ function mysqli_fetch_column(mysqli_result $result, int $column = 0): null|int|f
 
 function mysqli_field_count(mysqli $mysql): int {}
 
-function mysqli_field_seek(mysqli_result $result, int $index): true {} // TODO make return type void
+function mysqli_field_seek(mysqli_result $result, int $index): true {}
 
 function mysqli_field_tell(mysqli_result $result): int {}
 
@@ -1652,7 +1652,7 @@ function mysqli_ssl_set(
     ?string $ca_certificate,
     ?string $ca_path,
     ?string $cipher_algos
-): true {} // TODO make return type void
+): true {}
 
 /** @refcount 1 */
 function mysqli_stat(mysqli $mysql): string|false {}

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a8822bd2d34cadfd7c7e166cb7be38271ea3ae6a */
+ * Stub hash: 5cdfeec10f0f92e3e2f9d2df572b2681b208449d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -440,7 +440,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_character_set_name, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_close, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_close, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_commit arginfo_class_mysqli_begin_transaction
@@ -457,7 +457,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_dump_debug_info, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_debug, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_debug, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, options, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -479,7 +479,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_mysqli_get_warnings, 0, 0, mysqli_warning, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_mysqli_init arginfo_class_mysqli_close
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_init, 0, 0, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_kill, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
@@ -556,7 +557,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_set_opt arginfo_class_mysqli_options
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_ssl_set, 0, 0, 5)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_ssl_set, 0, 5, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, certificate, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, ca_certificate, IS_STRING, 1)
@@ -699,7 +700,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stmt_get_result arginfo_class_mysqli_use_result
 
-#define arginfo_class_mysqli_warning___construct arginfo_class_mysqli_close
+#define arginfo_class_mysqli_warning___construct arginfo_class_mysqli_init
 
 #define arginfo_class_mysqli_warning_next arginfo_mysqli_thread_safe
 

--- a/ext/pdo/pdo_stmt.stub.php
+++ b/ext/pdo/pdo_stmt.stub.php
@@ -61,8 +61,8 @@ class PDOStatement implements IteratorAggregate
     /** @tentative-return-type */
     public function setAttribute(int $attribute, mixed $value): bool {}
 
-    /** @return bool */
-    public function setFetchMode(int $mode, mixed ...$args) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function setFetchMode(int $mode, mixed ...$args): true {}
 
     public function getIterator(): Iterator {}
 }

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: adcbda7b6763141981700bec5d8c5b739f8de767 */
+ * Stub hash: 6a5b332ba4bfeceaca6aad734d38dabb66d82c97 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDOStatement_bindColumn, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_MASK(0, column, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -79,7 +79,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDOStatement_set
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_setFetchMode, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDOStatement_setFetchMode, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()

--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -95,8 +95,8 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
     /** @tentative-return-type */
     public function compressFiles(int $compression): void {}
 
-    /** @return bool */
-    public function decompressFiles() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function decompressFiles(): true {}
 
     /** @tentative-return-type */
     public function compress(int $compression, ?string $extension = null): ?Phar {}
@@ -110,17 +110,17 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
     /** @tentative-return-type */
     public function convertToData(?int $format = null, ?int $compression = null, ?string $extension = null): ?PharData {}
 
-    /** @return bool */
-    public function copy(string $from, string $to) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function copy(string $from, string $to): true {}
 
     /** @tentative-return-type */
     public function count(int $mode = COUNT_NORMAL): int {}
 
-    /** @return bool */
-    public function delete(string $localName) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function delete(string $localName): true {}
 
-    /** @return bool */
-    public function delMetadata() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function delMetadata(): true {}
 
     /** @tentative-return-type */
     public function extractTo(string $directory, array|string|null $files = null, bool $overwrite = false): bool {}
@@ -200,9 +200,9 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 
     /**
      * @param resource|string $stub
-     * @return bool
+     * @tentative-return-type
      */
-    public function setStub($stub, int $length = UNKNOWN) {} // TODO make return type void
+    public function setStub($stub, int $length = UNKNOWN): true {}
 
     /** @tentative-return-type */
     public function startBuffering(): void {}
@@ -236,7 +236,7 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 
     final public static function mungServer(array $variables): void {}
 
-    final public static function unlinkArchive(string $filename): bool {} // TODO make return type void
+    final public static function unlinkArchive(string $filename): true {}
 
     final public static function webPhar(
         ?string $alias = null, ?string $index = null, ?string $fileNotFoundScript = null,
@@ -288,10 +288,10 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
     public function compressFiles(int $compression): void {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @implementation-alias Phar::decompressFiles
      */
-    public function decompressFiles() {} // TODO make return type void
+    public function decompressFiles(): true {}
 
     /**
      * @tentative-return-type
@@ -318,10 +318,10 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
     public function convertToData(?int $format = null, ?int $compression = null, ?string $extension = null): ?PharData {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @implementation-alias Phar::copy
      */
-    public function copy(string $from, string $to) {} // TODO make return type void
+    public function copy(string $from, string $to): true {}
 
     /**
      * @tentative-return-type
@@ -330,16 +330,16 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
     public function count(int $mode = COUNT_NORMAL): int {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @implementation-alias Phar::delete
      */
-    public function delete(string $localName) {} // TODO make return type void
+    public function delete(string $localName): true {}
 
     /**
-     * @return bool
+     * @tentative-return-type
      * @implementation-alias Phar::delMetadata
      */
-    public function delMetadata() {} // TODO make return type void
+    public function delMetadata(): true {}
 
     /**
      * @tentative-return-type
@@ -474,10 +474,9 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
 
     /**
      * @param resource|string $stub
-     * @return bool
      * @implementation-alias Phar::setStub
      */
-    public function setStub($stub, int $length = UNKNOWN) {} // TODO make return type void
+    public function setStub($stub, int $length = UNKNOWN): true {}
 
     /**
      * @tentative-return-type
@@ -531,7 +530,7 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
     final public static function mungServer(array $variables): void {}
 
     /** @implementation-alias Phar::unlinkArchive */
-    final public static function unlinkArchive(string $filename): bool {} // TODO make return type void
+    final public static function unlinkArchive(string $filename): true {}
 
     /** @implementation-alias Phar::webPhar */
     final public static function webPhar(
@@ -548,14 +547,14 @@ class PharFileInfo extends SplFileInfo
     /** @tentative-return-type */
     public function chmod(int $perms): void {}
 
-    /** @return bool */
-    public function compress(int $compression) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function compress(int $compression): true {}
 
-    /** @return bool */
-    public function decompress() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function decompress(): true {}
 
-    /** @return bool */
-    public function delMetadata() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function delMetadata(): true {}
 
     /** @tentative-return-type */
     public function getCompressedSize(): int {}

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 03ae11b93de6df5cfb494662f96a1474ddc2fd28 */
+ * Stub hash: 4182a1159f6cf8a0d71a7814d0435b5e2be29276 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -38,7 +38,8 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_compressFil
 	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Phar_decompressFiles arginfo_class_Phar___destruct
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_decompressFiles, 0, 0, IS_TRUE, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_Phar_compress, 0, 1, Phar, 1)
 	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
@@ -61,7 +62,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_Phar_convertToDat
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, extension, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar_copy, 0, 0, 2)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_copy, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, from, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, to, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -70,11 +71,11 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_count, 0, 0
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "COUNT_NORMAL")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar_delete, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_delete, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Phar_delMetadata arginfo_class_Phar___destruct
+#define arginfo_class_Phar_delMetadata arginfo_class_Phar_decompressFiles
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_extractTo, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, directory, IS_STRING, 0)
@@ -150,7 +151,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_setSignatur
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, privateKey, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar_setStub, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Phar_setStub, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_INFO(0, stub)
 	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -211,7 +212,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Phar_mungServer, 0, 1, IS_
 	ZEND_ARG_TYPE_INFO(0, variables, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Phar_unlinkArchive, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Phar_unlinkArchive, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -244,7 +245,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_PharData_compressFiles arginfo_class_Phar_compressFiles
 
-#define arginfo_class_PharData_decompressFiles arginfo_class_Phar___destruct
+#define arginfo_class_PharData_decompressFiles arginfo_class_Phar_decompressFiles
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_PharData_compress, 0, 1, PharData, 1)
 	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
@@ -265,7 +266,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_PharData_delete arginfo_class_Phar_delete
 
-#define arginfo_class_PharData_delMetadata arginfo_class_Phar___destruct
+#define arginfo_class_PharData_delMetadata arginfo_class_Phar_decompressFiles
 
 #define arginfo_class_PharData_extractTo arginfo_class_Phar_extractTo
 
@@ -309,7 +310,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_PharData_setSignatureAlgorithm arginfo_class_Phar_setSignatureAlgorithm
 
-#define arginfo_class_PharData_setStub arginfo_class_Phar_setStub
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_PharData_setStub, 0, 1, IS_TRUE, 0)
+	ZEND_ARG_INFO(0, stub)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_PharData_startBuffering arginfo_class_Phar_startBuffering
 
@@ -355,13 +359,13 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PharFileInfo_chm
 	ZEND_ARG_TYPE_INFO(0, perms, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PharFileInfo_compress, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PharFileInfo_compress, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_PharFileInfo_decompress arginfo_class_Phar___destruct
+#define arginfo_class_PharFileInfo_decompress arginfo_class_Phar_decompressFiles
 
-#define arginfo_class_PharFileInfo_delMetadata arginfo_class_Phar___destruct
+#define arginfo_class_PharFileInfo_delMetadata arginfo_class_Phar_decompressFiles
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PharFileInfo_getCompressedSize, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -25,8 +25,8 @@ class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable, JsonSe
     /** @tentative-return-type */
     public function getSize(): int {}
 
-    /** @return bool */
-    public function setSize(int $size) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function setSize(int $size): true {}
 
     /**
      * @param int $index

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0b508ad6499b70c92bf25960b30fefa913532a3c */
+ * Stub hash: 35a9585a433b9e3d57263c07ccafd1b6edd2f10b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
@@ -28,7 +28,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_SplFixedArray_getSize arginfo_class_SplFixedArray_count
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray_setSize, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFixedArray_setSize, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, size, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -281,8 +281,8 @@ class SQLite3
      */
     public function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = ""): void {}
 
-    /** @return bool */
-    public function close() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function close(): true {}
 
     /** @tentative-return-type */
     public static function version(): array {}
@@ -405,6 +405,6 @@ class SQLite3Result
     /** @tentative-return-type */
     public function reset(): bool {}
 
-    /** @return bool */
-    public function finalize() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function finalize(): true {}
 }

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -282,7 +282,7 @@ class SQLite3
     public function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = ""): void {}
 
     /** @tentative-return-type */
-    public function close(): true {}
+    public function close(): bool {}
 
     /** @tentative-return-type */
     public static function version(): array {}
@@ -367,7 +367,7 @@ class SQLite3Stmt
     public function clear(): bool {}
 
     /** @tentative-return-type */
-    public function close(): bool {}
+    public function close(): true {}
 
     /** @tentative-return-type */
     public function execute(): SQLite3Result|false {}

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 28a003d4e83b956ab1e24b65c65e9ac28cfad0f4 */
+ * Stub hash: 4474d0a8fb45923895d172af430663932675a4ac */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -13,7 +13,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_open, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encryptionKey, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_close, 0, 0, IS_TRUE, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_close, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_version, 0, 0, IS_ARRAY, 0)
@@ -126,10 +126,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3Stmt_bind
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SQLITE3_TEXT")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3Stmt_clear, 0, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_SQLite3Stmt_clear arginfo_class_SQLite3_close
 
-#define arginfo_class_SQLite3Stmt_close arginfo_class_SQLite3Stmt_clear
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3Stmt_close, 0, 0, IS_TRUE, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_SQLite3Stmt_execute, 0, 0, SQLite3Result, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
@@ -140,9 +140,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Stmt_paramCount arginfo_class_SQLite3_lastInsertRowID
 
-#define arginfo_class_SQLite3Stmt_readOnly arginfo_class_SQLite3Stmt_clear
+#define arginfo_class_SQLite3Stmt_readOnly arginfo_class_SQLite3_close
 
-#define arginfo_class_SQLite3Stmt_reset arginfo_class_SQLite3Stmt_clear
+#define arginfo_class_SQLite3Stmt_reset arginfo_class_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Result___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -161,9 +161,9 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_SQLite3Result_fe
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "SQLITE3_BOTH")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_SQLite3Result_reset arginfo_class_SQLite3Stmt_clear
+#define arginfo_class_SQLite3Result_reset arginfo_class_SQLite3_close
 
-#define arginfo_class_SQLite3Result_finalize arginfo_class_SQLite3_close
+#define arginfo_class_SQLite3Result_finalize arginfo_class_SQLite3Stmt_close
 
 ZEND_METHOD(SQLite3, open);
 ZEND_METHOD(SQLite3, close);

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec304d7a3db5b3a50c0d95755691bc055dffe047 */
+ * Stub hash: 28a003d4e83b956ab1e24b65c65e9ac28cfad0f4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -13,7 +13,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_open, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encryptionKey, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_close, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_close, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_version, 0, 0, IS_ARRAY, 0)
@@ -144,7 +144,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Stmt_reset arginfo_class_SQLite3Stmt_clear
 
-#define arginfo_class_SQLite3Result___construct arginfo_class_SQLite3_close
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Result___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Result_numColumns arginfo_class_SQLite3_lastInsertRowID
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2232,7 +2232,7 @@ function openlog(string $prefix, int $flags, int $facility): true {}
 
 function closelog(): true {}
 
-function syslog(int $priority, string $message): true {} // TODO make return type void
+function syslog(int $priority, string $message): true {}
 #endif
 
 /** @refcount 1 */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2094d8e51f7bfd0fd7b61060786a1e8ae182b0d3 */
+ * Stub hash: 954bf48ac1f24a14fd7508c8bf4b781883398499 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)

--- a/ext/xmlreader/php_xmlreader.stub.php
+++ b/ext/xmlreader/php_xmlreader.stub.php
@@ -127,8 +127,8 @@ class XMLReader
 
     public string $xmlLang;
 
-    /** @return true */
-    public function close() {} // TODO make return type void
+    /** @tentative-return-type */
+    public function close(): true {}
 
     /** @tentative-return-type */
     public function getAttribute(string $name): ?string {}

--- a/ext/xmlreader/php_xmlreader_arginfo.h
+++ b/ext/xmlreader/php_xmlreader_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6284a7b9f4477a9c0b2dd268d6229653bf66297c */
+ * Stub hash: fc01b7eacbd96dbeaf0b6a3a045692a77ef033f1 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLReader_close, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XMLReader_close, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XMLReader_getAttribute, 0, 1, IS_STRING, 1)

--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -116,8 +116,8 @@ class XSLTProcessor
 
     public function registerPHPFunctionNS(string $namespaceURI, string $name, callable $callable): void {}
 
-    /** @return true */
-    public function setProfiling(?string $filename) {} // TODO make return type void
+    /** @tentative-return-type */
+    public function setProfiling(?string $filename): true {}
 
     /** @tentative-return-type */
     public function setSecurityPrefs(int $preferences): int {}

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 855b4db5fd6a8f99ee0580008ecca2a747174b02 */
+ * Stub hash: ae093276a1caf53c34d429076458bc8b802d69e9 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
@@ -48,7 +48,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_registerPHPF
 	ZEND_ARG_TYPE_INFO(0, callable, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XSLTProcessor_setProfiling, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_setProfiling, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
We have previously gave up on making these return types void, so it's better to declare them now as `true`, than to defer it until a new major version is already released.