### PR TITLE
Fix the aligned variable attribute check

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2743,3 +2743,32 @@ AC_DEFUN([PHP_CHECK_AVX512_VBMI_SUPPORTS], [
   AC_DEFINE_UNQUOTED([PHP_HAVE_AVX512_VBMI_SUPPORTS],
    [$have_avx512_vbmi_supports], [Whether the compiler supports AVX512 VBMI])
 ])
+
+dnl
+dnl PHP_CHECK_VARIABLE_ATTRIBUTE(attribute)
+dnl
+dnl Check whether the compiler supports the GNU C variable attribute.
+dnl
+AC_DEFUN([PHP_CHECK_VARIABLE_ATTRIBUTE],
+[AS_VAR_PUSHDEF([php_var], [php_cv_have_variable_attribute_$1])
+AC_CACHE_CHECK([for variable __attribute__(($1))], [php_var],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([m4_case([$1],
+  [aligned],
+    [unsigned char test[32] __attribute__(($1(__alignof__(int))));],
+  [
+    m4_warn([syntax], [Unsupported variable attribute $1, the test may fail])
+    int var __attribute__(($1));
+  ])],
+  [])],
+dnl By default, compilers may not classify attribute warnings as errors
+dnl (-Werror=attributes) when encountering an unknown attribute. Accept the
+dnl attribute only if no warnings were generated.
+  [AS_IF([test -s conftest.err],
+    [AS_VAR_SET([php_var], [no])],
+    [AS_VAR_SET([php_var], [yes])])],
+  [AS_VAR_SET([php_var], [no])])
+])
+AS_VAR_IF([php_var], [yes],
+  [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_ATTRIBUTE_$1]), [1],
+    [Define to 1 if the compiler supports the '$1' variable attribute.])])
+])

--- a/build/php.m4
+++ b/build/php.m4
@@ -2771,4 +2771,5 @@ dnl attribute only if no warnings were generated.
 AS_VAR_IF([php_var], [yes],
   [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_ATTRIBUTE_$1]), [1],
     [Define to 1 if the compiler supports the '$1' variable attribute.])])
+AS_VAR_POPDEF([php_var])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -567,6 +567,9 @@ AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*|*openbsd*], [true]
   fi
 ])
 
+dnl Check for __attribute__ ((__aligned__)) support in the compiler.
+PHP_CHECK_VARIABLE_ATTRIBUTE([aligned])
+
 dnl Check for IPv6 support.
 AC_CACHE_CHECK([for IPv6 support], ac_cv_ipv6_support,
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -275,22 +275,6 @@ else
   PHP_ADD_SOURCES(PHP_EXT_DIR(standard), crypt_freesec.c crypt_blowfish.c crypt_sha512.c crypt_sha256.c php_crypt_r.c)
 fi
 
-dnl
-dnl Check for __attribute__ ((__aligned__)) support in the compiler
-dnl
-AC_CACHE_CHECK(whether the compiler supports aligned attribute, ac_cv_attribute_aligned,[
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-]],[[
-  unsigned char test[32] __attribute__ ((__aligned__ (__alignof__ (int))));
-]])],[
-  ac_cv_attribute_aligned=yes
-],[
-  ac_cv_attribute_aligned=no
-])])
-if test "$ac_cv_attribute_aligned" = "yes"; then
-  AC_DEFINE([HAVE_ATTRIBUTE_ALIGNED], 1, [whether the compiler supports __attribute__ ((__aligned__))])
-fi
-
 if test "$cross_compiling" = yes ; then
   case $host_alias in
     *linux*)


### PR DESCRIPTION
By default compilers may not treat attribute warnings as errors when encountering an unknown `__attribute__`, unless some error option is provided (-Werror=attributes, -Werror...). This fixes the check and wraps it into a separate M4 macro to be extendable in the future if needed. It checks if conftest.err file was generated by the compilation check when warnings appear. Also, PHP check is a bit customized by using `__alignof__` keyword, so it is left in there for now to not break existing checks.