### PR TITLE
Fix header errors when parsed standalone

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 
+#include "zend_types.h"
 #include "../TSRM/TSRM.h"
 
 #ifndef ZEND_MM_ALIGNMENT

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_ATTRIBUTES_H
 #define ZEND_ATTRIBUTES_H
 
+#include "zend_compile.h"
+
 #define ZEND_ATTRIBUTE_TARGET_CLASS			(1<<0)
 #define ZEND_ATTRIBUTE_TARGET_FUNCTION		(1<<1)
 #define ZEND_ATTRIBUTE_TARGET_METHOD		(1<<2)

--- a/Zend/zend_builtin_functions.h
+++ b/Zend/zend_builtin_functions.h
@@ -20,6 +20,10 @@
 #ifndef ZEND_BUILTIN_FUNCTIONS_H
 #define ZEND_BUILTIN_FUNCTIONS_H
 
+#include "zend_types.h"
+
+typedef struct _zval_struct zval;
+
 zend_result zend_startup_builtin_functions(void);
 
 BEGIN_EXTERN_C()

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_CLOSURES_H
 #define ZEND_CLOSURES_H
 
+#include "zend_types.h"
+
 BEGIN_EXTERN_C()
 
 /* This macro depends on zend_closure structure layout */

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -20,7 +20,7 @@
 #define ZEND_ENUM_H
 
 #include "zend.h"
-#include "zend_types.h"
+#include "zend_API.h"
 
 #include <stdint.h>
 

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -22,6 +22,8 @@
 #ifndef ZEND_EXCEPTIONS_H
 #define ZEND_EXCEPTIONS_H
 
+#include "zend_types.h"
+
 BEGIN_EXTERN_C()
 
 extern ZEND_API zend_class_entry *zend_ce_throwable;

--- a/Zend/zend_float.h
+++ b/Zend/zend_float.h
@@ -19,6 +19,8 @@
 #ifndef ZEND_FLOAT_H
 #define ZEND_FLOAT_H
 
+#include "zend_portability.h"
+
 BEGIN_EXTERN_C()
 
 /*

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "zend_compile.h"
+
 BEGIN_EXTERN_C()
 
 extern ZEND_API zend_class_entry *zend_ce_generator;

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_GLOBALS_MACROS_H
 #define ZEND_GLOBALS_MACROS_H
 
+#include "zend_portability.h"
+
 typedef struct _zend_compiler_globals zend_compiler_globals;
 typedef struct _zend_executor_globals zend_executor_globals;
 typedef struct _zend_php_scanner_globals zend_php_scanner_globals;

--- a/Zend/zend_highlight.h
+++ b/Zend/zend_highlight.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_HIGHLIGHT_H
 #define ZEND_HIGHLIGHT_H
 
+#include "zend_types.h"
+
 #define HL_COMMENT_COLOR     "#FF8000"    /* orange */
 #define HL_DEFAULT_COLOR     "#0000BB"    /* blue */
 #define HL_HTML_COLOR        "#000000"    /* black */

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -19,6 +19,8 @@
 #ifndef ZEND_INI_H
 #define ZEND_INI_H
 
+#include "zend_modules.h"
+
 #define ZEND_INI_USER	(1<<0)
 #define ZEND_INI_PERDIR	(1<<1)
 #define ZEND_INI_SYSTEM	(1<<2)

--- a/Zend/zend_ini_scanner.h
+++ b/Zend/zend_ini_scanner.h
@@ -20,6 +20,10 @@
 #ifndef _ZEND_INI_SCANNER_H
 #define _ZEND_INI_SCANNER_H
 
+#include "zend_types.h"
+
+typedef struct _zend_file_handle zend_file_handle;
+
 /* Scanner modes */
 #define ZEND_INI_SCANNER_NORMAL 0 /* Normal mode. [DEFAULT] */
 #define ZEND_INI_SCANNER_RAW    1 /* Raw mode. Option values are not parsed */

--- a/Zend/zend_iterators.h
+++ b/Zend/zend_iterators.h
@@ -17,6 +17,11 @@
    +----------------------------------------------------------------------+
 */
 
+#ifndef ZEND_ITERATORS_H
+#define ZEND_ITERATORS_H
+
+#include "zend_types.h"
+
 /* These iterators were designed to operate within the foreach()
  * structures provided by the engine, but could be extended for use
  * with other iterative engine opcodes.
@@ -89,3 +94,5 @@ ZEND_API void zend_iterator_dtor(zend_object_iterator *iter);
 
 ZEND_API void zend_register_iterator_wrapper(void);
 END_EXTERN_C()
+
+#endif /* ZEND_ITERATORS_H */

--- a/Zend/zend_language_scanner.h
+++ b/Zend/zend_language_scanner.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_SCANNER_H
 #define ZEND_SCANNER_H
 
