### PR TITLE
Normalize mysqlnd extension sources

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -24,13 +24,6 @@ PHP_ARG_ENABLE([mysqlnd-compression-support],
 
 dnl If some extension uses mysqlnd it will get compiled in PHP core
 if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
-  mysqlnd_ps_sources="mysqlnd_ps.c mysqlnd_ps_codec.c"
-  mysqlnd_base_sources="mysqlnd_connection.c mysqlnd_alloc.c mysqlnd_charset.c mysqlnd_wireprotocol.c \
-                   mysqlnd_loaddata.c mysqlnd_reverse_api.c mysqlnd_vio.c mysqlnd_protocol_frame_codec.c \
-                   mysqlnd_statistics.c mysqlnd_driver.c mysqlnd_ext_plugin.c mysqlnd_auth.c \
-				   mysqlnd_result.c mysqlnd_result_meta.c mysqlnd_debug.c mysqlnd_commands.c \
-				   mysqlnd_block_alloc.c mysqlnd_read_buffer.c mysqlnd_plugin.c php_mysqlnd.c"
-
   AS_VAR_IF([PHP_MYSQLND_COMPRESSION_SUPPORT], [no],,
     [PHP_SETUP_ZLIB([MYSQLND_SHARED_LIBADD],
       [AC_DEFINE([MYSQLND_COMPRESSION_ENABLED], [1],
@@ -45,8 +38,33 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
     PHP_SETUP_OPENSSL(MYSQLND_SHARED_LIBADD, [AC_DEFINE(MYSQLND_HAVE_SSL,1,[Enable mysqlnd code that uses OpenSSL directly])])
   fi
 
-  mysqlnd_sources="$mysqlnd_base_sources $mysqlnd_ps_sources"
-  PHP_NEW_EXTENSION(mysqlnd, $mysqlnd_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_NEW_EXTENSION([mysqlnd], [m4_normalize([
+    mysqlnd_alloc.c
+    mysqlnd_auth.c
+    mysqlnd_block_alloc.c
+    mysqlnd_charset.c
+    mysqlnd_commands.c
+    mysqlnd_connection.c
+    mysqlnd_debug.c
+    mysqlnd_driver.c
+    mysqlnd_ext_plugin.c
+    mysqlnd_loaddata.c
+    mysqlnd_plugin.c
+    mysqlnd_protocol_frame_codec.c
+    mysqlnd_ps_codec.c
+    mysqlnd_ps.c
+    mysqlnd_read_buffer.c
+    mysqlnd_result_meta.c
+    mysqlnd_result.c
+    mysqlnd_reverse_api.c
+    mysqlnd_statistics.c
+    mysqlnd_vio.c
+    mysqlnd_wireprotocol.c
+    php_mysqlnd.c
+  ])],
+  [$ext_shared],,
+  [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
   PHP_INSTALL_HEADERS([ext/mysqlnd/])
   PHP_SUBST([MYSQLND_SHARED_LIBADD])
 fi


### PR DESCRIPTION
The m4_normalize() can simplify the list argument. It removes leading and trailing spaces and tabs, sequences of backslash-then-newline, and replaces multiple spaces, tabs, and newlines with a single space.