### PR TITLE
Fix GH-13745: fix header inclusion in pdo_pgsql.c

### DIFF
--- a/ext/pdo_pgsql/pdo_pgsql.c
+++ b/ext/pdo_pgsql/pdo_pgsql.c
@@ -22,7 +22,7 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 #include "pdo/php_pdo.h"
-#include "pdo/php_pdo_int.h"
+#include "pdo/php_pdo_error.h"
 #include "pdo/php_pdo_driver.h"
 #include "php_pdo_pgsql.h"
 #include "php_pdo_pgsql_int.h"


### PR DESCRIPTION
pdo/php_pdo_int.h is not part of the PDO's headers to install.