### PR TITLE
Fix GH-13891: memleak and segfault when using ini_set with session.trans_sid_hosts

### DIFF
--- a/ext/session/tests/gh13891.phpt
+++ b/ext/session/tests/gh13891.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-13891 (memleak and segfault when using ini_set with session.trans_sid_hosts)
+--INI--
+session.use_cookies=0
+session.use_only_cookies=0
+session.use_trans_sid=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+// We *must* set it here because the bug only triggers on a runtime edit
+ini_set('session.trans_sid_hosts','php.net');
+session_id('sessionidhere');
+session_start();
+?>
+<p><a href="index.php">Click This Anchor Tag!</a></p>
+<p><a href="index.php#place">External link with anchor</a></p>
+<p><a href="http://php.net#foo">External link with anchor 2</a></p>
+<p><a href="#place">Internal link</a></p>
+--EXPECT--
+<p><a href="index.php?PHPSESSID=sessionidhere">Click This Anchor Tag!</a></p>
+<p><a href="index.php?PHPSESSID=sessionidhere#place">External link with anchor</a></p>
+<p><a href="http://php.net?PHPSESSID=sessionidhere#foo">External link with anchor 2</a></p>
+<p><a href="#place">Internal link</a></p>

--- a/ext/session/tests/gh13891.phpt
+++ b/ext/session/tests/gh13891.phpt
@@ -12,15 +12,5 @@ session
 <?php
 // We *must* set it here because the bug only triggers on a runtime edit
 ini_set('session.trans_sid_hosts','php.net');
-session_id('sessionidhere');
-session_start();
 ?>
-<p><a href="index.php">Click This Anchor Tag!</a></p>
-<p><a href="index.php#place">External link with anchor</a></p>
-<p><a href="http://php.net#foo">External link with anchor 2</a></p>
-<p><a href="#place">Internal link</a></p>
 --EXPECT--
-<p><a href="index.php?PHPSESSID=sessionidhere">Click This Anchor Tag!</a></p>
-<p><a href="index.php?PHPSESSID=sessionidhere#place">External link with anchor</a></p>
-<p><a href="http://php.net?PHPSESSID=sessionidhere#foo">External link with anchor 2</a></p>
-<p><a href="#place">Internal link</a></p>

--- a/ext/session/tests/gh13891.phpt
+++ b/ext/session/tests/gh13891.phpt
@@ -4,6 +4,7 @@ GH-13891 (memleak and segfault when using ini_set with session.trans_sid_hosts)
 session.use_cookies=0
 session.use_only_cookies=0
 session.use_trans_sid=1
+session.trans_sid_hosts=php.net
 --EXTENSIONS--
 session
 --SKIPIF--

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -138,9 +138,13 @@ static int php_ini_on_update_hosts(zend_ini_entry *entry, zend_string *new_value
 		}
 		keylen = q - key;
 		if (keylen > 0) {
-			tmp_key = zend_string_init(key, keylen, 0);
+			/* Note: the hash table is persistently allocated, so the strings must be too!
+			 * FIXME: the reason this is persistent is because the tables are allocated in GINIT,
+			 *        so it survives the request. This also means that the values set by `init_set` carry
+			 *        over from request to request, which is strange... */
+			tmp_key = zend_string_init(key, keylen, true);
 			zend_hash_add_empty_element(hosts, tmp_key);
-			zend_string_release_ex(tmp_key, 0);
+			zend_string_release_ex(tmp_key, true);
 		}
 	}
 	efree(tmp);

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -138,10 +138,7 @@ static int php_ini_on_update_hosts(zend_ini_entry *entry, zend_string *new_value
 		}
 		keylen = q - key;
 		if (keylen > 0) {
-			/* Note: the hash table is persistently allocated, so the strings must be too!
-			 * FIXME: the reason this is persistent is because the tables are allocated in GINIT,
-			 *        so it survives the request. This also means that the values set by `ini_set` carry
-			 *        over from request to request, which is strange... */
+			/* Note: the hash table is persistently allocated, so the strings must be too! */
 			tmp_key = zend_string_init(key, keylen, true);
 			zend_hash_add_empty_element(hosts, tmp_key);
 			zend_string_release_ex(tmp_key, true);

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -140,7 +140,7 @@ static int php_ini_on_update_hosts(zend_ini_entry *entry, zend_string *new_value
 		if (keylen > 0) {
 			/* Note: the hash table is persistently allocated, so the strings must be too!
 			 * FIXME: the reason this is persistent is because the tables are allocated in GINIT,
-			 *        so it survives the request. This also means that the values set by `init_set` carry
+			 *        so it survives the request. This also means that the values set by `ini_set` carry
 			 *        over from request to request, which is strange... */
 			tmp_key = zend_string_init(key, keylen, true);
 			zend_hash_add_empty_element(hosts, tmp_key);


### PR DESCRIPTION
The hash tables used are allocated via the persistent allocator. When using ini_set, the allocation happens via the non-persistent allocator. When the table is then freed in GSHUTDOWN, we get a crash because the allocators are mismatched.

~~As a side note, it is strange that this is designed this way, because it means that ini_sets persist between requests...~~

Test credits go to Kamil Tekiela.