### PR TITLE
Fix persistent local flag in session url updating

### DIFF
--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -140,6 +140,7 @@ static int php_ini_on_update_hosts(zend_ini_entry *entry, zend_string *new_value
 		if (keylen > 0) {
 			/* Note: the hash table is persistently allocated, so the strings must be too! */
 			tmp_key = zend_string_init(key, keylen, true);
+			GC_MAKE_PERSISTENT_LOCAL(tmp_key);
 			zend_hash_add_empty_element(hosts, tmp_key);
 			zend_string_release_ex(tmp_key, true);
 		}


### PR DESCRIPTION
Short-lived regression from 5ce9687cb2bc49e5d95b1c9bda5dc7f711c3da62. I forgot to add the persistent local flag, so that means that RC_DEBUG will complain. These strings are local to the thread so we can just add the flag to silence the debug checker in this case.
This fixes the nightly failure in ext-session.