### PR TITLE
Zend: Enable -Wcast-align warning

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -217,6 +217,7 @@ AX_CHECK_COMPILE_FLAG([-Wduplicated-cond], CFLAGS="-Wduplicated-cond $CFLAGS", ,
 AX_CHECK_COMPILE_FLAG([-Wlogical-op], CFLAGS="-Wlogical-op $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wformat-truncation], CFLAGS="-Wformat-truncation $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], CFLAGS="-Wstrict-prototypes $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wcast-align], CFLAGS="-Wcast-align $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-fno-common], CFLAGS="-fno-common $CFLAGS", , [-Werror])
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"


### PR DESCRIPTION
It should be noted that using `-Wcast-align=strict` generates an enormous amount of warnings

Edit: okay this is not going to work, as it seems that the semantics of that for Clang is the same as GCC's `-Wcast-align=strict`