### PR TITLE
Fix OSS-Fuzz #69765

### DIFF
--- a/Zend/tests/oss-fuzz-69765.phpt
+++ b/Zend/tests/oss-fuzz-69765.phpt
@@ -1,0 +1,10 @@
+--TEST--
+OSS-Fuzz #69765: yield reference to nullsafe chain
+--FILE--
+<?php
+function &test($object) {
+    yield $object->y?->y;
+}
+?>
+--EXPECTF--
+Fatal error: Cannot take reference of a nullsafe chain in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9329,6 +9329,10 @@ static void zend_compile_yield(znode *result, zend_ast *ast) /* {{{ */
 
 	if (value_ast) {
 		if (returns_by_ref && zend_is_variable(value_ast)) {
+			if (zend_ast_is_short_circuited(value_ast)) {
+				zend_error_noreturn(E_COMPILE_ERROR, "Cannot take reference of a nullsafe chain");
+			}
+
 			zend_compile_var(&value_node, value_ast, BP_VAR_W, 1);
 		} else {
 			zend_compile_expr(&value_node, value_ast);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2312,6 +2312,13 @@ static bool zend_ast_is_short_circuited(const zend_ast *ast)
 	}
 }
 
+static void zend_assert_not_short_circuited(const zend_ast *ast)
+{
+	if (zend_ast_is_short_circuited(ast)) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Cannot take reference of a nullsafe chain");
+	}
+}
+
 /* Mark nodes that are an inner part of a short-circuiting chain.
  * We should not perform a "commit" on them, as it will be performed by the outer-most node.
  * We do this to avoid passing down an argument in various compile functions. */
@@ -3304,9 +3311,8 @@ static void zend_compile_assign(znode *result, zend_ast *ast) /* {{{ */
 				if (!zend_is_variable_or_call(expr_ast)) {
 					zend_error_noreturn(E_COMPILE_ERROR,
 						"Cannot assign reference to non referenceable value");
-				} else if (zend_ast_is_short_circuited(expr_ast)) {
-					zend_error_noreturn(E_COMPILE_ERROR,
-						"Cannot take reference of a nullsafe chain");
+				} else {
+					zend_assert_not_short_circuited(expr_ast);
 				}
 
 				zend_compile_var(&expr_node, expr_ast, BP_VAR_W, 1);
@@ -3348,9 +3354,7 @@ static void zend_compile_assign_ref(znode *result, zend_ast *ast) /* {{{ */
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot re-assign $this");
 	}
 	zend_ensure_writable_variable(target_ast);
-	if (zend_ast_is_short_circuited(source_ast)) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Cannot take reference of a nullsafe chain");
-	}
+	zend_assert_not_short_circuited(source_ast);
 	if (is_globals_fetch(source_ast)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot acquire reference to $GLOBALS");
 	}
@@ -5026,10 +5030,7 @@ static void zend_compile_return(zend_ast *ast) /* {{{ */
 		expr_node.op_type = IS_CONST;
 		ZVAL_NULL(&expr_node.u.constant);
 	} else if (by_ref && zend_is_variable(expr_ast)) {
-		if (zend_ast_is_short_circuited(expr_ast)) {
-			zend_error_noreturn(E_COMPILE_ERROR, "Cannot take reference of a nullsafe chain");
-		}
-
+		zend_assert_not_short_circuited(expr_ast);
 		zend_compile_var(&expr_node, expr_ast, BP_VAR_W, 1);
 	} else {
 		zend_compile_expr(&expr_node, expr_ast);
@@ -9329,10 +9330,7 @@ static void zend_compile_yield(znode *result, zend_ast *ast) /* {{{ */
 
 	if (value_ast) {
 		if (returns_by_ref && zend_is_variable(value_ast)) {
-			if (zend_ast_is_short_circuited(value_ast)) {
-				zend_error_noreturn(E_COMPILE_ERROR, "Cannot take reference of a nullsafe chain");
-			}
-
+			zend_assert_not_short_circuited(value_ast);
 			zend_compile_var(&value_node, value_ast, BP_VAR_W, 1);
 		} else {
 			zend_compile_expr(&value_node, value_ast);


### PR DESCRIPTION
You cannot return or yield a reference to a nullsafe chain. This was
checked already in zend_compile_return but not yet in
zend_compile_yield.

First commit fixes the bug, second commit factors out the common code.