### PR TITLE
[ci skip] Revert2: Add Hamada-san(@youkidearitai) to CODEOWNERS for mbstring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /ext/intl @devnexen
 /ext/json @bukka
 /ext/libxml @nielsdos
-/ext/mbstring @alexdowad
+/ext/mbstring @alexdowad @youkidearitai
 /ext/mysqlnd @SakiTakamachi
 /ext/odbc @NattyNarwhal
 /ext/opcache @dstogov @iluuu1994


### PR DESCRIPTION
This reverts commit 1b47fd026a3a2cdb0a6b214c5f7dbde3eb555e1e.
I (@youkidearitai) join to CODEOWNERS for mbstring.