### PR TITLE
Remove support for EOL Apache 2.0 and 2.2 in favor of 2.4+

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -365,6 +365,10 @@ PHP 8.4 UPGRADE NOTES
 3. Changes in SAPI modules
 ========================================
 
+- apache2handler
+  . Support for EOL Apache 2.0 and 2.2 has been removed. Minimum required Apache
+    version is now 2.4.
+
 ========================================
 4. Deprecated Functionality
 ========================================

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -165,8 +165,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      once used (use with_pear variable name).
 
  c. Windows build system changes
-   - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19 have
-     been removed.
+   - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19,
+     --enable-apache2-2handler have been removed.
+   - The configure option --enable-apache2-4handler is now an alias for the
+     preferred --enable-apache2handler.
    - Added Bison flag '-Wall' when generating lexer files as done in *nix build
      system.
    - HAVE_WIN32_NATIVE_THREAD, USE_WIN32_NATIVE_THREAD, ENABLE_THREADS symbols

--- a/configure.ac
+++ b/configure.ac
@@ -1847,8 +1847,7 @@ if test -n "\$REDO_ALL"; then
   AWK="$AWK" sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in "$EXT_CLI_STATIC" > main/internal_functions_cli.c
 
     if test "$PHP_SAPI" = "apache2handler"; then
-      if test "$APACHE_VERSION" -ge 2004001; then
-        if test -z "$APACHE_THREADED_MPM"; then
+      if test -z "$APACHE_THREADED_MPM"; then
 cat <<X
 +--------------------------------------------------------------------+
 |                        *** WARNING ***                             |
@@ -1857,10 +1856,8 @@ cat <<X
 | If you change Apache to use a threaded MPM you must reconfigure    |
 | PHP with --enable-zts                                              |
 X
-        fi
       fi
     fi
-
 fi
 ])
 AC_OUTPUT

--- a/ext/standard/credits_sapi.h
+++ b/ext/standard/credits_sapi.h
@@ -10,7 +10,7 @@
 
 */
 
-CREDIT_LINE("Apache 2.0 Handler", "Ian Holsman, Justin Erenkrantz (based on Apache 2.0 Filter code)");
+CREDIT_LINE("Apache 2 Handler", "Ian Holsman, Justin Erenkrantz (based on Apache 2 Filter code)");
 CREDIT_LINE("CGI / FastCGI", "Rasmus Lerdorf, Stig Bakken, Shane Caraveo, Dmitry Stogov");
 CREDIT_LINE("CLI", "Edin Kadribasic, Marcus Boerger, Johannes Schlueter, Moriyoshi Koizumi, Xinchen Hui");
 CREDIT_LINE("Embed", "Edin Kadribasic");

--- a/sapi/apache2handler/CREDITS
+++ b/sapi/apache2handler/CREDITS
@@ -1,2 +1,2 @@
-Apache 2.0 Handler
-Ian Holsman, Justin Erenkrantz (based on Apache 2.0 Filter code)
+Apache 2 Handler
+Ian Holsman, Justin Erenkrantz (based on Apache 2 Filter code)

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -38,7 +38,7 @@ if test "$PHP_APXS2" != "no"; then
   APU_BINDIR=`$APXS -q APU_BINDIR`
   APR_BINDIR=`$APXS -q APR_BINDIR`
 
