### PR TITLE
Add missing ext/libxml dependency to ext/xmlwriter

### DIFF
--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -5,14 +5,10 @@ PHP_ARG_ENABLE([xmlwriter],
   [yes])
 
 if test "$PHP_XMLWRITER" != "no"; then
-
-  if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XMLWriter extension requires LIBXML extension, add --with-libxml])
-  fi
-
   PHP_SETUP_LIBXML(XMLWRITER_SHARED_LIBADD, [
     AC_DEFINE(HAVE_XMLWRITER,1,[ ])
     PHP_NEW_EXTENSION(xmlwriter, php_xmlwriter.c, $ext_shared)
+    PHP_ADD_EXTENSION_DEP(xmlwriter, libxml)
     PHP_SUBST(XMLWRITER_SHARED_LIBADD)
   ])
 fi

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -175,9 +175,15 @@ static char *_xmlwriter_get_valid_file_path(char *source, char *resolved_path, i
 }
 /* }}} */
 
+static const zend_module_dep xmlwriter_deps[] = {
+	ZEND_MOD_REQUIRED("libxml")
+	ZEND_MOD_END
+};
+
 /* {{{ xmlwriter_module_entry */
 zend_module_entry xmlwriter_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX, NULL,
+	xmlwriter_deps,
 	"xmlwriter",
 	ext_functions,
 	PHP_MINIT(xmlwriter),


### PR DESCRIPTION
This adds the libxml extension to required dependencies for xmlwriter during the configuration phase (PHP_ADD_EXTENSION_DEP) and the runtime (ZEND_MOD_REQUIRED).

I'm not sure if there is some internal limitation on adding these ZEND_MOD_* dependencies. Would this cause any performance overhead? These are also used so that extensions are sorted properly when being registered into the Zend hash table. 