### PR TITLE
Fix linking library for POSIX shared memory functions

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -238,9 +238,16 @@ int main(void) {
   fi
   AC_MSG_RESULT([$have_shm_mmap_anon])
 
-  PHP_CHECK_FUNC_LIB(shm_open, rt, root)
-  AC_MSG_CHECKING(for mmap() using shm_open() shared memory support)
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+  dnl Check POSIX shared memory object operations and link required library as
+  dnl needed: rt (older Linux and Solaris <= 10). Most systems have it in the C
+  dnl standard library (newer Linux, illumos, Solaris 11.4, macOS, BSD-based
+  dnl systems...). Haiku has it in the root library, which is linked by default.
+  LIBS_save="$LIBS"
+  LIBS=
+  AC_SEARCH_LIBS([shm_open], [rt],
+    [AC_CACHE_CHECK([for mmap() using shm_open() shared memory support],
+      [php_cv_shm_mmap_posix],
+      [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
@@ -302,13 +309,20 @@ int main(void) {
     return 9;
   }
   return 0;
-}
-]])],[have_shm_mmap_posix=yes],[have_shm_mmap_posix=no],[have_shm_mmap_posix=no])
-  AC_MSG_RESULT([$have_shm_mmap_posix])
-  if test "$have_shm_mmap_posix" = "yes"; then
-    AC_DEFINE(HAVE_SHM_MMAP_POSIX, 1, [Define if you have POSIX mmap() SHM support])
-    PHP_CHECK_LIBRARY(rt, shm_unlink, [PHP_ADD_LIBRARY(rt,1,OPCACHE_SHARED_LIBADD)])
-  fi
+}]])],
+      [php_cv_shm_mmap_posix=yes],
+      [php_cv_shm_mmap_posix=no],
+      [php_cv_shm_mmap_posix=no])
+    ])
+
+    if test "$php_cv_shm_mmap_posix" = "yes"; then
+      AS_VAR_IF([ac_cv_search_shm_open], ["none required"],,
+        [OPCACHE_SHARED_LIBADD="$OPCACHE_SHARED_LIBADD $ac_cv_search_shm_open"])
+      AC_DEFINE([HAVE_SHM_MMAP_POSIX], [1],
+        [Define if you have POSIX mmap() SHM support])
+    fi
+  ])
+  LIBS="$LIBS_save"
 
   PHP_NEW_EXTENSION(opcache,
 	ZendAccelerator.c \
@@ -329,7 +343,7 @@ int main(void) {
 
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 
-  if test "$have_shm_ipc" != "yes" && test "$have_shm_mmap_posix" != "yes" && test "$have_shm_mmap_anon" != "yes"; then
+  if test "$have_shm_ipc" != "yes" && test "$php_cv_shm_mmap_posix" != "yes" && test "$have_shm_mmap_anon" != "yes"; then
     AC_MSG_ERROR([No supported shared memory caching support was found when configuring opcache. Check config.log for any errors or missing dependencies.])
   fi
 


### PR DESCRIPTION
I'll recheck this in the morning but I think I got this right. The Autoconf CS is horrible yet it is something like this:

The POSIX shared memory object operations functions (shm_open, shm_unlink...) are in:
* C library on most systems (newer Linux, Solaris 11.4, illumos, BSD*, macOS, Haiku R1, etc.)
* real-time (rt) library on older Linux distributions and Solaris <= 10.
* root library on Haiku nightly

Previous check always added additional rt or root library to global LIBS and rt to OPCACHE_SHARED_LIBADD. Now, the library containing shm_open is linked as needed to the always shared opcache extension.

This also removes unused HAVE_SHM_OPEN and HAVE_LIBROOT symbols.