### PR TITLE
Fix PdoSqlite::loadExtension() test

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -37,6 +37,7 @@ runs:
           libxpm-dev \
           libzip-dev \
           libsqlite3-dev \
+          libsqlite3-mod-spatialite \
           libwebp-dev \
           libonig-dev \
           libkrb5-dev \

--- a/ext/pdo_sqlite/tests/subclasses/pdosqlite_003.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdosqlite_003.phpt
@@ -28,11 +28,7 @@ if (!$db instanceof PdoSqlite) {
     echo "Wrong class type. Should be PdoSqlite but is " . get_class($db) . "\n";
 }
 
-$result = $db->loadExtension(getSpatialiteExtensionLocation(););
-if ($result !== true) {
-    echo "Failed to load extension mod_spatialite.so";
-    exit(-1);
-}
+$db->loadExtension(getSpatialiteExtensionLocation());
 
 $result = $db->query('SELECT AsText(Buffer(GeomFromText("LINESTRING(0 0, 1 0)"), 0.2)) as geometry_data;');
 


### PR DESCRIPTION
The test contained a syntax error and an incorrect use of loadExtension(), which returns void not bool.

Also install the necessary package in CI, so it gets tested there.