### PR TITLE
Declare the method return type of Serializable

### DIFF
--- a/Zend/tests/bug64354.phpt
+++ b/Zend/tests/bug64354.phpt
@@ -3,12 +3,12 @@ Bug #64354 (Unserialize array of objects whose class can't be autoloaded fail)
 --FILE--
 <?php
 class B implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         throw new Exception("serialize");
         return NULL;
     }
 
-    public function unserialize($data) {
+    public function unserialize($data): void {
     }
 }
 

--- a/Zend/tests/enum/no-implement-serializable-indirect.phpt
+++ b/Zend/tests/enum/no-implement-serializable-indirect.phpt
@@ -8,12 +8,12 @@ interface MySerializable extends Serializable {}
 enum Foo implements MySerializable {
     case Bar;
 
-    public function serialize() {
+    public function serialize(): ?string {
         return serialize('Hello');
     }
 
-    public function unserialize($data) {
-        return unserialize($data);
+    public function unserialize($data): void {
+        unserialize($data);
     }
 }
 

--- a/Zend/tests/enum/no-implement-serializable.phpt
+++ b/Zend/tests/enum/no-implement-serializable.phpt
@@ -6,12 +6,12 @@ Enum must not implement Serializable
 enum Foo implements Serializable {
     case Bar;
 
-    public function serialize() {
+    public function serialize(): ?string {
         return serialize('Hello');
     }
 
-    public function unserialize($data) {
-        return unserialize($data);
+    public function unserialize($data): void {
+        unserialize($data);
     }
 }
 

--- a/Zend/tests/serializable_deprecation.phpt
+++ b/Zend/tests/serializable_deprecation.phpt
@@ -8,12 +8,12 @@ abstract class A implements Serializable {}
 
 class C extends A implements I {
     public function serialize(): string {}
-    public function unserialize(string $data) {}
+    public function unserialize(string $data): void {}
 }
 
 class D extends A implements I {
     public function serialize(): string {}
-    public function unserialize(string $data) {}
+    public function unserialize(string $data): void {}
     public function __serialize(): array {}
     public function __unserialize(array $data) {}
 }

--- a/Zend/tests/traits/interface_003.phpt
+++ b/Zend/tests/traits/interface_003.phpt
@@ -4,10 +4,10 @@ Testing to implement Serializable interface by traits
 <?php
 
 trait foo {
-    public function serialize() {
+    public function serialize(): ?string {
         return 'foobar';
     }
-    public function unserialize($x) {
+    public function unserialize($x): void {
         var_dump($x);
     }
 }

--- a/Zend/zend_interfaces.stub.php
+++ b/Zend/zend_interfaces.stub.php
@@ -48,11 +48,11 @@ interface ArrayAccess
 
 interface Serializable
 {
-    /** @return string|null */
-    public function serialize();
+    /** @tentative-return-type */
+    public function serialize(): ?string;
 
-    /** @return void */
-    public function unserialize(string $data);
+    /** @tentative-return-type */
+    public function unserialize(string $data): void;
 }
 
 interface Countable

--- a/Zend/zend_interfaces_arginfo.h
+++ b/Zend/zend_interfaces_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a9c915c11e5989d8c7cf2d704ada09ca765670c3 */
+ * Stub hash: bab3bd2a129b2d2b12579c0bf0a958d9493be4ad */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IteratorAggregate_getIterator, 0, 0, Traversable, 0)
 ZEND_END_ARG_INFO()
@@ -34,10 +34,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ArrayAccess_offs
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Serializable_serialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Serializable_serialize, 0, 0, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Serializable_unserialize, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Serializable_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -47,7 +47,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Stringable___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_InternalIterator___construct arginfo_class_Serializable_serialize
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_InternalIterator___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_InternalIterator_current, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()

--- a/ext/pdo/tests/bug_44409.phpt
+++ b/ext/pdo/tests/bug_44409.phpt
@@ -25,12 +25,12 @@ class bug44409 implements Serializable
         printf("Method called: %s()\n", __METHOD__);
     }
 
-    public function serialize()
+    public function serialize(): ?string
     {
         return "any data from serizalize()";
     }
 
-    public function unserialize($dat)
+    public function unserialize($dat): void
     {
         printf("Method called: %s(%s)\n", __METHOD__, var_export($dat, true));
     }

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -21,7 +21,7 @@ class TestBase implements Serializable
     protected $BasePro = 'Protected';
     private   $BasePri = 'Private';
 
-    function serialize()
+    function serialize(): ?string
     {
         $serialized = array();
         foreach($this as $prop => $val) {
@@ -32,7 +32,7 @@ class TestBase implements Serializable
         return $serialized;
     }
 
-    function unserialize($serialized)
+    function unserialize($serialized): void
     {
         echo __METHOD__ . "($serialized)\n";
         foreach(unserialize($serialized) as $prop => $val) {
@@ -50,13 +50,13 @@ class TestDerived extends TestBase
     protected $DerivedPro = 'Protected';
     private   $DerivedPri = 'Private';
 
-    function serialize()
+    function serialize(): ?string
     {
         echo __METHOD__ . "()\n";
         return TestBase::serialize();
     }
 
-    function unserialize($serialized)
+    function unserialize($serialized): void
     {
         echo __METHOD__ . "()\n";
         return TestBase::unserialize($serialized);

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
@@ -64,12 +64,12 @@ MySQLPDOTest::skip();
             }
 
             // Serializable
-            public function serialize() {
+            public function serialize(): ?string {
                 printf("%s()\n", __METHOD__);
                 return 'Data from serialize';
             }
 
-            public function unserialize($data) {
+            public function unserialize($data): void {
                 printf("%s(%s)\n", __METHOD__, var_export($data, true));
             }
 

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
@@ -64,12 +64,12 @@ MySQLPDOTest::skip();
             }
 
             // Serializable
-            public function serialize() {
+            public function serialize(): ?string {
                 printf("%s()\n", __METHOD__);
                 return 'Data from serialize';
             }
 
-            public function unserialize($data) {
+            public function unserialize($data): void {
                 printf("%s(%s)\n", __METHOD__, var_export($data, true));
             }
 

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
@@ -64,12 +64,12 @@ MySQLPDOTest::skip();
             }
 
             // Serializable
-            public function serialize() {
+            public function serialize(): ?string {
                 printf("%s()\n", __METHOD__);
                 return 'Data from serialize';
             }
 
-            public function unserialize($data) {
+            public function unserialize($data): void {
                 printf("%s(%s)\n", __METHOD__, var_export($data, true));
             }
 

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
@@ -25,12 +25,12 @@ MySQLPDOTest::skip();
                 $this->{$prop} = $value;
             }
 
-            public function serialize() {
+            public function serialize(): ?string {
                 printf("%s()\n", __METHOD__);
                 return 'Value from serialize()';
             }
 
-            public function unserialize($data) {
+            public function unserialize($data): void {
                 printf("%s(%s)\n", __METHOD__, var_export($data, true));
             }
 

--- a/ext/session/tests/bug79031.phpt
+++ b/ext/session/tests/bug79031.phpt
@@ -17,11 +17,11 @@ class SerializableClass implements Serializable {
     {
         $this->$key = $value;
     }
-    public function serialize()
+    public function serialize(): ?string
     {
         return serialize(get_object_vars($this));
     }
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         $ar = unserialize($data);
         if ($ar === false) {

--- a/ext/standard/tests/serialize/005.phpt
+++ b/ext/standard/tests/serialize/005.phpt
@@ -14,7 +14,7 @@ function do_autoload($class_name)
     echo __FUNCTION__ . "($class_name)\n";
 }
 
-function unserializer($class_name)
+function unserializer($class_name): void
 {
     echo __METHOD__ . "($class_name)\n";
     switch($class_name)
@@ -42,12 +42,12 @@ ini_set('unserialize_callback_func', 'unserializer');
 
 class TestOld
 {
-    function serialize()
+    function serialize(): ?string
     {
         echo __METHOD__ . "()\n";
     }
 
-    function unserialize($serialized)
+    function unserialize($serialized): void
     {
         echo __METHOD__ . "()\n";
     }
@@ -68,7 +68,7 @@ class TestNew implements Serializable
 {
     protected static $check = 0;
 
-    function serialize()
+    function serialize(): ?string
     {
         echo __METHOD__ . "()\n";
         switch(++self::$check)
@@ -80,7 +80,7 @@ class TestNew implements Serializable
         }
     }
 
-    function unserialize($serialized)
+    function unserialize($serialized): void
     {
         echo __METHOD__ . "()\n";
     }

--- a/ext/standard/tests/serialize/__serialize_003.phpt
+++ b/ext/standard/tests/serialize/__serialize_003.phpt
@@ -22,12 +22,12 @@ class Test implements Serializable {
         var_dump($data);
     }
 
-    public function serialize() {
+    public function serialize(): ?string {
         echo "serialize() called\n";
         return "payload";
     }
 
-    public function unserialize($payload) {
+    public function unserialize($payload): void {
         echo "unserialize() called\n";
         var_dump($payload);
     }

--- a/ext/standard/tests/serialize/bug36424.phpt
+++ b/ext/standard/tests/serialize/bug36424.phpt
@@ -5,10 +5,10 @@ Bug #36424 - Serializable interface breaks object references
 
 #[AllowDynamicProperties]
 class a implements Serializable {
-    function serialize() {
+    function serialize(): ?string {
         return serialize(get_object_vars($this));
     }
-    function unserialize($s) {
+    function unserialize($s): void {
         foreach (unserialize($s) as $p=>$v) {
             $this->$p=$v;
         }

--- a/ext/standard/tests/serialize/bug64146.phpt
+++ b/ext/standard/tests/serialize/bug64146.phpt
@@ -23,12 +23,12 @@ class B implements Serializable
         $this->b = new C($c);
     }
 
-    public function serialize()
+    public function serialize(): ?string
     {
         return serialize(clone $this->b);
     }
 
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         $this->b = unserialize($data);
     }

--- a/ext/standard/tests/serialize/bug64354_3.phpt
+++ b/ext/standard/tests/serialize/bug64354_3.phpt
@@ -9,11 +9,11 @@ class A {
 }
 
 class B implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         return NULL;
     }
 
-    public function unserialize($data) {
+    public function unserialize($data): void {
     }
 }
 

--- a/ext/standard/tests/serialize/bug65481.phpt
+++ b/ext/standard/tests/serialize/bug65481.phpt
@@ -8,7 +8,7 @@ class A {
 }
 
 class Token implements \Serializable {
-    public function serialize()
+    public function serialize(): ?string
     {
         $c = new A;
 
@@ -22,7 +22,7 @@ class Token implements \Serializable {
         return serialize(array(serialize($c)));
     }
 
-    public function unserialize($str)
+    public function unserialize($str): void
     {
         $r = unserialize($str);
         $r = unserialize($r[0]);

--- a/ext/standard/tests/serialize/bug70172.phpt
+++ b/ext/standard/tests/serialize/bug70172.phpt
@@ -4,10 +4,10 @@ Bug #70172 - Use After Free Vulnerability in unserialize()
 <?php
 class obj implements Serializable {
     var $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         $this->data = unserialize($data);
     }
 }

--- a/ext/standard/tests/serialize/bug70172_2.phpt
+++ b/ext/standard/tests/serialize/bug70172_2.phpt
@@ -4,10 +4,10 @@ Bug #70172 - Use After Free Vulnerability in unserialize()
 <?php
 class obj implements Serializable {
     var $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         $this->data = unserialize($data);
     }
 }

--- a/ext/standard/tests/serialize/bug70219.phpt
+++ b/ext/standard/tests/serialize/bug70219.phpt
@@ -8,10 +8,10 @@ error_reporting=E_ALL&~E_DEPRECATED
 <?php
 class obj implements Serializable {
     var $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         session_start();
         session_decode($data);
     }

--- a/ext/standard/tests/serialize/bug70219_1.phpt
+++ b/ext/standard/tests/serialize/bug70219_1.phpt
@@ -9,10 +9,10 @@ session_start();
 
 class obj implements Serializable {
     var $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         session_decode($data);
     }
 }

--- a/ext/standard/tests/serialize/bug70436.phpt
+++ b/ext/standard/tests/serialize/bug70436.phpt
@@ -7,12 +7,12 @@ class obj implements Serializable
 {
     var $data;
 
-    function serialize()
+    function serialize(): ?string
     {
         return serialize($this->data);
     }
 
-    function unserialize($data)
+    function unserialize($data): void
     {
         $this->data = unserialize($data);
     }

--- a/ext/standard/tests/serialize/bug71940.phpt
+++ b/ext/standard/tests/serialize/bug71940.phpt
@@ -22,12 +22,12 @@ class Entry implements \Serializable
         $this->identity = $identity;
     }
 
-    public function serialize()
+    public function serialize(): ?string
     {
         return serialize(array($this->identity));
     }
 
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         list($this->identity) = unserialize($serialized);
     }

--- a/ext/standard/tests/serialize/bug72663_2.phpt
+++ b/ext/standard/tests/serialize/bug72663_2.phpt
@@ -5,10 +5,10 @@ Bug #72663 (2): Don't allow references into failed unserialize
 
 class obj implements Serializable {
     public $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         $this->data = unserialize($data);
     }
 }

--- a/ext/standard/tests/serialize/bug80411.phpt
+++ b/ext/standard/tests/serialize/bug80411.phpt
@@ -5,8 +5,8 @@ Bug #80411: References to null-serialized object break serialize()
 
 class UnSerializable implements Serializable
 {
-  public function serialize() {}
-  public function unserialize($serialized) {}
+  public function serialize(): ?string {}
+  public function unserialize($serialized): void {}
 }
 
 $unser = new UnSerializable();

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -66,10 +66,10 @@ var_dump(unserialize(
 ini_set("unserialize_max_depth", 4096);
 
 class Test implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         return '';
     }
-    public function unserialize($str) {
+    public function unserialize($str): void {
         // Should fail, due to combined nesting level
         var_dump(unserialize(create_nested_data(129, 'a:1:{i:0;', '}')));
         // Should succeed, below combined nesting level
@@ -83,10 +83,10 @@ var_dump(is_array(unserialize(
 )));
 
 class Test2 implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         return '';
     }
-    public function unserialize($str) {
+    public function unserialize($str): void {
         // If depth limit is overridden, the depth should be counted
         // from zero again.
         var_dump(unserialize(

--- a/ext/standard/tests/serialize/ref_to_failed_serialize.phpt
+++ b/ext/standard/tests/serialize/ref_to_failed_serialize.phpt
@@ -4,11 +4,11 @@ References to objects for which Serializable::serialize() returned NULL should u
 <?php
 
 class NotSerializable implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         return null;
     }
 
-    public function unserialize($serialized) {
+    public function unserialize($serialized): void {
     }
 }
 

--- a/ext/standard/tests/serialize/serialization_objects_010.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_010.phpt
@@ -3,11 +3,11 @@ Serialize() must return a string or NULL
 --FILE--
 <?php
 Class C implements Serializable {
-    public function serialize() {
+    public function serialize(): ?string {
         return $this;
     }
 
-    public function unserialize($blah) {
+    public function unserialize($blah): void {
     }
 }
 

--- a/ext/standard/tests/serialize/serialization_objects_018.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_018.phpt
@@ -3,8 +3,8 @@ Object serialization / unserialization: Strict format (2)
 --FILE--
 <?php
 class A implements Serializable {
-	public function serialize() {}
-	public function unserialize($data) {}
+	public function serialize(): ?string {}
+	public function unserialize($data): void {}
 	public function __serialize() {}
 	public function __unserialize($data) {}
 }

--- a/ext/standard/tests/serialize/unserialize_extra_data_003.phpt
+++ b/ext/standard/tests/serialize/unserialize_extra_data_003.phpt
@@ -6,7 +6,7 @@ Test unserialize() with extra data at the end of a valid value with Serializable
 final class Foo implements Serializable {
     public $foo;
 
-    public function unserialize(string $foo)
+    public function unserialize(string $foo): void
     {
         $this->foo = unserialize($foo);
     }

--- a/ext/standard/tests/strings/bug72663.phpt
+++ b/ext/standard/tests/strings/bug72663.phpt
@@ -4,10 +4,10 @@ Bug #72663: Create an Unexpected Object and Don't Invoke __wakeup() in Deseriali
 <?php
 class obj implements Serializable {
     var $data;
-    function serialize() {
+    function serialize(): ?string {
         return serialize($this->data);
     }
-    function unserialize($data) {
+    function unserialize($data): void {
         $this->data = unserialize($data);
     }
 }

--- a/tests/classes/serialize_001.phpt
+++ b/tests/classes/serialize_001.phpt
@@ -13,13 +13,13 @@ class Test implements Serializable
         $this->data = $data;
     }
 
-    function serialize()
+    function serialize(): ?string
     {
         echo __METHOD__ . "({$this->data})\n";
         return $this->data;
     }
 
-    function unserialize($serialized)
+    function unserialize($serialized): void
     {
         echo __METHOD__ . "($serialized)\n";
         $this->data = $serialized;


### PR DESCRIPTION
I'm not sure why we didn't declare these return types so far, but these are the last two return types in php-src which haven't got a return type yet and it's possible to declare it. The rest either return resources or it doesn't make sense to declare the return type (old, sepc-incompatible DOM methods).