### PR TITLE
ext/pcntl: pcntl_getqos_class/pcntl_setqos_class addition.

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -7,7 +7,7 @@ if test "$PHP_PCNTL" != "no"; then
   AC_CHECK_FUNCS([fork], [], [AC_MSG_ERROR([pcntl: fork() not supported by this platform])])
   AC_CHECK_FUNCS([waitpid], [], [AC_MSG_ERROR([pcntl: waitpid() not supported by this platform])])
   AC_CHECK_FUNCS([sigaction], [], [AC_MSG_ERROR([pcntl: sigaction() not supported by this platform])])
-  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open sched_setaffinity])
+  AC_CHECK_FUNCS([getpriority setpriority wait3 wait4 sigwaitinfo sigtimedwait unshare rfork forkx pidfd_open sched_setaffinity pthread_set_qos_class_self_np])
 
   dnl if unsupported, -1 means automatically ENOSYS in this context
   AC_MSG_CHECKING([if sched_getcpu is supported])

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1637,13 +1637,13 @@ static qos_class_t qos_zval_to_lval(const zval *qos_obj)
 	qos_class_t qos_class = QOS_CLASS_DEFAULT;
 	zend_string *entry = Z_STR_P(zend_enum_fetch_case_name(Z_OBJ_P(qos_obj)));
 
-	if (zend_string_equals_cstr(entry, "UserInteractive", sizeof("UserInteractive") - 1)) {
+	if (zend_string_equals_literal(entry, "UserInteractive")) {
 		qos_class = QOS_CLASS_USER_INTERACTIVE;
-	} else if (zend_string_equals_cstr(entry, "UserInitiated", sizeof("UserInitiated") - 1)) {
+	} else if (zend_string_equals_literal(entry, "UserInitiated")) {
 		qos_class = QOS_CLASS_USER_INITIATED;
-	} else if (zend_string_equals_cstr(entry, "Utility", sizeof("Utility") - 1)) {
+	} else if (zend_string_equals_literal(entry, "Utility")) {
 		qos_class = QOS_CLASS_UTILITY;
-	} else if (zend_string_equals_cstr(entry, "Background", sizeof("Background") - 1)) {
+	} else if (zend_string_equals_literal(entry, "Background")) {
 		qos_class = QOS_CLASS_BACKGROUND;
 	}
 

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -1005,14 +1005,13 @@ function pcntl_getcpu(): int {}
 #endif
 
 #ifdef HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP
-enum QosClass: int
+enum QosClass
 {
-	case UserInteractive = 0x21;
-	case UserInitiated = 0x19;
-	case Default = 0x15;
-	case Utility = 0x11;
-	case Background = 0x09;
-	case Unspecified = 0x00;
+	case UserInteractive;
+	case UserInitiated;
+	case Default;
+	case Utility;
+	case Background;
 }
 
 function pcntl_getqos_class(): QosClass {}

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -1003,3 +1003,18 @@ function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): boo
 #ifdef HAVE_SCHED_GETCPU
 function pcntl_getcpu(): int {}
 #endif
+
+#ifdef HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP
+enum QosClass: int
+{
+	case UserInteractive = 0x21;
+	case UserInitiated = 0x19;
+	case Default = 0x15;
+	case Utility = 0x11;
+	case Background = 0x09;
+	case Unspecified = 0x00;
+}
+
+function pcntl_getqos_class(): QosClass {}
+function pcntl_setqos_class(QosClass $qos_class = QosClass::Default): void {}
+#endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 75eacf08a17e18c30fb2111bb742c36b18aa9ead */
+ * Stub hash: fdd48ba3c71ec80eb3ae740c5a6b8539efcdaa6c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -157,6 +157,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_getcpu, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_pcntl_getqos_class, 0, 0, QosClass, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setqos_class, 0, 0, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, qos_class, QosClass, 0, "QosClass::Default")
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pcntl_fork);
 ZEND_FUNCTION(pcntl_waitpid);
 ZEND_FUNCTION(pcntl_wait);
@@ -212,6 +223,12 @@ ZEND_FUNCTION(pcntl_setcpuaffinity);
 #endif
 #if defined(HAVE_SCHED_GETCPU)
 ZEND_FUNCTION(pcntl_getcpu);
+#endif
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+ZEND_FUNCTION(pcntl_getqos_class);
+#endif
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+ZEND_FUNCTION(pcntl_setqos_class);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -272,8 +289,20 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_SCHED_GETCPU)
 	ZEND_FE(pcntl_getcpu, arginfo_pcntl_getcpu)
 #endif
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+	ZEND_FE(pcntl_getqos_class, arginfo_pcntl_getqos_class)
+#endif
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+	ZEND_FE(pcntl_setqos_class, arginfo_pcntl_setqos_class)
+#endif
 	ZEND_FE_END
 };
+
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+static const zend_function_entry class_QosClass_methods[] = {
+	ZEND_FE_END
+};
+#endif
 
 static void register_pcntl_symbols(int module_number)
 {
@@ -628,3 +657,36 @@ static void register_pcntl_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("PCNTL_ECAPMODE", ECAPMODE, CONST_PERSISTENT);
 #endif
 }
