### PR TITLE
Phar offset exist issue with entry classes not based on PharFileInfo

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -3529,6 +3529,10 @@ PHP_METHOD(Phar, offsetExists)
 		}
 		RETURN_TRUE;
 	} else {
+		/* If the info class is not based on PharFileInfo, directories are not directly instantiable */
+		if (UNEXPECTED(!instanceof_function(phar_obj->spl.info_class, phar_ce_entry))) {
+			RETURN_FALSE;
+		}
 		RETURN_BOOL(zend_hash_exists(&phar_obj->archive->virtual_dirs, file_name));
 	}
 }

--- a/ext/phar/tests/phar_oo_011.phpt
+++ b/ext/phar/tests/phar_oo_011.phpt
@@ -43,13 +43,13 @@ __halt_compiler();
 bool(true)
 object(PharFileInfo)#%d (2) {
   ["pathName":"SplFileInfo":private]=>
-  string(%s) "phar:///%s/phar_oo_011.phar.php/hi"
+  string(%d) "phar://%s/phar_oo_011.phar.php/hi"
   ["fileName":"SplFileInfo":private]=>
   string(2) "hi"
 }
 bool(true)
-phar:///%s/phar_oo_011.phar.php/hi/f.php
-bool(true)
+phar://%s/phar_oo_011.phar.php/hi/f.php
+bool(false)
 LogicException: Cannot use SplFileObject with directories
 bool(true)
 hi

--- a/ext/phar/tests/phar_oo_011.phpt
+++ b/ext/phar/tests/phar_oo_011.phpt
@@ -13,10 +13,22 @@ $pharconfig = 0;
 require_once 'files/phar_oo_test.inc';
 
 $phar = new Phar($fname);
-$phar->setInfoClass('SplFileObject');
 
 $phar['hi/f.php'] = 'hi';
 var_dump(isset($phar['hi']));
+var_dump($phar['hi']);
+var_dump(isset($phar['hi/f.php']));
+echo $phar['hi/f.php'];
+echo "\n";
+
+$phar->setInfoClass('SplFileObject');
+$phar['hi/f.php'] = 'hi';
+var_dump(isset($phar['hi']));
+try {
+    var_dump($phar['hi']);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 var_dump(isset($phar['hi/f.php']));
 echo $phar['hi/f.php'];
 echo "\n";
@@ -27,7 +39,17 @@ echo "\n";
 unlink(__DIR__ . '/files/phar_oo_011.phar.php');
 __halt_compiler();
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
+object(PharFileInfo)#%d (2) {
+  ["pathName":"SplFileInfo":private]=>
+  string(%s) "phar:///%s/phar_oo_011.phar.php/hi"
+  ["fileName":"SplFileInfo":private]=>
+  string(2) "hi"
+}
+bool(true)
+phar:///%s/phar_oo_011.phar.php/hi/f.php
+bool(true)
+LogicException: Cannot use SplFileObject with directories
 bool(true)
 hi


### PR DESCRIPTION
When checking for the existence of a directory the entry CE should be based on PharFileInfo, as SplFileInfo does not accept directories.