### PR TITLE
sapi/phpdbg: Update of userfaultfd workflow.

### DIFF
--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -1472,7 +1472,14 @@ void phpdbg_setup_watchpoints(void) {
 	PHPDBG_G(watch_tmp) = NULL;
 
 #ifdef HAVE_USERFAULTFD_WRITEFAULT
-	PHPDBG_G(watch_userfaultfd) = syscall(SYS_userfaultfd, O_CLOEXEC);
+	int flags = O_CLOEXEC;
+#ifdef UFFD_USER_MODE_ONLY
+	// unpriviliged userfaultfd are disabled by default,
+	// with this flag it allows ranges from the user space
+	// being reported.
+	flags |= UFFD_USER_MODE_ONLY;
+#endif
+	PHPDBG_G(watch_userfaultfd) = syscall(SYS_userfaultfd, flags);
 	if (PHPDBG_G(watch_userfaultfd) < 0) {
 		PHPDBG_G(watch_userfaultfd) = 0;
 	} else {


### PR DESCRIPTION
unpriviliged_userfaultfd is set to 0 by default. Since Linux 5.11 handling memory ranges from the user-space is allowed with the `UFFD_USER_MODE_ONLY` fd open mode flag.