### PR TITLE
Restore Warning instead of Fatal Error in gd_webp.c

### DIFF
--- a/ext/gd/libgd/gd_webp.c
+++ b/ext/gd/libgd/gd_webp.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "gd.h"
+#include "gd_errors.h"
 #include "gdhelpers.h"
 
 #ifdef HAVE_LIBWEBP
@@ -56,7 +57,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 			if (filedata) {
 				gdFree(filedata);
 			}
-			zend_error_noreturn(E_ERROR, "WebP decode: realloc failed");
+			gd_error("WebP decode: realloc failed");
 			return NULL;
 		}
 
@@ -67,7 +68,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 	} while (n>0 && n!=EOF);
 
 	if (WebPGetInfo(filedata,size, &width, &height) == 0) {
-		zend_error_noreturn(E_ERROR, "gd-webp cannot get webp info");
+		gd_error("gd-webp cannot get webp info");
 		gdFree(filedata);
 		return NULL;
 	}
@@ -79,7 +80,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 	}
 	argb = WebPDecodeARGB(filedata, size, &width, &height);
 	if (!argb) {
-		zend_error_noreturn(E_ERROR, "gd-webp cannot allocate temporary buffer");
+		gd_error("gd-webp cannot allocate temporary buffer");
 		gdFree(filedata);
 		gdImageDestroy(im);
 		return NULL;
@@ -113,7 +114,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	if (!gdImageTrueColor(im)) {
-		zend_error_noreturn(E_ERROR, "Palette image not supported by webp");
+		gd_error("Palette image not supported by webp");
 		return;
 	}
 
@@ -159,7 +160,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	if (out_size == 0) {
-		zend_error_noreturn(E_ERROR, "gd-webp encoding failed");
+		gd_error("gd-webp encoding failed");
 		goto freeargb;
 	}
 	gdPutBuf(out, out_size, outfile);


### PR DESCRIPTION
According to the docs (see https://www.php.net/manual/en/function.imagecreatefromwebp.php and https://www.php.net/manual/en/function.imagewebp.php), `false` should be returned on errors (similar to other functions of the `gd` extension), but actually all errors result in a `Fatal Error`. It doesn't look normal when trying to read an empty file or a file in the wrong format causes the program to stop.

The problem seems to be related to a mega-patch that replaced `zend_error` with `zend_error_noreturn` almost everywhere.

My patch fixes this behavior by switching from `zend_error_noerror` to `gd_error` (i.e. to `E_WARNING` level). All necessary memory cleanup is already in the code (as it was before the "zend_error_noreturn" patch).

You can use the following code to test:
```php
<?php
$empty_webp = __DIR__ . '/empty.webp';
file_put_contents($empty_webp, '');
$im = imagecreatefromwebp($empty_webp);
```

**Current** result:
```
Fatal error: gd-webp cannot get webp info in ...
```

**Expected** result:
```
Warning: imagecreatefromwebp(): gd-webp cannot get webp info in ...
```