### PR TITLE
Fix gcc-14 Wcalloc-transposed-args warnings

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2159,7 +2159,7 @@ static zend_result zend_ffi_cdata_get_closure(zend_object *obj, zend_class_entry
 	if (EXPECTED(EG(trampoline).common.function_name == NULL)) {
 		func = &EG(trampoline);
 	} else {
-		func = ecalloc(sizeof(zend_internal_function), 1);
+		func = ecalloc(1, sizeof(zend_internal_function));
 	}
 	func->type = ZEND_INTERNAL_FUNCTION;
 	func->common.arg_flags[0] = 0;
@@ -2912,7 +2912,7 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 	if (EXPECTED(EG(trampoline).common.function_name == NULL)) {
 		func = &EG(trampoline);
 	} else {
-		func = ecalloc(sizeof(zend_internal_function), 1);
+		func = ecalloc(1, sizeof(zend_internal_function));
 	}
 	func->common.type = ZEND_INTERNAL_FUNCTION;
 	func->common.arg_flags[0] = 0;

--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -58,7 +58,7 @@ void zend_accel_blacklist_init(zend_blacklist *blacklist)
 		zend_accel_blacklist_shutdown(blacklist);
 	}
 
-	blacklist->entries = (zend_blacklist_entry *) calloc(sizeof(zend_blacklist_entry), blacklist->size);
+	blacklist->entries = (zend_blacklist_entry *) calloc(blacklist->size, sizeof(zend_blacklist_entry));
 	if (!blacklist->entries) {
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Blacklist initialization: no memory\n");
 		return;

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -690,7 +690,7 @@ static zend_string* get_command_from_array(HashTable *array, char ***argv, int n
 static descriptorspec_item* alloc_descriptor_array(HashTable *descriptorspec)
 {
 	uint32_t ndescriptors = zend_hash_num_elements(descriptorspec);
-	return ecalloc(sizeof(descriptorspec_item), ndescriptors);
+	return ecalloc(ndescriptors, sizeof(descriptorspec_item));
 }
 
 static zend_string* get_string_parameter(zval *array, int index, char *param_name)

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -226,7 +226,7 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, const cha
 		}
 	}
 
-	pglob = ecalloc(sizeof(*pglob), 1);
+	pglob = ecalloc(1, sizeof(*pglob));
 
 	if (0 != (ret = glob(path, pglob->flags & GLOB_FLAGMASK, NULL, &pglob->glob))) {
 #ifdef GLOB_NOMATCH


### PR DESCRIPTION
gcc-14 and later warns of inverted arguments in calloc or calloc-like __alloc_size__ annotated functions.