### PR TITLE
Check asm goto support with AC_LINK_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -744,9 +744,8 @@ if test "$ac_cv_func___crc32d" = "yes"; then
 fi
 
 dnl Check for asm goto support.
-AC_CACHE_CHECK([for asm goto], ac_cv__asm_goto,
-[AC_RUN_IFELSE([AC_LANG_SOURCE([[
-int main(void) {
+AC_CACHE_CHECK([for asm goto], [ac_cv__asm_goto],
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
 #if defined(__x86_64__) || defined(__i386__)
     __asm__ goto("jmp %l0\n" :::: end);
 #elif defined(__aarch64__)
@@ -754,23 +753,9 @@ int main(void) {
 #endif
 end:
     return 0;
-}
-  ]])], [ac_cv__asm_goto=yes], [ac_cv__asm_goto=no], [
-    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-int main(void) {
-#if defined(__x86_64__) || defined(__i386__)
-    __asm__ goto("jmp %l0\n" :::: end);
-#elif defined(__aarch64__)
-    __asm__ goto("b %l0\n" :::: end);
-#endif
-end:
-    return 0;
-}
-  ]])], [ac_cv__asm_goto=yes], [ac_cv__asm_goto=no])
-])])
-
+]])], [ac_cv__asm_goto=yes], [ac_cv__asm_goto=no])])
 if test "$ac_cv__asm_goto" = yes; then
-  AC_DEFINE(HAVE_ASM_GOTO,1,[Define if asm goto support])
+  AC_DEFINE([HAVE_ASM_GOTO], [1], [Define if asm goto support is available.])
 fi
 
 dnl Check valgrind support.


### PR DESCRIPTION
The '__asm__ goto' support is properly recognized by a simpler linking check instead of a run check for easier cross-compilation. The compile only check (AC_COMPILE_IFELSE) might produce false positives results with certain compiler options.