### PR TITLE
Refactor ext/mbstring/libmbfl/config.h usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,5 +294,6 @@ tmp-php.ini
 !/ext/fileinfo/libmagic.patch
 !/ext/fileinfo/magicdata.patch
 !/ext/dom/lexbor/patches/*.patch
+!/ext/mbstring/libmbfl/config.h
 !/ext/pcre/pcre2lib/config.h
 !/win32/build/Makefile

--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -35,16 +35,6 @@ AC_DEFUN([PHP_MBSTRING_EXTENSION], [
     PHP_ADD_INCLUDE([$ext_builddir/$dir])
   done
 
-  out="php_config.h"
-
-  if test "$ext_shared" != "no" && test -f "$ext_builddir/config.h.in"; then
-    out="$abs_builddir/config.h"
-  fi
-
-  cat > $ext_builddir/libmbfl/config.h <<EOF
-#include "$out"
-EOF
-
   PHP_MBSTRING_ADD_INSTALL_HEADERS([mbstring.h])
   PHP_INSTALL_HEADERS([ext/mbstring], [$PHP_MBSTRING_INSTALL_HEADERS])
 ])

--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -11,10 +11,7 @@ if (PHP_MBSTRING != "no") {
 		STDOUT.WriteLine("Using bundled libmbfl...");
 
 		ADD_FLAG("CFLAGS_MBSTRING", "-Iext/mbstring -Iext/mbstring/libmbfl -Iext/mbstring/libmbfl/mbfl \
-			/D HAVE_STRICMP /D MBFL_DLL_EXPORT=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1")
-
-		FSO.CopyFile("ext\\mbstring\\libmbfl\\config.h.w32",
-			"ext\\mbstring\\libmbfl\\config.h", true);
+			/D MBFL_DLL_EXPORT=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1")
 
 		ADD_SOURCES("ext/mbstring/libmbfl/filters", "html_entities.c \
 			mbfilter_7bit.c mbfilter_base64.c \

--- a/ext/mbstring/libmbfl/config.h
+++ b/ext/mbstring/libmbfl/config.h
@@ -1,0 +1,7 @@
+#ifdef _WIN32
+# define HAVE_STRICMP 1
+#elif defined(HAVE_CONFIG_H)
+# include <config.h>
+#else
+# include <main/php_config.h>
+#endif

--- a/ext/mbstring/libmbfl/config.h.w32
+++ b/ext/mbstring/libmbfl/config.h.w32
@@ -1,1 +1,0 @@
-#define HAVE_STRICMP 1


### PR DESCRIPTION
This simplifies the libmbfl/config.h usage and removes duplicate compile definitions on Windows (HAVE_STRICMP).

The _WIN32 symbol is always defined when compiling on Windows with any current compiler, the HAVE_CONFIG_H symbol is defined only when doing phpize build inside mbstring extension (an edge case but if that is used by someone perhaps), otherwise the regular main/php_config.h is used.

This is sort of an addition to make it managing changes in #13516 easier. The include style of angle brackets is based on the linked PR. Perhaps we don't even need phpize build for the mbstring extension since it is part of the php-src core. But I'm not sure what is the accepted usage for this so I've added it like it was previously in the config.m4 file (the config.h included with absolute path).

I'm adding also @arnaud-lb in the PR to have an overview a bit and when @alexdowad has time for checking this a bit.

Regarding Windows, I have another change planned there with this HAVE_STRICMP but that is beyond the scope here and can be done in the future.