### PR TITLE
BCMath: Avoid using the heap for temporary objects by using arena allocations

### DIFF
--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -37,7 +37,8 @@
 
 static bc_num _bc_new_num_nonzeroed_ex_internal(size_t length, size_t scale, bool persistent)
 {
-	size_t required_size = zend_safe_address_guarded(1, sizeof(bc_struct) + length, scale);
+	size_t required_size = zend_safe_address_guarded(1, sizeof(bc_struct) + ZEND_MM_ALIGNMENT + length, scale);
+	required_size &= -ZEND_MM_ALIGNMENT;
 	bc_num temp;
 
 	if (!persistent && BCG(arena) && required_size <= BC_ARENA_SIZE - BCG(arena_offset)) {

--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -37,7 +37,7 @@
 
 static bc_num _bc_new_num_nonzeroed_ex_internal(size_t length, size_t scale, bool persistent)
 {
-	size_t required_size = zend_safe_address_guarded(1, sizeof(bc_struct) + ZEND_MM_ALIGNMENT + length, scale);
+	size_t required_size = zend_safe_address_guarded(1, sizeof(bc_struct) + (ZEND_MM_ALIGNMENT - 1) + length, scale);
 	required_size &= -ZEND_MM_ALIGNMENT;
 	bc_num temp;
 

--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -35,14 +35,24 @@
 #include <string.h>
 #include "zend_alloc.h"
 
-static zend_always_inline bc_num _bc_new_num_nonzeroed_ex_internal(size_t length, size_t scale, bool persistent)
+static bc_num _bc_new_num_nonzeroed_ex_internal(size_t length, size_t scale, bool persistent)
 {
-	/* PHP Change: malloc() -> pemalloc(), removed free_list code, merged n_ptr and n_value */
-	bc_num temp = safe_pemalloc(1, sizeof(bc_struct) + length, scale, persistent);
+	size_t required_size = zend_safe_address_guarded(1, sizeof(bc_struct) + length, scale);
+	bc_num temp;
+
+	if (!persistent && BCG(arena) && required_size <= BC_ARENA_SIZE - BCG(arena_offset)) {
+		temp = (bc_num) (BCG(arena) + BCG(arena_offset));
+		BCG(arena_offset) += required_size;
+		temp->n_refs = 2; /* prevent freeing */
+	} else {
+		/* PHP Change: malloc() -> pemalloc(), removed free_list code, merged n_ptr and n_value */
+		temp = pemalloc(required_size, persistent);
+		temp->n_refs = 1;
+	}
+
 	temp->n_sign = PLUS;
 	temp->n_len = length;
 	temp->n_scale = scale;
-	temp->n_refs = 1;
 	temp->n_value = (char *) temp + sizeof(bc_struct);
 	return temp;
 }

--- a/ext/bcmath/php_bcmath.h
+++ b/ext/bcmath/php_bcmath.h
@@ -27,11 +27,15 @@ extern zend_module_entry bcmath_module_entry;
 #include "php_version.h"
 #define PHP_BCMATH_VERSION PHP_VERSION
 
+#define BC_ARENA_SIZE 256
+
 ZEND_BEGIN_MODULE_GLOBALS(bcmath)
 	bc_num _zero_;
 	bc_num _one_;
 	bc_num _two_;
 	int bc_precision;
+	char *arena;
+	size_t arena_offset;
 ZEND_END_MODULE_GLOBALS(bcmath)
 
 #if defined(ZTS) && defined(COMPILE_DL_BCMATH)


### PR DESCRIPTION
Benchmark: https://github.com/php/php-src/pull/14132

Bench 1:
```
Benchmark 1: ./sapi/cli/php 1.php
  Time (mean ± σ):     401.4 ms ±   2.4 ms    [User: 397.9 ms, System: 3.2 ms]
  Range (min … max):   399.2 ms … 407.8 ms    10 runs
 
Benchmark 2: ./sapi/cli/php_old 1.php
  Time (mean ± σ):     450.6 ms ±   8.0 ms    [User: 448.0 ms, System: 2.2 ms]
  Range (min … max):   445.1 ms … 472.8 ms    10 runs

Summary
  ./sapi/cli/php 1.php ran
    1.12 ± 0.02 times faster than ./sapi/cli/php_old 1.php
```

Bench 2:
```
Benchmark 1: ./sapi/cli/php 2.php
  Time (mean ± σ):     462.0 ms ±   4.5 ms    [User: 459.8 ms, System: 1.9 ms]
  Range (min … max):   454.2 ms … 467.6 ms    10 runs
 
Benchmark 2: ./sapi/cli/php_old 2.php
  Time (mean ± σ):     521.8 ms ±   8.7 ms    [User: 519.8 ms, System: 1.5 ms]
  Range (min … max):   515.1 ms … 536.5 ms    10 runs
 
Summary
  ./sapi/cli/php 2.php ran
    1.13 ± 0.02 times faster than ./sapi/cli/php_old 2.php
```

Bench 3:
```
Benchmark 1: ./sapi/cli/php 3.php
  Time (mean ± σ):     562.3 ms ±   4.9 ms    [User: 560.9 ms, System: 0.6 ms]
  Range (min … max):   557.7 ms … 571.9 ms    10 runs
 
Benchmark 2: ./sapi/cli/php_old 3.php
  Time (mean ± σ):     607.9 ms ±   9.4 ms    [User: 604.8 ms, System: 2.5 ms]
  Range (min … max):   602.9 ms … 634.0 ms    10 runs

Summary
  ./sapi/cli/php 3.php ran
    1.08 ± 0.02 times faster than ./sapi/cli/php_old 3.php
```