### PR TITLE
ext/hash: Swap the checking order of __has_builtin and __GNUC__

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,10 @@ PHP                                                                        NEWS
   . Fix crash when calling childNodes next() when iterator is exhausted.
     (nielsdos)
 
+- Hash:
+  . ext/hash: Swap the checking order of `__has_builtin` and `__GNUC__`
+    (Saki Takamachi)
+
 09 May 2024, PHP 8.2.19
 
 - Core:

--- a/ext/hash/murmur/endianness.h
+++ b/ext/hash/murmur/endianness.h
@@ -13,14 +13,7 @@ FORCE_INLINE int IsBigEndian(void)
 #  define BSWAP32(u) _byteswap_ulong(u)
 #  define BSWAP64(u) _byteswap_uint64(u)
 #else
-#  ifdef __has_builtin
-#    if __has_builtin(__builtin_bswap32)
-#      define BSWAP32(u) __builtin_bswap32(u)
-#    endif // __has_builtin(__builtin_bswap32)
-#    if __has_builtin(__builtin_bswap64)
-#      define BSWAP64(u) __builtin_bswap64(u)
-#    endif // __has_builtin(__builtin_bswap64)
-#  elif defined(__GNUC__) && ( \
+#  if defined(__GNUC__) && ( \
                     __GNUC__ > 4 || ( \
                       __GNUC__ == 4 && ( \
                         __GNUC_MINOR__ >= 3 \
@@ -29,6 +22,13 @@ FORCE_INLINE int IsBigEndian(void)
                   )
 #    define BSWAP32(u) __builtin_bswap32(u)
 #    define BSWAP64(u) __builtin_bswap64(u)
+#  elif defined(__has_builtin)
+#    if __has_builtin(__builtin_bswap32)
+#      define BSWAP32(u) __builtin_bswap32(u)
+#    endif // __has_builtin(__builtin_bswap32)
+#    if __has_builtin(__builtin_bswap64)
+#      define BSWAP64(u) __builtin_bswap64(u)
+#    endif // __has_builtin(__builtin_bswap64)
 #  endif // __has_builtin
 #endif // defined(_MSC_VER)
 


### PR DESCRIPTION
If `__has_builtin` is defined and `__has_builtin(__builtin_bswap64)` is `false`, `__GNUC__` is not used even if it is defined.