### PR TITLE
Fix GH-13789 build failed mbstring_arginfo.h when Visual C++ on Windows

### DIFF
--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -13,6 +13,8 @@ if (PHP_MBSTRING != "no") {
 		ADD_FLAG("CFLAGS_MBSTRING", "-Iext/mbstring -Iext/mbstring/libmbfl -Iext/mbstring/libmbfl/mbfl \
 			/D HAVE_STRICMP /D MBFL_DLL_EXPORT=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1")
 
+		ADD_FLAG("CFLAGS_BD_EXT_MBSTRING", "/utf-8")
+
 		FSO.CopyFile("ext\\mbstring\\libmbfl\\config.h.w32",
 			"ext\\mbstring\\libmbfl\\config.h", true);
 


### PR DESCRIPTION
CP932 environment can't compile. So add /utf-8 flag on CFLAGS_BD_EXT_MBSTRING.