### PR TITLE
Reduce unused variable warnings in config.log

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -21,6 +21,7 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
     _FPU_SETCW(fpu_cw);
     result = a / b;
     _FPU_SETCW(fpu_oldcw);
+    (void)result;
   ]])],[ac_cfp_have__fpu_setcw=yes],[ac_cfp_have__fpu_setcw=no])
   if test "$ac_cfp_have__fpu_setcw" = "yes" ; then
     AC_DEFINE(HAVE__FPU_SETCW, 1, [whether _FPU_SETCW is present and usable])
@@ -42,6 +43,7 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
     fpsetprec(FP_PD);
     result = a / b;
     fpsetprec(fpu_oldprec);
+    (void)result;
   ]])], [ac_cfp_have_fpsetprec=yes], [ac_cfp_have_fpsetprec=no])
   if test "$ac_cfp_have_fpsetprec" = "yes" ; then
     AC_DEFINE(HAVE_FPSETPREC, 1, [whether fpsetprec is present and usable])
@@ -63,6 +65,7 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
     _controlfp(_PC_53, _MCW_PC);
     result = a / b;
     _controlfp(fpu_oldcw, _MCW_PC);
+    (void)result;
   ]])], [ac_cfp_have__controlfp=yes], [ac_cfp_have__controlfp=no])
   if test "$ac_cfp_have__controlfp" = "yes" ; then
     AC_DEFINE(HAVE__CONTROLFP, 1, [whether _controlfp is present usable])
@@ -85,6 +88,7 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
     _controlfp_s(&fpu_cw, _PC_53, _MCW_PC);
     result = a / b;
     _controlfp_s(&fpu_cw, fpu_oldcw, _MCW_PC);
+    (void)result;
   ]])], [ac_cfp_have__controlfp_s=yes], [ac_cfp_have__controlfp_s=no])
   if test "$ac_cfp_have__controlfp_s" = "yes" ; then
     AC_DEFINE(HAVE__CONTROLFP_S, 1, [whether _controlfp_s is present and usable])
@@ -105,10 +109,9 @@ AC_DEFUN([ZEND_CHECK_FLOAT_PRECISION],[
     __asm__ __volatile__ ("fnstcw %0" : "=m" (*&oldcw));
     cw = (oldcw & ~0x0 & ~0x300) | 0x200;
     __asm__ __volatile__ ("fldcw %0" : : "m" (*&cw));
-
     result = a / b;
-
     __asm__ __volatile__ ("fldcw %0" : : "m" (*&oldcw));
+    (void)result;
   ]])], [ac_cfp_have_fpu_inline_asm_x86=yes], [ac_cfp_have_fpu_inline_asm_x86=no])
   if test "$ac_cfp_have_fpu_inline_asm_x86" = "yes" ; then
     AC_DEFINE(HAVE_FPU_INLINE_ASM_X86, 1, [whether FPU control word can be manipulated by inline assembler])

--- a/configure.ac
+++ b/configure.ac
@@ -531,6 +531,7 @@ AC_CACHE_CHECK(whether the compiler supports __alignof__, ac_cv_alignof_exists,[
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ]],[[
   int align = __alignof__(int);
+  (void)align;
 ]])],[
   ac_cv_alignof_exists=yes
 ],[
@@ -571,7 +572,14 @@ dnl Check for IPv6 support.
 AC_CACHE_CHECK([for IPv6 support], ac_cv_ipv6_support,
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 #include <sys/socket.h>
-#include <netinet/in.h>]], [[struct sockaddr_in6 s; struct in6_addr t=in6addr_any; int i=AF_INET6; s; t.s6_addr[0] = 0;]])],
+#include <netinet/in.h>]], [[
+  struct sockaddr_in6 s;
+  struct in6_addr t=in6addr_any;
+  int i=AF_INET6;
+  (void)s;
+  t.s6_addr[0] = 0;
+  (void)i;
+]])],
   [ac_cv_ipv6_support=yes], [ac_cv_ipv6_support=no])])
 
 dnl Checks for library functions.

--- a/configure.ac
+++ b/configure.ac
@@ -574,8 +574,8 @@ AC_CACHE_CHECK([for IPv6 support], ac_cv_ipv6_support,
 #include <sys/socket.h>
 #include <netinet/in.h>]], [[
   struct sockaddr_in6 s;
-  struct in6_addr t=in6addr_any;
-  int i=AF_INET6;
+  struct in6_addr t = in6addr_any;
+  int i = AF_INET6;
   (void)s;
   t.s6_addr[0] = 0;
   (void)i;

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -265,7 +265,12 @@ AC_DEFUN([AC_FPM_LQ],
 
   AC_MSG_CHECKING([for TCP_INFO])
 
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netinet/tcp.h>]], [[struct tcp_info ti; int x = TCP_INFO;]])], [
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netinet/tcp.h>]], [[
+    struct tcp_info ti;
+    int x = TCP_INFO;
+    (void)ti;
+    (void)x;
+  ]])], [
     have_lq=tcp_info
     AC_MSG_RESULT([yes])
   ], [
@@ -278,7 +283,12 @@ AC_DEFUN([AC_FPM_LQ],
 
   AC_MSG_CHECKING([for TCP_CONNECTION_INFO])
 
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netinet/tcp.h>]], [[struct tcp_connection_info ti; int x = TCP_CONNECTION_INFO;]])], [
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netinet/tcp.h>]], [[
+    struct tcp_connection_info ti;
+    int x = TCP_CONNECTION_INFO;
+    (void)ti;
+    (void)x;
+  ]])], [
     have_lq=tcp_connection_info
     AC_MSG_RESULT([yes])
   ], [
@@ -292,7 +302,12 @@ AC_DEFUN([AC_FPM_LQ],
   if test "$have_lq" = "no" ; then
     AC_MSG_CHECKING([for SO_LISTENQLEN])
 
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]], [[int x = SO_LISTENQLIMIT; int y = SO_LISTENQLEN;]])], [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]], [[
+      int x = SO_LISTENQLIMIT;
+      int y = SO_LISTENQLEN;
+      (void)x;
+      (void)y;
+    ]])], [
       have_lq=so_listenq
       AC_MSG_RESULT([yes])
     ], [


### PR DESCRIPTION
This reduces -Wunused-variable and -Wunused-but-set-variable warnings generated in the Autoconf's config.log to comply with possible stricter default compiler configuration on the system to avoid having false results.