### PR TITLE
ext/openssl: Add option to load legacy algorithm provider

### DIFF
--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -10,6 +10,13 @@ PHP_ARG_WITH([system-ciphers],
   [no],
   [no])
 
+PHP_ARG_WITH([openssl-legacy-provider],
+  [whether to load legacy algorithm provider],
+  [AS_HELP_STRING([--with-openssl-legacy-provider],
+    [OPENSSL: Load legacy algorithm provider in addition to default provider])],
+  [no],
+  [no])
+
 if test "$PHP_OPENSSL" != "no"; then
   PHP_NEW_EXTENSION(openssl, openssl.c xp_ssl.c, $ext_shared)
   PHP_SUBST(OPENSSL_SHARED_LIBADD)
@@ -24,5 +31,9 @@ if test "$PHP_OPENSSL" != "no"; then
 
   if test "$PHP_SYSTEM_CIPHERS" != "no"; then
     AC_DEFINE(USE_OPENSSL_SYSTEM_CIPHERS,1,[ Use system default cipher list instead of hardcoded value ])
+  fi
+
+  if test "$PHP_OPENSSL_LEGACY_PROVIDER" != "no"; then
+    AC_DEFINE(LOAD_OPENSSL_LEGACY_PROVIDER,1,[ Load legacy algorithm provider in addition to default provider ])
   fi
 fi

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -59,6 +59,7 @@
 #if PHP_OPENSSL_API_VERSION >= 0x30000
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
+#include <openssl/provider.h>
 #endif
 
 #if defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ENGINE)
@@ -1277,6 +1278,10 @@ PHP_MINIT_FUNCTION(openssl)
 	OpenSSL_add_all_algorithms();
 	SSL_load_error_strings();
 #else
+#if PHP_OPENSSL_API_VERSION >= 0x30000 && defined(LOAD_OPENSSL_LEGACY_PROVIDER)
+	OSSL_PROVIDER_load(NULL, "legacy");
+	OSSL_PROVIDER_load(NULL, "default");
+#endif
 	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
 #endif
 


### PR DESCRIPTION
OpenSSL 3.x relegated a set of insecure algorithms to a "legacy" provider which is not loaded by default. Some of these algorithms have utility beyond encryption such as for hashing, e.g., DES[1]

Add a compile-time option to load the legacy provider in 3.x. When enabled, also load the default provider because loading any provider explicitly disables auto-loading the default provider.

Node.js has a similar option[2].

[1] https://github.com/vitessio/vitess/blob/9e40015748ede158357bd7291f583db138abc3df/go/vt/vtgate/vindexes/hash.go#L157

[2] https://github.com/nodejs/node/blob/1091efc2ab4e960e010d4d2094ae8d5d8d70f1d3/src/node_options.cc#L1043