### PR TITLE
ext/gd/config.m4: don't forget GDLIB_CFLAGS in feature tests

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -150,6 +150,8 @@ dnl or run test insufficient.
 AC_DEFUN([PHP_GD_CHECK_FORMAT],[
   old_LIBS="${LIBS}"
   LIBS="${LIBS} ${GD_SHARED_LIBADD}"
+  old_CFLAGS="${CFLAGS}"
+  CFLAGS="${CFLAGS} ${GDLIB_CFLAGS}"
   AC_MSG_CHECKING([for working gdImageCreateFrom$1 in libgd])
   AC_LANG_PUSH([C])
   AC_RUN_IFELSE([AC_LANG_SOURCE([
@@ -180,6 +182,7 @@ int main(int argc, char** argv) {
     AC_MSG_RESULT([no])
   ])
   AC_LANG_POP([C])
+  CFLAGS="${old_CFLAGS}"
   LIBS="${old_LIBS}"
 ])
 


### PR DESCRIPTION
In commit 85e5635a, a feature test for the various libgd image formats was added. That test however erroneously omits the `GDLIB_CFLAGS` (from pkg-config) during compilation. This can lead to build failures and therefore false negatives from the test.

Here, we add `$GDLIB_CFLAGS` to `$CFLAGS` for the duration of the test.

Moreover, we replace `$GD_SHARED_LIBADD` with `$GDLIB_LIBS` in the same test. The variable `$GD_SHARED_LIBADD` is actually empty when we try to use it. Fortunately(?), the library flags are appended elsewhere, so this was not causing a problem. But of course it's better to explicitly do the right thing.

Closes GH-12019