### PR TITLE
Fix RAND_egd check

### DIFF
--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -24,7 +24,10 @@ if test "$PHP_OPENSSL" != "no"; then
     [AC_DEFINE([HAVE_OPENSSL_EXT], [1],
       [Define to 1 if the openssl extension is available.])])
 
-  AC_CHECK_FUNCS([RAND_egd])
+  PHP_CHECK_LIBRARY([crypto], [RAND_egd],
+    [AC_DEFINE([HAVE_RAND_EGD], [1],
+      [Define to 1 if OpenSSL crypto library has the 'RAND_egd' function.])],,
+    [$OPENSSL_LIBS])
 
   if test "$PHP_SYSTEM_CIPHERS" != "no"; then
     AC_DEFINE(USE_OPENSSL_SYSTEM_CIPHERS,1,[ Use system default cipher list instead of hardcoded value ])


### PR DESCRIPTION
When building with OpenSSL (--with-openssl) the OpenSSL libraries (crypto and ssl) are added to LIBS. When building --with-openssl=shared the libraries are added to OPENSSL_SHARED_LIBADD. This fixes the check for the shared build when OpenSSL is built with RAND_egd support.