### PR TITLE
Fix GH-14189: PHP Interactive shell input state incorrectly handles quoted heredoc literals.

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -343,6 +343,7 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 					case ' ':
 					case '\t':
 					case '\'':
+					case '"':
 						break;
 					case '\r':
 					case '\n':

--- a/sapi/cli/tests/gh14189.phpt
+++ b/sapi/cli/tests/gh14189.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-14189 (PHP Interactive shell input state incorrectly handles quoted heredoc literals.)
+--EXTENSIONS--
+readline
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (readline_info('done') === NULL) {
+    die ("skip need readline support");
+}
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+
+// disallow console escape sequences that may break the output
+putenv('TERM=VT100');
+
+$code = <<<EOT
+\$test = <<<"EOF"
+foo
+bar
+baz
+EOF;
+echo \$test;
+exit
+EOT;
+
+$code = escapeshellarg($code);
+echo `echo $code | "$php" -a`, "\n";
+?>
+--EXPECT--
+Interactive shell
+
+php > $test = <<<"EOF"
+<<< > foo
+<<< > bar
+<<< > baz
+<<< > EOF;
+php > echo $test;
+foo
+bar
+baz
+php > exit


### PR DESCRIPTION
Only `'` was handled, no handling case for `"` existed. Simply add it so the heredoc tag is set up correctly.