### PR TITLE
Generic `pack()` test for 64-bit

### DIFF
--- a/ext/standard/tests/strings/pack.phpt
+++ b/ext/standard/tests/strings/pack.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Generic pack()/unpack() tests
---SKIPIF--
-<?php
-if (PHP_INT_MAX > 2147483647) {
-    die("skip 32bit test only");
-}
-?>
 --FILE--
 <?php
 echo "A\n";
@@ -26,25 +20,25 @@ print_r(unpack("H", pack("H", 0x04)));
 echo "I\n";
 print_r(unpack("I", pack("I", 65534)));
 print_r(unpack("I", pack("I", 0)));
-print_r(unpack("I", pack("I", -1000)));
-print_r(unpack("I", pack("I", -64434)));
+echo bin2hex(pack("I", -1000)), "\n";
+echo bin2hex(pack("I", -64434)), "\n";
 print_r(unpack("I", pack("I", 4294967296)));
 print_r(unpack("I", pack("I", -4294967296)));
 
 echo "L\n";
 print_r(unpack("L", pack("L", 65534)));
 print_r(unpack("L", pack("L", 0)));
-print_r(unpack("L", pack("L", 2147483650)));
-print_r(unpack("L", pack("L", 4294967295)));
-print_r(unpack("L", pack("L", -2147483648)));
+echo bin2hex(pack("L", 2147483650)), "\n";
+echo bin2hex(pack("L", 4294967295)), "\n";
+echo bin2hex(pack("L", -2147483648)), "\n";
 
 echo "N\n";
 print_r(unpack("N", pack("N", 65534)));
 print_r(unpack("N", pack("N", 0)));
-print_r(unpack("N", pack("N", 2147483650)));
+echo bin2hex(pack("N", 2147483650)), "\n";
 print_r(unpack("N", pack("N", 4294967296)));
-print_r(unpack("N", pack("N", -2147483648)));
-print_r(unpack("N", pack("N", -30000)));
+echo bin2hex(pack("N", -2147483648)), "\n";
+echo bin2hex(pack("N", -30000)), "\n";
 
 echo "S\n";
 print_r(unpack("S", pack("S", 65534)));
@@ -57,9 +51,9 @@ print_r(unpack("S", pack("S", -65535)));
 echo "V\n";
 print_r(unpack("V", pack("V", 65534)));
 print_r(unpack("V", pack("V", 0)));
-print_r(unpack("V", pack("V", 2147483650)));
+echo bin2hex(pack("V", 2147483650)), "\n";
 print_r(unpack("V", pack("V", 4294967296)));
-print_r(unpack("V", pack("V", -2147483648)));
+echo bin2hex(pack("V", -2147483648)), "\n";
 
 echo "a\n";
 print_r(unpack("a", pack("a", "hello world")));
@@ -155,14 +149,8 @@ Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -1000
-)
-Array
-(
-    [1] => -64434
-)
+18fcffff
+4e04ffff
 Array
 (
     [1] => 0
@@ -180,18 +168,9 @@ Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -2147483646
-)
-Array
-(
-    [1] => -1
-)
-Array
-(
-    [1] => -2147483648
-)
+02000080
+ffffffff
+00000080
 N
 Array
 (
@@ -201,22 +180,13 @@ Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -2147483646
-)
+80000002
 Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -2147483648
-)
-Array
-(
-    [1] => -30000
-)
+80000000
+ffff8ad0
 S
 Array
 (
@@ -251,18 +221,12 @@ Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -2147483646
-)
+02000080
 Array
 (
     [1] => 0
 )
