### PR TITLE
Remote heap feng chui / heap spraying protection 

### DIFF
--- a/Zend/tests/bug70258.phpt
+++ b/Zend/tests/bug70258.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #70258 (Segfault if do_resize fails to allocated memory)
 --INI--
-memory_limit=2M
+memory_limit=4M
 --SKIPIF--
 <?php
 $zend_mm_enabled = getenv("USE_ZEND_ALLOC");
@@ -25,4 +25,4 @@ $a = new A;
 $a->core();
 ?>
 --EXPECTF--
-Fatal error: Allowed memory size of 2097152 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
+Fatal error: Allowed memory size of 4194304 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d

--- a/Zend/tests/fibers/out-of-memory-in-fiber.phpt
+++ b/Zend/tests/fibers/out-of-memory-in-fiber.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Out of Memory in a fiber
 --INI--
-memory_limit=2M
+memory_limit=4M
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {

--- a/Zend/tests/fibers/out-of-memory-in-nested-fiber.phpt
+++ b/Zend/tests/fibers/out-of-memory-in-nested-fiber.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Out of Memory in a nested fiber
 --INI--
-memory_limit=2M
+memory_limit=4M
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {

--- a/Zend/tests/fibers/out-of-memory-in-recursive-fiber.phpt
+++ b/Zend/tests/fibers/out-of-memory-in-recursive-fiber.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Out of Memory from recursive fiber creation
 --INI--
-memory_limit=2M
+memory_limit=4M
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {

--- a/Zend/tests/gh11189.phpt
+++ b/Zend/tests/gh11189.phpt
@@ -5,7 +5,7 @@ GH-11189: Exceeding memory limit in zend_hash_do_resize leaves the array in an i
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip ZMM is disabled");
 ?>
 --INI--
-memory_limit=2M
+memory_limit=4M
 --FILE--
 <?php
 

--- a/Zend/tests/gh11189_1.phpt
+++ b/Zend/tests/gh11189_1.phpt
@@ -5,7 +5,7 @@ GH-11189: Exceeding memory limit in zend_hash_do_resize leaves the array in an i
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip ZMM is disabled");
 ?>
 --INI--
-memory_limit=2M
+memory_limit=4M
 --FILE--
 <?php
 

--- a/Zend/tests/gh12073.phpt
+++ b/Zend/tests/gh12073.phpt
@@ -16,7 +16,7 @@ function test() {
 	};
 }
 
-ini_set('memory_limit', '2M');
+ini_set('memory_limit', '4M');
 
 $array = [];
 for ($i = 0; $i < 10_000; $i++) {

--- a/Zend/tests/new_oom.inc
+++ b/Zend/tests/new_oom.inc
@@ -1,6 +1,6 @@
 <?php
 
-$mb_used = (int) ceil(memory_get_usage() / (1024 ** 2));
+$mb_used = (int) ceil(memory_get_usage(true) / (1024 ** 2));
 ini_set('memory_limit', ($mb_used + 1) . 'M');
 
 $class = $argv[1];

--- a/Zend/tests/object_gc_in_shutdown.phpt
+++ b/Zend/tests/object_gc_in_shutdown.phpt
@@ -2,9 +2,9 @@
 Bug object gc not working in shutdown
 --FILE--
 <?php
-ini_set('memory_limit', '2M');
+ini_set('memory_limit', '4M');
 register_shutdown_function(function () {
-    for ($n = 1000 * 1000; $n--;) {
+    for ($n = 2 * 1000 * 1000; $n--;) {
         new stdClass;
     }
     echo "OK\n";

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -94,6 +94,7 @@ ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 ZEND_API zend_result (*zend_post_startup_cb)(void) = NULL;
 ZEND_API void (*zend_post_shutdown_cb)(void) = NULL;
+ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
 
 /* This callback must be signal handler safe! */
 void (*zend_on_timeout)(int seconds);
@@ -911,6 +912,10 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 #ifdef ZEND_WIN32
 	php_win32_cp_set_by_id(65001);
 #endif
+
+	/* Set up early utility functions. zend_mm depends on
+	 * zend_os_csprng_random_bytes */
+	zend_os_csprng_random_bytes = utility_functions->os_csprng_randomn_bytes_function;
 
 	start_memory_manager();
 

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -94,8 +94,8 @@ ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 ZEND_API zend_result (*zend_post_startup_cb)(void) = NULL;
 ZEND_API void (*zend_post_shutdown_cb)(void) = NULL;
-ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
-ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size) = NULL;
+ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
+ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size) = NULL;
 
 /* This callback must be signal handler safe! */
 void (*zend_on_timeout)(int seconds);

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -95,6 +95,7 @@ ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 ZEND_API zend_result (*zend_post_startup_cb)(void) = NULL;
 ZEND_API void (*zend_post_shutdown_cb)(void) = NULL;
 ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
+ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size) = NULL;
 
 /* This callback must be signal handler safe! */
 void (*zend_on_timeout)(int seconds);
@@ -914,8 +915,9 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 #endif
 
 	/* Set up early utility functions. zend_mm depends on
-	 * zend_os_csprng_random_bytes */
-	zend_os_csprng_random_bytes = utility_functions->os_csprng_randomn_bytes_function;
+	 * zend_general_random_bytes */
+	zend_os_csprng_random_bytes = utility_functions->os_csprng_random_bytes_function;
+	zend_general_random_bytes = utility_functions->general_random_bytes_function;
 
 	start_memory_manager();
 

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -94,8 +94,8 @@ ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 ZEND_API zend_result (*zend_post_startup_cb)(void) = NULL;
 ZEND_API void (*zend_post_shutdown_cb)(void) = NULL;
-ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
-ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size) = NULL;
+ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
+ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_random_bytes_insecure)(zend_utility_random_bytes_insecure_state *state, void *bytes, size_t size) = NULL;
 
 /* This callback must be signal handler safe! */
 void (*zend_on_timeout)(int seconds);
@@ -915,9 +915,9 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 #endif
 
 	/* Set up early utility functions. zend_mm depends on
-	 * zend_general_random_bytes */
-	zend_os_csprng_random_bytes = utility_functions->os_csprng_random_bytes_function;
-	zend_general_random_bytes = utility_functions->general_random_bytes_function;
+	 * zend_random_bytes_insecure */
+	zend_random_bytes = utility_functions->random_bytes_function;
+	zend_random_bytes_insecure = utility_functions->random_bytes_insecure_function;
 
 	start_memory_manager();
 

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -237,7 +237,7 @@ struct _zend_class_entry {
 typedef union {
 	zend_max_align_t align;
 	uint64_t opaque[5];
-} zend_utility_general_random_state;
+} zend_utility_random_bytes_insecure_state;
 
 typedef struct _zend_utility_functions {
 	void (*error_function)(int type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
@@ -253,8 +253,8 @@ typedef struct _zend_utility_functions {
 	void (*printf_to_smart_str_function)(smart_str *buf, const char *format, va_list ap);
 	char *(*getenv_function)(const char *name, size_t name_len);
 	zend_string *(*resolve_path_function)(zend_string *filename);
-	zend_result (*os_csprng_random_bytes_function)(void *bytes, size_t size, char *errstr, size_t errstr_size);
-	zend_result (*general_random_bytes_function)(zend_utility_general_random_state *state, void *bytes, size_t size);
+	zend_result (*random_bytes_function)(void *bytes, size_t size, char *errstr, size_t errstr_size);
+	zend_result (*random_bytes_insecure_function)(zend_utility_random_bytes_insecure_state *state, void *bytes, size_t size);
 } zend_utility_functions;
 
 typedef struct _zend_utility_values {
@@ -348,10 +348,13 @@ extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_l
 extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 /* Generate 'size' random bytes into 'bytes' with the OS CSPRNG. */
-extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size);
-/* Generate 'size' random bytes into 'bytes' with a general purpose PRNG.
- * 'state' must be zeroed before the first call and can be reused. */
-extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size);
+extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_random_bytes)(
+		void *bytes, size_t size, char *errstr, size_t errstr_size);
+/* Generate 'size' random bytes into 'bytes' with a general purpose PRNG (not
+ * crypto safe). 'state' must be zeroed before the first call and can be reused.
+ */
+extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_random_bytes_insecure)(
+		zend_utility_random_bytes_insecure_state *state, void *bytes, size_t size);
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -248,6 +248,7 @@ typedef struct _zend_utility_functions {
 	void (*printf_to_smart_str_function)(smart_str *buf, const char *format, va_list ap);
 	char *(*getenv_function)(const char *name, size_t name_len);
 	zend_string *(*resolve_path_function)(zend_string *filename);
+	zend_result (*os_csprng_randomn_bytes_function)(void *bytes, size_t size, char *errstr, size_t errstr_size);
 } zend_utility_functions;
 
 typedef struct _zend_utility_values {
@@ -340,6 +341,7 @@ extern void (*zend_printf_to_smart_string)(smart_string *buf, const char *format
 extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_list ap);
 extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
+extern ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size);
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -234,6 +234,11 @@ struct _zend_class_entry {
 	} info;
 };
 
+typedef union {
+	zend_max_align_t align;
+	uint64_t opaque[5];
+} zend_utility_general_random_state;
+
 typedef struct _zend_utility_functions {
 	void (*error_function)(int type, zend_string *error_filename, const uint32_t error_lineno, zend_string *message);
 	size_t (*printf_function)(const char *format, ...) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 1, 2);
@@ -248,7 +253,8 @@ typedef struct _zend_utility_functions {
 	void (*printf_to_smart_str_function)(smart_str *buf, const char *format, va_list ap);
 	char *(*getenv_function)(const char *name, size_t name_len);
 	zend_string *(*resolve_path_function)(zend_string *filename);
-	zend_result (*os_csprng_randomn_bytes_function)(void *bytes, size_t size, char *errstr, size_t errstr_size);
+	zend_result (*os_csprng_random_bytes_function)(void *bytes, size_t size, char *errstr, size_t errstr_size);
+	zend_result (*general_random_bytes_function)(zend_utility_general_random_state *state, void *bytes, size_t size);
 } zend_utility_functions;
 
 typedef struct _zend_utility_values {
@@ -342,6 +348,7 @@ extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_l
 extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 extern ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size);
+extern ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size);
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -347,8 +347,11 @@ extern void (*zend_printf_to_smart_string)(smart_string *buf, const char *format
 extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_list ap);
 extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
-extern ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size);
-extern ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size);
+/* Generate 'size' random bytes into 'bytes' with the OS CSPRNG. */
+extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_os_csprng_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size);
+/* Generate 'size' random bytes into 'bytes' with a general purpose PRNG.
+ * 'state' must be zeroed before the first call and can be reused. */
+extern ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_general_random_bytes)(zend_utility_general_random_state *state, void *bytes, size_t size);
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1341,13 +1341,7 @@ static zend_always_inline void zend_mm_set_next_free_slot(zend_mm_heap *heap, ui
 	ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num) = zend_mm_encode_free_slot(heap, next);
 }
 
-static zend_always_inline void zend_mm_copy_next_free_slot(zend_mm_free_slot* dest, uint32_t bin_num, zend_mm_free_slot* from)
-{
-	dest->next_free_slot = from->next_free_slot;
-	ZEND_MM_FREE_SLOT_PTR_SHADOW(dest, bin_num) = ZEND_MM_FREE_SLOT_PTR_SHADOW(from, bin_num);
-}
-
-static zend_always_inline zend_mm_free_slot *zend_mm_check_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot* slot)
+static zend_always_inline zend_mm_free_slot *zend_mm_get_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot* slot)
 {
 	zend_mm_free_slot *next = slot->next_free_slot;
 	if (EXPECTED(next != NULL)) {
@@ -1428,7 +1422,7 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 
 	if (EXPECTED(heap->free_slot[bin_num] != NULL)) {
 		zend_mm_free_slot *p = heap->free_slot[bin_num];
-		heap->free_slot[bin_num] = zend_mm_check_next_free_slot(heap, bin_num, p);
+		heap->free_slot[bin_num] = zend_mm_get_next_free_slot(heap, bin_num, p);
 		return p;
 	} else {
 		return zend_mm_alloc_small_slow(heap, bin_num ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
@@ -2135,7 +2129,7 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 				has_free_pages = true;
 			}
 			chunk->map[page_num] = ZEND_MM_SRUN_EX(i, free_counter);
-			p = zend_mm_check_next_free_slot(heap, i, p);
+			p = zend_mm_get_next_free_slot(heap, i, p);
 		}
 
 		if (!has_free_pages) {
@@ -2161,18 +2155,18 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == i);
 			if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[i]) {
 				/* remove from cache */
+				p = zend_mm_get_next_free_slot(heap, i, p);
 				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
-					q->next_free_slot = zend_mm_check_next_free_slot(heap, i, p);
+					q->next_free_slot = p;
 				} else {
-					zend_mm_copy_next_free_slot((zend_mm_free_slot*)q, i, p);
+					zend_mm_set_next_free_slot(heap, i, q, p);
 				}
-				p = zend_mm_check_next_free_slot(heap, i, p);
 			} else {
 				q = p;
 				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
 					p = q->next_free_slot;
 				} else {
-					p = zend_mm_check_next_free_slot(heap, i, q);
+					p = zend_mm_get_next_free_slot(heap, i, q);
 				}
 			}
 		}

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -54,13 +54,12 @@
 #include "zend.h"
 #include "zend_alloc.h"
 #include "zend_globals.h"
+#include "zend_hrtime.h"
 #include "zend_operators.h"
 #include "zend_multiply.h"
 #include "zend_bitset.h"
 #include "zend_mmap.h"
 #include "zend_portability.h"
-#include "ext/random/php_random_csprng.h"
-#include "ext/random/php_random.h"
 #include <signal.h>
 
 #ifdef HAVE_UNISTD_H
@@ -248,6 +247,10 @@ typedef struct  _zend_mm_huge_list zend_mm_huge_list;
 
 static bool zend_mm_use_huge_pages = false;
 
+typedef struct _zend_mm_rand_state {
+	uint32_t state[4];
+} zend_mm_rand_state;
+
 /*
  * Memory is retrieved from OS by chunks of fixed size 2MB.
  * Inside chunk it's managed by pages of fixed size 4096B.
@@ -323,7 +326,7 @@ struct _zend_mm_heap {
 	HashTable *tracked_allocs;
 #endif
 	pid_t pid;
-	php_random_status_state_xoshiro256starstar random_state;
+	zend_mm_rand_state rand_state;
 };
 
 struct _zend_mm_chunk {
@@ -2024,29 +2027,104 @@ static void zend_mm_free_huge(zend_mm_heap *heap, void *ptr ZEND_FILE_LINE_DC ZE
 #endif
 }
 
+/********/
+/* Rand */
+/********/
+
+/* Xoshiro256** PRNG based on implementation from Go Kudo in
+ * ext/random/engine_xoshiro256starstar.c, based on code from David Blackman,
+ * Sebastiano Vigna. */
+
+static inline uint64_t splitmix64(uint64_t *seed)
+{
+	uint64_t r;
+
+	r = (*seed += 0x9e3779b97f4a7c15ULL);
+	r = (r ^ (r >> 30)) * 0xbf58476d1ce4e5b9ULL;
+	r = (r ^ (r >> 27)) * 0x94d049bb133111ebULL;
+	return (r ^ (r >> 31));
+}
+
+ZEND_ATTRIBUTE_CONST static inline uint64_t rotl(const uint64_t x, int k)
+{
+	return (x << k) | (x >> (64 - k));
+}
+
+static inline uint64_t zend_mm_rand_generate(zend_mm_rand_state *s)
+{
+	const uint64_t r = rotl(s->state[1] * 5, 7) * 9;
+	const uint64_t t = s->state[1] << 17;
+
+	s->state[2] ^= s->state[0];
+	s->state[3] ^= s->state[1];
+	s->state[1] ^= s->state[2];
+	s->state[0] ^= s->state[3];
+
+	s->state[2] ^= t;
+
+	s->state[3] = rotl(s->state[3], 45);
+
+	return r;
+}
+
+static inline void zend_mm_rand_seed256(zend_mm_rand_state *state, uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3)
+{
+	state->state[0] = s0;
+	state->state[1] = s1;
+	state->state[2] = s2;
+	state->state[3] = s3;
+}
+
+static inline void zend_mm_rand_seed64(zend_mm_rand_state *state, uint64_t seed)
+{
+	uint64_t s[4];
+
+	s[0] = splitmix64(&seed);
+	s[1] = splitmix64(&seed);
+	s[2] = splitmix64(&seed);
+	s[3] = splitmix64(&seed);
+
+	zend_mm_rand_seed256(state, s[0], s[1], s[2], s[3]);
+}
+
 /******************/
 /* Initialization */
 /******************/
 
 static zend_result zend_mm_refresh_key(zend_mm_heap *heap)
 {
-	php_random_result result = php_random_algo_xoshiro256starstar.generate(&heap->random_state);
-	ZEND_ASSERT(result.size == sizeof(uint64_t));
-	heap->shadow_key = (uintptr_t) result.result;
+	heap->shadow_key = (uintptr_t) zend_mm_rand_generate(&heap->rand_state);
+
 	return SUCCESS;
 }
 
 static zend_result zend_mm_init_key(zend_mm_heap *heap)
 {
 	uint64_t seed[4];
-	if (php_random_bytes_silent(&seed, sizeof(seed)) != SUCCESS) {
-		for (int i = 0; i < sizeof(seed)/sizeof(seed[0]); i++) {
-			seed[i] = php_random_generate_fallback_seed();
-		}
+	char errstr[128];
+	if (zend_os_csprng_random_bytes(&seed, sizeof(seed), errstr, sizeof(errstr)) == SUCCESS) {
+		zend_mm_rand_seed256(&heap->rand_state,
+				seed[0], seed[1], seed[2], seed[3]);
+	} else {
+		/* Fallback to weak seed generation */
+#if ZEND_MM_ERROR
+		fprintf(stderr, "Could not generate secure random seed: %s\n", errstr);
+#endif
+		zend_hrtime_t nanotime = zend_hrtime();
+		uint64_t v = 0;
+		v ^= (uint64_t) nanotime;
+		splitmix64(&v);
+		v ^= (uint64_t) getpid();
+		splitmix64(&v);
+#ifdef ZTS
+		THREAD_T tid = tsrm_thread_id();
+		uint64_t tmp = 0;
+		memcpy(&tmp, tid, MIN(sizeof(tmp), sizeof(tid)));
+		v ^= tmp;
+		splitmix64(&v);
+#endif
+		zend_mm_rand_seed64(&heap->rand_state, v);
 	}
-
-	php_random_xoshiro256starstar_seed256(&heap->random_state,
-			seed[0], seed[1], seed[2], seed[3]);
 
 	return zend_mm_refresh_key(heap);
 }

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -71,6 +71,8 @@
 # include <wincrypt.h>
 # include <process.h>
 # include "win32/winutil.h"
+# define getpid _getpid
+typedef int pid_t;
 #endif
 
 #include <stdio.h>

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -58,6 +58,9 @@
 #include "zend_multiply.h"
 #include "zend_bitset.h"
 #include "zend_mmap.h"
+#include "zend_portability.h"
+#include "ext/random/php_random_csprng.h"
+#include "ext/random/php_random.h"
 #include <signal.h>
 
 #ifdef HAVE_UNISTD_H
@@ -245,6 +248,7 @@ struct _zend_mm_heap {
 	size_t             size;                    /* current memory usage */
 	size_t             peak;                    /* peak memory usage */
 #endif
+	uintptr_t          key;                     /* free slot shadow ptr key */
 	zend_mm_free_slot *free_slot[ZEND_MM_BINS]; /* free lists for small sizes */
 #if ZEND_MM_STAT || ZEND_MM_LIMIT
 	size_t             real_size;               /* current size of allocated pages */
@@ -275,6 +279,8 @@ struct _zend_mm_heap {
 	} custom_heap;
 	HashTable *tracked_allocs;
 #endif
+	pid_t pid;
+	php_random_status_state_xoshiro256starstar random_state;
 };
 
 struct _zend_mm_chunk {
@@ -318,19 +324,37 @@ struct _zend_mm_huge_list {
 #define ZEND_MM_PAGE_ADDR(chunk, page_num) \
 	((void*)(((zend_mm_page*)(chunk)) + (page_num)))
 
-#define _BIN_DATA_SIZE(num, size, elements, pages, x, y) size,
+#define _BIN_DATA_SIZE(num, size, elements, pages, x, y) \
+	/* Need two words for free slot pointer and shadow */ \
+	MAX(size, sizeof(zend_mm_free_slot*)*2)
+#define _BIN_DATA_SIZE_C(num, size, elements, pages, x, y) \
+	_BIN_DATA_SIZE(num, size, elements, pages, x, y),
 static const uint32_t bin_data_size[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_SIZE, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_SIZE_C, x, y)
 };
 
-#define _BIN_DATA_ELEMENTS(num, size, elements, pages, x, y) elements,
+#define _BIN_DATA_ELEMENTS(num, size, elements, pages, x, y) \
+	/* Adjusting size requires adjusting elements */ \
+	(elements / (_BIN_DATA_SIZE(num, size, elements, pages, x, y) / size))
+#define _BIN_DATA_ELEMENTS_C(num, size, elements, pages, x, y) \
+	_BIN_DATA_ELEMENTS(num, size, elements, pages, x, y),
 static const uint32_t bin_elements[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_ELEMENTS, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_ELEMENTS_C, x, y)
 };
 
-#define _BIN_DATA_PAGES(num, size, elements, pages, x, y) pages,
+#define _BIN_DATA_PAGES(num, size, elements, pages, x, y) pages
+#define _BIN_DATA_PAGES_C(num, size, elements, pages, x, y) \
+	_BIN_DATA_PAGES(num, size, elements, pages, x, y),
 static const uint32_t bin_pages[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_PAGES, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_PAGES_C, x, y)
+};
+
+#define _BIN_SHADOW_OFFSET(num, size, elements, pages, x, y) \
+	(_BIN_DATA_SIZE(num, size, elements, pages, x, y) - sizeof(zend_mm_free_slot*))
+#define _BIN_SHADOW_OFFSET_C(num, size, elements, pages, x, y) \
+	_BIN_SHADOW_OFFSET(num, size, elements, pages, x, y),
+static const uint32_t bin_shadow_offset[] = {
+	ZEND_MM_BINS_INFO(_BIN_SHADOW_OFFSET_C, x, y)
 };
 
 #if ZEND_DEBUG
