### PR TITLE
Fix GH-13789 Build failed mbstring_arginfo.h on VC++

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3913,6 +3913,7 @@ class FileInfo {
     public bool $generateClassEntries = false;
     public bool $isUndocumentable = false;
     public bool $legacyArginfoGeneration = false;
+    public bool $insertBom = false;
     private ?int $minimumPhpVersionIdCompatibility = null;
 
     /**
@@ -4779,6 +4780,8 @@ function parseStubFile(string $code): FileInfo {
                 $fileInfo->declarationPrefix = $tag->value ? $tag->value . " " : "";
             } else if ($tag->name === 'undocumentable') {
                 $fileInfo->isUndocumentable = true;
+            } else if ($tag->name === 'insert-bom') {
+                $fileInfo->insertBom = true;
             }
         }
     }
@@ -4952,7 +4955,12 @@ function generateArgInfoCode(
     array $allConstInfos,
     string $stubHash
 ): string {
-    $code = "/* This is a generated file, edit the .stub.php file instead.\n"
+    if (isset($fileInfo->insertBom) && $fileInfo->insertBom === true) {
+        $code = "\xEF\xBB\xBF";
+    } else {
+        $code = "";
+    }
+    $code .= "/* This is a generated file, edit the .stub.php file instead.\n"
           . " * Stub hash: $stubHash */\n";
 
     $minimumPhpVersionIdCompatibility = $fileInfo->getMinimumPhpVersionIdCompatibility();

--- a/ext/mbstring/mbstring.stub.php
+++ b/ext/mbstring/mbstring.stub.php
@@ -1,6 +1,7 @@
 <?php
 
 /** @generate-class-entries */
+/** @insert-bom */
 
 #ifdef HAVE_MBREGEX
 /**

--- a/ext/mbstring/mbstring_arginfo.h
+++ b/ext/mbstring/mbstring_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ea642b9010bc38a3b13710662fef48663d4385e1 */
+﻿/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: c57c25f084c1d0b6fb546f4048c9432f14ee9428 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_language, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, language, IS_STRING, 1, "null")


### PR DESCRIPTION
mbstring.stub.php uses Unicode special character.
Some environment(Japanese CP932) VC++ is fail to compile. I found solution that insert Byte Order Mark.
However, scope of impact is very big. Hence add `@insert-bom` block comment at .stub.php file.