### PR TITLE
Autotools: Move openpty check to libraries section

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,10 @@ AC_SEARCH_LIBS([Pgrab], [proc])
 dnl Haiku does not have network api in libc.
 AC_SEARCH_LIBS([setsockopt], [network])
 
+dnl Check for openpty. It may require linking against libutil or libbsd.
+AC_CHECK_FUNCS([openpty],,
+  [AC_SEARCH_LIBS([openpty], [util bsd], [AC_DEFINE([HAVE_OPENPTY], [1])])])
+
 dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
@@ -786,10 +790,6 @@ if test "$PHP_VALGRIND" != "no"; then
     fi
   fi
 fi
-
-dnl Check for openpty. It may require linking against libutil or libbsd.
-AC_CHECK_FUNCS([openpty],,
-  [AC_SEARCH_LIBS([openpty], [util bsd], [AC_DEFINE([HAVE_OPENPTY], [1])])])
 
 dnl General settings.
 dnl ----------------------------------------------------------------------------


### PR DESCRIPTION
This is just a sync and alignment with Autoconf documentation style order of checks in configure.ac ("Standard configure.ac Layout"): https://www.gnu.org/software/autoconf/manual/autoconf-2.72/autoconf.html#Autoconf-Input-Layout