### PR TITLE
ext/sockets: adding solaris/illumos SO_EXCLBIND constant.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -570,6 +570,7 @@ PHP 8.4 UPGRADE NOTES
   . SOCK_CONN_DGRAM (NetBSD only).
   . SOCK_DCCP (NetBSD only).
   . TCP_SYNCNT (Linux only).
+  . SO_EXCLBIND (Solaris/Illumos only).
 
 - Sodium:
   . SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -410,6 +410,13 @@ const SO_MEMINFO = UNKNOWN;
  */
 const SO_BPF_EXTENSIONS = UNKNOWN;
 #endif
+#ifdef SO_EXCLBIND
+/**
+ * @var int
+ * @cvalue SO_EXCLBIND
+ */
+const SO_EXCLBIND = UNKNOWN;
+#endif
 #ifdef SKF_AD_OFF
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c761db0839535812316a42200f68c7db22639d81 */
+ * Stub hash: 98bd7f47a1aa8d1c2cb40bf768115da2633f56fb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -477,6 +477,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(SO_BPF_EXTENSIONS)
 	REGISTER_LONG_CONSTANT("SO_BPF_EXTENSIONS", SO_BPF_EXTENSIONS, CONST_PERSISTENT);
+#endif
+#if defined(SO_EXCLBIND)
+	REGISTER_LONG_CONSTANT("SO_EXCLBIND", SO_EXCLBIND, CONST_PERSISTENT);
 #endif
 #if defined(SKF_AD_OFF)
 	REGISTER_LONG_CONSTANT("SKF_AD_OFF", SKF_AD_OFF, CONST_PERSISTENT);


### PR DESCRIPTION
when set to "true", neutralises the effect of SO_REUSEADDR/SO_REUSEPORT making the socket binding exclusive.