### PR TITLE
Remove PROG_SENDMAIL from Makefile

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1606,7 +1606,6 @@ dnl
 AC_DEFUN([PHP_PROG_SENDMAIL], [
   PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
   AC_PATH_PROG(PROG_SENDMAIL, sendmail, /usr/sbin/sendmail, $PATH:$PHP_ALT_PATH)
-  PHP_SUBST(PROG_SENDMAIL)
 ])
 
 dnl


### PR DESCRIPTION
PROG_SENDMAIL is not used in the generated Makefile. For the main/build-defs.h it is substituted automatically with AC_PATH_PROG.