-Array
-(
-    [1] => -2147483648
-)
+00000080
 a
 Array
 (

--- a/ext/standard/tests/strings/pack.phpt
+++ b/ext/standard/tests/strings/pack.phpt
@@ -8,18 +8,22 @@ if (PHP_INT_MAX > 2147483647) {
 ?>
 --FILE--
 <?php
+echo "A\n";
 print_r(unpack("A", pack("A", "hello world")));
 print_r(unpack("A*", pack("A*", "hello world")));
 echo '"'.pack("A9", "hello").'"';
 echo "\n";
 
+echo "C\n";
 print_r(unpack("C", pack("C", -127)));
 print_r(unpack("C", pack("C", 127)));
 print_r(unpack("C", pack("C", 255)));
 print_r(unpack("C", pack("C", -129)));
 
+echo "H\n";
 print_r(unpack("H", pack("H", 0x04)));
 
+echo "I\n";
 print_r(unpack("I", pack("I", 65534)));
 print_r(unpack("I", pack("I", 0)));
 print_r(unpack("I", pack("I", -1000)));
@@ -27,12 +31,14 @@ print_r(unpack("I", pack("I", -64434)));
 print_r(unpack("I", pack("I", 4294967296)));
 print_r(unpack("I", pack("I", -4294967296)));
 
+echo "L\n";
 print_r(unpack("L", pack("L", 65534)));
 print_r(unpack("L", pack("L", 0)));
 print_r(unpack("L", pack("L", 2147483650)));
 print_r(unpack("L", pack("L", 4294967295)));
 print_r(unpack("L", pack("L", -2147483648)));
 
+echo "N\n";
 print_r(unpack("N", pack("N", 65534)));
 print_r(unpack("N", pack("N", 0)));
 print_r(unpack("N", pack("N", 2147483650)));
@@ -40,6 +46,7 @@ print_r(unpack("N", pack("N", 4294967296)));
 print_r(unpack("N", pack("N", -2147483648)));
 print_r(unpack("N", pack("N", -30000)));
 
+echo "S\n";
 print_r(unpack("S", pack("S", 65534)));
 print_r(unpack("S", pack("S", 65537)));
 print_r(unpack("S", pack("S", 0)));
@@ -47,22 +54,27 @@ print_r(unpack("S", pack("S", -1000)));
 print_r(unpack("S", pack("S", -64434)));
 print_r(unpack("S", pack("S", -65535)));
 
+echo "V\n";
 print_r(unpack("V", pack("V", 65534)));
 print_r(unpack("V", pack("V", 0)));
 print_r(unpack("V", pack("V", 2147483650)));
 print_r(unpack("V", pack("V", 4294967296)));
 print_r(unpack("V", pack("V", -2147483648)));
 
+echo "a\n";
 print_r(unpack("a", pack("a", "hello world")));
 print_r(unpack("a*", pack("a*", "hello world")));
 
+echo "c\n";
 print_r(unpack("c", pack("c", -127)));
 print_r(unpack("c", pack("c", 127)));
 print_r(unpack("c", pack("c", 255)));
 print_r(unpack("c", pack("c", -129)));
 
+echo "h\n";
 print_r(unpack("h", pack("h", 3000000)));
 
+echo "i\n";
 print_r(unpack("i", pack("i", 65534)));
 print_r(unpack("i", pack("i", 0)));
 print_r(unpack("i", pack("i", -1000)));
@@ -70,12 +82,14 @@ print_r(unpack("i", pack("i", -64434)));
 print_r(unpack("i", pack("i", -65535)));
 print_r(unpack("i", pack("i", -2147483647)));
 
+echo "l\n";
 print_r(unpack("l", pack("l", 65534)));
 print_r(unpack("l", pack("l", 0)));
 print_r(unpack("l", pack("l", 2147483650)));
 print_r(unpack("l", pack("l", 4294967296)));
 print_r(unpack("l", pack("l", -2147483648)));
 
+echo "n\n";
 print_r(unpack("n", pack("n", 65534)));
 print_r(unpack("n", pack("n", 65537)));
 print_r(unpack("n", pack("n", 0)));
@@ -83,6 +97,7 @@ print_r(unpack("n", pack("n", -1000)));
 print_r(unpack("n", pack("n", -64434)));
 print_r(unpack("n", pack("n", -65535)));
 
+echo "s\n";
 print_r(unpack("s", pack("s", 32767)));
 print_r(unpack("s", pack("s", 65535)));
 print_r(unpack("s", pack("s", 0)));
@@ -90,6 +105,7 @@ print_r(unpack("s", pack("s", -1000)));
 print_r(unpack("s", pack("s", -64434)));
 print_r(unpack("s", pack("s", -65535)));
 
+echo "v\n";
 print_r(unpack("v", pack("v", 65534)));
 print_r(unpack("v", pack("v", 65537)));
 print_r(unpack("v", pack("v", 0)));
@@ -98,6 +114,7 @@ print_r(unpack("v", pack("v", -64434)));
 print_r(unpack("v", pack("v", -65535)));
 ?>
 --EXPECT--
+A
 Array
 (
     [1] => h
@@ -107,6 +124,7 @@ Array
     [1] => hello world
 )
 "hello    "
+C
 Array
 (
     [1] => 129
@@ -123,10 +141,12 @@ Array
 (
     [1] => 127
 )
+H
 Array
 (
     [1] => 4
 )
+I
 Array
 (
     [1] => 65534
@@ -151,6 +171,7 @@ Array
 (
     [1] => 0
 )
+L
 Array
 (
     [1] => 65534
@@ -171,6 +192,7 @@ Array
 (
     [1] => -2147483648
 )
+N
 Array
 (
     [1] => 65534
@@ -195,6 +217,7 @@ Array
 (
     [1] => -30000
 )
+S
 Array
 (
     [1] => 65534
@@ -219,6 +242,7 @@ Array
 (
     [1] => 1
 )
+V
 Array
 (
     [1] => 65534
@@ -239,6 +263,7 @@ Array
 (
     [1] => -2147483648
 )
+a
 Array
 (
     [1] => h
@@ -247,6 +272,7 @@ Array
 (
     [1] => hello world
 )
+c
 Array
 (
     [1] => -127
@@ -263,10 +289,12 @@ Array
 (
     [1] => 127
 )
+h
 Array
 (
     [1] => 3
 )
+i
 Array
 (
     [1] => 65534
@@ -291,6 +319,7 @@ Array
 (
     [1] => -2147483647
 )
+l
 Array
 (
     [1] => 65534
@@ -311,6 +340,7 @@ Array
 (
     [1] => -2147483648
 )
+n
 Array
 (
     [1] => 65534
@@ -335,6 +365,7 @@ Array
 (
     [1] => 1
 )
+s
 Array
 (
     [1] => 32767
@@ -359,6 +390,7 @@ Array
 (
     [1] => 1
 )
+v
 Array
 (
     [1] => 65534

--- a/ext/standard/tests/strings/pack_int.phpt
+++ b/ext/standard/tests/strings/pack_int.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Int size-dependent input pack()/unpack() tests
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE > 4) {
+    die("skip 32bit test only");
+}
+?>
+--FILE--
+<?php
+echo "I\n";
+print_r(unpack("I", hex2bin('18fcffff')));
+print_r(unpack("I", hex2bin('4e04ffff')));
+
+echo "L\n";
+print_r(unpack("L", hex2bin('02000080')));
+print_r(unpack("L", hex2bin('ffffffff')));
+print_r(unpack("L", hex2bin('00000080')));
+
+echo "N\n";
+print_r(unpack("N", hex2bin('80000002')));
+print_r(unpack("N", hex2bin('80000000')));
+print_r(unpack("N", hex2bin('ffff8ad0')));
+
+echo "V\n";
+print_r(unpack("V", hex2bin('02000080')));
+print_r(unpack("V", hex2bin('00000080')));
+?>
+--EXPECT--
+I
+Array
+(
+    [1] => -1000
+)
+Array
+(
+    [1] => -64434
+)
+L
+Array
+(
+    [1] => -2147483646
+)
+Array
+(
+    [1] => -1
+)
+Array
+(
+    [1] => -2147483648
+)
+N
+Array
+(
+    [1] => -2147483646
+)
+Array
+(
+    [1] => -2147483648
+)
+Array
+(
+    [1] => -30000
+)
+V
+Array
+(
+    [1] => -2147483646
+)
+Array
+(
+    [1] => -2147483648
+)

--- a/ext/standard/tests/strings/pack_int_64bit.phpt
+++ b/ext/standard/tests/strings/pack_int_64bit.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Int size-dependent input pack()/unpack() tests
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE < 8) {
+    die("skip 64bit test only");
+}
+?>
+--FILE--
+<?php
+echo "I\n";
+print_r(unpack("I", hex2bin('18fcffff')));
+print_r(unpack("I", hex2bin('4e04ffff')));
+
+echo "L\n";
+print_r(unpack("L", hex2bin('02000080')));
+print_r(unpack("L", hex2bin('ffffffff')));
+print_r(unpack("L", hex2bin('00000080')));
+
+echo "N\n";
+print_r(unpack("N", hex2bin('80000002')));
+print_r(unpack("N", hex2bin('80000000')));
+print_r(unpack("N", hex2bin('ffff8ad0')));
+
+echo "V\n";
+print_r(unpack("V", hex2bin('02000080')));
+print_r(unpack("V", hex2bin('00000080')));
+?>
+--EXPECT--
+I
+Array
+(
+    [1] => 4294966296
+)
+Array
+(
+    [1] => 4294902862
+)
+L
+Array
+(
+    [1] => 2147483650
+)
+Array
+(
+    [1] => 4294967295
+)
+Array
+(
+    [1] => 2147483648
+)
+N
+Array
+(
+    [1] => 2147483650
+)
+Array
+(
+    [1] => 2147483648
+)
+Array
+(
+    [1] => 4294937296
+)
+V
+Array
+(
+    [1] => 2147483650
+)
+Array
+(
+    [1] => 2147483648
+)


### PR DESCRIPTION
Recreating. I'm sorry for the one that failed to create properly.

----
Generic `pack()` test for 64-bit.
Also add some test cases for better coverage.

- Add headers to generic pack test:
  To make the output easier to read.
- Add generic pack test for 64bit:
  Split int size-dependent test cases.
- Add missing test cases for generic pack() test:
   Add tests for uncovered lines. (For one uncovered part, I'd like to make a code fix later day...)
   Locally the coverage increased as follows with the third commit on master:

   |          |Before  |After   |
   |----------|-------:|-------:|
   |Lines:    |  87.9 %|  98.1 %|
   |Functions:| 100.0 %| 100.0 %|
   |Branches: |  68.1 %|  76.1 %|
   
   ```
   make test TESTS="$(printf 'ext/standard/tests/strings/%s.phpt ' bug35817 \
     bug36148 bug38770 bug61764 bug69522 bug70487 bug78833 gh10940 htmlentities17 \
     htmlentities20 htmlentities_html4 htmlentities_html5 pack pack64 pack64_32 \
     pack_A pack_arrays pack_float pack_int pack_int_64bit pack_Z unpack_bug68225 \
     unpack_error unpack_offset)"
   ```
