### PR TITLE
Fix libmysql download to stable URL

### DIFF
--- a/.github/actions/build-libmysqlclient/action.yml
+++ b/.github/actions/build-libmysqlclient/action.yml
@@ -15,10 +15,9 @@ runs:
         set -x
         LIBMYSQL=${{ inputs.libmysql }}
         MYSQL_BASE=${LIBMYSQL%%-linux-*}
-        MYSQL_VERSION=${MYSQL_BASE#*-}
         MYSQL_DIR=$HOME/$MYSQL_BASE
         mkdir -p $MYSQL_DIR
-        URL=https://cdn.mysql.com/Downloads/MySQL-${MYSQL_VERSION%.*}/$LIBMYSQL
+        URL=https://downloads.mysql.com/archives/get/p/23/file/$LIBMYSQL
         wget -nv $URL
         tar -xf $LIBMYSQL --strip-components=1 -C $MYSQL_DIR
         PDO_MYSQL=${MYSQL_DIR}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -745,7 +745,7 @@ jobs:
         uses: ./.github/actions/build-libmysqlclient
         with:
           configurationParameters: --enable-werror
-          libmysql: mysql-8.0.35-linux-glibc2.28-x86_64.tar.xz
+          libmysql: mysql-8.0.36-linux-glibc2.28-x86_64.tar.xz
           withMysqli: ${{ matrix.branch.ref == 'PHP-8.1' }}
       - name: Test mysql-8.0
         uses: ./.github/actions/test-libmysqlclient


### PR DESCRIPTION
Fixed an issue where libmysql download failed in Nightly Test.

Although this issue has not yet occurred in our repository, Once the CDN cache ceases to exist, issues will begin to occur. I've personally tried this on my own repository with mixed success and failure, with inconsistent results:
https://github.com/KentarouTakeda/php-src/actions/runs/8931850864/job/24534685059

![nightly-libmysqlclient](https://github.com/php/php-src/assets/4785040/e7d9dfbb-778e-4000-a25f-58d5691525c5)

With this fix:

* As of today, use the URL officially posted on [MySQL Community Downloads](https://dev.mysql.com/downloads/mysql/).
   * The URL before the correction is not officially posted as of today.
* Use versions from the *Archives* instead of the *GA Releases*, which are frequently updated and removed..
   * Corrected `8.0.35` to `8.0.36` at that time.

I have done the above. You can see the test path for this condition [here](https://github.com/KentarouTakeda/php-src/actions/runs/8948215889/job/24581114749).

The key to this fix is to avoid downloading from *GA Releases* and select the one older version. I checked the URLs for each version, and it seems that when a new GA Release is published, the previous releases are moved to *Archives*, and the GA Release URLs are deleted at irregular intervals.

The reason why our build broke this time was because `8.0.35` as GA was deleted due to this operation, so we should refer to the longer-lived *Archives* URL from the beginning. In the future, it will no longer break for the same reason.