### PR TITLE
Fix GH-14474: Better document remote user in PHP-FPM access.format

### DIFF
--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -348,7 +348,7 @@ pm.max_spare_servers = 3
 ;      %d/%b/%Y:%H:%M:%S %z (default)
 ;      The strftime(3) format must be encapsulated in a %{<strftime_format>}t tag
 ;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
-;  %u: remote user
+;  %u: basic auth user if specified in Authorization header
 ;
 ; Default: "%R - %u %t \"%m %r\" %s"
 ;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{milli}d %{kilo}M %C%%"


### PR DESCRIPTION
The current description of %u access log specifier is confusing - this tries to clarify it better. Better wording suggestions appreciated.