### PR TITLE
parse_str: new flag to merge duplicated params

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2579,7 +2579,7 @@ function strip_tags(string $string, array|string|null $allowed_tags = null): str
 function setlocale(int $category, $locales, ...$rest): string|false {}
 
 /** @param array $result */
-function parse_str(string $string, &$result): void {}
+function parse_str(string $string, &$result, bool $merge_params = false): void {}
 
 /**
  * @return array<int, string|null>

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7d588414e84ed62088cd5b1c668b29c0e51d406f */
+ * Stub hash: 2367a5cd4285e99917d59cf47caa790118689987 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1026,6 +1026,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_parse_str, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_INFO(1, result)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, merge_params, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_getcsv, 0, 1, IS_ARRAY, 0)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5010,10 +5010,13 @@ PHP_FUNCTION(parse_str)
 	zval *arrayArg = NULL;
 	char *res = NULL;
 	size_t arglen;
+	bool mergeParams = 0;
 
-	ZEND_PARSE_PARAMETERS_START(2, 2)
+	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_STRING(arg, arglen)
 		Z_PARAM_ZVAL(arrayArg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(mergeParams)
 	ZEND_PARSE_PARAMETERS_END();
 
 	arrayArg = zend_try_array_init(arrayArg);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5023,6 +5023,7 @@ PHP_FUNCTION(parse_str)
 	if (!arrayArg) {
 		RETURN_THROWS();
 	}
+	Z_EXTRA_P(arrayArg) = (uint16_t)mergeParams;
 
 	res = estrndup(arg, arglen);
 	sapi_module.treat_data(PARSE_STRING, res, arrayArg);

--- a/ext/standard/tests/strings/parse_str_basic5.phpt
+++ b/ext/standard/tests/strings/parse_str_basic5.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test parse_str() function : test with duplicated param name
+--FILE--
+<?php
+echo "\nTest with duplicated param name should be treated as single var with latest value set\n";
+$str = "foo=sid&foo=bill";
+var_dump(parse_str($str, $res));
+var_dump($res);
+
+echo "\nTest with duplicated param name should be treated as array\n";
+$str = "foo=sid&foo=bill";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
+?>
+--EXPECTF--
+Test with duplicated param name should be treated as single var with latest value set
+NULL
+array(1) {
+  ["foo"]=>
+  string(4) "bill"
+}
+
+Test with duplicated param name should be treated as array
+NULL
+array(1) {
+  ["foo"]=>
+  array(2) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+  }
+}

--- a/ext/standard/tests/strings/parse_str_basic5.phpt
+++ b/ext/standard/tests/strings/parse_str_basic5.phpt
@@ -11,6 +11,36 @@ echo "\nTest with duplicated param name should be treated as array\n";
 $str = "foo=sid&foo=bill";
 var_dump(parse_str($str, $res, true));
 var_dump($res);
+
+echo "\nTest with duplicated param name should not be treated as array\n";
+$str = "foo[]=sid&foo=bill";
+var_dump(parse_str($str, $res));
+var_dump($res);
+
+echo "\nTest with duplicated mixed param name should be treated as array\n";
+$str = "foo[]=sid&foo=bill";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
+
+echo "\nTest with duplicated mixed param name should be treated as array (reverse)\n";
+$str = "foo=sid&foo[]=bill";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
+
+echo "\nTest with more duplicated mixed param name should be treated as array\n";
+$str = "foo=sid&foo[]=bill&foo=bar&foo[]=baz";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
+
+echo "\nTest with more duplicated mixed param name should be treated as array 2\n";
+$str = "foo[]=sid&foo=bill&foo[]=bar&foo[]=baz";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
+
+echo "\nTest with 2 different array vars\n";
+$str = "foo[]=sid&foo=bill&bar=bar&bar[]=baz";
+var_dump(parse_str($str, $res, true));
+var_dump($res);
 ?>
 --EXPECTF--
 Test with duplicated param name should be treated as single var with latest value set
@@ -29,5 +59,87 @@ array(1) {
     string(3) "sid"
     [1]=>
     string(4) "bill"
+  }
+}
+
+Test with duplicated param name should not be treated as array
+NULL
+array(1) {
+  ["foo"]=>
+  string(4) "bill"
+}
+
+Test with duplicated mixed param name should be treated as array
+NULL
+array(1) {
+  ["foo"]=>
+  array(2) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+  }
+}
+
+Test with duplicated mixed param name should be treated as array (reverse)
+NULL
+array(1) {
+  ["foo"]=>
+  array(2) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+  }
+}
+
+Test with more duplicated mixed param name should be treated as array
+NULL
+array(1) {
+  ["foo"]=>
+  array(4) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+    [2]=>
+    string(3) "bar"
+    [3]=>
+    string(3) "baz"
+  }
+}
+
+Test with more duplicated mixed param name should be treated as array 2
+NULL
+array(1) {
+  ["foo"]=>
+  array(4) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+    [2]=>
+    string(3) "bar"
+    [3]=>
+    string(3) "baz"
+  }
+}
+
+Test with 2 different array vars
+NULL
+array(2) {
+  ["foo"]=>
+  array(2) {
+    [0]=>
+    string(3) "sid"
+    [1]=>
+    string(4) "bill"
+  }
+  ["bar"]=>
+  array(2) {
+    [0]=>
+    string(3) "bar"
+    [1]=>
+    string(3) "baz"
   }
 }


### PR DESCRIPTION
This is a POC for parse_str to merge params on duplicated keys without brackets

Related issue: https://github.com/php/php-src/issues/13802
See also: https://github.com/symfony/symfony/issues/54376