### PR TITLE
Fix GH-13984: Buffer size is now checked before memcmp

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -751,7 +751,7 @@ static char *make_filename_safe(const char *filename)
 		}
 		return estrdup(filename);
 	}
-	if (*filename && memcmp(filename, ":memory:", sizeof(":memory:"))) {
+	if (*filename && (sizeof(filename) != sizeof(":memory:") || memcmp(filename, ":memory:", sizeof(":memory:")) != 0)) {
 		char *fullpath = expand_filepath(filename, NULL);
 
 		if (!fullpath) {

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -751,7 +751,7 @@ static char *make_filename_safe(const char *filename)
 		}
 		return estrdup(filename);
 	}
-	if (*filename && zend_binary_strcmp(filename, strlen(filename), ":memory:", strlen(":memory:"))) {
+	if (*filename && strcmp(filename, ":memory:")) {
 		char *fullpath = expand_filepath(filename, NULL);
 
 		if (!fullpath) {

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -751,7 +751,7 @@ static char *make_filename_safe(const char *filename)
 		}
 		return estrdup(filename);
 	}
-	if (*filename && zend_binary_strcmp(filename, strlen(filename)-1, ":memory:", strlen(":memory:")-1)) {
+	if (*filename && zend_binary_strcmp(filename, strlen(filename), ":memory:", strlen(":memory:"))) {
 		char *fullpath = expand_filepath(filename, NULL);
 
 		if (!fullpath) {

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -751,7 +751,7 @@ static char *make_filename_safe(const char *filename)
 		}
 		return estrdup(filename);
 	}
-	if (*filename && (sizeof(filename) != sizeof(":memory:") || memcmp(filename, ":memory:", sizeof(":memory:")) != 0)) {
+	if (*filename && zend_binary_strcmp(filename, strlen(filename)-1, ":memory:", strlen(":memory:")-1)) {
 		char *fullpath = expand_filepath(filename, NULL);
 
 		if (!fullpath) {

--- a/ext/pdo_sqlite/tests/gh13991.phpt
+++ b/ext/pdo_sqlite/tests/gh13991.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Fix GH-13984: Buffer size is now checked before memcmp
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$dbfile = 'z.db';
+$db = new PDO('sqlite:' . $dbfile, null, null, [PDO::ATTR_PERSISTENT => true]);
+echo 'done!';
+?>
+--CLEAN--
+<?php
+@unlink(getcwd() . '/z.db');
+?>
+--EXPECT--
+done!

--- a/ext/pdo_sqlite/tests/gh13991.phpt
+++ b/ext/pdo_sqlite/tests/gh13991.phpt
@@ -2,15 +2,17 @@
 Fix GH-13984: Buffer size is now checked before memcmp
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php if (file_exists(getcwd() . '/13991db')) die('skip File "13991db" already exists.'); ?>
 --FILE--
 <?php
-$dbfile = 'z.db';
+$dbfile = '13991db';
 $db = new PDO('sqlite:' . $dbfile, null, null, [PDO::ATTR_PERSISTENT => true]);
 echo 'done!';
 ?>
 --CLEAN--
 <?php
-@unlink(getcwd() . '/z.db');
+@unlink(getcwd() . '/13991db');
 ?>
 --EXPECT--
 done!


### PR DESCRIPTION
fixes #13984 

This was also reproduced in 8.2.
Can the push test detect overflow?