### PR TITLE
Fix GH-14183: XMLReader::open() can't be overridden

### DIFF
--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -186,19 +186,17 @@ zval *xmlreader_write_property(zend_object *object, zend_string *name, zval *val
 /* {{{ */
 static zend_function *xmlreader_get_method(zend_object **obj, zend_string *name, const zval *key)
 {
-	if (ZSTR_LEN(name) == sizeof("open") - 1
-			&& (ZSTR_VAL(name)[0] == 'o' || ZSTR_VAL(name)[0] == 'O')
-			&& (ZSTR_VAL(name)[1] == 'p' || ZSTR_VAL(name)[1] == 'P')
-			&& (ZSTR_VAL(name)[2] == 'e' || ZSTR_VAL(name)[2] == 'E')
-			&& (ZSTR_VAL(name)[3] == 'n' || ZSTR_VAL(name)[3] == 'N')) {
-		return (zend_function*)&xmlreader_open_fn;
-	} else if (ZSTR_LEN(name) == sizeof("xml") - 1
-			&& (ZSTR_VAL(name)[0] == 'x' || ZSTR_VAL(name)[0] == 'X')
-			&& (ZSTR_VAL(name)[1] == 'm' || ZSTR_VAL(name)[1] == 'M')
-			&& (ZSTR_VAL(name)[2] == 'l' || ZSTR_VAL(name)[2] == 'L')) {
-		return (zend_function*)&xmlreader_xml_fn;
+	zend_function *method = zend_std_get_method(obj, name, key);
+	if (method && (method->common.fn_flags & ZEND_ACC_STATIC) && method->common.type == ZEND_INTERNAL_FUNCTION) {
+		/* There are only two static internal methods and they both have overrides. */
+		if (ZSTR_LEN(name) == sizeof("xml") - 1) {
+			return (zend_function *) &xmlreader_xml_fn;
+		} else {
+			ZEND_ASSERT(ZSTR_LEN(name) == sizeof("open") - 1);
+			return (zend_function *) &xmlreader_open_fn;
+		}
 	}
-	return zend_std_get_method(obj, name, key);;
+	return method;
 }
 /* }}} */
 

--- a/ext/xmlreader/tests/gh14183.phpt
+++ b/ext/xmlreader/tests/gh14183.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-14183 (XMLReader::open() can't be overridden)
+--EXTENSIONS--
+xmlreader
+--FILE--
+<?php
+class MyXMLReader extends XMLReader
+{
+    public static function open(string $uri, string $encoding = null, int $flags = 0): bool|\XMLReader
+    {
+        echo 'overridden', PHP_EOL;
+        return true;
+    }
+}
+
+var_dump(MyXMLReader::open('asdf'));
+$o = new MyXMLReader;
+var_dump($o->open('asdf'));
+?>
+--EXPECT--
+overridden
+bool(true)
+overridden
+bool(true)


### PR DESCRIPTION
We should only return the override if the internal static method is matched.