### PR TITLE
Fix GH-14368: Test failure in ext/session/tests/gh13856.phpt

### DIFF
--- a/ext/session/tests/gh13856.phpt
+++ b/ext/session/tests/gh13856.phpt
@@ -6,6 +6,7 @@ session
 session.save_handler=files
 open_basedir=.
 error_reporting=E_ALL
+session.save_path=
 --FILE--
 <?php
 session_set_save_handler(new \SessionHandler(), true);


### PR DESCRIPTION
If the runner overrides session.save_path, the test fails. Manually set it to a value known to trigger the issue.