### PR TITLE
Define default RE2C_FLAGS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -141,6 +141,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      AC_CHECK_MEMBERS).
    - M4 macro PHP_CHECK_GCC_ARG has been removed since PHP 8.0 (use
      AX_CHECK_COMPILE_FLAG).
+   - M4 macro PHP_PROG_RE2C got a new 2nd argument to define common default re2c
+     command-line options substituted to the Makefile RE2C_FLAGS variable.
    - Added php-config --lib-dir and --lib-embed options for PHP embed SAPI.
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.

--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -6,7 +6,7 @@ $(builddir)/zend_language_scanner.lo: $(srcdir)/zend_language_parser.h
 $(builddir)/zend_ini_scanner.lo: $(srcdir)/zend_ini_parser.h
 
 $(srcdir)/zend_language_scanner.c $(srcdir)/zend_language_scanner_defs.h: $(srcdir)/zend_language_scanner.l
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l)
 
 $(srcdir)/zend_language_parser.h: $(srcdir)/zend_language_parser.c
 $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
@@ -26,7 +26,7 @@ $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
 	@$(YACC) $(YFLAGS) -v -d $(srcdir)/zend_ini_parser.y -o $@
 
 $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)
 
 # Use an intermediate target to indicate that zend_vm_gen.php produces both files
 # at the same time, rather than the same recipe applying for two different targets.

--- a/build/php.m4
+++ b/build/php.m4
@@ -1690,10 +1690,11 @@ AC_DEFUN([PHP_PROG_BISON], [
 ])
 
 dnl
-dnl PHP_PROG_RE2C([MIN-VERSION])
+dnl PHP_PROG_RE2C([min-version], [options])
 dnl
 dnl Search for the re2c and optionally check if version is at least the minimum
