### PR TITLE
Callable curl options should be nullable

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1520,6 +1520,11 @@ static bool php_curl_set_callable_handler(zend_fcall_info_cache *const handler_f
 		zend_fcc_dtor(handler_fcc);
 	}
 
+	if (Z_TYPE_P(callable) == IS_NULL) {
+		handler_fcc->function_handler = NULL;
+		return true;
+	}
+
 	char *error = NULL;
 	if (UNEXPECTED(!zend_is_callable_ex(callable, /* object */ NULL, /* check_flags */ 0, /* callable_name */ NULL, handler_fcc, /* error */ &error))) {
 		if (!EG(exception)) {

--- a/ext/curl/tests/callable_nullable_option.phpt
+++ b/ext/curl/tests/callable_nullable_option.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Callable options are nullable
+--EXTENSIONS--
+curl
+--FILE--
+<?php
+
+$ch = curl_init();
+curl_setopt_array($ch, [
+    CURLOPT_PROGRESSFUNCTION => null,
+]);
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
symfony/http-client/Response/CurlResponse.php depends on this behavior.

See https://github.com/php/php-src/actions/runs/8978207495/job/24658271316.