### PR TITLE
Fix GH-13727: Building with -Werror=strict-prototypes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-14013 (Erroneous dnl appended in configure). (Peter Kokot)
   . Fixed bug GH-10232 (If autoloading occurs during constant resolution
     filename and lineno are identified incorrectly). (ranvis)
+  . Fixed bug GH-13727 (Missing void keyword). (Peter Kokot)
 
 - Fibers:
   . Fixed bug GH-13903 (ASAN false positive underflow when executing copy()).

--- a/build/libtool.m4
+++ b/build/libtool.m4
@@ -4636,7 +4636,7 @@ for ac_symprfx in "" "_"; do
 extern "C" {
 #endif
 char nm_test_var;
-void nm_test_func(){}
+void nm_test_func(void){}
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is addon to the GH-13727 bug fix that was fixed in GH-13732. When configuring the build with:

    ./configure CFLAGS=-Werror=strict-prototypes

libtool check for parsing nm command would fail:

    checking command to parse /usr/bin/nm -B output from cc object... failed

Upstream libtool has this specific check already fixed. Note that this works only with Autoconf version 2.72 and later and is preparation for future compilers that might have this error enabled by default.