### PR TITLE
Sync HAVE_GRP_H definition

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -63,7 +63,7 @@
 # endif
 #endif
 
-#if HAVE_GRP_H
+#ifdef HAVE_GRP_H
 # include <grp.h>
 #endif
 

--- a/ext/standard/link.c
+++ b/ext/standard/link.c
@@ -37,7 +37,7 @@
 #include <pwd.h>
 #endif
 #endif
-#if HAVE_GRP_H
+#ifdef HAVE_GRP_H
 # include <grp.h>
 #endif
 #include <errno.h>

--- a/ext/standard/pageinfo.c
+++ b/ext/standard/pageinfo.c
@@ -27,7 +27,7 @@
 #include <pwd.h>
 #endif
 #endif
-#if HAVE_GRP_H
+#ifdef HAVE_GRP_H
 # include <grp.h>
 #endif
 #ifdef PHP_WIN32

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -66,7 +66,7 @@
 #define HAVE_UTIME 1
 #undef HAVE_DIRENT_H
 #define HAVE_FCNTL_H 1
-#define HAVE_GRP_H 0
+#undef HAVE_GRP_H
 #undef HAVE_PWD_H
 #undef HAVE_SYS_FILE_H
 #undef HAVE_SYS_SOCKET_H


### PR DESCRIPTION
This syncs the HAVE_GRP_H definition on Windows (manually defined) and Autotools (checked with AC_CHECK_HEADERS):
HAVE_GRP_H is is either undefined or defined to value 1.