### PR TITLE
ext/pgsql: add pg_jit server info.

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -333,6 +333,7 @@ static const func_info_t func_infos[] = {
 	F1("pg_tty", MAY_BE_STRING),
 	F1("pg_host", MAY_BE_STRING),
 	F1("pg_version", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
+	F1("pg_jit", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
 	F1("pg_parameter_status", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("pg_query", MAY_BE_OBJECT|MAY_BE_FALSE),
 	F1("pg_query_params", MAY_BE_OBJECT|MAY_BE_FALSE),

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -864,6 +864,7 @@ PHP_FUNCTION(pg_close)
 #define PHP_PG_TTY 5
 #define PHP_PG_HOST 6
 #define PHP_PG_VERSION 7
+#define PHP_PG_JIT 8
 
 /* php_pgsql_get_link_info */
 static void php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type)
@@ -929,6 +930,25 @@ static void php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type
 			PHP_PQ_COPY_PARAM("application_name");
 			return;
 		}
+		case PHP_PG_JIT: {
+			PGresult *res;
+			array_init(return_value);
+			res = PQexec(pgsql, "SHOW jit_provider");
+			if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+                            add_assoc_null(return_value, "jit_provider");
+			} else {
+                            add_assoc_string(return_value, "jit_provider", PQgetvalue(res, 0, 0));
+			}
+			PQclear(res);
+			res = PQexec(pgsql, "SHOW jit");
+			if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+                            add_assoc_null(return_value, "jit");
+			} else {
+                            add_assoc_string(return_value, "jit", PQgetvalue(res, 0, 0));
+			}
+			PQclear(res);
+			return;
+		}
 		EMPTY_SWITCH_DEFAULT_CASE()
 	}
 	if (result) {
@@ -978,6 +998,11 @@ PHP_FUNCTION(pg_host)
 PHP_FUNCTION(pg_version)
 {
 	php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAM_PASSTHRU,PHP_PG_VERSION);
+}
+
+PHP_FUNCTION(pg_jit)
+{
+	php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAM_PASSTHRU,PHP_PG_JIT);
 }
 
 /* Returns the value of a server parameter */

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -498,6 +498,12 @@ namespace {
     function pg_version(?PgSql\Connection $connection = null): array {}
 
     /**
+     * @return array<string, string|null>
+     * @refcount 1
+     */
+    function pg_jit(?PgSql\Connection $connection = null): array {}
+
+    /**
      * @param PgSql\Connection|string $connection
      * @refcount 1
      */

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 464db6ede26d59885bec20e40346702f84c3e515 */
+ * Stub hash: c4b75f8f59a1c4f906cf89fb6aea66436a4eedc3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -35,6 +35,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_version, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, connection, PgSql\\Connection, 1, "null")
 ZEND_END_ARG_INFO()
+
+#define arginfo_pg_jit arginfo_pg_version
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_parameter_status, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
@@ -499,6 +501,7 @@ ZEND_FUNCTION(pg_port);
 ZEND_FUNCTION(pg_tty);
 ZEND_FUNCTION(pg_host);
 ZEND_FUNCTION(pg_version);
+ZEND_FUNCTION(pg_jit);
 ZEND_FUNCTION(pg_parameter_status);
 ZEND_FUNCTION(pg_ping);
 ZEND_FUNCTION(pg_query);
@@ -603,6 +606,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_tty, arginfo_pg_tty)
 	ZEND_FE(pg_host, arginfo_pg_host)
 	ZEND_FE(pg_version, arginfo_pg_version)
+	ZEND_FE(pg_jit, arginfo_pg_jit)
 	ZEND_FE(pg_parameter_status, arginfo_pg_parameter_status)
 	ZEND_FE(pg_ping, arginfo_pg_ping)
 	ZEND_FE(pg_query, arginfo_pg_query)

--- a/ext/pgsql/tests/pg_jit.phpt
+++ b/ext/pgsql/tests/pg_jit.phpt
@@ -1,0 +1,21 @@
+--TEST--
+PostgreSQL JIT support
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("inc/skipif.inc"); ?>
+--FILE--
+<?php
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+var_dump(pg_jit($db));
+pg_close($db);
+?>
+--EXPECTF--
+array(2) {
+  ["jit_provider"]=>
+  %s
+  ["jit"]=>
+  %s
+}


### PR DESCRIPTION
since PostgreSQL 11, LLVM JIT feature had been brought thus reporting the settings to the client connection.