### PR TITLE
Implement configure command visibility option for phpinfo

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -87,6 +87,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The configure option --with-mhash emits deprecation warning.
    - The configure option --with-pdo-oci has been removed.
    - The configure option --with-pspell has been removed.
+   - New configure option --disable-configure-command to hide the PHP build
+     configure command and options in the phpinfo() output (enabled by default).
    - Symbol SIZEOF_SHORT removed (size of 2 on 32-bit and 64-bit platforms).
    - Symbol DBA_CDB_MAKE removed in ext/dba.
    - Symbol HAVE_LIBM has been removed.

--- a/configure.ac
+++ b/configure.ac
@@ -1077,6 +1077,17 @@ PHP_ARG_ENABLE([undefined-sanitizer],,
   [no],
   [no])
 
+PHP_ARG_ENABLE([configure-command],
+  [whether to show the configure command in phpinfo],
+  [AS_HELP_STRING([--disable-configure-command],
+    [Hide PHP build configure command and options in the phpinfo output])],
+  [yes],
+  [no])
+
+if test "x$PHP_CONFIGURE_COMMAND" = xyes; then
+  AC_DEFINE([PHP_SHOW_CONFIGURE_COMMAND], [1], [Show configure command in phpinfo.])
+fi
+
 dnl Extension configuration.
 dnl ----------------------------------------------------------------------------
 

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -834,7 +834,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 #ifdef PHP_BUILD_ARCH
 		php_info_print_table_row(2, "Architecture", PHP_BUILD_ARCH);
 #endif
-#ifdef CONFIGURE_COMMAND
+#if defined(CONFIGURE_COMMAND) && defined(PHP_SHOW_CONFIGURE_COMMAND)
 		php_info_print_table_row(2, "Configure Command", CONFIGURE_COMMAND );
 #endif
 

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -399,3 +399,9 @@ ARG_ENABLE("native-intrinsics", "Comma separated list of intrinsic optimizations
 	might not work properly, if the chosen instruction sets are not available on the target \
 	processor.", "no");
 toolset_setup_intrinsic_cflags();
+
+ARG_ENABLE("configure-command", "Hide PHP build configure command and options \
+	in the phpinfo output", "yes");
+if(PHP_CONFIGURE_COMMAND == "yes") {
+	AC_DEFINE('PHP_SHOW_CONFIGURE_COMMAND', 1, "Show configure command in phpinfo.");
+}


### PR DESCRIPTION
This introduces a new --disable-configure-command option to optionally suppress the display of the configure command in the phpinfo() output:

    ./configure --disable-configure-command

When building PHP, many packages have patches to hide the PHP build configure command and its options in the phpinfo() output:

    Configure Command: './configure' '--enable-foo' 'CFLAGS=...' '...'

This simplifies the PHP build process for package maintainers who prefer more concise phpinfo() output without detailed build configuration.

The CONFIGURE_COMMAND symbol remains defined in the configuration headers (main/build-defs.h for *nix, main/config.w32.h for Windows) regardless of this option.

By default the configure command and options are displayed as before.