### PR TITLE
Fix GH-13806: openssl_x509_parse_basic test fails with OpenSSL 3.2+

### DIFF
--- a/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
+++ b/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
@@ -4,7 +4,7 @@ openssl_x509_parse() tests
 openssl
 --SKIPIF--
 <?php
-if (OPENSSL_VERSION_NUMBER >= 0x30200000) die('skip For OpenSSL < 3.2');
+if (OPENSSL_VERSION_NUMBER < 0x30200000) die('skip For OpenSSL >= 3.2');
 ?>
 --FILE--
 <?php
@@ -69,7 +69,7 @@ array(16) {
   ["signatureTypeNID"]=>
   int(65)
   ["purposes"]=>
-  array(9) {
+  array(10) {
     [1]=>
     array(3) {
       [0]=>
@@ -151,6 +151,15 @@ array(16) {
       [2]=>
       string(13) "timestampsign"
     }
+    [10]=>
+    array(3) {
+      [0]=>
+      bool(false)
+      [1]=>
+      bool(true)
+      [2]=>
+      string(8) "codesign"
+    }
   }
   ["extensions"]=>
   array(3) {
@@ -216,7 +225,7 @@ array(16) {
   ["signatureTypeNID"]=>
   int(65)
   ["purposes"]=>
-  array(9) {
+  array(10) {
     [1]=>
     array(3) {
       [0]=>
@@ -297,6 +306,15 @@ array(16) {
       bool(true)
       [2]=>
       string(18) "Time Stamp signing"
+    }
+    [10]=>
+    array(3) {
+      [0]=>
+      bool(false)
+      [1]=>
+      bool(true)
+      [2]=>
+      string(12) "Code signing"
     }
   }
   ["extensions"]=>


### PR DESCRIPTION
Fixes GH-13806