### PR TITLE
Refactor fopencookie check

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1364,7 +1364,7 @@ int main(void) {
   [php_cv_type_cookie_off64_t=no],
   [AS_CASE([$host_alias],
     [*linux*], [php_cv_type_cookie_off64_t=yes],
-    [*], [php_cv_type_cookie_off64_t=no])]
+    [php_cv_type_cookie_off64_t=no])]
   )])
   AS_VAR_IF([php_cv_type_cookie_off64_t], [yes],
     [AC_DEFINE([COOKIE_SEEKER_USES_OFF64_T], [1],


### PR DESCRIPTION
- This checks for a type cookie_io_functions_t and defines the HAVE_FOPENCOOKIE based on type check result and the fopencookie() function presence.
- Fixed -Wunused... warnings in config.log on stricter compiler configurations
- The run check for off64_t is wrapped into AC_CACHE_CHECK for having the php_cv_type_cookie_off64_t cache variable available to customize possible cross-compilation edge cases
- Comment about glibcs 2.1.2 removed because also some other earlier versions provided this type already