### PR TITLE
Sync -Wno-implicit-fallthrough

### DIFF
--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -4,11 +4,7 @@ AC_CHECK_HEADERS([io.h])
 dnl Check for strtoll, atoll
 AC_CHECK_FUNCS([strtoll atoll])
 
-AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
-  [PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -Wno-implicit-fallthrough"],,
-  [-Werror])
-
-PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
+PHP_DATE_CFLAGS="-I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 


### PR DESCRIPTION
This is a sync of the https://github.com/php/php-src/pull/6252 after few years:
- ext/date: ~fixed since derickr/timelib@f8caaeff9f0fb8a321b6ff3cd5b4104715e45767~ Edited: wrong commit pasted, flag was removed in one of the commits 
- [X] ext/hash: warning happens only on 32-bit build in ext/hash/sha3/generic32lc/KeccakP-1600-inplace32BI.c
- [X] ext/opcache: IR JIT doesn't seem to have this issue
- [X] ext/pcre remains disabled due to pcre2lib/sljit/sljitNativeARM_64.c

And I'm also checking CI how it looks.