-dnl required version MIN-VERSION.
+dnl required version "min-version". The whitespace separated "options" argument
+dnl are the re2c command-line flags added to all re2c command-line invocations.
 dnl
 AC_DEFUN([PHP_PROG_RE2C],[
   AC_CHECK_PROG(RE2C, re2c, re2c)
@@ -1745,6 +1746,8 @@ AC_DEFUN([PHP_PROG_RE2C],[
   esac
 
   PHP_SUBST(RE2C)
+  AS_VAR_SET([RE2C_FLAGS], [m4_normalize([$2])])
+  PHP_SUBST([RE2C_FLAGS])
 ])
 
 AC_DEFUN([PHP_PROG_PHP],[

--- a/build/php.m4
+++ b/build/php.m4
@@ -1694,7 +1694,8 @@ dnl PHP_PROG_RE2C([min-version], [options])
 dnl
 dnl Search for the re2c and optionally check if version is at least the minimum
 dnl required version "min-version". The whitespace separated "options" argument
-dnl are the re2c command-line flags added to all re2c invocations.
+dnl are the re2c command-line flags substituted into a Makefile variable
+dnl RE2C_FLAGS which can be added to all re2c invocations.
 dnl
 AC_DEFUN([PHP_PROG_RE2C],[
   AC_CHECK_PROG(RE2C, re2c, re2c)

--- a/build/php.m4
+++ b/build/php.m4
@@ -1694,7 +1694,7 @@ dnl PHP_PROG_RE2C([min-version], [options])
 dnl
 dnl Search for the re2c and optionally check if version is at least the minimum
 dnl required version "min-version". The whitespace separated "options" argument
-dnl are the re2c command-line flags added to all re2c command-line invocations.
+dnl are the re2c command-line flags added to all re2c invocations.
 dnl
 AC_DEFUN([PHP_PROG_RE2C],[
   AC_CHECK_PROG(RE2C, re2c, re2c)

--- a/build/php.m4
+++ b/build/php.m4
@@ -1693,9 +1693,9 @@ dnl
 dnl PHP_PROG_RE2C([min-version], [options])
 dnl
 dnl Search for the re2c and optionally check if version is at least the minimum
-dnl required version "min-version". The whitespace separated "options" argument
-dnl are the re2c command-line flags substituted into a Makefile variable
-dnl RE2C_FLAGS which can be added to all re2c invocations.
+dnl required version "min-version". The blank-or-newline-separated "options" are
+dnl the re2c command-line flags substituted into a Makefile variable RE2C_FLAGS
+dnl which can be added to all re2c invocations.
 dnl
 AC_DEFUN([PHP_PROG_RE2C],[
   AC_CHECK_PROG(RE2C, re2c, re2c)

--- a/configure.ac
+++ b/configure.ac
@@ -192,7 +192,7 @@ label2:
   ]])],[
     AC_MSG_RESULT([no])
   ],[
-    RE2C_FLAGS="$RE2C_FLAGS -g"
+    AS_VAR_APPEND([RE2C_FLAGS], [" -g"])
     AC_MSG_RESULT([yes])
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,7 @@ PHP_RUNPATH_SWITCH
 dnl Checks for some support/generator progs.
 PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
-PHP_PROG_RE2C([1.0.3])
+PHP_PROG_RE2C([1.0.3], [--no-generation-date])
 PHP_PROG_PHP()
 
 PHP_ARG_ENABLE([re2c-cgoto],
@@ -176,9 +176,7 @@ PHP_ARG_ENABLE([re2c-cgoto],
   [no],
   [no])
 
-if test "$PHP_RE2C_CGOTO" = "no"; then
-  RE2C_FLAGS=""
-else
+AS_VAR_IF([PHP_RE2C_CGOTO], [no],, [
   AC_MSG_CHECKING([whether re2c -g works])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 int main(int argc, const char **argv)
@@ -192,14 +190,12 @@ label2:
   return 0;
 }
   ]])],[
-    RE2C_FLAGS=""
     AC_MSG_RESULT([no])
   ],[
-    RE2C_FLAGS="-g"
+    RE2C_FLAGS="$RE2C_FLAGS -g"
     AC_MSG_RESULT([yes])
   ])
-fi
-PHP_SUBST(RE2C_FLAGS)
+])
 
 dnl Platform-specific compile settings.
 dnl ----------------------------------------------------------------------------

--- a/ext/json/Makefile.frag
+++ b/ext/json/Makefile.frag
@@ -1,5 +1,5 @@
 $(srcdir)/json_scanner.c $(srcdir)/php_json_scanner_defs.h: $(srcdir)/json_scanner.re $(srcdir)/json_parser.tab.h
-	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $(srcdir)/json_scanner.c $(srcdir)/json_scanner.re
+	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h -bci -o $(srcdir)/json_scanner.c $(srcdir)/json_scanner.re
 
 $(srcdir)/json_parser.tab.c $(srcdir)/json_parser.tab.h: $(srcdir)/json_parser.y
 	@$(YACC) $(YFLAGS) --defines -l $(srcdir)/json_parser.y -o $(srcdir)/json_parser.tab.c

--- a/ext/json/Makefile.frag.w32
+++ b/ext/json/Makefile.frag.w32
@@ -1,5 +1,5 @@
 ext\json\json_scanner.c ext\json\php_json_scanner_defs.h: ext\json\json_scanner.re ext\json\json_parser.tab.h
-	$(RE2C) $(RE2C_FLAGS) -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
+	$(RE2C) $(RE2C_FLAGS) -t ext/json/php_json_scanner_defs.h -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
 
 ext\json\json_parser.tab.c ext\json\json_parser.tab.h: ext\json\json_parser.y
 	$(BISON) $(BISON_FLAGS) --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c

--- a/ext/pdo/Makefile.frag
+++ b/ext/pdo/Makefile.frag
@@ -1,7 +1,7 @@
 $(srcdir)/pdo_sql_parser.c: $(srcdir)/pdo_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./pdo_sql_parser.re; then \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o pdo_sql_parser.c pdo_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o pdo_sql_parser.c pdo_sql_parser.re; \
 	else \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re; \
 	fi)

--- a/ext/pdo/Makefile.frag.w32
+++ b/ext/pdo/Makefile.frag.w32
@@ -1,3 +1,3 @@
 ext\pdo\pdo_sql_parser.c: ext\pdo\pdo_sql_parser.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re
+	$(RE2C) $(RE2C_FLAGS) -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re

--- a/ext/pdo_mysql/Makefile.frag
+++ b/ext/pdo_mysql/Makefile.frag
@@ -1,7 +1,7 @@
 $(srcdir)/mysql_sql_parser.c: $(srcdir)/mysql_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./mysql_sql_parser.re; then \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o mysql_sql_parser.c mysql_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o mysql_sql_parser.c mysql_sql_parser.re; \
 	else \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re; \
 	fi)

