### PR TITLE
ext/pcre: update Config to match upstream

### DIFF
--- a/ext/pcre/pcre2lib/config.h
+++ b/ext/pcre/pcre2lib/config.h
@@ -75,7 +75,7 @@
    Care must be taken if it is increased, because it guards against integer
    overflow caused by enormously large patterns. */
 #ifndef MAX_NAME_SIZE
-#define MAX_NAME_SIZE 32
+#define MAX_NAME_SIZE 128
 #endif
 
 /* Defining NEVER_BACKSLASH_C locks out the use of \C in all patterns. */


### PR DESCRIPTION
In GH-14498, we updated pcre2lib to v10.44. However, it missed syncing the config, that changes upstream `MAX_NAME_SIZE` from 32 to 128.

Ref: [1](https://github.com/PCRE2Project/pcre2/commit/ced3b0f06fe9cd2a66ce7c52f4aec62bb2dd29c1#diff-91c5b46dc84a94604a4e4d0caed9bf85590a2eddbb12d2e8dc80badf324a9dfb), [2](https://github.com/PCRE2Project/pcre2/commit/6c670c780ae1bd8041aab12b5531125d0fbce39e)