### PR TITLE
Simplify always-true check in zend_generator_update_current

### DIFF
--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -579,7 +579,7 @@ ZEND_API zend_generator *zend_generator_update_current(zend_generator *generator
 
 				EG(current_execute_data) = original_execute_data;
 
-				if (!((old_root ? old_root : generator)->flags & ZEND_GENERATOR_CURRENTLY_RUNNING)) {
+				if (!(old_root->flags & ZEND_GENERATOR_CURRENTLY_RUNNING)) {
 					new_root->node.parent = NULL;
 					OBJ_RELEASE(&new_root_parent->std);
 					zend_generator_resume(generator);


### PR DESCRIPTION
`old_root` is dereferenced at top, so `old_root` must not be NULL, and the check doesn't actually do anything.