### PR TITLE
Remove redundant check in mysqlnd_conn_data::connect

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -577,7 +577,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 
 	DBG_INF_FMT("host=%s user=%s db=%s port=%u flags=%u persistent=%u state=%u",
 				hostname.s?hostname.s:"", username.s?username.s:"", database.s?database.s:"", port, mysql_flags,
-				conn? conn->persistent:0, conn? (int)GET_CONNECTION_STATE(&conn->state):-1);
+				conn->persistent, (int)GET_CONNECTION_STATE(&conn->state));
 
 	if (GET_CONNECTION_STATE(&conn->state) > CONN_ALLOCED) {
 		DBG_INF("Connecting on a connected handle.");


### PR DESCRIPTION
`conn` is dereferenced at top so it is always non-NULL.