### PR TITLE
Use return value of getpwuid_r(), not errno

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -952,7 +952,7 @@ PHP_FUNCTION(posix_getpwuid)
 try_again:
 	err = getpwuid_r(uid, &_pw, pwbuf, pwbuflen, &retpwptr);
 	if (err || retpwptr == NULL) {
-		if (errno == ERANGE) {
+		if (err == ERANGE) {
 			pwbuflen *= 2;
 			pwbuf = erealloc(pwbuf, pwbuflen);
 			goto try_again;


### PR DESCRIPTION
getpwuid_r() and other reentrant functions used in ext/posix return an error number and may not set errno. https://github.com/php/php-src/pull/13921 updated ext/posix to use the return value, but one change was forgotten.

https://github.com/php/php-src/pull/13921 also sets the buffer len to `1` by default in debug builds, which allowed to detect this issue on Mac OS.