### PR TITLE
fix(intl): ICU now requires C++ 17

### DIFF
--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -80,7 +80,7 @@ if test "$PHP_INTL" != "no"; then
     breakiterator/codepointiterator_methods.cpp"
 
   PHP_REQUIRE_CXX()
-  PHP_CXX_COMPILE_STDCXX(11, mandatory, PHP_INTL_STDCXX)
+  PHP_CXX_COMPILE_STDCXX(17, mandatory, PHP_INTL_STDCXX)
   PHP_INTL_CXX_FLAGS="$INTL_COMMON_FLAGS $PHP_INTL_STDCXX $ICU_CXXFLAGS"
   case $host_alias in
   *cygwin*) PHP_INTL_CXX_FLAGS="$PHP_INTL_CXX_FLAGS -D_POSIX_C_SOURCE=200809L"


### PR DESCRIPTION
[ICU 75 requires C++17](https://icu.unicode.org/download/75). Without this patch, the compilation of the intl extension with the latest version of ICU fails.