### PR TITLE
Fix double to microseconds conversion in ext/date.

### DIFF
--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -15,6 +15,11 @@ $timestamps = array(
     -1696883232.013981,
     0.123456,
     -0.123456,
+    1.000_001,
+    -1.000_001,
+    1.000_000_1,
+    -1.000_000_1,
+    1599828571.235_612,
     0,
     0.0,
     -0.0,
@@ -148,6 +153,86 @@ DateTime::createFromTimestamp(-0.123456): object(DateTime)#%d (3) {
 DateTimeImmutable::createFromTimestamp(-0.123456): object(DateTimeImmutable)#%d (3) {
   ["date"]=>
   string(26) "1969-12-31 23:59:59.876544"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(1.000001): object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "1970-01-01 00:00:01.000001"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(1.000001): object(DateTimeImmutable)#1 (3) {
+  ["date"]=>
+  string(26) "1970-01-01 00:00:01.000001"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-1.000001): object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "1969-12-31 23:59:58.999999"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(-1.000001): object(DateTimeImmutable)#1 (3) {
+  ["date"]=>
+  string(26) "1969-12-31 23:59:58.999999"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(1.0000001): object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "1970-01-01 00:00:01.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(1.0000001): object(DateTimeImmutable)#1 (3) {
+  ["date"]=>
+  string(26) "1970-01-01 00:00:01.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-1.0000001): object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "1969-12-31 23:59:58.999999"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(-1.0000001): object(DateTimeImmutable)#1 (3) {
+  ["date"]=>
+  string(26) "1969-12-31 23:59:58.999999"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(1599828571.235612): object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "2020-09-11 12:49:31.235612"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(1599828571.235612): object(DateTimeImmutable)#1 (3) {
+  ["date"]=>
+  string(26) "2020-09-11 12:49:31.235612"
   ["timezone_type"]=>
   int(1)
   ["timezone"]=>


### PR DESCRIPTION
As mentioned by @kylekatarnls in <https://github.com/php/php-src/issues/14332#issuecomment-2132794556>, `php_date_initialize_from_ts_double()` doesn't handle the fractional part of a double in the way users would expect.

> ```
> var_dump(DateTime::createFromTimestamp(1599828571.235612)); // => ...235611
> ```

Also for example, 1.000_001 (1.000_000_99999999991773...) is transformed to @1.000000.

The updated code calculates the delta between the provided value and the next double value (in the case above, 1.000_001_00000000013978...), and if the delta is less than or equal to 0.5 microseconds, it uses the next value.
I think this solves the problem while keeping the original results on other cases.

CC: @marc-mabe