### PR TITLE
Add PHP_SETUP_ZLIB M4 macro

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -662,6 +662,9 @@ PHP 8.4 UPGRADE NOTES
   . The typed properties XSLTProcessor::$cloneDocument and
     XSLTProcessor::$doXInclude are now declared.
 
+- zlib:
+  . The zlib extension now requires at least zlib 1.2.11.
+
 ========================================
 10. New Global Constants
 ========================================

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -142,7 +142,6 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
-   - Minimum required zlib library version is 1.2.11.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -142,7 +142,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
-   - Minimum required zlib library version is 1.2.3.1.
+   - Minimum required zlib library version is 1.2.11.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -142,6 +142,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
+   - Minimum required zlib library version is 1.2.3.1.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/build/php.m4
+++ b/build/php.m4
@@ -1929,6 +1929,20 @@ PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.7.7], [
 ])
 ])
 
+dnl
+dnl PHP_SETUP_ZLIB(shared-add [, action-found, [action-not-found]])
+dnl
+dnl Common setup macro for zlib library. If zlib is not found on the system, the
+dnl default error by PKG_CHECK_MODULES is emitted, unless the action-not-found
+dnl is given.
+dnl
+AC_DEFUN([PHP_SETUP_ZLIB], [dnl
+PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4], [dnl
+  PHP_EVAL_INCLINE([$ZLIB_CFLAGS])
+  PHP_EVAL_LIBLINE([$ZLIB_LIBS], [$1])
+  $2], [$3])dnl
+])
+
 dnl ----------------------------------------------------------------------------
 dnl Misc. macros
 dnl ----------------------------------------------------------------------------

--- a/build/php.m4
+++ b/build/php.m4
@@ -1937,7 +1937,7 @@ dnl default error by PKG_CHECK_MODULES is emitted, unless the action-not-found
 dnl is given.
 dnl
 AC_DEFUN([PHP_SETUP_ZLIB], [dnl
-PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.3.1], [dnl
+PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.11], [dnl
   PHP_EVAL_INCLINE([$ZLIB_CFLAGS])
   PHP_EVAL_LIBLINE([$ZLIB_LIBS], [$1])
   $2], [$3])dnl

--- a/build/php.m4
+++ b/build/php.m4
@@ -1937,7 +1937,7 @@ dnl default error by PKG_CHECK_MODULES is emitted, unless the action-not-found
 dnl is given.
 dnl
 AC_DEFUN([PHP_SETUP_ZLIB], [dnl
-PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4], [dnl
+PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.3.1], [dnl
   PHP_EVAL_INCLINE([$ZLIB_CFLAGS])
   PHP_EVAL_LIBLINE([$ZLIB_LIBS], [$1])
   $2], [$3])dnl

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -65,13 +65,6 @@ dnl
 dnl Checks for the configure options
 dnl
 
