### PR TITLE
Improve randomness of uploaded file names and files created by tempnam()

### DIFF
--- a/ext/standard/tests/file/tempnam_variation9.phpt
+++ b/ext/standard/tests/file/tempnam_variation9.phpt
@@ -57,17 +57,17 @@ if (file_exists($file_path)) {
 --EXPECTF--
 *** Testing tempnam() maximum prefix size ***
 -- Iteration 0 --
-File name is => begin_%rx{7}%r_end%r.{38}%r
-File name length is => 55
+File name is => begin_%rx{7}%r_end%r.{16,17}%r
+File name length is => %r33|34%r
 -- Iteration 1 --
-File name is => begin_%rx{53}%r_end%r.{38}%r
-File name length is => 101
+File name is => begin_%rx{53}%r_end%r.{16,17}%r
+File name length is => %r79|80%r
 -- Iteration 2 --
-File name is => begin_%rx{54}%r_en%r.{38}%r
-File name length is => 101
+File name is => begin_%rx{54}%r_en%r.{16,17}%r
+File name length is => %r79|80%r
 -- Iteration 3 --
-File name is => begin_%rx{55}%r_e%r.{38}%r
-File name length is => 101
+File name is => begin_%rx{55}%r_e%r.{16,17}%r
+File name length is => %r79|80%r
 -- Iteration 4 --
-File name is => begin_%rx{57}%r%r.{38}%r
-File name length is => 101
+File name is => begin_%rx{57}%r%r.{16,17}%r
+File name length is => %r79|80%r

--- a/ext/standard/tests/file/tempnam_variation9.phpt
+++ b/ext/standard/tests/file/tempnam_variation9.phpt
@@ -57,17 +57,17 @@ if (file_exists($file_path)) {
 --EXPECTF--
 *** Testing tempnam() maximum prefix size ***
 -- Iteration 0 --
-File name is => begin_%rx{7}%r_end%r.{6}%r
-File name length is => 23
+File name is => begin_%rx{7}%r_end%r.{38}%r
+File name length is => 55
 -- Iteration 1 --
-File name is => begin_%rx{53}%r_end%r.{6}%r
-File name length is => 69
+File name is => begin_%rx{53}%r_end%r.{38}%r
+File name length is => 101
 -- Iteration 2 --
-File name is => begin_%rx{54}%r_en%r.{6}%r
-File name length is => 69
+File name is => begin_%rx{54}%r_en%r.{38}%r
+File name length is => 101
 -- Iteration 3 --
-File name is => begin_%rx{55}%r_e%r.{6}%r
-File name length is => 69
+File name is => begin_%rx{55}%r_e%r.{38}%r
+File name length is => 101
 -- Iteration 4 --
-File name is => begin_%rx{57}%r%r.{6}%r
-File name length is => 69
+File name is => begin_%rx{57}%r%r.{38}%r
+File name length is => 101

--- a/ext/standard/tests/file/tempnam_variation9.phpt
+++ b/ext/standard/tests/file/tempnam_variation9.phpt
@@ -57,17 +57,17 @@ if (file_exists($file_path)) {
 --EXPECTF--
 *** Testing tempnam() maximum prefix size ***
 -- Iteration 0 --
-File name is => begin_%rx{7}%r_end%r.{16,17}%r
-File name length is => %r33|34%r
+File name is => begin_%rx{7}%r_end%r.{19}%r
+File name length is => 36
 -- Iteration 1 --
-File name is => begin_%rx{53}%r_end%r.{16,17}%r
-File name length is => %r79|80%r
+File name is => begin_%rx{53}%r_end%r.{19}%r
+File name length is => 82
 -- Iteration 2 --
-File name is => begin_%rx{54}%r_en%r.{16,17}%r
-File name length is => %r79|80%r
+File name is => begin_%rx{54}%r_en%r.{19}%r
+File name length is => 82
 -- Iteration 3 --
-File name is => begin_%rx{55}%r_e%r.{16,17}%r
-File name length is => %r79|80%r
+File name is => begin_%rx{55}%r_e%r.{19}%r
+File name length is => 82
 -- Iteration 4 --
-File name is => begin_%rx{57}%r%r.{16,17}%r
-File name length is => %r79|80%r
+File name is => begin_%rx{57}%r%r.{19}%r
+File name length is => 82

--- a/main/php_open_temporary_file.c
+++ b/main/php_open_temporary_file.c
@@ -87,7 +87,7 @@
  * SUCH DAMAGE.
  */
 
-static const char letters[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+static const char base32alphabet[] = "0123456789abcdefghijklmnopqrstuv";
 
 static int php_do_open_temporary_file(const char *path, const char *pfx, zend_string **opened_path_p)
 {
@@ -148,9 +148,9 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
 	random_prefix = emalloc(len);
 	p = zend_mempcpy(random_prefix, pfx, strlen(pfx));
 	while (p + 1 < random_prefix + len) {
-		*p = letters[random % strlen(letters)];
+		*p = base32alphabet[random % strlen(base32alphabet)];
 		p++;
-		random /= strlen(letters);
+		random /= strlen(base32alphabet);
 	}
 	*p = '\0';
 


### PR DESCRIPTION
Uploaded files are created with a name in the form `/tmp/phpXXXXXX`, where `XXXXXX` is given one of 62^6 different values by [`mkstemp(3)`](https://man7.org/linux/man-pages/man3/mkstemp.3.html). According to [this blogpost](https://swarm.ptsecurity.com/exploiting-arbitrary-object-instantiations/), it is possible to guess this name by brute forcing, with a reasonable number of attempts. This can be used to exploit a vulnerable applications.

Here I add 64 bits of additional randomness before the `XXXXXX` pattern, to make this attack unpractical.

The change also applies to [tempnam()](https://www.php.net/tempnam) and to platforms without `mkstemp()`.