### PR TITLE
Avoid call to php_socket_errno() if possible

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2577,13 +2577,17 @@ static int php_openssl_sockop_set_option(php_stream *stream, int option, int val
 #else
 						ssize_t ret;
 #endif
-						int err;
 
 						ret = recv(sslsock->s.socket, &buf, sizeof(buf), MSG_PEEK|MSG_DONTWAIT);
-						err = php_socket_errno();
-						if (0 == ret || /* the counterpart did properly shutdown */
-							(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+						if (0 == ret) {
+							/* the counterpart did properly shutdown */
 							alive = 0;
+						} else if (0 > ret) {
+							int err = php_socket_errno();
+							if (err != EWOULDBLOCK && err != EMSGSIZE && err != EAGAIN) {
+								/* there was an unrecoverable error */
+								alive = 0;
+							}
 						}
 					}
 				}

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -373,13 +373,17 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
 #else
 					ssize_t ret;
 #endif
-					int err;
 
 					ret = recv(sock->socket, &buf, sizeof(buf), MSG_PEEK|MSG_DONTWAIT);
-					err = php_socket_errno();
-					if (0 == ret || /* the counterpart did properly shutdown*/
-						(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+					if (0 == ret) {
+						/* the counterpart did properly shutdown */
 						alive = 0;
+					} else if (0 > ret) {
+						int err = php_socket_errno();
+						if (err != EWOULDBLOCK && err != EMSGSIZE && err != EAGAIN) {
+							/* there was an unrecoverable error */
+							alive = 0;
+						}
 					}
 				}
 				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;


### PR DESCRIPTION
This call is only necessary if ret < 0.
Note that I also had to reoder the checks for EWOULDBLOCK, EMSGSIZE, EAGAIN to avoid a false positive GCC warning about a duplicate condition (EAGAIN == EWOULDBLOCK on my system).