### PR TITLE
Fix bug #76232: SoapClient Cookie Header Semicolon

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -833,6 +833,7 @@ try_again:
 			zval *data;
 			zend_string *key;
 			has_cookies = 1;
+			bool first_cookie = true;
 			smart_str_append_const(&soap_headers, "Cookie: ");
 			ZEND_HASH_MAP_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(cookies), key, data) {
 				if (key && Z_TYPE_P(data) == IS_ARRAY) {
@@ -848,10 +849,13 @@ try_again:
 						   Z_TYPE_P(tmp) != IS_STRING ||
 						   in_domain(ZSTR_VAL(phpurl->host),Z_STRVAL_P(tmp))) &&
 						  (use_ssl || (tmp = zend_hash_index_find(Z_ARRVAL_P(data), 3)) == NULL)) {
+							if (!first_cookie) {
+								smart_str_appends(&soap_headers, "; ");
+							}
+							first_cookie = false;
 							smart_str_append(&soap_headers, key);
 							smart_str_appendc(&soap_headers, '=');
 							smart_str_append(&soap_headers, Z_STR_P(value));
-							smart_str_appendc(&soap_headers, ';');
 						}
 					}
 				}

--- a/ext/soap/tests/bugs/bug76232.phpt
+++ b/ext/soap/tests/bugs/bug76232.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Bug #76232 (SoapClient Cookie Header Semicolon)
+--EXTENSIONS--
+soap
+--SKIPIF--
+<?php
+    if (!file_exists(__DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc")) {
+        echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+    }
+?>
+--FILE--
+<?php
+
+include __DIR__ . "/../../../../sapi/cli/tests/php_cli_server.inc";
+
+$args = ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
+if (php_ini_loaded_file()) {
+  // Necessary such that it works from a development directory in which case extension_dir might not be the real extension dir
+  $args[] = "-c";
+  $args[] = php_ini_loaded_file();
+}
+$code = <<<'PHP'
+/* Receive */
+$content = trim(file_get_contents("php://input")) . PHP_EOL;
+PHP;
+
+php_cli_server_start($code, null, $args);
+
+$client = new soapclient(NULL, [
+  'location' => 'http://' . PHP_CLI_SERVER_ADDRESS,
+  'uri' => 'misc-uri',
+  'trace' => true,
+]);
+
+echo "=== Request with one cookie ===\n";
+
+$client->__setCookie('testcookie1', 'true');
+$client->__soapCall("foo", []);
+echo $client->__getLastRequestHeaders();
+
+echo "=== Request with two cookies ===\n";
+
+$client->__setCookie('testcookie2', 'true');
+$client->__soapCall("foo", []);
+
+echo $client->__getLastRequestHeaders();
+?>
+--EXPECTF--
+=== Request with one cookie ===
+POST / HTTP/1.1
+Host: %s
+Connection: Keep-Alive
+User-Agent: PHP-SOAP/%s
+Content-Type: text/xml; charset=utf-8
+SOAPAction: "misc-uri#foo"
+Content-Length: %d
+Cookie: testcookie1=true
+
+=== Request with two cookies ===
+POST / HTTP/1.1
+Host: %s
+Connection: Keep-Alive
+User-Agent: PHP-SOAP/%s
+Content-Type: text/xml; charset=utf-8
+SOAPAction: "misc-uri#foo"
+Content-Length: %d
+Cookie: testcookie1=true; testcookie2=true


### PR DESCRIPTION
According to RFC 6265 [1] the cookies must be separated by "; " not ";", and it must not end with ";".

[1] https://datatracker.ietf.org/doc/html/rfc6265