### PR TITLE
Fix ZEND_DEBUG condition

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2286,7 +2286,7 @@ static void do_soap_call(zend_execute_data *execute_data,
 
 	tmp = Z_CLIENT_SDL_P(this_ptr);
 	if (Z_TYPE_P(tmp) == IS_OBJECT) {
-#ifdef ZEND_DEBUG
+#if ZEND_DEBUG
 		ZEND_ASSERT(instanceof_function(Z_OBJCE_P(tmp), soap_sdl_class_entry));
 #endif
 		sdl = Z_SOAP_SDL_P(tmp)->sdl;


### PR DESCRIPTION
ZEND_DEBUG is always defined by the build system automatically, either to value 0 or value 1.

If I'm not mistaken, this should be ok. Or should the `#ifdef` parts be removed?