### PR TITLE
Update ext/ldap sanity check

### DIFF
--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -124,9 +124,9 @@ if test "$PHP_LDAP" != "no"; then
   fi
 
   dnl Sanity check
-  AC_CHECK_FUNC(ldap_bind_s, [], [
-    AC_MSG_ERROR([LDAP build check failed. Please check config.log for more information.])
-  ])
+  AC_CHECK_FUNC([ldap_sasl_bind_s],,
+    [AC_CHECK_FUNC([ldap_simple_bind_s],,
+      [AC_MSG_ERROR([LDAP build check failed. Please check config.log for details.])])])
 
   dnl Restore original values
   CPPFLAGS=$_SAVE_CPPFLAGS


### PR DESCRIPTION
The ldap_bind_s() has been deprecated and isn't used in the code in favor of ldap_sasl_bind_s(). PHP falls back to deprecated ldap_simple_bind_s() if for some reason ldap_sasl_bind_s() isn't available and this check likewise.