### PR TITLE
[wip] DFA based func call optimizations

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -24,6 +24,7 @@
 #include "zend_API.h"
 #include "zend_constants.h"
 #include "zend_execute.h"
+#include "zend_types.h"
 #include "zend_vm.h"
 #include "zend_bitset.h"
 #include "zend_cfg.h"
@@ -36,6 +37,7 @@ bool zend_optimizer_get_persistent_constant(zend_string *name, zval *result, int
 	if (c) {
 		if ((ZEND_CONSTANT_FLAGS(c) & CONST_PERSISTENT)
 		 && !(ZEND_CONSTANT_FLAGS(c) & CONST_DEPRECATED)
+		 && (Z_TYPE(c->value) < IS_STRING || Z_TYPE(c->value) == IS_ARRAY || Z_TYPE(c->value) == IS_CONSTANT_AST)
 		 && (!(ZEND_CONSTANT_FLAGS(c) & CONST_NO_FILE_CACHE)
 		  || !(CG(compiler_options) & ZEND_COMPILE_WITH_FILE_CACHE))) {
 			ZVAL_COPY_VALUE(result, &c->value);

--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -173,8 +173,10 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 							 || Z_TYPE(result) == IS_CONSTANT_AST) {
 								break;
 							}
-						} else {
+						} else if (Z_TYPE_P(c) < IS_STRING || Z_TYPE_P(c) == IS_ARRAY) {
 							ZVAL_COPY_OR_DUP(&result, c);
+						} else {
+							break;
 						}
 
 						replace_by_const_or_qm_assign(op_array, opline, &result);

--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -98,7 +98,7 @@ typedef struct _sccp_ctx {
 #define MAKE_TOP(zv) (Z_TYPE_INFO_P(zv) = TOP)
 #define MAKE_BOT(zv) (Z_TYPE_INFO_P(zv) = BOT)
 
-static void scp_dump_value(zval *zv) {
+static void scp_dump_value(const zval *zv) {
 	if (IS_TOP(zv)) {
 		fprintf(stderr, " top");
 	} else if (IS_BOT(zv)) {

--- a/Zend/Optimizer/zend_call_graph.h
+++ b/Zend/Optimizer/zend_call_graph.h
@@ -39,6 +39,7 @@ struct _zend_call_info {
 	bool               named_args;   /* Function has named arguments */
 	bool               is_prototype; /* An overridden child method may be called */
 	bool               is_frameless; /* A frameless function sends arguments through operands */
+	bool               infer;        /* callee_func to be inferred */
 	int                     num_args;	/* Number of arguments, excluding named and variadic arguments */
 	zend_send_arg_info      arg_info[1];
 };
@@ -62,7 +63,7 @@ typedef struct _zend_call_graph {
 BEGIN_EXTERN_C()
 
 ZEND_API void zend_build_call_graph(zend_arena **arena, zend_script *script, zend_call_graph *call_graph);
-ZEND_API void zend_analyze_call_graph(zend_arena **arena, zend_script *script, zend_call_graph *call_graph);
+ZEND_API void zend_analyze_call_graph(zend_arena **arena, zend_script *script, zend_call_graph *call_graph, uint32_t build_flags);
 ZEND_API zend_call_info **zend_build_call_map(zend_arena **arena, zend_func_info *info, const zend_op_array *op_array);
 ZEND_API void zend_analyze_calls(zend_arena **arena, zend_script *script, uint32_t build_flags, zend_op_array *op_array, zend_func_info *func_info);
 

--- a/Zend/Optimizer/zend_cfg.h
+++ b/Zend/Optimizer/zend_cfg.h
@@ -99,6 +99,7 @@ typedef struct _zend_cfg {
 #define ZEND_CFG_RECV_ENTRY            (1<<24)
 #define ZEND_CALL_TREE                 (1<<23)
 #define ZEND_SSA_USE_CV_RESULTS        (1<<22)
+#define ZEND_INFERRED_CALLS            (1<<24)
 
 #define CRT_CONSTANT_EX(op_array, opline, node) \
 	(((op_array)->fn_flags & ZEND_ACC_DONE_PASS_TWO) ? \

--- a/Zend/Optimizer/zend_inference.h
+++ b/Zend/Optimizer/zend_inference.h
@@ -220,6 +220,9 @@ BEGIN_EXTERN_C()
 ZEND_API void zend_ssa_find_false_dependencies(const zend_op_array *op_array, zend_ssa *ssa);
 ZEND_API void zend_ssa_find_sccs(const zend_op_array *op_array, zend_ssa *ssa);
 ZEND_API zend_result zend_ssa_inference(zend_arena **raena, const zend_op_array *op_array, const zend_script *script, zend_ssa *ssa, zend_long optimization_level);
+ZEND_API zend_result zend_ssa_callee_inference(zend_arena **arena,
+		zend_op_array *op_array, const zend_script *script, zend_ssa *ssa,
+		zend_long optimization_level);
 
 ZEND_API uint32_t zend_array_element_type(uint32_t t1, uint8_t op_type, int write, int insert);
 

--- a/Zend/Optimizer/zend_optimizer.h
+++ b/Zend/Optimizer/zend_optimizer.h
@@ -41,6 +41,7 @@
 #define ZEND_OPTIMIZER_PASS_14		(1<<13)  /* DCE (dead code elimination) */
 #define ZEND_OPTIMIZER_PASS_15		(1<<14)  /* (unsafe) Collect constants */
 #define ZEND_OPTIMIZER_PASS_16		(1<<15)  /* Inline functions */
+#define ZEND_OPTIMIZER_PASS_17		(1<<18)  /* DFA based function call optimizations */
 
 #define ZEND_OPTIMIZER_IGNORE_OVERLOADING	(1<<16)  /* (unsafe) Ignore possibility of operator overloading */
 

--- a/Zend/Optimizer/zend_optimizer_internal.h
+++ b/Zend/Optimizer/zend_optimizer_internal.h
@@ -109,6 +109,8 @@ zend_class_entry *zend_optimizer_get_class_entry_from_op1(
 void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimizer_pass3(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimize_func_calls(zend_op_array *op_array, zend_optimizer_ctx *ctx);
+void zend_optimize_func_calls_ssa(zend_arena **arena, zend_op_array *op_array,
+		const zend_script *script, zend_ssa *ssa, zend_long optimization_level);
 void zend_optimize_cfg(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimize_dfa(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 zend_result zend_dfa_analyze_op_array(zend_op_array *op_array, zend_optimizer_ctx *ctx, zend_ssa *ssa);
@@ -118,7 +120,11 @@ void zend_optimizer_nop_removal(zend_op_array *op_array, zend_optimizer_ctx *ctx
 void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx *ctx);
 void zend_optimizer_compact_vars(zend_op_array *op_array);
 zend_function *zend_optimizer_get_called_func(
-		zend_script *script, zend_op_array *op_array, zend_op *opline, bool *is_prototype);
+		const zend_script *script, const zend_op_array *op_array,
+		const zend_op *opline, bool *is_prototype);
+zend_function *zend_optimizer_get_called_func_ssa(
+		const zend_script *script, const zend_op_array *op_array,
+		const zend_op *opline, bool *is_prototype, const zend_ssa *ssa);
 uint32_t zend_optimizer_classify_function(zend_string *name, uint32_t num_args);
 void zend_optimizer_migrate_jump(zend_op_array *op_array, zend_op *new_opline, zend_op *opline);
 void zend_optimizer_shift_jump(zend_op_array *op_array, zend_op *opline, uint32_t *shiftlist);

--- a/Zend/Optimizer/zend_ssa.c
+++ b/Zend/Optimizer/zend_ssa.c
@@ -23,6 +23,8 @@
 #include "zend_dump.h"
 #include "zend_inference.h"
 #include "Optimizer/zend_optimizer_internal.h"
+#include "Optimizer/zend_call_graph.h"
+#include "zend_vm_opcodes.h"
 
 static bool dominates(const zend_basic_block *blocks, int a, int b) {
 	while (blocks[b].level > blocks[a].level) {

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3091,7 +3091,7 @@ ZEND_EXT_API int zend_jit_script(zend_script *script)
 	call_graph.op_arrays_count = 0;
 	zend_build_call_graph(&CG(arena), script, &call_graph);
 
-	zend_analyze_call_graph(&CG(arena), script, &call_graph);
+	zend_analyze_call_graph(&CG(arena), script, &call_graph, ZEND_CALL_TREE);
 
 	if (JIT_G(trigger) == ZEND_JIT_ON_FIRST_EXEC ||
 	    JIT_G(trigger) == ZEND_JIT_ON_PROF_REQUEST ||

--- a/ext/opcache/tests/opt/verify_return_type.phpt
+++ b/ext/opcache/tests/opt/verify_return_type.phpt
@@ -8,8 +8,6 @@ opcache.opt_debug_level=0x20000
 opcache.preload=
 --EXTENSIONS--
 opcache
---XFAIL--
-Return types cannot be inferred through prototypes
 --FILE--
 <?php
 
@@ -57,6 +55,17 @@ function getClassIntersection(): Traversable&Countable {
     return new ArrayObject;
 }
 
+function test4(Test1 $t1): int {
+    return $t1->getInt();
+}
+
+function test5(Test1 $t1, Test2 $t2): int {
+    $r = $t1->getInt();
+    if (rand()) {
+        $r = $t2->getInt();
+    }
+    return $r;
+}
 ?>
 --EXPECTF--
 $_main:
@@ -85,6 +94,32 @@ getClassIntersection:
 LIVE RANGES:
      0: 0001 - 0002 (new)
 
+test4:
+     ; (lines=4, args=1, vars=1, tmps=1)
+     ; (after optimizer)
+     ; /home/arnaud/dev/php-src/ext/opcache/tests/opt/verify_return_type.php:47-49
+0000 CV0($t1) = RECV 1
+0001 INIT_METHOD_CALL 0 CV0($t1) string("getInt")
+0002 V1 = DO_FCALL
+0003 RETURN V1
+
+test5:
+     ; (lines=12, args=2, vars=3, tmps=1)
+     ; (after optimizer)
+     ; /home/arnaud/dev/php-src/ext/opcache/tests/opt/verify_return_type.php:51-57
+0000 CV0($t1) = RECV 1
+0001 CV1($t2) = RECV 2
+0002 INIT_METHOD_CALL 0 CV0($t1) string("getInt")
+0003 CV2($r) = DO_FCALL
+0004 INIT_FCALL 0 80 string("rand")
+0005 V3 = DO_ICALL
+0006 JMPZ V3 0010
+0007 INIT_METHOD_CALL 0 CV1($t2) string("getInt")
+0008 V3 = DO_FCALL
+0009 CV2($r) = QM_ASSIGN V3
+0010 VERIFY_RETURN_TYPE CV2($r)
+0011 RETURN CV2($r)
+
 Test1::getIntOrFloat:
      ; (lines=2, args=1, vars=1, tmps=0)
      ; (after optimizer)
@@ -107,12 +142,15 @@ Test2::getInt:
 0000 RETURN int(42)
 
 Test2::getInt2:
-     ; (lines=3, args=0, vars=0, tmps=1)
+     ; (lines=4, args=0, vars=0, tmps=1)
      ; (after optimizer)
      ; %s
 0000 INIT_METHOD_CALL 0 THIS string("getInt")
 0001 V0 = DO_FCALL
-0002 RETURN V0
+0002 VERIFY_RETURN_TYPE V0
+0003 RETURN V0
+LIVE RANGES:
+     0: 0002 - 0003 (tmp/var)
 
 Test2::getIntOrFloat:
      ; (lines=2, args=1, vars=1, tmps=0)
@@ -131,6 +169,8 @@ Test2::getInt3:
 0003 V1 = DO_FCALL
 0004 VERIFY_RETURN_TYPE V1
 0005 RETURN V1
+LIVE RANGES:
+     1: 0004 - 0005 (tmp/var)
 
 Test3::getBool:
      ; (lines=1, args=0, vars=0, tmps=0)
@@ -143,4 +183,4 @@ Test3::getBool2:
      ; (after optimizer)
      ; %s
 0000 V0 = QM_ASSIGN bool(true)
-0001 RETURN bool(true)
+0001 RETURN V0


### PR DESCRIPTION
The func call optimization pass update the `INIT_FCALL`, `SEND_`, and `DO_FCALL` opcodes to specialized variants when the function is known. In particular, there are variants of the `SEND_` operands that never pass by ref, which I assume improves the effectiveness of later passes.

Similarly, the call graph optimization builds a graph of known callers/callees that other passes can use.

@kocsismate noticed that method calls were ignored by these passes unless op1 is `$this`, because the type of op1 is only known after these passes.

This PR attempts to improve that updating the call graph during type inference, and by running the func call optimization pass again after that:

- The call graph is updated to also include unknown callees
- Type inference updates callees when possible
- Type inference uses callees to determine if SEND_ ops may pass by ref instead of relying exclusively on the opcode
- The func call optimization pass is executed again after callee inference

The third point requires to run type inference before zend_mark_cv_references, otherwise we may narrow types, so we run zend_infer_types twice: Once for its effect on callees, and a second time after the func call optimization.

The DFA needs to admit a dependency between the INIT_METHOD_CALL op1_use and the related SEND and DO_FCALL ops. Currently the SSA can not represent this: I've tried adding a fake operand to SEND and DO_FCALL ops, or adding fake use/defs; but I wasn't happy with either, so instead I've added a special case in add_usages().

Unfortunately the effectiveness of these changes is limited by the fact that we must ignore classes declared in other compilation units. Here is a comparison of the number of SEND opcodes emitted when executing the symfony demo before and after this change: 

```
opcode              before  after
SEND_FUNC_ARG       794     791
SEND_REF            13      14
SEND_UNPACK         26      26
SEND_USER           1       1
SEND_VAL            622     627
SEND_VAL_EX         4965    4960
SEND_VAR            1506    1523
SEND_VAR_EX         4068    4058
SEND_VAR_NO_REF_EX  1470    1465
```

Benchmarks also show no noticeable improvement, so I don't plan on attempting to merge this as-is, but this may benefit other optimizations (or benefit from them) in the future.