### PR TITLE
Improve check for broken iconv //IGNORE

### DIFF
--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -112,8 +112,8 @@ int main(void) {
       AC_MSG_RESULT(yes, cross-compiling)
     ])
 
-    AC_MSG_CHECKING([if iconv supports //IGNORE])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore],
+      [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <iconv.h>
 #include <stdlib.h>
 
@@ -132,16 +132,13 @@ int main(void) {
   }
   return 0;
 }
-   ]])],[
-      AC_MSG_RESULT(yes)
-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
-    ],[
-      AC_MSG_RESULT(no)
-      AC_DEFINE([ICONV_BROKEN_IGNORE],1,[Whether iconv supports IGNORE])
-    ],[
-      AC_MSG_RESULT(no, cross-compiling)
-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
-    ])
+      ]])],
+      [php_cv_iconv_ignore=yes],
+      [php_cv_iconv_ignore=no],
+      [php_cv_iconv_ignore=no])])
+
+    AS_VAR_IF([php_cv_iconv_ignore], [no],
+      [AC_DEFINE([ICONV_BROKEN_IGNORE], [1], [Whether iconv has broken IGNORE.])])
 
     LDFLAGS="$save_LDFLAGS"
     CFLAGS="$save_CFLAGS"


### PR DESCRIPTION
As discussed in #13894 with @Redfoxymoon about ext/iconv and Autoconf checks...

Previous check defined the symbol ICONV_BROKEN_IGNORE to 0 or 1 and the `#ifdef` macro condition in iconv.c file was always using a bypass. Even when the //IGNORE is supported (for example, on GNU Libiconv).

With this change, the ICONV_BROKEN_IGNORE symbol is only defined if the //IGNORE Autoconf check fails or when cross-compiling without setting the php_cv_iconv_ignore variable.

This also enables overriding the ext/iconv //IGNORE check when cross-compiling, by setting the php_cv_iconv_ignore variable to "yes" in case the iconv library is known to have a working //IGNORE (for example, GNU libiconv).

These cache variables can be set at configure step, when cross-compiling

    ./configure php_cv_iconv_ignore=yes