### PR TITLE
Fix sign conversion warnings, part 3

### DIFF
--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -96,7 +96,7 @@ static ssize_t php_bz2iop_read(php_stream *stream, char *buf, size_t count)
 
 static ssize_t php_bz2iop_write(php_stream *stream, const char *buf, size_t count)
 {
-	ssize_t wrote = 0;
+	size_t wrote = 0;
 	struct php_bz2_stream_data_t *self = (struct php_bz2_stream_data_t *)stream->abstract;
 
 	do {

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -788,7 +788,7 @@ static size_t curl_read(char *data, size_t size, size_t nmemb, void *ctx)
 			if (!Z_ISUNDEF(retval)) {
 				_php_curl_verify_handlers(ch, /* reporterror */ true);
 				if (Z_TYPE(retval) == IS_STRING) {
-					length = MIN((int) (size * nmemb), Z_STRLEN(retval));
+					length = MIN((size * nmemb), Z_STRLEN(retval));
 					memcpy(data, Z_STRVAL(retval), length);
 				} else if (Z_TYPE(retval) == IS_LONG) {
 					length = Z_LVAL_P(&retval);

--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -135,7 +135,7 @@ PHP_METHOD(DOMCharacterData, substringData)
 		RETURN_FALSE;
 	}
 
-	if (offset > length) {
+	if (offset > (unsigned int)length) {
 		php_dom_throw_error(INDEX_SIZE_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}
@@ -230,7 +230,7 @@ static void dom_character_data_insert_data(INTERNAL_FUNCTION_PARAMETERS, bool re
 		RETURN_FALSE;
 	}
 
-	if (offset > length) {
+	if (offset > (unsigned int)length) {
 		php_dom_throw_error(INDEX_SIZE_ERR, dom_get_strict_error(intern->document));
 		RETURN_FALSE;
 	}

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -220,7 +220,7 @@ ZEND_GET_MODULE(exif)
  * is read or until there is no more data available to read. */
 static ssize_t exif_read_from_stream_file_looped(php_stream *stream, char *buf, size_t count)
 {
-	ssize_t total_read = 0;
+	size_t total_read = 0;
 	while (total_read < count) {
 		ssize_t ret = php_stream_read(stream, buf + total_read, count - total_read);
 		if (ret == -1) {
@@ -2185,16 +2185,12 @@ static image_info_data *exif_alloc_image_info_data(image_info_list *info_list) {
 /* {{{ exif_iif_add_value
  Add a value to image_info
 */
-static void exif_iif_add_value(image_info_type *image_info, int section_index, char *name, int tag, int format, int length, void* value, size_t value_len, int motorola_intel)
+static void exif_iif_add_value(image_info_type *image_info, int section_index, char *name, int tag, int format, size_t length, void* value, size_t value_len, int motorola_intel)
 {
 	size_t idex;
 	void *vptr, *vptr_end;
 	image_info_value *info_value;
 	image_info_data  *info_data;
-
-	if (length < 0) {
-		return;
-	}
 
 	info_data = exif_alloc_image_info_data(&image_info->info_list[section_index]);
 	memset(info_data, 0, sizeof(image_info_data));
@@ -2211,7 +2207,7 @@ static void exif_iif_add_value(image_info_type *image_info, int section_index, c
 				value = NULL;
 			}
 			if (value) {
-				length = (int)zend_strnlen(value, length);
+				length = zend_strnlen(value, length);
 				info_value->s = estrndup(value, length);
 				info_data->length = length;
 			} else {
@@ -2242,7 +2238,7 @@ static void exif_iif_add_value(image_info_type *image_info, int section_index, c
 			}
 			if (value) {
 				if (tag == TAG_MAKER_NOTE) {
-					length = (int) zend_strnlen(value, length);
+					length = zend_strnlen(value, length);
 				}
 
 				/* do not recompute length here */
@@ -2264,14 +2260,14 @@ static void exif_iif_add_value(image_info_type *image_info, int section_index, c
 		case TAG_FMT_DOUBLE:
 			if (length==0) {
 				break;
-			} else
+			}
 			if (length>1) {
 				info_value->list = safe_emalloc(length, sizeof(image_info_value), 0);
 			} else {
 				info_value = &info_data->value;
 			}
 			vptr_end = (char *) value + value_len;
-			for (idex=0,vptr=value; idex<(size_t)length; idex++,vptr=(char *) vptr + php_tiff_bytes_per_format[format]) {
+			for (idex=0,vptr=value; idex<length; idex++,vptr=(char *) vptr + php_tiff_bytes_per_format[format]) {
 				if ((char *) vptr_end - (char *) vptr < php_tiff_bytes_per_format[format]) {
 					exif_error_docref("exif_iif_add_value" EXIFERR_CC, image_info, E_WARNING, "Value too short");
 					break;
@@ -2330,7 +2326,7 @@ static void exif_iif_add_value(image_info_type *image_info, int section_index, c
 */
 static void exif_iif_add_tag(image_info_type *image_info, int section_index, char *name, int tag, int format, size_t length, void* value, size_t value_len)
 {
-	exif_iif_add_value(image_info, section_index, name, tag, format, (int)length, value, value_len, image_info->motorola_intel);
+	exif_iif_add_value(image_info, section_index, name, tag, format, length, value, value_len, image_info->motorola_intel);
 }
 /* }}} */
 

--- a/ext/fileinfo/php_libmagic.c
+++ b/ext/fileinfo/php_libmagic.c
@@ -19,7 +19,7 @@
 
 zend_string* convert_libmagic_pattern(const char *val, size_t len, uint32_t options)
 {
-	int i, j;
+	size_t i, j;
 	zend_string *t;
 
 	for (i = j = 0; i < len; i++) {

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
@@ -164,7 +164,7 @@ static inline void mb_convert_buf_init(mb_convert_buf *buf, size_t initsize, uin
 
 #define MB_CONVERT_BUF_ENSURE(buf, out, limit, needed) \
 	ZEND_ASSERT(out <= limit); \
-	if ((limit - out) < (needed)) { \
+	if ((size_t)(limit - out) < (needed)) { \
 		size_t oldsize = limit - (unsigned char*)ZSTR_VAL((buf)->str); \
 		size_t newsize = oldsize + MAX(oldsize >> 1, needed); \
 		zend_string *newstr = erealloc((buf)->str, _ZSTR_STRUCT_SIZE(newsize)); \

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -689,7 +689,7 @@ mb_regex_groups_iter(const OnigUChar* name, const OnigUChar* name_end, int ngrou
 	gn = onig_name_to_backref_number(reg, name, name_end, args->region);
 	beg = args->region->beg[gn];
 	end = args->region->end[gn];
-	if (beg >= 0 && beg < end && end <= args->search_len) {
+	if (beg >= 0 && beg < end && ((size_t)end <= args->search_len)) {
 		add_assoc_stringl_ex(args->groups, (char *)name, name_end - name, &args->search_str[beg], end - beg);
 	} else {
 		add_assoc_bool_ex(args->groups, (char *)name, name_end - name, 0);

--- a/ext/mbstring/php_unicode.c
+++ b/ext/mbstring/php_unicode.c
@@ -301,28 +301,28 @@ MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, cons
 		/* In all cases, handle invalid characters early, as we assign special meaning to codepoints > 0xFFFFFF */
 		switch (case_mode) {
 		case PHP_UNICODE_CASE_UPPER_SIMPLE:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				*p++ = (UNEXPECTED(w > 0xFFFFFF)) ? w : php_unicode_toupper_simple(w, src_encoding);
 			}
 			break;
 
 		case PHP_UNICODE_CASE_LOWER_SIMPLE:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				*p++ = (UNEXPECTED(w > 0xFFFFFF)) ? w : php_unicode_tolower_simple(w, src_encoding);
 			}
 			break;
 
 		case PHP_UNICODE_CASE_FOLD_SIMPLE:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				*p++ = (UNEXPECTED(w > 0xFFFFFF)) ? w : php_unicode_tofold_simple(w, src_encoding);
 			}
 			break;
 
 		case PHP_UNICODE_CASE_TITLE_SIMPLE:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				if (UNEXPECTED(w > 0xFFFFFF)) {
 					*p++ = w;
@@ -336,7 +336,7 @@ MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, cons
 			break;
 
 		case PHP_UNICODE_CASE_UPPER:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				if (UNEXPECTED(w > 0xFFFFFF)) {
 					*p++ = w;
@@ -352,7 +352,7 @@ MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, cons
 			break;
 
 		case PHP_UNICODE_CASE_LOWER:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				if (UNEXPECTED(w > 0xFFFFFF)) {
 					*p++ = w;
@@ -405,7 +405,7 @@ MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, cons
 			break;
 
 		case PHP_UNICODE_CASE_FOLD:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				if (UNEXPECTED(w > 0xFFFFFF)) {
 					*p++ = w;
@@ -421,7 +421,7 @@ MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, cons
 			break;
 
 		case PHP_UNICODE_CASE_TITLE:
-			for (int i = 0; i < out_len; i++) {
+			for (size_t i = 0; i < out_len; i++) {
 				uint32_t w = wchar_buf[i];
 				if (UNEXPECTED(w > 0xFFFFFF)) {
 					*p++ = w;

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -714,8 +714,7 @@ PHP_FUNCTION(pcntl_signal)
 	if (!PCNTL_G(spares)) {
 		/* since calling malloc() from within a signal handler is not portable,
 		 * pre-allocate a few records for recording signals */
-		int i;
-		for (i = 0; i < PCNTL_G(num_signals); i++) {
+		for (unsigned int i = 0; i < PCNTL_G(num_signals); i++) {
 			struct php_pcntl_pending_signal *psig;
 
 			psig = emalloc(sizeof(*psig));
@@ -903,7 +902,7 @@ PHP_FUNCTION(pcntl_sigprocmask)
 			RETURN_THROWS();
 		}
 
-		for (int signal_no = 1; signal_no < PCNTL_G(num_signals); ++signal_no) {
+		for (unsigned int signal_no = 1; signal_no < PCNTL_G(num_signals); ++signal_no) {
 			if (sigismember(&old_set, signal_no) != 1) {
 				continue;
 			}
@@ -1656,7 +1655,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 
 	// 0 == getpid in this context, we're just saving a syscall
 	pid = pid_is_null ? 0 : pid;
-	zend_ulong maxcpus = (zend_ulong)sysconf(_SC_NPROCESSORS_CONF);
+	zend_long maxcpus = sysconf(_SC_NPROCESSORS_CONF);
 	PCNTL_CPU_ZERO(mask);
 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(hmask), ncpu) {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -1321,8 +1321,7 @@ PHP_ZEND_TEST_API struct bug79096 bug79096(void)
 
 PHP_ZEND_TEST_API void bug79532(off_t *array, size_t elems)
 {
-	int i;
-	for (i = 0; i < elems; i++) {
+	for (size_t i = 0; i < elems; i++) {
 		array[i] = i;
 	}
 }

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -395,7 +395,7 @@ static void php_load_zend_extension_cb(void *arg) { }
 #endif
 /* }}} */
 
-static void append_ini_path(char *php_ini_search_path, int search_path_size, const char *path)
+static void append_ini_path(char *php_ini_search_path, size_t search_path_size, const char *path)
 {
 	static const char paths_separator[] = { ZEND_PATHS_SEPARATOR, 0 };
 
@@ -432,7 +432,7 @@ int php_init_config(void)
 		php_ini_search_path = sapi_module.php_ini_path_override;
 		free_ini_search_path = 0;
 	} else if (!sapi_module.php_ini_ignore) {
-		int search_path_size;
+		size_t search_path_size;
 		char *default_location;
 		char *env_location;
 #ifdef PHP_WIN32
@@ -478,7 +478,7 @@ int php_init_config(void)
 		 * Prepare search path
 		 */
 
-		search_path_size = MAXPATHLEN * 4 + (int)strlen(env_location) + 3 + 1;
+		search_path_size = MAXPATHLEN * 4 + strlen(env_location) + 3 + 1;
 		php_ini_search_path = (char *) emalloc(search_path_size);
 		free_ini_search_path = 1;
 		php_ini_search_path[0] = 0;


### PR DESCRIPTION
Part of #14448

MBString is going to be tricky to get warning free, as I don't necessarily understand everything what is happening, but the ones in this PR should be safe. However, I will likely add the `-Wno-sign-compare` warning to the extension CFLAGS to let someone else deal with those issues long term.