### PR TITLE
Make documentURI and URL not readonly

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1515,9 +1515,7 @@ namespace DOM
     {
         /** @readonly */
         public Implementation $implementation;
-        /** @readonly */
         public string $URL;
-        /** @readonly */
         public string $documentURI;
         public string $characterSet;
         public string $charset;

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 37a1c811bfc8c611d686f0842d06fc327b54511f */
+ * Stub hash: 49a153db3d3aa28031d7a15c15f89f6f3e9c33a5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)


### PR DESCRIPTION
These aren't actually readonly right now because `@readonly` means nothing, and the setters are configured in php_dom.c. So no functional changes here.

DOM spec marks these as readonly, but the problem is that this reduces usefulness in XML contexts (like WSDL scheme handling). In context of a browser, for which DOM was designed, this actually makes sense to have as readonly because it is tied to the origin of the page etc. But PHP is not a browser. This also wasn't readonly in "old DOM".