### PR TITLE
fix: prevent C errors when using weird max_execution_time values

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1518,6 +1518,11 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 		struct itimerval t_r;		/* timeout requested */
 		int signo;
 
+		// Prevent EINVAL error
+		if (seconds < 0 || seconds > 999999999) {
+			seconds = 0;
+		}
+
 		if(seconds) {
 			t_r.it_value.tv_sec = seconds;
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;

--- a/Zend/zend_max_execution_timer.c
+++ b/Zend/zend_max_execution_timer.c
@@ -71,6 +71,11 @@ void zend_max_execution_timer_settime(zend_long seconds) /* {{{ }*/
 
 	timer_t timer = EG(max_execution_timer_timer);
 
+	// Prevent EINVAL error
+	if (seconds < 0 || seconds > 999999999) {
+		seconds = 0;
+	}
+
 	struct itimerspec its;
 	its.it_value.tv_sec = seconds;
 	its.it_value.tv_nsec = its.it_interval.tv_sec = its.it_interval.tv_nsec = 0;


### PR DESCRIPTION
Calling `set_time_limit()` or setting `max_execution_time` to a negative value or to a value superior to 999,999,999 can trigger C errors: https://github.com/dunglas/frankenphp/issues/713 / https://linux.die.net/man/2/setitimer

This patch normalizes such values as 0.

@withinboredom raised the issue on https://externals.io/message/123108, and we may indeed correctly specify this behavior, but in the meantime, we should at least not throw a C error, which is inconsistent with what is done on other platforms.