### PR TITLE
Fix missing handling of CALLABLE_CONVERT in cleanup_unfinished_calls()

### DIFF
--- a/Zend/tests/gh14003.phpt
+++ b/Zend/tests/gh14003.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-14003: Missing handling of CALLABLE_CONVERT in cleanup_unfinished_calls()
+--FILE--
+<?php
+
+function foo(string $key): string {
+    throw new \Exception('Test');
+}
+
+array_filter(
+    array_combine(
+        ['a'],
+        array_map(foo(...), ['a']),
+    ),
+);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Test in %s:%d
+Stack trace:
+#0 [internal function]: foo('a')
+#1 %s(%d): array_map(Object(Closure), Array)
+#2 {main}
+  thrown in %s on line %d

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4104,6 +4104,7 @@ ZEND_API void zend_unfinished_calls_gc(zend_execute_data *execute_data, zend_exe
 				case ZEND_DO_ICALL:
 				case ZEND_DO_UCALL:
 				case ZEND_DO_FCALL_BY_NAME:
+				case ZEND_CALLABLE_CONVERT:
 					level++;
 					break;
 				case ZEND_INIT_FCALL:
@@ -4159,6 +4160,7 @@ ZEND_API void zend_unfinished_calls_gc(zend_execute_data *execute_data, zend_exe
 					case ZEND_DO_ICALL:
 					case ZEND_DO_UCALL:
 					case ZEND_DO_FCALL_BY_NAME:
+					case ZEND_CALLABLE_CONVERT:
 						level++;
 						break;
 					case ZEND_INIT_FCALL:
@@ -4237,6 +4239,7 @@ static void cleanup_unfinished_calls(zend_execute_data *execute_data, uint32_t o
 					case ZEND_DO_ICALL:
 					case ZEND_DO_UCALL:
 					case ZEND_DO_FCALL_BY_NAME:
+					case ZEND_CALLABLE_CONVERT:
 						level++;
 						break;
 					case ZEND_INIT_FCALL:
@@ -4292,6 +4295,7 @@ static void cleanup_unfinished_calls(zend_execute_data *execute_data, uint32_t o
 						case ZEND_DO_ICALL:
 						case ZEND_DO_UCALL:
 						case ZEND_DO_FCALL_BY_NAME:
+						case ZEND_CALLABLE_CONVERT:
 							level++;
 							break;
 						case ZEND_INIT_FCALL:


### PR DESCRIPTION
Fixes GH-14003