### PR TITLE
[ci skip] ext/sockets: followup on #14065.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -209,8 +209,8 @@ PHP                                                                        NEWS
     (David Carlier)
   . Updated the socket_create_listen backlog argument default value to SOMAXCONN.
     (David Carlier)
-  . Added the SO_NOSIGPIPE constant to control the generation of SIGPIPE for macOs.
-    (David Carlier)
+  . Added the SO_NOSIGPIPE constant to control the generation of SIGPIPE for
+    macOs and FreeBSD. (David Carlier)
 
 - SNMP:
   . Removed the deprecated inet_ntoa call support. (David Carlier)

--- a/UPGRADING
+++ b/UPGRADING
@@ -611,7 +611,7 @@ PHP 8.4 UPGRADE NOTES
   . SOCK_DCCP (NetBSD only).
   . TCP_SYNCNT (Linux only).
   . SO_EXCLBIND (Solaris/Illumos only).
-  . SO_NOSIGPIPE (macOs only).
+  . SO_NOSIGPIPE (macOs and FreeBSD).
 
 - Sodium:
   . SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES


### PR DESCRIPTION
freebsd supports SO_NOSIGPIPE too.