### PR TITLE
Get rid of uses of sprintf

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -477,12 +477,13 @@ TSRM_API FILE *popen_ex(const char *command, const char *type, const char *cwd, 
 		return NULL;
 	}
 
-	cmd = (char*)malloc(strlen(command)+strlen(TWG(comspec))+sizeof(" /s /c ")+2);
+	size_t cmd_buffer_size = strlen(command) + strlen(TWG(comspec)) + sizeof(" /s /c ") + 2;
+	cmd = malloc(cmd_buffer_size);
 	if (!cmd) {
 		return NULL;
 	}
 
-	sprintf(cmd, "%s /s /c \"%s\"", TWG(comspec), command);
+	snprintf(cmd, cmd_buffer_size, "%s /s /c \"%s\"", TWG(comspec), command);
 	cmdw = php_win32_cp_any_to_w(cmd);
 	if (!cmdw) {
 		free(cmd);

--- a/Zend/zend_gdb.c
+++ b/Zend/zend_gdb.c
@@ -130,7 +130,7 @@ ZEND_API bool zend_gdb_present(void)
 				pid = atoi(s);
 				if (pid) {
 					char out[1024];
-					sprintf(buf, "/proc/%d/exe", (int)pid);
+					snprintf(buf, sizeof(buf), "/proc/%d/exe", (int)pid);
 					if (readlink(buf, out, sizeof(out) - 1) > 0) {
 						if (strstr(out, "gdb")) {
 							ret = 1;

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -257,7 +257,7 @@ PHP_MINFO_FUNCTION(curl)
 	php_info_print_table_start();
 	php_info_print_table_row(2, "cURL support",    "enabled");
 	php_info_print_table_row(2, "cURL Information", d->version);
-	sprintf(str, "%d", d->age);
+	snprintf(str, sizeof(str), "%d", d->age);
 	php_info_print_table_row(2, "Age", str);
 
 	/* To update on each new cURL release using src/main.c in cURL sources */
@@ -324,7 +324,7 @@ PHP_MINFO_FUNCTION(curl)
 	n = 0;
 	p = (char **) d->protocols;
 	while (*p != NULL) {
-			n += sprintf(str + n, "%s%s", *p, *(p + 1) != NULL ? ", " : "");
+			n += snprintf(str + n, sizeof(str) - n, "%s%s", *p, *(p + 1) != NULL ? ", " : "");
 			p++;
 	}
 	php_info_print_table_row(2, "Protocols", str);

--- a/ext/gd/libgd/gd_gif_in.c
+++ b/ext/gd/libgd/gd_gif_in.c
@@ -360,7 +360,7 @@ GetDataBlock(gdIOCtx *fd, unsigned char *buf, int *ZeroDataBlockP)
 		if (rv > 0) {
 			tmp = safe_emalloc(3 * rv, sizeof(char), 1);
 			for (i=0;i<rv;i++) {
-				sprintf(&tmp[3*sizeof(char)*i], " %02x", buf[i]);
+				snprintf(tmp + 3 * i, 4, " %02x", buf[i]);
 			}
 		} else {
 			tmp = estrdup("");

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -1080,12 +1080,14 @@ static int add_array_entry(const char* loc_name, zval* hash_arr, char* key_name)
 			if( cur_key_name ){
 				efree( cur_key_name);
 			}
-			cur_key_name = (char*)ecalloc( 25,  25);
-			sprintf( cur_key_name , "%s%d", key_name , cnt++);
+			/* Over-allocates a few bytes for the integer so we don't have to reallocate. */
+			size_t cur_key_name_size = (sizeof("-2147483648") - 1) + strlen(key_name) + 1;
+			cur_key_name = emalloc(cur_key_name_size);
+			snprintf( cur_key_name, cur_key_name_size , "%s%d", key_name , cnt++);
 			add_assoc_string( hash_arr, cur_key_name , token);
 			/* tokenize on the "_" or "-" and stop  at singleton if any */
 			while( (token = php_strtok_r(NULL , DELIMITER , &last_ptr)) && (strlen(token)>1) ){
-				sprintf( cur_key_name , "%s%d", key_name , cnt++);
+				snprintf( cur_key_name , cur_key_name_size, "%s%d", key_name , cnt++);
 				add_assoc_string( hash_arr, cur_key_name , token);
 			}
 /*

--- a/ext/mysqlnd/mysqlnd_statistics.c
+++ b/ext/mysqlnd/mysqlnd_statistics.c
@@ -203,7 +203,7 @@ mysqlnd_fill_stats_hash(const MYSQLND_STATS * const stats, const MYSQLND_STRING 
 	for (i = 0; i < stats->count; i++) {
 		char tmp[25];
 
-		sprintf((char *)&tmp, "%" PRIu64, stats->values[i]);
+		snprintf(tmp, sizeof(tmp), "%" PRIu64, stats->values[i]);
 		add_assoc_string_ex(return_value, names[i].s, names[i].l, tmp);
 	}
 }

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -1574,7 +1574,7 @@ php_mysqlnd_rowp_read_text_protocol(MYSQLND_ROW_BUFFER * row_buffer, zval * fiel
 				if (Z_TYPE_P(current_field) == IS_LONG && !as_int_or_float) {
 					/* we are using the text protocol, so convert to string */
 					char tmp[22];
-					const size_t tmp_len = sprintf((char *)&tmp, ZEND_ULONG_FMT, Z_LVAL_P(current_field));
+					const size_t tmp_len = snprintf(tmp, sizeof(tmp), ZEND_ULONG_FMT, Z_LVAL_P(current_field));
 					ZVAL_STRINGL(current_field, tmp, tmp_len);
 				} else if (Z_TYPE_P(current_field) == IS_STRING) {
 					/* nothing to do here, as we want a string and ps_fetch_from_1_to_8_bytes() has given us one */

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -16121,7 +16121,7 @@ static const void *zend_jit_trace_allocate_exit_group(uint32_t n)
 			char name[32];
 
 			for (i = 0; i < ZEND_JIT_EXIT_POINTS_PER_GROUP; i++) {
-				sprintf(name, "jit$$trace_exit_%d", n + i);
+				snprintf(name, sizeof(name), "jit$$trace_exit_%d", n + i);
 				ir_disasm_add_symbol(name, (uintptr_t)entry + (i * ZEND_JIT_EXIT_POINTS_SPACING), ZEND_JIT_EXIT_POINTS_SPACING);
 			}
 		}

--- a/ext/opcache/shared_alloc_posix.c
+++ b/ext/opcache/shared_alloc_posix.c
@@ -77,7 +77,7 @@ static int create_segments(size_t requested_size, zend_shared_segment_posix ***s
 	shared_segment = (zend_shared_segment_posix *)((char *)(*shared_segments_p) + sizeof(void *));
 	(*shared_segments_p)[0] = shared_segment;
 
-	sprintf(shared_segment_name, "/ZendAccelerator.%d", getpid());
+	snprintf(shared_segment_name, sizeof(shared_segment_name), "/ZendAccelerator.%d", getpid());
 #if defined(HAVE_SHM_CREATE_LARGEPAGE)
 	if (shared_segment_lg_index > 0) {
 		shared_segment->shm_fd =  shm_create_largepage(shared_segment_name, shared_segment_flags, shared_segment_lg_index, SHM_LARGEPAGE_ALLOC_DEFAULT, shared_segment_mode);

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1641,9 +1641,7 @@ PHP_FUNCTION(openssl_spki_new)
 		goto cleanup;
 	}
 
-	s = zend_string_alloc(strlen(spkac) + strlen(spkstr), 0);
-	sprintf(ZSTR_VAL(s), "%s%s", spkac, spkstr);
-	ZSTR_LEN(s) = strlen(ZSTR_VAL(s));
+	s = zend_string_concat2(spkac, strlen(spkac), spkstr, strlen(spkstr));
 	OPENSSL_free(spkstr);
 
 	RETVAL_STR(s);

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -498,7 +498,7 @@ static bool php_openssl_matches_san_list(X509 *peer, const char *subject_name) /
 			OPENSSL_free(cert_name);
 		} else if (san->type == GEN_IPADD) {
 			if (san->d.iPAddress->length == 4) {
-				sprintf(ipbuffer, "%d.%d.%d.%d",
+				snprintf(ipbuffer, sizeof(ipbuffer), "%d.%d.%d.%d",
 					san->d.iPAddress->data[0],
 					san->d.iPAddress->data[1],
 					san->d.iPAddress->data[2],

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -528,7 +528,7 @@ retry:
 								buf2[0] = '\0';
 								count = rootlen;
 								while(count < vars->name_length){
-									sprintf(buf, "%lu.", vars->name[count]);
+									snprintf(buf, sizeof(buf), "%lu.", vars->name[count]);
 									strcat(buf2, buf);
 									count++;
 								}
@@ -873,8 +873,9 @@ static bool netsnmp_session_init(php_snmp_session **session_p, int version, zend
 
 	/* put back non-standard SNMP port */
 	if (remote_port != SNMP_PORT) {
-		pptr = session->peername + strlen(session->peername);
-		sprintf(pptr, ":%d", remote_port);
+		size_t peername_length = strlen(session->peername);
+		pptr = session->peername + peername_length;
+		snprintf(pptr, MAX_NAME_LEN - peername_length, ":%d", remote_port);
 	}
 
 	php_network_freeaddresses(psal);

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -641,7 +641,7 @@ static uint8_t *php_parserr(uint8_t *cp, uint8_t *end, querybuf *answer, int typ
 						tp[0] = ':';
 						tp++;
 					}
-					tp += sprintf((char*)tp,"%x",s);
+					tp += snprintf((char*)tp, sizeof(name) - (tp - (uint8_t *) name), "%x", s);
 				} else {
 					if (!have_v6_break) {
 						have_v6_break = 1;
@@ -686,7 +686,7 @@ static uint8_t *php_parserr(uint8_t *cp, uint8_t *end, querybuf *answer, int typ
 						tp[0] = ':';
 						tp++;
 					}
-					sprintf((char*)tp, "%x", cp[0] & 0xFF);
+					snprintf((char*)tp, sizeof(name) - (tp - (uint8_t *) name), "%x", cp[0] & 0xFF);
 				} else {
 					if (!have_v6_break) {
 						have_v6_break = 1;
@@ -711,7 +711,7 @@ static uint8_t *php_parserr(uint8_t *cp, uint8_t *end, querybuf *answer, int typ
 						tp[0] = ':';
 						tp++;
 					}
-					tp += sprintf((char*)tp,"%x",s);
+					tp += snprintf((char*)tp, sizeof(name) - (tp - (uint8_t *) name),"%x",s);
 				} else {
 					if (!have_v6_break) {
 						have_v6_break = 1;

--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -282,7 +282,7 @@ static void php_parserr(PDNS_RECORD pRec, int type_to_fetch, int store, bool raw
 							tp[0] = ':';
 							tp++;
 						}
-						tp += sprintf((char*)tp,"%x", out[i]);
+						tp += snprintf((char*)tp, sizeof(buf) - (tp - (char *) buf), "%x", out[i]);
 					} else {
 						if (!have_v6_break) {
 							have_v6_break = 1;

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -201,9 +201,7 @@ static zend_string* php_password_bcrypt_hash(const zend_string *password, zend_a
 	}
 	ZSTR_VAL(salt)[ZSTR_LEN(salt)] = 0;
 
-	hash = zend_string_alloc(ZSTR_LEN(salt) + hash_format_len, 0);
-	sprintf(ZSTR_VAL(hash), "%s%s", hash_format, ZSTR_VAL(salt));
-	ZSTR_VAL(hash)[hash_format_len + ZSTR_LEN(salt)] = 0;
+	hash = zend_string_concat2(hash_format, hash_format_len, ZSTR_VAL(salt), ZSTR_LEN(salt));
 
 	zend_string_release_ex(salt, 0);
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3846,7 +3846,7 @@ PHPAPI zend_string *php_addcslashes_str(const char *str, size_t len, const char 
 					case '\v': *target++ = 'v'; break;
 					case '\b': *target++ = 'b'; break;
 					case '\f': *target++ = 'f'; break;
-					default: target += sprintf(target, "%03o", (unsigned char) c);
+					default: target += snprintf(target, 4, "%03o", (unsigned char) c);
 				}
 				continue;
 			}

--- a/sapi/cli/ps_title.c
+++ b/sapi/cli/ps_title.c
@@ -321,7 +321,7 @@ const char* ps_title_errno(int rc)
 
 #ifdef PS_USE_WIN32
     case PS_TITLE_WINDOWS_ERROR:
-        sprintf(windows_error_details, "Windows error code: %lu", GetLastError());
+        snprintf(windows_error_details, sizeof(windows_error_details), "Windows error code: %lu", GetLastError());
         return windows_error_details;
 #endif
     }

--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -1262,7 +1262,7 @@ int fpm_conf_write_pid(void)
 			return -1;
 		}
 
-		len = sprintf(buf, "%d", (int) fpm_globals.parent_pid);
+		len = snprintf(buf, sizeof(buf), "%d", (int) fpm_globals.parent_pid);
 
 		if (len != write(fd, buf, len)) {
 			zlog(ZLOG_SYSERROR, "Unable to write to the PID file.");

--- a/sapi/fpm/fpm/fpm_env.c
+++ b/sapi/fpm/fpm/fpm_env.c
@@ -32,10 +32,11 @@ int setenv(char *name, char *value, int clobber) /* {{{ */
 		return 0;
 	}
 
-	if ((cp = malloc(strlen(name) + strlen(value) + 2)) == 0) {
+	size_t length = strlen(name) + strlen(value) + 2;
+	if ((cp = malloc(length)) == 0) {
 		return 1;
 	}
-	sprintf(cp, "%s=%s", name, value);
+	snprintf(cp, length, "%s=%s", name, value);
 	return putenv(cp);
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -165,7 +165,7 @@ static int fpm_php_set_fcgi_mgmt_vars(struct fpm_worker_pool_s *wp) /* {{{ */
 	char max_workers[10 + 1]; /* 4294967295 */
 	int len;
 
-	len = sprintf(max_workers, "%u", (unsigned int) wp->config->pm_max_children);
+	len = snprintf(max_workers, sizeof(max_workers), "%u", (unsigned int) wp->config->pm_max_children);
 
 	fcgi_set_mgmt_var("FCGI_MAX_CONNS", sizeof("FCGI_MAX_CONNS")-1, max_workers, len);
 	fcgi_set_mgmt_var("FCGI_MAX_REQS",  sizeof("FCGI_MAX_REQS")-1,  max_workers, len);

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -43,12 +43,12 @@ enum { FPM_GET_USE_SOCKET = 1, FPM_STORE_SOCKET = 2, FPM_STORE_USE_SOCKET = 3 };
 static int routemax = -1;
 #endif
 
-static inline void fpm_sockets_get_env_name(char *envname, unsigned idx) /* {{{ */
+static inline void fpm_sockets_get_env_name(char *envname, size_t envname_length, unsigned idx) /* {{{ */
 {
 	if (!idx) {
 		strcpy(envname, "FPM_SOCKETS");
 	} else {
-		sprintf(envname, "FPM_SOCKETS_%d", idx);
+		snprintf(envname, envname_length, "FPM_SOCKETS_%d", idx);
 	}
 }
 /* }}} */
@@ -70,7 +70,7 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 		} else { /* on PARENT EXEC we want socket fds to be inherited through environment variable */
 			char fd[32];
 			char *tmpenv_value;
-			sprintf(fd, "%d", ls->sock);
+			snprintf(fd, sizeof(fd), "%d", ls->sock);
 
 			socket_set_buf = (i % FPM_ENV_SOCKET_SET_SIZE == 0 && i) ? 1 : 0;
 			tmpenv_value = realloc(env_value, p + (p ? 1 : 0) + strlen(ls->key) + 1 + strlen(fd) + socket_set_buf + 1);
@@ -104,10 +104,10 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 
 	if (env_value) {
 		for (i = 0; i < socket_set_count; i++) {
-			fpm_sockets_get_env_name(envname, i);
+			fpm_sockets_get_env_name(envname, sizeof(envname), i);
 			setenv(envname, env_value + socket_set[i], 1);
 		}
-		fpm_sockets_get_env_name(envname, socket_set_count);
+		fpm_sockets_get_env_name(envname, sizeof(envname), socket_set_count);
 		unsetenv(envname);
 		free(env_value);
 	}
@@ -143,7 +143,8 @@ static int fpm_sockets_hash_op(int sock, struct sockaddr *sa, char *key, int typ
 			case FPM_AF_INET : {
 				key = alloca(INET6_ADDRSTRLEN+10);
 				inet_ntop(sa->sa_family, fpm_get_in_addr(sa), key, INET6_ADDRSTRLEN);
-				sprintf(key+strlen(key), ":%d", fpm_get_in_port(sa));
+				size_t key_length = strlen(key);
+				snprintf(key + key_length, INET6_ADDRSTRLEN + 10 - key_length, ":%d", fpm_get_in_port(sa));
 				break;
 			}
 
@@ -455,7 +456,7 @@ int fpm_sockets_init_main(void)
 
 	/* import inherited sockets */
 	for (i = 0; i < FPM_ENV_SOCKET_SET_MAX; i++) {
-		fpm_sockets_get_env_name(envname, i);
+		fpm_sockets_get_env_name(envname, sizeof(envname), i);
 		inherited = getenv(envname);
 		if (!inherited) {
 			break;

--- a/sapi/fpm/fpm/fpm_trace_pread.c
+++ b/sapi/fpm/fpm/fpm_trace_pread.c
@@ -33,7 +33,7 @@ int fpm_trace_ready(pid_t pid) /* {{{ */
 {
 	char buf[128];
 
-	sprintf(buf, "/proc/%d/" PROC_MEM_FILE, (int) pid);
+	snprintf(buf, sizeof(buf), "/proc/%d/" PROC_MEM_FILE, (int) pid);
 	mem_file = open(buf, O_RDONLY);
 	if (0 > mem_file) {
 		zlog(ZLOG_SYSERROR, "failed to open %s", buf);

--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -533,14 +533,15 @@ int fpm_unix_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 			return -1;
 		}
 
-		new_con = malloc(strlen(con) + strlen(wp->config->apparmor_hat) + 3); // // + 0 Byte
+		size_t new_con_length = strlen(con) + strlen(wp->config->apparmor_hat) + 3; // // + 0 Byte
+		new_con = malloc(new_con_length);
 		if (!new_con) {
 			zlog(ZLOG_SYSERROR, "[pool %s] failed to allocate memory for apparmor hat change.", wp->config->name);
 			free(con);
 			return -1;
 		}
 
-		if (0 > sprintf(new_con, "%s//%s", con, wp->config->apparmor_hat)) {
+		if (0 > snprintf(new_con, new_con_length, "%s//%s", con, wp->config->apparmor_hat)) {
 			zlog(ZLOG_SYSERROR, "[pool %s] failed to construct apparmor confinement.", wp->config->name);
 			free(con);
 			free(new_con);

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1672,9 +1672,10 @@ phpdbg_out:
 
 		if (PHPDBG_G(exec) && strcmp("Standard input code", PHPDBG_G(exec)) == SUCCESS) { /* i.e. execution context has been read from stdin - back it up */
 			phpdbg_file_source *data = zend_hash_str_find_ptr(&PHPDBG_G(file_sources), PHPDBG_G(exec), PHPDBG_G(exec_len));
-			backup_phpdbg_compile = zend_string_alloc(data->len + 2, 1);
+			size_t size = data->len + 2;
+			backup_phpdbg_compile = zend_string_alloc(size, 1);
 			GC_MAKE_PERSISTENT_LOCAL(backup_phpdbg_compile);
-			sprintf(ZSTR_VAL(backup_phpdbg_compile), "?>%.*s", (int) data->len, data->buf);
+			snprintf(ZSTR_VAL(backup_phpdbg_compile), size + 1, "?>%.*s", (int) data->len, data->buf);
 		}
 
 		zend_try {

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -503,8 +503,9 @@ PHPDBG_API int phpdbg_parse_variable_with_arg(char *input, size_t len, HashTable
 						keylen = spprintf(&key, 0, ZEND_ULONG_FMT, numkey);
 					}
 					propkey = phpdbg_get_property_key(key);
-					name = emalloc(i + keylen + 2);
-					namelen = sprintf(name, "%.*s%.*s%s", (int) i, input, (int) (keylen - (propkey - key)), propkey, input[len - 1] == ']'?"]":"");
+					namelen = i + keylen + 2;
+					name = emalloc(namelen);
+					namelen = snprintf(name, namelen, "%.*s%.*s%s", (int) i, input, (int) (keylen - (propkey - key)), propkey, input[len - 1] == ']'?"]":"");
 					if (!strkey) {
 						efree(key);
 					}

--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -691,8 +691,10 @@ static int SendText(char *RPath, const char *Subject, const char *mailTo, char *
 
 static int addToHeader(char **header_buffer, const char *specifier, const char *string)
 {
-	*header_buffer = erealloc(*header_buffer, strlen(*header_buffer) + strlen(specifier) + strlen(string) + 1);
-	sprintf(*header_buffer + strlen(*header_buffer), specifier, string);
+	size_t header_buffer_size = strlen(*header_buffer);
+	size_t total_size = header_buffer_size + strlen(specifier) + strlen(string) + 1;
+	*header_buffer = erealloc(*header_buffer, total_size);
+	snprintf(*header_buffer + header_buffer_size, total_size - header_buffer_size, specifier, string);
 	return 1;
 }
 


### PR DESCRIPTION
`sprintf` is a function that is prone to buffer overflows. Some compilers (e.g. Clang on macOS) have also started emitting warnings about calling `sprintf`. This patch replaces the uses of `sprintf` with `snprintf` and in some cases with `strpprintf`.