### PR TITLE
Fix GH-13970: Incorrect validation of #[\Attribute]’s first parameter

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3755,6 +3755,19 @@ static zend_result preload_resolve_deps(preload_error *error, const zend_class_e
 	return SUCCESS;
 }
 
+static zend_result preload_update_constant(zval *val, zend_class_entry *scope)
+{
+	zval tmp;
+	ZVAL_COPY(&tmp, val);
+	if (zval_update_constant_ex(&tmp, scope) == FAILURE || Z_COLLECTABLE(tmp)) {
+		zval_ptr_dtor(&tmp);
+		return FAILURE;
+	}
+	zval_ptr_dtor_nogc(val);
+	ZVAL_COPY_VALUE(val, &tmp);
+	return SUCCESS;
+}
+
 static bool preload_try_resolve_constants(zend_class_entry *ce)
 {
 	bool ok, changed, was_changed = false;
@@ -3768,7 +3781,7 @@ static bool preload_try_resolve_constants(zend_class_entry *ce)
 		ZEND_HASH_MAP_FOREACH_PTR(&ce->constants_table, c) {
 			val = &c->value;
 			if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
-				if (EXPECTED(zval_update_constant_ex(val, c->ce) == SUCCESS)) {
+				if (EXPECTED(preload_update_constant(val, c->ce) == SUCCESS)) {
 					was_changed = changed = true;
 				} else {
 					ok = false;
@@ -3786,7 +3799,7 @@ static bool preload_try_resolve_constants(zend_class_entry *ce)
 				val = &ce->default_properties_table[i];
 				if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
 					zend_property_info *prop = ce->properties_info_table[i];
-					if (UNEXPECTED(zval_update_constant_ex(val, prop->ce) != SUCCESS)) {
+					if (UNEXPECTED(preload_update_constant(val, prop->ce) != SUCCESS)) {
 						resolved = ok = false;
 					}
 				}
@@ -3802,7 +3815,7 @@ static bool preload_try_resolve_constants(zend_class_entry *ce)
 			val = ce->default_static_members_table + ce->default_static_members_count - 1;
 			while (count) {
 				if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
-					if (UNEXPECTED(zval_update_constant_ex(val, ce) != SUCCESS)) {
+					if (UNEXPECTED(preload_update_constant(val, ce) != SUCCESS)) {
 						resolved = ok = false;
 					}
 				}

--- a/ext/zend_test/tests/gh13970.phpt
+++ b/ext/zend_test/tests/gh13970.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-13970 (Incorrect validation of #[\Attribute]’s first parameter)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+#[Attribute(\ZendTestUnitEnum::Foo)]
+class Foo {
+
+}
+
+#[Foo]
+function test1() {
+
+}
+
+$reflection = new ReflectionFunction('test1');
+var_dump($reflection->getAttributes()[0]->newInstance());
+?>
+--EXPECTF--
+Fatal error: Attribute::__construct(): Argument #1 ($flags) must be of type int, ZendTestUnitEnum given in %s on line %d


### PR DESCRIPTION
In c1959e63e5 code was added to deal with preloading of enums, which had to be special cased because they are object instances. In 4397811db2 this code was changed because array instances can contain object instances due to enums. In that commit, the code started using zval_update_constant_ex() and stopped ZEND_AST_CONST_ENUM_INIT resolution when in compilation.

Since the attribute in the testcase is resolved during compilation, the resolution fails as well, even though in this case we can resolve it fine as the problem is only with persisting constants during preloading.

This patch restores the original code but changes the IS_OBJECT condition to Z_COLLECTABLE such that both arrays and objects that are resolved from IS_CONSTANT_AST are not persisted to shm.

I don't know for sure if this is the best approach. An alternative I thought of is looping through the array to see if it contains objects but that seems more complicated and I'm not sure that's better.