### PR TITLE
Implement BCMath LRU cache

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -193,13 +193,13 @@ static PHP_GSHUTDOWN_FUNCTION(bcmath)
 
 static PHP_RINIT_FUNCTION(bcmath)
 {
-	bcmath_lru_init(&bcmath_globals.lru_cache);
+	bcmath_lru_init(&BCG(lru_cache));
 	return SUCCESS;
 }
 
 static PHP_RSHUTDOWN_FUNCTION(bcmath)
 {
-	bcmath_lru_destroy(&bcmath_globals.lru_cache);
+	bcmath_lru_destroy(&BCG(lru_cache));
 	return SUCCESS;
 }
 

--- a/ext/bcmath/php_bcmath.h
+++ b/ext/bcmath/php_bcmath.h
@@ -21,17 +21,31 @@
 #include "zend_API.h"
 #include "ext/standard/php_math_round_mode.h"
 
+#define PHP_BCMATH_LRU_SIZE 16
+
 extern zend_module_entry bcmath_module_entry;
 #define phpext_bcmath_ptr &bcmath_module_entry
 
 #include "php_version.h"
 #define PHP_BCMATH_VERSION PHP_VERSION
 
+typedef struct php_bc_lru_entry {
+	zend_string *str;
+	bc_num num;
+	struct php_bc_lru_entry *prev, *next;
+} php_bc_lru_entry;
+
+typedef struct php_bc_lru_cache {
+	HashTable table;
+	php_bc_lru_entry *head, *tail;
+} php_bc_lru_cache;
+
 ZEND_BEGIN_MODULE_GLOBALS(bcmath)
 	bc_num _zero_;
 	bc_num _one_;
 	bc_num _two_;
 	int bc_precision;
+	php_bc_lru_cache lru_cache;
 ZEND_END_MODULE_GLOBALS(bcmath)
 
 #if defined(ZTS) && defined(COMPILE_DL_BCMATH)


### PR DESCRIPTION
This is a prototype for an LRU cache for operands used in BCMath.

We notice in profiles that parsing operands takes a long time (like over 30% for the benchmark in #14076).
This PR implements a cache for the 16 most recently used operands, such that parsing can be avoided. The underlying idea is that in a particular time window the same operands are likely to be used again (*).

This implementation could probably be improved too performance-wise.
*Important:* One notable thing missing is that results are not stored in the LRU cache yet.

(*) The question is whether this is true in real-world use-cases. If this is not true most of the time, then a patch like this will cause a performance degradation because maintaining the LRU also has some overhead.