### PR TITLE
Update ext/simplexml dependencies

### DIFF
--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -5,17 +5,12 @@ PHP_ARG_ENABLE([simplexml],
   [yes])
 
 if test "$PHP_SIMPLEXML" != "no"; then
-
-  if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([SimpleXML extension requires LIBXML extension, add --with-libxml])
-  fi
-
   PHP_SETUP_LIBXML(SIMPLEXML_SHARED_LIBADD, [
     AC_DEFINE(HAVE_SIMPLEXML,1,[ ])
     PHP_NEW_EXTENSION(simplexml, simplexml.c, $ext_shared)
+    PHP_ADD_EXTENSION_DEP(simplexml, libxml)
+    PHP_ADD_EXTENSION_DEP(simplexml, spl)
     PHP_INSTALL_HEADERS([ext/simplexml], [php_simplexml.h php_simplexml_exports.h])
     PHP_SUBST(SIMPLEXML_SHARED_LIBADD)
   ])
-  PHP_ADD_EXTENSION_DEP(simplexml, libxml)
-  PHP_ADD_EXTENSION_DEP(simplexml, spl, true)
 fi

--- a/ext/simplexml/config.w32
+++ b/ext/simplexml/config.w32
@@ -5,6 +5,7 @@ ARG_WITH("simplexml", "Simple XML support", "yes");
 if (PHP_SIMPLEXML == "yes") {
 	if(PHP_LIBXML == "yes" &&
 		ADD_EXTENSION_DEP('simplexml', 'libxml') &&
+		ADD_EXTENSION_DEP('simplexml', 'spl') &&
 		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SIMPLEXML", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("simplexml", "simplexml.c");
@@ -17,9 +18,6 @@ if (PHP_SIMPLEXML == "yes") {
 			}
 		}
 
-		if (!ADD_EXTENSION_DEP('simplexml', 'spl', true)) {
-			MESSAGE("\tSPL support in simplexml disabled");
-		}
 		ADD_FLAG("CFLAGS_SIMPLEXML", "/D PHP_SIMPLEXML_EXPORTS ");
 		PHP_INSTALL_HEADERS("ext/simplexml", "php_simplexml.h php_simplexml_exports.h");
 	} else {


### PR DESCRIPTION
This syncs the configure time dependencies for ext/simplexml:
- ext/spl was once optional but since being always available, conditional usage was removed
- ext/libxml required