### PR TITLE
Implement request #71571: XSLT processor should provide option to change maxDepth

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -224,5 +224,7 @@ PHP                                                                        NEWS
   . Implement request #64137 (XSLTProcessor::setParameter() should allow both
     quotes to be used). (nielsdos)
   . Implemented "Improve callbacks in ext/dom and ext/xsl" RFC. (nielsdos)
+  . Added XSLTProcessor::$maxTemplateDepth and XSLTProcessor::$maxTemplateVars.
+    (nielsdos)
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/UPGRADING
+++ b/UPGRADING
@@ -259,6 +259,8 @@ PHP 8.4 UPGRADE NOTES
     quotes.
   . It is now possible to pass any callable to registerPhpFunctions().
     RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl
+  . Added XSLTProcessor::$maxTemplateDepth and XSLTProcessor::$maxTemplateVars
+    to control the recursion depth of XSL template evaluation.
 
 ========================================
 3. Changes in SAPI modules

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -182,6 +182,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
  d. ext/libxml
    - Added php_libxml_pretend_ctx_error_ex() to emit errors as if they had come
      from libxml.
+   - Added php_libxml_error_handler_va() to pass libxml errors, and
+     corresponding php_libxml_error_level enum.
    - Removed the "properties" HashTable field from php_libxml_node_object.
    - Added a way to attached private data to a php_libxml_ref_obj.
    - Added a way to fix a class type onto php_libxml_ref_obj.

--- a/ext/dom/xpath_callbacks.c
+++ b/ext/dom/xpath_callbacks.c
@@ -67,8 +67,9 @@ PHP_DOM_EXPORT void php_dom_xpath_callbacks_clean_argument_stack(xmlXPathParserC
 		xmlXPathFreeObject(obj);
 	}
 
-	/* Push sentinel value */
-	valuePush(ctxt, xmlXPathNewString((const xmlChar *) ""));
+	/* Don't push a sentinel value here. If this is called from an error situation, then by *not* pushing a sentinel
+	 * the execution will halt. If this is called from a regular situation, then it is the caller's responsibility
+	 * to ensure the stack remains balanced. */
 }
 
 PHP_DOM_EXPORT void php_dom_xpath_callbacks_dtor(php_dom_xpath_callbacks *registry)

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -45,9 +45,6 @@
 #include "php_libxml.h"
 
 #define PHP_LIBXML_LOADED_VERSION ((char *)xmlParserVersion)
-#define PHP_LIBXML_ERROR 0
-#define PHP_LIBXML_CTX_ERROR 1
-#define PHP_LIBXML_CTX_WARNING 2
 
 #include "libxml_arginfo.h"
 
@@ -647,12 +644,12 @@ void php_libxml_issue_error(int level, const char *msg)
 	}
 }
 
-static void php_libxml_internal_error_handler_ex(int error_type, void *ctx, const char **msg, va_list ap, int line, int column)
+static void php_libxml_internal_error_handler_ex(php_libxml_error_level error_type, void *ctx, const char *msg, va_list ap, int line, int column)
 {
 	char *buf;
 	int len, len_iter, output = 0;
 
-	len = vspprintf(&buf, 0, *msg, ap);
+	len = vspprintf(&buf, 0, msg, ap);
 	len_iter = len;
 
 	/* remove any trailing \n */
@@ -685,7 +682,7 @@ static void php_libxml_internal_error_handler_ex(int error_type, void *ctx, cons
 	}
 }
 
