### PR TITLE
Simplify conversion in BCMath

### DIFF
--- a/ext/bcmath/libbcmath/src/convert.h
+++ b/ext/bcmath/libbcmath/src/convert.h
@@ -17,7 +17,6 @@
 #ifndef BCMATH_CONVERT_H
 #define BCMATH_CONVERT_H
 
-char *bc_copy_ch_val(char *restrict dest, const char *source, const char *source_end);
-char *bc_copy_bcd_val(char *restrict dest, const char *source, const char *source_end);
+char *bc_copy_and_toggle_bcd(char *restrict dest, const char *source, const char *source_end);
 
 #endif

--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -57,13 +57,13 @@ zend_string *bc_num2str_ex(bc_num num, size_t scale)
 
 	/* Load the whole number. */
 	const char *nptr = num->n_value;
-	sptr = bc_copy_bcd_val(sptr, nptr, nptr + num->n_len);
+	sptr = bc_copy_and_toggle_bcd(sptr, nptr, nptr + num->n_len);
 	nptr += num->n_len;
 
 	/* Now the fraction. */
 	if (scale > 0) {
 		*sptr++ = '.';
-		sptr = bc_copy_bcd_val(sptr, nptr, nptr + min_scale);
+		sptr = bc_copy_and_toggle_bcd(sptr, nptr, nptr + min_scale);
 		for (index = num->n_scale; index < scale; index++) {
 			*sptr++ = BCD_CHAR(0);
 		}

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -165,12 +165,12 @@ after_fractional:
 		 * If zero_int is true and the str_scale is 0, there is an early return,
 		 * so here str_scale is always greater than 0.
 		 */
-		nptr = bc_copy_ch_val(nptr, fractional_ptr, fractional_end);
+		nptr = bc_copy_and_toggle_bcd(nptr, fractional_ptr, fractional_end);
 	} else {
 		const char *integer_end = integer_ptr + digits;
-		nptr = bc_copy_ch_val(nptr, integer_ptr, integer_end);
+		nptr = bc_copy_and_toggle_bcd(nptr, integer_ptr, integer_end);
 		if (str_scale > 0) {
-			nptr = bc_copy_ch_val(nptr, fractional_ptr, fractional_end);
+			nptr = bc_copy_and_toggle_bcd(nptr, fractional_ptr, fractional_end);
 		}
 	}
 


### PR DESCRIPTION
This simplifies the code, and also might indirectly improve performance due to a decrease in instruction cache pressure. Although the latter is probably negligible.

This works because 0x30 has no overlapping bits with [0, 9].