### PR TITLE
Handle BSD checksum and file utilities

### DIFF
--- a/scripts/dev/gen_verify_stub
+++ b/scripts/dev/gen_verify_stub
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Handle GNU vs. BSD checksum utilities
+sha256sum="$(which sha256sum)"
+sha256sum="${sha256sum:-$(which shasum) -a 256}"
+
 if [ "x$1" == "x" ]
 then
 	echo "Usage: $0 <version> [email]"
@@ -41,7 +45,7 @@ done
 for TARBALL in "$PHPROOT/php-$RELEASE_VER.tar.bz2" "$PHPROOT/php-$RELEASE_VER.tar.gz" "$PHPROOT/php-$RELEASE_VER.tar.xz"
 do
 	basename $TARBALL
-	echo "SHA256 hash: `sha256sum $TARBALL | cut -d' ' -f1`";
+	echo "SHA256 hash: `$sha256sum $TARBALL | cut -d' ' -f1`";
 	echo PGP signature:
 	cat $TARBALL.asc
 	echo -e "\n"

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -9,6 +9,10 @@
 tar="$(which gtar)"
 tar="${tar:-$(which tar)}"
 
+# Handle GNU vs. BSD checksum utilities
+md5sum="$(which md5sum)"
+md5sum="${md5sum:-$(which md5)}"
+
 if [[ $($tar --version) == *"bsdtar"* ]]; then
   echo "Found bsdtar at $tar, but this script needs GNU tar."
   exit 1
@@ -181,7 +185,7 @@ rm -rf "$prefix" "$prefix".tar.*
 
 echo "makedist: Creating $prefix.tar.gz archive."
 gzip -9 -k "$prefix".tar || exit 6
-md5sum "$prefix".tar.gz
+"$md5sum" "$prefix".tar.gz
 gzip -t "$prefix".tar.gz
 
 sync
@@ -189,7 +193,7 @@ sleep 2
 
 echo "makedist: Creating $prefix.tar.bz2 archive."
 bzip2 -9 -k $prefix.tar || exit 7
-md5sum $prefix.tar.bz2
+"$md5sum" $prefix.tar.bz2
 bzip2 -t $prefix.tar.bz2
 
 sync
@@ -197,7 +201,7 @@ sleep 2
 
 echo "makedist: Creating $prefix.tar.xz archive."
 xz -9 -k "$prefix".tar || exit 9
-md5sum "$prefix".tar.xz
+"$md5sum" "$prefix".tar.xz
 xz -t "$prefix".tar.xz
 
 echo ""

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -13,6 +13,10 @@ tar="${tar:-$(which tar)}"
 md5sum="$(which md5sum)"
 md5sum="${md5sum:-$(which md5)}"
 
+# GNU touch is preferred since it handles local TZ in timestamps
+touch="$(which gtouch)"
+touch="${touch:-$(which touch)}"
+
 if [[ $($tar --version) == *"bsdtar"* ]]; then
   echo "Found bsdtar at $tar, but this script needs GNU tar."
   exit 1
@@ -173,8 +177,8 @@ fi
 # Reset the modification and access times of all files to be packaged.
 commitDate="$(git log -1 --format=%cI $treeish)"
 echo "makedist: Resetting the modification and access times of package files to $commitDate"
-touch -c -d"$commitDate" NEWS
-find . -exec touch -r NEWS -c {} \;
+"$touch" -c -d"$commitDate" NEWS
+find . -exec "$touch" -r NEWS -c {} \;
 
 cd ..
 


### PR DESCRIPTION
The BSDs have different checksum utilities than GNU systems do. If we don't see the GNU checksum utilities installed, use the BSD ones, as their output is compatible enough.

Also prefers GNU touch if installed, since it supports non-UTC timestamps.

Fixes GH-14688.