### PR TITLE
Disable ASLR for benchmark

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -225,6 +225,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # ASLR can cause a lot of noise due to missed sse opportunities for memcpy
+      # and other operations, so we disable it during benchmarking.
+      - name: Disable ASLR
+        run: echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
       - name: apt
         run: |
           set -x


### PR DESCRIPTION
This brought deviation down to 0.0003% for 10 runs of Symfony Demo. That's not very many runs, but it might be easier to just try it. /cc @nielsdos