### PR TITLE
Fix GCC warning when using getThis() in a conditional

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -521,7 +521,8 @@ ZEND_API const char *zend_get_type_by_const(int type);
 
 #define ZEND_THIS                           (&EX(This))
 
-#define getThis()							((Z_TYPE_P(ZEND_THIS) == IS_OBJECT) ? ZEND_THIS : NULL)
+#define hasThis()							(Z_TYPE_P(ZEND_THIS) == IS_OBJECT)
+#define getThis()							(hasThis() ? ZEND_THIS : NULL)
 #define ZEND_IS_METHOD_CALL()				(EX(func)->common.scope != NULL)
 
 #define WRONG_PARAM_COUNT					ZEND_WRONG_PARAM_COUNT()

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -44,21 +44,21 @@ using icu::Locale;
 
 #define ZEND_VALUE_ERROR_INVALID_FIELD(argument, zpp_arg_position) \
 	if (argument < 0 || argument >= UCAL_FIELD_COUNT) { \
-		zend_argument_value_error(getThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
+		zend_argument_value_error(hasThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
 			"must be a valid field"); \
 		RETURN_THROWS(); \
 	}
 
 #define ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(argument, zpp_arg_position) \
 	if (UNEXPECTED(argument < INT32_MIN || argument > INT32_MAX)) { \
-		zend_argument_value_error(getThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
+		zend_argument_value_error(hasThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
 			"must be between %d and %d", INT32_MIN, INT32_MAX); \
 		RETURN_THROWS(); \
 	}
 
 #define ZEND_VALUE_ERROR_INVALID_DAY_OF_WEEK(argument, zpp_arg_position) \
 	if (argument < UCAL_SUNDAY || argument > UCAL_SATURDAY) { \
-		zend_argument_value_error(getThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
+		zend_argument_value_error(hasThis() ? ((zpp_arg_position)-1) : zpp_arg_position, \
 			"must be a valid day of the week"); \
 		RETURN_THROWS(); \
 	}
@@ -641,7 +641,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_locale)
 	}
 
 	if (locale_type != ULOC_ACTUAL_LOCALE && locale_type != ULOC_VALID_LOCALE) {
-		zend_argument_value_error(getThis() ? 1 : 2, "must be either Locale::ACTUAL_LOCALE or Locale::VALID_LOCALE");
+		zend_argument_value_error(hasThis() ? 1 : 2, "must be either Locale::ACTUAL_LOCALE or Locale::VALID_LOCALE");
 		RETURN_THROWS();
 	}
 
@@ -886,7 +886,7 @@ U_CFUNC PHP_FUNCTION(intlcal_set_minimal_days_in_first_week)
 
 	// Use ZEND_VALUE_ERROR_INVALID_DAY_OF_WEEK ?
 	if (num_days < 1 || num_days > 7) {
-		zend_argument_value_error(getThis() ? 1 : 2, "must be between 1 and 7");
+		zend_argument_value_error(hasThis() ? 1 : 2, "must be between 1 and 7");
 		RETURN_THROWS();
 	}
 
@@ -961,7 +961,7 @@ U_CFUNC PHP_FUNCTION(intlcal_set_repeated_wall_time_option)
 	}
 
 	if (option != UCAL_WALLTIME_FIRST && option != UCAL_WALLTIME_LAST) {
-		zend_argument_value_error(getThis() ? 1 : 2, "must be either IntlCalendar::WALLTIME_FIRST or "
+		zend_argument_value_error(hasThis() ? 1 : 2, "must be either IntlCalendar::WALLTIME_FIRST or "
 			"IntlCalendar::WALLTIME_LAST");
 		RETURN_THROWS();
 	}
@@ -985,7 +985,7 @@ U_CFUNC PHP_FUNCTION(intlcal_set_skipped_wall_time_option)
 
 	if (option != UCAL_WALLTIME_FIRST && option != UCAL_WALLTIME_LAST
 			&& option != UCAL_WALLTIME_NEXT_VALID) {
-		zend_argument_value_error(getThis() ? 1 : 2, "must be one of IntlCalendar::WALLTIME_FIRST, "
+		zend_argument_value_error(hasThis() ? 1 : 2, "must be one of IntlCalendar::WALLTIME_FIRST, "
 			"IntlCalendar::WALLTIME_LAST, or IntlCalendar::WALLTIME_NEXT_VALID");
 		RETURN_THROWS();
 	}

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -178,7 +178,7 @@ static void _php_intlgregcal_constructor_body(
 	} else {
 		// From date/time (3, 5 or 6 arguments)
 		for (int i = 0; i < variant; i++) {
-			ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(largs[i], getThis() ? (i-1) : i);
+			ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(largs[i], hasThis() ? (i-1) : i);
 		}
 
 		if (variant == 3) {
@@ -348,7 +348,7 @@ U_CFUNC PHP_FUNCTION(intlgregcal_is_leap_year)
 	}
 
 	if (UNEXPECTED(year < INT32_MIN || year > INT32_MAX)) {
-		zend_argument_value_error(getThis() ? 1 : 2, "must be between %d and %d", INT32_MIN, INT32_MAX);
+		zend_argument_value_error(hasThis() ? 1 : 2, "must be between %d and %d", INT32_MIN, INT32_MAX);
 		RETURN_THROWS();
 	}
 

--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -114,7 +114,7 @@ PHP_FUNCTION( numfmt_format )
 			}
 			RETURN_THROWS();
 		default:
-			zend_argument_value_error(getThis() ? 2 : 3, "must be a NumberFormatter::TYPE_* constant");
+			zend_argument_value_error(hasThis() ? 2 : 3, "must be a NumberFormatter::TYPE_* constant");
 			RETURN_THROWS();
 	}
 

--- a/ext/intl/formatter/formatter_parse.c
+++ b/ext/intl/formatter/formatter_parse.c
@@ -96,7 +96,7 @@ PHP_FUNCTION( numfmt_parse )
 			}
 			goto cleanup;
 		default:
-			zend_argument_value_error(getThis() ? 2 : 3, "must be a NumberFormatter::TYPE_* constant");
+			zend_argument_value_error(hasThis() ? 2 : 3, "must be a NumberFormatter::TYPE_* constant");
 			goto cleanup;
 	}
 

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -49,7 +49,7 @@ static PHP_GINIT_FUNCTION(mysqli);
 	} \
 }
 
-#define ERROR_ARG_POS(arg_num) (getThis() ? (arg_num-1) : (arg_num))
+#define ERROR_ARG_POS(arg_num) (hasThis() ? (arg_num-1) : (arg_num))
 
 static HashTable classes;
 static zend_object_handlers mysqli_object_handlers;

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -31,7 +31,7 @@
 #include "mysqli_priv.h"
 #include "ext/mysqlnd/mysql_float_to_double.h"
 
-#define ERROR_ARG_POS(arg_num) (getThis() ? (arg_num-1) : (arg_num))
+#define ERROR_ARG_POS(arg_num) (hasThis() ? (arg_num-1) : (arg_num))
 
 /* {{{ Get number of affected rows in previous MySQL operation */
 PHP_FUNCTION(mysqli_affected_rows)
@@ -157,7 +157,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 		RETURN_THROWS();
 	}
 
-	RETVAL_BOOL(!mysqli_stmt_bind_param_do_bind(stmt, argc, args, types, getThis() ? 1 : 2));
+	RETVAL_BOOL(!mysqli_stmt_bind_param_do_bind(stmt, argc, args, types, hasThis() ? 1 : 2));
 	MYSQLI_REPORT_STMT_ERROR(stmt->stmt);
 }
 /* }}} */

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -28,7 +28,7 @@
 #include "zend_smart_str.h"
 #include "php_mysqli_structs.h"
 #include "mysqli_priv.h"
-#define ERROR_ARG_POS(arg_num) (getThis() ? (arg_num-1) : (arg_num))
+#define ERROR_ARG_POS(arg_num) (hasThis() ? (arg_num-1) : (arg_num))
 
 #define SAFE_STR(a) ((a)?a:"")
 

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -1176,7 +1176,7 @@ PHP_FUNCTION(tidy_get_opt_doc)
 	opt = tidyGetOptionByName(obj->ptdoc->doc, optname);
 
 	if (!opt) {
-		zend_argument_value_error(getThis() ? 1 : 2, "is an invalid configuration option, \"%s\" given", optname);
+		zend_argument_value_error(hasThis() ? 1 : 2, "is an invalid configuration option, \"%s\" given", optname);
 		RETURN_THROWS();
 	}
 
@@ -1320,7 +1320,7 @@ PHP_FUNCTION(tidy_getopt)
 	opt = tidyGetOptionByName(obj->ptdoc->doc, optname);
 
 	if (!opt) {
-		zend_argument_value_error(getThis() ? 1 : 2, "is an invalid configuration option, \"%s\" given", optname);
+		zend_argument_value_error(hasThis() ? 1 : 2, "is an invalid configuration option, \"%s\" given", optname);
 		RETURN_THROWS();
 	}
 


### PR DESCRIPTION
Since GCC 12.x, using getThis() in a conditional yields a warning:

    <source>:12:22: warning: the comparison will always evaluate as 'true' for
                    the address of 'This' will never be NULL [-Waddress]
       12 |     return getThis() ? 2 : 3;
          |                      ^


See example [here](https://godbolt.org/z/67M3f5MvK).

GCC considers this is not a bug, and that only the diagnostic location is wrong.