+#include "zend_globals.h"
+
 typedef struct _zend_lex_state {
 	unsigned int yy_leng;
 	unsigned char *yy_start;

--- a/Zend/zend_llist.h
+++ b/Zend/zend_llist.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_LLIST_H
 #define ZEND_LLIST_H
 
+#include "zend_portability.h"
+
 typedef struct _zend_llist_element {
 	struct _zend_llist_element *next;
 	struct _zend_llist_element *prev;

--- a/Zend/zend_map_ptr.h
+++ b/Zend/zend_map_ptr.h
@@ -21,6 +21,8 @@
 
 #include "zend_portability.h"
 
+typedef struct _zend_string zend_string;
+
 #define ZEND_MAP_PTR_KIND_PTR           0
 #define ZEND_MAP_PTR_KIND_PTR_OR_OFFSET 1
 

--- a/Zend/zend_multibyte.h
+++ b/Zend/zend_multibyte.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_MULTIBYTE_H
 #define ZEND_MULTIBYTE_H
 
+#include "zend_types.h"
+
 typedef struct _zend_encoding zend_encoding;
 
 typedef size_t (*zend_encoding_filter)(unsigned char **str, size_t *str_length, const unsigned char *buf, size_t length);

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "zend_types.h"
+
 struct _zend_property_info;
 
 #define ZEND_WRONG_PROPERTY_INFO \

--- a/Zend/zend_ptr_stack.h
+++ b/Zend/zend_ptr_stack.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_PTR_STACK_H
 #define ZEND_PTR_STACK_H
 
+#include "zend_alloc.h"
+
 typedef struct _zend_ptr_stack {
 	int top, max;
 	void **elements;

--- a/Zend/zend_signal.h
+++ b/Zend/zend_signal.h
@@ -25,6 +25,8 @@
 
 #include <signal.h>
 
+#include "zend_portability.h"
+
 #ifndef NSIG
 #define NSIG 65
 #endif

--- a/Zend/zend_smart_str_public.h
+++ b/Zend/zend_smart_str_public.h
@@ -17,6 +17,10 @@
 #ifndef ZEND_SMART_STR_PUBLIC_H
 #define ZEND_SMART_STR_PUBLIC_H
 
+#include <stddef.h>
+
+typedef struct _zend_string zend_string;
+
 typedef struct {
 	/** See smart_str_extract() */
 	zend_string *s;

--- a/Zend/zend_sort.h
+++ b/Zend/zend_sort.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_SORT_H
 #define ZEND_SORT_H
 
+#include "zend_types.h"
+
 BEGIN_EXTERN_C()
 ZEND_API void zend_sort(void *base, size_t nmemb, size_t siz, compare_func_t cmp, swap_func_t swp);
 ZEND_API void zend_insert_sort(void *base, size_t nmemb, size_t siz, compare_func_t cmp, swap_func_t swp);

--- a/Zend/zend_stack.h
+++ b/Zend/zend_stack.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_STACK_H
 #define ZEND_STACK_H
 
+#include "zend_portability.h"
+
 typedef struct _zend_stack {
 	int size, top, max;
 	void *elements;

--- a/Zend/zend_stream.h
+++ b/Zend/zend_stream.h
@@ -25,6 +25,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "zend_types.h"
+
 /* Lightweight stream implementation for the ZE scanners.
  * These functions are private to the engine.
  * */

--- a/Zend/zend_system_id.c
+++ b/Zend/zend_system_id.c
@@ -26,7 +26,7 @@ ZEND_API char zend_system_id[32];
 static PHP_MD5_CTX context;
 static int finalized = 0;
 
-ZEND_API ZEND_RESULT_CODE zend_add_system_entropy(const char *module_name, const char *hook_name, const void *data, size_t size)
+ZEND_API zend_result zend_add_system_entropy(const char *module_name, const char *hook_name, const void *data, size_t size)
 {
 	if (finalized == 0) {
 		PHP_MD5Update(&context, module_name, strlen(module_name));

--- a/Zend/zend_system_id.h
+++ b/Zend/zend_system_id.h
@@ -17,11 +17,13 @@
 #ifndef ZEND_SYSTEM_ID_H
 #define ZEND_SYSTEM_ID_H
 
+#include "zend_types.h"
+
 BEGIN_EXTERN_C()
 /* True global; Write-only during MINIT/startup */
 extern ZEND_API char zend_system_id[32];
 
-ZEND_API ZEND_RESULT_CODE zend_add_system_entropy(const char *module_name, const char *hook_name, const void *data, size_t size);
+ZEND_API zend_result zend_add_system_entropy(const char *module_name, const char *hook_name, const void *data, size_t size);
 END_EXTERN_C()
 
 void zend_startup_system_id(void);

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -63,6 +63,8 @@
 #include <errno.h>
 #endif
 
+#include "zend_stream.h"
+
 #ifdef ZEND_WIN32
 #include "win32/readdir.h"
 #include <sys/utime.h>

--- a/Zend/zend_vm.h
+++ b/Zend/zend_vm.h
@@ -19,6 +19,11 @@
 #ifndef ZEND_VM_H
 #define ZEND_VM_H
 
+#include "zend_portability.h"
+
+typedef struct _zend_op zend_op;
+typedef struct _zend_execute_data zend_execute_data;
+
 BEGIN_EXTERN_C()
 
 ZEND_API void ZEND_FASTCALL zend_vm_set_opcode_handler(zend_op* opcode);


### PR DESCRIPTION
This is annoying for multiple reasons:

1. LSPs can show many errors for these files.
2. LSP can stop parsing these files completely if there are too many errors, resulting in spotty LSP features.

On my machine, two debug build without ccache took 55s/56s for `master`, and 56s/56s for this branch, so it does not seem like it changed significantly.