### PR TITLE
Fixed rounding error with new DateTime[Immutable]::createFromTimestamp method

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2538,7 +2538,7 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 	}
 
 	sec = (zend_long)sec_dval;
-	usec = (int)(fmod(ts, 1) * 1000000);
+	usec = (int) round(fmod(ts, 1) * 1000000);
 
 	if (UNEXPECTED(usec < 0)) {
 		if (UNEXPECTED(sec == TIMELIB_LONG_MIN)) {

--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -22,7 +22,9 @@ $timestamps = array(
     PHP_INT_MIN - 1025.0,
     NAN,
     +INF,
-    -INF
+    -INF,
+    1599828571.235628,
+    -1599828571.235628,
 );
 
 foreach ($timestamps as $ts) {
@@ -211,6 +213,38 @@ DateTime::createFromTimestamp(INF): DateRangeError: DateTime::createFromTimestam
 DateTimeImmutable::createFromTimestamp(INF): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, INF given
 DateTime::createFromTimestamp(-INF): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, -INF given
 DateTimeImmutable::createFromTimestamp(-INF): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, -INF given
+DateTime::createFromTimestamp(1599828571.235628): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2020-09-11 12:49:31.235628"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(1599828571.235628): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2020-09-11 12:49:31.235628"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-1599828571.235628): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "1919-04-22 11:10:28.764372"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(-1599828571.235628): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "1919-04-22 11:10:28.764372"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
 MyDateTime::createFromTimestamp(0): object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "1970-01-01 00:00:00.000000"


### PR DESCRIPTION
This is in a new method, so no news entry required.

Without this patch, the result has `2020-09-11 12:49:31.235627` and `1919-04-22 11:10:28.764373`.

/cc @marc-mabe 