### PR TITLE
Update ext/xmlreader dependencies

### DIFF
--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -5,15 +5,11 @@ PHP_ARG_ENABLE([xmlreader],
   [yes])
 
 if test "$PHP_XMLREADER" != "no"; then
-
-  if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XMLReader extension requires LIBXML extension, add --with-libxml])
-  fi
-
   PHP_SETUP_LIBXML(XMLREADER_SHARED_LIBADD, [
     AC_DEFINE(HAVE_XMLREADER,1,[ ])
     PHP_NEW_EXTENSION(xmlreader, php_xmlreader.c, $ext_shared)
     PHP_ADD_EXTENSION_DEP(xmlreader, dom, true)
+    PHP_ADD_EXTENSION_DEP(xmlreader, libxml)
     PHP_SUBST(XMLREADER_SHARED_LIBADD)
   ])
 fi

--- a/ext/xmlreader/config.w32
+++ b/ext/xmlreader/config.w32
@@ -12,6 +12,6 @@ if (PHP_XMLREADER == "yes" &&
 	if (!PHP_XMLREADER_SHARED) {
 		ADD_FLAG("CFLAGS_XMLREADER", "/D LIBXML_STATIC");
 	}
+	ADD_EXTENSION_DEP('xmlreader', 'dom', true);
 	ADD_EXTENSION_DEP('xmlreader', 'libxml');
-	ADD_EXTENSION_DEP('xmlreader', 'dom');
 }

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -277,6 +277,9 @@ static xmlRelaxNGPtr _xmlreader_get_relaxNG(char *source, size_t source_len, siz
 #endif
 
 static const zend_module_dep xmlreader_deps[] = {
+#ifdef HAVE_DOM
+	ZEND_MOD_REQUIRED("dom")
+#endif
 	ZEND_MOD_REQUIRED("libxml")
 	ZEND_MOD_END
 };


### PR DESCRIPTION
- ext/dom is optional (using HAVE_DOM for cases when dom is build as a shared extension to make it required in that case)
- ext/libxml is required