### PR TITLE
Wrap gdImageCreateFrom* checks in AC_CACHE_CHECK

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -147,14 +147,15 @@ dnl that gd defines "junk" versions of each gdImageCreateFromFoo function
 dnl even when it does not support the Foo format. Those junk functions
 dnl display a warning but eventually return normally, making a simple link
 dnl or run test insufficient.
-AC_DEFUN([PHP_GD_CHECK_FORMAT],[
-  old_LIBS="${LIBS}"
-  LIBS="${LIBS} ${GD_SHARED_LIBADD}"
-  old_CFLAGS="${CFLAGS}"
-  CFLAGS="${CFLAGS} ${GDLIB_CFLAGS}"
-  AC_MSG_CHECKING([for working gdImageCreateFrom$1 in libgd])
-  AC_LANG_PUSH([C])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([
+AC_DEFUN([PHP_GD_CHECK_FORMAT],
+[AS_VAR_PUSHDEF([php_var], [php_cv_lib_gd_gdImageCreateFrom$1])
+old_LIBS="${LIBS}"
+LIBS="${LIBS} ${GD_SHARED_LIBADD}"
+old_CFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS} ${GDLIB_CFLAGS}"
+AC_LANG_PUSH([C])
+AC_CACHE_CHECK([for working gdImageCreateFrom$1 in libgd], [php_var],
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <unistd.h>
 #include <gd.h>
@@ -173,17 +174,17 @@ int main(int argc, char** argv) {
   gdSetErrorMethod(exit1);
   gdImagePtr p = gdImageCreateFrom$1(f);
   return 0;
-}])],[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE($2, 1, [Does gdImageCreateFrom$1 work?])
-  ],[
-    AC_MSG_RESULT([no])
-  ],[
-    AC_MSG_RESULT([no])
-  ])
-  AC_LANG_POP([C])
-  CFLAGS="${old_CFLAGS}"
-  LIBS="${old_LIBS}"
+}])],
+  [AS_VAR_SET([php_var], [yes])],
+  [AS_VAR_SET([php_var], [no])],
+  [AS_VAR_SET([php_var], [no])])])
+AS_VAR_IF([php_var], [yes],
+  [AC_DEFINE_UNQUOTED([$2], [1],
+    [Define to 1 if GD library has 'gdImageCreateFrom$1'.])])
+AC_LANG_POP([C])
+CFLAGS="${old_CFLAGS}"
+LIBS="${old_LIBS}"
+AS_VAR_POPDEF([php_var])
 ])
 
 AC_DEFUN([PHP_GD_CHECK_VERSION],[


### PR DESCRIPTION
This enables cross-compiling edge cases to manually override the checks with the php_cv_lib_gd_gdImageCreateFrom* cache variables.

I'll double recheck this if everything is written correctly... Creating dynamic cache variables names might be a bit error prone. Otherwise, it seems to work ok.