### PR TITLE
CI: Skip building docs if GitHub repository is not php/php-src

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    if: github.repository == 'php/php-src'
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The doc pages build is failing for forks...