### PR TITLE
makedist: Reset tar timestamps to the commit date

### DIFF
--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -167,8 +167,9 @@ else
 fi
 
 # Reset the modification and access times of all files to be packaged.
-echo "makedist: Resetting the modification and access times of package files."
-touch -c NEWS
+commitDate="$(git log -1 --format=%cI $treeish)"
+echo "makedist: Resetting the modification and access times of package files to $commitDate"
+touch -c -d"$commitDate" NEWS
 find . -exec touch -r NEWS -c {} \;
 
 cd ..


### PR DESCRIPTION
This change should make the underlying `.tar` archive fully reproducible (given identical tool versions).

----------

see #10613 
see #10615 