### PR TITLE
gen_stub: Add return by reference flag

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1583,6 +1583,10 @@ class FuncInfo {
             $flags[] = "ZEND_ACC_DEPRECATED";
         }
 
+        if ($this->return->byRef) {
+            $flags[] = "ZEND_ACC_RETURN_REFERENCE";
+        }
+
         $php82AndAboveFlags = $flags;
         if ($this->isMethod() === false && $this->supportsCompileTimeEval) {
             $php82AndAboveFlags[] = "ZEND_ACC_COMPILE_TIME_EVAL";

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1583,10 +1583,6 @@ class FuncInfo {
             $flags[] = "ZEND_ACC_DEPRECATED";
         }
 
-        if ($this->return->byRef) {
-            $flags[] = "ZEND_ACC_RETURN_REFERENCE";
-        }
-
         $php82AndAboveFlags = $flags;
         if ($this->isMethod() === false && $this->supportsCompileTimeEval) {
             $php82AndAboveFlags[] = "ZEND_ACC_COMPILE_TIME_EVAL";

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -1045,6 +1045,19 @@ static ZEND_METHOD(_ZendTestClass, takesUnionType)
 	RETURN_NULL();
 }
 
+static ZEND_METHOD(_ZendTestClass, returnByRefIntProp)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_object *obj = Z_OBJ_P(ZEND_THIS);
+	zend_string *name = zend_string_init("intProp", strlen("intProp"), false);
+	zval *int_prop = obj->handlers->get_property_ptr_ptr(obj, name, BP_VAR_W, NULL);
+	zend_string_release_ex(name, false);
+
+	//ZVAL_MAKE_REF(int_prop, int_prop);
+	RETURN_COPY(int_prop);
+}
+
 // Returns a newly allocated DNF type `Iterator|(Traversable&Countable)`.
 //
 // We need to generate it "manually" because gen_stubs.php does not support codegen for DNF types ATM.

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -1057,26 +1057,14 @@ static ZEND_METHOD(_ZendTestClass, returnByRefIntProp)
 	ZEND_ASSERT(int_prop);
 	ZEND_ASSERT(!Z_ISERROR_P(int_prop));
 
-	/* Copied from zend_assign_to_variable_reference() */
-	zend_reference *ref;
-
-	if (EXPECTED(!Z_ISREF_P(int_prop))) {
-		ZVAL_NEW_REF(int_prop, int_prop);
+	if (!Z_ISREF_P(int_prop)) {
+		zend_property_info *prop_info = zend_get_property_info_for_slot(obj, int_prop);
+		ZEND_ASSERT(ZEND_TYPE_IS_SET(prop_info->type));
+		ZVAL_MAKE_REF(int_prop);
+		ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(int_prop), prop_info);
 	}
-	//else if (UNEXPECTED(return_value == int_prop)) {
-	//	return;
-	//}
 
-	ref = Z_REF_P(int_prop);
-	GC_ADDREF(ref);
-	if (Z_REFCOUNTED_P(return_value)) {
-		zend_refcounted *garbage = NULL;
-		garbage = Z_COUNTED_P(return_value);
-		if (garbage) {
-			GC_DTOR(garbage);
-		}
-	}
-	ZVAL_REF(return_value, ref);
+	ZVAL_COPY(return_value, int_prop);
 }
 
 // Returns a newly allocated DNF type `Iterator|(Traversable&Countable)`.

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -65,6 +65,8 @@ namespace {
         static public function variadicTest(string|Iterator ...$elements) : static {}
 
         public function takesUnionType(stdclass|Iterator $arg): void {}
+
+        public function &returnByRefIntProp(): int {}
     }
 
     class _ZendTestMagicCall

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 53027610adee7e1c675b1c1b38886100ce4e63ef */
+ * Stub hash: 9f38fdbb3b987bccaa873bd005559ce52b96b0dd */
 
 ZEND_STATIC_ASSERT(PHP_VERSION_ID >= 80000, "test_arginfo.h only supports PHP version ID 80000 or newer, "
 	"but it is included on an older PHP version");
@@ -187,6 +187,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestClass_takesUnionT
 	ZEND_ARG_OBJ_TYPE_MASK(0, arg, stdclass|Iterator, 0, NULL)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestClass_returnByRefIntProp, 1, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestMagicCall___call, 0, 2, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, args, IS_ARRAY, 0)
