### PR TITLE
No ext/com-dotnet resources

### DIFF
--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -175,7 +175,6 @@ PHP_MINIT_FUNCTION(com_dotnet)
 {
 	zend_class_entry *tmp;
 
-	php_com_wrapper_minit(INIT_FUNC_ARGS_PASSTHRU);
 	php_com_persist_minit(INIT_FUNC_ARGS_PASSTHRU);
 
 	php_com_exception_class_entry = register_class_com_exception(zend_ce_exception);

--- a/ext/com_dotnet/com_persist.c
+++ b/ext/com_dotnet/com_persist.c
@@ -16,8 +16,11 @@
 
 /* Infrastructure for working with persistent COM objects.
  * Implements: IStream* wrapper for PHP streams.
- * TODO: Magic __wakeup and __sleep handlers for serialization
- * (can wait till 5.1) */
+ * TODO:
+ *  - Magic __wakeup and __sleep handlers for serialization.
+ *  - Track the stream and dispatch instances in a global list to make sure
+ *    they are destroyed when a fatal error occurs.
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -103,7 +103,6 @@ zend_result php_com_do_invoke_byref(php_com_dotnet_object *obj, zend_internal_fu
 		WORD flags,	VARIANT *v, int nargs, zval *args);
 
 /* com_wrapper.c */
-int php_com_wrapper_minit(INIT_FUNC_ARGS);
 PHP_COM_DOTNET_API IDispatch *php_com_wrapper_export_as_sink(zval *val, GUID *sinkid, HashTable *id_to_name);
 PHP_COM_DOTNET_API IDispatch *php_com_wrapper_export(zval *val);
 


### PR DESCRIPTION
Note: I think that for these internal data structures, moving them away from resources has a downside: if for example a fatal error occurs during execution, then they won't be cleaned up now whereas they would've been cleaned up if they were resources.

Also need to check if the refcount can be > 0 at the end of script execution.