### PR TITLE
hash: Add simple HashContext::__debugInfo() implementation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,7 @@ PHP                                                                        NEWS
 
 - Hash:
   . Changed return type of hash_update() to true. (nielsdos)
+  . Added HashContext::__debugInfo(). (timwolla)
 
 - IMAP:
   . Moved to PECL. (Derick Rethans)

--- a/UPGRADING
+++ b/UPGRADING
@@ -230,6 +230,9 @@ PHP 8.4 UPGRADE NOTES
 - FPM:
   . Flushing headers without a body will now succeed. See GH-12785.
 
+- Hash:
+  . Added HashContext::__debugInfo().
+
 - Intl:
   . NumberFormatter::ROUND_HALFODD added to complement existing
     NumberFormatter::ROUND_HALFEVEN functionality.

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1560,6 +1560,21 @@ PHP_METHOD(HashContext, __unserialize)
 }
 /* }}} */
 
+ZEND_METHOD(HashContext, __debugInfo)
+{
+	zval *object = ZEND_THIS;
+	php_hashcontext_object *hash = php_hashcontext_from_object(Z_OBJ_P(object));
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zval tmp;
+
+	array_init(return_value);
+
+	ZVAL_STRING(&tmp, hash->ops->algo);
+	zend_hash_str_update(Z_ARR_P(return_value), "algo", strlen("algo"), &tmp);
+}
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(hash)
 {

--- a/ext/hash/hash.stub.php
+++ b/ext/hash/hash.stub.php
@@ -102,4 +102,6 @@ final class HashContext
     public function __serialize(): array {}
 
     public function __unserialize(array $data): void {}
+
+    public function __debugInfo(): array {}
 }

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9c0f01839a287d394b78b0dfd37b278a59d1b366 */
+ * Stub hash: df078e28c10c9af51b6c4e98c4ad4827e1f32bed */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
@@ -133,6 +133,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_HashContext___unserialize,
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_HashContext___debugInfo arginfo_hash_algos
+
 ZEND_FUNCTION(hash);
 ZEND_FUNCTION(hash_file);
 ZEND_FUNCTION(hash_hmac);
@@ -166,6 +168,7 @@ ZEND_FUNCTION(mhash);
 ZEND_METHOD(HashContext, __construct);
 ZEND_METHOD(HashContext, __serialize);
 ZEND_METHOD(HashContext, __unserialize);
+ZEND_METHOD(HashContext, __debugInfo);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(hash, arginfo_hash)
@@ -205,6 +208,7 @@ static const zend_function_entry class_HashContext_methods[] = {
 	ZEND_ME(HashContext, __construct, arginfo_class_HashContext___construct, ZEND_ACC_PRIVATE)
 	ZEND_ME(HashContext, __serialize, arginfo_class_HashContext___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(HashContext, __unserialize, arginfo_class_HashContext___unserialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(HashContext, __debugInfo, arginfo_class_HashContext___debugInfo, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/hash/tests/HashContext_debugInfo.phpt
+++ b/ext/hash/tests/HashContext_debugInfo.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Hash: HashContext::__debugInfo()
+--FILE--
+<?php
+
+var_dump(hash_init('sha256'));
+var_dump(hash_init('sha3-512'));
+
+?>
+--EXPECTF--
+object(HashContext)#%d (1) {
+  ["algo"]=>
+  string(6) "sha256"
+}
+object(HashContext)#%d (1) {
+  ["algo"]=>
+  string(8) "sha3-512"
+}


### PR DESCRIPTION
Alternatively a `public readonly string $algo;` could be added to the object. It would implicitly show up in the debug info output and can also be programmatically be accessed. But I'm not sure of programmatic access to just the `$algo` is useful, without also having the flags and/or HMAC key.