-static void php_libxml_internal_error_handler(int error_type, void *ctx, const char **msg, va_list ap)
+PHP_LIBXML_API void php_libxml_error_handler_va(php_libxml_error_level error_type, void *ctx, const char *msg, va_list ap)
 {
 	int line = 0;
 	int column = 0;
@@ -831,7 +828,7 @@ PHP_LIBXML_API void php_libxml_pretend_ctx_error_ex(const char *file, int line, 
 {
 	va_list args;
 	va_start(args, msg);
-	php_libxml_internal_error_handler_ex(PHP_LIBXML_CTX_ERROR, NULL, &msg, args, line, column);
+	php_libxml_internal_error_handler_ex(PHP_LIBXML_CTX_ERROR, NULL, msg, args, line, column);
 	va_end(args);
 
 	/* Propagate back into libxml */
@@ -853,7 +850,7 @@ PHP_LIBXML_API void php_libxml_ctx_error(void *ctx, const char *msg, ...)
 {
 	va_list args;
 	va_start(args, msg);
-	php_libxml_internal_error_handler(PHP_LIBXML_CTX_ERROR, ctx, &msg, args);
+	php_libxml_error_handler_va(PHP_LIBXML_CTX_ERROR, ctx, msg, args);
 	va_end(args);
 }
 
@@ -861,7 +858,7 @@ PHP_LIBXML_API void php_libxml_ctx_warning(void *ctx, const char *msg, ...)
 {
 	va_list args;
 	va_start(args, msg);
-	php_libxml_internal_error_handler(PHP_LIBXML_CTX_WARNING, ctx, &msg, args);
+	php_libxml_error_handler_va(PHP_LIBXML_CTX_WARNING, ctx, msg, args);
 	va_end(args);
 }
 
@@ -878,7 +875,7 @@ PHP_LIBXML_API void php_libxml_error_handler(void *ctx, const char *msg, ...)
 {
 	va_list args;
 	va_start(args, msg);
-	php_libxml_internal_error_handler(PHP_LIBXML_ERROR, ctx, &msg, args);
+	php_libxml_error_handler_va(PHP_LIBXML_ERROR, ctx, msg, args);
 	va_end(args);
 }
 

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -141,6 +141,12 @@ static zend_always_inline void php_libxml_invalidate_node_list_cache_from_doc(xm
 
 typedef void * (*php_libxml_export_node) (zval *object);
 
+typedef enum {
+	PHP_LIBXML_ERROR = 0,
+	PHP_LIBXML_CTX_ERROR = 1,
+	PHP_LIBXML_CTX_WARNING = 2,
+} php_libxml_error_level;
+
 PHP_LIBXML_API int php_libxml_increment_node_ptr(php_libxml_node_object *object, xmlNodePtr node, void *private_data);
 PHP_LIBXML_API int php_libxml_decrement_node_ptr(php_libxml_node_object *object);
 PHP_LIBXML_API int php_libxml_increment_doc_ref(php_libxml_node_object *object, xmlDocPtr docp);
@@ -157,6 +163,7 @@ PHP_LIBXML_API void php_libxml_error_handler(void *ctx, const char *msg, ...);
 PHP_LIBXML_API void php_libxml_ctx_warning(void *ctx, const char *msg, ...);
 PHP_LIBXML_API void php_libxml_pretend_ctx_error_ex(const char *file, int line, int column, const char *msg,...);
 PHP_LIBXML_API void php_libxml_ctx_error(void *ctx, const char *msg, ...);
+PHP_LIBXML_API void php_libxml_error_handler_va(php_libxml_error_level error_type, void *ctx, const char *msg, va_list args);
 PHP_LIBXML_API int php_libxml_xmlCheckUTF8(const unsigned char *s);
 PHP_LIBXML_API void php_libxml_switch_context(zval *context, zval *oldcontext);
 PHP_LIBXML_API void php_libxml_issue_error(int level, const char *msg);

--- a/ext/xsl/php_xsl.h
+++ b/ext/xsl/php_xsl.h
@@ -77,6 +77,9 @@ void xsl_objects_free_storage(zend_object *object);
 void xsl_ext_function_string_php(xmlXPathParserContextPtr ctxt, int nargs);
 void xsl_ext_function_object_php(xmlXPathParserContextPtr ctxt, int nargs);
 
+zval *xsl_prop_max_template_depth(zend_object *object);
+zval *xsl_prop_max_template_vars(zend_object *object);
+
 PHP_MINIT_FUNCTION(xsl);
 PHP_MSHUTDOWN_FUNCTION(xsl);
 PHP_RINIT_FUNCTION(xsl);

--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -75,6 +75,10 @@ class XSLTProcessor
 
     public bool $cloneDocument = false;
 
+    public int $maxTemplateDepth;
+
+    public int $maxTemplateVars;
+
     /**
      * @param DOMDocument|DOM\Document|SimpleXMLElement $stylesheet
      * @tentative-return-type

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ae093276a1caf53c34d429076458bc8b802d69e9 */
+ * Stub hash: f7f9951cbb437f1985016dc06490d55f711bc725 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
@@ -130,6 +130,18 @@ static zend_class_entry *register_class_XSLTProcessor(void)
 	zend_string *property_cloneDocument_name = zend_string_init("cloneDocument", sizeof("cloneDocument") - 1, 1);
 	zend_declare_typed_property(class_entry, property_cloneDocument_name, &property_cloneDocument_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_cloneDocument_name);
+
+	zval property_maxTemplateDepth_default_value;
+	ZVAL_UNDEF(&property_maxTemplateDepth_default_value);
+	zend_string *property_maxTemplateDepth_name = zend_string_init("maxTemplateDepth", sizeof("maxTemplateDepth") - 1, 1);
+	zend_declare_typed_property(class_entry, property_maxTemplateDepth_name, &property_maxTemplateDepth_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_maxTemplateDepth_name);
+
+	zval property_maxTemplateVars_default_value;
+	ZVAL_UNDEF(&property_maxTemplateVars_default_value);
+	zend_string *property_maxTemplateVars_name = zend_string_init("maxTemplateVars", sizeof("maxTemplateVars") - 1, 1);
+	zend_declare_typed_property(class_entry, property_maxTemplateVars_name, &property_maxTemplateVars_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_maxTemplateVars_name);
 
 	return class_entry;
 }

--- a/ext/xsl/tests/bug71571_a.phpt
+++ b/ext/xsl/tests/bug71571_a.phpt
@@ -35,7 +35,7 @@ $proc->transformToDoc($doc);
 Warning: XSLTProcessor::transformToDoc(): runtime error: file %s line 8 element call-template in %s on line %d
 
 Warning: XSLTProcessor::transformToDoc(): xsltApplySequenceConstructor: A potential infinite template recursion was detected.
-You can adjust xsltMaxDepth (--maxdepth) in order to raise the maximum number of nested template calls and variables/params (currently set to 2). in %s on line %d
+You can adjust $maxTemplateDepth in order to raise the maximum number of nested template calls and variables/params (currently set to 2). in %s on line %d
 
 Warning: XSLTProcessor::transformToDoc(): Templates: in %s on line %d
 

--- a/ext/xsl/tests/bug71571_a.phpt
+++ b/ext/xsl/tests/bug71571_a.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Request #71571 (XSLT processor should provide option to change maxDepth) - variant A
+--EXTENSIONS--
+xsl
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+$myxsl = <<<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match="/">
+        <xsl:call-template name="recurse"/>
+    </xsl:template>
+
+    <xsl:template name="recurse">
+        <xsl:call-template name="recurse"/>
+    </xsl:template>
+</xsl:stylesheet>
+EOF;
+
+$xsl = new DOMDocument();
+$xsl->loadXML($myxsl);
+
+$doc = new DOMDocument();
+
+$proc = new XSLTProcessor;
+$proc->maxTemplateDepth = 2;
+$proc->importStyleSheet($xsl);
+$proc->transformToDoc($doc);
+
+?>
+--EXPECTF--
+Warning: XSLTProcessor::transformToDoc(): runtime error: file %s line 8 element call-template in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): xsltApplySequenceConstructor: A potential infinite template recursion was detected.
+You can adjust xsltMaxDepth (--maxdepth) in order to raise the maximum number of nested template calls and variables/params (currently set to 2). in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): Templates: in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #0 name recurse  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #1 name recurse  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #2 name /  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): Variables: in %s on line %d

--- a/ext/xsl/tests/bug71571_b.phpt
+++ b/ext/xsl/tests/bug71571_b.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Request #71571 (XSLT processor should provide option to change maxDepth) - variant B
+--EXTENSIONS--
+xsl
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+$myxsl = <<<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match="/">
+        <xsl:call-template name="recurse"/>
+    </xsl:template>
+
+    <xsl:template name="recurse">
+        <xsl:param name="COUNT">1</xsl:param>
+        <xsl:call-template name="recurse">
+            <xsl:with-param name="COUNT" select="$COUNT + 1"/>
+        </xsl:call-template>
+    </xsl:template>
+</xsl:stylesheet>
+EOF;
+
+$xsl = new DOMDocument();
+$xsl->loadXML($myxsl);
+
+$doc = new DOMDocument();
+
+$proc = new XSLTProcessor;
+// Set the template depth limit so high that we will certainly hit the variable depth limit first.
+$proc->maxTemplateDepth = 2**30;
+$proc->maxTemplateVars = 2;
+$proc->importStyleSheet($xsl);
+$proc->transformToDoc($doc);
+
+?>
+--EXPECTF--
+Warning: XSLTProcessor::transformToDoc(): runtime error: file %s line 8 element param in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): xsltApplyXSLTTemplate: A potential infinite template recursion was detected.
+You can adjust maxTemplateVars (--maxvars) in order to raise the maximum number of variables/params (currently set to 2). in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): Templates: in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #0 name recurse  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #1 name recurse  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #2 name /  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): Variables: in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #0 in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): COUNT  in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): #1 in %s on line %d
+
+Warning: XSLTProcessor::transformToDoc(): param COUNT  in %s on line %d

