### PR TITLE
Add optional pkg-config support for PostgreSQL

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -134,6 +134,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_MYSQL has been removed.
    - Symbol HAVE_PDO_SQLITELIB has been removed.
    - Symbol HAVE_WAITPID has been removed.
+   - Symbol HAVE_LIBPQ has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
@@ -145,6 +146,11 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
+   - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
+     extensions. The libpq paths can be customized with the PGSQL_CFLAGS and
+     PGSQL_LIBS environment variables. When a directory argument is provided to
+     configure options (--with-pgsql=DIR or --with-pdo-pgsql=DIR), it will be
+     used instead of the pkg-config search.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -1,81 +1,24 @@
 PHP_ARG_WITH([pdo-pgsql],
   [for PostgreSQL support for PDO],
   [AS_HELP_STRING([[--with-pdo-pgsql[=DIR]]],
-    [PDO: PostgreSQL support. DIR is the PostgreSQL base install directory or
-    the path to pg_config])])
+    [PDO: PostgreSQL support. Optional DIR is the PostgreSQL base install
+    directory or the path to pg_config. Also, the PGSQL_CFLAGS and PGSQL_LIBS
+    environment variables can be used instead of the DIR argument to customize
+    the libpq paths.])])
 
 if test "$PHP_PDO_PGSQL" != "no"; then
-
   if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
     AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
   fi
 
-  PHP_EXPAND_PATH($PGSQL_INCLUDE, PGSQL_INCLUDE)
-
-  AC_MSG_CHECKING(for pg_config)
-  for i in $PHP_PDO_PGSQL $PHP_PDO_PGSQL/bin /usr/local/pgsql/bin /usr/local/bin /usr/bin ""; do
-    if test -x $i/pg_config; then
-      PG_CONFIG="$i/pg_config"
-      break;
-    fi
-  done
-
-  if test -n "$PG_CONFIG"; then
-    AC_MSG_RESULT([$PG_CONFIG])
-    PGSQL_INCLUDE=`$PG_CONFIG --includedir`
-    PGSQL_LIBDIR=`$PG_CONFIG --libdir`
-  else
-    AC_MSG_RESULT(not found)
-    if test "$PHP_PDO_PGSQL" = "yes"; then
-      PGSQL_SEARCH_PATHS="/usr /usr/local /usr/local/pgsql"
-    else
-      PGSQL_SEARCH_PATHS=$PHP_PDO_PGSQL
-    fi
-
-    for i in $PGSQL_SEARCH_PATHS; do
-      for j in include include/pgsql include/postgres include/postgresql ""; do
-        if test -r "$i/$j/libpq-fe.h"; then
-          PGSQL_INC_BASE=$i
-          PGSQL_INCLUDE=$i/$j
-        fi
-      done
-
-      for j in $PHP_LIBDIR $PHP_LIBDIR/pgsql $PHP_LIBDIR/postgres $PHP_LIBDIR/postgresql ""; do
-        if test -f "$i/$j/libpq.so" || test -f "$i/$j/libpq.a"; then
-          PGSQL_LIBDIR=$i/$j
-        fi
-      done
-    done
-  fi
-
-  if test -z "$PGSQL_INCLUDE"; then
-    AC_MSG_ERROR(Cannot find libpq-fe.h. Please specify correct PostgreSQL installation path)
-  fi
-
-  if test -z "$PGSQL_LIBDIR"; then
-    AC_MSG_ERROR(Cannot find libpq.so. Please specify correct PostgreSQL installation path)
-  fi
-
-  if test -z "$PGSQL_INCLUDE" && test -z "$PGSQL_LIBDIR"; then
-    AC_MSG_ERROR([Unable to find libpq anywhere under $PGSQL_SEARCH_PATHS])
-  fi
+  PHP_SETUP_PGSQL([PDO_PGSQL_SHARED_LIBADD],,, [$PHP_PDO_PGSQL])
+  PHP_SUBST([PDO_PGSQL_SHARED_LIBADD])
 
   AC_DEFINE(HAVE_PDO_PGSQL,1,[Whether to build PostgreSQL for PDO support or not])
 
