### PR TITLE
Fix various new compiler warnings generated by GCC 14

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -128,7 +128,7 @@ int bc_modulo(bc_num num1, bc_num num2, bc_num *resul, int scale);
 
 int bc_divmod(bc_num num1, bc_num num2, bc_num *quo, bc_num *rem, int scale);
 
-int bc_raisemod(bc_num base, bc_num expo, bc_num mo, bc_num *result, int scale);
+zend_result bc_raisemod(bc_num base, bc_num expo, bc_num mo, bc_num *result, int scale);
 
 void bc_raise(bc_num num1, bc_num num2, bc_num *resul, int scale);
 

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -3552,7 +3552,7 @@ static void parse(void) {
 	}
 }
 
-int zend_ffi_parse_decl(const char *str, size_t len) {
+zend_result zend_ffi_parse_decl(const char *str, size_t len) {
 	if (SETJMP(FFI_G(bailout))==0) {
 		FFI_G(allow_vla) = 0;
 		FFI_G(attribute_parsing) = 0;
@@ -3565,7 +3565,7 @@ int zend_ffi_parse_decl(const char *str, size_t len) {
 	}
 }
 
-int zend_ffi_parse_type(const char *str, size_t len, zend_ffi_dcl *dcl) {
+zend_result zend_ffi_parse_type(const char *str, size_t len, zend_ffi_dcl *dcl) {
 	int sym;
 
 	if (SETJMP(FFI_G(bailout))==0) {

--- a/ext/gd/libgd/gd_topal.c
+++ b/ext/gd/libgd/gd_topal.c
@@ -1498,7 +1498,7 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
       colorsWanted = maxColors;
     }
   if (!cimP) {
-    nim->pixels = gdCalloc (sizeof (unsigned char *), oim->sy);
+    nim->pixels = gdCalloc (oim->sy, sizeof (unsigned char *));
     if (!nim->pixels)
       {
         /* No can do */
@@ -1506,7 +1506,7 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
       }
     for (i = 0; (i < nim->sy); i++)
       {
-        nim->pixels[i] = gdCalloc (sizeof (unsigned char *), oim->sx);
+        nim->pixels[i] = gdCalloc (oim->sx, sizeof (unsigned char *));
         if (!nim->pixels[i])
   	{
   	  goto outOfMemory;
@@ -1514,7 +1514,7 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
       }
   }
 
-  cquantize = (my_cquantize_ptr) gdCalloc (sizeof (my_cquantizer), 1);
+  cquantize = (my_cquantize_ptr) gdCalloc (1, sizeof (my_cquantizer));
   if (!cquantize)
     {
       /* No can do */

--- a/ext/json/php_json_encoder.h
+++ b/ext/json/php_json_encoder.h
@@ -35,6 +35,6 @@ static inline void php_json_encode_init(php_json_encoder *encoder)
 
 zend_result php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder);
 
-int php_json_escape_string(smart_str *buf, const char *s, size_t len, int options, php_json_encoder *encoder);
+zend_result php_json_escape_string(smart_str *buf, const char *s, size_t len, int options, php_json_encoder *encoder);
 
 #endif	/* PHP_JSON_ENCODER_H */

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -581,7 +581,7 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 	}
 
 	if (!S->current_row) {
-		S->current_row = ecalloc(sizeof(zval), stmt->column_count);
+		S->current_row = ecalloc(stmt->column_count, sizeof(zval));
 	}
 	for (unsigned i = 0; i < stmt->column_count; i++) {
 		zval_ptr_dtor_nogc(&S->current_row[i]);

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -456,7 +456,7 @@ char **php_readline_completion_cb(const char *text, int start, int end)
 				matches = rl_completion_matches(text,_readline_command_generator);
 			} else {
 				/* libedit will read matches[2] */
-				matches = calloc(sizeof(char *), 3);
+				matches = calloc(3, sizeof(char *));
 				if (!matches) {
 					return NULL;
 				}


### PR DESCRIPTION
This is mainly about `[-Wcalloc-transposed-args]`

The `[-Wenum-int-mismatch]` warnings were mostly fixed in master anyway as some of them relate to `ZEND_API` signatures that we cannot fix due to ABI compatibility, so I am happy to drop them.