### PR TITLE
zend_compile: Optimize `sprintf()` into a rope

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -10193,6 +10193,8 @@ static void zend_compile_rope_finalize(znode *result, uint32_t rope_elements, ze
 	if (rope_elements == 1) {
 		if (opline->op2_type == IS_CONST) {
 			GET_NODE(result, opline->op2);
+			ZVAL_UNDEF(CT_CONSTANT(opline->op2));
+			SET_UNUSED(opline->op2);
 			MAKE_NOP(opline);
 		} else {
 			opline->opcode = ZEND_CAST;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4773,6 +4773,14 @@ static zend_result zend_compile_func_sprintf(znode *result, zend_ast_list *args)
 		return FAILURE;
 	}
 
+	/* Handle empty format strings. */
+	if (Z_STRLEN_P(format_string) == 0) {
+		result->op_type = IS_CONST;
+		ZVAL_EMPTY_STRING(&result->u.constant);
+
+		return SUCCESS;
+	}
+
 	znode *elements = NULL;
 
 	if (string_placeholder_count > 0) {
@@ -4853,16 +4861,6 @@ static zend_result zend_compile_func_sprintf(znode *result, zend_ast_list *args)
 		znode const_node;
 		const_node.op_type = IS_CONST;
 		ZVAL_STRINGL(&const_node.u.constant, offset, end - offset);
-		if (rope_elements == 0) {
-			rope_init_lineno = get_next_op_number();
-		}
-		opline = zend_compile_rope_add(result, rope_elements++, &const_node);
-	}
-	if (rope_elements == 0) {
-		/* Handle empty format strings. */
-		znode const_node;
-		const_node.op_type = IS_CONST;
-		ZVAL_EMPTY_STRING(&const_node.u.constant);
 		if (rope_elements == 0) {
 			rope_init_lineno = get_next_op_number();
 		}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4718,11 +4718,13 @@ static void zend_compile_rope_finalize(znode *result, uint32_t j, zend_op *init_
 
 static zend_result zend_compile_func_sprintf(znode *result, zend_ast_list *args) /* {{{ */
 {
+	/* Bail out if we do not have a format string. */
 	if (args->children < 1) {
 		return FAILURE;
 	}
 
 	zend_eval_const_expr(&args->child[0]);
+	/* Bail out if the format string is not constant. */
 	if (args->child[0]->kind != ZEND_AST_ZVAL) {
 		return FAILURE;
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -10188,9 +10188,9 @@ static zend_op *zend_compile_rope_add(znode *result, uint32_t num, znode *elem_n
 }
 /* }}} */
 
-static void zend_compile_rope_finalize(znode *result, uint32_t j, zend_op *init_opline, zend_op *opline)
+static void zend_compile_rope_finalize(znode *result, uint32_t rope_elements, zend_op *init_opline, zend_op *opline)
 {
-	if (j == 1) {
+	if (rope_elements == 1) {
 		if (opline->op2_type == IS_CONST) {
 			GET_NODE(result, opline->op2);
 			MAKE_NOP(opline);
@@ -10202,7 +10202,7 @@ static void zend_compile_rope_finalize(znode *result, uint32_t j, zend_op *init_
 			SET_UNUSED(opline->op2);
 			zend_make_tmp_result(result, opline);
 		}
-	} else if (j == 2) {
+	} else if (rope_elements == 2) {
 		opline->opcode = ZEND_FAST_CONCAT;
 		opline->extended_value = 0;
 		opline->op1_type = init_opline->op2_type;
@@ -10212,13 +10212,13 @@ static void zend_compile_rope_finalize(znode *result, uint32_t j, zend_op *init_
 	} else {
 		uint32_t var;
 
-		init_opline->extended_value = j;
+		init_opline->extended_value = rope_elements;
 		opline->opcode = ZEND_ROPE_END;
 		zend_make_tmp_result(result, opline);
 		var = opline->op1.var = get_temporary_variable();
 
 		/* Allocates the necessary number of zval slots to keep the rope */
-		uint32_t i = ((j * sizeof(zend_string*)) + (sizeof(zval) - 1)) / sizeof(zval);
+		uint32_t i = ((rope_elements * sizeof(zend_string*)) + (sizeof(zval) - 1)) / sizeof(zval);
 		while (i > 1) {
 			get_temporary_variable();
 			i--;

--- a/ext/standard/tests/strings/sprintf_rope_optimization_001.phpt
+++ b/ext/standard/tests/strings/sprintf_rope_optimization_001.phpt
@@ -1,0 +1,167 @@
+--TEST--
+Test sprintf() function : Rope Optimization
+--FILE--
+<?php
+function func($str) {
+	return strtoupper($str);
+}
+function sideeffect() {
+	echo "Called!\n";
+	return "foo";
+}
+class Foo {
+	public function __construct() {
+		echo "Called\n";
+	}
+}
+
+$a = "foo";
+$b = "bar";
+$c = new stdClass();
+
+try {
+	var_dump(sprintf("const"));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s", $a));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s/%s", $a, $b));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s/%s/%s", $a, $b));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s/%s/%s", $a, $b, $c));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s/", func("baz")));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("/%s", func("baz")));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("/%s/", func("baz")));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s%s%s%s", $a, $b, func("baz"), $a));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s/%s", sprintf("%s:%s", $a, $b), sprintf("%s-%s", func('baz'), func('baz'))));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf(sideeffect()));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s-%s-%s", __FILE__, __LINE__, 1));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	$values = range('a', 'z');
+	var_dump(sprintf("%s%s%s", "{$values[0]}{$values[1]}{$values[2]}", "{$values[3]}{$values[4]}{$values[5]}", "{$values[6]}{$values[7]}{$values[8]}"));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf("%s%s%s", new Foo(), new Foo(), new Foo(), ));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf(...));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf('%%s'));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf('%%s', 'test'));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf('%s-%s-%s', [], [], []));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+try {
+	var_dump(sprintf(""));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+echo "Done";
+?>
+--EXPECTF--
+string(5) "const"
+
+string(3) "foo"
+
+string(7) "foo/bar"
+
+ArgumentCountError: 4 arguments are required, 3 given in %s:32
+Stack trace:
+#0 %s(32): sprintf('%s/%s/%s', 'foo', 'bar')
+#1 {main}
+
+Error: Object of class stdClass could not be converted to string in %s:36
+Stack trace:
+#0 {main}
+
+string(4) "BAZ/"
+
+string(4) "/BAZ"
+
+string(5) "/BAZ/"
+
+string(12) "foobarBAZfoo"
+
+string(15) "foo:bar/BAZ-BAZ"
+
+Called!
+string(3) "foo"
+
+string(%d) "%ssprintf_rope_optimization_001.php-%d-1"
+
+string(9) "abcdefghi"
+
+Called
+Called
+Called
+Error: Object of class Foo could not be converted to string in %s:73
+Stack trace:
+#0 {main}
+
+object(Closure)#3 (2) {
+  ["function"]=>
+  string(7) "sprintf"
+  ["parameter"]=>
+  array(2) {
+    ["$format"]=>
+    string(10) "<required>"
+    ["$values"]=>
+    string(10) "<optional>"
+  }
+}
+
+string(2) "%s"
+
+string(2) "%s"
+
+
+Warning: Array to string conversion in %s on line 89
+
+Warning: Array to string conversion in %s on line 89
+
+Warning: Array to string conversion in %s on line 89
+string(17) "Array-Array-Array"
+
+string(0) ""
+
+Done

