### PR TITLE
Fix GH-13628: Changed the test expected value of `mysqli::info` to `%s`

### DIFF
--- a/ext/mysqli/tests/bug34810.phpt
+++ b/ext/mysqli/tests/bug34810.phpt
@@ -84,7 +84,7 @@ object(mysqli)#%d (%d) {
   ["host_info"]=>
   string(%d) "%s"
   ["info"]=>
-  NULL
+  %s
   ["insert_id"]=>
   int(0)
   ["server_info"]=>


### PR DESCRIPTION
fixes #13628

I use the MariaDB 11.4-rc docker image on my local and have confirmed that the test passes.