### PR TITLE
CircleCI: Specify mysql_native_password as the default authentication method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_ROOT_PASSWORD: ''
           MYSQL_DATABASE: test
+        command: --mysql_native_password=ON
       - image: postgres:16
         environment:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Starting with MySQL8.4, mysql_native_password is disabled by default.
(I think it will probably fail from today as docker image 8.4 was released today)