### PR TITLE
Remove setlocale pragma that no longer is significant.

### DIFF
--- a/ext/calendar/jewish.c
+++ b/ext/calendar/jewish.c
@@ -260,10 +260,6 @@
  *
  **************************************************************************/
 
-#if defined(PHP_WIN32)
-#pragma setlocale("english")
-#endif
-
 #include "sdncal.h"
 
 #define HALAKIM_PER_HOUR 1080


### PR DESCRIPTION
After 99fdf5916eccbd72c10cc4d84693e677996b1229, ext/calendar/jewish.c no longer contains non-ASCII characters that may confuse MSVC compiler.