### PR TITLE
SQLite pdo::quote use ('foo'||x'0000'||'bar') for null bytes

### DIFF
--- a/ext/pdo_sqlite/tests/gh13952.phpt
+++ b/ext/pdo_sqlite/tests/gh13952.phpt
@@ -1,0 +1,83 @@
+--TEST--
+GH-13952 (sqlite PDO::quote silently corrupts strings with null bytes)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+--FILE--
+<?php
+$db = new \PDO('sqlite::memory:', null, null, array(
+    \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+    \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+    \PDO::ATTR_EMULATE_PREPARES => false,
+));
+
+$test_cases = [
+    "",
+    "x",
+    "\x00",
+    "a\x00b",
+    "\x00\x00\x00",
+    "foobar",
+    "foo'''bar",
+    "'foo'''bar'",
+    "'foo'\x00'bar'",
+    "foo\x00\x00\x00bar",
+    "\x00foo\x00\x00\x00bar\x00",
+    "\x00\x00\x00foo",
+    "foo\x00\x00\x00",
+    "\x80", // << invalid UTF8
+    "\x00\x80\x00", // << invalid UTF8
+];
+
+foreach($test_cases as $test){
+    $res = $db->query("SELECT " . $db->quote($test))->fetch($db::FETCH_NUM)[0] === $test;
+    if(!$res){
+        throw new Exception("Failed for $test");
+    }
+}
+
+$db->exec('CREATE TABLE test (name TEXT)');
+
+foreach ($test_cases as $test_case) {
+    $quoted = $db->quote($test_case);
+    echo trim(json_encode($test_case,  JSON_PARTIAL_OUTPUT_ON_ERROR), '"'), " -> $quoted\n";
+    $db->exec("INSERT INTO test (name) VALUES (" . $quoted . ")");
+}
+
+$stmt = $db->prepare('SELECT * from test');
+$stmt->execute();
+foreach ($stmt->fetchAll() as $result) {
+    var_dump($result['name']);
+}
+?>
+--EXPECTF--
+-> ''
+x -> 'x'
+\u0000 -> (x'00')
+a\u0000b -> ('a'||x'00'||'b')
+\u0000\u0000\u0000 -> (x'000000')
+foobar -> 'foobar'
+foo'''bar -> 'foo''''''bar'
+'foo'''bar' -> '''foo''''''bar'''
+'foo'\u0000'bar' -> ('''foo'''||x'00'||'''bar''')
+foo\u0000\u0000\u0000bar -> ('foo'||x'000000'||'bar')
+\u0000foo\u0000\u0000\u0000bar\u0000 -> (x'00'||'foo'||x'000000'||'bar'||x'00')
+\u0000\u0000\u0000foo -> (x'000000'||'foo')
+foo\u0000\u0000\u0000 -> ('foo'||x'000000')
+null -> '€'
+null -> (x'00'||'€'||x'00')
+string(0) ""
+string(1) "x"
+string(1) "%0"
+string(3) "a%0b"
+string(3) "%0%0%0"
+string(6) "foobar"
+string(9) "foo'''bar"
+string(11) "'foo'''bar'"
+string(11) "'foo'%0'bar'"
+string(9) "foo%0%0%0bar"
+string(11) "%0foo%0%0%0bar%0"
+string(6) "%0%0%0foo"
+string(6) "foo%0%0%0"
+string(1) "€"
+string(3) "%0€%0"


### PR DESCRIPTION
resolves issue GH-13952,
this is basically a smart_str() version of PR #13956

per https://github.com/php/php-src/pull/13962#issuecomment-2056696180 this is 1 of the 4 proposed alternatives to the problem, and the pros of this solution is that it produces smaller queries than the alternatives, and retains the sqlite datatype 'string' (instead of changing it to blob), and should make PDO::quote faster as we now avoid the overhead of copying data to/from sqlite3_snprintf.

The cons of this solution, that I can think of right now,
 is that the implementation is non-trivial,
 involves a bunch of php-allocator-reallocs() (PR #13956 does not invovle reallocs, as it pre-computes the length.
also worth noting that php allocator's reallocs() are faster than libc realloc, often avoiding talking to the OS),
 and SQLite's LENGTH(('foo'||x'00'||'bar')) returns 3 instead of 7,
 and binary strings gets the datatype 'string' instead of 'blob' (that can be considered both a pro and a con)