### PR TITLE
Remove unused HAVE_PDO_SQLITELIB symbol

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -122,6 +122,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol ZEND_FIBER_ASM has been removed.
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
    - Symbol HAVE_MYSQL has been removed.
+   - Symbol HAVE_PDO_SQLITELIB has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -16,7 +16,6 @@ if test "$PHP_PDO_SQLITE" != "no"; then
 
   PHP_EVAL_INCLINE($SQLITE_CFLAGS)
   PHP_EVAL_LIBLINE($SQLITE_LIBS, PDO_SQLITE_SHARED_LIBADD)
-  AC_DEFINE(HAVE_PDO_SQLITELIB, 1, [Define to 1 if you have the pdo_sqlite extension enabled.])
 
   PHP_CHECK_LIBRARY(sqlite3, sqlite3_close_v2, [
     AC_DEFINE(HAVE_SQLITE3_CLOSE_V2, 1, [have sqlite3_close_v2])


### PR DESCRIPTION
Symbol isn't defined on Windows and is redundant since the SQLite library is required for ext/pdo_sqlite and isn't bundled in php-src anymore. Also after a quick scan over the open sourced PHP extensions sources, it doesn't seem to be used anywhere.