### PR TITLE
Bcmath multiply speedup

### DIFF
--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -92,7 +92,7 @@ static inline void bc_convert_to_uint(BC_UINT_T *n_uint, const char *nend, size_
  * If the n_values of n1 and n2 are both 4 (32-bit) or 8 (64-bit) digits or less,
  * the calculation will be performed at high speed without using an array.
  */
-static inline void bc_fast_mul(bc_num n1, size_t n1len, bc_num n2, int n2len, bc_num *prod)
+static inline void bc_fast_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len, bc_num *prod)
 {
 	const char *n1end = n1->n_value + n1len - 1;
 	const char *n2end = n2->n_value + n2len - 1;


### PR DESCRIPTION
Using the benchmark from https://github.com/php/php-src/pull/14213

Marking as draft to run in CI as I'm not sure I got the endianness right in all places.

Before:
```
1.316251039505
0.10821485519409
2.3945400714874
0.81185293197632
2.3537800312042
```

After "Faster writing of BCD representation":
```
1.1644039154053
0.094422101974487
1.7769658565521
0.66193199157715
2.0062921047211
```

After "Faster BCD into integer parsing":
```
1.0797188282013
0.08667516708374
1.4775879383087
0.42826008796692
1.6225161552429
```