### PR TITLE
Define HAVE_VISIBILITY for fileinfo extension

### DIFF
--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -21,6 +21,8 @@ if test "$PHP_FILEINFO" != "no"; then
     libmagic_sources="$libmagic_sources libmagic/strcasestr.c"
   ])
 
+  AX_GCC_FUNC_ATTRIBUTE([visibility])
+
   PHP_NEW_EXTENSION(fileinfo, fileinfo.c php_libmagic.c $libmagic_sources, $ext_shared,,-I@ext_srcdir@/libmagic)
   PHP_ADD_BUILD_DIR($ext_builddir/libmagic)
 

--- a/ext/fileinfo/libmagic/config.h
+++ b/ext/fileinfo/libmagic/config.h
@@ -8,3 +8,11 @@
 #ifndef HAVE_STDINT_H
 #define HAVE_STDINT_H 1
 #endif
+
+#ifndef HAVE_VISIBILITY
+# ifdef HAVE_FUNC_ATTRIBUTE_VISIBILITY
+#  define HAVE_VISIBILITY 1
+# else
+#  define HAVE_VISIBILITY 0
+# endif
+#endif


### PR DESCRIPTION
The libmagic library also uses the HAVE_VISIBILITY macro that should be defined to 1 if visibility is supported or 0 if not.

Follow-up of GH-5526 (-Wundef)