### PR TITLE
Avoid additional allocation in Document\createElementNS

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -913,7 +913,7 @@ PHP_METHOD(DOM_Document, createElementNS)
 	if (errorcode == 0) {
 		php_dom_libxml_ns_mapper *ns_mapper = php_dom_get_ns_mapper(intern);
 		xmlNsPtr ns = php_dom_libxml_ns_mapper_get_ns_raw_prefix_string(ns_mapper, prefix, xmlStrlen(prefix), uri);
-		xmlNodePtr nodep = xmlNewDocNode(docp, ns, localname, NULL);
+		xmlNodePtr nodep = xmlNewDocNodeEatName(docp, ns, localname, NULL);
 		if (UNEXPECTED(nodep == NULL)) {
 			php_dom_throw_error(INVALID_STATE_ERR, /* strict */ true);
 		} else {
@@ -921,9 +921,9 @@ PHP_METHOD(DOM_Document, createElementNS)
 		}
 	} else {
 		php_dom_throw_error(errorcode, dom_get_strict_error(intern->document));
+		xmlFree(localname);
 	}
 
-	xmlFree(localname);
 	xmlFree(prefix);
 }
 /* }}} end dom_document_create_element_ns */


### PR DESCRIPTION
For the following benchmark code:
```php
$dom = DOM\XMLDocument::createEmpty();
for ($i = 0; $i < 1000*100; $i++) $dom->createElementNS("urn:a", "thisisaveryverylongname");
```

We obtain the following on an i7-4790:
```
Benchmark 1: ./sapi/cli/php bench.php
  Time (mean ± σ):      34.5 ms ±   1.2 ms    [User: 31.4 ms, System: 2.9 ms]
  Range (min … max):    32.4 ms …  39.3 ms    84 runs

Benchmark 2: ./sapi/cli/php_old bench.php
  Time (mean ± σ):      36.6 ms ±   1.6 ms    [User: 33.6 ms, System: 2.9 ms]
  Range (min … max):    34.3 ms …  45.3 ms    80 runs

Summary
  ./sapi/cli/php bench.php ran
    1.06 ± 0.06 times faster than ./sapi/cli/php_old bench.php
```