### PR TITLE
Fix erroneous dnl appended in configure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ PHP                                                                        NEWS
     other timeout implementations). (Kévin Dunglas)
   . Fixed bug GH-14003 (Broken cleanup of unfinished calls with callable convert
     parameters). (ilutov)
+  . Fixed bug GH-14013 (Erroneous dnl appended in configure). (Peter Kokot)
 
 - Fibers:
   . Fixed bug GH-13903 (ASAN false positive underflow when executing copy()).

--- a/build/php_cxx_compile_stdcxx.m4
+++ b/build/php_cxx_compile_stdcxx.m4
@@ -27,11 +27,11 @@ AC_DEFUN([PHP_CXX_COMPILE_STDCXX], [dnl
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [$1], [20], [ax_cxx_compile_alternatives="20"],
-        [m4_fatal([invalid first argument `$1' to PHP_CXX_COMPILE_STDCXX])])dnl
+        [m4_fatal([invalid first argument `$1' to PHP_CXX_COMPILE_STDCXX])])[]dnl
   m4_if([$2], [], [ax_cxx_compile_cxx$1_required=true],
         [$2], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$2], [optional], [ax_cxx_compile_cxx$1_required=false],
-        [m4_fatal([invalid third argument `$2' to PHP_CXX_COMPILE_STDCXX])])dnl
+        [m4_fatal([invalid third argument `$2' to PHP_CXX_COMPILE_STDCXX])])[]dnl
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 


### PR DESCRIPTION
This is a backport of commit 03f15534a17c7031b89dac7aaa21d59474517321 to PHP-8.2 due to GH-14002 and fixes the PHP_CXX_COMPILE_STDCXX check in ext/intl whether the specified C++ standard is mandatory or optional.

The `dnl` (Discard to Next Line) M4 macro in this combination of `m4_if` macros and arguments isn't properly replaced and a literal `dnl` string is appended in the configure script. The `[]dnl` works ok.

The configure script diff before and after:

```diff
47520,47521c47520
<       ax_cxx_compile_alternatives="17 1z"  ax_cxx_compile_cxx17_required=truednl
<   ac_ext=cpp
---
>       ax_cxx_compile_alternatives="17 1z"  ax_cxx_compile_cxx17_required=true  ac_ext=cpp
48373,48374c48372
<       ax_cxx_compile_alternatives="11 0x"  ax_cxx_compile_cxx11_required=truednl
<   ac_ext=cpp
---
>       ax_cxx_compile_alternatives="11 0x"  ax_cxx_compile_cxx11_required=true  ac_ext=cpp
```