### PR TITLE
Show build provider and unify version information printing

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -108,6 +108,38 @@ PHPAPI unsigned int php_version_id(void)
 	return PHP_VERSION_ID;
 }
 
+PHPAPI void php_print_version(sapi_module_struct *sapi_module)
+{
+	php_printf("PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
+		PHP_VERSION, sapi_module->name, __DATE__, __TIME__,
+#ifdef ZTS
+		"ZTS"
+#else
+		"NTS"
+#endif
+#ifdef PHP_BUILD_COMPILER
+		" " PHP_BUILD_COMPILER
+#endif
+#ifdef PHP_BUILD_ARCH
+		" " PHP_BUILD_ARCH
+#endif
+#if ZEND_DEBUG
+		" DEBUG"
+#endif
+#ifdef HAVE_GCOV
+		" GCOV"
+#endif
+		,
+#ifdef PHP_BUILD_PROVIDER
+		"Built by " PHP_BUILD_PROVIDER "\n"
+#else
+					""
+#endif
+		,
+		get_zend_version()
+	);
+}
+
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnSetFacility)
 {

--- a/main/main.c
+++ b/main/main.c
@@ -108,9 +108,10 @@ PHPAPI unsigned int php_version_id(void)
 	return PHP_VERSION_ID;
 }
 
