### PR TITLE
Rename HAVE_DECL_ARC4RANDOM_BUF to HAVE_ARC4RANDOM_BUF

### DIFF
--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -1,7 +1,6 @@
-dnl
-dnl Check for arc4random on BSD systems
-dnl
-AC_CHECK_DECLS([arc4random_buf])
+AC_CHECK_DECL([arc4random_buf],
+  [AC_DEFINE([HAVE_ARC4RANDOM_BUF], [1],
+    [Define to 1 if you have the 'arc4random_buf' function.])])
 
 dnl
 dnl Check for CCRandomGenerateBytes

--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -85,7 +85,7 @@ ZEND_ATTRIBUTE_NONNULL PHPAPI zend_result php_random_bytes_ex(void *bytes, size_
 		snprintf(errstr, errstr_size, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)");
 		return FAILURE;
 	}
-#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001 && __NetBSD_Version__ < 1000000000) || \
+#elif defined(HAVE_ARC4RANDOM_BUF) && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001 && __NetBSD_Version__ < 1000000000) || \
   defined(__APPLE__))
 	/*
 	 * OpenBSD until there is a valid equivalent


### PR DESCRIPTION
AC_CHECK_DECLS defines HAVE_DECL_ARC4RANDOM_BUF to 0 or 1. On Windows this isn't defined to 0. To avoid the undefined state, the AC_CHECK_DECL is used to manually define the HAVE_ARC4RANDOM_BUF to 1 if declaration is found, otherwise undefined.

In the future on current platforms, also AC_CHECK_FUNCS can be used instead since the arc4random_buf is located in default libraries (C) with declaration available in headers.