### PR TITLE
Add --enable-phpdbg-debug option on Windows

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -159,6 +159,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The HAVE_OPENSSL symbol has been removed.
    - The HAVE_OPENSSL_EXT symbol is now consistently defined to value 1 whether
      the openssl extension is available either as shared or built statically.
+   - Added configure option --enable-phpdbg-debug to build phpdbg in debug mode.
 
 ========================
 3. Module changes

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -8,7 +8,8 @@ PHP_ARG_ENABLE([phpdbg],
 PHP_ARG_ENABLE([phpdbg-debug],
   [for phpdbg debug build],
   [AS_HELP_STRING([--enable-phpdbg-debug],
-    [Build phpdbg in debug mode])],
+    [Build phpdbg in debug mode to enable additional diagnostic output for
+    developing and troubleshooting phpdbg itself])],
   [no],
   [no])
 
@@ -23,13 +24,10 @@ if test "$PHP_PHPDBG" != "no"; then
   AC_HEADER_TIOCGWINSZ
   AC_DEFINE(HAVE_PHPDBG, 1, [ ])
 
-  if test "$PHP_PHPDBG_DEBUG" != "no"; then
-    AC_DEFINE(PHPDBG_DEBUG, 1, [ ])
-  else
-    AC_DEFINE(PHPDBG_DEBUG, 0, [ ])
-  fi
-
   PHP_PHPDBG_CFLAGS="-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  AS_VAR_IF([PHP_PHPDBG_DEBUG], [no],,
+    [AS_VAR_APPEND([PHP_PHPDBG_CFLAGS], [" -DPHPDBG_DEBUG=1"])])
+
   PHP_PHPDBG_FILES="phpdbg.c phpdbg_parser.c phpdbg_lexer.c phpdbg_prompt.c phpdbg_help.c phpdbg_break.c phpdbg_print.c phpdbg_bp.c phpdbg_list.c phpdbg_utils.c phpdbg_info.c phpdbg_cmd.c phpdbg_set.c phpdbg_frame.c phpdbg_watch.c phpdbg_btree.c phpdbg_sigsafe.c phpdbg_io.c phpdbg_out.c"
 
   AC_MSG_CHECKING([for phpdbg and readline integration])

--- a/sapi/phpdbg/config.w32
+++ b/sapi/phpdbg/config.w32
@@ -1,5 +1,6 @@
 ARG_ENABLE('phpdbg', 'Build phpdbg', 'no');
 ARG_ENABLE('phpdbgs', 'Build phpdbg shared', 'no');
+ARG_ENABLE('phpdbg-debug', 'Build phpdbg in debug mode for phpdbg development', 'no');
 
 PHPDBG_SOURCES='phpdbg.c phpdbg_prompt.c phpdbg_cmd.c phpdbg_info.c phpdbg_help.c phpdbg_break.c ' +
 		'phpdbg_print.c phpdbg_bp.c phpdbg_list.c phpdbg_utils.c ' +
@@ -17,10 +18,18 @@ if (PHP_PHPDBG == "yes") {
 	ADD_FLAG("LIBS_PHPDBG", "ws2_32.lib user32.lib");
 	ADD_FLAG("CFLAGS_PHPDBG", "/D YY_NO_UNISTD_H");
 	ADD_FLAG("LDFLAGS_PHPDBG", "/stack:8388608");
+
+	if(PHP_PHPDBG_DEBUG == "yes") {
+		ADD_FLAG("CFLAGS_PHPDBG", "/D PHPDBG_DEBUG=1");
+	}
 }
 
 if (PHP_PHPDBGS == "yes") {
 	SAPI('phpdbgs', PHPDBG_SOURCES, PHPDBG_DLL, '/D PHP_PHPDBG_EXPORTS /I win32');
 	ADD_FLAG("LIBS_PHPDBGS", "ws2_32.lib user32.lib");
 	ADD_FLAG("CFLAGS_PHPDBGS", "/D YY_NO_UNISTD_H");
+
+	if(PHP_PHPDBG_DEBUG == "yes") {
+		ADD_FLAG("CFLAGS_PHPDBGS", "/D PHPDBG_DEBUG=1");
+	}
 }

--- a/sapi/phpdbg/config.w32
+++ b/sapi/phpdbg/config.w32
@@ -1,6 +1,7 @@
 ARG_ENABLE('phpdbg', 'Build phpdbg', 'no');
 ARG_ENABLE('phpdbgs', 'Build phpdbg shared', 'no');
-ARG_ENABLE('phpdbg-debug', 'Build phpdbg in debug mode for phpdbg development', 'no');
+ARG_ENABLE('phpdbg-debug', 'Build phpdbg in debug mode to enable additional \
+diagnostic output for developing and troubleshooting phpdbg itself', 'no');
 
 PHPDBG_SOURCES='phpdbg.c phpdbg_prompt.c phpdbg_cmd.c phpdbg_info.c phpdbg_help.c phpdbg_break.c ' +
 		'phpdbg_print.c phpdbg_bp.c phpdbg_list.c phpdbg_utils.c ' +

--- a/sapi/phpdbg/phpdbg_out.h
+++ b/sapi/phpdbg/phpdbg_out.h
@@ -19,6 +19,10 @@
 #ifndef PHPDBG_OUT_H
 #define PHPDBG_OUT_H
 
+#ifndef PHPDBG_DEBUG
+# define PHPDBG_DEBUG 0
+#endif
+
 /**
  * Error/notice/formatting helpers
  */

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -455,7 +455,8 @@ can be built that way. \
 
 	var snapshot_build_exclusions = new Array(
 		'debug', 'lzf-better-compression', 'php-build', 'snapshot-template', 'zts',
-		'ipv6', 'fd-setsize', 'pgi', 'pgo', 'all-shared', 'config-profile', 'sanitizer'
+		'ipv6', 'fd-setsize', 'pgi', 'pgo', 'all-shared', 'config-profile', 'sanitizer',
+		'phpdbg-debug'
 	);
 	var force;
 


### PR DESCRIPTION
This enables outputting additional debugging messages when running phpdbg for developing and troubleshooting phpdbg itself. Option was already added in Autotools and this adds it also to Windows build system.