### PR TITLE
Fix implicitly marking parameter as nullable deprecation warning

### DIFF
--- a/ext/phar/phar/pharcommand.inc
+++ b/ext/phar/phar/pharcommand.inc
@@ -630,15 +630,15 @@ class PharCommand extends CLICommand
      * This function will take a directory and iterate through
      * it and get the files to insert into the Phar archive.
      *
-     * @param Phar        $phar      The phar object.
-     * @param string      $input     The input directory
-     * @param string      $regex     The regex used in RegexIterator.
-     * @param string      $invregex  The InvertedRegexIterator expression.
-     * @param SplFileInfo $stub Stub file object
-     * @param mixed       $compress  Compression algorithm or NULL
-     * @param boolean     $noloader  Whether to prevent adding the loader
+     * @param Phar         $phar      The phar object.
+     * @param string       $input     The input directory
+     * @param string       $regex     The regex used in RegexIterator.
+     * @param string       $invregex  The InvertedRegexIterator expression.
+     * @param ?SplFileInfo $stub Stub file object
+     * @param mixed        $compress  Compression algorithm or NULL
+     * @param boolean      $noloader  Whether to prevent adding the loader
      */
-    static function phar_add(Phar $phar, $level, $input, $regex, $invregex, SplFileInfo $stub = NULL, $compress = NULL, $noloader = false)
+    static function phar_add(Phar $phar, $level, $input, $regex, $invregex, ?SplFileInfo $stub, $compress = NULL, $noloader = false)
     {
         if ($input && is_file($input) && !is_dir($input)) {
             return self::phar_add_file($phar, $level, $input, $input, $compress);


### PR DESCRIPTION
A follow up around the php-src code regarding the RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

I think this is the only one throwing deprecation warning, but I haven't looked all the files yet.