### PR TITLE
Fix missing deref in C14N

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1667,6 +1667,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 			inclusive_ns_prefixes = safe_emalloc(zend_hash_num_elements(Z_ARRVAL_P(ns_prefixes)) + 1,
 				sizeof(xmlChar *), 0);
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(ns_prefixes), tmpns) {
+				ZVAL_DEREF(tmpns);
 				if (Z_TYPE_P(tmpns) == IS_STRING) {
 					inclusive_ns_prefixes[nscount++] = (xmlChar *) Z_STRVAL_P(tmpns);
 				}

--- a/ext/dom/tests/DOMNode_C14N_references.phpt
+++ b/ext/dom/tests/DOMNode_C14N_references.phpt
@@ -38,4 +38,4 @@ unset($v);
 echo $doc->C14N(true, false, $xpath, $prefixes);
 ?>
 --EXPECT--
-<contain xmlns="http://www.example.com/ns/foo"><bar></bar><bar></bar></contain>
+<contain xmlns="http://www.example.com/ns/foo" xmlns:test="urn::test"><bar></bar><bar></bar></contain>


### PR DESCRIPTION
Follow-up for 30a0b0359ed8338c0e3acd1682de3cf96429e898, which didn't fix all places. This is the last remaining place.