### PR TITLE
Update ext/session spl dependency

### DIFF
--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -15,7 +15,8 @@ if test "$PHP_SESSION" != "no"; then
   PHP_PWRITE_TEST
   PHP_PREAD_TEST
   PHP_NEW_EXTENSION(session, mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_ADD_EXTENSION_DEP(session, spl)
+  dnl https://bugs.php.net/53141
+  PHP_ADD_EXTENSION_DEP(session, spl, true)
   PHP_SUBST(SESSION_SHARED_LIBADD)
   PHP_INSTALL_HEADERS([ext/session], [php_session.h mod_files.h mod_user.h])
   AC_DEFINE(HAVE_PHP_SESSION,1,[ ])

--- a/ext/session/config.w32
+++ b/ext/session/config.w32
@@ -4,6 +4,8 @@ ARG_ENABLE("session", "session support", "yes");
 
 if (PHP_SESSION == "yes") {
 	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	// https://bugs.php.net/53141
+	ADD_EXTENSION_DEP('session', 'spl', true);
 	AC_DEFINE("HAVE_PHP_SESSION", 1, "Session support");
 	PHP_INSTALL_HEADERS("ext/session", "mod_mm.h php_session.h mod_files.h mod_user.h");
 }

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2998,7 +2998,7 @@ static PHP_MINFO_FUNCTION(session) /* {{{ */
 /* }}} */
 
 static const zend_module_dep session_deps[] = { /* {{{ */
-	ZEND_MOD_REQUIRED("spl")
+	ZEND_MOD_OPTIONAL("spl")
 	ZEND_MOD_END
 };
 /* }}} */


### PR DESCRIPTION
The spl dependency is configured so the spl_autoload_register is available when session_start() is used, meaning the spl extension needs to be loaded before the session. It is marked as optional to be more explicit as spl is not directly used nor required in the session extension.