### PR TITLE
Emit error when building fuzzer with ZTS

### DIFF
--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -22,7 +22,7 @@ AC_DEFUN([PHP_FUZZER_TARGET], [
 if test "$PHP_FUZZER" != "no"; then
   AC_MSG_RESULT([yes])
 
-  AS_IF([test "$enable_zts" = "yes"], [AC_MSG_ERROR(m4_normalize([
+  AS_VAR_IF([enable_zts], [yes], [AC_MSG_ERROR(m4_normalize([
     Thread safety (--enable-zts) is not supported when building fuzzing module
     (--enable-fuzzer). Please build fuzzer without ZTS.
   ]))])

--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -21,6 +21,12 @@ AC_DEFUN([PHP_FUZZER_TARGET], [
 
 if test "$PHP_FUZZER" != "no"; then
   AC_MSG_RESULT([yes])
+
+  AS_IF([test "$enable_zts" = "yes"], [AC_MSG_ERROR(m4_normalize([
+    Thread safety (--enable-zts) is not supported when building fuzzing module
+    (--enable-fuzzer). Please build fuzzer without ZTS.
+  ]))])
+
   dnl Don't use PHP_REQUIRE_CXX() to avoid unnecessarily pulling in -lstdc++
   AC_PROG_CXX
   AC_PROG_CXXCPP


### PR DESCRIPTION
Thread safety (--enable-zts) is not supported when building fuzzer (--enable-fuzzer).

Fixes GH-14243

This sound good?