### PR TITLE
Fix AX_GCC_FUNC_ATTRIBUTE failure

### DIFF
--- a/build/ax_gcc_func_attribute.m4
+++ b/build/ax_gcc_func_attribute.m4
@@ -216,7 +216,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                     static int bar( void ) __attribute__(($1("foo")));
                 ],
                 [target], [
-                    static int bar( void ) __attribute__(($1("sse2")));
+                    int bar( void ) __attribute__(($1("sse2")));
                 ],
                 [
                  m4_warn([syntax], [Unsupported attribute $1, the test may fail])


### PR DESCRIPTION
 ` AX_GCC_FUNC_ATTRIBUTE([target])` may fail breaking various optimization (ex: base64_encode/base64_decode)

In config.log

```
configure:17050: checking for __attribute__((target))
configure:17072: cc -o conftest -Wall -Werror=format-security -Werror=implicit-function-declaration -Werror=implicit-int -Werror=return-type -Werror=incompatible-pointer-types -fvisibility=hidden  -D_GNU_SOURCE  conftest.c -lm  >&5
conftest.c:146:32: warning: 'bar' declared 'static' but never defined [-Wunused-function]
  146 |                     static int bar( void ) __attribute__((target("sse2")));
      |                                ^~~
configure:17072: $? = 0
configure:17087: result: no

```

Dropping the `static` keyword allow the test to work

Notice, this file is outdated, see http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_gcc_func_attribute.m4  (serial 9 => 13) but "target" is not part of this upstream file, and only `ifunc` and `target` are used.