### PR TITLE
Update ext/spl as required dependency for ext/pdo

### DIFF
--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -10,7 +10,7 @@ if test "$PHP_PDO" != "no"; then
   PHP_PDO=yes
 
   PHP_NEW_EXTENSION(pdo, pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c, $ext_shared)
-  PHP_ADD_EXTENSION_DEP(pdo, spl, true)
+  PHP_ADD_EXTENSION_DEP(pdo, spl)
   PHP_INSTALL_HEADERS([ext/pdo], [php_pdo.h php_pdo_driver.h php_pdo_error.h])
   PHP_ADD_MAKEFILE_FRAGMENT
 fi

--- a/ext/pdo/config.w32
+++ b/ext/pdo/config.w32
@@ -4,7 +4,7 @@ ARG_ENABLE("pdo", "Enable PHP Data Objects support", "no");
 
 if (PHP_PDO != "no") {
 	EXTENSION('pdo', 'pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c', false /* force static, PHP_PDO_SHARED is broken yet somehow */);
-	ADD_EXTENSION_DEP('pdo', 'spl', true);
+	ADD_EXTENSION_DEP('pdo', 'spl');
 	ADD_MAKEFILE_FRAGMENT();
 	PHP_INSTALL_HEADERS("ext/pdo", "php_pdo.h php_pdo_driver.h php_pdo_error.h");
 }


### PR DESCRIPTION
Since ZEND_MOD_REQUIRED is used and spl can't be disabled, this marks the configure time dependency also as required.