### PR TITLE
Fix GH-14067: Check for ZEND_MOD_CONFLICTS in zend_startup_module_ex

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2323,13 +2323,11 @@ ZEND_API zend_result zend_startup_module_ex(zend_module_entry *module) /* {{{ */
 				}
 				zend_string_efree(lcname);
 			} else if (dep->type == MODULE_DEP_CONFLICTS) {
-				zend_module_entry *conflict_mod;
-
 				name_len = strlen(dep->name);
 				lcname = zend_string_alloc(name_len, 0);
 				zend_str_tolower_copy(ZSTR_VAL(lcname), dep->name, name_len);
 
-				if ((conflict_mod = zend_hash_find_ptr(&module_registry, lcname)) != NULL) {
+				if (zend_hash_exists(&module_registry, lcname) || zend_get_extension(dep->name)) {
 					zend_string_efree(lcname);
 					/* TODO: Check version relationship */
 					zend_error(E_CORE_WARNING, "Cannot load module \"%s\" because conflicting module \"%s\" is already loaded", module->name, dep->name);


### PR DESCRIPTION
This is still work in progress and doesn't work for all cases yet, but could be a starting point to improve the ZEND_MOD_* macros a bit. For example, it still doesn't work when two conflicting extensions has conflicts listed for each other.

When extension has conflicting extension(s) listed in ZEND_MOD_CONFLICTS this now properly emits a warning and doesn't load the extension.

Previously it relied on the sort order of the registered extensions:
- first the statically built extensions based on the PHP_ADD_EXTENSION_DEP (*nix) or ADD_EXTENSION_DEP (Windows) listed in the main/internal_functions.c or main/internal_functions_cli.c.
- then dynamically loaded extensions using the extension=<ext> and zend_extension=<ext> INI directives.

And it didn't detect conflicting extensions when they were loaded later in the list or when loaded as shared modules.