### PR TITLE
[ci skip] Update CODEOWNERS and EXTENSIONS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 
 /.github @iluuu1994 @TimWolla
 /build/gen_stub.php @kocsismate
-/ext/bcmath @Girgias
+/ext/bcmath @Girgias @nielsdos
 /ext/curl @adoy
 /ext/date @derickr
 /ext/dba @Girgias
@@ -37,10 +37,13 @@
 /ext/pgsql @devnexen
 /ext/random @TimWolla @zeriyoshi
 /ext/session @Girgias
+/ext/simplexml @nielsdos
 /ext/sockets @devnexen
 /ext/spl @Girgias
 /ext/standard @bukka
+/ext/xml @nielsdos
 /ext/xmlreader @nielsdos
+/ext/xmlwriter @nielsdos
 /ext/xsl @nielsdos
 /main @bukka
 /sapi/fpm @bukka

--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -170,12 +170,14 @@ EXTENSION:           dom
 PRIMARY MAINTAINER:  Christian Stocker <chregu@php.net> (2003 - 2011)
                      Rob Richards <rrichards@php.net> (2003 - 2012)
                      Marcus Börger <helly@php.net> (2003 - 2006)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 SINCE:               5.0
 -------------------------------------------------------------------------------
 EXTENSION:           simplexml
 PRIMARY MAINTAINER:  Marcus Börger <helly@php.net> (2003 - 2008)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 SINCE:               5.0
@@ -188,30 +190,35 @@ STATUS:              Working
 EXTENSION:           xml
 PRIMARY MAINTAINER:  Thies C. Arntzen <thies@thieso.net> (1999 - 2002)
                      Rob Richards <rrichards@php.net> (2003 - 2013)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           libxml
 PRIMARY MAINTAINER:  Rob Richards <rrichards@php.net> (2003 - 2009)
                      Christian Stocker <chregu@php.net> (2004 - 2011)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           xmlreader
 PRIMARY MAINTAINER:  Rob Richards <rrichards@php.net> (2004 - 2010)
                      Christian Stocker <chregu@php.net> (2004 - 2004)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           xmlwriter
 PRIMARY MAINTAINER:  Rob Richards <rrichards@php.net> (2004 - 2010)
                      Pierre-Alain Joye <pajoye@php.net> (2005-2009)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           xsl
 PRIMARY MAINTAINER:  Christian Stocker <chregu@php.net> (2003 - 2011)
                      Rob Richards <rrichards@php.net> (2003 - 2010)
+                     Niels Dossche <nielsdos@php.net> (2023 - 2024)
 MAINTENANCE:         Maintained
 STATUS:              Working
 SINCE:               5.0


### PR DESCRIPTION
I'm defacto already maintaining most XML stuff anyway, so update CODEOWNERS accordingly. The EXTENSIONS file was not yet updated for my maintenance status so do that as well.

Furthermore, as suggested by @Girgias, add myself as CODEOWNER to BCMath.