### PR TITLE
Enable native SSL support in ext/phar

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -132,6 +132,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      --with-ftp-ssl and --with-mysqlnd-ssl.
    - New configure option --with-openssl-legacy-provider to enable OpenSSL
      legacy provider.
+   - New configure option --with-phar-ssl to explicitly enable SSL support in
+     phar extension when building without openssl extension. When building with
+     openssl extension (shared or static), SSL support is enabled implicitly.
    - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
    - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
    - HAVE_UTSNAME_DOMAINNAME symbol renamed to HAVE_STRUCT_UTSNAME_DOMAINNAME.

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -13,14 +13,9 @@ if (PHP_PHAR != "no") {
 		ADD_FLAG("CFLAGS_PHAR", "/D COMPILE_DL_PHAR ");
 	}
 	if (PHP_PHAR_NATIVE_SSL != "no") {
-		if (CHECK_LIB("libeay32st.lib", "phar")) {
-			/* We don't really need GDI for this, but there's no
-			way to avoid linking it in the static openssl build */
-			ADD_FLAG("LIBS_PHAR", "libeay32st.lib gdi32.lib");
-			if (PHP_DEBUG == "no") {
-				/* Silence irrelevant-to-us warning in release builds */
-				ADD_FLAG("LDFLAGS_PHAR", "/IGNORE:4089 ");
-			}
+		var ret = SETUP_OPENSSL("phar", PHP_PHAR);
+
+		if (ret >= 2) {
 			AC_DEFINE('PHAR_HAVE_OPENSSL', 1);
 			STDOUT.WriteLine('        Native OpenSSL support in Phar enabled');
 		} else {

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -12,7 +12,7 @@ if (PHP_PHAR != "no") {
 	if (PHP_PHAR_SHARED || (PHP_PHAR_NATIVE_SSL_SHARED && PHP_SNAPSHOT_BUILD == "no")) {
 		ADD_FLAG("CFLAGS_PHAR", "/D COMPILE_DL_PHAR ");
 	}
-	if (PHP_PHAR_NATIVE_SSL != "no") {
+	if (PHP_PHAR_NATIVE_SSL != "no" && PHP_SNAPSHOT_BUILD == "no") {
 		var ret = SETUP_OPENSSL("phar", PHP_PHAR);
 
 		if (ret >= 2) {

--- a/ext/phar/tests/phar_setsignaturealgo.phpt
+++ b/ext/phar/tests/phar_setsignaturealgo.phpt
@@ -1,10 +1,10 @@
 --TEST--
-Phar::setSignatureAlgorithm() with hash, tar-based
+Phar::setSignatureAlgorithm() with native OpenSSL and without ext/openssl
 --EXTENSIONS--
-openssl
 phar
 --SKIPIF--
 <?php
+if (extension_loaded("openssl")) die("skip ext/openssl must be disabled for this test");
 $arr = Phar::getSupportedSignatures();
 if (!in_array("OpenSSL", $arr)) die("skip openssl support required");
 ?>
@@ -13,7 +13,7 @@ phar.require_hash=0
 phar.readonly=0
 --FILE--
 <?php
-$fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar.tar';
+$fname = __DIR__ . '/' . basename(__FILE__, '.php') . '.phar';
 $p = new Phar($fname);
 $p['file1.txt'] = 'hi';
 var_dump($p->getSignature());
@@ -34,16 +34,23 @@ var_dump($p->getSignature());
 echo $e->getMessage();
 }
 try {
-$config = __DIR__ . '/../files/openssl.cnf';
-$config_arg = array('config' => $config);
-$private = openssl_get_privatekey(file_get_contents(dirname(__DIR__) . '/files/private.pem'));
-$pkey = '';
-openssl_pkey_export($private, $pkey, NULL, $config_arg);
+$pkey = '-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMDcANSIpkgSF6Rh
+KHM8JncsVuCsO5XjiMf3g50lB+poJAG9leoygbVtY55h9tzeI7SAdZbdIoHbtJ/V
+kGdzlzX5jMGbH1sWKk5fZbai4pLZigd4ihH2V4M27jKrAGy6CAU8ZU/Ez2KQQj5g
+A4ZVMJ3iZXlqCmRWwcs0lZvP+c9XAgMBAAECgYAaJLioFu4TjwBNdC47kMfWF9if
+FDnvk6yTDuZ0gvSTvhJDeiO8X6Rdp7p9WeJRBnvomBFYphlraREPKbAtlenFVuIY
+v10O9BjxkQ0O1Y7L2ztMO3E2LFtmWgoGimAnsbUHTkuB61Hd2AWdA7C357eQ67vZ
+GlLu2HIFpSbzMcJFIQJBAPD6Hm7ETuL0ILwofImXAahHbwpmCtKmjvjJaFD5vWXP
+FD6uTbBOgUP+n5Y17+d/vxhSX9yrQueAIodju3bbxUsCQQDM4fMCO4OUYbMroql7
+ruIqBd34akrA+v2JoV+bMAE6RHBC6DgsI3uySbMJfmnPGoxlbXE0gKN4ONawwDd3
+gTKlAkEAnJc8DWidhpdzajG488Pf/NUmkBBNOiOnxn1Cv1P6Ql01X6HutAHfuCqO
+05KLKdj2ebyVtJTJrhuy1F33pL4dTwJBAKnIEB3ofahnshdV64cALJFQXVpvktUK
+6TG1Vcn/ZPUJI9J+J5aELQxYwJH8fOhQAspGgEpW06Bb0aWVFCHnIbUCQBFVhu+P
+RcHLpdSl7lZmws1bCnDUmt5GzKBw9diHxuyfGEJ0c0clDTWVEMyO80u0jxrliMkT
+8h5bvpPaY8KIlkg=
+-----END PRIVATE KEY-----';
 $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
-var_dump($p->getSignature());
-$p->setSignatureAlgorithm(Phar::OPENSSL_SHA512, $pkey);
-var_dump($p->getSignature());
-$p->setSignatureAlgorithm(Phar::OPENSSL_SHA256, $pkey);
 var_dump($p->getSignature());
 } catch (Exception $e) {
 echo $e->getMessage();
@@ -51,7 +58,7 @@ echo $e->getMessage();
 ?>
 --CLEAN--
 <?php
-unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar.tar');
+unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar');
 ?>
 --EXPECTF--
 array(2) {
@@ -89,16 +96,4 @@ array(2) {
   string(%d) "%s"
   ["hash_type"]=>
   string(7) "OpenSSL"
-}
-array(2) {
-  ["hash"]=>
-  string(%d) "%s"
-  ["hash_type"]=>
-  string(14) "OpenSSL_SHA512"
-}
-array(2) {
-  ["hash"]=>
-  string(%d) "%s"
-  ["hash_type"]=>
-  string(14) "OpenSSL_SHA256"
 }

--- a/ext/phar/tests/phar_setsignaturealgo.phpt
+++ b/ext/phar/tests/phar_setsignaturealgo.phpt
@@ -21,19 +21,21 @@ $p->setSignatureAlgorithm(Phar::MD5);
 var_dump($p->getSignature());
 $p->setSignatureAlgorithm(Phar::SHA1);
 var_dump($p->getSignature());
+
 try {
-$p->setSignatureAlgorithm(Phar::SHA256);
-var_dump($p->getSignature());
+    $p->setSignatureAlgorithm(Phar::SHA256);
+    var_dump($p->getSignature());
 } catch (Exception $e) {
-echo $e->getMessage();
+    echo $e->getMessage();
 }
+
 try {
-$p->setSignatureAlgorithm(Phar::SHA512);
-var_dump($p->getSignature());
+    $p->setSignatureAlgorithm(Phar::SHA512);
+    var_dump($p->getSignature());
 } catch (Exception $e) {
-echo $e->getMessage();
+    echo $e->getMessage();
 }
-try {
+
 $pkey = '-----BEGIN PRIVATE KEY-----
 MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMDcANSIpkgSF6Rh
 KHM8JncsVuCsO5XjiMf3g50lB+poJAG9leoygbVtY55h9tzeI7SAdZbdIoHbtJ/V
@@ -50,10 +52,12 @@ gTKlAkEAnJc8DWidhpdzajG488Pf/NUmkBBNOiOnxn1Cv1P6Ql01X6HutAHfuCqO
 RcHLpdSl7lZmws1bCnDUmt5GzKBw9diHxuyfGEJ0c0clDTWVEMyO80u0jxrliMkT
 8h5bvpPaY8KIlkg=
 -----END PRIVATE KEY-----';
-$p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
-var_dump($p->getSignature());
+
+try {
+    $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
+    var_dump($p->getSignature());
 } catch (Exception $e) {
-echo $e->getMessage();
+    echo $e->getMessage();
 }
 ?>
 --CLEAN--

--- a/ext/phar/tests/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/phar_setsignaturealgo2.phpt
@@ -1,6 +1,7 @@
 --TEST--
-Phar::setSupportedSignatures() with hash
+Phar::setSignatureAlgorithm() with hash
 --EXTENSIONS--
+openssl
 phar
 --SKIPIF--
 <?php

--- a/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
@@ -1,6 +1,7 @@
 --TEST--
-Phar::setSupportedSignatures() with hash, zip-based
+Phar::setSignatureAlgorithm() with hash, zip-based
 --EXTENSIONS--
+openssl
 phar
 --SKIPIF--
 <?php


### PR DESCRIPTION
SSL support in ext/phar is enabled either as native (using the system's OpenSSL and its Crypto library linked directly) or as a wrapper provided by ext/openssl.

Native OpenSSL support previously couldn't be enabled when building with shared openssl extension:

    ./configure --with-openssl=shared --enable-phar=shared

or:

    ./configure --with-openssl=shared --enable-phar

Some PHP packages build both of these extensions as shared and it makes sense to provide native OpenSSL support in ext/phar also when ext/openssl is build as shared.

Shared phar extension with native OpenSSL enabled now gets libcrypto linked directly:

    ldd modules/phar.so
        linux-vdso.so.1
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
        /lib64/ld-linux-x86-64.so.2

The new --with-phar-ssl Autotools configure option enables the SSL support in phar when building without openssl extension or in edge cases when building with phpize. Windows already includes similar option (--enable-phar-native-ssl):

    ./configure --with-phar --with-phar-ssl --without-openssl

Changed tests:

- ext/phar/tests/**/phar_setsignaturealgo2.phpt - needs ext/openssl enabled due to openssl_get_privatekey().
- ext/phar/tests/phar_setsignaturealgo.phpt - test for ext/phar with native OpenSSL support and ext/openssl disabled.