### PR TITLE
Remove obsolete enable_pear BC compatibility check

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -151,6 +151,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      PGSQL_LIBS environment variables. When a directory argument is provided to
      configure options (--with-pgsql=DIR or --with-pdo-pgsql=DIR), it will be
      used instead of the pkg-config search.
+   - Removed BC enable_pear variable check due to --enable-pear configure option
+     once used (use with_pear variable name).
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have

--- a/configure.ac
+++ b/configure.ac
@@ -1195,11 +1195,6 @@ dnl ----------------------------------------------------------------------------
 PHP_HELP_SEPARATOR([PEAR:])
 PHP_CONFIGURE_PART(Configuring PEAR)
 
-dnl Compatibility
-if test -z "$with_pear" && test "$enable_pear" = "no"; then
-  with_pear=no
-fi
-
 dnl If CLI is disabled disable PEAR.
 if test "$PHP_CLI" = "no"; then
   with_pear=no


### PR DESCRIPTION
This was added due to configure option rename from --enable-pear to --with-pear:
2cf1b8d3459736457b46c295eb2e8b87acb4f521