@@ -1248,6 +1272,45 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 
 #define ZEND_MM_SMALL_SIZE_TO_BIN(size)  zend_mm_small_size_to_bin(size)
 
+static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
+{
+	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->key);
+}
+
+static zend_always_inline zend_mm_free_slot* zend_mm_decode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
+{
+	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->key);
+}
+
+static zend_always_inline void zend_mm_set_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot *slot, zend_mm_free_slot *next)
+{
+	slot->next_free_slot = next;
+	*(zend_mm_free_slot**)((char*)slot + bin_shadow_offset[bin_num]) = zend_mm_encode_free_slot(heap, next);
+}
+
+static zend_always_inline void zend_mm_copy_next_free_slot(zend_mm_free_slot* dest, uint32_t bin_num, zend_mm_free_slot* from)
+{
+	dest->next_free_slot = from->next_free_slot;
+	*(zend_mm_free_slot**)((char*)dest + bin_shadow_offset[bin_num]) = *(zend_mm_free_slot**)((char*)from + bin_shadow_offset[bin_num]);
+}
+
+static ZEND_COLD ZEND_NORETURN void zend_mm_free_slot_corrupted(void)
+{
+	zend_mm_panic("zend_mm_heap corrupted");
+}
+
+static zend_always_inline zend_mm_free_slot *zend_mm_check_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot* slot)
+{
+	zend_mm_free_slot *next = slot->next_free_slot;
+	zend_mm_free_slot *shadow = *(zend_mm_free_slot**)((char*)slot + bin_shadow_offset[bin_num]);
+	if (EXPECTED(next != NULL)) {
+		if (UNEXPECTED(next != zend_mm_decode_free_slot(heap, shadow))) {
+			zend_mm_free_slot_corrupted();
+		}
+	}
+	return (zend_mm_free_slot*)next;
+}
+
 static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint32_t bin_num ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
 	zend_mm_chunk *chunk;
@@ -1281,7 +1344,7 @@ static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint
 	end = (zend_mm_free_slot*)((char*)bin + (bin_data_size[bin_num] * (bin_elements[bin_num] - 1)));
 	heap->free_slot[bin_num] = p = (zend_mm_free_slot*)((char*)bin + bin_data_size[bin_num]);
 	do {
-		p->next_free_slot = (zend_mm_free_slot*)((char*)p + bin_data_size[bin_num]);
+		zend_mm_set_next_free_slot(heap, bin_num, p, (zend_mm_free_slot*)((char*)p + bin_data_size[bin_num]));
 #if ZEND_DEBUG
 		do {
 			zend_mm_debug_info *dbg = (zend_mm_debug_info*)((char*)p + bin_data_size[bin_num] - ZEND_MM_ALIGNED_SIZE(sizeof(zend_mm_debug_info)));
@@ -1317,7 +1380,7 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 
 	if (EXPECTED(heap->free_slot[bin_num] != NULL)) {
 		zend_mm_free_slot *p = heap->free_slot[bin_num];
-		heap->free_slot[bin_num] = p->next_free_slot;
+		heap->free_slot[bin_num] = zend_mm_check_next_free_slot(heap, bin_num, p);
 		return p;
 	} else {
 		return zend_mm_alloc_small_slow(heap, bin_num ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
@@ -1340,7 +1403,7 @@ static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, void *ptr,
 #endif
 
 	p = (zend_mm_free_slot*)ptr;
-	p->next_free_slot = heap->free_slot[bin_num];
+	zend_mm_set_next_free_slot(heap, bin_num, p, heap->free_slot[bin_num]);
 	heap->free_slot[bin_num] = p;
 }
 
@@ -1904,6 +1967,27 @@ static void zend_mm_free_huge(zend_mm_heap *heap, void *ptr ZEND_FILE_LINE_DC ZE
 /* Initialization */
 /******************/
 
+static zend_result zend_mm_refresh_key(zend_mm_heap *heap)
+{
+	php_random_result result = php_random_algo_xoshiro256starstar.generate(&heap->random_state);
+	ZEND_ASSERT(result.size == sizeof(uint64_t));
+	heap->key = (uintptr_t) result.result;
+	return SUCCESS;
+}
+
+static zend_result zend_mm_init_key(zend_mm_heap *heap)
+{
+	uint64_t seed[4];
+	if (php_random_bytes(&seed, sizeof(seed), false) != SUCCESS) {
+		return FAILURE;
+	}
+
+	php_random_xoshiro256starstar_seed256(&heap->random_state,
+			seed[0], seed[1], seed[2], seed[3]);
+
+	return zend_mm_refresh_key(heap);
+}
+
 static zend_mm_heap *zend_mm_init(void)
 {
 	zend_mm_chunk *chunk = (zend_mm_chunk*)zend_mm_chunk_alloc_int(ZEND_MM_CHUNK_SIZE, ZEND_MM_CHUNK_SIZE);
@@ -1940,6 +2024,12 @@ static zend_mm_heap *zend_mm_init(void)
 	heap->size = 0;
 	heap->peak = 0;
 #endif
+	if (zend_mm_init_key(heap) != SUCCESS) {
+#if ZEND_MM_ERROR
+		fprintf(stderr, "Can't initialize heap\n");
+#endif
+		return NULL;
+	}
 #if ZEND_MM_LIMIT
 	heap->limit = (size_t)Z_L(-1) >> 1;
 	heap->overflow = 0;
@@ -1951,12 +2041,13 @@ static zend_mm_heap *zend_mm_init(void)
 	heap->storage = NULL;
 #endif
 	heap->huge_list = NULL;
+	heap->pid = getpid();
 	return heap;
 }
 
 ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 {
-	zend_mm_free_slot *p, **q;
+	zend_mm_free_slot *p, *q;
 	zend_mm_chunk *chunk;
 	size_t page_offset;
 	int page_num;
@@ -1994,15 +2085,15 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 				has_free_pages = true;
 			}
 			chunk->map[page_num] = ZEND_MM_SRUN_EX(i, free_counter);
-			p = p->next_free_slot;
+			p = zend_mm_check_next_free_slot(heap, i, p);
 		}
 
 		if (!has_free_pages) {
 			continue;
 		}
 
-		q = &heap->free_slot[i];
-		p = *q;
+		q = (zend_mm_free_slot*)&heap->free_slot[i];
+		p = q->next_free_slot;
 		while (p != NULL) {
 			chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(p, ZEND_MM_CHUNK_SIZE);
 			ZEND_MM_CHECK(chunk->heap == heap, "zend_mm_heap corrupted");
@@ -2020,11 +2111,19 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == i);
 			if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[i]) {
 				/* remove from cache */
-				p = p->next_free_slot;
-				*q = p;
+				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
+					q->next_free_slot = zend_mm_check_next_free_slot(heap, i, p);
+				} else {
+					zend_mm_copy_next_free_slot((zend_mm_free_slot*)q, i, p);
+				}
+				p = zend_mm_check_next_free_slot(heap, i, p);
 			} else {
-				q = &p->next_free_slot;
-				p = *q;
+				q = p;
+				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
+					p = q->next_free_slot;
+				} else {
+					p = zend_mm_check_next_free_slot(heap, i, q);
+				}
 			}
 		}
 	}
@@ -2376,6 +2475,18 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 		memset(p->free_map, 0, sizeof(p->free_map) + sizeof(p->map));
 		p->free_map[0] = (1L << ZEND_MM_FIRST_PAGE) - 1;
 		p->map[0] = ZEND_MM_LRUN(ZEND_MM_FIRST_PAGE);
+
+		pid_t pid = getpid();
+		if (heap->pid != pid) {
+			if (zend_mm_init_key(heap) != SUCCESS) {
+				zend_mm_panic("Can't initialize heap");
+			}
+			heap->pid = pid;
+		} else {
+			if (zend_mm_refresh_key(heap) != SUCCESS) {
+				zend_mm_panic("Can't initialize heap");
+			}
+		}
 	}
 }
 
@@ -3052,6 +3163,12 @@ ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void
 	heap->size = 0;
 	heap->peak = 0;
 #endif
+	if (zend_mm_init_key(heap) != SUCCESS) {
+#if ZEND_MM_ERROR
+		fprintf(stderr, "Can't initialize heap\n");
+#endif
+		return NULL;
+	}
 #if ZEND_MM_LIMIT
 	heap->limit = (size_t)Z_L(-1) >> 1;
 	heap->overflow = 0;
@@ -3076,6 +3193,7 @@ ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void
 		memcpy(storage->data, data, data_size);
 	}
 	heap->storage = storage;
+	heap->pid = getpid();
 	return heap;
 #else
 	return NULL;

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2119,7 +2119,7 @@ static zend_result zend_mm_init_key(zend_mm_heap *heap)
 #ifdef ZTS
 		THREAD_T tid = tsrm_thread_id();
 		uint64_t tmp = 0;
-		memcpy(&tmp, tid, MIN(sizeof(tmp), sizeof(tid)));
+		memcpy(&tmp, &tid, MIN(sizeof(tmp), sizeof(tid)));
 		v ^= tmp;
 		splitmix64(&v);
 #endif

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -197,6 +197,44 @@ typedef zend_mm_bitset zend_mm_page_map[ZEND_MM_PAGE_MAP_LEN];     /* 64B */
 
 #define ZEND_MM_BINS 30
 
+#if defined(_MSC_VER)
+# if UINTPTR_MAX == UINT64_MAX
+#  define BSWAPPTR(u) _byteswap_uint64(u)
+# else
+#  define BSWAPPTR(u) _byteswap_ulong(u)
+# endif
+#else
+# if UINTPTR_MAX == UINT64_MAX
+#  if __has_builtin(__builtin_bswap64)
+#   define BSWAPPTR(u) __builtin_bswap64(u)
+#  else
+zend_always_inline uintptr_t BSWAPPTR(uintptr_t u)
+{
+   return (((u & 0xff00000000000000ULL) >> 56)
+          | ((u & 0x00ff000000000000ULL) >> 40)
+          | ((u & 0x0000ff0000000000ULL) >> 24)
+          | ((u & 0x000000ff00000000ULL) >>  8)
+          | ((u & 0x00000000ff000000ULL) <<  8)
+          | ((u & 0x0000000000ff0000ULL) << 24)
+          | ((u & 0x000000000000ff00ULL) << 40)
+          | ((u & 0x00000000000000ffULL) << 56));
+}
+#  endif /* __has_builtin(__builtin_bswap64) */
+# else /* UINTPTR_MAX == UINT64_MAX */
+#  if __has_builtin(__builtin_bswap32)
+#   define BSWAPPTR(u) __builtin_bswap32(u)
+#  else
+zend_always_inline uintptr_t BSWAPPTR(uintptr_t u)
+{
+  return (((u & 0xff000000) >> 24)
+          | ((u & 0x00ff0000) >>  8)
+          | ((u & 0x0000ff00) <<  8)
+          | ((u & 0x000000ff) << 24));
+}
+#  endif /* __has_builtin(__builtin_bswap32) */
+# endif /* UINTPTR_MAX == UINT64_MAX */
+#endif /* defined(_MSC_VER) */
+
 typedef struct  _zend_mm_page      zend_mm_page;
 typedef struct  _zend_mm_bin       zend_mm_bin;
 typedef struct  _zend_mm_free_slot zend_mm_free_slot;
@@ -248,7 +286,7 @@ struct _zend_mm_heap {
 	size_t             size;                    /* current memory usage */
 	size_t             peak;                    /* peak memory usage */
 #endif
-	uintptr_t          key;                     /* free slot shadow ptr key */
+	uintptr_t          shadow_key;              /* free slot shadow ptr xor key */
 	zend_mm_free_slot *free_slot[ZEND_MM_BINS]; /* free lists for small sizes */
 #if ZEND_MM_STAT || ZEND_MM_LIMIT
 	size_t             real_size;               /* current size of allocated pages */
@@ -347,14 +385,6 @@ static const uint32_t bin_elements[] = {
 	_BIN_DATA_PAGES(num, size, elements, pages, x, y),
 static const uint32_t bin_pages[] = {
 	ZEND_MM_BINS_INFO(_BIN_DATA_PAGES_C, x, y)
-};
-
-#define _BIN_SHADOW_OFFSET(num, size, elements, pages, x, y) \
-	(_BIN_DATA_SIZE(num, size, elements, pages, x, y) - sizeof(zend_mm_free_slot*))
-#define _BIN_SHADOW_OFFSET_C(num, size, elements, pages, x, y) \
-	_BIN_SHADOW_OFFSET(num, size, elements, pages, x, y),
-static const uint32_t bin_shadow_offset[] = {
-	ZEND_MM_BINS_INFO(_BIN_SHADOW_OFFSET_C, x, y)
 };
 
 #if ZEND_DEBUG
@@ -1272,40 +1302,58 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 
 #define ZEND_MM_SMALL_SIZE_TO_BIN(size)  zend_mm_small_size_to_bin(size)
 
+/* We keep track of free slots by organizing them in a linked list, with the
+ * first word of every free slot being a pointer to the next one.
+ *
+ * In order to frustrate corruptions, we check the consistency of these pointers
+ * before dereference by comparing them with a shadow.
+ *
+ * The shadow is a copy of the pointer, stored at the end of the slot. It is
+ * XOR'ed with a random key, and converted to big-endian so that smaller
+ * corruptions affect the most significant bytes, which has a high chance of
+ * resulting in an invalid address instead of pointing to an adjacent slot.
+ */
+
+#define ZEND_MM_FREE_SLOT_PTR_SHADOW(free_slot, bin_num) \
+	*((zend_mm_free_slot**)((char*)(free_slot) + bin_data_size[(bin_num)] - sizeof(zend_mm_free_slot*)))
+
 static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
 {
-	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->key);
+#if WORDS_BIGENDIAN
+	return (zend_mm_free_slot*)(((uintptr_t)slot) ^ heap->shadow_key);
+#else
+	return (zend_mm_free_slot*)(BSWAPPTR((uintptr_t)slot) ^ heap->shadow_key);
+#endif
 }
 
 static zend_always_inline zend_mm_free_slot* zend_mm_decode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
 {
-	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->key);
+#if WORDS_BIGENDIAN
+	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->shadow_key));
+#else
+	return (zend_mm_free_slot*)(BSWAPPTR((uintptr_t)slot ^ heap->shadow_key));
+#endif
 }
 
 static zend_always_inline void zend_mm_set_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot *slot, zend_mm_free_slot *next)
 {
 	slot->next_free_slot = next;
-	*(zend_mm_free_slot**)((char*)slot + bin_shadow_offset[bin_num]) = zend_mm_encode_free_slot(heap, next);
+	ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num) = zend_mm_encode_free_slot(heap, next);
 }
 
 static zend_always_inline void zend_mm_copy_next_free_slot(zend_mm_free_slot* dest, uint32_t bin_num, zend_mm_free_slot* from)
 {
 	dest->next_free_slot = from->next_free_slot;
-	*(zend_mm_free_slot**)((char*)dest + bin_shadow_offset[bin_num]) = *(zend_mm_free_slot**)((char*)from + bin_shadow_offset[bin_num]);
-}
-
-static ZEND_COLD ZEND_NORETURN void zend_mm_free_slot_corrupted(void)
-{
-	zend_mm_panic("zend_mm_heap corrupted");
+	ZEND_MM_FREE_SLOT_PTR_SHADOW(dest, bin_num) = ZEND_MM_FREE_SLOT_PTR_SHADOW(from, bin_num);
 }
 
 static zend_always_inline zend_mm_free_slot *zend_mm_check_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot* slot)
 {
 	zend_mm_free_slot *next = slot->next_free_slot;
-	zend_mm_free_slot *shadow = *(zend_mm_free_slot**)((char*)slot + bin_shadow_offset[bin_num]);
+	zend_mm_free_slot *shadow = ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num);
 	if (EXPECTED(next != NULL)) {
 		if (UNEXPECTED(next != zend_mm_decode_free_slot(heap, shadow))) {
-			zend_mm_free_slot_corrupted();
+			zend_mm_panic("zend_mm_heap corrupted");
 		}
 	}
 	return (zend_mm_free_slot*)next;
