### PR TITLE
Add missing MYSQLND_SHARED_LIBADD substitution

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -51,4 +51,5 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
   mysqlnd_sources="$mysqlnd_base_sources $mysqlnd_ps_sources"
   PHP_NEW_EXTENSION(mysqlnd, $mysqlnd_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_INSTALL_HEADERS([ext/mysqlnd/])
+  PHP_SUBST([MYSQLND_SHARED_LIBADD])
 fi


### PR DESCRIPTION
This is used in Makefile when building mysqlnd as shared to get zlib and crypto libraries linked in the mysqlnd.so (-lz -lcrypto). For static build these are in the resulting binary like before.

```sh
./buildconf
./configure --enable-mysqlnd=shared --with-openssl
grep MYSQLND_SHARED_LIBADD Makefile
```