### PR TITLE
Fix incorrect check in fpm_shm_free()

### DIFF
--- a/sapi/fpm/fpm/fpm_shm.c
+++ b/sapi/fpm/fpm/fpm_shm.c
@@ -50,7 +50,7 @@ int fpm_shm_free(void *mem, size_t size) /* {{{ */
 		return 0;
 	}
 
-	if (fpm_shm_size - size > 0) {
+	if (fpm_shm_size > size) {
 		fpm_shm_size -= size;
 	} else {
 		fpm_shm_size = 0;


### PR DESCRIPTION
`if (fpm_shm_size - size > 0)` will be rewritten by the compiler as this: `if (fpm_shm_size != size)`, which is undesirable. The reason this happens is that both variables are size_t, so subtracting them cannot be negative. The only way it can be not > 0, is if they're equal because the result will then be 0. This means that the else branch won't work properly. E.g. if `fpm_shm_size == 50` and `size == 51`, then `fpm_shm_size` will wraparound instead of becoming zero.

To showcase that the compiler actually does this, take a look at this isolated case: https://godbolt.org/z/azobdWcrY. Here we can see the usage of the compare instruction + cmove, so the "then" branch is only done if the variables are equal.

That all being said, I think it's better to be an assertion + an unconditional subtraction, as the check itself already looks weird.