### PR TITLE
Always load EX(opline) into the current frame in tracing JIT when observers are enabled

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -9449,7 +9449,12 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		}
 
 		if (ZEND_OBSERVER_ENABLED) {
-			|	SAVE_IP
+			if (trace && (trace->op != ZEND_JIT_TRACE_END || trace->stop != ZEND_JIT_TRACE_STOP_INTERPRETER)) {
+				ZEND_ASSERT(trace[1].op == ZEND_JIT_TRACE_VM || trace[1].op == ZEND_JIT_TRACE_END);
+				|	SET_EX_OPLINE trace[1].opline, REG0
+			} else {
+				|	SAVE_IP
+			}
 			|	mov FCARG1x, FP
 			|	EXT_CALL zend_observer_fcall_begin, REG0
 		}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -10187,7 +10187,12 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		}
 
 		if (ZEND_OBSERVER_ENABLED) {
-			|	SAVE_IP
+			if (trace && (trace->op != ZEND_JIT_TRACE_END || trace->stop != ZEND_JIT_TRACE_STOP_INTERPRETER)) {
+				ZEND_ASSERT(trace[1].op == ZEND_JIT_TRACE_VM || trace[1].op == ZEND_JIT_TRACE_END);
+				|	SET_EX_OPLINE trace[1].opline, r0
+			} else {
+				|	SAVE_IP
+			}
 			|	mov FCARG1a, FP
 			|	EXT_CALL zend_observer_fcall_begin, r0
 		}

--- a/ext/opcache/tests/jit/gh13772.phpt
+++ b/ext/opcache/tests/jit/gh13772.phpt
@@ -1,0 +1,26 @@
+--TEST--
+EX(opline) is correctly set for nested JIT user code calls
+--EXTENSIONS--
+opcache
+zend_test
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_output=0
+--FILE--
+<?php
+
+function Ack($m, $n) {
+	if ($m == 0) return $n+1;
+	if ($n == 0) return Ack($m-1, 1);
+	return Ack($m - 1, Ack($m, ($n - 1)));
+}
+
+var_dump(Ack(3, 3));
+
+?>
+--EXPECT--
+int(61)
+

--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -67,8 +67,16 @@ static void observer_show_opcode(zend_execute_data *execute_data)
 	php_printf("%*s<!-- opcode: '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
 }
 
+static inline void assert_observer_opline(zend_execute_data *execute_data) {
+	ZEND_ASSERT(!ZEND_USER_CODE(EX(func)->type) ||
+		(EX(opline) >= EX(func)->op_array.opcodes && EX(opline) < EX(func)->op_array.opcodes + EX(func)->op_array.last) ||
+		(EX(opline) >= EG(exception_op) && EX(opline) < EG(exception_op) + 3));
+}
+
 static void observer_begin(zend_execute_data *execute_data)
 {
+	assert_observer_opline(execute_data);
+
 	if (!ZT_G(observer_show_output)) {
 		return;
 	}
@@ -112,6 +120,8 @@ static void get_retval_info(zval *retval, smart_str *buf)
 
 static void observer_end(zend_execute_data *execute_data, zval *retval)
 {
+	assert_observer_opline(execute_data);
+
 	if (!ZT_G(observer_show_output)) {
 		return;
 	}


### PR DESCRIPTION
Fixes #13772.

I.e. disabling the optimization of the tracing jit where setting EX(opline) is elided.