### PR TITLE
random: Improve the output quality of RANDOM_SEED()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -174,6 +174,11 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The CSPRNG API (php_random_(bytes|int)_*) is now provided by the new
      and much smaller php_random_csprng.h header. The new header is included
      in php_random.h for compatibility with existing users.
+   - A new php_random_generate_fallback_seed() function has been added as a
+     replacement for the generically named GENERATE_SEED(). The internal
+     implementation has been improved to generate better seeds, however any
+     users should use the opportunity to verify that seeding is first
+     attempted using the CSPRNG for better output size flexibility.
 
  c. ext/xsl
    - The function php_xsl_create_object() was removed as it was not used

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1734,9 +1734,9 @@ static void gmp_init_random(void)
 		/* Initialize */
 		gmp_randinit_mt(GMPG(rand_state));
 		/* Seed */
-		zend_long seed = 0;
-		if (php_random_bytes_silent(&seed, sizeof(zend_long)) == FAILURE) {
-			seed = GENERATE_SEED();
+		unsigned long int seed = 0;
+		if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
+			seed = (unsigned long int)php_random_generate_fallback_seed();
 		}
 		gmp_randseed_ui(GMPG(rand_state), seed);
 

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -242,7 +242,7 @@ PHPAPI void php_random_mt19937_seed_default(php_random_status_state_mt19937 *sta
 	uint32_t seed = 0;
 
 	if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
-		seed = GENERATE_SEED();
+		seed = (uint32_t)php_random_generate_fallback_seed();
 	}
 
 	php_random_mt19937_seed32(state, seed);

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -37,17 +37,11 @@
 
 PHPAPI double php_combined_lcg(void);
 
+PHPAPI uint64_t php_random_generate_fallback_seed(void);
+
 static inline zend_long GENERATE_SEED(void)
 {
-	zend_ulong pid;
-
-# ifdef PHP_WIN32
-	pid = (zend_ulong) GetCurrentProcessId();
-# else
-	pid = (zend_ulong) getpid();
-# endif
-
-	return (((zend_long) ((zend_ulong) time(NULL) * pid)) ^ ((zend_long) (1000000.0 * php_combined_lcg())));
+	return (zend_long)php_random_generate_fallback_seed();
 }
 
 # define PHP_MT_RAND_MAX ((zend_long) (0x7FFFFFFF)) /* (1<<31) - 1 */
@@ -213,6 +207,8 @@ ZEND_BEGIN_MODULE_GLOBALS(random)
 	int random_fd;
 	bool combined_lcg_seeded;
 	bool mt19937_seeded;
+	bool fallback_seed_initialized;
+	unsigned char fallback_seed[20];
 	php_random_status_state_combinedlcg combined_lcg;
 	php_random_status_state_mt19937 mt19937;
 ZEND_END_MODULE_GLOBALS(random)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -660,7 +660,9 @@ uint64_t php_random_generate_fallback_seed(void)
 		write_32(&c, tv.tv_usec);
 		/* Various PIDs. */
 		write_32(&c, getpid());
+#ifndef WIN32
 		write_32(&c, getppid());
+#endif
 #ifdef ZTS
 		write_32(&c, tsrm_thread_id());
 #endif

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -661,7 +661,9 @@ uint64_t php_random_generate_fallback_seed(void)
 		/* Various PIDs. */
 		write_32(&c, getpid());
 		write_32(&c, getppid());
+#ifdef ZTS
 		write_32(&c, tsrm_thread_id());
+#endif
 		/* Pointer values to benefit from ASLR. */
 		write_p(&c, (uintptr_t)&RANDOM_G(fallback_seed_initialized));
 		write_p(&c, (uintptr_t)&c);

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2879,7 +2879,10 @@ static PHP_GINIT_FUNCTION(ps) /* {{{ */
 	};
 	php_random_uint128_t seed;
 	if (php_random_bytes_silent(&seed, sizeof(seed)) == FAILURE) {
-		seed = php_random_uint128_constant(GENERATE_SEED(), GENERATE_SEED());
+		seed = php_random_uint128_constant(
+			php_random_generate_fallback_seed(),
+			php_random_generate_fallback_seed()
+		);
 	}
 	php_random_pcgoneseq128xslrr64_seed128(ps_globals->random.state, seed);
 }


### PR DESCRIPTION
Previously 4 consecutive calls to `RANDOM_SEED()` each for 4 different CLI
requests resulted in:

    $ sapi/cli/php test.php
    2c13e9fde9caa
    2c13e9fd1d6b0
    2c13e9fd4de34
    2c13e9fd1610e
    $ sapi/cli/php test.php
    2c1436764fe07
    2c14367621770
    2c143676c0bf6
    2c143676e02f5
    $ sapi/cli/php test.php
    2c144995a0626
    2c14499590fe2
    2c144995c65db
    2c14499536833
    $ sapi/cli/php test.php
    2c145cb30860b
    2c145cb3ec027
    2c145cb33b4ca
    2c145cb38ff63

Now they result in:

    $ sapi/cli/php test.php
    6796973ace1b5f3d
    1913daf5c158cb4b
    255dbf24237bc8c9
    7c3ba22e60f35196
    $ sapi/cli/php test.php
    afb7cc9ba9819cd2
    3e01a71b91ad020c
    6b718364d3ef108
    bdcd17beeb4b31d2
    $ sapi/cli/php test.php
    53d36eb9b83f8788
    4381c85e816187aa
    2e9b32ee9898e71e
    31d15c946842bddb
    $ sapi/cli/php test.php
    2037a3cba88114b4
    ba0b0d93a9bb43aa
    e13d82d2421269e2
    191de474f3292240