### PR TITLE
Fix nightly test failure

### DIFF
--- a/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_1.phpt
+++ b/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_1.phpt
@@ -12,7 +12,7 @@ $batch_file_content = <<<EOT
 @echo off
 powershell -Command "Write-Output '%1%'"
 EOT;
-$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv.bat';
+$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv_1.bat';
 
 file_put_contents($batch_file_path, $batch_file_content);
 
@@ -25,5 +25,5 @@ proc_close($proc);
 "&notepad.exe
 --CLEAN--
 <?php
-@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv.bat');
+@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv_1.bat');
 ?>

--- a/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_2.phpt
+++ b/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_2.phpt
@@ -12,7 +12,7 @@ $batch_file_content = <<<EOT
 @echo off
 powershell -Command "Write-Output '%1%'"
 EOT;
-$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv.cmd';
+$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv_2.cmd';
 
 file_put_contents($batch_file_path, $batch_file_content);
 
@@ -25,5 +25,5 @@ proc_close($proc);
 "&notepad<>^()!.exe
 --CLEAN--
 <?php
-@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv.cmd');
+@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv_2.cmd');
 ?>

--- a/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_3.phpt
+++ b/ext/standard/tests/general_functions/ghsa-pc52-254m-w9w7_3.phpt
@@ -12,7 +12,7 @@ $batch_file_content = <<<EOT
 @echo off
 powershell -Command "Write-Output '%1%'"
 EOT;
-$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv.bat';
+$batch_file_path = __DIR__ . '/ghsa-54hq-v5wp-fqgv_3.bat';
 
 file_put_contents($batch_file_path, $batch_file_content);
 
@@ -25,5 +25,5 @@ proc_close($proc);
 "&notepad.exe
 --CLEAN--
 <?php
-@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv.bat');
+@unlink(__DIR__ . '/ghsa-54hq-v5wp-fqgv_3.bat');
 ?>


### PR DESCRIPTION
The created files have the same filename, creating conflicts. Fix this by adding a unique suffix.