### PR TITLE
Fix ASan build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,7 @@ jobs:
             zts: true
             asan: true
     name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}${{ matrix.asan && '_ASAN' || '' }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-${{ !matrix.asan && '22' || '20' }}.04
     container:
       image: ${{ matrix.asan && 'ubuntu:23.04' || null }}
     steps:


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917

The mentioned workaround doesn't work for us because we run ASan inside Docker.
Instead, we switch to ubuntu-20.04 as the host. The docker setup itself remains
the same.