### PR TITLE
Fix GH-13968 Build failed when with --enable-mbregex on MSVC

### DIFF
--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -46,7 +46,7 @@ if (PHP_MBSTRING != "no") {
 				AC_DEFINE('HAVE_MBREGEX', 1);
 
 				/* XXX libonig is only usable as a static library ATM, code change required to link with a DLL. */
-				ADD_FLAG("CFLAGS_MBSTRING", "/DONIG_EXTERN=extern /DPHP_ONIG_BAD_KOI8_ENTRY=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+				ADD_FLAG("CFLAGS_MBSTRING", "/DONIG_EXTERN=extern /DPHP_ONIG_BAD_KOI8_ENTRY=1 /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /utf-8");
 
 				ADD_SOURCES("ext/mbstring", "php_mbregex.c", "mbstring");
 				PHP_INSTALL_HEADERS("ext/mbstring", "php_mbregex.h php_onig_compat.h");


### PR DESCRIPTION
I added /utf-8 flag in CFLAGS_MBSTRING at config.w32

Advised from Hirokawa-san (@hirokawa) thanks