### PR TITLE
Add test for session_start with read_and_close option

### DIFF
--- a/ext/session/tests/session_start_read_and_close.phpt
+++ b/ext/session/tests/session_start_read_and_close.phpt
@@ -26,8 +26,8 @@ foreach ($valuesDisablingReadAndClose as $value) {
 
 try {
     session_start(["read_and_close" => 1.1]);
-} catch (Exception $e) {
-    echo $e->getMessage();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
 ob_end_flush();
@@ -46,9 +46,4 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-
-Fatal error: Uncaught TypeError: session_start(): Option "read_and_close" must be of type string|int|bool, float given in %s:%d
-Stack trace:
-#0 %s(%d): session_start(Array)
-#1 {main}
-  thrown in %s on line %d
+TypeError: session_start(): Option "read_and_close" must be of type string|int|bool, float given

--- a/ext/session/tests/session_start_read_and_close.phpt
+++ b/ext/session/tests/session_start_read_and_close.phpt
@@ -9,7 +9,7 @@ session
 
 ob_start();
 
-$valuesEnablingReadAndClose = [true, 1, "1", "777"];
+$valuesEnablingReadAndClose = [true, 1, "1", "777", 777, -1];
 
 $valuesDisablingReadAndClose = ["true", false, "false", 0, "0", "no", "00000"];
 
@@ -33,6 +33,8 @@ try {
 ob_end_flush();
 ?>
 --EXPECTF--
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/ext/session/tests/session_start_read_and_close.phpt
+++ b/ext/session/tests/session_start_read_and_close.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Test session_start() with flag read_and_close
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+$valuesEnablingReadAndClose = [true, 1, "1", "777"];
+
+$valuesDisablingReadAndClose = ["true", false, "false", 0, "0", "no", "00000"];
+
+foreach ($valuesEnablingReadAndClose as $value) {
+    session_start(["read_and_close" => $value]);
+    var_dump(session_status() === PHP_SESSION_NONE);
+}
+
+foreach ($valuesDisablingReadAndClose as $value) {
+    session_start(["read_and_close" => $value]);
+    var_dump(session_status() === PHP_SESSION_ACTIVE);
+    session_write_close();
+}
+
+try {
+    session_start(["read_and_close" => 1.1]);
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+
+ob_end_flush();
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Fatal error: Uncaught TypeError: session_start(): Option "read_and_close" must be of type string|int|bool, float given in %s:%d
+Stack trace:
+#0 %s(%d): session_start(Array)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/session/tests/session_start_read_and_close.phpt
+++ b/ext/session/tests/session_start_read_and_close.phpt
@@ -25,7 +25,7 @@ foreach ($valuesDisablingReadAndClose as $value) {
 }
 
 try {
-    session_start(["read_and_close" => 1.1]);
+    session_start(["read_and_close" => 1.0]);
 } catch (Throwable $e) {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }


### PR DESCRIPTION
There were no tests for `session_start` with the `read_and_close` flag.  I will add later tests for other options.