### PR TITLE
Remove use of SDWORD and SWORD in ODBC extensions

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -32,7 +32,7 @@ enum pdo_odbc_conv_result {
 	PDO_ODBC_CONV_FAIL
 };
 
-static int pdo_odbc_sqltype_is_unicode(pdo_odbc_stmt *S, SWORD sqltype)
+static int pdo_odbc_sqltype_is_unicode(pdo_odbc_stmt *S, SQLSMALLINT sqltype)
 {
 	if (!S->assume_utf8) return 0;
 	switch (sqltype) {
@@ -287,7 +287,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 {
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	RETCODE rc;
-	SWORD sqltype = 0, ctype = 0, scale = 0, nullable = 0;
+	SQLSMALLINT sqltype = 0, ctype = 0, scale = 0, nullable = 0;
 	SQLULEN precision = 0;
 	pdo_odbc_param *P;
 	zval *parameter;
@@ -563,7 +563,7 @@ static int odbc_stmt_describe(pdo_stmt_t *stmt, int colno)
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	struct pdo_column_data *col = &stmt->columns[colno];
 	RETCODE rc;
-	SWORD	colnamelen;
+	SQLSMALLINT colnamelen;
 	SQLULEN	colsize;
 	SQLLEN displaysize = 0;
 

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -112,7 +112,7 @@
 typedef struct {
 	char last_state[6];
 	char last_err_msg[SQL_MAX_MESSAGE_LENGTH];
-	SDWORD last_error;
+	SQLINTEGER last_error;
 	const char *file, *what;
 	int line;
 } pdo_odbc_errinfo;

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -129,7 +129,7 @@ typedef struct {
 	char *data;
 	zend_ulong datalen;
 	SQLLEN fetched_len;
-	SWORD	coltype;
+	SQLSMALLINT coltype;
 	char colname[128];
 	unsigned is_long;
 	unsigned is_unicode:1;


### PR DESCRIPTION
This changes instances of SDWORD to SQLINTEGER and instances of SWORD to SQLSMALLINT. There's no point in using these, when we should what the functions define the parameters to actually be. The former change fixes GH-14367.

----

There are still references to SDWORD and SWORD, but it seems isolated to the Solid driver manager. There is a curious comment in `odbc_column_lengths`, as well as some orphan definitions of them for Solid in headers. I have no removed these because I'm not sure if Solid still needs these.

----

I'm targeting master because of the SWORD refactor, but the SDWORD change should presumably be backported as a bug fix that fixes the build.