### PR TITLE
Remove unused defined CPP macros in fpm SAPI

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -136,6 +136,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_WAITPID has been removed.
    - Symbol HAVE_LIBPQ has been removed.
    - Symbols HAVE_LIBRT and HAVE_TIMER_CREATE removed.
+   - Symbols PHP_FPM_SYSTEMD, PHP_FPM_USER, and PHP_FPM_GROUP removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -554,7 +554,6 @@ if test "$PHP_FPM" != "no"; then
   fi
 
   AC_SUBST([php_fpm_systemd])
-  AC_DEFINE_UNQUOTED(PHP_FPM_SYSTEMD, "$php_fpm_systemd", [fpm systemd service type])
 
   if test -z "$PHP_FPM_USER" || test "$PHP_FPM_USER" = "yes" || test "$PHP_FPM_USER" = "no"; then
     php_fpm_user="nobody"
@@ -576,9 +575,6 @@ if test "$PHP_FPM" != "no"; then
   AC_SUBST([php_fpm_localstatedir])
   php_fpm_prefix=`eval echo $prefix`
   AC_SUBST([php_fpm_prefix])
-
-  AC_DEFINE_UNQUOTED(PHP_FPM_USER, "$php_fpm_user", [fpm user name])
-  AC_DEFINE_UNQUOTED(PHP_FPM_GROUP, "$php_fpm_group", [fpm group name])
 
   PHP_ADD_BUILD_DIR(sapi/fpm/fpm)
   PHP_ADD_BUILD_DIR(sapi/fpm/fpm/events)


### PR DESCRIPTION
- PHP_FPM_SYSTEMD
- PHP_FPM_USER
- PHP_FPM_GROUP