### PR TITLE
Use a link test to check for GNU libiconv availability

### DIFF
--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -28,20 +28,11 @@ if test "$PHP_ICONV" != "no"; then
 
     if test -z "$iconv_impl_name"; then
       AC_MSG_CHECKING([if using GNU libiconv])
-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <iconv.h>
-#include <stdio.h>
-int main(void) {
-  printf("%d", _libiconv_version);
-  return 0;
-}
-      ]])],[
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <iconv.h>], [(void) _libiconv_version])],[
         AC_MSG_RESULT(yes)
         iconv_impl_name="gnu_libiconv"
       ],[
         AC_MSG_RESULT(no)
-      ],[
-        AC_MSG_RESULT([no, cross-compiling])
       ])
     fi
 


### PR DESCRIPTION
Allows checking for GNU libiconv when cross compiling, the other iconv libraries are already checked for with link tests, the //IGNORE test is still left as a runtest, not sure how to handle that however.