### PR TITLE
Make the CLI mode available via the SAPI globals

### DIFF
--- a/sapi/cli/cli.h
+++ b/sapi/cli/cli.h
@@ -36,4 +36,23 @@ typedef struct  {
 
 extern PHP_CLI_API cli_shell_callbacks_t *php_cli_get_shell_callbacks(void);
 
+typedef enum php_cli_mode {
+	PHP_CLI_MODE_STANDARD = 1,
+	PHP_CLI_MODE_HIGHLIGHT = 2,
+	PHP_CLI_MODE_LINT = 4,
+	PHP_CLI_MODE_STRIP = 5,
+	PHP_CLI_MODE_CLI_DIRECT = 6,
+	PHP_CLI_MODE_PROCESS_STDIN = 7,
+	PHP_CLI_MODE_REFLECTION_FUNCTION = 8,
+	PHP_CLI_MODE_REFLECTION_CLASS = 9,
+	PHP_CLI_MODE_REFLECTION_EXTENSION = 10,
+	PHP_CLI_MODE_REFLECTION_EXT_INFO = 11,
+	PHP_CLI_MODE_REFLECTION_ZEND_EXTENSION = 12,
+	PHP_CLI_MODE_SHOW_INI_CONFIG = 13,
+} php_cli_mode;
+
+typedef struct php_cli_server_context {
+	php_cli_mode mode;
+} php_cli_server_context;
+
 #endif /* CLI_H */

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -916,7 +916,7 @@ do_repeat:
 			/* is also accessible. */
 			php_self = "Standard input code";
 			if (behavior < PHP_MODE_CLI_DIRECT
-			 && (!interactive || PHP_MODE_STANDARD != PHP_MODE_STANDARD)) {
+			 && !interactive) {
 				zend_stream_init_fp(&file_handle, stdin, php_self);
 				file_handle.primary_script = 1;
 			}


### PR DESCRIPTION
When hooking into RINIT it is currently pretty much impossible to determine whether a file will actually be executed or if it just will be linted, highlighted, or comments stripped: The startup is identical for all of them and the chosen mode is not currently exposed to other extensions.

The `SG(server_context)` is currently entirely unused for the `cli` SAPI. It appears to be appropriate to store the mode as a SAPI-specific information inside of it.