### PR TITLE
Bump minimum libpq version to 10.0

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -685,6 +685,12 @@ PHP 8.4 UPGRADE NOTES
 - PDO:
   . The class constants are typed now.
 
+- pdo_pgsql:
+  . The pdo_pgsql extension now requires at least libpq 10.0.
+
+- pgsql:
+  . The pgsql extension now requires at least libpq 10.0.
+
 - Reflection:
   . The class constants are typed now.
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -1957,7 +1957,7 @@ found_pgsql=no
 dnl Set PostgreSQL installation directory if given from the configure argument.
 AS_CASE([$4], [yes], [pgsql_dir=""], [pgsql_dir=$4])
 AS_VAR_IF([pgsql_dir],,
-  [PKG_CHECK_MODULES([PGSQL], [libpq >= 9.3],
+  [PKG_CHECK_MODULES([PGSQL], [libpq >= 10.0],
     [found_pgsql=yes],
     [found_pgsql=no])])
 
@@ -2000,8 +2000,8 @@ AS_VAR_IF([found_pgsql], [yes], [dnl
   PHP_EVAL_INCLINE([$PGSQL_CFLAGS])
   PHP_EVAL_LIBLINE([$PGSQL_LIBS], [$1])
 dnl PostgreSQL minimum version sanity check.
-  PHP_CHECK_LIBRARY([pq], [PQlibVersion],, [AC_MSG_ERROR([m4_normalize([
-    PostgreSQL check failed: libpq 9.1 or later is required, please see
+  PHP_CHECK_LIBRARY([pq], [PQencryptPasswordConn],, [AC_MSG_ERROR([m4_normalize([
+    PostgreSQL check failed: libpq 10.0 or later is required, please see
     config.log for details.
   ])])],
   [$PGSQL_LIBS])

--- a/ext/pdo_pgsql/config.w32
+++ b/ext/pdo_pgsql/config.w32
@@ -7,10 +7,6 @@ if (PHP_PDO_PGSQL != "no") {
 			CHECK_HEADER_ADD_INCLUDE("libpq-fe.h", "CFLAGS_PDO_PGSQL", PHP_PDO_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;")) {
 		EXTENSION("pdo_pgsql", "pdo_pgsql.c pgsql_driver.c pgsql_statement.c pgsql_sql_parser.c");
 
-		if (X64) {
-			ADD_FLAG('CFLAGS_PDO_PGSQL', "/D HAVE_PG_LO64=1");
-		}
-
 		AC_DEFINE('HAVE_PDO_PGSQL',		1, 'Have PostgreSQL library');
 
 		ADD_EXTENSION_DEP('pdo_pgsql', 'pdo');

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -177,7 +177,7 @@ static int pgsql_lob_seek(php_stream *stream, zend_off_t offset, int whence,
 		zend_off_t *newoffset)
 {
 	struct pdo_pgsql_lob_self *self = (struct pdo_pgsql_lob_self*)stream->abstract;
-#if defined(HAVE_PG_LO64) && defined(ZEND_ENABLE_ZVAL_LONG64)
+#ifdef ZEND_ENABLE_ZVAL_LONG64
 	zend_off_t pos = lo_lseek64(self->conn, self->lfd, offset, whence);
 #else
 	zend_off_t pos = lo_lseek(self->conn, self->lfd, offset, whence);

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -12,12 +12,6 @@ if test "$PHP_PGSQL" != "no"; then
 
   AC_DEFINE(HAVE_PGSQL,1,[Whether to build PostgreSQL support or not])
 
-  PHP_CHECK_LIBRARY([pq], [lo_truncate64],
-    [AC_DEFINE([HAVE_PG_LO64], [1], [PostgreSQL 9.3 or later])],,
-    [$PGSQL_LIBS])
-  PHP_CHECK_LIBRARY([pq], [PQsetErrorContextVisibility],
-    [AC_DEFINE([HAVE_PG_CONTEXT_VISIBILITY], [1], [PostgreSQL 9.6 or later])],,
-    [$PGSQL_LIBS])
   PHP_CHECK_LIBRARY([pq], [PQresultMemorySize],
     [AC_DEFINE([HAVE_PG_RESULT_MEMORY_SIZE], [1], [PostgreSQL 12 or later])],,
     [$PGSQL_LIBS])

--- a/ext/pgsql/config.w32
+++ b/ext/pgsql/config.w32
@@ -7,7 +7,7 @@ if (PHP_PGSQL != "no") {
 		CHECK_HEADER_ADD_INCLUDE("libpq-fe.h", "CFLAGS_PGSQL", PHP_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;" + PHP_PGSQL)) {
 		EXTENSION("pgsql", "pgsql.c", PHP_PGSQL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_PGSQL', 1, 'Have PostgreSQL library');
-		ADD_FLAG("CFLAGS_PGSQL", "/D PGSQL_EXPORTS" + (X64 ? " /D HAVE_PG_LO64" : "") + " ");
+		ADD_FLAG("CFLAGS_PGSQL", "/D PGSQL_EXPORTS");
 		ADD_EXTENSION_DEP('pgsql', 'pcre');
 	} else {
 		WARNING("pgsql not enabled; libraries and headers not found");

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2934,15 +2934,12 @@ PHP_FUNCTION(pg_lo_seek)
 	pgsql = Z_PGSQL_LOB_P(pgsql_id);
 	CHECK_PGSQL_LOB(pgsql);
 
-#ifdef HAVE_PG_LO64
 	if (PQserverVersion((PGconn *)pgsql->conn) >= 90300) {
 		result = lo_lseek64((PGconn *)pgsql->conn, pgsql->lofd, offset, (int)whence);
 	} else {
 		result = lo_lseek((PGconn *)pgsql->conn, pgsql->lofd, (int)offset, (int)whence);
 	}
-#else
-	result = lo_lseek((PGconn *)pgsql->conn, pgsql->lofd, offset, whence);
-#endif
+
 	if (result > -1) {
 		RETURN_TRUE;
 	} else {
@@ -3046,7 +3043,6 @@ PHP_FUNCTION(pg_set_error_verbosity)
 }
 /* }}} */
 
-#ifdef HAVE_PG_CONTEXT_VISIBILITY
 PHP_FUNCTION(pg_set_error_context_visibility)
 {
 	zval *pgsql_link = NULL;
@@ -3071,7 +3067,6 @@ PHP_FUNCTION(pg_set_error_context_visibility)
 		RETURN_THROWS();
 	}
 }
-#endif
 
 #ifdef HAVE_PG_RESULT_MEMORY_SIZE
 PHP_FUNCTION(pg_result_memory_size)

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -447,7 +447,6 @@ namespace {
     const PGSQL_TRACE_REGRESS_MODE = UNKNOWN;
 #endif
 
-#ifdef HAVE_PG_CONTEXT_VISIBILITY
     /* For pg_set_error_context_visibility() */
 
     /**
@@ -465,7 +464,6 @@ namespace {
      * @cvalue PQSHOW_CONTEXT_ALWAYS
      */
     const PGSQL_SHOW_CONTEXT_ALWAYS = UNKNOWN;
-#endif
 
     function pg_connect(string $connection_string, int $flags = 0): PgSql\Connection|false {}
 
@@ -953,9 +951,7 @@ namespace {
      */
     function pg_select(PgSql\Connection $connection, string $table_name, array $conditions = [], int $flags = PGSQL_DML_EXEC, int $mode = PGSQL_ASSOC): array|string|false {}
 
-#ifdef HAVE_PG_CONTEXT_VISIBILITY
     function pg_set_error_context_visibility(PgSql\Connection $connection, int $visibility): int {}
-#endif
 
 #ifdef HAVE_PG_RESULT_MEMORY_SIZE
     function pg_result_memory_size(PgSql\Result $result): int {}

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8feb7d195444838a4c016910593d30dd76aafe89 */
+ * Stub hash: 84535fbc63b6fe9766088d884c89f5c4a4db0ddf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -454,12 +454,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_select, 0, 2, MAY_BE_ARRAY|MA
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_ASSOC")
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_set_error_context_visibility, 0, 2, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, connection, PgSql\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, visibility, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_result_memory_size, 0, 1, IS_LONG, 0)
@@ -589,9 +587,7 @@ ZEND_FUNCTION(pg_insert);
 ZEND_FUNCTION(pg_update);
 ZEND_FUNCTION(pg_delete);
 ZEND_FUNCTION(pg_select);
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 ZEND_FUNCTION(pg_set_error_context_visibility);
-#endif
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 ZEND_FUNCTION(pg_result_memory_size);
 #endif
@@ -719,9 +715,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_update, arginfo_pg_update)
 	ZEND_FE(pg_delete, arginfo_pg_delete)
 	ZEND_FE(pg_select, arginfo_pg_select)
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	ZEND_FE(pg_set_error_context_visibility, arginfo_pg_set_error_context_visibility)
-#endif
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 	ZEND_FE(pg_result_memory_size, arginfo_pg_result_memory_size)
 #endif
@@ -852,15 +846,9 @@ static void register_pgsql_symbols(int module_number)
 #if defined(PQTRACE_REGRESS_MODE)
 	REGISTER_LONG_CONSTANT("PGSQL_TRACE_REGRESS_MODE", PQTRACE_REGRESS_MODE, CONST_PERSISTENT);
 #endif
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_NEVER", PQSHOW_CONTEXT_NEVER, CONST_PERSISTENT);
-#endif
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ERRORS", PQSHOW_CONTEXT_ERRORS, CONST_PERSISTENT);
-#endif
-#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
-#endif
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_change_password", sizeof("pg_change_password") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);

--- a/ext/pgsql/tests/02connection.phpt
+++ b/ext/pgsql/tests/02connection.phpt
@@ -25,11 +25,9 @@ if (pg_connection_busy($db))
 {
     echo "pg_connection_busy() error\n";
 }
-if (function_exists('pg_transaction_status')) {
-    if (pg_transaction_status($db) != PGSQL_TRANSACTION_IDLE)
-    {
-        echo "pg_transaction_status() error\n";
-    }
+if (pg_transaction_status($db) != PGSQL_TRANSACTION_IDLE)
+{
+    echo "pg_transaction_status() error\n";
 }
 if (false === pg_host($db))
 {

--- a/ext/pgsql/tests/03sync_query.phpt
+++ b/ext/pgsql/tests/03sync_query.phpt
@@ -63,26 +63,26 @@ try {
 }
 
 pg_result_error($result);
-if (function_exists('pg_result_error_field')) {
-    pg_result_error_field($result, PGSQL_DIAG_SEVERITY);
-    pg_result_error_field($result, PGSQL_DIAG_SQLSTATE);
-    pg_result_error_field($result, PGSQL_DIAG_MESSAGE_PRIMARY);
-    pg_result_error_field($result, PGSQL_DIAG_MESSAGE_DETAIL);
-    pg_result_error_field($result, PGSQL_DIAG_MESSAGE_HINT);
-    pg_result_error_field($result, PGSQL_DIAG_STATEMENT_POSITION);
-    if (defined('PGSQL_DIAG_INTERNAL_POSITION'))
-    {
-        pg_result_error_field($result, PGSQL_DIAG_INTERNAL_POSITION);
-    }
-    if (defined('PGSQL_DIAG_INTERNAL_QUERY'))
-    {
-        pg_result_error_field($result, PGSQL_DIAG_INTERNAL_QUERY);
-    }
-    pg_result_error_field($result, PGSQL_DIAG_CONTEXT);
-    pg_result_error_field($result, PGSQL_DIAG_SOURCE_FILE);
-    pg_result_error_field($result, PGSQL_DIAG_SOURCE_LINE);
-    pg_result_error_field($result, PGSQL_DIAG_SOURCE_FUNCTION);
+
+pg_result_error_field($result, PGSQL_DIAG_SEVERITY);
+pg_result_error_field($result, PGSQL_DIAG_SQLSTATE);
+pg_result_error_field($result, PGSQL_DIAG_MESSAGE_PRIMARY);
+pg_result_error_field($result, PGSQL_DIAG_MESSAGE_DETAIL);
+pg_result_error_field($result, PGSQL_DIAG_MESSAGE_HINT);
+pg_result_error_field($result, PGSQL_DIAG_STATEMENT_POSITION);
+if (defined('PGSQL_DIAG_INTERNAL_POSITION'))
+{
+    pg_result_error_field($result, PGSQL_DIAG_INTERNAL_POSITION);
 }
+if (defined('PGSQL_DIAG_INTERNAL_QUERY'))
+{
+    pg_result_error_field($result, PGSQL_DIAG_INTERNAL_QUERY);
+}
+pg_result_error_field($result, PGSQL_DIAG_CONTEXT);
+pg_result_error_field($result, PGSQL_DIAG_SOURCE_FILE);
+pg_result_error_field($result, PGSQL_DIAG_SOURCE_LINE);
+pg_result_error_field($result, PGSQL_DIAG_SOURCE_FUNCTION);
+
 pg_num_rows(pg_query($db, "SELECT * FROM ".$table_name.";"));
 pg_num_fields(pg_query($db, "SELECT * FROM ".$table_name.";"));
 pg_field_name($result, 0);

--- a/ext/pgsql/tests/07optional.phpt
+++ b/ext/pgsql/tests/07optional.phpt
@@ -15,17 +15,15 @@ $enc = pg_client_encoding($db);
 
 pg_set_client_encoding($db, $enc);
 
-if (function_exists('pg_set_error_verbosity')) {
-    pg_set_error_verbosity($db, PGSQL_ERRORS_TERSE);
-    pg_set_error_verbosity($db, PGSQL_ERRORS_DEFAULT);
-    pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
-    pg_set_error_verbosity($db, PGSQL_ERRORS_SQLSTATE);
-}
-if (function_exists('pg_set_error_context_visibility')) {
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
-}
+pg_set_error_verbosity($db, PGSQL_ERRORS_TERSE);
+pg_set_error_verbosity($db, PGSQL_ERRORS_DEFAULT);
+pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
+pg_set_error_verbosity($db, PGSQL_ERRORS_SQLSTATE);
+
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
+
 echo "OK";
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/23sync_query_params.phpt
+++ b/ext/pgsql/tests/23sync_query_params.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_query_params')) die('skip function pg_query_params() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/24sync_query_prepared.phpt
+++ b/ext/pgsql/tests/24sync_query_prepared.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_prepare')) die('skip function pg_prepare() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/25async_query_params.phpt
+++ b/ext/pgsql/tests/25async_query_params.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_send_query_params')) die('skip function pg_send_query_params() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/26async_query_prepared.phpt
+++ b/ext/pgsql/tests/26async_query_prepared.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_send_prepare')) die('skip function pg_send_prepare() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/30nb_async_query_params.phpt
+++ b/ext/pgsql/tests/30nb_async_query_params.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_send_query_params')) die('skip function pg_send_query_params() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/31nb_async_query_prepared.phpt
+++ b/ext/pgsql/tests/31nb_async_query_prepared.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_send_prepare')) die('skip function pg_send_prepare() does not exist');
 ?>
 --FILE--
 <?php

--- a/ext/pgsql/tests/32nb_async_query.phpt
+++ b/ext/pgsql/tests/32nb_async_query.phpt
@@ -5,7 +5,6 @@ pgsql
 --SKIPIF--
 <?php
 include("inc/skipif.inc");
-if (!function_exists('pg_send_prepare')) die('skip function pg_send_prepare() does not exist');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
This bumps the libpq client-side PostgreSQL library minimum required version from 9.1 to 10.0.

- Sanity check: PQlibVersion -> PQencryptPasswordConn (available since libpq 10.0)
- PQsetErrorContextVisibility (available since libpq 9.6)
- lo_truncate64 (available since libpq 9.3), if 32-bit system doesn't support lo_*64 functions, error is returned and functions are always available

Additionally, the conditional functions usages in pdo_pgsql and pgsql extensions that got piled up are cleaned and synced:

- pg_prepare (PQprepare available since libpq 7.4)
- pg_query_params (PQexecParams available since libpq 7.4)
- pg_result_error_field (PQresultErrorField available since libpq 7.4)
- pg_send_prepare (PQsendPrepare available since libpq 7.4)
- pg_send_query_params (PQsendQueryParams available since libpq 7.4)
- pg_set_error_verbosity (PQsetErrorVerbosity available since libpq 7.4)
- pg_transaction_status (PQtransactionStatus available since libpq 7.4)

The Windows libpq version updated to current 11.4 available at https://github.com/winlibs/postgresql

Discussion: https://news-web.php.net/php.internals/123609
Follow-up of GH-14540