### PR TITLE
Fix GH-13833: Applying zero offset to null pointer in zend_hash.c

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -1090,6 +1090,9 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, size_t fname_len, ch
 
 	mydata = pecalloc(1, sizeof(phar_archive_data), PHAR_G(persist));
 	mydata->is_persistent = PHAR_G(persist);
+	HT_INVALIDATE(&mydata->manifest);
+	HT_INVALIDATE(&mydata->mounted_dirs);
+	HT_INVALIDATE(&mydata->virtual_dirs);
 
 	/* check whether we have meta data, zero check works regardless of byte order */
 	SAFE_PHAR_GET_32(buffer, endbuffer, len);

--- a/ext/phar/tests/gh13836.phpt
+++ b/ext/phar/tests/gh13836.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-13836 (Renaming a file in a Phar to an already existing filename causes a NULL pointer dereference)
+--EXTENSIONS--
+phar
+--INI--
+phar.require_hash=0
+phar.readonly=0
+--FILE--
+<?php
+$fname = __DIR__ . '/gh13836.phar';
+
+$phar = new Phar($fname, 0, 'a.phar');
+$phar['x'] = 'hi1';
+$phar['y'] = 'hi2';
+
+var_dump(rename("phar://a.phar/x", "phar://a.phar/y"));
+
+var_dump(isset($phar['x']));
+var_dump($phar['y']);
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/gh13836.phar');
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+object(PharFileInfo)#2 (2) {
+  ["pathName":"SplFileInfo":private]=>
+  string(%d) "phar://%sgh13836.phar/y"
+  ["fileName":"SplFileInfo":private]=>
+  string(1) "y"
+}


### PR DESCRIPTION
MAPPHAR_FAIL will call the destructor of the manifest, mounted_dirs, and virtual_dirs tables. When a new phar object is allocated using (p)ecalloc, the bytes are zeroed, but the flag for an uninitialized table is non-zero. So we have to manually set the flag in case that we have a code path that can destroy the tables without first initializing them at least once.

Diff looks a bit strange because of the github issue renumbering in the file names...