### PR TITLE
Update PEAR failed download installation banner

### DIFF
--- a/pear/install-pear.txt
+++ b/pear/install-pear.txt
@@ -4,9 +4,9 @@
 |                                                                      |
 |   PEAR: PHP Extension and Application Repository                     |
 |                                                                      |
-| To install these components,                                         |
-| download http://pear.php.net/go-pear.phar to php-src/pear/           |
+| To install these components, download                                |
+| https://pear.php.net/install-pear-nozlib.phar to php-src/pear/       |
 | become the superuser and execute:                                    |
 |                                                                      |
-|   # make install-su                                                  |
+|   # make install-pear                                                |
 +----------------------------------------------------------------------+


### PR DESCRIPTION
There was once install-su Makefile rule, now the install-pear can be used instead.