### PR TITLE
refactor: change `zend_is_true` to return `bool`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -86,6 +86,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
   for internal functions. If you need a cache slot for both internal and user
   functions, you may obtain a slot for each through the corresponding function.
 
+* zend_is_true now returns bool rather than int. Note that on PHP 8 this has
+  always returned 0 or 1, so conversion should be trivial.
 
 ========================
 2. Build system changes

--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -309,7 +309,7 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 		case ZEND_JMPZ:
 		case ZEND_JMPNZ:
 			if (opline->op1_type == IS_CONST) {
-				int should_jmp = zend_is_true(&ZEND_OP1_LITERAL(opline));
+				bool should_jmp = zend_is_true(&ZEND_OP1_LITERAL(opline));
 
 				if (opline->opcode == ZEND_JMPZ) {
 					should_jmp = !should_jmp;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1057,6 +1057,7 @@ ZEND_API void zend_std_write_dimension(zend_object *object, zval *offset, zval *
 }
 /* }}} */
 
+// todo: make zend_std_has_dimension return bool as well
 ZEND_API int zend_std_has_dimension(zend_object *object, zval *offset, int check_empty) /* {{{ */
 {
 	zend_class_entry *ce = object->ce;
@@ -1082,8 +1083,7 @@ ZEND_API int zend_std_has_dimension(zend_object *object, zval *offset, int check
 		return 0;
 	}
 
-	// todo: make zend_std_has_dimension return bool as well
-	return (int)result;
+	return result;
 }
 /* }}} */
 
@@ -1812,6 +1812,7 @@ ZEND_API int zend_objects_not_comparable(zval *o1, zval *o2)
 	return ZEND_UNCOMPARABLE;
 }
 
+// todo: make zend_std_has_property return bool as well
 ZEND_API int zend_std_has_property(zend_object *zobj, zend_string *name, int has_set_exists, void **cache_slot) /* {{{ */
 {
 	bool result;
@@ -1904,8 +1905,7 @@ found:
 	}
 
 exit:
-	// todo: make zend_std_has_property return bool as well
-	return (int)result;
+	return result;
 }
 /* }}} */
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1061,7 +1061,7 @@ ZEND_API int zend_std_has_dimension(zend_object *object, zval *offset, int check
 {
 	zend_class_entry *ce = object->ce;
 	zval retval, tmp_offset;
-	int result;
+	bool result;
 
 	zend_class_arrayaccess_funcs *funcs = ce->arrayaccess_funcs_ptr;
 	if (EXPECTED(funcs)) {
@@ -1081,7 +1081,9 @@ ZEND_API int zend_std_has_dimension(zend_object *object, zval *offset, int check
 	    zend_bad_array_access(ce);
 		return 0;
 	}
-	return result;
+
+	// todo: make zend_std_has_dimension return bool as well
+	return (int)result;
 }
 /* }}} */
 
@@ -1812,7 +1814,7 @@ ZEND_API int zend_objects_not_comparable(zval *o1, zval *o2)
 
 ZEND_API int zend_std_has_property(zend_object *zobj, zend_string *name, int has_set_exists, void **cache_slot) /* {{{ */
 {
-	int result;
+	bool result;
 	zval *value = NULL;
 	uintptr_t property_offset;
 	const zend_property_info *prop_info = NULL;
@@ -1826,7 +1828,7 @@ ZEND_API int zend_std_has_property(zend_object *zobj, zend_string *name, int has
 		}
 		if (UNEXPECTED(Z_PROP_FLAG_P(value) & IS_PROP_UNINIT)) {
 			/* Skip __isset() for uninitialized typed properties */
-			result = 0;
+			result = false;
 			goto exit;
 		}
 	} else if (EXPECTED(IS_DYNAMIC_PROPERTY_OFFSET(property_offset))) {
@@ -1862,17 +1864,17 @@ found:
 					result = (Z_TYPE_P(value) != IS_NULL);
 				} else {
 					ZEND_ASSERT(has_set_exists == ZEND_PROPERTY_EXISTS);
-					result = 1;
+					result = true;
 				}
 				goto exit;
 			}
 		}
 	} else if (UNEXPECTED(EG(exception))) {
-		result = 0;
+		result = false;
 		goto exit;
 	}
 
