### PR TITLE
Migrate ext/soap resources to objects

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -135,6 +135,10 @@ PHP 8.4 UPGRADE NOTES
   . Calling simplexml_import_dom() with a non-XML object now throws a TypeError
     instead of a ValueError.
 
+- SOAP:
+  . SoapClient::$httpurl is now a Soap\Url object rather than a resource.
+    Checks using is_resource() (i.e. is_resource($client->httpurl)) should be
+    replaced with checks for null (i.e. $client->httpurl !== null).
 - SPL:
   . Out of bounds accesses in SplFixedArray now throw an exception of type
     OutOfBoundsException instead of RuntimeException. As OutOfBoundsException

--- a/UPGRADING
+++ b/UPGRADING
@@ -139,6 +139,10 @@ PHP 8.4 UPGRADE NOTES
   . SoapClient::$httpurl is now a Soap\Url object rather than a resource.
     Checks using is_resource() (i.e. is_resource($client->httpurl)) should be
     replaced with checks for null (i.e. $client->httpurl !== null).
+  . SoapClient::$sdl is now a Soap\Sdl object rather than a resource.
+    Checks using is_resource() (i.e. is_resource($client->sdl)) should be
+    replaced with checks for null (i.e. $client->sdl !== null).
+
 - SPL:
   . Out of bounds accesses in SplFixedArray now throw an exception of type
     OutOfBoundsException instead of RuntimeException. As OutOfBoundsException

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -3449,12 +3449,10 @@ void delete_sdl_impl(void *handle)
 	efree(tmp);
 }
 
-void delete_sdl(void *handle)
+void delete_sdl(sdl *handle)
 {
-	sdlPtr tmp = (sdlPtr)handle;
-
-	if (!tmp->is_persistent) {
-		delete_sdl_impl(tmp);
+	if (!handle->is_persistent) {
+		delete_sdl_impl(handle);
 	}
 }
 

--- a/ext/soap/php_sdl.h
+++ b/ext/soap/php_sdl.h
@@ -260,7 +260,7 @@ encodePtr get_encoder_ex(sdlPtr sdl, const char *nscat, int len);
 sdlBindingPtr get_binding_from_type(sdlPtr sdl, sdlBindingType type);
 sdlBindingPtr get_binding_from_name(sdlPtr sdl, char *name, char *ns);
 
-void delete_sdl(void *handle);
+void delete_sdl(sdl *handle);
 void delete_sdl_impl(void *handle);
 
 void sdl_set_uri_credentials(sdlCtx *ctx, char *uri);

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -193,6 +193,7 @@ ZEND_TSRMLS_CACHE_EXTERN()
 extern zend_class_entry* soap_class_entry;
 extern zend_class_entry* soap_var_class_entry;
 extern zend_class_entry* soap_url_class_entry;
+extern zend_class_entry* soap_sdl_class_entry;
 
 void add_soap_fault(zval *obj, char *fault_code, char *fault_string, char *fault_actor, zval *fault_detail);
 
@@ -263,4 +264,10 @@ static inline soap_url_object *soap_url_object_fetch(zend_object *obj)
 }
 
 #define Z_SOAP_URL_P(zv) soap_url_object_fetch(Z_OBJ_P(zv))
+
+typedef struct soap_sdl_object {
+	sdl *sdl;
+	zend_object std;
+} soap_sdl_object;
+
 #endif

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -40,8 +40,6 @@
 # define stricmp strcasecmp
 #endif
 
-extern int le_url;
-
 typedef struct _encodeType encodeType, *encodeTypePtr;
 typedef struct _encode encode, *encodePtr;
 
@@ -194,6 +192,7 @@ ZEND_TSRMLS_CACHE_EXTERN()
 
 extern zend_class_entry* soap_class_entry;
 extern zend_class_entry* soap_var_class_entry;
+extern zend_class_entry* soap_url_class_entry;
 
 void add_soap_fault(zval *obj, char *fault_code, char *fault_string, char *fault_actor, zval *fault_detail);
 
