### PR TITLE
Fix bug #81227: PDO::inTransaction reports false when in transaction

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -178,6 +178,8 @@ PHP                                                                        NEWS
 
 - PDO_SQLITE:
   . Added class PdoSqlite. (danack, kocsismate)
+  . Fixed bug #81227 (PDO::inTransaction reports false when in transaction).
+    (nielsdos)
 
 - PGSQL:
   . Added the possibility to have no conditions for pg_select. (OmarEmaraDev)

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -282,6 +282,15 @@ static int pdo_sqlite_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return
 	return 1;
 }
 
+static bool pdo_sqlite_in_transaction(pdo_dbh_t *dbh)
+{
+	pdo_sqlite_db_handle* H = (pdo_sqlite_db_handle*) dbh->driver_data;
+	/* It's not possible in sqlite3 to explicitly turn autocommit off other
+	 * than manually starting a transaction. Manual transactions always are
+	 * the mode of operation when autocommit is off. */
+	return H->db && sqlite3_get_autocommit(H->db) == 0;
+}
+
 static bool pdo_sqlite_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
@@ -733,7 +742,7 @@ static const struct pdo_dbh_methods sqlite_methods = {
 	NULL,	/* check_liveness: not needed */
 	get_driver_methods,
 	pdo_sqlite_request_shutdown,
-	NULL, /* in transaction, use PDO's internal tracking mechanism */
+	pdo_sqlite_in_transaction,
 	pdo_sqlite_get_gc
 };
 

--- a/ext/pdo_sqlite/tests/bug81227.phpt
+++ b/ext/pdo_sqlite/tests/bug81227.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #81227 (PDO::inTransaction reports false when in transaction)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = new PDO("sqlite::memory:");
+var_dump($db->inTransaction());
+
+$db->exec("BEGIN EXCLUSIVE TRANSACTION");
+var_dump($db->inTransaction());
+
+try {
+    $db->beginTransaction();
+} catch (PDOException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$db->commit();
+var_dump($db->inTransaction());
+
+$db->beginTransaction();
+var_dump($db->inTransaction());
+?>
+--EXPECT--
+bool(false)
+bool(true)
+There is already an active transaction
+bool(false)
+bool(true)


### PR DESCRIPTION
Instead of tracking the transaction state internally, implement the internal PDO getter to check with the sqlite library itself.
Fixes https://bugs.php.net/bug.php?id=81227

Applying to master only because this bugfix is a behaviour change.