### PR TITLE
ext/pcre: update to PCRE2 v10.44

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -162,6 +162,7 @@ PHP                                                                        NEWS
 - PCRE:
   . Upgrade bundled pcre2lib to version 10.43. (nielsdos)
   . Add "/r" modifier. (Ayesh)
+  . Upgrade bundled pcre2lib to version 10.44. (Ayesh)
 
 - PDO:
   . Fixed setAttribute and getAttribute. (SakiTakamachi)

--- a/UPGRADING
+++ b/UPGRADING
@@ -90,7 +90,7 @@ PHP 8.4 UPGRADE NOTES
     of JIT startup initialization issues.
 
 - PCRE:
-  . The bundled pcre2lib has been updated to version 10.43.
+  . The bundled pcre2lib has been updated to version 10.44.
     As a consequence, this means {,3} is now recognized as a quantifier instead
     of as text. Furthermore, the meaning of some character classes in UCP mode
     has changed. Consult https://github.com/PCRE2Project/pcre2/blob/master/NEWS
@@ -243,10 +243,12 @@ PHP 8.4 UPGRADE NOTES
   . Added support for the unix timestamp extension for zip archives.
 
 - PCRE:
-  . The bundled pcre2lib has been updated to version 10.43.
+  . The bundled pcre2lib has been updated to version 10.44.
     As a consequence, LoongArch JIT support has been added, spaces
     are now allowed between braces in Perl-compatible items, and
     variable-length lookbehind assertions are now supported.
+  . With pcre2lib version 10.44, the maximum length of named capture groups
+    has changed from 32 to 128.
   . Added support for the "r" (PCRE2_EXTRA_CASELESS_RESTRICT) modifier, as well
     as the (?r) mode modifier. When enabled along with the case-insensitive
     modifier ("i"), the expression locks out mixing of ASCII and non-ASCII

--- a/ext/pcre/pcre2lib/pcre2.h
+++ b/ext/pcre/pcre2lib/pcre2.h
@@ -42,9 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
 /* The current PCRE version information. */
 
 #define PCRE2_MAJOR           10
-#define PCRE2_MINOR           43
+#define PCRE2_MINOR           44
 #define PCRE2_PRERELEASE      
-#define PCRE2_DATE            2024-02-16
+#define PCRE2_DATE            2024-06-07
 
 /* When an application links to a PCRE DLL in Windows, the symbols that are
 imported have to be identified as such. When building PCRE2, the appropriate
@@ -604,6 +604,8 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_max_pattern_length(pcre2_compile_context *, PCRE2_SIZE); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_max_pattern_compiled_length(pcre2_compile_context *, PCRE2_SIZE); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_max_varlookbehind(pcre2_compile_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_newline(pcre2_compile_context *, uint32_t); \
@@ -901,6 +903,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_match_limit                 PCRE2_SUFFIX(pcre2_set_match_limit_)
 #define pcre2_set_max_varlookbehind           PCRE2_SUFFIX(pcre2_set_max_varlookbehind_)
 #define pcre2_set_max_pattern_length          PCRE2_SUFFIX(pcre2_set_max_pattern_length_)
+#define pcre2_set_max_pattern_compiled_length PCRE2_SUFFIX(pcre2_set_max_pattern_compiled_length_)
 #define pcre2_set_newline                     PCRE2_SUFFIX(pcre2_set_newline_)
 #define pcre2_set_parens_nest_limit           PCRE2_SUFFIX(pcre2_set_parens_nest_limit_)
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)

--- a/ext/pcre/pcre2lib/pcre2_context.c
+++ b/ext/pcre/pcre2lib/pcre2_context.c
@@ -7,7 +7,7 @@ and semantics are as close as possible to those of the Perl 5 language.
 
                        Written by Philip Hazel
      Original API code Copyright (c) 1997-2012 University of Cambridge
-          New API code Copyright (c) 2016-2023 University of Cambridge
+          New API code Copyright (c) 2016-2024 University of Cambridge
 
 -----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
@@ -136,6 +136,7 @@ const pcre2_compile_context PRIV(default_compile_context) = {
   NULL,                                      /* Stack guard data */
   PRIV(default_tables),                      /* Character tables */
   PCRE2_UNSET,                               /* Max pattern length */
+  PCRE2_UNSET,                               /* Max pattern compiled length */
   BSR_DEFAULT,                               /* Backslash R default */
   NEWLINE_DEFAULT,                           /* Newline convention */
   PARENS_NEST_LIMIT,                         /* As it says */
@@ -349,6 +350,13 @@ PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
 pcre2_set_max_pattern_length(pcre2_compile_context *ccontext, PCRE2_SIZE length)
 {
 ccontext->max_pattern_length = length;
+return 0;
+}
+
+PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
+pcre2_set_max_pattern_compiled_length(pcre2_compile_context *ccontext, PCRE2_SIZE length)
+{
+ccontext->max_pattern_compiled_length = length;
 return 0;
 }
 

--- a/ext/pcre/pcre2lib/pcre2_error.c
+++ b/ext/pcre/pcre2lib/pcre2_error.c
@@ -7,7 +7,7 @@ and semantics are as close as possible to those of the Perl 5 language.
 
                        Written by Philip Hazel
      Original API code Copyright (c) 1997-2012 University of Cambridge
-          New API code Copyright (c) 2016-2023 University of Cambridge
+          New API code Copyright (c) 2016-2024 University of Cambridge
 
 -----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
@@ -189,6 +189,7 @@ static const unsigned char compile_error_texts[] =
   "\\K is not allowed in lookarounds (but see PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK)\0"
   /* 100 */
   "branch too long in variable-length lookbehind assertion\0"
+  "compiled pattern would be longer than the limit set by the application\0"
   ;
 
 /* Match-time and UTF error texts are in the same format. */

--- a/ext/pcre/pcre2lib/pcre2_extuni.c
+++ b/ext/pcre/pcre2lib/pcre2_extuni.c
@@ -7,7 +7,7 @@ and semantics are as close as possible to those of the Perl 5 language.
 
                        Written by Philip Hazel
      Original API code Copyright (c) 1997-2012 University of Cambridge
-          New API code Copyright (c) 2016-2021 University of Cambridge
+          New API code Copyright (c) 2016-2024 University of Cambridge
 
 -----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,11 @@ return NULL;
 *      Match an extended grapheme sequence       *
 *************************************************/
 
-/*
+/* NOTE: The logic contained in this function is replicated in three special-
+purpose functions in the pcre2_jit_compile.c module. If the logic below is
+changed, they must be kept in step so that the interpreter and the JIT have the
+same behaviour.
+
 Arguments:
   c              the first character
   eptr           pointer to next character
@@ -92,6 +96,7 @@ PCRE2_SPTR
 PRIV(extuni)(uint32_t c, PCRE2_SPTR eptr, PCRE2_SPTR start_subject,
   PCRE2_SPTR end_subject, BOOL utf, int *xcount)
 {
+BOOL was_ep_ZWJ = FALSE;
 int lgb = UCD_GRAPHBREAK(c);
 
 while (eptr < end_subject)
@@ -101,6 +106,12 @@ while (eptr < end_subject)
   if (!utf) c = *eptr; else { GETCHARLEN(c, eptr, len); }
   rgb = UCD_GRAPHBREAK(c);
   if ((PRIV(ucp_gbtable)[lgb] & (1u << rgb)) == 0) break;
+
+  /* ZWJ followed by Extended Pictographic is allowed only if the ZWJ was
+  preceded by Extended Pictographic. */
+
+  if (lgb == ucp_gbZWJ && rgb == ucp_gbExtended_Pictographic && !was_ep_ZWJ)
+    break;
 
   /* Not breaking between Regional Indicators is allowed only if there
   are an even number of preceding RIs. */
@@ -129,12 +140,15 @@ while (eptr < end_subject)
     if ((ricount & 1) != 0) break;  /* Grapheme break required */
     }
 
-  /* If Extend or ZWJ follows Extended_Pictographic, do not update lgb; this
-  allows any number of them before a following Extended_Pictographic. */
+  /* Set a flag when ZWJ follows Extended Pictographic (with optional Extend in
+  between; see next statement). */
 
-  if ((rgb != ucp_gbExtend && rgb != ucp_gbZWJ) ||
-       lgb != ucp_gbExtended_Pictographic)
-    lgb = rgb;
+  was_ep_ZWJ = (lgb == ucp_gbExtended_Pictographic && rgb == ucp_gbZWJ);
+
+  /* If Extend follows Extended_Pictographic, do not update lgb; this allows
+  any number of them before a following ZWJ. */
+
+  if (rgb != ucp_gbExtend || lgb != ucp_gbExtended_Pictographic) lgb = rgb;
 
   eptr += len;
   if (xcount != NULL) *xcount += 1;

--- a/ext/pcre/pcre2lib/pcre2_intmodedep.h
+++ b/ext/pcre/pcre2lib/pcre2_intmodedep.h
@@ -7,7 +7,7 @@ and semantics are as close as possible to those of the Perl 5 language.
 
                        Written by Philip Hazel
      Original API code Copyright (c) 1997-2012 University of Cambridge
-          New API code Copyright (c) 2016-2023 University of Cambridge
+          New API code Copyright (c) 2016-2024 University of Cambridge
 
 -----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
@@ -568,6 +568,7 @@ typedef struct pcre2_real_compile_context {
   void *stack_guard_data;
   const uint8_t *tables;
   PCRE2_SIZE max_pattern_length;
+  PCRE2_SIZE max_pattern_compiled_length;
   uint16_t bsr_convention;
   uint16_t newline_convention;
   uint32_t parens_nest_limit;

--- a/ext/pcre/pcre2lib/pcre2_jit_misc.c
+++ b/ext/pcre/pcre2lib/pcre2_jit_misc.c
@@ -141,8 +141,8 @@ if (startsize == 0 || maxsize == 0 || maxsize > SIZE_MAX - STACK_GROWTH_RATE)
   return NULL;
 if (startsize > maxsize)
   startsize = maxsize;
-startsize = (startsize + STACK_GROWTH_RATE - 1) & ~(STACK_GROWTH_RATE - 1);
-maxsize = (maxsize + STACK_GROWTH_RATE - 1) & ~(STACK_GROWTH_RATE - 1);
+startsize = (startsize + STACK_GROWTH_RATE - 1) & (size_t)(~(STACK_GROWTH_RATE - 1));
+maxsize = (maxsize + STACK_GROWTH_RATE - 1) & (size_t)(~(STACK_GROWTH_RATE - 1));
 
 jit_stack = PRIV(memctl_malloc)(sizeof(pcre2_real_jit_stack), (pcre2_memctl *)gcontext);
 if (jit_stack == NULL) return NULL;

--- a/ext/pcre/pcre2lib/pcre2_jit_simd_inc.h
+++ b/ext/pcre/pcre2lib/pcre2_jit_simd_inc.h
@@ -2176,7 +2176,7 @@ struct sljit_label *restart;
 struct sljit_jump *jump[2];
 
 SLJIT_ASSERT(common->mode == PCRE2_JIT_COMPLETE && offs1 > offs2);
-SLJIT_ASSERT(diff <= IN_UCHARS(max_fast_forward_char_pair_offset()));
+SLJIT_ASSERT(diff <= (unsigned)IN_UCHARS(max_fast_forward_char_pair_offset()));
 
 /* Initialize. */
 if (common->match_end_ptr != 0)

--- a/ext/pcre/pcre2lib/pcre2_match.c
+++ b/ext/pcre/pcre2lib/pcre2_match.c
@@ -5862,7 +5862,7 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
 
       {
       ptrdiff_t diff = Feptr - mb->start_subject;
-      uint32_t available = (diff > 65535)? 65535 : ((diff > 0)? diff : 0);
+      uint32_t available = (diff > 65535)? 65535 : ((diff > 0)? (int)diff : 0);
       if (Lmin > available) RRETURN(MATCH_NOMATCH);
       if (Lmax > available) Lmax = available;
       Feptr -= Lmax;

--- a/ext/pcre/pcre2lib/pcre2_tables.c
+++ b/ext/pcre/pcre2lib/pcre2_tables.c
@@ -7,7 +7,7 @@ and semantics are as close as possible to those of the Perl 5 language.
 
                        Written by Philip Hazel
      Original API code Copyright (c) 1997-2012 University of Cambridge
-          New API code Copyright (c) 2016-2021 University of Cambridge
+          New API code Copyright (c) 2016-2024 University of Cambridge
 
 -----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
@@ -171,9 +171,9 @@ are implementing).
 6. Do not break after Prepend characters.
 
 7. Do not break within emoji modifier sequences or emoji zwj sequences. That
-   is, do not break between characters with the Extended_Pictographic property.
-   Extend and ZWJ characters are allowed between the characters; this cannot be
-   represented in this table, the code has to deal with it.
+   is, do not break between characters with the Extended_Pictographic property
+   if a ZWJ intervenes. Extend characters are allowed between the characters;
+   this cannot be represented in this table, the code has to deal with it.
 
 8. Do not break within emoji flag sequences. That is, do not break between
    regional indicator (RI) symbols if there are an odd number of RI characters
@@ -203,8 +203,8 @@ const uint32_t PRIV(ucp_gbtable)[] = {
    ESZ|(1u<<ucp_gbT),                                   /* 10 LVT */
    (1u<<ucp_gbRegional_Indicator),                      /* 11 Regional Indicator */
    ESZ,                                                 /* 12 Other */
-   ESZ,                                                 /* 13 ZWJ */
-   ESZ|(1u<<ucp_gbExtended_Pictographic)                /* 14 Extended Pictographic */
+   ESZ|(1u<<ucp_gbExtended_Pictographic),               /* 13 ZWJ */
+   ESZ                                                  /* 14 Extended Pictographic */
 };
 
 #undef ESZ

--- a/ext/pcre/pcre2lib/sljit/allocator_src/sljitExecAllocatorApple.c
+++ b/ext/pcre/pcre2lib/sljit/allocator_src/sljitExecAllocatorApple.c
@@ -41,9 +41,10 @@
 #include <sys/utsname.h>
 #include <stdlib.h>
 
-#define SLJIT_MAP_JIT	(get_map_jit_flag())
 #define SLJIT_UPDATE_WX_FLAGS(from, to, enable_exec)
 
+#ifdef MAP_JIT
+#define SLJIT_MAP_JIT	(get_map_jit_flag())
 static SLJIT_INLINE int get_map_jit_flag(void)
 {
 	size_t page_size;
@@ -70,6 +71,9 @@ static SLJIT_INLINE int get_map_jit_flag(void)
 	}
 	return map_jit_flag;
 }
+#else /* !defined(MAP_JIT) */
+#define SLJIT_MAP_JIT	(0)
+#endif
 
 #elif defined(SLJIT_CONFIG_ARM) && SLJIT_CONFIG_ARM
 

--- a/ext/pcre/pcre2lib/sljit/allocator_src/sljitExecAllocatorCore.c
+++ b/ext/pcre/pcre2lib/sljit/allocator_src/sljitExecAllocatorCore.c
@@ -181,8 +181,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 				header->executable_offset = free_block->header.executable_offset;
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
 				AS_BLOCK_HEADER(header, size)->prev_size = size;
-			}
-			else {
+			} else {
 				sljit_remove_free_block(free_block);
 				header = (struct block_header*)free_block;
 				size = chunk_size;
@@ -230,26 +229,25 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
 		sljit_insert_free_block(free_block, chunk_size);
 		next_header = AS_BLOCK_HEADER(free_block, chunk_size);
-	}
-	else {
+	} else {
 		/* All space belongs to this allocation. */
 		allocated_size += chunk_size;
 		header->size = chunk_size;
 		next_header = AS_BLOCK_HEADER(header, chunk_size);
 	}
-	SLJIT_ALLOCATOR_UNLOCK();
 	next_header->size = 1;
 	next_header->prev_size = chunk_size;
 #ifdef SLJIT_HAS_EXECUTABLE_OFFSET
 	next_header->executable_offset = executable_offset;
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
+	SLJIT_ALLOCATOR_UNLOCK();
 	return MEM_START(header);
 }
 
-SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void* ptr)
+SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void *ptr)
 {
 	struct block_header *header;
-	struct free_block* free_block;
+	struct free_block *free_block;
 
 	SLJIT_ALLOCATOR_LOCK();
 	header = AS_BLOCK_HEADER(ptr, -(sljit_sw)sizeof(struct block_header));
@@ -269,8 +267,7 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void* ptr)
 		free_block->size += header->size;
 		header = AS_BLOCK_HEADER(free_block, free_block->size);
 		header->prev_size = free_block->size;
-	}
-	else {
+	} else {
 		free_block = (struct free_block*)header;
 		sljit_insert_free_block(free_block, header->size);
 	}
@@ -308,7 +305,7 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_unused_memory_exec(void)
 	free_block = free_blocks;
 	while (free_block) {
 		next_free_block = free_block->next;
-		if (!free_block->header.prev_size && 
+		if (!free_block->header.prev_size &&
 				AS_BLOCK_HEADER(free_block, free_block->size)->size == 1) {
 			total_size -= free_block->size;
 			sljit_remove_free_block(free_block);
@@ -317,14 +314,14 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_unused_memory_exec(void)
 		free_block = next_free_block;
 	}
 
-	SLJIT_ASSERT((total_size && free_blocks) || (!total_size && !free_blocks));
+	SLJIT_ASSERT(total_size || (!total_size && !free_blocks));
 	SLJIT_UPDATE_WX_FLAGS(NULL, NULL, 1);
 	SLJIT_ALLOCATOR_UNLOCK();
 }
 
 #ifdef SLJIT_HAS_EXECUTABLE_OFFSET
-SLJIT_API_FUNC_ATTRIBUTE sljit_sw sljit_exec_offset(void* ptr)
+SLJIT_API_FUNC_ATTRIBUTE sljit_sw sljit_exec_offset(void *code)
 {
-	return ((struct block_header *)(ptr))[-1].executable_offset;
+	return ((struct block_header*)SLJIT_CODE_TO_PTR(code))[-1].executable_offset;
 }
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */

--- a/ext/pcre/pcre2lib/sljit/sljitLir.h
+++ b/ext/pcre/pcre2lib/sljit/sljitLir.h
@@ -427,7 +427,10 @@ struct sljit_memory_fragment {
 
 struct sljit_label {
 	struct sljit_label *next;
-	sljit_uw addr;
+	union {
+		sljit_uw index;
+		sljit_uw addr;
+	} u;
 	/* The maximum size difference. */
 	sljit_uw size;
 };
@@ -443,16 +446,15 @@ struct sljit_jump {
 	} u;
 };
 
-struct sljit_put_label {
-	struct sljit_put_label *next;
-	struct sljit_label *label;
-	sljit_uw addr;
-	sljit_uw flags;
-};
-
 struct sljit_const {
 	struct sljit_const *next;
 	sljit_uw addr;
+};
+
+struct sljit_generate_code_buffer {
+	void *buffer;
+	sljit_uw size;
+	sljit_sw executable_offset;
 };
 
 struct sljit_compiler {
@@ -461,18 +463,18 @@ struct sljit_compiler {
 
 	struct sljit_label *labels;
 	struct sljit_jump *jumps;
-	struct sljit_put_label *put_labels;
 	struct sljit_const *consts;
 	struct sljit_label *last_label;
 	struct sljit_jump *last_jump;
 	struct sljit_const *last_const;
-	struct sljit_put_label *last_put_label;
 
 	void *allocator_data;
-	void *exec_allocator_data;
+	void *user_data;
 	struct sljit_memory_fragment *buf;
 	struct sljit_memory_fragment *abuf;
 
+	/* Number of labels created by the compiler. */
+	sljit_uw label_count;
 	/* Available scratch registers. */
 	sljit_s32 scratches;
 	/* Available saved registers. */
@@ -492,15 +494,16 @@ struct sljit_compiler {
 
 #if (defined SLJIT_HAS_STATUS_FLAGS_STATE && SLJIT_HAS_STATUS_FLAGS_STATE)
 	sljit_s32 status_flags_state;
-#endif
+#endif /* SLJIT_HAS_STATUS_FLAGS_STATE */
 
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
 	sljit_s32 args_size;
-#endif
+#endif /* SLJIT_CONFIG_X86_32 */
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	/* Temporary fields. */
 	sljit_s32 mode32;
-#endif
+#endif /* SLJIT_CONFIG_X86_64 */
 
 #if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
 	/* Constant pool handling. */
@@ -511,7 +514,7 @@ struct sljit_compiler {
 	/* Other members. */
 	/* Contains pointer, "ldr pc, [...]" pairs. */
 	sljit_uw patches;
-#endif
+#endif /* SLJIT_CONFIG_ARM_V6 */
 
 #if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6) || (defined SLJIT_CONFIG_ARM_V7 && SLJIT_CONFIG_ARM_V7)
 	/* Temporary fields. */
@@ -520,40 +523,45 @@ struct sljit_compiler {
 
 #if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32) && (defined __SOFTFP__)
 	sljit_uw args_size;
-#endif
+#endif /* SLJIT_CONFIG_ARM_32 && __SOFTFP__ */
 
 #if (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
+	/* Temporary fields. */
 	sljit_u32 imm;
-#endif
+#endif /* SLJIT_CONFIG_PPC */
 
 #if (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
 	sljit_s32 delay_slot;
+	/* Temporary fields. */
 	sljit_s32 cache_arg;
 	sljit_sw cache_argw;
-#endif
+#endif /* SLJIT_CONFIG_MIPS */
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
 	sljit_uw args_size;
-#endif
+#endif /* SLJIT_CONFIG_MIPS_32 */
 
 #if (defined SLJIT_CONFIG_RISCV && SLJIT_CONFIG_RISCV)
+	/* Temporary fields. */
 	sljit_s32 cache_arg;
 	sljit_sw cache_argw;
-#endif
+#endif /* SLJIT_CONFIG_RISCV */
 
 #if (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X)
 	/* Need to allocate register save area to make calls. */
+	/* Temporary fields. */
 	sljit_s32 mode;
-#endif
+#endif /* SLJIT_CONFIG_S390X */
 
 #if (defined SLJIT_CONFIG_LOONGARCH && SLJIT_CONFIG_LOONGARCH)
+	/* Temporary fields. */
 	sljit_s32 cache_arg;
 	sljit_sw cache_argw;
-#endif
+#endif /* SLJIT_CONFIG_LOONGARCH */
 
 #if (defined SLJIT_VERBOSE && SLJIT_VERBOSE)
 	FILE* verbose;
-#endif
+#endif /* SLJIT_VERBOSE */
 
 #if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
 		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
@@ -564,7 +572,7 @@ struct sljit_compiler {
 	sljit_s32 last_return;
 	/* Local size passed to entry functions. */
 	sljit_s32 logical_local_size;
-#endif
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
 
 #if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
 		|| (defined SLJIT_DEBUG && SLJIT_DEBUG) \
@@ -572,7 +580,7 @@ struct sljit_compiler {
 	/* Trust arguments when an API function is called.
 	   Used internally for calling API functions. */
 	sljit_s32 skip_checks;
-#endif
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG || SLJIT_VERBOSE */
 };
 
 /* --------------------------------------------------------------------- */
@@ -583,12 +591,10 @@ struct sljit_compiler {
    custom memory managers. This pointer is passed to SLJIT_MALLOC
    and SLJIT_FREE macros. Most allocators (including the default
    one) ignores this value, and it is recommended to pass NULL
-   as a dummy value for allocator_data. The exec_allocator_data
-   has the same purpose but this one is passed to SLJIT_MALLOC_EXEC /
-   SLJIT_MALLOC_FREE functions.
+   as a dummy value for allocator_data.
 
    Returns NULL if failed. */
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_compiler* sljit_create_compiler(void *allocator_data, void *exec_allocator_data);
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_compiler* sljit_create_compiler(void *allocator_data);
 
 /* Frees everything except the compiled machine code. */
 SLJIT_API_FUNC_ATTRIBUTE void sljit_free_compiler(struct sljit_compiler *compiler);
@@ -619,20 +625,31 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_compiler_memory_error(struct sljit_compi
    of the compiler to out-of-memory status). */
 SLJIT_API_FUNC_ATTRIBUTE void* sljit_alloc_memory(struct sljit_compiler *compiler, sljit_s32 size);
 
-/* Returns the allocator data passed to sljit_create_compiler. These pointers
-   may contain context data even if the normal/exec allocator ignores it. */
-static SLJIT_INLINE void* sljit_get_allocator_data(struct sljit_compiler *compiler) { return compiler->allocator_data; }
-static SLJIT_INLINE void* sljit_get_exec_allocator_data(struct sljit_compiler *compiler) { return compiler->exec_allocator_data; }
+/* Returns the allocator data passed to sljit_create_compiler. */
+static SLJIT_INLINE void* sljit_compiler_get_allocator_data(struct sljit_compiler *compiler) { return compiler->allocator_data; }
+/* Sets/get the user data for a compiler. */
+static SLJIT_INLINE void sljit_compiler_set_user_data(struct sljit_compiler *compiler, void *user_data) { compiler->user_data = user_data; }
+static SLJIT_INLINE void* sljit_compiler_get_user_data(struct sljit_compiler *compiler) { return compiler->user_data; }
 
 #if (defined SLJIT_VERBOSE && SLJIT_VERBOSE)
 /* Passing NULL disables verbose. */
 SLJIT_API_FUNC_ATTRIBUTE void sljit_compiler_verbose(struct sljit_compiler *compiler, FILE* verbose);
 #endif
 
-/* Create executable code from the instruction stream. This is the final step
-   of the code generation so no more instructions can be emitted after this call. */
+/* Option bits for sljit_generate_code. */
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler);
+/* The exec_allocator_data points to a pre-allocated
+   buffer which type is sljit_generate_code_buffer. */
+#define SLJIT_GENERATE_CODE_BUFFER		0x1
+
+/* Create executable code from the instruction stream. This is the final step
+   of the code generation, and no more instructions can be emitted after this call.
+
+   options is the combination of SLJIT_GENERATE_CODE_* bits
+   exec_allocator_data is passed to SLJIT_MALLOC_EXEC and
+                       SLJIT_MALLOC_FREE functions */
+
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data);
 
 /* Free executable code. */
 
@@ -708,6 +725,11 @@ static SLJIT_INLINE sljit_uw sljit_get_generated_code_size(struct sljit_compiler
 #define SLJIT_HAS_AVX2			101
 #endif
 
+#if (defined SLJIT_CONFIG_LOONGARCH)
+/* [Not emulated] LASX support is available on LoongArch */
+#define SLJIT_HAS_LASX        201
+#endif
+
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type);
 
 /* If type is between SLJIT_ORDERED_EQUAL and SLJIT_ORDERED_LESS_EQUAL,
@@ -777,17 +799,22 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_cmp_info(sljit_s32 type);
    global / local context pointers) across function calls. The
    value of n must be between 1 and 3. This option is only
    supported by SLJIT_ENTER_REG_ARG calling convention. */
-#define SLJIT_ENTER_KEEP(n)	(n)
+#define SLJIT_ENTER_KEEP(n)		(n)
 
 /* The compiled function uses an SLJIT specific register argument
    calling convention. This is a lightweight function call type where
    both the caller and the called functions must be compiled by
    SLJIT. The type argument of the call must be SLJIT_CALL_REG_ARG
    and all arguments must be stored in scratch registers. */
-#define SLJIT_ENTER_REG_ARG	0x00000004
+#define SLJIT_ENTER_REG_ARG		0x00000004
 
 /* The local_size must be >= 0 and <= SLJIT_MAX_LOCAL_SIZE. */
-#define SLJIT_MAX_LOCAL_SIZE	1048576
+#define SLJIT_MAX_LOCAL_SIZE		1048576
+
+#if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86)
+/* Use VEX prefix for all SIMD operations on x86. */
+#define SLJIT_ENTER_USE_VEX		0x00010000
+#endif /* !SLJIT_CONFIG_X86 */
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_enter(struct sljit_compiler *compiler,
 	sljit_s32 options, sljit_s32 arg_types, sljit_s32 scratches, sljit_s32 saveds,
@@ -855,7 +882,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return_to(struct sljit_compiler *c
      int    | 4 byte (physical_address & 0x3 == 0)
      word   | 4 byte if SLJIT_32BIT_ARCHITECTURE is defined and its value is 1
             | 8 byte if SLJIT_64BIT_ARCHITECTURE is defined and its value is 1
-    pointer | size of sljit_p type (4 byte on 32 bit machines, 4 or 8 byte
+    pointer | size of sljit_up type (4 byte on 32 bit machines, 4 or 8 byte
             | on 64 bit machines)
 
    Note:   Different architectures have different addressing limitations.
@@ -912,6 +939,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return_to(struct sljit_compiler *c
 #define SLJIT_IS_MEM2(arg)	(((arg) & SLJIT_MEM) && (arg) >= (SLJIT_MEM << 1))
 #define SLJIT_IS_IMM(arg)	((arg) == SLJIT_IMM)
 #define SLJIT_IS_REG_PAIR(arg)	(!((arg) & SLJIT_MEM) && (arg) >= (SLJIT_MEM << 1))
+
+/* Macros for extracting registers from operands. */
+/* Support operands which contains a single register or
+   constructed using SLJIT_MEM1, SLJIT_MEM2, or SLJIT_REG_PAIR. */
+#define SLJIT_EXTRACT_REG(arg)		((arg) & 0x7f)
+/* Support operands which constructed using SLJIT_MEM2, or SLJIT_REG_PAIR. */
+#define SLJIT_EXTRACT_SECOND_REG(arg)	((arg) >> 8)
 
 /* Sets 32 bit operation mode on 64 bit CPUs. This option is ignored on
    32 bit CPUs. When this option is set for an arithmetic operation, only
@@ -1084,7 +1118,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
    S16 - signed 16 bit data transfer
    U32 - unsigned int (32 bit) data transfer
    S32 - signed int (32 bit) data transfer
-   P   - pointer (sljit_p) data transfer
+   P   - pointer (sljit_up) data transfer
 */
 
 /* Flags: - (does not modify flags) */
@@ -1251,6 +1285,19 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 	sljit_s32 src1, sljit_sw src1w,
 	sljit_s32 src2, sljit_sw src2w);
 
+/* Starting index of opcodes for sljit_emit_op2r. */
+#define SLJIT_OP2R_BASE			96
+
+/* Flags: - (may destroy flags) */
+#define SLJIT_MULADD			(SLJIT_OP2R_BASE + 0)
+#define SLJIT_MULADD32			(SLJIT_MULADD | SLJIT_32)
+
+/* Similar to sljit_emit_fop2, except the destination is always a register. */
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w);
+
 /* Emit a left or right shift operation, where the bits shifted
    in comes from a separate source operand. All operands are
    interpreted as unsigned integers.
@@ -1298,7 +1345,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *
 
 /* Starting index of opcodes for sljit_emit_op_src
    and sljit_emit_op_dst. */
-#define SLJIT_OP_SRC_DST_BASE		96
+#define SLJIT_OP_SRC_DST_BASE		112
 
 /* Fast return, see SLJIT_FAST_CALL for more details.
    Note: src cannot be an immedate value
@@ -1350,7 +1397,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_dst(struct sljit_compiler *comp
 	sljit_s32 dst, sljit_sw dstw);
 
 /* Starting index of opcodes for sljit_emit_fop1. */
-#define SLJIT_FOP1_BASE			128
+#define SLJIT_FOP1_BASE			144
 
 /* Flags: - (does not modify flags) */
 #define SLJIT_MOV_F64			(SLJIT_FOP1_BASE + 0)
@@ -1395,7 +1442,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 	sljit_s32 src, sljit_sw srcw);
 
 /* Starting index of opcodes for sljit_emit_fop2. */
-#define SLJIT_FOP2_BASE			160
+#define SLJIT_FOP2_BASE			176
 
 /* Flags: - (may destroy flags) */
 #define SLJIT_ADD_F64			(SLJIT_FOP2_BASE + 0)
@@ -1416,7 +1463,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 	sljit_s32 src2, sljit_sw src2w);
 
 /* Starting index of opcodes for sljit_emit_fop2r. */
-#define SLJIT_FOP2R_BASE		168
+#define SLJIT_FOP2R_BASE		192
 
 /* Flags: - (may destroy flags) */
 #define SLJIT_COPYSIGN_F64		(SLJIT_FOP2R_BASE + 0)
@@ -2138,17 +2185,15 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_get_local_base(struct sljit_compiler *c
    Flags: - (does not modify flags) */
 SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw, sljit_sw init_value);
 
-/* Store the value of a label (see: sljit_set_put_label)
+/* Store the value of a label (see: sljit_set_label / sljit_set_target)
    Flags: - (does not modify flags) */
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw);
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw);
 
-/* Set the value stored by put_label to this label. */
-SLJIT_API_FUNC_ATTRIBUTE void sljit_set_put_label(struct sljit_put_label *put_label, struct sljit_label *label);
-
-/* After the code generation the address for label, jump and const instructions
-   are computed. Since these structures are freed by sljit_free_compiler, the
-   addresses must be preserved by the user program elsewere. */
-static SLJIT_INLINE sljit_uw sljit_get_label_addr(struct sljit_label *label) { return label->addr; }
+/* Provides the address of label, jump and const instructions after sljit_generate_code
+   is called. The returned value is unspecified before the sljit_generate_code call.
+   Since these structures are freed by sljit_free_compiler, the addresses must be
+   preserved by the user program elsewere. */
+static SLJIT_INLINE sljit_uw sljit_get_label_addr(struct sljit_label *label) { return label->u.addr; }
 static SLJIT_INLINE sljit_uw sljit_get_jump_addr(struct sljit_jump *jump) { return jump->addr; }
 static SLJIT_INLINE sljit_uw sljit_get_const_addr(struct sljit_const *const_) { return const_->addr; }
 
@@ -2220,6 +2265,98 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_custom(struct sljit_compiler *c
 
 SLJIT_API_FUNC_ATTRIBUTE void sljit_set_current_flags(struct sljit_compiler *compiler,
 	sljit_s32 current_flags);
+
+/* --------------------------------------------------------------------- */
+/*  Serialization functions                                              */
+/* --------------------------------------------------------------------- */
+
+/* Label/jump/const enumeration functions. The items in each group
+   are enumerated in creation order. Serialization / deserialization
+   preserves this order for each group. For example the fifth label
+   after deserialization refers to the same machine code location as
+   the fifth label before the serialization. */
+static SLJIT_INLINE struct sljit_label *sljit_get_first_label(struct sljit_compiler *compiler) { return compiler->labels; }
+static SLJIT_INLINE struct sljit_jump *sljit_get_first_jump(struct sljit_compiler *compiler) { return compiler->jumps; }
+static SLJIT_INLINE struct sljit_const *sljit_get_first_const(struct sljit_compiler *compiler) { return compiler->consts; }
+
+static SLJIT_INLINE struct sljit_label *sljit_get_next_label(struct sljit_label *label) { return label->next; }
+static SLJIT_INLINE struct sljit_jump *sljit_get_next_jump(struct sljit_jump *jump) { return jump->next; }
+static SLJIT_INLINE struct sljit_const *sljit_get_next_const(struct sljit_const *const_) { return const_->next; }
+
+/* A number starting from 0 is assigned to each label, which
+represents its creation index. The first label created by the
+compiler has index 0, the second has index 1, the third has
+index 2, and so on. The returned value is unspecified after
+sljit_generate_code() is called. */
+static SLJIT_INLINE sljit_uw sljit_get_label_index(struct sljit_label *label) { return label->u.index; }
+
+/* The sljit_jump_has_label() and sljit_jump_has_target() functions
+returns non-zero value if a label or target is set for the jump
+respectively. Both may return with a zero value. The other two
+functions return the value assigned to the jump. */
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_has_label(struct sljit_jump *jump);
+static SLJIT_INLINE struct sljit_label *sljit_jump_get_label(struct sljit_jump *jump) { return jump->u.label; }
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_has_target(struct sljit_jump *jump);
+static SLJIT_INLINE sljit_uw sljit_jump_get_target(struct sljit_jump *jump) { return jump->u.target; }
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_is_mov_addr(struct sljit_jump *jump);
+
+/* Option bits for sljit_serialize_compiler. */
+
+/* When debugging is enabled, the serialized buffer contains
+debugging information unless this option is specified. */
+#define SLJIT_SERIALIZE_IGNORE_DEBUG		0x1
+
+/* Serialize the internal structure of the compiler into a buffer.
+If the serialization is successful, the returned value is a newly
+allocated buffer which is allocated by the memory allocator assigned
+to the compiler. Otherwise the returned value is NULL. Unlike
+sljit_generate_code(), serialization does not modify the internal
+state of the compiler, so the code generation can be continued.
+
+  options must be the combination of SLJIT_SERIALIZE_* option bits
+  size is an output argument, which is set to the byte size of
+    the result buffer if the operation is successful
+
+Notes:
+  - This function is useful for ahead-of-time compilation (AOT).
+  - The returned buffer must be freed later by the caller.
+    The SLJIT_FREE() macro is suitable for this purpose:
+    SLJIT_FREE(returned_buffer, sljit_get_allocator_data(compiler))
+  - Memory allocated by sljit_alloc_memory() is not serialized.
+  - The type of the returned buffer is sljit_uw* to emphasize that
+    the buffer is word aligned. However, the 'size' output argument
+    contains the byte size, so this value is always divisible by
+    sizeof(sljit_uw).
+*/
+SLJIT_API_FUNC_ATTRIBUTE sljit_uw* sljit_serialize_compiler(struct sljit_compiler *compiler,
+	sljit_s32 options, sljit_uw *size);
+
+/* Construct a new compiler instance from a buffer produced by
+sljit_serialize_compiler(). If the operation is successful, the new
+compiler instance is returned. Otherwise the returned value is NULL.
+
+  buffer points to a word aligned memory data which was
+    created by sljit_serialize_compiler()
+  size is the byte size of the buffer
+  options must be 0
+  allocator_data specify an allocator specific data, see
+                 sljit_create_compiler() for further details
+
+Notes:
+  - Labels assigned to jumps are restored with their
+    corresponding label in the label set created by
+    the deserializer. Target addresses assigned to
+    jumps are also restored. Uninitialized jumps
+    remain uninitialized.
+  - After the deserialization, sljit_generate_code() does
+    not need to be the next operation on the returned
+    compiler, the code generation can be continued.
+    Even sljit_serialize_compiler() can be called again.
+  - When debugging is enabled, a buffers without debug
+    information cannot be deserialized.
+*/
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_compiler *sljit_deserialize_compiler(sljit_uw* buffer, sljit_uw size,
+	sljit_s32 options, void *allocator_data);
 
 /* --------------------------------------------------------------------- */
 /*  Miscellaneous utility functions                                      */

--- a/ext/pcre/pcre2lib/sljit/sljitNativeLOONGARCH_64.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeLOONGARCH_64.c
@@ -85,10 +85,12 @@ lower parts in the instruction word, denoted by the “L” and “H” suffixes
 #define FRK(fk) ((sljit_ins)freg_map[fk] << 10)
 #define FRA(fa) ((sljit_ins)freg_map[fa] << 15)
 
+#define IMM_V(imm) ((sljit_ins)(imm) << 10)
 #define IMM_I8(imm) (((sljit_ins)(imm)&0xff) << 10)
 #define IMM_I12(imm) (((sljit_ins)(imm)&0xfff) << 10)
 #define IMM_I14(imm) (((sljit_ins)(imm)&0xfff3) << 10)
 #define IMM_I16(imm) (((sljit_ins)(imm)&0xffff) << 10)
+#define IMM_I20(imm) (((sljit_ins)(imm)&0xffffffff) >> 12 << 5)
 #define IMM_I21(imm) ((((sljit_ins)(imm)&0xffff) << 10) | (((sljit_ins)(imm) >> 16) & 0x1f))
 #define IMM_I26(imm) ((((sljit_ins)(imm)&0xffff) << 10) | (((sljit_ins)(imm) >> 16) & 0x3ff))
 
@@ -318,6 +320,36 @@ lower parts in the instruction word, denoted by the “L” and “H” suffixes
 #define FSTX_S OPC_3R(0x7070)
 #define FSTX_D OPC_3R(0x7078)
 
+/* Vector Instructions */
+
+/* Vector Arithmetic Instructions */
+#define VOR_V OPC_3R(0xe24d)
+#define VXOR_V OPC_3R(0xe24e)
+#define VAND_V OPC_3R(0xe24c)
+#define VMSKLTZ OPC_2R(0x1ca710)
+
+/* Vector Memory Access Instructions */
+#define VLD OPC_2RI12(0xb0)
+#define VST OPC_2RI12(0xb1)
+#define XVLD OPC_2RI12(0xb2)
+#define XVST OPC_2RI12(0xb3)
+#define VSTELM OPC_2RI8(0xc40)
+
+/* Vector Float Conversion Instructions */
+#define VFCVTL_D_S OPC_2R(0x1ca77c)
+
+/* Vector Bit Manipulate Instructions */
+#define VSLLWIL OPC_2R(0x1cc200)
+
+/* Vector Move And Shuffle Instructions */
+#define VLDREPL OPC_2R(0xc0000)
+#define VINSGR2VR OPC_2R(0x1cbac0)
+#define VPICKVE2GR_U OPC_2R(0x1cbce0)
+#define VREPLGR2VR OPC_2R(0x1ca7c0)
+#define VREPLVE OPC_3R(0xe244)
+#define VREPLVEI OPC_2R(0x1cbde0)
+#define XVPERMI OPC_2RI8(0x1dfa)
+
 #define I12_MAX (0x7ff)
 #define I12_MIN (-0x800)
 #define BRANCH16_MAX (0x7fff << 2)
@@ -337,16 +369,32 @@ lower parts in the instruction word, denoted by the “L” and “H” suffixes
 
 /* LoongArch CPUCFG register for feature detection */
 #define LOONGARCH_CFG2			0x02
-#define LOONGARCH_FEATURE_LAMCAS	(1 << 28)
+#define LOONGARCH_CFG2_LAMCAS	(1 << 28)
 
-static sljit_u32 cpu_feature_list = 0;
+static sljit_u32 cfg2_feature_list = 0;
 
-static SLJIT_INLINE sljit_u32 get_cpu_features(void)
-{
-	if (cpu_feature_list == 0)
-		__asm__ ("cpucfg %0, %1" : "+&r"(cpu_feature_list) : "r"(LOONGARCH_CFG2));
-	return cpu_feature_list;
-}
+/* According to Software Development and Build Convention for LoongArch Architectures,
++   the status of LSX and LASX extension must be checked through HWCAP */
+#include <sys/auxv.h>
+
+#define LOONGARCH_HWCAP_LSX		(1 << 4)
+#define LOONGARCH_HWCAP_LASX	(1 << 5)
+
+static sljit_u32 hwcap_feature_list = 0;
+
+/* Feature type */
+#define GET_CFG2 	0
+#define GET_HWCAP	1
+
+static SLJIT_INLINE sljit_u32 get_cpu_features(sljit_u32 feature_type)
+ {
+ 	if (cfg2_feature_list == 0)
+ 		__asm__ ("cpucfg %0, %1" : "+&r"(cfg2_feature_list) : "r"(LOONGARCH_CFG2));
+	if (hwcap_feature_list == 0)
+		hwcap_feature_list = (sljit_u32)getauxval(AT_HWCAP);
+
+	return feature_type ? hwcap_feature_list : cfg2_feature_list;
+ }
 
 static sljit_s32 push_inst(struct sljit_compiler *compiler, sljit_ins ins)
 {
@@ -371,24 +419,23 @@ static SLJIT_INLINE sljit_ins* detect_jump_type(struct sljit_jump *jump, sljit_i
 	if (jump->flags & JUMP_ADDR)
 		target_addr = jump->u.target;
 	else {
-		SLJIT_ASSERT(jump->flags & JUMP_LABEL);
+		SLJIT_ASSERT(jump->u.label != NULL);
 		target_addr = (sljit_uw)(code + jump->u.label->size) + (sljit_uw)executable_offset;
 	}
 
 	diff = (sljit_sw)target_addr - (sljit_sw)inst - executable_offset;
 
 	if (jump->flags & IS_COND) {
-		inst--;
 		diff += SSIZE_OF(ins);
 
 		if (diff >= BRANCH16_MIN && diff <= BRANCH16_MAX) {
-			jump->flags |= PATCH_B;
+			inst--;
 			inst[0] = (inst[0] & 0xfc0003ff) ^ 0x4000000;
+			jump->flags |= PATCH_B;
 			jump->addr = (sljit_uw)inst;
 			return inst;
 		}
 
-		inst++;
 		diff -= SSIZE_OF(ins);
 	}
 
@@ -435,65 +482,179 @@ exit:
 	return inst + 3;
 }
 
-static SLJIT_INLINE sljit_sw put_label_get_length(struct sljit_put_label *put_label, sljit_uw max_label)
+static SLJIT_INLINE sljit_sw mov_addr_get_length(struct sljit_jump *jump, sljit_ins *code_ptr, sljit_ins *code, sljit_sw executable_offset)
 {
-	if (max_label <= (sljit_uw)S32_MAX) {
-		put_label->flags = PATCH_ABS32;
+	sljit_uw addr;
+	sljit_sw diff;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	SLJIT_ASSERT(jump->flags < ((sljit_uw)6 << JUMP_SIZE_SHIFT));
+	if (jump->flags & JUMP_ADDR)
+		addr = jump->u.target;
+	else
+		addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code + jump->u.label->size, executable_offset);
+
+	diff = (sljit_sw)addr - (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+
+	if (diff >= S32_MIN && diff <= S32_MAX) {
+		SLJIT_ASSERT(jump->flags >= ((sljit_uw)1 << JUMP_SIZE_SHIFT));
+		jump->flags |= PATCH_REL32;
 		return 1;
 	}
 
-	if (max_label <= S52_MAX) {
-		put_label->flags = PATCH_ABS52;
+	if (addr <= S32_MAX) {
+		SLJIT_ASSERT(jump->flags >= ((sljit_uw)1 << JUMP_SIZE_SHIFT));
+		jump->flags |= PATCH_ABS32;
+		return 1;
+	}
+
+	if (addr <= S52_MAX) {
+		SLJIT_ASSERT(jump->flags >= ((sljit_uw)2 << JUMP_SIZE_SHIFT));
+		jump->flags |= PATCH_ABS52;
 		return 2;
 	}
 
-	put_label->flags = 0;
+	SLJIT_ASSERT(jump->flags >= ((sljit_uw)3 << JUMP_SIZE_SHIFT));
 	return 3;
 }
 
-static SLJIT_INLINE void load_addr_to_reg(void *dst, sljit_u32 reg)
+static SLJIT_INLINE void load_addr_to_reg(struct sljit_jump *jump, sljit_sw executable_offset)
 {
-	struct sljit_jump *jump = NULL;
-	struct sljit_put_label *put_label;
-	sljit_uw flags;
-	sljit_ins *inst;
-	sljit_uw addr;
+	sljit_uw flags = jump->flags;
+	sljit_uw addr = (flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
+	sljit_ins *ins = (sljit_ins*)jump->addr;
+	sljit_u32 reg = (flags & JUMP_MOV_ADDR) ? *ins : TMP_REG1;
+	SLJIT_UNUSED_ARG(executable_offset);
 
-	if (reg != 0) {
-		jump = (struct sljit_jump*)dst;
-		flags = jump->flags;
-		inst = (sljit_ins*)jump->addr;
-		addr = (flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target;
-	} else {
-		put_label = (struct sljit_put_label*)dst;
-		flags = put_label->flags;
-		inst = (sljit_ins*)put_label->addr;
-		addr = put_label->label->addr;
-		reg = *inst;
+	if (flags & PATCH_REL32) {
+		addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(ins, executable_offset);
+
+		SLJIT_ASSERT((sljit_sw)addr >= S32_MIN && (sljit_sw)addr <= S32_MAX);
+
+		if ((addr & 0x800) != 0)
+			addr += 0x1000;
+
+		ins[0] = PCADDU12I | RD(reg) | IMM_I20(addr);
+
+		if (!(flags & JUMP_MOV_ADDR)) {
+			SLJIT_ASSERT((ins[1] & OPC_2RI16(0x3f)) == JIRL);
+			ins[1] = (ins[1] & (OPC_2RI16(0x3f) | 0x3ff)) | IMM_I16((addr & 0xfff) >> 2);
+		} else
+			ins[1] = ADDI_D | RD(reg) | RJ(reg) | IMM_I12(addr);
+		return;
 	}
 
 	if (flags & PATCH_ABS32) {
 		SLJIT_ASSERT(addr <= S32_MAX);
-		inst[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
+		ins[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
 	} else if (flags & PATCH_ABS52) {
-		inst[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
-		inst[1] = LU32I_D | RD(reg) | (sljit_ins)(((addr >> 32) & 0xfffff) << 5);
-		inst += 1;
+		ins[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
+		ins[1] = LU32I_D | RD(reg) | (sljit_ins)(((addr >> 32) & 0xfffff) << 5);
+		ins += 1;
 	} else {
-		inst[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
-		inst[1] = LU32I_D | RD(reg) | (sljit_ins)(((addr >> 32) & 0xfffff) << 5);
-		inst[2] = LU52I_D | RD(reg) | RJ(reg) | IMM_I12(addr >> 52);
-		inst += 2;
+		ins[0] = LU12I_W | RD(reg) | (sljit_ins)(((addr & 0xffffffff) >> 12) << 5);
+		ins[1] = LU32I_D | RD(reg) | (sljit_ins)(((addr >> 32) & 0xfffff) << 5);
+		ins[2] = LU52I_D | RD(reg) | RJ(reg) | IMM_I12(addr >> 52);
+		ins += 2;
 	}
 
-	if (jump != NULL) {
-		SLJIT_ASSERT((inst[1] & OPC_2RI16(0x3f)) == JIRL);
-		inst[1] = (inst[1] & (OPC_2RI16(0x3f) | 0x3ff)) | IMM_I16((addr & 0xfff) >> 2);
+	if (!(flags & JUMP_MOV_ADDR)) {
+		SLJIT_ASSERT((ins[1] & OPC_2RI16(0x3f)) == JIRL);
+		ins[1] = (ins[1] & (OPC_2RI16(0x3f) | 0x3ff)) | IMM_I16((addr & 0xfff) >> 2);
 	} else
-		inst[1] = ORI | RD(reg) | RJ(reg) | IMM_I12(addr);
+		ins[1] = ORI | RD(reg) | RJ(reg) | IMM_I12(addr);
 }
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler)
+static void reduce_code_size(struct sljit_compiler *compiler)
+{
+	struct sljit_label *label;
+	struct sljit_jump *jump;
+	struct sljit_const *const_;
+	SLJIT_NEXT_DEFINE_TYPES;
+	sljit_uw total_size;
+	sljit_uw size_reduce = 0;
+	sljit_sw diff;
+
+	label = compiler->labels;
+	jump = compiler->jumps;
+	const_ = compiler->consts;
+
+	SLJIT_NEXT_INIT_TYPES();
+
+	while (1) {
+		SLJIT_GET_NEXT_MIN();
+
+		if (next_min_addr == SLJIT_MAX_ADDRESS)
+			break;
+
+		if (next_min_addr == next_label_size) {
+			label->size -= size_reduce;
+
+			label = label->next;
+			next_label_size = SLJIT_GET_NEXT_SIZE(label);
+		}
+
+		if (next_min_addr == next_const_addr) {
+			const_->addr -= size_reduce;
+			const_ = const_->next;
+			next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
+			continue;
+		}
+
+		if (next_min_addr != next_jump_addr)
+			continue;
+
+		jump->addr -= size_reduce;
+		if (!(jump->flags & JUMP_MOV_ADDR)) {
+			total_size = JUMP_MAX_SIZE;
+
+			if (!(jump->flags & SLJIT_REWRITABLE_JUMP)) {
+				if (jump->flags & JUMP_ADDR) {
+					if (jump->u.target <= S32_MAX)
+							total_size = 2;
+					else if (jump->u.target <= S52_MAX)
+							total_size = 3;
+				} else {
+					/* Unit size: instruction. */
+					diff = (sljit_sw)jump->u.label->size - (sljit_sw)jump->addr;
+
+					if ((jump->flags & IS_COND) && (diff + 1) <= (BRANCH16_MAX / SSIZE_OF(ins)) && (diff + 1) >= (BRANCH16_MIN / SSIZE_OF(ins)))
+						total_size = 0;
+					else if (diff >= (JUMP_MIN / SSIZE_OF(ins)) && diff <= (JUMP_MAX / SSIZE_OF(ins)))
+						total_size = 1;
+					else if (diff >= (S32_MIN / SSIZE_OF(ins)) && diff <= (S32_MAX / SSIZE_OF(ins)))
+						total_size = 2;
+				}
+			}
+
+			size_reduce += JUMP_MAX_SIZE - total_size;
+			jump->flags |= total_size << JUMP_SIZE_SHIFT;
+		} else {
+			total_size = 3;
+
+			if (!(jump->flags & JUMP_ADDR)) {
+				/* Real size minus 1. Unit size: instruction. */
+				diff = (sljit_sw)jump->u.label->size - (sljit_sw)jump->addr;
+
+				if (diff >= (S32_MIN / SSIZE_OF(ins)) && diff <= (S32_MAX / SSIZE_OF(ins)))
+					total_size = 1;
+			} else if (jump->u.target < S32_MAX)
+				total_size = 1;
+			else if (jump->u.target <= S52_MAX)
+				total_size = 2;
+
+			size_reduce += 3 - total_size;
+			jump->flags |= total_size << JUMP_SIZE_SHIFT;
+		}
+
+		jump = jump->next;
+		next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+	}
+
+	compiler->size -= size_reduce;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data)
 {
 	struct sljit_memory_fragment *buf;
 	sljit_ins *code;
@@ -501,70 +662,72 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	sljit_ins *buf_ptr;
 	sljit_ins *buf_end;
 	sljit_uw word_count;
-	sljit_uw next_addr;
+	SLJIT_NEXT_DEFINE_TYPES;
 	sljit_sw executable_offset;
 	sljit_uw addr;
 
 	struct sljit_label *label;
 	struct sljit_jump *jump;
 	struct sljit_const *const_;
-	struct sljit_put_label *put_label;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_generate_code(compiler));
-	reverse_buf(compiler);
 
-	code = (sljit_ins*)SLJIT_MALLOC_EXEC(compiler->size * sizeof(sljit_ins), compiler->exec_allocator_data);
+	reduce_code_size(compiler);
+
+	code = (sljit_ins*)allocate_executable_memory(compiler->size * sizeof(sljit_ins), options, exec_allocator_data, &executable_offset);
 	PTR_FAIL_WITH_EXEC_IF(code);
+
+	reverse_buf(compiler);
 	buf = compiler->buf;
 
 	code_ptr = code;
 	word_count = 0;
-	next_addr = 0;
-	executable_offset = SLJIT_EXEC_OFFSET(code);
-
 	label = compiler->labels;
 	jump = compiler->jumps;
 	const_ = compiler->consts;
-	put_label = compiler->put_labels;
+	SLJIT_NEXT_INIT_TYPES();
+	SLJIT_GET_NEXT_MIN();
 
 	do {
 		buf_ptr = (sljit_ins*)buf->memory;
 		buf_end = buf_ptr + (buf->used_size >> 2);
 		do {
 			*code_ptr = *buf_ptr++;
-			if (next_addr == word_count) {
+			if (next_min_addr == word_count) {
 				SLJIT_ASSERT(!label || label->size >= word_count);
 				SLJIT_ASSERT(!jump || jump->addr >= word_count);
 				SLJIT_ASSERT(!const_ || const_->addr >= word_count);
-				SLJIT_ASSERT(!put_label || put_label->addr >= word_count);
 
 				/* These structures are ordered by their address. */
-				if (label && label->size == word_count) {
-					label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+				if (next_min_addr == next_label_size) {
+					label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 					label->size = (sljit_uw)(code_ptr - code);
 					label = label->next;
+					next_label_size = SLJIT_GET_NEXT_SIZE(label);
 				}
-				if (jump && jump->addr == word_count) {
-					word_count += 3;
-					jump->addr = (sljit_uw)code_ptr;
-					code_ptr = detect_jump_type(jump, code, executable_offset);
+
+				if (next_min_addr == next_jump_addr) {
+					if (!(jump->flags & JUMP_MOV_ADDR)) {
+						word_count = word_count - 1 + (jump->flags >> JUMP_SIZE_SHIFT);
+						jump->addr = (sljit_uw)code_ptr;
+						code_ptr = detect_jump_type(jump, code, executable_offset);
+						SLJIT_ASSERT((jump->flags & PATCH_B) || ((sljit_uw)code_ptr - jump->addr < (jump->flags >> JUMP_SIZE_SHIFT) * sizeof(sljit_ins)));
+					} else {
+						word_count += jump->flags >> JUMP_SIZE_SHIFT;
+						addr = (sljit_uw)code_ptr;
+						code_ptr += mov_addr_get_length(jump, code_ptr, code, executable_offset);
+						jump->addr = addr;
+					}
 					jump = jump->next;
-				}
-				if (const_ && const_->addr == word_count) {
+					next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+				} else if (next_min_addr == next_const_addr) {
 					const_->addr = (sljit_uw)code_ptr;
 					const_ = const_->next;
+					next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
 				}
-				if (put_label && put_label->addr == word_count) {
-					SLJIT_ASSERT(put_label->label);
-					put_label->addr = (sljit_uw)code_ptr;
 
-					code_ptr += put_label_get_length(put_label, (sljit_uw)(SLJIT_ADD_EXEC_OFFSET(code, executable_offset) + put_label->label->size));
-					word_count += 3;
-
-					put_label = put_label->next;
-				}
-				next_addr = compute_next_addr(label, jump, const_, put_label);
+				SLJIT_GET_NEXT_MIN();
 			}
 			code_ptr++;
 			word_count++;
@@ -574,7 +737,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	} while (buf);
 
 	if (label && label->size == word_count) {
-		label->addr = (sljit_uw)code_ptr;
+		label->u.addr = (sljit_uw)code_ptr;
 		label->size = (sljit_uw)(code_ptr - code);
 		label = label->next;
 	}
@@ -582,33 +745,23 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	SLJIT_ASSERT(!label);
 	SLJIT_ASSERT(!jump);
 	SLJIT_ASSERT(!const_);
-	SLJIT_ASSERT(!put_label);
 	SLJIT_ASSERT(code_ptr - code <= (sljit_sw)compiler->size);
 
 	jump = compiler->jumps;
 	while (jump) {
 		do {
-			if (!(jump->flags & (PATCH_B | PATCH_J | PATCH_REL32))) {
-				load_addr_to_reg(jump, TMP_REG1);
+			if (!(jump->flags & (PATCH_B | PATCH_J)) || (jump->flags & JUMP_MOV_ADDR)) {
+				load_addr_to_reg(jump, executable_offset);
 				break;
 			}
 
-			addr = (jump->flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target;
+			addr = (jump->flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
 			buf_ptr = (sljit_ins *)jump->addr;
 			addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(buf_ptr, executable_offset);
 
 			if (jump->flags & PATCH_B) {
 				SLJIT_ASSERT((sljit_sw)addr >= BRANCH16_MIN && (sljit_sw)addr <= BRANCH16_MAX);
 				buf_ptr[0] |= (sljit_ins)IMM_I16(addr >> 2);
-				break;
-			}
-
-			if (jump->flags & PATCH_REL32) {
-				SLJIT_ASSERT((sljit_sw)addr >= S32_MIN && (sljit_sw)addr <= S32_MAX);
-
-				buf_ptr[0] = PCADDU12I | RD(TMP_REG1) | (sljit_ins)((sljit_sw)addr & ~0xfff);
-				SLJIT_ASSERT((buf_ptr[1] & OPC_2RI16(0x3f)) == JIRL);
-				buf_ptr[1] |= IMM_I16((addr & 0xfff) >> 2);
 				break;
 			}
 
@@ -619,12 +772,6 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 				buf_ptr[0] = B | (sljit_ins)IMM_I26(addr >> 2);
 		} while (0);
 		jump = jump->next;
-	}
-
-	put_label = compiler->put_labels;
-	while (put_label) {
-		load_addr_to_reg(put_label, 0);
-		put_label = put_label->next;
 	}
 
 	compiler->error = SLJIT_ERR_COMPILED;
@@ -651,8 +798,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 		return 1;
 #endif
 
+	case SLJIT_HAS_LASX:
+		return (LOONGARCH_HWCAP_LASX & get_cpu_features(GET_HWCAP));
+
+	case SLJIT_HAS_SIMD:
+		return (LOONGARCH_HWCAP_LSX & get_cpu_features(GET_HWCAP));
+
 	case SLJIT_HAS_ATOMIC:
-		return (LOONGARCH_FEATURE_LAMCAS & get_cpu_features());
+		return (LOONGARCH_CFG2_LAMCAS & get_cpu_features(GET_CFG2));
 
 	case SLJIT_HAS_CLZ:
 	case SLJIT_HAS_CTZ:
@@ -707,6 +860,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_cmp_info(sljit_s32 type)
 #define SLOW_SRC1	0x08000
 #define SLOW_SRC2	0x10000
 #define SLOW_DEST	0x20000
+#define MEM_USE_TMP2	0x40000
 
 #define STACK_STORE	ST_D
 #define STACK_LOAD	LD_D
@@ -1039,7 +1193,7 @@ static sljit_s32 can_cache(sljit_s32 arg, sljit_sw argw, sljit_s32 next_arg, slj
 static sljit_s32 getput_arg(struct sljit_compiler *compiler, sljit_s32 flags, sljit_s32 reg, sljit_s32 arg, sljit_sw argw, sljit_s32 next_arg, sljit_sw next_argw)
 {
 	sljit_s32 base = arg & REG_MASK;
-	sljit_s32 tmp_r = TMP_REG1;
+	sljit_s32 tmp_r = (flags & MEM_USE_TMP2) ? TMP_REG2 : TMP_REG1;
 	sljit_sw offset;
 
 	SLJIT_ASSERT(arg & SLJIT_MEM);
@@ -1047,11 +1201,6 @@ static sljit_s32 getput_arg(struct sljit_compiler *compiler, sljit_s32 flags, sl
 		next_arg = 0;
 		next_argw = 0;
 	}
-
-	/* Since tmp can be the same as base or offset registers,
-	 * these might be unavailable after modifying tmp. */
-	if ((flags & MEM_MASK) <= GPR_REG && (flags & LOAD_DATA))
-		tmp_r = reg;
 
 	if (SLJIT_UNLIKELY(arg & OFFS_REG_MASK)) {
 		argw &= 0x3;
@@ -1149,8 +1298,7 @@ static SLJIT_INLINE sljit_s32 emit_op_mem2(struct sljit_compiler *compiler, slji
 				FAIL_IF(push_inst(compiler, op_reg | RD(dst) | RJ(src1) | RK(dst))); \
 			} \
 		} \
-	} \
-	else { \
+	} else { \
 		if (op & SLJIT_SET_Z) \
 			FAIL_IF(push_inst(compiler, op_reg | RD(EQUAL_FLAG) | RJ(src1) | RK(src2))); \
 		if (!(flags & UNUSED_DEST)) \
@@ -1165,88 +1313,88 @@ static SLJIT_INLINE sljit_s32 emit_op_mem2(struct sljit_compiler *compiler, slji
 static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s32 flags,
 	sljit_s32 dst, sljit_s32 src1, sljit_sw src2)
 {
-	sljit_s32 is_overflow, is_carry, carry_src_r, is_handled;
+	sljit_s32 is_overflow, is_carry, carry_src_r, is_handled, reg;
 	sljit_ins op_imm, op_reg;
 	sljit_ins word_size = ((op & SLJIT_32) ? 32 : 64);
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if (dst != src2)
 			return push_inst(compiler, INST(ADD, op) | RD(dst) | RJ(src2) | IMM_I12(0));
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_U8:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, ANDI | RD(dst) | RJ(src2) | IMM_I12(0xff));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_S8:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, EXT_W_B | RD(dst) | RJ(src2));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_U16:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, INST(BSTRPICK, op) | RD(dst) | RJ(src2) | (15 << 16));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_S16:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, EXT_W_H | RD(dst) | RJ(src2));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_U32:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, BSTRPICK_D | RD(dst) | RJ(src2) | (31 << 16));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_MOV_S32:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE))
 			return push_inst(compiler, SLLI_W | RD(dst) | RJ(src2) | IMM_I12(0));
 		SLJIT_ASSERT(dst == src2);
 		return SLJIT_SUCCESS;
 
 	case SLJIT_CLZ:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		return push_inst(compiler, INST(CLZ, op) | RD(dst) | RJ(src2));
 
 	case SLJIT_CTZ:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		return push_inst(compiler, INST(CTZ, op) | RD(dst) | RJ(src2));
 
 	case SLJIT_REV:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		return push_inst(compiler, ((op & SLJIT_32) ? REVB_2W : REVB_D) | RD(dst) | RJ(src2));
 
 	case SLJIT_REV_S16:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		FAIL_IF(push_inst(compiler, REVB_2H | RD(dst) | RJ(src2)));
 		return push_inst(compiler, EXT_W_H | RD(dst) | RJ(dst));
 
 	case SLJIT_REV_U16:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM));
 		FAIL_IF(push_inst(compiler, REVB_2H | RD(dst) | RJ(src2)));
 		return push_inst(compiler, INST(BSTRPICK, op) | RD(dst) | RJ(dst) | (15 << 16));
 
 	case SLJIT_REV_S32:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM) && dst != TMP_REG1);
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM) && dst != TMP_REG1);
 		FAIL_IF(push_inst(compiler, REVB_2W | RD(dst) | RJ(src2)));
 		return push_inst(compiler, SLLI_W | RD(dst) | RJ(dst) | IMM_I12(0));
 
 	case SLJIT_REV_U32:
-		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM) && dst != TMP_REG1);
+		SLJIT_ASSERT(src1 == TMP_ZERO && !(flags & SRC2_IMM) && dst != TMP_REG1);
 		FAIL_IF(push_inst(compiler, REVB_2W | RD(dst) | RJ(src2)));
 		return push_inst(compiler, BSTRPICK_D | RD(dst) | RJ(dst) | (31 << 16));
 
@@ -1263,15 +1411,13 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 					FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(EQUAL_FLAG) | RJ(TMP_ZERO) | IMM_I12(-1)));
 					FAIL_IF(push_inst(compiler, XOR | RD(EQUAL_FLAG) | RJ(src1) | RK(EQUAL_FLAG)));
 				}
-			}
-			else if (op & SLJIT_SET_Z)
+			} else if (op & SLJIT_SET_Z)
 				FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(EQUAL_FLAG) | RJ(src1) | IMM_I12(src2)));
 
 			/* Only the zero flag is needed. */
 			if (!(flags & UNUSED_DEST) || (op & VARIABLE_FLAG_MASK))
 				FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(dst) | RJ(src1) | IMM_I12(src2)));
-		}
-		else {
+		} else {
 			if (is_overflow)
 				FAIL_IF(push_inst(compiler, XOR | RD(EQUAL_FLAG) | RJ(src1) | RK(src2)));
 			else if (op & SLJIT_SET_Z)
@@ -1361,8 +1507,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			if (GET_FLAG_TYPE(op) == SLJIT_LESS) {
 				FAIL_IF(push_inst(compiler, SLTUI | RD(OTHER_FLAG) | RJ(src1) | IMM_I12(src2)));
 				is_handled = 1;
-			}
-			else if (GET_FLAG_TYPE(op) == SLJIT_SIG_LESS) {
+			} else if (GET_FLAG_TYPE(op) == SLJIT_SIG_LESS) {
 				FAIL_IF(push_inst(compiler, SLTI | RD(OTHER_FLAG) | RJ(src1) | IMM_I12(src2)));
 				is_handled = 1;
 			}
@@ -1372,8 +1517,9 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			is_handled = 1;
 
 			if (flags & SRC2_IMM) {
-				FAIL_IF(push_inst(compiler, ADDI_D | RD(TMP_REG2) | RJ(TMP_ZERO) | IMM_I12(src2)));
-				src2 = TMP_REG2;
+				reg = (src1 == TMP_REG1) ? TMP_REG2 : TMP_REG1;
+				FAIL_IF(push_inst(compiler, ADDI_D | RD(reg) | RJ(TMP_ZERO) | IMM_I12(src2)));
+				src2 = reg;
 				flags &= ~SRC2_IMM;
 			}
 
@@ -1399,8 +1545,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 					FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(EQUAL_FLAG) | RJ(src1) | IMM_I12(-src2)));
 				if (!(flags & UNUSED_DEST))
 					return push_inst(compiler, INST(ADDI, op) | RD(dst) | RJ(src1) | IMM_I12(-src2));
-			}
-			else {
+			} else {
 				if (op & SLJIT_SET_Z)
 					FAIL_IF(push_inst(compiler, INST(SUB, op) | RD(EQUAL_FLAG) | RJ(src1) | RK(src2)));
 				if (!(flags & UNUSED_DEST))
@@ -1420,8 +1565,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 					FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(EQUAL_FLAG) | RJ(src1) | IMM_I12(-1)));
 					FAIL_IF(push_inst(compiler, XOR | RD(EQUAL_FLAG) | RJ(src1) | RK(EQUAL_FLAG)));
 				}
-			}
-			else if (op & SLJIT_SET_Z)
+			} else if (op & SLJIT_SET_Z)
 				FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(EQUAL_FLAG) | RJ(src1) | IMM_I12(-src2)));
 
 			if (is_overflow || is_carry)
@@ -1430,8 +1574,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			/* Only the zero flag is needed. */
 			if (!(flags & UNUSED_DEST) || (op & VARIABLE_FLAG_MASK))
 				FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(dst) | RJ(src1) | IMM_I12(-src2)));
-		}
-		else {
+		} else {
 			if (is_overflow)
 				FAIL_IF(push_inst(compiler, XOR | RD(EQUAL_FLAG) | RJ(src1) | RK(src2)));
 			else if (op & SLJIT_SET_Z)
@@ -1468,8 +1611,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 				FAIL_IF(push_inst(compiler, SLTUI | RD(EQUAL_FLAG) | RJ(src1) | IMM_I12(src2)));
 
 			FAIL_IF(push_inst(compiler, INST(ADDI, op) | RD(dst) | RJ(src1) | IMM_I12(-src2)));
-		}
-		else {
+		} else {
 			if (is_carry)
 				FAIL_IF(push_inst(compiler, SLTU | RD(EQUAL_FLAG) | RJ(src1) | RK(src2)));
 
@@ -1550,7 +1692,6 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			if (GET_OPCODE(op) == SLJIT_ROTL)
 				src2 = word_size - src2;
 			return push_inst(compiler, INST(ROTRI, op) | RD(dst) | RJ(src1) | IMM_I12(src2));
-
 		}
 
 		if (src2 == TMP_ZERO) {
@@ -1601,7 +1742,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	sljit_s32 dst_r = TMP_REG2;
 	sljit_s32 src1_r;
 	sljit_sw src2_r = 0;
-	sljit_s32 sugg_src2_r = TMP_REG2;
+	sljit_s32 src2_tmp_reg = (GET_OPCODE(op) >= SLJIT_OP2_BASE && FAST_IS_REG(src1)) ? TMP_REG1 : TMP_REG2;
 
 	if (!(flags & ALT_KEEP_CACHE)) {
 		compiler->cache_arg = 0;
@@ -1612,22 +1753,19 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 		SLJIT_ASSERT(HAS_FLAGS(op));
 		flags |= UNUSED_DEST;
 		dst = TMP_REG2;
-	}
-	else if (FAST_IS_REG(dst)) {
+	} else if (FAST_IS_REG(dst)) {
 		dst_r = dst;
 		flags |= REG_DEST;
 		if (flags & MOVE_OP)
-			sugg_src2_r = dst_r;
-	}
-	else if ((dst & SLJIT_MEM) && !getput_arg_fast(compiler, flags | ARG_TEST, TMP_REG1, dst, dstw))
+			src2_tmp_reg = dst_r;
+	} else if ((dst & SLJIT_MEM) && !getput_arg_fast(compiler, flags | ARG_TEST, TMP_REG1, dst, dstw))
 		flags |= SLOW_DEST;
 
 	if (flags & IMM_OP) {
 		if (src2 == SLJIT_IMM && src2w != 0 && src2w <= I12_MAX && src2w >= I12_MIN) {
 			flags |= SRC2_IMM;
 			src2_r = src2w;
-		}
-		else if ((flags & CUMULATIVE_OP) && src1 == SLJIT_IMM && src1w != 0 && src1w <= I12_MAX && src1w >= I12_MIN) {
+		} else if ((flags & CUMULATIVE_OP) && src1 == SLJIT_IMM && src1w != 0 && src1w <= I12_MAX && src1w >= I12_MIN) {
 			flags |= SRC2_IMM;
 			src2_r = src1w;
 
@@ -1643,16 +1781,14 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	if (FAST_IS_REG(src1)) {
 		src1_r = src1;
 		flags |= REG1_SOURCE;
-	}
-	else if (src1 == SLJIT_IMM) {
+	} else if (src1 == SLJIT_IMM) {
 		if (src1w) {
 			FAIL_IF(load_immediate(compiler, TMP_REG1, src1w));
 			src1_r = TMP_REG1;
 		}
 		else
 			src1_r = TMP_ZERO;
-	}
-	else {
+	} else {
 		if (getput_arg_fast(compiler, flags | LOAD_DATA, TMP_REG1, src1, src1w))
 			FAIL_IF(compiler->error);
 		else
@@ -1666,14 +1802,12 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 		flags |= REG2_SOURCE;
 		if ((flags & (REG_DEST | MOVE_OP)) == MOVE_OP)
 			dst_r = (sljit_s32)src2_r;
-	}
-	else if (src2 == SLJIT_IMM) {
+	} else if (src2 == SLJIT_IMM) {
 		if (!(flags & SRC2_IMM)) {
 			if (src2w) {
-				FAIL_IF(load_immediate(compiler, sugg_src2_r, src2w));
-				src2_r = sugg_src2_r;
-			}
-			else {
+				FAIL_IF(load_immediate(compiler, src2_tmp_reg, src2w));
+				src2_r = src2_tmp_reg;
+			} else {
 				src2_r = TMP_ZERO;
 				if (flags & MOVE_OP) {
 					if (dst & SLJIT_MEM)
@@ -1683,31 +1817,29 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 				}
 			}
 		}
-	}
-	else {
-		if (getput_arg_fast(compiler, flags | LOAD_DATA, sugg_src2_r, src2, src2w))
+	} else {
+		if (getput_arg_fast(compiler, flags | LOAD_DATA, src2_tmp_reg, src2, src2w))
 			FAIL_IF(compiler->error);
 		else
 			flags |= SLOW_SRC2;
 
-		src2_r = sugg_src2_r;
+		src2_r = src2_tmp_reg;
 	}
 
 	if ((flags & (SLOW_SRC1 | SLOW_SRC2)) == (SLOW_SRC1 | SLOW_SRC2)) {
 		SLJIT_ASSERT(src2_r == TMP_REG2);
-		if (!can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
+		if ((flags & SLOW_DEST) && !can_cache(src2, src2w, src1, src1w) && can_cache(src2, src2w, dst, dstw)) {
+			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG1, src1, src1w, src2, src2w));
+			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA | MEM_USE_TMP2, TMP_REG2, src2, src2w, dst, dstw));
+		} else {
 			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG2, src2, src2w, src1, src1w));
 			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG1, src1, src1w, dst, dstw));
-		}
-		else {
-			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG1, src1, src1w, src2, src2w));
-			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG2, src2, src2w, dst, dstw));
 		}
 	}
 	else if (flags & SLOW_SRC1)
 		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, TMP_REG1, src1, src1w, dst, dstw));
 	else if (flags & SLOW_SRC2)
-		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, sugg_src2_r, src2, src2w, dst, dstw));
+		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA | ((src1_r == TMP_REG1) ? MEM_USE_TMP2 : 0), src2_tmp_reg, src2, src2w, dst, dstw));
 
 	FAIL_IF(emit_single_op(compiler, op, flags, dst_r, src1_r, src2_r));
 
@@ -1778,40 +1910,40 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compile
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
 	case SLJIT_MOV_P:
-		return emit_op(compiler, SLJIT_MOV, WORD_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, srcw);
+		return emit_op(compiler, SLJIT_MOV, WORD_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, srcw);
 
 	case SLJIT_MOV_U32:
-		return emit_op(compiler, SLJIT_MOV_U32, INT_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_u32)srcw : srcw);
+		return emit_op(compiler, SLJIT_MOV_U32, INT_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_u32)srcw : srcw);
 
 	case SLJIT_MOV_S32:
 	/* Logical operators have no W variant, so sign extended input is necessary for them. */
 	case SLJIT_MOV32:
-		return emit_op(compiler, SLJIT_MOV_S32, INT_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_s32)srcw : srcw);
+		return emit_op(compiler, SLJIT_MOV_S32, INT_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_s32)srcw : srcw);
 
 	case SLJIT_MOV_U8:
-		return emit_op(compiler, op, BYTE_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_u8)srcw : srcw);
+		return emit_op(compiler, op, BYTE_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_u8)srcw : srcw);
 
 	case SLJIT_MOV_S8:
-		return emit_op(compiler, op, BYTE_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_s8)srcw : srcw);
+		return emit_op(compiler, op, BYTE_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_s8)srcw : srcw);
 
 	case SLJIT_MOV_U16:
-		return emit_op(compiler, op, HALF_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_u16)srcw : srcw);
+		return emit_op(compiler, op, HALF_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_u16)srcw : srcw);
 
 	case SLJIT_MOV_S16:
-		return emit_op(compiler, op, HALF_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_REG1, 0, src, (src == SLJIT_IMM) ? (sljit_s16)srcw : srcw);
+		return emit_op(compiler, op, HALF_DATA | SIGNED_DATA | MOVE_OP, dst, dstw, TMP_ZERO, 0, src, (src == SLJIT_IMM) ? (sljit_s16)srcw : srcw);
 
 	case SLJIT_CLZ:
 	case SLJIT_CTZ:
 	case SLJIT_REV:
-		return emit_op(compiler, op, flags, dst, dstw, TMP_REG1, 0, src, srcw);
+		return emit_op(compiler, op, flags, dst, dstw, TMP_ZERO, 0, src, srcw);
 
 	case SLJIT_REV_U16:
 	case SLJIT_REV_S16:
-		return emit_op(compiler, op, HALF_DATA, dst, dstw, TMP_REG1, 0, src, srcw);
+		return emit_op(compiler, op, HALF_DATA, dst, dstw, TMP_ZERO, 0, src, srcw);
 
 	case SLJIT_REV_U32:
 	case SLJIT_REV_S32:
-		return emit_op(compiler, op | SLJIT_32, INT_DATA, dst, dstw, TMP_REG1, 0, src, srcw);
+		return emit_op(compiler, op | SLJIT_32, INT_DATA, dst, dstw, TMP_ZERO, 0, src, srcw);
 	}
 
 	SLJIT_UNREACHABLE();
@@ -1891,6 +2023,24 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 
 	SLJIT_SKIP_CHECKS(compiler);
 	return sljit_emit_op2(compiler, op, 0, 0, src1, src1w, src2, src2w);
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_op2r(compiler, op, dst_reg, src1, src1w, src2, src2w));
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MULADD:
+		SLJIT_SKIP_CHECKS(compiler);
+		FAIL_IF(sljit_emit_op2(compiler, SLJIT_MUL | (op & SLJIT_32), TMP_REG2, 0, src1, src1w, src2, src2w));
+		return push_inst(compiler, ADD_D | RD(dst_reg) | RJ(dst_reg) | RK(TMP_REG2));
+	}
+
+	return SLJIT_SUCCESS;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *compiler, sljit_s32 op,
@@ -2045,7 +2195,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_get_register_index(sljit_s32 type, slji
 	if (type == SLJIT_GP_REGISTER)
 		return reg_map[reg];
 
-	if (type != SLJIT_FLOAT_REGISTER)
+	if (type != SLJIT_FLOAT_REGISTER && type != SLJIT_SIMD_REG_128 && type != SLJIT_SIMD_REG_256)
 		return -1;
 
 	return freg_map[reg];
@@ -2292,7 +2442,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV_F64:
 		if (src != dst_r) {
-			if (dst_r != TMP_FREG1)
+			if (!(dst & SLJIT_MEM))
 				FAIL_IF(push_inst(compiler, FINST(FMOV, op) | FRD(dst_r) | FRJ(src)));
 			else
 				dst_r = src;
@@ -2351,11 +2501,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 	}
 
 	if ((flags & (SLOW_SRC1 | SLOW_SRC2)) == (SLOW_SRC1 | SLOW_SRC2)) {
-		if (!can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
+		if ((dst & SLJIT_MEM) && !can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG2, src2, src2w, src1, src1w));
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG1, src1, src1w, dst, dstw));
-		}
-		else {
+		} else {
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG1, src1, src1w, src2, src2w));
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG2, src2, src2w, dst, dstw));
 		}
@@ -2385,7 +2534,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 		break;
 	}
 
-	if (dst_r == TMP_FREG2)
+	if (dst_r != dst)
 		FAIL_IF(emit_op_mem2(compiler, FLOAT_DATA(op), TMP_FREG2, dst, dstw, 0, 0));
 	return SLJIT_SUCCESS;
 }
@@ -2573,8 +2722,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 	PTR_FAIL_IF(push_inst(compiler, inst));
 
 	/* Maximum number of instructions required for generating a constant. */
-	compiler->size += 3;
-
+	compiler->size += JUMP_MAX_SIZE - 1;
 	return jump;
 }
 
@@ -2601,6 +2749,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 	struct sljit_jump *jump;
 	sljit_s32 flags;
 	sljit_ins inst;
+	sljit_s32 src2_tmp_reg = FAST_IS_REG(src1) ? TMP_REG1 : TMP_REG2;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_emit_cmp(compiler, type, src1, src1w, src2, src2w));
@@ -2618,8 +2767,8 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 	}
 
 	if (src2 & SLJIT_MEM) {
-		PTR_FAIL_IF(emit_op_mem2(compiler, flags, TMP_REG2, src2, src2w, 0, 0));
-		src2 = TMP_REG2;
+		PTR_FAIL_IF(emit_op_mem2(compiler, flags, src2_tmp_reg, src2, src2w, 0, 0));
+		src2 = src2_tmp_reg;
 	}
 
 	if (src1 == SLJIT_IMM) {
@@ -2633,8 +2782,8 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 
 	if (src2 == SLJIT_IMM) {
 		if (src2w != 0) {
-			PTR_FAIL_IF(load_immediate(compiler, TMP_REG2, src2w));
-			src2 = TMP_REG2;
+			PTR_FAIL_IF(load_immediate(compiler, src2_tmp_reg, src2w));
+			src2 = src2_tmp_reg;
 		}
 		else
 			src2 = TMP_ZERO;
@@ -2687,7 +2836,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 	PTR_FAIL_IF(push_inst(compiler, JIRL | RD(TMP_ZERO) | RJ(TMP_REG1) | IMM_I12(0)));
 
 	/* Maximum number of instructions required for generating a constant. */
-	compiler->size += 3;
+	compiler->size += JUMP_MAX_SIZE - 1;
 
 	return jump;
 }
@@ -2718,7 +2867,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 	FAIL_IF(push_inst(compiler, JIRL | RD((type >= SLJIT_FAST_CALL) ? RETURN_ADDR_REG : TMP_ZERO) | RJ(TMP_REG1) | IMM_I12(0)));
 
 	/* Maximum number of instructions required for generating a constant. */
-	compiler->size += 3;
+	compiler->size += JUMP_MAX_SIZE - 1;
 
 	return SLJIT_SUCCESS;
 }
@@ -2860,13 +3009,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *comp
 			type ^= 0x1;
 		} else {
 			if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
-				FAIL_IF(push_inst(compiler, ADDI_D | RD(TMP_REG2) | RJ(dst_reg) | IMM_I12(0)));
+				FAIL_IF(push_inst(compiler, ADDI_D | RD(TMP_REG1) | RJ(dst_reg) | IMM_I12(0)));
 
 				if ((src1 & REG_MASK) == dst_reg)
-					src1 = (src1 & ~REG_MASK) | TMP_REG2;
+					src1 = (src1 & ~REG_MASK) | TMP_REG1;
 
 				if (OFFS_REG(src1) == dst_reg)
-					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG2);
+					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG1);
 			}
 
 			FAIL_IF(push_inst(compiler, ADDI_D | RD(dst_reg) | RJ(src2_reg) | IMM_I12(0)));
@@ -2908,15 +3057,17 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fselect(struct sljit_compiler *com
 		if ((type & ~SLJIT_32) == SLJIT_EQUAL)
 			invert = 1;
 		FAIL_IF(push_inst(compiler, MOVGR2CF | FCD(F_OTHER_FLAG) | RJ(EQUAL_FLAG)));
-	}
-	else
+	} else {
+		if (get_jump_instruction(type & ~SLJIT_32) == (BNE | RJ(OTHER_FLAG) | RD(TMP_ZERO)))
+			invert = 1;
 		FAIL_IF(push_inst(compiler, MOVGR2CF | FCD(F_OTHER_FLAG) | RJ(OTHER_FLAG)));
+	}
 
 	if (src1 & SLJIT_MEM) {
-		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(type) | LOAD_DATA, dst_freg, src1, src1w));
+		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(type) | LOAD_DATA, TMP_FREG2, src1, src1w));
 		if (invert)
-			return push_inst(compiler, FSEL | FRD(dst_freg) | FRJ(dst_freg) | FRK(src2_freg) | FCA(F_OTHER_FLAG));
-		return push_inst(compiler, FSEL | FRD(dst_freg) | FRJ(src2_freg) | FRK(dst_freg) | FCA(F_OTHER_FLAG));
+			return push_inst(compiler, FSEL | FRD(dst_freg) | FRJ(TMP_FREG2) | FRK(src2_freg) | FCA(F_OTHER_FLAG));
+		return push_inst(compiler, FSEL | FRD(dst_freg) | FRJ(src2_freg) | FRK(TMP_FREG2) | FCA(F_OTHER_FLAG));
 	} else {
 		if (invert)
 			return push_inst(compiler, FSEL | FRD(dst_freg) | FRJ(src1) | FRK(src2_freg) | FCA(F_OTHER_FLAG));
@@ -2982,6 +3133,468 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 
 #undef TO_ARGW_HI
 
+static sljit_s32 sljit_emit_simd_mem_offset(struct sljit_compiler *compiler, sljit_s32 *mem_ptr, sljit_sw memw)
+{
+	sljit_s32 mem = *mem_ptr;
+
+	if (SLJIT_UNLIKELY(mem & OFFS_REG_MASK)) {
+		*mem_ptr = TMP_REG3;
+		FAIL_IF(push_inst(compiler, SLLI_D | RD(TMP_REG3) | RJ(OFFS_REG(mem)) | IMM_I12(memw & 0x3)));
+		return push_inst(compiler, ADD_D | RD(TMP_REG3) | RJ(TMP_REG3) | RK(mem & REG_MASK));
+	}
+
+	if (!(mem & REG_MASK)) {
+		*mem_ptr = TMP_REG3;
+		return load_immediate(compiler, TMP_REG3, memw);
+	}
+
+	mem &= REG_MASK;
+
+	if (memw == 0) {
+		*mem_ptr = mem;
+		return SLJIT_SUCCESS;
+	}
+
+	*mem_ptr = TMP_REG3;
+
+	FAIL_IF(load_immediate(compiler, TMP_REG3, memw));
+	return push_inst(compiler, ADD_D | RD(TMP_REG3) | RJ(TMP_REG3) | RK(mem));
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_mov(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg,
+	sljit_s32 srcdst, sljit_sw srcdstw)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_mov(compiler, type, freg, srcdst, srcdstw));
+
+	ADJUST_LOCAL_OFFSET(srcdst, srcdstw);
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	if (!(srcdst & SLJIT_MEM)) {
+		if (type & SLJIT_SIMD_STORE)
+			ins = FRD(srcdst) | FRJ(freg) | FRK(freg);
+		else
+			ins = FRD(freg) | FRJ(srcdst) | FRK(srcdst);
+
+		if (reg_size == 5)
+			ins |= VOR_V | (sljit_ins)1 << 26;
+		else
+			ins |= VOR_V;
+
+		return push_inst(compiler, ins);
+	}
+
+	ins = (type & SLJIT_SIMD_STORE) ? VST : VLD;
+
+	if (reg_size == 5)
+		ins = (type & SLJIT_SIMD_STORE) ? XVST : XVLD;
+
+	if (FAST_IS_REG(srcdst) && srcdst >= 0 && (srcdstw >= I12_MIN && srcdstw <= I12_MAX))
+		return push_inst(compiler, ins | FRD(freg) | RJ((sljit_u8)srcdst) | IMM_I12(srcdstw));
+	else {
+		FAIL_IF(sljit_emit_simd_mem_offset(compiler, &srcdst, srcdstw));
+		return push_inst(compiler, ins | FRD(freg) | RJ(srcdst) | IMM_I12(0));
+	}
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg,
+	sljit_s32 src, sljit_sw srcw)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_replicate(compiler, type, freg, src, srcw));
+
+	ADJUST_LOCAL_OFFSET(src, srcw);
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	if (src & SLJIT_MEM) {
+		FAIL_IF(sljit_emit_simd_mem_offset(compiler, &src, srcw));
+
+		if (reg_size == 5)
+			ins = (sljit_ins)1 << 25;
+
+		return push_inst(compiler, VLDREPL | ins | FRD(freg) | RJ(src) | (sljit_ins)1 << (23 - elem_size));
+	}
+
+	if (reg_size == 5)
+		ins = (sljit_ins)1 << 26;
+
+	if (type & SLJIT_SIMD_FLOAT) {
+		if (src == SLJIT_IMM)
+			return push_inst(compiler, VREPLGR2VR | ins | FRD(freg) | RJ(TMP_ZERO) | (sljit_ins)elem_size << 10);
+
+		FAIL_IF(push_inst(compiler, VREPLVE | ins | FRD(freg) | FRJ(src) | RK(TMP_ZERO) | (sljit_ins)elem_size << 15));
+
+		if (reg_size == 5) {
+			ins = (sljit_ins)(0x44 << 10);
+			return push_inst(compiler, XVPERMI | ins | FRD(freg) | FRJ(freg));
+		}
+
+		return SLJIT_SUCCESS;
+	}
+
+	ins |= VREPLGR2VR | (sljit_ins)elem_size << 10;
+
+	if (src == SLJIT_IMM) {
+		FAIL_IF(load_immediate(compiler, TMP_REG2, srcw));
+		src = TMP_REG2;
+	}
+
+	return push_inst(compiler, ins | FRD(freg) | RJ(src));
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg, sljit_s32 lane_index,
+	sljit_s32 srcdst, sljit_sw srcdstw)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_lane_mov(compiler, type, freg, lane_index, srcdst, srcdstw));
+
+	ADJUST_LOCAL_OFFSET(srcdst, srcdstw);
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if ((type & SLJIT_SIMD_FLOAT) && (elem_size < 2 || elem_size > 3))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if ((type & SLJIT_SIMD_FLOAT) && (elem_size < 2 || elem_size > 3))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	if (type & SLJIT_SIMD_LANE_ZERO) {
+		ins = (reg_size == 5) ? ((sljit_ins)1 << 26) : 0;
+
+		if ((type & SLJIT_SIMD_FLOAT) && freg == srcdst) {
+			FAIL_IF(push_inst(compiler, VOR_V | ins | FRD(TMP_FREG1) | FRJ(freg) | FRK(freg)));
+			srcdst = TMP_FREG1;
+			srcdstw = 0;
+		}
+
+		FAIL_IF(push_inst(compiler, VXOR_V | ins | FRD(freg) | FRJ(freg) | FRK(freg)));
+	}
+
+	if (srcdst & SLJIT_MEM) {
+		FAIL_IF(sljit_emit_simd_mem_offset(compiler, &srcdst, srcdstw));
+
+		if (reg_size == 5)
+			ins = (sljit_ins)1 << 25;
+
+		if (type & SLJIT_SIMD_STORE) {
+			ins |= (sljit_ins)lane_index << 18 | (sljit_ins)(1 << (23 - elem_size));
+			return push_inst(compiler, VSTELM | ins | FRD(freg) | RJ(srcdst));
+		} else {
+			emit_op_mem(compiler, (elem_size == 3 ? WORD_DATA : (elem_size == 2 ? INT_DATA : (elem_size == 1 ? HALF_DATA : BYTE_DATA))) | LOAD_DATA, TMP_REG1, srcdst | SLJIT_MEM, 0);
+			srcdst = TMP_REG1;
+			ins = (sljit_ins)(0x3f ^ (0x1f >> elem_size)) << 10;
+
+			if (reg_size == 5) {
+				if (elem_size < 2) {
+					FAIL_IF(push_inst(compiler, VOR_V | (sljit_ins)1 << 26 | FRD(TMP_FREG1) | FRJ(freg) | FRK(freg)));
+					if (lane_index >= (2 << (3 - elem_size))) {
+						FAIL_IF(push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(TMP_FREG1) | FRJ(freg) | IMM_I8(1)));
+						FAIL_IF(push_inst(compiler, VINSGR2VR | ins | FRD(TMP_FREG1) | RJ(srcdst) | IMM_V(lane_index % (2 << (3 - elem_size)))));
+						return push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(freg) | FRJ(TMP_FREG1) | IMM_I8(2));
+					} else {
+						FAIL_IF(push_inst(compiler, VINSGR2VR | ins | FRD(freg) | RJ(srcdst) | IMM_V(lane_index)));
+						return push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(freg) | FRJ(TMP_FREG1) | IMM_I8(18));
+					}
+				} else
+					ins = (sljit_ins)(0x3f ^ (0x3f >> elem_size)) << 10 | (sljit_ins)1 << 26;
+			}
+
+			return push_inst(compiler, VINSGR2VR | ins | FRD(freg) | RJ(srcdst) | IMM_V(lane_index));
+		}
+	}
+
+	if (type & SLJIT_SIMD_FLOAT) {
+		ins = (reg_size == 5) ? (sljit_ins)(0x3f ^ (0x3f >> elem_size)) << 10 | (sljit_ins)1 << 26 : (sljit_ins)(0x3f ^ (0x1f >> elem_size)) << 10;
+
+		if (type & SLJIT_SIMD_STORE) {
+			FAIL_IF(push_inst(compiler, VPICKVE2GR_U | ins | RD(TMP_REG1) | FRJ(freg) | IMM_V(lane_index)));
+			return push_inst(compiler, VINSGR2VR | ins | FRD(srcdst) | RJ(TMP_REG1) | IMM_V(0));
+		} else {
+			FAIL_IF(push_inst(compiler, VPICKVE2GR_U | ins | RD(TMP_REG1) | FRJ(srcdst) | IMM_V(0)));
+			return push_inst(compiler, VINSGR2VR | ins | FRD(freg) | RJ(TMP_REG1) | IMM_V(lane_index));
+		}
+	}
+
+	if (srcdst == SLJIT_IMM) {
+		FAIL_IF(load_immediate(compiler, TMP_REG1, srcdstw));
+		srcdst = TMP_REG1;
+	}
+
+	if (type & SLJIT_SIMD_STORE) {
+		ins = (sljit_ins)(0x3f ^ (0x1f >> elem_size)) << 10;
+
+		if (type & SLJIT_SIMD_LANE_SIGNED)
+			ins |= (sljit_ins)(VPICKVE2GR_U ^ (0x7 << 18));
+		else
+			ins |= VPICKVE2GR_U;
+
+		if (reg_size == 5) {
+			if (elem_size < 2) {
+				if (lane_index >= (2 << (3 - elem_size))) {
+					if (type & SLJIT_SIMD_LANE_SIGNED)
+						ins |= (sljit_ins)(VPICKVE2GR_U ^ (0x7 << 18));
+					else
+						ins |= VPICKVE2GR_U;
+
+					FAIL_IF(push_inst(compiler, VOR_V | (sljit_ins)1 << 26 | FRD(TMP_FREG1) | FRJ(freg) | FRK(freg)));
+					FAIL_IF(push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(TMP_FREG1) | FRJ(freg) | IMM_I8(1)));
+					return push_inst(compiler, ins | RD(srcdst) | FRJ(TMP_FREG1) | IMM_V(lane_index % (2 << (3 - elem_size))));
+				}
+			} else {
+				ins ^= (sljit_ins)1 << (15 - elem_size);
+				ins |= (sljit_ins)1 << 26;
+			}
+		}
+
+		return push_inst(compiler, ins | RD(srcdst) | FRJ(freg) | IMM_V(lane_index));
+	} else {
+		ins = (sljit_ins)(0x3f ^ (0x1f >> elem_size)) << 10;
+
+		if (reg_size == 5) {
+			if (elem_size < 2) {
+				FAIL_IF(push_inst(compiler, VOR_V | (sljit_ins)1 << 26 | FRD(TMP_FREG1) | FRJ(freg) | FRK(freg)));
+				if (lane_index >= (2 << (3 - elem_size))) {
+					FAIL_IF(push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(TMP_FREG1) | FRJ(freg) | IMM_I8(1)));
+					FAIL_IF(push_inst(compiler, VINSGR2VR | ins | FRD(TMP_FREG1) | RJ(srcdst) | IMM_V(lane_index % (2 << (3 - elem_size)))));
+					return push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(freg) | FRJ(TMP_FREG1) | IMM_I8(2));
+				} else {
+					FAIL_IF(push_inst(compiler, VINSGR2VR | ins | FRD(freg) | RJ(srcdst) | IMM_V(lane_index)));
+					return push_inst(compiler, XVPERMI | (sljit_ins)1 << 18 | FRD(freg) | FRJ(TMP_FREG1) | IMM_I8(18));
+				}
+			} else
+				ins = (sljit_ins)(0x3f ^ (0x3f >> elem_size)) << 10 | (sljit_ins)1 << 26;
+		}
+
+		return push_inst(compiler, VINSGR2VR | ins | FRD(freg) | RJ(srcdst) | IMM_V(lane_index));
+	}
+
+	return SLJIT_ERR_UNSUPPORTED;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg,
+	sljit_s32 src, sljit_s32 src_lane_index)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_lane_replicate(compiler, type, freg, src, src_lane_index));
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	ins = (sljit_ins)(0x3f ^ (0x1f >> elem_size)) << 10;
+
+	if (reg_size == 5) {
+		FAIL_IF(push_inst(compiler, VREPLVEI | (sljit_ins)1 << 26 | ins | FRD(freg) | FRJ(src) | IMM_V(src_lane_index % (2 << (3 - elem_size)))));
+
+		ins = (src_lane_index < (2 << (3 - elem_size))) ? (sljit_ins)(0x44 << 10) : (sljit_ins)(0xee << 10);
+
+		return push_inst(compiler, XVPERMI | ins | FRD(freg) | FRJ(freg));
+	}
+
+	return push_inst(compiler, VREPLVEI | ins | FRD(freg) | FRJ(src) | IMM_V(src_lane_index));
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_extend(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg,
+	sljit_s32 src, sljit_sw srcw)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_s32 elem2_size = SLJIT_SIMD_GET_ELEM2_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_extend(compiler, type, freg, src, srcw));
+
+	ADJUST_LOCAL_OFFSET(src, srcw);
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	if (src & SLJIT_MEM) {
+		ins = (type & SLJIT_SIMD_STORE) ? VST : VLD;
+
+		if (reg_size == 5)
+			ins = (type & SLJIT_SIMD_STORE) ? XVST : XVLD;
+
+		if (FAST_IS_REG(src) && src >= 0 && (srcw >= I12_MIN && srcw <= I12_MAX))
+			FAIL_IF(push_inst(compiler, ins | FRD(freg) | RJ(src) | IMM_I12(srcw)));
+		else {
+			FAIL_IF(sljit_emit_simd_mem_offset(compiler, &src, srcw));
+			FAIL_IF(push_inst(compiler, ins | FRD(freg) | RJ(src) | IMM_I12(0)));
+		}
+		src = freg;
+	}
+
+	if (type & SLJIT_SIMD_FLOAT) {
+		if (elem_size != 2 || elem2_size != 3)
+			return SLJIT_ERR_UNSUPPORTED;
+
+		ins = 0;
+		if (reg_size == 5) {
+			ins = (sljit_ins)1 << 26;
+			FAIL_IF(push_inst(compiler, XVPERMI | FRD(src) | FRJ(src) | IMM_I8(16)));
+		}
+
+		return push_inst(compiler, VFCVTL_D_S | ins | FRD(freg) | FRJ(src));
+	}
+
+	ins = (type & SLJIT_SIMD_EXTEND_SIGNED) ? VSLLWIL : (VSLLWIL | (sljit_ins)1 << 18);
+
+	if (reg_size == 5)
+		ins |= (sljit_ins)1 << 26;
+
+	do {
+		if (reg_size == 5)
+			FAIL_IF(push_inst(compiler, XVPERMI | FRD(src) | FRJ(src) | IMM_I8(16)));
+
+		FAIL_IF(push_inst(compiler, ins | ((sljit_ins)1 << (13 + elem_size)) | FRD(freg) | FRJ(src)));
+		src = freg;
+	} while (++elem_size < elem2_size);
+
+	return SLJIT_SUCCESS;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_sign(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 freg,
+	sljit_s32 dst, sljit_sw dstw)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_ins ins = 0;
+	sljit_s32 dst_r;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_sign(compiler, type, freg, dst, dstw));
+
+	ADJUST_LOCAL_OFFSET(dst, dstw);
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (elem_size > 3 || ((type & SLJIT_SIMD_FLOAT) && elem_size < 2))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	dst_r = FAST_IS_REG(dst) ? dst : TMP_REG2;
+
+	if (reg_size == 5)
+		ins = (sljit_ins)1 << 26;
+
+	FAIL_IF(push_inst(compiler, VMSKLTZ | ins | (sljit_ins)(elem_size << 10) | FRD(TMP_FREG1) | FRJ(freg)));
+
+	FAIL_IF(push_inst(compiler, VPICKVE2GR_U | (sljit_ins)(0x3c << 10) | RD(dst_r) | FRJ(TMP_FREG1)));
+
+	if (reg_size == 5) {
+		FAIL_IF(push_inst(compiler, VPICKVE2GR_U | (sljit_ins)(0x38 << 10) | ins | RD(TMP_REG3) | FRJ(TMP_FREG1) | IMM_V(2)));
+		FAIL_IF(push_inst(compiler, SLLI_W | RD(TMP_REG3) | RJ(TMP_REG3) | IMM_I12(2 << (3 - elem_size))));
+		FAIL_IF(push_inst(compiler, OR | RD(dst_r) | RJ(dst_r) | RK(TMP_REG3)));
+	}
+
+	if (dst_r == TMP_REG2)
+		return emit_op_mem(compiler, ((type & SLJIT_32) ? INT_DATA : WORD_DATA), TMP_REG2, dst, dstw);
+
+	return SLJIT_SUCCESS;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_op2(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 dst_freg, sljit_s32 src1_freg, sljit_s32 src2_freg)
+{
+	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
+	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_ins ins = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_simd_op2(compiler, type, dst_freg, src1_freg, src2_freg));
+
+	if (reg_size != 5 && reg_size != 4)
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (reg_size == 5 && !(get_cpu_features(GET_HWCAP) & LOONGARCH_HWCAP_LASX))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if ((type & SLJIT_SIMD_FLOAT) && (elem_size < 2 || elem_size > 3))
+		return SLJIT_ERR_UNSUPPORTED;
+
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
+
+	switch (SLJIT_SIMD_GET_OPCODE(type)) {
+	case SLJIT_SIMD_OP2_AND:
+		ins = VAND_V;
+		break;
+	case SLJIT_SIMD_OP2_OR:
+		ins = VOR_V;
+		break;
+	case SLJIT_SIMD_OP2_XOR:
+		ins = VXOR_V;
+		break;
+	}
+
+	if (reg_size == 5)
+		ins |= (sljit_ins)1 << 26;
+
+	return push_inst(compiler, ins | FRD(dst_freg) | FRJ(src1_freg) | FRK(src2_freg));
+}
+
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler *compiler,
 	sljit_s32 op,
 	sljit_s32 dst_reg,
@@ -2991,9 +3604,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_load(compiler, op, dst_reg, mem_reg));
-
-	if (!(LOONGARCH_FEATURE_LAMCAS & get_cpu_features()))
-		return SLJIT_ERR_UNSUPPORTED;
 
 	switch(GET_OPCODE(op)) {
 	case SLJIT_MOV_U8:
@@ -3028,9 +3638,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_store(compiler, op, src_reg, mem_reg, temp_reg));
-
-	if (!(LOONGARCH_FEATURE_LAMCAS & get_cpu_features()))
-		return SLJIT_ERR_UNSUPPORTED;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV_U8:
@@ -3128,28 +3735,28 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 	return const_;
 }
 
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
 {
-	struct sljit_put_label *put_label;
+	struct sljit_jump *jump;
 	sljit_s32 dst_r;
 
 	CHECK_ERROR_PTR();
-	CHECK_PTR(check_sljit_emit_put_label(compiler, dst, dstw));
+	CHECK_PTR(check_sljit_emit_mov_addr(compiler, dst, dstw));
 	ADJUST_LOCAL_OFFSET(dst, dstw);
 
-	put_label = (struct sljit_put_label*)ensure_abuf(compiler, sizeof(struct sljit_put_label));
-	PTR_FAIL_IF(!put_label);
-	set_put_label(put_label, compiler, 0);
+	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+	PTR_FAIL_IF(!jump);
+	set_mov_addr(jump, compiler, 0);
 
 	dst_r = FAST_IS_REG(dst) ? dst : TMP_REG2;
 	PTR_FAIL_IF(push_inst(compiler, (sljit_ins)dst_r));
 
-	compiler->size += 3;
+	compiler->size += JUMP_MAX_SIZE - 1;
 
 	if (dst & SLJIT_MEM)
 		PTR_FAIL_IF(emit_op_mem(compiler, WORD_DATA, TMP_REG2, dst, dstw));
 
-	return put_label;
+	return jump;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_sw new_constant, sljit_sw executable_offset)

--- a/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_32.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_32.c
@@ -225,7 +225,7 @@ static sljit_s32 call_with_args(struct sljit_compiler *compiler, sljit_s32 arg_t
 	sljit_ins f64_hi = TA(6), f64_lo = TA(7);
 #endif /* SLJIT_LITTLE_ENDIAN */
 
-	SLJIT_ASSERT(reg_map[TMP_REG1] == 4 && freg_map[TMP_FREG1] == 12);
+	SLJIT_ASSERT(reg_map[TMP_REG2] == 4 && freg_map[TMP_FREG1] == 12);
 
 	arg_types >>= SLJIT_ARG_SHIFT;
 
@@ -370,7 +370,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_call(struct sljit_compile
 	} else if (type & SLJIT_CALL_RETURN)
 		PTR_FAIL_IF(emit_stack_frame_release(compiler, 0, &ins));
 
-	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25 && PIC_ADDR_REG == TMP_REG2);
+	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25);
 
 	if (ins == NOP && compiler->delay_slot != UNMOVABLE_INS)
 		jump->flags |= IS_MOVABLE;
@@ -441,7 +441,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_icall(struct sljit_compiler *compi
 		return sljit_emit_ijump(compiler, type, src, srcw);
 	}
 
-	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25 && PIC_ADDR_REG == TMP_REG2);
+	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25);
 
 	if (src == SLJIT_IMM)
 		FAIL_IF(load_immediate(compiler, DR(PIC_ADDR_REG), srcw));

--- a/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_64.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_64.c
@@ -225,7 +225,7 @@ static sljit_s32 call_with_args(struct sljit_compiler *compiler, sljit_s32 arg_t
 	sljit_ins prev_ins = *ins_ptr;
 	sljit_ins ins = NOP;
 
-	SLJIT_ASSERT(reg_map[TMP_REG1] == 4 && freg_map[TMP_FREG1] == 12);
+	SLJIT_ASSERT(reg_map[TMP_REG2] == 4 && freg_map[TMP_FREG1] == 12);
 
 	arg_types >>= SLJIT_ARG_SHIFT;
 
@@ -309,7 +309,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_call(struct sljit_compile
 	if ((type & 0xff) != SLJIT_CALL_REG_ARG)
 		PTR_FAIL_IF(call_with_args(compiler, arg_types, &ins));
 
-	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25 && PIC_ADDR_REG == TMP_REG2);
+	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25);
 
 	if (ins == NOP && compiler->delay_slot != UNMOVABLE_INS)
 		jump->flags |= IS_MOVABLE;
@@ -366,7 +366,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_icall(struct sljit_compiler *compi
 		return sljit_emit_ijump(compiler, type, src, srcw);
 	}
 
-	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25 && PIC_ADDR_REG == TMP_REG2);
+	SLJIT_ASSERT(DR(PIC_ADDR_REG) == 25 && PIC_ADDR_REG == TMP_REG1);
 
 	if (src == SLJIT_IMM)
 		FAIL_IF(load_immediate(compiler, DR(PIC_ADDR_REG), srcw));

--- a/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_common.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeMIPS_common.c
@@ -83,7 +83,7 @@ typedef sljit_u32 sljit_ins;
 #define TMP_REG3	(SLJIT_NUMBER_OF_REGISTERS + 4)
 
 /* For position independent code, t9 must contain the function address. */
-#define PIC_ADDR_REG	TMP_REG2
+#define PIC_ADDR_REG	TMP_REG1
 
 /* Floating point status register. */
 #define FCSR_REG	31
@@ -95,7 +95,7 @@ typedef sljit_u32 sljit_ins;
 #define OTHER_FLAG	1
 
 static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 7] = {
-	0, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 24, 23, 22, 21, 20, 19, 18, 17, 16, 29, 4, 25, 31, 3, 1
+	0, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 24, 23, 22, 21, 20, 19, 18, 17, 16, 29, 25, 4, 31, 3, 1
 };
 
 #define TMP_FREG1	(SLJIT_NUMBER_OF_FLOAT_REGISTERS + 1)
@@ -504,7 +504,7 @@ static SLJIT_INLINE sljit_ins* detect_jump_type(struct sljit_jump *jump, sljit_i
 	if (jump->flags & JUMP_ADDR)
 		target_addr = jump->u.target;
 	else {
-		SLJIT_ASSERT(jump->flags & JUMP_LABEL);
+		SLJIT_ASSERT(jump->u.label != NULL);
 		target_addr = (sljit_uw)(code + jump->u.label->size) + (sljit_uw)executable_offset;
 	}
 
@@ -635,75 +635,66 @@ static __attribute__ ((noinline)) void sljit_cache_flush(void* code, void* code_
 
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 
-static SLJIT_INLINE sljit_sw put_label_get_length(struct sljit_put_label *put_label, sljit_uw max_label)
+static SLJIT_INLINE sljit_sw mov_addr_get_length(struct sljit_jump *jump, sljit_ins *code, sljit_sw executable_offset)
 {
-	if (max_label < 0x80000000l) {
-		put_label->flags = PATCH_ABS32;
+	sljit_uw addr;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	if (jump->flags & JUMP_ADDR)
+		addr = jump->u.target;
+	else
+		addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code + jump->u.label->size, executable_offset);
+
+	if (addr < 0x80000000l) {
+		jump->flags |= PATCH_ABS32;
 		return 1;
 	}
 
-	if (max_label < 0x800000000000l) {
-		put_label->flags = PATCH_ABS48;
+	if (addr < 0x800000000000l) {
+		jump->flags |= PATCH_ABS48;
 		return 3;
 	}
 
-	put_label->flags = 0;
 	return 5;
 }
 
 #endif /* SLJIT_CONFIG_MIPS_64 */
 
-static SLJIT_INLINE void load_addr_to_reg(void *dst, sljit_u32 reg)
+static SLJIT_INLINE void load_addr_to_reg(struct sljit_jump *jump)
 {
-	struct sljit_jump *jump;
-	struct sljit_put_label *put_label;
-	sljit_uw flags;
-	sljit_ins *inst;
-	sljit_uw addr;
-
-	if (reg != 0) {
-		jump = (struct sljit_jump*)dst;
-		flags = jump->flags;
-		inst = (sljit_ins*)jump->addr;
-		addr = (flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target;
-	} else {
-		put_label = (struct sljit_put_label*)dst;
-#if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
-		flags = put_label->flags;
-#endif
-		inst = (sljit_ins*)put_label->addr;
-		addr = put_label->label->addr;
-		reg = *inst;
-	}
+	sljit_uw flags = jump->flags;
+	sljit_ins *ins = (sljit_ins*)jump->addr;
+	sljit_uw addr = (flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
+	sljit_u32 reg = (flags & JUMP_MOV_ADDR) ? *ins : PIC_ADDR_REG;
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
-	inst[0] = LUI | T(reg) | IMM(addr >> 16);
+	ins[0] = LUI | T(reg) | IMM(addr >> 16);
 #else /* !SLJIT_CONFIG_MIPS_32 */
 	if (flags & PATCH_ABS32) {
 		SLJIT_ASSERT(addr < 0x80000000l);
-		inst[0] = LUI | T(reg) | IMM(addr >> 16);
+		ins[0] = LUI | T(reg) | IMM(addr >> 16);
 	}
 	else if (flags & PATCH_ABS48) {
 		SLJIT_ASSERT(addr < 0x800000000000l);
-		inst[0] = LUI | T(reg) | IMM(addr >> 32);
-		inst[1] = ORI | S(reg) | T(reg) | IMM((addr >> 16) & 0xffff);
-		inst[2] = DSLL | T(reg) | D(reg) | SH_IMM(16);
-		inst += 2;
+		ins[0] = LUI | T(reg) | IMM(addr >> 32);
+		ins[1] = ORI | S(reg) | T(reg) | IMM((addr >> 16) & 0xffff);
+		ins[2] = DSLL | T(reg) | D(reg) | SH_IMM(16);
+		ins += 2;
 	}
 	else {
-		inst[0] = LUI | T(reg) | IMM(addr >> 48);
-		inst[1] = ORI | S(reg) | T(reg) | IMM((addr >> 32) & 0xffff);
-		inst[2] = DSLL | T(reg) | D(reg) | SH_IMM(16);
-		inst[3] = ORI | S(reg) | T(reg) | IMM((addr >> 16) & 0xffff);
-		inst[4] = DSLL | T(reg) | D(reg) | SH_IMM(16);
-		inst += 4;
+		ins[0] = LUI | T(reg) | IMM(addr >> 48);
+		ins[1] = ORI | S(reg) | T(reg) | IMM((addr >> 32) & 0xffff);
+		ins[2] = DSLL | T(reg) | D(reg) | SH_IMM(16);
+		ins[3] = ORI | S(reg) | T(reg) | IMM((addr >> 16) & 0xffff);
+		ins[4] = DSLL | T(reg) | D(reg) | SH_IMM(16);
+		ins += 4;
 	}
 #endif /* SLJIT_CONFIG_MIPS_32 */
 
-	inst[1] = ORI | S(reg) | T(reg) | IMM(addr & 0xffff);
+	ins[1] = ORI | S(reg) | T(reg) | IMM(addr & 0xffff);
 }
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler)
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data)
 {
 	struct sljit_memory_fragment *buf;
 	sljit_ins *code;
@@ -711,77 +702,76 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	sljit_ins *buf_ptr;
 	sljit_ins *buf_end;
 	sljit_uw word_count;
-	sljit_uw next_addr;
+	SLJIT_NEXT_DEFINE_TYPES;
 	sljit_sw executable_offset;
 	sljit_uw addr;
-
 	struct sljit_label *label;
 	struct sljit_jump *jump;
 	struct sljit_const *const_;
-	struct sljit_put_label *put_label;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_generate_code(compiler));
 	reverse_buf(compiler);
 
-	code = (sljit_ins*)SLJIT_MALLOC_EXEC(compiler->size * sizeof(sljit_ins), compiler->exec_allocator_data);
+	code = (sljit_ins*)allocate_executable_memory(compiler->size * sizeof(sljit_ins), options, exec_allocator_data, &executable_offset);
 	PTR_FAIL_WITH_EXEC_IF(code);
 	buf = compiler->buf;
 
 	code_ptr = code;
 	word_count = 0;
-	next_addr = 0;
-	executable_offset = SLJIT_EXEC_OFFSET(code);
-
 	label = compiler->labels;
 	jump = compiler->jumps;
 	const_ = compiler->consts;
-	put_label = compiler->put_labels;
+	SLJIT_NEXT_INIT_TYPES();
+	SLJIT_GET_NEXT_MIN();
 
 	do {
 		buf_ptr = (sljit_ins*)buf->memory;
 		buf_end = buf_ptr + (buf->used_size >> 2);
 		do {
 			*code_ptr = *buf_ptr++;
-			if (next_addr == word_count) {
+			if (next_min_addr == word_count) {
 				SLJIT_ASSERT(!label || label->size >= word_count);
 				SLJIT_ASSERT(!jump || jump->addr >= word_count);
 				SLJIT_ASSERT(!const_ || const_->addr >= word_count);
-				SLJIT_ASSERT(!put_label || put_label->addr >= word_count);
 
 				/* These structures are ordered by their address. */
-				if (label && label->size == word_count) {
-					label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+				if (next_min_addr == next_label_size) {
+					label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 					label->size = (sljit_uw)(code_ptr - code);
 					label = label->next;
+					next_label_size = SLJIT_GET_NEXT_SIZE(label);
 				}
-				if (jump && jump->addr == word_count) {
+
+				if (next_min_addr == next_jump_addr) {
+					if (!(jump->flags & JUMP_MOV_ADDR)) {
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
-					word_count += 2;
-#else
-					word_count += 6;
-#endif
-					jump->addr = (sljit_uw)(code_ptr - 1);
-					code_ptr = detect_jump_type(jump, code, executable_offset);
+						word_count += 2;
+#else /* !SLJIT_CONFIG_MIPS_32 */
+						word_count += 6;
+#endif /* SLJIT_CONFIG_MIPS_32 */
+						jump->addr = (sljit_uw)(code_ptr - 1);
+						code_ptr = detect_jump_type(jump, code, executable_offset);
+					} else {
+						jump->addr = (sljit_uw)code_ptr;
+#if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
+						code_ptr += 1;
+						word_count += 1;
+#else /* !SLJIT_CONFIG_MIPS_32 */
+						code_ptr += mov_addr_get_length(jump, code, executable_offset);
+						word_count += 5;
+#endif /* SLJIT_CONFIG_MIPS_32 */
+					}
+
 					jump = jump->next;
-				}
-				if (const_ && const_->addr == word_count) {
+					next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+				} else if (next_min_addr == next_const_addr) {
 					const_->addr = (sljit_uw)code_ptr;
 					const_ = const_->next;
+					next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
 				}
-				if (put_label && put_label->addr == word_count) {
-					SLJIT_ASSERT(put_label->label);
-					put_label->addr = (sljit_uw)code_ptr;
-#if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
-					code_ptr += 1;
-					word_count += 1;
-#else
-					code_ptr += put_label_get_length(put_label, (sljit_uw)(SLJIT_ADD_EXEC_OFFSET(code, executable_offset) + put_label->label->size));
-					word_count += 5;
-#endif
-					put_label = put_label->next;
-				}
-				next_addr = compute_next_addr(label, jump, const_, put_label);
+
+				SLJIT_GET_NEXT_MIN();
 			}
 			code_ptr++;
 			word_count++;
@@ -791,7 +781,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	} while (buf);
 
 	if (label && label->size == word_count) {
-		label->addr = (sljit_uw)code_ptr;
+		label->u.addr = (sljit_uw)code_ptr;
 		label->size = (sljit_uw)(code_ptr - code);
 		label = label->next;
 	}
@@ -799,13 +789,12 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	SLJIT_ASSERT(!label);
 	SLJIT_ASSERT(!jump);
 	SLJIT_ASSERT(!const_);
-	SLJIT_ASSERT(!put_label);
 	SLJIT_ASSERT(code_ptr - code <= (sljit_sw)compiler->size);
 
 	jump = compiler->jumps;
 	while (jump) {
 		do {
-			addr = (jump->flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target;
+			addr = (jump->flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
 			buf_ptr = (sljit_ins *)jump->addr;
 
 			if (jump->flags & PATCH_B) {
@@ -821,15 +810,10 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 				break;
 			}
 
-			load_addr_to_reg(jump, PIC_ADDR_REG);
+			load_addr_to_reg(jump);
 		} while (0);
-		jump = jump->next;
-	}
 
-	put_label = compiler->put_labels;
-	while (put_label) {
-		load_addr_to_reg(put_label, 0);
-		put_label = put_label->next;
+		jump = jump->next;
 	}
 
 	compiler->error = SLJIT_ERR_COMPILED;
@@ -932,9 +916,9 @@ static sljit_s32 emit_op_mem(struct sljit_compiler *compiler, sljit_s32 flags, s
 static sljit_s32 emit_stack_frame_release(struct sljit_compiler *compiler, sljit_s32 frame_size, sljit_ins *ins_ptr);
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
-#define SELECT_OP(a, b)	(b)
+#define SELECT_OP(d, w)	(w)
 #else
-#define SELECT_OP(a, b)	(!(op & SLJIT_32) ? a : b)
+#define SELECT_OP(d, w)	(!(op & SLJIT_32) ? (d) : (w))
 #endif
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
@@ -1001,9 +985,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_enter(struct sljit_compiler *compi
 		offset = local_size - SSIZE_OF(sw);
 	} else {
 		FAIL_IF(load_immediate(compiler, OTHER_FLAG, local_size));
-		FAIL_IF(push_inst(compiler, ADDU_W | S(SLJIT_SP) | TA(0) | D(TMP_REG2), DR(TMP_REG2)));
+		FAIL_IF(push_inst(compiler, ADDU_W | S(SLJIT_SP) | TA(0) | D(TMP_REG1), DR(TMP_REG1)));
 		FAIL_IF(push_inst(compiler, SUBU_W | S(SLJIT_SP) | TA(OTHER_FLAG) | D(SLJIT_SP), DR(SLJIT_SP)));
-		base = S(TMP_REG2);
+		base = S(TMP_REG1);
 		offset = -SSIZE_OF(sw);
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
 		local_size = 0;
@@ -1212,8 +1196,8 @@ static sljit_s32 emit_stack_frame_release(struct sljit_compiler *compiler, sljit
 		if (tmp < frame_size)
 			tmp = frame_size;
 
-		FAIL_IF(load_immediate(compiler, DR(TMP_REG1), local_size - tmp));
-		FAIL_IF(push_inst(compiler, ADDU_W | S(SLJIT_SP) | T(TMP_REG1) | D(SLJIT_SP), DR(SLJIT_SP)));
+		FAIL_IF(load_immediate(compiler, DR(TMP_REG2), local_size - tmp));
+		FAIL_IF(push_inst(compiler, ADDU_W | S(SLJIT_SP) | T(TMP_REG2) | D(SLJIT_SP), DR(SLJIT_SP)));
 		local_size = tmp;
 	}
 
@@ -1711,7 +1695,7 @@ static sljit_s32 emit_rev16(struct sljit_compiler *compiler, sljit_s32 op, sljit
 static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s32 flags,
 	sljit_s32 dst, sljit_s32 src1, sljit_sw src2)
 {
-	sljit_s32 is_overflow, is_carry, carry_src_ar, is_handled;
+	sljit_s32 is_overflow, is_carry, carry_src_ar, is_handled, reg;
 	sljit_ins op_imm, op_v;
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 	sljit_ins ins, op_dimm, op_dimm32, op_dv;
@@ -1963,8 +1947,9 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			is_handled = 1;
 
 			if (flags & SRC2_IMM) {
-				FAIL_IF(push_inst(compiler, ADDIU | SA(0) | T(TMP_REG2) | IMM(src2), DR(TMP_REG2)));
-				src2 = TMP_REG2;
+				reg = (src1 == TMP_REG1) ? TMP_REG2 : TMP_REG1;
+				FAIL_IF(push_inst(compiler, ADDIU | SA(0) | T(reg) | IMM(src2), DR(reg)));
+				src2 = reg;
 				flags &= ~SRC2_IMM;
 			}
 
@@ -2283,7 +2268,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	sljit_s32 dst_r = TMP_REG2;
 	sljit_s32 src1_r;
 	sljit_sw src2_r = 0;
-	sljit_s32 sugg_src2_r = TMP_REG2;
+	sljit_s32 src2_tmp_reg = (GET_OPCODE(op) >= SLJIT_OP2_BASE && FAST_IS_REG(src1)) ? TMP_REG1 : TMP_REG2;
 
 	if (!(flags & ALT_KEEP_CACHE)) {
 		compiler->cache_arg = 0;
@@ -2299,7 +2284,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 		dst_r = dst;
 		flags |= REG_DEST;
 		if (flags & MOVE_OP)
-			sugg_src2_r = dst_r;
+			src2_tmp_reg = dst_r;
 	}
 	else if ((dst & SLJIT_MEM) && !getput_arg_fast(compiler, flags | ARG_TEST, DR(TMP_REG1), dst, dstw))
 		flags |= SLOW_DEST;
@@ -2351,8 +2336,8 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	else if (src2 == SLJIT_IMM) {
 		if (!(flags & SRC2_IMM)) {
 			if (src2w) {
-				FAIL_IF(load_immediate(compiler, DR(sugg_src2_r), src2w));
-				src2_r = sugg_src2_r;
+				FAIL_IF(load_immediate(compiler, DR(src2_tmp_reg), src2w));
+				src2_r = src2_tmp_reg;
 			}
 			else {
 				src2_r = 0;
@@ -2366,16 +2351,16 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 		}
 	}
 	else {
-		if (getput_arg_fast(compiler, flags | LOAD_DATA, DR(sugg_src2_r), src2, src2w))
+		if (getput_arg_fast(compiler, flags | LOAD_DATA, DR(src2_tmp_reg), src2, src2w))
 			FAIL_IF(compiler->error);
 		else
 			flags |= SLOW_SRC2;
-		src2_r = sugg_src2_r;
+		src2_r = src2_tmp_reg;
 	}
 
 	if ((flags & (SLOW_SRC1 | SLOW_SRC2)) == (SLOW_SRC1 | SLOW_SRC2)) {
 		SLJIT_ASSERT(src2_r == TMP_REG2);
-		if (!can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
+		if ((flags & SLOW_DEST) && !can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
 			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, DR(TMP_REG2), src2, src2w, src1, src1w));
 			FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, DR(TMP_REG1), src1, src1w, dst, dstw));
 		}
@@ -2387,7 +2372,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	else if (flags & SLOW_SRC1)
 		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, DR(TMP_REG1), src1, src1w, dst, dstw));
 	else if (flags & SLOW_SRC2)
-		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, DR(sugg_src2_r), src2, src2w, dst, dstw));
+		FAIL_IF(getput_arg(compiler, flags | LOAD_DATA, DR(src2_tmp_reg), src2, src2w, dst, dstw));
 
 	FAIL_IF(emit_single_op(compiler, op, flags, dst_r, src1_r, src2_r));
 
@@ -2659,11 +2644,27 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 #define SELECT_OP3(op, src2w, D, D32, W) (((op & SLJIT_32) ? (W) : ((src2w) < 32) ? (D) : (D32)) | (((sljit_ins)src2w & 0x1f) << 6))
-#define SELECT_OP2(op, D, W) ((op & SLJIT_32) ? (W) : (D))
 #else /* !SLJIT_CONFIG_MIPS_64 */
 #define SELECT_OP3(op, src2w, D, D32, W) ((W) | ((sljit_ins)(src2w) << 6))
-#define SELECT_OP2(op, D, W) (W)
 #endif /* SLJIT_CONFIG_MIPS_64 */
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_op2r(compiler, op, dst_reg, src1, src1w, src2, src2w));
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MULADD:
+		SLJIT_SKIP_CHECKS(compiler);
+		FAIL_IF(sljit_emit_op2(compiler, SLJIT_MUL | (op & SLJIT_32), TMP_REG2, 0, src1, src1w, src2, src2w));
+		return push_inst(compiler, SELECT_OP(DADDU, ADDU) | S(dst_reg) | T(TMP_REG2) | D(dst_reg), DR(dst_reg));
+	}
+
+	return SLJIT_SUCCESS;
+}
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *compiler, sljit_s32 op,
 	sljit_s32 dst_reg,
@@ -2718,18 +2719,18 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *
 		FAIL_IF(emit_op_mem(compiler, inp_flags, DR(TMP_REG2), src3, src3w));
 		src3 = TMP_REG2;
 	} else if (dst_reg == src3) {
-		FAIL_IF(push_inst(compiler, SELECT_OP2(op, DADDU, ADDU) | S(src3) | TA(0) | D(TMP_REG2), DR(TMP_REG2)));
+		FAIL_IF(push_inst(compiler, SELECT_OP(DADDU, ADDU) | S(src3) | TA(0) | D(TMP_REG2), DR(TMP_REG2)));
 		src3 = TMP_REG2;
 	}
 
 	if (is_left) {
-		ins1 = SELECT_OP2(op, DSRL, SRL);
-		ins2 = SELECT_OP2(op, DSLLV, SLLV);
-		ins3 = SELECT_OP2(op, DSRLV, SRLV);
+		ins1 = SELECT_OP(DSRL, SRL);
+		ins2 = SELECT_OP(DSLLV, SLLV);
+		ins3 = SELECT_OP(DSRLV, SRLV);
 	} else {
-		ins1 = SELECT_OP2(op, DSLL, SLL);
-		ins2 = SELECT_OP2(op, DSRLV, SRLV);
-		ins3 = SELECT_OP2(op, DSLLV, SLLV);
+		ins1 = SELECT_OP(DSLL, SLL);
+		ins2 = SELECT_OP(DSRLV, SRLV);
+		ins3 = SELECT_OP(DSLLV, SLLV);
 	}
 
 	FAIL_IF(push_inst(compiler, ins2 | S(src3) | T(src1_reg) | D(dst_reg), DR(dst_reg)));
@@ -2739,14 +2740,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *
 		FAIL_IF(push_inst(compiler, XORI | S(src3) | T(TMP_REG2) | ((sljit_ins)bit_length - 1), DR(TMP_REG2)));
 		src2_reg = TMP_REG1;
 	} else
-		FAIL_IF(push_inst(compiler, SELECT_OP2(op, DSUBU, SUBU) | SA(0) | T(src3) | D(TMP_REG2), DR(TMP_REG2)));
+		FAIL_IF(push_inst(compiler, SELECT_OP(DSUBU, SUBU) | SA(0) | T(src3) | D(TMP_REG2), DR(TMP_REG2)));
 
 	FAIL_IF(push_inst(compiler, ins3 | S(TMP_REG2) | T(src2_reg) | D(TMP_REG1), DR(TMP_REG1)));
 	return push_inst(compiler, OR | S(dst_reg) | T(TMP_REG1) | D(dst_reg), DR(dst_reg));
 }
 
 #undef SELECT_OP3
-#undef SELECT_OP2
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_src(struct sljit_compiler *compiler, sljit_s32 op,
 	sljit_s32 src, sljit_sw srcw)
@@ -3103,7 +3103,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV_F64:
 		if (src != dst_r) {
-			if (dst_r != TMP_FREG1)
+			if (!(dst & SLJIT_MEM))
 				FAIL_IF(push_inst(compiler, MOV_fmt(FMT(op)) | FS(src) | FD(dst_r), MOVABLE_INS));
 			else
 				dst_r = src;
@@ -3162,11 +3162,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 	}
 
 	if ((flags & (SLOW_SRC1 | SLOW_SRC2)) == (SLOW_SRC1 | SLOW_SRC2)) {
-		if (!can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
+		if ((dst & SLJIT_MEM) && !can_cache(src1, src1w, src2, src2w) && can_cache(src1, src1w, dst, dstw)) {
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, FR(TMP_FREG2), src2, src2w, src1, src1w));
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, FR(TMP_FREG1), src1, src1w, dst, dstw));
-		}
-		else {
+		} else {
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, FR(TMP_FREG1), src1, src1w, src2, src2w));
 			FAIL_IF(getput_arg(compiler, FLOAT_DATA(op) | LOAD_DATA, FR(TMP_FREG2), src2, src2w, dst, dstw));
 		}
@@ -3361,10 +3360,10 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 		PTR_FAIL_IF(push_inst(compiler, inst, UNMOVABLE_INS));
 
 	if (type <= SLJIT_JUMP)
-		PTR_FAIL_IF(push_inst(compiler, JR | S(TMP_REG2), UNMOVABLE_INS));
+		PTR_FAIL_IF(push_inst(compiler, JR | S(PIC_ADDR_REG), UNMOVABLE_INS));
 	else {
 		jump->flags |= IS_JAL;
-		PTR_FAIL_IF(push_inst(compiler, JALR | S(TMP_REG2) | DA(RETURN_ADDR_REG), UNMOVABLE_INS));
+		PTR_FAIL_IF(push_inst(compiler, JALR | S(PIC_ADDR_REG) | DA(RETURN_ADDR_REG), UNMOVABLE_INS));
 	}
 
 	jump->addr = compiler->size;
@@ -3392,8 +3391,8 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 #define RESOLVE_IMM2() \
 	if (src2 == SLJIT_IMM) { \
 		if (src2w) { \
-			PTR_FAIL_IF(load_immediate(compiler, DR(TMP_REG2), src2w)); \
-			src2 = TMP_REG2; \
+			PTR_FAIL_IF(load_immediate(compiler, DR(src2_tmp_reg), src2w)); \
+			src2 = src2_tmp_reg; \
 		} \
 		else \
 			src2 = 0; \
@@ -3406,6 +3405,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 	struct sljit_jump *jump;
 	sljit_s32 flags;
 	sljit_ins inst;
+	sljit_s32 src2_tmp_reg = FAST_IS_REG(src1) ? TMP_REG1 : TMP_REG2;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_emit_cmp(compiler, type, src1, src1w, src2, src2w));
@@ -3426,8 +3426,8 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 	}
 
 	if (src2 & SLJIT_MEM) {
-		PTR_FAIL_IF(emit_op_mem2(compiler, flags, DR(TMP_REG2), src2, src2w, 0, 0));
-		src2 = TMP_REG2;
+		PTR_FAIL_IF(emit_op_mem2(compiler, flags, DR(src2_tmp_reg), src2, src2w, 0, 0));
+		src2 = src2_tmp_reg;
 	}
 
 	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
@@ -3515,7 +3515,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 		PTR_FAIL_IF(push_inst(compiler, (type == SLJIT_EQUAL ? BNE : BEQ) | S(TMP_REG1) | TA(0) | BRANCH_LENGTH, UNMOVABLE_INS));
 	}
 
-	PTR_FAIL_IF(push_inst(compiler, JR | S(TMP_REG2), UNMOVABLE_INS));
+	PTR_FAIL_IF(push_inst(compiler, JR | S(PIC_ADDR_REG), UNMOVABLE_INS));
 	jump->addr = compiler->size;
 	PTR_FAIL_IF(push_inst(compiler, NOP, UNMOVABLE_INS));
 
@@ -3553,11 +3553,11 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 		if (compiler->delay_slot != UNMOVABLE_INS)
 			jump->flags |= IS_MOVABLE;
 
-		src = TMP_REG2;
+		src = PIC_ADDR_REG;
 	} else if (src & SLJIT_MEM) {
 		ADJUST_LOCAL_OFFSET(src, srcw);
-		FAIL_IF(emit_op_mem(compiler, WORD_DATA | LOAD_DATA, DR(TMP_REG2), src, srcw));
-		src = TMP_REG2;
+		FAIL_IF(emit_op_mem(compiler, WORD_DATA | LOAD_DATA, DR(PIC_ADDR_REG), src, srcw));
+		src = PIC_ADDR_REG;
 	}
 
 	if (type <= SLJIT_JUMP)
@@ -3755,8 +3755,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *comp
 
 #if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1 && SLJIT_MIPS_REV < 6)
 	if (src1 & SLJIT_MEM) {
-		FAIL_IF(emit_op_mem(compiler, inp_flags, DR(TMP_REG2), src1, src1w));
-		src1 = TMP_REG2;
+		FAIL_IF(emit_op_mem(compiler, inp_flags, DR(TMP_REG1), src1, src1w));
+		src1 = TMP_REG1;
 	} else if (src1 == SLJIT_IMM) {
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		if (type & SLJIT_32)
@@ -3784,13 +3784,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *comp
 			type ^= 0x1;
 		} else {
 			if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
-				FAIL_IF(push_inst(compiler, ADDU_W | S(dst_reg) | TA(0) | D(TMP_REG2), DR(TMP_REG2)));
+				FAIL_IF(push_inst(compiler, ADDU_W | S(dst_reg) | TA(0) | D(TMP_REG1), DR(TMP_REG1)));
 
 				if ((src1 & REG_MASK) == dst_reg)
-					src1 = (src1 & ~REG_MASK) | TMP_REG2;
+					src1 = (src1 & ~REG_MASK) | TMP_REG1;
 
 				if (OFFS_REG(src1) == dst_reg)
-					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG2);
+					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG1);
 			}
 
 			FAIL_IF(push_inst(compiler, mov_ins | S(src2_reg) | TA(0) | D(dst_reg), DR(dst_reg)));
@@ -3847,8 +3847,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fselect(struct sljit_compiler *com
 
 #if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1 && SLJIT_MIPS_REV < 6)
 	if (src1 & SLJIT_MEM) {
-		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(type) | LOAD_DATA, FR(TMP_FREG1), src1, src1w));
-		src1 = TMP_FREG1;
+		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(type) | LOAD_DATA, FR(TMP_FREG2), src1, src1w));
+		src1 = TMP_FREG2;
 	}
 
 	return push_inst(compiler, get_select_cc(type, 1) | FMT(type) | FS(src1) | FD(dst_freg), MOVABLE_INS);
@@ -4231,18 +4231,18 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 	return const_;
 }
 
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
 {
-	struct sljit_put_label *put_label;
+	struct sljit_jump *jump;
 	sljit_s32 dst_r;
 
 	CHECK_ERROR_PTR();
-	CHECK_PTR(check_sljit_emit_put_label(compiler, dst, dstw));
+	CHECK_PTR(check_sljit_emit_mov_addr(compiler, dst, dstw));
 	ADJUST_LOCAL_OFFSET(dst, dstw);
 
-	put_label = (struct sljit_put_label*)ensure_abuf(compiler, sizeof(struct sljit_put_label));
-	PTR_FAIL_IF(!put_label);
-	set_put_label(put_label, compiler, 0);
+	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+	PTR_FAIL_IF(!jump);
+	set_mov_addr(jump, compiler, 0);
 
 	dst_r = FAST_IS_REG(dst) ? dst : TMP_REG2;
 	PTR_FAIL_IF(push_inst(compiler, (sljit_ins)dst_r, UNMOVABLE_INS));
@@ -4255,5 +4255,5 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct slj
 	if (dst & SLJIT_MEM)
 		PTR_FAIL_IF(emit_op_mem(compiler, WORD_DATA, DR(TMP_REG2), dst, dstw));
 
-	return put_label;
+	return jump;
 }

--- a/ext/pcre/pcre2lib/sljit/sljitNativePPC_common.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativePPC_common.c
@@ -98,7 +98,7 @@ static void ppc_cache_flush(sljit_ins *from, sljit_ins *to)
 #if (defined SLJIT_PASS_ENTRY_ADDR_TO_CALL && SLJIT_PASS_ENTRY_ADDR_TO_CALL)
 #define TMP_CALL_REG	(SLJIT_NUMBER_OF_REGISTERS + 5)
 #else
-#define TMP_CALL_REG	TMP_REG2
+#define TMP_CALL_REG	TMP_REG1
 #endif
 
 #define TMP_FREG1	(SLJIT_NUMBER_OF_FLOAT_REGISTERS + 1)
@@ -310,24 +310,23 @@ static sljit_s32 push_inst(struct sljit_compiler *compiler, sljit_ins ins)
 	return SLJIT_SUCCESS;
 }
 
-static SLJIT_INLINE sljit_s32 detect_jump_type(struct sljit_jump *jump, sljit_ins *code_ptr, sljit_ins *code, sljit_sw executable_offset)
+static SLJIT_INLINE sljit_ins* detect_jump_type(struct sljit_jump *jump, sljit_ins *code_ptr, sljit_ins *code, sljit_sw executable_offset)
 {
 	sljit_sw diff;
 	sljit_uw target_addr;
-	sljit_uw extra_jump_flags;
 
 #if (defined SLJIT_PASS_ENTRY_ADDR_TO_CALL && SLJIT_PASS_ENTRY_ADDR_TO_CALL) && (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
 	if (jump->flags & (SLJIT_REWRITABLE_JUMP | IS_CALL))
-		return 0;
+		goto exit;
 #else
 	if (jump->flags & SLJIT_REWRITABLE_JUMP)
-		return 0;
+		goto exit;
 #endif
 
 	if (jump->flags & JUMP_ADDR)
 		target_addr = jump->u.target;
 	else {
-		SLJIT_ASSERT(jump->flags & JUMP_LABEL);
+		SLJIT_ASSERT(jump->u.label != NULL);
 		target_addr = (sljit_uw)(code + jump->u.label->size) + (sljit_uw)executable_offset;
 	}
 
@@ -336,101 +335,256 @@ static SLJIT_INLINE sljit_s32 detect_jump_type(struct sljit_jump *jump, sljit_in
 		goto keep_address;
 #endif
 
-	diff = ((sljit_sw)target_addr - (sljit_sw)(code_ptr) - executable_offset) & ~0x3l;
+	diff = (sljit_sw)target_addr - (sljit_sw)code_ptr - executable_offset;
 
-	extra_jump_flags = 0;
 	if (jump->flags & IS_COND) {
 		if (diff <= 0x7fff && diff >= -0x8000) {
 			jump->flags |= PATCH_B;
-			return 1;
+			return code_ptr;
 		}
 		if (target_addr <= 0xffff) {
 			jump->flags |= PATCH_B | PATCH_ABS_B;
-			return 1;
+			return code_ptr;
 		}
-		extra_jump_flags = REMOVE_COND;
 
 		diff -= SSIZE_OF(ins);
 	}
 
 	if (diff <= 0x01ffffff && diff >= -0x02000000) {
-		jump->flags |= PATCH_B | extra_jump_flags;
-		return 1;
+		jump->flags |= PATCH_B;
+	} else if (target_addr <= 0x01ffffff) {
+		jump->flags |= PATCH_B | PATCH_ABS_B;
 	}
 
-	if (target_addr <= 0x03ffffff) {
-		jump->flags |= PATCH_B | PATCH_ABS_B | extra_jump_flags;
-		return 1;
+	if (jump->flags & PATCH_B) {
+		if (!(jump->flags & IS_COND))
+			return code_ptr;
+
+		code_ptr[0] = BCx | (2 << 2) | ((code_ptr[0] ^ (8 << 21)) & 0x03ff0001);
+		code_ptr[1] = Bx;
+		jump->addr += sizeof(sljit_ins);
+		jump->flags -= IS_COND;
+		return code_ptr + 1;
 	}
 
 #if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
 #if (defined SLJIT_PASS_ENTRY_ADDR_TO_CALL && SLJIT_PASS_ENTRY_ADDR_TO_CALL)
 keep_address:
-#endif
-	if (target_addr <= 0x7fffffff) {
+#endif /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
+	if (target_addr < 0x80000000l) {
 		jump->flags |= PATCH_ABS32;
-		return 1;
+		code_ptr[2] = MTCTR | S(TMP_CALL_REG);
+		code_ptr[3] = code_ptr[0];
+		return code_ptr + 3;
 	}
 
-	if (target_addr <= 0x7fffffffffffl) {
+	if (target_addr < 0x800000000000l) {
 		jump->flags |= PATCH_ABS48;
-		return 1;
+		code_ptr[4] = MTCTR | S(TMP_CALL_REG);
+		code_ptr[5] = code_ptr[0];
+		return code_ptr + 5;
 	}
-#endif
+#endif /* SLJIT_CONFIG_PPC_64 */
 
-	return 0;
+exit:
+#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
+	code_ptr[2] = MTCTR | S(TMP_CALL_REG);
+	code_ptr[3] = code_ptr[0];
+#else /* !SLJIT_CONFIG_PPC_32 */
+	code_ptr[5] = MTCTR | S(TMP_CALL_REG);
+	code_ptr[6] = code_ptr[0];
+#endif /* SLJIT_CONFIG_PPC_32 */
+	return code_ptr + JUMP_MAX_SIZE - 1;
 }
 
 #if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
 
-static SLJIT_INLINE sljit_sw put_label_get_length(struct sljit_put_label *put_label, sljit_uw max_label)
+static SLJIT_INLINE sljit_sw mov_addr_get_length(struct sljit_jump *jump, sljit_ins *code, sljit_sw executable_offset)
 {
-	if (max_label < 0x100000000l) {
-		put_label->flags = 0;
+	sljit_uw addr;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	SLJIT_ASSERT(jump->flags < ((sljit_uw)5 << JUMP_SIZE_SHIFT));
+	if (jump->flags & JUMP_ADDR)
+		addr = jump->u.target;
+	else
+		addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code + jump->u.label->size, executable_offset);
+
+	if (addr < 0x80000000l) {
+		SLJIT_ASSERT(jump->flags >= ((sljit_uw)1 << JUMP_SIZE_SHIFT));
+		jump->flags |= PATCH_ABS32;
 		return 1;
 	}
 
-	if (max_label < 0x1000000000000l) {
-		put_label->flags = 1;
+	if (addr < 0x800000000000l) {
+		SLJIT_ASSERT(jump->flags >= ((sljit_uw)3 << JUMP_SIZE_SHIFT));
+		jump->flags |= PATCH_ABS48;
 		return 3;
 	}
 
-	put_label->flags = 2;
+	SLJIT_ASSERT(jump->flags >= ((sljit_uw)4 << JUMP_SIZE_SHIFT));
 	return 4;
-}
-
-static SLJIT_INLINE void put_label_set(struct sljit_put_label *put_label)
-{
-	sljit_uw addr = put_label->label->addr;
-	sljit_ins *inst = (sljit_ins *)put_label->addr;
-	sljit_u32 reg = *inst;
-
-	if (put_label->flags == 0) {
-		SLJIT_ASSERT(addr < 0x100000000l);
-		inst[0] = ORIS | S(TMP_ZERO) | A(reg) | IMM(addr >> 16);
-	}
-	else {
-		if (put_label->flags == 1) {
-			SLJIT_ASSERT(addr < 0x1000000000000l);
-			inst[0] = ORI | S(TMP_ZERO) | A(reg) | IMM(addr >> 32);
-		}
-		else {
-			inst[0] = ORIS | S(TMP_ZERO) | A(reg) | IMM(addr >> 48);
-			inst[1] = ORI | S(reg) | A(reg) | IMM((addr >> 32) & 0xffff);
-			inst++;
-		}
-
-		inst[1] = SLDI(32) | S(reg) | A(reg);
-		inst[2] = ORIS | S(reg) | A(reg) | IMM((addr >> 16) & 0xffff);
-		inst += 2;
-	}
-
-	inst[1] = ORI | S(reg) | A(reg) | IMM(addr & 0xffff);
 }
 
 #endif /* SLJIT_CONFIG_PPC_64 */
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler)
+static void generate_jump_or_mov_addr(struct sljit_jump *jump, sljit_sw executable_offset)
+{
+	sljit_uw flags = jump->flags;
+	sljit_uw addr = (flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
+	sljit_ins *ins = (sljit_ins*)jump->addr;
+	sljit_s32 reg;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	if (flags & PATCH_B) {
+		if (flags & IS_COND) {
+			if (!(flags & PATCH_ABS_B)) {
+				addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(ins, executable_offset);
+				SLJIT_ASSERT((sljit_sw)addr <= 0x7fff && (sljit_sw)addr >= -0x8000);
+				ins[0] = BCx | ((sljit_ins)addr & 0xfffc) | (ins[0] & 0x03ff0001);
+			} else {
+				SLJIT_ASSERT(addr <= 0xffff);
+				ins[0] = BCx | ((sljit_ins)addr & 0xfffc) | 0x2 | ((*ins) & 0x03ff0001);
+			}
+			return;
+		}
+
+		if (!(flags & PATCH_ABS_B)) {
+			addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(ins, executable_offset);
+			SLJIT_ASSERT((sljit_sw)addr <= 0x01ffffff && (sljit_sw)addr >= -0x02000000);
+			ins[0] = Bx | ((sljit_ins)addr & 0x03fffffc) | (ins[0] & 0x1);
+		} else {
+			SLJIT_ASSERT(addr <= 0x03ffffff);
+			ins[0] = Bx | ((sljit_ins)addr & 0x03fffffc) | 0x2 | (ins[0] & 0x1);
+		}
+		return;
+	}
+
+	reg = (flags & JUMP_MOV_ADDR) ? (sljit_s32)ins[0] : TMP_CALL_REG;
+
+#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
+	ins[0] = ADDIS | D(reg) | A(0) | IMM(addr >> 16);
+	ins[1] = ORI | S(reg) | A(reg) | IMM(addr);
+#else /* !SLJIT_CONFIG_PPC_32 */
+
+	/* The TMP_ZERO cannot be used because it is restored for tail calls. */
+	if (flags & PATCH_ABS32) {
+		SLJIT_ASSERT(addr < 0x80000000l);
+		ins[0] = ADDIS | D(reg) | A(0) | IMM(addr >> 16);
+		ins[1] = ORI | S(reg) | A(reg) | IMM(addr);
+		return;
+	}
+
+	if (flags & PATCH_ABS48) {
+		SLJIT_ASSERT(addr < 0x800000000000l);
+		ins[0] = ADDIS | D(reg) | A(0) | IMM(addr >> 32);
+		ins[1] = ORI | S(reg) | A(reg) | IMM(addr >> 16);
+		ins[2] = SLDI(16) | S(reg) | A(reg);
+		ins[3] = ORI | S(reg) | A(reg) | IMM(addr);
+		return;
+	}
+
+	ins[0] = ADDIS | D(reg) | A(0) | IMM(addr >> 48);
+	ins[1] = ORI | S(reg) | A(reg) | IMM(addr >> 32);
+	ins[2] = SLDI(32) | S(reg) | A(reg);
+	ins[3] = ORIS | S(reg) | A(reg) | IMM(addr >> 16);
+	ins[4] = ORI | S(reg) | A(reg) | IMM(addr);
+#endif /* SLJIT_CONFIG_PPC_32 */
+}
+
+static void reduce_code_size(struct sljit_compiler *compiler)
+{
+	struct sljit_label *label;
+	struct sljit_jump *jump;
+	struct sljit_const *const_;
+	SLJIT_NEXT_DEFINE_TYPES;
+	sljit_uw total_size;
+	sljit_uw size_reduce = 0;
+	sljit_sw diff;
+
+	label = compiler->labels;
+	jump = compiler->jumps;
+	const_ = compiler->consts;
+	SLJIT_NEXT_INIT_TYPES();
+
+	while (1) {
+		SLJIT_GET_NEXT_MIN();
+
+		if (next_min_addr == SLJIT_MAX_ADDRESS)
+			break;
+
+		if (next_min_addr == next_label_size) {
+			label->size -= size_reduce;
+
+			label = label->next;
+			next_label_size = SLJIT_GET_NEXT_SIZE(label);
+		}
+
+		if (next_min_addr == next_const_addr) {
+			const_->addr -= size_reduce;
+			const_ = const_->next;
+			next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
+			continue;
+		}
+
+		if (next_min_addr != next_jump_addr)
+			continue;
+
+		jump->addr -= size_reduce;
+		if (!(jump->flags & JUMP_MOV_ADDR)) {
+			total_size = JUMP_MAX_SIZE - 1;
+
+			if (!(jump->flags & SLJIT_REWRITABLE_JUMP)) {
+				if (jump->flags & JUMP_ADDR) {
+					if (jump->u.target <= 0x01ffffff)
+						total_size = 1 - 1;
+#if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
+					else if (jump->u.target < 0x80000000l)
+						total_size = 4 - 1;
+					else if (jump->u.target < 0x800000000000l)
+						total_size = 6 - 1;
+#endif /* SLJIT_CONFIG_PPC_64 */
+				} else {
+					/* Unit size: instruction. */
+					diff = (sljit_sw)jump->u.label->size - (sljit_sw)jump->addr;
+
+					if (jump->flags & IS_COND) {
+						if (diff <= (0x7fff / SSIZE_OF(ins)) && diff >= (-0x8000 / SSIZE_OF(ins)))
+							total_size = 1 - 1;
+						else if ((diff - 1) <= (0x01ffffff / SSIZE_OF(ins)) && (diff - 1) >= (-0x02000000 / SSIZE_OF(ins)))
+							total_size = 2 - 1;
+					} else if (diff <= (0x01ffffff / SSIZE_OF(ins)) && diff >= (-0x02000000 / SSIZE_OF(ins)))
+						total_size = 1 - 1;
+				}
+			}
+
+			size_reduce += (JUMP_MAX_SIZE - 1) - total_size;
+			jump->flags |= total_size << JUMP_SIZE_SHIFT;
+#if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
+		} else {
+			total_size = (sljit_uw)4 << JUMP_SIZE_SHIFT;
+
+			if (jump->flags & JUMP_ADDR) {
+				if (jump->u.target < 0x80000000l) {
+					total_size = (sljit_uw)1 << JUMP_SIZE_SHIFT;
+					size_reduce += 3;
+				} else if (jump->u.target < 0x800000000000l) {
+					total_size = (sljit_uw)3 << JUMP_SIZE_SHIFT;
+					size_reduce += 1;
+				}
+			}
+			jump->flags |= total_size;
+#endif /* SLJIT_CONFIG_PPC_64 */
+		}
+
+		jump = jump->next;
+		next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+	}
+
+	compiler->size -= size_reduce;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data)
 {
 	struct sljit_memory_fragment *buf;
 	sljit_ins *code;
@@ -438,18 +592,17 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	sljit_ins *buf_ptr;
 	sljit_ins *buf_end;
 	sljit_uw word_count;
-	sljit_uw next_addr;
+	SLJIT_NEXT_DEFINE_TYPES;
 	sljit_sw executable_offset;
-	sljit_uw addr;
 
 	struct sljit_label *label;
 	struct sljit_jump *jump;
 	struct sljit_const *const_;
-	struct sljit_put_label *put_label;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_generate_code(compiler));
-	reverse_buf(compiler);
+
+	reduce_code_size(compiler);
 
 #if (defined SLJIT_INDIRECT_CALL && SLJIT_INDIRECT_CALL)
 	/* add to compiler->size additional instruction space to hold the trampoline and padding */
@@ -459,93 +612,64 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	compiler->size += (sizeof(struct sljit_function_context) / sizeof(sljit_ins));
 #endif
 #endif
-	code = (sljit_ins*)SLJIT_MALLOC_EXEC(compiler->size * sizeof(sljit_ins), compiler->exec_allocator_data);
+	code = (sljit_ins*)allocate_executable_memory(compiler->size * sizeof(sljit_ins), options, exec_allocator_data, &executable_offset);
 	PTR_FAIL_WITH_EXEC_IF(code);
+
+	reverse_buf(compiler);
 	buf = compiler->buf;
 
 	code_ptr = code;
 	word_count = 0;
-	next_addr = 0;
-	executable_offset = SLJIT_EXEC_OFFSET(code);
-
 	label = compiler->labels;
 	jump = compiler->jumps;
 	const_ = compiler->consts;
-	put_label = compiler->put_labels;
+	SLJIT_NEXT_INIT_TYPES();
+	SLJIT_GET_NEXT_MIN();
 
 	do {
 		buf_ptr = (sljit_ins*)buf->memory;
 		buf_end = buf_ptr + (buf->used_size >> 2);
 		do {
 			*code_ptr = *buf_ptr++;
-			if (next_addr == word_count) {
+			if (next_min_addr == word_count) {
 				SLJIT_ASSERT(!label || label->size >= word_count);
 				SLJIT_ASSERT(!jump || jump->addr >= word_count);
 				SLJIT_ASSERT(!const_ || const_->addr >= word_count);
-				SLJIT_ASSERT(!put_label || put_label->addr >= word_count);
 
 				/* These structures are ordered by their address. */
-				if (label && label->size == word_count) {
+				if (next_min_addr == next_label_size) {
 					/* Just recording the address. */
-					label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+					label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 					label->size = (sljit_uw)(code_ptr - code);
 					label = label->next;
+					next_label_size = SLJIT_GET_NEXT_SIZE(label);
 				}
-				if (jump && jump->addr == word_count) {
-#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
-					jump->addr = (sljit_uw)(code_ptr - 3);
-#else
-					jump->addr = (sljit_uw)(code_ptr - 6);
-#endif
-					if (detect_jump_type(jump, code_ptr, code, executable_offset)) {
-#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
-						code_ptr[-3] = code_ptr[0];
-						code_ptr -= 3;
-#else
-						if (jump->flags & PATCH_ABS32) {
-							code_ptr -= 3;
-							code_ptr[-1] = code_ptr[2];
-							code_ptr[0] = code_ptr[3];
-						}
-						else if (jump->flags & PATCH_ABS48) {
-							code_ptr--;
-							code_ptr[-1] = code_ptr[0];
-							code_ptr[0] = code_ptr[1];
-							/* rldicr rX,rX,32,31 -> rX,rX,16,47 */
-							SLJIT_ASSERT((code_ptr[-3] & 0xfc00ffff) == 0x780007c6);
-							code_ptr[-3] ^= 0x8422;
-							/* oris -> ori */
-							code_ptr[-2] ^= 0x4000000;
-						}
-						else {
-							code_ptr[-6] = code_ptr[0];
-							code_ptr -= 6;
-						}
-#endif
-						if (jump->flags & REMOVE_COND) {
-							code_ptr[0] = BCx | (2 << 2) | ((code_ptr[0] ^ (8 << 21)) & 0x03ff0001);
-							code_ptr++;
-							jump->addr += sizeof(sljit_ins);
-							code_ptr[0] = Bx;
-							jump->flags -= IS_COND;
-						}
+
+				if (next_min_addr == next_jump_addr) {
+					if (!(jump->flags & JUMP_MOV_ADDR)) {
+						word_count += jump->flags >> JUMP_SIZE_SHIFT;
+						jump->addr = (sljit_uw)code_ptr;
+						code_ptr = detect_jump_type(jump, code_ptr, code, executable_offset);
+						SLJIT_ASSERT(((sljit_uw)code_ptr - jump->addr <= (jump->flags >> JUMP_SIZE_SHIFT) * sizeof(sljit_ins)));
+					} else {
+						jump->addr = (sljit_uw)code_ptr;
+#if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
+						word_count += jump->flags >> JUMP_SIZE_SHIFT;
+						code_ptr += mov_addr_get_length(jump, code, executable_offset);
+#else /* !SLJIT_CONFIG_PPC_64 */
+						word_count++;
+						code_ptr++;
+#endif /* SLJIT_CONFIG_PPC_64 */
 					}
 					jump = jump->next;
-				}
-				if (const_ && const_->addr == word_count) {
+					next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+				} else if (next_min_addr == next_const_addr) {
 					const_->addr = (sljit_uw)code_ptr;
 					const_ = const_->next;
+					next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
 				}
-				if (put_label && put_label->addr == word_count) {
-					SLJIT_ASSERT(put_label->label);
-					put_label->addr = (sljit_uw)code_ptr;
-#if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
-					code_ptr += put_label_get_length(put_label, (sljit_uw)(SLJIT_ADD_EXEC_OFFSET(code, executable_offset) + put_label->label->size));
-					word_count += 4;
-#endif
-					put_label = put_label->next;
-				}
-				next_addr = compute_next_addr(label, jump, const_, put_label);
+
+				SLJIT_GET_NEXT_MIN();
 			}
 			code_ptr++;
 			word_count++;
@@ -555,7 +679,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	} while (buf);
 
 	if (label && label->size == word_count) {
-		label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+		label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 		label->size = (sljit_uw)(code_ptr - code);
 		label = label->next;
 	}
@@ -563,7 +687,6 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	SLJIT_ASSERT(!label);
 	SLJIT_ASSERT(!jump);
 	SLJIT_ASSERT(!const_);
-	SLJIT_ASSERT(!put_label);
 
 #if (defined SLJIT_INDIRECT_CALL && SLJIT_INDIRECT_CALL)
 	SLJIT_ASSERT(code_ptr - code <= (sljit_sw)(compiler->size - (sizeof(struct sljit_function_context) / sizeof(sljit_ins))));
@@ -573,82 +696,8 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 
 	jump = compiler->jumps;
 	while (jump) {
-		do {
-			addr = (jump->flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target;
-			buf_ptr = (sljit_ins *)jump->addr;
-
-			if (jump->flags & PATCH_B) {
-				if (jump->flags & IS_COND) {
-					if (!(jump->flags & PATCH_ABS_B)) {
-						addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(buf_ptr, executable_offset);
-						SLJIT_ASSERT((sljit_sw)addr <= 0x7fff && (sljit_sw)addr >= -0x8000);
-						*buf_ptr = BCx | ((sljit_ins)addr & 0xfffc) | ((*buf_ptr) & 0x03ff0001);
-					}
-					else {
-						SLJIT_ASSERT(addr <= 0xffff);
-						*buf_ptr = BCx | ((sljit_ins)addr & 0xfffc) | 0x2 | ((*buf_ptr) & 0x03ff0001);
-					}
-				}
-				else {
-					if (!(jump->flags & PATCH_ABS_B)) {
-						addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET(buf_ptr, executable_offset);
-						SLJIT_ASSERT((sljit_sw)addr <= 0x01ffffff && (sljit_sw)addr >= -0x02000000);
-						*buf_ptr = Bx | ((sljit_ins)addr & 0x03fffffc) | ((*buf_ptr) & 0x1);
-					}
-					else {
-						SLJIT_ASSERT(addr <= 0x03ffffff);
-						*buf_ptr = Bx | ((sljit_ins)addr & 0x03fffffc) | 0x2 | ((*buf_ptr) & 0x1);
-					}
-				}
-				break;
-			}
-
-			/* Set the fields of immediate loads. */
-#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
-			SLJIT_ASSERT(((buf_ptr[0] | buf_ptr[1]) & 0xffff) == 0);
-			buf_ptr[0] |= (sljit_ins)(addr >> 16) & 0xffff;
-			buf_ptr[1] |= (sljit_ins)addr & 0xffff;
-#else
-			if (jump->flags & PATCH_ABS32) {
-				SLJIT_ASSERT(addr <= 0x7fffffff);
-				SLJIT_ASSERT(((buf_ptr[0] | buf_ptr[1]) & 0xffff) == 0);
-				buf_ptr[0] |= (sljit_ins)(addr >> 16) & 0xffff;
-				buf_ptr[1] |= (sljit_ins)addr & 0xffff;
-				break;
-			}
-
-			if (jump->flags & PATCH_ABS48) {
-				SLJIT_ASSERT(addr <= 0x7fffffffffff);
-				SLJIT_ASSERT(((buf_ptr[0] | buf_ptr[1] | buf_ptr[3]) & 0xffff) == 0);
-				buf_ptr[0] |= (sljit_ins)(addr >> 32) & 0xffff;
-				buf_ptr[1] |= (sljit_ins)(addr >> 16) & 0xffff;
-				buf_ptr[3] |= (sljit_ins)addr & 0xffff;
-				break;
-			}
-
-			SLJIT_ASSERT(((buf_ptr[0] | buf_ptr[1] | buf_ptr[3] | buf_ptr[4]) & 0xffff) == 0);
-			buf_ptr[0] |= (sljit_ins)(addr >> 48) & 0xffff;
-			buf_ptr[1] |= (sljit_ins)(addr >> 32) & 0xffff;
-			buf_ptr[3] |= (sljit_ins)(addr >> 16) & 0xffff;
-			buf_ptr[4] |= (sljit_ins)addr & 0xffff;
-#endif
-		} while (0);
+		generate_jump_or_mov_addr(jump, executable_offset);
 		jump = jump->next;
-	}
-
-	put_label = compiler->put_labels;
-	while (put_label) {
-#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
-		addr = put_label->label->addr;
-		buf_ptr = (sljit_ins *)put_label->addr;
-
-		SLJIT_ASSERT((buf_ptr[0] & 0xfc1f0000) == ADDIS && (buf_ptr[1] & 0xfc000000) == ORI);
-		buf_ptr[0] |= (addr >> 16) & 0xffff;
-		buf_ptr[1] |= addr & 0xffff;
-#else
-		put_label_set(put_label);
-#endif
-		put_label = put_label->next;
 	}
 
 	compiler->error = SLJIT_ERR_COMPILED;
@@ -671,11 +720,9 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 
 #if (defined SLJIT_INDIRECT_CALL && SLJIT_INDIRECT_CALL)
 	compiler->executable_size = (sljit_uw)(code_ptr - code) * sizeof(sljit_ins) + sizeof(struct sljit_function_context);
-
 	return code_ptr;
 #else
 	compiler->executable_size = (sljit_uw)(code_ptr - code) * sizeof(sljit_ins);
-
 	return code;
 #endif
 }
@@ -937,14 +984,16 @@ static sljit_s32 emit_stack_frame_release(struct sljit_compiler *compiler, sljit
 	sljit_s32 i, tmp, base, offset;
 	sljit_s32 local_size = compiler->local_size;
 
+	SLJIT_ASSERT(TMP_CALL_REG != TMP_REG2);
+
 	base = SLJIT_SP;
 	if (local_size > STACK_MAX_DISTANCE) {
-		base = TMP_REG1;
+		base = TMP_REG2;
 		if (local_size > 2 * STACK_MAX_DISTANCE + LR_SAVE_OFFSET) {
 			FAIL_IF(push_inst(compiler, STACK_LOAD | D(base) | A(SLJIT_SP) | IMM(0)));
 			local_size = 0;
 		} else {
-			FAIL_IF(push_inst(compiler, ADDI | D(TMP_REG1) | A(SLJIT_SP) | IMM(local_size - STACK_MAX_DISTANCE)));
+			FAIL_IF(push_inst(compiler, ADDI | D(TMP_REG2) | A(SLJIT_SP) | IMM(local_size - STACK_MAX_DISTANCE)));
 			local_size = STACK_MAX_DISTANCE;
 		}
 	}
@@ -986,7 +1035,7 @@ static sljit_s32 emit_stack_frame_release(struct sljit_compiler *compiler, sljit
 	if (local_size > 0)
 		return push_inst(compiler, ADDI | D(SLJIT_SP) | A(base) | IMM(local_size));
 
-	SLJIT_ASSERT(base == TMP_REG1);
+	SLJIT_ASSERT(base == TMP_REG2);
 	return push_inst(compiler, OR | S(base) | A(SLJIT_SP) | B(base));
 }
 
@@ -1253,7 +1302,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 	sljit_s32 dst_r = TMP_REG2;
 	sljit_s32 src1_r;
 	sljit_s32 src2_r;
-	sljit_s32 sugg_src2_r = TMP_REG2;
+	sljit_s32 src2_tmp_reg = (!(input_flags & ALT_SIGN_EXT) && GET_OPCODE(op) >= SLJIT_OP2_BASE && FAST_IS_REG(src1)) ? TMP_REG1 : TMP_REG2;
 	sljit_s32 flags = input_flags & (ALT_FORM1 | ALT_FORM2 | ALT_FORM3 | ALT_FORM4 | ALT_FORM5 | ALT_SIGN_EXT | ALT_SET_FLAGS);
 
 	/* Destination check. */
@@ -1264,24 +1313,7 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 		flags |= REG_DEST;
 
 		if (op >= SLJIT_MOV && op <= SLJIT_MOV_P)
-			sugg_src2_r = dst_r;
-	}
-
-	/* Source 1. */
-	if (FAST_IS_REG(src1)) {
-		src1_r = src1;
-		flags |= REG1_SOURCE;
-	}
-	else if (src1 == SLJIT_IMM) {
-		src1_r = TMP_ZERO;
-		if (src1w != 0) {
-			FAIL_IF(load_immediate(compiler, TMP_REG1, src1w));
-			src1_r = TMP_REG1;
-		}
-	}
-	else {
-		FAIL_IF(emit_op_mem(compiler, input_flags | LOAD_DATA, TMP_REG1, src1, src1w, TMP_REG1));
-		src1_r = TMP_REG1;
+			src2_tmp_reg = dst_r;
 	}
 
 	/* Source 2. */
@@ -1291,17 +1323,30 @@ static sljit_s32 emit_op(struct sljit_compiler *compiler, sljit_s32 op, sljit_s3
 
 		if (!(flags & REG_DEST) && op >= SLJIT_MOV && op <= SLJIT_MOV_P)
 			dst_r = src2_r;
-	}
-	else if (src2 == SLJIT_IMM) {
+	} else if (src2 == SLJIT_IMM) {
 		src2_r = TMP_ZERO;
 		if (src2w != 0) {
-			FAIL_IF(load_immediate(compiler, sugg_src2_r, src2w));
-			src2_r = sugg_src2_r;
+			FAIL_IF(load_immediate(compiler, src2_tmp_reg, src2w));
+			src2_r = src2_tmp_reg;
 		}
+	} else {
+		FAIL_IF(emit_op_mem(compiler, input_flags | LOAD_DATA, src2_tmp_reg, src2, src2w, TMP_REG1));
+		src2_r = src2_tmp_reg;
 	}
-	else {
-		FAIL_IF(emit_op_mem(compiler, input_flags | LOAD_DATA, sugg_src2_r, src2, src2w, TMP_REG2));
-		src2_r = sugg_src2_r;
+
+	/* Source 1. */
+	if (FAST_IS_REG(src1)) {
+		src1_r = src1;
+		flags |= REG1_SOURCE;
+	} else if (src1 == SLJIT_IMM) {
+		src1_r = TMP_ZERO;
+		if (src1w != 0) {
+			FAIL_IF(load_immediate(compiler, TMP_REG1, src1w));
+			src1_r = TMP_REG1;
+		}
+	} else {
+		FAIL_IF(emit_op_mem(compiler, input_flags | LOAD_DATA, TMP_REG1, src1, src1w, TMP_REG1));
+		src1_r = TMP_REG1;
 	}
 
 	FAIL_IF(emit_single_op(compiler, op, flags, dst_r, src1_r, src2_r));
@@ -1757,7 +1802,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2(struct sljit_compiler *compile
 		compiler->status_flags_state = SLJIT_CURRENT_FLAGS_SUB;
 
 		if (GET_FLAG_TYPE(op) >= SLJIT_LESS && GET_FLAG_TYPE(op) <= SLJIT_LESS_EQUAL) {
-			if (dst == TMP_REG2) {
+			if (dst == TMP_REG1) {
 				if (TEST_UL_IMM(src2, src2w)) {
 					compiler->imm = (sljit_ins)src2w & 0xffff;
 					return emit_op(compiler, SLJIT_SUB, flags | ALT_FORM1 | ALT_FORM2, dst, dstw, src1, src1w, TMP_REG2, 0);
@@ -1772,7 +1817,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2(struct sljit_compiler *compile
 			return emit_op(compiler, SLJIT_SUB, flags | ALT_FORM1 | ALT_FORM3, dst, dstw, src1, src1w, src2, src2w);
 		}
 
-		if (dst == TMP_REG2 && GET_FLAG_TYPE(op) <= SLJIT_SIG_LESS_EQUAL) {
+		if (dst == TMP_REG1 && GET_FLAG_TYPE(op) <= SLJIT_SIG_LESS_EQUAL) {
 			if (TEST_SL_IMM(src2, src2w)) {
 				compiler->imm = (sljit_ins)src2w & 0xffff;
 				return emit_op(compiler, SLJIT_SUB, flags | ALT_FORM2 | ALT_FORM3, dst, dstw, src1, src1w, TMP_REG2, 0);
@@ -1911,12 +1956,30 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 	CHECK(check_sljit_emit_op2(compiler, op, 1, 0, 0, src1, src1w, src2, src2w));
 
 	SLJIT_SKIP_CHECKS(compiler);
-	return sljit_emit_op2(compiler, op, TMP_REG2, 0, src1, src1w, src2, src2w);
+	return sljit_emit_op2(compiler, op, TMP_REG1, 0, src1, src1w, src2, src2w);
 }
 
 #undef TEST_ADD_FORM1
 #undef TEST_SUB_FORM2
 #undef TEST_SUB_FORM3
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_op2r(compiler, op, dst_reg, src1, src1w, src2, src2w));
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MULADD:
+		SLJIT_SKIP_CHECKS(compiler);
+		FAIL_IF(sljit_emit_op2(compiler, SLJIT_MUL | (op & SLJIT_32), TMP_REG2, 0, src1, src1w, src2, src2w));
+		return push_inst(compiler, ADD | D(dst_reg) | A(dst_reg) | B(TMP_REG2));
+	}
+
+	return SLJIT_SUCCESS;
+}
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *compiler, sljit_s32 op,
 	sljit_s32 dst_reg,
@@ -2228,7 +2291,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 		/* Fall through. */
 	case SLJIT_MOV_F64:
 		if (src != dst_r) {
-			if (dst_r != TMP_FREG1)
+			if (!(dst & SLJIT_MEM))
 				FAIL_IF(push_inst(compiler, FMR | FD(dst_r) | FB(src)));
 			else
 				dst_r = src;
@@ -2268,7 +2331,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 	}
 
 	if (src2 & SLJIT_MEM) {
-		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG2, src2, src2w, TMP_REG2));
+		FAIL_IF(emit_op_mem(compiler, FLOAT_DATA(op) | LOAD_DATA, TMP_FREG2, src2, src2w, TMP_REG1));
 		src2 = TMP_FREG2;
 	}
 
@@ -2451,7 +2514,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 	type &= 0xff;
 
 	if ((type | 0x1) == SLJIT_NOT_CARRY)
-		PTR_FAIL_IF(push_inst(compiler, ADDE | RC(ALT_SET_FLAGS) | D(TMP_REG1) | A(TMP_ZERO) | B(TMP_ZERO)));
+		PTR_FAIL_IF(push_inst(compiler, ADDE | RC(ALT_SET_FLAGS) | D(TMP_REG2) | A(TMP_ZERO) | B(TMP_ZERO)));
 
 	/* In PPC, we don't need to touch the arguments. */
 	if (type < SLJIT_JUMP)
@@ -2461,10 +2524,11 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 		jump->flags |= IS_CALL;
 #endif
 
-	PTR_FAIL_IF(emit_const(compiler, TMP_CALL_REG, 0));
-	PTR_FAIL_IF(push_inst(compiler, MTCTR | S(TMP_CALL_REG)));
 	jump->addr = compiler->size;
 	PTR_FAIL_IF(push_inst(compiler, BCCTR | bo_bi_flags | (type >= SLJIT_FAST_CALL ? 1 : 0)));
+
+	/* Maximum number of instructions required for generating a constant. */
+	compiler->size += JUMP_MAX_SIZE - 1;
 	return jump;
 }
 
@@ -2498,18 +2562,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_ijump(compiler, type, src, srcw));
 
-	if (FAST_IS_REG(src)) {
-#if (defined SLJIT_PASS_ENTRY_ADDR_TO_CALL && SLJIT_PASS_ENTRY_ADDR_TO_CALL)
-		if (type >= SLJIT_CALL && src != TMP_CALL_REG) {
-			FAIL_IF(push_inst(compiler, OR | S(src) | A(TMP_CALL_REG) | B(src)));
-			src_r = TMP_CALL_REG;
-		}
-		else
-			src_r = src;
-#else /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
-		src_r = src;
-#endif /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
-	} else if (src == SLJIT_IMM) {
+	if (src == SLJIT_IMM) {
 		/* These jumps are converted to jump/call instructions when possible. */
 		jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
 		FAIL_IF(!jump);
@@ -2521,8 +2574,24 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 			jump->flags |= IS_CALL;
 #endif /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
 
-		FAIL_IF(emit_const(compiler, TMP_CALL_REG, 0));
-		src_r = TMP_CALL_REG;
+		jump->addr = compiler->size;
+		FAIL_IF(push_inst(compiler, BCCTR | (20 << 21) | (type >= SLJIT_FAST_CALL ? 1 : 0)));
+
+		/* Maximum number of instructions required for generating a constant. */
+		compiler->size += JUMP_MAX_SIZE - 1;
+		return SLJIT_SUCCESS;
+	}
+
+	if (FAST_IS_REG(src)) {
+#if (defined SLJIT_PASS_ENTRY_ADDR_TO_CALL && SLJIT_PASS_ENTRY_ADDR_TO_CALL)
+		if (type >= SLJIT_CALL && src != TMP_CALL_REG) {
+			FAIL_IF(push_inst(compiler, OR | S(src) | A(TMP_CALL_REG) | B(src)));
+			src_r = TMP_CALL_REG;
+		} else
+			src_r = src;
+#else /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
+		src_r = src;
+#endif /* SLJIT_PASS_ENTRY_ADDR_TO_CALL */
 	} else {
 		ADJUST_LOCAL_OFFSET(src, srcw);
 		FAIL_IF(emit_op_mem(compiler, WORD_DATA | LOAD_DATA, TMP_CALL_REG, src, srcw, TMP_CALL_REG));
@@ -2530,8 +2599,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 	}
 
 	FAIL_IF(push_inst(compiler, MTCTR | S(src_r)));
-	if (jump)
-		jump->addr = compiler->size;
 	return push_inst(compiler, BCCTR | (20 << 21) | (type >= SLJIT_FAST_CALL ? 1 : 0));
 }
 
@@ -2748,13 +2815,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *comp
 				type ^= 0x1;
 		} else {
 			if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
-				FAIL_IF(push_inst(compiler, OR | S(dst_reg) | A(TMP_REG2) | B(dst_reg)));
+				FAIL_IF(push_inst(compiler, OR | S(dst_reg) | A(TMP_REG1) | B(dst_reg)));
 
 				if ((src1 & REG_MASK) == dst_reg)
-					src1 = (src1 & ~REG_MASK) | TMP_REG2;
+					src1 = (src1 & ~REG_MASK) | TMP_REG1;
 
 				if (OFFS_REG(src1) == dst_reg)
-					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG2);
+					src1 = (src1 & ~OFFS_REG_MASK) | TO_OFFS_REG(TMP_REG1);
 			}
 
 			FAIL_IF(push_inst(compiler, OR | S(src2_reg) | A(dst_reg) | B(src2_reg)));
@@ -3061,31 +3128,31 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 	return const_;
 }
 
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
 {
-	struct sljit_put_label *put_label;
+	struct sljit_jump *jump;
 	sljit_s32 dst_r;
 
 	CHECK_ERROR_PTR();
-	CHECK_PTR(check_sljit_emit_put_label(compiler, dst, dstw));
+	CHECK_PTR(check_sljit_emit_mov_addr(compiler, dst, dstw));
 	ADJUST_LOCAL_OFFSET(dst, dstw);
 
-	put_label = (struct sljit_put_label*)ensure_abuf(compiler, sizeof(struct sljit_put_label));
-	PTR_FAIL_IF(!put_label);
-	set_put_label(put_label, compiler, 0);
+	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+	PTR_FAIL_IF(!jump);
+	set_mov_addr(jump, compiler, 0);
 
 	dst_r = FAST_IS_REG(dst) ? dst : TMP_REG2;
-#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
-	PTR_FAIL_IF(emit_const(compiler, dst_r, 0));
-#else
 	PTR_FAIL_IF(push_inst(compiler, (sljit_ins)dst_r));
+#if (defined SLJIT_CONFIG_PPC_32 && SLJIT_CONFIG_PPC_32)
+	compiler->size++;
+#else
 	compiler->size += 4;
 #endif
 
 	if (dst & SLJIT_MEM)
 		PTR_FAIL_IF(emit_op(compiler, SLJIT_MOV, WORD_DATA, dst, dstw, TMP_REG1, 0, TMP_REG2, 0));
 
-	return put_label;
+	return jump;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_sw new_constant, sljit_sw executable_offset)

--- a/ext/pcre/pcre2lib/sljit/sljitNativeS390X.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeS390X.c
@@ -38,11 +38,8 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 	return "s390x" SLJIT_CPUINFO;
 }
 
-/* Instructions. */
+/* Instructions are stored as 64 bit values regardless their size. */
 typedef sljit_uw sljit_ins;
-
-/* Instruction tags (most significant halfword). */
-static const sljit_ins sljit_ins_const = (sljit_ins)1 << 48;
 
 #define TMP_REG1	(SLJIT_NUMBER_OF_REGISTERS + 2)
 #define TMP_REG2	(SLJIT_NUMBER_OF_REGISTERS + 3)
@@ -140,50 +137,21 @@ static SLJIT_INLINE sljit_gpr gpr(sljit_s32 r)
 	return reg_map[r];
 }
 
-/* Size of instruction in bytes. Tags must already be cleared. */
-static SLJIT_INLINE sljit_uw sizeof_ins(sljit_ins ins)
-{
-	/* keep faulting instructions */
-	if (ins == 0)
-		return 2;
-
-	if ((ins & 0x00000000ffffL) == ins)
-		return 2;
-	if ((ins & 0x0000ffffffffL) == ins)
-		return 4;
-	if ((ins & 0xffffffffffffL) == ins)
-		return 6;
-
-	SLJIT_UNREACHABLE();
-	return (sljit_uw)-1;
-}
-
 static sljit_s32 push_inst(struct sljit_compiler *compiler, sljit_ins ins)
 {
 	sljit_ins *ibuf = (sljit_ins *)ensure_buf(compiler, sizeof(sljit_ins));
 	FAIL_IF(!ibuf);
 	*ibuf = ins;
+
+	SLJIT_ASSERT(ins <= 0xffffffffffffL);
+
 	compiler->size++;
-	return SLJIT_SUCCESS;
-}
+	if (ins & 0xffff00000000L)
+		compiler->size++;
 
-static sljit_s32 encode_inst(void **ptr, sljit_ins ins)
-{
-	sljit_u16 *ibuf = (sljit_u16 *)*ptr;
-	sljit_uw size = sizeof_ins(ins);
+	if (ins & 0xffffffff0000L)
+		compiler->size++;
 
-	SLJIT_ASSERT((size & 6) == size);
-	switch (size) {
-	case 6:
-		*ibuf++ = (sljit_u16)(ins >> 32);
-		/* fallthrough */
-	case 4:
-		*ibuf++ = (sljit_u16)(ins >> 16);
-		/* fallthrough */
-	case 2:
-		*ibuf++ = (sljit_u16)(ins);
-	}
-	*ptr = (void*)ibuf;
 	return SLJIT_SUCCESS;
 }
 
@@ -1424,85 +1392,50 @@ static sljit_s32 emit_non_commutative(struct sljit_compiler *compiler, const str
 	return emit_rrf(compiler, ins, dst, src1, src1w, src2, src2w);
 }
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler)
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data)
 {
 	struct sljit_label *label;
 	struct sljit_jump *jump;
-	struct sljit_s390x_const *const_;
-	struct sljit_put_label *put_label;
+	struct sljit_const *const_;
 	sljit_sw executable_offset;
-	sljit_uw ins_size = 0; /* instructions */
+	sljit_uw ins_size = compiler->size << 1;
 	sljit_uw pool_size = 0; /* literal pool */
 	sljit_uw pad_size;
-	sljit_uw i, j = 0;
+	sljit_uw half_count;
+	SLJIT_NEXT_DEFINE_TYPES;
 	struct sljit_memory_fragment *buf;
-	void *code, *code_ptr;
+	sljit_ins *buf_ptr;
+	sljit_ins *buf_end;
+	sljit_u16 *code;
+	sljit_u16 *code_ptr;
 	sljit_uw *pool, *pool_ptr;
-	sljit_sw source, offset; /* TODO(carenas): only need 32 bit */
+	sljit_ins ins;
+	sljit_sw source, offset;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_generate_code(compiler));
 	reverse_buf(compiler);
 
-	/* branch handling */
-	label = compiler->labels;
 	jump = compiler->jumps;
-	put_label = compiler->put_labels;
-
-	/* TODO(carenas): compiler->executable_size could be calculated
-         *                before to avoid the following loop (except for
-         *                pool_size)
-         */
-	/* calculate the size of the code */
-	for (buf = compiler->buf; buf != NULL; buf = buf->next) {
-		sljit_uw len = buf->used_size / sizeof(sljit_ins);
-		sljit_ins *ibuf = (sljit_ins *)buf->memory;
-		for (i = 0; i < len; ++i, ++j) {
-			sljit_ins ins = ibuf[i];
-
-			/* TODO(carenas): instruction tag vs size/addr == j
-			 * using instruction tags for const is creative
-			 * but unlike all other architectures, and is not
-			 * done consistently for all other objects.
-			 * This might need reviewing later.
-			 */
-			if (ins & sljit_ins_const) {
-				pool_size += sizeof(*pool);
-				ins &= ~sljit_ins_const;
-			}
-			if (label && label->size == j) {
-				label->size = ins_size;
-				label = label->next;
-			}
-			if (jump && jump->addr == j) {
-				if ((jump->flags & SLJIT_REWRITABLE_JUMP) || (jump->flags & JUMP_ADDR)) {
-					/* encoded: */
-					/*   brasl %r14, <rel_addr> (or brcl <mask>, <rel_addr>) */
-					/* replace with: */
-					/*   lgrl %r1, <pool_addr> */
-					/*   bras %r14, %r1 (or bcr <mask>, %r1) */
-					pool_size += sizeof(*pool);
-					ins_size += 2;
-				}
-				jump = jump->next;
-			}
-			if (put_label && put_label->addr == j) {
-				pool_size += sizeof(*pool);
-				put_label = put_label->next;
-			}
-			ins_size += sizeof_ins(ins);
+	while (jump != NULL) {
+		if (jump->flags & (SLJIT_REWRITABLE_JUMP | JUMP_ADDR | JUMP_MOV_ADDR)) {
+			/* encoded: */
+			/*   brasl %r14, <rel_addr> (or brcl <mask>, <rel_addr>) */
+			/* replace with: */
+			/*   lgrl %r1, <pool_addr> */
+			/*   bras %r14, %r1 (or bcr <mask>, %r1) */
+			pool_size += sizeof(*pool);
+			if (!(jump->flags & JUMP_MOV_ADDR))
+				ins_size += 2;
 		}
+		jump = jump->next;
 	}
 
-	/* emit trailing label */
-	if (label && label->size == j) {
-		label->size = ins_size;
-		label = label->next;
+	const_ = compiler->consts;
+	while (const_) {
+		pool_size += sizeof(*pool);
+		const_ = const_->next;
 	}
-
-	SLJIT_ASSERT(!label);
-	SLJIT_ASSERT(!jump);
-	SLJIT_ASSERT(!put_label);
 
 	/* pad code size to 8 bytes so is accessible with half word offsets */
 	/* the literal pool needs to be doubleword aligned */
@@ -1510,11 +1443,9 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	SLJIT_ASSERT(pad_size < 8UL);
 
 	/* allocate target buffer */
-	code = SLJIT_MALLOC_EXEC(ins_size + pad_size + pool_size,
-					compiler->exec_allocator_data);
+	code = (sljit_u16*)allocate_executable_memory(ins_size + pad_size + pool_size, options, exec_allocator_data, &executable_offset);
 	PTR_FAIL_WITH_EXEC_IF(code);
 	code_ptr = code;
-	executable_offset = SLJIT_EXEC_OFFSET(code);
 
 	/* TODO(carenas): pool is optional, and the ABI recommends it to
          *                be created before the function code, instead of
@@ -1523,130 +1454,166 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
          */
 	pool = (sljit_uw *)((sljit_uw)code + ins_size + pad_size);
 	pool_ptr = pool;
-	const_ = (struct sljit_s390x_const *)compiler->consts;
+	buf = compiler->buf;
+	half_count = 0;
 
-	/* update label addresses */
 	label = compiler->labels;
-	while (label) {
-		label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(
-			(sljit_uw)code_ptr + label->size, executable_offset);
+	jump = compiler->jumps;
+	const_ = compiler->consts;
+	SLJIT_NEXT_INIT_TYPES();
+	SLJIT_GET_NEXT_MIN();
+
+	do {
+		buf_ptr = (sljit_ins*)buf->memory;
+		buf_end = buf_ptr + (buf->used_size >> 3);
+		do {
+			ins = *buf_ptr++;
+
+			if (next_min_addr == half_count) {
+				SLJIT_ASSERT(!label || label->size >= half_count);
+				SLJIT_ASSERT(!jump || jump->addr >= half_count);
+				SLJIT_ASSERT(!const_ || const_->addr >= half_count);
+
+				if (next_min_addr == next_label_size) {
+					label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+					label = label->next;
+					next_label_size = SLJIT_GET_NEXT_SIZE(label);
+				}
+
+				if (next_min_addr == next_jump_addr) {
+					if (SLJIT_UNLIKELY(jump->flags & JUMP_MOV_ADDR)) {
+						source = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+
+						jump->addr = (sljit_uw)pool_ptr;
+
+						/* store target into pool */
+						offset = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(pool_ptr, executable_offset) - source;
+						pool_ptr++;
+
+						SLJIT_ASSERT(!(offset & 1));
+						offset >>= 1;
+						SLJIT_ASSERT(is_s32(offset));
+						ins |= (sljit_ins)offset & 0xffffffff;
+					} else if (jump->flags & (SLJIT_REWRITABLE_JUMP | JUMP_ADDR)) {
+						sljit_ins arg;
+
+						jump->addr = (sljit_uw)pool_ptr;
+
+						/* load address into tmp1 */
+						source = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+						offset = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(pool_ptr, executable_offset) - source;
+
+						SLJIT_ASSERT(!(offset & 1));
+						offset >>= 1;
+						SLJIT_ASSERT(is_s32(offset));
+
+						code_ptr[0] = (sljit_u16)(0xc408 | R4A(tmp1) /* lgrl */);
+						code_ptr[1] = (sljit_u16)(offset >> 16);
+						code_ptr[2] = (sljit_u16)offset;
+						code_ptr += 3;
+						pool_ptr++;
+
+						/* branch to tmp1 */
+						arg = (ins >> 36) & 0xf;
+						if (((ins >> 32) & 0xf) == 4) {
+							/* brcl -> bcr */
+							ins = bcr(arg, tmp1);
+						} else {
+							SLJIT_ASSERT(((ins >> 32) & 0xf) == 5);
+							/* brasl -> basr */
+							ins = basr(arg, tmp1);
+						}
+
+						/* Adjust half_count. */
+						half_count += 2;
+					} else
+						jump->addr = (sljit_uw)code_ptr;
+
+					jump = jump->next;
+					next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+				} else  if (next_min_addr == next_const_addr) {
+					/* update instruction with relative address of constant */
+					source = (sljit_sw)code_ptr;
+					offset = (sljit_sw)pool_ptr - source;
+
+					SLJIT_ASSERT(!(offset & 0x1));
+					offset >>= 1; /* halfword (not byte) offset */
+					SLJIT_ASSERT(is_s32(offset));
+
+					ins |= (sljit_ins)offset & 0xffffffff;
+
+					/* update address */
+					const_->addr = (sljit_uw)pool_ptr;
+
+					/* store initial value into pool and update pool address */
+					*(pool_ptr++) = (sljit_uw)(((struct sljit_s390x_const*)const_)->init_value);
+
+					/* move to next constant */
+					const_ = const_->next;
+					next_const_addr = SLJIT_GET_NEXT_ADDRESS(const_);
+				}
+
+				SLJIT_GET_NEXT_MIN();
+			}
+
+			if (ins & 0xffff00000000L) {
+				*code_ptr++ = (sljit_u16)(ins >> 32);
+				half_count++;
+			}
+
+			if (ins & 0xffffffff0000L) {
+				*code_ptr++ = (sljit_u16)(ins >> 16);
+				half_count++;
+			}
+
+			*code_ptr++ = (sljit_u16)ins;
+			half_count++;
+		} while (buf_ptr < buf_end);
+
+		buf = buf->next;
+	} while (buf);
+
+	if (next_label_size == half_count) {
+		label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 		label = label->next;
 	}
 
-	/* reset jumps */
-	jump = compiler->jumps;
-	put_label = compiler->put_labels;
-
-	/* emit the code */
-	j = 0;
-	for (buf = compiler->buf; buf != NULL; buf = buf->next) {
-		sljit_uw len = buf->used_size / sizeof(sljit_ins);
-		sljit_ins *ibuf = (sljit_ins *)buf->memory;
-		for (i = 0; i < len; ++i, ++j) {
-			sljit_ins ins = ibuf[i];
-			if (ins & sljit_ins_const) {
-				/* clear the const tag */
-				ins &= ~sljit_ins_const;
-
-				/* update instruction with relative address of constant */
-				source = (sljit_sw)code_ptr;
-				offset = (sljit_sw)pool_ptr - source;
-
-				SLJIT_ASSERT(!(offset & 1));
-				offset >>= 1; /* halfword (not byte) offset */
-				SLJIT_ASSERT(is_s32(offset));
-
-				ins |= (sljit_ins)offset & 0xffffffff;
-
-				/* update address */
-				const_->const_.addr = (sljit_uw)pool_ptr;
-
-				/* store initial value into pool and update pool address */
-				*(pool_ptr++) = (sljit_uw)const_->init_value;
-
-				/* move to next constant */
-				const_ = (struct sljit_s390x_const *)const_->const_.next;
-			}
-			if (jump && jump->addr == j) {
-				sljit_sw target = (sljit_sw)((jump->flags & JUMP_LABEL) ? jump->u.label->addr : jump->u.target);
-				if ((jump->flags & SLJIT_REWRITABLE_JUMP) || (jump->flags & JUMP_ADDR)) {
-					sljit_ins op, arg;
-
-					jump->addr = (sljit_uw)pool_ptr;
-
-					/* load address into tmp1 */
-					source = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
-					offset = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(pool_ptr, executable_offset) - source;
-
-					SLJIT_ASSERT(!(offset & 1));
-					offset >>= 1;
-					SLJIT_ASSERT(is_s32(offset));
-
-					encode_inst(&code_ptr, lgrl(tmp1, offset & 0xffffffff));
-
-					/* store jump target into pool and update pool address */
-					*(pool_ptr++) = (sljit_uw)target;
-
-					/* branch to tmp1 */
-					op = (ins >> 32) & 0xf;
-					arg = (ins >> 36) & 0xf;
-					switch (op) {
-					case 4: /* brcl -> bcr */
-						ins = bcr(arg, tmp1);
-						break;
-					case 5: /* brasl -> basr */
-						ins = basr(arg, tmp1);
-						break;
-					default:
-						abort();
-					}
-				}
-				else {
-					jump->addr = (sljit_uw)code_ptr + 2;
-					source = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
-					offset = target - source;
-
-					/* offset must be halfword aligned */
-					SLJIT_ASSERT(!(offset & 1));
-					offset >>= 1;
-					SLJIT_ASSERT(is_s32(offset)); /* TODO(mundaym): handle arbitrary offsets */
-
-					/* patch jump target */
-					ins |= (sljit_ins)offset & 0xffffffff;
-				}
-				jump = jump->next;
-			}
-			if (put_label && put_label->addr == j) {
-				source = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
-
-				SLJIT_ASSERT(put_label->label);
-				put_label->addr = (sljit_uw)code_ptr;
-
-				/* store target into pool */
-				*pool_ptr = put_label->label->addr;
-				offset = (sljit_sw)SLJIT_ADD_EXEC_OFFSET(pool_ptr, executable_offset) - source;
-				pool_ptr++;
-
-				SLJIT_ASSERT(!(offset & 1));
-				offset >>= 1;
-				SLJIT_ASSERT(is_s32(offset));
-				ins |= (sljit_ins)offset & 0xffffffff;
-
-				put_label = put_label->next;
-			}
-			encode_inst(&code_ptr, ins);
-		}
-	}
-	SLJIT_ASSERT((sljit_u8 *)code + ins_size == code_ptr);
+	SLJIT_ASSERT(!label);
+	SLJIT_ASSERT(!jump);
+	SLJIT_ASSERT(!const_);
+	SLJIT_ASSERT(code + (ins_size >> 1) == code_ptr);
 	SLJIT_ASSERT((sljit_u8 *)pool + pool_size == (sljit_u8 *)pool_ptr);
+
+	jump = compiler->jumps;
+	while (jump != NULL) {
+		offset = (sljit_sw)((jump->flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr);
+
+		if (jump->flags & (SLJIT_REWRITABLE_JUMP | JUMP_ADDR | JUMP_MOV_ADDR)) {
+			/* Store jump target into pool. */
+			*(sljit_uw*)(jump->addr) = (sljit_uw)offset;
+		} else {
+			code_ptr = (sljit_u16*)jump->addr;
+			offset -= (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+
+			/* offset must be halfword aligned */
+			SLJIT_ASSERT(!(offset & 1));
+			offset >>= 1;
+			SLJIT_ASSERT(is_s32(offset)); /* TODO(mundaym): handle arbitrary offsets */
+
+			code_ptr[1] = (sljit_u16)(offset >> 16);
+			code_ptr[2] = (sljit_u16)offset;
+		}
+		jump = jump->next;
+	}
 
 	compiler->error = SLJIT_ERR_COMPILED;
 	compiler->executable_offset = executable_offset;
 	compiler->executable_size = ins_size;
 	if (pool_size)
 		compiler->executable_size += (pad_size + pool_size);
-	code = SLJIT_ADD_EXEC_OFFSET(code, executable_offset);
-	code_ptr = SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+
+	code = (sljit_u16 *)SLJIT_ADD_EXEC_OFFSET(code, executable_offset);
+	code_ptr = (sljit_u16 *)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 	SLJIT_CACHE_FLUSH(code, code_ptr);
 	SLJIT_UPDATE_WX_FLAGS(code, code_ptr, 1);
 	return code;
@@ -2497,7 +2464,7 @@ static sljit_s32 sljit_emit_sub(struct sljit_compiler *compiler, sljit_s32 op,
 	const struct ins_forms *forms;
 	sljit_ins ins;
 
-	if (dst == (sljit_s32)tmp0 && flag_type <= SLJIT_SIG_LESS_EQUAL) {
+	if (dst == TMP_REG2 && flag_type <= SLJIT_SIG_LESS_EQUAL) {
 		int compare_signed = flag_type >= SLJIT_SIG_LESS;
 
 		compiler->status_flags_state |= SLJIT_CURRENT_FLAGS_COMPARE;
@@ -2597,7 +2564,7 @@ done:
 			     - the first operand is less if the sign bit of the result is not set
 			   The -result operation sets the corrent sign, because the result cannot be zero.
 			   The overflow is considered greater, since the result must be equal to INT_MIN so its sign bit is set. */
-			FAIL_IF(push_inst(compiler, brc(0xe, 2 + 2)));
+			FAIL_IF(push_inst(compiler, brc(0xe, (op & SLJIT_32) ? (2 + 1) : (2 + 2))));
 			FAIL_IF(push_inst(compiler, (op & SLJIT_32) ? lcr(tmp1, dst_r) : lcgr(tmp1, dst_r)));
 		}
 		else if (op & SLJIT_SET_Z)
@@ -2759,7 +2726,7 @@ static sljit_s32 sljit_emit_bitwise(struct sljit_compiler *compiler, sljit_s32 o
 	sljit_s32 type = GET_OPCODE(op);
 	const struct ins_forms *forms;
 
-	if (src2 == SLJIT_IMM && (!(op & SLJIT_SET_Z) || (type == SLJIT_AND && dst == (sljit_s32)tmp0))) {
+	if (src2 == SLJIT_IMM && (!(op & SLJIT_SET_Z) || (type == SLJIT_AND && dst == TMP_REG2))) {
 		sljit_s32 count16 = 0;
 		sljit_uw imm = (sljit_uw)src2w;
 
@@ -2775,13 +2742,13 @@ static sljit_s32 sljit_emit_bitwise(struct sljit_compiler *compiler, sljit_s32 o
 		if ((imm & 0xffff000000000000ull) != 0)
 			count16++;
 
-		if (type == SLJIT_AND && dst == (sljit_s32)tmp0 && count16 == 1) {
-			sljit_gpr src_r = tmp0;
+		if (type == SLJIT_AND && dst == TMP_REG2 && count16 == 1) {
+			sljit_gpr src_r = tmp1;
 
 			if (FAST_IS_REG(src1))
 				src_r = gpr(src1 & REG_MASK);
 			else
-				FAIL_IF(emit_move(compiler, tmp0, src1, src1w));
+				FAIL_IF(emit_move(compiler, tmp1, src1, src1w));
 
 			if ((imm & 0x000000000000ffffull) != 0 || imm == 0)
 				return push_inst(compiler, 0xa7010000 /* tmll */ | R20A(src_r) | imm);
@@ -3002,11 +2969,31 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 	sljit_s32 src1, sljit_sw src1w,
 	sljit_s32 src2, sljit_sw src2w)
 {
+	sljit_s32 dst_reg = (GET_OPCODE(op) == SLJIT_SUB || GET_OPCODE(op) == SLJIT_AND) ? TMP_REG2 : TMP_REG1;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_op2(compiler, op, 1, 0, 0, src1, src1w, src2, src2w));
 
 	SLJIT_SKIP_CHECKS(compiler);
-	return sljit_emit_op2(compiler, op, (sljit_s32)tmp0, 0, src1, src1w, src2, src2w);
+	return sljit_emit_op2(compiler, op, dst_reg, 0, src1, src1w, src2, src2w);
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_op2r(compiler, op, dst_reg, src1, src1w, src2, src2w));
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MULADD:
+		SLJIT_SKIP_CHECKS(compiler);
+		FAIL_IF(sljit_emit_op2(compiler, SLJIT_MUL | (op & SLJIT_32), 0 /* tmp0 */, 0, src1, src1w, src2, src2w));
+		return push_inst(compiler, ((op & SLJIT_32) ? 0x1a00 /* ar */ : 0xb9080000 /* agr */) | R4A(gpr(dst_reg)) | R0A(tmp0));
+	}
+
+	return SLJIT_SUCCESS;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *compiler, sljit_s32 op,
@@ -3415,12 +3402,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 		FAIL_IF(push_inst(compiler, ins | F4(dst_r) | F0(src)));
 	}
 
-	if (!(dst & SLJIT_MEM))
-		return SLJIT_SUCCESS;
+	if (dst & SLJIT_MEM)
+		return float_mem(compiler, FLOAT_STORE | (op & SLJIT_32), TMP_FREG1, dst, dstw);
 
-	SLJIT_ASSERT(dst_r == TMP_FREG1);
-
-	return float_mem(compiler, FLOAT_STORE | (op & SLJIT_32), TMP_FREG1, dst, dstw);
+	return SLJIT_SUCCESS;
 }
 
 #define FLOAT_MOV(op, dst_r, src_r) \
@@ -3491,7 +3476,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 	if (dst & SLJIT_MEM)
 		return float_mem(compiler, FLOAT_STORE | (op & SLJIT_32), TMP_FREG1, dst, dstw);
 
-	SLJIT_ASSERT(dst_r != TMP_FREG1);
 	return SLJIT_SUCCESS;
 }
 
@@ -3738,8 +3722,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_flags(struct sljit_compiler *co
 		FAIL_IF(push_inst(compiler,
 			WHEN2(op & SLJIT_32, lochi, locghi)));
 	} else {
-		/* TODO(mundaym): no load/store-on-condition 2 facility (ipm? branch-and-set?) */
-		abort();
+		FAIL_IF(push_load_imm_inst(compiler, loc_r, 1));
+		FAIL_IF(push_inst(compiler, brc(mask, 2 + 2)));
+		FAIL_IF(push_load_imm_inst(compiler, loc_r, 0));
 	}
 	#undef LEVAL
 
@@ -3837,8 +3822,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *comp
 			return push_inst(compiler, ins | R36A(dst_r) | (mask << 32) | (sljit_ins)(src1w & 0xffff) << 16);
 		}
 
-		FAIL_IF(push_load_imm_inst(compiler, tmp0, src1w));
-		src_r = tmp0;
+		FAIL_IF(push_load_imm_inst(compiler, tmp1, src1w));
+		src_r = tmp1;
 	} else
 		src_r = gpr(src1);
 
@@ -4474,9 +4459,9 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 
 	dst_r = FAST_IS_REG(dst) ? gpr(dst & REG_MASK) : tmp0;
 	if (have_genext())
-		PTR_FAIL_IF(push_inst(compiler, sljit_ins_const | lgrl(dst_r, 0)));
+		PTR_FAIL_IF(push_inst(compiler, lgrl(dst_r, 0)));
 	else {
-		PTR_FAIL_IF(push_inst(compiler, sljit_ins_const | larl(tmp1, 0)));
+		PTR_FAIL_IF(push_inst(compiler, larl(tmp1, 0)));
 		PTR_FAIL_IF(push_inst(compiler, lg(dst_r, 0, r0, tmp1)));
 	}
 
@@ -4503,20 +4488,18 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_sw new_consta
 	sljit_set_jump_addr(addr, (sljit_uw)new_constant, executable_offset);
 }
 
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label *sljit_emit_put_label(
-	struct sljit_compiler *compiler,
-	sljit_s32 dst, sljit_sw dstw)
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
 {
-	struct sljit_put_label *put_label;
+	struct sljit_jump *jump;
 	sljit_gpr dst_r;
 
 	CHECK_ERROR_PTR();
-	CHECK_PTR(check_sljit_emit_put_label(compiler, dst, dstw));
+	CHECK_PTR(check_sljit_emit_mov_addr(compiler, dst, dstw));
 	ADJUST_LOCAL_OFFSET(dst, dstw);
 
-	put_label = (struct sljit_put_label*)ensure_abuf(compiler, sizeof(struct sljit_put_label));
-	PTR_FAIL_IF(!put_label);
-	set_put_label(put_label, compiler, 0);
+	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+	PTR_FAIL_IF(!jump);
+	set_mov_addr(jump, compiler, 0);
 
 	dst_r = FAST_IS_REG(dst) ? gpr(dst & REG_MASK) : tmp0;
 
@@ -4530,7 +4513,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label *sljit_emit_put_label(
 	if (dst & SLJIT_MEM)
 		PTR_FAIL_IF(store_word(compiler, dst_r, dst, dstw, 0));
 
-	return put_label;
+	return jump;
 }
 
 /* TODO(carenas): EVAL probably should move up or be refactored */

--- a/ext/pcre/pcre2lib/sljit/sljitNativeX86_32.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeX86_32.c
@@ -283,28 +283,25 @@ static sljit_s32 emit_vex_instruction(struct sljit_compiler *compiler, sljit_uw 
 /*  Enter / return                                                       */
 /* --------------------------------------------------------------------- */
 
-static sljit_u8* generate_far_jump_code(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_sw executable_offset)
+static sljit_u8* detect_far_jump_type(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_sw executable_offset)
 {
 	sljit_uw type = jump->flags >> TYPE_SHIFT;
 
 	if (type == SLJIT_JUMP) {
 		*code_ptr++ = JMP_i32;
-		jump->addr++;
-	}
-	else if (type >= SLJIT_FAST_CALL) {
+	} else if (type >= SLJIT_FAST_CALL) {
 		*code_ptr++ = CALL_i32;
-		jump->addr++;
-	}
-	else {
+	} else {
 		*code_ptr++ = GROUP_0F;
 		*code_ptr++ = get_jump_code(type);
-		jump->addr += 2;
 	}
 
-	if (jump->flags & JUMP_LABEL)
-		jump->flags |= PATCH_MW;
-	else
+	jump->addr = (sljit_uw)code_ptr;
+
+	if (jump->flags & JUMP_ADDR)
 		sljit_unaligned_store_sw(code_ptr, (sljit_sw)(jump->u.target - (jump->addr + 4) - (sljit_uw)executable_offset));
+	else
+		jump->flags |= PATCH_MW;
 	code_ptr += 4;
 
 	return code_ptr;
@@ -1249,6 +1246,68 @@ static sljit_s32 sljit_emit_get_return_address(struct sljit_compiler *compiler,
 /*  Other operations                                                     */
 /* --------------------------------------------------------------------- */
 
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2_reg)
+{
+	sljit_s32 dst = dst_reg;
+	sljit_sw dstw = 0;
+	sljit_sw src2w = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_select(compiler, type, dst_reg, src1, src1w, src2_reg));
+
+	ADJUST_LOCAL_OFFSET(src1, src1w);
+
+	CHECK_EXTRA_REGS(dst, dstw, (void)0);
+	CHECK_EXTRA_REGS(src1, src1w, (void)0);
+	CHECK_EXTRA_REGS(src2_reg, src2w, (void)0);
+
+	type &= ~SLJIT_32;
+
+	if (dst & SLJIT_MEM) {
+		if (src1 == SLJIT_IMM || (!(src1 & SLJIT_MEM) && (src2_reg & SLJIT_MEM))) {
+			EMIT_MOV(compiler, TMP_REG1, 0, src1, src1w);
+			src1 = src2_reg;
+			src1w = src2w;
+			type ^= 0x1;
+		} else
+			EMIT_MOV(compiler, TMP_REG1, 0, src2_reg, src2w);
+
+		dst_reg = TMP_REG1;
+	} else {
+		if (dst_reg != src2_reg) {
+			if (dst_reg == src1) {
+				src1 = src2_reg;
+				src1w = src2w;
+				type ^= 0x1;
+			} else if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
+				EMIT_MOV(compiler, dst_reg, 0, src1, src1w);
+				src1 = src2_reg;
+				src1w = src2w;
+				type ^= 0x1;
+			} else
+				EMIT_MOV(compiler, dst_reg, 0, src2_reg, src2w);
+		}
+	}
+
+	if (sljit_has_cpu_feature(SLJIT_HAS_CMOV) && (src1 != SLJIT_IMM || dst_reg != TMP_REG1)) {
+		if (SLJIT_UNLIKELY(src1 == SLJIT_IMM)) {
+			EMIT_MOV(compiler, TMP_REG1, 0, src1, src1w);
+			src1 = TMP_REG1;
+			src1w = 0;
+		}
+
+		FAIL_IF(emit_groupf(compiler, U8(get_jump_code((sljit_uw)type) - 0x40), dst_reg, src1, src1w));
+	} else
+		FAIL_IF(emit_cmov_generic(compiler, type, dst_reg, src1, src1w));
+
+	if (dst & SLJIT_MEM)
+		return emit_mov(compiler, dst, dstw, TMP_REG1, 0);
+	return SLJIT_SUCCESS;
+}
+
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 reg,
 	sljit_s32 mem, sljit_sw memw)
@@ -1449,10 +1508,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fset32(struct sljit_compiler *comp
 
 	if (u.imm == 0) {
 		inst[2] = PXOR_x_xm;
-		inst[3] = U8(freg | (freg << 3) | MOD_REG);
+		inst[3] = U8(freg_map[freg] | (freg_map[freg] << 3) | MOD_REG);
 	} else {
 		inst[2] = MOVD_x_rm;
-		inst[3] = U8(reg_map[TMP_REG1] | (freg << 3) | MOD_REG);
+		inst[3] = U8(reg_map[TMP_REG1] | (freg_map[freg] << 3) | MOD_REG);
 	}
 
 	return SLJIT_SUCCESS;
@@ -1462,7 +1521,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fset64(struct sljit_compiler *comp
 	sljit_s32 freg, sljit_f64 value)
 {
 	sljit_u8 *inst;
-	sljit_s32 tmp_freg = freg;
 	union {
 		sljit_s32 imm[2];
 		sljit_f64 value;
@@ -1478,8 +1536,18 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fset64(struct sljit_compiler *comp
 			return emit_groupf(compiler, PXOR_x_xm | EX86_PREF_66 | EX86_SSE2, freg, freg, 0);
 
 		EMIT_MOV(compiler, TMP_REG1, 0, SLJIT_IMM, u.imm[1]);
-	} else
+	} else {
+		SLJIT_ASSERT(cpu_feature_list != 0);
+
+		if (!(cpu_feature_list & CPU_FEATURE_SSE41) && u.imm[1] != 0 && u.imm[0] != u.imm[1]) {
+			EMIT_MOV(compiler, SLJIT_MEM1(SLJIT_SP), 0, SLJIT_IMM, u.imm[0]);
+			EMIT_MOV(compiler, SLJIT_MEM1(SLJIT_SP), sizeof(sljit_sw), SLJIT_IMM, u.imm[1]);
+
+			return emit_groupf(compiler, MOVLPD_x_m | EX86_SSE2, freg, SLJIT_MEM1(SLJIT_SP), 0);
+		}
+
 		EMIT_MOV(compiler, TMP_REG1, 0, SLJIT_IMM, u.imm[0]);
+	}
 
 	FAIL_IF(emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, freg, TMP_REG1, 0));
 
@@ -1493,23 +1561,17 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fset64(struct sljit_compiler *comp
 
 		inst[0] = GROUP_0F;
 		inst[1] = SHUFPS_x_xm;
-		inst[2] = U8(MOD_REG | (freg << 3) | freg);
+		inst[2] = U8(MOD_REG | (freg_map[freg] << 3) | freg_map[freg]);
 		inst[3] = 0x51;
 		return SLJIT_SUCCESS;
 	}
 
 	if (u.imm[0] != u.imm[1]) {
-		SLJIT_ASSERT(u.imm[1] != 0 && cpu_feature_list != 0);
-
+		SLJIT_ASSERT(cpu_feature_list & CPU_FEATURE_SSE41);
 		EMIT_MOV(compiler, TMP_REG1, 0, SLJIT_IMM, u.imm[1]);
 
-		if (cpu_feature_list & CPU_FEATURE_SSE41) {
-			FAIL_IF(emit_groupf_ext(compiler, PINSRD_x_rm_i8 | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2_OP1, freg, TMP_REG1, 0));
-			return emit_byte(compiler, 1);
-		}
-
-		FAIL_IF(emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, TMP_FREG, TMP_REG1, 0));
-		tmp_freg = TMP_FREG;
+		FAIL_IF(emit_groupf_ext(compiler, PINSRD_x_rm_i8 | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2_OP1, freg, TMP_REG1, 0));
+		return emit_byte(compiler, 1);
 	}
 
 	inst = (sljit_u8*)ensure_buf(compiler, 1 + 3);
@@ -1518,7 +1580,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fset64(struct sljit_compiler *comp
 
 	inst[0] = GROUP_0F;
 	inst[1] = UNPCKLPS_x_xm;
-	inst[2] = U8(MOD_REG | (freg << 3) | tmp_freg);
+	inst[2] = U8(MOD_REG | (freg_map[freg] << 3) | freg_map[freg]);
 	return SLJIT_SUCCESS;
 }
 
@@ -1581,7 +1643,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fcopy(struct sljit_compiler *compi
 		inst[0] = GROUP_66;
 		inst[1] = GROUP_0F;
 		inst[2] = PSHUFD_x_xm;
-		inst[3] = U8(MOD_REG | (TMP_FREG << 3) | freg);
+		inst[3] = U8(MOD_REG | (TMP_FREG << 3) | freg_map[freg]);
 		inst[4] = 1;
 	} else if (reg != 0)
 		FAIL_IF(emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, TMP_FREG, reg, regw));
@@ -1597,7 +1659,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fcopy(struct sljit_compiler *compi
 
 		inst[0] = GROUP_0F;
 		inst[1] = UNPCKLPS_x_xm;
-		inst[2] = U8(MOD_REG | (freg << 3) | (reg == 0 ? freg : TMP_FREG));
+		inst[2] = U8(MOD_REG | (freg_map[freg] << 3) | freg_map[reg == 0 ? freg : TMP_FREG]);
 	} else
 		FAIL_IF(emit_groupf(compiler, MOVD_rm_x | EX86_PREF_66 | EX86_SSE2_OP1, TMP_FREG, reg, regw));
 

--- a/ext/pcre/pcre2lib/sljit/sljitNativeX86_64.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeX86_64.c
@@ -358,26 +358,28 @@ static sljit_s32 emit_vex_instruction(struct sljit_compiler *compiler, sljit_uw 
 /*  Enter / return                                                       */
 /* --------------------------------------------------------------------- */
 
-static sljit_u8* generate_far_jump_code(struct sljit_jump *jump, sljit_u8 *code_ptr)
+static sljit_u8* detect_far_jump_type(struct sljit_jump *jump, sljit_u8 *code_ptr)
 {
 	sljit_uw type = jump->flags >> TYPE_SHIFT;
 
-	int short_addr = !(jump->flags & SLJIT_REWRITABLE_JUMP) && !(jump->flags & JUMP_LABEL) && (jump->u.target <= 0xffffffff);
+	int short_addr = !(jump->flags & SLJIT_REWRITABLE_JUMP) && (jump->flags & JUMP_ADDR) && (jump->u.target <= 0xffffffff);
 
 	/* The relative jump below specialized for this case. */
-	SLJIT_ASSERT(reg_map[TMP_REG2] >= 8);
+	SLJIT_ASSERT(reg_map[TMP_REG2] >= 8 && TMP_REG2 != SLJIT_TMP_DEST_REG);
 
 	if (type < SLJIT_JUMP) {
 		/* Invert type. */
-		*code_ptr++ = U8(get_jump_code(type ^ 0x1) - 0x10);
-		*code_ptr++ = short_addr ? (6 + 3) : (10 + 3);
+		code_ptr[0] = U8(get_jump_code(type ^ 0x1) - 0x10);
+		code_ptr[1] = short_addr ? (6 + 3) : (10 + 3);
+		code_ptr += 2;
 	}
 
-	*code_ptr++ = short_addr ? REX_B : (REX_W | REX_B);
-	*code_ptr++ = MOV_r_i32 | reg_lmap[TMP_REG2];
+	code_ptr[0] = short_addr ? REX_B : (REX_W | REX_B);
+	code_ptr[1] = MOV_r_i32 | reg_lmap[TMP_REG2];
+	code_ptr += 2;
 	jump->addr = (sljit_uw)code_ptr;
 
-	if (jump->flags & JUMP_LABEL)
+	if (!(jump->flags & JUMP_ADDR))
 		jump->flags |= PATCH_MD;
 	else if (short_addr)
 		sljit_unaligned_store_s32(code_ptr, (sljit_s32)jump->u.target);
@@ -386,60 +388,62 @@ static sljit_u8* generate_far_jump_code(struct sljit_jump *jump, sljit_u8 *code_
 
 	code_ptr += short_addr ? sizeof(sljit_s32) : sizeof(sljit_sw);
 
-	*code_ptr++ = REX_B;
-	*code_ptr++ = GROUP_FF;
-	*code_ptr++ = U8(MOD_REG | (type >= SLJIT_FAST_CALL ? CALL_rm : JMP_rm) | reg_lmap[TMP_REG2]);
+	code_ptr[0] = REX_B;
+	code_ptr[1] = GROUP_FF;
+	code_ptr[2] = U8(MOD_REG | (type >= SLJIT_FAST_CALL ? CALL_rm : JMP_rm) | reg_lmap[TMP_REG2]);
 
-	return code_ptr;
+	return code_ptr + 3;
 }
 
-static sljit_u8* generate_put_label_code(struct sljit_put_label *put_label, sljit_u8 *code_ptr, sljit_uw max_label)
+static sljit_u8* generate_mov_addr_code(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_u8 *code, sljit_sw executable_offset)
 {
-	if (max_label > HALFWORD_MAX) {
-		put_label->addr -= put_label->flags;
-		put_label->flags = PATCH_MD;
+	sljit_uw addr;
+	sljit_sw diff;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	SLJIT_ASSERT(((jump->flags >> JUMP_SIZE_SHIFT) & 0x1f) <= 10);
+	if (jump->flags & JUMP_ADDR)
+		addr = jump->u.target;
+	else
+		addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code, executable_offset) + jump->u.label->size;
+
+	if (addr > 0xffffffffl) {
+		diff = (sljit_sw)addr - (sljit_sw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+
+		if (diff <= HALFWORD_MAX && diff >= HALFWORD_MIN) {
+			SLJIT_ASSERT(((jump->flags >> JUMP_SIZE_SHIFT) & 0x1f) >= 7);
+			code_ptr -= SSIZE_OF(s32) - 1;
+
+			SLJIT_ASSERT((code_ptr[-3 - SSIZE_OF(s32)] & 0xf8) == REX_W);
+			SLJIT_ASSERT((code_ptr[-2 - SSIZE_OF(s32)] & 0xf8) == MOV_r_i32);
+
+			code_ptr[-3 - SSIZE_OF(s32)] = U8(REX_W | ((code_ptr[-3 - SSIZE_OF(s32)] & 0x1) << 2));
+			code_ptr[-1 - SSIZE_OF(s32)] = U8(((code_ptr[-2 - SSIZE_OF(s32)] & 0x7) << 3) | 0x5);
+			code_ptr[-2 - SSIZE_OF(s32)] = LEA_r_m;
+
+			jump->flags |= PATCH_MW;
+			return code_ptr;
+		}
+
+		jump->flags |= PATCH_MD;
 		return code_ptr;
 	}
 
-	if (put_label->flags == 0) {
-		/* Destination is register. */
-		code_ptr = (sljit_u8*)put_label->addr - 2 - sizeof(sljit_uw);
-
-		SLJIT_ASSERT((code_ptr[0] & 0xf8) == REX_W);
-		SLJIT_ASSERT((code_ptr[1] & 0xf8) == MOV_r_i32);
-
-		if ((code_ptr[0] & 0x07) != 0) {
-			code_ptr[0] = U8(code_ptr[0] & ~0x08);
-			code_ptr += 2 + sizeof(sljit_s32);
-		}
-		else {
-			code_ptr[0] = code_ptr[1];
-			code_ptr += 1 + sizeof(sljit_s32);
-		}
-
-		put_label->addr = (sljit_uw)code_ptr;
-		return code_ptr;
-	}
-
-	code_ptr -= put_label->flags + (2 + sizeof(sljit_uw));
-	SLJIT_MEMMOVE(code_ptr, code_ptr + (2 + sizeof(sljit_uw)), put_label->flags);
+	code_ptr -= 2 + sizeof(sljit_uw);
 
 	SLJIT_ASSERT((code_ptr[0] & 0xf8) == REX_W);
+	SLJIT_ASSERT((code_ptr[1] & 0xf8) == MOV_r_i32);
 
-	if ((code_ptr[1] & 0xf8) == MOV_r_i32) {
-		code_ptr += 2 + sizeof(sljit_uw);
-		SLJIT_ASSERT((code_ptr[0] & 0xf8) == REX_W);
+	if ((code_ptr[0] & 0x07) != 0) {
+		SLJIT_ASSERT(((jump->flags >> JUMP_SIZE_SHIFT) & 0x1f) >= 6);
+		code_ptr[0] = U8(code_ptr[0] & ~0x08);
+		code_ptr += 2 + sizeof(sljit_s32);
+	} else {
+		SLJIT_ASSERT(((jump->flags >> JUMP_SIZE_SHIFT) & 0x1f) >= 5);
+		code_ptr[0] = code_ptr[1];
+		code_ptr += 1 + sizeof(sljit_s32);
 	}
 
-	SLJIT_ASSERT(code_ptr[1] == MOV_rm_r);
-
-	code_ptr[0] = U8(code_ptr[0] & ~0x4);
-	code_ptr[1] = MOV_rm_i32;
-	code_ptr[2] = U8(code_ptr[2] & ~(0x7 << 3));
-
-	code_ptr = (sljit_u8*)(put_label->addr - (2 + sizeof(sljit_uw)) + sizeof(sljit_s32));
-	put_label->addr = (sljit_uw)code_ptr;
-	put_label->flags = 0;
 	return code_ptr;
 }
 
@@ -1002,6 +1006,46 @@ static sljit_s32 sljit_emit_get_return_address(struct sljit_compiler *compiler,
 /* --------------------------------------------------------------------- */
 /*  Other operations                                                     */
 /* --------------------------------------------------------------------- */
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *compiler, sljit_s32 type,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2_reg)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_select(compiler, type, dst_reg, src1, src1w, src2_reg));
+
+	ADJUST_LOCAL_OFFSET(src1, src1w);
+
+	compiler->mode32 = type & SLJIT_32;
+	type &= ~SLJIT_32;
+
+	if (dst_reg != src2_reg) {
+		if (dst_reg == src1) {
+			src1 = src2_reg;
+			src1w = 0;
+			type ^= 0x1;
+		} else if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
+			EMIT_MOV(compiler, dst_reg, 0, src1, src1w);
+			src1 = src2_reg;
+			src1w = 0;
+			type ^= 0x1;
+		} else
+			EMIT_MOV(compiler, dst_reg, 0, src2_reg, 0);
+	}
+
+	if (sljit_has_cpu_feature(SLJIT_HAS_CMOV)) {
+		if (SLJIT_UNLIKELY(src1 == SLJIT_IMM)) {
+			EMIT_MOV(compiler, TMP_REG2, 0, src1, src1w);
+			src1 = TMP_REG2;
+			src1w = 0;
+		}
+
+		return emit_groupf(compiler, U8(get_jump_code((sljit_uw)type) - 0x40), dst_reg, src1, src1w);
+	}
+
+	return emit_cmov_generic(compiler, type, dst_reg, src1, src1w);
+}
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 reg,

--- a/ext/pcre/pcre2lib/sljit/sljitNativeX86_common.c
+++ b/ext/pcre/pcre2lib/sljit/sljitNativeX86_common.c
@@ -24,12 +24,6 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-#include <sanitizer/msan_interface.h>
-#endif /* __has_feature(memory_sanitizer) */
-#endif /* defined(__has_feature) */
-
 SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 {
 	return "x86" SLJIT_CPUINFO;
@@ -71,7 +65,6 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 #define TMP_FREG	(SLJIT_NUMBER_OF_FLOAT_REGISTERS + 1)
 
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-
 
 static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 3] = {
 	0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 5, 7, 6, 4, 3
@@ -379,6 +372,11 @@ static const sljit_u8 freg_lmap[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 2] = {
 #define RET()			(*inst++ = RET_near)
 #define RET_I16(n)		(*inst++ = RET_i16, *inst++ = U8(n), *inst++ = 0)
 
+#define SLJIT_INST_LABEL	255
+#define SLJIT_INST_JUMP		254
+#define SLJIT_INST_MOV_ADDR	253
+#define SLJIT_INST_CONST	252
+
 /* Multithreading does not affect these static variables, since they store
    built-in CPU features. Therefore they can be overwritten by different threads
    if they detect the CPU features in the same time. */
@@ -392,6 +390,7 @@ static const sljit_u8 freg_lmap[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 2] = {
 #define CPU_FEATURE_CMOV		0x020
 #define CPU_FEATURE_AVX			0x040
 #define CPU_FEATURE_AVX2		0x080
+#define CPU_FEATURE_OSXSAVE		0x100
 
 static sljit_u32 cpu_feature_list = 0;
 
@@ -490,22 +489,50 @@ static void execute_cpu_id(sljit_u32 info[4])
 	}
 
 #endif /* _MSC_VER && _MSC_VER >= 1400 */
+}
 
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-__msan_unpoison(info, 4 * sizeof(sljit_u32));
-#endif /* __has_feature(memory_sanitizer) */
-#endif /* defined(__has_feature) */
+static sljit_u32 execute_get_xcr0_low(void)
+{
+	sljit_u32 xcr0;
 
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+
+	xcr0 = (sljit_u32)_xgetbv(0);
+
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__SUNPRO_C) || defined(__TINYC__)
+
+	/* AT&T syntax. */
+	__asm__ (
+		"xorl %%ecx, %%ecx\n"
+		"xgetbv\n"
+		: "=a" (xcr0)
+		:
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
+		: "ecx", "edx"
+#else /* !SLJIT_CONFIG_X86_32 */
+		: "rcx", "rdx"
+#endif /* SLJIT_CONFIG_X86_32 */
+	);
+
+#else /* _MSC_VER < 1400 */
+
+	/* Intel syntax. */
+	__asm {
+		mov ecx, 0
+		xgetbv
+		mov xcr0, eax
+	}
+
+#endif /* _MSC_VER && _MSC_VER >= 1400 */
+	return xcr0;
 }
 
 static void get_cpu_features(void)
 {
 	sljit_u32 feature_list = CPU_FEATURE_DETECTED;
-	sljit_u32 info[4];
+	sljit_u32 info[4] = {0};
 	sljit_u32 max_id;
 
-	info[0] = 0;
 	execute_cpu_id(info);
 	max_id = info[0];
 
@@ -526,6 +553,8 @@ static void get_cpu_features(void)
 
 		if (info[2] & 0x80000)
 			feature_list |= CPU_FEATURE_SSE41;
+		if (info[2] & 0x8000000)
+			feature_list |= CPU_FEATURE_OSXSAVE;
 		if (info[2] & 0x10000000)
 			feature_list |= CPU_FEATURE_AVX;
 #if (defined SLJIT_DETECT_SSE2 && SLJIT_DETECT_SSE2)
@@ -537,11 +566,13 @@ static void get_cpu_features(void)
 	}
 
 	info[0] = 0x80000001;
-	info[2] = 0; /* Silences an incorrect compiler warning. */
 	execute_cpu_id(info);
 
 	if (info[2] & 0x20)
 		feature_list |= CPU_FEATURE_LZCNT;
+
+	if ((feature_list & CPU_FEATURE_OSXSAVE) && (execute_get_xcr0_low() & 0x4) == 0)
+		feature_list &= ~(sljit_u32)(CPU_FEATURE_AVX | CPU_FEATURE_AVX2);
 
 	cpu_feature_list = feature_list;
 }
@@ -617,51 +648,46 @@ static sljit_u8 get_jump_code(sljit_uw type)
 }
 
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-static sljit_u8* generate_far_jump_code(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_sw executable_offset);
-#else
-static sljit_u8* generate_far_jump_code(struct sljit_jump *jump, sljit_u8 *code_ptr);
-static sljit_u8* generate_put_label_code(struct sljit_put_label *put_label, sljit_u8 *code_ptr, sljit_uw max_label);
-#endif
+static sljit_u8* detect_far_jump_type(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_sw executable_offset);
+#else /* !SLJIT_CONFIG_X86_32 */
+static sljit_u8* detect_far_jump_type(struct sljit_jump *jump, sljit_u8 *code_ptr);
+static sljit_u8* generate_mov_addr_code(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_u8 *code, sljit_sw executable_offset);
+#endif /* SLJIT_CONFIG_X86_32 */
 
-static sljit_u8* generate_near_jump_code(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_u8 *code, sljit_sw executable_offset)
+static sljit_u8* detect_near_jump_type(struct sljit_jump *jump, sljit_u8 *code_ptr, sljit_u8 *code, sljit_sw executable_offset)
 {
 	sljit_uw type = jump->flags >> TYPE_SHIFT;
 	sljit_s32 short_jump;
 	sljit_uw label_addr;
 
-	if (jump->flags & JUMP_LABEL)
-		label_addr = (sljit_uw)(code + jump->u.label->size);
-	else
+	if (jump->flags & JUMP_ADDR)
 		label_addr = jump->u.target - (sljit_uw)executable_offset;
+	else
+		label_addr = (sljit_uw)(code + jump->u.label->size);
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-	if ((sljit_sw)(label_addr - (jump->addr + 2)) > HALFWORD_MAX || (sljit_sw)(label_addr - (jump->addr + 6)) < HALFWORD_MIN)
-		return generate_far_jump_code(jump, code_ptr);
-#endif
+	if ((sljit_sw)(label_addr - (sljit_uw)(code_ptr + 6)) > HALFWORD_MAX || (sljit_sw)(label_addr - (sljit_uw)(code_ptr + 5)) < HALFWORD_MIN)
+		return detect_far_jump_type(jump, code_ptr);
+#endif /* SLJIT_CONFIG_X86_64 */
 
-	short_jump = (sljit_sw)(label_addr - (jump->addr + 2)) >= -128 && (sljit_sw)(label_addr - (jump->addr + 2)) <= 127;
+	short_jump = (sljit_sw)(label_addr - (sljit_uw)(code_ptr + 2)) >= -0x80 && (sljit_sw)(label_addr - (sljit_uw)(code_ptr + 2)) <= 0x7f;
 
 	if (type == SLJIT_JUMP) {
 		if (short_jump)
 			*code_ptr++ = JMP_i8;
 		else
 			*code_ptr++ = JMP_i32;
-		jump->addr++;
-	}
-	else if (type >= SLJIT_FAST_CALL) {
+	} else if (type > SLJIT_JUMP) {
 		short_jump = 0;
 		*code_ptr++ = CALL_i32;
-		jump->addr++;
-	}
-	else if (short_jump) {
+	} else if (short_jump) {
 		*code_ptr++ = U8(get_jump_code(type) - 0x10);
-		jump->addr++;
-	}
-	else {
+	} else {
 		*code_ptr++ = GROUP_0F;
 		*code_ptr++ = get_jump_code(type);
-		jump->addr += 2;
 	}
+
+	jump->addr = (sljit_uw)code_ptr;
 
 	if (short_jump) {
 		jump->flags |= PATCH_MB;
@@ -674,7 +700,172 @@ static sljit_u8* generate_near_jump_code(struct sljit_jump *jump, sljit_u8 *code
 	return code_ptr;
 }
 
-SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler)
+static void generate_jump_or_mov_addr(struct sljit_jump *jump, sljit_sw executable_offset)
+{
+	sljit_uw flags = jump->flags;
+	sljit_uw addr = (flags & JUMP_ADDR) ? jump->u.target : jump->u.label->u.addr;
+	sljit_uw jump_addr = jump->addr;
+	SLJIT_UNUSED_ARG(executable_offset);
+
+	if (SLJIT_UNLIKELY(flags & JUMP_MOV_ADDR)) {
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
+		sljit_unaligned_store_sw((void*)(jump_addr - sizeof(sljit_sw)), (sljit_sw)addr);
+#else /* SLJIT_CONFIG_X86_32 */
+		if (flags & PATCH_MD) {
+			SLJIT_ASSERT(addr > HALFWORD_MAX);
+			sljit_unaligned_store_sw((void*)(jump_addr - sizeof(sljit_sw)), (sljit_sw)addr);
+			return;
+		}
+
+		if (flags & PATCH_MW) {
+			addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET((sljit_u8*)jump_addr, executable_offset);
+			SLJIT_ASSERT((sljit_sw)addr <= HALFWORD_MAX && (sljit_sw)addr >= HALFWORD_MIN);
+		} else {
+			SLJIT_ASSERT(addr <= HALFWORD_MAX);
+		}
+		sljit_unaligned_store_s32((void*)(jump_addr - sizeof(sljit_s32)), (sljit_s32)addr);
+#endif /* !SLJIT_CONFIG_X86_32 */
+		return;
+	}
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	if (SLJIT_UNLIKELY(flags & PATCH_MD)) {
+		SLJIT_ASSERT(!(flags & JUMP_ADDR));
+		sljit_unaligned_store_sw((void*)jump_addr, (sljit_sw)addr);
+		return;
+	}
+#endif /* SLJIT_CONFIG_X86_64 */
+
+	addr -= (sljit_uw)SLJIT_ADD_EXEC_OFFSET((sljit_u8*)jump_addr, executable_offset);
+
+	if (flags & PATCH_MB) {
+		addr -= sizeof(sljit_s8);
+		SLJIT_ASSERT((sljit_sw)addr <= 0x7f && (sljit_sw)addr >= -0x80);
+		*(sljit_u8*)jump_addr = U8(addr);
+		return;
+	} else if (flags & PATCH_MW) {
+		addr -= sizeof(sljit_s32);
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
+		sljit_unaligned_store_sw((void*)jump_addr, (sljit_sw)addr);
+#else /* !SLJIT_CONFIG_X86_32 */
+		SLJIT_ASSERT((sljit_sw)addr <= HALFWORD_MAX && (sljit_sw)addr >= HALFWORD_MIN);
+		sljit_unaligned_store_s32((void*)jump_addr, (sljit_s32)addr);
+#endif /* SLJIT_CONFIG_X86_32 */
+	}
+}
+
+static void reduce_code_size(struct sljit_compiler *compiler)
+{
+	struct sljit_label *label;
+	struct sljit_jump *jump;
+	sljit_uw next_label_size;
+	sljit_uw next_jump_addr;
+	sljit_uw next_min_addr;
+	sljit_uw size_reduce = 0;
+	sljit_sw diff;
+	sljit_uw type;
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	sljit_uw size_reduce_max;
+#endif /* SLJIT_DEBUG */
+
+	label = compiler->labels;
+	jump = compiler->jumps;
+
+	next_label_size = SLJIT_GET_NEXT_SIZE(label);
+	next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+
+	while (1) {
+		next_min_addr = next_label_size;
+		if (next_jump_addr < next_min_addr)
+			next_min_addr = next_jump_addr;
+
+		if (next_min_addr == SLJIT_MAX_ADDRESS)
+			break;
+
+		if (next_min_addr == next_label_size) {
+			label->size -= size_reduce;
+
+			label = label->next;
+			next_label_size = SLJIT_GET_NEXT_SIZE(label);
+		}
+
+		if (next_min_addr != next_jump_addr)
+			continue;
+
+		if (!(jump->flags & JUMP_MOV_ADDR)) {
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+			size_reduce_max = size_reduce + (((jump->flags >> TYPE_SHIFT) < SLJIT_JUMP) ? CJUMP_MAX_SIZE : JUMP_MAX_SIZE);
+#endif /* SLJIT_DEBUG */
+
+			if (!(jump->flags & SLJIT_REWRITABLE_JUMP)) {
+				if (jump->flags & JUMP_ADDR) {
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+					if (jump->u.target <= 0xffffffffl)
+						size_reduce += sizeof(sljit_s32);
+#endif /* SLJIT_CONFIG_X86_64 */
+				} else {
+					/* Unit size: instruction. */
+					diff = (sljit_sw)jump->u.label->size - (sljit_sw)(jump->addr - size_reduce);
+					type = jump->flags >> TYPE_SHIFT;
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+					if (type == SLJIT_JUMP) {
+						if (diff <= 0x7f + 2 && diff >= -0x80 + 2)
+							size_reduce += JUMP_MAX_SIZE - 2;
+						else if (diff <= HALFWORD_MAX + 5 && diff >= HALFWORD_MIN + 5)
+							size_reduce += JUMP_MAX_SIZE - 5;
+					} else if (type < SLJIT_JUMP) {
+						if (diff <= 0x7f + 2 && diff >= -0x80 + 2)
+							size_reduce += CJUMP_MAX_SIZE - 2;
+						else if (diff <= HALFWORD_MAX + 6 && diff >= HALFWORD_MIN + 6)
+							size_reduce += CJUMP_MAX_SIZE - 6;
+					} else  {
+						if (diff <= HALFWORD_MAX + 5 && diff >= HALFWORD_MIN + 5)
+							size_reduce += JUMP_MAX_SIZE - 5;
+					}
+#else /* !SLJIT_CONFIG_X86_64 */
+					if (type == SLJIT_JUMP) {
+						if (diff <= 0x7f + 2 && diff >= -0x80 + 2)
+							size_reduce += JUMP_MAX_SIZE - 2;
+					} else if (type < SLJIT_JUMP) {
+						if (diff <= 0x7f + 2 && diff >= -0x80 + 2)
+							size_reduce += CJUMP_MAX_SIZE - 2;
+					}
+#endif /* SLJIT_CONFIG_X86_64 */
+				}
+			}
+
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+			jump->flags |= (size_reduce_max - size_reduce) << JUMP_SIZE_SHIFT;
+#endif /* SLJIT_DEBUG */
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+		} else {
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+			size_reduce_max = size_reduce + 10;
+#endif /* SLJIT_DEBUG */
+
+			if (!(jump->flags & JUMP_ADDR)) {
+				diff = (sljit_sw)jump->u.label->size - (sljit_sw)(jump->addr - size_reduce - 3);
+
+				if (diff <= HALFWORD_MAX && diff >= HALFWORD_MIN)
+					size_reduce += 3;
+			} else if (jump->u.target <= 0xffffffffl)
+				size_reduce += (jump->flags & MOV_ADDR_HI) ? 4 : 5;
+
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+			jump->flags |= (size_reduce_max - size_reduce) << JUMP_SIZE_SHIFT;
+#endif /* SLJIT_DEBUG */
+#endif /* SLJIT_CONFIG_X86_64 */
+		}
+
+		jump = jump->next;
+		next_jump_addr = SLJIT_GET_NEXT_ADDRESS(jump);
+	}
+
+	compiler->size -= size_reduce;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compiler, sljit_s32 options, void *exec_allocator_data)
 {
 	struct sljit_memory_fragment *buf;
 	sljit_u8 *code;
@@ -683,77 +874,82 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	sljit_u8 *buf_end;
 	sljit_u8 len;
 	sljit_sw executable_offset;
-	sljit_uw jump_addr;
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	sljit_uw addr;
+#endif /* SLJIT_DEBUG */
 
 	struct sljit_label *label;
 	struct sljit_jump *jump;
 	struct sljit_const *const_;
-	struct sljit_put_label *put_label;
 
 	CHECK_ERROR_PTR();
 	CHECK_PTR(check_sljit_generate_code(compiler));
-	reverse_buf(compiler);
+
+	reduce_code_size(compiler);
 
 	/* Second code generation pass. */
-	code = (sljit_u8*)SLJIT_MALLOC_EXEC(compiler->size, compiler->exec_allocator_data);
+	code = (sljit_u8*)allocate_executable_memory(compiler->size, options, exec_allocator_data, &executable_offset);
 	PTR_FAIL_WITH_EXEC_IF(code);
+
+	reverse_buf(compiler);
 	buf = compiler->buf;
 
 	code_ptr = code;
 	label = compiler->labels;
 	jump = compiler->jumps;
 	const_ = compiler->consts;
-	put_label = compiler->put_labels;
-	executable_offset = SLJIT_EXEC_OFFSET(code);
 
 	do {
 		buf_ptr = buf->memory;
 		buf_end = buf_ptr + buf->used_size;
 		do {
 			len = *buf_ptr++;
-			if (len > 0) {
+			SLJIT_ASSERT(len > 0);
+			if (len < SLJIT_INST_CONST) {
 				/* The code is already generated. */
 				SLJIT_MEMCPY(code_ptr, buf_ptr, len);
 				code_ptr += len;
 				buf_ptr += len;
-			}
-			else {
-				switch (*buf_ptr) {
-				case 0:
-					label->addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
+			} else {
+				switch (len) {
+				case SLJIT_INST_LABEL:
+					label->u.addr = (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code_ptr, executable_offset);
 					label->size = (sljit_uw)(code_ptr - code);
 					label = label->next;
 					break;
-				case 1:
-					jump->addr = (sljit_uw)code_ptr;
+				case SLJIT_INST_JUMP:
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+					addr = (sljit_uw)code_ptr;
+#endif /* SLJIT_DEBUG */
 					if (!(jump->flags & SLJIT_REWRITABLE_JUMP))
-						code_ptr = generate_near_jump_code(jump, code_ptr, code, executable_offset);
+						code_ptr = detect_near_jump_type(jump, code_ptr, code, executable_offset);
 					else {
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-						code_ptr = generate_far_jump_code(jump, code_ptr, executable_offset);
-#else
-						code_ptr = generate_far_jump_code(jump, code_ptr);
-#endif
+						code_ptr = detect_far_jump_type(jump, code_ptr, executable_offset);
+#else /* !SLJIT_CONFIG_X86_32 */
+						code_ptr = detect_far_jump_type(jump, code_ptr);
+#endif /* SLJIT_CONFIG_X86_32 */
 					}
+
+					SLJIT_ASSERT((sljit_uw)code_ptr - addr <= ((jump->flags >> JUMP_SIZE_SHIFT) & 0x1f));
 					jump = jump->next;
 					break;
-				case 2:
+				case SLJIT_INST_MOV_ADDR:
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+					code_ptr = generate_mov_addr_code(jump, code_ptr, code, executable_offset);
+#endif /* SLJIT_CONFIG_X86_64 */
+					jump->addr = (sljit_uw)code_ptr;
+					jump = jump->next;
+					break;
+				default:
+					SLJIT_ASSERT(len == SLJIT_INST_CONST);
 					const_->addr = ((sljit_uw)code_ptr) - sizeof(sljit_sw);
 					const_ = const_->next;
 					break;
-				default:
-					SLJIT_ASSERT(*buf_ptr == 3);
-					SLJIT_ASSERT(put_label->label);
-					put_label->addr = (sljit_uw)code_ptr;
-#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-					code_ptr = generate_put_label_code(put_label, code_ptr, (sljit_uw)SLJIT_ADD_EXEC_OFFSET(code, executable_offset) + put_label->label->size);
-#endif
-					put_label = put_label->next;
-					break;
 				}
-				buf_ptr++;
 			}
 		} while (buf_ptr < buf_end);
+
 		SLJIT_ASSERT(buf_ptr == buf_end);
 		buf = buf->next;
 	} while (buf);
@@ -761,59 +957,12 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	SLJIT_ASSERT(!label);
 	SLJIT_ASSERT(!jump);
 	SLJIT_ASSERT(!const_);
-	SLJIT_ASSERT(!put_label);
 	SLJIT_ASSERT(code_ptr <= code + compiler->size);
 
 	jump = compiler->jumps;
 	while (jump) {
-		if (jump->flags & (PATCH_MB | PATCH_MW)) {
-			if (jump->flags & JUMP_LABEL)
-				jump_addr = jump->u.label->addr;
-			else
-				jump_addr = jump->u.target;
-
-			jump_addr -= jump->addr + (sljit_uw)executable_offset;
-
-			if (jump->flags & PATCH_MB) {
-				jump_addr -= sizeof(sljit_s8);
-				SLJIT_ASSERT((sljit_sw)jump_addr >= -128 && (sljit_sw)jump_addr <= 127);
-				*(sljit_u8*)jump->addr = U8(jump_addr);
-			} else {
-				jump_addr -= sizeof(sljit_s32);
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-				sljit_unaligned_store_sw((void*)jump->addr, (sljit_sw)jump_addr);
-#else
-				SLJIT_ASSERT((sljit_sw)jump_addr >= HALFWORD_MIN && (sljit_sw)jump_addr <= HALFWORD_MAX);
-				sljit_unaligned_store_s32((void*)jump->addr, (sljit_s32)jump_addr);
-#endif
-			}
-		}
-#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-		else if (jump->flags & PATCH_MD) {
-				SLJIT_ASSERT(jump->flags & JUMP_LABEL);
-				sljit_unaligned_store_sw((void*)jump->addr, (sljit_sw)jump->u.label->addr);
-		}
-#endif
-
+		generate_jump_or_mov_addr(jump, executable_offset);
 		jump = jump->next;
-	}
-
-	put_label = compiler->put_labels;
-	while (put_label) {
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-		sljit_unaligned_store_sw((void*)(put_label->addr - sizeof(sljit_sw)), (sljit_sw)put_label->label->addr);
-#else
-		if (put_label->flags & PATCH_MD) {
-			SLJIT_ASSERT(put_label->label->addr > HALFWORD_MAX);
-			sljit_unaligned_store_sw((void*)(put_label->addr - sizeof(sljit_sw)), (sljit_sw)put_label->label->addr);
-		}
-		else {
-			SLJIT_ASSERT(put_label->label->addr <= HALFWORD_MAX);
-			sljit_unaligned_store_s32((void*)(put_label->addr - sizeof(sljit_s32)), (sljit_s32)put_label->label->addr);
-		}
-#endif
-
-		put_label = put_label->next;
 	}
 
 	compiler->error = SLJIT_ERR_COMPILED;
@@ -921,8 +1070,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_cmp_info(sljit_s32 type)
 			BINARY_IMM32(op_imm, immw, arg, argw); \
 		} \
 		else { \
-			FAIL_IF(emit_load_imm64(compiler, (arg == TMP_REG1) ? TMP_REG2 : TMP_REG1, immw)); \
-			inst = emit_x86_instruction(compiler, 1, (arg == TMP_REG1) ? TMP_REG2 : TMP_REG1, 0, arg, argw); \
+			FAIL_IF(emit_load_imm64(compiler, FAST_IS_REG(arg) ? TMP_REG2 : TMP_REG1, immw)); \
+			inst = emit_x86_instruction(compiler, 1, FAST_IS_REG(arg) ? TMP_REG2 : TMP_REG1, 0, arg, argw); \
 			FAIL_IF(!inst); \
 			*inst = (op_mr); \
 		} \
@@ -2248,10 +2397,9 @@ static sljit_s32 emit_test_binary(struct sljit_compiler *compiler,
 				inst = emit_x86_instruction(compiler, 1, SLJIT_IMM, src2w, src1, src1w);
 				FAIL_IF(!inst);
 				*inst = GROUP_F7;
-			}
-			else {
-				FAIL_IF(emit_load_imm64(compiler, TMP_REG1, src2w));
-				inst = emit_x86_instruction(compiler, 1, TMP_REG1, 0, src1, src1w);
+			} else {
+				FAIL_IF(emit_load_imm64(compiler, FAST_IS_REG(src1) ? TMP_REG2 : TMP_REG1, src2w));
+				inst = emit_x86_instruction(compiler, 1, FAST_IS_REG(src1) ? TMP_REG2 : TMP_REG1, 0, src1, src1w);
 				FAIL_IF(!inst);
 				*inst = TEST_rm_r;
 			}
@@ -2488,8 +2636,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2(struct sljit_compiler *compile
 	compiler->mode32 = op & SLJIT_32;
 #endif
 
-	SLJIT_ASSERT(dst != TMP_REG1 || HAS_FLAGS(op));
-
 	switch (GET_OPCODE(op)) {
 	case SLJIT_ADD:
 		if (!HAS_FLAGS(op)) {
@@ -2583,10 +2729,42 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2u(struct sljit_compiler *compil
 	compiler->mode32 = op & SLJIT_32;
 #endif
 
-	if (opcode == SLJIT_SUB) {
+	if (opcode == SLJIT_SUB)
 		return emit_cmp_binary(compiler, src1, src1w, src2, src2w);
-	}
+
 	return emit_test_binary(compiler, src1, src1w, src2, src2w);
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2r(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 dst_reg,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w)
+{
+	sljit_u8* inst;
+	sljit_sw dstw = 0;
+
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_op2r(compiler, op, dst_reg, src1, src1w, src2, src2w));
+	ADJUST_LOCAL_OFFSET(src1, src1w);
+	ADJUST_LOCAL_OFFSET(src2, src2w);
+
+	CHECK_EXTRA_REGS(dst_reg, dstw, (void)0);
+	CHECK_EXTRA_REGS(src1, src1w, (void)0);
+	CHECK_EXTRA_REGS(src2, src2w, (void)0);
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = op & SLJIT_32;
+#endif
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MULADD:
+		FAIL_IF(emit_mul(compiler, TMP_REG1, 0, src1, src1w, src2, src2w));
+		inst = emit_x86_instruction(compiler, 1, TMP_REG1, 0, dst_reg, dstw);
+		FAIL_IF(!inst);
+		*inst = ADD_rm_r;
+		return SLJIT_SUCCESS;
+	}
+
+	return SLJIT_SUCCESS;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_shift_into(struct sljit_compiler *compiler, sljit_s32 op,
@@ -3117,19 +3295,17 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 		dst_r = dst;
 		if (dst == src1)
 			; /* Do nothing here. */
-		else if (dst == src2 && (op == SLJIT_ADD_F64 || op == SLJIT_MUL_F64)) {
+		else if (dst == src2 && (GET_OPCODE(op) == SLJIT_ADD_F64 || GET_OPCODE(op) == SLJIT_MUL_F64)) {
 			/* Swap arguments. */
 			src2 = src1;
 			src2w = src1w;
-		}
-		else if (dst != src2)
+		} else if (dst != src2)
 			FAIL_IF(emit_sse2_load(compiler, op & SLJIT_32, dst_r, src1, src1w));
 		else {
 			dst_r = TMP_FREG;
 			FAIL_IF(emit_sse2_load(compiler, op & SLJIT_32, TMP_FREG, src1, src1w));
 		}
-	}
-	else {
+	} else {
 		dst_r = TMP_FREG;
 		FAIL_IF(emit_sse2_load(compiler, op & SLJIT_32, TMP_FREG, src1, src1w));
 	}
@@ -3152,7 +3328,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop2(struct sljit_compiler *compil
 		break;
 	}
 
-	if (dst_r == TMP_FREG)
+	if (dst_r != dst)
 		return emit_sse2_store(compiler, op & SLJIT_32, dst, dstw, TMP_FREG);
 	return SLJIT_SUCCESS;
 }
@@ -3215,10 +3391,9 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_label* sljit_emit_label(struct sljit_compi
 	PTR_FAIL_IF(!label);
 	set_label(label, compiler);
 
-	inst = (sljit_u8*)ensure_buf(compiler, 2);
+	inst = (sljit_u8*)ensure_buf(compiler, 1);
 	PTR_FAIL_IF(!inst);
-	inst[0] = 0;
-	inst[1] = 0;
+	inst[0] = SLJIT_INST_LABEL;
 
 	return label;
 }
@@ -3236,18 +3411,13 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compile
 	set_jump(jump, compiler, (sljit_u32)((type & SLJIT_REWRITABLE_JUMP) | ((type & 0xff) << TYPE_SHIFT)));
 	type &= 0xff;
 
+	jump->addr = compiler->size;
 	/* Worst case size. */
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-	compiler->size += (type >= SLJIT_JUMP) ? 5 : 6;
-#else
-	compiler->size += (type >= SLJIT_JUMP) ? (10 + 3) : (2 + 10 + 3);
-#endif
-
-	inst = (sljit_u8*)ensure_buf(compiler, 2);
+	compiler->size += (type >= SLJIT_JUMP) ? JUMP_MAX_SIZE : CJUMP_MAX_SIZE;
+	inst = (sljit_u8*)ensure_buf(compiler, 1);
 	PTR_FAIL_IF_NULL(inst);
 
-	inst[0] = 0;
-	inst[1] = 1;
+	inst[0] = SLJIT_INST_JUMP;
 	return jump;
 }
 
@@ -3268,20 +3438,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_ijump(struct sljit_compiler *compi
 		set_jump(jump, compiler, (sljit_u32)(JUMP_ADDR | (type << TYPE_SHIFT)));
 		jump->u.target = (sljit_uw)srcw;
 
+		jump->addr = compiler->size;
 		/* Worst case size. */
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-		compiler->size += 5;
-#else
-		compiler->size += 10 + 3;
-#endif
-
-		inst = (sljit_u8*)ensure_buf(compiler, 2);
+		compiler->size += JUMP_MAX_SIZE;
+		inst = (sljit_u8*)ensure_buf(compiler, 1);
 		FAIL_IF_NULL(inst);
 
-		inst[0] = 0;
-		inst[1] = 1;
-	}
-	else {
+		inst[0] = SLJIT_INST_JUMP;
+	} else {
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 		/* REX_W is not necessary (src is not immediate). */
 		compiler->mode32 = 1;
@@ -3414,82 +3578,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_flags(struct sljit_compiler *co
 #endif /* SLJIT_CONFIG_X86_64 */
 }
 
-SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_select(struct sljit_compiler *compiler, sljit_s32 type,
-	sljit_s32 dst_reg,
-	sljit_s32 src1, sljit_sw src1w,
-	sljit_s32 src2_reg)
-{
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-	sljit_s32 dst = dst_reg;
-	sljit_sw dstw = 0;
-#endif /* SLJIT_CONFIG_X86_32 */
-	sljit_sw src2w = 0;
-
-	CHECK_ERROR();
-	CHECK(check_sljit_emit_select(compiler, type, dst_reg, src1, src1w, src2_reg));
-
-	ADJUST_LOCAL_OFFSET(src1, src1w);
-
-	CHECK_EXTRA_REGS(dst, dstw, (void)0);
-	CHECK_EXTRA_REGS(src1, src1w, (void)0);
-	CHECK_EXTRA_REGS(src2_reg, src2w, (void)0);
-
-#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-	compiler->mode32 = type & SLJIT_32;
-#endif /* SLJIT_CONFIG_X86_64 */
-	type &= ~SLJIT_32;
-
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-	if (dst & SLJIT_MEM) {
-		if (src1 == SLJIT_IMM || (!(src1 & SLJIT_MEM) && (src2_reg & SLJIT_MEM))) {
-			EMIT_MOV(compiler, TMP_REG1, 0, src1, src1w);
-			src1 = src2_reg;
-			src1w = src2w;
-			type ^= 0x1;
-		} else
-			EMIT_MOV(compiler, TMP_REG1, 0, src2_reg, src2w);
-
-		dst_reg = TMP_REG1;
-	} else {
-#endif /* SLJIT_CONFIG_X86_32 */
-		if (dst_reg != src2_reg) {
-			if (dst_reg == src1) {
-				src1 = src2_reg;
-				src1w = src2w;
-				type ^= 0x1;
-			} else {
-				if (ADDRESSING_DEPENDS_ON(src1, dst_reg)) {
-					EMIT_MOV(compiler, dst_reg, 0, src1, src1w);
-					src1 = src2_reg;
-					src1w = src2w;
-					type ^= 0x1;
-				} else
-					EMIT_MOV(compiler, dst_reg, 0, src2_reg, src2w);
-			}
-		}
-
-		if (SLJIT_UNLIKELY(src1 == SLJIT_IMM)) {
-			SLJIT_ASSERT(dst_reg != TMP_REG1);
-			EMIT_MOV(compiler, TMP_REG1, 0, src1, src1w);
-			src1 = TMP_REG1;
-			src1w = 0;
-		}
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-	}
-#endif /* SLJIT_CONFIG_X86_32 */
-
-	if (sljit_has_cpu_feature(SLJIT_HAS_CMOV))
-		FAIL_IF(emit_groupf(compiler, U8(get_jump_code((sljit_uw)type) - 0x40), dst_reg, src1, src1w));
-	else
-		FAIL_IF(emit_cmov_generic(compiler, type, dst_reg, src1, src1w));
-
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-	if (dst_reg == TMP_REG1)
-		return emit_mov(compiler, dst, dstw, TMP_REG1, 0);
-#endif /* SLJIT_CONFIG_X86_32 */
-	return SLJIT_SUCCESS;
-}
-
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fselect(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 dst_freg,
 	sljit_s32 src1, sljit_sw src1w,
@@ -3581,7 +3669,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_mov(struct sljit_compiler *co
 	if (type & SLJIT_SIMD_TEST)
 		return SLJIT_SUCCESS;
 
-	if (op & VEX_256)
+	if ((op & VEX_256) || ((cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX)))
 		return emit_vex_instruction(compiler, op, freg, 0, srcdst, srcdstw);
 
 	return emit_groupf(compiler, op, freg, srcdst, srcdstw);
@@ -3593,9 +3681,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 {
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_s32 use_vex = (cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX);
 	sljit_u8 *inst;
 	sljit_u8 opcode = 0;
-	sljit_uw size;
+	sljit_uw op;
 
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_simd_replicate(compiler, type, freg, src, srcw));
@@ -3616,20 +3705,55 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 		return SLJIT_ERR_UNSUPPORTED;
 #endif /* SLJIT_CONFIG_X86_32 */
 
-	if (cpu_feature_list & CPU_FEATURE_AVX2) {
-		if (reg_size < 4 || reg_size > 5)
-			return SLJIT_ERR_UNSUPPORTED;
+	if (reg_size != 4 && (reg_size != 5 || !(cpu_feature_list & CPU_FEATURE_AVX2)))
+		return SLJIT_ERR_UNSUPPORTED;
 
-		if (src != SLJIT_IMM && (reg_size == 5 || elem_size < 3 || !(type & SLJIT_SIMD_FLOAT))) {
-			if (type & SLJIT_SIMD_TEST)
-				return SLJIT_SUCCESS;
+	if (type & SLJIT_SIMD_TEST)
+		return SLJIT_SUCCESS;
 
+	if (reg_size == 5)
+		use_vex = 1;
+
+	if (use_vex && src != SLJIT_IMM) {
+		op = 0;
+
+		switch (elem_size) {
+		case 0:
+			if (cpu_feature_list & CPU_FEATURE_AVX2)
+				op = VPBROADCASTB_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+			break;
+		case 1:
+			if (cpu_feature_list & CPU_FEATURE_AVX2)
+				op = VPBROADCASTW_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+			break;
+		case 2:
+			if (type & SLJIT_SIMD_FLOAT) {
+				if ((cpu_feature_list & CPU_FEATURE_AVX2) || ((cpu_feature_list & CPU_FEATURE_AVX) && (src & SLJIT_MEM)))
+					op = VBROADCASTSS_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+			} else if (cpu_feature_list & CPU_FEATURE_AVX2)
+				op = VPBROADCASTD_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+			break;
+		default:
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+			if (!(type & SLJIT_SIMD_FLOAT)) {
+				if (cpu_feature_list & CPU_FEATURE_AVX2)
+					op = VPBROADCASTQ_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+				break;
+			}
+#endif /* SLJIT_CONFIG_X86_64 */
+
+			if (reg_size == 5)
+				op = VBROADCASTSD_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
+			break;
+		}
+
+		if (op != 0) {
 			if (!(src & SLJIT_MEM) && !(type & SLJIT_SIMD_FLOAT)) {
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 				if (elem_size >= 3)
 					compiler->mode32 = 0;
 #endif /* SLJIT_CONFIG_X86_64 */
-				FAIL_IF(emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, freg, src, srcw));
+				FAIL_IF(emit_vex_instruction(compiler, MOVD_x_rm | VEX_AUTO_W | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, src, srcw));
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 				compiler->mode32 = 1;
 #endif /* SLJIT_CONFIG_X86_64 */
@@ -3637,42 +3761,30 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 				srcw = 0;
 			}
 
-			switch (elem_size) {
-			case 0:
-				size = VPBROADCASTB_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
-				break;
-			case 1:
-				size = VPBROADCASTW_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
-				break;
-			case 2:
-				size = ((type & SLJIT_SIMD_FLOAT) ? VBROADCASTSS_x_xm : VPBROADCASTD_x_xm) | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
-				break;
-			default:
-#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-				size = VBROADCASTSD_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
-#else /* !SLJIT_CONFIG_X86_32 */
-				size = ((type & SLJIT_SIMD_FLOAT) ? VBROADCASTSD_x_xm : VPBROADCASTQ_x_xm) | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
-#endif /* SLJIT_CONFIG_X86_32 */
-				break;
-			}
-
 			if (reg_size == 5)
-				size |= VEX_256;
+				op |= VEX_256;
 
-			return emit_vex_instruction(compiler, size, freg, 0, src, srcw);
+			return emit_vex_instruction(compiler, op, freg, 0, src, srcw);
 		}
-	} else if (reg_size != 4)
-		return SLJIT_ERR_UNSUPPORTED;
-
-	if (type & SLJIT_SIMD_TEST)
-		return SLJIT_SUCCESS;
+	}
 
 	if (type & SLJIT_SIMD_FLOAT) {
 		if (src == SLJIT_IMM) {
-			if (reg_size == 5)
-				return emit_vex_instruction(compiler, XORPD_x_xm | VEX_256 | (elem_size == 3 ? EX86_PREF_66 : 0) | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, freg, 0);
+			if (use_vex)
+				return emit_vex_instruction(compiler, XORPD_x_xm | (reg_size == 5 ? VEX_256 : 0) | (elem_size == 3 ? EX86_PREF_66 : 0) | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, freg, 0);
 
 			return emit_groupf(compiler, XORPD_x_xm | (elem_size == 3 ? EX86_PREF_66 : 0) | EX86_SSE2, freg, freg, 0);
+		}
+
+		SLJIT_ASSERT(reg_size == 4);
+
+		if (use_vex) {
+			if (elem_size == 3)
+				return emit_vex_instruction(compiler, MOVDDUP_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, 0, src, srcw);
+
+			SLJIT_ASSERT(!(src & SLJIT_MEM));
+			FAIL_IF(emit_vex_instruction(compiler, SHUFPS_x_xm | EX86_SSE2 | VEX_SSE2_OPV, freg, src, src, 0));
+			return emit_byte(compiler, 0);
 		}
 
 		if (elem_size == 2 && freg != src) {
@@ -3681,7 +3793,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 			srcw = 0;
 		}
 
-		FAIL_IF(emit_groupf(compiler, (elem_size == 2 ? SHUFPS_x_xm : MOVDDUP_x_xm) | (elem_size == 2 ? 0 : EX86_PREF_F2) | EX86_SSE2, freg, src, srcw));
+		op = (elem_size == 2 ? SHUFPS_x_xm : MOVDDUP_x_xm) | (elem_size == 2 ? 0 : EX86_PREF_F2) | EX86_SSE2;
+		FAIL_IF(emit_groupf(compiler, op, freg, src, srcw));
 
 		if (elem_size == 2)
 			return emit_byte(compiler, 0);
@@ -3706,8 +3819,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 #endif /* SLJIT_CONFIG_X86_64 */
 
 		if (srcw == 0 || srcw == -1) {
-			if (reg_size == 5)
-				return emit_vex_instruction(compiler, (srcw == 0 ? PXOR_x_xm : PCMPEQD_x_xm) | VEX_256 | EX86_PREF_66 | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, freg, 0);
+			if (use_vex)
+				return emit_vex_instruction(compiler, (srcw == 0 ? PXOR_x_xm : PCMPEQD_x_xm) | (reg_size == 5 ? VEX_256 : 0) | EX86_PREF_66 | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, freg, 0);
 
 			return emit_groupf(compiler, (srcw == 0 ? PXOR_x_xm : PCMPEQD_x_xm) | EX86_PREF_66 | EX86_SSE2, freg, freg, 0);
 		}
@@ -3721,16 +3834,17 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 
 		src = TMP_REG1;
 		srcw = 0;
+
 	}
 
-	size = 2;
+	op = 2;
 	opcode = MOVD_x_rm;
 
 	switch (elem_size) {
 	case 0:
 		if (!FAST_IS_REG(src)) {
 			opcode = 0x3a /* Prefix of PINSRB_x_rm_i8. */;
-			size = 3;
+			op = 3;
 		}
 		break;
 	case 1:
@@ -3747,44 +3861,66 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 #endif /* SLJIT_CONFIG_X86_64 */
 	}
 
-	inst = emit_x86_instruction(compiler, size | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, src, srcw);
-	FAIL_IF(!inst);
-	inst[0] = GROUP_0F;
-	inst[1] = opcode;
+	if (use_vex) {
+		if (opcode != MOVD_x_rm) {
+			op = (opcode == 0x3a) ? (PINSRB_x_rm_i8 | VEX_OP_0F3A) : opcode;
+			FAIL_IF(emit_vex_instruction(compiler, op | EX86_PREF_66 | EX86_SSE2_OP1 | VEX_SSE2_OPV, freg, freg, src, srcw));
+		} else
+			FAIL_IF(emit_vex_instruction(compiler, MOVD_x_rm | VEX_AUTO_W | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, src, srcw));
+	} else {
+		inst = emit_x86_instruction(compiler, op | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, src, srcw);
+		FAIL_IF(!inst);
+		inst[0] = GROUP_0F;
+		inst[1] = opcode;
 
-	if (reg_size == 5) {
-		SLJIT_ASSERT(opcode == MOVD_x_rm);
+		if (op == 3) {
+			SLJIT_ASSERT(opcode == 0x3a);
+			inst[2] = PINSRB_x_rm_i8;
+		}
+	}
+
+	if (use_vex && elem_size >= 2) {
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-		size = VPBROADCASTD_x_xm;
+		op = VPBROADCASTD_x_xm;
 #else /* !SLJIT_CONFIG_X86_32 */
-		size = (elem_size == 3) ? VPBROADCASTQ_x_xm : VPBROADCASTD_x_xm;
+		op = (elem_size == 3) ? VPBROADCASTQ_x_xm : VPBROADCASTD_x_xm;
 #endif /* SLJIT_CONFIG_X86_32 */
-		return emit_vex_instruction(compiler, size | VEX_256 | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, freg, 0);
+		return emit_vex_instruction(compiler, op | ((reg_size == 5) ? VEX_256 : 0) | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, freg, 0);
 	}
 
-	if (size == 3) {
-		SLJIT_ASSERT(opcode == 0x3a);
-		inst[2] = PINSRB_x_rm_i8;
-	}
+	SLJIT_ASSERT(reg_size == 4);
 
 	if (opcode != MOVD_x_rm)
 		FAIL_IF(emit_byte(compiler, 0));
 
 	switch (elem_size) {
 	case 0:
+		if (use_vex) {
+			FAIL_IF(emit_vex_instruction(compiler, PXOR_x_xm | EX86_PREF_66 | EX86_SSE2 | VEX_SSE2_OPV, TMP_FREG, TMP_FREG, TMP_FREG, 0));
+			return emit_vex_instruction(compiler, PSHUFB_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, TMP_FREG, 0);
+		}
 		FAIL_IF(emit_groupf(compiler, PXOR_x_xm | EX86_PREF_66 | EX86_SSE2, TMP_FREG, TMP_FREG, 0));
 		return emit_groupf_ext(compiler, PSHUFB_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, TMP_FREG, 0);
 	case 1:
-		FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, freg, 0));
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, PSHUFLW_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, 0, freg, 0));
+		else
+			FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, freg, 0));
 		FAIL_IF(emit_byte(compiler, 0));
 		/* fallthrough */
 	default:
-		FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, freg, 0));
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, 0, freg, 0));
+		else
+			FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, freg, 0));
 		return emit_byte(compiler, 0);
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	case 3:
 		compiler->mode32 = 1;
-		FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, freg, 0));
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, 0, freg, 0));
+		else
+			FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, freg, 0));
 		return emit_byte(compiler, 0x44);
 #endif /* SLJIT_CONFIG_X86_64 */
 	}
@@ -3796,9 +3932,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 {
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_s32 use_vex = (cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX);
 	sljit_u8 *inst;
 	sljit_u8 opcode = 0;
-	sljit_uw size;
+	sljit_uw op;
 	sljit_s32 freg_orig = freg;
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
 	sljit_s32 srcdst_is_ereg = 0;
@@ -3814,6 +3951,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 	if (reg_size == 5) {
 		if (!(cpu_feature_list & CPU_FEATURE_AVX2))
 			return SLJIT_ERR_UNSUPPORTED;
+		use_vex = 1;
 	} else if (reg_size != 4)
 		return SLJIT_ERR_UNSUPPORTED;
 
@@ -3865,20 +4003,23 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 				}
 
 				if (elem_size == 2) {
-					if (reg_size == 4)
-						return emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, freg, srcdst, srcdstw);
-					return emit_vex_instruction(compiler, MOVD_x_rm | VEX_AUTO_W | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, srcdst, srcdstw);
+					if (use_vex)
+						return emit_vex_instruction(compiler, MOVD_x_rm | VEX_AUTO_W | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, srcdst, srcdstw);
+					return emit_groupf(compiler, MOVD_x_rm | EX86_PREF_66 | EX86_SSE2_OP1, freg, srcdst, srcdstw);
 				}
 			} else if (srcdst & SLJIT_MEM) {
 				SLJIT_ASSERT(elem_size == 2 || elem_size == 3);
 
-				if (reg_size == 4)
-					return emit_groupf(compiler, MOVSD_x_xm | (elem_size == 2 ? EX86_PREF_F3 : EX86_PREF_F2) | EX86_SSE2, freg, srcdst, srcdstw);
-				return emit_vex_instruction(compiler, MOVSD_x_xm | (elem_size == 2 ? EX86_PREF_F3 : EX86_PREF_F2) | EX86_SSE2, freg, 0, srcdst, srcdstw);
+				if (use_vex)
+					return emit_vex_instruction(compiler, MOVSD_x_xm | (elem_size == 2 ? EX86_PREF_F3 : EX86_PREF_F2) | EX86_SSE2, freg, 0, srcdst, srcdstw);
+				return emit_groupf(compiler, MOVSD_x_xm | (elem_size == 2 ? EX86_PREF_F3 : EX86_PREF_F2) | EX86_SSE2, freg, srcdst, srcdstw);
 			} else if (elem_size == 3) {
-				if (reg_size == 4)
-					return emit_groupf(compiler, MOVQ_x_xm | EX86_PREF_F3 | EX86_SSE2, freg, srcdst, 0);
-				return emit_vex_instruction(compiler, MOVQ_x_xm | EX86_PREF_F3 | EX86_SSE2, freg, 0, srcdst, 0);
+				if (use_vex)
+					return emit_vex_instruction(compiler, MOVQ_x_xm | EX86_PREF_F3 | EX86_SSE2, freg, 0, srcdst, 0);
+				return emit_groupf(compiler, MOVQ_x_xm | EX86_PREF_F3 | EX86_SSE2, freg, srcdst, 0);
+			} else if (use_vex) {
+				FAIL_IF(emit_vex_instruction(compiler, XORPD_x_xm | EX86_SSE2 | VEX_SSE2_OPV, TMP_FREG, TMP_FREG, TMP_FREG, 0));
+				return emit_vex_instruction(compiler, MOVSD_x_xm | EX86_PREF_F3 | EX86_SSE2 | VEX_SSE2_OPV, freg, TMP_FREG, srcdst, 0);
 			}
 		}
 
@@ -3886,18 +4027,21 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 			freg = TMP_FREG;
 			lane_index -= (1 << (4 - elem_size));
 		} else if ((type & SLJIT_SIMD_FLOAT) && freg == srcdst) {
-			FAIL_IF(emit_sse2_load(compiler, elem_size == 2, TMP_FREG, srcdst, srcdstw));
+			if (use_vex)
+				FAIL_IF(emit_vex_instruction(compiler, MOVSD_x_xm | (elem_size == 2 ? EX86_PREF_F3 : EX86_PREF_F2) | EX86_SSE2 | VEX_SSE2_OPV, TMP_FREG, TMP_FREG, srcdst, srcdstw));
+			else
+				FAIL_IF(emit_sse2_load(compiler, elem_size == 2, TMP_FREG, srcdst, srcdstw));
 			srcdst = TMP_FREG;
 			srcdstw = 0;
 		}
 
-		size = ((!(type & SLJIT_SIMD_FLOAT) || elem_size != 2) ? EX86_PREF_66 : 0)
+		op = ((!(type & SLJIT_SIMD_FLOAT) || elem_size != 2) ? EX86_PREF_66 : 0)
 			| ((type & SLJIT_SIMD_FLOAT) ? XORPD_x_xm : PXOR_x_xm) | EX86_SSE2;
 
-		if (reg_size == 5)
-			FAIL_IF(emit_vex_instruction(compiler,  size | VEX_256 | VEX_SSE2_OPV, freg, freg, freg, 0));
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, op | (reg_size == 5 ? VEX_256 : 0) | VEX_SSE2_OPV, freg, freg, freg, 0));
 		else
-			FAIL_IF(emit_groupf(compiler, size, freg, freg, 0));
+			FAIL_IF(emit_groupf(compiler, op, freg, freg, 0));
 	} else if (reg_size == 5 && lane_index >= (1 << (4 - elem_size))) {
 		FAIL_IF(emit_vex_instruction(compiler, ((type & SLJIT_SIMD_FLOAT) ? VEXTRACTF128_x_ym : VEXTRACTI128_x_ym) | VEX_256 | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2, freg, 0, TMP_FREG, 0));
 		FAIL_IF(emit_byte(compiler, 1));
@@ -3910,58 +4054,80 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 		if (elem_size == 3) {
 			if (srcdst & SLJIT_MEM) {
 				if (type & SLJIT_SIMD_STORE)
-					size = lane_index == 0 ? MOVLPD_m_x : MOVHPD_m_x;
+					op = lane_index == 0 ? MOVLPD_m_x : MOVHPD_m_x;
 				else
-					size = lane_index == 0 ? MOVLPD_x_m : MOVHPD_x_m;
+					op = lane_index == 0 ? MOVLPD_x_m : MOVHPD_x_m;
 
-				FAIL_IF(emit_groupf(compiler, size | EX86_PREF_66 | EX86_SSE2, freg, srcdst, srcdstw));
+				/* VEX prefix clears upper bits of the target register. */
+				if (use_vex && ((type & SLJIT_SIMD_STORE) || reg_size == 4 || freg == TMP_FREG))
+					FAIL_IF(emit_vex_instruction(compiler, op | EX86_PREF_66 | EX86_SSE2
+						| ((type & SLJIT_SIMD_STORE) ? 0 : VEX_SSE2_OPV), freg, (type & SLJIT_SIMD_STORE) ? 0 : freg, srcdst, srcdstw));
+				else
+					FAIL_IF(emit_groupf(compiler, op | EX86_PREF_66 | EX86_SSE2, freg, srcdst, srcdstw));
 
 				/* In case of store, freg is not TMP_FREG. */
 			} else if (type & SLJIT_SIMD_STORE) {
-				if (lane_index == 1)
+				if (lane_index == 1) {
+					if (use_vex)
+						return emit_vex_instruction(compiler, MOVHLPS_x_x | EX86_SSE2 | VEX_SSE2_OPV, srcdst, srcdst, freg, 0);
 					return emit_groupf(compiler, MOVHLPS_x_x | EX86_SSE2, srcdst, freg, 0);
+				}
+				if (use_vex)
+					return emit_vex_instruction(compiler, MOVSD_x_xm | EX86_PREF_F2 | EX86_SSE2 | VEX_SSE2_OPV, srcdst, srcdst, freg, 0);
 				return emit_sse2_load(compiler, 0, srcdst, freg, 0);
+			} else if (use_vex && (reg_size == 4 || freg == TMP_FREG)) {
+				if (lane_index == 1)
+					FAIL_IF(emit_vex_instruction(compiler, MOVLHPS_x_x | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, srcdst, 0));
+				else
+					FAIL_IF(emit_vex_instruction(compiler, MOVSD_x_xm | EX86_PREF_F2 | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, srcdst, 0));
 			} else {
 				if (lane_index == 1)
 					FAIL_IF(emit_groupf(compiler, MOVLHPS_x_x | EX86_SSE2, freg, srcdst, 0));
 				else
-					FAIL_IF(emit_sse2_store(compiler, 0, freg, 0, srcdst));
+					FAIL_IF(emit_sse2_load(compiler, 0, freg, srcdst, 0));
 			}
 		} else if (type & SLJIT_SIMD_STORE) {
-			if (lane_index == 0)
+			if (lane_index == 0) {
+				if (use_vex)
+					return emit_vex_instruction(compiler, ((srcdst & SLJIT_MEM) ? MOVSD_xm_x : MOVSD_x_xm) | EX86_PREF_F3 | EX86_SSE2
+						| ((srcdst & SLJIT_MEM) ? 0 : VEX_SSE2_OPV), freg, ((srcdst & SLJIT_MEM) ? 0 : freg), srcdst, srcdstw);
 				return emit_sse2_store(compiler, 1, srcdst, srcdstw, freg);
+			}
 
 			if (srcdst & SLJIT_MEM) {
-				FAIL_IF(emit_groupf_ext(compiler, EXTRACTPS_x_xm | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2, freg, srcdst, srcdstw));
+				if (use_vex)
+					FAIL_IF(emit_vex_instruction(compiler, EXTRACTPS_x_xm | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2, freg, 0, srcdst, srcdstw));
+				else
+					FAIL_IF(emit_groupf_ext(compiler, EXTRACTPS_x_xm | EX86_PREF_66 | VEX_OP_0F3A | EX86_SSE2, freg, srcdst, srcdstw));
+				return emit_byte(compiler, U8(lane_index));
+			}
+
+			if (use_vex) {
+				FAIL_IF(emit_vex_instruction(compiler, SHUFPS_x_xm | EX86_SSE2 | VEX_SSE2_OPV, srcdst, freg, freg, 0));
 				return emit_byte(compiler, U8(lane_index));
 			}
 
 			if (srcdst == freg)
-				size = SHUFPS_x_xm | EX86_SSE2;
+				op = SHUFPS_x_xm | EX86_SSE2;
 			else {
-				if (cpu_feature_list & CPU_FEATURE_AVX) {
-					FAIL_IF(emit_vex_instruction(compiler, SHUFPS_x_xm | EX86_SSE2 | VEX_SSE2_OPV, srcdst, freg, freg, 0));
-					return emit_byte(compiler, U8(lane_index));
-				}
-
 				switch (lane_index) {
 				case 1:
-					size = MOVSHDUP_x_xm | EX86_PREF_F3 | EX86_SSE2;
+					op = MOVSHDUP_x_xm | EX86_PREF_F3 | EX86_SSE2;
 					break;
 				case 2:
-					size = MOVHLPS_x_x | EX86_SSE2;
+					op = MOVHLPS_x_x | EX86_SSE2;
 					break;
 				default:
 					SLJIT_ASSERT(lane_index == 3);
-					size = PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2;
+					op = PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2;
 					break;
 				}
 			}
 
-			FAIL_IF(emit_groupf(compiler, size, srcdst, freg, 0));
+			FAIL_IF(emit_groupf(compiler, op, srcdst, freg, 0));
 
-			size &= 0xff;
-			if (size == SHUFPS_x_xm || size == PSHUFD_x_xm)
+			op &= 0xff;
+			if (op == SHUFPS_x_xm || op == PSHUFD_x_xm)
 				return emit_byte(compiler, U8(lane_index));
 
 			return SLJIT_SUCCESS;
@@ -3993,7 +4159,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 		srcdstw = 0;
 	}
 
-	size = 3;
+	op = 3;
 
 	switch (elem_size) {
 	case 0:
@@ -4001,7 +4167,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 		break;
 	case 1:
 		if (!(type & SLJIT_SIMD_STORE)) {
-			size = 2;
+			op = 2;
 			opcode = PINSRW_x_rm_i8;
 		} else
 			opcode = PEXTRW_rm_x_i8;
@@ -4018,15 +4184,20 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 #endif /* SLJIT_CONFIG_X86_64 */
 	}
 
-	inst = emit_x86_instruction(compiler, size | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, srcdst, srcdstw);
-	FAIL_IF(!inst);
-	inst[0] = GROUP_0F;
+	if (use_vex && (type & SLJIT_SIMD_STORE)) {
+		op = opcode | ((op == 3) ? VEX_OP_0F3A : 0);
+		FAIL_IF(emit_vex_instruction(compiler, op | EX86_PREF_66 | VEX_AUTO_W | EX86_SSE2_OP1 | VEX_SSE2_OPV, freg, 0, srcdst, srcdstw));
+	} else {
+		inst = emit_x86_instruction(compiler, op | EX86_PREF_66 | EX86_SSE2_OP1, freg, 0, srcdst, srcdstw);
+		FAIL_IF(!inst);
+		inst[0] = GROUP_0F;
 
-	if (size == 3) {
-		inst[1] = 0x3a;
-		inst[2] = opcode;
-	} else
-		inst[1] = opcode;
+		if (op == 3) {
+			inst[1] = 0x3a;
+			inst[2] = opcode;
+		} else
+			inst[1] = opcode;
+	}
 
 	FAIL_IF(emit_byte(compiler, U8(lane_index)));
 
@@ -4056,23 +4227,23 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_mov(struct sljit_compile
 
 	compiler->mode32 = (type & SLJIT_32);
 
-	size = 2;
+	op = 2;
 
 	if (elem_size == 0)
-		size |= EX86_REX;
+		op |= EX86_REX;
 
 	if (elem_size == 2) {
 		if (type & SLJIT_32)
 			return SLJIT_SUCCESS;
 
 		SLJIT_ASSERT(!(compiler->mode32));
-		size = 1;
+		op = 1;
 	}
 
-	inst = emit_x86_instruction(compiler, size, srcdst, 0, srcdst, 0);
+	inst = emit_x86_instruction(compiler, op, srcdst, 0, srcdst, 0);
 	FAIL_IF(!inst);
 
-	if (size != 1) {
+	if (op != 1) {
 		inst[0] = GROUP_0F;
 		inst[1] = U8((elem_size == 0) ? MOVSX_r_rm8 : MOVSX_r_rm16);
 	} else
@@ -4096,6 +4267,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 {
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_s32 use_vex = (cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX);
 	sljit_uw pref;
 	sljit_u8 byte;
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
@@ -4115,6 +4287,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 	if (reg_size == 5) {
 		if (!(cpu_feature_list & CPU_FEATURE_AVX2))
 			return SLJIT_ERR_UNSUPPORTED;
+		use_vex = 1;
 	} else if (reg_size != 4)
 		return SLJIT_ERR_UNSUPPORTED;
 
@@ -4136,8 +4309,11 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 				return emit_byte(compiler, U8(byte | (byte << 4)));
 			}
 
-			if (src_lane_index == 0)
+			if (src_lane_index == 0) {
+				if (use_vex)
+					return emit_vex_instruction(compiler, MOVDDUP_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, 0, src, 0);
 				return emit_groupf(compiler, MOVDDUP_x_xm | EX86_PREF_F2 | EX86_SSE2, freg, src, 0);
+			}
 
 			/* Changes it to SHUFPD_x_xm. */
 			pref = EX86_PREF_66;
@@ -4163,7 +4339,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 			FAIL_IF(emit_byte(compiler, byte));
 			FAIL_IF(emit_vex_instruction(compiler, SHUFPS_x_xm | VEX_256 | pref | EX86_SSE2 | VEX_SSE2_OPV, freg, freg, freg, 0));
 			byte = U8(src_lane_index);
-		} else if (freg != src && (cpu_feature_list & CPU_FEATURE_AVX)) {
+		} else if (use_vex) {
 			FAIL_IF(emit_vex_instruction(compiler, SHUFPS_x_xm | pref | EX86_SSE2 | VEX_SSE2_OPV, freg, src, src, 0));
 		} else {
 			if (freg != src)
@@ -4192,7 +4368,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 			src = freg;
 		}
 
-		if ((freg != src && !(cpu_feature_list & CPU_FEATURE_AVX2)) || src_lane_index != 0) {
+		if (src_lane_index != 0 || (freg != src && (!(cpu_feature_list & CPU_FEATURE_AVX2) || !use_vex))) {
 			pref = 0;
 
 			if ((src_lane_index & 0x3) == 0) {
@@ -4202,7 +4378,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 				pref = EX86_PREF_F2;
 				byte = U8(src_lane_index >> 1);
 			} else {
-				if (freg == src || !(cpu_feature_list & CPU_FEATURE_AVX2)) {
+				if (!use_vex) {
 					if (freg != src)
 						FAIL_IF(emit_groupf(compiler, MOVDQA_x_xm | EX86_PREF_66 | EX86_SSE2, freg, src, 0));
 
@@ -4214,14 +4390,17 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 			}
 
 			if (pref != 0) {
-				FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, src, 0));
+				if (use_vex)
+					FAIL_IF(emit_vex_instruction(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, 0, src, 0));
+				else
+					FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, src, 0));
 				FAIL_IF(emit_byte(compiler, byte));
 			}
 
 			src = freg;
 		}
 
-		if (cpu_feature_list & CPU_FEATURE_AVX2)
+		if (use_vex && (cpu_feature_list & CPU_FEATURE_AVX2))
 			return emit_vex_instruction(compiler, VPBROADCASTB_x_xm | (reg_size == 5 ? VEX_256 : 0) | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, src, 0);
 
 		SLJIT_ASSERT(reg_size == 4);
@@ -4229,7 +4408,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 		return emit_groupf_ext(compiler, PSHUFB_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, TMP_FREG, 0);
 	}
 
-	if ((cpu_feature_list & CPU_FEATURE_AVX2) && src_lane_index == 0 && elem_size <= 3) {
+	if ((cpu_feature_list & CPU_FEATURE_AVX2) && use_vex && src_lane_index == 0 && elem_size <= 3) {
 		switch (elem_size) {
 		case 1:
 			pref = VPBROADCASTW_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2;
@@ -4291,11 +4470,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 		src_lane_index >>= 1;
 		pref = (src_lane_index & 2) == 0 ? EX86_PREF_F2 : EX86_PREF_F3;
 
-		FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, src, 0));
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, 0, src, 0));
+		else
+			FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | pref | EX86_SSE2, freg, src, 0));
 		byte = U8(byte | (byte << 2));
 		FAIL_IF(emit_byte(compiler, U8(byte | (byte << 4))));
 
-		if ((cpu_feature_list & CPU_FEATURE_AVX2) && pref == EX86_PREF_F2)
+		if ((cpu_feature_list & CPU_FEATURE_AVX2) && use_vex && pref == EX86_PREF_F2)
 			return emit_vex_instruction(compiler, VPBROADCASTD_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, freg, 0);
 
 		src = freg;
@@ -4310,7 +4492,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 		break;
 	}
 
-	FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, src, 0));
+	if (use_vex)
+		FAIL_IF(emit_vex_instruction(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, 0, src, 0));
+	else
+		FAIL_IF(emit_groupf(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, freg, src, 0));
 	return emit_byte(compiler, U8(byte | (byte << 4)));
 }
 
@@ -4321,6 +4506,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_extend(struct sljit_compiler 
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
 	sljit_s32 elem2_size = SLJIT_SIMD_GET_ELEM2_SIZE(type);
+	sljit_s32 use_vex = (cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX);
 	sljit_u8 opcode;
 
 	CHECK_ERROR();
@@ -4335,6 +4521,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_extend(struct sljit_compiler 
 	if (reg_size == 5) {
 		if (!(cpu_feature_list & CPU_FEATURE_AVX2))
 			return SLJIT_ERR_UNSUPPORTED;
+		use_vex = 1;
 	} else if (reg_size != 4)
 		return SLJIT_ERR_UNSUPPORTED;
 
@@ -4345,9 +4532,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_extend(struct sljit_compiler 
 		if (type & SLJIT_SIMD_TEST)
 			return SLJIT_SUCCESS;
 
-		if (reg_size == 4)
-			return emit_groupf(compiler, CVTPS2PD_x_xm | EX86_SSE2, freg, src, srcw);
-		return emit_vex_instruction(compiler, CVTPS2PD_x_xm | VEX_256 | EX86_SSE2, freg, 0, src, srcw);
+		if (use_vex)
+			return emit_vex_instruction(compiler, CVTPS2PD_x_xm | ((reg_size == 5) ? VEX_256 : 0) | EX86_SSE2, freg, 0, src, srcw);
+		return emit_groupf(compiler, CVTPS2PD_x_xm | EX86_SSE2, freg, src, srcw);
 	}
 
 	switch (elem_size) {
@@ -4382,9 +4569,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_extend(struct sljit_compiler 
 	if (type & SLJIT_SIMD_TEST)
 		return SLJIT_SUCCESS;
 
-	if (reg_size == 4)
-		return emit_groupf_ext(compiler, opcode | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, src, srcw);
-	return emit_vex_instruction(compiler, opcode | VEX_256 | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, src, srcw);
+	if (use_vex)
+		return emit_vex_instruction(compiler, opcode | ((reg_size == 5) ? VEX_256 : 0) | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, 0, src, srcw);
+	return emit_groupf_ext(compiler, opcode | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, freg, src, srcw);
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_sign(struct sljit_compiler *compiler, sljit_s32 type,
@@ -4393,8 +4580,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_sign(struct sljit_compiler *c
 {
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
+	sljit_s32 use_vex = (cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX);
 	sljit_s32 dst_r;
-	sljit_uw pref;
+	sljit_uw op;
 	sljit_u8 *inst;
 
 	CHECK_ERROR();
@@ -4414,20 +4602,28 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_sign(struct sljit_compiler *c
 		if (type & SLJIT_SIMD_TEST)
 			return SLJIT_SUCCESS;
 
-		pref = EX86_PREF_66 | EX86_SSE2_OP2;
+		op = EX86_PREF_66 | EX86_SSE2_OP2;
 
 		switch (elem_size) {
 		case 1:
-			FAIL_IF(emit_groupf(compiler, PACKSSWB_x_xm | EX86_PREF_66 | EX86_SSE2, TMP_FREG, freg, 0));
+			if (use_vex)
+				FAIL_IF(emit_vex_instruction(compiler, PACKSSWB_x_xm | EX86_PREF_66 | EX86_SSE2 | VEX_SSE2_OPV, TMP_FREG, freg, freg, 0));
+			else
+				FAIL_IF(emit_groupf(compiler, PACKSSWB_x_xm | EX86_PREF_66 | EX86_SSE2, TMP_FREG, freg, 0));
 			freg = TMP_FREG;
 			break;
 		case 2:
-			pref = EX86_SSE2_OP2;
+			op = EX86_SSE2_OP2;
 			break;
 		}
 
 		dst_r = FAST_IS_REG(dst) ? dst : TMP_REG1;
-		FAIL_IF(emit_groupf(compiler, (elem_size < 2 ? PMOVMSKB_r_x : MOVMSKPS_r_x) | pref, dst_r, freg, 0));
+		op |= (elem_size < 2) ? PMOVMSKB_r_x : MOVMSKPS_r_x;
+
+		if (use_vex)
+			FAIL_IF(emit_vex_instruction(compiler, op, dst_r, 0, freg, 0));
+		else
+			FAIL_IF(emit_groupf(compiler, op, dst_r, freg, 0));
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 		compiler->mode32 = type & SLJIT_32;
@@ -4459,14 +4655,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_sign(struct sljit_compiler *c
 		FAIL_IF(emit_vex_instruction(compiler, PACKSSWB_x_xm | VEX_256 | EX86_PREF_66 | EX86_SSE2 | VEX_SSE2_OPV, TMP_FREG, freg, TMP_FREG, 0));
 		FAIL_IF(emit_groupf(compiler, PMOVMSKB_r_x | EX86_PREF_66 | EX86_SSE2_OP2, dst_r, TMP_FREG, 0));
 	} else {
-		pref = MOVMSKPS_r_x | VEX_256 | EX86_SSE2_OP2;
+		op = MOVMSKPS_r_x | VEX_256 | EX86_SSE2_OP2;
 
 		if (elem_size == 0)
-			pref = PMOVMSKB_r_x | VEX_256 | EX86_PREF_66 | EX86_SSE2_OP2;
+			op = PMOVMSKB_r_x | VEX_256 | EX86_PREF_66 | EX86_SSE2_OP2;
 		else if (elem_size == 3)
-			pref |= EX86_PREF_66;
+			op |= EX86_PREF_66;
 
-		FAIL_IF(emit_vex_instruction(compiler, pref, dst_r, 0, freg, 0));
+		FAIL_IF(emit_vex_instruction(compiler, op, dst_r, 0, freg, 0));
 	}
 
 	if (dst_r == TMP_REG1) {
@@ -4497,7 +4693,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_op2(struct sljit_compiler *co
 {
 	sljit_s32 reg_size = SLJIT_SIMD_GET_REG_SIZE(type);
 	sljit_s32 elem_size = SLJIT_SIMD_GET_ELEM_SIZE(type);
-	sljit_s32 needs_move = 0;
 	sljit_uw op = 0;
 
 	CHECK_ERROR();
@@ -4540,20 +4735,18 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_op2(struct sljit_compiler *co
 	if (type & SLJIT_SIMD_TEST)
 		return SLJIT_SUCCESS;
 
-	needs_move = dst_freg != src1_freg && dst_freg != src2_freg;
-
-	if (reg_size == 5 || (needs_move && (cpu_feature_list & CPU_FEATURE_AVX2))) {
+	if (reg_size == 5 || ((cpu_feature_list & CPU_FEATURE_AVX) && (compiler->options & SLJIT_ENTER_USE_VEX))) {
 		if (reg_size == 5)
 			op |= VEX_256;
 
 		return emit_vex_instruction(compiler, op | EX86_SSE2 | VEX_SSE2_OPV, dst_freg, src1_freg, src2_freg, 0);
 	}
 
-	if (needs_move) {
-		FAIL_IF(emit_simd_mov(compiler, type, dst_freg, src1_freg));
-	} else if (dst_freg != src1_freg) {
-		SLJIT_ASSERT(dst_freg == src2_freg);
-		src2_freg = src1_freg;
+	if (dst_freg != src1_freg) {
+		if (dst_freg == src2_freg)
+			src2_freg = src1_freg;
+		else
+			FAIL_IF(emit_simd_mov(compiler, type, dst_freg, src1_freg));
 	}
 
 	FAIL_IF(emit_groupf(compiler, op | EX86_SSE2, dst_freg, src2_freg, 0));
@@ -4727,11 +4920,10 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 		return NULL;
 #endif
 
-	inst = (sljit_u8*)ensure_buf(compiler, 2);
+	inst = (sljit_u8*)ensure_buf(compiler, 1);
 	PTR_FAIL_IF(!inst);
 
-	inst[0] = 0;
-	inst[1] = 2;
+	inst[0] = SLJIT_INST_CONST;
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	if (dst & SLJIT_MEM)
@@ -4742,52 +4934,48 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 	return const_;
 }
 
-SLJIT_API_FUNC_ATTRIBUTE struct sljit_put_label* sljit_emit_put_label(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_mov_addr(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw)
 {
-	struct sljit_put_label *put_label;
+	struct sljit_jump *jump;
 	sljit_u8 *inst;
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	sljit_s32 reg;
-	sljit_uw start_size;
-#endif
+#endif /* SLJIT_CONFIG_X86_64 */
 
 	CHECK_ERROR_PTR();
-	CHECK_PTR(check_sljit_emit_put_label(compiler, dst, dstw));
+	CHECK_PTR(check_sljit_emit_mov_addr(compiler, dst, dstw));
 	ADJUST_LOCAL_OFFSET(dst, dstw);
 
 	CHECK_EXTRA_REGS(dst, dstw, (void)0);
 
-	put_label = (struct sljit_put_label*)ensure_abuf(compiler, sizeof(struct sljit_put_label));
-	PTR_FAIL_IF(!put_label);
-	set_put_label(put_label, compiler, 0);
+	jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+	PTR_FAIL_IF(!jump);
+	set_mov_addr(jump, compiler, 0);
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	compiler->mode32 = 0;
 	reg = FAST_IS_REG(dst) ? dst : TMP_REG1;
 
-	if (emit_load_imm64(compiler, reg, 0))
-		return NULL;
-#else
-	if (emit_mov(compiler, dst, dstw, SLJIT_IMM, 0))
-		return NULL;
-#endif
+	PTR_FAIL_IF(emit_load_imm64(compiler, reg, 0));
+	jump->addr = compiler->size;
 
-#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-	if (dst & SLJIT_MEM) {
-		start_size = compiler->size;
-		if (emit_mov(compiler, dst, dstw, TMP_REG1, 0))
-			return NULL;
-		put_label->flags = compiler->size - start_size;
-	}
-#endif
+	if (reg_map[reg] >= 8)
+		jump->flags |= MOV_ADDR_HI;
+#else /* !SLJIT_CONFIG_X86_64 */
+	PTR_FAIL_IF(emit_mov(compiler, dst, dstw, SLJIT_IMM, 0));
+#endif /* SLJIT_CONFIG_X86_64 */
 
-	inst = (sljit_u8*)ensure_buf(compiler, 2);
+	inst = (sljit_u8*)ensure_buf(compiler, 1);
 	PTR_FAIL_IF(!inst);
 
-	inst[0] = 0;
-	inst[1] = 3;
+	inst[0] = SLJIT_INST_MOV_ADDR;
 
-	return put_label;
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	if (dst & SLJIT_MEM)
+		PTR_FAIL_IF(emit_mov(compiler, dst, dstw, TMP_REG1, 0));
+#endif /* SLJIT_CONFIG_X86_64 */
+
+	return jump;
 }
 
 SLJIT_API_FUNC_ATTRIBUTE void sljit_set_jump_addr(sljit_uw addr, sljit_uw new_target, sljit_sw executable_offset)

--- a/ext/pcre/pcre2lib/sljit/sljitSerialize.c
+++ b/ext/pcre/pcre2lib/sljit/sljitSerialize.c
@@ -1,0 +1,516 @@
+/*
+ *    Stack-less Just-In-Time compiler
+ *
+ *    Copyright Zoltan Herczeg (hzmester@freemail.hu). All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list of
+ *      conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *      of conditions and the following disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER(S) OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_has_label(struct sljit_jump *jump)
+{
+	return !(jump->flags & JUMP_ADDR) && (jump->u.label != NULL);
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_has_target(struct sljit_jump *jump)
+{
+	return (jump->flags & JUMP_ADDR) != 0;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_jump_is_mov_addr(struct sljit_jump *jump)
+{
+	return (jump->flags & JUMP_MOV_ADDR) != 0;
+}
+
+#define SLJIT_SERIALIZE_DEBUG ((sljit_u16)0x1)
+
+struct sljit_serialized_compiler {
+	sljit_u32 signature;
+	sljit_u16 version;
+	sljit_u16 cpu_type;
+
+	sljit_uw buf_segment_count;
+	sljit_uw label_count;
+	sljit_uw jump_count;
+	sljit_uw const_count;
+
+	sljit_s32 options;
+	sljit_s32 scratches;
+	sljit_s32 saveds;
+	sljit_s32 fscratches;
+	sljit_s32 fsaveds;
+	sljit_s32 local_size;
+	sljit_uw size;
+
+#if (defined SLJIT_HAS_STATUS_FLAGS_STATE && SLJIT_HAS_STATUS_FLAGS_STATE)
+	sljit_s32 status_flags_state;
+#endif /* SLJIT_HAS_STATUS_FLAGS_STATE */
+
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
+	sljit_s32 args_size;
+#endif /* SLJIT_CONFIG_X86_32 */
+
+#if ((defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32) && (defined __SOFTFP__)) \
+		|| (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
+	sljit_uw args_size;
+#endif /* (SLJIT_CONFIG_ARM_32 && __SOFTFP__) || SLJIT_CONFIG_MIPS_32 */
+
+#if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
+	sljit_uw cpool_diff;
+	sljit_uw cpool_fill;
+	sljit_uw patches;
+#endif /* SLJIT_CONFIG_ARM_V6 */
+
+#if (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
+	sljit_s32 delay_slot;
+#endif /* SLJIT_CONFIG_MIPS */
+
+};
+
+struct sljit_serialized_debug_info {
+	sljit_sw last_flags;
+	sljit_s32 last_return;
+	sljit_s32 logical_local_size;
+};
+
+struct sljit_serialized_label {
+	sljit_uw size;
+};
+
+struct sljit_serialized_jump {
+	sljit_uw addr;
+	sljit_uw flags;
+	sljit_uw value;
+};
+
+struct sljit_serialized_const {
+	sljit_uw addr;
+};
+
+#define SLJIT_SERIALIZE_ALIGN(v) (((v) + sizeof(sljit_uw) - 1) & ~(sljit_uw)(sizeof(sljit_uw) - 1))
+#if (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
+#define SLJIT_SERIALIZE_SIGNATURE 0x534c4a54
+#else /* !SLJIT_LITTLE_ENDIAN */
+#define SLJIT_SERIALIZE_SIGNATURE 0x544a4c53
+#endif /* SLJIT_LITTLE_ENDIAN */
+#define SLJIT_SERIALIZE_VERSION 1
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_uw* sljit_serialize_compiler(struct sljit_compiler *compiler,
+	sljit_s32 options, sljit_uw *size)
+{
+	sljit_uw serialized_size = sizeof(struct sljit_serialized_compiler);
+	struct sljit_memory_fragment *buf;
+	struct sljit_label *label;
+	struct sljit_jump *jump;
+	struct sljit_const *const_;
+	struct sljit_serialized_compiler *serialized_compiler;
+	struct sljit_serialized_label *serialized_label;
+	struct sljit_serialized_jump *serialized_jump;
+	struct sljit_serialized_const *serialized_const;
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	struct sljit_serialized_debug_info *serialized_debug_info;
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+	sljit_uw counter, used_size;
+	sljit_u8 *result;
+	sljit_u8 *ptr;
+	SLJIT_UNUSED_ARG(options);
+
+	if (size != NULL)
+		*size = 0;
+
+	PTR_FAIL_IF(compiler->error);
+
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	if (!(options & SLJIT_SERIALIZE_IGNORE_DEBUG))
+		serialized_size += sizeof(struct sljit_serialized_debug_info);
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+
+#if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
+	serialized_size += SLJIT_SERIALIZE_ALIGN(compiler->cpool_fill * (sizeof(sljit_uw) + 1));
+#endif /* SLJIT_CONFIG_ARM_V6 */
+
+	/* Compute the size of the data. */
+	buf = compiler->buf;
+	while (buf != NULL) {
+		serialized_size += sizeof(sljit_uw) + SLJIT_SERIALIZE_ALIGN(buf->used_size);
+		buf = buf->next;
+	}
+
+	serialized_size += compiler->label_count * sizeof(struct sljit_serialized_label);
+
+	jump = compiler->jumps;
+	while (jump != NULL) {
+		serialized_size += sizeof(struct sljit_serialized_jump);
+		jump = jump->next;
+	}
+
+	const_ = compiler->consts;
+	while (const_ != NULL) {
+		serialized_size += sizeof(struct sljit_serialized_const);
+		const_ = const_->next;
+	}
+
+	result = (sljit_u8*)SLJIT_MALLOC(serialized_size, compiler->allocator_data);
+	PTR_FAIL_IF_NULL(result);
+
+	if (size != NULL)
+		*size = serialized_size;
+
+	ptr = result;
+	serialized_compiler = (struct sljit_serialized_compiler*)ptr;
+	ptr += sizeof(struct sljit_serialized_compiler);
+
+	serialized_compiler->signature = SLJIT_SERIALIZE_SIGNATURE;
+	serialized_compiler->version = SLJIT_SERIALIZE_VERSION;
+	serialized_compiler->cpu_type = 0;
+	serialized_compiler->label_count = compiler->label_count;
+	serialized_compiler->options = compiler->options;
+	serialized_compiler->scratches = compiler->scratches;
+	serialized_compiler->saveds = compiler->saveds;
+	serialized_compiler->fscratches = compiler->fscratches;
+	serialized_compiler->fsaveds = compiler->fsaveds;
+	serialized_compiler->local_size = compiler->local_size;
+	serialized_compiler->size = compiler->size;
+
+#if (defined SLJIT_HAS_STATUS_FLAGS_STATE && SLJIT_HAS_STATUS_FLAGS_STATE)
+	serialized_compiler->status_flags_state = compiler->status_flags_state;
+#endif /* SLJIT_HAS_STATUS_FLAGS_STATE */
+
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32) \
+		|| ((defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32) && (defined __SOFTFP__)) \
+		|| (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
+	serialized_compiler->args_size = compiler->args_size;
+#endif /* SLJIT_CONFIG_X86_32 || (SLJIT_CONFIG_ARM_32 && __SOFTFP__) || SLJIT_CONFIG_MIPS_32 */
+
+#if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
+	serialized_compiler->cpool_diff = compiler->cpool_diff;
+	serialized_compiler->cpool_fill = compiler->cpool_fill;
+	serialized_compiler->patches = compiler->patches;
+
+	SLJIT_MEMCPY(ptr, compiler->cpool, compiler->cpool_fill * sizeof(sljit_uw));
+	SLJIT_MEMCPY(ptr + compiler->cpool_fill * sizeof(sljit_uw), compiler->cpool_unique, compiler->cpool_fill);
+	ptr += SLJIT_SERIALIZE_ALIGN(compiler->cpool_fill * (sizeof(sljit_uw) + 1));
+#endif /* SLJIT_CONFIG_ARM_V6 */
+
+#if (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
+	serialized_compiler->delay_slot = compiler->delay_slot;
+#endif /* SLJIT_CONFIG_MIPS */
+
+	buf = compiler->buf;
+	counter = 0;
+	while (buf != NULL) {
+		used_size = buf->used_size;
+		*(sljit_uw*)ptr = used_size;
+		ptr += sizeof(sljit_uw);
+		SLJIT_MEMCPY(ptr, buf->memory, used_size);
+		ptr += SLJIT_SERIALIZE_ALIGN(used_size);
+		buf = buf->next;
+		counter++;
+	}
+	serialized_compiler->buf_segment_count = counter;
+
+	label = compiler->labels;
+	while (label != NULL) {
+		serialized_label = (struct sljit_serialized_label*)ptr;
+		serialized_label->size = label->size;
+		ptr += sizeof(struct sljit_serialized_label);
+		label = label->next;
+	}
+
+	jump = compiler->jumps;
+	counter = 0;
+	while (jump != NULL) {
+		serialized_jump = (struct sljit_serialized_jump*)ptr;
+		serialized_jump->addr = jump->addr;
+		serialized_jump->flags = jump->flags;
+
+		if (jump->flags & JUMP_ADDR)
+			serialized_jump->value = jump->u.target;
+		else if (jump->u.label != NULL)
+			serialized_jump->value = jump->u.label->u.index;
+		else
+			serialized_jump->value = SLJIT_MAX_ADDRESS;
+
+		ptr += sizeof(struct sljit_serialized_jump);
+		jump = jump->next;
+		counter++;
+	}
+	serialized_compiler->jump_count = counter;
+
+	const_ = compiler->consts;
+	counter = 0;
+	while (const_ != NULL) {
+		serialized_const = (struct sljit_serialized_const*)ptr;
+		serialized_const->addr = const_->addr;
+		ptr += sizeof(struct sljit_serialized_const);
+		const_ = const_->next;
+		counter++;
+	}
+	serialized_compiler->const_count = counter;
+
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	if (!(options & SLJIT_SERIALIZE_IGNORE_DEBUG)) {
+		serialized_debug_info = (struct sljit_serialized_debug_info*)ptr;
+		serialized_debug_info->last_flags = compiler->last_flags;
+		serialized_debug_info->last_return = compiler->last_return;
+		serialized_debug_info->logical_local_size = compiler->logical_local_size;
+		serialized_compiler->cpu_type |= SLJIT_SERIALIZE_DEBUG;
+#if (defined SLJIT_DEBUG && SLJIT_DEBUG)
+		ptr += sizeof(struct sljit_serialized_debug_info);
+#endif /* SLJIT_DEBUG */
+	}
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+
+	SLJIT_ASSERT((sljit_uw)(ptr - result) == serialized_size);
+	return (sljit_uw*)result;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE struct sljit_compiler *sljit_deserialize_compiler(sljit_uw* buffer, sljit_uw size,
+	sljit_s32 options, void *allocator_data)
+{
+	struct sljit_compiler *compiler;
+	struct sljit_serialized_compiler *serialized_compiler;
+	struct sljit_serialized_label *serialized_label;
+	struct sljit_serialized_jump *serialized_jump;
+	struct sljit_serialized_const *serialized_const;
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	struct sljit_serialized_debug_info *serialized_debug_info;
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+	struct sljit_memory_fragment *buf;
+	struct sljit_memory_fragment *last_buf;
+	struct sljit_label *label;
+	struct sljit_label *last_label;
+	struct sljit_label **label_list = NULL;
+	struct sljit_jump *jump;
+	struct sljit_jump *last_jump;
+	struct sljit_const *const_;
+	struct sljit_const *last_const;
+	sljit_u8 *ptr = (sljit_u8*)buffer;
+	sljit_u8 *end = ptr + size;
+	sljit_uw i, used_size, aligned_size, label_count;
+	SLJIT_UNUSED_ARG(options);
+
+	if (size < sizeof(struct sljit_serialized_compiler) || (size & (sizeof(sljit_uw) - 1)) != 0)
+		return NULL;
+
+	serialized_compiler = (struct sljit_serialized_compiler*)ptr;
+
+	if (serialized_compiler->signature != SLJIT_SERIALIZE_SIGNATURE || serialized_compiler->version != SLJIT_SERIALIZE_VERSION)
+		return NULL;
+
+	compiler = sljit_create_compiler(allocator_data);
+	PTR_FAIL_IF(compiler == NULL);
+
+	compiler->label_count = serialized_compiler->label_count;
+	compiler->options = serialized_compiler->options;
+	compiler->scratches = serialized_compiler->scratches;
+	compiler->saveds = serialized_compiler->saveds;
+	compiler->fscratches = serialized_compiler->fscratches;
+	compiler->fsaveds = serialized_compiler->fsaveds;
+	compiler->local_size = serialized_compiler->local_size;
+	compiler->size = serialized_compiler->size;
+
+#if (defined SLJIT_HAS_STATUS_FLAGS_STATE && SLJIT_HAS_STATUS_FLAGS_STATE)
+	compiler->status_flags_state = serialized_compiler->status_flags_state;
+#endif /* SLJIT_HAS_STATUS_FLAGS_STATE */
+
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32) \
+		|| ((defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32) && (defined __SOFTFP__)) \
+		|| (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
+	compiler->args_size = serialized_compiler->args_size;
+#endif /* SLJIT_CONFIG_X86_32 || (SLJIT_CONFIG_ARM_32 && __SOFTFP__) || SLJIT_CONFIG_MIPS_32 */
+
+#if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
+	used_size = serialized_compiler->cpool_fill;
+	aligned_size = SLJIT_SERIALIZE_ALIGN(used_size * (sizeof(sljit_uw) + 1));
+	compiler->cpool_diff = serialized_compiler->cpool_diff;
+	compiler->cpool_fill = used_size;
+	compiler->patches = serialized_compiler->patches;
+
+	if ((sljit_uw)(end - ptr) < aligned_size)
+		goto error;
+
+	SLJIT_MEMCPY(compiler->cpool, ptr, used_size * sizeof(sljit_uw));
+	SLJIT_MEMCPY(compiler->cpool_unique, ptr + used_size * sizeof(sljit_uw), used_size);
+	ptr += aligned_size;
+#endif /* SLJIT_CONFIG_ARM_V6 */
+
+#if (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
+	compiler->delay_slot = serialized_compiler->delay_slot;
+#endif /* SLJIT_CONFIG_MIPS */
+
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	if (!(serialized_compiler->cpu_type & SLJIT_SERIALIZE_DEBUG))
+		goto error;
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+
+	ptr += sizeof(struct sljit_serialized_compiler);
+	i = serialized_compiler->buf_segment_count;
+	last_buf = NULL;
+	while (i > 0) {
+		if ((sljit_uw)(end - ptr) < sizeof(sljit_uw))
+			goto error;
+
+		used_size = *(sljit_uw*)ptr;
+		aligned_size = SLJIT_SERIALIZE_ALIGN(used_size);
+		ptr += sizeof(sljit_uw);
+
+		if ((sljit_uw)(end - ptr) < aligned_size)
+			goto error;
+
+		if (last_buf == NULL) {
+			SLJIT_ASSERT(compiler->buf != NULL && compiler->buf->next == NULL);
+			buf = compiler->buf;
+		} else {
+			buf = (struct sljit_memory_fragment*)SLJIT_MALLOC(BUF_SIZE, allocator_data);
+			if (!buf)
+				goto error;
+			buf->next = NULL;
+		}
+
+		buf->used_size = used_size;
+		SLJIT_MEMCPY(buf->memory, ptr, used_size);
+
+		if (last_buf != NULL)
+			last_buf->next = buf;
+		last_buf = buf;
+
+		ptr += aligned_size;
+		i--;
+	}
+
+	last_label = NULL;
+	label_count = serialized_compiler->label_count;
+	if ((sljit_uw)(end - ptr) < label_count * sizeof(struct sljit_serialized_label))
+		goto error;
+
+	label_list = (struct sljit_label **)SLJIT_MALLOC(label_count * sizeof(struct sljit_label*), allocator_data);
+	if (label_list == NULL)
+		goto error;
+
+	for (i = 0; i < label_count; i++) {
+		label = (struct sljit_label*)ensure_abuf(compiler, sizeof(struct sljit_label));
+		if (label == NULL)
+			goto error;
+
+		serialized_label = (struct sljit_serialized_label*)ptr;
+		label->next = NULL;
+		label->u.index = i;
+		label->size = serialized_label->size;
+
+		if (last_label != NULL)
+			last_label->next = label;
+		else
+			compiler->labels = label;
+		last_label = label;
+
+		label_list[i] = label;
+		ptr += sizeof(struct sljit_serialized_label);
+	}
+	compiler->last_label = last_label;
+
+	last_jump = NULL;
+	i = serialized_compiler->jump_count;
+	if ((sljit_uw)(end - ptr) < i * sizeof(struct sljit_serialized_jump))
+		goto error;
+
+	while (i > 0) {
+		jump = (struct sljit_jump*)ensure_abuf(compiler, sizeof(struct sljit_jump));
+		if (jump == NULL)
+			goto error;
+
+		serialized_jump = (struct sljit_serialized_jump*)ptr;
+		jump->next = NULL;
+		jump->addr = serialized_jump->addr;
+		jump->flags = serialized_jump->flags;
+
+		if (!(serialized_jump->flags & JUMP_ADDR)) {
+			if (serialized_jump->value != SLJIT_MAX_ADDRESS) {
+				if (serialized_jump->value >= label_count)
+					goto error;
+				jump->u.label = label_list[serialized_jump->value];
+			} else
+				jump->u.label = NULL;
+		} else
+			jump->u.target = serialized_jump->value;
+
+		if (last_jump != NULL)
+			last_jump->next = jump;
+		else
+			compiler->jumps = jump;
+		last_jump = jump;
+
+		ptr += sizeof(struct sljit_serialized_jump);
+		i--;
+	}
+	compiler->last_jump = last_jump;
+
+	SLJIT_FREE(label_list, allocator_data);
+	label_list = NULL;
+
+	last_const = NULL;
+	i = serialized_compiler->const_count;
+	if ((sljit_uw)(end - ptr) < i * sizeof(struct sljit_serialized_const))
+		goto error;
+
+	while (i > 0) {
+		const_ = (struct sljit_const*)ensure_abuf(compiler, sizeof(struct sljit_const));
+		if (const_ == NULL)
+			goto error;
+
+		serialized_const = (struct sljit_serialized_const*)ptr;
+		const_->next = NULL;
+		const_->addr = serialized_const->addr;
+
+		if (last_const != NULL)
+			last_const->next = const_;
+		else
+			compiler->consts = const_;
+		last_const = const_;
+
+		ptr += sizeof(struct sljit_serialized_const);
+		i--;
+	}
+	compiler->last_const = last_const;
+
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS) \
+		|| (defined SLJIT_DEBUG && SLJIT_DEBUG)
+	if ((sljit_uw)(end - ptr) < sizeof(struct sljit_serialized_debug_info))
+		goto error;
+
+	serialized_debug_info = (struct sljit_serialized_debug_info*)ptr;
+	compiler->last_flags = (sljit_s32)serialized_debug_info->last_flags;
+	compiler->last_return = serialized_debug_info->last_return;
+	compiler->logical_local_size = serialized_debug_info->logical_local_size;
+#endif /* SLJIT_ARGUMENT_CHECKS || SLJIT_DEBUG */
+
+	return compiler;
+
+error:
+	sljit_free_compiler(compiler);
+	if (label_list != NULL)
+		SLJIT_FREE(label_list, allocator_data);
+	return NULL;
+}


### PR DESCRIPTION
Previously: GH-13413.

This version also contains a fix with `preg_match('\X')`, so that it can correctly detect grapheme clusters (PCRE2Project/pcre2#410). This is useful to correctly [polyfill the new `grapheme_str_split` function](https://php.watch/versions/8.4/grapheme_str_split#polyfill).

Diff: pcre2lib [v10.43..v10.44](https://github.com/PCRE2Project/pcre2/compare/pcre2-10.43...pcre2-10.44)