### PR TITLE
ext/pgsql: adding pg_socket_poll.

### DIFF
--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -68,6 +68,7 @@ if test "$PHP_PGSQL" != "no"; then
   AC_CHECK_LIB(pq, PQsetErrorContextVisibility, AC_DEFINE(HAVE_PG_CONTEXT_VISIBILITY,1,[PostgreSQL 9.6 or later]))
   AC_CHECK_LIB(pq, PQresultMemorySize, AC_DEFINE(HAVE_PG_RESULT_MEMORY_SIZE,1,[PostgreSQL 12 or later]))
   AC_CHECK_LIB(pq, PQchangePassword, AC_DEFINE(HAVE_PG_CHANGE_PASSWORD,1,[PostgreSQL 17 or later]))
+  AC_CHECK_LIB(pq, PQsocketPoll, AC_DEFINE(HAVE_PG_SOCKET_POLL,1,[PostgreSQL 17 or later]))
   LIBS=$old_LIBS
   LDFLAGS=$old_LDFLAGS
 

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -952,6 +952,11 @@ namespace {
 
     function pg_put_copy_data(PgSql\Connection $connection, string $cmd): int {}
     function pg_put_copy_end(PgSql\Connection $connection, ?string $error = null): int {}
+
+    /**
+     * @param resource $socket
+     */
+    function pg_socket_poll($socket, int $read, int $write, int $timeout = -1): int {}
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: edc626b255224ed76333223c90cfab062415637f */
+ * Stub hash: 4a2a5778003aa741952e16617e5bdb2ad06e6e16 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -481,6 +481,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_put_copy_end, 0, 1, IS_LONG, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, error, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_socket_poll, 0, 3, IS_LONG, 0)
+	ZEND_ARG_INFO(0, socket)
+	ZEND_ARG_TYPE_INFO(0, read, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, write, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_LONG, 0, "-1")
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(pg_connect);
 ZEND_FUNCTION(pg_pconnect);
 ZEND_FUNCTION(pg_connect_poll);
@@ -581,6 +588,7 @@ ZEND_FUNCTION(pg_result_memory_size);
 ZEND_FUNCTION(pg_change_password);
 ZEND_FUNCTION(pg_put_copy_data);
 ZEND_FUNCTION(pg_put_copy_end);
+ZEND_FUNCTION(pg_socket_poll);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_connect, arginfo_pg_connect)
@@ -706,6 +714,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_change_password, arginfo_pg_change_password)
 	ZEND_FE(pg_put_copy_data, arginfo_pg_put_copy_data)
 	ZEND_FE(pg_put_copy_end, arginfo_pg_put_copy_end)
+	ZEND_FE(pg_socket_poll, arginfo_pg_socket_poll)
 	ZEND_FE_END
 };
 

--- a/ext/pgsql/tests/pg_socket_poll.phpt
+++ b/ext/pgsql/tests/pg_socket_poll.phpt
@@ -1,0 +1,49 @@
+--TEST--
+PostgreSQL poll on connection's socket
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php
+include("inc/skipif.inc");
+?>
+--FILE--
+<?php
+
+include('inc/config.inc');
+include('inc/nonblocking.inc');
+
+if (!($db = pg_connect($conn_str, PGSQL_CONNECT_ASYNC))) die("pg_connect failed");
+$socket = pg_socket($db);
+$fp = fopen(__DIR__ . "/inc/config.inc", "r");
+try {
+	pg_socket_poll($fp, 0, 0);
+} catch (\TypeError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+if (($topoll = pg_socket_poll($socket, 1, 1, 1)) === -1) die("pg_socket_poll failed");
+stream_set_blocking($socket, false);
+
+while (1) {
+    switch ($status = pg_connect_poll($db)) {
+        case PGSQL_POLLING_READING:
+            nb_is_writable($socket);
+            break;
+        case PGSQL_POLLING_WRITING:
+            nb_is_writable($socket);
+            break;
+        case PGSQL_POLLING_OK:
+            break 2;
+        default:
+            die("poll failed");
+    }
+}
+assert(pg_connection_status($db) === PGSQL_CONNECTION_OK);
+echo "OK";
+
+pg_close($db);
+
+?>
+--EXPECT--
+pg_socket_poll(): Argument #1 ($socket) invalid resource socket
+OK


### PR DESCRIPTION
Using PQSocketPoll to poll on a connection's socket. Returns immediatly is there no event expected on read and write. Other than that, it is a thin wrapper on top of poll, thus reflecting
 its return value.