### PR TITLE
Fix GH-13856: Member access within null pointer of type 'ps_files' in ext/session/mod_files.c

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -47,14 +47,16 @@ PHP_METHOD(SessionHandler, open)
 
 	PS_SANITY_CHECK;
 
-	PS(mod_user_is_open) = 1;
-
 	zend_try {
 		ret = PS(default_mod)->s_open(&PS(mod_data), save_path, session_name);
 	} zend_catch {
 		PS(session_status) = php_session_none;
 		zend_bailout();
 	} zend_end_try();
+
+	if (SUCCESS == ret) {
+		PS(mod_user_is_open) = 1;
+	}
 
 	RETURN_BOOL(SUCCESS == ret);
 }

--- a/ext/session/tests/gh13856.phpt
+++ b/ext/session/tests/gh13856.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-13856 (Member access within null pointer of type 'ps_files' in ext/session/mod_files.c)
+--EXTENSIONS--
+session
+--INI--
+session.save_handler=files
+open_basedir=.
+error_reporting=E_ALL
+--FILE--
+<?php
+session_set_save_handler(new \SessionHandler(), true);
+session_start();
+?>
+--EXPECTF--
+Warning: SessionHandler::open(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
+
+Warning: SessionHandler::close(): Parent session handler is not open in %s on line %d
+
+Warning: session_start(): Failed to initialize storage module: user (path: ) in %s on line %d


### PR DESCRIPTION
We should not mark the session as opened when there was a failure in open.