### PR TITLE
Include HRESULT error code if native .NET initialization fails

### DIFF
--- a/ext/com_dotnet/com_dotnet.c
+++ b/ext/com_dotnet/com_dotnet.c
@@ -245,7 +245,7 @@ PHP_METHOD(dotnet, __construct)
 		if (FAILED(hr)) {
 			char buf[1024];
 			char *err = php_win32_error_to_msg(hr);
-			snprintf(buf, sizeof(buf), "Failed to init .Net runtime [%s] %s", where, err);
+			snprintf(buf, sizeof(buf), "Failed to init .Net runtime [%s] [0x%08x] %s", where, hr, err);
 			php_win32_error_msg_free(err);
 			php_com_throw_exception(hr, buf);
 			RETURN_THROWS();
@@ -258,7 +258,7 @@ PHP_METHOD(dotnet, __construct)
 		if (FAILED(hr)) {
 			char buf[1024];
 			char *err = php_win32_error_to_msg(hr);
-			snprintf(buf, sizeof(buf), "Failed to re-init .Net domain [%s] %s", where, err);
+			snprintf(buf, sizeof(buf), "Failed to re-init .Net domain [%s] [0x%08x] %s", where, hr, err);
 			php_win32_error_msg_free(err);
 			php_com_throw_exception(hr, buf);
 			ZVAL_NULL(object);
@@ -270,7 +270,7 @@ PHP_METHOD(dotnet, __construct)
 		if (FAILED(hr)) {
 			char buf[1024];
 			char *err = php_win32_error_to_msg(hr);
-			snprintf(buf, sizeof(buf), "Failed to re-init .Net domain [%s] %s", where, err);
+			snprintf(buf, sizeof(buf), "Failed to re-init .Net domain [%s] [0x%08x] %s", where, hr, err);
 			php_win32_error_msg_free(err);
 			php_com_throw_exception(hr, buf);
 			ZVAL_NULL(object);


### PR DESCRIPTION
This is a local patch I used to figure out why it didn't work on my machine. Without the error codes: good luck to figure out what's wrong.