### PR TITLE
Fix tests when stdout is unbuffered

### DIFF
--- a/ext/opcache/tests/issue0115.phpt
+++ b/ext/opcache/tests/issue0115.phpt
@@ -33,7 +33,13 @@ $p->setStub($stub);
 unset($p);
 
 include "php_cli_server.inc";
-php_cli_server_start('-d opcache.enable=1 -d opcache.enable_cli=1 -d extension=phar.'.PHP_SHLIB_SUFFIX);
+
+$ini = '-d opcache.enable=1 -d opcache.enable_cli=1';
+if (file_exists(ini_get('extension_dir').'/phar.'.PHP_SHLIB_SUFFIX)) {
+    $ini .= ' -d extension=phar.'.PHP_SHLIB_SUFFIX;
+}
+php_cli_server_start($ini);
+
 echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/issue0115_1.phar.php');
 echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/issue0115_2.phar.php');
 ?>

--- a/ext/opcache/tests/issue0149.phpt
+++ b/ext/opcache/tests/issue0149.phpt
@@ -21,7 +21,13 @@ $p->setStub($stub);
 unset($p);
 
 include "php_cli_server.inc";
-php_cli_server_start('-d opcache.enable=1 -d opcache.enable_cli=1 -d extension=phar.'.PHP_SHLIB_SUFFIX);
+
+$ini = '-d opcache.enable=1 -d opcache.enable_cli=1';
+if (file_exists(ini_get('extension_dir').'/phar.'.PHP_SHLIB_SUFFIX)) {
+    $ini .= ' -d extension=phar.'.PHP_SHLIB_SUFFIX;
+}
+php_cli_server_start($ini);
+
 echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/issue0149.phar.php');
 echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/issue0149.phar.php');
 echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/issue0149.phar.php');


### PR DESCRIPTION
These tests spawn a sub-process with `-d extension=phar.so`, which emits a warning on `stdout` when the extension is compiled statically in the php binary.

In glibc, `stdout` is buffered, and we also don't flush it explicitly. The process is later killed with SIGTERM, so the buffer is never flushed, and the warning is not visible.

With musl, `stdout` is unbuffered (or maybe line-buffered, or the buffer is smaller), so the warning is visible, causing the tests to fail.

In this PR I add `-d extension=phar.so` only if `phar` was compiled as a dynamic module, so that no warning is emitted.

This is out of scope of this PR, but we should probably flush after emitting a warning. Also, I think that warnings go to `stdout` as part of the `display_errors` functionality, but ideally they should be written to `stderr` when using the CLI SAPI.