-	result = 0;
+	result = false;
 	if ((has_set_exists != ZEND_PROPERTY_EXISTS) && zobj->ce->__isset) {
 		uint32_t *guard = zend_get_property_guard(zobj, name);
 
@@ -1893,7 +1895,7 @@ found:
 					result = i_zend_is_true(&rv);
 					zval_ptr_dtor(&rv);
 				} else {
-					result = 0;
+					result = false;
 				}
 			}
 			(*guard) &= ~IN_ISSET;
@@ -1902,7 +1904,8 @@ found:
 	}
 
 exit:
-	return result;
+	// todo: make zend_std_has_property return bool as well
+	return (int)result;
 }
 /* }}} */
 

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2818,9 +2818,9 @@ try_again:
 }
 /* }}} */
 
-ZEND_API int ZEND_FASTCALL zend_is_true(const zval *op) /* {{{ */
+ZEND_API bool ZEND_FASTCALL zend_is_true(const zval *op) /* {{{ */
 {
-	return (int) i_zend_is_true(op);
+	return i_zend_is_true(op);
 }
 /* }}} */
 

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -372,7 +372,7 @@ static zend_always_inline bool try_convert_to_string(zval *op) {
 #define convert_to_string(op) if (Z_TYPE_P(op) != IS_STRING) { _convert_to_string((op)); }
 
 
-ZEND_API int ZEND_FASTCALL zend_is_true(const zval *op);
+ZEND_API bool ZEND_FASTCALL zend_is_true(const zval *op);
 ZEND_API bool ZEND_FASTCALL zend_object_is_true(const zval *op);
 
 #define zval_is_true(op) \

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7313,8 +7313,7 @@ ZEND_VM_HANDLER(114, ZEND_ISSET_ISEMPTY_VAR, CONST|TMPVAR|CV, UNUSED, VAR_FETCH|
 {
 	USE_OPLINE
 	zval *value;
-	/* Should be bool result? as below got: result = (opline->extended_value & ZEND_ISEMPTY) */
-	int result;
+	bool result;
 	zval *varname;
 	zend_string *name, *tmp_name;
 	HashTable *target_symbol_table;
@@ -7351,7 +7350,7 @@ ZEND_VM_HANDLER(114, ZEND_ISSET_ISEMPTY_VAR, CONST|TMPVAR|CV, UNUSED, VAR_FETCH|
 		}
 	}
 
-	ZEND_VM_SMART_BRANCH(result, 1);
+	ZEND_VM_SMART_BRANCH(result, true);
 }
 
 /* No specialization for op_types (CONST|TMPVAR|CV, UNUSED|CLASS_FETCH|CONST|VAR) */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -10856,8 +10856,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CONST_U
 {
 	USE_OPLINE
 	zval *value;
-	/* Should be bool result? as below got: result = (opline->extended_value & ZEND_ISEMPTY) */
-	int result;
+	bool result;
 	zval *varname;
 	zend_string *name, *tmp_name;
 	HashTable *target_symbol_table;
@@ -10893,7 +10892,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CONST_U
 		}
 	}
 
-	ZEND_VM_SMART_BRANCH(result, 1);
+	ZEND_VM_SMART_BRANCH(result, true);
 }
 
 /* No specialization for op_types (CONST|TMPVAR|CV, UNUSED|CLASS_FETCH|CONST|VAR) */
@@ -18221,8 +18220,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_TMPVAR_
 {
 	USE_OPLINE
 	zval *value;
-	/* Should be bool result? as below got: result = (opline->extended_value & ZEND_ISEMPTY) */
-	int result;
+	bool result;
 	zval *varname;
 	zend_string *name, *tmp_name;
 	HashTable *target_symbol_table;
@@ -18259,7 +18257,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_TMPVAR_
 		}
 	}
 
