### PR TITLE
Add missing pcre dependency definition to zip extension

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -63,6 +63,7 @@ if test "$PHP_ZIP" != "no"; then
 
   PHP_ZIP_SOURCES="php_zip.c zip_stream.c"
   PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared)
+  PHP_ADD_EXTENSION_DEP(zip, pcre)
 
   PHP_SUBST(ZIP_SHARED_LIBADD)
 fi

--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -9,6 +9,7 @@ if (PHP_ZIP != "no") {
 		 CHECK_LIB("libzip_a.lib", "zip", PHP_ZIP) && CHECK_LIB("libbz2_a.lib", "zip", PHP_ZIP) && CHECK_LIB("zlib_a.lib", "zip", PHP_ZIP) && CHECK_LIB("liblzma_a.lib", "zip", PHP_ZIP))
 	) {
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
+		ADD_EXTENSION_DEP('zip', 'pcre');
 
 		if (get_define("LIBS_ZIP").match("libzip_a(?:_debug)?\.lib")) {
 			/* Using static dependency lib. */

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1146,9 +1146,15 @@ static PHP_MSHUTDOWN_FUNCTION(zip);
 static PHP_MINFO_FUNCTION(zip);
 /* }}} */
 
+static const zend_module_dep zip_deps[] = {
+	ZEND_MOD_REQUIRED("pcre")
+	ZEND_MOD_END
+};
+
 /* {{{ zip_module_entry */
 zend_module_entry zip_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX, NULL,
+	zip_deps,
 	"zip",
 	ext_functions,
 	PHP_MINIT(zip),


### PR DESCRIPTION
The zip extension also requires the pcre extension.

Upstream PR also at https://github.com/pierrejoye/php_zip/pull/39