### PR TITLE
Remove unused always-available extension headers

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -24,7 +24,6 @@
 #include "ext/standard/info.h"
 #include "ext/standard/file.h"
 #include "ext/standard/php_var.h"
-#include "ext/spl/spl_exceptions.h"
 
 #include "zend_attributes.h"
 #include "zend_exceptions.h"

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -40,7 +40,6 @@
 #include "zend_smart_str.h"
 #include "zend_bitset.h"
 #include "zend_exceptions.h"
-#include "ext/spl/spl_array.h"
 #include "ext/random/php_random.h"
 #include "zend_frameless_function.h"
 

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -18,7 +18,6 @@
 #include "php_browscap.h"
 #include "php_ini.h"
 #include "php_string.h"
-#include "ext/pcre/php_pcre.h"
 
 #include "zend_ini_scanner.h"
 #include "zend_globals.h"

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -18,6 +18,7 @@
 
 #include <ctype.h>
 #include <sys/stat.h>
+#include <locale.h>
 
 #include "php.h"
 #include "SAPI.h"
@@ -25,7 +26,6 @@
 #include "php_ini.h"
 #include "ext/standard/php_string.h"
 #include "ext/standard/pageinfo.h"
-#include "ext/pcre/php_pcre.h"
 #ifdef ZTS
 #include "TSRM.h"
 #endif


### PR DESCRIPTION
These were once used in these files but at this point aren't and are only causing confusion whether file depends on additional extension.