-	ZEND_VM_SMART_BRANCH(result, 1);
+	ZEND_VM_SMART_BRANCH(result, true);
 }
 
 /* No specialization for op_types (CONST|TMPVAR|CV, UNUSED|CLASS_FETCH|CONST|VAR) */
@@ -49703,8 +49701,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CV_UNUS
 {
 	USE_OPLINE
 	zval *value;
-	/* Should be bool result? as below got: result = (opline->extended_value & ZEND_ISEMPTY) */
-	int result;
+	bool result;
 	zval *varname;
 	zend_string *name, *tmp_name;
 	HashTable *target_symbol_table;
@@ -49740,7 +49737,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ISSET_ISEMPTY_VAR_SPEC_CV_UNUS
 		}
 	}
 
-	ZEND_VM_SMART_BRANCH(result, 1);
+	ZEND_VM_SMART_BRANCH(result, true);
 }
 
 /* No specialization for op_types (CONST|TMPVAR|CV, UNUSED|CLASS_FETCH|CONST|VAR) */

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -405,6 +405,7 @@ static void zend_weakmap_write_dimension(zend_object *object, zval *offset, zval
 	zend_hash_index_add_new(&wm->ht, obj_key, value);
 }
 
+// todo: make zend_weakmap_has_dimension return bool as well
 /* int return and check_empty due to Object Handler API */
 static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int check_empty)
 {
@@ -421,8 +422,7 @@ static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int che
 	}
 
 	if (check_empty) {
-		// todo: make zend_weakmap_has_dimension return bool as well
-		return (int)i_zend_is_true(zv);
+		return i_zend_is_true(zv);
 	}
 	return Z_TYPE_P(zv) != IS_NULL;
 }

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -421,7 +421,8 @@ static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int che
 	}
 
 	if (check_empty) {
-		return i_zend_is_true(zv);
+		// todo: make zend_weakmap_has_dimension return bool as well
+		return (int)i_zend_is_true(zv);
 	}
 	return Z_TYPE_P(zv) != IS_NULL;
 }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -409,7 +409,7 @@ static int dom_property_exists(zend_object *object, zend_string *name, int check
 {
 	dom_object *obj = php_dom_obj_from_obj(object);
 	dom_prop_handler *hnd = NULL;
-	int retval = 0;
+	bool retval = false;
 
 	if (obj->prop_handler != NULL) {
 		hnd = zend_hash_find_ptr(obj->prop_handler, name);
@@ -418,7 +418,7 @@ static int dom_property_exists(zend_object *object, zend_string *name, int check
 		zval tmp;
 
 		if (check_empty == 2) {
-			retval = 1;
+			retval = true;
 		} else if (hnd->read_func(obj, &tmp) == SUCCESS) {
 			if (check_empty == 1) {
 				retval = zend_is_true(&tmp);
@@ -428,10 +428,11 @@ static int dom_property_exists(zend_object *object, zend_string *name, int check
 			zval_ptr_dtor(&tmp);
 		}
 	} else {
-		retval = zend_std_has_property(object, name, check_empty, cache_slot);
+		retval = (bool)zend_std_has_property(object, name, check_empty, cache_slot);
 	}
 
-	return retval;
+	// todo: make dom_property_exists return bool as well
+	return (int)retval;
 }
 /* }}} */
 
@@ -1441,7 +1442,7 @@ zend_object *dom_xpath_objects_new(zend_class_entry *class_type)
 	dom_xpath_object *intern = zend_object_alloc(sizeof(dom_xpath_object), class_type);
 
 	php_dom_xpath_callbacks_ctor(&intern->xpath_callbacks);
-	intern->register_node_ns = 1;
+	intern->register_node_ns = true;
 
 	intern->dom.prop_handler = &dom_xpath_prop_handlers;
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -404,6 +404,7 @@ zval *dom_write_property(zend_object *object, zend_string *name, zval *value, vo
 	return zend_std_write_property(object, name, value, cache_slot);
 }
 
+// todo: make dom_property_exists return bool as well
 /* {{{ dom_property_exists */
 static int dom_property_exists(zend_object *object, zend_string *name, int check_empty, void **cache_slot)
 {
@@ -428,11 +429,10 @@ static int dom_property_exists(zend_object *object, zend_string *name, int check
 			zval_ptr_dtor(&tmp);
 		}
 	} else {
-		retval = (bool)zend_std_has_property(object, name, check_empty, cache_slot);
+		retval = zend_std_has_property(object, name, check_empty, cache_slot);
 	}
 
-	// todo: make dom_property_exists return bool as well
-	return (int)retval;
+	return retval;
 }
 /* }}} */
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -66,7 +66,7 @@ extern zend_module_entry dom_module_entry;
 
 typedef struct _dom_xpath_object {
 	php_dom_xpath_callbacks xpath_callbacks;
-	int register_node_ns;
+	bool register_node_ns;
 	dom_object dom;
 } dom_xpath_object;
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2363,11 +2363,15 @@ static int row_prop_exists(zend_object *object, zend_string *name, int check_emp
 		return false;
 	}
 	ZEND_ASSERT(retval == &tmp_val);
-	int res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
+	bool res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
 	zval_ptr_dtor_nogc(retval);
-	return res;
+
+	// todo: make row_prop_exists return bool as well
+	return (int)res;
 }
 
+
+// todo: make row_dim_exists return bool as well
 static int row_dim_exists(zend_object *object, zval *offset, int check_empty)
 {
 	if (Z_TYPE_P(offset) == IS_LONG) {
@@ -2386,9 +2390,9 @@ static int row_dim_exists(zend_object *object, zval *offset, int check_empty)
 			return false;
 		}
 		ZEND_ASSERT(retval == &tmp_val);
-		int res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
+		bool res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
 		zval_ptr_dtor_nogc(retval);
-		return res;
+		return (int)res;
 	} else {
 		zend_string *member = zval_try_get_string(offset);
 		if (!member) {

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2344,6 +2344,7 @@ static void row_dim_write(zend_object *object, zval *member, zval *value)
 	}
 }
 
+// todo: make row_prop_exists return bool as well
 static int row_prop_exists(zend_object *object, zend_string *name, int check_empty, void **cache_slot)
 {
 	pdo_row_t *row = (pdo_row_t *)object;
@@ -2366,8 +2367,7 @@ static int row_prop_exists(zend_object *object, zend_string *name, int check_emp
 	bool res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
 	zval_ptr_dtor_nogc(retval);
 
-	// todo: make row_prop_exists return bool as well
-	return (int)res;
+	return res;
 }
 
 
@@ -2392,7 +2392,7 @@ static int row_dim_exists(zend_object *object, zval *offset, int check_empty)
 		ZEND_ASSERT(retval == &tmp_val);
 		bool res = check_empty ? i_zend_is_true(retval) : Z_TYPE(tmp_val) != IS_NULL;
 		zval_ptr_dtor_nogc(retval);
-		return (int)res;
+		return res;
 	} else {
 		zend_string *member = zval_try_get_string(offset);
 		if (!member) {

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -851,7 +851,7 @@ PHP_METHOD(DirectoryIterator, seek)
 	}
 
 	while (intern->u.dir.index < pos) {
-		bool valid = 0;
+		bool valid = false;
 		zend_call_method_with_0_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), &intern->u.dir.func_valid, "valid", &retval);
 		valid = zend_is_true(&retval);
 		zval_ptr_dtor(&retval);

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -263,7 +263,6 @@ static void spl_recursive_it_move_forward_ex(spl_recursive_it_object *object, zv
 	zend_class_entry          *ce;
 	zval                      retval, child;
 	zend_object_iterator      *sub_iter;
-	int                       has_children;
 
 	SPL_FETCH_SUB_ITERATOR(iterator, object);
 
@@ -308,7 +307,7 @@ next_step:
 					}
 				}
 				if (Z_TYPE(retval) != IS_UNDEF) {
-					has_children = zend_is_true(&retval);
+					bool has_children = zend_is_true(&retval);
 					zval_ptr_dtor(&retval);
 					if (has_children) {
 						if (object->max_depth == -1 || object->max_depth > object->level) {

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -440,6 +440,7 @@ PHP_METHOD(SplObjectStorage, attach)
 	spl_object_storage_attach(intern, obj, inf);
 } /* }}} */
 
+// todo: make spl_object_storage_has_dimension return bool as well
 static int spl_object_storage_has_dimension(zend_object *object, zval *offset, int check_empty)
 {
 	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6548,7 +6548,7 @@ PHP_FUNCTION(array_filter)
 			fci.params = args;
 
 			if (zend_call_function(&fci, &fci_cache) == SUCCESS) {
-				int retval_true;
+				bool retval_true;
 
 				zval_ptr_dtor(&args[0]);
 				if (use_type == ARRAY_FILTER_USE_BOTH) {

--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1113,20 +1113,20 @@ static php_conv_err_t php_conv_get_ulong_prop_ex(const HashTable *ht, zend_ulong
 	}
 }
 
-static php_conv_err_t php_conv_get_bool_prop_ex(const HashTable *ht, int *pretval, char *field_name, size_t field_name_len)
+static php_conv_err_t php_conv_get_bool_prop_ex(const HashTable *ht, bool *pretval, char *field_name, size_t field_name_len)
 {
 	zval *tmpval = zend_hash_str_find((HashTable *)ht, field_name, field_name_len-1);
 	if (tmpval != NULL) {
 		*pretval = zend_is_true(tmpval);
 		return PHP_CONV_ERR_SUCCESS;
 	} else {
-		*pretval = 0;
+		*pretval = false;
 		return PHP_CONV_ERR_NOT_FOUND;
 	}
 }
 
 /* XXX this might need an additional fix so it uses size_t, whereby unsigned is quite big so leaving as is for now */
-static int php_conv_get_uint_prop_ex(const HashTable *ht, unsigned int *pretval, char *field_name, size_t field_name_len)
+static php_conv_err_t php_conv_get_uint_prop_ex(const HashTable *ht, unsigned int *pretval, char *field_name, size_t field_name_len)
 {
 	zend_ulong l;
 	php_conv_err_t err;
@@ -1206,8 +1206,8 @@ static php_conv *php_conv_open(int conv_mode, const HashTable *options, int pers
 			int opts = 0;
 
 			if (options != NULL) {
-				int opt_binary = 0;
-				int opt_force_encode_first = 0;
+				bool opt_binary = false;
+				bool opt_force_encode_first = false;
 
 				GET_STR_PROP(options, lbchars, lbchars_len, "line-break-chars", 0);
 				GET_UINT_PROP(options, line_len, "line-length");

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -136,7 +136,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 	zend_string *transport_string;
 	zend_string *errstr = NULL;
 	int have_header = 0;
-	bool request_fulluri = 0, ignore_errors = 0;
+	bool request_fulluri = false, ignore_errors = false;
 	struct timeval timeout;
 	char *user_headers = NULL;
 	int header_init = ((flags & HTTP_WRAPPER_HEADER_INIT) != 0);
@@ -171,7 +171,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 			return php_stream_open_wrapper_ex(path, mode, REPORT_ERRORS, NULL, context);
 		}
 		/* Called from a non-http wrapper with http proxying requested (i.e. ftp) */
-		request_fulluri = 1;
+		request_fulluri = true;
 		use_ssl = 0;
 		use_proxy = 1;
 		transport_string = zend_string_copy(Z_STR_P(tmpzval));
@@ -801,7 +801,7 @@ finish:
 
 				/* create filter to decode response body */
 				if (!(options & STREAM_ONLY_GET_HEADERS)) {
-					zend_long decode = 1;
+					bool decode = true;
 
 					if (context && (tmpzval = php_stream_context_get_option(context, "http", "auto_decode")) != NULL) {
 						decode = zend_is_true(tmpzval);

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -197,7 +197,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 	zval *id, *docp = NULL;
 	xmlDoc *doc = NULL, *newdoc = NULL;
 	xsltStylesheetPtr sheetp;
-	int clone_docu = 0;
+	bool clone_docu = false;
 	xmlNode *nodep = NULL;
 	zval *cloneDocu, rv;
 	zend_string *member;
@@ -257,7 +257,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 	cloneDocu = zend_std_read_property(Z_OBJ_P(id), member, BP_VAR_R, NULL, &rv);
 	clone_docu = zend_is_true(cloneDocu);
 	zend_string_release_ex(member, 0);
-	if (clone_docu == 0) {
+	if (!clone_docu) {
 		/* Check if the stylesheet is using xsl:key, if yes, we have to clone the document _always_ before a transformation.
 		 * xsl:key elements may only occur at the top level. Furthermore, all elements at the top level must be in a
 		 * namespace (if not, then the stylesheet is not well-formed and this function will have returned false earlier). */

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -949,11 +949,12 @@ static zval *php_zip_read_property(zend_object *object, zend_string *name, int t
 }
 /* }}} */
 
+// todo: make php_zip_has_property return bool as well
 static int php_zip_has_property(zend_object *object, zend_string *name, int type, void **cache_slot) /* {{{ */
 {
 	ze_zip_object *obj;
 	zip_prop_handler *hnd = NULL;
-	int retval = 0;
+	bool retval = false;
 
 	obj = php_zip_fetch_object(object);
 
@@ -965,7 +966,7 @@ static int php_zip_has_property(zend_object *object, zend_string *name, int type
 		zval tmp, *prop;
 
 		if (type == 2) {
-			retval = 1;
+			retval = true;
 		} else if ((prop = php_zip_property_reader(obj, hnd, &tmp)) != NULL) {
 			if (type == 1) {
 				retval = zend_is_true(&tmp);
@@ -976,10 +977,10 @@ static int php_zip_has_property(zend_object *object, zend_string *name, int type
 
 		zval_ptr_dtor(&tmp);
 	} else {
-		retval = zend_std_has_property(object, name, type, cache_slot);
+		retval = (bool)zend_std_has_property(object, name, type, cache_slot);
 	}
 
-	return retval;
+	return (int)retval;
 }
 /* }}} */
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -977,10 +977,10 @@ static int php_zip_has_property(zend_object *object, zend_string *name, int type
 
 		zval_ptr_dtor(&tmp);
 	} else {
-		retval = (bool)zend_std_has_property(object, name, type, cache_slot);
+		retval = zend_std_has_property(object, name, type, cache_slot);
 	}
 
-	return (int)retval;
+	return retval;
 }
 /* }}} */
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -491,8 +491,8 @@ PHP_FUNCTION(phpdbg_get_executable)
 {
 	HashTable *options = NULL;
 	zval *option_buffer;
-	bool by_function = 0;
-	bool by_opcode = 0;
+	bool by_function = false;
+	bool by_opcode = false;
 	HashTable *insert_ht;
 
 	zend_function *func;
@@ -592,8 +592,8 @@ PHP_FUNCTION(phpdbg_end_oplog)
 
 	HashTable *options = NULL;
 	zval *option_buffer;
-	bool by_function = 0;
-	bool by_opcode = 0;
+	bool by_function = false;
+	bool by_opcode = false;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|H", &options) == FAILURE) {
 		RETURN_THROWS();


### PR DESCRIPTION
Previously this returned `int`. Many function actually take advantage of the fact this returns exactly 0 or 1. For instance, `main/streams/xp_socket.c` does:

    sockopts |= STREAM_SOCKOP_IPV6_V6ONLY_ENABLED * zend_is_true(tmpzval);

And `Zend/zend_compile.c` does:

    child = &ast->child[2 - zend_is_true(zend_ast_get_zval(ast->child[0]))];

I changed a few places trivially from `int` to `bool`, but there are still many places such as the object handlers which return `int` that should eventually be `bool`.

I'm not quite sure yet what to do with `ext/opcache/jit/zend_jit_ir.c`:

    ref = ir_CALL_1(IR_BOOL, ir_CONST_FC_FUNC(zend_is_true), jit_ZVAL_ADDR(jit, op1_addr));

What I understand from `IR_BOOL` and such so far, is that this is probably correct for `bool` returns already, but it's worth mentioning for people more expert than I am to comment on.