--- a/ext/pdo_mysql/Makefile.frag.w32
+++ b/ext/pdo_mysql/Makefile.frag.w32
@@ -1,3 +1,3 @@
 ext\pdo_mysql\mysql_sql_parser.c: ext\pdo_mysql\mysql_sql_parser.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re
+	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re

--- a/ext/pdo_pgsql/Makefile.frag
+++ b/ext/pdo_pgsql/Makefile.frag
@@ -1,7 +1,7 @@
 $(srcdir)/pgsql_sql_parser.c: $(srcdir)/pgsql_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./pgsql_sql_parser.re; then \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o pgsql_sql_parser.c pgsql_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o pgsql_sql_parser.c pgsql_sql_parser.re; \
 	else \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re; \
 	fi)

--- a/ext/pdo_pgsql/Makefile.frag.w32
+++ b/ext/pdo_pgsql/Makefile.frag.w32
@@ -1,3 +1,3 @@
 ext\pdo_pgsql\pgsql_sql_parser.c: ext\pdo_pgsql\pgsql_sql_parser.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re
+	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re

--- a/ext/pdo_sqlite/Makefile.frag
+++ b/ext/pdo_sqlite/Makefile.frag
@@ -1,7 +1,7 @@
 $(srcdir)/sqlite_sql_parser.c: $(srcdir)/sqlite_sql_parser.re
 	@(cd $(top_srcdir); \
 	if test -f ./sqlite_sql_parser.re; then \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o sqlite_sql_parser.c sqlite_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o sqlite_sql_parser.c sqlite_sql_parser.re; \
 	else \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re; \
+		$(RE2C) $(RE2C_FLAGS) -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re; \
 	fi)

--- a/ext/pdo_sqlite/Makefile.frag.w32
+++ b/ext/pdo_sqlite/Makefile.frag.w32
@@ -1,3 +1,3 @@
 ext\pdo_sqlite\sqlite_sql_parser.c: ext\pdo_sqlite\sqlite_sql_parser.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re
+	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re

--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -1,9 +1,9 @@
 $(srcdir)/phar_path_check.c: $(srcdir)/phar_path_check.re
 	@(cd $(top_srcdir); \
 	if test -f ./php_phar.h; then \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o phar_path_check.c phar_path_check.re; \
+		$(RE2C) $(RE2C_FLAGS) -b -o phar_path_check.c phar_path_check.re; \
 	else \
-		$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re; \
+		$(RE2C) $(RE2C_FLAGS) -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re; \
 	fi)
 
 pharcmd: $(builddir)/phar.php $(builddir)/phar.phar

--- a/ext/phar/Makefile.frag.w32
+++ b/ext/phar/Makefile.frag.w32
@@ -1,3 +1,3 @@
 ext\phar\phar_path_check.c: ext\phar\phar_path_check.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re
+	$(RE2C) $(RE2C_FLAGS) -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re

--- a/ext/standard/Makefile.frag
+++ b/ext/standard/Makefile.frag
@@ -1,8 +1,8 @@
 $(srcdir)/var_unserializer.c: $(srcdir)/var_unserializer.re
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re)
 
 $(srcdir)/url_scanner_ex.c: $(srcdir)/url_scanner_ex.re
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/url_scanner_ex.c	ext/standard/url_scanner_ex.re)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) -b -o ext/standard/url_scanner_ex.c	ext/standard/url_scanner_ex.re)
 
 $(builddir)/info.lo: $(builddir)/../../main/build-defs.h
 

--- a/ext/standard/Makefile.frag.w32
+++ b/ext/standard/Makefile.frag.w32
@@ -1,9 +1,9 @@
 ext\standard\var_unserializer.c: ext\standard\var_unserializer.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re
