### PR TITLE
Fix warnings function declaration isn't a prototype

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -807,7 +807,7 @@ typedef union {
 	double d;
 	long double ld;
 	void *p;
-	void (*fun)();
+	void (*fun)(void);
 } zend_max_align_t;
 #endif
 


### PR DESCRIPTION
This fixes the -Wstrict-prototypes warnings that might pop up in certain builds.

If I'm not mistaken this last element can be specified like this, yes?