### PR TITLE
Fix reference handling in SpoofChecker

### DIFF
--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -42,9 +42,7 @@ PHP_METHOD(Spoofchecker, isSuspicious)
 	}
 
 	if (error_code) {
-		zval_ptr_dtor(error_code);
-		ZVAL_LONG(Z_REFVAL_P(error_code), ret);
-		Z_TRY_ADDREF_P(error_code);
+		ZEND_TRY_ASSIGN_REF_LONG(error_code, ret);
 	}
 	RETVAL_BOOL(ret != 0);
 }
@@ -76,9 +74,7 @@ PHP_METHOD(Spoofchecker, areConfusable)
 	}
 
 	if (error_code) {
-		zval_ptr_dtor(error_code);
-		ZVAL_LONG(Z_REFVAL_P(error_code), ret);
-		Z_TRY_ADDREF_P(error_code);
+		ZEND_TRY_ASSIGN_REF_LONG(error_code, ret);
 	}
 	RETVAL_BOOL(ret != 0);
 }

--- a/ext/intl/tests/spoofchecker_self_references.phpt
+++ b/ext/intl/tests/spoofchecker_self_references.phpt
@@ -16,7 +16,3 @@ echo "Done\n";
 ?>
 --EXPECT--
 Done
-[Sat Jun  1 19:32:47 2024]  Script:  '/run/media/niels/MoreData/php-8.2/ext/intl/tests/spoofchecker_self_references.php'
-/run/media/niels/MoreData/php-8.2/Zend/zend_objects_API.h(92) :  Freeing 0x0000796cc9205780 (64 bytes), script=/run/media/niels/MoreData/php-8.2/ext/intl/tests/spoofchecker_self_references.php
-Last leak repeated 1 time
-=== Total 2 memory leaks detected ===

--- a/ext/intl/tests/spoofchecker_self_references.phpt
+++ b/ext/intl/tests/spoofchecker_self_references.phpt
@@ -1,0 +1,22 @@
+--TEST--
+SpoofChecker with self references
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$checker = new Spoofchecker();
+$checker->isSuspicious("", $checker);
+
+$checker = new Spoofchecker();
+$checker->areConfusable("", "", $checker);
+
+echo "Done\n";
+
+?>
+--EXPECT--
+Done
+[Sat Jun  1 19:32:47 2024]  Script:  '/run/media/niels/MoreData/php-8.2/ext/intl/tests/spoofchecker_self_references.php'
+/run/media/niels/MoreData/php-8.2/Zend/zend_objects_API.h(92) :  Freeing 0x0000796cc9205780 (64 bytes), script=/run/media/niels/MoreData/php-8.2/ext/intl/tests/spoofchecker_self_references.php
+Last leak repeated 1 time
+=== Total 2 memory leaks detected ===

--- a/ext/intl/tests/spoofchecker_typed_references.phpt
+++ b/ext/intl/tests/spoofchecker_typed_references.phpt
@@ -1,0 +1,35 @@
+--TEST--
+SpoofChecker with typed references
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+class Test {
+    public string $x;
+}
+
+$test = new Test;
+$test->x = "";
+
+$checker = new Spoofchecker();
+$checker->isSuspicious("", $test->x);
+var_dump($test);
+
+$test = new Test;
+$test->x = "";
+
+$checker = new Spoofchecker();
+$checker->areConfusable("", "", $test->x);
+var_dump($test);
+
+?>
+--EXPECT--
+object(Test)#1 (1) {
+  ["x"]=>
+  int(0)
+}
+object(Test)#3 (1) {
+  ["x"]=>
+  int(1)
+}

--- a/ext/intl/tests/spoofchecker_typed_references.phpt
+++ b/ext/intl/tests/spoofchecker_typed_references.phpt
@@ -27,9 +27,9 @@ var_dump($test);
 --EXPECT--
 object(Test)#1 (1) {
   ["x"]=>
-  int(0)
+  string(1) "0"
 }
 object(Test)#3 (1) {
   ["x"]=>
-  int(1)
+  string(1) "1"
 }


### PR DESCRIPTION
First commit demonstrates the problem, second commit fixes it.
Will squash on merge.