### PR TITLE
Use AC_DEFINE_UNQUOTED where variables are present

### DIFF
--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -15,7 +15,7 @@ if test "$PHP_FFI" != "no"; then
 
   AC_DEFUN([PHP_FFI_CHECK_DECL],
     [AC_CHECK_DECL([$1],
-      [AC_DEFINE(AS_TR_CPP([HAVE_$1]), [1],
+      [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
         [Whether libffi supports the '$1' calling convention.])],,
       [#include <ffi.h>])])
 


### PR DESCRIPTION
According to Autoconf docs and upstream code, AC_DEFINE_UNQUOTED must be used where variables are present in the arguments.

Follow up of GH-13552