### PR TITLE
Remove redundant win32/unistd.h includes

### DIFF
--- a/ext/fileinfo/php_libmagic.h
+++ b/ext/fileinfo/php_libmagic.h
@@ -22,7 +22,6 @@
 
 #ifdef PHP_WIN32
 #include "win32/param.h"
-#include "win32/unistd.h"
 
 #ifdef _WIN64
 #define FINFO_LSEEK_FUNC _lseeki64

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -26,9 +26,6 @@
 #include <math.h>
 #include <time.h>
 #include <string.h>
-#ifdef PHP_WIN32
-#include "win32/unistd.h"
-#endif
 #include "zend_globals.h"
 #include "zend_interfaces.h"
 #include "php_array.h"


### PR DESCRIPTION
At this point win32/unistd.h only declares usleep which isn't used at these places.