### PR TITLE
 Changed DateTime(Immutable)::setDate parameters to all be optional

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -3729,13 +3729,29 @@ static void php_date_date_set(zval *object, zend_long y, zend_long m, zend_long 
 PHP_FUNCTION(date_date_set)
 {
 	zval *object;
-	zend_long  y, m, d;
+	php_date_obj* dateobj;
+	zend_long y, m, d;
+	bool y_is_null = 1, m_is_null = 1, d_is_null = 1;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Olll", &object, date_ce_date, &y, &m, &d) == FAILURE) {
+	if (zend_parse_method_parameters(
+        ZEND_NUM_ARGS(), getThis(), "O|l!l!l!",
+        &object, date_ce_date,
+        &y, &y_is_null,
+        &m, &m_is_null,
+        &d, &d_is_null
+    ) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	php_date_date_set(object, y, m, d, return_value);
+	dateobj = Z_PHPDATE_P(object);
+
+	php_date_date_set(
+		object,
+		y_is_null ? dateobj->time->y : y,
+		m_is_null ? dateobj->time->m : m,
+		d_is_null ? dateobj->time->d : d,
+		return_value
+	);
 
 	RETURN_OBJ_COPY(Z_OBJ_P(object));
 }
@@ -3744,16 +3760,23 @@ PHP_FUNCTION(date_date_set)
 /* {{{ */
 PHP_METHOD(DateTimeImmutable, setDate)
 {
-	zval *object, new_object;
-	zend_long  y, m, d;
+	zval *object = ZEND_THIS, new_object;
+	php_date_obj* dateobj = Z_PHPDATE_P(object);
+	zend_long y, m, d;
+	bool y_is_null = 1, m_is_null = 1, d_is_null = 1;
 
-	object = ZEND_THIS;
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lll", &y, &m, &d) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!l!l!", &y, &y_is_null, &m, &m_is_null, &d, &d_is_null) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	date_clone_immutable(object, &new_object);
-	php_date_date_set(&new_object, y, m, d, return_value);
+	php_date_date_set(
+		&new_object,
+		y_is_null ? dateobj->time->y : y,
+		m_is_null ? dateobj->time->m : m,
+		d_is_null ? dateobj->time->d : d,
+		return_value
+	);
 
 	RETURN_OBJ(Z_OBJ(new_object));
 }

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -200,7 +200,7 @@ function date_diff(
 function date_time_set(
     DateTime $object, int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTime {}
 
-function date_date_set(DateTime $object, int $year, int $month, int $day): DateTime {}
+function date_date_set(DateTime $object, ?int $year = null, ?int $month = null, ?int $day = null): DateTime {}
 
 function date_isodate_set(DateTime $object, int $year, int $week, int $dayOfWeek = 1): DateTime {}
 

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -426,7 +426,7 @@ class DateTime implements DateTimeInterface
      * @tentative-return-type
      * @alias date_date_set
      */
-    public function setDate(int $year, int $month, int $day): DateTime {}
+    public function setDate(?int $year = null, ?int $month = null, ?int $day = null): DateTime {}
 
     /**
      * @tentative-return-type
@@ -536,7 +536,7 @@ class DateTimeImmutable implements DateTimeInterface
     public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): DateTimeImmutable {}
 
     /** @tentative-return-type */
-    public function setDate(int $year, int $month, int $day): DateTimeImmutable {}
+    public function setDate(?int $year = null, ?int $month = null, ?int $day = null): DateTimeImmutable {}
 
     /** @tentative-return-type */
     public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTimeImmutable {}

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 199789cfbbb53ead5c5418ae30935ffdd7c9685f */
+ * Stub hash: b1074dd4267e9e8212242470a3ceb12b26a251ff */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -318,10 +318,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setTime,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setDate, 0, 3, DateTime, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setDate, 0, 0, DateTime, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, year, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, month, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, day, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTime_setISODate, 0, 2, DateTime, 0)
@@ -397,10 +397,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setDate, 0, 3, DateTimeImmutable, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setDate, 0, 0, DateTimeImmutable, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, year, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, month, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, day, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateTimeImmutable_setISODate, 0, 2, DateTimeImmutable, 0)

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b1074dd4267e9e8212242470a3ceb12b26a251ff */
+ * Stub hash: 4c18eb8bd8644dab99376db4b4e38621b8d20664 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -132,11 +132,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_time_set, 0, 3, DateTime, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microsecond, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_date_set, 0, 4, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_date_set, 0, 1, DateTime, 0)
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
-	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, month, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, day, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, year, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, month, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, day, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_isodate_set, 0, 3, DateTime, 0)

