### PR TITLE
Remove DBA_DB1 definition from Windows build

### DIFF
--- a/ext/dba/config.w32
+++ b/ext/dba/config.w32
@@ -16,7 +16,7 @@ if (PHP_DBA != "no") {
 	if (PHP_DB != "no") {
 		if (CHECK_LIB("libdb31s.lib;libdb61.lib", "dba", PHP_DBA) &&
 			CHECK_HEADER_ADD_INCLUDE("db.h", "CFLAGS_DBA")) {
-			ADD_FLAG("CFLAGS_DBA", "/D DBA_DB1=0 /D DB1_VERSION=\"\\\"Berkeley DB 1.85 emulation in DB3\\\"\" /D DB1_INCLUDE_FILE=\"\\\"db_185.h\\\"\" /D DBA_DB3=1 /D DB3_INCLUDE_FILE=\"\\\"db.h\\\"\"");
+			ADD_FLAG("CFLAGS_DBA", "/D DB1_VERSION=\"\\\"Berkeley DB 1.85 emulation in DB3\\\"\" /D DB1_INCLUDE_FILE=\"\\\"db_185.h\\\"\" /D DBA_DB3=1 /D DB3_INCLUDE_FILE=\"\\\"db.h\\\"\"");
 		} else {
 			WARNING("dba: db handlers not enabled; libraries and headers not found");
 		}


### PR DESCRIPTION
The DBA_DB1 is checked with #ifdef and version 1 emulation is present in DB version 3.

Or if this should be defined (to 1 to be more clear and match the Autotools)...