### PR TITLE
Fix missing error restore code in ext-soap

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ PHP                                                                        NEWS
 
 - Soap:
   . Fixed bug #47925 (PHPClient can't decompress response). (nielsdos)
+  . Fix missing error restore code. (nielsdos)
 
 - Sodium:
   . Fix memory leaks in ext/sodium on failure of some functions. (nielsdos)

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -899,11 +899,9 @@ PHP_METHOD(SoapServer, setPersistence)
 			zend_argument_value_error(
 				1, "must be either SOAP_PERSISTENCE_SESSION or SOAP_PERSISTENCE_REQUEST when the SOAP server is used in class mode"
 			);
-			RETURN_THROWS();
 		}
 	} else {
 		zend_throw_error(NULL, "SoapServer::setPersistence(): Persistence cannot be set when the SOAP server is used in function mode");
-		RETURN_THROWS();
 	}
 
 	SOAP_SERVER_END_CODE();
@@ -1042,6 +1040,7 @@ PHP_METHOD(SoapServer, addFunction)
 
 				if (Z_TYPE_P(tmp_function) != IS_STRING) {
 					zend_argument_type_error(1, "must contain only strings");
+					SOAP_SERVER_END_CODE();
 					RETURN_THROWS();
 				}
 
@@ -1049,6 +1048,7 @@ PHP_METHOD(SoapServer, addFunction)
 
 				if ((f = zend_hash_find_ptr(EG(function_table), key)) == NULL) {
 					zend_type_error("SoapServer::addFunction(): Function \"%s\" not found", Z_STRVAL_P(tmp_function));
+					SOAP_SERVER_END_CODE();
 					RETURN_THROWS();
 				}
 
@@ -1066,6 +1066,7 @@ PHP_METHOD(SoapServer, addFunction)
 
 		if ((f = zend_hash_find_ptr(EG(function_table), key)) == NULL) {
 			zend_argument_type_error(1, "must be a valid function name, function \"%s\" not found", Z_STRVAL_P(function_name));
+			SOAP_SERVER_END_CODE();
 			RETURN_THROWS();
 		}
 		if (service->soap_functions.ft == NULL) {
@@ -1086,11 +1087,9 @@ PHP_METHOD(SoapServer, addFunction)
 			service->soap_functions.functions_all = TRUE;
 		} else {
 			zend_argument_value_error(1, "must be SOAP_FUNCTIONS_ALL when an integer is passed");
-			RETURN_THROWS();
 		}
 	} else {
 		zend_argument_type_error(1, "must be of type array|string|int, %s given", zend_zval_type_name(function_name));
-		RETURN_THROWS();
 	}
 
 	SOAP_SERVER_END_CODE();
@@ -1150,6 +1149,7 @@ PHP_METHOD(SoapServer, handle)
 
 	if (arg && ZEND_SIZE_T_INT_OVFL(arg_len)) {
 		soap_server_fault("Server", "Input string is too long", NULL, NULL, NULL);
+		SOAP_SERVER_END_CODE();
 		return;
 	}
 
@@ -1231,10 +1231,12 @@ PHP_METHOD(SoapServer, handle)
 						php_stream_filter_append(&SG(request_info).request_body->readfilters, zf);
 					} else {
 						php_error_docref(NULL, E_WARNING,"Can't uncompress compressed request");
+						SOAP_SERVER_END_CODE();
 						return;
 					}
 				} else {
 					php_error_docref(NULL, E_WARNING,"Request is compressed with unknown compression '%s'",Z_STRVAL_P(encoding));
+					SOAP_SERVER_END_CODE();
 					return;
 				}
 			}
@@ -1246,6 +1248,7 @@ PHP_METHOD(SoapServer, handle)
 			}
 		} else {
 			zval_ptr_dtor(&retval);
+			SOAP_SERVER_END_CODE();
 			return;
 		}
 	} else {
@@ -1622,6 +1625,7 @@ PHP_METHOD(SoapServer, addSoapHeader)
 
 	if (!service || !service->soap_headers_ptr) {
 		zend_throw_error(NULL, "SoapServer::addSoapHeader() may be called only during SOAP request processing");
+		SOAP_SERVER_END_CODE();
 		RETURN_THROWS();
 	}
 


### PR DESCRIPTION
The begin and end macros should be paired, but some of the end macro calls were missing.