### PR TITLE
Refactor BCMath 1

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -134,17 +134,7 @@ PHP_MINFO_FUNCTION(bcmath)
    Convert to bc_num detecting scale */
 static zend_result php_str2num(bc_num *num, char *str)
 {
-	char *p;
-
-	if (!(p = strchr(str, '.'))) {
-		if (!bc_str2num(num, str, 0)) {
-			return FAILURE;
-		}
-
-		return SUCCESS;
-	}
-
-	if (!bc_str2num(num, str, strlen(p+1))) {
+	if (!bc_str2num(num, str, 0, true)) {
 		return FAILURE;
 	}
 
@@ -624,12 +614,12 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
+	if (!bc_str2num(&first, ZSTR_VAL(left), scale, false)) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
-	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
+	if (!bc_str2num(&second, ZSTR_VAL(right), scale, false)) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -39,16 +39,16 @@ typedef enum {PLUS, MINUS} sign;
 typedef struct bc_struct *bc_num;
 
 typedef struct bc_struct {
-	sign   n_sign;
 	size_t n_len;   /* The number of digits before the decimal point. */
 	size_t n_scale; /* The number of digits after the decimal point. */
-	int    n_refs;  /* The number of pointers to this number. */
 	char  *n_ptr;   /* The pointer to the actual storage.
 	                  If NULL, n_value points to the inside of another number
 	                  (bc_multiply...) and should not be "freed." */
 	char  *n_value; /* The number. Not zero char terminated.
 	                   May not point to the same place as n_ptr as
 	                   in the case of leading zeros generated. */
+	int    n_refs;  /* The number of pointers to this number. */
+	sign   n_sign;
 } bc_struct;
 
 #ifdef HAVE_CONFIG_H

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -97,7 +97,7 @@ bc_num bc_copy_num(bc_num num);
 
 void bc_init_num(bc_num *num);
 
-bool bc_str2num(bc_num *num, char *str, size_t scale);
+bool bc_str2num(bc_num *num, char *str, size_t scale, bool auto_scale);
 
 zend_string *bc_num2str_ex(bc_num num, size_t scale);
 

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -69,7 +69,7 @@ bool bc_str2num(bc_num *num, char *str, size_t scale, bool auto_scale)
 	/* decimal point */
 	decimal_point = (*ptr == '.') ? ptr : NULL;
 
-	/* If a string other than numbers exists */
+	/* If a non-digit and non-decimal-point indicator is in the string, i.e. an invalid character */
 	if (!decimal_point && *ptr != '\0') {
 		goto fail;
 	}


### PR DESCRIPTION
- Adjusting the order of structure members
- Refactor `bc_str2num`

Very rough speed comparison

code (Increased loop count to 1 million):
```
<?php

$num1 = '1.2345678901234567890';
$num2 = '-2.12345678901234567890';

$start = microtime(true);
for ($i = 0; $i < 10000000; $i++) {
    bcadd($num1, $num2, 20);
}
echo microtime(true) - $start . PHP_EOL;

$num1 = '12345678901234567890.12345678901234567890';
$num2 = '-212345678901234567890.12345678901234567890';

$start = microtime(true);
for ($i = 0; $i < 10000000; $i++) {
    bcadd($num1, $num2, 20);
}
echo microtime(true) - $start . PHP_EOL;

$num1 = '12345678901234567890.00000000000000000000000000000000000000000000000000';
$num2 = '-212345678901234567890.00000000000000000000000000000000000000000000000000';

$start = microtime(true);
for ($i = 0; $i < 10000000; $i++) {
    bcadd($num1, $num2, 20);
}
echo microtime(true) - $start . PHP_EOL;
```

Executed 3 times each

before:
```
// 1
2.5999221801758
3.0079250335693
3.2259128093719

// 2
2.5655269622803
3.0276448726654
3.2609598636627

// 3
2.5622088909149
3.0198249816895
3.3219320774078
```

after adjusting the order of structure members:
```
// 1
2.4207520484924
3.0243470668793
3.2665190696716

// 2
2.4135448932648
2.987694978714
3.2447309494019

// 3
2.414500951767
2.9784641265869
3.2391669750214
```

after refactor `bc_str2num`:
```
// 1
2.0390820503235
2.5814299583435
2.589555978775

// 2
2.0322518348694
2.5541210174561
2.5936360359192

// 3
2.0435800552368
2.60458111763
2.5752019882202
```