### PR TITLE
Check for library functions on one place in Zend.m4

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -148,8 +148,18 @@ _LT_AC_TRY_DLOPEN_SELF([
 ], [])
 ])
 
-dnl Checks for library functions.
-AC_CHECK_FUNCS(getpid kill pthread_getattr_np pthread_attr_get_np pthread_get_stackaddr_np pthread_attr_getstack pthread_stackseg_np gettid)
+dnl Check for library functions.
+AC_CHECK_FUNCS(m4_normalize([
+  getpid
+  gettid
+  kill
+  mremap
+  pthread_attr_get_np
+  pthread_attr_getstack
+  pthread_get_stackaddr_np
+  pthread_getattr_np
+  pthread_stackseg_np
+]))
 
 dnl Check for sigsetjmp. If it's defined as a macro, AC_CHECK_FUNCS won't work.
 AC_CHECK_FUNCS([sigsetjmp],,
@@ -278,8 +288,6 @@ int main(void)
 ])
 
 AC_MSG_RESULT(done)
-
-AC_CHECK_FUNCS(mremap)
 
 AC_ARG_ENABLE([zend-signals],
   [AS_HELP_STRING([--disable-zend-signals],


### PR DESCRIPTION
The m4_normalize is for Autoconf < 2.70 (on 2.70 and later versions a blank-or-newline separated items can be expanded without using backslash-newline).