### PR TITLE
Fix GH-13931: Applying zero offset to null pointer in Zend/zend_opcode.c

### DIFF
--- a/Zend/tests/gh13931.phpt
+++ b/Zend/tests/gh13931.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-13931 (Applying zero offset to null pointer in Zend/zend_opcode.c)
+--FILE--
+<?php
+
+register_shutdown_function(function() {
+	var_dump(eval("return 1+3;"));
+});
+
+eval(<<<EVAL
+function foo () {
+    try {
+        break;
+    } finally {
+    }
+}
+foo();
+EVAL);
+
+?>
+--EXPECTF--
+Fatal error: 'break' not in the 'loop' or 'switch' context in %s on line %d
+int(4)

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1176,19 +1176,9 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
 		exit(-1);
 	}
 	gc_protect(1);
-
-	if (CG(in_compilation)) {
-		CG(in_compilation) = 0;
-		/* We bailout during compilation which may for example leave stale entries in CG(loop_var_stack).
-		 * If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
-		 * otherwise this will lead to incorrect compilation during shutdown.
-		 * We don't do a full re-initialization via init_compiler() because that will also reset streams and resources. */
-		shutdown_compiler();
-		zend_init_compiler_data_structures();
-	}
-
 	CG(unclean_shutdown) = 1;
 	CG(active_class_entry) = NULL;
+	CG(in_compilation) = 0;
 	CG(memoize_mode) = 0;
 	EG(current_execute_data) = NULL;
 	LONGJMP(*EG(bailout), FAILURE);

--- a/main/main.c
+++ b/main/main.c
@@ -1406,7 +1406,6 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 					zend_set_memory_limit(PG(memory_limit));
 					zend_objects_store_mark_destructed(&EG(objects_store));
 					if (CG(in_compilation)) {
-						CG(in_compilation) = 0;
 						/* We bailout during compilation which may for example leave stale entries in CG(loop_var_stack).
 						* If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
 						* otherwise this will lead to incorrect compilation during shutdown.

--- a/main/main.c
+++ b/main/main.c
@@ -1405,7 +1405,7 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 					/* restore memory limit */
 					zend_set_memory_limit(PG(memory_limit));
 					zend_objects_store_mark_destructed(&EG(objects_store));
-					if (CG(in_compilation)) {
+					if (CG(in_compilation) && (type == E_COMPILE_ERROR || type == E_PARSE)) {
 						/* We bailout during compilation which may for example leave stale entries in CG(loop_var_stack).
 						* If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
 						* otherwise this will lead to incorrect compilation during shutdown.

--- a/main/main.c
+++ b/main/main.c
@@ -1405,6 +1405,15 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 					/* restore memory limit */
 					zend_set_memory_limit(PG(memory_limit));
 					zend_objects_store_mark_destructed(&EG(objects_store));
+					if (CG(in_compilation)) {
+						CG(in_compilation) = 0;
+						/* We bailout during compilation which may for example leave stale entries in CG(loop_var_stack).
+						* If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
+						* otherwise this will lead to incorrect compilation during shutdown.
+						* We don't do a full re-initialization via init_compiler() because that will also reset streams and resources. */
+						shutdown_compiler();
+						zend_init_compiler_data_structures();
+					}
 					zend_bailout();
 					return;
 				}

--- a/main/main.c
+++ b/main/main.c
@@ -1407,9 +1407,9 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 					zend_objects_store_mark_destructed(&EG(objects_store));
 					if (CG(in_compilation) && (type == E_COMPILE_ERROR || type == E_PARSE)) {
 						/* We bailout during compilation which may for example leave stale entries in CG(loop_var_stack).
-						* If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
-						* otherwise this will lead to incorrect compilation during shutdown.
-						* We don't do a full re-initialization via init_compiler() because that will also reset streams and resources. */
+						 * If code is compiled during shutdown, we need to make sure the compiler is reset to a clean state,
+						 * otherwise this will lead to incorrect compilation during shutdown.
+						 * We don't do a full re-initialization via init_compiler() because that will also reset streams and resources. */
 						shutdown_compiler();
 						zend_init_compiler_data_structures();
 					}

--- a/sapi/phpdbg/tests/gh13931.phpt
+++ b/sapi/phpdbg/tests/gh13931.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Applying zero offset to null pointer in Zend/zend_opcode.c
+--FILE--
+<?php
+function foo () {
+    try {
+        break;
+    } finally {
+    }
+}
+foo();
+?>
+--PHPDBG--
+ev 1 + 3
+ev 2 ** 3
+q
+--EXPECTF--
+Fatal error: 'break' not in the 'loop' or 'switch' context in %s on line %d
+prompt> 4
+prompt> 8
+prompt>


### PR DESCRIPTION
In the test cases, the compiler bails out due to a fatal error. The data structures used by the compiler will contain stale values. In particular, for the test case CG(loop_var_stack) will contain data. The next compilation will incorrectly use elements from the previous stack. This causes a segfault in pass2 because wrong instructions will be emitted due to the stale data.
To solve this, we reset part of the compiler data structures. We don't do a full re-initialization via init_compiler() because that will also reset streams and resources.