### PR TITLE
Fix #13865 Improve parameter and return value related deprecation mesages

### DIFF
--- a/Zend/tests/bug71428.3.phpt
+++ b/Zend/tests/bug71428.3.phpt
@@ -7,6 +7,6 @@ class B           {  public function m(A $a = NULL, $n) { echo "B.m";} };
 class C extends B {  public function m(A $a       , $n) { echo "C.m";} };
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: B::m(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
 Fatal error: Declaration of C::m(A $a, $n) must be compatible with B::m(?A $a, $n) in %sbug71428.3.php on line 4

--- a/Zend/tests/call_user_func_005.phpt
+++ b/Zend/tests/call_user_func_005.phpt
@@ -18,7 +18,7 @@ var_dump(call_user_func(array('foo', 'teste')));
 
 ?>
 --EXPECTF--
-Deprecated: Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
+Deprecated: {closure}(): Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
 string(1) "x"
 array(1) {
   [0]=>

--- a/Zend/tests/gh11488.phpt
+++ b/Zend/tests/gh11488.phpt
@@ -16,8 +16,8 @@ function c(
 ) {}
 ?>
 --EXPECTF--
-Deprecated: Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
+Deprecated: a(): Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
 
-Deprecated: Implicitly marking parameter $c as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: b(): Implicitly marking parameter $c as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Optional parameter $e declared before required parameter $f is implicitly treated as a required parameter in %s on line %d
+Deprecated: c(): Optional parameter $e declared before required parameter $f is implicitly treated as a required parameter in %s on line %d

--- a/Zend/tests/ns_073.phpt
+++ b/Zend/tests/ns_073.phpt
@@ -14,7 +14,7 @@ $x(new \stdclass);
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $x as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo\{closure}(): Implicitly marking parameter $x as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 NULL
 object(stdClass)#%d (0) {
 }

--- a/Zend/tests/required_param_after_optional.phpt
+++ b/Zend/tests/required_param_after_optional.phpt
@@ -9,14 +9,14 @@ function test3(Type $test3A = null, ?Type2 $test3B = null, $test3C) {}
 
 ?>
 --EXPECTF--
-Deprecated: Optional parameter $testA declared before required parameter $testC is implicitly treated as a required parameter in %s on line %d
+Deprecated: test(): Optional parameter $testA declared before required parameter $testC is implicitly treated as a required parameter in %s on line %d
 
-Deprecated: Optional parameter $testB declared before required parameter $testC is implicitly treated as a required parameter in %s on line %d
+Deprecated: test(): Optional parameter $testB declared before required parameter $testC is implicitly treated as a required parameter in %s on line %d
 
-Deprecated: Implicitly marking parameter $test2A as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test2(): Implicitly marking parameter $test2A as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Optional parameter $test2B declared before required parameter $test2C is implicitly treated as a required parameter in %s on line %d
+Deprecated: test2(): Optional parameter $test2B declared before required parameter $test2C is implicitly treated as a required parameter in %s on line %d
 
-Deprecated: Implicitly marking parameter $test3A as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test3(): Implicitly marking parameter $test3A as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Optional parameter $test3B declared before required parameter $test3C is implicitly treated as a required parameter in %s on line %d
+Deprecated: test3(): Optional parameter $test3B declared before required parameter $test3C is implicitly treated as a required parameter in %s on line %d

--- a/Zend/tests/required_param_after_optional_named_args.phpt
+++ b/Zend/tests/required_param_after_optional_named_args.phpt
@@ -13,5 +13,5 @@ try {
 
 ?>
 --EXPECTF--
-Deprecated: Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
+Deprecated: test(): Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in %s on line %d
 test(): Argument #1 ($a) not passed

--- a/Zend/tests/return_by_ref_from_void_function.phpt
+++ b/Zend/tests/return_by_ref_from_void_function.phpt
@@ -11,7 +11,7 @@ var_dump($r);
 
 ?>
 --EXPECTF--
-Deprecated: Returning by reference from a void function is deprecated in %s on line %d
+Deprecated: test(): Returning by reference from a void function is deprecated in %s on line %d
 
 Notice: Only variable references should be returned by reference in %s on line %d
 NULL

--- a/Zend/tests/traits/bug60717.phpt
+++ b/Zend/tests/traits/bug60717.phpt
@@ -70,9 +70,9 @@ namespace HTML
 }
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: HTML\Helper::attributes(): Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: HTML\TextArea::attributes(): Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: HTML\HTMLAttributes::attributes(): Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 Done

--- a/Zend/tests/type_declarations/callable_003.phpt
+++ b/Zend/tests/type_declarations/callable_003.phpt
@@ -14,7 +14,7 @@ foo("strpos", 123, "strpos");
 bar("substr");
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: bar(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 string(6) "strpos"
 int(123)
 string(6) "strpos"

--- a/Zend/tests/type_declarations/intersection_types/implicit_nullable_intersection_type.phpt
+++ b/Zend/tests/type_declarations/intersection_types/implicit_nullable_intersection_type.phpt
@@ -11,5 +11,5 @@ foo(null);
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo(): Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 NULL

--- a/Zend/tests/type_declarations/intersection_types/implicit_nullable_intersection_type_error.phpt
+++ b/Zend/tests/type_declarations/intersection_types/implicit_nullable_intersection_type_error.phpt
@@ -15,5 +15,5 @@ try {
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo(): Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 foo(): Argument #1 ($foo) must be of type (X&Y)|null, int given, called in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_002.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_002.phpt
@@ -17,6 +17,6 @@ function baz(iterable $iterable = 1) {
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $iterable as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo(): Implicitly marking parameter $iterable as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
 Fatal error: Cannot use int as default value for parameter $iterable of type Traversable|array in %s on line %d

--- a/Zend/tests/type_declarations/literal_types/false_standalone_implicit_nullability.phpt
+++ b/Zend/tests/type_declarations/literal_types/false_standalone_implicit_nullability.phpt
@@ -9,6 +9,6 @@ var_dump(test(false));
 var_dump(test(null));
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $v as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test(): Implicitly marking parameter $v as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 bool(false)
 NULL

--- a/Zend/tests/type_declarations/literal_types/true_standalone_implicit_nullability.phpt
+++ b/Zend/tests/type_declarations/literal_types/true_standalone_implicit_nullability.phpt
@@ -9,6 +9,6 @@ var_dump(test(true));
 var_dump(test(null));
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $v as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test(): Implicitly marking parameter $v as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 bool(true)
 NULL

--- a/Zend/tests/type_declarations/nullable_null.phpt
+++ b/Zend/tests/type_declarations/nullable_null.phpt
@@ -8,5 +8,5 @@ function test(Foo $a = null) {
 test(null);
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 ok

--- a/ext/reflection/tests/ReflectionClass_export_basic1.phpt
+++ b/ext/reflection/tests/ReflectionClass_export_basic1.phpt
@@ -20,7 +20,7 @@ define('K', "16 chars long --");
 echo new ReflectionClass("C"), "\n";
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $h as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: A::pubf(): Implicitly marking parameter $h as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 Class [ <user> class C extends A ] {
   @@ %s 14-14
 

--- a/ext/reflection/tests/bug62715.phpt
+++ b/ext/reflection/tests/bug62715.phpt
@@ -17,9 +17,9 @@ foreach ($r->getParameters() as $p) {
 }
 ?>
 --EXPECTF--
-Deprecated: Optional parameter $a declared before required parameter $c is implicitly treated as a required parameter in %s on line %d
+Deprecated: test(): Optional parameter $a declared before required parameter $c is implicitly treated as a required parameter in %s on line %d
 
-Deprecated: Optional parameter $b declared before required parameter $c is implicitly treated as a required parameter in %s on line %d
+Deprecated: test(): Optional parameter $b declared before required parameter $c is implicitly treated as a required parameter in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/reflection/tests/parameters_002.phpt
+++ b/ext/reflection/tests/parameters_002.phpt
@@ -73,7 +73,7 @@ check_params(ReflectionMethod::createFromMethodName('test::method'));
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $opt as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: test(): Implicitly marking parameter $opt as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 #####test()#####
 ===0===
 getName: string(3) "nix"

--- a/ext/reflection/tests/types/ReflectionType_001.phpt
+++ b/ext/reflection/tests/types/ReflectionType_001.phpt
@@ -101,7 +101,7 @@ $r = (new ReflectionProperty($obj, 'std'))->getType();
 var_dump($r->getName());
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $d as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo(): Implicitly marking parameter $d as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 *** functions
 ** Function 0 - Parameter 0
 bool(true)

--- a/ext/reflection/tests/types/pure_intersection_type_implicitly_nullable.phpt
+++ b/ext/reflection/tests/types/pure_intersection_type_implicitly_nullable.phpt
@@ -25,7 +25,7 @@ dumpType((new ReflectionFunction('foo'))->getParameters()[0]->getType());
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: foo(): Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 Type (X&Y)|null is ReflectionUnionType:
 Allows Null: true
   Type X&Y is ReflectionIntersectionType:

--- a/tests/classes/type_hinting_003.phpt
+++ b/tests/classes/type_hinting_003.phpt
@@ -39,7 +39,7 @@ Test::f1(1);
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $ar as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: Test::f2(): Implicitly marking parameter $ar as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 Test::f1()
 array(1) {
   [0]=>

--- a/tests/classes/type_hinting_004.phpt
+++ b/tests/classes/type_hinting_004.phpt
@@ -143,11 +143,11 @@ Ensure type hints are enforced for functions invoked as callbacks.
 
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: f2(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: C::f2(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 
-Deprecated: Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: D::f2(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 ---> Type hints with callback function:
 0: f1(): Argument #1 ($a) must be of type A, int given%s(%d)
 

--- a/tests/lang/type_hints_002.phpt
+++ b/tests/lang/type_hints_002.phpt
@@ -16,7 +16,7 @@ $o->f();
 $o->f(NULL);
 ?>
 --EXPECTF--
-Deprecated: Implicitly marking parameter $p as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
+Deprecated: T::f(): Implicitly marking parameter $p as nullable is deprecated, the explicit nullable type must be used instead in %s on line %d
 object(P)#2 (0) {
 }
 -


### PR DESCRIPTION
At last, I added the function/method name to some compile-time deprecation messages which are related to parameters/return values. Consistent with the other similar error messages, I included the function/method name at the start of the message.