### PR TITLE
Check ext/pcntl required functions with for loop

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -128,6 +128,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
    - Symbol HAVE_MYSQL has been removed.
    - Symbol HAVE_PDO_SQLITELIB has been removed.
+   - Symbol HAVE_WAITPID has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -4,8 +4,10 @@ PHP_ARG_ENABLE([pcntl],
     [Enable pcntl support (CLI/CGI only)])])
 
 if test "$PHP_PCNTL" != "no"; then
-  AC_CHECK_FUNCS([fork waitpid sigaction],,
-    [AC_MSG_ERROR([ext/pcntl: required function $ac_func() not found.])])
+  for function in fork sigaction waitpid; do
+    AC_CHECK_FUNC([$function],,
+      [AC_MSG_ERROR([ext/pcntl: required function $function() not found.])])
+  done
 
   AC_CHECK_FUNCS(m4_normalize([
     forkx


### PR DESCRIPTION
This omits defining redundant HAVE_<function> symbols since these are used unconditionally in ext/pcntl.

* HAVE_FORK is defined via ext/standard/config.m4
* HAVE_SIGACTION is defined via Zend.m4
* HAVE_WAITPID symbol is removed