### PR TITLE
ext/intl: don't always enforce c++17

### DIFF
--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -82,7 +82,7 @@ if test "$PHP_INTL" != "no"; then
   PHP_REQUIRE_CXX()
 
   AC_MSG_CHECKING([if intl requires -std=gnu++17])
-  AS_IF([test "$PKG_CONFIG icu-uc --atleast-version=74"],[
+  AS_IF([$PKG_CONFIG icu-uc --atleast-version=74],[
     AC_MSG_RESULT([yes])
     PHP_CXX_COMPILE_STDCXX(17, mandatory, PHP_INTL_STDCXX)
   ],[


### PR DESCRIPTION
the intention of this condition was to check if build is done against icu >= 74 while in practice it's a condition in the form of `test STRING` which in turn is equivalent to `test -n STRING` that checks if passed string is not empty. condition is always satisfied and hence c++17 is also always required.

strip `test` part and invoke `pkg-config` directly in condition.