### PR TITLE
Fix potential NULL pointer argument to memcpy

### DIFF
--- a/ext/dom/html5_parser.c
+++ b/ext/dom/html5_parser.c
@@ -86,7 +86,9 @@ static xmlNodePtr lexbor_libxml2_bridge_new_text_node_fast(xmlDocPtr lxml_doc, c
         lxml_text->type = XML_TEXT_NODE;
         lxml_text->doc = lxml_doc;
         lxml_text->content = BAD_CAST &lxml_text->properties;
-        memcpy(lxml_text->content, data, data_length);
+        if (data != NULL) {
+            memcpy(lxml_text->content, data, data_length);
+        }
         return lxml_text;
     } else {
         return xmlNewDocTextLen(lxml_doc, (const xmlChar *) data, data_length);


### PR DESCRIPTION
This is only possible when the length is 0, but memcpy doesn't like NULL pointers, as UBSAN trips over it.