### PR TITLE
Wrap Zend max execution timers check in M4 macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -135,6 +135,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_PDO_SQLITELIB has been removed.
    - Symbol HAVE_WAITPID has been removed.
    - Symbol HAVE_LIBPQ has been removed.
+   - Symbols HAVE_LIBRT and HAVE_TIMER_CREATE removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).


### PR DESCRIPTION
- PHP_CHECK_FUNC -> AC_SEARCH_LIBS
- Redundant symbols HAVE_LIBRT and HAVE_TIMER_CREATE removed
- The rt library for some older systems (Solaris <= 10, older Linux) appended as needed
- This uses AC_ and AS_* macros and relies more on Autoconf shell code handling
- Help texts updated and synced