### PR TITLE
Remove PHP_SETUP_OPENSSL inactive 3rd argument

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -140,6 +140,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Added php-config --lib-dir and --lib-embed options for PHP embed SAPI.
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
+   - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -1794,7 +1794,7 @@ AC_DEFUN([PHP_SETUP_ICU],[
 ])
 
 dnl
-dnl PHP_SETUP_OPENSSL(shared-add [, action-found [, action-not-found]])
+dnl PHP_SETUP_OPENSSL(shared-add [, action-found])
 dnl
 dnl Common setup macro for openssl.
 dnl
@@ -1807,7 +1807,6 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
     PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)
     PHP_EVAL_INCLINE($OPENSSL_CFLAGS)
 ifelse([$2],[],:,[$2])
-ifelse([$3],[],,[else $3])
   fi
 ])
 

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -20,12 +20,8 @@ PHP_ARG_WITH([openssl-legacy-provider],
 if test "$PHP_OPENSSL" != "no"; then
   PHP_NEW_EXTENSION(openssl, openssl.c xp_ssl.c, $ext_shared)
   PHP_SUBST(OPENSSL_SHARED_LIBADD)
-  PHP_SETUP_OPENSSL(OPENSSL_SHARED_LIBADD,
-  [
-    AC_DEFINE(HAVE_OPENSSL_EXT,1,[ ])
-  ], [
-    AC_MSG_ERROR([OpenSSL check failed. Please check config.log for more information.])
-  ])
+  PHP_SETUP_OPENSSL([OPENSSL_SHARED_LIBADD],
+    [AC_DEFINE([HAVE_OPENSSL_EXT], [1], [ ])])
 
   AC_CHECK_FUNCS([RAND_egd])
 


### PR DESCRIPTION
If OpenSSL is not found, the PKG_CHECK_MODULES errors out already. To not introduce too big of a BC break with possible PECL extensions using this macro, it is perhaps simpler to remove this non-working argument. Redundant macro arguments are ignored by Autoconf anyway.