### PR TITLE
Fix build on Clang 18

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -913,7 +913,7 @@ typedef struct _zend_ffi_callback_data {
 	ffi_cif                cif;
 	uint32_t               arg_count;
 	ffi_type              *ret_type;
-	ffi_type              *arg_types[0] ZEND_ELEMENT_COUNT(arg_count);
+	ffi_type              *arg_types[] ZEND_ELEMENT_COUNT(arg_count);
 } zend_ffi_callback_data;
 
 static void zend_ffi_callback_hash_dtor(zval *zv) /* {{{ */

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -146,7 +146,7 @@
 typedef struct _ir_refs {
   uint32_t count;
   uint32_t limit;
-  ir_ref   refs[0] ZEND_ELEMENT_COUNT(count);
+  ir_ref   refs[] ZEND_ELEMENT_COUNT(count);
 } ir_refs;
 
 #define ir_refs_size(_n)          (offsetof(ir_refs, refs) + sizeof(ir_ref) * (_n))


### PR DESCRIPTION
Clang 18 only allows counted_by to work on real flexible array members, not ones with a zero size. Otherwise you get errors like:
```
ext/opcache/jit/zend_jit_ir.c:149:12: error: 'counted_by' only applies to C99 flexible array members
```