### PR TITLE
Refactor BCMath `_bc_do_sub`

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -78,6 +78,66 @@ typedef struct bc_struct {
 #define LONG_MAX 0x7ffffff
 #endif
 
+/* This will be 0x01010101 for 32-bit and 0x0101010101010101 for 64-bit */
+#define SWAR_ONES (~((size_t) 0) / 0xFF)
+/* This repeats a byte `x` into an entire 32/64-bit word.
+ * Example: SWAR_REPEAT(0xAB) will be 0xABABABAB for 32-bit and 0xABABABABABABABAB for 64-bit. */
+#define SWAR_REPEAT(x) (SWAR_ONES * (x))
+
+/* Bytes swap */
+#if defined(_MSC_VER)
+#  include <stdlib.h>
+#  define BSWAP32(u) _byteswap_ulong(u)
+#  define BSWAP64(u) _byteswap_uint64(u)
+#else
+#  ifdef __has_builtin
+#    if __has_builtin(__builtin_bswap32)
+#      define BSWAP32(u) __builtin_bswap32(u)
+#    endif // __has_builtin(__builtin_bswap32)
+#    if __has_builtin(__builtin_bswap64)
+#      define BSWAP64(u) __builtin_bswap64(u)
+#    endif // __has_builtin(__builtin_bswap64)
+#  elif defined(__GNUC__)
+#    define BSWAP32(u) __builtin_bswap32(u)
+#    define BSWAP64(u) __builtin_bswap64(u)
+#  endif // __has_builtin
+#endif // defined(_MSC_VER)
+#ifndef BSWAP32
+inline uint32_t BSWAP32(uint32_t u)
+{
+  return (((u & 0xff000000) >> 24)
+          | ((u & 0x00ff0000) >>  8)
+          | ((u & 0x0000ff00) <<  8)
+          | ((u & 0x000000ff) << 24));
+}
+#endif
+#ifndef BSWAP64
+inline uint64_t BSWAP64(uint64_t u)
+{
+   return (((u & 0xff00000000000000ULL) >> 56)
+          | ((u & 0x00ff000000000000ULL) >> 40)
+          | ((u & 0x0000ff0000000000ULL) >> 24)
+          | ((u & 0x000000ff00000000ULL) >>  8)
+          | ((u & 0x00000000ff000000ULL) <<  8)
+          | ((u & 0x0000000000ff0000ULL) << 24)
+          | ((u & 0x000000000000ff00ULL) << 40)
+          | ((u & 0x00000000000000ffULL) << 56));
+}
+#endif
+
+#if SIZEOF_SIZE_T >= 8
+#define BC_BSWAP(u) BSWAP64(u)
+#define BC_UINT_T uint64_t
+#else
+#define BC_BSWAP(u) BSWAP32(u)
+#define BC_UINT_T uint32_t
+#endif
+
+#ifdef WORDS_BIGENDIAN
+#define BC_LITTLE_ENDIAN 0
+#else
+#define BC_LITTLE_ENDIAN 1
+#endif
 
 /* Function Prototypes */
 

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -78,66 +78,6 @@ typedef struct bc_struct {
 #define LONG_MAX 0x7ffffff
 #endif
 
-/* This will be 0x01010101 for 32-bit and 0x0101010101010101 for 64-bit */
-#define SWAR_ONES (~((size_t) 0) / 0xFF)
-/* This repeats a byte `x` into an entire 32/64-bit word.
- * Example: SWAR_REPEAT(0xAB) will be 0xABABABAB for 32-bit and 0xABABABABABABABAB for 64-bit. */
-#define SWAR_REPEAT(x) (SWAR_ONES * (x))
-
-/* Bytes swap */
-#if defined(_MSC_VER)
-#  include <stdlib.h>
-#  define BSWAP32(u) _byteswap_ulong(u)
-#  define BSWAP64(u) _byteswap_uint64(u)
-#else
-#  ifdef __has_builtin
-#    if __has_builtin(__builtin_bswap32)
-#      define BSWAP32(u) __builtin_bswap32(u)
-#    endif // __has_builtin(__builtin_bswap32)
-#    if __has_builtin(__builtin_bswap64)
-#      define BSWAP64(u) __builtin_bswap64(u)
-#    endif // __has_builtin(__builtin_bswap64)
-#  elif defined(__GNUC__)
-#    define BSWAP32(u) __builtin_bswap32(u)
-#    define BSWAP64(u) __builtin_bswap64(u)
-#  endif // __has_builtin
-#endif // defined(_MSC_VER)
-#ifndef BSWAP32
-inline uint32_t BSWAP32(uint32_t u)
-{
-  return (((u & 0xff000000) >> 24)
-          | ((u & 0x00ff0000) >>  8)
-          | ((u & 0x0000ff00) <<  8)
-          | ((u & 0x000000ff) << 24));
-}
-#endif
-#ifndef BSWAP64
-inline uint64_t BSWAP64(uint64_t u)
-{
-   return (((u & 0xff00000000000000ULL) >> 56)
-          | ((u & 0x00ff000000000000ULL) >> 40)
-          | ((u & 0x0000ff0000000000ULL) >> 24)
-          | ((u & 0x000000ff00000000ULL) >>  8)
-          | ((u & 0x00000000ff000000ULL) <<  8)
-          | ((u & 0x0000000000ff0000ULL) << 24)
-          | ((u & 0x000000000000ff00ULL) << 40)
-          | ((u & 0x00000000000000ffULL) << 56));
-}
-#endif
-
-#if SIZEOF_SIZE_T >= 8
-#define BC_BSWAP(u) BSWAP64(u)
-#define BC_UINT_T uint64_t
-#else
-#define BC_BSWAP(u) BSWAP32(u)
-#define BC_UINT_T uint32_t
-#endif
-
-#ifdef WORDS_BIGENDIAN
-#define BC_LITTLE_ENDIAN 0
-#else
-#define BC_LITTLE_ENDIAN 1
-#endif
 
 /* Function Prototypes */
 

--- a/ext/bcmath/libbcmath/src/convert.c
+++ b/ext/bcmath/libbcmath/src/convert.c
@@ -16,6 +16,7 @@
 
 #include "bcmath.h"
 #include "convert.h"
+#include "private.h"
 #ifdef __SSE2__
 # include <emmintrin.h>
 #endif

--- a/ext/bcmath/libbcmath/src/convert.c
+++ b/ext/bcmath/libbcmath/src/convert.c
@@ -20,12 +20,6 @@
 # include <emmintrin.h>
 #endif
 
-/* This will be 0x01010101 for 32-bit and 0x0101010101010101 */
-#define SWAR_ONES (~((size_t) 0) / 0xFF)
-/* This repeats a byte `x` into an entire 32/64-bit word.
- * Example: SWAR_REPEAT(0xAB) will be 0xABABABAB for 32-bit and 0xABABABABABABABAB for 64-bit. */
-#define SWAR_REPEAT(x) (SWAR_ONES * (x))
-
 static char *bc_copy_and_shift_numbers(char *restrict dest, const char *source, const char *source_end, unsigned char shift, bool add)
 {
 	size_t bulk_shift = SWAR_REPEAT(shift);

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -124,26 +124,22 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 {
 	bc_num diff;
-	size_t diff_scale, diff_len;
-	size_t min_scale, min_len;
-	size_t borrow, count;
+	size_t diff_len = MAX(n1->n_len, n2->n_len);
+	size_t diff_scale = MAX(n1->n_scale, n2->n_scale);
+	size_t min_len = MIN(n1->n_len, n2->n_len);
+	size_t min_scale = MIN(n1->n_scale, n2->n_scale);
+	size_t borrow = 0;
+	size_t count;
 	int val;
 	char *n1ptr, *n2ptr, *diffptr;
 
 	/* Allocate temporary storage. */
-	diff_len = MAX(n1->n_len, n2->n_len);
-	diff_scale = MAX(n1->n_scale, n2->n_scale);
-	min_len = MIN(n1->n_len, n2->n_len);
-	min_scale = MIN(n1->n_scale, n2->n_scale);
 	diff = bc_new_num (diff_len, MAX(diff_scale, scale_min));
 
 	/* Initialize the subtract. */
 	n1ptr = (char *) (n1->n_value + n1->n_len + n1->n_scale - 1);
 	n2ptr = (char *) (n2->n_value + n2->n_len + n2->n_scale - 1);
 	diffptr = (char *) (diff->n_value + diff_len + diff_scale - 1);
-
-	/* Subtract the numbers. */
-	borrow = 0;
 
 	/* Take care of the longer scaled number. */
 	if (n1->n_scale != min_scale) {

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -124,36 +124,33 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 {
 	bc_num diff;
-	size_t diff_scale, diff_len;
-	size_t min_scale, min_len;
-	size_t borrow, count;
+
+	size_t diff_scale = MAX(n1->n_scale, n2->n_scale);
+	size_t diff_len = EXPECTED(n1->n_len >= n2->n_len) ? n1->n_len : n2->n_len;
+	size_t min_scale = MIN(n1->n_scale, n2->n_scale);
+	size_t min_len = n1->n_len >= n2->n_len ? n2->n_len : n1->n_len;
+	size_t min_bytes = min_len + min_scale;
+	size_t borrow = 0;
 	int val;
 	char *n1ptr, *n2ptr, *diffptr;
 
 	/* Allocate temporary storage. */
-	diff_len = MAX(n1->n_len, n2->n_len);
-	diff_scale = MAX(n1->n_scale, n2->n_scale);
-	min_len = MIN(n1->n_len, n2->n_len);
-	min_scale = MIN(n1->n_scale, n2->n_scale);
-	diff = bc_new_num (diff_len, MAX(diff_scale, scale_min));
+	diff = bc_new_num (n1->n_len, MAX(diff_scale, scale_min));
 
 	/* Initialize the subtract. */
 	n1ptr = (char *) (n1->n_value + n1->n_len + n1->n_scale - 1);
 	n2ptr = (char *) (n2->n_value + n2->n_len + n2->n_scale - 1);
 	diffptr = (char *) (diff->n_value + diff_len + diff_scale - 1);
 
-	/* Subtract the numbers. */
-	borrow = 0;
-
 	/* Take care of the longer scaled number. */
 	if (n1->n_scale != min_scale) {
 		/* n1 has the longer scale */
-		for (count = n1->n_scale - min_scale; count > 0; count--) {
+		for (size_t count = n1->n_scale - min_scale; count > 0; count--) {
 			*diffptr-- = *n1ptr--;
 		}
 	} else {
 		/* n2 has the longer scale */
-		for (count = n2->n_scale - min_scale; count > 0; count--) {
+		for (size_t count = n2->n_scale - min_scale; count > 0; count--) {
 			val = -*n2ptr-- - borrow;
 			if (val < 0) {
 				val += BASE;
@@ -166,7 +163,57 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 	}
 
 	/* Now do the equal length scale and integer parts. */
-	for (count = 0; count < min_len + min_scale; count++) {
+	size_t sub_count = 0;
+	if (min_bytes >= sizeof(BC_UINT_T)) {
+		diffptr++;
+		n1ptr++;
+		n2ptr++;
+		while (sub_count + sizeof(BC_UINT_T) <= min_bytes) {
+			diffptr -= sizeof(BC_UINT_T);
+			n1ptr -= sizeof(BC_UINT_T);
+			n2ptr -= sizeof(BC_UINT_T);
+
+			BC_UINT_T n1bytes;
+			BC_UINT_T n2bytes;
+			memcpy(&n1bytes, n1ptr, sizeof(n1bytes));
+			memcpy(&n2bytes, n2ptr, sizeof(n2bytes));
+
+#if BC_LITTLE_ENDIAN
+			/* Bytes swap */
+			n1bytes = BC_BSWAP(n1bytes);
+			n2bytes = BC_BSWAP(n2bytes);
+#endif
+
+			n1bytes -= (n2bytes + borrow);
+			/* If the most significant 4 bits of the 8 bytes are not 0, a carry-down has occurred. */
+			bool tmp_borrow = n1bytes >= ((BC_UINT_T) 0x10 << (8 * (sizeof(BC_UINT_T) - 1)));
+
+			/*
+			 * If any one of the upper 4 bits of each of the 8 bytes is 1, subtract 6 from that byte.
+			 * The fact that the upper 4 bits are not 0 means that a carry-down has occurred, and when
+			 * the hexadecimal number is carried down, there is a difference of 6 from the decimal
+			 * calculation, so 6 is subtracted.
+			 * Also, set all upper 4 bits to 0.
+			 */
+			BC_UINT_T borrow_mask = (((n1bytes | (n1bytes >> 1) | (n1bytes >> 2) | (n1bytes >> 3)) & SWAR_REPEAT(0x10)) * 0x06) >> 4;
+			n1bytes = (n1bytes & SWAR_REPEAT(0x0F)) - borrow_mask;
+
+#if BC_LITTLE_ENDIAN
+			/* Bytes swap */
+			n1bytes = BC_BSWAP(n1bytes);
+#endif
+
+			memcpy(diffptr, &n1bytes, sizeof(n1bytes));
+
+			borrow = tmp_borrow;
+			sub_count += sizeof(BC_UINT_T);
+		}
+		diffptr--;
+		n1ptr--;
+		n2ptr--;
+	}
+
+	for (; sub_count < min_bytes; sub_count++) {
 		val = *n1ptr-- - *n2ptr-- - borrow;
 		if (val < 0) {
 			val += BASE;
@@ -179,7 +226,7 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 
 	/* If n1 has more digits than n2, we now do that subtract. */
 	if (diff_len != min_len) {
-		for (count = diff_len - min_len; count > 0; count--) {
+		for (size_t count = diff_len - min_len; count > 0; count--) {
 			val = *n1ptr-- - borrow;
 			if (val < 0) {
 				val += BASE;

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -124,9 +124,9 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 {
 	bc_num diff;
-	size_t diff_len = MAX(n1->n_len, n2->n_len);
+	size_t diff_len = EXPECTED(n1->n_len >= n2->n_len) ? n1->n_len : n2->n_len;
 	size_t diff_scale = MAX(n1->n_scale, n2->n_scale);
-	size_t min_len = MIN(n1->n_len, n2->n_len);
+	size_t min_len = n1->n_len >= n2->n_len ? n2->n_len : n1->n_len;
 	size_t min_scale = MIN(n1->n_scale, n2->n_scale);
 	size_t borrow = 0;
 	size_t count;

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -192,7 +192,7 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 			bool tmp_borrow = n1bytes & ((BC_UINT_T) 1 << (8 * sizeof(BC_UINT_T) - 1));
 
 			/*
-			 * Check the most significant bit of each of the 16 bytes, and if it is 1, a carry down has
+			 * Check the most significant bit of each of the bytes, and if it is 1, a carry down has
 			 * occurred. When carrying down occurs, due to the difference between decimal and hexadecimal
 			 * numbers, an extra 6 is added to the lower 4 bits.
 			 * Therefore, for a byte that has been carried down, set all the upper 4 bits to 0 and subtract

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -128,6 +128,7 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 	size_t diff_scale = MAX(n1->n_scale, n2->n_scale);
 	size_t min_len = n1->n_len >= n2->n_len ? n2->n_len : n1->n_len;
 	size_t min_scale = MIN(n1->n_scale, n2->n_scale);
+	size_t min_bytes = min_len + min_scale;
 	size_t borrow = 0;
 	size_t count;
 	int val;
@@ -163,11 +164,11 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 
 	/* Now do the equal length scale and integer parts. */
 	count = 0;
-	if (min_len + min_scale >= sizeof(BC_UINT_T)) {
+	if (min_bytes >= sizeof(BC_UINT_T)) {
 		diffptr++;
 		n1ptr++;
 		n2ptr++;
-		while (count + sizeof(BC_UINT_T) <= min_len + min_scale) {
+		while (count + sizeof(BC_UINT_T) <= min_bytes) {
 			diffptr -= sizeof(BC_UINT_T);
 			n1ptr -= sizeof(BC_UINT_T);
 			n2ptr -= sizeof(BC_UINT_T);
@@ -212,7 +213,7 @@ bc_num _bc_do_sub(bc_num n1, bc_num n2, size_t scale_min)
 		n2ptr--;
 	}
 
-	for (; count < min_len + min_scale; count++) {
+	for (; count < min_bytes; count++) {
 		val = *n1ptr-- - *n2ptr-- - borrow;
 		if (val < 0) {
 			val += BASE;

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -34,6 +34,68 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* This will be 0x01010101 for 32-bit and 0x0101010101010101 for 64-bit */
+#define SWAR_ONES (~((size_t) 0) / 0xFF)
+/* This repeats a byte `x` into an entire 32/64-bit word.
+ * Example: SWAR_REPEAT(0xAB) will be 0xABABABAB for 32-bit and 0xABABABABABABABAB for 64-bit. */
+#define SWAR_REPEAT(x) (SWAR_ONES * (x))
+
+/* Bytes swap */
+#if defined(_MSC_VER)
+#  include <stdlib.h>
+#  define BSWAP32(u) _byteswap_ulong(u)
+#  define BSWAP64(u) _byteswap_uint64(u)
+#else
+#  ifdef __has_builtin
+#    if __has_builtin(__builtin_bswap32)
+#      define BSWAP32(u) __builtin_bswap32(u)
+#    endif // __has_builtin(__builtin_bswap32)
+#    if __has_builtin(__builtin_bswap64)
+#      define BSWAP64(u) __builtin_bswap64(u)
+#    endif // __has_builtin(__builtin_bswap64)
+#  elif defined(__GNUC__)
+#    define BSWAP32(u) __builtin_bswap32(u)
+#    define BSWAP64(u) __builtin_bswap64(u)
+#  endif // __has_builtin
+#endif // defined(_MSC_VER)
+#ifndef BSWAP32
+inline uint32_t BSWAP32(uint32_t u)
+{
+  return (((u & 0xff000000) >> 24)
+          | ((u & 0x00ff0000) >>  8)
+          | ((u & 0x0000ff00) <<  8)
+          | ((u & 0x000000ff) << 24));
+}
+#endif
+#ifndef BSWAP64
+inline uint64_t BSWAP64(uint64_t u)
+{
+   return (((u & 0xff00000000000000ULL) >> 56)
+          | ((u & 0x00ff000000000000ULL) >> 40)
+          | ((u & 0x0000ff0000000000ULL) >> 24)
+          | ((u & 0x000000ff00000000ULL) >>  8)
+          | ((u & 0x00000000ff000000ULL) <<  8)
+          | ((u & 0x0000000000ff0000ULL) << 24)
+          | ((u & 0x000000000000ff00ULL) << 40)
+          | ((u & 0x00000000000000ffULL) << 56));
+}
+#endif
+
+#if SIZEOF_SIZE_T >= 8
+#define BC_BSWAP(u) BSWAP64(u)
+#define BC_UINT_T uint64_t
+#else
+#define BC_BSWAP(u) BSWAP32(u)
+#define BC_UINT_T uint32_t
+#endif
+
+#ifdef WORDS_BIGENDIAN
+#define BC_LITTLE_ENDIAN 0
+#else
+#define BC_LITTLE_ENDIAN 1
+#endif
+
+
 /* routines */
 int _bc_do_compare (bc_num n1, bc_num n2, bool use_sign);
 bc_num _bc_do_add (bc_num n1, bc_num n2, size_t scale_min);

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -31,6 +31,7 @@
 
 #include "bcmath.h"
 #include "convert.h"
+#include "private.h"
 #include <stdbool.h>
 #include <stddef.h>
 #ifdef __SSE2__


### PR DESCRIPTION
I thought about separating SIMD and other changes into separate PRs, but it would be slow to measure them individually, so I combined them into one. There seems to be a synergistic effect.

Measure using hyperfine. Warm-up is 10 times.

Cases

1:
```
$num1 = '1.2345678901234567890';
$num2 = '-2.12345678901234567890';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}

```

2:
```
$num1 = '12345678901234567890.12345678901234567890';
$num2 = '-212345678901234567890.12345678901234567890';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}
```

3:
```
$num1 = '12345678901234567890.00000000000000000000000000000000000000000000000000';
$num2 = '-212345678901234567890.00000000000000000000000000000000000000000000000000';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}
```

# compare 

## before results

```
// 1
Time (mean ± σ):     600.0 ms ±  11.6 ms    [User: 594.6 ms, System: 4.7 ms]
Range (min … max):   587.2 ms … 620.7 ms    10 runs

// 2
Time (mean ± σ):     718.3 ms ±   3.9 ms    [User: 713.8 ms, System: 3.6 ms]
Range (min … max):   713.4 ms … 722.7 ms    10 runs

// 3
Time (mean ± σ):     762.9 ms ±  16.6 ms    [User: 759.0 ms, System: 3.1 ms]
Range (min … max):   750.9 ms … 808.1 ms    10 runs
```

## after calculate `min_len + min_scale first` (final state)

```
// 1
Time (mean ± σ):     585.4 ms ±   7.7 ms    [User: 580.7 ms, System: 3.9 ms]
Range (min … max):   573.7 ms … 598.4 ms    10 runs
 
// 2
Time (mean ± σ):     626.0 ms ±   5.3 ms    [User: 621.1 ms, System: 4.3 ms]
Range (min … max):   619.5 ms … 634.2 ms    10 runs
 
// 3
Time (mean ± σ):     713.3 ms ±   6.5 ms    [User: 708.6 ms, System: 3.9 ms]
Range (min … max):   700.9 ms … 720.5 ms    10 runs
```

# Measurement results for each commit

## after SIMD

```
// 1
Time (mean ± σ):     610.2 ms ±  18.5 ms    [User: 606.1 ms, System: 3.3 ms]
Range (min … max):   589.2 ms … 635.1 ms    10 runs
 
// 2
Time (mean ± σ):     657.8 ms ±   8.9 ms    [User: 653.6 ms, System: 3.3 ms]
Range (min … max):   646.3 ms … 675.9 ms    10 runs
 
// 3
Time (mean ± σ):     772.0 ms ±   8.8 ms    [User: 767.9 ms, System: 3.3 ms]
Range (min … max):   758.4 ms … 787.5 ms    10 runs
```

## after refactor initialization

```
// 1
Time (mean ± σ):     592.6 ms ±   3.5 ms    [User: 588.3 ms, System: 3.5 ms]
Range (min … max):   589.3 ms … 600.7 ms    10 runs
 
// 2
Time (mean ± σ):     691.1 ms ±  55.8 ms    [User: 687.3 ms, System: 3.0 ms]
Range (min … max):   647.6 ms … 812.9 ms    10 runs
 
// 3
Time (mean ± σ):     775.6 ms ±  11.2 ms    [User: 771.6 ms, System: 3.2 ms]
Range (min … max):   762.8 ms … 801.7 ms    10 runs
```

## after use EXPECTED

```
// 1
Time (mean ± σ):     595.0 ms ±   4.4 ms    [User: 590.6 ms, System: 3.6 ms]
Range (min … max):   588.1 ms … 603.0 ms    10 runs
 
// 2
Time (mean ± σ):     660.8 ms ±  16.2 ms    [User: 656.3 ms, System: 3.7 ms]
Range (min … max):   642.5 ms … 701.4 ms    10 runs
 
// 3
Time (mean ± σ):     770.1 ms ±   4.3 ms    [User: 766.1 ms, System: 3.2 ms]
Range (min … max):   763.9 ms … 777.5 ms    10 runs
```

## FYI: without SIMD

```
// 1
Time (mean ± σ):     669.6 ms ±   5.0 ms    [User: 665.3 ms, System: 3.4 ms]
Range (min … max):   664.6 ms … 679.9 ms    10 runs
 
// 2
Time (mean ± σ):     774.0 ms ±  10.1 ms    [User: 770.0 ms, System: 3.2 ms]
Range (min … max):   761.1 ms … 792.2 ms    10 runs

// 3
Time (mean ± σ):     802.5 ms ±  13.4 ms    [User: 797.5 ms, System: 4.2 ms]
Range (min … max):   789.2 ms … 832.6 ms    10 runs
```