### PR TITLE
QA - Test - filter_input_array - FILTER_NULL_ON_FAILURE

### DIFF
--- a/ext/filter/tests/filter_input_array_001.phpt
+++ b/ext/filter/tests/filter_input_array_001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+filter_input_array: test FILTER_NULL_ON_FAILURE option
+--EXTENSIONS--
+filter
+--GET--
+b="test"
+--FILE--
+<?php
+    $args = [
+        "a" => [
+            "flags" => FILTER_NULL_ON_FAILURE,
+            "filter" => FILTER_VALIDATE_BOOLEAN,
+        ],
+        "b" => [
+            "filter" => FILTER_VALIDATE_BOOLEAN,
+        ]
+    ];
+
+    var_dump(filter_input_array(INPUT_GET, $args, true));
+?>
+--EXPECT--
+array(2) {
+  ["a"]=>
+  NULL
+  ["b"]=>
+  bool(false)
+}


### PR DESCRIPTION
I thought to write this test in order to increase the test coverage related to the flag FILTER_NULL_ON_FAILURE, now with `filter_array_input`

`ext/filter/tests/filter_input_array_001.phpt`

Honestly I dont know how far should I go on this, I think this simple example in enough but I am open to opinions