### PR TITLE
Remove HAVE_MYSQL

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -111,6 +111,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_BSD_ICONV has been removed.
    - Symbol ZEND_FIBER_ASM has been removed.
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
+   - Symbol HAVE_MYSQL has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -41,8 +41,6 @@ if test "$PHP_PDO_MYSQL" != "no"; then
     PHP_MYSQLND_ENABLED=yes
     AC_DEFINE([PDO_USE_MYSQLND], 1, [Whether pdo_mysql uses mysqlnd])
   else
-    AC_DEFINE(HAVE_MYSQL, 1, [Whether you have MySQL])
-
     AC_MSG_CHECKING([for mysql_config])
     if test -n "$PDO_MYSQL_CONFIG"; then
       AC_MSG_RESULT($PDO_MYSQL_CONFIG)


### PR DESCRIPTION
The ext/pdo_mysql symbol has been once used together with the removed ext/mysql extension and isn't defined on Windows neither used in the code anymore.

Perhaps it would be better to define in the future either HAVE_PDO_MYSQL or similar for these extensions not dependent on the mysql or mysqli library driver. Or if extensions can successfully use `zend_hash_str_exists()`... 