### PR TITLE
Remove unused os/signpost.h header check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,7 +399,6 @@ grp.h \
 ieeefp.h \
 langinfo.h \
 linux/sock_diag.h \
-os/signpost.h \
 poll.h \
 pty.h \
 pwd.h \


### PR DESCRIPTION
Removed via be275433d936e41d95b2fd656464bcc4d7138b76.