### PR TITLE
Fix GH-13836: Renaming a file in a Phar to an already existing filename causes a NULL pointer dereference

### DIFF
--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -858,8 +858,9 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 		entry->link = entry->tmp = NULL;
 		source = entry;
 
-		/* add to the manifest, and then store the pointer to the new guy in entry */
-		entry = zend_hash_str_add_mem(&(phar->manifest), ZSTR_VAL(resource_to->path)+1, ZSTR_LEN(resource_to->path)-1, (void **)&new, sizeof(phar_entry_info));
+		/* add to the manifest, and then store the pointer to the new guy in entry
+		 * if it already exists, we overwrite the destination like what copy('phar://...', 'phar://...') does. */
+		entry = zend_hash_str_update_mem(&(phar->manifest), ZSTR_VAL(resource_to->path)+1, ZSTR_LEN(resource_to->path)-1, (void **)&new, sizeof(phar_entry_info));
 
 		entry->filename = estrndup(ZSTR_VAL(resource_to->path)+1, ZSTR_LEN(resource_to->path)-1);
 		if (FAILURE == phar_copy_entry_fp(source, entry, &error)) {

--- a/ext/phar/tests/gh13833.phpt
+++ b/ext/phar/tests/gh13833.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-13836 (Renaming a file in a Phar to an already existing filename causes a NULL pointer dereference)
+--EXTENSIONS--
+phar
+--INI--
+phar.require_hash=0
+phar.readonly=0
+--FILE--
+<?php
+$fname = __DIR__ . '/gh13836.phar';
+
+$phar = new Phar($fname, 0, 'a.phar');
+$phar['x'] = 'hi1';
+$phar['y'] = 'hi2';
+
+var_dump(rename("phar://a.phar/x", "phar://a.phar/y"));
+
+var_dump(isset($phar['x']));
+var_dump($phar['y']);
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/gh13836.phar');
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+object(PharFileInfo)#2 (2) {
+  ["pathName":"SplFileInfo":private]=>
+  string(%d) "phar://%sgh13836.phar/y"
+  ["fileName":"SplFileInfo":private]=>
+  string(1) "y"
+}


### PR DESCRIPTION
If the destination already exists, then the `add` function on the manifest will return NULL, resulting in a NULL entry and therefore a NULL deref. As `copy()` (not `Phar::copy`) chooses to succeed and overwrite the destination if it already exists, we should do the same. Therefore the fix is as simple as changing `add` to `update`.