### PR TITLE
Remove hash dependency from session extension

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -258,6 +258,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      equivalent to reading PS(session_status) but works with shared objects too.
    - Added the php_get_session_var_str() API to set a session variable without
      needing to create a zend_string.
+   - The ext/session/php_session.h doesn't transitively include the
+     ext/hash/php_hash.h header anymore.
 
 ========================
 4. OpCode changes

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -15,7 +15,6 @@ if test "$PHP_SESSION" != "no"; then
   PHP_PWRITE_TEST
   PHP_PREAD_TEST
   PHP_NEW_EXTENSION(session, mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_ADD_EXTENSION_DEP(session, hash, true)
   PHP_ADD_EXTENSION_DEP(session, spl)
   PHP_SUBST(SESSION_SHARED_LIBADD)
   PHP_INSTALL_HEADERS([ext/session], [php_session.h mod_files.h mod_user.h])

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -18,7 +18,6 @@
 #define PHP_SESSION_H
 
 #include "ext/standard/php_var.h"
-#include "ext/hash/php_hash.h"
 #include "ext/random/php_random.h"
 
 #define PHP_SESSION_API 20161017

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2998,7 +2998,6 @@ static PHP_MINFO_FUNCTION(session) /* {{{ */
 /* }}} */
 
 static const zend_module_dep session_deps[] = { /* {{{ */
-	ZEND_MOD_OPTIONAL("hash")
 	ZEND_MOD_REQUIRED("spl")
 	ZEND_MOD_END
 };


### PR DESCRIPTION
The session extension once depended on the hash extension for having hash functions available when using the `session.hash_function` INI directive. This directive was removed in PHP-7.1 via 3467526a65bfb15eaf9ec49a0b5673b84e26bca4. At the time it could be marked as optional dependency, because it only needed to be loaded before the session in that case.

The removed ext/hash/php_hash.h in the ext/session/php_session.h might cause BC break for PHP extensions if they rely on transitive include and use hash extension in the code without explicitly including the ext/hash/php_hash.h header. Solution is to include the ext/hash/php_hash.h separately.

I'm just checking the CI if this is the case, but ext/hash doesn't seem to be needed in ext/session... 