### PR TITLE
random: Add PHPAPI to all `php_random_algo` definitions

### DIFF
--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -101,7 +101,7 @@ static bool unserialize(void *state, HashTable *data)
 	return true;
 }
 
-const php_random_algo php_random_algo_combinedlcg = {
+PHPAPI const php_random_algo php_random_algo_combinedlcg = {
 	sizeof(php_random_status_state_combinedlcg),
 	generate,
 	range,

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -228,7 +228,7 @@ static bool unserialize(void *state, HashTable *data)
 	return true;
 }
 
-const php_random_algo php_random_algo_mt19937 = {
+PHPAPI const php_random_algo php_random_algo_mt19937 = {
 	sizeof(php_random_status_state_mt19937),
 	generate,
 	range,

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -105,7 +105,7 @@ static bool unserialize(void *state, HashTable *data)
 	return true;
 }
 
-const php_random_algo php_random_algo_pcgoneseq128xslrr64 = {
+PHPAPI const php_random_algo php_random_algo_pcgoneseq128xslrr64 = {
 	sizeof(php_random_status_state_pcgoneseq128xslrr64),
 	generate,
 	range,

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -46,7 +46,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 	return result;
 }
 
-const php_random_algo php_random_algo_secure = {
+PHPAPI const php_random_algo php_random_algo_secure = {
 	0,
 	generate,
 	range,

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -73,7 +73,7 @@ static zend_long range(void *state, zend_long min, zend_long max)
 	}, min, max);
 }
 
-const php_random_algo php_random_algo_user = {
+PHPAPI const php_random_algo php_random_algo_user = {
 	sizeof(php_random_status_state_user),
 	generate,
 	range,

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -154,7 +154,7 @@ static bool unserialize(void *state, HashTable *data)
 	return true;
 }
 
-const php_random_algo php_random_algo_xoshiro256starstar = {
+PHPAPI const php_random_algo php_random_algo_xoshiro256starstar = {
 	sizeof(php_random_status_state_xoshiro256starstar),
 	generate,
 	range,


### PR DESCRIPTION
The php_random.h header already defines them as `PHPAPI` and they actually are part of the public API.

----------------------

see https://github.com/php/php-src/pull/14054#issuecomment-2085450926