### PR TITLE
Fix GH-13563: Setting bool values via env in FPM config fails

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -213,8 +213,21 @@ static int fpm_conf_expand_pool_name(char **value) {
 static char *fpm_conf_set_boolean(zval *value, void **config, intptr_t offset) /* {{{ */
 {
 	zend_string *val = Z_STR_P(value);
-	bool value_y = zend_string_equals_literal(val, "1");
-	bool value_n = ZSTR_LEN(val) == 0; /* Empty string is the only valid false value */
+	/* we need to check all alowed values to correctly set value from the environment varaible */
+	bool value_y = (
+		zend_string_equals_literal(val, "1") ||
+		zend_string_equals_literal(val, "yes") ||
+		zend_string_equals_literal(val, "true") ||
+		zend_string_equals_literal(val, "on")
+	);
+	bool value_n = (
+		value_y || ZSTR_LEN(val) == 0 ||
+		zend_string_equals_literal(val, "no") ||
+		zend_string_equals_literal(val, "none") ||
+		zend_string_equals_literal(val, "false") ||
+		zend_string_equals_literal(val, "off")
+	);
+
 
 	if (!value_y && !value_n) {
 		return "invalid boolean value";

--- a/sapi/fpm/tests/gh13563-conf-bool-env.phpt
+++ b/sapi/fpm/tests/gh13563-conf-bool-env.phpt
@@ -1,0 +1,72 @@
+--TEST--
+FPM: GH-13563 - conf boolean environment variables values
+--SKIPIF--
+<?php
+include "skipif.inc";
+FPM\Tester::skipIfRoot();
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+log_limit = 1024
+log_buffering = \${FPM_TEST_LOG_BUF}
+daemonize = \${FPM_TEST_DAEMONIZE}
+[unconfined]
+listen = {{ADDR}}
+process.dumpable = \${FPM_TEST_PROC_DUMP}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+catch_workers_output = \${FPM_TEST_CATCH_WRK_OUT}
+decorate_workers_output = \${FPM_TEST_DECOR_WRK_OUT}
+clear_env = \${FPM_TEST_CLEAR_ENV}
+EOT;
+
+$code = <<<EOT
+<?php
+foreach (getenv() as \$name => \$val) {
+    if (str_starts_with(\$name, 'FPM_TEST')) {
+        printf("%s: %s\n", \$name, \$val);
+    }
+}
+file_put_contents('php://stderr', str_repeat('a', 20) . "\n");
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start(envVars: [
+    'FPM_TEST_LOG_BUF' => 'on',
+    'FPM_TEST_DAEMONIZE' => 'false',
+    'FPM_TEST_PROC_DUMP' => 'no',
+    'FPM_TEST_CATCH_WRK_OUT' => 'yes',
+    'FPM_TEST_DECOR_WRK_OUT' => 'true',
+    'FPM_TEST_CLEAR_ENV' => 'none',
+]);
+$tester->expectLogStartNotices();
+$tester->request()->expectBody([
+    'FPM_TEST_LOG_BUF: on',
+    'FPM_TEST_DAEMONIZE: false',
+    'FPM_TEST_PROC_DUMP: no',
+    'FPM_TEST_CATCH_WRK_OUT: yes',
+    'FPM_TEST_DECOR_WRK_OUT: true',
+    'FPM_TEST_CLEAR_ENV: none',
+]);
+$tester->terminate();
+$tester->expectLogMessage('a', 1024, 20, true);
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -432,6 +432,7 @@ class Tester
         bool $daemonize = false,
         array $extensions = [],
         array $iniEntries = [],
+        array $envVars = [],
     ) {
         $configFile = $this->createConfig();
         $desc       = $this->outDesc ? [] : [1 => array('pipe', 'w'), 2 => array('redirect', 1)];
@@ -465,7 +466,7 @@ class Tester
         $cmd = array_merge($cmd, $extraArgs);
         $this->trace('Starting FPM using command:', $cmd, true);
 
-        $this->masterProcess = proc_open($cmd, $desc, $pipes);
+        $this->masterProcess = proc_open($cmd, $desc, $pipes, null, $envVars);
         register_shutdown_function(
             function ($masterProcess) use ($configFile) {
                 @unlink($configFile);


### PR DESCRIPTION
This is a fix for GH-13563 . It is caused by the fact that env vars are always passed as strings and it is evaluated after the ini scanning. Currently only "1" and "" are valid boolean strings which is not very useful if passed from environment variable. This adds extra check to allow other string to be parsed as boolean.