### PR TITLE
Fixed `mysql_native_password` being used due to empty password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ jobs:
     resource_class: arm.medium
     docker:
       - image: cimg/base:current-22.04
-      - image: mysql:8.3
+      - image: mysql:8
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_ROOT_PASSWORD: ''
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test
       - image: postgres:16
         environment:
@@ -18,10 +18,10 @@ jobs:
       LANGUAGE: ''
       LANG: en_US.UTF-8
       MYSQL_TEST_HOST: '127.0.0.1'
-      MYSQL_TEST_PASSWD: ''
+      MYSQL_TEST_PASSWD: root
       MYSQL_TEST_USER: root
       PDO_MYSQL_TEST_DSN: 'mysql:host=127.0.0.1;dbname=test'
-      PDO_MYSQL_TEST_PASS: ''
+      PDO_MYSQL_TEST_PASS: root
       PDO_MYSQL_TEST_USER: root
       PDO_PGSQL_TEST_DSN: 'pgsql:host=127.0.0.1 port=5432 dbname=test user=postgres password=postgres'
     steps:


### PR DESCRIPTION
I resolved a test failure on CircleCI with the newly released MySQL 8.4 Server. This issue is discussed in the following references:
https://externals.io/message/123253
#14112 
#14113 

In MySQL 8.4, the authentication plugin `mysql_native_password` is no longer loaded by default.However, mysqlnd still defaults to using `mysql_native_password` as the authentication method when the password is not set, as specified in `.circleci/config.yml`.

The same test passes on GitHub Actions because the password is set as follows:
https://github.com/php/php-src/blob/master/.github/workflows/push.yml#L52-L54

By aligning the test configurations in CircleCI with those in GitHub Actions, we can ensure compatibility with MySQL 8.4 Server.