--- a/ext/date/tests/DateTimeImmutable_setDate_partial.phpt
+++ b/ext/date/tests/DateTimeImmutable_setDate_partial.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test DateTimeImmutable::setDate() function : partial application
+--FILE--
+<?php
+date_default_timezone_set('UTC');
+$datetime = new DateTimeImmutable('1234-05-06 00:00:00');
+
+echo $datetime->format('c'), "\n";
+echo $datetime->setDate(1)->format('c'), "\n";
+echo $datetime->setDate(month: 2)->format('c'), "\n";
+echo $datetime->setDate(3, day: 4)->format('c'), "\n";
+?>
+--EXPECT--
+1234-05-06T00:00:00+00:00
+0001-05-06T00:00:00+00:00
+1234-02-06T00:00:00+00:00
+0003-05-04T00:00:00+00:00

--- a/ext/date/tests/DateTimeImmutable_setDate_partial.phpt
+++ b/ext/date/tests/DateTimeImmutable_setDate_partial.phpt
@@ -5,7 +5,7 @@ Test DateTimeImmutable::setDate() function : partial application
 date_default_timezone_set('UTC');
 $datetime = new DateTimeImmutable('1234-05-06 00:00:00');
 
-echo $datetime->format('c'), "\n";
+echo $datetime->setDate()->format('c'), "\n";
 echo $datetime->setDate(1)->format('c'), "\n";
 echo $datetime->setDate(month: 2)->format('c'), "\n";
 echo $datetime->setDate(3, day: 4)->format('c'), "\n";

--- a/ext/date/tests/DateTime_setDate_partial.phpt
+++ b/ext/date/tests/DateTime_setDate_partial.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test DateTime::setDate() function : partial application
+--FILE--
+<?php
+date_default_timezone_set('UTC');
+$datetime = new DateTime('1234-05-06 00:00:00');
+
+echo $datetime->format('c'), "\n";
+echo $datetime->setDate(1)->format('c'), "\n";
+echo $datetime->setDate(month: 2)->format('c'), "\n";
+echo $datetime->setDate(3, day: 4)->format('c'), "\n";
+?>
+--EXPECT--
+1234-05-06T00:00:00+00:00
+0001-05-06T00:00:00+00:00
+0001-02-06T00:00:00+00:00
+0003-02-04T00:00:00+00:00

--- a/ext/date/tests/DateTime_setDate_partial.phpt
+++ b/ext/date/tests/DateTime_setDate_partial.phpt
@@ -5,7 +5,7 @@ Test DateTime::setDate() function : partial application
 date_default_timezone_set('UTC');
 $datetime = new DateTime('1234-05-06 00:00:00');
 
-echo $datetime->format('c'), "\n";
+echo $datetime->setDate()->format('c'), "\n";
 echo $datetime->setDate(1)->format('c'), "\n";
 echo $datetime->setDate(month: 2)->format('c'), "\n";
 echo $datetime->setDate(3, day: 4)->format('c'), "\n";


### PR DESCRIPTION
When calling `DateTime::setDate` or `DateTimeImmutable::setDate`, any and all parameters can now be omitted. Any parameters omitted are unchanged. Omitting all parameters is equivalent to a no-op (although in practice the same values overwrite themselves).

Run tests with `make test TESTS=ext\date\tests\DateTime*_setDate_partial.phpt`

Thanks to @Girgias for implementation guidance.