### PR TITLE
Fix GH-14712: segfault on invalid object.

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3127,6 +3127,9 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 		}
 	}
 
+	/* Pointer on property callback is required */
+	ZEND_ASSERT(zobj->handlers->get_property_ptr_ptr != NULL);
+
 	if (prop_op_type == IS_CONST) {
 		name = Z_STR_P(prop_ptr);
 	} else {

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2453,6 +2453,16 @@ static zend_function *row_get_ctor(zend_object *object)
 	return NULL;
 }
 
+static zval *pdo_row_get_property_ptr_ptr(zend_object *object, zend_string *name, int type, void **cache_slot)
+{
+	ZEND_IGNORE_VALUE(object);
+	ZEND_IGNORE_VALUE(name);
+	ZEND_IGNORE_VALUE(type);
+	ZEND_IGNORE_VALUE(cache_slot);
+
+	return NULL;
+}
+
 void pdo_row_free_storage(zend_object *std)
 {
 	pdo_row_t *row = (pdo_row_t *)std;
@@ -2492,7 +2502,7 @@ void pdo_stmt_init(void)
 	memcpy(&pdo_row_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pdo_row_object_handlers.free_obj = pdo_row_free_storage;
 	pdo_row_object_handlers.clone_obj = NULL;
-	pdo_row_object_handlers.get_property_ptr_ptr = NULL;
+	pdo_row_object_handlers.get_property_ptr_ptr = pdo_row_get_property_ptr_ptr;
 	pdo_row_object_handlers.read_property = row_prop_read;
 	pdo_row_object_handlers.write_property = row_prop_write;
 	pdo_row_object_handlers.has_property = row_prop_exists;

--- a/ext/pdo_sqlite/tests/gh14712.phpt
+++ b/ext/pdo_sqlite/tests/gh14712.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-14712: segfault on PDORow
+--EXTENSIONS--
+pdo_sqlite
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$db = new PDO('sqlite::memory:');
+
+try {
+	$db->query("select 1 as queryStringxx")->fetch(PDO::FETCH_LAZY)->documentElement->firstChild->nextElementSibling->textContent = "Ã©";
+} catch (Error $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+Attempt to modify property "firstChild" on null


### PR DESCRIPTION
If the extension does not allow to get a property pointer (like PDORow object), we fallback
to the read property cb anyway.