### PR TITLE
ext/pcntl: cpu affinity api introduction.

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -7,18 +7,7 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([fork], [], [AC_MSG_ERROR([pcntl: fork() not supported by this platform])])
   AC_CHECK_FUNCS([waitpid], [], [AC_MSG_ERROR([pcntl: waitpid() not supported by this platform])])
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
-  AC_CHECK_FUNCS([
-	getpriority
-	setpriority
-	wait3
-	wait4
-	sigwaitinfo
-	sigtimedwait
-	unshare
-	rfork 
-	forkx
-	pidfd_open
-	sched_setaffinity])
+  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open sched_setaffinity])
 
   AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
 

--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -7,7 +7,18 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([fork], [], [AC_MSG_ERROR([pcntl: fork() not supported by this platform])])
   AC_CHECK_FUNCS([waitpid], [], [AC_MSG_ERROR([pcntl: waitpid() not supported by this platform])])
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
-  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open])
+  AC_CHECK_FUNCS([
+	getpriority
+	setpriority
+	wait3
+	wait4
+	sigwaitinfo
+	sigtimedwait
+	unshare
+	rfork 
+	forkx
+	pidfd_open
+	sched_setaffinity])
 
   AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
 

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -996,6 +996,6 @@ function pcntl_setns(?int $process_id = null, int $nstype = CLONE_NEWNET): bool 
 #endif
 
 #ifdef HAVE_SCHED_SETAFFINITY
-function pcntl_getcpuaffinity(?int $process_id = null): array {}
+function pcntl_getcpuaffinity(?int $process_id = null): array|false {}
 function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): bool {}
 #endif

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -994,3 +994,8 @@ function pcntl_forkx(int $flags): int{}
 #ifdef HAVE_PIDFD_OPEN
 function pcntl_setns(?int $process_id = null, int $nstype = CLONE_NEWNET): bool {}
 #endif
+
+#ifdef HAVE_SCHED_SETAFFINITY
+function pcntl_getcpuaffinity(?int $process_id = null): array {}
+function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): bool {}
+#endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3b3fd6aaaca61451cad2679aafa3abef1a7056db */
+ * Stub hash: a61b0327f5c36ca91e19c5f370377794b7950dee */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -140,7 +140,7 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_SCHED_SETAFFINITY)
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_getcpuaffinity, 0, 0, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_getcpuaffinity, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 #endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e5204cee68c41ff1201992f2572940c8f87980a3 */
+ * Stub hash: 3b3fd6aaaca61451cad2679aafa3abef1a7056db */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -139,6 +139,19 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setns, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_SCHED_SETAFFINITY)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_getcpuaffinity, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 1, "null")
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(HAVE_SCHED_SETAFFINITY)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setcpuaffinity, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cpu_ids, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pcntl_fork);
 ZEND_FUNCTION(pcntl_waitpid);
 ZEND_FUNCTION(pcntl_wait);
@@ -185,6 +198,12 @@ ZEND_FUNCTION(pcntl_forkx);
 #endif
 #if defined(HAVE_PIDFD_OPEN)
 ZEND_FUNCTION(pcntl_setns);
+#endif
+#if defined(HAVE_SCHED_SETAFFINITY)
+ZEND_FUNCTION(pcntl_getcpuaffinity);
+#endif
+#if defined(HAVE_SCHED_SETAFFINITY)
+ZEND_FUNCTION(pcntl_setcpuaffinity);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -235,6 +254,12 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_PIDFD_OPEN)
 	ZEND_FE(pcntl_setns, arginfo_pcntl_setns)
+#endif
+#if defined(HAVE_SCHED_SETAFFINITY)
+	ZEND_FE(pcntl_getcpuaffinity, arginfo_pcntl_getcpuaffinity)
+#endif
+#if defined(HAVE_SCHED_SETAFFINITY)
+	ZEND_FE(pcntl_setcpuaffinity, arginfo_pcntl_setcpuaffinity)
 #endif
 	ZEND_FE_END
 };

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -60,9 +60,10 @@ array(0) {
 }
 bool(true)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) must not be empty
-cpu id must be between 0 and %d (%d)
-cpu id must be between 0 and %d (-1024)
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid value (def)
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (%d)
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (-1024)
 pcntl_getcpuaffinity(): Argument #1 ($process_id) invalid process (-1024)
 
 Warning: Array to string conversion in %s on line %d
-cpu id invalid type (Array)
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid type (Array)

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -14,6 +14,7 @@ $act_mask = pcntl_getcpuaffinity();
 var_dump(array_diff($mask, $act_mask));
 $n_act_mask = pcntl_getcpuaffinity();
 var_dump(array_diff($act_mask, $n_act_mask));
+var_dump(pcntl_setcpuaffinity(null, ["0", "1"]));
 
 try {
 	pcntl_setcpuaffinity(null, []);
@@ -42,17 +43,26 @@ try {
 try {
 	pcntl_getcpuaffinity(-1024);
 } catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	pcntl_setcpuaffinity(null, [1, array(1)]);
+} catch (\ValueError $e) {
 	echo $e->getMessage();
 }
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 array(0) {
 }
 array(0) {
 }
+bool(true)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) must not be empty
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
+cpu id must be between 0 and %d (%d)
+cpu id must be between 0 and %d (-1024)
 pcntl_getcpuaffinity(): Argument #1 ($process_id) invalid process (-1024)
+
+Warning: Array to string conversion in %s on line %d
+cpu id invalid type (Array)

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -1,0 +1,58 @@
+--TEST--
+pcntl_getcpuaffinity() and pcntl_setcpuaffinity()
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (!function_exists("pcntl_setcpuaffinity")) die("skip pcntl_setcpuaffinity is not available");
+?>
+--FILE--
+<?php
+$mask = [0, 1];
+var_dump(pcntl_setcpuaffinity(null, $mask));
+$act_mask = pcntl_getcpuaffinity();
+var_dump(array_diff($mask, $act_mask));
+$n_act_mask = pcntl_getcpuaffinity();
+var_dump(array_diff($act_mask, $n_act_mask));
+
+try {
+	pcntl_setcpuaffinity(null, []);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	pcntl_setcpuaffinity(null, ["abc" => "def", 0 => "cpuid"]);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	pcntl_setcpuaffinity(null, [PHP_INT_MAX]);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	pcntl_setcpuaffinity(null, [-1024, 64, -2]);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+	pcntl_getcpuaffinity(-1024);
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+bool(true)
+array(0) {
+}
+array(0) {
+}
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) must not be empty
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) invalid cpu affinity mapping
+pcntl_getcpuaffinity(): Argument #1 ($process_id) invalid process (-1024)


### PR DESCRIPTION
For now, working on Linux, FreeBSD >= 13.x and DragonFlyBSD. Handy wrapper to assign an array of cpu ids or to retrieve the cpu ids assigned to a given process.

pcntl_setaffinity inserts valid unique cpu ids (within the range of available
cpus).