### PR TITLE
Adjust zlog warning and error message in FPM kqueue event

### DIFF
--- a/sapi/fpm/fpm/events/kqueue.c
+++ b/sapi/fpm/fpm/events/kqueue.c
@@ -81,7 +81,7 @@ static int fpm_event_kqueue_init(int max) /* {{{ */
 
 	kevents = calloc(max, sizeof(struct kevent));
 	if (!kevents) {
-		zlog(ZLOG_ERROR, "epoll: unable to allocate %d events", max);
+		zlog(ZLOG_ERROR, "kevent: unable to allocate %d events", max);
 		return -1;
 	}
 
@@ -128,7 +128,7 @@ static int fpm_event_kqueue_wait(struct fpm_event_queue_s *queue, unsigned long 
 
 		/* trigger error unless signal interrupt */
 		if (errno != EINTR) {
-			zlog(ZLOG_WARNING, "epoll_wait() returns %d", errno);
+			zlog(ZLOG_WARNING, "kevent() returns %d", errno);
 			return -1;
 		}
 	}


### PR DESCRIPTION
This is just a small pull requests changing some strings and does not fix any bugs.

This merge request modifies the `zlog` warning and error message in the kqueue fpm-event (`sapi/fpm/fpm/events/`). These were incorrect, presumably the kqueue code was written based on the epoll code, and it was forgotten to adjust the strings accordingly. This improves it.