### PR TITLE
random: Make `php_random_bytes()` useable early during engine startup

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -269,6 +269,16 @@ char *alloca();
 # define ZEND_ATTRIBUTE_UNUSED
 #endif
 
+#if ZEND_GCC_VERSION >= 3003 || __has_attribute(nonnull)
+/* All pointer arguments must be non-null */
+# define ZEND_ATTRIBUTE_NONNULL  __attribute__((nonnull))
+/* Specified arguments must be non-null (1-based) */
+# define ZEND_ATTRIBUTE_NONNULL_ARGS(...)  __attribute__((nonnull(__VA_ARGS__)))
+#else
+# define ZEND_ATTRIBUTE_NONNULL
+# define ZEND_ATTRIBUTE_NONNULL_ARGS(...)
+#endif
+
 #if defined(__GNUC__) && ZEND_GCC_VERSION >= 4003
 # define ZEND_COLD __attribute__((cold))
 # ifdef __OPTIMIZE__

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -222,7 +222,7 @@ ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t s
 	return result;
 }
 
-PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw)
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw)
 {
 	zend_ulong umax;
 	zend_ulong trial;

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -195,7 +195,6 @@ PHP_MSHUTDOWN_FUNCTION(random);
 PHP_RINIT_FUNCTION(random);
 
 ZEND_BEGIN_MODULE_GLOBALS(random)
-	int random_fd;
 	bool combined_lcg_seeded;
 	bool mt19937_seeded;
 	bool fallback_seed_initialized;

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -23,24 +23,24 @@
 ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
 ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
 
-PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 
-static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
+ZEND_ATTRIBUTE_NONNULL static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
 {
 	return php_random_bytes(bytes, size, true);
 }
 
-static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
+ZEND_ATTRIBUTE_NONNULL static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
 {
 	return php_random_bytes(bytes, size, false);
 }
 
-static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
+ZEND_ATTRIBUTE_NONNULL static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
 {
 	return php_random_int(min, max, result, true);
 }
 
-static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
+ZEND_ATTRIBUTE_NONNULL static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
 {
 	return php_random_int(min, max, result, false);
 }

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -20,7 +20,9 @@
 
 # include "php.h"
 
-PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
+
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 
 static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
@@ -42,5 +44,7 @@ static inline zend_result php_random_int_silent(zend_long min, zend_long max, ze
 {
 	return php_random_int(min, max, result, false);
 }
+
+PHPAPI void php_random_csprng_shutdown(void);
 
 #endif	/* PHP_RANDOM_CSPRNG_H */

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -688,16 +688,6 @@ static PHP_GINIT_FUNCTION(random)
 }
 /* }}} */
 
-/* {{{ PHP_GSHUTDOWN_FUNCTION */
-static PHP_GSHUTDOWN_FUNCTION(random)
-{
-	if (random_globals->random_fd >= 0) {
-		close(random_globals->random_fd);
-		random_globals->random_fd = -1;
-	}
-}
-/* }}} */
-
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(random)
 {
@@ -766,6 +756,15 @@ PHP_MINIT_FUNCTION(random)
 }
 /* }}} */
 
+/* {{{ PHP_MSHUTDOWN_FUNCTION */
+PHP_MSHUTDOWN_FUNCTION(random)
+{
+	php_random_csprng_shutdown();
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ PHP_RINIT_FUNCTION */
 PHP_RINIT_FUNCTION(random)
 {
@@ -782,14 +781,14 @@ zend_module_entry random_module_entry = {
 	"random",					/* Extension name */
 	ext_functions,				/* zend_function_entry */
 	PHP_MINIT(random),			/* PHP_MINIT - Module initialization */
-	NULL,						/* PHP_MSHUTDOWN - Module shutdown */
+	PHP_MSHUTDOWN(random),		/* PHP_MSHUTDOWN - Module shutdown */
 	PHP_RINIT(random),			/* PHP_RINIT - Request initialization */
 	NULL,						/* PHP_RSHUTDOWN - Request shutdown */
 	NULL,						/* PHP_MINFO - Module info */
 	PHP_VERSION,				/* Version */
 	PHP_MODULE_GLOBALS(random),	/* ZTS Module globals */
 	PHP_GINIT(random),			/* PHP_GINIT - Global initialization */
-	PHP_GSHUTDOWN(random),		/* PHP_GSHUTDOWN - Global shutdown */
+	NULL,						/* PHP_GSHUTDOWN - Global shutdown */
 	NULL,						/* Post deactivate */
 	STANDARD_MODULE_PROPERTIES_EX
 };

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -683,7 +683,6 @@ PHPAPI uint64_t php_random_generate_fallback_seed(void)
 /* {{{ PHP_GINIT_FUNCTION */
 static PHP_GINIT_FUNCTION(random)
 {
-	random_globals->random_fd = -1;
 	random_globals->fallback_seed_initialized = false;
 }
 /* }}} */


### PR DESCRIPTION
`php_random_bytes()` uses some thread-specific state and can not be used too early. In this PR I refactor it so that is uses a true global instead.

I also introduce `php_random_bytes_ex()`, with a slightly different API that can expose errors without throwing exceptions.

This is a dependency of #14054.