### PR TITLE
Normalize AC_CHECK_HEADER* arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -373,55 +373,55 @@ dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
 dnl QNX requires unix.h to allow functions in libunix to work properly.
-AC_CHECK_HEADERS([ \
-dirent.h \
-sys/param.h \
-sys/types.h \
-sys/time.h \
-netinet/in.h \
-alloca.h \
-arpa/inet.h \
-arpa/nameser.h \
-dns.h \
-fcntl.h \
-grp.h \
-ieeefp.h \
-langinfo.h \
-linux/sock_diag.h \
-poll.h \
-pty.h \
-pwd.h \
-resolv.h \
-strings.h \
-syslog.h \
-sysexits.h \
-sys/ioctl.h \
-sys/file.h \
-sys/mman.h \
-sys/mount.h \
-sys/poll.h \
-sys/resource.h \
-sys/select.h \
-sys/socket.h \
-sys/stat.h \
-sys/statfs.h \
-sys/statvfs.h \
-sys/vfs.h \
-sys/sysexits.h \
-sys/uio.h \
-sys/wait.h \
-sys/loadavg.h \
-unistd.h \
-unix.h \
-utime.h \
-sys/utsname.h \
-sys/ipc.h \
-dlfcn.h \
-tmmintrin.h \
-nmmintrin.h \
-wmmintrin.h \
-immintrin.h
-],[],[],[
+AC_CHECK_HEADERS(m4_normalize([
+  dirent.h
+  sys/param.h
+  sys/types.h
+  sys/time.h
+  netinet/in.h
+  alloca.h
+  arpa/inet.h
+  arpa/nameser.h
+  dns.h
+  fcntl.h
+  grp.h
+  ieeefp.h
+  langinfo.h
+  linux/sock_diag.h
+  poll.h
+  pty.h
+  pwd.h
+  resolv.h
+  strings.h
+  syslog.h
+  sysexits.h
+  sys/ioctl.h
+  sys/file.h
+  sys/mman.h
+  sys/mount.h
+  sys/poll.h
+  sys/resource.h
+  sys/select.h
+  sys/socket.h
+  sys/stat.h
+  sys/statfs.h
+  sys/statvfs.h
+  sys/vfs.h
+  sys/sysexits.h
+  sys/uio.h
+  sys/wait.h
+  sys/loadavg.h
+  unistd.h
+  unix.h
+  utime.h
+  sys/utsname.h
+  sys/ipc.h
+  dlfcn.h
+  tmmintrin.h
+  nmmintrin.h
+  wmmintrin.h
+  immintrin.h
+]),,, [dnl
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -1336,11 +1336,9 @@ else
   if test "$fiber_os" = 'mac'; then
     AC_DEFINE([_XOPEN_SOURCE], 1, [ ])
   fi
-  AC_CHECK_HEADER(ucontext.h, [
-    AC_DEFINE([ZEND_FIBER_UCONTEXT], 1, [ ])
-  ], [
-       AC_MSG_ERROR([fibers not available on this platform])
-  ])
+  AC_CHECK_HEADER([ucontext.h],
+    [AC_DEFINE([ZEND_FIBER_UCONTEXT], [1], [ ])],
+    [AC_MSG_ERROR([fibers not available on this platform])])
 fi
 
 ZEND_INIT

--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -6,11 +6,10 @@ dnl
 dnl Check for CCRandomGenerateBytes
 dnl header absent in previous macOs releases
 dnl
-AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h], [], [],
-[
-	#include <sys/types.h>
-	#include <Availability.h>
-	#include <CommonCrypto/CommonCryptoError.h>
+AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h],,, [dnl
+  #include <sys/types.h>
+  #include <Availability.h>
+  #include <CommonCrypto/CommonCryptoError.h>
 ])
 
 dnl

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -61,7 +61,7 @@ PHP_ARG_WITH([external-libcrypt],
 if test "$PHP_EXTERNAL_LIBCRYPT" != "no"; then
   PHP_CHECK_FUNC(crypt, crypt)
   PHP_CHECK_FUNC(crypt_r, crypt)
-  AC_CHECK_HEADERS(crypt.h)
+  AC_CHECK_HEADERS([crypt.h])
   if test "$ac_cv_func_crypt_r" = "yes"; then
     PHP_CRYPT_R_STYLE
   fi
@@ -384,8 +384,7 @@ dnl
 dnl Check net/if.h for net_get_interfaces. Darwin and BSD-like systems need
 dnl sys/socket.h to be included with net/if.h.
 dnl
-AC_CHECK_HEADERS([net/if.h],[], [],
-[
+AC_CHECK_HEADERS([net/if.h],,, [dnl
   #ifdef HAVE_SYS_SOCKET_H
   #include <sys/socket.h>
   #endif

--- a/ext/sysvmsg/config.m4
+++ b/ext/sysvmsg/config.m4
@@ -4,10 +4,8 @@ PHP_ARG_ENABLE([sysvmsg],
     [Enable sysvmsg support])])
 
 if test "$PHP_SYSVMSG" != "no"; then
-  AC_CHECK_HEADER([sys/msg.h],
-    [],
-    [AC_MSG_ERROR([Cannot enable System V IPC support, sys/msg.h is missing])
-  ])
+  AC_CHECK_HEADER([sys/msg.h],,
+    [AC_MSG_ERROR([Cannot enable System V IPC support, sys/msg.h is missing])])
 
   AC_DEFINE(HAVE_SYSVMSG, 1, [ ])
   PHP_NEW_EXTENSION(sysvmsg, sysvmsg.c, $ext_shared)


### PR DESCRIPTION
The m4_normalize is for Autoconf < 2.70 (on 2.70 and later versions a blank-or-newline separated items can be expanded without using backslash-newline). The order of headers in configure.ac is left as is because the first few headers depend on checking other headers (for those includes the 4th argument).