### PR TITLE
Remove zend_strtod mutex

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1161,6 +1161,7 @@ void zend_shutdown(void) /* {{{ */
 
 	zend_hash_destroy(GLOBAL_CONSTANTS_TABLE);
 	free(GLOBAL_CONSTANTS_TABLE);
+	zend_shutdown_strtod();
 	zend_attributes_shutdown();
 
 #ifdef ZTS
@@ -1277,7 +1278,6 @@ ZEND_API void zend_activate(void) /* {{{ */
 #ifdef ZTS
 	virtual_cwd_activate();
 #endif
-	zend_strtod_activate();
 	gc_reset();
 	init_compiler();
 	init_executor();
@@ -1347,8 +1347,6 @@ ZEND_API void zend_deactivate(void) /* {{{ */
 	if (zend_hash_num_elements(&CG(interned_strings)) > 0) {
 		zend_map_ptr_reset();
 	}
-
-	zend_strtod_deactivate();
 
 #if GC_BENCH
 	gc_bench_print();

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -41,6 +41,7 @@
 #include "zend_arena.h"
 #include "zend_call_stack.h"
 #include "zend_max_execution_timer.h"
+#include "zend_strtod.h"
 
 /* Define ZTS if you want a thread-safe Zend */
 /*#undef ZTS*/
