### PR TITLE
Temporary fix for CircleCI ARM MySQL build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     resource_class: arm.medium
     docker:
       - image: cimg/base:current-22.04
-      - image: mysql:8
+      - image: mysql:8.3
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_ROOT_PASSWORD: ''


### PR DESCRIPTION
MySQL 8.4 does not load the 'mysql_native_password' plugin by default and I couldn't figure out how to initialise the container to load it.