### PR TITLE
Fix GH-14407 mb_http_input tests failed on Windows

### DIFF
--- a/ext/mbstring/tests/mb_http_input.phpt
+++ b/ext/mbstring/tests/mb_http_input.phpt
@@ -5,7 +5,7 @@ mbstring
 --POST--
 a=日本語0123456789日本語カタカナひらがな
 --GET--
-b=日本語0123456789日本語カタカナひらがな
+b=%C6%FC%CB%DC%B8%EC0123456789%C6%FC%CB%DC%B8%EC%A5%AB%A5%BF%A5%AB%A5%CA%A4%D2%A4%E9%A4%AC%A4%CA
 --INI--
 mbstring.encoding_translation=1
 input_encoding=latin1

--- a/ext/mbstring/tests/mb_http_input_pass.phpt
+++ b/ext/mbstring/tests/mb_http_input_pass.phpt
@@ -5,7 +5,7 @@ mbstring
 --POST--
 a=日本語0123456789日本語カタカナひらがな
 --GET--
-b=日本語0123456789日本語カタカナひらがな
+b=%C6%FC%CB%DC%B8%EC0123456789%C6%FC%CB%DC%B8%EC%A5%AB%A5%BF%A5%AB%A5%CA%A4%D2%A4%E9%A4%AC%A4%CA
 --INI--
 mbstring.encoding_translation=1
 input_encoding=pass


### PR DESCRIPTION
Originally, the GET method had to be percent encoded. This test did not pass on Windows, so I changed it to a percent-encoded parameter.

closes: #14407 