-  dnl Pick up ap[ru]-N-config if using httpd >=2.1
+  dnl Pick up ap[ru]-N-config.
   APR_CONFIG=`$APXS -q APR_CONFIG 2>/dev/null ||
     echo $APR_BINDIR/apr-config`
   APU_CONFIG=`$APXS -q APU_CONFIG 2>/dev/null ||
@@ -55,11 +55,10 @@ if test "$PHP_APXS2" != "no"; then
 
   APACHE_CFLAGS="$APACHE_CPPFLAGS -I$APXS_INCLUDEDIR $APR_CFLAGS $APU_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
-  dnl Test that we're trying to configure with apache 2.x
-  PHP_AP_EXTRACT_VERSION($APXS_HTTPD)
-  if test "$APACHE_VERSION" -lt 2000044; then
-    AC_MSG_ERROR([Please note that Apache version >= 2.0.44 is required])
-  fi
+  dnl Check Apache version.
+  PHP_AP_EXTRACT_VERSION([$APXS_HTTPD])
+  AS_VERSION_COMPARE([$APACHE_VERSION], [2004000],
+    [AC_MSG_ERROR([Please note that Apache version >= 2.4 is required])])
 
   APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
   if test -z `$APXS -q SYSCONFDIR`; then
@@ -106,15 +105,6 @@ if test "$PHP_APXS2" != "no"; then
     ;;
   esac
 
-  if test "$APACHE_VERSION" -lt 2004001; then
-    APXS_MPM=`$APXS -q MPM_NAME`
-    if test "$APXS_MPM" != "prefork" && test "$APXS_MPM" != "peruser" && test "$APXS_MPM" != "itk"; then
-      PHP_BUILD_THREAD_SAFE
-    fi
-  else
-    APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`
-    if test -n "$APACHE_THREADED_MPM"; then
-      PHP_BUILD_THREAD_SAFE
-    fi
-  fi
+  APACHE_THREADED_MPM=$($APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes')
+  AS_VAR_SET_IF([APACHE_THREADED_MPM], [PHP_BUILD_THREAD_SAFE])
 fi

--- a/sapi/apache2handler/config.w32
+++ b/sapi/apache2handler/config.w32
@@ -1,56 +1,24 @@
 // vim:ft=javascript
 
-ARG_ENABLE('apache2handler', 'Build Apache 2.x handler', 'no');
+ARG_ENABLE('apache2handler', 'Build Apache 2 handler', 'no');
+ARG_ENABLE('apache2-4handler', 'Build Apache 2 handler (alias for --enable--apache2handler)', 'no');
+
+if(PHP_APACHE2_4HANDLER != "no" && PHP_APACHE2HANDLER == "no") {
+	PHP_APACHE2HANDLER="yes";
+}
 
 if (PHP_APACHE2HANDLER != "no") {
 	if (PHP_ZTS == "no") {
-		WARNING("Apache 2.0 module requires an --enable-zts build of PHP on windows");
-	} else if (CHECK_HEADER_ADD_INCLUDE("httpd.h", "CFLAGS_APACHE2HANDLER", PHP_PHP_BUILD + "\\include\\apache2") &&
-			CHECK_LIB("libhttpd.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2") &&
-			CHECK_LIB("libapr.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2") &&
-			CHECK_LIB("libaprutil.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2")
+		WARNING("Apache module requires an --enable-zts build of PHP on windows");
+	} else if (CHECK_HEADER_ADD_INCLUDE("httpd.h", "CFLAGS_APACHE2HANDLER", PHP_PHP_BUILD + "\\include\\apache2_4") &&
+			CHECK_LIB("libhttpd.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
+			CHECK_LIB("libapr-1.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
+			CHECK_LIB("libaprutil-1.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4")
 			) {
 		SAPI('apache2handler', 'mod_php.c sapi_apache2.c apache_config.c php_functions.c',
-				'php' + PHP_VERSION + 'apache2.dll',
+				'php' + PHP_VERSION + 'apache2_4.dll',
 				'/D PHP_APACHE2_EXPORTS /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 	} else {
-		WARNING("Could not find apache2 libraries/headers");
-	}
-}
-
-ARG_ENABLE('apache2-2handler', 'Build Apache 2.2.x handler', 'no');
-
-if (PHP_APACHE2_2HANDLER != "no") {
-	if (PHP_ZTS == "no") {
-		WARNING("Apache 2.2 module requires an --enable-zts build of PHP on windows");
-	} else if (CHECK_HEADER_ADD_INCLUDE("httpd.h", "CFLAGS_APACHE2_2HANDLER", PHP_PHP_BUILD + "\\include\\apache2_2") &&
-			CHECK_LIB("libhttpd.lib", "apache2_2handler", PHP_PHP_BUILD + "\\lib\\apache2_2") &&
-			CHECK_LIB("libapr-1.lib", "apache2_2handler", PHP_PHP_BUILD + "\\lib\\apache2_2") &&
-			CHECK_LIB("libaprutil-1.lib", "apache2_2handler", PHP_PHP_BUILD + "\\lib\\apache2_2")
-			) {
-		SAPI('apache2_2handler', 'mod_php.c sapi_apache2.c apache_config.c php_functions.c',
-				'php' + PHP_VERSION + 'apache2_2.dll',
-				'/D PHP_APACHE2_EXPORTS /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1',
-				'sapi\\apache2_2handler');
-	} else {
-		WARNING("Could not find apache2.2 libraries/headers");
-	}
-}
-
-ARG_ENABLE('apache2-4handler', 'Build Apache 2.4.x handler', 'no');
-if (PHP_APACHE2_4HANDLER != "no") {
-	if (PHP_ZTS == "no") {
-		WARNING("Apache 2.4 module requires an --enable-zts build of PHP on windows");
-	} else if (CHECK_HEADER_ADD_INCLUDE("httpd.h", "CFLAGS_APACHE2_4HANDLER", PHP_PHP_BUILD + "\\include\\apache2_4") &&
-			CHECK_LIB("libhttpd.lib", "apache2_4handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
-			CHECK_LIB("libapr-1.lib", "apache2_4handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
-			CHECK_LIB("libaprutil-1.lib", "apache2_4handler", PHP_PHP_BUILD + "\\lib\\apache2_4")
-			) {
-		SAPI('apache2_4handler', 'mod_php.c sapi_apache2.c apache_config.c php_functions.c',
-				'php' + PHP_VERSION + 'apache2_4.dll',
-				'/D PHP_APACHE2_EXPORTS /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1',
-				'sapi\\apache2handler');
-	} else {
-		WARNING("Could not find apache 2.4 libraries/headers");
+		WARNING("Could not find Apache libraries/headers");
 	}
 }

--- a/sapi/apache2handler/php_apache.h
+++ b/sapi/apache2handler/php_apache.h
@@ -25,10 +25,8 @@
 #include "php.h"
 #include "main/php_streams.h"
 
-/* Enable per-module logging in Apache 2.4+ */
-#ifdef APLOG_USE_MODULE
+/* Enable per-module logging. */
 APLOG_USE_MODULE(php);
-#endif
 
 /* Declare this so we can get to it from outside the sapi_apache2.c file */
 extern module AP_MODULE_DECLARE_DATA php_module;

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -29,7 +29,6 @@
 #include "php_ini.h"
 #include "SAPI.h"
 
-#define CORE_PRIVATE
 #include "apr_strings.h"
 #include "apr_time.h"
 #include "ap_config.h"
@@ -141,9 +140,6 @@ PHP_FUNCTION(apache_lookup_uri)
 		ADD_STRING(method);
 		ADD_TIME(mtime);
 		ADD_LONG(clength);
-#if MODULE_MAGIC_NUMBER < 20020506
-		ADD_STRING(boundary);
-#endif
 		ADD_STRING(range);
 		ADD_LONG(chunked);
 		ADD_STRING(content_type);
@@ -319,11 +315,7 @@ PHP_FUNCTION(apache_getenv)
 
 static char *php_apache_get_version(void)
 {
-#if MODULE_MAGIC_NUMBER_MAJOR >= 20060905
 	return (char *) ap_get_server_banner();
-#else
-	return (char *) ap_get_server_version();
-#endif
 }
 
 /* {{{ Fetch Apache version */
@@ -367,11 +359,7 @@ PHP_MINFO_FUNCTION(apache)
 	char *p;
 	server_rec *serv = ((php_struct *) SG(server_context))->r->server;
 #ifndef PHP_WIN32
-# if MODULE_MAGIC_NUMBER_MAJOR >= 20081201
 	AP_DECLARE_DATA extern unixd_config_rec ap_unixd_config;
-# else
-	AP_DECLARE_DATA extern unixd_config_rec unixd_config;
-# endif
 #endif
 
 	for (n = 0; ap_loaded_modules[n]; ++n) {
@@ -395,7 +383,7 @@ PHP_MINFO_FUNCTION(apache)
 	if (apv && *apv) {
 		php_info_print_table_row(2, "Apache Version", apv);
 	}
-	snprintf(tmp, sizeof(tmp), "%d", MODULE_MAGIC_NUMBER);
+	snprintf(tmp, sizeof(tmp), "%d", MODULE_MAGIC_NUMBER_MAJOR);
 	php_info_print_table_row(2, "Apache API Version", tmp);
 
 	if (serv->server_admin && *(serv->server_admin)) {
@@ -406,11 +394,7 @@ PHP_MINFO_FUNCTION(apache)
 	php_info_print_table_row(2, "Hostname:Port", tmp);
 
 #ifndef PHP_WIN32
-#if MODULE_MAGIC_NUMBER_MAJOR >= 20081201
 	snprintf(tmp, sizeof(tmp), "%s(%d)/%d", ap_unixd_config.user_name, ap_unixd_config.user_id, ap_unixd_config.group_id);
-#else
-	snprintf(tmp, sizeof(tmp), "%s(%d)/%d", unixd_config.user_name, unixd_config.user_id, unixd_config.group_id);
-#endif
 	php_info_print_table_row(2, "User/Group", tmp);
 #endif
 

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -388,7 +388,7 @@ static int php_apache2_startup(sapi_module_struct *sapi_module)
 
 static sapi_module_struct apache2_sapi_module = {
 	"apache2handler",
-	"Apache 2.0 Handler",
+	"Apache 2 Handler",
 
 	php_apache2_startup,				/* startup */
 	php_module_shutdown_wrapper,			/* shutdown */


### PR DESCRIPTION
Remove support for EOL Apache 2.0 and 2.2 in favor of 2.4+

Apache 2.2 has been marked as EOL in December 2017 and doesn't receive
security patches any longer. Also, most *nix distributions and packages
mostly support 2.4 as minimum by now.

On Windows, this removes the configure option --enable-apache2-2handler
and merges the --enable-apache2handler and --enable-apache2-4handler
into a single option with favoring the --enable-apache2handler.

- The upstream MODULE_MAGIC_NUMBER is deprecated in favor of
  MODULE_MAGIC_NUMBER_MAJOR in apache2/ap_mmn.h
- The initial upstream MODULE_MAGIC_NUMBER_MAJOR was 20111025 in Apache
  2.4.0
- The upstream APLOG_USE_MODULE is always available since Apache 2.3.6
- The upstream CORE_PRIVATE is unnecessary and ignored since Apache
  2.4.0

Apache announcement:
https://forum.apachehaus.com/news-general-discussion/apache-2-2-users-your-time-is-running-out/

PHP discussion: https://news-web.php.net/php.internals/124067