### PR TITLE
Fix GH-14100: Corrected spelling mistake in php.ini files

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -75,7 +75,7 @@
 
 ; php.ini-production contains settings which hold security, performance and
 ; best practices at its core. But please be aware, these settings may break
-; compatibility with older or less security conscience applications. We
+; compatibility with older or less security-conscious applications. We
 ; recommending using the production ini in production and testing environments.
 
 ; php.ini-development is very similar to its production variant, except it is

--- a/php.ini-production
+++ b/php.ini-production
@@ -75,7 +75,7 @@
 
 ; php.ini-production contains settings which hold security, performance and
 ; best practices at its core. But please be aware, these settings may break
-; compatibility with older or less security conscience applications. We
+; compatibility with older or less security-conscious applications. We
 ; recommending using the production ini in production and testing environments.
 
 ; php.ini-development is very similar to its production variant, except it is


### PR DESCRIPTION
Resolved issue GH-14100 found in branch 8.2 and submitted a PR with the fix. It seems that the issue is already resolved in branches 8.3 and master.

