### PR TITLE
Make the `fcc` parameter `const` in `zend_call_known_fcc`

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -833,7 +833,7 @@ ZEND_API void zend_call_known_function(
 		uint32_t param_count, zval *params, HashTable *named_params);
 
 static zend_always_inline void zend_call_known_fcc(
-	zend_fcall_info_cache *fcc, zval *retval_ptr, uint32_t param_count, zval *params, HashTable *named_params)
+	const zend_fcall_info_cache *fcc, zval *retval_ptr, uint32_t param_count, zval *params, HashTable *named_params)
 {
 	zend_function *func = fcc->function_handler;
 	/* Need to copy trampolines as they get released after they are called */


### PR DESCRIPTION
This makes it legal to call the function from a caller that only has a `const` pointer to the `fcc` to prevent accidental modification.