### PR TITLE
Sync missing hash and pcre dependencies for opcache on Windows

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -48,7 +48,10 @@
 #include "zend_file_cache.h"
 #include "ext/pcre/php_pcre.h"
 #include "ext/standard/md5.h"
-#include "ext/hash/php_hash.h"
+
+#ifdef ZEND_WIN32
+# include "ext/hash/php_hash.h"
+#endif
 
 #ifdef HAVE_JIT
 # include "jit/zend_jit.h"

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -18,6 +18,9 @@ if (PHP_OPCACHE != "no") {
 		zend_shared_alloc.c \
 		shared_alloc_win32.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
+	ADD_EXTENSION_DEP('opcache', 'hash');
+	ADD_EXTENSION_DEP('opcache', 'pcre');
+
 	if (PHP_OPCACHE_JIT == "yes") {
 		if (CHECK_HEADER_ADD_INCLUDE("ir/ir.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
 			var dasm_flags = (X64 ? "-D X64=1" : "") + (X64 ? " -D X64WIN=1" : "") + " -D WIN=1";


### PR DESCRIPTION
- ext/hash is required only on Windows
- ext/pcre is required

ZEND_MOD_REQUIRED is not added yet here due to fragility of the dependencies sorting which I can't fully test ATM but probably could be done in the future. And to add also ext/date for consistency.