### PR TITLE
Squeeze PHP_CHECK_LIBRARY to reduce generated configure

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1381,23 +1381,16 @@ dnl PHP_CHECK_LIBRARY(library, function [, action-found [, action-not-found [, e
 dnl
 dnl Wrapper for AC_CHECK_LIB.
 dnl
-AC_DEFUN([PHP_CHECK_LIBRARY], [
-  save_old_LDFLAGS=$LDFLAGS
-  ac_stuff="$5"
-
-  save_ext_shared=$ext_shared
-  ext_shared=yes
-  PHP_EVAL_LIBLINE([$]ac_stuff, LDFLAGS)
-  AC_CHECK_LIB([$1],[$2],[
-    LDFLAGS=$save_old_LDFLAGS
-    ext_shared=$save_ext_shared
-    $3
-  ],[
-    LDFLAGS=$save_old_LDFLAGS
-    ext_shared=$save_ext_shared
-    unset ac_cv_lib_$1[]_$2
-    $4
-  ])dnl
+AC_DEFUN([PHP_CHECK_LIBRARY], [dnl
+save_old_LDFLAGS=$LDFLAGS
+save_ext_shared=$ext_shared
+ext_shared=yes
+ac_stuff="$5"
+PHP_EVAL_LIBLINE([$ac_stuff], [LDFLAGS])dnl
+AC_CHECK_LIB([$1], [$2], [m4_default([$3], [:])], [unset ac_cv_lib_$1[]_$2
+$4])dnl
+LDFLAGS=$save_old_LDFLAGS
+ext_shared=$save_ext_shared
 ])
 
 dnl


### PR DESCRIPTION
This trims redundant newlines in the generated configure script.

The `:` is a [shell builtin command that does nothing][1] used in AC_CHECK_LIB to prevent doing its default action when library is found and 3rd argument is not given. Supported by all today's shells where Autoconf's configure works.

The 5th argument (ac_stuff) is left quoted with double quotes to properly pass it further to PHP_EVAL_LIBLINE which has the for loop at this point when given argument includes newlines.

[1]: https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bourne-Shell-Builtins