### PR TITLE
ext/bcmath: Made the same changes to `_bc_do_add` as `_bc_do_sub`

### DIFF
--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -140,11 +140,11 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 	}
 
 	/* Now add carry the longer integer part. */
-	if (sum_len - 1 != min_len) {
+	if (n1->n_len != n2->n_len) {
 		if (n2->n_len > n1->n_len) {
 			n1ptr = n2ptr;
 		}
-		for (count = sum_len - 1 - min_len; count > 0; count--) {
+		for (count = sum_len - min_len; count > 1; count--) {
 			*sumptr = *n1ptr-- + carry;
 			if (*sumptr >= BASE) {
 				*sumptr -= BASE;

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -140,11 +140,11 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 	}
 
 	/* Now add carry the longer integer part. */
-	if (sum_len != min_len) {
+	if (sum_len - 1 != min_len) {
 		if (n2->n_len > n1->n_len) {
 			n1ptr = n2ptr;
 		}
-		for (count = sum_len - min_len; count > 0; count--) {
+		for (count = sum_len - 1 - min_len; count > 0; count--) {
 			*sumptr = *n1ptr-- + carry;
 			if (*sumptr >= BASE) {
 				*sumptr -= BASE;


### PR DESCRIPTION
benchmark codes:

1:
```
$num1 = '1.2345678901234567890';
$num2 = '2.12345678901234567890';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}
```

2:
```
$num1 = '-12345678901234567890.12345678901234567890';
$num2 = '-212345678901234567890.12345678901234567890';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}
```

3:
```
$num1 = '12345678901234567890.00000000000000000000000000000000000000000000000000';
$num2 = '212345678901234567890.00000000000000000000000000000000000000000000000000';

for ($i = 0; $i < 4000000; $i++) {
    bcadd($num1, $num2, 20);
}
```

## before

```
Time (mean ± σ):     551.0 ms ±  30.3 ms    [User: 547.0 ms, System: 3.1 ms]
Range (min … max):   515.8 ms … 619.9 ms    10 runs

Time (mean ± σ):     666.1 ms ±   7.1 ms    [User: 662.5 ms, System: 2.6 ms]
Range (min … max):   655.2 ms … 679.0 ms    10 runs

Time (mean ± σ):     599.4 ms ±  34.4 ms    [User: 596.0 ms, System: 2.5 ms]
Range (min … max):   565.1 ms … 663.9 ms    10 runs
```

## after
```
Time (mean ± σ):     515.2 ms ±   5.6 ms    [User: 509.9 ms, System: 4.2 ms]
Range (min … max):   508.5 ms … 526.8 ms    10 runs

Time (mean ± σ):     597.8 ms ±  10.9 ms    [User: 592.1 ms, System: 3.8 ms]
Range (min … max):   586.0 ms … 622.5 ms    10 runs

Time (mean ± σ):     559.5 ms ±  14.5 ms    [User: 554.8 ms, System: 3.6 ms]
Range (min … max):   544.5 ms … 584.3 ms    10 runs
```

## FYI: after the first commit
```
Time (mean ± σ):     563.6 ms ±  23.4 ms    [User: 559.0 ms, System: 3.5 ms]
Range (min … max):   544.6 ms … 616.3 ms    10 runs

Time (mean ± σ):     637.8 ms ±   5.5 ms    [User: 633.8 ms, System: 3.0 ms]
Range (min … max):   630.0 ms … 646.7 ms    10 runs

Time (mean ± σ):     580.4 ms ±   6.6 ms    [User: 575.3 ms, System: 4.0 ms]
Range (min … max):   574.9 ms … 595.6 ms    10 runs
```