### PR TITLE
Check Apache HTTP Server command-line utility

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2040,6 +2040,7 @@ dnl
 dnl This macro is used to get a comparable version for Apache.
 dnl
 AC_DEFUN([PHP_AP_EXTRACT_VERSION],[
+AS_IF([test -x "$1"], [
   ac_output=`$1 -v 2>&1 | grep version | $SED -e 's/Oracle-HTTP-//'`
   ac_IFS=$IFS
 IFS="- /.
@@ -2048,6 +2049,7 @@ IFS="- /.
   IFS=$ac_IFS
 
   APACHE_VERSION=`expr [$]4 \* 1000000 + [$]5 \* 1000 + [$]6`
+])
 ])
 
 dnl

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -34,6 +34,11 @@ if test "$PHP_APXS2" != "no"; then
 
   APXS_INCLUDEDIR=`$APXS -q INCLUDEDIR`
   APXS_HTTPD=`$APXS -q SBINDIR`/`$APXS -q TARGET`
+  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR([m4_normalize([
+    $APXS_HTTPD executable not found. Please, install Apache HTTP Server
+    command-line utility.
+  ])])])
+
   APXS_CFLAGS=`$APXS -q CFLAGS`
   APU_BINDIR=`$APXS -q APU_BINDIR`
   APR_BINDIR=`$APXS -q APR_BINDIR`


### PR DESCRIPTION
The Apache HTTP server command-line tool (/usr/sbin/apache2) might be part of a separate package, such as apache2-bin or similar. If not installed, the configure script can still find the apxs tool, but previously didn't check for the HTTP server tool separately. Otherwise, configure syntax errors (integer expression expected) are thrown when checking for the Apache version. Version checks have been replaced with Autoconf's AS_VERSION_COMPARE macro.