### PR TITLE
Fix unused variable warning when using libpq < 12

### DIFF
--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -727,6 +727,7 @@ static int pgsql_stmt_get_attr(pdo_stmt_t *stmt, zend_long attr, zval *val)
 #endif
 
 		default:
+			(void)S;
 			return 0;
 	}
 }


### PR DESCRIPTION
The variable S is not used if PQresultMemorySize is not available in this switch at this point.