### PR TITLE
Fix bug #47925 again

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -1256,14 +1256,16 @@ try_again:
 		zval retval;
 		zval params[1];
 
+		/* Warning: the zlib function names are chosen in an unfortunate manner.
+		 * Check zlib.c to see how a function corresponds with a particular format. */
 		if ((strcmp(content_encoding,"gzip") == 0 ||
 		     strcmp(content_encoding,"x-gzip") == 0) &&
-		     zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
-			ZVAL_STRING(&func, "gzuncompress");
+		     zend_hash_str_exists(EG(function_table), "gzdecode", sizeof("gzdecode")-1)) {
+			ZVAL_STRING(&func, "gzdecode");
 			ZVAL_STR_COPY(&params[0], http_body);
 		} else if (strcmp(content_encoding,"deflate") == 0 &&
-		           zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1)) {
-			ZVAL_STRING(&func, "gzinflate");
+		           zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
+			ZVAL_STRING(&func, "gzuncompress");
 			ZVAL_STR_COPY(&params[0], http_body);
 		} else {
 			efree(content_encoding);

--- a/ext/soap/tests/bugs/bug47925.phpt
+++ b/ext/soap/tests/bugs/bug47925.phpt
@@ -32,8 +32,8 @@ function test($compressed_response, $compression_name) {
     http_server_kill($pid);
 }
 
-test(gzcompress($plain_response), "gzip");
-test(gzdeflate($plain_response), "deflate");
+test(gzencode($plain_response), "gzip");
+test(gzcompress($plain_response), "deflate");
 ?>
 --EXPECT--
 int(7)


### PR DESCRIPTION
The naming of the userland functions is terrible and confused me. gzdecode() is actually the function to decompress a gzip stream, and gzuncompress() is the one to decompress a deflate stream... See zlib.c to see the internal function -> type mapping.