--- a/ext/xsl/tests/bug71571_b.phpt
+++ b/ext/xsl/tests/bug71571_b.phpt
@@ -40,7 +40,7 @@ $proc->transformToDoc($doc);
 Warning: XSLTProcessor::transformToDoc(): runtime error: file %s line 8 element param in %s on line %d
 
 Warning: XSLTProcessor::transformToDoc(): xsltApplyXSLTTemplate: A potential infinite template recursion was detected.
-You can adjust maxTemplateVars (--maxvars) in order to raise the maximum number of variables/params (currently set to 2). in %s on line %d
+You can adjust $maxTemplateVars in order to raise the maximum number of variables/params (currently set to 2). in %s on line %d
 
 Warning: XSLTProcessor::transformToDoc(): Templates: in %s on line %d
 

--- a/ext/xsl/tests/maxTemplateDepth_errors.phpt
+++ b/ext/xsl/tests/maxTemplateDepth_errors.phpt
@@ -1,0 +1,44 @@
+--TEST--
+XSLTProcessor::$maxTemplateDepth errors
+--EXTENSIONS--
+xsl
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
+--FILE--
+<?php
+
+$processor = new XSLTProcessor;
+$oldValue = $processor->maxTemplateDepth;
+
+try {
+    $processor->maxTemplateDepth = -1;
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateDepth === $oldValue);
+
+try {
+    $processor->maxTemplateDepth = -32.1;
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateDepth === $oldValue);
+
+try {
+    $processor->maxTemplateDepth = "-1";
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateDepth === $oldValue);
+
+?>
+--EXPECT--
+XSLTProcessor::$maxTemplateDepth must be greater than or equal to 0
+bool(true)
+XSLTProcessor::$maxTemplateDepth must be greater than or equal to 0
+bool(true)
+XSLTProcessor::$maxTemplateDepth must be greater than or equal to 0
+bool(true)

