### PR TITLE
Fix return type of loading DOM documents on PHP 8.0-8.2 branches.

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -296,11 +296,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
     /** @return DOMNode|false */
     public function importNode(DOMNode $node, bool $deep = false) {}
 
-    /** @return DOMDocument|bool */
-    public function load(string $filename, int $options = 0) {}
+    /** @tentative-return-type */
+    public function load(string $filename, int $options = 0): bool {}
 
-    /** @return DOMDocument|bool */
-    public function loadXML(string $source, int $options = 0) {}
+    /** @tentative-return-type */
+    public function loadXML(string $source, int $options = 0): bool {}
 
     /** @return void */
     public function normalizeDocument() {}
@@ -312,11 +312,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
     public function save(string $filename, int $options = 0) {}
 
 #ifdef LIBXML_HTML_ENABLED
-    /** @return DOMDocument|bool */
-    public function loadHTML(string $source, int $options = 0) {}
+    /** @tentative-return-type */
+    public function loadHTML(string $source, int $options = 0): bool {}
 
-    /** @return DOMDocument|bool */
-    public function loadHTMLFile(string $filename, int $options = 0) {}
+    /** @tentative-return-type */
+    public function loadHTMLFile(string $filename, int $options = 0): bool {}
 
     /** @return string|false */
     public function saveHTML(?DOMNode $node = null) {}


### PR DESCRIPTION
Hi @nielsdos,

In https://github.com/php/php-src/pull/11803 you fixed the return type of loading DOM documents on PHP 8.3 branch.
I'd like to fix the PHPdoc too on PHP-8.0, PHP-8.1 and PHP-8.2 branch.

The https://github.com/phpstan/php-8-stubs library is generating stub/phpdoc directly from the four PHP-8.0, PHP-8.1, PHP-8.2 and PHP-8.3 branches and merging the results. 
Unfortunately the fact that the phpdoc is wrong on PHP 8.0-8.2 branches ends with a wrong phpdoc on phpstan stubs 
https://github.com/phpstan/php-8-stubs/blob/main/stubs/ext/dom/DOMDocument.php#L84

It would be great to fix the phpdoc too on 8.0 branch (and 8.1 and 8.2) to solve this phpstan issue.
https://github.com/phpstan/phpstan/issues/10057#issuecomment-2003486252

I know PHP 8.0 is EOL, but does such PR would be ok ?