### PR TITLE
Zend/zend_call_stack.c: fix build without pthread

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -35,7 +35,8 @@
 #  include <sys/types.h>
 # endif
 #endif /* ZEND_WIN32 */
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || \
+#if (defined(HAVE_PTHREAD_GETATTR_NP) && defined(HAVE_PTHREAD_ATTR_GETSTACK)) || \
+    defined(__FreeBSD__) || defined(__APPLE__) || \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
     defined(__sun)
 # include <pthread.h>


### PR DESCRIPTION
Fix the following build failure without pthread raised since version 8.3.0 and https://github.com/php/php-src/commit/a11c8a30399e90c17c287b9656c0077bc5131c9c:

```
/home/buildroot/instance-0/output-1/build/php-8.3.4/Zend/zend_call_stack.c:39:11: fatal error: pthread.h: No such file or directory
   39 | # include <pthread.h>
      |           ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/a4ef648a9da50b26ed56d5d490e4cf5a1bfff970