### PR TITLE
Remove impossible paths from session_decode and session_encode

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -247,10 +247,7 @@ static void php_session_track_init(void) /* {{{ */
 static zend_string *php_session_encode(void) /* {{{ */
 {
 	IF_SESSION_VARS() {
-		if (!PS(serializer)) {
-			php_error_docref(NULL, E_WARNING, "Unknown session.serialize_handler. Failed to encode session object");
-			return NULL;
-		}
+        ZEND_ASSERT(PS(serializer));
 		return PS(serializer)->encode();
 	} else {
 		php_error_docref(NULL, E_WARNING, "Cannot encode non-existent session");
@@ -268,10 +265,7 @@ static ZEND_COLD void php_session_cancel_decode(void)
 
 static zend_result php_session_decode(zend_string *data) /* {{{ */
 {
-	if (!PS(serializer)) {
-		php_error_docref(NULL, E_WARNING, "Unknown session.serialize_handler. Failed to decode session object");
-		return FAILURE;
-	}
+    ZEND_ASSERT(PS(serializer));
 	zend_result result = SUCCESS;
 	zend_try {
 		if (PS(serializer)->decode(ZSTR_VAL(data), ZSTR_LEN(data)) == FAILURE) {

--- a/ext/session/tests/session_decode_error3.phpt
+++ b/ext/session/tests/session_decode_error3.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test session_decode() function : error functionality
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--INI--
+session.serialize_handler = wrong_handler
+--FILE--
+<?php
+
+ob_start();
+session_start();
+ini_set('session.serialize_handler', 'wrong_handler');
+var_dump(session_decode(''));
+
+echo "Done";
+ob_end_flush();
+?>
+--EXPECTF--
+Warning: session_start(): Cannot find session serialization handler "wrong_handler" - session startup failed in %s on line 4
+
+Warning: ini_set(): Serialization handler "wrong_handler" cannot be found in %s on line 5
+
+Warning: session_decode(): Session data cannot be decoded when there is no active session in %s on line 6
+bool(false)
+Done


### PR DESCRIPTION
Removed paths from `session_decode` and `session_encode` that are impossible to reach, because:
- session must be active before those functions are called
- it's impossible to pass an invalid `session.serialize_handler`. Neither by `ini_set` or `session_start($options)`.

I have added a test case, but I'm not sure in this case is very relevant.