### PR TITLE
fix: set SG(rfc1867_uploaded_files) to null after destroy

### DIFF
--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -197,6 +197,7 @@ PHPAPI void destroy_uploaded_files_hash(void) /* {{{ */
 	} ZEND_HASH_FOREACH_END();
 	zend_hash_destroy(SG(rfc1867_uploaded_files));
 	FREE_HASHTABLE(SG(rfc1867_uploaded_files));
+	SG(rfc1867_uploaded_files) = NULL;
 }
 /* }}} */
 
@@ -1157,7 +1158,7 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler) /* {{{ */
 			register_http_post_files_variable(lbuf, s, &PG(http_globals)[TRACK_VARS_FILES], 0);
 			s = NULL;
 
-			/* Add full path of supplied file for folder uploads via 
+			/* Add full path of supplied file for folder uploads via
 			 * <input type="file" name="files" multiple webkitdirectory>
 			 */
 			/* Add $foo[full_path] */


### PR DESCRIPTION
Prevents issues like https://github.com/dunglas/frankenphp/pull/857.
It probably doesn't affect anyone except FrankenPHP and maybe a few extensions, but it looks cleaner to me.

Feel free to close if you feel this patch is useless.