### PR TITLE
ext/pcntl: adding pcntl_setns for Linux > 5.3

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -7,7 +7,7 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([fork], [], [AC_MSG_ERROR([pcntl: fork() not supported by this platform])])
   AC_CHECK_FUNCS([waitpid], [], [AC_MSG_ERROR([pcntl: waitpid() not supported by this platform])])
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
-  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx])
+  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open])
 
   AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1442,6 +1442,9 @@ PHP_FUNCTION(pcntl_setns)
 			case ENOMEM:
 				php_error_docref(NULL, E_WARNING, "Error %d: Insufficient memory for pidfd_open", errno);
 				break;
+
+			default:
+			        php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
 		RETURN_FALSE;
 	}
@@ -1462,6 +1465,9 @@ PHP_FUNCTION(pcntl_setns)
 			case EPERM:
 				php_error_docref(NULL, E_WARNING, "Error %d: No required capability for this process", errno);
 				break;
+
+			default:
+			        php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
 		RETURN_FALSE;
 	} else {

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -990,3 +990,7 @@ function pcntl_rfork(int $flags, int $signal = 0): int{}
 #ifdef HAVE_FORKX
 function pcntl_forkx(int $flags): int{}
 #endif
+
+#ifdef HAVE_PIDFD_OPEN
+function pcntl_setns(int $process_id = null, int $nstype = CLONE_NEWNET): bool {}
+#endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3b03373d1bb68de779baaa62db14d98ca9018339 */
+ * Stub hash: 614bd67bb4cfcdc68d37141ff9dfad0a49c318b5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -132,6 +132,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_forkx, 0, 1, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_PIDFD_OPEN)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setns, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nstype, IS_LONG, 0, "CLONE_NEWNET")
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pcntl_fork);
 ZEND_FUNCTION(pcntl_waitpid);
 ZEND_FUNCTION(pcntl_wait);
@@ -175,6 +182,9 @@ ZEND_FUNCTION(pcntl_rfork);
 #endif
 #if defined(HAVE_FORKX)
 ZEND_FUNCTION(pcntl_forkx);
+#endif
+#if defined(HAVE_PIDFD_OPEN)
+ZEND_FUNCTION(pcntl_setns);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -222,6 +232,9 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_FORKX)
 	ZEND_FE(pcntl_forkx, arginfo_pcntl_forkx)
+#endif
+#if defined(HAVE_PIDFD_OPEN)
+	ZEND_FE(pcntl_setns, arginfo_pcntl_setns)
 #endif
 	ZEND_FE_END
 };

--- a/ext/pcntl/tests/pcntl_setns_basic.phpt
+++ b/ext/pcntl/tests/pcntl_setns_basic.phpt
@@ -1,0 +1,24 @@
+--TEST--
+pcntl_setns()
+--EXTENSIONS--
+pcntl
+posix
+--SKIPIF--
+<?php
+if (!function_exists("pcntl_setns")) die("skip pcntl_setns is not available");
+if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+?>
+--FILE--
+<?php
+$pid = pcntl_fork();
+if ($pid == -1) die("pcntl_fork failed");
+if ($pid != 0) {
+	try {
+		pcntl_setns($pid, 0);
+	} catch (\ValueError $e) {
+		echo $e->getMessage();
+	}
+}
+?>
+--EXPECTF--
+pcntl_setns(): Argument #2 ($nstype) is an invalid nstype (%d) 

--- a/ext/pcntl/tests/pcntl_setns_newpid.phpt
+++ b/ext/pcntl/tests/pcntl_setns_newpid.phpt
@@ -1,0 +1,21 @@
+--TEST--
+pcntl_setns()
+--EXTENSIONS--
+pcntl
+posix
+--SKIPIF--
+<?php
+if (!function_exists("pcntl_setns")) die("skip pcntl_setns is not available");
+if (posix_getuid() !== 0) die('skip Test needs root user');
+if (getenv('SKIP_ASAN')) die('skip Timeouts under ASAN');
+?>
+--FILE--
+<?php
+$pid = pcntl_fork();
+if ($pid == -1) die("pcntl_fork failed");
+if ($pid != 0) {
+	var_dump(pcntl_setns($pid, CLONE_NEWPID));
+}
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
allows a given process to join an existing Linux namespace, relatively complementary to the existing pcntl_unshare.