### PR TITLE
Add -Wno-type-limits and -Wno-logical-op only on 32-bit

### DIFF
--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -11,9 +11,16 @@ if test "$PHP_SODIUM" != "no"; then
 
   AC_DEFINE(HAVE_LIBSODIUMLIB, 1, [ ])
 
+  SODIUM_COMPILER_FLAGS="$LIBSODIUM_CFLAGS"
+
   dnl Add -Wno-type-limits and -Wno-logical-op as this may arise on 32bits platforms
-  SODIUM_COMPILER_FLAGS="$LIBSODIUM_CFLAGS -Wno-type-limits"
-  AX_CHECK_COMPILE_FLAG([-Wno-logical-op], SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op", , [-Werror])
+  AC_CHECK_SIZEOF([long])
+  AS_IF([test "$ac_cv_sizeof_long" -eq 4], [
+    SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-type-limits"
+    AX_CHECK_COMPILE_FLAG([-Wno-logical-op],
+      [SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op"],, [-Werror])
+  ])
+
   PHP_NEW_EXTENSION(sodium, libsodium.c sodium_pwhash.c, $ext_shared, , $SODIUM_COMPILER_FLAGS)
   PHP_INSTALL_HEADERS([ext/sodium], [php_libsodium.h])
   PHP_SUBST(SODIUM_SHARED_LIBADD)


### PR DESCRIPTION
For ext/sodium these two flags can be added conditionally only for the 32-bit target architecture.