### PR TITLE
Refactor root build directories

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -877,7 +877,11 @@ AC_DEFUN([PHP_SELECT_SAPI],[
 ])
 
 dnl
-dnl PHP_ADD_BUILD_DIR
+dnl PHP_ADD_BUILD_DIR(dirs [, create])
+dnl
+dnl Add build directories and directories required for the out-of-source builds.
+dnl When "create" is given, the provided "dirs" are created immediately upon
+dnl macro invocation, instead of deferring it to the PHP_GEN_BUILD_DIRS.
 dnl
 AC_DEFUN([PHP_ADD_BUILD_DIR],[
   ifelse($2,,[

--- a/configure.ac
+++ b/configure.ac
@@ -1225,6 +1225,7 @@ if test "$PHP_PEAR" != "no"; then
     esac
   fi
 
+  PHP_ADD_BUILD_DIR([pear])
   PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/pear/Makefile.frag,$abs_srcdir/pear,pear)
 fi
 
@@ -1740,19 +1741,21 @@ PHP_ADD_SOURCES(Zend, \
 	Optimizer/zend_dump.c \
     , -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 
-PHP_ADD_BUILD_DIR(main main/streams)
-PHP_ADD_BUILD_DIR(TSRM)
-PHP_ADD_BUILD_DIR(Zend Zend/asm Zend/Optimizer)
-
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/scripts/Makefile.frag,$abs_srcdir/scripts,scripts)
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Zend/Makefile.frag,$abs_srcdir/Zend,Zend)
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 
-dnl Make directories when building in a separate build directory.
-$php_shtool mkdir -p pear
-$php_shtool mkdir -p scripts
-$php_shtool mkdir -p scripts/man1
+PHP_ADD_BUILD_DIR([m4_normalize([
+  main
+  main/streams
+  scripts
+  scripts/man1
+  TSRM
+  Zend
+  Zend/asm
+  Zend/Optimizer
+])])
 
 ALL_OUTPUT_FILES="main/build-defs.h \
 scripts/phpize scripts/man1/phpize.1 \
@@ -1787,8 +1790,6 @@ fi
 
 dnl Create configuration headers.
 dnl ----------------------------------------------------------------------------
-test -d Zend || $php_shtool mkdir Zend
-
 cat >Zend/zend_config.h <<FEO
 #include <../main/php_config.h>
 FEO


### PR DESCRIPTION
This adds all root build directories in one call. PEAR directory is created only when enabled and duplicated Zend directory creation is removed, because it was intended for the zend_config.h when building out-of-source or using the config.status manually before the PHP_ADD_BUILD_DIR was introduced in the build system.