### PR TITLE
Fix tests for glibc 2.39

### DIFF
--- a/ext/standard/tests/strings/setlocale_variation3.phpt
+++ b/ext/standard/tests/strings/setlocale_variation3.phpt
@@ -47,7 +47,7 @@ if($locale_info_before ==  $locale_info_after){
 
 echo "\nDone\n";
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing setlocale() : usage variations - setting system locale = 0 ***
 Locale info, before setting the locale
 array(18) {
@@ -84,17 +84,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }
@@ -134,17 +130,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }

--- a/ext/standard/tests/strings/setlocale_variation4.phpt
+++ b/ext/standard/tests/strings/setlocale_variation4.phpt
@@ -45,7 +45,7 @@ if($locale_info_before != $locale_info_after){
 
 echo "\nDone\n";
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing setlocale() : usage variations - Setting system locale = null ***
 Locale info, before setting the locale
 array(18) {
@@ -82,17 +82,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }
@@ -132,17 +128,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }

--- a/ext/standard/tests/strings/setlocale_variation5.phpt
+++ b/ext/standard/tests/strings/setlocale_variation5.phpt
@@ -49,7 +49,7 @@ if($locale_info_before != $locale_info_after){
 
 echo "\nDone\n";
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing setlocale() : usage variations - setting system locale = "" ***
 Locale info, before setting the locale
 array(18) {
@@ -86,17 +86,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }
@@ -136,17 +132,13 @@ array(18) {
   ["n_sign_posn"]=>
   int(1)
   ["grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
   ["mon_grouping"]=>
-  array(2) {
-    [0]=>
-    int(3)
-    [1]=>
+  array(%d) {%A
+    [%d]=>
     int(3)
   }
 }


### PR DESCRIPTION
Glibc 2.39 has fixed inconsistent (mon_)grouping formats in localedata:

* https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;hb=refs/tags/glibc-2.39#l237
* https://sourceware.org/git/?p=glibc.git;a=blob;f=localedata/locales/en_AU;hb=refs/tags/glibc-2.39#l65

For en_AU locale now it returns array of 1 item instead of 2 for grouping and mon_grouping.

Since this is upstream change depending on the system, this only syncs tests for such case.

Steps to reproduce the issue:
- run tests on Ubuntu 24.04