### PR TITLE
Optimize levenshtein a bit for memory usage

### DIFF
--- a/ext/standard/levenshtein.c
+++ b/ext/standard/levenshtein.c
@@ -32,6 +32,15 @@ static zend_long reference_levdist(const zend_string *string1, const zend_string
 		return ZSTR_LEN(string1) * cost_del;
 	}
 
+	/* When all costs are equal, levenshtein fulfills the requirements of a metric, which means
+	 * that the distance is symmetric. If string1 is shorter than string 2 we can save memory (and CPU time)
+	 * by having shorter rows (p1 & p2). */
+	if (ZSTR_LEN(string1) < ZSTR_LEN(string2) && cost_ins == cost_rep && cost_rep == cost_del) {
+		const zend_string *tmp = string1;
+		string1 = string2;
+		string2 = tmp;
+	}
+
 	p1 = safe_emalloc((ZSTR_LEN(string2) + 1), sizeof(zend_long), 0);
 	p2 = safe_emalloc((ZSTR_LEN(string2) + 1), sizeof(zend_long), 0);
 


### PR DESCRIPTION
When all costs are equal, levenshtein fulfills the requirements of being a metric. A metric is symmetric, so we can swap the strings in that case. Since we use rows of a partial matrix of length |string2| we can make the choice of using string1 instead if |string1| < |string2|, which will optimize memory usage and CPU time.

Sample bench script:
```
<?php
for ($i = 0;$i<2000;$i++)
    levenshtein(str_repeat('a', 100), str_repeat('b', 1000), 1, 1, 1);
```

results:
```
Benchmark 1: ./sapi/cli/php x.php 
  Time (mean ± σ):     254.5 ms ±   1.7 ms    [User: 251.5 ms, System: 2.2 ms]
  Range (min … max):   252.5 ms … 257.4 ms    11 runs
 
Benchmark 2: ./sapi/cli/php_old x.php
  Time (mean ± σ):     292.0 ms ±   2.7 ms    [User: 289.8 ms, System: 1.8 ms]
  Range (min … max):   287.4 ms … 295.6 ms    10 runs
 
Summary
  ./sapi/cli/php x.php  ran
    1.15 ± 0.01 times faster than ./sapi/cli/php_old x.php

```