### PR TITLE
Fix Intel CET / SHSTK support in fibers

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -69,10 +69,14 @@
 #endif
 
 # if defined __CET__
+#  include <sys/syscall.h>
+#  include <unistd.h>
 #  include <cet.h>
 #  define SHSTK_ENABLED (__CET__ & 0x2)
 #  define BOOST_CONTEXT_SHADOW_STACK (SHSTK_ENABLED && SHADOW_STACK_SYSCALL)
-#  define __NR_map_shadow_stack 451
+# ifndef SYS_map_shadow_stack
+#  define SYS_map_shadow_stack 453
+# endif
 # ifndef SHADOW_STACK_SET_TOKEN
 #  define SHADOW_STACK_SET_TOKEN 0x1
 #endif
@@ -283,7 +287,7 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
 
 	/* issue syscall to create shadow stack for the new fcontext */
 	/* SHADOW_STACK_SET_TOKEN option will put "restore token" on the new shadow stack */
-	stack->ss_base = (void *)syscall(__NR_map_shadow_stack, 0, stack->ss_size, SHADOW_STACK_SET_TOKEN);
+	stack->ss_base = (void *)syscall(SYS_map_shadow_stack, 0, stack->ss_size, SHADOW_STACK_SET_TOKEN);
 
 	if (stack->ss_base == MAP_FAILED) {
 		zend_throw_exception_ex(NULL, 0, "Fiber shadow stack allocate failed: mmap failed: %s (%d)", strerror(errno), errno);

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -279,11 +279,7 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
 	stack->size = stack_size;
 
 #if !defined(ZEND_FIBER_UCONTEXT) && BOOST_CONTEXT_SHADOW_STACK
-	/* shadow stack saves ret address only, need less space */
-	stack->ss_size= stack_size >> 5;
-
-	/* align shadow stack to 8 bytes. */
-	stack->ss_size = (stack->ss_size + 7) & ~7;
+	stack->ss_size = stack_size;
 
 	/* issue syscall to create shadow stack for the new fcontext */
 	/* SHADOW_STACK_SET_TOKEN option will put "restore token" on the new shadow stack */

--- a/configure.ac
+++ b/configure.ac
@@ -1274,11 +1274,18 @@ fi
 AC_CACHE_CHECK([whether syscall to create shadow stack exists],
 [php_cv_have_shadow_stack_syscall],
 [AC_RUN_IFELSE([AC_LANG_SOURCE([
+#include <sys/syscall.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#ifndef SYS_map_shadow_stack
+# define SYS_map_shadow_stack 453
+#endif
+#ifndef SHADOW_STACK_SET_TOKEN
+# define SHADOW_STACK_SET_TOKEN 0x1
+#endif
 int main(void) {
-  /* test if syscall 451, i.e., map_shadow_stack is available */
-  void* base = (void *)syscall(451, 0, 0x20000, 0x1);
+  /* test if map_shadow_stack is available */
+  void* base = (void *)syscall(SYS_map_shadow_stack, 0, 0x20000, SHADOW_STACK_SET_TOKEN);
   if (base != (void*)-1) {
     munmap(base, 0x20000);
     return 0;


### PR DESCRIPTION
This fixes SHSTK support in fibers:

* The syscall number for `map_shadow_stack` has changed since initial support was added. I update the syscall number and use the SYS_map_shadow_stack macro instead of the hard coded number when possible. Note: when the configure check is broken, SHSTK is _not_ disabled. Instead, SHSTK handling is not added, causing fibers to crash. So there is no risk of disabling a security feature by breaking this check.
* make_fcontext/jump_fcontext was broken due to accidental duplication of shadow stack handling
* Set the the shadow stack to the same size as the normal stack, as in the worse case the shadow stack needs as much space. This matches [what the kernel does](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/shstk.c?id=977b1ef51866aa7170409af80740788d4f9c4841#n132) for the main stack. This size is excluding the guard page the kernel adds.
* Enable SHSTK in CI. For now this should only check that we can build with -fcf-protection, and that the linker adds the SHSTK flag on the binary (cet-report=error). The glibc version used in CI will not enable SHSTK at runtime, but I believe it will in Ubuntu 24.

This can be tested with a kernel >= 6.6 and glibc >= 2.39, when compiling with `CFLAGS=-fcf-protection=full LDFLAGS=-Wl,-z,cet-report=error`, and running with `GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK`.

Check that the binary was compiled with SHSTK:

```
$ readelf -n sapi/cli/php | grep -a SHSTK
Properties: x86 feature: IBT, SHSTK
```

Check CPU and kernel support:

```
$ grep user_shstk /proc/cpuinfo
flags		: [...] user_shstk [...]
```

Check that `ld` enables SHSTK:

```
$ GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK strace sapi/cli/php -r '' 2>&1 | grep ARCH_SHSTK
arch_prctl(ARCH_SHSTK_ENABLE, 0x1)      = 0
arch_prctl(ARCH_SHSTK_STATUS, 0x7ffe4933a418) = 0
arch_prctl(ARCH_SHSTK_LOCK, 0xffffffffffffffff) = 0
```

See https://docs.kernel.org/next/x86/shstk.html
See https://www.phoronix.com/news/Glibc-Intel-CET-Shadow-Stack