### PR TITLE
Fix mysqlnd pipe crash

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -236,6 +236,7 @@ MYSQLND_METHOD(mysqlnd_vio, open_tcp_or_unix)(MYSQLND_VIO * const vio, const MYS
 		zend_resource *le;
 
 		if ((le = zend_hash_str_find_ptr(&EG(persistent_list), hashed_details, hashed_details_len))) {
+			ZEND_ASSERT(le->ptr == net_stream);
 			origin_dtor = EG(persistent_list).pDestructor;
 			/*
 			  in_free will let streams code skip destructing - big HACK,

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -141,6 +141,7 @@ MYSQLND_METHOD(mysqlnd_vio, open_pipe)(MYSQLND_VIO * const vio, const MYSQLND_CS
 	EG(regular_list).pDestructor = NULL;
 	zend_hash_index_del(&EG(regular_list), net_stream->res->handle); /* ToDO: should it be res->handle, do streams register with addref ?*/
 	EG(regular_list).pDestructor = origin_dtor;
+	efree(net_stream->res);
 	net_stream->res = NULL;
 
 	DBG_RETURN(net_stream);

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -145,6 +145,33 @@ MYSQLND_METHOD(mysqlnd_vio, open_pipe)(MYSQLND_VIO * const vio, const MYSQLND_CS
 		SET_CLIENT_ERROR(error_info, CR_CONNECTION_ERROR, UNKNOWN_SQLSTATE, "Unknown error while connecting");
 		DBG_RETURN(NULL);
 	}
+
+	if (persistent) {
+		/* This is a similar hack as for mysqlnd_vio::open_tcp_or_unix.
+		 * The main difference here is that we have no access to the hashed key.
+		 * We can however perform a loop over the persistent resource list to find
+		 * which one corresponds to our newly allocated stream.
+		 * This loop is pretty cheap because it will normally either be the last entry or second to last entry
+		 * in the list, depending on whether the socket connection itself is persistent or not.
+		 * That's why we use a reverse loop. */
+		Bucket *bucket;
+		/* Use a bucket loop to make deletion cheap. */
+		ZEND_HASH_MAP_REVERSE_FOREACH_BUCKET(&EG(persistent_list), bucket) {
+			zend_resource *current_res = Z_RES(bucket->val);
+			if (current_res->ptr == net_stream) {
+				dtor_func_t origin_dtor = EG(persistent_list).pDestructor;
+				EG(persistent_list).pDestructor = NULL;
+				zend_hash_del_bucket(&EG(persistent_list), bucket);
+				EG(persistent_list).pDestructor = origin_dtor;
+				pefree(current_res, 1);
+				break;
+			}
+		} ZEND_HASH_FOREACH_END();
+#if ZEND_DEBUG
+		php_stream_auto_cleanup(net_stream);
+#endif
+	}
+
 	mysqlnd_fixup_regular_list(net_stream);
 
 	DBG_RETURN(net_stream);

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -652,15 +652,11 @@ MYSQLND_METHOD(mysqlnd_vio, close_stream)(MYSQLND_VIO * const net, MYSQLND_STATS
 		bool pers = net->persistent;
 		DBG_INF_FMT("Freeing stream. abstract=%p", net_stream->abstract);
 		/* We removed the resource from the stream, so pass FREE_RSRC_DTOR now to force
-		 * destruction to occur during shutdown, because it won't happen through the resource. */
-		/* TODO: The EG(active) check here is dead -- check IN_SHUTDOWN? */
-		if (pers && EG(active)) {
+		 * destruction to occur during shutdown, because it won't happen through the resource
+		 * because we removed the resource from the EG resource list(s). */
+		if (pers) {
 			php_stream_free(net_stream, PHP_STREAM_FREE_CLOSE_PERSISTENT | PHP_STREAM_FREE_RSRC_DTOR);
 		} else {
-			/*
-			  otherwise we will crash because the EG(persistent_list) has been freed already,
-			  before the modules are shut down
-			*/
 			php_stream_free(net_stream, PHP_STREAM_FREE_CLOSE | PHP_STREAM_FREE_RSRC_DTOR);
 		}
 		net->data->m.set_stream(net, NULL);

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -249,7 +249,7 @@ MYSQLND_METHOD(mysqlnd_vio, open_tcp_or_unix)(MYSQLND_VIO * const vio, const MYS
 		}
 #if ZEND_DEBUG
 		/* Shut-up the streams, they don't know what they are doing */
-		net_stream->__exposed = 1;
+		php_stream_auto_cleanup(net_stream);
 #endif
 		mnd_sprintf_free(hashed_details);
 	}


### PR DESCRIPTION
The individual commits have descriptions that explain the change. This fixes the bug fully on the master branch.
I tested this with both persistent and non-persistent connections. As mysqlnd's stream handling is a bit tricky and has some hacks, it's best to review this with at least 2 people.

As for backporting: All commits except the first one can be backported to stable branches I think, which means that in that case it's fixed on stable branches that use NTS. On ZTS, I'm not entirely sure if there's still cases where it will crash. Since the resources are removed from the persistent list, and managed by the extension itself now, it may work around the crash that the old code was protecting against.

Should fix GH-10599.

To test with ASAN on Windows (to reproduce the crash), you need to modify `configure.js`:
Find `ADD_FLAG('CFLAGS', ' /wd4996 ');` and change it into `ADD_FLAG('CFLAGS', ' /wd4996 /fsanitize=address ');`.