### PR TITLE
ext/pcntl simplification.

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -28,7 +28,5 @@ int main(void) {
     AC_MSG_RESULT([no, cross-compiling])
   ])
 
-  AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
-
   PHP_NEW_EXTENSION(pcntl, pcntl.c php_signal.c, $ext_shared, cli, $PCNTL_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 fi

--- a/ext/pcntl/pcntl.stub.php
+++ b/ext/pcntl/pcntl.stub.php
@@ -932,14 +932,12 @@ function pcntl_signal_dispatch(): bool {}
 function pcntl_sigprocmask(int $mode, array $signals, &$old_signals = null): bool {}
 #endif
 
-#ifdef HAVE_STRUCT_SIGINFO_T
 #if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 /** @param array $info */
 function pcntl_sigwaitinfo(array $signals, &$info = []): int|false {}
 
 /** @param array $info */
 function pcntl_sigtimedwait(array $signals, &$info = [], int $seconds = 0, int $nanoseconds = 0): int|false {}
-#endif
 #endif
 
 function pcntl_wifexited(int $status): bool {}

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3e15bebb568e6e2031acbd932d6eefbd23984c83 */
+ * Stub hash: a1f98440ed557fafc97ed685df0adc989fda9a79 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_fork, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -38,14 +38,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_sigprocmask, 0, 2, _IS_BOO
 ZEND_END_ARG_INFO()
 #endif
 
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_sigwaitinfo, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, signals, IS_ARRAY, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, info, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_sigtimedwait, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, signals, IS_ARRAY, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, info, "[]")
@@ -177,10 +177,10 @@ ZEND_FUNCTION(pcntl_signal_dispatch);
 #if defined(HAVE_SIGPROCMASK)
 ZEND_FUNCTION(pcntl_sigprocmask);
 #endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_FUNCTION(pcntl_sigwaitinfo);
 #endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_FUNCTION(pcntl_sigtimedwait);
 #endif
 ZEND_FUNCTION(pcntl_wifexited);
@@ -241,10 +241,10 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_SIGPROCMASK)
 	ZEND_FE(pcntl_sigprocmask, arginfo_pcntl_sigprocmask)
 #endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 	ZEND_FE(pcntl_sigwaitinfo, arginfo_pcntl_sigwaitinfo)
 #endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
+#if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 	ZEND_FE(pcntl_sigtimedwait, arginfo_pcntl_sigtimedwait)
 #endif
 	ZEND_FE(pcntl_wifexited, arginfo_pcntl_wifexited)

--- a/ext/pcntl/php_pcntl.h
+++ b/ext/pcntl/php_pcntl.h
@@ -36,9 +36,7 @@ PHP_MINFO_FUNCTION(pcntl);
 struct php_pcntl_pending_signal {
 	struct php_pcntl_pending_signal *next;
 	zend_long signo;
-#ifdef HAVE_STRUCT_SIGINFO_T
 	siginfo_t siginfo;
-#endif
 };
 
 ZEND_BEGIN_MODULE_GLOBALS(pcntl)

--- a/ext/pcntl/php_signal.c
+++ b/ext/pcntl/php_signal.c
@@ -21,24 +21,18 @@
 
 /* php_signal using sigaction is derived from Advanced Programming
  * in the Unix Environment by W. Richard Stevens p 298. */
-Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all)
+Sigfunc *php_signal4(int signo, Sigfunc *func, bool restart, bool mask_all)
 {
 	struct sigaction act,oact;
 
-#ifdef HAVE_STRUCT_SIGINFO_T
 	act.sa_sigaction = func;
-#else
-	act.sa_handler = func;
-#endif
 	if (mask_all) {
 		sigfillset(&act.sa_mask);
 	} else {
 		sigemptyset(&act.sa_mask);
 	}
 	act.sa_flags = SA_ONSTACK;
-#ifdef HAVE_STRUCT_SIGINFO_T
 	act.sa_flags |= SA_SIGINFO;
-#endif
 	if (!restart) {
 #ifdef SA_INTERRUPT
 		act.sa_flags |= SA_INTERRUPT; /* SunOS */
@@ -50,14 +44,10 @@ Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all)
 	}
 	zend_sigaction(signo, &act, &oact);
 
-#ifdef HAVE_STRUCT_SIGINFO_T
 	return oact.sa_sigaction;
-#else
-	return oact.sa_handler;
-#endif
 }
 
-Sigfunc *php_signal(int signo, Sigfunc *func, int restart)
+Sigfunc *php_signal(int signo, Sigfunc *func, bool restart)
 {
-	return php_signal4(signo, func, restart, 0);
+	return php_signal4(signo, func, restart, false);
 }

--- a/ext/pcntl/php_signal.h
+++ b/ext/pcntl/php_signal.h
@@ -18,12 +18,9 @@
 #ifndef PHP_SIGNAL_H
 #define PHP_SIGNAL_H
 
-#ifdef HAVE_STRUCT_SIGINFO_T
 typedef void Sigfunc(int, siginfo_t*, void*);
-#else
-typedef void Sigfunc(int);
-#endif
-Sigfunc *php_signal(int signo, Sigfunc *func, int restart);
-Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all);
+
+Sigfunc *php_signal(int signo, Sigfunc *func, bool restart);
+Sigfunc *php_signal4(int signo, Sigfunc *func, bool restart, bool mask_all);
 
 #endif


### PR DESCRIPTION
assuming pcntl is an unix-only extension and they all support the siginfo_t type,
 we re using exclusively this more advanced api.