### PR TITLE
Fix exception IP in JIT

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -688,7 +688,7 @@ static bool logical_immediate_p(uint64_t value, uint32_t reg_size)
 |	.if ZTS
 ||		if (GCC_GLOBAL_REGS) {
 |			LOAD_TSRM_CACHE IP
-|	   		MEM_ACCESS_64_WITH_UOFFSET ldr, IP, IP, (struct.._offset+offsetof(zend_..struct, field)), tmp_reg
+|	   		ADD_SUB_64_WITH_CONST_32 add, IP, IP, (struct.._offset+offsetof(zend_..struct, field)), tmp_reg
 ||		} else {
 |			LOAD_TSRM_CACHE RX
 |			ADD_SUB_64_WITH_CONST_32 add, RX, RX, (struct.._offset+offsetof(zend_..struct, field)), tmp_reg
@@ -1935,6 +1935,7 @@ static int zend_jit_leave_throw_stub(dasm_State **Dst)
 		|5:
 		|	// opline = EG(exception_op);
 		|	LOAD_IP_ADDR_ZTS executor_globals, exception_op, TMP2
+		|	str IP, EX->opline
 		|	// HANDLE_EXCEPTION()
 		|	b ->exception_handler
 	} else {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -406,7 +406,7 @@ static size_t tsrm_tls_offset;
 |	.if ZTS
 ||		if (GCC_GLOBAL_REGS) {
 |			LOAD_TSRM_CACHE IP
-|			mov IP, aword [IP + (struct.._offset + offsetof(zend_..struct, field))]
+|			lea IP, aword [IP + (struct.._offset + offsetof(zend_..struct, field))]
 ||		} else {
 |			LOAD_TSRM_CACHE RX
 |			lea RX, aword [RX + (struct.._offset + offsetof(zend_..struct, field))]
@@ -1884,6 +1884,7 @@ static int zend_jit_leave_throw_stub(dasm_State **Dst)
 		|5:
 		|	// opline = EG(exception_op);
 		|	LOAD_IP_ADDR_ZTS executor_globals, exception_op
+		|	mov aword EX->opline, IP
 		|	// HANDLE_EXCEPTION()
 		|	jmp ->exception_handler
 	} else {


### PR DESCRIPTION
Not sure why IP was being loaded the dereferenced value of EG(exception_op), being the ZEND_EXCEPTION_HANDLER itself rather than &EG(exception_op)[0].
I believe that was wrong. I'm surprised the code worked at all...

This fixes the current failures in nightly github actions too: https://github.com/php/php-src/actions/runs/8608918170/job/23592077166

Please verify @dstogov.