### PR TITLE
Refactor SHADOW_STACK_SYSCALL check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1322,9 +1322,9 @@ else
   fiber_asm="no"
 fi
 
-dnl Check whether syscall to create shadow stack exists, should be a better way, but...
-AC_CACHE_CHECK([whether syscall to create shadow stack exists], ac_cv_syscall_shadow_stack_exists,
-[AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_CACHE_CHECK([whether syscall to create shadow stack exists],
+[php_cv_have_shadow_stack_syscall],
+[AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <unistd.h>
 #include <sys/mman.h>
 int main(void) {
@@ -1334,18 +1334,19 @@ int main(void) {
     munmap(base, 0x20000);
     return 0;
   }
-  else
-    return 1;
+  return 1;
 }
-  ]])], [ac_cv_syscall_shadow_stack_exists=yes], [ac_cv_syscall_shadow_stack_exists=no], [ac_cv_syscall_shadow_stack_exists=no])
+])],
+  [php_cv_have_shadow_stack_syscall=yes],
+  [php_cv_have_shadow_stack_syscall=no],
+  [php_cv_have_shadow_stack_syscall=no])
 ])
-if test "$ac_cv_syscall_shadow_stack_exists" = yes; then
-  AC_DEFINE([SHADOW_STACK_SYSCALL], 1, [ ])
-  # asm file can't see macro from AC_DEFINE, workaround this via cflag
-  fiber_asm_cflag="-DSHADOW_STACK_SYSCALL=1"
-  # if the syscall doesn't exist, we may block the final ELF from __PROPERTY_SHSTK
-  # via redefine macro as "-D__CET__=1"
-fi
+dnl The asm files can't see macro from AC_DEFINE, workaround this via cflag. If
+dnl the syscall doesn't exist, we may block the final ELF from __PROPERTY_SHSTK
+dnl via redefine macro as "-D__CET__=1".
+AS_VAR_IF([php_cv_have_shadow_stack_syscall], [yes],
+  [fiber_asm_cflag="-DSHADOW_STACK_SYSCALL=1"],
+  [fiber_asm_cflag="-DSHADOW_STACK_SYSCALL=0"])
 
 if test "$fiber_asm" = 'yes'; then
   AC_MSG_CHECKING([for fiber switching context])
@@ -1776,7 +1777,7 @@ PHP_ADD_SOURCES(Zend, \
 	Optimizer/escape_analysis.c \
 	Optimizer/compact_vars.c \
 	Optimizer/zend_dump.c \
-    , -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+    , [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $fiber_asm_cflag])
 
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/scripts/Makefile.frag,$abs_srcdir/scripts,scripts)
 PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Zend/Makefile.frag,$abs_srcdir/Zend,Zend)


### PR DESCRIPTION
This fixes -Wundef warnings present where SHADOW_STACK_SYSCALL should be defined to value 0 and refactors the check with cache variable php_cv_have_shadow_stack_syscall. The SHADOW_STACK_SYSCALL CPP macro definition is removed from php_config.h in favor of a compilation definition on asm files and Zend engine files.