### PR TITLE
Add a way to set a custom serialization algorithm for XML and refactor serialization

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -202,6 +202,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Added a way to attached private data to a php_libxml_ref_obj.
    - Added a way to fix a class type onto php_libxml_ref_obj.
    - Added php_libxml_uses_internal_errors().
+   - Added a way to override document handlers (e.g. serialization) with
+     php_libxml_document_handlers.
 
  e. ext/date
    - Added the php_format_date_ex() API to format instances of php_date_obj.

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1540,7 +1540,7 @@ PHP_METHOD(DOMDocument, save)
 	zval *id;
 	xmlDoc *docp;
 	size_t file_len = 0;
-	int bytes, format, saveempty = 0;
+	int saveempty = 0;
 	dom_object *intern;
 	char *file;
 	zend_long options = 0;
@@ -1560,13 +1560,12 @@ PHP_METHOD(DOMDocument, save)
 	/* encoding handled by property on doc */
 
 	libxml_doc_props const* doc_props = dom_get_doc_props_read_only(intern->document);
-	format = doc_props->formatoutput;
+	bool format = doc_props->formatoutput;
 	if (options & LIBXML_SAVE_NOEMPTYTAG) {
 		saveempty = xmlSaveNoEmptyTags;
 		xmlSaveNoEmptyTags = 1;
 	}
-	// TODO: use modern API when necessary
-	bytes = xmlSaveFormatFileEnc(file, docp, NULL, format);
+	zend_long bytes = intern->document->handlers->dump_doc_to_file(file, docp, format, (const char *) docp->encoding);
 	if (options & LIBXML_SAVE_NOEMPTYTAG) {
 		xmlSaveNoEmptyTags = saveempty;
 	}

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -306,7 +306,7 @@ PHP_METHOD(Dom_Implementation, createDocument)
 		(xmlNodePtr) document,
 		NULL
 	);
-	intern->document->class_type = PHP_LIBXML_CLASS_MODERN;
+	dom_set_xml_class(intern->document);
 	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
 
 	/* 4. If doctype is non-null, append doctype to document. */
@@ -407,7 +407,7 @@ PHP_METHOD(Dom_Implementation, createHTMLDocument)
 		(xmlNodePtr) doc,
 		NULL
 	);
-	intern->document->class_type = PHP_LIBXML_CLASS_MODERN;
+	dom_set_xml_class(intern->document);
 	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
 }
 /* }}} */

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -756,7 +756,7 @@ PHP_METHOD(Dom_HTMLDocument, createEmpty)
 		(xmlNodePtr) lxml_doc,
 		NULL
 	);
-	intern->document->class_type = PHP_LIBXML_CLASS_MODERN;
+	dom_set_xml_class(intern->document);
 	intern->document->private_data = php_dom_libxml_ns_mapper_header(php_dom_libxml_ns_mapper_create());
 	return;
 
@@ -916,7 +916,7 @@ PHP_METHOD(Dom_HTMLDocument, createFromString)
 		(xmlNodePtr) lxml_doc,
 		NULL
 	);
-	intern->document->class_type = PHP_LIBXML_CLASS_MODERN;
+	dom_set_xml_class(intern->document);
 	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
 	return;
 
@@ -1136,7 +1136,7 @@ PHP_METHOD(Dom_HTMLDocument, createFromFile)
 		(xmlNodePtr) lxml_doc,
 		NULL
 	);
-	intern->document->class_type = PHP_LIBXML_CLASS_MODERN;
+	dom_set_xml_class(intern->document);
 	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
 	return;
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -246,6 +246,7 @@ static void dom_copy_document_ref(php_libxml_ref_obj *source_doc, php_libxml_ref
 		}
 
 		dest_doc->class_type = source_doc->class_type;
