### PR TITLE
Cast the parameter type of arm `BLOCKCONV_LOAD`

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -122,7 +122,7 @@ static _locale_t current_locale = NULL;
 
 #define BLOCKCONV_LOAD(input) \
 	int8x16_t blconv_operand = vld1q_s8((const int8_t*)(input)); \
-	uint8x16_t blconv_mask = vcltq_s8(vaddq_s8(blconv_operand, blconv_offset), blconv_threshold);
+	uint8x16_t blconv_mask = vcltq_s8(vreinterpretq_s8_u8(vaddq_u8(vreinterpretq_u8_s8(blconv_operand), vreinterpretq_u8_s8(blconv_offset))), blconv_threshold);
 
 #define BLOCKCONV_FOUND() vmaxvq_u8(blconv_mask)
 


### PR DESCRIPTION
take2 of #14151
The conflict was bothersome, so I redid the PR.

When compiling with a combination of Arm and gcc, the following runtime error will occur, so fix it.

```
# export  UBSAN_OPTIONS=print_stacktrace=1
# php -v
/usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h:758:14: runtime error: signed integer overflow: 103 + 63 cannot be represented in type 'signed char'
    #0 0xaaaac38f7ddc in vaddq_s8 /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h:758
    #1 0xaaaac38f7ddc in zend_string_tolower_ex /php-src/Zend/zend_operators.c:3056
    #2 0xaaaac3953a34 in zend_register_functions /php-src/Zend/zend_API.c:2981
    #3 0xaaaac394b9b0 in zend_register_module_ex /php-src/Zend/zend_API.c:2568
    #4 0xaaaac39c98f8 in zend_startup_builtin_functions /php-src/Zend/zend_builtin_functions.c:63
    #5 0xaaaac39120c4 in zend_startup /php-src/Zend/zend.c:1030
    #6 0xaaaac3630ee0 in php_module_startup /php-src/main/main.c:2117
    #7 0xaaaac41e31dc in php_cli_startup /php-src/sapi/cli/php_cli.c:410
    #8 0xaaaac41e8f58 in main /php-src/sapi/cli/php_cli.c:1307
    #9 0xffff9cea73f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #10 0xffff9cea74c8 in __libc_start_main_impl ../csu/libc-start.c:392
    #11 0xaaaac2a161ec in _start (/usr/local/bin/php+0x20361ec)
```

configure:
```
./configure --enable-debug --disable-all CFLAGS='-ffp-contract=off -fsanitize=undefined,address -fno-sanitize-recover -DZEND_TRACK_ARENA_ALLOC' LDFLAGS='-fsanitize=undefined,address'
```

master: OK
8.3: OK