### PR TITLE
ext/pcntl: pcntl_unshare minor error message clarification (for EINVAL).

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1262,7 +1262,7 @@ PHP_FUNCTION(pcntl_unshare)
 		switch (errno) {
 #ifdef EINVAL
 			case EINVAL:
-				zend_argument_value_error(1, "must be a combination of CLONE_* flags");
+				zend_argument_value_error(1, "must be a combination of CLONE_* flags, or at least one flag is unsupported by the kernel");
 				RETURN_THROWS();
 				break;
 #endif

--- a/ext/pcntl/tests/pcntl_unshare_04.phpt
+++ b/ext/pcntl/tests/pcntl_unshare_04.phpt
@@ -23,4 +23,4 @@ try {
 
 ?>
 --EXPECT--
-pcntl_unshare(): Argument #1 ($flags) must be a combination of CLONE_* flags
+pcntl_unshare(): Argument #1 ($flags) must be a combination of CLONE_* flags, or at least one flag is unsupported by the kernel 


### PR DESCRIPTION
it is not necessarily a bad flag but can just be unsupported by the current kernel.