### PR TITLE
Remove unused ext/spl SPL_API code

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -38,10 +38,6 @@
 #include "zend_interfaces.h"
 #include "main/snprintf.h"
 
-#ifdef COMPILE_DL_SPL
-ZEND_GET_MODULE(spl)
-#endif
-
 ZEND_TLS zend_string *spl_autoload_extensions;
 ZEND_TLS HashTable *spl_autoload_functions;
 

--- a/ext/spl/php_spl.h
+++ b/ext/spl/php_spl.h
@@ -25,25 +25,6 @@
 extern zend_module_entry spl_module_entry;
 #define phpext_spl_ptr &spl_module_entry
 
-#ifdef PHP_WIN32
-#	ifdef SPL_EXPORTS
-#		define SPL_API __declspec(dllexport)
-#	elif defined(COMPILE_DL_SPL)
-#		define SPL_API __declspec(dllimport)
-#	else
-#		define SPL_API /* nothing */
-#	endif
-#elif defined(__GNUC__) && __GNUC__ >= 4
-#	define SPL_API __attribute__ ((visibility("default")))
-#else
-#	define SPL_API
-#endif
-
-#if defined(PHP_WIN32) && !defined(COMPILE_DL_SPL)
-#undef phpext_spl
-#define phpext_spl NULL
-#endif
-
 PHP_MINIT_FUNCTION(spl);
 PHP_MSHUTDOWN_FUNCTION(spl);
 PHP_RINIT_FUNCTION(spl);

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -36,10 +36,6 @@
 static zend_object_handlers spl_handler_SplFixedArray;
 PHPAPI zend_class_entry *spl_ce_SplFixedArray;
 
-#ifdef COMPILE_DL_SPL_FIXEDARRAY
-ZEND_GET_MODULE(spl_fixedarray)
-#endif
-
 /* Check if the object is an instance of a subclass of SplFixedArray that overrides method's implementation.
  * Expect subclassing SplFixedArray to be rare and check that first. */
 #define HAS_FIXEDARRAY_ARRAYACCESS_OVERRIDE(object, method) UNEXPECTED((object)->ce != spl_ce_SplFixedArray && (object)->ce->arrayaccess_funcs_ptr->method->common.scope != spl_ce_SplFixedArray)


### PR DESCRIPTION
The ext/spl is always enabled and building it as shared is no longer relevant.