--- a/ext/standard/tests/strings/sprintf_rope_optimization_001.phpt
+++ b/ext/standard/tests/strings/sprintf_rope_optimization_001.phpt
@@ -96,6 +96,10 @@ try {
 	var_dump(sprintf(""));
 } catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
 
+try {
+	var_dump(sprintf());
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
 echo "Done";
 ?>
 --EXPECTF--
@@ -163,5 +167,10 @@ Warning: Array to string conversion in %s on line 89
 string(17) "Array-Array-Array"
 
 string(0) ""
+
+ArgumentCountError: sprintf() expects at least 1 argument, 0 given in %s:97
+Stack trace:
+#0 %s(97): sprintf()
+#1 {main}
 
 Done

--- a/ext/standard/tests/strings/sprintf_rope_optimization_002.phpt
+++ b/ext/standard/tests/strings/sprintf_rope_optimization_002.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test sprintf() function : Rope Optimization with a throwing error handler.
+--FILE--
+<?php
+
+function exception_error_handler(int $errno, string $errstr, ?string $errfile, int $errline) {
+	if (!(error_reporting() & $errno)) {
+		// This error code is not included in error_reporting
+		return;
+	}
+	throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+}
+set_error_handler(exception_error_handler(...));
+
+try {
+	var_dump(sprintf("%s-%s", new stdClass(), []));
+} catch (\Throwable $e) {echo $e, PHP_EOL; } echo PHP_EOL;
+
+echo "Done";
+?>
+--EXPECTF--
+Error: Object of class stdClass could not be converted to string in %s:13
+Stack trace:
+#0 {main}
+
+Done


### PR DESCRIPTION
This optimization will compile `sprintf()` using only `%s` placeholders into a rope at compile time, effectively making those calls equivalent to the use of string interpolation, with the added benefit of supporting arbitrary expressions instead of just expressions starting with a `$`.

For a synthetic test using:

```php
<?php

$a = 'foo';
$b = 'bar';

for ($i = 0; $i < 100_000_000; $i++) {
    sprintf("%s-%s", $a, $b);
}
```

This optimization yields a 2.1× performance improvement:

    $ hyperfine 'sapi/cli/php -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php' \
          '/tmp/unoptimized -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php'
    Benchmark 1: sapi/cli/php -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php
      Time (mean ± σ):      1.869 s ±  0.033 s    [User: 1.865 s, System: 0.003 s]
      Range (min … max):    1.840 s …  1.945 s    10 runs

    Benchmark 2: /tmp/unoptimized -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php
      Time (mean ± σ):      4.011 s ±  0.034 s    [User: 4.006 s, System: 0.005 s]
      Range (min … max):    3.964 s …  4.079 s    10 runs

    Summary
      sapi/cli/php -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php ran
        2.15 ± 0.04 times faster than /tmp/unoptimized -d zend_extension=php-src/modules/opcache.so -d opcache.enable_cli=1 test.php

This optimization comes with a small and probably insignificant behavioral change: If one of the values cannot be (cleanly) converted to a string, for example when attempting to insert an object that is not `Stringable`, the resulting Exception will naturally not show the `sprintf()` call in the resulting stack trace, because there is no call to `sprintf()`.

Nevertheless it will correctly point out the line of the `sprintf()` call as the source of the Exception, pointing the user towards the correct location.

-----------

I'd like to thank Ilija for his preliminary review and great feedback during development of this :smiley: 