+	$(RE2C) $(RE2C_FLAGS) -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re
 
 ext\standard\url_scanner_ex.c: ext\standard\url_scanner_ex.re
 	cd $(PHP_SRC_DIR)
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -b -o ext/standard/url_scanner_ex.c ext/standard/url_scanner_ex.re
+	$(RE2C) $(RE2C_FLAGS) -b -o ext/standard/url_scanner_ex.c ext/standard/url_scanner_ex.re
 
 $(BUILD_DIR)\ext\standard\basic_functions.obj: $(PHP_SRC_DIR)\Zend\zend_language_parser.h

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -14,7 +14,7 @@ $(BUILD_BINARY): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
 $(builddir)/phpdbg_lexer.lo: $(srcdir)/phpdbg_parser.h
 
 $(srcdir)/phpdbg_lexer.c: $(srcdir)/phpdbg_lexer.l
-	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date -cbdFo sapi/phpdbg/phpdbg_lexer.c sapi/phpdbg/phpdbg_lexer.l)
+	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) -cbdFo sapi/phpdbg/phpdbg_lexer.c sapi/phpdbg/phpdbg_lexer.l)
 
 $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -37,7 +37,7 @@ YACC=${YACC:-bison}
 YACC="$YACC -l"
 YFLAGS="-Wall"
 RE2C=${RE2C:-re2c}
-RE2C_FLAGS="-i"
+RE2C_FLAGS="--no-generation-date -i"
 SED=${SED:-sed}
 MAKE=${MAKE:-make}
 
@@ -70,7 +70,7 @@ else
 fi
 
 # Check required re2c version from the configure.ac file.
-required_re2c_version=$($SED -n 's/PHP_PROG_RE2C(\[\(.*\)\])/\1/p' configure.ac)
+required_re2c_version=$($SED -n 's/PHP_PROG_RE2C(\[\([0-9.]*\)\][^)]*)*/\1/p' configure.ac)
 set -f; IFS='.'; set -- $required_re2c_version; set +f; IFS=' '
 required_re2c_num="$(expr ${1:-0} \* 10000 + ${2:-0} \* 100 + ${3:-0})"
 

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -90,13 +90,13 @@ sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_parser.h: sapi\phpdbg\phpdbg_pars
 
 !if $(RE2C) != ""
 Zend\zend_ini_scanner.c Zend\zend_ini_scanner_defs.h: Zend\zend_ini_scanner.l
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l
+	$(RE2C) $(RE2C_FLAGS) --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l
 
 Zend\zend_language_scanner.c Zend\zend_language_scanner_defs.h: Zend\zend_language_scanner.l
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l
+	$(RE2C) $(RE2C_FLAGS) --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l
 
 sapi\phpdbg\phpdbg_lexer.c: sapi\phpdbg\phpdbg_lexer.l
-	$(RE2C) $(RE2C_FLAGS) --no-generation-date -cbdFo sapi/phpdbg/phpdbg_lexer.c sapi/phpdbg/phpdbg_lexer.l
+	$(RE2C) $(RE2C_FLAGS) -cbdFo sapi/phpdbg/phpdbg_lexer.c sapi/phpdbg/phpdbg_lexer.l
 !endif
 
 !if "$(ZTS)" == "1"

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3006,6 +3006,7 @@ function toolset_setup_project_tools()
 	}
 
 	var RE2C = PATH_PROG('re2c');
+	DEFINE('RE2C_FLAGS', '--no-generation-date');
 	if (RE2C) {
 		var RE2CVERS = probe_binary(RE2C, "version");
 		STDOUT.WriteLine('  Detected re2c version ' + RE2CVERS);


### PR DESCRIPTION
The --no-generation-date flag is a common re2c flag used in all re2c invocations. This adds the 2nd optional argument to PHP_PROG_RE2C M4 macro in BC manner to set the default re2c command-line options and sets the default RE2C_FLAGS similarly on Windows.

* [x] I'll recheck if everything works correctly and matches the php-src workflow, otherwise looks ok already.