### PR TITLE
Remove unused field from _phar_archive_data

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -1231,7 +1231,6 @@ static int phar_parse_pharfile(php_stream *fp, char *fname, size_t fname_len, ch
 	}
 
 	snprintf(mydata->version, sizeof(mydata->version), "%u.%u.%u", manifest_ver >> 12, (manifest_ver >> 8) & 0xF, (manifest_ver >> 4) & 0xF);
-	mydata->internal_file_start = halt_offset + manifest_len + 4;
 	mydata->halt_offset = halt_offset;
 	mydata->flags = manifest_flags;
 	endbuffer = strrchr(mydata->fname, '/');
@@ -1472,7 +1471,6 @@ int phar_create_or_parse_filename(char *fname, size_t fname_len, char *alias, si
 	mydata->fname_len = fname_len;
 	snprintf(mydata->version, sizeof(mydata->version), "%s", PHP_PHAR_API_VERSION);
 	mydata->is_temporary_alias = alias ? 0 : 1;
-	mydata->internal_file_start = -1;
 	mydata->fp = NULL;
 	mydata->is_writeable = 1;
 	mydata->is_brandnew = 1;
@@ -3181,7 +3179,6 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 		php_stream_close(oldfile);
 	}
 
-	phar->internal_file_start = halt_offset + manifest_len + 4;
 	phar->halt_offset = halt_offset;
 	phar->is_brandnew = 0;
 

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -285,7 +285,6 @@ struct _phar_archive_data {
 	char                     *alias;
 	uint32_t                      alias_len;
 	char                     version[12];
-	size_t                   internal_file_start;
 	size_t                   halt_offset;
 	HashTable                manifest;
 	/* hash of virtual directories, as in path/to/file.txt has path/to and path as virtual directories */

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -146,7 +146,6 @@ int phar_open_or_create_tar(char *fname, size_t fname_len, char *alias, size_t a
 	if (phar->is_brandnew) {
 		phar->is_tar = 1;
 		phar->is_zip = 0;
-		phar->internal_file_start = 0;
 		return SUCCESS;
 	}
 

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -842,7 +842,6 @@ int phar_open_or_create_zip(char *fname, size_t fname_len, char *alias, size_t a
 	}
 
 	if (phar->is_brandnew) {
-		phar->internal_file_start = 0;
 		phar->is_zip = 1;
 		phar->is_tar = 0;
 		return SUCCESS;


### PR DESCRIPTION
This field is only ever written to, but never read.