### PR TITLE
Fix bug #47925: PHPClient can't decompress response (transposed uncompress methods?)

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -1258,12 +1258,12 @@ try_again:
 
 		if ((strcmp(content_encoding,"gzip") == 0 ||
 		     strcmp(content_encoding,"x-gzip") == 0) &&
-		     zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1)) {
-			ZVAL_STRING(&func, "gzinflate");
-			ZVAL_STRINGL(&params[0], http_body->val+10, http_body->len-10);
-		} else if (strcmp(content_encoding,"deflate") == 0 &&
-		           zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
+		     zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
 			ZVAL_STRING(&func, "gzuncompress");
+			ZVAL_STR_COPY(&params[0], http_body);
+		} else if (strcmp(content_encoding,"deflate") == 0 &&
+		           zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1)) {
+			ZVAL_STRING(&func, "gzinflate");
 			ZVAL_STR_COPY(&params[0], http_body);
 		} else {
 			efree(content_encoding);

--- a/ext/soap/tests/bugs/bug47925.phpt
+++ b/ext/soap/tests/bugs/bug47925.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #47925 (PHPClient can't decompress response (transposed uncompress methods?))
+--EXTENSIONS--
+soap
+zlib
+--SKIPIF--
+<?php
+if (@!include __DIR__."/../../../standard/tests/http/server.inc") die('skip server.inc not available');
+http_server_skipif();
+?>
+--FILE--
+<?php
+require __DIR__."/../../../standard/tests/http/server.inc";
+
+$plain_response = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://testuri.org" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <SOAP-ENV:Body>
+        <ns1:AddResponse>
+            <return xsi:type="xsd:int">7</return>
+        </ns1:AddResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+XML;
+
+function test($compressed_response, $compression_name) {
+    $length = strlen($compressed_response);
+    $server_response = "data://text/xml;base64," . base64_encode("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Encoding: $compression_name\r\nContent-Length: $length\r\n\r\n$compressed_response");
+    ['pid' => $pid, 'uri' => $uri] = http_server([$server_response]);
+    $client = new SoapClient(NULL, ['location' => $uri, 'uri' => $uri]);
+    var_dump($client->Add(3, 4));
+    http_server_kill($pid);
+}
+
+test(gzcompress($plain_response), "gzip");
+test(gzdeflate($plain_response), "deflate");
+?>
+--EXPECT--
+int(7)
+int(7)


### PR DESCRIPTION
The incorrect functions are being called to deal with incoming compressed data.
gzip/x-gzip corresponds to gzuncompress(), while deflate corresponds to gzinflate().

The existing code for gzip compression also plays with removing the first 10 bytes (i.e. the gzip header) to pass it to the inflate implementation but that doesn't always work properly due to trailer data. Get rid of that entirely by using the correct functions.