### PR TITLE
ext/pcntl: adding pcntl_getcpu.

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -9,6 +9,25 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
   AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open sched_setaffinity])
 
+  dnl if unsupported, -1 means automatically ENOSYS in this context
+  AC_MSG_CHECKING([if sched_getcpu is supported])
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <sched.h>
+int main(void) {
+  if (sched_getcpu() == -1) {
+      return 1;
+  }
+  return 0;
+}
+  ]])],[
+    AC_MSG_RESULT(yes)
+    AC_DEFINE([HAVE_SCHED_GETCPU],1,[Whether sched_getcpu is properly supported])
+  ],[
+    AC_MSG_RESULT(no)
+  ],[
+    AC_MSG_RESULT([no, cross-compiling])
+  ])
+
   AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
 
   PHP_NEW_EXTENSION(pcntl, pcntl.c php_signal.c, $ext_shared, cli, $PCNTL_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -42,7 +42,7 @@
 #endif
 
 #include <errno.h>
-#if defined(HAVE_UNSHARE) || defined(HAVE_SCHED_SETAFFINITY)
+#if defined(HAVE_UNSHARE) || defined(HAVE_SCHED_SETAFFINITY) || defined(HAVE_SCHED_GETCPU)
 #include <sched.h>
 #if defined(__FreeBSD__)
 #include <sys/types.h>
@@ -1610,6 +1610,15 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 	} else {
 		RETURN_TRUE;
 	}
+}
+#endif
+
+#if defined(HAVE_SCHED_GETCPU)
+PHP_FUNCTION(pcntl_getcpu)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_LONG(sched_getcpu());
 }
 #endif
 

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -999,3 +999,7 @@ function pcntl_setns(?int $process_id = null, int $nstype = CLONE_NEWNET): bool 
 function pcntl_getcpuaffinity(?int $process_id = null): array|false {}
 function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): bool {}
 #endif
+
+#ifdef HAVE_SCHED_GETCPU
+function pcntl_getcpu(): int {}
+#endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a61b0327f5c36ca91e19c5f370377794b7950dee */
+ * Stub hash: 75eacf08a17e18c30fb2111bb742c36b18aa9ead */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -152,6 +152,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setcpuaffinity, 0, 0, _IS_
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_SCHED_GETCPU)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_getcpu, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pcntl_fork);
 ZEND_FUNCTION(pcntl_waitpid);
 ZEND_FUNCTION(pcntl_wait);
@@ -204,6 +209,9 @@ ZEND_FUNCTION(pcntl_getcpuaffinity);
 #endif
 #if defined(HAVE_SCHED_SETAFFINITY)
 ZEND_FUNCTION(pcntl_setcpuaffinity);
+#endif
+#if defined(HAVE_SCHED_GETCPU)
+ZEND_FUNCTION(pcntl_getcpu);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -260,6 +268,9 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_SCHED_SETAFFINITY)
 	ZEND_FE(pcntl_setcpuaffinity, arginfo_pcntl_setcpuaffinity)
+#endif
+#if defined(HAVE_SCHED_GETCPU)
+	ZEND_FE(pcntl_getcpu, arginfo_pcntl_getcpu)
 #endif
 	ZEND_FE_END
 };

--- a/ext/pcntl/tests/pcntl_getcpu.phpt
+++ b/ext/pcntl/tests/pcntl_getcpu.phpt
@@ -1,0 +1,23 @@
+--TEST--
+pcntl_getcpu()
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (!function_exists("pcntl_getcpu")) die("skip pcntl_getcpu() is not available");
+if (!function_exists("pcntl_setcpuaffinity")) die("skip pcntl_setcpuaffinity() is not available");
+if (getenv('TRAVIS')) die('skip Currently fails on Travis');
+?>
+--FILE--
+<?php
+$pid = pcntl_fork();
+if ($pid == -1) {
+	die("fork failed");
+} else if ($pid == 0) {
+	var_dump(pcntl_setcpuaffinity(null, [1]));
+	var_dump(pcntl_getcpu());
+}
+?>
+--EXPECTF--
+bool(true)
+int(1)


### PR DESCRIPTION
using sched_getcpu under the hood (Linux and FreeBSD). Returns the current cpu id for the current process. For Linux, we need to see beyond the sole presence of the symbol to consider it.
Mostly useful, for now, in the cpu affinity context since the os can migrate processes as it sees fits otherwise.