### PR TITLE
Update basic_functions.stub.php: Renaming argument of `getmxrr()`

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2175,10 +2175,10 @@ function dns_get_mx(string $hostname, &$hosts, &$weights = null): bool {}
 
 /**
  * @param array $hosts
- * @param array $weights
+ * @param array $preferences
  * @alias dns_get_mx
  */
-function getmxrr(string $hostname, &$hosts, &$weights = null): bool {}
+function getmxrr(string $hostname, &$hosts, &$preferences = null): bool {}
 #endif
 
 /* net.c */


### PR DESCRIPTION
Follow-up of https://github.com/php/doc-en/pull/3269

I'm suggesting to rename the argument to "preferences", since this is the term that the RFC uses: https://datatracker.ietf.org/doc/html/rfc5321#section-5.1

> MX records contain a preference indication that MUST be used in
   sorting if more than one such record appears (see below).  Lower
   numbers are more preferred than higher ones.