### PR TITLE
Fix GH-14563: Build failure with libxml2 v2.13.0

### DIFF
--- a/ext/libxml/php_libxml2.def
+++ b/ext/libxml/php_libxml2.def
@@ -345,7 +345,6 @@ xmlElemDump
 xmlEncodeEntities
 xmlEncodeEntitiesReentrant
 xmlEncodeSpecialChars
-xmlErrMemory
 xmlFileClose
 xmlFileMatch
 xmlFileOpen


### PR DESCRIPTION
Remove xmlErrMemory from the export section for Windows, this fixes the build. Even though the original function was renamed [1] it is hidden, so removing this should be sufficient and not be a BC break.

[1] https://github.com/GNOME/libxml2/commit/130436917c362d14f0eb3705a0edddc523a9640e