### PR TITLE
ext/bcmath: Avoid unnecessary `memset` from `_bc_do_add`

### DIFF
--- a/ext/bcmath/libbcmath/src/add.c
+++ b/ext/bcmath/libbcmath/src/add.c
@@ -44,7 +44,7 @@ bc_num bc_add(bc_num n1, bc_num n2, size_t scale_min)
 	bc_num sum = NULL;
 
 	if (n1->n_sign == n2->n_sign) {
-		sum = _bc_do_add(n1, n2, scale_min);
+		sum = _bc_do_add(n1, n2);
 		sum->n_sign = n1->n_sign;
 	} else {
 		/* subtraction must be done. */

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -38,7 +38,7 @@
    returned.  The signs of N1 and N2 are ignored.
    SCALE_MIN is to set the minimum scale of the result. */
 
-bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
+bc_num _bc_do_add(bc_num n1, bc_num n2)
 {
 	bc_num sum;
 	size_t sum_len = MAX(n1->n_len, n2->n_len) + 1;
@@ -51,7 +51,7 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 	size_t count;
 
 	/* Prepare sum. */
-	sum = bc_new_num (sum_len, MAX(sum_scale, scale_min));
+	sum = bc_new_num_nonzeroed(sum_len, sum_scale);
 
 	/* Start with the fraction part.  Initialize the pointers. */
 	n1ptr = (char *) (n1->n_value + n1->n_len + n1->n_scale - 1);
@@ -157,7 +157,7 @@ bc_num _bc_do_add(bc_num n1, bc_num n2, size_t scale_min)
 	}
 
 	/* Set final carry. */
-	*sumptr += carry;
+	*sumptr = carry;
 
 	/* Adjust sum and return. */
 	_bc_rm_leading_zeros(sum);

--- a/ext/bcmath/libbcmath/src/floor_or_ceil.c
+++ b/ext/bcmath/libbcmath/src/floor_or_ceil.c
@@ -47,7 +47,7 @@ bc_num bc_floor_or_ceil(bc_num num, bool is_floor)
 	}
 
 	/* Increment the absolute value of the result by 1 and add sign information */
-	bc_num tmp = _bc_do_add(result, BCG(_one_), 0);
+	bc_num tmp = _bc_do_add(result, BCG(_one_));
 	tmp->n_sign = result->n_sign;
 	bc_free_num(&result);
 	return tmp;

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -98,6 +98,6 @@ static inline uint64_t BC_BSWAP64(uint64_t u)
 
 /* routines */
 int _bc_do_compare (bc_num n1, bc_num n2, bool use_sign);
-bc_num _bc_do_add (bc_num n1, bc_num n2, size_t scale_min);
+bc_num _bc_do_add (bc_num n1, bc_num n2);
 bc_num _bc_do_sub (bc_num n1, bc_num n2);
 void _bc_rm_leading_zeros (bc_num num);

--- a/ext/bcmath/libbcmath/src/round.c
+++ b/ext/bcmath/libbcmath/src/round.c
@@ -168,7 +168,7 @@ up:
 			bc_num scaled_one = bc_new_num((*result)->n_len, (*result)->n_scale);
 			scaled_one->n_value[rounded_len - 1] = 1;
 
-			tmp = _bc_do_add(*result, scaled_one, (*result)->n_scale);
+			tmp = _bc_do_add(*result, scaled_one);
 			tmp->n_sign = (*result)->n_sign;
 			bc_free_num(&scaled_one);
 		}

--- a/ext/bcmath/libbcmath/src/sub.c
+++ b/ext/bcmath/libbcmath/src/sub.c
@@ -44,7 +44,7 @@ bc_num bc_sub(bc_num n1, bc_num n2, size_t scale_min)
 	bc_num diff = NULL;
 
 	if (n1->n_sign != n2->n_sign) {
-		diff = _bc_do_add(n1, n2, scale_min);
+		diff = _bc_do_add(n1, n2);
 		diff->n_sign = n1->n_sign;
 	} else {
 		/* subtraction must be done. */


### PR DESCRIPTION
Apply the same changes as #14180 to `_bc_do_add`.