### PR TITLE
Fix bug GH-11941: soap with session persistence will silently fails when "seession" built as a shared object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -245,6 +245,8 @@ PHP                                                                        NEWS
   . Fixed bug #49278 (SoapClient::__getLastResponseHeaders returns NULL if
     wsdl operation !has output). (nielsdos)
   . Fixed bug #44383 (PHP DateTime not converted to xsd:datetime). (nielsdos)
+  . Fixed bug GH-11941 (soap with session persistence will silently fail when
+    "session" built as a shared object). (nielsdos)
 
 - Sockets:
   . Removed the deprecated inet_ntoa call support. (David Carlier)

--- a/UPGRADING
+++ b/UPGRADING
@@ -145,6 +145,10 @@ PHP 8.4 UPGRADE NOTES
   . SoapClient::$typemap is now an array rather than a resource.
     Checks using is_resource() (i.e. is_resource($client->typemap)) should be
     replaced with checks for null (i.e. $client->typemap !== null).
+  . The SOAP extension gained an optional dependency on the session extension.
+    If you build PHP without the session extension and with --enable-rtld-now,
+    you will experience errors on startup if you also use the SOAP extension.
+    To solve this, either don't use rtld-now or load the session extension.
 
 - SPL:
   . Out of bounds accesses in SplFixedArray now throw an exception of type
@@ -300,6 +304,7 @@ PHP 8.4 UPGRADE NOTES
   . Instances of DateTimeInterface that are passed to xsd:datetime or similar
     elements are now serialized as such instead of being serialized as an
     empty string.
+  . Session persistence now works with a shared session module.
 
 - XSL:
   . It is now possible to use parameters that contain both single and double

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -253,6 +253,12 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      Moreover, providing it with a binary safe string is the responsibility of
      the caller now.
 
+ h. ext/session
+   - Added the php_get_session_status() API to get the session status, which is
+     equivalent to reading PS(session_status) but works with shared objects too.
+   - Added the php_get_session_var_str() API to set a session variable without
+     needing to create a zend_string.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -256,6 +256,7 @@ PHPAPI zend_result php_session_destroy(void);
 PHPAPI void php_add_session_var(zend_string *name);
 PHPAPI zval *php_set_session_var(zend_string *name, zval *state_val, php_unserialize_data_t *var_hash);
 PHPAPI zval *php_get_session_var(zend_string *name);
+PHPAPI zval* php_get_session_var_str(const char *name, size_t name_len);
 
 PHPAPI zend_result php_session_register_module(const ps_module *);
 
@@ -265,6 +266,7 @@ PHPAPI zend_result php_session_register_serializer(const char *name,
 
 PHPAPI zend_result php_session_start(void);
 PHPAPI zend_result php_session_flush(int write);
+PHPAPI php_session_status php_get_session_status(void);
 
 PHPAPI const ps_module *_php_find_ps_module(const char *name);
 PHPAPI const ps_serializer *_php_find_ps_serializer(const char *name);

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -225,6 +225,14 @@ PHPAPI zval* php_get_session_var(zend_string *name) /* {{{ */
 }
 /* }}} */
 
+PHPAPI zval* php_get_session_var_str(const char *name, size_t name_len)
+{
+	IF_SESSION_VARS() {
+		return zend_hash_str_find(Z_ARRVAL_P(Z_REFVAL(PS(http_session_vars))), name, name_len);
+	}
+	return NULL;
+}
+
 static void php_session_track_init(void) /* {{{ */
 {
 	zval session_vars;
@@ -1631,6 +1639,11 @@ PHPAPI zend_result php_session_flush(int write) /* {{{ */
 	return FAILURE;
 }
 /* }}} */
+
+PHPAPI php_session_status php_get_session_status(void)
+{
+	return PS(session_status);
+}
 
 static zend_result php_session_abort(void) /* {{{ */
 {

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -10,4 +10,5 @@ if test "$PHP_SOAP" != "no"; then
     PHP_SUBST(SOAP_SHARED_LIBADD)
   ])
   PHP_ADD_EXTENSION_DEP(soap, libxml)
+  PHP_ADD_EXTENSION_DEP(soap, session, true)
 fi

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -10,6 +10,7 @@ if (PHP_SOAP != "no") {
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_SOAP', 1, "SOAP support");
+		ADD_EXTENSION_DEP('soap', 'session', true);
 
 		if (!PHP_SOAP_SHARED) {
 			ADD_FLAG('CFLAGS_SOAP', "/D LIBXML_STATIC ");

--- a/ext/soap/tests/bugs/gh11941_errors.phpt
+++ b/ext/soap/tests/bugs/gh11941_errors.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-11941 (soap with session persistence will silently fail when "session" built as a shared object)
+--EXTENSIONS--
+soap
+--SKIPIF--
+<?php
+// We explicitly want to test with the soap extension enabled and session extension disabled
+if (extension_loaded("session")) die("skip this test must run with the session extension disabled");
+?>
+--FILE--
+<?php
+$server = new SoapServer(null, array('uri'=>"http://testuri.org"));
+$server->setPersistence(SOAP_PERSISTENCE_SESSION);
+?>
+--EXPECTF--
+%aUncaught Error: SoapServer::setPersistence(): Persistence cannot be set when the SOAP server is used in function mode in %s:%d
+%a


### PR DESCRIPTION
This adds an optional dependency on the session extension and adds the necessary APIs to make the functionality work with lazy binding.

This can be tested by configuring PHP with `--enable-session=shared` and `--enable-soap=shared` and running the test suite, in particular the buggy behaviour can be observed by the existing test `server009.phpt`.