### PR TITLE
Fix GH-14590: Memory leak in FPM test gh13563-conf-bool-env.phpt

### DIFF
--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -173,8 +173,10 @@ static void zend_ini_get_var(zval *result, zval *name)
 	if ((curval = zend_get_configuration_directive(Z_STR_P(name))) != NULL) {
 		ZVAL_NEW_STR(result, zend_string_init(Z_STRVAL_P(curval), Z_STRLEN_P(curval), ZEND_SYSTEM_INI));
 	/* ..or if not found, try ENV */
-	} else if ((envvar = zend_getenv(Z_STRVAL_P(name), Z_STRLEN_P(name))) != NULL ||
-			   (envvar = getenv(Z_STRVAL_P(name))) != NULL) {
+	} else if ((envvar = zend_getenv(Z_STRVAL_P(name), Z_STRLEN_P(name))) != NULL) {
+		ZVAL_NEW_STR(result, zend_string_init(envvar, strlen(envvar), ZEND_SYSTEM_INI));
+		efree(envvar);
+	} else if ((envvar = getenv(Z_STRVAL_P(name))) != NULL) {
 		ZVAL_NEW_STR(result, zend_string_init(envvar, strlen(envvar), ZEND_SYSTEM_INI));
 	} else {
 		zend_ini_init_string(result);


### PR DESCRIPTION
The issue is not related to FPM. Values retrieved from zend_getenv should be freed.
Making a test is not trivial because the CLI sapi doesn't implement the sapi getenv hook, so zend_getenv always returns NULL.