-  old_LIBS=$LIBS
-  old_LDFLAGS=$LDFLAGS
-  LDFLAGS="-L$PGSQL_LIBDIR $LDFLAGS"
-
-  AC_CHECK_LIB(pq, PQlibVersion,, AC_MSG_ERROR([Unable to build the PDO PostgreSQL driver: at least libpq 9.1 is required]))
-  AC_CHECK_LIB(pq, PQresultMemorySize, AC_DEFINE(HAVE_PG_RESULT_MEMORY_SIZE,1,[PostgreSQL 12 or later]))
-
-  LIBS=$old_LIBS
-  LDFLAGS=$old_LDFLAGS
-
-  PHP_ADD_LIBRARY_WITH_PATH(pq, $PGSQL_LIBDIR, PDO_PGSQL_SHARED_LIBADD)
-  PHP_SUBST(PDO_PGSQL_SHARED_LIBADD)
-
-  PHP_ADD_INCLUDE($PGSQL_INCLUDE)
+  PHP_CHECK_LIBRARY([pq], [PQresultMemorySize],
+    [AC_DEFINE([HAVE_PG_RESULT_MEMORY_SIZE], [1], [PostgreSQL 12 or later])],,
+    [$PGSQL_LIBS])
 
   PHP_CHECK_PDO_INCLUDES
 

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -1,76 +1,38 @@
 PHP_ARG_WITH([pgsql],
   [for PostgreSQL support],
   [AS_HELP_STRING([[--with-pgsql[=DIR]]],
-    [Include PostgreSQL support. DIR is the PostgreSQL base install directory or
-    the path to pg_config])])
+    [Include PostgreSQL support. Optional DIR is the PostgreSQL base install
+    directory or the path to pg_config. Also, the PGSQL_CFLAGS and PGSQL_LIBS
+    environment variables can be used instead of the DIR argument to customize
+    the libpq paths.])])
 
 if test "$PHP_PGSQL" != "no"; then
-  PHP_EXPAND_PATH($PGSQL_INCLUDE, PGSQL_INCLUDE)
-
-  dnl pg_config is still the default way to retrieve build options
-  dnl pkgconfig support was only introduced in 9.3
-
-  AC_MSG_CHECKING(for pg_config)
-  for i in $PHP_PGSQL $PHP_PGSQL/bin /usr/local/pgsql/bin /usr/local/bin /usr/bin ""; do
-	if test -x $i/pg_config; then
-      PG_CONFIG="$i/pg_config"
-      break;
-    fi
-  done
-
-  if test -n "$PG_CONFIG"; then
-    AC_MSG_RESULT([$PG_CONFIG])
-    PGSQL_INCLUDE=`$PG_CONFIG --includedir`
-    PGSQL_LIBDIR=`$PG_CONFIG --libdir`
-  else
-    AC_MSG_RESULT(not found)
-    if test "$PHP_PGSQL" = "yes"; then
-      PGSQL_SEARCH_PATHS="/usr /usr/local /usr/local/pgsql"
-    else
-      PGSQL_SEARCH_PATHS=$PHP_PGSQL
-    fi
-
-    for i in $PGSQL_SEARCH_PATHS; do
-      for j in include include/pgsql include/postgres include/postgresql ""; do
-        if test -r "$i/$j/libpq-fe.h"; then
-          PGSQL_INC_BASE=$i
-          PGSQL_INCLUDE=$i/$j
-        fi
-      done
-
-      for j in lib $PHP_LIBDIR/pgsql $PHP_LIBDIR/postgres $PHP_LIBDIR/postgresql ""; do
-        if test -f "$i/$j/libpq.so" || test -f "$i/$j/libpq.a"; then
-          PGSQL_LIBDIR=$i/$j
-        fi
-      done
-    done
-  fi
-
-  if test -z "$PGSQL_INCLUDE"; then
-    AC_MSG_ERROR(Cannot find libpq-fe.h. Please specify correct PostgreSQL installation path)
-  fi
-
-  if test -z "$PGSQL_LIBDIR"; then
-    AC_MSG_ERROR(Cannot find libpq.so. Please specify correct PostgreSQL installation path)
-  fi
-
-  if test -z "$PGSQL_INCLUDE" && test -z "$PGSQL_LIBDIR"; then
-    AC_MSG_ERROR([Unable to find libpq anywhere under $PGSQL_SEARCH_PATHS])
-  fi
+  PHP_SETUP_PGSQL([PGSQL_SHARED_LIBADD],,, [$PHP_PGSQL])
+  PHP_SUBST([PGSQL_SHARED_LIBADD])
 
   AC_DEFINE(HAVE_PGSQL,1,[Whether to build PostgreSQL support or not])
