### PR TITLE
Fix posix_spawn cwd incompatibility

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1272,9 +1272,14 @@ PHP_FUNCTION(proc_open)
 	}
 
 	if (cwd) {
-		r = posix_spawn_file_actions_addchdir_np(&factions, cwd);
-		if (r != 0) {
-			php_error_docref(NULL, E_WARNING, "posix_spawn_file_actions_addchdir_np() failed: %s", strerror(r));
+		r = access(cwd, X_OK);
+		if (r == 0) {
+			r = posix_spawn_file_actions_addchdir_np(&factions, cwd);
+			if (r != 0) {
+				php_error_docref(NULL, E_WARNING, "posix_spawn_file_actions_addchdir_np() failed: %s", strerror(r));
+			}
+		} else {
+			php_error_docref(NULL, E_DEPRECATED, "Provided cwd does not exist, falling back to current cwd");
 		}
 	}
 

--- a/ext/standard/tests/general_functions/proc_open_invalid_cwd.phpt
+++ b/ext/standard/tests/general_functions/proc_open_invalid_cwd.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Using proc_open() with invalid cwd
+--FILE--
+<?php
+
+function wait_for_proc($process) {
+    for ($i = 0; $i < 10; $i++) {
+        $status = proc_get_status($process);
+        if (!$status['running']) {
+            return;
+        }
+        usleep(100000);
+    }
+    throw new Exception('Process did not terminate');
+}
+
+function test($desired_cwd) {
+    $php = getenv('TEST_PHP_EXECUTABLE');
+    $ds = [STDIN, STDOUT, STDERR];
+    $current_cwd = getcwd();
+    wait_for_proc(proc_open([$php, '-r', "var_dump(getcwd() != '$current_cwd');"], $ds, $pipes, $desired_cwd));
+}
+
+$dir = __DIR__ . '/proc_open_invalid_cwd_no_prot';
+mkdir($dir);
+chmod($dir, 0666);
+
+test('.');
+test('/tmp');
+test('/does/not/exist');
+test($dir);
+
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . '/proc_open_invalid_cwd_no_prot';
+@rmdir($dir);
+?>
+--EXPECTF--
+bool(false)
+bool(true)
+
+Deprecated: proc_open(): Provided cwd does not exist, falling back to current cwd in %s on line %d
+bool(false)
+
+Deprecated: proc_open(): Provided cwd does not exist, falling back to current cwd in %s on line %d
+bool(false)


### PR DESCRIPTION
We switched from fork+exec to posix_spawn for proc_open when available in PHP 8.3. Previously, a cwd that does not exist, or doesn't have the executable chmod flag set would silent be ignored. posix_spawn fails, on the other hand.

We provide better backwards compatibility by manually checking for the path. This patch is technically subject to data races. I'm not sure there is a way to avoid this with posix_spawn.

Fixes GH-13743