### PR TITLE
reflection: Fix ReflectionFunction::getShortName() for first class callables

### DIFF
--- a/Zend/tests/closure_068.phpt
+++ b/Zend/tests/closure_068.phpt
@@ -1,0 +1,13 @@
+--TEST--
+ReflectionFunction::getShortName() returns the short name for first class callables defined in namespaces.
+--FILE--
+<?php
+namespace Foo;
+
+function foo() {
+}
+$r = new \ReflectionFunction(foo(...));
+var_dump($r->getShortName());
+?>
+--EXPECT--
+string(3) "foo"

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3609,7 +3609,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getShortName)
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
 	zend_string *name = fptr->common.function_name;
-	if (!(fptr->common.fn_flags & ZEND_ACC_CLOSURE)) {
+	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) != ZEND_ACC_CLOSURE) {
 		const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
 		if (backslash) {
 			RETURN_STRINGL(backslash + 1, ZSTR_LEN(name) - (backslash - ZSTR_VAL(name) + 1));


### PR DESCRIPTION
Fix fixes an incorrect fix in php/php-src#14001.