### PR TITLE
Sync #if/ifdef/defined for LIBXML_EXPAT_COMPAT

### DIFF
--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -270,7 +270,7 @@ static int xml_parse_helper(xml_parser *parser, const char *data, size_t data_le
 	ZEND_ASSERT(!parser->isparsing);
 
 	/* libxml2 specific options */
-#if LIBXML_EXPAT_COMPAT
+#ifdef LIBXML_EXPAT_COMPAT
 	/* See xmlInitSAXParserCtxt() and xmlCtxtUseOptions() */
 	if (parser->parsehuge) {
 		parser->parser->parser->options |= XML_PARSE_HUGE;


### PR DESCRIPTION
This one can be undefined or defined to value 1.