### PR TITLE
Make some parts of _zend_mm_heap read-only at runtime

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -242,6 +242,7 @@ ZEND_API void zend_memory_reset_peak_usage(void);
 
 /* Heap functions */
 typedef struct _zend_mm_heap zend_mm_heap;
+typedef struct _zend_mm_ro_heap zend_mm_ro_heap;
 
 ZEND_API zend_mm_heap *zend_mm_startup(void);
 ZEND_API void zend_mm_shutdown(zend_mm_heap *heap, bool full_shutdown, bool silent);


### PR DESCRIPTION
~~PHP's heap implementation is the one that virtually everybody uses: it's fast, it's there by default, it works, …
The only major ever I've found of custom heap implementation [is phpdbg](https://github.com/rogercaetanos/php-src/blob/e39db5773d9443e2cfee92bc31651848c044c325/sapi/phpdbg/phpdbg.c#L968-L999) but it looks dispensable at best. Some other debuggers and profilers might use it, and that's alright, but I don't think that this feature should be enabled by default.~~

~~Disabling ZEND_MM_CUSTOM will allow to save a couple of bytes (yay), but the main goal is to close a low-hanging exploitation vector: as [presented at OffensiveCon 2024](https://youtu.be/dqKFHjcK9hM?t=1622), having trivially callable writeable function pointers at the top of the heap makes it straightforward to turn a limited write into an arbitrary code execution.~~

As [presented at OffensiveCon 2024](https://youtu.be/dqKFHjcK9hM?t=1622), having trivially
callable writeable function pointers at the top of the heap makes it straightforward to turn a limited write into an arbitrary code execution.
    
Disabling ZEND_MM_HEAP by default isn't doable, as it's used by a couple of profilers, so we're making some parts of `_zend_mm_heap` read-only at runtime instead: this will prevent the custom heap functions pointers from being hijacked.

cc @arnaud-lb 