--- a/ext/xsl/tests/maxTemplateDepth_modification_validation_bypass.phpt
+++ b/ext/xsl/tests/maxTemplateDepth_modification_validation_bypass.phpt
@@ -1,0 +1,57 @@
+--TEST--
+XSLTProcessor::$maxTemplateDepth modification validation bypass
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+$proc = new XSLTProcessor();
+foreach ([1,-1] as $value) {
+    echo "--- Set to $value ---\n";
+    try {
+        $proc->maxTemplateDepth = $value;
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+echo "--- Get reference ---\n";
+
+try {
+    $ref =& $proc->maxTemplateDepth;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Unset ---\n";
+
+try {
+    unset($proc->maxTemplateDepth);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Dump ---\n";
+
+var_dump($proc);
+
+?>
+--EXPECT--
+--- Set to 1 ---
+--- Set to -1 ---
+XSLTProcessor::$maxTemplateDepth must be greater than or equal to 0
+--- Get reference ---
+Indirect modification of XSLTProcessor::$maxTemplateDepth is not allowed
+--- Unset ---
+Cannot unset XSLTProcessor::$maxTemplateDepth
+--- Dump ---
+object(XSLTProcessor)#1 (4) {
+  ["doXInclude"]=>
+  bool(false)
+  ["cloneDocument"]=>
+  bool(false)
+  ["maxTemplateDepth"]=>
+  int(1)
+  ["maxTemplateVars"]=>
+  int(15000)
+}

--- a/ext/xsl/tests/maxTemplateVars_errors.phpt
+++ b/ext/xsl/tests/maxTemplateVars_errors.phpt
@@ -1,0 +1,44 @@
+--TEST--
+XSLTProcessor::$maxTemplateVars errors
+--EXTENSIONS--
+xsl
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
+--FILE--
+<?php
+
+$processor = new XSLTProcessor;
+$oldValue = $processor->maxTemplateVars;
+
+try {
+    $processor->maxTemplateVars = -1;
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateVars === $oldValue);
+
+try {
+    $processor->maxTemplateVars = -32.1;
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateVars === $oldValue);
+
+try {
+    $processor->maxTemplateVars = "-1";
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+var_dump($processor->maxTemplateVars === $oldValue);
+
+?>
+--EXPECT--
+XSLTProcessor::$maxTemplateVars must be greater than or equal to 0
+bool(true)
+XSLTProcessor::$maxTemplateVars must be greater than or equal to 0
+bool(true)
+XSLTProcessor::$maxTemplateVars must be greater than or equal to 0
+bool(true)

--- a/ext/xsl/tests/maxTemplateVars_modification_validation_bypass.phpt
+++ b/ext/xsl/tests/maxTemplateVars_modification_validation_bypass.phpt
@@ -1,0 +1,57 @@
+--TEST--
+XSLTProcessor::$maxTemplateVars modification validation bypass
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+$proc = new XSLTProcessor();
+foreach ([1,-1] as $value) {
+    echo "--- Set to $value ---\n";
+    try {
+        $proc->maxTemplateVars = $value;
+    } catch (ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+echo "--- Get reference ---\n";
+
+try {
+    $ref =& $proc->maxTemplateVars;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Unset ---\n";
+
+try {
+    unset($proc->maxTemplateVars);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Dump ---\n";
+
+var_dump($proc);
+
+?>
+--EXPECT--
+--- Set to 1 ---
+--- Set to -1 ---
+XSLTProcessor::$maxTemplateVars must be greater than or equal to 0
+--- Get reference ---
+Indirect modification of XSLTProcessor::$maxTemplateVars is not allowed
+--- Unset ---
+Cannot unset XSLTProcessor::$maxTemplateVars
+--- Dump ---
+object(XSLTProcessor)#1 (4) {
+  ["doXInclude"]=>
+  bool(false)
+  ["cloneDocument"]=>
+  bool(false)
+  ["maxTemplateDepth"]=>
+  int(3000)
+  ["maxTemplateVars"]=>
+  int(1)
+}

--- a/ext/xsl/tests/new_without_constructor.phpt
+++ b/ext/xsl/tests/new_without_constructor.phpt
@@ -1,0 +1,23 @@
+--TEST--
+XSLTProcessor: new instance without constructor
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+$rc = new ReflectionClass('XSLTProcessor');
+$processor = $rc->newInstanceWithoutConstructor();
+var_dump($processor);
+
+?>
+--EXPECTF--
+object(XSLTProcessor)#2 (4) {
+  ["doXInclude"]=>
+  bool(false)
+  ["cloneDocument"]=>
+  bool(false)
+  ["maxTemplateDepth"]=>
+  int(%d)
+  ["maxTemplateVars"]=>
+  int(%d)
+}

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -360,6 +360,14 @@ static xmlDocPtr php_xsl_apply_stylesheet(zval *id, xsl_object *intern, xsltStyl
 	ctxt->xinclude = zend_is_true(doXInclude);
 	zend_string_release_ex(member, 0);
 
+	zval *max_template_depth = xsl_prop_max_template_depth(Z_OBJ_P(id));
+	ZEND_ASSERT(Z_TYPE_P(max_template_depth) == IS_LONG);
+	ctxt->maxTemplateDepth = Z_LVAL_P(max_template_depth);
+
+	zval *max_template_vars = xsl_prop_max_template_vars(Z_OBJ_P(id));
+	ZEND_ASSERT(Z_TYPE_P(max_template_vars) == IS_LONG);
+	ctxt->maxTemplateVars = Z_LVAL_P(max_template_vars);
+
 	secPrefsValue = intern->securityPrefs;
 
 	/* if securityPrefs is set to NONE, we don't have to do any checks, but otherwise... */


### PR DESCRIPTION
There are two depth limiting parameters for XSLT templates.

1) maxTemplateDepth
   This corresponds to the recursion depth of a template. For very
   complicated templates this can be hit.
2) maxTemplateVars
   This is the total number of live variables. When using recursive
   templates with lots of parameters you can hit this limit.

This patch introduces two new properties to XSLTProcessor that corresponds to the above variables.