+		dest_doc->handlers = source_doc->handlers;
 	}
 }
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -173,7 +173,7 @@ void dom_document_convert_to_modern(php_libxml_ref_obj *document, xmlDocPtr lxml
 dom_object *php_dom_instantiate_object_helper(zval *return_value, zend_class_entry *ce, xmlNodePtr obj, dom_object *parent);
 xmlDocPtr php_dom_create_html_doc(void);
 xmlEntityPtr dom_entity_reference_fetch_and_sync_declaration(xmlNodePtr reference);
-
+void dom_set_xml_class(php_libxml_ref_obj *document);
 bool dom_compare_value(const xmlAttr *attr, const xmlChar *value);
 
 typedef enum {

--- a/ext/dom/tests/modern/common/namespace_sxe_interaction.phpt
+++ b/ext/dom/tests/modern/common/namespace_sxe_interaction.phpt
@@ -24,6 +24,11 @@ var_dump($dom->documentElement->firstElementChild->firstElementChild->lookupName
 echo "=== serialize SimpleXML ===\n";
 
 echo $sxe->saveXML(), "\n";
+echo $sxe->foo->saveXML(), "\n";
+$sxe->asXML(__DIR__ . "/namespace_sxe_interaction1.xml");
+$sxe->foo->asXML(__DIR__ . "/namespace_sxe_interaction2.xml");
+echo file_get_contents(__DIR__ . "/namespace_sxe_interaction1.xml"), "\n";
+echo file_get_contents(__DIR__ . "/namespace_sxe_interaction2.xml"), "\n";
 
 echo "=== serialize DOM ===\n";
 
@@ -37,17 +42,26 @@ $new_dom->append($new_dom->importNode($dom->documentElement, true));
 echo $new_dom->saveXML(), "\n";
 
 ?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/namespace_sxe_interaction1.xml");
+@unlink(__DIR__ . "/namespace_sxe_interaction2.xml");
+?>
 --EXPECT--
 namespace c: string(5) "urn:c"
 namespace b: string(5) "urn:b"
 namespace a: NULL
 === serialize SimpleXML ===
 <?xml version="1.0" encoding="UTF-8"?>
-<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child><foo>value2</foo></root>
+<foo>value2</foo>
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child><foo>value2</foo></root>
+<foo>value2</foo>
 === serialize DOM ===
 <?xml version="1.0" encoding="UTF-8"?>
-<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child><foo>value2</foo></root>
 
 === serialize imported DOM ===
 <?xml version="1.0" encoding="UTF-8"?>
-<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child><foo>value2</foo></root>

--- a/ext/dom/tests/modern/common/namespace_sxe_interaction.phpt
+++ b/ext/dom/tests/modern/common/namespace_sxe_interaction.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Serialization interaction between simplexml and dom for namespaces
+--EXTENSIONS--
+dom
+simplexml
+--FILE--
+<?php
+
+$dom = Dom\XMLDocument::createFromString('<root/>');
+$sxe = simplexml_import_dom($dom);
+
+$sxe->addAttribute('a:attr', 'value', 'urn:a');
+$sxe->addChild('b:child', 'value', 'urn:b');
+$sxe->addChild('foo', 'value2');
+$dom->documentElement->firstElementChild->appendChild($dom->createElementNS('urn:c', 'c:child'));
+
+echo "namespace c: ";
+var_dump($dom->documentElement->firstElementChild->firstElementChild->lookupNamespaceURI('c'));
+echo "namespace b: ";
+var_dump($dom->documentElement->firstElementChild->firstElementChild->lookupNamespaceURI('b'));
+echo "namespace a: ";
+var_dump($dom->documentElement->firstElementChild->firstElementChild->lookupNamespaceURI('a'));
+
+echo "=== serialize SimpleXML ===\n";
+
+echo $sxe->saveXML(), "\n";
+
+echo "=== serialize DOM ===\n";
+
+echo $dom->saveXML(), "\n\n";
+
+echo "=== serialize imported DOM ===\n";
+
+// Importing should yield the exact same document
+$new_dom = Dom\XMLDocument::createEmpty();
+$new_dom->append($new_dom->importNode($dom->documentElement, true));
+echo $new_dom->saveXML(), "\n";
+
+?>
+--EXPECT--
+namespace c: string(5) "urn:c"
+namespace b: string(5) "urn:b"
+namespace a: NULL
+=== serialize SimpleXML ===
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>
+=== serialize DOM ===
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>
+
+=== serialize imported DOM ===
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:a="urn:a" a:attr="value"><b:child xmlns:b="urn:b">value<c:child xmlns:c="urn:c"/></b:child></root>

--- a/ext/dom/tests/modern/xml/XMLDocument_fromString_02.phpt
+++ b/ext/dom/tests/modern/xml/XMLDocument_fromString_02.phpt
@@ -6,10 +6,15 @@ dom
 <?php
 
 $dom = Dom\XMLDocument::createFromString('<?xml version="1.0"?><container/>');
-var_dump($dom->saveXmlFile("php://stdout"));
+var_dump($dom->saveXmlFile(__DIR__ . "/fromString_02.xml"));
+echo file_get_contents(__DIR__ . "/fromString_02.xml");
 
 ?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/fromString_02.xml");
+?>
 --EXPECT--
+int(51)
 <?xml version="1.0" encoding="UTF-8"?>
 <container/>
-int(52)

--- a/ext/dom/xml_document.c
+++ b/ext/dom/xml_document.c
@@ -293,7 +293,7 @@ static zend_string *php_new_dom_dump_doc_to_str(xmlDocPtr doc, int options, cons
 	return php_new_dom_dump_node_to_str(doc, (xmlNodePtr) doc, options & XML_SAVE_FORMAT, encoding);
 }
 
-static zend_long php_new_dom_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding)
+zend_long php_new_dom_dump_node_to_file(const char *filename, xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding)
 {
 	xmlCharEncodingHandlerPtr handler = xmlFindCharEncodingHandler(encoding);
 	xmlOutputBufferPtr out = xmlOutputBufferCreateFilename(filename, handler, 0);
@@ -307,7 +307,7 @@ static zend_long php_new_dom_dump_doc_to_file(const char *filename, xmlDocPtr do
 	int status = -1;
 	xmlSaveCtxtPtr ctxt = xmlSaveToIO(out->writecallback, NULL, stream, encoding, XML_SAVE_AS_XML);
 	if (EXPECTED(ctxt != NULL)) {
-		status = dom_xml_serialize(ctxt, out, (xmlNodePtr) doc, format);
+		status = dom_xml_serialize(ctxt, out, node, format);
 		status |= xmlOutputBufferFlush(out);
 		(void) xmlSaveClose(ctxt);
 	}
@@ -319,9 +319,15 @@ static zend_long php_new_dom_dump_doc_to_file(const char *filename, xmlDocPtr do
 	return status < 0 ? status : (zend_long) offset;
 }
 
+static zend_long php_new_dom_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding)
+{
+	return php_new_dom_dump_node_to_file(filename, doc, (xmlNodePtr) doc, format, encoding);
+}
+
 static const php_libxml_document_handlers php_new_dom_default_document_handlers = {
 	.dump_node_to_str = php_new_dom_dump_node_to_str,
 	.dump_doc_to_str = php_new_dom_dump_doc_to_str,
+	.dump_node_to_file = php_new_dom_dump_node_to_file,
 	.dump_doc_to_file = php_new_dom_dump_doc_to_file,
 };
 

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -83,6 +83,7 @@ static zend_result php_libxml_post_deactivate(void);
 
 static zend_string *php_libxml_default_dump_node_to_str(xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 static zend_string *php_libxml_default_dump_doc_to_str(xmlDocPtr doc, int options, const char *encoding);
+static zend_long php_libxml_default_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding);
 
 /* }}} */
 
@@ -108,6 +109,7 @@ zend_module_entry libxml_module_entry = {
 static const php_libxml_document_handlers php_libxml_default_document_handlers = {
 	.dump_node_to_str = php_libxml_default_dump_node_to_str,
 	.dump_doc_to_str = php_libxml_default_dump_doc_to_str,
+	.dump_doc_to_file = php_libxml_default_dump_doc_to_file,
 };
 
 static void php_libxml_set_old_ns_list(xmlDocPtr doc, xmlNsPtr first, xmlNsPtr last)
@@ -1531,6 +1533,11 @@ static zend_string *php_libxml_default_dump_node_to_str(xmlDocPtr doc, xmlNodePt
 	zend_string *str = zend_string_init((const char *) content, size, false);
 	xmlOutputBufferClose(buf);
 	return str;
+}
+
+static zend_long php_libxml_default_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding)
+{
+	return xmlSaveFormatFileEnc(filename, doc, encoding, format);
 }
 
 #if defined(PHP_WIN32) && defined(COMPILE_DL_LIBXML)

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -83,6 +83,7 @@ static zend_result php_libxml_post_deactivate(void);
 
 static zend_string *php_libxml_default_dump_node_to_str(xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 static zend_string *php_libxml_default_dump_doc_to_str(xmlDocPtr doc, int options, const char *encoding);
+static zend_long php_libxml_dump_node_to_file(const char *filename, xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 static zend_long php_libxml_default_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding);
 
 /* }}} */
@@ -109,6 +110,7 @@ zend_module_entry libxml_module_entry = {
 static const php_libxml_document_handlers php_libxml_default_document_handlers = {
 	.dump_node_to_str = php_libxml_default_dump_node_to_str,
 	.dump_doc_to_str = php_libxml_default_dump_doc_to_str,
+	.dump_node_to_file = php_libxml_dump_node_to_file,
 	.dump_doc_to_file = php_libxml_default_dump_doc_to_file,
 };
 
@@ -1538,6 +1540,17 @@ static zend_string *php_libxml_default_dump_node_to_str(xmlDocPtr doc, xmlNodePt
 static zend_long php_libxml_default_dump_doc_to_file(const char *filename, xmlDocPtr doc, bool format, const char *encoding)
 {
 	return xmlSaveFormatFileEnc(filename, doc, encoding, format);
+}
+
+static zend_long php_libxml_dump_node_to_file(const char *filename, xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding)
+{
+	xmlOutputBufferPtr outbuf = xmlOutputBufferCreateFilename(filename, NULL, 0);
+	if (!outbuf) {
+		return -1;
+	}
+
+	xmlNodeDumpOutput(outbuf, doc, node, 0, format, encoding);
+	return xmlOutputBufferClose(outbuf);
 }
 
 #if defined(PHP_WIN32) && defined(COMPILE_DL_LIBXML)

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -75,6 +75,7 @@ typedef struct _php_libxml_private_data_header {
 typedef struct php_libxml_document_handlers {
 	zend_string *(*dump_node_to_str)(xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 	zend_string *(*dump_doc_to_str)(xmlDocPtr doc, int options, const char *encoding);
+	zend_long (*dump_doc_to_file)(const char *filename, xmlDocPtr doc, bool format, const char *encoding);
 } php_libxml_document_handlers;
 
 /**

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -75,6 +75,7 @@ typedef struct _php_libxml_private_data_header {
 typedef struct php_libxml_document_handlers {
 	zend_string *(*dump_node_to_str)(xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 	zend_string *(*dump_doc_to_str)(xmlDocPtr doc, int options, const char *encoding);
+	zend_long (*dump_node_to_file)(const char *filename, xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
 	zend_long (*dump_doc_to_file)(const char *filename, xmlDocPtr doc, bool format, const char *encoding);
 } php_libxml_document_handlers;
 

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -68,6 +68,16 @@ typedef struct _php_libxml_private_data_header {
 } php_libxml_private_data_header;
 
 /**
+ * It's possible to set custom handlers for certain actions depending on the type of document.
+ * For example, there exist multiple ways to serialize an XML document,
+ * therefore this structure allows setting up a custom handler.
+ */
+typedef struct php_libxml_document_handlers {
+	zend_string *(*dump_node_to_str)(xmlDocPtr doc, xmlNodePtr node, bool format, const char *encoding);
+	zend_string *(*dump_doc_to_str)(xmlDocPtr doc, int options, const char *encoding);
+} php_libxml_document_handlers;
+
+/**
  * Multiple representations are possible of the same underlying node data.
  * This is the case for example when a SimpleXML node is imported into DOM.
  * It must not be possible to obtain both a legacy and a modern representation
@@ -88,6 +98,7 @@ typedef struct _php_libxml_ref_obj {
 	libxml_doc_props *doc_props;
 	php_libxml_cache_tag cache_tag;
 	php_libxml_private_data_header *private_data;
+	const php_libxml_document_handlers *handlers;
 	int refcount;
 	php_libxml_class_type class_type;
 } php_libxml_ref_obj;

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1358,10 +1358,11 @@ PHP_METHOD(SimpleXMLElement, asXML)
 		RETURN_FALSE;
 	}
 
+	xmlDocPtr doc = sxe->document->ptr;
+
 	if (filename) {
 		if (node->parent && (XML_DOCUMENT_NODE == node->parent->type)) {
-			int bytes;
-			bytes = xmlSaveFile(filename, (xmlDocPtr) sxe->document->ptr);
+			zend_long bytes = sxe->document->handlers->dump_doc_to_file(filename, doc, false, (const char *) doc->encoding);
 			if (bytes == -1) {
 				RETURN_FALSE;
 			} else {
@@ -1380,7 +1381,6 @@ PHP_METHOD(SimpleXMLElement, asXML)
 		}
 	}
 
-	xmlDocPtr doc = sxe->document->ptr;
 	zend_string *result;
 	if (node->parent && (XML_DOCUMENT_NODE == node->parent->type)) {
 		result = sxe->document->handlers->dump_doc_to_str(doc, 0, (const char *) doc->encoding);

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1342,7 +1342,6 @@ PHP_METHOD(SimpleXMLElement, asXML)
 {
 	php_sxe_object     *sxe;
 	xmlNodePtr          node;
-	xmlOutputBufferPtr  outbuf;
 	char               *filename = NULL;
 	size_t                 filename_len;
 
@@ -1361,22 +1360,15 @@ PHP_METHOD(SimpleXMLElement, asXML)
 	xmlDocPtr doc = sxe->document->ptr;
 
 	if (filename) {
+		zend_long bytes;
 		if (node->parent && (XML_DOCUMENT_NODE == node->parent->type)) {
-			zend_long bytes = sxe->document->handlers->dump_doc_to_file(filename, doc, false, (const char *) doc->encoding);
-			if (bytes == -1) {
-				RETURN_FALSE;
-			} else {
-				RETURN_TRUE;
-			}
+			bytes = sxe->document->handlers->dump_doc_to_file(filename, doc, false, (const char *) doc->encoding);
 		} else {
-			outbuf = xmlOutputBufferCreateFilename(filename, NULL, 0);
-
-			if (outbuf == NULL) {
-				RETURN_FALSE;
-			}
-
-			xmlNodeDumpOutput(outbuf, (xmlDocPtr) sxe->document->ptr, node, 0, 0, NULL);
-			xmlOutputBufferClose(outbuf);
+			bytes = sxe->document->handlers->dump_node_to_file(filename, doc, node, false, NULL);
+		}
+		if (bytes == -1) {
+			RETURN_FALSE;
+		} else {
 			RETURN_TRUE;
 		}
 	}


### PR DESCRIPTION
There are multiple algorithms to serialize an XML document.
This may cause a problem: if we import a DOM document into SimpleXML, we may get different serializations between the two. This should be consistent. To solve this, we add a `php_libxml_document_handlers` function table that can set custom handlers for serialization. A reference to that table is stored within the internal document object.
Also factor out all the common serialization code, which in itself is a cleanup and preparation for a memory+performance optimization.