### PR TITLE
Fixed off-by-one error in checking length of abstract namespace Unix sockets

### DIFF
--- a/ext/standard/tests/streams/bug60106-001.phpt
+++ b/ext/standard/tests/streams/bug60106-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug#60106 (stream_socket_server silently truncates long unix socket paths)
+Bug #60106 (stream_socket_server silently truncates long unix socket paths)
 --SKIPIF--
 <?php
 if( substr(PHP_OS, 0, 3) == "WIN" )
@@ -11,9 +11,9 @@ error_reporting(E_ALL | E_NOTICE);
 $socket_file = "/tmp/" . str_repeat("a", 512);
 function get_truncated_socket_filename($errno, $errmsg, $file, $line) {
     global $socket_file;
-    print_r ($errmsg);
+    echo $errmsg, "\n";
     preg_match("#maximum allowed length of (\d+) bytes#", $errmsg, $matches);
-    $socket_file = substr($socket_file, 0, intval($matches[1]) - 1);
+    $socket_file = substr($socket_file, 0, intval($matches[1]));
 }
 set_error_handler("get_truncated_socket_filename", E_NOTICE);
 stream_socket_server("unix://" . $socket_file);

--- a/ext/standard/tests/streams/bug60106-002.phpt
+++ b/ext/standard/tests/streams/bug60106-002.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #60106 (stream_socket_server with abstract unix socket paths)
+--SKIPIF--
+<?php
+if (PHP_OS != "Linux") die("skip Only for Linux systems");
+?>
+--FILE--
+<?php
+error_reporting(E_ALL | E_NOTICE);
+
+/* This figures out the max length for normal sockets */
+$socket_file = "/tmp/" . str_repeat("a", 512);
+function get_truncated_socket_filename($errno, $errmsg, $file, $line) {
+    global $socket_file, $max_normal_length;
+    echo $errmsg, "\n";
+    preg_match("#maximum allowed length of (\d+) bytes#", $errmsg, $matches);
+    $max_normal_length = intval($matches[1]);
+    $socket_file = substr($socket_file, 0, $max_normal_length);
+}
+set_error_handler("get_truncated_socket_filename", E_NOTICE);
+
+stream_socket_server("unix://" . $socket_file);
+unlink($socket_file);
+
+/* No we create an abstract one, prefixed with \0 so this should now work */
+$abstract_socket = "\0" . $socket_file;
+stream_socket_server("unix://" . $abstract_socket);
+
+$old_max_length = $max_normal_length;
+
+/* And now one longer, which should fail again */
+$abstract_socket_long = "\0" . $abstract_socket . 'X';
+stream_socket_server("unix://" . $abstract_socket_long);
+
+echo "Allowed length is now one more: ", $max_normal_length == $old_max_length + 1 ? "yes" : "no", "\n";
+?>
+--EXPECTF--
+stream_socket_server(): socket path exceeded the maximum allowed length of %d bytes and was truncated
+stream_socket_server(): socket path exceeded the maximum allowed length of %d bytes and was truncated
+Allowed length is now one more: yes

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -564,18 +564,23 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
 	memset(unix_addr, 0, sizeof(*unix_addr));
 	unix_addr->sun_family = AF_UNIX;
 
+	/* Abstract namespace does not need to be NUL-terminated, while path-based
+	 * sockets should be. */
+	bool is_abstract_ns = xparam->inputs.namelen > 0 && xparam->inputs.name[0] == '\0';
+	unsigned long max_length = is_abstract_ns ? sizeof(unix_addr->sun_path) : sizeof(unix_addr->sun_path) - 1;
+
 	/* we need to be binary safe on systems that support an abstract
 	 * namespace */
-	if (xparam->inputs.namelen >= sizeof(unix_addr->sun_path)) {
+	if (xparam->inputs.namelen > max_length) {
 		/* On linux, when the path begins with a NUL byte we are
 		 * referring to an abstract namespace.  In theory we should
 		 * allow an extra byte below, since we don't need the NULL.
 		 * BUT, to get into this branch of code, the name is too long,
 		 * so we don't care. */
-		xparam->inputs.namelen = sizeof(unix_addr->sun_path) - 1;
+		xparam->inputs.namelen = max_length;
 		php_error_docref(NULL, E_NOTICE,
 			"socket path exceeded the maximum allowed length of %lu bytes "
-			"and was truncated", (unsigned long)sizeof(unix_addr->sun_path));
+			"and was truncated", max_length);
 	}
 
 	memcpy(unix_addr->sun_path, xparam->inputs.name, xparam->inputs.namelen);


### PR DESCRIPTION
I was trying to use PHP to talk to Xdebug's new out-of-band control sockets, which use the abstract Unix domain socket namespace (socket names starting with a `\0` character).

Xdebug uses names that are the maximum allowed length for these socket names (108 bytes). 

However, when I tried to run:

```
<?php
$name = "\0xdebug-ctrl.2078073yxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
echo strlen($name), "\n";
$f = stream_socket_client("unix://$name");
```

I got the following output and error:

```
108

Notice: stream_socket_client(): socket path exceeded the maximum allowed length of 108 bytes and was truncated in Standard input code on line 2
```

But the path is exactly 108 characters, not *more*. It turned out that the check for this maximum length is wrong.

No new test can easily be created, as the `108` is implementation specific, and `ext/standard/tests/streams/bug60106.phpt` already covers it.

With this change, I can now correctly connection to these sockets.