### PR TITLE
Remove unused PHP_PGSQL_API_VERSION

### DIFF
--- a/ext/pgsql/php_pgsql.h
+++ b/ext/pgsql/php_pgsql.h
@@ -20,8 +20,6 @@
 
 #ifdef HAVE_PGSQL
 
-#define PHP_PGSQL_API_VERSION 20140217
-
 extern zend_module_entry pgsql_module_entry;
 #define pgsql_module_ptr &pgsql_module_entry
 


### PR DESCRIPTION
The pgsql extension headers aren't installed and this API version hasn't been used nor bumped yet.