### PR TITLE
Fix GH-14124: Segmentation fault on unknown address 0x0001ffff8041 with XML extension under certain memory limit

### DIFF
--- a/ext/xml/tests/gh14124.phpt
+++ b/ext/xml/tests/gh14124.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-14124 (Segmentation fault on unknown address 0x0001ffff8041 with XML extension under certain memory limit)
+--EXTENSIONS--
+xml
+--INI--
+memory_limit=33M
+--SKIPIF--
+<?php
+if (!defined("LIBXML_VERSION")) die('skip this is a libxml2 test');
+if (getenv('SKIP_ASAN')) die('xleak libxml does not use the request allocator');
+?>
+--FILE--
+<?php
+function createParser(bool $huge) {
+    $parser = xml_parser_create();
+    xml_parser_set_option($parser, XML_OPTION_PARSE_HUGE, $huge);
+    return $parser;
+}
+
+$long_text = str_repeat("A", 1000 * 1000 * 5 /* 5 MB */);
+$long_xml_head = "<?xml version=\"1.0\"?><container><$long_text/><$long_text/><second>foo</second>";
+$long_xml_tail = "</container>";
+$parser = createParser(true);
+xml_parse_into_struct($parser, $long_xml_head . $long_xml_tail, $values, $index);
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted at %s in %s on line %d

--- a/ext/xml/tests/gh14124.phpt
+++ b/ext/xml/tests/gh14124.phpt
@@ -24,4 +24,4 @@ $parser = createParser(true);
 xml_parse_into_struct($parser, $long_xml_head . $long_xml_tail, $values, $index);
 ?>
 --EXPECTF--
-Fatal error: Allowed memory size of %d bytes exhausted at %s in %s on line %d
+Fatal error: Allowed memory size of %d bytes exhausted %s in %s on line %d

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1363,6 +1363,7 @@ PHP_FUNCTION(xml_parse_into_struct)
 	parser->level = 0;
 	xml_parser_free_ltags(parser);
 	parser->ltags = safe_emalloc(XML_MAXLEVEL, sizeof(char *), 0);
+	memset(parser->ltags, 0, XML_MAXLEVEL * sizeof(char *));
 
 	XML_SetElementHandler(parser->parser, _xml_startElementHandler, _xml_endElementHandler);
 	XML_SetCharacterDataHandler(parser->parser, _xml_characterDataHandler);


### PR DESCRIPTION
The ltags were not initialized.

This issue exists also on all lower branches, but it's only easily testable on master. So after merging I'll backport the fix without test to lower branches.