### PR TITLE
Fix zend_string_starts_with_literal_ci

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -422,7 +422,7 @@ static zend_always_inline bool zend_string_starts_with_ci(const zend_string *str
 }
 
 #define zend_string_starts_with_literal_ci(str, prefix) \
-	zend_string_starts_with_cstr(str, prefix, strlen(prefix))
+	zend_string_starts_with_cstr_ci(str, prefix, strlen(prefix))
 
 /*
  * DJBX33A (Daniel J. Bernstein, Times 33 with Addition)


### PR DESCRIPTION
Accidentally discovered while dealing with extension downward compatibility.