### PR TITLE
ext/pgsql: adding pg_change_password functionality.

### DIFF
--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -67,6 +67,7 @@ if test "$PHP_PGSQL" != "no"; then
   AC_CHECK_LIB(pq, lo_truncate64, AC_DEFINE(HAVE_PG_LO64,1,[PostgreSQL 9.3 or later]))
   AC_CHECK_LIB(pq, PQsetErrorContextVisibility, AC_DEFINE(HAVE_PG_CONTEXT_VISIBILITY,1,[PostgreSQL 9.6 or later]))
   AC_CHECK_LIB(pq, PQresultMemorySize, AC_DEFINE(HAVE_PG_RESULT_MEMORY_SIZE,1,[PostgreSQL 12 or later]))
+  AC_CHECK_LIB(pq, PQchangePassword, AC_DEFINE(HAVE_PG_CHANGE_PASSWORD,1,[PostgreSQL 17 or later]))
   LIBS=$old_LIBS
   LDFLAGS=$old_LDFLAGS
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -39,6 +39,7 @@
 #include "php_pgsql.h"
 #include "php_globals.h"
 #include "zend_exceptions.h"
+#include "zend_attributes.h"
 
 #ifdef HAVE_PGSQL
 
@@ -6117,11 +6118,7 @@ PHP_FUNCTION(pg_change_password)
 	CHECK_PGSQL_LINK(link);
 
 	pg_result = PQchangePassword(link->conn, ZSTR_VAL(user), ZSTR_VAL(passwd));
-	if (PQresultStatus(pg_result) == PGRES_COMMAND_OK) {
-		RETVAL_TRUE;
-	} else {
-		RETVAL_FALSE;
-	}
+	RETVAL_BOOL(PQresultStatus(pg_result) == PGRES_COMMAND_OK);
 	PQclear(pg_result);
 }
 

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -947,6 +947,8 @@ namespace {
 #ifdef HAVE_PG_RESULT_MEMORY_SIZE
     function pg_result_memory_size(PgSql\Result $result): int {}
 #endif
+
+    function pg_change_password(PgSql\Connection $connection, string $user, string $password): bool {}
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -948,7 +948,7 @@ namespace {
     function pg_result_memory_size(PgSql\Result $result): int {}
 #endif
 
-    function pg_change_password(PgSql\Connection $connection, string $user, string $password): bool {}
+    function pg_change_password(PgSql\Connection $connection, string $user, #[\SensitiveParameter] string $password): bool {}
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f87a0f47f6d84deba971d86ba6c79449d9a8483 */
+ * Stub hash: c5cb23b6536c1908d3dcc804f5fa176323f4db07 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -818,6 +818,9 @@ static void register_pgsql_symbols(int module_number)
 #if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
 #endif
+
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_change_password", sizeof("pg_change_password") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_PgSql_Connection(void)

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e06a7116c1048975cbb348ffcdb36c9b65cee659 */
+ * Stub hash: 8f87a0f47f6d84deba971d86ba6c79449d9a8483 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -465,6 +465,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_result_memory_size, 0, 1, IS_
 ZEND_END_ARG_INFO()
 #endif
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_change_password, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, connection, PgSql\\Connection, 0)
+	ZEND_ARG_TYPE_INFO(0, user, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(pg_connect);
 ZEND_FUNCTION(pg_pconnect);
 ZEND_FUNCTION(pg_connect_poll);
@@ -562,6 +568,7 @@ ZEND_FUNCTION(pg_set_error_context_visibility);
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 ZEND_FUNCTION(pg_result_memory_size);
 #endif
+ZEND_FUNCTION(pg_change_password);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_connect, arginfo_pg_connect)
@@ -684,6 +691,7 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 	ZEND_FE(pg_result_memory_size, arginfo_pg_result_memory_size)
 #endif
+	ZEND_FE(pg_change_password, arginfo_pg_change_password)
 	ZEND_FE_END
 };
 

--- a/ext/pgsql/tests/changepassword.phpt
+++ b/ext/pgsql/tests/changepassword.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Changing user password with pg_change_password
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+include('inc/config.inc');
+
+$conn = pg_connect($conn_str);
+
+try {
+	pg_change_password($conn, "", "pass");
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	pg_change_password($conn, "user", "");
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+var_dump(pg_change_password($conn, "inexistent_user", "postitpwd"));
+?>
+--EXPECT--
+pg_change_password(): Argument #2 ($user) cannot be empty
+pg_change_password(): Argument #3 ($password) cannot be empty
+bool(false)


### PR DESCRIPTION
handy call to change an user password while taking care transparently of the password's encryption.