### PR TITLE
Fix tempnam() path in test when running from out-of-source

### DIFF
--- a/ext/standard/tests/file/002.phpt
+++ b/ext/standard/tests/file/002.phpt
@@ -22,7 +22,7 @@ blah blah blah blah blah blah blah
 blah blah blah blah blah blah blah
 EOD;
 
-$name = tempnam("./ext/standard/tests/file/", "php");
+$name = tempnam(__DIR__, "php");
 $fp = fopen($name, "w");
 fwrite($fp, $data);
 fclose($fp);


### PR DESCRIPTION
This fixes test when running the test from unusual paths such as in out-of-source builds:

```sh
mkdir php-build
cd php-build
../buildconf
../configure
make
./sapi/cli/php ../run-tests.php ../ext/standard/tests/file/002.phpt
```