### PR TITLE
Sync HAVE_ENCHANT_BROKER_SET_PARAM definitions

### DIFF
--- a/ext/enchant/config.w32
+++ b/ext/enchant/config.w32
@@ -7,7 +7,6 @@ if (PHP_ENCHANT == "yes") {
 			CHECK_HEADER_ADD_INCLUDE("glib.h", "CFLAGS_ENCHANT", PHP_ENCHANT+ ";" + PHP_PHP_BUILD + "\\include\\glib-2.0")) {
 		if (CHECK_LIB("libenchant2.lib", "enchant", PHP_ENCHANT)) {
 			have_enchant = true;
-			AC_DEFINE('HAVE_ENCHANT_BROKER_SET_PARAM', 0);
 		} else if (CHECK_LIB("libenchant.lib", "enchant", PHP_ENCHANT)) {
 			have_enchant = true;
 			AC_DEFINE('HAVE_ENCHANT_BROKER_SET_PARAM', 1);

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -342,7 +342,7 @@ PHP_FUNCTION(enchant_broker_set_dict_path)
 		RETURN_THROWS();
 	}
 
-#if HAVE_ENCHANT_BROKER_SET_PARAM
+#ifdef HAVE_ENCHANT_BROKER_SET_PARAM
 	enchant_broker *pbroker;
 	if (!value_len) {
 		RETURN_FALSE;
@@ -381,7 +381,7 @@ PHP_FUNCTION(enchant_broker_get_dict_path)
 		RETURN_THROWS();
 	}
 
-#if HAVE_ENCHANT_BROKER_SET_PARAM
+#ifdef HAVE_ENCHANT_BROKER_SET_PARAM
 	enchant_broker *pbroker;
 	char *value;
 	PHP_ENCHANT_GET_BROKER;


### PR DESCRIPTION
This defines the HAVE_ENCHANT_BROKER_SET_PARAM to 1 or doesn't define it so it can be used in a similar way between platforms. It is only defined for Enchant versions 1.5.0 to 2.x. Previously on Windows it was defined to 0 if not found.