@@ -303,6 +304,8 @@ struct _zend_executor_globals {
 	pid_t pid;
 	struct sigaction oldact;
 #endif
+
+	zend_strtod_state strtod_state;
 
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -234,8 +234,8 @@ extern char *MALLOC();
 extern void *MALLOC(size_t);
 #endif
 #else
-#define MALLOC emalloc
-#define FREE   efree
+#define MALLOC malloc
+#define FREE   free
 #endif
 
 #ifndef Omit_Private_Memory
@@ -557,12 +557,7 @@ static MUTEX_T dtoa_mutex;
 static MUTEX_T pow5mult_mutex;
 #endif /* ZTS */
 
-ZEND_API int zend_strtod_activate(void) /* {{{ */
-{
-	return 1;
-}
-/* }}} */
-ZEND_API int zend_strtod_deactivate(void) /* {{{ */
+ZEND_API int zend_shutdown_strtod(void) /* {{{ */
 {
 	destroy_freelist();
 	free_p5s();

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -189,6 +189,7 @@
 #include <zend_operators.h>
 #include <zend_strtod.h>
 #include "zend_strtod_int.h"
+#include "zend_globals.h"
 
 #ifndef Long
 #define Long int32_t
@@ -196,6 +197,16 @@
 #ifndef ULong
 #define ULong uint32_t
 #endif
+
+#undef Bigint
+#undef freelist
+#undef p5s
+#undef dtoa_result
+
+#define Bigint      _zend_strtod_bigint
+#define freelist    (EG(strtod_state).freelist)
+#define p5s         (EG(strtod_state).p5s)
+#define dtoa_result (EG(strtod_state).result)
 
 #ifdef DEBUG
 static void Bug(const char *message) {
@@ -223,7 +234,8 @@ extern char *MALLOC();
 extern void *MALLOC(size_t);
 #endif
 #else
-#define MALLOC malloc
+#define MALLOC emalloc
+#define FREE   efree
 #endif
 
 #ifndef Omit_Private_Memory
@@ -522,7 +534,7 @@ BCinfo { int dp0, dp1, dplen, dsign, e0, inexact, nd, nd0, rounding, scale, uflc
 #define FREE_DTOA_LOCK(n)	/*nothing*/
 #endif
 
-#define Kmax 7
+#define Kmax ZEND_STRTOD_K_MAX
 
  struct
 Bigint {
@@ -533,37 +545,28 @@ Bigint {
 
  typedef struct Bigint Bigint;
 
+#ifndef Bigint
  static Bigint *freelist[Kmax+1];
+#endif
 
 static void destroy_freelist(void);
 static void free_p5s(void);
 
-#ifdef ZTS
+#ifdef MULTIPLE_THREADS
 static MUTEX_T dtoa_mutex;
 static MUTEX_T pow5mult_mutex;
 #endif /* ZTS */
 
-ZEND_API int zend_startup_strtod(void) /* {{{ */
+ZEND_API int zend_strtod_activate(void) /* {{{ */
 {
-#ifdef ZTS
-	dtoa_mutex = tsrm_mutex_alloc();
-	pow5mult_mutex = tsrm_mutex_alloc();
-#endif
 	return 1;
 }
 /* }}} */
-ZEND_API int zend_shutdown_strtod(void) /* {{{ */
+ZEND_API int zend_strtod_deactivate(void) /* {{{ */
 {
 	destroy_freelist();
 	free_p5s();
 
-#ifdef ZTS
-	tsrm_mutex_free(dtoa_mutex);
-	dtoa_mutex = NULL;
-
-	tsrm_mutex_free(pow5mult_mutex);
-	pow5mult_mutex = NULL;
-#endif
 	return 1;
 }
 /* }}} */
@@ -627,11 +630,7 @@ Bfree
 {
 	if (v) {
 		if (v->k > Kmax)
-#ifdef FREE
 			FREE((void*)v);
-#else
-			free((void*)v);
-#endif
 		else {
 			ACQUIRE_DTOA_LOCK(0);
 			v->next = freelist[v->k];
@@ -947,7 +946,9 @@ mult
 	return c;
 	}
 
+#ifndef p5s
  static Bigint *p5s;
+#endif
 
  static Bigint *
 pow5mult
@@ -3602,7 +3603,7 @@ zend_strtod
 	return sign ? -dval(&rv) : dval(&rv);
 	}
 
-#ifndef MULTIPLE_THREADS
+#if !defined(MULTIPLE_THREADS) && !defined(dtoa_result)
  ZEND_TLS char *dtoa_result;
 #endif
 
@@ -4616,7 +4617,7 @@ static void destroy_freelist(void)
 		Bigint **listp = &freelist[i];
 		while ((tmp = *listp) != NULL) {
 			*listp = tmp->next;
-			free(tmp);
+			FREE(tmp);
 		}
 		freelist[i] = NULL;
 	}
@@ -4631,7 +4632,8 @@ static void free_p5s(void)
 	listp = &p5s;
 	while ((tmp = *listp) != NULL) {
 		*listp = tmp->next;
-		free(tmp);
+		FREE(tmp);
 	}
+	p5s = NULL;
 	FREE_DTOA_LOCK(1)
 }

--- a/Zend/zend_strtod.h
+++ b/Zend/zend_strtod.h
@@ -37,8 +37,7 @@ ZEND_API double zend_strtod(const char *s00, const char **se);
 ZEND_API double zend_hex_strtod(const char *str, const char **endptr);
 ZEND_API double zend_oct_strtod(const char *str, const char **endptr);
 ZEND_API double zend_bin_strtod(const char *str, const char **endptr);
-ZEND_API int zend_strtod_activate(void);
-ZEND_API int zend_strtod_deactivate(void);
+ZEND_API int zend_shutdown_strtod(void);
 END_EXTERN_C()
 
 /* double limits */

--- a/Zend/zend_strtod.h
+++ b/Zend/zend_strtod.h
@@ -23,6 +23,13 @@
 #include <zend.h>
 
 BEGIN_EXTERN_C()
+#define ZEND_STRTOD_K_MAX 7
+typedef struct _zend_strtod_bigint zend_strtod_bigint;
+typedef struct _zend_strtod_state {
+	zend_strtod_bigint *freelist[ZEND_STRTOD_K_MAX+1];
+	zend_strtod_bigint *p5s;
+	char *result;
+} zend_strtod_state;
 ZEND_API void zend_freedtoa(char *s);
 ZEND_API char *zend_dtoa(double _d, int mode, int ndigits, int *decpt, bool *sign, char **rve);
 ZEND_API char *zend_gcvt(double value, int ndigit, char dec_point, char exponent, char *buf);
@@ -30,8 +37,8 @@ ZEND_API double zend_strtod(const char *s00, const char **se);
 ZEND_API double zend_hex_strtod(const char *str, const char **endptr);
 ZEND_API double zend_oct_strtod(const char *str, const char **endptr);
 ZEND_API double zend_bin_strtod(const char *str, const char **endptr);
-ZEND_API int zend_startup_strtod(void);
-ZEND_API int zend_shutdown_strtod(void);
+ZEND_API int zend_strtod_activate(void);
+ZEND_API int zend_strtod_deactivate(void);
 END_EXTERN_C()
 
 /* double limits */

--- a/Zend/zend_strtod_int.h
+++ b/Zend/zend_strtod_int.h
@@ -104,24 +104,4 @@
 #endif
 #endif
 
-#ifdef ZTS
-#define MULTIPLE_THREADS 1
-
-#define  ACQUIRE_DTOA_LOCK(x) \
-	if (0 == x) { \
-		tsrm_mutex_lock(dtoa_mutex); \
-	} else if (1 == x) { \
-		tsrm_mutex_lock(pow5mult_mutex); \
-	}
-
-#define FREE_DTOA_LOCK(x) \
-	if (0 == x) { \
-		tsrm_mutex_unlock(dtoa_mutex); \
-	} else if (1 == x) { \
-		tsrm_mutex_unlock(pow5mult_mutex); \
-	}
-
-
-#endif
-
 #endif /* ZEND_STRTOD_INT_H */


### PR DESCRIPTION
`zend_strtod.c` uses a global state (mostly an allocation freelist) protected by a mutex in ZTS builds. This state is used by `zend_dtoa()`, `zend_strtod()`, and variants. This creates a lot of contention in concurrent loads. `zend_dtoa()` is used to format floats to string, e.g. in sprintf, json_encode, serialize, uniqid.

In this PR I move the global state to the thread specific `executor_globals` and remove the mutex.

The impact on non-concurrent environments is null or negligible, but there is a considerable speed up on concurrent environments, especially on Alpine/Musl. When comparing master to this branch, the frankenphp-demo is sped up 10% under Apache/musl, 20% under FrankenPHP/glibc, and 40% under FrankenPHP/musl. Some synthetic benchmark is 80% faster.

<details>
  <summary>Benchmarks:</summary>

I'm using two benchmarks:
 - [frankenphp-demo](https://github.com/dunglas/frankenphp-demo) (requesting `/api/monsters.jsonld`). In this benchmark, the frankenphp-demo app is setup in dev mode
 - [json_encode.php](https://gist.github.com/arnaud-lb/602ee3a0b6d96edbed2ed6aa5cf0d553) is a synthetic benchmark encoding an array or 100 floats

In 3 separate environments:
 - php-cgi without concurrency
 - Apache mpm_event mod_php ZTS (100 concurrent requests)
 - FrankenPHP in worker mode (100 concurrent requests)

Opcache is enabled in the php-cgi and apache benchmarks, otherwise compilation time dominates. It is disabled in FrankenPHP because it is redundant in worker mode.

Bookworm uses glibc, Alpine (3.19.1) uses musl (1.2.4).

Results:

php-cgi -T10,500 frankenphp-demo repeated 5 times:

```
master-bookworm:      mean:  1.7227;  stddev:  0.0035;  diff:  +0.00% (baseline)
branch-bookworm:      mean:  1.7195;  stddev:  0.0037;  diff:  -0.19%  

master-alpine:        mean:  1.8676;  stddev:  0.0031;  diff:  -0.00% (baseline)
branch-alpine:        mean:  1.8700;  stddev:  0.0029;  diff:  +0.13%  

master-zts-bookworm:  mean:  1.7909;  stddev:  0.0026;  diff:  -0.00% (baseline)
branch-zts-bookworm:  mean:  1.7943;  stddev:  0.0014;  diff:  +0.19%  

master-zts-alpine:    mean:  1.9928;  stddev:  0.0059;  diff:  -0.00% (baseline)
branch-zts-alpine:    mean:  1.9900;  stddev:  0.0031;  diff:  -0.14%
```
Also in Valgrind:
```
valgrind php-cgi -T1,10:

master-bookworm:      mean:  1200273448.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-bookworm:      mean:  1200174784.0000;  stddev:  0.0000;  diff:  -0.01%

master-alpine:        mean:  1193572485.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-alpine:        mean:  1193577574.0000;  stddev:  0.0000;  diff:  +0.00%

master-zts-bookworm:  mean:  1245688708.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-zts-bookworm:  mean:  1245684830.0000;  stddev:  0.0000;  diff:  -0.00%

master-zts-alpine:    mean:  1275329963.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-zts-alpine:    mean:  1275302862.0000;  stddev:  0.0000;  diff:  -0.00%  
```

php-cgi -T10,5000 json_encode.php repeated 5 times:

```
master-bookworm:      mean:  0.2541;  stddev:  0.0003;  diff:  -0.00% (baseline)
branch-bookworm:      mean:  0.2532;  stddev:  0.0002;  diff:  -0.33%

master-alpine:        mean:  0.2694;  stddev:  0.0057;  diff:  +0.00% (baseline)
branch-alpine:        mean:  0.2702;  stddev:  0.0098;  diff:  +0.30%

master-zts-bookworm:  mean:  0.4092;  stddev:  0.0014;  diff:  -0.00% (baseline)
branch-zts-bookworm:  mean:  0.2665;  stddev:  0.0023;  diff:  -34.86%

master-zts-alpine:    mean:  0.5691;  stddev:  0.0015;  diff:  -0.00% (baseline)
branch-zts-alpine:    mean:  0.2862;  stddev:  0.0006;  diff:  -49.71%
```
Valgrind:
```
master-bookworm:      mean:  67901890.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-bookworm:      mean:  68082973.0000;  stddev:  0.0000;  diff:  +0.27%

master-alpine:        mean:  39943906.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-alpine:        mean:  40117586.0000;  stddev:  0.0000;  diff:  +0.43%

master-zts-bookworm:  mean:  74304991.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-zts-bookworm:  mean:  69262486.0000;  stddev:  0.0000;  diff:  -6.79%

master-zts-alpine:    mean:  45453755.0000;  stddev:  0.0000;  diff:  +0.00% (baseline)
branch-zts-alpine:    mean:  41906922.0000;  stddev:  0.0000;  diff:  -7.80%
```

Apache mpm_event mod_php ZTS frankenphp-demo:

```
master-zts-bookworm: 10.863000; +0.00% (baseline)
branch-zts-bookworm: 10.876000; +0.12%

master-zts-alpine: 12.218000; +0.00% (baseline)
branch-zts-alpine: 10.885000; -10.91%
```

Apache mpm_event mod_php ZTS json_encode.php:

```
master-zts-bookworm: 1.476000; +0.00% (baseline)
branch-zts-bookworm: 0.228000; -84.55%

master-zts-alpine: 1.499000; +0.00% (baseline)
branch-zts-alpine: 0.243000; -83.79%
```

FrankenPHP frankenphp-demo:

```
master-bookworm:       77   +0.00% (baseline)
branch-bookworm:       62   -18.99%

master-alpine:  120  +0.00% (baseline)
branch-alpine:  68   -43.57%
```
</details>