### PR TITLE
Fix string concatenation in ZEND_JIT_SRC variable

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -87,7 +87,7 @@ if test "$PHP_OPCACHE" != "no"; then
         AC_DEFINE([HAVE_CAPSTONE], [1], [Capstone is available])
         PHP_EVAL_LIBLINE($CAPSTONE_LIBS, OPCACHE_SHARED_LIBADD)
         PHP_EVAL_INCLINE($CAPSTONE_CFLAGS)
-        ZEND_JIT_SRC+=" jit/ir/ir_disasm.c"
+        ZEND_JIT_SRC="$ZEND_JIT_SRC jit/ir/ir_disasm.c"
       ],[
         AC_MSG_ERROR([capstone >= 3.0 required but not found])
       ])


### PR DESCRIPTION
The += operator only works in bash shells and when using /bin/sh, for example in Alpine Linux, the warning is thrown during configuration step

./configure: line 51396: ZEND_JIT_SRC+= jit/ir/ir_disasm.c: not found