### PR TITLE
random: Remove internal aliases for the global Mt19937 functionality

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -174,6 +174,17 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The macro RAND_RANGE_BADSCALING() has been removed. The implementation
      should either be inlined and undefined behavior fixed or it should be
      replaced by a non-biased scaler.
+   - The php_srand() and php_rand() functions have been removed. These were
+     slim wrappers around the corresponding php_mt_srand() and php_mt_rand()
+     function since PHP 7.1, but using zend_long instead of uint32_t as their
+     input/output types. This made their behavior incompatible between 32-bit
+     and 64-bit builds of PHP. Users of these functions are encouraged to
+     migrate to one of the more modern engines provided since PHP 8.2. If that
+     is not possible, due to backwards compatibility requirements, then the
+     php_mt_srand() and php_mt_rand() functions should be called directly and
+     the values appropriately casted.
+   - The PHP_RAND_MAX and RAND_MAX constants corresponding to the removed
+     php_rand() have also been removed.
    - The generate member of a php_random_algo is now expected to return
      the new php_random_result struct, replacing the last_generated_size
      member of the php_random_status struct and the generate_size member of

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -65,7 +65,6 @@ PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max);
 # define PHP_RAND_MAX PHP_MT_RAND_MAX
 
 PHPAPI void php_srand(zend_long seed);
-PHPAPI zend_long php_rand(void);
 
 typedef struct _php_random_status_state_combinedlcg {
 	int32_t state[2];

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -58,12 +58,6 @@ PHPAPI uint32_t php_mt_rand(void);
 PHPAPI zend_long php_mt_rand_range(zend_long min, zend_long max);
 PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max);
 
-# ifndef RAND_MAX
-#  define RAND_MAX PHP_MT_RAND_MAX
-# endif
-
-# define PHP_RAND_MAX PHP_MT_RAND_MAX
-
 typedef struct _php_random_status_state_combinedlcg {
 	int32_t state[2];
 } php_random_status_state_combinedlcg;

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -64,8 +64,6 @@ PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max);
 
 # define PHP_RAND_MAX PHP_MT_RAND_MAX
 
-PHPAPI void php_srand(zend_long seed);
-
 typedef struct _php_random_status_state_combinedlcg {
 	int32_t state[2];
 } php_random_status_state_combinedlcg;

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -446,13 +446,6 @@ PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max)
 }
 /* }}} */
 
-/* {{{ php_srand */
-PHPAPI void php_srand(zend_long seed)
-{
-	php_mt_srand((uint32_t) seed);
-}
-/* }}} */
-
 /* {{{ Returns a value from the combined linear congruential generator */
 PHP_FUNCTION(lcg_value)
 {

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -453,13 +453,6 @@ PHPAPI void php_srand(zend_long seed)
 }
 /* }}} */
 
-/* {{{ php_rand */
-PHPAPI zend_long php_rand(void)
-{
-	return php_mt_rand();
-}
-/* }}} */
-
 /* {{{ Returns a value from the combined linear congruential generator */
 PHP_FUNCTION(lcg_value)
 {


### PR DESCRIPTION
With the removal of the backwards compatibility headers in #13108, breaking compatibility for extensions designed for PHP versions before 8.2, I'm using the opportunity to remove some more legacy warts of the internal API.

See the commit messages of the individual commits for more details regarding the reasoning for the removal of each piece of the API.