-  old_LIBS=$LIBS
-  old_LDFLAGS=$LDFLAGS
-  LDFLAGS="-L$PGSQL_LIBDIR $LDFLAGS"
+
+  PHP_CHECK_LIBRARY([pq], [lo_truncate64],
+    [AC_DEFINE([HAVE_PG_LO64], [1], [PostgreSQL 9.3 or later])],,
+    [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQsetErrorContextVisibility],
+    [AC_DEFINE([HAVE_PG_CONTEXT_VISIBILITY], [1], [PostgreSQL 9.6 or later])],,
+    [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQresultMemorySize],
+    [AC_DEFINE([HAVE_PG_RESULT_MEMORY_SIZE], [1], [PostgreSQL 12 or later])],,
+    [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQchangePassword],
+    [AC_DEFINE([HAVE_PG_CHANGE_PASSWORD], [1], [PostgreSQL 17 or later])],,
+    [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQsocketPoll],
+    [AC_DEFINE([HAVE_PG_SOCKET_POLL], [1], [PostgreSQL 17 or later])],,
+    [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQsetChunkedRowsMode],
+    [AC_DEFINE([HAVE_PG_SET_CHUNKED_ROWS_SIZE], [1], [PostgreSQL 17 or later])],,
+    [$PGSQL_LIBS])
+
   old_CFLAGS=$CFLAGS
-  CFLAGS="$CFLAGS -I$PGSQL_INCLUDE"
-  AC_CHECK_LIB(pq, PQlibVersion,, AC_MSG_ERROR([Unable to build the PostgreSQL extension: at least libpq 9.1 is required]))
-  AC_CHECK_LIB(pq, lo_truncate64, AC_DEFINE(HAVE_PG_LO64,1,[PostgreSQL 9.3 or later]))
-  AC_CHECK_LIB(pq, PQsetErrorContextVisibility, AC_DEFINE(HAVE_PG_CONTEXT_VISIBILITY,1,[PostgreSQL 9.6 or later]))
-  AC_CHECK_LIB(pq, PQresultMemorySize, AC_DEFINE(HAVE_PG_RESULT_MEMORY_SIZE,1,[PostgreSQL 12 or later]))
-  AC_CHECK_LIB(pq, PQchangePassword, AC_DEFINE(HAVE_PG_CHANGE_PASSWORD,1,[PostgreSQL 17 or later]))
-  AC_CHECK_LIB(pq, PQsocketPoll, AC_DEFINE(HAVE_PG_SOCKET_POLL,1,[PostgreSQL 17 or later]))
-  AC_CHECK_LIB(pq, PQsetChunkedRowsMode, AC_DEFINE(HAVE_PG_SET_CHUNKED_ROWS_SIZE,1,[PostgreSQL 17 or later]))
+  CFLAGS="$CFLAGS $PGSQL_CFLAGS"
 
   dnl Available since PostgreSQL 12.
   AC_CACHE_CHECK([if PGVerbosity enum has PQERRORS_SQLSTATE],
@@ -83,14 +45,7 @@ if test "$PHP_PGSQL" != "no"; then
     [AC_DEFINE([HAVE_PQERRORS_SQLSTATE], [1],
       [Define to 1 if PGVerbosity enum has PQERRORS_SQLSTATE.])])
 
-  LIBS=$old_LIBS
-  LDFLAGS=$old_LDFLAGS
   CFLAGS=$old_CFLAGS
-
-  PHP_ADD_LIBRARY_WITH_PATH(pq, $PGSQL_LIBDIR, PGSQL_SHARED_LIBADD)
-  PHP_SUBST(PGSQL_SHARED_LIBADD)
-
-  PHP_ADD_INCLUDE($PGSQL_INCLUDE)
 
   PHP_NEW_EXTENSION(pgsql, pgsql.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_ADD_EXTENSION_DEP(pgsql, pcre)


### PR DESCRIPTION
The pkg-config (libpq.pc file) was added in PostgreSQL 9.3. This adds a common setup M4 macro PHP_SETUP_PGSQL to find libpq on the system with pkg-config. If not found, it falls back to pg_config to find the libpq library and its headers in common locations as before.

When using pkg-config, the PGSQL_CFLAGS and PGSQL_LIBS environment variables can override the paths to libpq installation:

    ./configure --with-pgsql --with-pdo-pgsql \
        PGSQL_CFLAGS=-I/path/to/libpq \
        PGSQL_LIBS="-L/path/to/libpq -lpq"

Follow-up of GH-4235 (Use PKG_CHECK_MODULES to detect the pq library)