### PR TITLE
Add ReflectionClassConstant::isDeprecated()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -257,6 +257,7 @@ PHP 8.4 UPGRADE NOTES
   . ReflectionClassConstant::__toString() and ReflectionProperty::__toString()
     now returns the attached doc comments.
   . ReflectionConstant was introduced.
+  . ReflectionClassConstant::isDeprecated() was introduced.
 
 - Standard:
   . stream_bucket_make_writeable() and stream_bucket_new() will now return a

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4067,6 +4067,20 @@ ZEND_METHOD(ReflectionClassConstant, isEnumCase)
 	RETURN_BOOL(ZEND_CLASS_CONST_FLAGS(ref) & ZEND_CLASS_CONST_IS_CASE);
 }
 
+ZEND_METHOD(ReflectionClassConstant, isDeprecated)
+{
+	reflection_object *intern;
+	zend_constant *ref;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	GET_REFLECTION_OBJECT_PTR(ref);
+
+	RETURN_BOOL(ZEND_CLASS_CONST_FLAGS(ref) & ZEND_ACC_DEPRECATED);
+}
+
 /* {{{ reflection_class_object_ctor */
 static void reflection_class_object_ctor(INTERNAL_FUNCTION_PARAMETERS, int is_object)
 {

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -554,6 +554,8 @@ class ReflectionClassConstant implements Reflector
 
     public function isEnumCase(): bool {}
 
+    public function isDeprecated(): bool {}
+
     public function hasType(): bool {}
 
     public function getType(): ?ReflectionType {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c81572d388f2539d861df717b3cc8c0491fe72a0 */
+ * Stub hash: f3fd5084866ba31bfa4e7e2bf78d95107cfe4b61 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -418,6 +418,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionClassConstant_isEnumCase arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
+#define arginfo_class_ReflectionClassConstant_isDeprecated arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
+
 #define arginfo_class_ReflectionClassConstant_hasType arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionClassConstant_getType arginfo_class_ReflectionFunctionAbstract_getTentativeReturnType
@@ -783,6 +785,7 @@ ZEND_METHOD(ReflectionClassConstant, getDeclaringClass);
 ZEND_METHOD(ReflectionClassConstant, getDocComment);
 ZEND_METHOD(ReflectionClassConstant, getAttributes);
 ZEND_METHOD(ReflectionClassConstant, isEnumCase);
+ZEND_METHOD(ReflectionClassConstant, isDeprecated);
 ZEND_METHOD(ReflectionClassConstant, hasType);
 ZEND_METHOD(ReflectionClassConstant, getType);
 ZEND_METHOD(ReflectionParameter, __construct);
@@ -1068,6 +1071,7 @@ static const zend_function_entry class_ReflectionClassConstant_methods[] = {
 	ZEND_ME(ReflectionClassConstant, getDocComment, arginfo_class_ReflectionClassConstant_getDocComment, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getAttributes, arginfo_class_ReflectionClassConstant_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, isEnumCase, arginfo_class_ReflectionClassConstant_isEnumCase, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClassConstant, isDeprecated, arginfo_class_ReflectionClassConstant_isDeprecated, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, hasType, arginfo_class_ReflectionClassConstant_hasType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getType, arginfo_class_ReflectionClassConstant_getType, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -38,6 +38,11 @@ namespace {
          */
         public const int|string TYPED_CLASS_CONST3 = UNKNOWN;
 
+        /**
+         * @deprecated
+         */
+        public const int ZEND_TEST_DEPRECATED = 42;
+
         /** @var mixed */
         public static $_StaticProp;
         public static int $staticIntProp = 123;

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dd3f852ea9f8e3a356ed226380edf5cc336f8a4e */
+ * Stub hash: 1f258f37425d3f6458c447ac2e7b3cbe0a221be0 */
 
 ZEND_STATIC_ASSERT(PHP_VERSION_ID >= 80000, "test_arginfo.h only supports PHP version ID 80000 or newer, "
 	"but it is included on an older PHP version");
@@ -585,6 +585,16 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 	zend_declare_class_constant_ex(class_entry, const_TYPED_CLASS_CONST3_name, &const_TYPED_CLASS_CONST3_value, ZEND_ACC_PUBLIC, NULL);
 #endif
 	zend_string_release(const_TYPED_CLASS_CONST3_name);
+
+	zval const_ZEND_TEST_DEPRECATED_value;
+	ZVAL_LONG(&const_ZEND_TEST_DEPRECATED_value, 42);
+	zend_string *const_ZEND_TEST_DEPRECATED_name = zend_string_init_interned("ZEND_TEST_DEPRECATED", sizeof("ZEND_TEST_DEPRECATED") - 1, 1);
+#if (PHP_VERSION_ID >= 80300)
+	zend_declare_typed_class_constant(class_entry, const_ZEND_TEST_DEPRECATED_name, &const_ZEND_TEST_DEPRECATED_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+#else
+	zend_declare_class_constant_ex(class_entry, const_ZEND_TEST_DEPRECATED_name, &const_ZEND_TEST_DEPRECATED_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
+#endif
+	zend_string_release(const_ZEND_TEST_DEPRECATED_name);
 
 	zval property__StaticProp_default_value;
 	ZVAL_NULL(&property__StaticProp_default_value);

--- a/ext/zend_test/tests/class_constant_deprecated.phpt
+++ b/ext/zend_test/tests/class_constant_deprecated.phpt
@@ -1,0 +1,17 @@
+--TEST--
+ReflectionClassConstant::isDeprecated()
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$r = new ReflectionClassConstant('_ZendTestClass', 'ZEND_TEST_DEPRECATED');
+var_dump($r->isDeprecated());
+
+$r = new ReflectionClassConstant('_ZendTestClass', 'TYPED_CLASS_CONST2');
+var_dump($r->isDeprecated());
+
+?>
+--EXPECTF--
+bool(true)
+bool(false)


### PR DESCRIPTION
This is in preparation for php/php-src#11293 and for consistency with ReflectionConstant::isDeprecated() that was added in php/php-src#13669.