### PR TITLE
Replace configure option --with-openssl-dir

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -102,6 +102,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The configure option --with-oci8 has been removed.
    - The configure option --with-zlib-dir has been removed.
    - The configure option --with-kerberos has been removed.
+   - The configure option --with-openssl-dir has been removed. SSL support in
+     ext/ftp and ext/mysqlnd is enabled implicitly, when building with
+     ext/openssl (--with-openssl), or explicitly by using new configure options
+     --with-ftp-ssl and --with-mysqlnd-ssl.
    - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
    - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
    - HAVE_UTSNAME_DOMAINNAME symbol renamed to HAVE_STRUCT_UTSNAME_DOMAINNAME.

--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -3,11 +3,12 @@ PHP_ARG_ENABLE([ftp],
   [AS_HELP_STRING([--enable-ftp],
     [Enable FTP support])])
 
-dnl TODO: Rename this option for master.
-PHP_ARG_WITH([openssl-dir],
+PHP_ARG_WITH([ftp-ssl],
   [whether to explicitly enable FTP SSL support],
-  [AS_HELP_STRING([[--with-openssl-dir]],
-    [FTP: Whether to enable FTP SSL support without ext/openssl])],
+  [AS_HELP_STRING([--with-ftp-ssl],
+    [Explicitly enable SSL support in ext/ftp when not building with
+    ext/openssl. If ext/openssl is enabled at the configure step, SSL is enabled
+    implicitly.])],
   [no],
   [no])
 
@@ -15,10 +16,10 @@ if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])
   PHP_NEW_EXTENSION(ftp, php_ftp.c ftp.c, $ext_shared)
 
-  dnl Empty variable means 'no'
+  dnl Empty variable means 'no' (for phpize builds).
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
+  if test "$PHP_OPENSSL" != "no" || test "$PHP_FTP_SSL" != "no"; then
     PHP_SETUP_OPENSSL(FTP_SHARED_LIBADD)
     PHP_SUBST(FTP_SHARED_LIBADD)
     AC_DEFINE(HAVE_FTP_SSL,1,[Whether FTP over SSL is supported])

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -6,6 +6,15 @@ PHP_ARG_ENABLE([mysqlnd],
   [no],
   [yes])
 
+PHP_ARG_WITH([mysqlnd-ssl],
+  [whether to explicitly enable SSL support in mysqlnd],
+  [AS_HELP_STRING([--with-mysqlnd-ssl],
+    [Explicitly enable SSL support in ext/mysqlnd when not building with
+    ext/openssl. If ext/openssl is enabled at the configure step, SSL is enabled
+    implicitly.])],
+  [no],
+  [no])
+
 PHP_ARG_ENABLE([mysqlnd-compression-support],
   [whether to enable compressed protocol support in mysqlnd],
   [AS_HELP_STRING([--disable-mysqlnd-compression-support],
@@ -32,9 +41,10 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 
   AC_DEFINE([MYSQLND_SSL_SUPPORTED], 1, [Enable core mysqlnd SSL code])
 
+  dnl Empty variable means 'no' (for phpize builds).
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
-  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
+  if test "$PHP_OPENSSL" != "no" || test "$PHP_MYSQLND_SSL" != "no"; then
     PHP_SETUP_OPENSSL(MYSQLND_SHARED_LIBADD, [AC_DEFINE(MYSQLND_HAVE_SSL,1,[Enable mysqlnd code that uses OpenSSL directly])])
   fi
 


### PR DESCRIPTION
This is a leftover from the refactoring of the --with-openssl-dir option that once accepted the path to OpenSSL but wasn't renamed back then.

Instead of --with-openssl-dir, SSL support in ext/ftp and ext/mysqlnd can be enabled implicitly when building with ext/openssl enabled (--with-openssl) or explicitly by using new separate configure options --with-ftp-ssl and --with-mysqlnd-ssl.