### PR TITLE
fix memleak due to missing `pthread_attr_destroy()`-call

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -119,11 +119,13 @@ static bool zend_call_stack_get_linux_pthread(zend_call_stack *stack)
 
 	error = pthread_getattr_np(pthread_self(), &attr);
 	if (error) {
+		pthread_attr_destroy(&attr);
 		return false;
 	}
 
 	error = pthread_attr_getstack(&attr, &addr, &max_size);
 	if (error) {
+		pthread_attr_destroy(&attr);
 		return false;
 	}
 
@@ -133,6 +135,7 @@ static bool zend_call_stack_get_linux_pthread(zend_call_stack *stack)
 		/* In glibc prior to 2.8, addr and size include the guard pages */
 		error = pthread_attr_getguardsize(&attr, &guard_size);
 		if (error) {
+			pthread_attr_destroy(&attr);
 			return false;
 		}
 
@@ -143,6 +146,8 @@ static bool zend_call_stack_get_linux_pthread(zend_call_stack *stack)
 
 	stack->base = (int8_t*)addr + max_size;
 	stack->max_size = max_size;
+
+	pthread_attr_destroy(&attr);
 
 	return true;
 }

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -119,7 +119,6 @@ static bool zend_call_stack_get_linux_pthread(zend_call_stack *stack)
 
 	error = pthread_getattr_np(pthread_self(), &attr);
 	if (error) {
-		pthread_attr_destroy(&attr);
 		return false;
 	}
 


### PR DESCRIPTION
Hey there 👋 

I just added [PHP 8.3 with ASAN to `ext-parallel`](https://github.com/krakjoe/parallel/actions/runs/9412788403/job/25928700526) and it is failing. The stack traces I attached led me to the docs of the `pthread_getattr_np()` call where it is stated that:

> When the thread attributes object returned by pthread_getattr_np() is no longer required, it should be destroyed using [pthread_attr_destroy(3)](https://man7.org/linux/man-pages/man3/pthread_attr_destroy.3.html).

The implementation of `pthread_attr_setaffinity_np()` (which is called by `pthread_getattr_np()`) does some allocations, that are freed in the `pthread_attr_destroy()` function, so I added this call. It looks like this code is related to #9104, so I'd appreciate a review from @arnaud-lb.

With the proposed changes, ASAN in `ext-parallel` is green again. I can not rule out, that I missed something, or that I am just misusing the API in some way.

This is the stack trace ASAN is showing locally:
``` 
Direct leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0xffff96b0a4b4 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0xffff9688ad30  (/lib/aarch64-linux-gnu/libc.so.6+0x7ad30)
    #2 0xffff9688b098 in pthread_attr_setaffinity_np (/lib/aarch64-linux-gnu/libc.so.6+0x7b098)
    #3 0xffff9688e7b0 in pthread_getattr_np (/lib/aarch64-linux-gnu/libc.so.6+0x7e7b0)
    #4 0xaaaabe8c9820 in zend_call_stack_get_linux_pthread /opt/src/php-src/Zend/zend_call_stack.c:120
    #5 0xaaaabe8c9e28 in zend_call_stack_get_linux /opt/src/php-src/Zend/zend_call_stack.c:239
    #6 0xaaaabe8c9e98 in zend_call_stack_get /opt/src/php-src/Zend/zend_call_stack.c:511
    #7 0xaaaabe8c9078 in zend_call_stack_init /opt/src/php-src/Zend/zend_call_stack.c:63
    #8 0xaaaabe9896d4 in zend_new_thread_end_handler /opt/src/php-src/Zend/zend.c:848
    #9 0xaaaabe75d030 in allocate_new_resource /opt/src/php-src/TSRM/TSRM.c:412
    #10 0xaaaabe75d39c in ts_resource_ex /opt/src/php-src/TSRM/TSRM.c:461
    #11 0xffff9377e1f8  (<unknown module>)
    #12 0xffff93780b88  (<unknown module>)
    #13 0xffff9688d5c4  (/lib/aarch64-linux-gnu/libc.so.6+0x7d5c4)
    #14 0xffff968f5ed8  (/lib/aarch64-linux-gnu/libc.so.6+0xe5ed8)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0xffff96b0a69c in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0xffff9688b0bc in pthread_attr_setaffinity_np (/lib/aarch64-linux-gnu/libc.so.6+0x7b0bc)
    #2 0xffff9688e7b0 in pthread_getattr_np (/lib/aarch64-linux-gnu/libc.so.6+0x7e7b0)
    #3 0xaaaabe8c9820 in zend_call_stack_get_linux_pthread /opt/src/php-src/Zend/zend_call_stack.c:120
    #4 0xaaaabe8c9e28 in zend_call_stack_get_linux /opt/src/php-src/Zend/zend_call_stack.c:239
    #5 0xaaaabe8c9e98 in zend_call_stack_get /opt/src/php-src/Zend/zend_call_stack.c:511
    #6 0xaaaabe8c9078 in zend_call_stack_init /opt/src/php-src/Zend/zend_call_stack.c:63
    #7 0xaaaabe9896d4 in zend_new_thread_end_handler /opt/src/php-src/Zend/zend.c:848
    #8 0xaaaabe75d030 in allocate_new_resource /opt/src/php-src/TSRM/TSRM.c:412
    #9 0xaaaabe75d39c in ts_resource_ex /opt/src/php-src/TSRM/TSRM.c:461
    #10 0xffff9377e1f8  (<unknown module>)
    #11 0xffff93780b88  (<unknown module>)
    #12 0xffff9688d5c4  (/lib/aarch64-linux-gnu/libc.so.6+0x7d5c4)
    #13 0xffff968f5ed8  (/lib/aarch64-linux-gnu/libc.so.6+0xe5ed8)

SUMMARY: AddressSanitizer: 184 byte(s) leaked in 2 allocation(s).
```