### PR TITLE
Fix undefined behaviour in fastcgi.c

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -744,7 +744,7 @@ int fcgi_listen(const char *path, int backlog)
 		memset(&sa.sa_unix, 0, sizeof(sa.sa_unix));
 		sa.sa_unix.sun_family = AF_UNIX;
 		memcpy(sa.sa_unix.sun_path, path, path_len + 1);
-		sock_len = (size_t)(((struct sockaddr_un *)0)->sun_path)	+ path_len;
+		sock_len = XtOffsetOf(struct sockaddr_un, sun_path) + path_len;
 #ifdef HAVE_SOCKADDR_UN_SUN_LEN
 		sa.sa_unix.sun_len = sock_len;
 #endif


### PR DESCRIPTION
Arithmetic on NULL pointers is undefined.