### PR TITLE
Make /ping of php-fpm work again

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -752,6 +752,8 @@ static int fpm_worker_pool_shared_status_alloc(struct fpm_worker_pool_s *shared_
 	FPM_WPC_STR_CP(config, shared_config, user);
 	FPM_WPC_STR_CP(config, shared_config, group);
 	FPM_WPC_STR_CP(config, shared_config, pm_status_path);
+	FPM_WPC_STR_CP(config, shared_config, ping_path);
+	FPM_WPC_STR_CP(config, shared_config, ping_response);
 
 	config->pm = PM_STYLE_ONDEMAND;
 	config->pm_max_children = 2;

--- a/sapi/fpm/tests/status-ping.phpt
+++ b/sapi/fpm/tests/status-ping.phpt
@@ -1,0 +1,40 @@
+--TEST--
+FPM: Ping on the status invisible pool
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_listen = {{ADDR[status]}}
+pm.status_path = /status
+ping.path = /ping
+ping.response = pong
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->ping('{{ADDR[status]}}');
+usleep(100000);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
The ping feature of php-fpm monitoring was previously not working (but the status is) due to the configuration variables `ping.path` and `ping.response` not being copied over to the worker when forked (but `pm.status_path` does). This results in the ping code path being disabled because the worker detects that `ping.path` is not configured.