### PR TITLE
Fix persisting of inherited class constants

### DIFF
--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -806,11 +806,16 @@ static zend_property_info *zend_persist_property_info(zend_property_info *prop)
 
 static void zend_persist_class_constant(zval *zv)
 {
-	zend_class_constant *c = zend_shared_alloc_get_xlat_entry(Z_PTR_P(zv));
+	zend_class_constant *orig_c = Z_PTR_P(zv);
+	zend_class_constant *c = zend_shared_alloc_get_xlat_entry(orig_c);
 	zend_class_entry *ce;
 
 	if (c) {
 		Z_PTR_P(zv) = c;
+		return;
+	} else if (((orig_c->ce->ce_flags & ZEND_ACC_IMMUTABLE) && !(Z_CONSTANT_FLAGS(orig_c->value) & CONST_OWNED))
+	 || orig_c->ce->type == ZEND_INTERNAL_CLASS) {
+		/* Class constant comes from a different file in shm or internal class, keep existing pointer. */
 		return;
 	} else if (!ZCG(current_persistent_script)->corrupted
 	 && zend_accel_in_shm(Z_PTR_P(zv))) {

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -26,6 +26,7 @@
 #include "zend_shared_alloc.h"
 #include "zend_operators.h"
 #include "zend_attributes.h"
+#include "zend_constants.h"
 
 #define ADD_DUP_SIZE(m,s)  ZCG(current_persistent_script)->size += zend_shared_memdup_size((void*)m, s)
 #define ADD_SIZE(m)        ZCG(current_persistent_script)->size += ZEND_ALIGNED_SIZE(m)
@@ -386,6 +387,11 @@ static void zend_persist_class_constant_calc(zval *zv)
 	zend_class_constant *c = Z_PTR_P(zv);
 
 	if (!zend_shared_alloc_get_xlat_entry(c)) {
+		if (((c->ce->ce_flags & ZEND_ACC_IMMUTABLE) && !(Z_CONSTANT_FLAGS(c->value) & CONST_OWNED))
+		 || c->ce->type == ZEND_INTERNAL_CLASS) {
+			/* Class constant comes from a different file in shm or internal class, keep existing pointer. */
+			return;
+		}
 		if (!ZCG(current_persistent_script)->corrupted
 		 && zend_accel_in_shm(Z_PTR_P(zv))) {
 			return;

--- a/ext/zend_test/tests/gh14109.phpt
+++ b/ext/zend_test/tests/gh14109.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-14109: User class extending internal class with attributes
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+class Test extends ZendAttributeTest {}
+foreach ((new ReflectionClassConstant(Test::class, 'TEST_CONST'))->getAttributes() as $attribute) {
+    var_dump($attribute->newInstance());
+}
+?>
+--EXPECTF--
+object(ZendTestRepeatableAttribute)#%d (0) {
+}
+object(ZendTestRepeatableAttribute)#%d (0) {
+}


### PR DESCRIPTION
Class constants are inherited to user classes without cloning. Thus, internal class constants should not be persisted at all. Simply keep pointing to the internal class constant. If the internal class constants are persisted, the attempt to free the `attributes` hash map after persistence will fail, because it's persistently allocated.

Fixes GH-14109

This will need to be rebased to PHP-8.2. I target master for now only because `ZendAttributeTest` doesn't exist on lower branches, and I was too lazy to backport.