### PR TITLE
ext/sockets: adding SO_NOSIGPIPE constant.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -611,6 +611,7 @@ PHP 8.4 UPGRADE NOTES
   . SOCK_DCCP (NetBSD only).
   . TCP_SYNCNT (Linux only).
   . SO_EXCLBIND (Solaris/Illumos only).
+  . SO_NOSIGPIPE (macOs only).
 
 - Sodium:
   . SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -1782,6 +1782,13 @@ const SO_DETACH_BPF = UNKNOWN;
  */
 const SO_EXCLUSIVEADDRUSE = UNKNOWN;
 #endif
+#if defined(SO_NOSIGPIPE)
+/**
+ * @var int
+ * @cvalue SO_NOSIGPIPE
+ */
+const SO_NOSIGPIPE = UNKNOWN;
+#endif
 #if defined(TCP_QUICKACK)
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 88a8e188f73c18c510eb984586b21109b347f251 */
+ * Stub hash: 70a996a13d739c1d2d165c73427cff59ebae1c5f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -1019,6 +1019,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(SO_EXCLUSIVEADDRUSE)
 	REGISTER_LONG_CONSTANT("SO_EXCLUSIVEADDRUSE", SO_EXCLUSIVEADDRUSE, CONST_PERSISTENT);
+#endif
+#if defined(SO_NOSIGPIPE)
+	REGISTER_LONG_CONSTANT("SO_NOSIGPIPE", SO_NOSIGPIPE, CONST_PERSISTENT);
 #endif
 #if defined(TCP_QUICKACK)
 	REGISTER_LONG_CONSTANT("TCP_QUICKACK", TCP_QUICKACK, CONST_PERSISTENT);


### PR DESCRIPTION
it s the macOs way to disable the SIGPIPE signal emission, same
 as doing `signal(SIGPIPE, SIG_IGN)` but on the socket level.