### PR TITLE
Fixed bug #14007

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -180,8 +180,8 @@ static zend_string* php_password_bcrypt_hash(const zend_string *password, zend_a
 	zval *zcost;
 	zend_long cost = PHP_PASSWORD_BCRYPT_COST;
 
-	if (memchr(ZSTR_VAL(password), '\0', ZSTR_LEN(password))) {
-		zend_value_error("Bcrypt password must not contain null character");
+	if (ZSTR_VAL(password)[0] == '\0') {
+		zend_value_error("Bcrypt password must not start with null character");
 		return NULL;
 	}
 

--- a/ext/standard/tests/password/password_bcrypt_cve2024_3096.phpt
+++ b/ext/standard/tests/password/password_bcrypt_cve2024_3096.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test of password_hash() with bcrypt hashing for CVE-2024-3096
+--FILE--
+<?php
+//-=-=-=-
+try {
+    $hash = password_hash("\0password", PASSWORD_BCRYPT);
+    var_dump(password_verify('', $hash));
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$hash = password_hash("p\0assword", PASSWORD_BCRYPT);
+var_dump(password_verify('', $hash));
+?>
+--EXPECT--
+Bcrypt password must not start with null character
+bool(false)

--- a/ext/standard/tests/password/password_bcrypt_errors.phpt
+++ b/ext/standard/tests/password/password_bcrypt_errors.phpt
@@ -14,14 +14,7 @@ try {
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
-
-try {
-    var_dump(password_hash("null\0password", PASSWORD_BCRYPT));
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
-}
 ?>
 --EXPECT--
 Invalid bcrypt cost parameter specified: 3
 Invalid bcrypt cost parameter specified: 32
-Bcrypt password must not contain null character


### PR DESCRIPTION
password_hash does not allow \0 character anywhere. However it might cause some problem, as `$password` might contain it. CVE-2024-3096 only happens if `$password` starts with `\0`, so just checking the first character should be enough.