### PR TITLE
Remove obsolete Makefile .NOEXPORT target

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -161,4 +161,3 @@ prof-use:
 	fi;
 
 .PHONY: all clean install distclean test prof-gen prof-clean prof-use
-.NOEXPORT:


### PR DESCRIPTION
This was once used on GNU Make from versions 3.59 to 3.63 (released in 1994) to not export all variables, otherwise a system limit may be exceeded. This was the case for the obsolete UNIX System V (SysV) and is on current systems not applicable anymore, with such target ignored.

P.S.: I find these museum features really fascinating because you can learn really a lot but it's also kind of redundant in today's code and causes only bloat since there isn't any documentation anymore about this.