### PR TITLE
Enable static tsrmls cache in pdo_mysql with mysqlnd

### DIFF
--- a/ext/pdo_mysql/config.w32
+++ b/ext/pdo_mysql/config.w32
@@ -6,7 +6,7 @@ if (PHP_PDO_MYSQL != "no") {
 	if (PHP_PDO_MYSQL == "yes" || PHP_PDO_MYSQL == "mysqlnd") {
 		AC_DEFINE('PDO_USE_MYSQLND', 1, 'Using MySQL native driver');
 		STDOUT.WriteLine("INFO: mysqlnd build");
-		EXTENSION("pdo_mysql", "pdo_mysql.c mysql_driver.c mysql_statement.c mysql_sql_parser.c");
+		EXTENSION("pdo_mysql", "pdo_mysql.c mysql_driver.c mysql_statement.c mysql_sql_parser.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		ADD_EXTENSION_DEP('pdo_mysql', 'pdo');
 		ADD_MAKEFILE_FRAGMENT();
 	} else {


### PR DESCRIPTION
The tsrmls cache has been integrated in
aac7b1db7c9df59ffb0860de7692c653719cf4d0 but not enabled when pdo_mysql is built for mysqlnd extension.

Unless I'm missing something and this is intentionally disabled for pdo_mysql and mysqlnd build on Windows.