### PR TITLE
Mark multple functions as static

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -637,16 +637,6 @@ static zend_ulong maxAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 	return b & d;
 }
 
-static zend_ulong minXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
-{
-	return minAND(a, b, ~d, ~c) | minAND(~b, ~a, c, d);
-}
-
-static zend_ulong maxXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
-{
-	return maxOR(0, maxAND(a, b, ~d, ~c), 0, maxAND(~b, ~a, c, d));
-}
-
 /* Based on "Hacker's Delight" */
 
 /*

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -543,7 +543,7 @@ ZEND_API void zend_ssa_find_false_dependencies(const zend_op_array *op_array, ze
 /* }}} */
 
 /* From "Hacker's Delight" */
-zend_ulong minOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong minOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	zend_ulong m, temp;
 
@@ -567,7 +567,7 @@ zend_ulong minOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 	return a | c;
 }
 
-zend_ulong maxOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong maxOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	zend_ulong m, temp;
 
@@ -590,7 +590,7 @@ zend_ulong maxOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 	return b | d;
 }
 
-zend_ulong minAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong minAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	zend_ulong m, temp;
 
@@ -613,7 +613,7 @@ zend_ulong minAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 	return a & c;
 }
 
-zend_ulong maxAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong maxAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	zend_ulong m, temp;
 
@@ -637,12 +637,12 @@ zend_ulong maxAND(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 	return b & d;
 }
 
-zend_ulong minXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong minXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	return minAND(a, b, ~d, ~c) | minAND(~b, ~a, c, d);
 }
 
-zend_ulong maxXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
+static zend_ulong maxXOR(zend_ulong a, zend_ulong b, zend_ulong c, zend_ulong d)
 {
 	return maxOR(0, maxAND(a, b, ~d, ~c), 0, maxAND(~b, ~a, c, d));
 }

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -491,7 +491,7 @@ static zend_result zend_ast_add_unpacked_element(zval *result, zval *expr) {
 	return FAILURE;
 }
 
-zend_class_entry *zend_ast_fetch_class(zend_ast *ast, zend_class_entry *scope)
+static zend_class_entry *zend_ast_fetch_class(zend_ast *ast, zend_class_entry *scope)
 {
 	return zend_fetch_class_with_scope(zend_ast_get_str(ast), (ast->attr >> ZEND_CONST_EXPR_NEW_FETCH_TYPE_SHIFT) | ZEND_FETCH_CLASS_EXCEPTION, scope);
 }

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -43,7 +43,7 @@ ZEND_MINIT_FUNCTION(core) { /* {{{ */
 }
 /* }}} */
 
