### PR TITLE
ext/pgsql: adding pg_result_memory_size.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -339,6 +339,7 @@ PHP 8.4 UPGRADE NOTES
     3-parameter signature with a null $row parameter instead.
   . Calling pg_field_is_null() with 2 arguments is deprecated. Use the
     3-parameter signature with a null $row parameter instead.
+  . Added pg_result_memory_size to get the visibility the memory used by a query result.
 
 - Reflection:
   . Calling ReflectionMethod::__construct() with 1 argument is deprecated.

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -66,6 +66,7 @@ if test "$PHP_PGSQL" != "no"; then
   AC_CHECK_LIB(pq, pg_encoding_to_char,AC_DEFINE(HAVE_PGSQL_WITH_MULTIBYTE_SUPPORT,1,[Whether libpq is compiled with --enable-multibyte]))
   AC_CHECK_LIB(pq, lo_truncate64, AC_DEFINE(HAVE_PG_LO64,1,[PostgreSQL 9.3 or later]))
   AC_CHECK_LIB(pq, PQsetErrorContextVisibility, AC_DEFINE(HAVE_PG_CONTEXT_VISIBILITY,1,[PostgreSQL 9.6 or later]))
+  AC_CHECK_LIB(pq, PQresultMemorySize, AC_DEFINE(HAVE_PG_RESULT_MEMORY_SIZE,1,[PostgreSQL 12 or later]))
   LIBS=$old_LIBS
   LDFLAGS=$old_LDFLAGS
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2911,6 +2911,23 @@ PHP_FUNCTION(pg_set_error_context_visibility)
 }
 #endif
 
+#ifdef HAVE_PG_RESULT_MEMORY_SIZE
+PHP_FUNCTION(pg_result_memory_size)
+{
+	zval *result;
+	pgsql_result_handle *pg_result;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &result, pgsql_result_ce) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	pg_result = Z_PGSQL_RESULT_P(result);
+	CHECK_PGSQL_RESULT(pg_result);
+
+	RETURN_LONG(PQresultMemorySize(pg_result->result));
+}
+#endif
+
 /* {{{ Set client encoding */
 PHP_FUNCTION(pg_set_client_encoding)
 {

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -943,6 +943,10 @@ namespace {
 #ifdef HAVE_PG_CONTEXT_VISIBILITY
     function pg_set_error_context_visibility(PgSql\Connection $connection, int $visibility): int {}
 #endif
+
+#ifdef HAVE_PG_RESULT_MEMORY_SIZE
+    function pg_result_memory_size(PgSql\Result $result): int {}
+#endif
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a37b9df0c3b172d1160b1a7ef953cbd5a0a811b6 */
+ * Stub hash: e06a7116c1048975cbb348ffcdb36c9b65cee659 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -459,6 +459,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_set_error_context_visibility,
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_PG_RESULT_MEMORY_SIZE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_result_memory_size, 0, 1, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, result, PgSql\\Result, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pg_connect);
 ZEND_FUNCTION(pg_pconnect);
 ZEND_FUNCTION(pg_connect_poll);
@@ -552,6 +558,9 @@ ZEND_FUNCTION(pg_delete);
 ZEND_FUNCTION(pg_select);
 #if defined(HAVE_PG_CONTEXT_VISIBILITY)
 ZEND_FUNCTION(pg_set_error_context_visibility);
+#endif
+#if defined(HAVE_PG_RESULT_MEMORY_SIZE)
+ZEND_FUNCTION(pg_result_memory_size);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -671,6 +680,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_select, arginfo_pg_select)
 #if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	ZEND_FE(pg_set_error_context_visibility, arginfo_pg_set_error_context_visibility)
+#endif
+#if defined(HAVE_PG_RESULT_MEMORY_SIZE)
+	ZEND_FE(pg_result_memory_size, arginfo_pg_result_memory_size)
 #endif
 	ZEND_FE_END
 };

--- a/ext/pgsql/tests/pg_result_memory_size.phpt
+++ b/ext/pgsql/tests/pg_result_memory_size.phpt
@@ -1,0 +1,29 @@
+--TEST--
+pg_result_memory_size
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php
+include("inc/skipif.inc");
+if (!function_exists('pg_result_memory_size')) die('skip function pg_result_memory_size() does not exist');
+?>
+--FILE--
+<?php
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+
+$result = pg_query($db, 'select 1');
+$size_1 = pg_result_memory_size($result);
+
+$result = pg_query($db, "select generate_series(1, 10000) as i, repeat('string', 100)");
+$size_2 = pg_result_memory_size($result);
+
+var_dump($size_1);
+var_dump($size_2);
+var_dump($size_1 < $size_2);
+?>
+--EXPECTF--
+int(%d)
+int(%d)
+bool(true)


### PR DESCRIPTION
Retrieve the memory usage of the query result resource.

Returns the value of `PQresultMemorySize()` provided by the client library `libpq` as is. The memory here is allocated internally by `libpq`, so until now there was no way for the user to directly check it.

Is an RFC necessary to introduce this feature? Although `pg_set_error_context_visibility()` added in #11395 did not require an RFC, please confirm if one is needed for this case.
