### PR TITLE
Enable erase_empty_line in ext/readline

### DIFF
--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -75,6 +75,11 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
     -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
   ])
 
+  AC_CHECK_DECL([rl_erase_empty_line],
+    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1],
+      [Define to 1 if readline library has rl_erase_empty_line variable.])],,
+    [#include <readline/readline.h>])
+
   AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
   AC_DEFINE(HAVE_LIBREADLINE, 1, [ ])
 
@@ -132,6 +137,11 @@ elif test "$PHP_LIBEDIT" != "no"; then
   ],[],[
     $READLINE_SHARED_LIBADD
   ])
+
+  AC_CHECK_DECL([rl_erase_empty_line],
+    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1],
+      [Define to 1 if edit library has rl_erase_empty_line variable.])],,
+    [#include <editline/readline.h>])
 
   AC_DEFINE(HAVE_LIBEDIT, 1, [ ])
 fi

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -171,7 +171,7 @@ PHP_FUNCTION(readline_info)
 				: ZSTR_CHAR(rl_completion_append_character));
 		add_assoc_bool(return_value,"completion_suppress_append",rl_completion_suppress_append);
 #endif
-#if HAVE_ERASE_EMPTY_LINE
+#ifdef HAVE_ERASE_EMPTY_LINE
 		add_assoc_long(return_value,"erase_empty_line",rl_erase_empty_line);
 #endif
 #ifndef PHP_WIN32
@@ -235,7 +235,7 @@ PHP_FUNCTION(readline_info)
 			RETVAL_INTERNED_STR(
 				oldval == 0 ? ZSTR_EMPTY_ALLOC() : ZSTR_CHAR(oldval));
 #endif
-#if HAVE_ERASE_EMPTY_LINE
+#ifdef HAVE_ERASE_EMPTY_LINE
 		} else if (zend_string_equals_literal_ci(what, "erase_empty_line")) {
 			oldval = rl_erase_empty_line;
 			if (value) {

--- a/ext/readline/tests/libedit_info_001.phpt
+++ b/ext/readline/tests/libedit_info_001.phpt
@@ -30,7 +30,7 @@ array(%d) {
   ["point"]=>
   int(0)
   ["end"]=>
-  int%a
+  int(0)%A
   ["library_version"]=>
   string(%d) "%s"
   ["readline_name"]=>

--- a/ext/readline/tests/libedit_info_001.phpt
+++ b/ext/readline/tests/libedit_info_001.phpt
@@ -24,13 +24,13 @@ var_dump(readline_info('attempted_completion_over'));
 
 ?>
 --EXPECTF--
-array(6) {
+array(%d) {
   ["line_buffer"]=>
   string(0) ""
   ["point"]=>
   int(0)
   ["end"]=>
-  int(0)
+  int%a
   ["library_version"]=>
   string(%d) "%s"
   ["readline_name"]=>

--- a/ext/readline/tests/readline_info_001.phpt
+++ b/ext/readline/tests/readline_info_001.phpt
@@ -45,7 +45,7 @@ array(%d) {
   ["completion_append_character"]=>
   string(1) " "
   ["completion_suppress_append"]=>
-  bool%a
+  bool(false)%A
   ["library_version"]=>
   string(%d) "%s"
   ["readline_name"]=>

--- a/ext/readline/tests/readline_info_001.phpt
+++ b/ext/readline/tests/readline_info_001.phpt
@@ -25,7 +25,7 @@ var_dump(readline_info('completion_suppress_append'));
 
 ?>
 --EXPECTF--
-array(13) {
+array(%d) {
   ["line_buffer"]=>
   string(0) ""
   ["point"]=>
@@ -45,7 +45,7 @@ array(13) {
   ["completion_append_character"]=>
   string(1) " "
   ["completion_suppress_append"]=>
-  bool(false)
+  bool%a
   ["library_version"]=>
   string(%d) "%s"
   ["readline_name"]=>


### PR DESCRIPTION
This wasn't activated due to inconsistent availability over the editline/readline versions and variants. This now checks whether the rl_erase_empty_line variable is available in library headers and enables it based on that. On Windows this is for now still disabled due to wineditline library, which doesn't have this yet.

Documentation already mentions the erase_empty_line setting: https://www.php.net/manual/en/function.readline-info.php