### PR TITLE
Fix GH-11188: Error when building TSRM in ARM64 (for IR JIT)

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -800,11 +800,20 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 	asm("adrp %0, #__tsrm_ls_cache@TLVPPAGE\n\t"
 	    "ldr %0, [%0, #__tsrm_ls_cache@TLVPPAGEOFF]"
 	     : "=r" (ret));
-# else
+# elif defined(TSRM_TLS_MODEL_DEFAULT)
+	/* Surplus Static TLS space isn't guaranteed. */
+	ret = 0;
+# elif defined(TSRM_TLS_MODEL_INITIAL_EXEC)
+	asm("adrp %0, :gottprel:_tsrm_ls_cache\n\t"
+		"ldr %0, [%0, #:gottprel_lo12:_tsrm_ls_cache]"
+		: "=r" (ret));
+# elif defined(TSRM_TLS_MODEL_LOCAL_EXEC)
 	asm("mov %0, xzr\n\t"
 	    "add %0, %0, #:tprel_hi12:_tsrm_ls_cache, lsl #12\n\t"
 	    "add %0, %0, #:tprel_lo12_nc:_tsrm_ls_cache"
 	     : "=r" (ret));
+# else
+#  error "TSRM TLS model not set"
 # endif
 	return ret;
 #else

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -154,10 +154,13 @@ TSRM_API bool tsrm_is_managed_thread(void);
 
 #if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__MUSL__) || defined(__HAIKU__)
 # define TSRM_TLS_MODEL_ATTR
+# define TSRM_TLS_MODEL_DEFAULT
 #elif __PIC__
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))
+# define TSRM_TLS_MODEL_INITIAL_EXEC
 #else
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("local-exec")))
+# define TSRM_TLS_MODEL_LOCAL_EXEC
 #endif
 
 #define TSRM_SHUFFLE_RSRC_ID(rsrc_id)		((rsrc_id)+1)


### PR DESCRIPTION
This is GH-11236 for IR JIT.
TSRM change is the same.
The only real difference is the place where the tsrm_tls_offset and tsrm_tls_index are filled in for FreeBSD but the code is otherwise identical.
Asking @arnaud-lb for review as he did it for the 8.2 & 8.3 version.