@@ -253,4 +252,15 @@ static zend_always_inline zval *php_soap_deref(zval *zv) {
 #define Z_CLIENT_LAST_REQUEST_HEADERS_P(zv) php_soap_deref(OBJ_PROP_NUM(Z_OBJ_P(zv), 34))
 #define Z_CLIENT_LAST_RESPONSE_HEADERS_P(zv) php_soap_deref(OBJ_PROP_NUM(Z_OBJ_P(zv), 35))
 
+typedef struct soap_url_object {
+	php_url *url;
+	zend_object std;
+} soap_url_object;
+
+static inline soap_url_object *soap_url_object_fetch(zend_object *obj)
+{
+	return (soap_url_object *) ((char *) obj - XtOffsetOf(soap_url_object, std));
+}
+
+#define Z_SOAP_URL_P(zv) soap_url_object_fetch(Z_OBJ_P(zv))
 #endif

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -29,7 +29,6 @@
 #include "ext/standard/php_incomplete_class.h"
 
 
-static int le_sdl = 0;
 static int le_typemap = 0;
 
 typedef struct _soapHeader {
@@ -128,14 +127,12 @@ static void soap_error_handler(int error_num, zend_string *error_filename, const
 #define FETCH_THIS_SDL(ss) \
 	{ \
 		zval *__tmp = Z_CLIENT_SDL_P(ZEND_THIS); \
-		if (Z_TYPE_P(__tmp) == IS_RESOURCE) { \
-			FETCH_SDL_RES(ss,__tmp); \
+		if (Z_TYPE_P(__tmp) == IS_OBJECT && instanceof_function(Z_OBJCE_P(__tmp), soap_sdl_class_entry)) { \
+			ss = Z_SOAP_SDL_P(__tmp)->sdl; \
 		} else { \
 			ss = NULL; \
 		} \
 	}
-
-#define FETCH_SDL_RES(ss,tmp) ss = (sdlPtr) zend_fetch_resource_ex(tmp, "sdl", le_sdl)
 
 #define FETCH_TYPEMAP_RES(ss,tmp) ss = (HashTable*) zend_fetch_resource_ex(tmp, "typemap", le_typemap)
 
@@ -177,9 +174,11 @@ static zend_class_entry* soap_header_class_entry;
 static zend_class_entry* soap_param_class_entry;
 zend_class_entry* soap_var_class_entry;
 zend_class_entry *soap_url_class_entry;
+zend_class_entry *soap_sdl_class_entry;
 
 static zend_object_handlers soap_server_object_handlers;
 static zend_object_handlers soap_url_object_handlers;
+static zend_object_handlers soap_sdl_object_handlers;
 
 typedef struct {
 	soapServicePtr service;
@@ -234,6 +233,43 @@ static zend_function *soap_url_object_get_constructor(zend_object *object)
 
 	return NULL;
 }
+
+static inline soap_sdl_object *soap_sdl_object_fetch(zend_object *obj)
+{
+	return (soap_sdl_object *) ((char *) obj - XtOffsetOf(soap_sdl_object, std));
+}
+
+#define Z_SOAP_SDL_P(zv) soap_sdl_object_fetch(Z_OBJ_P(zv))
+
+static zend_object *soap_sdl_object_create(zend_class_entry *ce)
+{
+	soap_sdl_object *sdl_obj = zend_object_alloc(sizeof(soap_sdl_object), ce);
+
+	zend_object_std_init(&sdl_obj->std, ce);
+	object_properties_init(&sdl_obj->std, ce);
+
+	return &sdl_obj->std;
+}
+
+static void soap_sdl_object_free(zend_object *obj)
+{
+	soap_sdl_object *sdl_obj = soap_sdl_object_fetch(obj);
+
+	if (sdl_obj->sdl) {
+		delete_sdl(sdl_obj->sdl);
+		sdl_obj->sdl = NULL;
+	}
+
+	zend_object_std_dtor(&sdl_obj->std);
+}
+
+static zend_function *soap_sdl_object_get_constructor(zend_object *object)
+{
+	zend_throw_error(NULL, "Cannot directly construct Soap\\Sdl");
+
+	return NULL;
+}
+
 ZEND_DECLARE_MODULE_GLOBALS(soap)
 
 static void (*old_error_handler)(int, zend_string *, const uint32_t, zend_string *);
@@ -418,11 +454,6 @@ PHP_RINIT_FUNCTION(soap)
 	return SUCCESS;
 }
 
-static void delete_sdl_res(zend_resource *res)
-{
-	delete_sdl(res->ptr);
-}
-
 static void delete_hashtable_res(zend_resource *res)
 {
 	delete_hashtable(res->ptr);
@@ -458,7 +489,6 @@ PHP_MINIT_FUNCTION(soap)
 
 	soap_header_class_entry = register_class_SoapHeader();
 
-	le_sdl = zend_register_list_destructors_ex(delete_sdl_res, NULL, "SOAP SDL", module_number);
 	le_typemap = zend_register_list_destructors_ex(delete_hashtable_res, NULL, "SOAP table", module_number);
 
 	soap_url_class_entry = register_class_Soap_Url();
@@ -471,6 +501,17 @@ PHP_MINIT_FUNCTION(soap)
 	soap_url_object_handlers.get_constructor = soap_url_object_get_constructor;
 	soap_url_object_handlers.clone_obj = NULL;
 	soap_url_object_handlers.compare = zend_objects_not_comparable;
+
+	soap_sdl_class_entry = register_class_Soap_Sdl();
+	soap_sdl_class_entry->create_object = soap_sdl_object_create;
+	soap_sdl_class_entry->default_object_handlers = &soap_sdl_object_handlers;
+
+	memcpy(&soap_sdl_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	soap_sdl_object_handlers.offset = XtOffsetOf(soap_sdl_object, std);
+	soap_sdl_object_handlers.free_obj = soap_sdl_object_free;
+	soap_sdl_object_handlers.get_constructor = soap_sdl_object_get_constructor;
+	soap_sdl_object_handlers.clone_obj = NULL;
+	soap_sdl_object_handlers.compare = zend_objects_not_comparable;
 
 	register_soap_symbols(module_number);
 
@@ -2086,15 +2127,20 @@ PHP_METHOD(SoapClient, __construct)
 
 	if (wsdl) {
 		int    old_soap_version;
-		zend_resource *res;
 
 		old_soap_version = SOAP_GLOBAL(soap_version);
 		SOAP_GLOBAL(soap_version) = soap_version;
 
 		sdl = get_sdl(this_ptr, ZSTR_VAL(wsdl), cache_wsdl);
-		res = zend_register_resource(sdl, le_sdl);
 
-		ZVAL_RES(Z_CLIENT_SDL_P(this_ptr), res);
+		zval *sdl_zval = Z_CLIENT_SDL_P(this_ptr);
+		if (Z_TYPE_P(sdl_zval) == IS_OBJECT) {
+			zval_ptr_dtor(sdl_zval);
+		}
+
+		object_init_ex(sdl_zval, soap_sdl_class_entry);
+		soap_sdl_object *sdl_object = Z_SOAP_SDL_P(sdl_zval);
+		sdl_object->sdl = sdl;
 
 		SOAP_GLOBAL(soap_version) = old_soap_version;
 	}
@@ -2227,8 +2273,11 @@ static void do_soap_call(zend_execute_data *execute_data,
 	}
 
 	tmp = Z_CLIENT_SDL_P(this_ptr);
-	if (Z_TYPE_P(tmp) == IS_RESOURCE) {
-		FETCH_SDL_RES(sdl,tmp);
+	if (Z_TYPE_P(tmp) == IS_OBJECT) {
+#ifdef ZEND_DEBUG
+		ZEND_ASSERT(instanceof_function(Z_OBJCE_P(tmp), soap_sdl_class_entry));
+#endif
+		sdl = Z_SOAP_SDL_P(tmp)->sdl;
 	}
 
 	tmp = Z_CLIENT_TYPEMAP_P(this_ptr);
@@ -2536,13 +2585,12 @@ PHP_METHOD(SoapClient, __soapCall)
 /* {{{ Returns list of SOAP functions */
 PHP_METHOD(SoapClient, __getFunctions)
 {
-	sdlPtr sdl;
-
-	FETCH_THIS_SDL(sdl);
-
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
 	}
+
+	sdl *sdl;
+	FETCH_THIS_SDL(sdl);
 
 	if (sdl) {
 		smart_str buf = {0};
@@ -2562,13 +2610,12 @@ PHP_METHOD(SoapClient, __getFunctions)
 /* {{{ Returns list of SOAP types */
 PHP_METHOD(SoapClient, __getTypes)
 {
-	sdlPtr sdl;
-
-	FETCH_THIS_SDL(sdl);
-
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
 	}
+
+	sdl *sdl;
+	FETCH_THIS_SDL(sdl);
 
 	if (sdl) {
 		sdlTypePtr type;

--- a/ext/soap/soap.stub.php
+++ b/ext/soap/soap.stub.php
@@ -2,603 +2,614 @@
 
 /** @generate-class-entries */
 
-/**
- * @var int
- * @cvalue SOAP_1_1
- */
-const SOAP_1_1 = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_1_2
- */
-const SOAP_1_2 = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_PERSISTENCE_SESSION
- */
-const SOAP_PERSISTENCE_SESSION = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_PERSISTENCE_REQUEST
- */
-const SOAP_PERSISTENCE_REQUEST = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_FUNCTIONS_ALL
- */
-const SOAP_FUNCTIONS_ALL = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_ENCODED
- */
-const SOAP_ENCODED = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_LITERAL
- */
-const SOAP_LITERAL = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_RPC
- */
-const SOAP_RPC = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_DOCUMENT
- */
-const SOAP_DOCUMENT = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_ACTOR_NEXT
- */
-const SOAP_ACTOR_NEXT = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_ACTOR_NONE
- */
-const SOAP_ACTOR_NONE = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_ACTOR_UNLIMATERECEIVER
- */
-const SOAP_ACTOR_UNLIMATERECEIVER = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_COMPRESSION_ACCEPT
- */
-const SOAP_COMPRESSION_ACCEPT = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_COMPRESSION_GZIP
- */
-const SOAP_COMPRESSION_GZIP = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_COMPRESSION_DEFLATE
- */
-const SOAP_COMPRESSION_DEFLATE = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_AUTHENTICATION_BASIC
- */
-const SOAP_AUTHENTICATION_BASIC = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_AUTHENTICATION_DIGEST
- */
-const SOAP_AUTHENTICATION_DIGEST = UNKNOWN;
-
-/**
- * @var int
- * @cvalue UNKNOWN_TYPE
- */
-const UNKNOWN_TYPE = UNKNOWN;
-
-/**
- * @var int
- * @cvalue XSD_STRING
- */
-const XSD_STRING = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_BOOLEAN
- */
-const XSD_BOOLEAN = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_DECIMAL
- */
-const XSD_DECIMAL = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_FLOAT
- */
-const XSD_FLOAT = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_DOUBLE
- */
-const XSD_DOUBLE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_DURATION
- */
-const XSD_DURATION = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_DATETIME
- */
-const XSD_DATETIME = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_TIME
- */
-const XSD_TIME = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_DATE
- */
-const XSD_DATE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_GYEARMONTH
- */
-const XSD_GYEARMONTH = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_GYEAR
- */
-const XSD_GYEAR = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_GMONTHDAY
- */
-const XSD_GMONTHDAY = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_GDAY
- */
-const XSD_GDAY = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_GMONTH
- */
-const XSD_GMONTH = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_HEXBINARY
- */
-const XSD_HEXBINARY = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_BASE64BINARY
- */
-const XSD_BASE64BINARY = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ANYURI
- */
-const XSD_ANYURI = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_QNAME
- */
-const XSD_QNAME = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NOTATION
- */
-const XSD_NOTATION = UNKNOWN;
-
-/**
- * @var int
- * @cvalue XSD_NORMALIZEDSTRING
- */
-const XSD_NORMALIZEDSTRING = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_TOKEN
- */
-const XSD_TOKEN = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_LANGUAGE
- */
-const XSD_LANGUAGE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NMTOKEN
- */
-const XSD_NMTOKEN = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NAME
- */
-const XSD_NAME = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NCNAME
- */
-const XSD_NCNAME = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ID
- */
-const XSD_ID = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_IDREF
- */
-const XSD_IDREF = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_IDREFS
- */
-const XSD_IDREFS = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ENTITY
- */
-const XSD_ENTITY = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ENTITIES
- */
-const XSD_ENTITIES = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_INTEGER
- */
-const XSD_INTEGER = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NONPOSITIVEINTEGER
- */
-const XSD_NONPOSITIVEINTEGER = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NEGATIVEINTEGER
- */
-const XSD_NEGATIVEINTEGER = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_LONG
- */
-const XSD_LONG = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_INT
- */
-const XSD_INT = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_SHORT
- */
-const XSD_SHORT = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_BYTE
- */
-const XSD_BYTE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NONNEGATIVEINTEGER
- */
-const XSD_NONNEGATIVEINTEGER = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_UNSIGNEDLONG
- */
-const XSD_UNSIGNEDLONG = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_UNSIGNEDINT
- */
-const XSD_UNSIGNEDINT = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_UNSIGNEDSHORT
- */
-const XSD_UNSIGNEDSHORT = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_UNSIGNEDBYTE
- */
-const XSD_UNSIGNEDBYTE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_POSITIVEINTEGER
- */
-const XSD_POSITIVEINTEGER = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_NMTOKENS
- */
-const XSD_NMTOKENS = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ANYTYPE
- */
-const XSD_ANYTYPE = UNKNOWN;
-/**
- * @var int
- * @cvalue XSD_ANYXML
- */
-const XSD_ANYXML = UNKNOWN;
-
-/**
- * @var int
- * @cvalue APACHE_MAP
- */
-const APACHE_MAP = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_ENC_OBJECT
- */
-const SOAP_ENC_OBJECT = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_ENC_ARRAY
- */
-const SOAP_ENC_ARRAY = UNKNOWN;
-
-/**
- * @var int
- * @cvalue XSD_1999_TIMEINSTANT
- */
-const XSD_1999_TIMEINSTANT = UNKNOWN;
-
-/**
- * @var string
- * @cvalue XSD_NAMESPACE
- */
-const XSD_NAMESPACE = UNKNOWN;
-/**
- * @var string
- * @cvalue XSD_1999_NAMESPACE
- */
-const XSD_1999_NAMESPACE = UNKNOWN;
-
-/**
- * @var int
- * @cvalue SOAP_SINGLE_ELEMENT_ARRAYS
- */
-const SOAP_SINGLE_ELEMENT_ARRAYS = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_WAIT_ONE_WAY_CALLS
- */
-const SOAP_WAIT_ONE_WAY_CALLS = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_USE_XSI_ARRAY_TYPE
- */
-const SOAP_USE_XSI_ARRAY_TYPE = UNKNOWN;
-
-/**
- * @var int
- * @cvalue WSDL_CACHE_NONE
- */
-const WSDL_CACHE_NONE = UNKNOWN;
-/**
- * @var int
- * @cvalue WSDL_CACHE_DISK
- */
-const WSDL_CACHE_DISK = UNKNOWN;
-/**
- * @var int
- * @cvalue WSDL_CACHE_MEMORY
- */
-const WSDL_CACHE_MEMORY = UNKNOWN;
-/**
- * @var int
- * @cvalue WSDL_CACHE_BOTH
- */
-const WSDL_CACHE_BOTH = UNKNOWN;
-
-/* New SOAP SSL Method Constants */
-
-/**
- * @var int
- * @cvalue SOAP_SSL_METHOD_TLS
- */
-const SOAP_SSL_METHOD_TLS = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_SSL_METHOD_SSLv2
- */
-const SOAP_SSL_METHOD_SSLv2 = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_SSL_METHOD_SSLv3
- */
-const SOAP_SSL_METHOD_SSLv3 = UNKNOWN;
-/**
- * @var int
- * @cvalue SOAP_SSL_METHOD_SSLv23
- */
-const SOAP_SSL_METHOD_SSLv23 = UNKNOWN;
-
-function use_soap_error_handler(bool $enable = true): bool {}
-
-function is_soap_fault(mixed $object): bool {}
-
-class SoapParam
-{
-    public string $param_name;
-    public mixed $param_data;
-
-    public function __construct(mixed $data, string $name) {}
+namespace Soap {
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Url
+    {
+    }
 }
 
-class SoapHeader
-{
-    public string $namespace;
-    public string $name;
-    public mixed $data = null;
-    public bool $mustUnderstand;
-    public string|int|null $actor;
-
-    public function __construct(string $namespace, string $name, mixed $data = UNKNOWN, bool $mustUnderstand = false, string|int|null $actor = null) {}
-}
-
-class SoapFault extends Exception
-{
-    public string $faultstring;
-    public ?string $faultcode = null;
-    public ?string $faultcodens = null;
-    public ?string $faultactor = null;
-    public mixed $detail = null;
-    public ?string $_name = null;
-    public mixed $headerfault = null;
-
-    public function __construct(array|string|null $code, string $string, ?string $actor = null, mixed $details = null, ?string $name = null, mixed $headerFault = null) {}
-
-    public function __toString(): string {}
-}
-
-class SoapVar
-{
-    public int $enc_type;
-    public mixed $enc_value = null;
-    public ?string $enc_stype = null;
-    public ?string $enc_ns = null;
-    public ?string $enc_name = null;
-    public ?string $enc_namens = null;
-
-    public function __construct(mixed $data, ?int $encoding, ?string $typeName = null, ?string $typeNamespace = null, ?string $nodeName = null, ?string $nodeNamespace = null) {}
-}
-
-class SoapServer
-{
-    private ?SoapFault $__soap_fault = null;
-
-    public function __construct(?string $wsdl, array $options = []) {}
-
-    /** @tentative-return-type */
-    public function fault(string $code, string $string, string $actor = "", mixed $details = null, string $name = ""): void {}
-
-    /** @tentative-return-type */
-    public function addSoapHeader(SoapHeader $header): void {}
-
-    /** @tentative-return-type */
-    public function setPersistence(int $mode): void {}
-
-    /** @tentative-return-type */
-    public function setClass(string $class, mixed ...$args): void {}
-
-    /** @tentative-return-type */
-    public function setObject(object $object): void {}
-
-    /** @tentative-return-type */
-    public function getFunctions(): array {}
+namespace {
+    /**
+     * @var int
+     * @cvalue SOAP_1_1
+     */
+    const SOAP_1_1 = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_1_2
+     */
+    const SOAP_1_2 = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_PERSISTENCE_SESSION
+     */
+    const SOAP_PERSISTENCE_SESSION = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_PERSISTENCE_REQUEST
+     */
+    const SOAP_PERSISTENCE_REQUEST = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_FUNCTIONS_ALL
+     */
+    const SOAP_FUNCTIONS_ALL = UNKNOWN;
 
     /**
-     * @param array|string|int $functions
-     * @tentative-return-type
+     * @var int
+     * @cvalue SOAP_ENCODED
      */
-    public function addFunction($functions): void {}
-
-    /** @tentative-return-type */
-    public function handle(?string $request = null): void {}
-}
-
-class SoapClient
-{
-    private ?string $uri = null;
-    private ?int $style = null;
-    private ?int $use = null;
-    private ?string $location = null;
-    private bool $trace = false;
-    private ?int $compression = null;
-    /** @var resource|null */
-    private $sdl = null;
-    /** @var resource|null */
-    private $typemap = null;
-    /** @var resource|null */
-    private $httpsocket = null;
-    /** @var resource|null */
-    private $httpurl = null;
-
-    private ?string $_login = null;
-    private ?string $_password = null;
-    private bool $_use_digest = false;
-    private ?string $_digest = null;
-    private ?string $_proxy_host = null;
-    private ?int $_proxy_port = null;
-    private ?string $_proxy_login = null;
-    private ?string $_proxy_password = null;
-    private bool $_exceptions = true;
-    private ?string $_encoding = null;
-    private ?array $_classmap = null;
-    private ?int $_features = null;
-    private int $_connection_timeout = 0;
-    /** @var resource|null */
-    private $_stream_context = null;
-    private ?string $_user_agent = null;
-    private bool $_keep_alive = true;
-    private ?int $_ssl_method = null;
-    private int $_soap_version;
-    private ?int $_use_proxy = null;
-    private array $_cookies = [];
-    private ?array $__default_headers = null;
-    private ?SoapFault $__soap_fault = null;
-    private ?string $__last_request = null;
-    private ?string $__last_response = null;
-    private ?string $__last_request_headers = null;
-    private ?string $__last_response_headers = null;
-
-    public function __construct(?string $wsdl, array $options = []) {}
-
-    /** @tentative-return-type */
-    public function __call(string $name, array $args): mixed {}
+    const SOAP_ENCODED = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_LITERAL
+     */
+    const SOAP_LITERAL = UNKNOWN;
 
     /**
-     * @param SoapHeader|array|null $inputHeaders
-     * @param array $outputHeaders
-     * @tentative-return-type
+     * @var int
+     * @cvalue SOAP_RPC
      */
-    public function __soapCall(string $name, array $args, ?array $options = null, $inputHeaders = null, &$outputHeaders = null): mixed {}
-
-    /** @tentative-return-type */
-    public function __getFunctions(): ?array {}
-
-    /** @tentative-return-type */
-    public function __getTypes(): ?array {}
-
-    /** @tentative-return-type */
-    public function __getLastRequest(): ?string {}
-
-    /** @tentative-return-type */
-    public function __getLastResponse(): ?string {}
-
-    /** @tentative-return-type */
-    public function __getLastRequestHeaders(): ?string {}
-
-    /** @tentative-return-type */
-    public function __getLastResponseHeaders(): ?string {}
-
-    /** @tentative-return-type */
-    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string {}
-
-    /** @tentative-return-type */
-    public function __setCookie(string $name, ?string $value = null): void {}
-
-    /** @tentative-return-type */
-    public function __getCookies(): array {}
+    const SOAP_RPC = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_DOCUMENT
+     */
+    const SOAP_DOCUMENT = UNKNOWN;
 
     /**
-     * @param SoapHeader|array|null $headers
-     * @tentative-return-type
+     * @var int
+     * @cvalue SOAP_ACTOR_NEXT
      */
-    public function __setSoapHeaders($headers = null): bool {}
+    const SOAP_ACTOR_NEXT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_ACTOR_NONE
+     */
+    const SOAP_ACTOR_NONE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_ACTOR_UNLIMATERECEIVER
+     */
+    const SOAP_ACTOR_UNLIMATERECEIVER = UNKNOWN;
 
-    /** @tentative-return-type */
-    public function __setLocation(?string $location = null): ?string {}
+    /**
+     * @var int
+     * @cvalue SOAP_COMPRESSION_ACCEPT
+     */
+    const SOAP_COMPRESSION_ACCEPT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_COMPRESSION_GZIP
+     */
+    const SOAP_COMPRESSION_GZIP = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_COMPRESSION_DEFLATE
+     */
+    const SOAP_COMPRESSION_DEFLATE = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue SOAP_AUTHENTICATION_BASIC
+     */
+    const SOAP_AUTHENTICATION_BASIC = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_AUTHENTICATION_DIGEST
+     */
+    const SOAP_AUTHENTICATION_DIGEST = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue UNKNOWN_TYPE
+     */
+    const UNKNOWN_TYPE = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue XSD_STRING
+     */
+    const XSD_STRING = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_BOOLEAN
+     */
+    const XSD_BOOLEAN = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_DECIMAL
+     */
+    const XSD_DECIMAL = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_FLOAT
+     */
+    const XSD_FLOAT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_DOUBLE
+     */
+    const XSD_DOUBLE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_DURATION
+     */
+    const XSD_DURATION = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_DATETIME
+     */
+    const XSD_DATETIME = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_TIME
+     */
+    const XSD_TIME = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_DATE
+     */
+    const XSD_DATE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_GYEARMONTH
+     */
+    const XSD_GYEARMONTH = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_GYEAR
+     */
+    const XSD_GYEAR = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_GMONTHDAY
+     */
+    const XSD_GMONTHDAY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_GDAY
+     */
+    const XSD_GDAY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_GMONTH
+     */
+    const XSD_GMONTH = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_HEXBINARY
+     */
+    const XSD_HEXBINARY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_BASE64BINARY
+     */
+    const XSD_BASE64BINARY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ANYURI
+     */
+    const XSD_ANYURI = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_QNAME
+     */
+    const XSD_QNAME = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NOTATION
+     */
+    const XSD_NOTATION = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue XSD_NORMALIZEDSTRING
+     */
+    const XSD_NORMALIZEDSTRING = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_TOKEN
+     */
+    const XSD_TOKEN = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_LANGUAGE
+     */
+    const XSD_LANGUAGE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NMTOKEN
+     */
+    const XSD_NMTOKEN = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NAME
+     */
+    const XSD_NAME = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NCNAME
+     */
+    const XSD_NCNAME = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ID
+     */
+    const XSD_ID = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_IDREF
+     */
+    const XSD_IDREF = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_IDREFS
+     */
+    const XSD_IDREFS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ENTITY
+     */
+    const XSD_ENTITY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ENTITIES
+     */
+    const XSD_ENTITIES = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_INTEGER
+     */
+    const XSD_INTEGER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NONPOSITIVEINTEGER
+     */
+    const XSD_NONPOSITIVEINTEGER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NEGATIVEINTEGER
+     */
+    const XSD_NEGATIVEINTEGER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_LONG
+     */
+    const XSD_LONG = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_INT
+     */
+    const XSD_INT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_SHORT
+     */
+    const XSD_SHORT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_BYTE
+     */
+    const XSD_BYTE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NONNEGATIVEINTEGER
+     */
+    const XSD_NONNEGATIVEINTEGER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_UNSIGNEDLONG
+     */
+    const XSD_UNSIGNEDLONG = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_UNSIGNEDINT
+     */
+    const XSD_UNSIGNEDINT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_UNSIGNEDSHORT
+     */
+    const XSD_UNSIGNEDSHORT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_UNSIGNEDBYTE
+     */
+    const XSD_UNSIGNEDBYTE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_POSITIVEINTEGER
+     */
+    const XSD_POSITIVEINTEGER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_NMTOKENS
+     */
+    const XSD_NMTOKENS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ANYTYPE
+     */
+    const XSD_ANYTYPE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue XSD_ANYXML
+     */
+    const XSD_ANYXML = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue APACHE_MAP
+     */
+    const APACHE_MAP = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue SOAP_ENC_OBJECT
+     */
+    const SOAP_ENC_OBJECT = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_ENC_ARRAY
+     */
+    const SOAP_ENC_ARRAY = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue XSD_1999_TIMEINSTANT
+     */
+    const XSD_1999_TIMEINSTANT = UNKNOWN;
+
+    /**
+     * @var string
+     * @cvalue XSD_NAMESPACE
+     */
+    const XSD_NAMESPACE = UNKNOWN;
+    /**
+     * @var string
+     * @cvalue XSD_1999_NAMESPACE
+     */
+    const XSD_1999_NAMESPACE = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue SOAP_SINGLE_ELEMENT_ARRAYS
+     */
+    const SOAP_SINGLE_ELEMENT_ARRAYS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_WAIT_ONE_WAY_CALLS
+     */
+    const SOAP_WAIT_ONE_WAY_CALLS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_USE_XSI_ARRAY_TYPE
+     */
+    const SOAP_USE_XSI_ARRAY_TYPE = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue WSDL_CACHE_NONE
+     */
+    const WSDL_CACHE_NONE = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue WSDL_CACHE_DISK
+     */
+    const WSDL_CACHE_DISK = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue WSDL_CACHE_MEMORY
+     */
+    const WSDL_CACHE_MEMORY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue WSDL_CACHE_BOTH
+     */
+    const WSDL_CACHE_BOTH = UNKNOWN;
+
+    /* New SOAP SSL Method Constants */
+
+    /**
+     * @var int
+     * @cvalue SOAP_SSL_METHOD_TLS
+     */
+    const SOAP_SSL_METHOD_TLS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_SSL_METHOD_SSLv2
+     */
+    const SOAP_SSL_METHOD_SSLv2 = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_SSL_METHOD_SSLv3
+     */
+    const SOAP_SSL_METHOD_SSLv3 = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue SOAP_SSL_METHOD_SSLv23
+     */
+    const SOAP_SSL_METHOD_SSLv23 = UNKNOWN;
+
+    function use_soap_error_handler(bool $enable = true): bool {}
+
+    function is_soap_fault(mixed $object): bool {}
+
+    class SoapParam
+    {
+        public string $param_name;
+        public mixed $param_data;
+
+        public function __construct(mixed $data, string $name) {}
+    }
+
+    class SoapHeader
+    {
+        public string $namespace;
+        public string $name;
+        public mixed $data = null;
+        public bool $mustUnderstand;
+        public string|int|null $actor;
+
+        public function __construct(string $namespace, string $name, mixed $data = UNKNOWN, bool $mustUnderstand = false, string|int|null $actor = null) {}
+    }
+
+    class SoapFault extends Exception
+    {
+        public string $faultstring;
+        public ?string $faultcode = null;
+        public ?string $faultcodens = null;
+        public ?string $faultactor = null;
+        public mixed $detail = null;
+        public ?string $_name = null;
+        public mixed $headerfault = null;
+
+        public function __construct(array|string|null $code, string $string, ?string $actor = null, mixed $details = null, ?string $name = null, mixed $headerFault = null) {}
+
+        public function __toString(): string {}
+    }
+
+    class SoapVar
+    {
+        public int $enc_type;
+        public mixed $enc_value = null;
+        public ?string $enc_stype = null;
+        public ?string $enc_ns = null;
+        public ?string $enc_name = null;
+        public ?string $enc_namens = null;
+
+        public function __construct(mixed $data, ?int $encoding, ?string $typeName = null, ?string $typeNamespace = null, ?string $nodeName = null, ?string $nodeNamespace = null) {}
+    }
+
+    class SoapServer
+    {
+        private ?SoapFault $__soap_fault = null;
+
+        public function __construct(?string $wsdl, array $options = []) {}
+
+        /** @tentative-return-type */
+        public function fault(string $code, string $string, string $actor = "", mixed $details = null, string $name = ""): void {}
+
+        /** @tentative-return-type */
+        public function addSoapHeader(SoapHeader $header): void {}
+
+        /** @tentative-return-type */
+        public function setPersistence(int $mode): void {}
+
+        /** @tentative-return-type */
+        public function setClass(string $class, mixed ...$args): void {}
+
+        /** @tentative-return-type */
+        public function setObject(object $object): void {}
+
+        /** @tentative-return-type */
+        public function getFunctions(): array {}
+
+        /**
+         * @param array|string|int $functions
+         * @tentative-return-type
+         */
+        public function addFunction($functions): void {}
+
+        /** @tentative-return-type */
+        public function handle(?string $request = null): void {}
+    }
+
+    class SoapClient
+    {
+        private ?string $uri = null;
+        private ?int $style = null;
+        private ?int $use = null;
+        private ?string $location = null;
+        private bool $trace = false;
+        private ?int $compression = null;
+        /** @var resource|null */
+        private $sdl = null;
+        /** @var resource|null */
+        private $typemap = null;
+        /** @var resource|null */
+        private $httpsocket = null;
+        private ?Soap\Url $httpurl = null;
+
+        private ?string $_login = null;
+        private ?string $_password = null;
+        private bool $_use_digest = false;
+        private ?string $_digest = null;
+        private ?string $_proxy_host = null;
+        private ?int $_proxy_port = null;
+        private ?string $_proxy_login = null;
+        private ?string $_proxy_password = null;
+        private bool $_exceptions = true;
+        private ?string $_encoding = null;
+        private ?array $_classmap = null;
+        private ?int $_features = null;
+        private int $_connection_timeout = 0;
+        /** @var resource|null */
+        private $_stream_context = null;
+        private ?string $_user_agent = null;
+        private bool $_keep_alive = true;
+        private ?int $_ssl_method = null;
+        private int $_soap_version;
+        private ?int $_use_proxy = null;
+        private array $_cookies = [];
+        private ?array $__default_headers = null;
+        private ?SoapFault $__soap_fault = null;
+        private ?string $__last_request = null;
+        private ?string $__last_response = null;
+        private ?string $__last_request_headers = null;
+        private ?string $__last_response_headers = null;
+
+        public function __construct(?string $wsdl, array $options = []) {}
+
+        /** @tentative-return-type */
+        public function __call(string $name, array $args): mixed {}
+
+        /**
+         * @param SoapHeader|array|null $inputHeaders
+         * @param array $outputHeaders
+         * @tentative-return-type
+         */
+        public function __soapCall(string $name, array $args, ?array $options = null, $inputHeaders = null, &$outputHeaders = null): mixed {}
+
+        /** @tentative-return-type */
+        public function __getFunctions(): ?array {}
+
+        /** @tentative-return-type */
+        public function __getTypes(): ?array {}
+
+        /** @tentative-return-type */
+        public function __getLastRequest(): ?string {}
+
+        /** @tentative-return-type */
+        public function __getLastResponse(): ?string {}
+
+        /** @tentative-return-type */
+        public function __getLastRequestHeaders(): ?string {}
+
+        /** @tentative-return-type */
+        public function __getLastResponseHeaders(): ?string {}
+
+        /** @tentative-return-type */
+        public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string {}
+
+        /** @tentative-return-type */
+        public function __setCookie(string $name, ?string $value = null): void {}
+
+        /** @tentative-return-type */
+        public function __getCookies(): array {}
+
+        /**
+         * @param SoapHeader|array|null $headers
+         * @tentative-return-type
+         */
+        public function __setSoapHeaders($headers = null): bool {}
+
+        /** @tentative-return-type */
+        public function __setLocation(?string $location = null): ?string {}
+    }
 }

--- a/ext/soap/soap.stub.php
+++ b/ext/soap/soap.stub.php
@@ -10,6 +10,14 @@ namespace Soap {
     final class Url
     {
     }
+
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Sdl
+    {
+    }
 }
 
 namespace {
@@ -528,8 +536,7 @@ namespace {
         private ?string $location = null;
         private bool $trace = false;
         private ?int $compression = null;
-        /** @var resource|null */
-        private $sdl = null;
+        private ?Soap\Sdl $sdl = null;
         /** @var resource|null */
         private $typemap = null;
         /** @var resource|null */

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4dfc98696d4bc5e36610bdf03de906dbae049cf3 */
+ * Stub hash: 038c8f9ba355fba63e661148b48cdf0299b922f6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_use_soap_error_handler, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enable, _IS_BOOL, 0, "true")
@@ -173,6 +173,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
+static const zend_function_entry class_Soap_Url_methods[] = {
+	ZEND_FE_END
+};
+
 static const zend_function_entry class_SoapParam_methods[] = {
 	ZEND_ME(SoapParam, __construct, arginfo_class_SoapParam___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
@@ -308,6 +312,17 @@ static void register_soap_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("SOAP_SSL_METHOD_SSLv2", SOAP_SSL_METHOD_SSLv2, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SOAP_SSL_METHOD_SSLv3", SOAP_SSL_METHOD_SSLv3, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SOAP_SSL_METHOD_SSLv23", SOAP_SSL_METHOD_SSLv23, CONST_PERSISTENT);
+}
+
+static zend_class_entry *register_class_Soap_Url(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Soap", "Url", class_Soap_Url_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
+
+	return class_entry;
 }
 
 static zend_class_entry *register_class_SoapParam(void)
@@ -551,7 +566,8 @@ static zend_class_entry *register_class_SoapClient(void)
 	zval property_httpurl_default_value;
 	ZVAL_NULL(&property_httpurl_default_value);
 	zend_string *property_httpurl_name = zend_string_init("httpurl", sizeof("httpurl") - 1, 1);
-	zend_declare_typed_property(class_entry, property_httpurl_name, &property_httpurl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	zend_string *property_httpurl_class_Soap_Url = zend_string_init("Soap\\\125rl", sizeof("Soap\\\125rl")-1, 1);
+	zend_declare_typed_property(class_entry, property_httpurl_name, &property_httpurl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_httpurl_class_Soap_Url, 0, MAY_BE_NULL));
 	zend_string_release(property_httpurl_name);
 
 	zval property__login_default_value;

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 038c8f9ba355fba63e661148b48cdf0299b922f6 */
+ * Stub hash: 70fce84457c1e8fc45832d1fa6e7e070c67ad03f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_use_soap_error_handler, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enable, _IS_BOOL, 0, "true")
@@ -177,6 +177,10 @@ static const zend_function_entry class_Soap_Url_methods[] = {
 	ZEND_FE_END
 };
 
+static const zend_function_entry class_Soap_Sdl_methods[] = {
+	ZEND_FE_END
+};
+
 static const zend_function_entry class_SoapParam_methods[] = {
 	ZEND_ME(SoapParam, __construct, arginfo_class_SoapParam___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
@@ -319,6 +323,17 @@ static zend_class_entry *register_class_Soap_Url(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Soap", "Url", class_Soap_Url_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Soap_Sdl(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Soap", "Sdl", class_Soap_Sdl_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
@@ -548,7 +563,8 @@ static zend_class_entry *register_class_SoapClient(void)
 	zval property_sdl_default_value;
 	ZVAL_NULL(&property_sdl_default_value);
 	zend_string *property_sdl_name = zend_string_init("sdl", sizeof("sdl") - 1, 1);
-	zend_declare_typed_property(class_entry, property_sdl_name, &property_sdl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	zend_string *property_sdl_class_Soap_Sdl = zend_string_init("Soap\\Sdl", sizeof("Soap\\Sdl")-1, 1);
+	zend_declare_typed_property(class_entry, property_sdl_name, &property_sdl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_sdl_class_Soap_Sdl, 0, MAY_BE_NULL));
 	zend_string_release(property_sdl_name);
 
 	zval property_typemap_default_value;


### PR DESCRIPTION
Part of https://github.com/php/php-tasks/issues/6. Migrates 2 out of 3 resource types in ext/soap to opaque objects.