### PR TITLE
Fix GH-13860: Incorrect PHP_STREAM_OPTION_CHECK_LIVENESS case in ext/openssl/xp_ssl.c - causing use of dead socket

### DIFF
--- a/ext/openssl/tests/gh13860.phpt
+++ b/ext/openssl/tests/gh13860.phpt
@@ -1,0 +1,49 @@
+--TEST--
+GH-13860 (Incorrect PHP_STREAM_OPTION_CHECK_LIVENESS case in ext/openssl/xp_ssl.c - causing use of dead socket)
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) die("skip no proc_open");
+?>
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+    $serverUri = "tcp://127.0.0.1:64325";
+    $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
+    $serverCtx = stream_context_create();
+
+    $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
+    phpt_notify();
+
+    $client = @stream_socket_accept($server);
+    if ($client) {
+        fwrite($client, "xx");
+        phpt_wait();
+        fclose($client);
+    }
+CODE;
+
+$clientCode = <<<'CODE'
+    $serverUri = "tcp://127.0.0.1:64325";
+    $clientFlags = STREAM_CLIENT_CONNECT;
+
+    phpt_wait();
+    $fp = stream_socket_client($serverUri);
+    stream_set_blocking($fp, false);
+
+    fread($fp, 2);
+
+    phpt_notify();
+    while (!($in = fread($fp, 2))) {
+        usleep(1000);
+    }
+    var_dump(feof($fp));
+    fclose($fp);
+CODE;
+
+include 'ServerClientTestCase.inc';
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--EXPECT--
+bool(true)

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2575,8 +2575,20 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 							php_set_sock_blocking(sslsock->s.socket, 1);
 							sslsock->s.is_blocked = 1;
 						}
-					} else if (0 == recv(sslsock->s.socket, &buf, sizeof(buf), MSG_PEEK|MSG_DONTWAIT) && php_socket_errno() != EAGAIN) {
-						alive = 0;
+					} else {
+#ifdef PHP_WIN32
+						int ret;
+#else
+						ssize_t ret;
+#endif
+						int err;
+
+						ret = recv(sslsock->s.socket, &buf, sizeof(buf), MSG_PEEK|MSG_DONTWAIT);
+						err = php_socket_errno();
+						if (0 == ret || /* the counterpart did properly shutdown */
+							(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+							alive = 0;
+						}
 					}
 				}
 				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;


### PR DESCRIPTION
php_socket_errno() may return a stale value when recv returns a value >= 0. As such, the liveness check is wrong.
This is the same bug as #70198 (fixed in GH-1456). So we fix it in the same way.