-dnl zlib is always required
-AC_DEFUN([PHP_GD_ZLIB],[
-  PKG_CHECK_MODULES([ZLIB], [zlib])
-  PHP_EVAL_LIBLINE($ZLIB_LIBS, GD_SHARED_LIBADD)
-  PHP_EVAL_INCLINE($ZLIB_CFLAGS)
-])
-
 dnl libpng is always required
 AC_DEFUN([PHP_GD_PNG],[
   PKG_CHECK_MODULES([PNG], [libpng])
@@ -224,7 +217,7 @@ dnl These are always available with bundled library
     AC_DEFINE(HAVE_GD_TGA,              1, [ ])
 
 dnl Various checks for GD features
-    PHP_GD_ZLIB
+    PHP_SETUP_ZLIB([GD_SHARED_LIBADD])
     PHP_GD_PNG
     PHP_GD_AVIF
     PHP_GD_WEBP

--- a/ext/mysqlnd/config.w32
+++ b/ext/mysqlnd/config.w32
@@ -34,7 +34,7 @@ if (PHP_MYSQLND != "no") {
 			CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
 			)
 		{
-			AC_DEFINE("MYSQLND_COMPRESSION_ENABLED", 1, "Compression support");
+			AC_DEFINE("MYSQLND_COMPRESSION_ENABLED", 1, "Define to 1 if mysqlnd has compressed protocol support.");
 			AC_DEFINE("MYSQLND_SSL_SUPPORTED", 1, "SSL support");
 			if (CHECK_LIB("crypt32.lib", "mysqlnd")) {
 				AC_DEFINE("MYSQLND_HAVE_SSL", 1, "Extended SSL support");

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -31,13 +31,10 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 				   mysqlnd_result.c mysqlnd_result_meta.c mysqlnd_debug.c mysqlnd_commands.c \
 				   mysqlnd_block_alloc.c mysqlnd_read_buffer.c mysqlnd_plugin.c php_mysqlnd.c"
 
-
-  if test "$PHP_MYSQLND_COMPRESSION_SUPPORT" != "no"; then
-    PKG_CHECK_MODULES([ZLIB], [zlib])
-    PHP_EVAL_LIBLINE($ZLIB_LIBS, MYSQLND_SHARED_LIBADD)
-    PHP_EVAL_INCLINE($ZLIB_CFLAGS)
-    AC_DEFINE([MYSQLND_COMPRESSION_ENABLED], 1, [Enable compressed protocol support])
-  fi
+  AS_VAR_IF([PHP_MYSQLND_COMPRESSION_SUPPORT], [no],,
+    [PHP_SETUP_ZLIB([MYSQLND_SHARED_LIBADD],
+      [AC_DEFINE([MYSQLND_COMPRESSION_ENABLED], [1],
+        [Define to 1 if mysqlnd has compressed protocol support.])])])
 
   AC_DEFINE([MYSQLND_SSL_SUPPORTED], 1, [Enable core mysqlnd SSL code])
 

--- a/ext/zlib/config.w32
+++ b/ext/zlib/config.w32
@@ -7,7 +7,7 @@ if (PHP_ZLIB == "yes") {
 		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)) {
 
 		EXTENSION("zlib", "zlib.c zlib_fopen_wrapper.c zlib_filter.c", PHP_ZLIB_SHARED, "/D ZLIB_EXPORTS /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE("HAVE_ZLIB", 1, "ZLIB support");
+		AC_DEFINE("HAVE_ZLIB", 1, "Define to 1 if zlib extension is available.");
 
 		if (!PHP_ZLIB_SHARED) {
 			ADD_DEF_FILE("ext\\zlib\\php_zlib.def");

--- a/ext/zlib/config0.m4
+++ b/ext/zlib/config0.m4
@@ -1,7 +1,7 @@
 PHP_ARG_WITH([zlib],
   [for ZLIB support],
   [AS_HELP_STRING([--with-zlib],
-    [Include ZLIB support (requires zlib >= 1.2.0.4)])])
+    [Include ZLIB support (requires zlib library)])])
 
 if test "$PHP_ZLIB" != "no"; then
   PHP_SETUP_ZLIB([ZLIB_SHARED_LIBADD], [dnl

--- a/ext/zlib/config0.m4
+++ b/ext/zlib/config0.m4
@@ -4,13 +4,11 @@ PHP_ARG_WITH([zlib],
     [Include ZLIB support (requires zlib >= 1.2.0.4)])])
 
 if test "$PHP_ZLIB" != "no"; then
-  PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0.4])
-
-  PHP_EVAL_LIBLINE($ZLIB_LIBS, ZLIB_SHARED_LIBADD)
-  PHP_EVAL_INCLINE($ZLIB_CFLAGS)
-
-  AC_DEFINE(HAVE_ZLIB,1,[ ])
-
-  PHP_NEW_EXTENSION(zlib, zlib.c zlib_fopen_wrapper.c zlib_filter.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_SUBST(ZLIB_SHARED_LIBADD)
+  PHP_SETUP_ZLIB([ZLIB_SHARED_LIBADD], [dnl
+    AC_DEFINE([HAVE_ZLIB], [1], [Define to 1 if zlib extension is available.])
+    PHP_NEW_EXTENSION([zlib],
+      [zlib.c zlib_fopen_wrapper.c zlib_filter.c],
+      [$ext_shared],,
+      [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+    PHP_SUBST([ZLIB_SHARED_LIBADD])])
 fi


### PR DESCRIPTION
This enables the zlib library (https://zlib.net/) from a single place to match the minimum required version across the php-src. This provides a possible simpler version bump in the future. Macro's 2nd and 3rd arguments can pass additional actions whether zlib library is found or not for the possible future adjustments in the ext/standard where also zlib might be required.