### PR TITLE
Autotools: Refactor Valgrind support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -766,26 +766,19 @@ if test "$ac_cv__asm_goto" = yes; then
   AC_DEFINE([HAVE_ASM_GOTO], [1], [Define if asm goto support is available.])
 fi
 
-dnl Check valgrind support.
+dnl Check Valgrind support.
 PHP_ARG_WITH([valgrind],
-  [whether to enable valgrind support],
+  [whether to enable Valgrind support],
   [AS_HELP_STRING([--with-valgrind],
-    [Enable valgrind support])],
+    [Enable Valgrind support])],
   [no],
   [no])
 
-if test "$PHP_VALGRIND" != "no"; then
-  PKG_CHECK_MODULES([VALGRIND], [valgrind], [have_valgrind="yes"], [have_valgrind="no"])
-
-  if test "$have_valgrind" = "yes"; then
-    PHP_EVAL_INCLINE($VALGRIND_CFLAGS)
-    AC_DEFINE(HAVE_VALGRIND, 1, [ ])
-  else
-    if test "$with_valgrind" = "yes"; then
-      AC_MSG_ERROR([Valgrind not found. Please install Valgrind.])
-    fi
-  fi
-fi
+AS_VAR_IF([PHP_VALGRIND], [no],,
+  [PKG_CHECK_MODULES([VALGRIND], [valgrind],
+    [PHP_EVAL_INCLINE([$VALGRIND_CFLAGS])
+      AC_DEFINE([HAVE_VALGRIND], [1],
+        [Define to 1 if Valgrind is enabled and supported.])])])
 
 dnl Check for openpty. It may require linking against libutil or libbsd.
 AC_CHECK_FUNCS([openpty],,

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -95,14 +95,13 @@ else
     AC_MSG_RESULT([no])
   fi
 
+  dnl Enable pcre Valgrind support only in DEBUG build (it affects performance).
+  AS_VAR_IF([PHP_VALGRIND], [no],,
+    [AS_VAR_IF([ZEND_DEBUG], [yes],
+      [AC_DEFINE([HAVE_PCRE_VALGRIND_SUPPORT], [1],
+        [Define to 1 if pcre has Valgrind support enabled.])])])
+
   PHP_NEW_EXTENSION(pcre, $pcrelib_sources php_pcre.c, no,,$PHP_PCRE_CFLAGS)
   PHP_ADD_BUILD_DIR($ext_builddir/pcre2lib)
   PHP_INSTALL_HEADERS([ext/pcre], [php_pcre.h pcre2lib/])
-
-  if test "$PHP_VALGRIND" != "no" && test "$have_valgrind" = "yes"; then
-      dnl Enable pcre valgrind support only in DEBUG build (it affects performance)
-      if test "$ZEND_DEBUG" = "yes"; then
-        AC_DEFINE(HAVE_PCRE_VALGRIND_SUPPORT, 1, [ ])
-      fi
-  fi
 fi


### PR DESCRIPTION
When Valgrind is enabled and not found on the system, default error can be thrown by PKG_CHECK_MODULES instead of writing a manual error step.
- This uses less redundant variables and has synced CS.
- AS_VAR_IF used instead of raw shell ifs
- Added some basic help descriptions for macro definitions

Default error is also more descriptive 

```
configure: error: Package requirements (valgrind) were not met:

Package 'valgrind', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables VALGRIND_CFLAGS
and VALGRIND_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```