### PR TITLE
Update mysqli and pdo_mysql extension dependencies

### DIFF
--- a/ext/mysqli/config.w32
+++ b/ext/mysqli/config.w32
@@ -21,7 +21,7 @@ if (PHP_MYSQLI != "no") {
 
 	if (PHP_MYSQLI != "no") {
 		EXTENSION("mysqli", mysqli_source, PHP_MYSQLI_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		ADD_EXTENSION_DEP('mysqli', 'mysqlnd', true);
+		ADD_EXTENSION_DEP('mysqli', 'mysqlnd');
 		PHP_INSTALL_HEADERS("ext/mysqli", "php_mysqli_structs.h mysqli_mysqlnd.h");
 	}
 }

--- a/ext/pdo_mysql/config.w32
+++ b/ext/pdo_mysql/config.w32
@@ -8,6 +8,7 @@ if (PHP_PDO_MYSQL != "no") {
 		STDOUT.WriteLine("INFO: mysqlnd build");
 		EXTENSION("pdo_mysql", "pdo_mysql.c mysql_driver.c mysql_statement.c mysql_sql_parser.c");
 		ADD_EXTENSION_DEP('pdo_mysql', 'pdo');
+		ADD_EXTENSION_DEP('pdo_mysql', 'mysqlnd');
 		ADD_MAKEFILE_FRAGMENT();
 	} else {
 		if (CHECK_LIB("libmysql.lib", "pdo_mysql", PHP_PDO_MYSQL) &&
@@ -16,7 +17,8 @@ if (PHP_PDO_MYSQL != "no") {
 					PHP_PHP_BUILD + "\\include\\mysql;" +
 					PHP_PDO_MYSQL)) {
 			EXTENSION("pdo_mysql", "pdo_mysql.c mysql_driver.c mysql_statement.c mysql_sql_parser.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		    ADD_MAKEFILE_FRAGMENT();
+			ADD_EXTENSION_DEP('pdo_mysql', 'pdo');
+			ADD_MAKEFILE_FRAGMENT();
 		} else {
 			WARNING("pdo_mysql not enabled; libraries and headers not found");
 		}


### PR DESCRIPTION
- The mysqlnd is required dependency in mysqli extension
- When building pdo_mysql with mysqlnd (--with-pdo-mysql or --with-pdo-mysql=mysqlnd) mysqlnd is required
- This also adds missing configure time pdo dependency to pdo_mysql