### PR TITLE
Make (DOM)XPath::quote only accept strings without NULL bytes

### DIFF
--- a/ext/dom/tests/gh13960.phpt
+++ b/ext/dom/tests/gh13960.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-13960 (NULL bytes in XPath query)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$domd = new DOMDocument();
+@$domd->loadHTML("<foo>tes\x00t</foo>");
+$xp = new DOMXPath($domd);
+try {
+    $xp->query("//foo[contains(text(), " . $xp->quote("tes\x00t") . ")]");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+DOMXPath::quote(): Argument #1 ($str) must not contain any null bytes

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -473,7 +473,7 @@ PHP_METHOD(DOMXPath, registerPhpFunctionNS)
 PHP_METHOD(DOMXPath, quote) {
 	const char *input;
 	size_t input_len;
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &input, &input_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p", &input, &input_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 	if (memchr(input, '\'', input_len) == NULL) {


### PR DESCRIPTION
The reason is that libxml will cut off on a NULL byte, and so strings containing NULL bytes may not be necessarily safe even when coming out of quoting.