-PHPAPI void php_print_version(sapi_module_struct *sapi_module)
+PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 {
-	php_printf("PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
+	char *version_info;
+	int size = spprintf(&version_info, 0, "PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
 		PHP_VERSION, sapi_module->name, __DATE__, __TIME__,
 #ifdef ZTS
 		"ZTS"
@@ -138,6 +139,14 @@ PHPAPI void php_print_version(sapi_module_struct *sapi_module)
 		,
 		get_zend_version()
 	);
+	return version_info;
+}
+
+PHPAPI void php_print_version(sapi_module_struct *sapi_module)
+{
+	char *version_info = php_get_version(sapi_module);
+	php_printf("%s", version_info);
+	efree(version_info);
 }
 
 /* {{{ PHP_INI_MH */

--- a/main/main.c
+++ b/main/main.c
@@ -111,7 +111,7 @@ PHPAPI unsigned int php_version_id(void)
 PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 {
 	char *version_info;
-	int size = spprintf(&version_info, 0, "PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
+	spprintf(&version_info, 0, "PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
 		PHP_VERSION, sapi_module->name, __DATE__, __TIME__,
 #ifdef ZTS
 		"ZTS"

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -36,6 +36,11 @@ PHPAPI const char *php_version(void);
  */
 PHPAPI unsigned int php_version_id(void);
 
+/* Prints the PHP version string for the -v option. It's in main/ so that
+ * it can be shared between SAPIs.
+ */
+PHPAPI void php_print_version(sapi_module_struct *sapi_module);
+
 PHPAPI zend_result php_request_startup(void);
 PHPAPI void php_request_shutdown(void *dummy);
 PHPAPI zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_module);

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -39,6 +39,7 @@ PHPAPI unsigned int php_version_id(void);
 /* Prints the PHP version string for the -v option. It's in main/ so that
  * it can be shared between SAPIs.
  */
+PHPAPI char *php_get_version(sapi_module_struct *sapi_module);
 PHPAPI void php_print_version(sapi_module_struct *sapi_module);
 
 PHPAPI zend_result php_request_startup(void);

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2377,11 +2377,7 @@ parent_loop_end:
 							}
 							SG(headers_sent) = 1;
 							SG(request_info).no_headers = 1;
-#if ZEND_DEBUG
-							php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-#else
-							php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-#endif
+							php_print_version(&cgi_sapi_module);
 							php_request_shutdown((void *) 0);
 							fcgi_shutdown();
 							exit_status = 0;

--- a/sapi/cgi/tests/001.phpt
+++ b/sapi/cgi/tests/001.phpt
@@ -17,6 +17,6 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "PHP %s (cgi%s (built: %s
 Copyright (c) The PHP Group
-Zend Engine v%s, Copyright (c) Zend Technologies
+%AZend Engine v%s, Copyright (c) Zend Technologies
 "
 Done

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -625,34 +625,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				goto out;
 
 			case 'v': /* show php version & quit */
-				php_printf("PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
-					PHP_VERSION, cli_sapi_module.name, __DATE__, __TIME__,
-#ifdef ZTS
-					"ZTS"
-#else
-					"NTS"
-#endif
-#ifdef PHP_BUILD_COMPILER
-					" " PHP_BUILD_COMPILER
-#endif
-#ifdef PHP_BUILD_ARCH
-					" " PHP_BUILD_ARCH
-#endif
-#if ZEND_DEBUG
-					" DEBUG"
-#endif
-#ifdef HAVE_GCOV
-					" GCOV"
-#endif
-					,
-#ifdef PHP_BUILD_PROVIDER
-					"Built by " PHP_BUILD_PROVIDER "\n"
-#else
-					""
-#endif
-					,
-					get_zend_version()
-				);
+				php_print_version(&cli_sapi_module);
 				sapi_deactivate();
 				goto out;
 

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -646,7 +646,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 #endif
 					,
 #ifdef PHP_BUILD_PROVIDER
-					"This build by " PHP_BUILD_PROVIDER "\n"
+					"Built by " PHP_BUILD_PROVIDER "\n"
 #else
 					""
 #endif

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -625,7 +625,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				goto out;
 
 			case 'v': /* show php version & quit */
-				php_printf("PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s",
+				php_printf("PHP %s (%s) (built: %s %s) (%s)\nCopyright (c) The PHP Group\n%s%s",
 					PHP_VERSION, cli_sapi_module.name, __DATE__, __TIME__,
 #ifdef ZTS
 					"ZTS"
@@ -643,6 +643,12 @@ static int do_cli(int argc, char **argv) /* {{{ */
 #endif
 #ifdef HAVE_GCOV
 					" GCOV"
+#endif
+					,
+#ifdef PHP_BUILD_PROVIDER
+					"This build by " PHP_BUILD_PROVIDER "\n"
+#else
+					""
 #endif
 					,
 					get_zend_version()

--- a/sapi/cli/tests/001.phpt
+++ b/sapi/cli/tests/001.phpt
@@ -14,6 +14,7 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "PHP %s (cli) (built: %s)%s
 Copyright (c) The PHP Group
+%A
 Zend Engine v%s, Copyright (c) Zend Technologies
 "
 Done

--- a/sapi/cli/tests/001.phpt
+++ b/sapi/cli/tests/001.phpt
@@ -14,7 +14,6 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "PHP %s (cli) (built: %s)%s
 Copyright (c) The PHP Group
-%A
-Zend Engine v%s, Copyright (c) Zend Technologies
+%AZend Engine v%s, Copyright (c) Zend Technologies
 "
 Done

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1705,11 +1705,7 @@ int main(int argc, char *argv[])
 				SG(headers_sent) = 1;
 				SG(request_info).no_headers = 1;
 
-#if ZEND_DEBUG
-				php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__,        __TIME__, get_zend_version());
-#else
-				php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__,      get_zend_version());
-#endif
+				php_print_version(&sapi_module);
 				php_request_shutdown((void *) 0);
 				fcgi_shutdown();
 				exit_status = FPM_EXIT_OK;

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1272,11 +1272,7 @@ static int cli_main( int argc, char * argv[] )
                 break;
             case 'v':
                 if (php_request_startup() != FAILURE) {
-#if ZEND_DEBUG
-                    php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-#else
-                    php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-#endif
+                    php_print_version(&sapi_module);
 #ifdef PHP_OUTPUT_NEWAPI
                     php_output_end_all();
 #else

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1370,7 +1370,14 @@ phpdbg_main:
 			if (show_help) {
 				phpdbg_do_help_cmd(exec);
 			} else if (show_version) {
-				php_print_version(&phpdbg_sapi_module);
+				char *version_info = php_get_version(&phpdbg_sapi_module);
+				/* we also want to include phpdbg version */
+				char *prepended_version_info;
+				int pvi_size = spprintf(&prepended_version_info, 0,
+						"phpdbg %s, %s", PHPDBG_VERSION, version_info);
+				phpdbg_out(prepended_version_info);
+				efree(prepended_version_info);
+				efree(version_info);
 			}
 			PHPDBG_G(flags) |= PHPDBG_IS_QUITTING;
 			php_module_shutdown();

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1375,7 +1375,7 @@ phpdbg_main:
 				char *prepended_version_info;
 				spprintf(&prepended_version_info, 0,
 						"phpdbg %s, %s", PHPDBG_VERSION, version_info);
-				phpdbg_out(prepended_version_info);
+				phpdbg_out("%s", prepended_version_info);
 				efree(prepended_version_info);
 				efree(version_info);
 			}

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1373,7 +1373,7 @@ phpdbg_main:
 				char *version_info = php_get_version(&phpdbg_sapi_module);
 				/* we also want to include phpdbg version */
 				char *prepended_version_info;
-				int pvi_size = spprintf(&prepended_version_info, 0,
+				spprintf(&prepended_version_info, 0,
 						"phpdbg %s, %s", PHPDBG_VERSION, version_info);
 				phpdbg_out(prepended_version_info);
 				efree(prepended_version_info);

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1369,14 +1369,7 @@ phpdbg_main:
 			if (show_help) {
 				phpdbg_do_help_cmd(exec);
 			} else if (show_version) {
-				phpdbg_out(
-					"phpdbg %s (built: %s %s)\nPHP %s, Copyright (c) The PHP Group\n%s",
-					PHPDBG_VERSION,
-					__DATE__,
-					__TIME__,
-					PHP_VERSION,
-					get_zend_version()
-				);
+				php_print_version(&phpdbg_sapi_module);
 			}
 			PHPDBG_G(flags) |= PHPDBG_IS_QUITTING;
 			php_module_shutdown();

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -30,6 +30,7 @@
 #include "phpdbg_arginfo.h"
 #include "zend_vm.h"
 #include "php_ini_builder.h"
+#include "php_main.h"
 
 #include "ext/standard/basic_functions.h"
 


### PR DESCRIPTION
Vendors can set the `PHP_BUILD_PROVIDER` variable, that gets printed in phpinfo. However, I find that users check `php -v` more often than phpinfo to see what PHP they're running. The problem with this is that it does not show that build provider information.

This change makes the build provider information printed on an additional line of the version information.