### PR TITLE
Fix GH-14343: Memory leak in xml and dom

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ PHP                                                                        NEWS
 - Curl:
   . Fixed bug GH-14307 (Test curl_basic_024 fails with curl 8.8.0). (nielsdos)
 
+- DOM:
+  . Fixed bug GH-14343 (Memory leak in xml and dom). (nielsdos)
+
 - Opcache:
   . Fixed bug GH-14267 (opcache.jit=off does not allow enabling JIT at runtime).
     (ilutov)

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -848,8 +848,13 @@ PHP_METHOD(DOMDocument, importNode)
 			if (nsptr == NULL) {
 				int errorcode;
 				nsptr = dom_get_ns(root, (char *) nodep->ns->href, &errorcode, (char *) nodep->ns->prefix);
+
+				/* If there is no root, the namespace cannot be attached to it, so we have to attach it to the old list. */
+				if (nsptr != NULL && root == NULL) {
+					dom_set_old_ns(nodep->doc, nsptr);
+				}
 			}
-			xmlSetNs(retnodep, nsptr);
+			retnodep->ns = nsptr;
 		}
 	}
 

--- a/ext/dom/tests/gh14343.phpt
+++ b/ext/dom/tests/gh14343.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-14343 (Memory leak in xml and dom)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$aDOM = new DOMDocument();
+$fromdom = new DOMDocument();
+$fromdom->loadXML('<data xmlns:ai="http://test.org" ai:attr="namespaced" />');
+$attr= $fromdom->firstChild->attributes->item(0);
+$att = $aDOM->importNode($attr);
+echo $aDOM->saveXML($att);
+?>
+--EXPECT--
+ ai:attr="namespaced"


### PR DESCRIPTION
If there is no root, the namespace cannot be attached to it, so we have to attach it to the old list.

This isn't a problem in "new DOM" because namespaces are managed in a separate structure there.