### PR TITLE
Remove broken check in var_unserializer

### DIFF
--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -326,11 +326,6 @@ static zend_string *unserialize_str(const unsigned char **p, size_t len, size_t 
 	zend_string *str = zend_string_safe_alloc(1, len, 0, 0);
 	unsigned char *end = *(unsigned char **)p+maxlen;
 
-	if (end < *p) {
-		zend_string_efree(str);
-		return NULL;
-	}
-
 	for (i = 0; i < len; i++) {
 		if (*p >= end) {
 			zend_string_efree(str);


### PR DESCRIPTION
`end = *p+maxlen`, and pointer overflow is UB, so that means that a check of the form `end < *p` will always be false because it can only be true on pointer overflow. In particular, the compiler simplifies this to `maxlen < 0` which is always false because maxlen is unsigned.