-zend_module_entry zend_builtin_module = { /* {{{ */
+static zend_module_entry zend_builtin_module = { /* {{{ */
 	STANDARD_MODULE_HEADER,
 	"Core",
 	ext_functions,

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1149,7 +1149,7 @@ static zend_string *zend_resolve_class_name(zend_string *name, uint32_t type) /*
 }
 /* }}} */
 
-zend_string *zend_resolve_class_name_ast(zend_ast *ast) /* {{{ */
+static zend_string *zend_resolve_class_name_ast(zend_ast *ast) /* {{{ */
 {
 	zval *class_name = zend_ast_get_zval(ast);
 	if (Z_TYPE_P(class_name) != IS_STRING) {

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -1135,7 +1135,7 @@ static const zend_object_iterator_funcs zend_generator_iterator_functions = {
 };
 
 /* by_ref is int due to Iterator API */
-zend_object_iterator *zend_generator_get_iterator(zend_class_entry *ce, zval *object, int by_ref) /* {{{ */
+static zend_object_iterator *zend_generator_get_iterator(zend_class_entry *ce, zval *object, int by_ref) /* {{{ */
 {
 	zend_object_iterator *iterator;
 	zend_generator *generator = (zend_generator*)Z_OBJ_P(object);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1239,7 +1239,7 @@ static void do_inherit_method(zend_string *key, zend_function *parent, zend_clas
 }
 /* }}} */
 
-inheritance_status property_types_compatible(
+static inheritance_status property_types_compatible(
 		const zend_property_info *parent_info, const zend_property_info *child_info) {
 	if (ZEND_TYPE_PURE_MASK(parent_info->type) == ZEND_TYPE_PURE_MASK(child_info->type)
 			&& ZEND_TYPE_NAME(parent_info->type) == ZEND_TYPE_NAME(child_info->type)) {

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -32,7 +32,7 @@
 #include "win32/syslog.h"
 #endif
 
-int ini_parse(void);
+static int ini_parse(void);
 
 #define ZEND_INI_PARSER_CB	(CG(ini_parser_param))->ini_parser_cb
 #define ZEND_INI_PARSER_ARG	(CG(ini_parser_param))->arg

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -32,13 +32,13 @@
 #define ZEND_OBSERVABLE_FN(function) \
 	(ZEND_MAP_PTR(function->common.run_time_cache) && !(function->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE))
 
-zend_llist zend_observers_fcall_list;
-zend_llist zend_observer_function_declared_callbacks;
-zend_llist zend_observer_class_linked_callbacks;
-zend_llist zend_observer_error_callbacks;
-zend_llist zend_observer_fiber_init;
-zend_llist zend_observer_fiber_switch;
-zend_llist zend_observer_fiber_destroy;
+static zend_llist zend_observers_fcall_list;
+static zend_llist zend_observer_function_declared_callbacks;
+static zend_llist zend_observer_class_linked_callbacks;
+static zend_llist zend_observer_error_callbacks;
+static zend_llist zend_observer_fiber_init;
+static zend_llist zend_observer_fiber_switch;
+static zend_llist zend_observer_fiber_destroy;
 
 int zend_observer_fcall_op_array_extension;
 int zend_observer_fcall_internal_function_extension;

--- a/Zend/zend_signal.c
+++ b/Zend/zend_signal.c
@@ -81,7 +81,7 @@ static sigset_t            global_sigmask;
 
 /* {{{ zend_signal_handler_defer
  *  Blocks signals if in critical section */
-void zend_signal_handler_defer(int signo, siginfo_t *siginfo, void *context)
+static void zend_signal_handler_defer(int signo, siginfo_t *siginfo, void *context)
 {
 	int errno_save = errno;
 	zend_signal_queue_t *queue, *qtmp;

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -54,7 +54,7 @@ typedef struct _zend_weakmap_iterator {
 #define ZEND_WEAKREF_ENCODE(p, t) ((void *) (((uintptr_t) (p)) | (t)))
 
 zend_class_entry *zend_ce_weakref;
-zend_class_entry *zend_ce_weakmap;
+static zend_class_entry *zend_ce_weakmap;
 static zend_object_handlers zend_weakref_handlers;
 static zend_object_handlers zend_weakmap_handlers;
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -267,10 +267,10 @@ PHP_INI_BEGIN()
 PHP_INI_END()
 /* }}} */
 
-zend_class_entry *date_ce_date, *date_ce_timezone, *date_ce_interval, *date_ce_period;
-zend_class_entry *date_ce_immutable, *date_ce_interface;
-zend_class_entry *date_ce_date_error, *date_ce_date_object_error, *date_ce_date_range_error;
-zend_class_entry *date_ce_date_exception, *date_ce_date_invalid_timezone_exception, *date_ce_date_invalid_operation_exception, *date_ce_date_malformed_string_exception, *date_ce_date_malformed_interval_string_exception, *date_ce_date_malformed_period_string_exception;
+static zend_class_entry *date_ce_date, *date_ce_timezone, *date_ce_interval, *date_ce_period;
+static zend_class_entry *date_ce_immutable, *date_ce_interface;
+static zend_class_entry *date_ce_date_error, *date_ce_date_object_error, *date_ce_date_range_error;
+static zend_class_entry *date_ce_date_exception, *date_ce_date_invalid_timezone_exception, *date_ce_date_invalid_operation_exception, *date_ce_date_malformed_string_exception, *date_ce_date_malformed_interval_string_exception, *date_ce_date_malformed_period_string_exception;
 
 
 PHPAPI zend_class_entry *php_date_get_date_ce(void)

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -41,7 +41,7 @@
 # endif
 #endif
 
-HashTable php_hash_hashtable;
+static HashTable php_hash_hashtable;
 zend_class_entry *php_hashcontext_ce;
 static zend_object_handlers php_hashcontext_handlers;
 

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -64,7 +64,7 @@
 #define PHP_ICONV_IMPL_VALUE "unknown"
 #endif
 
-char *get_iconv_version(void) {
+static char *get_iconv_version(void) {
 	char *version = "unknown";
 
 #ifdef HAVE_LIBICONV

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1877,7 +1877,7 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	return new_persistent_script;
 }
 
-zend_op_array *file_cache_compile_file(zend_file_handle *file_handle, int type)
+static zend_op_array *file_cache_compile_file(zend_file_handle *file_handle, int type)
 {
 	zend_persistent_script *persistent_script;
 	zend_op_array *op_array = NULL;

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -185,7 +185,7 @@ typedef struct _php_openssl_x509_request_object {
 	zend_object std;
 } php_openssl_request_object;
 
-zend_class_entry *php_openssl_request_ce;
+static zend_class_entry *php_openssl_request_ce;
 
 static inline php_openssl_request_object *php_openssl_request_from_obj(zend_object *obj) {
 	return (php_openssl_request_object *)((char *)(obj) - XtOffsetOf(php_openssl_request_object, std));
@@ -225,7 +225,7 @@ typedef struct _php_openssl_pkey_object {
 	zend_object std;
 } php_openssl_pkey_object;
 
-zend_class_entry *php_openssl_pkey_ce;
+static zend_class_entry *php_openssl_pkey_ce;
 
 static inline php_openssl_pkey_object *php_openssl_pkey_from_obj(zend_object *obj) {
 	return (php_openssl_pkey_object *)((char *)(obj) - XtOffsetOf(php_openssl_pkey_object, std));
@@ -486,7 +486,7 @@ void php_openssl_store_errors(void)
 /* }}} */
 
 /* {{{ php_openssl_errors_set_mark */
-void php_openssl_errors_set_mark(void) {
+static void php_openssl_errors_set_mark(void) {
 	if (!OPENSSL_G(errors)) {
 		return;
 	}
@@ -500,7 +500,7 @@ void php_openssl_errors_set_mark(void) {
 /* }}} */
 
 /* {{{ php_openssl_errors_restore_mark */
-void php_openssl_errors_restore_mark(void) {
+static void php_openssl_errors_restore_mark(void) {
 	if (!OPENSSL_G(errors)) {
 		return;
 	}

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -159,7 +159,7 @@ static struct timeval php_openssl_subtract_timeval(struct timeval a, struct time
 static int php_openssl_compare_timeval(struct timeval a, struct timeval b);
 static ssize_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, size_t count);
 
-const php_stream_ops php_openssl_socket_ops;
+static const php_stream_ops php_openssl_socket_ops;
 
 /* Certificate contexts used for server-side SNI selection */
 typedef struct _php_openssl_sni_cert_t {
@@ -1650,7 +1650,7 @@ static int php_openssl_server_alpn_callback(SSL *ssl_handle,
 
 #endif
 
-zend_result php_openssl_setup_crypto(php_stream *stream,
+static zend_result php_openssl_setup_crypto(php_stream *stream,
 		php_openssl_netstream_data_t *sslsock,
 		php_stream_xport_crypto_param *cparam) /* {{{ */
 {
@@ -2701,7 +2701,7 @@ static int php_openssl_sockop_cast(php_stream *stream, int castas, void **ret)  
 }
 /* }}} */
 
-const php_stream_ops php_openssl_socket_ops = {
+static const php_stream_ops php_openssl_socket_ops = {
 	php_openssl_sockop_write, php_openssl_sockop_read,
 	php_openssl_sockop_close, php_openssl_sockop_flush,
 	"tcp_socket/ssl",

--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -23,7 +23,7 @@
 
 void phar_dostat(phar_archive_data *phar, phar_entry_info *data, php_stream_statbuf *ssb, bool is_dir);
 
-const php_stream_ops phar_dir_ops = {
+static const php_stream_ops phar_dir_ops = {
 	phar_dir_write, /* write */
 	phar_dir_read,  /* read  */
 	phar_dir_close, /* close */

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -22,7 +22,7 @@
 #include "stream.h"
 #include "dirstream.h"
 
-const php_stream_ops phar_ops = {
+static const php_stream_ops phar_ops = {
 	phar_stream_write, /* write */
 	phar_stream_read,  /* read */
 	phar_stream_close, /* close */
@@ -34,7 +34,7 @@ const php_stream_ops phar_ops = {
 	NULL, /* set option */
 };
 
-const php_stream_wrapper_ops phar_stream_wops = {
+static const php_stream_wrapper_ops phar_stream_wops = {
 	phar_wrapper_open_url,
 	NULL,                  /* phar_wrapper_close */
 	NULL,                  /* phar_wrapper_stat, */

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -2868,7 +2868,7 @@ PHP_METHOD(EmptyIterator, next)
 	}
 } /* }}} */
 
-zend_result spl_append_it_next_iterator(spl_dual_it_object *intern) /* {{{*/
+static zend_result spl_append_it_next_iterator(spl_dual_it_object *intern) /* {{{*/
 {
 	spl_dual_it_free(intern);
 

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -73,7 +73,7 @@ static inline spl_SplObjectStorage *spl_object_storage_from_obj(zend_object *obj
 
 #define Z_SPLOBJSTORAGE_P(zv)  spl_object_storage_from_obj(Z_OBJ_P((zv)))
 
-void spl_SplObjectStorage_free_storage(zend_object *object) /* {{{ */
+static void spl_SplObjectStorage_free_storage(zend_object *object) /* {{{ */
 {
 	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -72,9 +72,9 @@ static zend_object_handlers sqlite3_stmt_object_handlers;
 static zend_object_handlers sqlite3_result_object_handlers;
 
 /* Class entries */
-zend_class_entry *php_sqlite3_exception_ce;
-zend_class_entry *php_sqlite3_sc_entry;
-zend_class_entry *php_sqlite3_stmt_entry;
+static zend_class_entry *php_sqlite3_exception_ce;
+static zend_class_entry *php_sqlite3_sc_entry;
+static zend_class_entry *php_sqlite3_stmt_entry;
 zend_class_entry *php_sqlite3_result_entry;
 
 /* {{{ Error Handler */

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -678,7 +678,7 @@ static const php_stream_ops php_ftp_dirstream_ops = {
 };
 
 /* {{{ php_stream_ftp_opendir */
-php_stream * php_stream_ftp_opendir(php_stream_wrapper *wrapper, const char *path, const char *mode, int options,
+static php_stream * php_stream_ftp_opendir(php_stream_wrapper *wrapper, const char *path, const char *mode, int options,
 									zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	php_stream *stream, *reuseid, *datastream = NULL;

--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -341,7 +341,7 @@ PHP_FUNCTION(mail)
 /* }}} */
 
 
-void php_mail_log_crlf_to_spaces(char *message) {
+static void php_mail_log_crlf_to_spaces(char *message) {
 	/* Find all instances of carriage returns or line feeds and
 	 * replace them with spaces. Thus, a log line is always one line
 	 * long
@@ -352,7 +352,7 @@ void php_mail_log_crlf_to_spaces(char *message) {
 	}
 }
 
-void php_mail_log_to_syslog(char *message) {
+static void php_mail_log_to_syslog(char *message) {
 	/* Write 'message' to syslog. */
 #ifdef HAVE_SYSLOG_H
 	php_syslog(LOG_NOTICE, "%s", message);
@@ -360,7 +360,7 @@ void php_mail_log_to_syslog(char *message) {
 }
 
 
-void php_mail_log_to_file(char *filename, char *message, size_t message_size) {
+static void php_mail_log_to_file(char *filename, char *message, size_t message_size) {
 	/* Write 'message' to the given file. */
 	uint32_t flags = REPORT_ERRORS | STREAM_DISABLE_OPEN_BASEDIR;
 	php_stream *stream = php_stream_open_wrapper(filename, "a", flags, NULL);

--- a/ext/standard/php_fopen_wrapper.c
+++ b/ext/standard/php_fopen_wrapper.c
@@ -49,7 +49,7 @@ static int php_stream_output_close(php_stream *stream, int close_handle) /* {{{ 
 }
 /* }}} */
 
-const php_stream_ops php_stream_output_ops = {
+static const php_stream_ops php_stream_output_ops = {
 	php_stream_output_write,
 	php_stream_output_read,
 	php_stream_output_close,
@@ -134,7 +134,7 @@ static int php_stream_input_seek(php_stream *stream, zend_off_t offset, int when
 }
 /* }}} */
 
-const php_stream_ops php_stream_input_ops = {
+static const php_stream_ops php_stream_input_ops = {
 	php_stream_input_write,
 	php_stream_input_read,
 	php_stream_input_close,
@@ -173,7 +173,7 @@ static void php_stream_apply_filter_list(php_stream *stream, char *filterlist, i
 }
 /* }}} */
 
-php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *path, const char *mode, int options,
+static php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *path, const char *mode, int options,
 									 zend_string **opened_path, php_stream_context *context STREAMS_DC) /* {{{ */
 {
 	int fd = -1;

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -123,7 +123,7 @@ static void userfilter_dtor(php_stream_filter *thisfilter)
 	zval_ptr_dtor(obj);
 }
 
-php_stream_filter_status_t userfilter_filter(
+static php_stream_filter_status_t userfilter_filter(
 			php_stream *stream,
 			php_stream_filter *thisfilter,
 			php_stream_bucket_brigade *buckets_in,

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -38,7 +38,7 @@
 #define zendcursor LANG_SCNG(yy_cursor)
 #define zendlimit  LANG_SCNG(yy_limit)
 
-zend_class_entry *php_token_ce;
+static zend_class_entry *php_token_ce;
 
 /* {{{ tokenizer_module_entry */
 zend_module_entry tokenizer_module_entry = {
@@ -410,7 +410,7 @@ static zval *extract_token_id_to_replace(zval *token_zv, const char *text, size_
 	return NULL;
 }
 
-void on_event(
+static void on_event(
 		zend_php_scanner_event event, int token, int line,
 		const char *text, size_t length, void *context)
 {

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -186,7 +186,7 @@ zend_module_entry xml_module_entry = {
 /* All the encoding functions are set to NULL right now, since all
  * the encoding is currently done internally by expat/xmltok.
  */
-const xml_encoding xml_encodings[] = {
+static const xml_encoding xml_encodings[] = {
 	{ (XML_Char *)"ISO-8859-1", xml_decode_iso_8859_1, xml_encode_iso_8859_1 },
 	{ (XML_Char *)"US-ASCII",   xml_decode_us_ascii,   xml_encode_us_ascii   },
 	{ (XML_Char *)"UTF-8",      NULL,                  NULL                  },

--- a/main/network.c
+++ b/main/network.c
@@ -1236,7 +1236,7 @@ PHPAPI int php_poll2(php_pollfd *ufds, unsigned int nfds, int timeout)
 
 #if defined(HAVE_GETHOSTBYNAME_R)
 #ifdef HAVE_FUNC_GETHOSTBYNAME_R_6
-struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
+static struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
 {
 	struct hostent *hp;
 	int herr,res;
@@ -1262,7 +1262,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
 }
 #endif
 #ifdef HAVE_FUNC_GETHOSTBYNAME_R_5
-struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
+static struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
 {
 	struct hostent *hp;
 	int herr;
@@ -1283,7 +1283,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
 }
 #endif
 #ifdef HAVE_FUNC_GETHOSTBYNAME_R_3
-struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
+static struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char **tmphstbuf,size_t *hstbuflen)
 {
 	if (*hstbuflen == 0) {
 		*hstbuflen = sizeof(struct hostent_data);

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -28,8 +28,8 @@
 #include "zend_exceptions.h"
 
 /* for systems that need to override reading of environment variables */
-void _php_import_environment_variables(zval *array_ptr);
-void _php_load_environment_variables(zval *array_ptr);
+static void _php_import_environment_variables(zval *array_ptr);
+static void _php_load_environment_variables(zval *array_ptr);
 PHPAPI void (*php_import_environment_variables)(zval *array_ptr) = _php_import_environment_variables;
 PHPAPI void (*php_load_environment_variables)(zval *array_ptr) = _php_load_environment_variables;
 
@@ -626,7 +626,7 @@ static zend_always_inline void import_environment_variable(HashTable *ht, char *
 	}
 }
 
-void _php_import_environment_variables(zval *array_ptr)
+static void _php_import_environment_variables(zval *array_ptr)
 {
 	tsrm_env_lock();
 
@@ -649,7 +649,7 @@ void _php_import_environment_variables(zval *array_ptr)
 	tsrm_env_unlock();
 }
 
-void _php_load_environment_variables(zval *array_ptr)
+static void _php_load_environment_variables(zval *array_ptr)
 {
 	php_import_environment_variables(array_ptr);
 }

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -44,10 +44,10 @@
 
 const php_stream_ops php_stream_generic_socket_ops;
 PHPAPI const php_stream_ops php_stream_socket_ops;
-const php_stream_ops php_stream_udp_socket_ops;
+static const php_stream_ops php_stream_udp_socket_ops;
 #ifdef AF_UNIX
-const php_stream_ops php_stream_unix_socket_ops;
-const php_stream_ops php_stream_unixdg_socket_ops;
+static const php_stream_ops php_stream_unix_socket_ops;
+static const php_stream_ops php_stream_unixdg_socket_ops;
 #endif
 
 
@@ -550,7 +550,7 @@ const php_stream_ops php_stream_socket_ops = {
 	php_tcp_sockop_set_option,
 };
 
-const php_stream_ops php_stream_udp_socket_ops = {
+static const php_stream_ops php_stream_udp_socket_ops = {
 	php_sockop_write, php_sockop_read,
 	php_sockop_close, php_sockop_flush,
 	"udp_socket",
@@ -561,7 +561,7 @@ const php_stream_ops php_stream_udp_socket_ops = {
 };
 
 #ifdef AF_UNIX
-const php_stream_ops php_stream_unix_socket_ops = {
+static const php_stream_ops php_stream_unix_socket_ops = {
 	php_sockop_write, php_sockop_read,
 	php_sockop_close, php_sockop_flush,
 	"unix_socket",
@@ -570,7 +570,7 @@ const php_stream_ops php_stream_unix_socket_ops = {
 	php_sockop_stat,
 	php_tcp_sockop_set_option,
 };
-const php_stream_ops php_stream_unixdg_socket_ops = {
+static const php_stream_ops php_stream_unixdg_socket_ops = {
 	php_sockop_write, php_sockop_read,
 	php_sockop_close, php_sockop_flush,
 	"udg_socket",

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -120,13 +120,13 @@ static DWORD orig_cp = 0;
 #define PHP_MODE_REFLECTION_ZEND_EXTENSION 12
 #define PHP_MODE_SHOW_INI_CONFIG        13
 
-cli_shell_callbacks_t cli_shell_callbacks = { NULL, NULL, NULL };
+static cli_shell_callbacks_t cli_shell_callbacks = { NULL, NULL, NULL };
 PHP_CLI_API cli_shell_callbacks_t *php_cli_get_shell_callbacks(void)
 {
 	return &cli_shell_callbacks;
 }
 
-const char HARDCODED_INI[] =
+static const char HARDCODED_INI[] =
 	"html_errors=0\n"
 	"register_argc_argv=1\n"
 	"implicit_flush=1\n"

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -487,7 +487,7 @@ static PHP_MINFO_FUNCTION(cli_server)
 	DISPLAY_INI_ENTRIES();
 }
 
-zend_module_entry cli_server_module_entry = {
+static zend_module_entry cli_server_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"cli_server",
 	NULL,

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -23,7 +23,7 @@
 #include <fcntl.h>
 #endif
 
-const char HARDCODED_INI[] =
+static const char HARDCODED_INI[] =
 	"html_errors=0\n"
 	"register_argc_argv=1\n"
 	"implicit_flush=1\n"

--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -721,7 +721,7 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	} while (0)
 #define FPM_WPC_STR_CP(_cfg, _scfg, _field) FPM_WPC_STR_CP_EX(_cfg, _scfg, _field, _field)
 
-void fpm_conf_apply_kv_array_to_kv_array(struct key_value_s *src, void *dest) {
+static void fpm_conf_apply_kv_array_to_kv_array(struct key_value_s *src, void *dest) {
 	struct key_value_s *kv;
 
 	for (kv = src; kv; kv = kv->next) {

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -606,7 +606,7 @@ static void sapi_cgi_register_variables(zval *track_vars_array) /* {{{ */
  *
  * Ignore level, we want to send all messages through fastcgi
  */
-void sapi_cgi_log_fastcgi(int level, char *message, size_t len)
+static void sapi_cgi_log_fastcgi(int level, char *message, size_t len)
 {
 
 	fcgi_request *request = (fcgi_request*) SG(server_context);

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -93,9 +93,6 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
 #include "fpm_log.h"
 #include "zlog.h"
 
-/* XXX this will need to change later when threaded fastcgi is implemented.  shane */
-struct sigaction act, old_term, old_quit, old_int;
-
 static void (*php_php_import_environment_variables)(zval *array_ptr);
 
 /* these globals used for forking children on unix systems */

--- a/sapi/fuzzer/fuzzer-sapi.c
+++ b/sapi/fuzzer/fuzzer-sapi.c
@@ -30,7 +30,7 @@
 #include "fuzzer.h"
 #include "fuzzer-sapi.h"
 
-const char HARDCODED_INI[] =
+static const char HARDCODED_INI[] =
 	"html_errors=0\n"
 	"implicit_flush=1\n"
 	"output_buffering=0\n"

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -46,7 +46,7 @@ int phpdbg_startup_run = 0;
 
 static bool phpdbg_booted = 0;
 static bool phpdbg_fully_started = 0;
-bool use_mm_wrappers = 1;
+static bool use_mm_wrappers = 1;
 
 static void php_phpdbg_destroy_bp_file(zval *brake) /* {{{ */
 {
@@ -1046,7 +1046,7 @@ static inline void phpdbg_sigint_handler(int signo) /* {{{ */
 } /* }}} */
 
 #ifndef _WIN32
-void phpdbg_signal_handler(int sig, siginfo_t *info, void *context) /* {{{ */
+static void phpdbg_signal_handler(int sig, siginfo_t *info, void *context) /* {{{ */
 {
 	int is_handled = FAILURE;
 
@@ -1066,7 +1066,7 @@ void phpdbg_signal_handler(int sig, siginfo_t *info, void *context) /* {{{ */
 } /* }}} */
 
 
-ZEND_NORETURN void phpdbg_sighup_handler(int sig) /* {{{ */
+static ZEND_NORETURN void phpdbg_sighup_handler(int sig) /* {{{ */
 {
 	exit(0);
 } /* }}} */


### PR DESCRIPTION
They are not exported as API, neither for internal usage, only to be used by the current source file. 