### PR TITLE
FIX file_get_contents() on Windows fails with "errno=22 Invalid argument"

### DIFF
--- a/ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test file_put_contents() function with 5GB string
+Test file_put_contents() and file_get_contents() functions with 5GB string
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE < 5) {
@@ -30,7 +30,7 @@ function get_system_memory(): int|float|false
 if (get_system_memory() < 10 * 1024 * 1024 * 1024) {
     die('skip Reason: Insufficient RAM (less than 10GB)');
 }
-$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";
+$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "file_get_contents_file_put_contents_5gb.bin";
 $tmpfileh = fopen($tmpfile, "wb");
 if ($tmpfileh === false) {
     die('skip Reason: Unable to create temporary file');
@@ -45,15 +45,27 @@ if (disk_free_space(dirname($tmpfile)) < 10 * 1024 * 1024 * 1024) {
 memory_limit=6G
 --FILE--
 <?php
-$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin";
-$large_string = str_repeat('a', 5 * 1024 * 1024 * 1024);
+$tmpfile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "file_get_contents_file_put_contents_5gb.bin";
+$large_string_len = 5 * 1024 * 1024 * 1024;
+
+$large_string = str_repeat('a', $large_string_len);
 $result = file_put_contents($tmpfile, $large_string);
-if ($result !== strlen($large_string)) {
-    echo "Could only write $result bytes of " . strlen($large_string) . " bytes.";
+if ($result !== $large_string_len) {
+    echo "Could only write $result bytes of $large_string_len bytes.";
     var_dump(error_get_last());
 } else {
-    echo "File written successfully.";
+    echo "File written successfully." . PHP_EOL;
 }
+unset($large_string);
+
+$result_large_string = file_get_contents($tmpfile);
+if (strlen($result_large_string) !== $large_string_len) {
+    echo "Could only read " . strlen($result_large_string) . " bytes of $large_string_len bytes.";
+    var_dump(error_get_last());
+} else {
+    echo "File read successfully." . PHP_EOL;
+}
+
 clearstatcache(true, $tmpfile);
 if (file_exists($tmpfile)) {
     unlink($tmpfile);
@@ -61,7 +73,8 @@ if (file_exists($tmpfile)) {
 ?>
 --CLEAN--
 <?php
-@unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . "test_file_put_contents_5gb.bin");
+@unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . "file_get_contents_file_put_contents_5gb.bin");
 ?>
 --EXPECT--
 File written successfully.
+File read successfully.

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -54,7 +54,7 @@ extern int php_get_gid_by_name(const char *name, gid_t *gid);
 #endif
 
 #if defined(PHP_WIN32)
-# define PLAIN_WRAP_BUF_SIZE(st) (((st) > UINT_MAX) ? UINT_MAX : (unsigned int)(st))
+# define PLAIN_WRAP_BUF_SIZE(st) ((unsigned int)(st > INT_MAX ? INT_MAX : st))
 #define fsync _commit
 #define fdatasync fsync
 #else

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -353,8 +353,11 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 	assert(data != NULL);
 
 	if (data->fd >= 0) {
-		ssize_t bytes_written = write(data->fd, buf, PLAIN_WRAP_BUF_SIZE(count));
-
+#ifdef PHP_WIN32
+		ssize_t bytes_written = _write(data->fd, buf, PLAIN_WRAP_BUF_SIZE(count));
+#else
+		ssize_t bytes_written = write(data->fd, buf, count);
+#endif
 		if (bytes_written < 0) {
 			if (PHP_IS_TRANSIENT_ERROR(errno)) {
 				return 0;

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -353,11 +353,8 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 	assert(data != NULL);
 
 	if (data->fd >= 0) {
-#ifdef PHP_WIN32
-		ssize_t bytes_written = _write(data->fd, buf, (unsigned int)(count > INT_MAX ? INT_MAX : count));
-#else
-		ssize_t bytes_written = write(data->fd, buf, count);
-#endif
+		ssize_t bytes_written = write(data->fd, buf, PLAIN_WRAP_BUF_SIZE(count));
+
 		if (bytes_written < 0) {
 			if (PHP_IS_TRANSIENT_ERROR(errno)) {
 				return 0;


### PR DESCRIPTION
I encountered a problem when attempting to load a large file using file_get_contents(), but only on Windows.

Attempting to load a large file resulted in the following error (or notice, depending on the PHP version):
```
Read of 3866046082 bytes failed with errno=22 Invalid argument
```

I did some research and found bug which was quite similar, but for `file_put_contents()` 

Old bug: https://github.com/php/php-src/pull/13205 

This issue is likely due to an integer overflow on Windows, which probably is treated as negative number which is invalid argument.
