### PR TITLE
Autotools: Move HAVE_DTRACE and PHP_DTRACE_OBJS to PHP_INIT_DTRACE

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2283,7 +2283,10 @@ int main(void)
 dnl
 dnl PHP_INIT_DTRACE(providerdesc, header-file, sources [, module])
 dnl
-AC_DEFUN([PHP_INIT_DTRACE],[
+AC_DEFUN([PHP_INIT_DTRACE],
+[AC_CHECK_HEADER([sys/sdt.h],,
+  [AC_MSG_ERROR([Cannot find sys/sdt.h which is required for DTrace support.])])
+
 dnl Set paths properly when called from extension.
   case "$4" in
     ""[)] ac_srcdir="$abs_srcdir/"; unset ac_bdir;;
@@ -2388,6 +2391,9 @@ $ac_bdir[$]ac_provsrc.o: \$(PHP_DTRACE_OBJS)
 EOF
     ;;
   esac
+
+AC_DEFINE([HAVE_DTRACE], [1], [Define to 1 if DTrace support is enabled.])
+PHP_SUBST([PHP_DTRACE_OBJS])
 ])
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1031,17 +1031,12 @@ PHP_ARG_ENABLE([dtrace],
   [no],
   [no])
 
-if test "$PHP_DTRACE" = "yes"; then
-  AC_CHECK_HEADER([sys/sdt.h], [
-    PHP_INIT_DTRACE([Zend/zend_dtrace.d],[Zend/zend_dtrace_gen.h],[main/main.c Zend/zend_API.c \
+AS_VAR_IF([PHP_DTRACE], [yes],
+  [PHP_INIT_DTRACE([Zend/zend_dtrace.d],
+    [Zend/zend_dtrace_gen.h],
+    [main/main.c Zend/zend_API.c \
       Zend/zend_execute.c Zend/zend_exceptions.c \
-      Zend/zend_dtrace.c Zend/zend.c])
-    AC_DEFINE(HAVE_DTRACE, 1, [Whether to enable DTrace support])
-    PHP_SUBST(PHP_DTRACE_OBJS)
-  ], [
-    AC_MSG_ERROR([Cannot find sys/sdt.h which is required for DTrace support])
-  ])
-fi
+      Zend/zend_dtrace.c Zend/zend.c])])
 
 AC_MSG_CHECKING([how big to make fd sets])
 PHP_ARG_ENABLE([fd-setsize],,


### PR DESCRIPTION
The sys/sdt.h is required header when using DTrace, HAVE_DTRACE can be defined together when initializing and PHP_DTRACE_OBJS can be substituted to simplify the macro usage a bit further.