### PR TITLE
Follow-up on GH-13516: include config.h from build dir for new files in ext-dom

### DIFF
--- a/ext/dom/html_collection.c
+++ b/ext/dom/html_collection.c
@@ -15,7 +15,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #include "php.h"

--- a/ext/dom/infra.c
+++ b/ext/dom/infra.c
@@ -15,7 +15,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #include "php.h"

--- a/ext/dom/xml_serializer.c
+++ b/ext/dom/xml_serializer.c
@@ -15,7 +15,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #include "php.h"


### PR DESCRIPTION
GH-13516 was created before the new DOM files were added, and the PR was never rebased to include the new DOM files, so there are three places which were not replaced.