### PR TITLE
cli: allow to change ~/.php_history with PHP_HISTFILE

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -617,7 +617,12 @@ static int readline_shell_run(void) /* {{{ */
 	}
 
 #ifndef PHP_WIN32
-	history_file = tilde_expand("~/.php_history");
+#define PHP_HISTFILE_ENV "PHP_HISTFILE"
+	if (getenv(PHP_HISTFILE_ENV)) {
+		spprintf(&history_file, MAXPATHLEN, "%s", getenv(PHP_HISTFILE_ENV));
+	} else {
+		spprintf(&history_file, MAXPATHLEN, "%s/.php_history", getenv("HOME"));
+	}
 #else
 	spprintf(&history_file, MAX_PATH, "%s/.php_history", getenv("USERPROFILE"));
 #endif
@@ -717,11 +722,7 @@ static int readline_shell_run(void) /* {{{ */
 
 		php_last_char = '\0';
 	}
-#ifdef PHP_WIN32
 	efree(history_file);
-#else
-	free(history_file);
-#endif
 	efree(code);
 	zend_string_release_ex(prompt, 0);
 	return EG(exit_status);

--- a/sapi/cli/tests/017.phpt
+++ b/sapi/cli/tests/017.phpt
@@ -11,9 +11,18 @@ if (readline_info('done') !== NULL) {
 ?>
 --FILE--
 <?php
-$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
-$ini = getenv('TEST_PHP_EXTRA_ARGS');
-$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+function runReplCodes($codes) {
+    $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+    $ini = getenv('TEST_PHP_EXTRA_ARGS');
+    $descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+    foreach ($codes as $key => $code) {
+        echo "\n--------------\nSnippet no. $key:\n--------------\n";
+        $proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+        fwrite($pipes[0], $code);
+        fclose($pipes[0]);
+        proc_close($proc);
+    }
+}
 
 $codes = array();
 
@@ -52,17 +61,26 @@ function a_function_with_some_name() {
 a_function_w	);
 EOT;
 
-foreach ($codes as $key => $code) {
-    echo "\n--------------\nSnippet no. $key:\n--------------\n";
-    $proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
-    fwrite($pipes[0], $code);
-    fclose($pipes[0]);
-    proc_close($proc);
-}
-
+runReplCodes($codes);
 echo "\nDone\n";
+
 $dir = PHP_OS_FAMILY == 'Windows' ? getenv("USERPROFILE") : getenv("HOME");
 var_dump(file_exists($dir . '/.php_history'));
+
+$php_history_tmp = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, 'php_history');
+putenv('PHP_HISTFILE=' . $php_history_tmp);
+var_dump(file_exists($php_history_tmp));
+
+$last[6] = <<<EOT
+echo 'Hello World';
+exit
+EOT;
+runReplCodes($last);
+echo "\nDone\n";
+
+$php_history_path = PHP_OS_FAMILY == 'Windows' ? getenv("USERPROFILE") : $php_history_tmp;
+var_dump(file_exists($php_history_path));
+@unlink($php_history_tmp);
 ?>
 --EXPECT--
 --------------
@@ -105,6 +123,17 @@ Interactive shell
 
 
 Parse error: Unmatched ')' in php shell code on line 1
+
+Done
+bool(true)
+bool(false)
+
+--------------
+Snippet no. 6:
+--------------
+Interactive shell
+
+Hello World
 
 Done
 bool(true)


### PR DESCRIPTION
# why

Allow to change .php_history repl file with PHP_HISTFILE environment variable

# how

If the env var is present use it first then fallback to HOME or USERPROFILE on windows

(i'm not a C developer any help/feedback welcome thanks)