### PR TITLE
Fix negation in shell tests

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -1,8 +1,6 @@
-AC_DEFUN([PHP_ODBC_CHECK_HEADER],[
-if ! test -f "$ODBC_INCDIR/$1"; then
-  AC_MSG_ERROR([ODBC header file '$ODBC_INCDIR/$1' not found!])
-fi
-])
+AC_DEFUN([PHP_ODBC_CHECK_HEADER],
+[AS_IF([test ! -f "$ODBC_INCDIR/$1"],
+  [AC_MSG_ERROR([ODBC header file '$ODBC_INCDIR/$1' not found!])])])
 
 dnl
 dnl Figure out which library file to link with for the Solid support.

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -95,7 +95,7 @@ else
 fi
 
 # Check if make exists.
-if ! test -x "$(command -v $MAKE)"; then
+if test ! -x "$(command -v $MAKE)"; then
   echo "genfiles: make not found. Please install make to generate files." >&2
   exit 1
 fi


### PR DESCRIPTION
According to documentation the `if test ! ...` is preferred to `if ! test ...`. The later is not portable:
https://www.gnu.org/software/autoconf/manual/autoconf-2.72/autoconf.html

(Manual currently doesn't show up, some work on the server probably, but it's written under portability of using test in ifs).