### PR TITLE
Refactor bcmath 2

### DIFF
--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -38,7 +38,6 @@ zend_string *bc_num2str_ex(bc_num num, size_t scale)
 {
 	zend_string *str;
 	char *sptr;
-	size_t index;
 	bool signch;
 	size_t min_scale = MIN(num->n_scale, scale);
 
@@ -64,8 +63,15 @@ zend_string *bc_num2str_ex(bc_num num, size_t scale)
 	if (scale > 0) {
 		*sptr++ = '.';
 		sptr = bc_copy_bcd_val(sptr, nptr, nptr + min_scale);
-		for (index = num->n_scale; index < scale; index++) {
-			*sptr++ = BCD_CHAR(0);
+
+		size_t scale_diff;
+		if (scale > num->n_scale && (scale_diff = scale - num->n_scale) > 8) {
+			memset(sptr, BCD_CHAR(0), scale_diff);
+			sptr += scale_diff;
+		} else {
+			for (size_t index = num->n_scale; index < scale; index++) {
+				*sptr++ = BCD_CHAR(0);
+			}
 		}
 	}
 

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -75,7 +75,7 @@ bool bc_str2num(bc_num *num, char *str, size_t scale, bool auto_scale)
 	if (decimal_point) {
 		/* search */
 		fractional_ptr = fractional_end = decimal_point + 1;
-		if (*fractional_ptr == '\0') {
+		if (UNEXPECTED(*fractional_ptr == '\0')) {
 			goto after_fractional;
 		}
 


### PR DESCRIPTION
benchmark: https://github.com/php/php-src/pull/14076

before:
```
1.6825220584869
2.0993950366974
2.1744661331177
```

use UNEXPECTED:
```
1.6566438674927
2.0563621520996
2.1560161113739
```

use memset:
```
1.6639218330383
1.9661808013916
2.0960700511932
```

The difference is small, so it would be helpful if someone also could try it on.