### PR TITLE
Fix Windows SKIPIF

### DIFF
--- a/tests/lang/bug38579.phpt
+++ b/tests/lang/bug38579.phpt
@@ -2,7 +2,7 @@
 Bug #38579 (include_once() may include the same file twice)
 --SKIPIF--
 <?php
-if(PHP_OS_FAMILY !== "WIN") {
+if(PHP_OS_FAMILY !== "Windows") {
     die('skip only for Windows');
 }
 ?>


### PR DESCRIPTION
PHP_OS_FAMILY never has the value WIN, for Windows platforms it is the string "Windows". As such, this test was never executed. Fix this.