+
+#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
+static zend_class_entry *register_class_QosClass(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("QosClass", IS_LONG, class_QosClass_methods);
+
+	zval enum_case_UserInteractive_value;
+	ZVAL_LONG(&enum_case_UserInteractive_value, 0x21);
+	zend_enum_add_case_cstr(class_entry, "UserInteractive", &enum_case_UserInteractive_value);
+
+	zval enum_case_UserInitiated_value;
+	ZVAL_LONG(&enum_case_UserInitiated_value, 0x19);
+	zend_enum_add_case_cstr(class_entry, "UserInitiated", &enum_case_UserInitiated_value);
+
+	zval enum_case_Default_value;
+	ZVAL_LONG(&enum_case_Default_value, 0x15);
+	zend_enum_add_case_cstr(class_entry, "Default", &enum_case_Default_value);
+
+	zval enum_case_Utility_value;
+	ZVAL_LONG(&enum_case_Utility_value, 0x11);
+	zend_enum_add_case_cstr(class_entry, "Utility", &enum_case_Utility_value);
+
+	zval enum_case_Background_value;
+	ZVAL_LONG(&enum_case_Background_value, 0x9);
+	zend_enum_add_case_cstr(class_entry, "Background", &enum_case_Background_value);
+
+	zval enum_case_Unspecified_value;
+	ZVAL_LONG(&enum_case_Unspecified_value, 0x0);
+	zend_enum_add_case_cstr(class_entry, "Unspecified", &enum_case_Unspecified_value);
+
+	return class_entry;
+}
+#endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fdd48ba3c71ec80eb3ae740c5a6b8539efcdaa6c */
+ * Stub hash: 3e15bebb568e6e2031acbd932d6eefbd23984c83 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -661,31 +661,17 @@ static void register_pcntl_symbols(int module_number)
 #if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 static zend_class_entry *register_class_QosClass(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("QosClass", IS_LONG, class_QosClass_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("QosClass", IS_UNDEF, class_QosClass_methods);
 
-	zval enum_case_UserInteractive_value;
-	ZVAL_LONG(&enum_case_UserInteractive_value, 0x21);
-	zend_enum_add_case_cstr(class_entry, "UserInteractive", &enum_case_UserInteractive_value);
+	zend_enum_add_case_cstr(class_entry, "UserInteractive", NULL);
 
-	zval enum_case_UserInitiated_value;
-	ZVAL_LONG(&enum_case_UserInitiated_value, 0x19);
-	zend_enum_add_case_cstr(class_entry, "UserInitiated", &enum_case_UserInitiated_value);
+	zend_enum_add_case_cstr(class_entry, "UserInitiated", NULL);
 
-	zval enum_case_Default_value;
-	ZVAL_LONG(&enum_case_Default_value, 0x15);
-	zend_enum_add_case_cstr(class_entry, "Default", &enum_case_Default_value);
+	zend_enum_add_case_cstr(class_entry, "Default", NULL);
 
-	zval enum_case_Utility_value;
-	ZVAL_LONG(&enum_case_Utility_value, 0x11);
-	zend_enum_add_case_cstr(class_entry, "Utility", &enum_case_Utility_value);
+	zend_enum_add_case_cstr(class_entry, "Utility", NULL);
 
-	zval enum_case_Background_value;
-	ZVAL_LONG(&enum_case_Background_value, 0x9);
-	zend_enum_add_case_cstr(class_entry, "Background", &enum_case_Background_value);
-
-	zval enum_case_Unspecified_value;
-	ZVAL_LONG(&enum_case_Unspecified_value, 0x0);
-	zend_enum_add_case_cstr(class_entry, "Unspecified", &enum_case_Unspecified_value);
+	zend_enum_add_case_cstr(class_entry, "Background", NULL);
 
 	return class_entry;
 }

--- a/ext/pcntl/tests/pcntl_qosclass.phpt
+++ b/ext/pcntl/tests/pcntl_qosclass.phpt
@@ -1,0 +1,26 @@
+--TEST--
+pcntl_getqos_class()/pcntl_setqos_class()
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (!function_exists("pcntl_getqos_class")) die("skip pcntl_getqos_class() is not available");
+if (getenv('SKIP_REPEAT')) die("skip Not repeatable");
+?>
+--FILE--
+<?php
+pcntl_setqos_class(QosClass::Default);
+var_dump(QosClass::Default === pcntl_getqos_class());
+
+try {
+	pcntl_setqos_class(QosClass::Unspecified);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+pcntl_setqos_class(QosClass::Background);
+var_dump(QosClass::Background == pcntl_getqos_class());
+?>
+--EXPECT--
+bool(true)
+pcntl_setqos_class(): Argument #1 ($qos_class) must be one of QosClass enum entries : ::UserInteractive, ::UserInitiated, ::Default, ::Utility or ::Background
+bool(true)

--- a/ext/pcntl/tests/pcntl_qosclass.phpt
+++ b/ext/pcntl/tests/pcntl_qosclass.phpt
@@ -11,16 +11,9 @@ if (getenv('SKIP_REPEAT')) die("skip Not repeatable");
 <?php
 pcntl_setqos_class(QosClass::Default);
 var_dump(QosClass::Default === pcntl_getqos_class());
-
-try {
-	pcntl_setqos_class(QosClass::Unspecified);
-} catch (\ValueError $e) {
-	echo $e->getMessage() . PHP_EOL;
-}
 pcntl_setqos_class(QosClass::Background);
 var_dump(QosClass::Background == pcntl_getqos_class());
 ?>
 --EXPECT--
 bool(true)
-pcntl_setqos_class(): Argument #1 ($qos_class) must be one of QosClass enum entries : ::UserInteractive, ::UserInitiated, ::Default, ::Utility or ::Background
 bool(true)


### PR DESCRIPTION
Introducting macOs Quality Of Service through those two calls. on macOs arm64/M*, there is no concept of individual cores, thus the old thread policy for cpu affinity does not work here. Instead, the user can apply to the current process the level of
 performance/energy consumption they wish from the highest
QOS_CLASS_USER_INTERACTIVE to QOS_CLASS_BACKGROUND.