@@ -287,6 +290,7 @@ static ZEND_METHOD(_ZendTestClass, returnsStatic);
 static ZEND_METHOD(_ZendTestClass, returnsThrowable);
 static ZEND_METHOD(_ZendTestClass, variadicTest);
 static ZEND_METHOD(_ZendTestClass, takesUnionType);
+static ZEND_METHOD(_ZendTestClass, returnByRefIntProp);
 static ZEND_METHOD(_ZendTestMagicCall, __call);
 static ZEND_METHOD(_ZendTestChildClass, returnsThrowable);
 static ZEND_METHOD(ZendAttributeTest, testMethod);
@@ -426,6 +430,7 @@ static const zend_function_entry class__ZendTestClass_methods[] = {
 	ZEND_ME(_ZendTestClass, returnsThrowable, arginfo_class__ZendTestClass_returnsThrowable, ZEND_ACC_PUBLIC)
 	ZEND_ME(_ZendTestClass, variadicTest, arginfo_class__ZendTestClass_variadicTest, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(_ZendTestClass, takesUnionType, arginfo_class__ZendTestClass_takesUnionType, ZEND_ACC_PUBLIC)
+	ZEND_ME(_ZendTestClass, returnByRefIntProp, arginfo_class__ZendTestClass_returnByRefIntProp, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/zend_test/tests/gen_stub_test_return_by_ref.phpt
+++ b/ext/zend_test/tests/gen_stub_test_return_by_ref.phpt
@@ -1,0 +1,53 @@
+--TEST--
+gen_stub.php: Test that return by ref flag is set
+--XFAIL--
+Does not work currently
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$reflectionMethod = new ReflectionMethod(_ZendTestClass::class, "returnByRefIntProp");
+var_dump($reflectionMethod->returnsReference());
+
+$o = new _ZendTestClass();
+var_dump($o);
+$i = $o->returnByRefIntProp();
+var_dump($i);
+$i = 24;
+var_dump($i);
+var_dump($o);
+
+?>
+--EXPECT--
+bool(true)
+object(_ZendTestClass)#2 (3) {
+  ["intProp"]=>
+  int(123)
+  ["classProp"]=>
+  NULL
+  ["classUnionProp"]=>
+  NULL
+  ["classIntersectionProp"]=>
+  uninitialized(Traversable&Countable)
+  ["readonlyProp"]=>
+  uninitialized(int)
+  ["dnfProperty"]=>
+  uninitialized(Iterator|(Traversable&Countable))
+}
+int(123)
+int(24)
+object(_ZendTestClass)#2 (3) {
+  ["intProp"]=>
+  int(24)
+  ["classProp"]=>
+  NULL
+  ["classUnionProp"]=>
+  NULL
+  ["classIntersectionProp"]=>
+  uninitialized(Traversable&Countable)
+  ["readonlyProp"]=>
+  uninitialized(int)
+  ["dnfProperty"]=>
+  uninitialized(Iterator|(Traversable&Countable))
+}

--- a/ext/zend_test/tests/gen_stub_test_return_by_ref.phpt
+++ b/ext/zend_test/tests/gen_stub_test_return_by_ref.phpt
@@ -1,7 +1,5 @@
 --TEST--
 gen_stub.php: Test that return by ref flag is set
---XFAIL--
-Does not work currently
 --EXTENSIONS--
 zend_test
 --FILE--
@@ -12,7 +10,7 @@ var_dump($reflectionMethod->returnsReference());
 
 $o = new _ZendTestClass();
 var_dump($o);
-$i = $o->returnByRefIntProp();
+$i =& $o->returnByRefIntProp();
 var_dump($i);
 $i = 24;
 var_dump($i);
@@ -39,7 +37,7 @@ int(123)
 int(24)
 object(_ZendTestClass)#2 (3) {
   ["intProp"]=>
-  int(24)
+  &int(24)
   ["classProp"]=>
   NULL
   ["classUnionProp"]=>


### PR DESCRIPTION
Looks like this information is never set anywhere for internal functions/methods that return by reference.

EDIT: I'm not exactly sure that's the correct fix even if it looks like it, because I'm still running into some issues for https://github.com/Girgias/php-src/pull/19