### PR TITLE
Fix GH-14361: Deep recursion in zend_cfg.c causes segfault instead of error

### DIFF
--- a/Zend/Optimizer/zend_cfg.c
+++ b/Zend/Optimizer/zend_cfg.c
@@ -28,6 +28,8 @@ static void zend_mark_reachable(zend_op *opcodes, zend_cfg *cfg, zend_basic_bloc
 {
 	zend_basic_block *blocks = cfg->blocks;
 
+	zend_check_stack_limit("Try reducing function size");
+
 	while (1) {
 		int i;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -800,6 +800,8 @@ ZEND_API size_t zend_get_scanned_file_offset(void);
 
 ZEND_API zend_string *zend_get_compiled_variable_name(const zend_op_array *op_array, uint32_t var);
 
+void zend_check_stack_limit(const char *suggestion);
+
 #ifdef ZTS
 const char *zend_get_zendtext(void);
 int zend_get_zendleng(void);

--- a/ext/opcache/tests/jit/gh14361.phpt
+++ b/ext/opcache/tests/jit/gh14361.phpt
@@ -3,21 +3,24 @@ GH-14361 (Deep recursion in zend_cfg.c causes segfault instead of error)
 --SKIPIF--
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
+if (PHP_ZTS !== 0) die("skip gives additional warning on ZTS");
 ?>
 --EXTENSIONS--
 zend_test
 opcache
 --INI--
-zend.max_allowed_stack_size=64K
+error_reporting=E_COMPILE_ERROR
+zend.max_allowed_stack_size=128K
 opcache.enable=1
 opcache.enable_cli=1
 opcache.jit=tracing
+opcache.jit_buffer_size=64M
 opcache.optimization_level=0x000000a0
 --FILE--
 <?php
 $tmp = fopen(__DIR__."/gh14361_tmp.php", "w");
 fwrite($tmp, '<?php ');
-for ($i = 0; $i < 10000; $i++) {
+for ($i = 0; $i < 70000; $i++) {
     fwrite($tmp, 'if (@((0) == (0)) !== (true)) { $f++; }');
 }
 fclose($tmp);
@@ -29,5 +32,4 @@ include __DIR__."/gh14361_tmp.php";
 @unlink(__DIR__."/gh14361_tmp.php");
 ?>
 --EXPECTF--
-Fatal error: Maximum call stack size of 32768 bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached during compilation. Try reducing function size in %s on line %d
-%A
+Fatal error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached during compilation. Try reducing function size in %s on line %d

--- a/ext/opcache/tests/jit/gh14361.phpt
+++ b/ext/opcache/tests/jit/gh14361.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-14361 (Deep recursion in zend_cfg.c causes segfault instead of error)
+--SKIPIF--
+<?php
+if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
+?>
+--EXTENSIONS--
+zend_test
+opcache
+--INI--
+zend.max_allowed_stack_size=64K
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.optimization_level=0x000000a0
+--FILE--
+<?php
+$tmp = fopen(__DIR__."/gh14361_tmp.php", "w");
+fwrite($tmp, '<?php ');
+for ($i = 0; $i < 10000; $i++) {
+    fwrite($tmp, 'if (@((0) == (0)) !== (true)) { $f++; }');
+}
+fclose($tmp);
+
+include __DIR__."/gh14361_tmp.php";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__."/gh14361_tmp.php");
+?>
+--EXPECTF--
+Fatal error: Maximum call stack size of 32768 bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached during compilation. Try reducing function size in %s on line %d
+%A


### PR DESCRIPTION
Use the same stack limit check already used elsewhere in compilation.