### PR TITLE
Fix the MySQL Server version used for testing to `8.3`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -159,7 +159,7 @@ jobs:
       image: ubuntu:${{ matrix.branch.version.minor >= 3 && '22.04' || '20.04' }}
     services:
       mysql:
-        image: mysql:8
+        image: mysql:8.3
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,7 @@ jobs:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     services:
       mysql:
-        image: mysql:8
+        image: mysql:8.3
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
Refer to #14118 

MySQL 8.4 has been released, but some server behavior seems to be unstable. Therefore, we will fix the version of the `mysql` image used for testing to `8.3`.