### PR TITLE
Fix TLS access in JIT with Musl

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -3255,7 +3255,7 @@ static void zend_jit_setup(void)
 			"leaq _tsrm_ls_cache@tlsgd(%%rip), %0\n"
 			: "=a" (ti));
 		tsrm_tls_offset = ti[1];
-		tsrm_tls_index = ti[0] * 16;
+		tsrm_tls_index = ti[0] * 8;
 #else
 		size_t *ti;
 


### PR DESCRIPTION
ABI specifies that each DTV element is 8 bytes in size on x86-64. The factor 16 was defined in 71cccc0bcc5f083ae6022face1c2514b5240b96a, but it's probably a merge error of 94ba883e195613d5a01be07b6ca9a73024b5575b, which used the right value.