@@ -1971,15 +2019,17 @@ static zend_result zend_mm_refresh_key(zend_mm_heap *heap)
 {
 	php_random_result result = php_random_algo_xoshiro256starstar.generate(&heap->random_state);
 	ZEND_ASSERT(result.size == sizeof(uint64_t));
-	heap->key = (uintptr_t) result.result;
+	heap->shadow_key = (uintptr_t) result.result;
 	return SUCCESS;
 }
 
 static zend_result zend_mm_init_key(zend_mm_heap *heap)
 {
 	uint64_t seed[4];
-	if (php_random_bytes(&seed, sizeof(seed), false) != SUCCESS) {
-		return FAILURE;
+	if (php_random_bytes_silent(&seed, sizeof(seed)) != SUCCESS) {
+		for (int i = 0; i < sizeof(seed)/sizeof(seed[0]); i++) {
+			seed[i] = php_random_generate_fallback_seed();
+		}
 	}
 
 	php_random_xoshiro256starstar_seed256(&heap->random_state,

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -263,10 +263,6 @@ typedef struct  _zend_mm_huge_list zend_mm_huge_list;
 
 static bool zend_mm_use_huge_pages = false;
 
-typedef struct _zend_mm_rand_state {
-	uint32_t state[4];
-} zend_mm_rand_state;
-
 /*
  * Memory is retrieved from OS by chunks of fixed size 2MB.
  * Inside chunk it's managed by pages of fixed size 4096B.
@@ -342,7 +338,7 @@ struct _zend_mm_heap {
 	HashTable *tracked_allocs;
 #endif
 	pid_t pid;
-	zend_mm_rand_state rand_state;
+	zend_utility_general_random_state rand_state;
 };
 
 struct _zend_mm_chunk {
@@ -2043,105 +2039,18 @@ static void zend_mm_free_huge(zend_mm_heap *heap, void *ptr ZEND_FILE_LINE_DC ZE
 #endif
 }
 
-/********/
-/* Rand */
-/********/
-
-/* Xoshiro256** PRNG based on implementation from Go Kudo in
- * ext/random/engine_xoshiro256starstar.c, based on code from David Blackman,
- * Sebastiano Vigna. */
-
-static inline uint64_t splitmix64(uint64_t *seed)
-{
-	uint64_t r;
-
-	r = (*seed += 0x9e3779b97f4a7c15ULL);
-	r = (r ^ (r >> 30)) * 0xbf58476d1ce4e5b9ULL;
-	r = (r ^ (r >> 27)) * 0x94d049bb133111ebULL;
-	return (r ^ (r >> 31));
-}
-
-ZEND_ATTRIBUTE_CONST static inline uint64_t rotl(const uint64_t x, int k)
-{
-	return (x << k) | (x >> (64 - k));
-}
-
-static inline uint64_t zend_mm_rand_generate(zend_mm_rand_state *s)
-{
-	const uint64_t r = rotl(s->state[1] * 5, 7) * 9;
-	const uint64_t t = s->state[1] << 17;
-
-	s->state[2] ^= s->state[0];
-	s->state[3] ^= s->state[1];
-	s->state[1] ^= s->state[2];
-	s->state[0] ^= s->state[3];
-
-	s->state[2] ^= t;
-
-	s->state[3] = rotl(s->state[3], 45);
-
-	return r;
-}
-
-static inline void zend_mm_rand_seed256(zend_mm_rand_state *state, uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3)
-{
-	state->state[0] = s0;
-	state->state[1] = s1;
-	state->state[2] = s2;
-	state->state[3] = s3;
-}
-
-static inline void zend_mm_rand_seed64(zend_mm_rand_state *state, uint64_t seed)
-{
-	uint64_t s[4];
-
-	s[0] = splitmix64(&seed);
-	s[1] = splitmix64(&seed);
-	s[2] = splitmix64(&seed);
-	s[3] = splitmix64(&seed);
-
-	zend_mm_rand_seed256(state, s[0], s[1], s[2], s[3]);
-}
-
 /******************/
 /* Initialization */
 /******************/
 
 static zend_result zend_mm_refresh_key(zend_mm_heap *heap)
 {
-	heap->shadow_key = (uintptr_t) zend_mm_rand_generate(&heap->rand_state);
-
-	return SUCCESS;
+	return zend_general_random_bytes(&heap->rand_state, &heap->shadow_key, sizeof(heap->shadow_key));
 }
 
 static zend_result zend_mm_init_key(zend_mm_heap *heap)
 {
-	uint64_t seed[4];
-	char errstr[128];
-	if (zend_os_csprng_random_bytes(&seed, sizeof(seed), errstr, sizeof(errstr)) == SUCCESS) {
-		zend_mm_rand_seed256(&heap->rand_state,
-				seed[0], seed[1], seed[2], seed[3]);
-	} else {
-		/* Fallback to weak seed generation */
-#if ZEND_MM_ERROR
-		fprintf(stderr, "Could not generate secure random seed: %s\n", errstr);
-#endif
-		zend_hrtime_t nanotime = zend_hrtime();
-		uint64_t v = 0;
-		v ^= (uint64_t) nanotime;
-		splitmix64(&v);
-		v ^= (uint64_t) getpid();
-		splitmix64(&v);
-#ifdef ZTS
-		THREAD_T tid = tsrm_thread_id();
-		uint64_t tmp = 0;
-		memcpy(&tmp, &tid, MIN(sizeof(tmp), sizeof(tid)));
-		v ^= tmp;
-		splitmix64(&v);
-#endif
-		zend_mm_rand_seed64(&heap->rand_state, v);
-	}
-
+	memset(&heap->rand_state, 0, sizeof(heap->rand_state));
 	return zend_mm_refresh_key(heap);
 }
 

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -367,29 +367,19 @@ struct _zend_mm_huge_list {
 #define ZEND_MM_PAGE_ADDR(chunk, page_num) \
 	((void*)(((zend_mm_page*)(chunk)) + (page_num)))
 
-#define _BIN_DATA_SIZE(num, size, elements, pages, x, y) \
-	/* Need two words for free slot pointer and shadow */ \
-	(ZEND_MM_HEAP_PROTECTION ? MAX(size, sizeof(zend_mm_free_slot*)*2) : size)
-#define _BIN_DATA_SIZE_C(num, size, elements, pages, x, y) \
-	_BIN_DATA_SIZE(num, size, elements, pages, x, y),
+#define _BIN_DATA_SIZE(num, size, elements, pages, x, y) size,
 static const uint32_t bin_data_size[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_SIZE_C, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_SIZE, x, y)
 };
 
-#define _BIN_DATA_ELEMENTS(num, size, elements, pages, x, y) \
-	/* Adjusting size requires adjusting elements */ \
-	(elements / (_BIN_DATA_SIZE(num, size, elements, pages, x, y) / size))
-#define _BIN_DATA_ELEMENTS_C(num, size, elements, pages, x, y) \
-	_BIN_DATA_ELEMENTS(num, size, elements, pages, x, y),
+#define _BIN_DATA_ELEMENTS(num, size, elements, pages, x, y) elements,
 static const uint32_t bin_elements[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_ELEMENTS_C, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_ELEMENTS, x, y)
 };
 
-#define _BIN_DATA_PAGES(num, size, elements, pages, x, y) pages
-#define _BIN_DATA_PAGES_C(num, size, elements, pages, x, y) \
-	_BIN_DATA_PAGES(num, size, elements, pages, x, y),
+#define _BIN_DATA_PAGES(num, size, elements, pages, x, y) pages,
 static const uint32_t bin_pages[] = {
-	ZEND_MM_BINS_INFO(_BIN_DATA_PAGES_C, x, y)
+	ZEND_MM_BINS_INFO(_BIN_DATA_PAGES, x, y)
 };
 
 #if ZEND_DEBUG
@@ -1343,6 +1333,8 @@ static zend_always_inline zend_mm_free_slot* zend_mm_decode_free_slot(zend_mm_he
 
 static zend_always_inline void zend_mm_set_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot *slot, zend_mm_free_slot *next)
 {
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+
 	slot->next_free_slot = next;
 	ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num) = zend_mm_encode_free_slot(heap, next);
 }
@@ -1424,6 +1416,8 @@ static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint
 
 static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_num ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+
 #if ZEND_MM_STAT
 	do {
 		size_t size = heap->size + bin_data_size[bin_num];
@@ -1444,6 +1438,8 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 
 static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, void *ptr, int bin_num)
 {
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+
 	zend_mm_free_slot *p;
 
 #if ZEND_MM_STAT
@@ -1493,6 +1489,11 @@ static zend_always_inline zend_mm_debug_info *zend_mm_get_debug_info(zend_mm_hea
 static zend_always_inline void *zend_mm_alloc_heap(zend_mm_heap *heap, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
 	void *ptr;
+#if ZEND_MM_HEAP_PROTECTION
+	if (size < ZEND_MM_MIN_SMALL_SIZE) {
+		size = ZEND_MM_MIN_SMALL_SIZE;
+	}
+#endif /* ZEND_MM_HEAP_PROTECTION */
 #if ZEND_DEBUG
 	size_t real_size = size;
 	zend_mm_debug_info *dbg;
@@ -1714,6 +1715,11 @@ static zend_always_inline void *zend_mm_realloc_heap(zend_mm_heap *heap, void *p
 		zend_mm_chunk *chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(ptr, ZEND_MM_CHUNK_SIZE);
 		int page_num = (int)(page_offset / ZEND_MM_PAGE_SIZE);
 		zend_mm_page_info info = chunk->map[page_num];
+#if ZEND_MM_HEAP_PROTECTION
+		if (size < ZEND_MM_MIN_SMALL_SIZE) {
+			size = ZEND_MM_MIN_SMALL_SIZE;
+		}
+#endif /* ZEND_MM_HEAP_PROTECTION */
 #if ZEND_DEBUG
 		size_t real_size = size;
 
@@ -2677,6 +2683,7 @@ ZEND_API bool is_zend_ptr(const void *ptr)
 
 # define _ZEND_BIN_ALLOCATOR(_num, _size, _elements, _pages, x, y) \
 	ZEND_API void* ZEND_FASTCALL _emalloc_ ## _size(void) { \
+		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_ALLOCATOR(_size); \
 		return zend_mm_alloc_small(AG(mm_heap), _num ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC); \
 	}
@@ -2698,6 +2705,7 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 #if ZEND_DEBUG
 # define _ZEND_BIN_FREE(_num, _size, _elements, _pages, x, y) \
 	ZEND_API void ZEND_FASTCALL _efree_ ## _size(void *ptr) { \
+		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_DEALLOCATOR(ptr); \
 		{ \
 			size_t page_offset = ZEND_MM_ALIGNED_OFFSET(ptr, ZEND_MM_CHUNK_SIZE); \
@@ -2712,6 +2720,7 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 #else
 # define _ZEND_BIN_FREE(_num, _size, _elements, _pages, x, y) \
 	ZEND_API void ZEND_FASTCALL _efree_ ## _size(void *ptr) { \
+		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_DEALLOCATOR(ptr); \
 		{ \
 			zend_mm_chunk *chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(ptr, ZEND_MM_CHUNK_SIZE); \

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -149,6 +149,22 @@ static size_t _real_page_size = ZEND_MM_PAGE_SIZE;
 # define ZEND_MM_HEAP_PROTECTION 1 /* protect heap against corruptions       */
 #endif
 
+#if ZEND_MM_HEAP_PROTECTION
+/* Define ZEND_MM_MIN_USEABLE_BIN_SIZE to the size of two pointers */
+# if UINTPTR_MAX == UINT64_MAX
+#  define ZEND_MM_MIN_USEABLE_BIN_SIZE 16
+# elif UINTPTR_MAX == UINT32_MAX
+#  define ZEND_MM_MIN_USEABLE_BIN_SIZE 8
+# else
+#  error
+# endif
+# if ZEND_MM_MIN_USEABLE_BIN_SIZE < ZEND_MM_MIN_SMALL_SIZE
+#  error
+# endif
+#else /* ZEND_MM_HEAP_PROTECTION */
+# define ZEND_MM_MIN_USEABLE_BIN_SIZE ZEND_MM_MIN_SMALL_SIZE
+#endif /* ZEND_MM_HEAP_PROTECTION */
+
 #ifndef ZEND_MM_CHECK
 # define ZEND_MM_CHECK(condition, message)  do { \
 		if (UNEXPECTED(!(condition))) { \
@@ -1336,7 +1352,7 @@ static zend_always_inline zend_mm_free_slot* zend_mm_decode_free_slot(zend_mm_he
 
 static zend_always_inline void zend_mm_set_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot *slot, zend_mm_free_slot *next)
 {
-	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_USEABLE_BIN_SIZE);
 
 	slot->next_free_slot = next;
 	ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num) = zend_mm_encode_free_slot(heap, next);
@@ -1419,7 +1435,7 @@ static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint
 
 static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_num ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
-	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_USEABLE_BIN_SIZE);
 
 #if ZEND_MM_STAT
 	do {
@@ -1441,7 +1457,7 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 
 static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, void *ptr, int bin_num)
 {
-	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_SMALL_SIZE);
+	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_USEABLE_BIN_SIZE);
 
 	zend_mm_free_slot *p;
 
@@ -1493,8 +1509,8 @@ static zend_always_inline void *zend_mm_alloc_heap(zend_mm_heap *heap, size_t si
 {
 	void *ptr;
 #if ZEND_MM_HEAP_PROTECTION
-	if (size < ZEND_MM_MIN_SMALL_SIZE) {
-		size = ZEND_MM_MIN_SMALL_SIZE;
+	if (size < ZEND_MM_MIN_USEABLE_BIN_SIZE) {
+		size = ZEND_MM_MIN_USEABLE_BIN_SIZE;
 	}
 #endif /* ZEND_MM_HEAP_PROTECTION */
 #if ZEND_DEBUG
@@ -1719,8 +1735,8 @@ static zend_always_inline void *zend_mm_realloc_heap(zend_mm_heap *heap, void *p
 		int page_num = (int)(page_offset / ZEND_MM_PAGE_SIZE);
 		zend_mm_page_info info = chunk->map[page_num];
 #if ZEND_MM_HEAP_PROTECTION
-		if (size < ZEND_MM_MIN_SMALL_SIZE) {
-			size = ZEND_MM_MIN_SMALL_SIZE;
+		if (size < ZEND_MM_MIN_USEABLE_BIN_SIZE) {
+			size = ZEND_MM_MIN_USEABLE_BIN_SIZE;
 		}
 #endif /* ZEND_MM_HEAP_PROTECTION */
 #if ZEND_DEBUG
@@ -2759,14 +2775,16 @@ ZEND_API bool is_zend_ptr(const void *ptr)
 # define ZEND_MM_CUSTOM_DEALLOCATOR(ptr)
 #endif
 
-# define _ZEND_BIN_ALLOCATOR(_num, _size, _elements, _pages, x, y) \
+# define _ZEND_BIN_ALLOCATOR(_num, _size, _elements, _pages, _min_size, y) \
 	ZEND_API void* ZEND_FASTCALL _emalloc_ ## _size(void) { \
-		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_ALLOCATOR(_size); \
+		if (_size < _min_size) { \
+			return _emalloc_ ## _min_size(); \
+		} \
 		return zend_mm_alloc_small(AG(mm_heap), _num ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC); \
 	}
 
-ZEND_MM_BINS_INFO(_ZEND_BIN_ALLOCATOR, x, y)
+ZEND_MM_BINS_INFO(_ZEND_BIN_ALLOCATOR, ZEND_MM_MIN_USEABLE_BIN_SIZE, y)
 
 ZEND_API void* ZEND_FASTCALL _emalloc_large(size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
@@ -2781,10 +2799,13 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 }
 
 #if ZEND_DEBUG
-# define _ZEND_BIN_FREE(_num, _size, _elements, _pages, x, y) \
+# define _ZEND_BIN_FREE(_num, _size, _elements, _pages, _min_size, y) \
 	ZEND_API void ZEND_FASTCALL _efree_ ## _size(void *ptr) { \
-		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_DEALLOCATOR(ptr); \
+		if (_size < _min_size) { \
+			_efree_ ## _min_size(ptr); \
+			return; \
+		} \
 		{ \
 			size_t page_offset = ZEND_MM_ALIGNED_OFFSET(ptr, ZEND_MM_CHUNK_SIZE); \
 			zend_mm_chunk *chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(ptr, ZEND_MM_CHUNK_SIZE); \
@@ -2796,10 +2817,13 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 		} \
 	}
 #else
-# define _ZEND_BIN_FREE(_num, _size, _elements, _pages, x, y) \
+# define _ZEND_BIN_FREE(_num, _size, _elements, _pages, _min_size, y) \
 	ZEND_API void ZEND_FASTCALL _efree_ ## _size(void *ptr) { \
-		ZEND_ASSERT(_size >= ZEND_MM_MIN_SMALL_SIZE); \
 		ZEND_MM_CUSTOM_DEALLOCATOR(ptr); \
+		if (_size < _min_size) { \
+			_efree_ ## _min_size(ptr); \
+			return; \
+		} \
 		{ \
 			zend_mm_chunk *chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(ptr, ZEND_MM_CHUNK_SIZE); \
 			ZEND_MM_CHECK(chunk->heap == AG(mm_heap), "zend_mm_heap corrupted"); \
@@ -2808,7 +2832,7 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 	}
 #endif
 
-ZEND_MM_BINS_INFO(_ZEND_BIN_FREE, x, y)
+ZEND_MM_BINS_INFO(_ZEND_BIN_FREE, ZEND_MM_MIN_USEABLE_BIN_SIZE, y)
 
 ZEND_API void ZEND_FASTCALL _efree_large(void *ptr, size_t size)
 {

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -144,6 +144,9 @@ static size_t _real_page_size = ZEND_MM_PAGE_SIZE;
 #ifndef ZEND_MM_ERROR
 # define ZEND_MM_ERROR 1   /* report system errors                           */
 #endif
+#ifndef ZEND_MM_HEAP_PROTECTION
+# define ZEND_MM_HEAP_PROTECTION 1 /* protect heap against corruptions       */
+#endif
 
 #ifndef ZEND_MM_CHECK
 # define ZEND_MM_CHECK(condition, message)  do { \
@@ -364,7 +367,7 @@ struct _zend_mm_huge_list {
 
 #define _BIN_DATA_SIZE(num, size, elements, pages, x, y) \
 	/* Need two words for free slot pointer and shadow */ \
-	MAX(size, sizeof(zend_mm_free_slot*)*2)
+	(ZEND_MM_HEAP_PROTECTION ? MAX(size, sizeof(zend_mm_free_slot*)*2) : size)
 #define _BIN_DATA_SIZE_C(num, size, elements, pages, x, y) \
 	_BIN_DATA_SIZE(num, size, elements, pages, x, y),
 static const uint32_t bin_data_size[] = {
@@ -1302,6 +1305,7 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 
 #define ZEND_MM_SMALL_SIZE_TO_BIN(size)  zend_mm_small_size_to_bin(size)
 
+#if ZEND_MM_HEAP_PROTECTION
 /* We keep track of free slots by organizing them in a linked list, with the
  * first word of every free slot being a pointer to the next one.
  *
@@ -1352,6 +1356,13 @@ static zend_always_inline zend_mm_free_slot *zend_mm_get_next_free_slot(zend_mm_
 	}
 	return (zend_mm_free_slot*)next;
 }
+
+#else /* ZEND_MM_HEAP_PROTECTION */
+# define zend_mm_set_next_free_slot(heap, bin_num, slot, next) do { \
+		(slot)->next_free_slot = (next);                            \
+	} while (0)
+# define zend_mm_get_next_free_slot(heap, bin_num, slot) (slot)->next_free_slot
+#endif /* ZEND_MM_HEAP_PROTECTION */
 
 static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint32_t bin_num ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1330,7 +1330,7 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 
 static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(const zend_mm_heap *heap, const zend_mm_free_slot *slot)
 {
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 	return (zend_mm_free_slot*)(((uintptr_t)slot) ^ heap->shadow_key);
 #else
 	return (zend_mm_free_slot*)(BSWAPPTR((uintptr_t)slot) ^ heap->shadow_key);
@@ -1339,7 +1339,7 @@ static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(const zend
 
 static zend_always_inline zend_mm_free_slot* zend_mm_decode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
 {
-#if WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
 	return (zend_mm_free_slot*)((uintptr_t)slot ^ heap->shadow_key));
 #else
 	return (zend_mm_free_slot*)(BSWAPPTR((uintptr_t)slot ^ heap->shadow_key));

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -338,7 +338,7 @@ struct _zend_mm_heap {
 	HashTable *tracked_allocs;
 #endif
 	pid_t pid;
-	zend_utility_general_random_state rand_state;
+	zend_utility_random_bytes_insecure_state rand_state;
 };
 
 struct _zend_mm_chunk {
@@ -2045,7 +2045,7 @@ static void zend_mm_free_huge(zend_mm_heap *heap, void *ptr ZEND_FILE_LINE_DC ZE
 
 static zend_result zend_mm_refresh_key(zend_mm_heap *heap)
 {
-	return zend_general_random_bytes(&heap->rand_state, &heap->shadow_key, sizeof(heap->shadow_key));
+	return zend_random_bytes_insecure(&heap->rand_state, &heap->shadow_key, sizeof(heap->shadow_key));
 }
 
 static zend_result zend_mm_init_key(zend_mm_heap *heap)

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -148,6 +148,11 @@ static size_t _real_page_size = ZEND_MM_PAGE_SIZE;
 #ifndef ZEND_MM_HEAP_PROTECTION
 # define ZEND_MM_HEAP_PROTECTION 1 /* protect heap against corruptions       */
 #endif
+#ifndef ZEND_MM_HEAP_SPRAYING_PROTECTION
+# define ZEND_MM_HEAP_SPRAYING_PROTECTION 1 /* protect against remote heap
+											   spraying or heap feng chui via
+											   environment / user input */
+#endif
 
 #if ZEND_MM_HEAP_PROTECTION
 /* Define ZEND_MM_MIN_USEABLE_BIN_SIZE to the size of two pointers */
@@ -217,6 +222,48 @@ typedef zend_mm_bitset zend_mm_page_map[ZEND_MM_PAGE_MAP_LEN];     /* 64B */
 
 #define ZEND_MM_BINS 30
 
+#define ZEND_MM_ZONE_LEN        32 /* ZEND_MM_BINS rounded to next power of two */
+#define ZEND_MM_FREE_SLOT_LEN   (ZEND_MM_ZONE_LEN * ZEND_MM_ZONES)
+#define ZEND_MM_ZONE_DEFAULT    0
+
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+
+# define ZEND_MM_ZONES 2
+
+# define ZEND_MM_ZONE_FOREACH(_heap, _zone) do {                        \
+		zend_mm_heap *__heap = (_heap);                                 \
+		zend_mm_zone *__zone = &__heap->zones[0];                       \
+		zend_mm_zone *__end = &__heap->zones[ZEND_MM_ZONES];            \
+		for (; __zone!= __end; __zone++) {                              \
+			_zone = __zone;
+
+# define ZEND_MM_ZONE_FOREACH_END()                                     \
+		}                                                               \
+	} while (0)
+
+# define ZEND_MM_ZONE_FREE_SLOT(heap, num)          (&(heap)->free_slot[ZEND_MM_ZONE_LEN * num])
+# define ZEND_MM_CURRENT_ZONE(heap)                 (&(heap)->zones[(uintptr_t)(&(heap)->zone_free_slot[0] - &(heap)->free_slot[0]) / ZEND_MM_ZONE_LEN])
+# define ZEND_MM_FREE_SLOT(heap, bin_num)           ((heap)->zone_free_slot[(bin_num)])
+# define ZEND_MM_FREE_SLOT_EX(heap, chunk, bin_num) ((chunk)->zone_free_slot[(bin_num)])
+# define ZEND_MM_CHUNK_ZONE(heap, chunk)            ((chunk)->zone)
+
+#else /* ZEND_MM_HEAP_SPRAYING_PROTECTION */
+
+# define ZEND_MM_ZONES 1
+
+# define ZEND_MM_ZONE_FOREACH(_heap, _zone) do {                        \
+		_zone = &_heap->zones[0];                                       \
+
+# define ZEND_MM_ZONE_FOREACH_END()                                     \
+	} while (0)
+
+# define ZEND_MM_CURRENT_ZONE(heap)                 (&(heap)->zones[0])
+# define ZEND_MM_FREE_SLOT(heap, bin_num)           ((heap)->free_slot[(bin_num)])
+# define ZEND_MM_FREE_SLOT_EX(heap, chunk, bin_num) ZEND_MM_FREE_SLOT(heap, bin_num)
+# define ZEND_MM_CHUNK_ZONE(heap, chunk)            (&(heap)->zones[0])
+
+#endif /* ZEND_MM_HEAP_SPRAYING_PROTECTION */
+
 #if defined(_MSC_VER)
 # if UINTPTR_MAX == UINT64_MAX
 #  define BSWAPPTR(u) _byteswap_uint64(u)
@@ -259,9 +306,14 @@ typedef struct  _zend_mm_page      zend_mm_page;
 typedef struct  _zend_mm_bin       zend_mm_bin;
 typedef struct  _zend_mm_free_slot zend_mm_free_slot;
 typedef struct  _zend_mm_chunk     zend_mm_chunk;
+typedef struct  _zend_mm_zone      zend_mm_zone;
 typedef struct  _zend_mm_huge_list zend_mm_huge_list;
 
 static bool zend_mm_use_huge_pages = false;
+
+struct _zend_mm_zone {
+	zend_mm_chunk *chunks;
+};
 
 /*
  * Memory is retrieved from OS by chunks of fixed size 2MB.
@@ -307,7 +359,10 @@ struct _zend_mm_heap {
 	size_t             peak;                    /* peak memory usage */
 #endif
 	uintptr_t          shadow_key;              /* free slot shadow ptr xor key */
-	zend_mm_free_slot *free_slot[ZEND_MM_BINS]; /* free lists for small sizes */
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	zend_mm_free_slot **zone_free_slot;
+#endif
+	zend_mm_free_slot *free_slot[ZEND_MM_FREE_SLOT_LEN]; /* free lists for small sizes */
 #if ZEND_MM_STAT || ZEND_MM_LIMIT
 	size_t             real_size;               /* current size of allocated pages */
 #endif
@@ -329,6 +384,7 @@ struct _zend_mm_heap {
 	double             avg_chunks_count;		/* average number of chunks allocated per request */
 	int                last_chunks_delete_boundary; /* number of chunks after last deletion */
 	int                last_chunks_delete_count;    /* number of deletion over the last boundary */
+	zend_mm_zone       zones[ZEND_MM_ZONES];
 #if ZEND_MM_CUSTOM
 	struct {
 		void      *(*_malloc)(size_t ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
@@ -343,6 +399,9 @@ struct _zend_mm_heap {
 
 struct _zend_mm_chunk {
 	zend_mm_heap      *heap;
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	zend_mm_free_slot **zone_free_slot;
+#endif
 	zend_mm_chunk     *next;
 	zend_mm_chunk     *prev;
 	uint32_t           free_pages;				/* number of free pages */
@@ -350,9 +409,14 @@ struct _zend_mm_chunk {
 	uint32_t           num;
 	char               reserve[64 - (sizeof(void*) * 3 + sizeof(uint32_t) * 3)];
 	zend_mm_heap       heap_slot;               /* used only in main chunk */
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	zend_mm_zone      *zone;
+#endif
 	zend_mm_page_map   free_map;                /* 512 bits or 64 bytes */
 	zend_mm_page_info  map[ZEND_MM_PAGES];      /* 2 KB = 512 * 4 */
 };
+
+ZEND_STATIC_ASSERT(sizeof(zend_mm_chunk) <= ZEND_MM_FIRST_PAGE * ZEND_MM_PAGE_SIZE, "");
 
 struct _zend_mm_page {
 	char               bytes[ZEND_MM_PAGE_SIZE];
@@ -903,13 +967,23 @@ static int zend_mm_chunk_extend(zend_mm_heap *heap, void *addr, size_t old_size,
 #endif
 }
 
-static zend_always_inline void zend_mm_chunk_init(zend_mm_heap *heap, zend_mm_chunk *chunk)
+static zend_always_inline void zend_mm_chunk_init(zend_mm_heap *heap, zend_mm_zone *zone, zend_mm_chunk *chunk)
 {
 	chunk->heap = heap;
-	chunk->next = heap->main_chunk;
-	chunk->prev = heap->main_chunk->prev;
-	chunk->prev->next = chunk;
-	chunk->next->prev = chunk;
+	if (UNEXPECTED(zone->chunks == NULL)) {
+		zone->chunks = chunk;
+		chunk->next = chunk;
+		chunk->prev = chunk;
+	} else {
+		chunk->next = zone->chunks;
+		chunk->prev = zone->chunks->prev;
+		chunk->prev->next = chunk;
+		chunk->next->prev = chunk;
+	}
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	chunk->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(heap, (uintptr_t)(zone - &heap->zones[0]));
+	chunk->zone = zone;
+#endif
 	/* mark first pages as allocated */
 	chunk->free_pages = ZEND_MM_PAGES - ZEND_MM_FIRST_PAGE;
 	chunk->free_tail = ZEND_MM_FIRST_PAGE;
@@ -944,9 +1018,14 @@ static void *zend_mm_alloc_pages(zend_mm_heap *heap, uint32_t pages_count, size_
 static void *zend_mm_alloc_pages(zend_mm_heap *heap, uint32_t pages_count ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 #endif
 {
-	zend_mm_chunk *chunk = heap->main_chunk;
+	zend_mm_zone *zone = ZEND_MM_CURRENT_ZONE(heap);
+	zend_mm_chunk *chunk = zone->chunks;
 	uint32_t page_num, len;
 	int steps = 0;
+
+	if (UNEXPECTED(!chunk)) {
+		goto get_chunk;
+	}
 
 	while (1) {
 		if (UNEXPECTED(chunk->free_pages < pages_count)) {
@@ -1063,7 +1142,7 @@ static void *zend_mm_alloc_pages(zend_mm_heap *heap, uint32_t pages_count ZEND_F
 		}
 
 not_found:
-		if (chunk->next == heap->main_chunk) {
+		if (chunk->next == zone->chunks) {
 get_chunk:
 			if (heap->cached_chunks) {
 				heap->cached_chunks_count--;
@@ -1117,7 +1196,7 @@ get_chunk:
 			if (heap->chunks_count > heap->peak_chunks_count) {
 				heap->peak_chunks_count = heap->chunks_count;
 			}
-			zend_mm_chunk_init(heap, chunk);
+			zend_mm_chunk_init(heap, zone, chunk);
 			page_num = ZEND_MM_FIRST_PAGE;
 			len = ZEND_MM_PAGES - ZEND_MM_FIRST_PAGE;
 			goto found;
@@ -1135,8 +1214,8 @@ found:
 		/* move chunk into the head of the linked-list */
 		chunk->prev->next = chunk->next;
 		chunk->next->prev = chunk->prev;
-		chunk->next = heap->main_chunk->next;
-		chunk->prev = heap->main_chunk;
+		chunk->next = zone->chunks->next;
+		chunk->prev = zone->chunks;
 		chunk->prev->next = chunk;
 		chunk->next->prev = chunk;
 	}
@@ -1186,8 +1265,13 @@ static zend_always_inline void zend_mm_delete_chunk(zend_mm_heap *heap, zend_mm_
 	ZEND_MM_CHECK(chunk->next->prev == chunk, "zend_mm_heap corrupted");
 	ZEND_MM_CHECK(chunk->prev->next == chunk, "zend_mm_heap corrupted");
 
-	chunk->next->prev = chunk->prev;
-	chunk->prev->next = chunk->next;
+	if (ZEND_MM_CHUNK_ZONE(heap, chunk)->chunks == chunk && chunk->next == chunk) {
+		ZEND_ASSERT(chunk->prev == chunk);
+		ZEND_MM_CHUNK_ZONE(heap, chunk)->chunks = NULL;
+	} else {
+		chunk->next->prev = chunk->prev;
+		chunk->prev->next = chunk->next;
+	}
 	heap->chunks_count--;
 	if (heap->chunks_count + heap->cached_chunks_count < heap->avg_chunks_count + 0.1
 	 || (heap->chunks_count == heap->last_chunks_delete_boundary
@@ -1404,7 +1488,7 @@ static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint
 
 	/* create a linked list of elements from 1 to last */
 	end = (zend_mm_free_slot*)((char*)bin + (bin_data_size[bin_num] * (bin_elements[bin_num] - 1)));
-	heap->free_slot[bin_num] = p = (zend_mm_free_slot*)((char*)bin + bin_data_size[bin_num]);
+	ZEND_MM_FREE_SLOT(heap, bin_num) = p = (zend_mm_free_slot*)((char*)bin + bin_data_size[bin_num]);
 	do {
 		zend_mm_set_next_free_slot(heap, bin_num, p, (zend_mm_free_slot*)((char*)p + bin_data_size[bin_num]));
 #if ZEND_DEBUG
@@ -1431,6 +1515,7 @@ static zend_never_inline void *zend_mm_alloc_small_slow(zend_mm_heap *heap, uint
 
 static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_num ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC)
 {
+	ZEND_ASSERT(bin_num <= ZEND_MM_BINS);
 	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_USEABLE_BIN_SIZE);
 
 #if ZEND_MM_STAT
@@ -1442,17 +1527,18 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 	} while (0);
 #endif
 
-	if (EXPECTED(heap->free_slot[bin_num] != NULL)) {
-		zend_mm_free_slot *p = heap->free_slot[bin_num];
-		heap->free_slot[bin_num] = zend_mm_get_next_free_slot(heap, bin_num, p);
+	if (EXPECTED(ZEND_MM_FREE_SLOT(heap, bin_num) != NULL)) {
+		zend_mm_free_slot *p = ZEND_MM_FREE_SLOT(heap, bin_num);
+		ZEND_MM_FREE_SLOT(heap, bin_num) = zend_mm_get_next_free_slot(heap, bin_num, p);
 		return p;
 	} else {
 		return zend_mm_alloc_small_slow(heap, bin_num ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 	}
 }
 
-static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, void *ptr, int bin_num)
+static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, zend_mm_chunk *chunk, void *ptr, int bin_num)
 {
+	ZEND_ASSERT(bin_num <= ZEND_MM_BINS);
 	ZEND_ASSERT(bin_data_size[bin_num] >= ZEND_MM_MIN_USEABLE_BIN_SIZE);
 
 	zend_mm_free_slot *p;
@@ -1469,8 +1555,8 @@ static zend_always_inline void zend_mm_free_small(zend_mm_heap *heap, void *ptr,
 #endif
 
 	p = (zend_mm_free_slot*)ptr;
-	zend_mm_set_next_free_slot(heap, bin_num, p, heap->free_slot[bin_num]);
-	heap->free_slot[bin_num] = p;
+	zend_mm_set_next_free_slot(heap, bin_num, p, ZEND_MM_FREE_SLOT_EX(heap, chunk, bin_num));
+	ZEND_MM_FREE_SLOT_EX(heap, chunk, bin_num) = p;
 }
 
 /********/
@@ -1566,7 +1652,7 @@ static zend_always_inline void zend_mm_free_heap(zend_mm_heap *heap, void *ptr Z
 
 		ZEND_MM_CHECK(chunk->heap == heap, "zend_mm_heap corrupted");
 		if (EXPECTED(info & ZEND_MM_IS_SRUN)) {
-			zend_mm_free_small(heap, ptr, ZEND_MM_SRUN_BIN_NUM(info));
+			zend_mm_free_small(heap, chunk, ptr, ZEND_MM_SRUN_BIN_NUM(info));
 		} else /* if (info & ZEND_MM_IS_LRUN) */ {
 			int pages_count = ZEND_MM_LRUN_PAGES(info);
 
@@ -1756,7 +1842,7 @@ static zend_always_inline void *zend_mm_realloc_heap(zend_mm_heap *heap, void *p
 						ret = zend_mm_alloc_small(heap, ZEND_MM_SMALL_SIZE_TO_BIN(size) ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 						copy_size = use_copy_size ? MIN(size, copy_size) : size;
 						memcpy(ret, ptr, copy_size);
-						zend_mm_free_small(heap, ptr, old_bin_num);
+						zend_mm_free_small(heap, chunk, ptr, old_bin_num);
 					} else {
 						/* reallocation in-place */
 						ret = ptr;
@@ -1771,7 +1857,7 @@ static zend_always_inline void *zend_mm_realloc_heap(zend_mm_heap *heap, void *p
 						ret = zend_mm_alloc_small(heap, ZEND_MM_SMALL_SIZE_TO_BIN(size) ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
 						copy_size = use_copy_size ? MIN(old_size, copy_size) : old_size;
 						memcpy(ret, ptr, copy_size);
-						zend_mm_free_small(heap, ptr, old_bin_num);
+						zend_mm_free_small(heap, chunk, ptr, old_bin_num);
 #if ZEND_MM_STAT
 						heap->peak = MAX(orig_peak, heap->size);
 					} while (0);
@@ -2067,6 +2153,10 @@ static zend_mm_heap *zend_mm_init(void)
 	}
 	heap = &chunk->heap_slot;
 	chunk->heap = heap;
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	chunk->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(heap, ZEND_MM_ZONE_DEFAULT);
+	chunk->zone = &heap->zones[0];
+#endif
 	chunk->next = chunk;
 	chunk->prev = chunk;
 	chunk->free_pages = ZEND_MM_PAGES - ZEND_MM_FIRST_PAGE;
@@ -2076,6 +2166,13 @@ static zend_mm_heap *zend_mm_init(void)
 	chunk->map[0] = ZEND_MM_LRUN(ZEND_MM_FIRST_PAGE);
 	heap->main_chunk = chunk;
 	heap->cached_chunks = NULL;
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	heap->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(heap, ZEND_MM_ZONE_DEFAULT);
+#endif
+	heap->zones[0].chunks = chunk;
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	heap->zones[1].chunks = NULL;
+#endif
 	heap->chunks_count = 1;
 	heap->peak_chunks_count = 1;
 	heap->cached_chunks_count = 0;
@@ -2118,9 +2215,10 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 	size_t page_offset;
 	int page_num;
 	zend_mm_page_info info;
-	uint32_t i, free_counter;
+	uint32_t i, free_counter, bin_num;
 	bool has_free_pages;
 	size_t collected = 0;
+	zend_mm_zone *zone;
 
 #if ZEND_MM_CUSTOM
 	if (heap->use_custom_heap) {
@@ -2128,9 +2226,10 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 	}
 #endif
 
-	for (i = 0; i < ZEND_MM_BINS; i++) {
+	for (i = 0; i < ZEND_MM_FREE_SLOT_LEN; i++) {
 		has_free_pages = false;
 		p = heap->free_slot[i];
+		bin_num = i % ZEND_MM_ZONE_LEN;
 		while (p != NULL) {
 			chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(p, ZEND_MM_CHUNK_SIZE);
 			ZEND_MM_CHECK(chunk->heap == heap, "zend_mm_heap corrupted");
@@ -2145,13 +2244,13 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 				ZEND_ASSERT(info & ZEND_MM_IS_SRUN);
 				ZEND_ASSERT(!(info & ZEND_MM_IS_LRUN));
 			}
-			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == i);
+			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == bin_num);
 			free_counter = ZEND_MM_SRUN_FREE_COUNTER(info) + 1;
-			if (free_counter == bin_elements[i]) {
+			if (free_counter == bin_elements[bin_num]) {
 				has_free_pages = true;
 			}
-			chunk->map[page_num] = ZEND_MM_SRUN_EX(i, free_counter);
-			p = zend_mm_get_next_free_slot(heap, i, p);
+			chunk->map[page_num] = ZEND_MM_SRUN_EX(bin_num, free_counter);
+			p = zend_mm_get_next_free_slot(heap, bin_num, p);
 		}
 
 		if (!has_free_pages) {
@@ -2174,61 +2273,66 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap)
 				ZEND_ASSERT(info & ZEND_MM_IS_SRUN);
 				ZEND_ASSERT(!(info & ZEND_MM_IS_LRUN));
 			}
-			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == i);
-			if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[i]) {
+			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(info) == bin_num);
+			if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[bin_num]) {
 				/* remove from cache */
-				p = zend_mm_get_next_free_slot(heap, i, p);
+				p = zend_mm_get_next_free_slot(heap, bin_num, p);
 				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
 					q->next_free_slot = p;
 				} else {
-					zend_mm_set_next_free_slot(heap, i, q, p);
+					zend_mm_set_next_free_slot(heap, bin_num, q, p);
 				}
 			} else {
 				q = p;
 				if (q == (zend_mm_free_slot*)&heap->free_slot[i]) {
 					p = q->next_free_slot;
 				} else {
-					p = zend_mm_get_next_free_slot(heap, i, q);
+					p = zend_mm_get_next_free_slot(heap, bin_num, q);
 				}
 			}
 		}
 	}
 
-	chunk = heap->main_chunk;
-	do {
-		i = ZEND_MM_FIRST_PAGE;
-		while (i < chunk->free_tail) {
-			if (zend_mm_bitset_is_set(chunk->free_map, i)) {
-				info = chunk->map[i];
-				if (info & ZEND_MM_IS_SRUN) {
-					int bin_num = ZEND_MM_SRUN_BIN_NUM(info);
-					int pages_count = bin_pages[bin_num];
+	ZEND_MM_ZONE_FOREACH(heap, zone) {
+		chunk = zone->chunks;
+		if (chunk == NULL) {
+			continue;
+		}
+		do {
+			i = ZEND_MM_FIRST_PAGE;
+			while (i < chunk->free_tail) {
+				if (zend_mm_bitset_is_set(chunk->free_map, i)) {
+					info = chunk->map[i];
+					if (info & ZEND_MM_IS_SRUN) {
+						bin_num = ZEND_MM_SRUN_BIN_NUM(info);
+						int pages_count = bin_pages[bin_num];
 
-					if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[bin_num]) {
-						/* all elements are free */
-						zend_mm_free_pages_ex(heap, chunk, i, pages_count, 0);
-						collected += pages_count;
-					} else {
-						/* reset counter */
-						chunk->map[i] = ZEND_MM_SRUN(bin_num);
+						if (ZEND_MM_SRUN_FREE_COUNTER(info) == bin_elements[bin_num]) {
+							/* all elements are free */
+							zend_mm_free_pages_ex(heap, chunk, i, pages_count, 0);
+							collected += pages_count;
+						} else {
+							/* reset counter */
+							chunk->map[i] = ZEND_MM_SRUN(bin_num);
+						}
+						i += bin_pages[bin_num];
+					} else /* if (info & ZEND_MM_IS_LRUN) */ {
+						i += ZEND_MM_LRUN_PAGES(info);
 					}
-					i += bin_pages[bin_num];
-				} else /* if (info & ZEND_MM_IS_LRUN) */ {
-					i += ZEND_MM_LRUN_PAGES(info);
+				} else {
+					i++;
 				}
-			} else {
-				i++;
 			}
-		}
-		if (chunk->free_pages == ZEND_MM_PAGES - ZEND_MM_FIRST_PAGE) {
-			zend_mm_chunk *next_chunk = chunk->next;
+			if (chunk->free_pages == ZEND_MM_PAGES - ZEND_MM_FIRST_PAGE) {
+				zend_mm_chunk *next_chunk = chunk->next;
 
-			zend_mm_delete_chunk(heap, chunk);
-			chunk = next_chunk;
-		} else {
-			chunk = chunk->next;
-		}
-	} while (chunk != heap->main_chunk);
+				zend_mm_delete_chunk(heap, chunk);
+				chunk = next_chunk;
+			} else {
+				chunk = chunk->next;
+			}
+		} while (zone->chunks && chunk != zone->chunks);
+	} ZEND_MM_ZONE_FOREACH_END();
 
 	return collected * ZEND_MM_PAGE_SIZE;
 }
@@ -2265,7 +2369,7 @@ static zend_long zend_mm_find_leaks_small(zend_mm_chunk *p, uint32_t i, uint32_t
 	return count;
 }
 
-static zend_long zend_mm_find_leaks(zend_mm_heap *heap, zend_mm_chunk *p, uint32_t i, zend_leak_info *leak)
+static zend_long zend_mm_find_leaks(zend_mm_zone *zone, zend_mm_chunk *p, uint32_t i, zend_leak_info *leak)
 {
 	zend_long count = 0;
 
@@ -2292,7 +2396,7 @@ static zend_long zend_mm_find_leaks(zend_mm_heap *heap, zend_mm_chunk *p, uint32
 		}
 		p = p->next;
 		i = ZEND_MM_FIRST_PAGE;
-	} while (p != heap->main_chunk);
+	} while (p != zone->chunks);
 	return count;
 }
 
@@ -2325,6 +2429,7 @@ static void zend_mm_check_leaks(zend_mm_heap *heap)
 	zend_long repeated = 0;
 	uint32_t total = 0;
 	uint32_t i, j;
+	zend_mm_zone *zone;
 
 	/* find leaked huge blocks and free them */
 	list = heap->huge_list;
@@ -2351,73 +2456,78 @@ static void zend_mm_check_leaks(zend_mm_heap *heap)
 		zend_mm_free_heap(heap, q, NULL, 0, NULL, 0);
 	}
 
-	/* for each chunk */
-	p = heap->main_chunk;
-	do {
-		i = ZEND_MM_FIRST_PAGE;
-		while (i < p->free_tail) {
-			if (zend_mm_bitset_is_set(p->free_map, i)) {
-				if (p->map[i] & ZEND_MM_IS_SRUN) {
-					int bin_num = ZEND_MM_SRUN_BIN_NUM(p->map[i]);
-					zend_mm_debug_info *dbg = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * i + bin_data_size[bin_num] - ZEND_MM_ALIGNED_SIZE(sizeof(zend_mm_debug_info)));
-
-					j = 0;
-					while (j < bin_elements[bin_num]) {
-						if (dbg->size != 0) {
-							leak.addr = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * i + bin_data_size[bin_num] * j);
-							leak.size = dbg->size;
-							leak.filename = dbg->filename;
-							leak.orig_filename = dbg->orig_filename;
-							leak.lineno = dbg->lineno;
-							leak.orig_lineno = dbg->orig_lineno;
-
-							zend_message_dispatcher(ZMSG_LOG_SCRIPT_NAME, NULL);
-							zend_message_dispatcher(ZMSG_MEMORY_LEAK_DETECTED, &leak);
-
-							dbg->size = 0;
-							dbg->filename = NULL;
-							dbg->lineno = 0;
-
-							repeated = zend_mm_find_leaks_small(p, i, j + 1, &leak) +
-							           zend_mm_find_leaks(heap, p, i + bin_pages[bin_num], &leak);
-							total += 1 + repeated;
-							if (repeated) {
-								zend_message_dispatcher(ZMSG_MEMORY_LEAK_REPEATED, (void *)(uintptr_t)repeated);
-							}
-						}
-						dbg = (zend_mm_debug_info*)((char*)dbg + bin_data_size[bin_num]);
-						j++;
-					}
-					i += bin_pages[bin_num];
-				} else /* if (p->map[i] & ZEND_MM_IS_LRUN) */ {
-					int pages_count = ZEND_MM_LRUN_PAGES(p->map[i]);
-					zend_mm_debug_info *dbg = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * (i + pages_count) - ZEND_MM_ALIGNED_SIZE(sizeof(zend_mm_debug_info)));
-
-					leak.addr = (void*)((char*)p + ZEND_MM_PAGE_SIZE * i);
-					leak.size = dbg->size;
-					leak.filename = dbg->filename;
-					leak.orig_filename = dbg->orig_filename;
-					leak.lineno = dbg->lineno;
-					leak.orig_lineno = dbg->orig_lineno;
-
-					zend_message_dispatcher(ZMSG_LOG_SCRIPT_NAME, NULL);
-					zend_message_dispatcher(ZMSG_MEMORY_LEAK_DETECTED, &leak);
-
-					zend_mm_bitset_reset_range(p->free_map, i, pages_count);
-
-					repeated = zend_mm_find_leaks(heap, p, i + pages_count, &leak);
-					total += 1 + repeated;
-					if (repeated) {
-						zend_message_dispatcher(ZMSG_MEMORY_LEAK_REPEATED, (void *)(uintptr_t)repeated);
-					}
-					i += pages_count;
-				}
-			} else {
-				i++;
-			}
+	ZEND_MM_ZONE_FOREACH(heap, zone) {
+		/* for each chunk */
+		p = zone->chunks;
+		if (p == NULL) {
+			continue;
 		}
-		p = p->next;
-	} while (p != heap->main_chunk);
+		do {
+			i = ZEND_MM_FIRST_PAGE;
+			while (i < p->free_tail) {
+				if (zend_mm_bitset_is_set(p->free_map, i)) {
+					if (p->map[i] & ZEND_MM_IS_SRUN) {
+						int bin_num = ZEND_MM_SRUN_BIN_NUM(p->map[i]);
+						zend_mm_debug_info *dbg = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * i + bin_data_size[bin_num] - ZEND_MM_ALIGNED_SIZE(sizeof(zend_mm_debug_info)));
+
+						j = 0;
+						while (j < bin_elements[bin_num]) {
+							if (dbg->size != 0) {
+								leak.addr = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * i + bin_data_size[bin_num] * j);
+								leak.size = dbg->size;
+								leak.filename = dbg->filename;
+								leak.orig_filename = dbg->orig_filename;
+								leak.lineno = dbg->lineno;
+								leak.orig_lineno = dbg->orig_lineno;
+
+								zend_message_dispatcher(ZMSG_LOG_SCRIPT_NAME, NULL);
+								zend_message_dispatcher(ZMSG_MEMORY_LEAK_DETECTED, &leak);
+
+								dbg->size = 0;
+								dbg->filename = NULL;
+								dbg->lineno = 0;
+
+								repeated = zend_mm_find_leaks_small(p, i, j + 1, &leak) +
+										   zend_mm_find_leaks(zone, p, i + bin_pages[bin_num], &leak);
+								total += 1 + repeated;
+								if (repeated) {
+									zend_message_dispatcher(ZMSG_MEMORY_LEAK_REPEATED, (void *)(uintptr_t)repeated);
+								}
+							}
+							dbg = (zend_mm_debug_info*)((char*)dbg + bin_data_size[bin_num]);
+							j++;
+						}
+						i += bin_pages[bin_num];
+					} else /* if (p->map[i] & ZEND_MM_IS_LRUN) */ {
+						int pages_count = ZEND_MM_LRUN_PAGES(p->map[i]);
+						zend_mm_debug_info *dbg = (zend_mm_debug_info*)((char*)p + ZEND_MM_PAGE_SIZE * (i + pages_count) - ZEND_MM_ALIGNED_SIZE(sizeof(zend_mm_debug_info)));
+
+						leak.addr = (void*)((char*)p + ZEND_MM_PAGE_SIZE * i);
+						leak.size = dbg->size;
+						leak.filename = dbg->filename;
+						leak.orig_filename = dbg->orig_filename;
+						leak.lineno = dbg->lineno;
+						leak.orig_lineno = dbg->orig_lineno;
+
+						zend_message_dispatcher(ZMSG_LOG_SCRIPT_NAME, NULL);
+						zend_message_dispatcher(ZMSG_MEMORY_LEAK_DETECTED, &leak);
+
+						zend_mm_bitset_reset_range(p->free_map, i, pages_count);
+
+						repeated = zend_mm_find_leaks(zone, p, i + pages_count, &leak);
+						total += 1 + repeated;
+						if (repeated) {
+							zend_message_dispatcher(ZMSG_MEMORY_LEAK_REPEATED, (void *)(uintptr_t)repeated);
+						}
+						i += pages_count;
+					}
+				} else {
+					i++;
+				}
+			}
+			p = p->next;
+		} while (p != zone->chunks);
+	} ZEND_MM_ZONE_FOREACH_END();
 	if (total) {
 		zend_message_dispatcher(ZMSG_MEMORY_LEAKS_GRAND_TOTAL, &total);
 	}
@@ -2433,6 +2543,7 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 {
 	zend_mm_chunk *p;
 	zend_mm_huge_list *list;
+	zend_mm_zone *zone;
 
 #if ZEND_MM_CUSTOM
 	if (heap->use_custom_heap) {
@@ -2475,16 +2586,25 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 		zend_mm_chunk_free(heap, q->ptr, q->size);
 	}
 
-	/* move all chunks except of the first one into the cache */
-	p = heap->main_chunk->next;
-	while (p != heap->main_chunk) {
-		zend_mm_chunk *q = p->next;
-		p->next = heap->cached_chunks;
-		heap->cached_chunks = p;
-		p = q;
-		heap->chunks_count--;
-		heap->cached_chunks_count++;
-	}
+	/* move all chunks except of the main one into the cache */
+	ZEND_MM_ZONE_FOREACH(heap, zone) {
+		p = zone->chunks;
+		if (p == NULL) {
+			continue;
+		}
+		do {
+			zend_mm_chunk *q = p->next;
+			if (p == heap->main_chunk) {
+				p = q;
+				continue;
+			}
+			p->next = heap->cached_chunks;
+			heap->cached_chunks = p;
+			p = q;
+			heap->chunks_count--;
+			heap->cached_chunks_count++;
+		} while (p != zone->chunks);
+	} ZEND_MM_ZONE_FOREACH_END();
 
 	if (full) {
 		/* free all cached chunks */
@@ -2498,6 +2618,7 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 	} else {
 		/* free some cached chunks to keep average count */
 		heap->avg_chunks_count = (heap->avg_chunks_count + (double)heap->peak_chunks_count) / 2.0;
+
 		while ((double)heap->cached_chunks_count + 0.9 > heap->avg_chunks_count &&
 		       heap->cached_chunks) {
 			p = heap->cached_chunks;
@@ -2537,6 +2658,16 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 		heap->peak_chunks_count = 1;
 		heap->last_chunks_delete_boundary = 0;
 		heap->last_chunks_delete_count = 0;
+
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+		heap->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(heap, ZEND_MM_ZONE_DEFAULT);
+#endif
+		heap->zones[0].chunks = p;
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+		heap->zones[1].chunks = NULL;
+		ZEND_MM_CHECK(p->zone == &heap->zones[0], "zend_mm_heap corrupted");
+		ZEND_MM_CHECK(p->zone_free_slot == ZEND_MM_ZONE_FREE_SLOT(heap, ZEND_MM_ZONE_DEFAULT), "zend_mm_heap corrupted");
+#endif
 
 		memset(p->free_map, 0, sizeof(p->free_map) + sizeof(p->map));
 		p->free_map[0] = (1L << ZEND_MM_FIRST_PAGE) - 1;
@@ -2603,6 +2734,7 @@ ZEND_API size_t ZEND_FASTCALL _zend_mm_block_size(zend_mm_heap *heap, void *ptr 
 
 typedef struct _zend_alloc_globals {
 	zend_mm_heap *mm_heap;
+	int use_input_zone;
 } zend_alloc_globals;
 
 #ifdef ZTS
@@ -2612,6 +2744,10 @@ static size_t alloc_globals_offset;
 #else
 # define AG(v) (alloc_globals.v)
 static zend_alloc_globals alloc_globals;
+#endif
+
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+# define ZEND_MM_ZONE_INPUT 1
 #endif
 
 ZEND_API bool is_zend_mm(void)
@@ -2662,6 +2798,33 @@ ZEND_API bool is_zend_ptr(const void *ptr)
 		} while (block != AG(mm_heap)->huge_list);
 	}
 	return 0;
+}
+
+ZEND_API void zend_mm_input_begin(void)
+{
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	AG(use_input_zone)++;
+	AG(mm_heap)->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(AG(mm_heap), ZEND_MM_ZONE_INPUT);
+#endif
+}
+
+ZEND_API void zend_mm_input_end(void)
+{
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	AG(use_input_zone)--;
+	if (!AG(use_input_zone)) {
+		AG(mm_heap)->zone_free_slot = ZEND_MM_ZONE_FREE_SLOT(AG(mm_heap), ZEND_MM_ZONE_DEFAULT);
+	}
+#endif
+}
+
+ZEND_API bool zend_mm_check_in_input(void)
+{
+#if ZEND_MM_HEAP_SPRAYING_PROTECTION
+	return AG(use_input_zone);
+#else
+	return true;
+#endif
 }
 
 #if !ZEND_DEBUG && defined(HAVE_BUILTIN_CONSTANT_P)
@@ -2722,7 +2885,7 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 			ZEND_MM_CHECK(chunk->heap == AG(mm_heap), "zend_mm_heap corrupted"); \
 			ZEND_ASSERT(chunk->map[page_num] & ZEND_MM_IS_SRUN); \
 			ZEND_ASSERT(ZEND_MM_SRUN_BIN_NUM(chunk->map[page_num]) == _num); \
-			zend_mm_free_small(AG(mm_heap), ptr, _num); \
+			zend_mm_free_small(AG(mm_heap), chunk, ptr, _num); \
 		} \
 	}
 #else
@@ -2736,7 +2899,7 @@ ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size)
 		{ \
 			zend_mm_chunk *chunk = (zend_mm_chunk*)ZEND_MM_ALIGNED_BASE(ptr, ZEND_MM_CHUNK_SIZE); \
 			ZEND_MM_CHECK(chunk->heap == AG(mm_heap), "zend_mm_heap corrupted"); \
-			zend_mm_free_small(AG(mm_heap), ptr, _num); \
+			zend_mm_free_small(AG(mm_heap), chunk, ptr, _num); \
 		} \
 	}
 #endif
@@ -2959,6 +3122,12 @@ ZEND_API void zend_memory_reset_peak_usage(void)
 ZEND_API void shutdown_memory_manager(bool silent, bool full_shutdown)
 {
 	zend_mm_shutdown(AG(mm_heap), full_shutdown, silent);
+
+	if (!full_shutdown) {
+		ZEND_ASSERT(AG(use_input_zone) == 0 || silent);
+		AG(use_input_zone) = 0;
+		zend_mm_input_begin();
+	}
 }
 
 static ZEND_COLD ZEND_NORETURN void zend_out_of_memory(void)
@@ -3061,6 +3230,8 @@ static void tracked_free_all(void) {
 static void alloc_globals_ctor(zend_alloc_globals *alloc_globals)
 {
 	char *tmp;
+
+	alloc_globals->use_input_zone = 0;
 
 #if ZEND_MM_CUSTOM
 	tmp = getenv("USE_ZEND_ALLOC");

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1317,7 +1317,7 @@ static zend_always_inline int zend_mm_small_size_to_bin(size_t size)
 #define ZEND_MM_FREE_SLOT_PTR_SHADOW(free_slot, bin_num) \
 	*((zend_mm_free_slot**)((char*)(free_slot) + bin_data_size[(bin_num)] - sizeof(zend_mm_free_slot*)))
 
-static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(zend_mm_heap *heap, zend_mm_free_slot *slot)
+static zend_always_inline zend_mm_free_slot* zend_mm_encode_free_slot(const zend_mm_heap *heap, const zend_mm_free_slot *slot)
 {
 #if WORDS_BIGENDIAN
 	return (zend_mm_free_slot*)(((uintptr_t)slot) ^ heap->shadow_key);
@@ -1350,8 +1350,8 @@ static zend_always_inline void zend_mm_copy_next_free_slot(zend_mm_free_slot* de
 static zend_always_inline zend_mm_free_slot *zend_mm_check_next_free_slot(zend_mm_heap *heap, uint32_t bin_num, zend_mm_free_slot* slot)
 {
 	zend_mm_free_slot *next = slot->next_free_slot;
-	zend_mm_free_slot *shadow = ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num);
 	if (EXPECTED(next != NULL)) {
+		zend_mm_free_slot *shadow = ZEND_MM_FREE_SLOT_PTR_SHADOW(slot, bin_num);
 		if (UNEXPECTED(next != zend_mm_decode_free_slot(heap, shadow))) {
 			zend_mm_panic("zend_mm_heap corrupted");
 		}

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -221,6 +221,9 @@ ZEND_API void start_memory_manager(void);
 ZEND_API void shutdown_memory_manager(bool silent, bool full_shutdown);
 ZEND_API bool is_zend_mm(void);
 ZEND_API bool is_zend_ptr(const void *ptr);
+ZEND_API void zend_mm_input_begin(void);
+ZEND_API void zend_mm_input_end(void);
+ZEND_API bool zend_mm_check_in_input(void);
 
 ZEND_API size_t zend_memory_usage(bool real_usage);
 ZEND_API size_t zend_memory_peak_usage(bool real_usage);

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -90,7 +90,7 @@ ZEND_API ZEND_ATTRIBUTE_MALLOC void* ZEND_FASTCALL _emalloc_large(size_t size) Z
 ZEND_API ZEND_ATTRIBUTE_MALLOC void* ZEND_FASTCALL _emalloc_huge(size_t size) ZEND_ATTRIBUTE_ALLOC_SIZE(1);
 
 # define _ZEND_BIN_ALLOCATOR_SELECTOR_START(_num, _size, _elements, _pages, size, y) \
-	((size <= _size) ? _emalloc_ ## _size() :
+	((size <= _size && _size >= ZEND_MM_MIN_SMALL_SIZE) ? _emalloc_ ## _size() :
 # define _ZEND_BIN_ALLOCATOR_SELECTOR_END(_num, _size, _elements, _pages, size, y) \
 	)
 
@@ -115,7 +115,7 @@ ZEND_API void ZEND_FASTCALL _efree_large(void *, size_t size);
 ZEND_API void ZEND_FASTCALL _efree_huge(void *, size_t size);
 
 # define _ZEND_BIN_DEALLOCATOR_SELECTOR_START(_num, _size, _elements, _pages, ptr, size) \
-	if (size <= _size) { _efree_ ## _size(ptr); } else
+	if (size <= _size && _size >= ZEND_MM_MIN_SMALL_SIZE) { _efree_ ## _size(ptr); } else
 
 # define ZEND_DEALLOCATOR(ptr, size) \
 	ZEND_MM_BINS_INFO(_ZEND_BIN_DEALLOCATOR_SELECTOR_START, ptr, size) \

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -90,7 +90,7 @@ ZEND_API ZEND_ATTRIBUTE_MALLOC void* ZEND_FASTCALL _emalloc_large(size_t size) Z
 ZEND_API ZEND_ATTRIBUTE_MALLOC void* ZEND_FASTCALL _emalloc_huge(size_t size) ZEND_ATTRIBUTE_ALLOC_SIZE(1);
 
 # define _ZEND_BIN_ALLOCATOR_SELECTOR_START(_num, _size, _elements, _pages, size, y) \
-	((size <= _size && _size >= ZEND_MM_MIN_SMALL_SIZE) ? _emalloc_ ## _size() :
+	((size <= _size) ? _emalloc_ ## _size() :
 # define _ZEND_BIN_ALLOCATOR_SELECTOR_END(_num, _size, _elements, _pages, size, y) \
 	)
 
@@ -115,7 +115,7 @@ ZEND_API void ZEND_FASTCALL _efree_large(void *, size_t size);
 ZEND_API void ZEND_FASTCALL _efree_huge(void *, size_t size);
 
 # define _ZEND_BIN_DEALLOCATOR_SELECTOR_START(_num, _size, _elements, _pages, ptr, size) \
-	if (size <= _size && _size >= ZEND_MM_MIN_SMALL_SIZE) { _efree_ ## _size(ptr); } else
+	if (size <= _size) { _efree_ ## _size(ptr); } else
 
 # define ZEND_DEALLOCATOR(ptr, size) \
 	ZEND_MM_BINS_INFO(_ZEND_BIN_DEALLOCATOR_SELECTOR_START, ptr, size) \

--- a/Zend/zend_alloc_sizes.h
+++ b/Zend/zend_alloc_sizes.h
@@ -19,20 +19,12 @@
 #ifndef ZEND_ALLOC_SIZES_H
 #define ZEND_ALLOC_SIZES_H
 
-#ifndef ZEND_MM_HEAP_PROTECTION
-# define ZEND_MM_HEAP_PROTECTION 1 /* protect heap against corruptions       */
-#endif
-
 #define ZEND_MM_CHUNK_SIZE ((size_t) (2 * 1024 * 1024))    /* 2 MB  */
 #define ZEND_MM_PAGE_SIZE  (4 * 1024)                      /* 4 KB  */
 #define ZEND_MM_PAGES      (ZEND_MM_CHUNK_SIZE / ZEND_MM_PAGE_SIZE)  /* 512 */
 #define ZEND_MM_FIRST_PAGE (1)
 
-#if ZEND_MM_HEAP_PROTECTION
-# define ZEND_MM_MIN_SMALL_SIZE     (sizeof(void*) * 2)
-#else
-# define ZEND_MM_MIN_SMALL_SIZE     8
-#endif
+#define ZEND_MM_MIN_SMALL_SIZE      8
 #define ZEND_MM_MAX_SMALL_SIZE      3072
 #define ZEND_MM_MAX_LARGE_SIZE      (ZEND_MM_CHUNK_SIZE - (ZEND_MM_PAGE_SIZE * ZEND_MM_FIRST_PAGE))
 

--- a/Zend/zend_alloc_sizes.h
+++ b/Zend/zend_alloc_sizes.h
@@ -19,12 +19,20 @@
 #ifndef ZEND_ALLOC_SIZES_H
 #define ZEND_ALLOC_SIZES_H
 
+#ifndef ZEND_MM_HEAP_PROTECTION
+# define ZEND_MM_HEAP_PROTECTION 1 /* protect heap against corruptions       */
+#endif
+
 #define ZEND_MM_CHUNK_SIZE ((size_t) (2 * 1024 * 1024))    /* 2 MB  */
 #define ZEND_MM_PAGE_SIZE  (4 * 1024)                      /* 4 KB  */
 #define ZEND_MM_PAGES      (ZEND_MM_CHUNK_SIZE / ZEND_MM_PAGE_SIZE)  /* 512 */
 #define ZEND_MM_FIRST_PAGE (1)
 
-#define ZEND_MM_MIN_SMALL_SIZE		8
+#if ZEND_MM_HEAP_PROTECTION
+# define ZEND_MM_MIN_SMALL_SIZE     (sizeof(void*) * 2)
+#else
+# define ZEND_MM_MIN_SMALL_SIZE     8
+#endif
 #define ZEND_MM_MAX_SMALL_SIZE      3072
 #define ZEND_MM_MAX_LARGE_SIZE      (ZEND_MM_CHUNK_SIZE - (ZEND_MM_PAGE_SIZE * ZEND_MM_FIRST_PAGE))
 

--- a/Zend/zend_atomic.c
+++ b/Zend/zend_atomic.c
@@ -20,19 +20,41 @@
  * is also where the code will go.
  */
 
-/* Defined for FFI users; everyone else use ZEND_ATOMIC_BOOL_INIT.
+/* Defined for FFI users; everyone else use ZEND_ATOMIC_*_INIT.
  * This is NOT ATOMIC as it is meant for initialization.
  */
 ZEND_API void zend_atomic_bool_init(zend_atomic_bool *obj, bool desired) {
 	ZEND_ATOMIC_BOOL_INIT(obj, desired);
 }
 
+ZEND_API void zend_atomic_int_init(zend_atomic_int *obj, int desired) {
+	ZEND_ATOMIC_INT_INIT(obj, desired);
+}
+
 ZEND_API bool zend_atomic_bool_exchange(zend_atomic_bool *obj, bool desired) {
 	return zend_atomic_bool_exchange_ex(obj, desired);
 }
 
+ZEND_API int zend_atomic_int_exchange(zend_atomic_int *obj, int desired) {
+	return zend_atomic_int_exchange_ex(obj, desired);
+}
+
+ZEND_API bool zend_atomic_bool_compare_exchange(zend_atomic_bool *obj, bool *expected, bool desired)
+{
+	return zend_atomic_bool_compare_exchange_ex(obj, expected, desired);
+}
+
+ZEND_API bool zend_atomic_int_compare_exchange(zend_atomic_int *obj, int *expected, int desired)
+{
+	return zend_atomic_int_compare_exchange_ex(obj, expected, desired);
+}
+
 ZEND_API void zend_atomic_bool_store(zend_atomic_bool *obj, bool desired) {
 	zend_atomic_bool_store_ex(obj, desired);
+}
+
+ZEND_API void zend_atomic_int_store(zend_atomic_int *obj, int desired) {
+	zend_atomic_int_store_ex(obj, desired);
 }
 
 #if defined(ZEND_WIN32) || defined(HAVE_SYNC_ATOMICS)
@@ -40,8 +62,14 @@ ZEND_API void zend_atomic_bool_store(zend_atomic_bool *obj, bool desired) {
 ZEND_API bool zend_atomic_bool_load(zend_atomic_bool *obj) {
 	return zend_atomic_bool_load_ex(obj);
 }
+ZEND_API int zend_atomic_int_load(zend_atomic_int *obj) {
+	return zend_atomic_int_load_ex(obj);
+}
 #else
 ZEND_API bool zend_atomic_bool_load(const zend_atomic_bool *obj) {
 	return zend_atomic_bool_load_ex(obj);
+}
+ZEND_API int zend_atomic_int_load(const zend_atomic_int *obj) {
+	return zend_atomic_int_load_ex(obj);
 }
 #endif

--- a/Zend/zend_atomic.h
+++ b/Zend/zend_atomic.h
@@ -43,14 +43,27 @@
 typedef struct zend_atomic_bool_s {
 	volatile char value;
 } zend_atomic_bool;
+typedef struct zend_atomic_int_s {
+# ifdef ZEND_WIN32
+	volatile long value;
+# else
+	volatile int value;
+# endif
+} zend_atomic_int;
 #elif defined(HAVE_C11_ATOMICS)
 typedef struct zend_atomic_bool_s {
 	_Atomic(bool) value;
 } zend_atomic_bool;
+typedef struct zend_atomic_int_s {
+	_Atomic(int) value;
+} zend_atomic_int;
 #else
 typedef struct zend_atomic_bool_s {
 	volatile bool value;
 } zend_atomic_bool;
+typedef struct zend_atomic_int_s {
+	volatile int value;
+} zend_atomic_int;
 #endif
 
 BEGIN_EXTERN_C()
@@ -63,11 +76,51 @@ BEGIN_EXTERN_C()
 #ifndef InterlockedOr8
 #define InterlockedOr8 _InterlockedOr8
 #endif
+#ifndef InterlockedCompareExchange8
+#define InterlockedCompareExchange8 _InterlockedCompareExchange8
+#endif
+#ifndef InterlockedExchange
+#define InterlockedExchange _InterlockedExchange
+#endif
+#ifndef InterlockedOr
+#define InterlockedOr _InterlockedOr
+#endif
+#ifndef InterlockedCompareExchange
+#define InterlockedCompareExchange _InterlockedCompareExchange
+#endif
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) ((obj)->value = (desired))
+#define ZEND_ATOMIC_INT_INIT(obj, desired)  ((obj)->value = (desired))
+
+#define ZEND_ATOMIC_BOOL_INITIALIZER(desired) {.value = (desired)}
+#define ZEND_ATOMIC_INT_INITIALIZER(desired)  {.value = (desired)}
 
 static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *obj, bool desired) {
 	return InterlockedExchange8(&obj->value, desired);
+}
+
+static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
+	return (int) InterlockedExchange(&obj->value, desired);
+}
+
+static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
+	bool prev = (bool) InterlockedCompareExchange8(&obj->value, *expected, desired);
+	if (prev == *expected) {
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
+}
+
+static zend_always_inline bool zend_atomic_int_compare_exchange_ex(zend_atomic_int *obj, int *expected, int desired) {
+	int prev = (int) InterlockedCompareExchange(&obj->value, *expected, desired);
+	if (prev == *expected) {
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
 }
 
 /* On this platform it is non-const due to Iterlocked API*/
@@ -76,19 +129,48 @@ static zend_always_inline bool zend_atomic_bool_load_ex(zend_atomic_bool *obj) {
 	return InterlockedOr8(&obj->value, false);
 }
 
+static zend_always_inline int zend_atomic_int_load_ex(zend_atomic_int *obj) {
+	/* Or'ing with 0 won't change the value. */
+	return (int) InterlockedOr(&obj->value, 0);
+}
+
 static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, bool desired) {
 	(void)InterlockedExchange8(&obj->value, desired);
+}
+
+static zend_always_inline void zend_atomic_int_store_ex(zend_atomic_int *obj, int desired) {
+	(void)InterlockedExchange(&obj->value, desired);
 }
 
 #elif defined(HAVE_C11_ATOMICS)
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) __c11_atomic_init(&(obj)->value, (desired))
+#define ZEND_ATOMIC_INT_INIT(obj, desired)  __c11_atomic_init(&(obj)->value, (desired))
+
+#define ZEND_ATOMIC_BOOL_INITIALIZER(desired) {.value = (desired)}
+#define ZEND_ATOMIC_INT_INITIALIZER(desired)  {.value = (desired)}
 
 static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *obj, bool desired) {
 	return __c11_atomic_exchange(&obj->value, desired, __ATOMIC_SEQ_CST);
 }
 
+static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
+	return __c11_atomic_exchange(&obj->value, desired, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
+	return __c11_atomic_compare_exchange_strong(&obj->value, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline bool zend_atomic_int_compare_exchange_ex(zend_atomic_int *obj, int *expected, int desired) {
+	return __c11_atomic_compare_exchange_strong(&obj->value, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
 static zend_always_inline bool zend_atomic_bool_load_ex(const zend_atomic_bool *obj) {
+	return __c11_atomic_load(&obj->value, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline int zend_atomic_int_load_ex(const zend_atomic_int *obj) {
 	return __c11_atomic_load(&obj->value, __ATOMIC_SEQ_CST);
 }
 
@@ -96,14 +178,38 @@ static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, 
 	__c11_atomic_store(&obj->value, desired, __ATOMIC_SEQ_CST);
 }
 
+static zend_always_inline void zend_atomic_int_store_ex(zend_atomic_int *obj, int desired) {
+	__c11_atomic_store(&obj->value, desired, __ATOMIC_SEQ_CST);
+}
+
 #elif defined(HAVE_GNUC_ATOMICS)
 
+/* bool */
+
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) ((obj)->value = (desired))
+#define ZEND_ATOMIC_INT_INIT(obj, desired)  ((obj)->value = (desired))
+
+#define ZEND_ATOMIC_BOOL_INITIALIZER(desired) {.value = (desired)}
+#define ZEND_ATOMIC_INT_INITIALIZER(desired)  {.value = (desired)}
 
 static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *obj, bool desired) {
 	bool prev = false;
 	__atomic_exchange(&obj->value, &desired, &prev, __ATOMIC_SEQ_CST);
 	return prev;
+}
+
+static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
+	int prev = false;
+	__atomic_exchange(&obj->value, &desired, &prev, __ATOMIC_SEQ_CST);
+	return prev;
+}
+
+static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
+	return __atomic_compare_exchange(&obj->value, expected, &desired, /* weak */ false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline bool zend_atomic_int_compare_exchange_ex(zend_atomic_int *obj, int *expected, int desired) {
+	return __atomic_compare_exchange(&obj->value, expected, &desired, /* weak */ false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 
 static zend_always_inline bool zend_atomic_bool_load_ex(const zend_atomic_bool *obj) {
@@ -112,13 +218,27 @@ static zend_always_inline bool zend_atomic_bool_load_ex(const zend_atomic_bool *
 	return prev;
 }
 
+static zend_always_inline int zend_atomic_int_load_ex(const zend_atomic_int *obj) {
+	int prev = false;
+	__atomic_load(&obj->value, &prev, __ATOMIC_SEQ_CST);
+	return prev;
+}
+
 static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, bool desired) {
+	__atomic_store(&obj->value, &desired, __ATOMIC_SEQ_CST);
+}
+
+static zend_always_inline void zend_atomic_int_store_ex(zend_atomic_int *obj, int desired) {
 	__atomic_store(&obj->value, &desired, __ATOMIC_SEQ_CST);
 }
 
 #elif defined(HAVE_SYNC_ATOMICS)
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) ((obj)->value = (desired))
+#define ZEND_ATOMIC_INT_INIT(obj, desired)  ((obj)->value = (desired))
+
+#define ZEND_ATOMIC_BOOL_INITIALIZER(desired) {.value = (desired)}
+#define ZEND_ATOMIC_INT_INITIALIZER(desired)  {.value = (desired)}
 
 static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *obj, bool desired) {
 	bool prev = __sync_lock_test_and_set(&obj->value, desired);
@@ -130,12 +250,53 @@ static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *ob
 	return prev;
 }
 
+static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
+	int prev = __sync_lock_test_and_set(&obj->value, desired);
+
+	/* __sync_lock_test_and_set only does an acquire barrier, so sync
+	 * immediately after.
+	 */
+	__sync_synchronize();
+	return prev;
+}
+
+static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_bool *obj, bool *expected, bool desired) {
+	bool prev = __sync_val_compare_and_swap(&obj->value, *expected, desired);
+	if (prev == *expected) {
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
+}
+
+static zend_always_inline bool zend_atomic_int_compare_exchange_ex(zend_atomic_int *obj, int *expected, int desired) {
+	int prev = __sync_val_compare_and_swap(&obj->value, *expected, desired);
+	if (prev == *expected) {
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
+}
+
 static zend_always_inline bool zend_atomic_bool_load_ex(zend_atomic_bool *obj) {
 	/* Or'ing false won't change the value */
 	return __sync_fetch_and_or(&obj->value, false);
 }
 
+static zend_always_inline int zend_atomic_int_load_ex(zend_atomic_int *obj) {
+	/* Or'ing 0 won't change the value */
+	return __sync_fetch_and_or(&obj->value, 0);
+}
+
 static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, bool desired) {
+	__sync_synchronize();
+	obj->value = desired;
+	__sync_synchronize();
+}
+
+static zend_always_inline void zend_atomic_int_store_ex(zend_atomic_int *obj, int desired) {
 	__sync_synchronize();
 	obj->value = desired;
 	__sync_synchronize();
@@ -146,12 +307,46 @@ static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, 
 #warning No atomics support detected. Please open an issue with platform details.
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) ((obj)->value = (desired))
+#define ZEND_ATOMIC_INT_INIT(obj, desired)  ((obj)->value = (desired))
+
+#define ZEND_ATOMIC_BOOL_INITIALIZER(desired) {.value = (desired)}
+#define ZEND_ATOMIC_INT_INITIALIZER(desired)  {.value = (desired)}
 
 static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, bool desired) {
 	obj->value = desired;
 }
 
+static zend_always_inline void zend_atomic_int_store_ex(zend_atomic_int *obj, int desired) {
+	obj->value = desired;
+}
+
+static zend_always_inline bool zend_atomic_bool_compare_exchange_ex(zend_atomic_int *obj, bool *expected, bool desired) {
+	bool prev = obj->value;
+	if (prev == *expected) {
+		obj->value = desired;
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
+}
+
+static zend_always_inline bool zend_atomic_int_compare_exchange_ex(zend_atomic_int *obj, int *expected, int desired) {
+	int prev = obj->value;
+	if (prev == *expected) {
+		obj->value = desired;
+		return true;
+	} else {
+		*expected = prev;
+		return false;
+	}
+}
+
 static zend_always_inline bool zend_atomic_bool_load_ex(const zend_atomic_bool *obj) {
+	return obj->value;
+}
+
+static zend_always_inline int zend_atomic_int_load_ex(const zend_atomic_int *obj) {
 	return obj->value;
 }
 
@@ -161,17 +356,33 @@ static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *ob
 	return prev;
 }
 
+static zend_always_inline int zend_atomic_int_exchange_ex(zend_atomic_int *obj, int desired) {
+	int prev = obj->value;
+	obj->value = desired;
+	return prev;
+}
+
 #endif
 
 ZEND_API void zend_atomic_bool_init(zend_atomic_bool *obj, bool desired);
+ZEND_API void zend_atomic_int_init(zend_atomic_int *obj, int desired);
+
 ZEND_API bool zend_atomic_bool_exchange(zend_atomic_bool *obj, bool desired);
+ZEND_API int zend_atomic_int_exchange(zend_atomic_int *obj, int desired);
+
+ZEND_API bool zend_atomic_bool_compare_exchange(zend_atomic_bool *obj, bool *expected, bool desired);
+ZEND_API bool zend_atomic_int_compare_exchange(zend_atomic_int *obj, int *expected, int desired);
+
 ZEND_API void zend_atomic_bool_store(zend_atomic_bool *obj, bool desired);
+ZEND_API void zend_atomic_int_store(zend_atomic_int *obj, int desired);
 
 #if defined(ZEND_WIN32) || defined(HAVE_SYNC_ATOMICS)
 /* On these platforms it is non-const due to underlying APIs. */
 ZEND_API bool zend_atomic_bool_load(zend_atomic_bool *obj);
+ZEND_API int zend_atomic_int_load(zend_atomic_int *obj);
 #else
 ZEND_API bool zend_atomic_bool_load(const zend_atomic_bool *obj);
+ZEND_API int zend_atomic_int_load(const zend_atomic_int *obj);
 #endif
 
 END_EXTERN_C()

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1916,7 +1916,9 @@ ZEND_API bool zend_is_auto_global_str(const char *name, size_t len) /* {{{ */ {
 
 	if ((auto_global = zend_hash_str_find_ptr(CG(auto_globals), name, len)) != NULL) {
 		if (auto_global->armed) {
+			zend_mm_input_begin();
 			auto_global->armed = auto_global->auto_global_callback(auto_global->name);
+			zend_mm_input_end();
 		}
 		return 1;
 	}
@@ -1930,7 +1932,9 @@ ZEND_API bool zend_is_auto_global(zend_string *name) /* {{{ */
 
 	if ((auto_global = zend_hash_find_ptr(CG(auto_globals), name)) != NULL) {
 		if (auto_global->armed) {
+			zend_mm_input_begin();
 			auto_global->armed = auto_global->auto_global_callback(auto_global->name);
+			zend_mm_input_end();
 		}
 		return 1;
 	}
@@ -1956,6 +1960,8 @@ ZEND_API zend_result zend_register_auto_global(zend_string *name, bool jit, zend
 ZEND_API void zend_activate_auto_globals(void) /* {{{ */
 {
 	zend_auto_global *auto_global;
+
+	ZEND_ASSERT(zend_mm_check_in_input());
 
 	ZEND_HASH_MAP_FOREACH_PTR(CG(auto_globals), auto_global) {
 		if (auto_global->jit) {
@@ -7714,7 +7720,7 @@ static zend_string *zend_begin_func_decl(znode *result, zend_op_array *op_array,
 		zend_string *separator = zend_empty_string;
 		zend_string *function = filename;
 		char *parens = "";
-		
+
 		if (CG(active_op_array) && CG(active_op_array)->function_name) {
 			if (CG(active_op_array)->fn_flags & ZEND_ACC_CLOSURE) {
 				/* If the parent function is a closure, don't redundantly

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -269,6 +269,16 @@ char *alloca();
 # define ZEND_ATTRIBUTE_UNUSED
 #endif
 
+#if ZEND_GCC_VERSION >= 3003 || __has_attribute(nonnull)
+/* All pointer arguments must be non-null */
+# define ZEND_ATTRIBUTE_NONNULL  __attribute__((nonnull))
+/* Specified arguments must be non-null (1-based) */
+# define ZEND_ATTRIBUTE_NONNULL_ARGS(...)  __attribute__((nonnull(__VA_ARGS__)))
+#else
+# define ZEND_ATTRIBUTE_NONNULL
+# define ZEND_ATTRIBUTE_NONNULL_ARGS(...)
+#endif
+
 #if defined(__GNUC__) && ZEND_GCC_VERSION >= 4003
 # define ZEND_COLD __attribute__((cold))
 # ifdef __OPTIMIZE__

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -791,4 +791,20 @@ extern "C++" {
 # define ZEND_STATIC_ASSERT(c, m)
 #endif
 
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) /* C11 */ \
+  || (defined(__cplusplus) && __cplusplus >= 201103L) /* C++11 */
+typedef max_align_t zend_max_align_t;
+#else
+typedef union {
+	char c;
+	short s;
+	int i;
+	long l;
+	float f;
+	double d;
+	void *p;
+	void (*fun)();
+} zend_max_align_t;
+#endif
+
 #endif /* ZEND_PORTABILITY_H */

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -800,8 +800,12 @@ typedef union {
 	short s;
 	int i;
 	long l;
+#if SIZEOF_LONG_LONG
+	long long ll;
+#endif
 	float f;
 	double d;
+	long double ld;
 	void *p;
 	void (*fun)();
 } zend_max_align_t;

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -22,6 +22,7 @@
 #include "main/php.h"
 #include "main/php_globals.h"
 #include "zend.h"
+#include "zend_alloc.h"
 #include "zend_extensions.h"
 #include "zend_compile.h"
 #include "ZendAccelerator.h"
@@ -4607,6 +4608,7 @@ static zend_result accel_finish_startup_preload(bool in_child)
 	orig_error_reporting = EG(error_reporting);
 	EG(error_reporting) = 0;
 
+	zend_mm_input_begin();
 	const zend_result rc = php_request_startup();
 
 	EG(error_reporting) = orig_error_reporting;

--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -27,6 +27,7 @@ PHP_NEW_EXTENSION(random,
       engine_secure.c \
       engine_user.c \
       gammasection.c \
-      randomizer.c,
+      randomizer.c \
+      zend_utils.c,
       no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 PHP_INSTALL_HEADERS([ext/random], [php_random.h php_random_csprng.h php_random_uint128.h])

--- a/ext/random/config.w32
+++ b/ext/random/config.w32
@@ -1,4 +1,4 @@
 EXTENSION("random", "random.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 PHP_RANDOM="yes";
-ADD_SOURCES(configure_module_dirname, "csprng.c engine_combinedlcg.c engine_mt19937.c engine_pcgoneseq128xslrr64.c engine_xoshiro256starstar.c engine_secure.c engine_user.c gammasection.c randomizer.c", "random");
+ADD_SOURCES(configure_module_dirname, "csprng.c engine_combinedlcg.c engine_mt19937.c engine_pcgoneseq128xslrr64.c engine_xoshiro256starstar.c engine_secure.c engine_user.c gammasection.c randomizer.c zend_utils.c", "random");
 PHP_INSTALL_HEADERS("ext/random", "php_random.h php_random_csprng.h php_random_uint128.h");

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -62,22 +62,17 @@
 # include <sanitizer/msan_interface.h>
 #endif
 
-#define php_random_bytes_error(...) do { \
-		if (errstr) { \
-			snprintf(errstr, errstr_size, __VA_ARGS__); \
-		} \
-	} while (0)
-
 #ifndef PHP_WIN32
 static zend_atomic_int random_fd = ZEND_ATOMIC_INT_INITIALIZER(-1);
 #endif
 
+ZEND_ATTRIBUTE_NONNULL
 PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size)
 {
 #ifdef PHP_WIN32
 	/* Defer to CryptGenRandom on Windows */
 	if (php_win32_get_random_bytes(bytes, size) == FAILURE) {
-		php_random_bytes_error("Failed to retrieve randomness from the operating system (BCryptGenRandom)");
+		snprintf(errstr, errstr_size, "Failed to retrieve randomness from the operating system (BCryptGenRandom)");
 		return FAILURE;
 	}
 #elif HAVE_COMMONCRYPTO_COMMONRANDOM_H
@@ -88,7 +83,7 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 	 * the vast majority of the time, it works fine ; but better make sure we catch failures
 	 */
 	if (CCRandomGenerateBytes(bytes, size) != kCCSuccess) {
-		php_random_bytes_error("Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)");
+		snprintf(errstr, errstr_size, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)");
 		return FAILURE;
 	}
 #elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001 && __NetBSD_Version__ < 1000000000) || \
@@ -162,9 +157,9 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 			fd = open("/dev/urandom", O_RDONLY);
 			if (fd < 0) {
 				if (errno != 0) {
-					php_random_bytes_error("Cannot open /dev/urandom: %s", strerror(errno));
+					snprintf(errstr, errstr_size, "Cannot open /dev/urandom: %s", strerror(errno));
 				} else {
-					php_random_bytes_error("Cannot open /dev/urandom");
+					snprintf(errstr, errstr_size, "Cannot open /dev/urandom");
 				}
 				return FAILURE;
 			}
@@ -180,9 +175,9 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 			) {
 				close(fd);
 				if (errno != 0) {
-					php_random_bytes_error("Error reading from /dev/urandom: %s", strerror(errno));
+					snprintf(errstr, errstr_size, "Error reading from /dev/urandom: %s", strerror(errno));
 				} else {
-					php_random_bytes_error("Error reading from /dev/urandom");
+					snprintf(errstr, errstr_size, "Error reading from /dev/urandom");
 				}
 				return FAILURE;
 			}
@@ -201,9 +196,9 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 
 			if (n <= 0) {
 				if (errno != 0) {
-					php_random_bytes_error("Could not gather sufficient random data: %s", strerror(errno));
+					snprintf(errstr, errstr_size, "Could not gather sufficient random data: %s", strerror(errno));
 				} else {
-					php_random_bytes_error("Could not gather sufficient random data");
+					snprintf(errstr, errstr_size, "Could not gather sufficient random data");
 				}
 				return FAILURE;
 			}
@@ -219,9 +214,7 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 {
 	char errstr[128];
-
-	zend_result result = php_random_bytes_ex(bytes, size,
-			should_throw ? errstr : NULL, should_throw ? sizeof(errstr) : 0);
+	zend_result result = php_random_bytes_ex(bytes, size, errstr, sizeof(errstr));
 
 	if (result == FAILURE && should_throw) {
 		zend_throw_exception(random_ce_Random_RandomException, errstr, 0);

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -48,7 +48,7 @@
 #if HAVE_SYS_PARAM_H
 # include <sys/param.h>
 # if (__FreeBSD__ && __FreeBSD_version > 1200000) || (__DragonFly__ && __DragonFly_version >= 500700) || \
-     defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000)
+     defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000) || defined(__midipix__)
 #  include <sys/random.h>
 # endif
 #endif
@@ -106,7 +106,7 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 #else
 	size_t read_bytes = 0;
 # if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || \
-  defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000)
+  defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000) || defined(__midipix__)
 	/* Linux getrandom(2) syscall or FreeBSD/DragonFlyBSD/NetBSD getrandom(2) function
 	 * Being a syscall, implemented in the kernel, getrandom offers higher quality output
 	 * compared to the arc4random api albeit a fallback to /dev/urandom is considered.

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -66,8 +66,7 @@
 static zend_atomic_int random_fd = ZEND_ATOMIC_INT_INITIALIZER(-1);
 #endif
 
-ZEND_ATTRIBUTE_NONNULL
-PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size)
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size)
 {
 #ifdef PHP_WIN32
 	/* Defer to CryptGenRandom on Windows */
@@ -211,7 +210,7 @@ PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, s
 	return SUCCESS;
 }
 
-PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 {
 	char errstr[128];
 	zend_result result = php_random_bytes_ex(bytes, size, errstr, sizeof(errstr));

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -26,6 +26,7 @@
 #include "php.h"
 
 #include "Zend/zend_exceptions.h"
+#include "Zend/zend_atomic.h"
 
 #include "php_random.h"
 #include "php_random_csprng.h"
@@ -47,7 +48,7 @@
 #if HAVE_SYS_PARAM_H
 # include <sys/param.h>
 # if (__FreeBSD__ && __FreeBSD_version > 1200000) || (__DragonFly__ && __DragonFly_version >= 500700) || \
-     defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000) || defined(__midipix__)
+     defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000)
 #  include <sys/random.h>
 # endif
 #endif
@@ -61,14 +62,22 @@
 # include <sanitizer/msan_interface.h>
 #endif
 
-PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
+#define php_random_bytes_error(...) do { \
+		if (errstr) { \
+			snprintf(errstr, errstr_size, __VA_ARGS__); \
+		} \
+	} while (0)
+
+#ifndef PHP_WIN32
+static zend_atomic_int random_fd = ZEND_ATOMIC_INT_INITIALIZER(-1);
+#endif
+
+PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size)
 {
 #ifdef PHP_WIN32
 	/* Defer to CryptGenRandom on Windows */
 	if (php_win32_get_random_bytes(bytes, size) == FAILURE) {
-		if (should_throw) {
-			zend_throw_exception(random_ce_Random_RandomException, "Failed to retrieve randomness from the operating system (BCryptGenRandom)", 0);
-		}
+		php_random_bytes_error("Failed to retrieve randomness from the operating system (BCryptGenRandom)");
 		return FAILURE;
 	}
 #elif HAVE_COMMONCRYPTO_COMMONRANDOM_H
@@ -79,9 +88,7 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 	 * the vast majority of the time, it works fine ; but better make sure we catch failures
 	 */
 	if (CCRandomGenerateBytes(bytes, size) != kCCSuccess) {
-		if (should_throw) {
-			zend_throw_exception(random_ce_Random_RandomException, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)", 0);
-		}
+		php_random_bytes_error("Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)");
 		return FAILURE;
 	}
 #elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001 && __NetBSD_Version__ < 1000000000) || \
@@ -99,7 +106,7 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 #else
 	size_t read_bytes = 0;
 # if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || \
-  defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000) || defined(__midipix__)
+  defined(__sun) || (defined(__NetBSD__) && __NetBSD_Version__ >= 1000000000)
 	/* Linux getrandom(2) syscall or FreeBSD/DragonFlyBSD/NetBSD getrandom(2) function
 	 * Being a syscall, implemented in the kernel, getrandom offers higher quality output
 	 * compared to the arc4random api albeit a fallback to /dev/urandom is considered.
@@ -147,19 +154,17 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 	}
 # endif
 	if (read_bytes < size) {
-		int    fd = RANDOM_G(random_fd);
+		int    fd = zend_atomic_int_load_ex(&random_fd);
 		struct stat st;
 
 		if (fd < 0) {
 			errno = 0;
 			fd = open("/dev/urandom", O_RDONLY);
 			if (fd < 0) {
-				if (should_throw) {
-					if (errno != 0) {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Cannot open /dev/urandom: %s", strerror(errno));
-					} else {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Cannot open /dev/urandom");
-					}
+				if (errno != 0) {
+					php_random_bytes_error("Cannot open /dev/urandom: %s", strerror(errno));
+				} else {
+					php_random_bytes_error("Cannot open /dev/urandom");
 				}
 				return FAILURE;
 			}
@@ -174,16 +179,19 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 # endif
 			) {
 				close(fd);
-				if (should_throw) {
-					if (errno != 0) {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Error reading from /dev/urandom: %s", strerror(errno));
-					} else {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Error reading from /dev/urandom");
-					}
+				if (errno != 0) {
+					php_random_bytes_error("Error reading from /dev/urandom: %s", strerror(errno));
+				} else {
+					php_random_bytes_error("Error reading from /dev/urandom");
 				}
 				return FAILURE;
 			}
-			RANDOM_G(random_fd) = fd;
+			int expected = -1;
+			if (!zend_atomic_int_compare_exchange_ex(&random_fd, &expected, fd)) {
+				close(fd);
+				/* expected is now the actual value of random_fd */
+				fd = expected;
+			}
 		}
 
 		read_bytes = 0;
@@ -192,12 +200,10 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 			ssize_t n = read(fd, bytes + read_bytes, size - read_bytes);
 
 			if (n <= 0) {
-				if (should_throw) {
-					if (errno != 0) {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data: %s", strerror(errno));
-					} else {
-						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data");
-					}
+				if (errno != 0) {
+					php_random_bytes_error("Could not gather sufficient random data: %s", strerror(errno));
+				} else {
+					php_random_bytes_error("Could not gather sufficient random data");
 				}
 				return FAILURE;
 			}
@@ -208,6 +214,20 @@ PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 #endif
 
 	return SUCCESS;
+}
+
+PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
+{
+	char errstr[128];
+
+	zend_result result = php_random_bytes_ex(bytes, size,
+			should_throw ? errstr : NULL, should_throw ? sizeof(errstr) : 0);
+
+	if (result == FAILURE && should_throw) {
+		zend_throw_exception(random_ce_Random_RandomException, errstr, 0);
+	}
+
+	return result;
 }
 
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw)
@@ -250,4 +270,14 @@ PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *resul
 
 	*result = (zend_long)((trial % umax) + min);
 	return SUCCESS;
+}
+
+PHPAPI void php_random_csprng_shutdown(void)
+{
+#ifndef PHP_WIN32
+	int fd = zend_atomic_int_exchange(&random_fd, -1);
+	if (fd != -1) {
+		close(fd);
+	}
+#endif
 }

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -37,7 +37,12 @@
 
 PHPAPI double php_combined_lcg(void);
 
+typedef struct _php_random_fallback_seed_state php_random_fallback_seed_state;
+typedef struct _php_random_state_for_zend php_random_state_for_zend;
+
 PHPAPI uint64_t php_random_generate_fallback_seed(void);
+PHPAPI uint64_t php_random_generate_fallback_seed_ex(php_random_fallback_seed_state *state);
+PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random_state *state, void *bytes, size_t size);
 
 static inline zend_long GENERATE_SEED(void)
 {
@@ -107,6 +112,18 @@ typedef struct _php_random_algo_with_state {
 	const php_random_algo *algo;
 	void *state;
 } php_random_algo_with_state;
+
+typedef struct _php_random_fallback_seed_state {
+	bool initialized;
+	unsigned char seed[20];
+} php_random_fallback_seed_state;
+
+typedef struct _php_random_state_for_zend {
+	bool initialized;
+	php_random_status_state_xoshiro256starstar xoshiro256starstar_state;
+} php_random_state_for_zend;
+
+ZEND_STATIC_ASSERT(sizeof(zend_utility_general_random_state) >= sizeof(php_random_state_for_zend), "");
 
 extern PHPAPI const php_random_algo php_random_algo_combinedlcg;
 extern PHPAPI const php_random_algo php_random_algo_mt19937;
@@ -206,8 +223,7 @@ PHP_RINIT_FUNCTION(random);
 ZEND_BEGIN_MODULE_GLOBALS(random)
 	bool combined_lcg_seeded;
 	bool mt19937_seeded;
-	bool fallback_seed_initialized;
-	unsigned char fallback_seed[20];
+	php_random_fallback_seed_state fallback_seed_state;
 	php_random_status_state_combinedlcg combined_lcg;
 	php_random_status_state_mt19937 mt19937;
 ZEND_END_MODULE_GLOBALS(random)

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -38,11 +38,9 @@
 PHPAPI double php_combined_lcg(void);
 
 typedef struct _php_random_fallback_seed_state php_random_fallback_seed_state;
-typedef struct _php_random_state_for_zend php_random_state_for_zend;
 
 PHPAPI uint64_t php_random_generate_fallback_seed(void);
 PHPAPI uint64_t php_random_generate_fallback_seed_ex(php_random_fallback_seed_state *state);
-PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random_state *state, void *bytes, size_t size);
 
 static inline zend_long GENERATE_SEED(void)
 {
@@ -117,13 +115,6 @@ typedef struct _php_random_fallback_seed_state {
 	bool initialized;
 	unsigned char seed[20];
 } php_random_fallback_seed_state;
-
-typedef struct _php_random_state_for_zend {
-	bool initialized;
-	php_random_status_state_xoshiro256starstar xoshiro256starstar_state;
-} php_random_state_for_zend;
-
-ZEND_STATIC_ASSERT(sizeof(zend_utility_general_random_state) >= sizeof(php_random_state_for_zend), "");
 
 extern PHPAPI const php_random_algo php_random_algo_combinedlcg;
 extern PHPAPI const php_random_algo php_random_algo_mt19937;

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -204,7 +204,6 @@ PHP_MSHUTDOWN_FUNCTION(random);
 PHP_RINIT_FUNCTION(random);
 
 ZEND_BEGIN_MODULE_GLOBALS(random)
-	int random_fd;
 	bool combined_lcg_seeded;
 	bool mt19937_seeded;
 	bool fallback_seed_initialized;

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -21,7 +21,6 @@
 # include "php.h"
 
 ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
-
 ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
 
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -21,6 +21,8 @@
 # include "php.h"
 
 PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
+
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 
 static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
@@ -42,5 +44,7 @@ static inline zend_result php_random_int_silent(zend_long min, zend_long max, ze
 {
 	return php_random_int(min, max, result, false);
 }
+
+PHPAPI void php_random_csprng_shutdown(void);
 
 #endif	/* PHP_RANDOM_CSPRNG_H */

--- a/ext/random/php_random_csprng.h
+++ b/ext/random/php_random_csprng.h
@@ -20,8 +20,9 @@
 
 # include "php.h"
 
-PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
-PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_t size, char *errstr, size_t errstr_size);
 
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 

--- a/ext/random/php_random_zend_utils.h
+++ b/ext/random/php_random_zend_utils.h
@@ -1,0 +1,35 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Arnaud Le Blanc <arnaud.lb@gmail.com>                       |
+   |          Tim Düsterhus <timwolla@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_RANDOM_ZEND_UTILS_H
+# define PHP_RANDOM_ZEND_UTILS_H
+
+# include "php.h"
+# include "php_random.h"
+# include "zend.h"
+
+typedef struct _php_random_bytes_insecure_state_for_zend {
+	bool initialized;
+	php_random_status_state_xoshiro256starstar xoshiro256starstar_state;
+} php_random_bytes_insecure_state_for_zend;
+
+ZEND_STATIC_ASSERT(sizeof(zend_utility_random_bytes_insecure_state) >= sizeof(php_random_bytes_insecure_state_for_zend), "");
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_insecure_for_zend(
+		zend_utility_random_bytes_insecure_state *state, void *bytes, size_t size);
+
+#endif /* PHP_RANDOM_ZEND_UTILS_H */

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -699,55 +699,6 @@ uint64_t php_random_generate_fallback_seed(void)
 	return php_random_generate_fallback_seed_ex(&RANDOM_G(fallback_seed_state));
 }
 
-static void php_general_random_bytes_for_zend_initialize(php_random_state_for_zend *state)
-{
-	uint64_t t[4];
-	php_random_fallback_seed_state fallback_state = {
-		.initialized = false,
-	};
-
-	do {
-		/* Skip the CSPRNG if it has already failed */
-		if (!fallback_state.initialized) {
-			char errstr[128];
-			if (php_random_bytes_ex(&t, sizeof(t), errstr, sizeof(errstr)) == FAILURE) {
-#if ZEND_DEBUG
-				fprintf(stderr, "php_random_bytes_ex: Failed to generate a random seed: %s\n", errstr);
-#endif
-				goto fallback;
-			}
-		} else {
-fallback:
-			t[0] = php_random_generate_fallback_seed_ex(&fallback_state);
-			t[1] = php_random_generate_fallback_seed_ex(&fallback_state);
-			t[2] = php_random_generate_fallback_seed_ex(&fallback_state);
-			t[3] = php_random_generate_fallback_seed_ex(&fallback_state);
-		}
-	} while (UNEXPECTED(t[0] == 0 && t[1] == 0 && t[2] == 0 && t[3] == 0));
-
-	php_random_xoshiro256starstar_seed256(&state->xoshiro256starstar_state, t[0], t[1], t[2], t[3]);
-}
-
-PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random_state *opaque_state, void *bytes, size_t size)
-{
-	php_random_state_for_zend *state = (php_random_state_for_zend*) opaque_state;
-
-	if (!state->initialized) {
-		php_general_random_bytes_for_zend_initialize(state);
-		state->initialized = true;
-	}
-
-	while (size > 0) {
-		php_random_result result = php_random_algo_xoshiro256starstar.generate(&state->xoshiro256starstar_state);
-		ZEND_ASSERT(result.size == 8 && sizeof(result.result) == 8);
-		size_t chunk_size = MIN(size, 8);
-		bytes = zend_mempcpy(bytes, &result.result, chunk_size);
-		size -= chunk_size;
-	}
-
-	return SUCCESS;
-}
-
 /* {{{ PHP_GINIT_FUNCTION */
 static PHP_GINIT_FUNCTION(random)
 {

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -699,35 +699,33 @@ uint64_t php_random_generate_fallback_seed(void)
 	return php_random_generate_fallback_seed_ex(&RANDOM_G(fallback_seed_state));
 }
 
-static zend_result php_general_random_bytes_for_zend_initialize(php_random_state_for_zend *state)
+static void php_general_random_bytes_for_zend_initialize(php_random_state_for_zend *state)
 {
 	uint64_t t[4];
+	php_random_fallback_seed_state fallback_state = {
+		.initialized = false,
+	};
 
 	do {
-		char errstr[128];
-		if (php_random_bytes_ex(&t, sizeof(t), errstr, sizeof(errstr)) == FAILURE) {
+		/* Skip the CSPRNG if it has already failed */
+		if (!fallback_state.initialized) {
+			char errstr[128];
+			if (php_random_bytes_ex(&t, sizeof(t), errstr, sizeof(errstr)) == FAILURE) {
 #if ZEND_DEBUG
-			fprintf(stderr, "php_random_bytes_ex: Failed to generate a random seed: %s\n", errstr);
+				fprintf(stderr, "php_random_bytes_ex: Failed to generate a random seed: %s\n", errstr);
 #endif
-			return FAILURE;
+				goto fallback;
+			}
+		} else {
+fallback:
+			t[0] = php_random_generate_fallback_seed_ex(&fallback_state);
+			t[1] = php_random_generate_fallback_seed_ex(&fallback_state);
+			t[2] = php_random_generate_fallback_seed_ex(&fallback_state);
+			t[3] = php_random_generate_fallback_seed_ex(&fallback_state);
 		}
 	} while (UNEXPECTED(t[0] == 0 && t[1] == 0 && t[2] == 0 && t[3] == 0));
 
 	php_random_xoshiro256starstar_seed256(&state->xoshiro256starstar_state, t[0], t[1], t[2], t[3]);
-
-	return SUCCESS;
-}
-
-static void php_general_random_bytes_for_zend_initialize_fallback(php_random_state_for_zend *state)
-{
-	uint64_t t;
-	php_random_fallback_seed_state fallback_state;
-
-	do {
-		t = php_random_generate_fallback_seed_ex(&fallback_state);
-	} while (UNEXPECTED(t == 0));
-
-	php_random_xoshiro256starstar_seed64(&state->xoshiro256starstar_state, t);
 }
 
 PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random_state *opaque_state, void *bytes, size_t size)
@@ -735,18 +733,16 @@ PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random
 	php_random_state_for_zend *state = (php_random_state_for_zend*) opaque_state;
 
 	if (!state->initialized) {
-		if (php_general_random_bytes_for_zend_initialize(state) == FAILURE) {
-			php_general_random_bytes_for_zend_initialize_fallback(state);
-		}
+		php_general_random_bytes_for_zend_initialize(state);
 		state->initialized = true;
 	}
 
 	while (size > 0) {
 		php_random_result result = php_random_algo_xoshiro256starstar.generate(&state->xoshiro256starstar_state);
-		size_t chunk_size = MIN(size, sizeof(result.size));
-		memcpy(bytes, &result.result, chunk_size);
+		ZEND_ASSERT(result.size == 8 && sizeof(result.result) == 8);
+		size_t chunk_size = MIN(size, 8);
+		bytes = zend_mempcpy(bytes, &result.result, chunk_size);
 		size -= chunk_size;
-		bytes = (char*)bytes + chunk_size;
 	}
 
 	return SUCCESS;

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -697,18 +697,7 @@ uint64_t php_random_generate_fallback_seed(void)
 /* {{{ PHP_GINIT_FUNCTION */
 static PHP_GINIT_FUNCTION(random)
 {
-	random_globals->random_fd = -1;
 	random_globals->fallback_seed_initialized = false;
-}
-/* }}} */
-
-/* {{{ PHP_GSHUTDOWN_FUNCTION */
-static PHP_GSHUTDOWN_FUNCTION(random)
-{
-	if (random_globals->random_fd >= 0) {
-		close(random_globals->random_fd);
-		random_globals->random_fd = -1;
-	}
 }
 /* }}} */
 
@@ -780,6 +769,15 @@ PHP_MINIT_FUNCTION(random)
 }
 /* }}} */
 
+/* {{{ PHP_MSHUTDOWN_FUNCTION */
+PHP_MSHUTDOWN_FUNCTION(random)
+{
+	php_random_csprng_shutdown();
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ PHP_RINIT_FUNCTION */
 PHP_RINIT_FUNCTION(random)
 {
@@ -796,14 +794,14 @@ zend_module_entry random_module_entry = {
 	"random",					/* Extension name */
 	ext_functions,				/* zend_function_entry */
 	PHP_MINIT(random),			/* PHP_MINIT - Module initialization */
-	NULL,						/* PHP_MSHUTDOWN - Module shutdown */
+	PHP_MSHUTDOWN(random),		/* PHP_MSHUTDOWN - Module shutdown */
 	PHP_RINIT(random),			/* PHP_RINIT - Request initialization */
 	NULL,						/* PHP_RSHUTDOWN - Request shutdown */
 	NULL,						/* PHP_MINFO - Module info */
 	PHP_VERSION,				/* Version */
 	PHP_MODULE_GLOBALS(random),	/* ZTS Module globals */
 	PHP_GINIT(random),			/* PHP_GINIT - Global initialization */
-	PHP_GSHUTDOWN(random),		/* PHP_GSHUTDOWN - Global shutdown */
+	NULL,						/* PHP_GSHUTDOWN - Global shutdown */
 	NULL,						/* Post deactivate */
 	STANDARD_MODULE_PROPERTIES_EX
 };

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -746,7 +746,7 @@ PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random
 		size_t chunk_size = MIN(size, sizeof(result.size));
 		memcpy(bytes, &result.result, chunk_size);
 		size -= chunk_size;
-		bytes += chunk_size;
+		bytes = (char*)bytes + chunk_size;
 	}
 
 	return SUCCESS;

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -622,7 +622,7 @@ static inline void fallback_seed_add(PHP_SHA1_CTX *c, void *p, size_t l){
 	PHP_SHA1Update(c, p, l);
 }
 
-uint64_t php_random_generate_fallback_seed(void)
+uint64_t php_random_generate_fallback_seed_ex(php_random_fallback_seed_state *state)
 {
 	/* Mix various values using SHA-1 as a PRF to obtain as
 	 * much entropy as possible, hopefully generating an
@@ -640,7 +640,7 @@ uint64_t php_random_generate_fallback_seed(void)
 	char buf[64 + 1];
 
 	PHP_SHA1Init(&c);
-	if (!RANDOM_G(fallback_seed_initialized)) {
+	if (!state->initialized) {
 		/* Current time. */
 		gettimeofday(&tv, NULL);
 		fallback_seed_add(&c, &tv, sizeof(tv));
@@ -656,7 +656,7 @@ uint64_t php_random_generate_fallback_seed(void)
 		fallback_seed_add(&c, &tid, sizeof(tid));
 #endif
 		/* Pointer values to benefit from ASLR. */
-		pointer = &RANDOM_G(fallback_seed_initialized);
+		pointer = state;
 		fallback_seed_add(&c, &pointer, sizeof(pointer));
 		pointer = &c;
 		fallback_seed_add(&c, &pointer, sizeof(pointer));
@@ -680,24 +680,82 @@ uint64_t php_random_generate_fallback_seed(void)
 		gettimeofday(&tv, NULL);
 		fallback_seed_add(&c, &tv, sizeof(tv));
 		/* Previous state. */
-		fallback_seed_add(&c, RANDOM_G(fallback_seed), 20);
+		fallback_seed_add(&c, state->seed, 20);
 	}
-	PHP_SHA1Final(RANDOM_G(fallback_seed), &c);
-	RANDOM_G(fallback_seed_initialized) = true;
+	PHP_SHA1Final(state->seed, &c);
+	state->initialized = true;
 
 	uint64_t result = 0;
 
 	for (int i = 0; i < sizeof(result); i++) {
-		result = result | (((uint64_t)RANDOM_G(fallback_seed)[i]) << (i * 8));
+		result = result | (((uint64_t)state->seed[i]) << (i * 8));
 	}
 
 	return result;
 }
 
+uint64_t php_random_generate_fallback_seed(void)
+{
+	return php_random_generate_fallback_seed_ex(&RANDOM_G(fallback_seed_state));
+}
+
+static zend_result php_general_random_bytes_for_zend_initialize(php_random_state_for_zend *state)
+{
+	uint64_t t[4];
+
+	do {
+		char errstr[128];
+		if (php_random_bytes_ex(&t, sizeof(t), errstr, sizeof(errstr)) == FAILURE) {
+#if ZEND_DEBUG
+			fprintf(stderr, "php_random_bytes_ex: Failed to generate a random seed: %s\n", errstr);
+#endif
+			return FAILURE;
+		}
+	} while (UNEXPECTED(t[0] == 0 && t[1] == 0 && t[2] == 0 && t[3] == 0));
+
+	php_random_xoshiro256starstar_seed256(&state->xoshiro256starstar_state, t[0], t[1], t[2], t[3]);
+
+	return SUCCESS;
+}
+
+static void php_general_random_bytes_for_zend_initialize_fallback(php_random_state_for_zend *state)
+{
+	uint64_t t;
+	php_random_fallback_seed_state fallback_state;
+
+	do {
+		t = php_random_generate_fallback_seed_ex(&fallback_state);
+	} while (UNEXPECTED(t == 0));
+
+	php_random_xoshiro256starstar_seed64(&state->xoshiro256starstar_state, t);
+}
+
+PHPAPI zend_result php_general_random_bytes_for_zend(zend_utility_general_random_state *opaque_state, void *bytes, size_t size)
+{
+	php_random_state_for_zend *state = (php_random_state_for_zend*) opaque_state;
+
+	if (!state->initialized) {
+		if (php_general_random_bytes_for_zend_initialize(state) == FAILURE) {
+			php_general_random_bytes_for_zend_initialize_fallback(state);
+		}
+		state->initialized = true;
+	}
+
+	while (size > 0) {
+		php_random_result result = php_random_algo_xoshiro256starstar.generate(&state->xoshiro256starstar_state);
+		size_t chunk_size = MIN(size, sizeof(result.size));
+		memcpy(bytes, &result.result, chunk_size);
+		size -= chunk_size;
+		bytes += chunk_size;
+	}
+
+	return SUCCESS;
+}
+
 /* {{{ PHP_GINIT_FUNCTION */
 static PHP_GINIT_FUNCTION(random)
 {
-	random_globals->fallback_seed_initialized = false;
+	random_globals->fallback_seed_state.initialized = false;
 }
 /* }}} */
 

--- a/ext/random/zend_utils.c
+++ b/ext/random/zend_utils.c
@@ -1,0 +1,67 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Arnaud Le Blanc <arnaud.lb@gmail.com>                       |
+   |          Tim Düsterhus <timwolla@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "php_random_zend_utils.h"
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_insecure_for_zend(
+		zend_utility_random_bytes_insecure_state *opaque_state, void *bytes, size_t size)
+{
+	php_random_bytes_insecure_state_for_zend *state = (php_random_bytes_insecure_state_for_zend*) opaque_state;
+
+	if (!state->initialized) {
+		uint64_t t[4];
+		php_random_fallback_seed_state fallback_state = {
+			.initialized = false,
+		};
+
+		do {
+			/* Skip the CSPRNG if it has already failed */
+			if (!fallback_state.initialized) {
+				char errstr[128];
+				if (php_random_bytes_ex(&t, sizeof(t), errstr, sizeof(errstr)) == FAILURE) {
+#if ZEND_DEBUG
+					fprintf(stderr, "php_random_bytes_ex: Failed to generate a random seed: %s\n", errstr);
+#endif
+					goto fallback;
+				}
+			} else {
+	fallback:
+				t[0] = php_random_generate_fallback_seed_ex(&fallback_state);
+				t[1] = php_random_generate_fallback_seed_ex(&fallback_state);
+				t[2] = php_random_generate_fallback_seed_ex(&fallback_state);
+				t[3] = php_random_generate_fallback_seed_ex(&fallback_state);
+			}
+		} while (UNEXPECTED(t[0] == 0 && t[1] == 0 && t[2] == 0 && t[3] == 0));
+
+		php_random_xoshiro256starstar_seed256(&state->xoshiro256starstar_state, t[0], t[1], t[2], t[3]);
+		state->initialized = true;
+	}
+
+	while (size > 0) {
+		php_random_result result = php_random_algo_xoshiro256starstar.generate(&state->xoshiro256starstar_state);
+		ZEND_ASSERT(result.size == 8 && sizeof(result.result) == 8);
+		size_t chunk_size = MIN(size, 8);
+		bytes = zend_mempcpy(bytes, &result.result, chunk_size);
+		size -= chunk_size;
+	}
+
+	return SUCCESS;
+}

--- a/ext/random/zend_utils.c
+++ b/ext/random/zend_utils.c
@@ -26,11 +26,10 @@ ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_insecure_for_zend(
 {
 	php_random_bytes_insecure_state_for_zend *state = (php_random_bytes_insecure_state_for_zend*) opaque_state;
 
-	if (!state->initialized) {
+	if (UNEXPECTED(!state->initialized)) {
 		uint64_t t[4];
-		php_random_fallback_seed_state fallback_state = {
-			.initialized = false,
-		};
+		php_random_fallback_seed_state fallback_state;
+		fallback_state.initialized = false;
 
 		do {
 			/* Skip the CSPRNG if it has already failed */

--- a/ext/standard/tests/streams/bug78902.phpt
+++ b/ext/standard/tests/streams/bug78902.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Bug #78902: Memory leak when using stream_filter_append
 --INI--
-memory_limit=2M
+memory_limit=4M
 --FILE--
 <?php
 
-/** create temporary file 2mb file */
+/** create temporary file 4mb file */
 $tmp_file_name = tempnam(sys_get_temp_dir(), 'test_');
 $fp = fopen($tmp_file_name, 'w+');
-$size = 1024 * 1024 * 2; // 2mb, larger than the memory limit
+$size = 1024 * 1024 * 4; // 4mb, larger than the memory limit
 $chunk = 1024;
 while ($size > 0) {
     fputs($fp, str_pad('', min($chunk,$size)));

--- a/ext/zend_test/tests/observer_error_01.phpt
+++ b/ext/zend_test/tests/observer_error_01.phpt
@@ -7,7 +7,7 @@ zend_test.observer.enabled=1
 zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
-memory_limit=2M
+memory_limit=4M
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip requires zmm");
@@ -16,7 +16,7 @@ if (getenv("USE_ZEND_ALLOC") === "0") die("skip requires zmm");
 <?php
 function foo()
 {
-    str_repeat('.', 1024 * 1024 * 2); // 2MB
+    str_repeat('.', 1024 * 1024 * 4); // 4MB
 }
 
 foo();
@@ -31,7 +31,7 @@ echo 'You should not see this.';
     <!-- init str_repeat() -->
     <str_repeat>
 
-Fatal error: Allowed memory size of 2097152 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
+Fatal error: Allowed memory size of 4194304 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
     </str_repeat:NULL>
   </foo:NULL>
 </file '%s%eobserver_error_%d.php'>

--- a/main/main.c
+++ b/main/main.c
@@ -49,6 +49,7 @@
 #include "fopen_wrappers.h"
 #include "ext/standard/php_standard.h"
 #include "ext/date/php_date.h"
+#include "ext/random/php_random_csprng.h"
 #include "php_variables.h"
 #include "ext/standard/credits.h"
 #ifdef PHP_WIN32
@@ -2114,6 +2115,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	zuf.printf_to_smart_str_function = php_printf_to_smart_str;
 	zuf.getenv_function = sapi_getenv;
 	zuf.resolve_path_function = php_resolve_path_for_zend;
+	zuf.os_csprng_randomn_bytes_function = php_random_bytes_ex;
 	zend_startup(&zuf);
 	zend_reset_lc_ctype_locale();
 	zend_update_current_locale();

--- a/main/main.c
+++ b/main/main.c
@@ -2115,7 +2115,8 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	zuf.printf_to_smart_str_function = php_printf_to_smart_str;
 	zuf.getenv_function = sapi_getenv;
 	zuf.resolve_path_function = php_resolve_path_for_zend;
-	zuf.os_csprng_randomn_bytes_function = php_random_bytes_ex;
+	zuf.os_csprng_random_bytes_function = php_random_bytes_ex;
+	zuf.general_random_bytes_function = php_general_random_bytes_for_zend;
 	zend_startup(&zuf);
 	zend_reset_lc_ctype_locale();
 	zend_update_current_locale();

--- a/main/main.c
+++ b/main/main.c
@@ -50,6 +50,7 @@
 #include "ext/standard/php_standard.h"
 #include "ext/date/php_date.h"
 #include "ext/random/php_random_csprng.h"
+#include "ext/random/php_random_zend_utils.h"
 #include "php_variables.h"
 #include "ext/standard/credits.h"
 #ifdef PHP_WIN32
@@ -2115,8 +2116,8 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	zuf.printf_to_smart_str_function = php_printf_to_smart_str;
 	zuf.getenv_function = sapi_getenv;
 	zuf.resolve_path_function = php_resolve_path_for_zend;
-	zuf.os_csprng_random_bytes_function = php_random_bytes_ex;
-	zuf.general_random_bytes_function = php_general_random_bytes_for_zend;
+	zuf.random_bytes_function = php_random_bytes_ex;
+	zuf.random_bytes_insecure_function = php_random_bytes_insecure_for_zend;
 	zend_startup(&zuf);
 	zend_reset_lc_ctype_locale();
 	zend_update_current_locale();

--- a/main/main.c
+++ b/main/main.c
@@ -1748,6 +1748,8 @@ zend_result php_request_startup(void)
 {
 	zend_result retval = SUCCESS;
 
+	ZEND_ASSERT(zend_mm_check_in_input());
+
 	zend_interned_strings_activate();
 
 #ifdef HAVE_DTRACE
@@ -1822,6 +1824,8 @@ zend_result php_request_startup(void)
 	} zend_end_try();
 
 	SG(sapi_started) = 1;
+
+	zend_mm_input_end();
 
 	return retval;
 }

--- a/tests/lang/bug45392.phpt
+++ b/tests/lang/bug45392.phpt
@@ -9,10 +9,10 @@ if (getenv("USE_ZEND_ALLOC") === "0") {
 --FILE--
 <?php
 echo __LINE__ . "\n";
-ini_set('memory_limit', "2M");
+ini_set('memory_limit', "4M");
 ob_start();
 $i = 0;
-while($i++ < 5000)  {
+while($i++ < 10000)  {
   echo str_repeat("may not be displayed ", 42);
 }
 ob_end_clean();


### PR DESCRIPTION
This isolates remotely-controlled allocations (user input / request environment) in separate chunks, to make it more difficult for a remote attacker to precisely control the layout of the heap before the application starts, or to spray the heap with specific content. The general idea is similar to https://lwn.net/Articles/965837/ (not necessarily the implementation).

Design:

The heap is split in two zones, each with its own set of freelists (free_slot) and chunks so that allocations in a zone do not impact the layout of the other one. There is a notion of current zone, from which all allocations are made. The current zone is switched to the input zone before handling a request, and switched back to the default zone after that.

A new field `heap.zone_free_slot` points to the freelist of the current zone. The only change required in allocation operations is to refer to that instead of `heap.free_slot`. Similarly, in free operations we find the `zone_free_slot` in the chunk.

realloc() allocates new blocks in the current zone (if truncation or extension is required), regardless of the original zone in which the block was allocated, so that it's not possible to profit of the layout of the original zone.

Future scope would be to activate the input heap in more places (e.g. when parsing json, during unserialize, etc).

Time overhead is very small (~+0% wall time, +0.13% valgrind).

The minimal memory usage is now 4MiB (two chunks) instead of 2MiB. It may be possible to ensure that this affects only virtual memory and not the RSS.

This depends on https://github.com/php/php-src/pull/14054 and a smaller diff can be viewed here: https://github.com/arnaud-lb/php-src/compare/freelist-corrupt...arnaud-lb:php-src:mm-zones.
