### PR TITLE
Sync HAVE_OPENSSL* symbols

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -156,6 +156,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Unused symbols CONFIGURATION_FILE_PATH, DISCARD_PATH, HAVE_ERRMSG_H,
      HAVE_REGCOMP, HAVE_RINT, NEED_ISBLANK, PHP_URL_FOPEN, REGEX, HSREGEX,
      USE_CONFIG_FILE have been removed.
+   - The HAVE_OPENSSL symbol has been removed.
+   - The HAVE_OPENSSL_EXT symbol is now consistently defined to value 1 whether
+     the openssl extension is available either as shared or built statically.
 
 ========================
 3. Module changes

--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -7,7 +7,6 @@ if (PHP_OPENSSL != "no") {
 
 	if (ret > 0) {
 		EXTENSION("openssl", "openssl.c xp_ssl.c");
-		AC_DEFINE("HAVE_OPENSSL_EXT", PHP_OPENSSL_SHARED ? 0 : 1, "Have openssl");
-		AC_DEFINE("HAVE_OPENSSL", 1);
+		AC_DEFINE("HAVE_OPENSSL_EXT", 1, "Define to 1 if the openssl extension is available.");
 	}
 }

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -21,7 +21,8 @@ if test "$PHP_OPENSSL" != "no"; then
   PHP_NEW_EXTENSION(openssl, openssl.c xp_ssl.c, $ext_shared)
   PHP_SUBST(OPENSSL_SHARED_LIBADD)
   PHP_SETUP_OPENSSL([OPENSSL_SHARED_LIBADD],
-    [AC_DEFINE([HAVE_OPENSSL_EXT], [1], [ ])])
+    [AC_DEFINE([HAVE_OPENSSL_EXT], [1],
+      [Define to 1 if the openssl extension is available.])])
 
   AC_CHECK_FUNCS([RAND_egd])
 

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -17,7 +17,7 @@
 
 #ifndef PHP_OPENSSL_H
 #define PHP_OPENSSL_H
-/* HAVE_OPENSSL would include SSL MySQL stuff */
+
 #ifdef HAVE_OPENSSL_EXT
 extern zend_module_entry openssl_module_entry;
 #define phpext_openssl_ptr &openssl_module_entry

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -87,7 +87,7 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
 #include "fastcgi.h"
 #include "cgi_main_arginfo.h"
 
-#if defined(PHP_WIN32) && defined(HAVE_OPENSSL)
+#if defined(PHP_WIN32) && defined(HAVE_OPENSSL_EXT)
 # include "openssl/applink.c"
 #endif
 

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -88,7 +88,7 @@
 # include "win32/select.h"
 #endif
 
-#if defined(PHP_WIN32) && defined(HAVE_OPENSSL)
+#if defined(PHP_WIN32) && defined(HAVE_OPENSSL_EXT)
 # include "openssl/applink.c"
 #endif
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -33,7 +33,7 @@
 
 #include "ext/standard/basic_functions.h"
 
-#if defined(PHP_WIN32) && defined(HAVE_OPENSSL)
+#if defined(PHP_WIN32) && defined(HAVE_OPENSSL_EXT)
 # include "openssl/applink.c"
 #endif
 


### PR DESCRIPTION
Hello, there is one more inconsistency in the build systems that I'd like to sync.

I've left this one as the last "HAVE_* symbols sync" in the PHP-8.4-dev branch (hopefully it is the last for the time being). These symbols are very error prone defined in the form of `HAVE_<extension>` but I'll leave this be for now. 

So, now we have for the ext/openssl the `HAVE_OPENSSL` defined to 1 on Windows, and `HAVE_OPENSSL_EXT` defined to 1 on both. On Windows the `HAVE_OPENSSL_EXT` is additionally defined to value 0 if the ext/openssl is built as shared. From my point of view this is not consistent and doesn't make much sense to be practical in extensions.  Although, I understand the motivation of 0 and 1 value.

My suggestion here would be:
- Define `HAVE_OPENSSL_EXT` in the same style on both systems (undefined - extension is not available, defined to 1 - extension is available)
- Remove the `HAVE_OPENSSL` as it was only defined on Windows and it was in the past defined also elsewhere

I've quickly scanned the PECL community open source extensions and so far only oath is using this HAVE_OPENSSL_EXT symbol with `#if HAVE_OPENSSL_EXT`, which can be resolved quite simple. I'll also recheck the extensions again but it doesn't seem to be problematic.

Your thoughts are welcome. Thanks.