### PR TITLE
Use AC_SEARCH_LIBS for socketpair, gethostname and gethostbyaddr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -356,16 +356,17 @@ test -d /usr/ucblib && PHP_ADD_LIBPATH(/usr/ucblib)
 dnl First, library checks.
 dnl ----------------------------------------------------------------------------
 
-dnl Some systems (OpenServer 5) dislike -lsocket -lnsl, so we try to avoid -lnsl
-dnl checks, if we already have the functions which are usually in libnsl. Also,
-dnl uClibc will bark at linking with glibc's libnsl.
-
 AC_SEARCH_LIBS([socket], [socket network])
-PHP_CHECK_FUNC(socketpair, socket, network)
-PHP_CHECK_FUNC(gethostname, nsl, network)
-PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
+
+AC_CHECK_FUNCS([socketpair],,
+  [AC_SEARCH_LIBS([socketpair], [socket network],
+    [AC_DEFINE([HAVE_SOCKETPAIR], [1])])])
+
+AC_SEARCH_LIBS([gethostbyaddr], [nsl network])
+
 AC_SEARCH_LIBS([dlopen], [dl],
   [AC_DEFINE([HAVE_LIBDL], [1], [Define to 1 if the dl library is available.])])
+
 AC_SEARCH_LIBS([sin], [m])
 
 case $host_alias in
@@ -588,6 +589,7 @@ ftok \
 funopen \
 gai_strerror \
 getcwd \
+gethostname \
 getloadavg \
 getlogin \
 getprotobyname \


### PR DESCRIPTION
The socketpair():
* C library: Solaris 11.4 and most other systems
* libsocket: Solaris <= 11.3 and illumos
* libnetwork: Haiku

The gethostname() check is moved to AC_CHECK_FUNCS:
* C library: most systems
* libnsl: none
* libnetwork: Haiku (which is already checked in the libraries section)

The gethostbyaddr():
* C library: most systems, Solaris 11.4
* libnsl: Solaris 11.3, illumos
* libnetwork: Haiku

This also removes redundant unused symbols:
- HAVE_GETHOSTBYADDR
- HAVE_LIBNETWORK
- HAVE_LIBNSL

The outdated comment about -lnsl and -lsocket linking has been removed because these systems are long not supported anymore and this issue is not relevant anymore like mentioned. The initial solution was different than the one with the PHP_CHECK_FUNC macros at the current versions. See commit a188fac946a65f4dcc2c6a0f37b0799d74500741 where the gethostbyaddr() was checked conditionally based on the gethostname() availability in libc. Main issue was mostly related to the redundant nsl library being always linked because of the AC_CHECK_LIB.