### PR TITLE
Cleanup and optimize attribute value reading

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -113,19 +113,9 @@ Since:
 */
 zend_result dom_attr_value_read(dom_object *obj, zval *retval)
 {
-	DOM_PROP_NODE(xmlAttrPtr, attrp, obj);
-	xmlChar *content;
-
-	/* Can't avoid a content copy because it's an attribute node */
-	if ((content = xmlNodeGetContent((xmlNodePtr) attrp)) != NULL) {
-		ZVAL_STRING(retval, (char *) content);
-		xmlFree(content);
-	} else {
-		ZVAL_EMPTY_STRING(retval);
-	}
-
+	DOM_PROP_NODE(xmlNodePtr, attrp, obj);
+	php_dom_get_content_into_zval(attrp, retval, false);
 	return SUCCESS;
-
 }
 
 zend_result dom_attr_value_write(dom_object *obj, zval *newval)


### PR DESCRIPTION
When the attribute has a single text child, we can avoid an allocating call to libxml2 and read the contents directly.

On my i7-4790, I tested the optimization with both the $value and $nodeValue property.

```
Summary
  ./sapi/cli/php bench_value.php ran
    1.82 ± 0.09 times faster than ./sapi/cli/php_old bench_value.php

Summary
  ./sapi/cli/php bench_nodeValue.php ran
    1.78 ± 0.10 times faster than ./sapi/cli/php_old bench_nodeValue.php
```

Test code:
```php
$dom = new DOMDocument;
$dom->loadXML('<root attrib="this is a relatively short text"/>');
$attrib = $dom->documentElement->attributes[0];

for ($i=0; $i<1000*1000; $i++) {
	$attrib->value; // or nodeValue
}
```