### PR TITLE
Replace `@deprecated` by `#[\Deprecated]` for internal functions / class constants

### DIFF
--- a/Zend/tests/bug69802_2.phpt
+++ b/Zend/tests/bug69802_2.phpt
@@ -7,7 +7,7 @@ $r = new ReflectionMethod($f, '__invoke');
 var_dump($r->getParameters()[0]->getClass());
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 object(ReflectionClass)#4 (1) {
   ["name"]=>
   string(11) "Traversable"

--- a/Zend/tests/type_declarations/callable_002.phpt
+++ b/Zend/tests/type_declarations/callable_002.phpt
@@ -21,11 +21,11 @@ var_dump($rc->getParameters()[0]->isCallable());
 
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::isCallable() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isCallable() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 
-Deprecated: Method ReflectionParameter::isCallable() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isCallable() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 
-Deprecated: Method ReflectionParameter::isCallable() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isCallable() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -20,6 +20,7 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_versioning.h"
 #include "php_date.h"
+#include "zend_attributes.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
 #include "lib/timelib.h"

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -120,14 +120,14 @@ function checkdate(int $month, int $day, int $year): bool {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1', message: 'use IntlDateFormatter::format() instead')]
 function strftime(string $format, ?int $timestamp = null): string|false {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1', message: 'use IntlDateFormatter::format() instead')]
 function gmstrftime(string $format, ?int $timestamp = null): string|false {}
 
 function time(): int {}
@@ -260,8 +260,8 @@ function date_default_timezone_get(): string {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1', message: 'use date_sun_info() instead')]
 function date_sunrise(
     int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING,
     ?float $latitude = null, ?float $longitude = null, ?float $zenith = null,
@@ -269,8 +269,8 @@ function date_sunrise(
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1', message: 'use date_sun_info() instead')]
 function date_sunset(
     int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING,
     ?float $latitude = null, ?float $longitude = null, ?float $zenith = null,

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8a84ebfe7bfd3107a5b4c3add5a2ab7116e951c0 */
+ * Stub hash: ec4cc71df0beb55d07dcc77d0bc47e1b67b48911 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -847,6 +847,55 @@ static void register_php_date_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("SUNFUNCS_RET_TIMESTAMP", SUNFUNCS_RET_TIMESTAMP, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SUNFUNCS_RET_STRING", SUNFUNCS_RET_STRING, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SUNFUNCS_RET_DOUBLE", SUNFUNCS_RET_DOUBLE, CONST_PERSISTENT);
+
+
+	zend_attribute *attribute_Deprecated_func_strftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strftime", sizeof("strftime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_strftime_0_arg0;
+	zend_string *attribute_Deprecated_func_strftime_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_strftime_0_arg0, attribute_Deprecated_func_strftime_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_strftime_0->args[0].value, &attribute_Deprecated_func_strftime_0_arg0);
+	attribute_Deprecated_func_strftime_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_strftime_0_arg1;
+	zend_string *attribute_Deprecated_func_strftime_0_arg1_str = zend_string_init("use IntlDateFormatter::format() instead", strlen("use IntlDateFormatter::format() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_strftime_0_arg1, attribute_Deprecated_func_strftime_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_strftime_0->args[1].value, &attribute_Deprecated_func_strftime_0_arg1);
+	attribute_Deprecated_func_strftime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_gmstrftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "gmstrftime", sizeof("gmstrftime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_gmstrftime_0_arg0;
+	zend_string *attribute_Deprecated_func_gmstrftime_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_gmstrftime_0_arg0, attribute_Deprecated_func_gmstrftime_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_gmstrftime_0->args[0].value, &attribute_Deprecated_func_gmstrftime_0_arg0);
+	attribute_Deprecated_func_gmstrftime_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_gmstrftime_0_arg1;
+	zend_string *attribute_Deprecated_func_gmstrftime_0_arg1_str = zend_string_init("use IntlDateFormatter::format() instead", strlen("use IntlDateFormatter::format() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_gmstrftime_0_arg1, attribute_Deprecated_func_gmstrftime_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_gmstrftime_0->args[1].value, &attribute_Deprecated_func_gmstrftime_0_arg1);
+	attribute_Deprecated_func_gmstrftime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_date_sunrise_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunrise", sizeof("date_sunrise") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_date_sunrise_0_arg0;
+	zend_string *attribute_Deprecated_func_date_sunrise_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_date_sunrise_0_arg0, attribute_Deprecated_func_date_sunrise_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_date_sunrise_0->args[0].value, &attribute_Deprecated_func_date_sunrise_0_arg0);
+	attribute_Deprecated_func_date_sunrise_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_date_sunrise_0_arg1;
+	zend_string *attribute_Deprecated_func_date_sunrise_0_arg1_str = zend_string_init("use date_sun_info() instead", strlen("use date_sun_info() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_date_sunrise_0_arg1, attribute_Deprecated_func_date_sunrise_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_date_sunrise_0->args[1].value, &attribute_Deprecated_func_date_sunrise_0_arg1);
+	attribute_Deprecated_func_date_sunrise_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_date_sunset_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunset", sizeof("date_sunset") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_date_sunset_0_arg0;
+	zend_string *attribute_Deprecated_func_date_sunset_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_date_sunset_0_arg0, attribute_Deprecated_func_date_sunset_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_date_sunset_0->args[0].value, &attribute_Deprecated_func_date_sunset_0_arg0);
+	attribute_Deprecated_func_date_sunset_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_date_sunset_0_arg1;
+	zend_string *attribute_Deprecated_func_date_sunset_0_arg1_str = zend_string_init("use date_sun_info() instead", strlen("use date_sun_info() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_date_sunset_0_arg1, attribute_Deprecated_func_date_sunset_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_date_sunset_0->args[1].value, &attribute_Deprecated_func_date_sunset_0_arg1);
+	attribute_Deprecated_func_date_sunset_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }
 
 static zend_class_entry *register_class_DateTimeInterface(void)

--- a/ext/date/tests/009.phpt
+++ b/ext/date/tests/009.phpt
@@ -23,29 +23,29 @@ var_dump(gmstrftime("blah", $t));
 echo "Done\n";
 ?>
 --EXPECTF--
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 bool(false)
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "Tue Tuesday Jun June Tue Jun 27 00:00:00 2006 %s
 %s %"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "%q %a"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "blah"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 bool(false)
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "Mon Monday Jun June Mon Jun 26 21:00:00 2006 %s
 %s %"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "%q %a"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "blah"
 Done

--- a/ext/date/tests/009_win32.phpt
+++ b/ext/date/tests/009_win32.phpt
@@ -35,27 +35,27 @@ echo "Done\n";
 setlocale(LC_TIME, $loc);
 ?>
 --EXPECTF--
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 bool(false)
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "Tue Tuesday Jun June 6/27/2006 12:00:00 AM 27 00 12 178 06 00 AM 00 26 26 2 6/27/2006 12:00:00 AM 06 2006 %s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "%q %a"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "blah"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 bool(false)
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "Mon Monday Jun June 6/26/2006 9:00:00 PM 26 21 09 177 06 00 PM 00 26 26 1 6/26/2006 9:00:00 PM 06 2006 %s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "%q %a"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "blah"
 Done

--- a/ext/date/tests/bug65371.phpt
+++ b/ext/date/tests/bug65371.phpt
@@ -19,9 +19,9 @@ p('あ');
 --EXPECTF--
 あ
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 あ
 e38182
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 e38182

--- a/ext/date/tests/date_sunrise_and_sunset_basic.phpt
+++ b/ext/date/tests/date_sunrise_and_sunset_basic.phpt
@@ -25,14 +25,14 @@ var_dump(gettype(date_sunset(time())));
 --EXPECTF--
 Basic test for date_sunrise() and date_sunset()
 
-Deprecated: Function date_sunrise() is deprecated in %s on line %d
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 %s %s %d %d, sunrise time : %d:%d
 
-Deprecated: Function date_sunset() is deprecated in %s on line %d
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 %s %s %d %d, sunset time : %d:%d
 
-Deprecated: Function date_sunrise() is deprecated in %s on line %d
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 string(6) "string"
 
-Deprecated: Function date_sunset() is deprecated in %s on line %d
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 string(6) "string"

--- a/ext/date/tests/date_sunrise_and_sunset_error.phpt
+++ b/ext/date/tests/date_sunrise_and_sunset_error.phpt
@@ -17,8 +17,8 @@ try {
 
 ?>
 --EXPECTF--
-Deprecated: Function date_sunrise() is deprecated in %s on line %d
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 date_sunrise(): Argument #2 ($returnFormat) must be one of SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, or SUNFUNCS_RET_DOUBLE
 
-Deprecated: Function date_sunset() is deprecated in %s on line %d
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 date_sunset(): Argument #2 ($returnFormat) must be one of SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, or SUNFUNCS_RET_DOUBLE

--- a/ext/date/tests/gmstrftime_basic.phpt
+++ b/ext/date/tests/gmstrftime_basic.phpt
@@ -18,8 +18,8 @@ var_dump( gmstrftime($format) );
 --EXPECTF--
 *** Testing gmstrftime() : basic functionality ***
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(20) "Aug 08 2008 08:08:08"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s %d %d %d:%d:%d"

--- a/ext/date/tests/gmstrftime_variation10.phpt
+++ b/ext/date/tests/gmstrftime_variation10.phpt
@@ -35,16 +35,16 @@ foreach($inputs as $key =>$value) {
 
 --The ISO 8601:1988 week number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "32"
 
 --Weekday as decimal--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/date/tests/gmstrftime_variation11.phpt
+++ b/ext/date/tests/gmstrftime_variation11.phpt
@@ -20,8 +20,8 @@ var_dump( gmstrftime($format, $timestamp) );
 
 -- Testing gmstrftime() function with  Abbreviated month name format %h --
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"

--- a/ext/date/tests/gmstrftime_variation12.phpt
+++ b/ext/date/tests/gmstrftime_variation12.phpt
@@ -26,8 +26,8 @@ var_dump( gmstrftime($format, $timestamp) );
 
 -- Testing gmstrftime() function with  Abbreviated month name format %h --
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"

--- a/ext/date/tests/gmstrftime_variation13.phpt
+++ b/ext/date/tests/gmstrftime_variation13.phpt
@@ -31,32 +31,32 @@ foreach($inputs as $key =>$value) {
 
 --Century number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "20"
 
 --Month Date Year--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Year with century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Year without century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/gmstrftime_variation14.phpt
+++ b/ext/date/tests/gmstrftime_variation14.phpt
@@ -37,32 +37,32 @@ foreach($inputs as $key =>$value) {
 
 --Century number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "20"
 
 --Month Date Year--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Year with century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Year without century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/gmstrftime_variation15.phpt
+++ b/ext/date/tests/gmstrftime_variation15.phpt
@@ -30,24 +30,24 @@ foreach($inputs as $key =>$value) {
 
 --Time in a.m/p.m notation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d %c%c"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(11) "08:08:08 AM"
 
 --Time in 24 hour notation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "08:08"
 
 --Current time %H:%M:%S format--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/gmstrftime_variation16.phpt
+++ b/ext/date/tests/gmstrftime_variation16.phpt
@@ -36,24 +36,24 @@ foreach($inputs as $key =>$value) {
 
 --Time in a.m/p.m notation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d %s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(11) "02:08:08 PM"
 
 --Time in 24 hour notation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "14:08"
 
 --Current time %H:%M:%S format--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "14:08:08"

--- a/ext/date/tests/gmstrftime_variation17.phpt
+++ b/ext/date/tests/gmstrftime_variation17.phpt
@@ -20,8 +20,8 @@ var_dump( gmstrftime($format, $timestamp) );
 
 -- Testing gmstrftime() function with Day of the month as decimal single digit format --
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%A%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) " 8"

--- a/ext/date/tests/gmstrftime_variation18.phpt
+++ b/ext/date/tests/gmstrftime_variation18.phpt
@@ -26,8 +26,8 @@ var_dump( gmstrftime($format, $timestamp) );
 
 -- Testing gmstrftime() function with Day of the month as decimal single digit format --
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) " 8"

--- a/ext/date/tests/gmstrftime_variation19.phpt
+++ b/ext/date/tests/gmstrftime_variation19.phpt
@@ -29,18 +29,18 @@ foreach($inputs as $key =>$value) {
 
 --Newline character--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
 --Tab character--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "	"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "	"

--- a/ext/date/tests/gmstrftime_variation20.phpt
+++ b/ext/date/tests/gmstrftime_variation20.phpt
@@ -35,18 +35,18 @@ foreach($inputs as $key =>$value) {
 
 --Newline character--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
 --Tab character--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%r\s%r"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%r\s%r"

--- a/ext/date/tests/gmstrftime_variation21.phpt
+++ b/ext/date/tests/gmstrftime_variation21.phpt
@@ -30,24 +30,24 @@ foreach($inputs as $key =>$value) {
 
 --Preferred date and time representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s %s %d %d:%d:%d %d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(24) "Fri Aug  8 08:08:08 2008"
 
 --Preferred date representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Preferred time representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/gmstrftime_variation22.phpt
+++ b/ext/date/tests/gmstrftime_variation22.phpt
@@ -39,15 +39,15 @@ foreach($inputs as $key =>$value) {
 
 --Preferred date and time representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(24) "Fri Aug  8 08:08:08 2008"
 
 --Preferred date representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Preferred time representation--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/gmstrftime_variation3.phpt
+++ b/ext/date/tests/gmstrftime_variation3.phpt
@@ -29,32 +29,32 @@ foreach($inputs as $key =>$value) {
 
 --Abbreviated weekday name--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Fri"
 
 --Full weekday name--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(6) "Friday"
 
 --Week number of the year--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "31"
 
 --Week number of the year in decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "31"

--- a/ext/date/tests/gmstrftime_variation4.phpt
+++ b/ext/date/tests/gmstrftime_variation4.phpt
@@ -28,24 +28,24 @@ foreach($inputs as $key =>$value) {
 
 --Abbreviated month name--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"
 
 --Full month name--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(6) "August"
 
 --Month as decimal--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/gmstrftime_variation5.phpt
+++ b/ext/date/tests/gmstrftime_variation5.phpt
@@ -32,24 +32,24 @@ foreach($inputs as $key =>$value) {
 
 --Year as decimal number without a century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Year as decimal number including the century--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Time zone offset--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%s) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%s) "%s"

--- a/ext/date/tests/gmstrftime_variation6.phpt
+++ b/ext/date/tests/gmstrftime_variation6.phpt
@@ -32,40 +32,40 @@ foreach($inputs as $key =>$value) {
 
 --Hour as decimal by 24-hour format--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Hour as decimal by 12-hour format--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Minute as decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --AM/PM format for a time--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%s"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "AM"
 
 --Second as decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/gmstrftime_variation7.phpt
+++ b/ext/date/tests/gmstrftime_variation7.phpt
@@ -30,24 +30,24 @@ foreach($inputs as $key =>$value) {
 
 --Day of the month as a decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Day of the year as a decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "221"
 
 --Day of the week as a decimal number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/date/tests/gmstrftime_variation8.phpt
+++ b/ext/date/tests/gmstrftime_variation8.phpt
@@ -28,8 +28,8 @@ foreach($inputs as $key =>$value) {
 
 --A literal % character--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%"

--- a/ext/date/tests/gmstrftime_variation9.phpt
+++ b/ext/date/tests/gmstrftime_variation9.phpt
@@ -29,16 +29,16 @@ foreach($inputs as $key =>$value) {
 
 --The ISO 8601:1988 week number--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "32"
 
 --Weekday as decimal--
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%d"
 
-Deprecated: Function gmstrftime() is deprecated in %s on line %d
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/date/tests/strftime_basic.phpt
+++ b/ext/date/tests/strftime_basic.phpt
@@ -19,8 +19,8 @@ var_dump( strftime($format) );
 --EXPECTF--
 *** Testing strftime() : basic functionality ***
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(20) "Aug 08 2008 08:08:08"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s %d %d %d:%d:%d"

--- a/ext/date/tests/strftime_variation10.phpt
+++ b/ext/date/tests/strftime_variation10.phpt
@@ -35,16 +35,16 @@ foreach($inputs as $key =>$value) {
 
 --The ISO 8601:1988 week number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "32"
 
 --Weekday as decimal--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/date/tests/strftime_variation11.phpt
+++ b/ext/date/tests/strftime_variation11.phpt
@@ -20,8 +20,8 @@ var_dump( strftime($format, $timestamp) );
 
 -- Testing strftime() function with  Abbreviated month name format %h --
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"

--- a/ext/date/tests/strftime_variation12.phpt
+++ b/ext/date/tests/strftime_variation12.phpt
@@ -26,8 +26,8 @@ var_dump( strftime($format, $timestamp) );
 
 -- Testing strftime() function with  Abbreviated month name format %h --
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"

--- a/ext/date/tests/strftime_variation13.phpt
+++ b/ext/date/tests/strftime_variation13.phpt
@@ -31,32 +31,32 @@ foreach($inputs as $key =>$value) {
 
 --Century number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "20"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "20"
 
 --Month Date Year--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Year with century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Year without century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/strftime_variation14.phpt
+++ b/ext/date/tests/strftime_variation14.phpt
@@ -37,32 +37,32 @@ foreach($inputs as $key =>$value) {
 
 --Century number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "20"
 
 --Month Date Year--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Year with century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Year without century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/strftime_variation15.phpt
+++ b/ext/date/tests/strftime_variation15.phpt
@@ -30,24 +30,24 @@ foreach($inputs as $key =>$value) {
 
 --Time in a.m/p.m notation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d %s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(11) "08:08:08 AM"
 
 --Time in 24 hour notation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "08:08"
 
 --Current time %H:%M:%S format--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/strftime_variation16.phpt
+++ b/ext/date/tests/strftime_variation16.phpt
@@ -36,24 +36,24 @@ foreach($inputs as $key =>$value) {
 
 --Time in a.m/p.m notation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d %s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(11) "08:08:08 AM"
 
 --Time in 24 hour notation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(5) "08:08"
 
 --Current time %H:%M:%S format--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/strftime_variation17.phpt
+++ b/ext/date/tests/strftime_variation17.phpt
@@ -19,8 +19,8 @@ var_dump( strftime($format, $timestamp) );
 
 -- Testing strftime() function with Day of the month as decimal single digit format --
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%A%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) " 8"

--- a/ext/date/tests/strftime_variation18.phpt
+++ b/ext/date/tests/strftime_variation18.phpt
@@ -25,8 +25,8 @@ var_dump( strftime($format, $timestamp) );
 
 -- Testing strftime() function with Day of the month as decimal single digit format --
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) " 8"

--- a/ext/date/tests/strftime_variation19.phpt
+++ b/ext/date/tests/strftime_variation19.phpt
@@ -29,18 +29,18 @@ foreach($inputs as $key =>$value) {
 
 --Newline character--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
 --Tab character--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "	"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "	"

--- a/ext/date/tests/strftime_variation20.phpt
+++ b/ext/date/tests/strftime_variation20.phpt
@@ -35,18 +35,18 @@ foreach($inputs as $key =>$value) {
 
 --Newline character--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "
 "
 
 --Tab character--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%r\s%r"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%r\s%r"

--- a/ext/date/tests/strftime_variation21.phpt
+++ b/ext/date/tests/strftime_variation21.phpt
@@ -30,24 +30,24 @@ foreach($inputs as $key =>$value) {
 
 --Preferred date and time representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s %s %d %d:%d:%d %d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(24) "Fri Aug  8 08:08:08 2008"
 
 --Preferred date representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d/%d/%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Preferred time representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d:%d:%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/strftime_variation22.phpt
+++ b/ext/date/tests/strftime_variation22.phpt
@@ -39,15 +39,15 @@ foreach($inputs as $key =>$value) {
 
 --Preferred date and time representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(24) "Fri Aug  8 08:08:08 2008"
 
 --Preferred date representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08/08/08"
 
 --Preferred time representation--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(8) "08:08:08"

--- a/ext/date/tests/strftime_variation3.phpt
+++ b/ext/date/tests/strftime_variation3.phpt
@@ -29,32 +29,32 @@ foreach($inputs as $key =>$value) {
 
 --Abbreviated weekday name--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Fri"
 
 --Full weekday name--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(6) "Friday"
 
 --Week number of the year--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "31"
 
 --Week number of the year in decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "31"

--- a/ext/date/tests/strftime_variation4.phpt
+++ b/ext/date/tests/strftime_variation4.phpt
@@ -29,24 +29,24 @@ foreach($inputs as $key =>$value) {
 
 --Abbreviated month name--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "Aug"
 
 --Full month name--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(6) "August"
 
 --Month as decimal--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/strftime_variation5.phpt
+++ b/ext/date/tests/strftime_variation5.phpt
@@ -31,24 +31,24 @@ foreach($inputs as $key =>$value) {
 
 --Year as decimal number without a century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Year as decimal number including the century--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(4) "2008"
 
 --Time zone offset--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"

--- a/ext/date/tests/strftime_variation6.phpt
+++ b/ext/date/tests/strftime_variation6.phpt
@@ -33,40 +33,40 @@ foreach($inputs as $key =>$value) {
 
 --Hour as decimal by 24-hour format--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "18"
 
 --Hour as decimal by 12-hour format--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "06"
 
 --Minute as decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --AM/PM format for a time--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%s"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "PM"
 
 --Second as decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"

--- a/ext/date/tests/strftime_variation7.phpt
+++ b/ext/date/tests/strftime_variation7.phpt
@@ -31,24 +31,24 @@ foreach($inputs as $key =>$value) {
 
 --Day of the month as a decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "08"
 
 --Day of the year as a decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(3) "221"
 
 --Day of the week as a decimal number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(%d) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/date/tests/strftime_variation8.phpt
+++ b/ext/date/tests/strftime_variation8.phpt
@@ -20,8 +20,8 @@ var_dump( strftime($format, $timestamp) );
 
 -- Testing strftime() function with a literal % character to format --
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%"

--- a/ext/date/tests/strftime_variation9.phpt
+++ b/ext/date/tests/strftime_variation9.phpt
@@ -29,16 +29,16 @@ foreach($inputs as $key =>$value) {
 
 --The ISO 8601:1988 week number--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(2) "32"
 
 --Weekday as decimal--
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "%d"
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 string(1) "5"

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -22,6 +22,7 @@
 #include "php.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"
+#include "Zend/zend_attributes.h"
 #include "Zend/zend_exceptions.h"
 #include <enchant.h>
 #include "php_enchant.h"

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -40,15 +40,15 @@ final class EnchantDictionary
 
 function enchant_broker_init(): EnchantBroker|false {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0', message: 'as EnchantBroker objects are freed automatically')]
 function enchant_broker_free(EnchantBroker $broker): bool {}
 
 function enchant_broker_get_error(EnchantBroker $broker): string|false {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0')]
 function enchant_broker_set_dict_path(EnchantBroker $broker, int $type, string $path): bool {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0')]
 function enchant_broker_get_dict_path(EnchantBroker $broker, int $type): string|false {}
 
 /**
@@ -61,7 +61,7 @@ function enchant_broker_request_dict(EnchantBroker $broker, string $tag): Enchan
 
 function enchant_broker_request_pwl_dict(EnchantBroker $broker, string $filename): EnchantDictionary|false {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0', message: 'as EnchantDictionary objects are freed automatically')]
 function enchant_broker_free_dict(EnchantDictionary $dictionary): bool {}
 
 function enchant_broker_dict_exists(EnchantBroker $broker, string $tag): bool {}
@@ -89,8 +89,8 @@ function enchant_dict_add(EnchantDictionary $dictionary, string $word): void {}
 
 /**
 * @alias enchant_dict_add
-* @deprecated
 */
+#[\Deprecated(since: '8.0', message: 'use enchant_dict_add() instead')]
 function enchant_dict_add_to_personal(EnchantDictionary $dictionary, string $word): void {}
 
 function enchant_dict_add_to_session(EnchantDictionary $dictionary, string $word): void {}
@@ -99,8 +99,8 @@ function enchant_dict_is_added(EnchantDictionary $dictionary, string $word): boo
 
 /**
 * @alias enchant_dict_is_added
-* @deprecated
 */
+#[\Deprecated(since: '8.0', message: 'use enchant_dict_is_added() instead')]
 function enchant_dict_is_in_session(EnchantDictionary $dictionary, string $word): bool {}
 
 function enchant_dict_store_replacement(EnchantDictionary $dictionary, string $misspelled, string $correct): void {}

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 42bb5a4488d254e87d763c75ccff62e283e63335 */
+ * Stub hash: bcd5195c8a1eea47d881747a57f1b1342ef0bbd1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_init, 0, 0, EnchantBroker, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
@@ -161,6 +161,69 @@ static void register_enchant_symbols(int module_number)
 #if defined(HAVE_ENCHANT_GET_VERSION)
 	REGISTER_STRING_CONSTANT("LIBENCHANT_VERSION", PHP_ENCHANT_GET_VERSION, CONST_PERSISTENT);
 #endif
+
+
+	zend_attribute *attribute_Deprecated_func_enchant_broker_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free", sizeof("enchant_broker_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_enchant_broker_free_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_broker_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_0_arg0, attribute_Deprecated_func_enchant_broker_free_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_0->args[0].value, &attribute_Deprecated_func_enchant_broker_free_0_arg0);
+	attribute_Deprecated_func_enchant_broker_free_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_enchant_broker_free_0_arg1;
+	zend_string *attribute_Deprecated_func_enchant_broker_free_0_arg1_str = zend_string_init("as EnchantBroker objects are freed automatically", strlen("as EnchantBroker objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_0_arg1, attribute_Deprecated_func_enchant_broker_free_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_0->args[1].value, &attribute_Deprecated_func_enchant_broker_free_0_arg1);
+	attribute_Deprecated_func_enchant_broker_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_enchant_broker_set_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_set_dict_path", sizeof("enchant_broker_set_dict_path") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0, attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_set_dict_path_0->args[0].value, &attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0);
+	attribute_Deprecated_func_enchant_broker_set_dict_path_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_attribute *attribute_Deprecated_func_enchant_broker_get_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_get_dict_path", sizeof("enchant_broker_get_dict_path") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0, attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_get_dict_path_0->args[0].value, &attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0);
+	attribute_Deprecated_func_enchant_broker_get_dict_path_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_attribute *attribute_Deprecated_func_enchant_broker_free_dict_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free_dict", sizeof("enchant_broker_free_dict") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_enchant_broker_free_dict_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_broker_free_dict_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_dict_0_arg0, attribute_Deprecated_func_enchant_broker_free_dict_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_dict_0->args[0].value, &attribute_Deprecated_func_enchant_broker_free_dict_0_arg0);
+	attribute_Deprecated_func_enchant_broker_free_dict_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_enchant_broker_free_dict_0_arg1;
+	zend_string *attribute_Deprecated_func_enchant_broker_free_dict_0_arg1_str = zend_string_init("as EnchantDictionary objects are freed automatically", strlen("as EnchantDictionary objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_dict_0_arg1, attribute_Deprecated_func_enchant_broker_free_dict_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_dict_0->args[1].value, &attribute_Deprecated_func_enchant_broker_free_dict_0_arg1);
+	attribute_Deprecated_func_enchant_broker_free_dict_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_enchant_dict_add_to_personal_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_add_to_personal", sizeof("enchant_dict_add_to_personal") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0, attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[0].value, &attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0);
+	attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1;
+	zend_string *attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1_str = zend_string_init("use enchant_dict_add() instead", strlen("use enchant_dict_add() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1, attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[1].value, &attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1);
+	attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_enchant_dict_is_in_session_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_is_in_session", sizeof("enchant_dict_is_in_session") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0;
+	zend_string *attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0, attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_dict_is_in_session_0->args[0].value, &attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0);
+	attribute_Deprecated_func_enchant_dict_is_in_session_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_enchant_dict_is_in_session_0_arg1;
+	zend_string *attribute_Deprecated_func_enchant_dict_is_in_session_0_arg1_str = zend_string_init("use enchant_dict_is_added() instead", strlen("use enchant_dict_is_added() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_is_in_session_0_arg1, attribute_Deprecated_func_enchant_dict_is_in_session_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_dict_is_in_session_0->args[1].value, &attribute_Deprecated_func_enchant_dict_is_in_session_0_arg1);
+	attribute_Deprecated_func_enchant_dict_is_in_session_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }
 
 static zend_class_entry *register_class_EnchantBroker(void)

--- a/ext/enchant/tests/broker_free.phpt
+++ b/ext/enchant/tests/broker_free.phpt
@@ -23,5 +23,5 @@ echo "OK\n";
 --EXPECTF--
 OK
 
-Deprecated: Function enchant_broker_free() is deprecated in %s
+Deprecated: Function enchant_broker_free() is deprecated since 8.0, as EnchantBroker objects are freed automatically in %s
 OK

--- a/ext/enchant/tests/broker_free_dict.phpt
+++ b/ext/enchant/tests/broker_free_dict.phpt
@@ -50,6 +50,6 @@ OK
 OK
 NULL
 
-Deprecated: Function enchant_broker_free_dict() is deprecated in %s
+Deprecated: Function enchant_broker_free_dict() is deprecated since 8.0, as EnchantDictionary objects are freed automatically in %s
 OK
 OK

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -16,14 +16,14 @@ var_dump(enchant_broker_get_dict_path($broker, ENCHANT_ISPELL));
 --EXPECTF--
 Deprecated: Constant ENCHANT_MYSPELL is deprecated in %s
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)
 
 Deprecated: Constant ENCHANT_ISPELL is deprecated in %s
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
 
 Warning: enchant_broker_get_dict_path(): dict_path not set in %s on line %d
 bool(false)

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -51,13 +51,13 @@ if (is_object($broker)) {
 --EXPECTF--
 OK
 
-Deprecated: Function enchant_broker_set_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s
 OK
 
-Deprecated: Function enchant_broker_set_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_set_dict_path() is deprecated since 8.0 in %s
 OK
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
 
-Deprecated: Function enchant_broker_get_dict_path() is deprecated in %s
+Deprecated: Function enchant_broker_get_dict_path() is deprecated since 8.0 in %s
 OK

--- a/ext/hash/hash.stub.php
+++ b/ext/hash/hash.stub.php
@@ -70,28 +70,28 @@ function hash_equals(#[\SensitiveParameter] string $known_string, #[\SensitivePa
 function hash_hkdf(string $algo, #[\SensitiveParameter] string $key, int $length = 0, string $info = "", string $salt = ""): string {}
 
 #ifdef PHP_MHASH_BC
-/** @deprecated */
+#[\Deprecated(since: '8.1')]
 function mhash_get_block_size(int $algo): int|false {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1')]
 function mhash_get_hash_name(int $algo): string|false {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1')]
 function mhash_keygen_s2k(int $algo, string $password, string $salt, int $length): string|false {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.1')]
 function mhash_count(): int {}
 
 /**
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.1')]
 function mhash(int $algo, string $data, ?string $key = null): string|false {}
 #endif
 

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df078e28c10c9af51b6c4e98c4ad4827e1f32bed */
+ * Stub hash: b0fe91da9b0469b44a9647b774b9b00498592e30 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
@@ -230,6 +230,51 @@ static void register_hash_symbols(int module_number)
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hkdf", sizeof("hash_hkdf") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#if defined(PHP_MHASH_BC)
+
+	zend_attribute *attribute_Deprecated_func_mhash_get_block_size_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_block_size", sizeof("mhash_get_block_size") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_mhash_get_block_size_0_arg0;
+	zend_string *attribute_Deprecated_func_mhash_get_block_size_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mhash_get_block_size_0_arg0, attribute_Deprecated_func_mhash_get_block_size_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_block_size_0->args[0].value, &attribute_Deprecated_func_mhash_get_block_size_0_arg0);
+	attribute_Deprecated_func_mhash_get_block_size_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
+#if defined(PHP_MHASH_BC)
+
+	zend_attribute *attribute_Deprecated_func_mhash_get_hash_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_hash_name", sizeof("mhash_get_hash_name") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_mhash_get_hash_name_0_arg0;
+	zend_string *attribute_Deprecated_func_mhash_get_hash_name_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mhash_get_hash_name_0_arg0, attribute_Deprecated_func_mhash_get_hash_name_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_hash_name_0->args[0].value, &attribute_Deprecated_func_mhash_get_hash_name_0_arg0);
+	attribute_Deprecated_func_mhash_get_hash_name_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
+#if defined(PHP_MHASH_BC)
+
+	zend_attribute *attribute_Deprecated_func_mhash_keygen_s2k_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_keygen_s2k", sizeof("mhash_keygen_s2k") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_mhash_keygen_s2k_0_arg0;
+	zend_string *attribute_Deprecated_func_mhash_keygen_s2k_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mhash_keygen_s2k_0_arg0, attribute_Deprecated_func_mhash_keygen_s2k_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].value, &attribute_Deprecated_func_mhash_keygen_s2k_0_arg0);
+	attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
+#if defined(PHP_MHASH_BC)
+
+	zend_attribute *attribute_Deprecated_func_mhash_count_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_count", sizeof("mhash_count") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_mhash_count_0_arg0;
+	zend_string *attribute_Deprecated_func_mhash_count_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mhash_count_0_arg0, attribute_Deprecated_func_mhash_count_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_count_0->args[0].value, &attribute_Deprecated_func_mhash_count_0_arg0);
+	attribute_Deprecated_func_mhash_count_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
+#if defined(PHP_MHASH_BC)
+
+	zend_attribute *attribute_Deprecated_func_mhash_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash", sizeof("mhash") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_mhash_0_arg0;
+	zend_string *attribute_Deprecated_func_mhash_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mhash_0_arg0, attribute_Deprecated_func_mhash_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_0->args[0].value, &attribute_Deprecated_func_mhash_0_arg0);
+	attribute_Deprecated_func_mhash_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
 }
 
 static zend_class_entry *register_class_HashContext(void)

--- a/ext/hash/tests/mhash_001.phpt
+++ b/ext/hash/tests/mhash_001.phpt
@@ -35,56 +35,56 @@ foreach ($supported_hash_al as $hash=>$wanted) {
 }
 ?>
 --EXPECTF--
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_MD5
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_SHA1
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL256
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL192
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL224
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL160
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_RIPEMD160
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_GOST
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_TIGER
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32
 ok
 
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32B
 ok

--- a/ext/hash/tests/mhash_003.phpt
+++ b/ext/hash/tests/mhash_003.phpt
@@ -35,56 +35,56 @@ foreach ($supported_hash_al as $hash=>$wanted) {
 }
 ?>
 --EXPECTF--
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_MD5
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_SHA1
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL256
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL224
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL192
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL160
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_RIPEMD160
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_GOST
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_TIGER
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32
 ok
 
 
-Deprecated: Function mhash_keygen_s2k() is deprecated in %s on line %d
+Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32B
 ok

--- a/ext/hash/tests/mhash_004.phpt
+++ b/ext/hash/tests/mhash_004.phpt
@@ -14,6 +14,6 @@ var_dump($algo);
 --EXPECTF--
 int(1)
 
-Deprecated: Function mhash() is deprecated in %s on line %d
+Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 string(32) "098f6bcd4621d373cade4e832627b4f6"
 int(1)

--- a/ext/intl/formatter/formatter.stub.php
+++ b/ext/intl/formatter/formatter.stub.php
@@ -180,9 +180,9 @@ class NumberFormatter
     /** @cvalue FORMAT_TYPE_DOUBLE */
     public const int TYPE_DOUBLE = UNKNOWN;
     /**
-     * @deprecated
      * @cvalue FORMAT_TYPE_CURRENCY
      */
+    #[\Deprecated(since: '8.3')]
     public const int TYPE_CURRENCY = UNKNOWN;
 
     public function __construct(string $locale, int $style, ?string $pattern = null) {}

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3f8b9961bc62392c50e3871c88ea4d0934d62c6a */
+ * Stub hash: 79398fd5abd2d1f5176388b67423d937d0e25da4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumberFormatter___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -589,8 +589,16 @@ static zend_class_entry *register_class_NumberFormatter(void)
 	zval const_TYPE_CURRENCY_value;
 	ZVAL_LONG(&const_TYPE_CURRENCY_value, FORMAT_TYPE_CURRENCY);
 	zend_string *const_TYPE_CURRENCY_name = zend_string_init_interned("TYPE_CURRENCY", sizeof("TYPE_CURRENCY") - 1, 1);
-	zend_declare_typed_class_constant(class_entry, const_TYPE_CURRENCY_name, &const_TYPE_CURRENCY_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_class_constant *const_TYPE_CURRENCY = zend_declare_typed_class_constant(class_entry, const_TYPE_CURRENCY_name, &const_TYPE_CURRENCY_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CURRENCY_name);
+
+
+	zend_attribute *attribute_Deprecated_const_TYPE_CURRENCY_0 = zend_add_class_constant_attribute(class_entry, const_TYPE_CURRENCY, ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_const_TYPE_CURRENCY_0_arg0;
+	zend_string *attribute_Deprecated_const_TYPE_CURRENCY_0_arg0_str = zend_string_init("8.3", strlen("8.3"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_TYPE_CURRENCY_0_arg0, attribute_Deprecated_const_TYPE_CURRENCY_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_TYPE_CURRENCY_0->args[0].value, &attribute_Deprecated_const_TYPE_CURRENCY_0_arg0);
+	attribute_Deprecated_const_TYPE_CURRENCY_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	return class_entry;
 }

--- a/ext/intl/formatter/formatter_class.c
+++ b/ext/intl/formatter/formatter_class.c
@@ -18,10 +18,12 @@
 #include "php_intl.h"
 #include "formatter_data.h"
 #include "formatter_format.h"
-#include "formatter_arginfo.h"
 
 #include <zend_exceptions.h>
+#include "Zend/zend_attributes.h"
 #include "Zend/zend_interfaces.h"
+
+#include "formatter_arginfo.h"
 
 zend_class_entry *NumberFormatter_ce_ptr = NULL;
 static zend_object_handlers NumberFormatter_handlers;

--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -72,6 +72,8 @@
 
 #include "php_ini.h"
 
+#include "zend_attributes.h"
+
 #include "php_intl_arginfo.h"
 
 /*

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -201,7 +201,7 @@ function intlcal_after(IntlCalendar $calendar, IntlCalendar $other): bool {}
 
 function intlcal_before(IntlCalendar $calendar, IntlCalendar $other): bool {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.4', message: 'use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead')]
 function intlcal_set(IntlCalendar $calendar, int $year, int $month, int $dayOfMonth = UNKNOWN, int $hour = UNKNOWN, int $minute = UNKNOWN, int $second = UNKNOWN): true {}
 
 /** @param int|bool $value */
@@ -278,8 +278,8 @@ function intlcal_get_error_message(IntlCalendar $calendar): string|false {}
  * @param int $hour
  * @param int $minute
  * @param int $second
- * @deprecated
  */
+#[\Deprecated(since: '8.4', message: 'use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead')]
 function intlgregcal_create_instance($timezoneOrYear = UNKNOWN, $localeOrMonth = UNKNOWN, $day = UNKNOWN, $hour = UNKNOWN, $minute = UNKNOWN, $second = UNKNOWN): ?IntlGregorianCalendar {}
 
 function intlgregcal_set_gregorian_change(IntlGregorianCalendar $calendar, float $timestamp): bool {}

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b45ef763d82e1ad9ab27336fd0ab95e2d2e79a90 */
+ * Stub hash: 7a1b6eb454be08742ba45131de8ec57ec70a88c7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -1218,6 +1218,31 @@ static void register_php_intl_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("IDNA_ERROR_INVALID_ACE_LABEL", UIDNA_ERROR_INVALID_ACE_LABEL, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IDNA_ERROR_BIDI", UIDNA_ERROR_BIDI, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IDNA_ERROR_CONTEXTJ", UIDNA_ERROR_CONTEXTJ, CONST_PERSISTENT);
+
+
+	zend_attribute *attribute_Deprecated_func_intlcal_set_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlcal_set", sizeof("intlcal_set") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_intlcal_set_0_arg0;
+	zend_string *attribute_Deprecated_func_intlcal_set_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_intlcal_set_0_arg0, attribute_Deprecated_func_intlcal_set_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_intlcal_set_0->args[0].value, &attribute_Deprecated_func_intlcal_set_0_arg0);
+	attribute_Deprecated_func_intlcal_set_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_intlcal_set_0_arg1;
+	zend_string *attribute_Deprecated_func_intlcal_set_0_arg1_str = zend_string_init("use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead", strlen("use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_intlcal_set_0_arg1, attribute_Deprecated_func_intlcal_set_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_intlcal_set_0->args[1].value, &attribute_Deprecated_func_intlcal_set_0_arg1);
+	attribute_Deprecated_func_intlcal_set_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_intlgregcal_create_instance_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlgregcal_create_instance", sizeof("intlgregcal_create_instance") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_intlgregcal_create_instance_0_arg0;
+	zend_string *attribute_Deprecated_func_intlgregcal_create_instance_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_intlgregcal_create_instance_0_arg0, attribute_Deprecated_func_intlgregcal_create_instance_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_intlgregcal_create_instance_0->args[0].value, &attribute_Deprecated_func_intlgregcal_create_instance_0_arg0);
+	attribute_Deprecated_func_intlgregcal_create_instance_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_intlgregcal_create_instance_0_arg1;
+	zend_string *attribute_Deprecated_func_intlgregcal_create_instance_0_arg1_str = zend_string_init("use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead", strlen("use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_intlgregcal_create_instance_0_arg1, attribute_Deprecated_func_intlgregcal_create_instance_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_intlgregcal_create_instance_0->args[1].value, &attribute_Deprecated_func_intlgregcal_create_instance_0_arg1);
+	attribute_Deprecated_func_intlgregcal_create_instance_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }
 
 static zend_class_entry *register_class_IntlException(zend_class_entry *class_entry_Exception)

--- a/ext/intl/tests/calendar_set_basic.phpt
+++ b/ext/intl/tests/calendar_set_basic.phpt
@@ -20,6 +20,6 @@ var_dump($intlcal->get(IntlCalendar::FIELD_DAY_OF_MONTH));
 bool(true)
 int(2)
 
-Deprecated: Function intlcal_set() is deprecated in %s on line %d
+Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
 bool(true)
 int(3)

--- a/ext/intl/tests/calendar_set_error.phpt
+++ b/ext/intl/tests/calendar_set_error.phpt
@@ -48,8 +48,8 @@ Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated
 IntlCalendar::set() has no variant with exactly 4 parameters
 IntlCalendar::set(): Argument #1 ($year) must be a valid field
 
-Deprecated: Function intlcal_set() is deprecated in %s on line %d
+Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
 intlcal_set(): Argument #2 ($year) must be a valid field
 
-Deprecated: Function intlcal_set() is deprecated in %s on line %d
+Deprecated: Function intlcal_set() is deprecated since 8.4, use IntlCalendar::set(), IntlCalendar::setDate(), or IntlCalendar::setDateTime() instead in %s on line %d
 intlcal_set(): Argument #1 ($calendar) must be of type IntlCalendar, int given

--- a/ext/intl/tests/deprecated_number_formater_type_currency.phpt
+++ b/ext/intl/tests/deprecated_number_formater_type_currency.phpt
@@ -8,8 +8,8 @@ var_dump(NumberFormatter::TYPE_CURRENCY);
 var_dump(constant('NumberFormatter::TYPE_CURRENCY'));
 ?>
 --EXPECTF--
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 int(4)
 
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 int(4)

--- a/ext/intl/tests/formatter_format_and_parse_errors.phpt
+++ b/ext/intl/tests/formatter_format_and_parse_errors.phpt
@@ -60,14 +60,14 @@ NumberFormatter::format(): Argument #2 ($type) must be a NumberFormatter::TYPE_*
 numfmt_parse(): Argument #3 ($type) must be a NumberFormatter::TYPE_* constant
 NumberFormatter::parse(): Argument #2 ($type) must be a NumberFormatter::TYPE_* constant
 
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 numfmt_format(): Argument #3 ($type) cannot be NumberFormatter::TYPE_CURRENCY constant, use numfmt_format_currency() function instead
 
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 NumberFormatter::format(): Argument #2 ($type) cannot be NumberFormatter::TYPE_CURRENCY constant, use NumberFormatter::formatCurrency() method instead
 
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 numfmt_parse(): Argument #3 ($type) cannot be NumberFormatter::TYPE_CURRENCY constant, use numfmt_parse_currency() function instead
 
-Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated in %s on line %d
+Deprecated: Constant NumberFormatter::TYPE_CURRENCY is deprecated since 8.3 in %s on line %d
 NumberFormatter::parse(): Argument #2 ($type) cannot be NumberFormatter::TYPE_CURRENCY constant, use NumberFormatter::parseCurrency() method instead

--- a/ext/intl/tests/gregoriancalendar___construct_basic.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_basic.phpt
@@ -32,7 +32,7 @@ var_dump($intlcal->getLocale(1));
 var_dump($intlcal->getType());
 ?>
 --EXPECTF--
-Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 string(16) "Europe/Amsterdam"
 string(5) "nl_NL"
 string(13) "Europe/Lisbon"

--- a/ext/intl/tests/gregoriancalendar___construct_error.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_error.phpt
@@ -40,13 +40,13 @@ try {
 }
 ?>
 --EXPECTF--
-Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 Too many arguments
 
-Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 Too many arguments
 
-Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 No variant with 4 arguments (excluding trailing NULLs)
 
 Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d

--- a/ext/intl/tests/gregoriancalendar___construct_variant1.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_variant1.phpt
@@ -18,7 +18,7 @@ var_dump($intlcal->getTime(), (float)strtotime('2012-02-29 16:07:08') * 1000);
 var_dump($intlcal->getType());
 ?>
 --EXPECTF--
-Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
+Deprecated: Function intlgregcal_create_instance() is deprecated since 8.4, use IntlGregorianCalendar::__construct(), IntlGregorianCalendar::createFromDate(), or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 string(16) "Europe/Amsterdam"
 float(1330527600000)
 float(1330527600000)

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -22,6 +22,7 @@
 #include "php.h"
 #include "SAPI.h"
 
+#include "zend_attributes.h"
 #include "zend_variables.h"
 #include "ext/standard/info.h"
 #include "ext/standard/file.h"

--- a/ext/libxml/libxml.stub.php
+++ b/ext/libxml/libxml.stub.php
@@ -179,7 +179,7 @@ function libxml_get_errors(): array {}
 
 function libxml_clear_errors(): void {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0', message: 'as external entity loading is disabled by default')]
 function libxml_disable_entity_loader(bool $disable = true): bool {}
 
 function libxml_set_external_entity_loader(?callable $resolver_function): bool {}

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9baeff96436234ec51bd329477c6143caca7dd20 */
+ * Stub hash: e0d2498c10cba72adb97504fd13e178e090de2cd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_libxml_set_streams_context, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, context)
@@ -89,6 +89,19 @@ static void register_libxml_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("LIBXML_ERR_WARNING", XML_ERR_WARNING, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LIBXML_ERR_ERROR", XML_ERR_ERROR, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LIBXML_ERR_FATAL", XML_ERR_FATAL, CONST_PERSISTENT);
+
+
+	zend_attribute *attribute_Deprecated_func_libxml_disable_entity_loader_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "libxml_disable_entity_loader", sizeof("libxml_disable_entity_loader") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0;
+	zend_string *attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0, attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_libxml_disable_entity_loader_0->args[0].value, &attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0);
+	attribute_Deprecated_func_libxml_disable_entity_loader_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_libxml_disable_entity_loader_0_arg1;
+	zend_string *attribute_Deprecated_func_libxml_disable_entity_loader_0_arg1_str = zend_string_init("as external entity loading is disabled by default", strlen("as external entity loading is disabled by default"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_libxml_disable_entity_loader_0_arg1, attribute_Deprecated_func_libxml_disable_entity_loader_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_libxml_disable_entity_loader_0->args[1].value, &attribute_Deprecated_func_libxml_disable_entity_loader_0_arg1);
+	attribute_Deprecated_func_libxml_disable_entity_loader_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }
 
 static zend_class_entry *register_class_LibXMLError(void)

--- a/ext/libxml/tests/libxml_disable_entity_loader.phpt
+++ b/ext/libxml/tests/libxml_disable_entity_loader.phpt
@@ -37,7 +37,7 @@ echo "Done\n";
 --EXPECTF--
 bool(true)
 
-Deprecated: Function libxml_disable_entity_loader() is deprecated in %s on line %d
+Deprecated: Function libxml_disable_entity_loader() is deprecated since 8.0, as external entity loading is disabled by default in %s on line %d
 bool(false)
 
 Warning: DOMDocument::loadXML(): I/O warning : failed to load external entity "%s" in %s on line %d

--- a/ext/libxml/tests/libxml_disable_entity_loader_2.phpt
+++ b/ext/libxml/tests/libxml_disable_entity_loader_2.phpt
@@ -37,7 +37,7 @@ echo "Done\n";
 --EXPECTF--
 bool(true)
 
-Deprecated: Function libxml_disable_entity_loader() is deprecated in %s on line %d
+Deprecated: Function libxml_disable_entity_loader() is deprecated since 8.0, as external entity loading is disabled by default in %s on line %d
 bool(false)
 
 Warning: DOMDocument::loadXML(): %Sfailed to load external entity "%s" in %s on line %d

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -821,8 +821,8 @@ class mysqli
     /**
      * @tentative-return-type
      * @alias mysqli_get_client_info
-     * @deprecated 8.1.0
      */
+    #[\Deprecated(since: '8.1', message: 'use mysqli_get_client_info() instead')]
     public function get_client_info(): string {}
 
     /**
@@ -845,9 +845,9 @@ class mysqli
     public function get_warnings(): mysqli_warning|false {}
 
     /**
-     * @deprecated
      * @return bool|null
      * */
+    #[\Deprecated(since: '8.1', message: 'replace calls to parent::init() with parent::__construct()')]
     public function init() {}
 
     /**

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eb43a01e76fc18bc56572129be8d6dfce1a1e52a */
+ * Stub hash: 69e41b1b2ec5f46193a9defb75e401ac69588d95 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -1330,6 +1330,30 @@ static zend_class_entry *register_class_mysqli(void)
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "change_user", sizeof("change_user") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_attribute *attribute_Deprecated_func_get_client_info_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "get_client_info", sizeof("get_client_info") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_get_client_info_0_arg0;
+	zend_string *attribute_Deprecated_func_get_client_info_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_get_client_info_0_arg0, attribute_Deprecated_func_get_client_info_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_get_client_info_0->args[0].value, &attribute_Deprecated_func_get_client_info_0_arg0);
+	attribute_Deprecated_func_get_client_info_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_get_client_info_0_arg1;
+	zend_string *attribute_Deprecated_func_get_client_info_0_arg1_str = zend_string_init("use mysqli_get_client_info() instead", strlen("use mysqli_get_client_info() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_get_client_info_0_arg1, attribute_Deprecated_func_get_client_info_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_get_client_info_0->args[1].value, &attribute_Deprecated_func_get_client_info_0_arg1);
+	attribute_Deprecated_func_get_client_info_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_init_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "init", sizeof("init") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_init_0_arg0;
+	zend_string *attribute_Deprecated_func_init_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_init_0_arg0, attribute_Deprecated_func_init_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_init_0->args[0].value, &attribute_Deprecated_func_init_0_arg0);
+	attribute_Deprecated_func_init_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_init_0_arg1;
+	zend_string *attribute_Deprecated_func_init_0_arg1_str = zend_string_init("replace calls to parent::init() with parent::__construct()", strlen("replace calls to parent::init() with parent::__construct()"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_init_0_arg1, attribute_Deprecated_func_init_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_init_0->args[1].value, &attribute_Deprecated_func_init_0_arg1);
+	attribute_Deprecated_func_init_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", sizeof("real_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 

--- a/ext/mysqli/tests/bug46109.phpt
+++ b/ext/mysqli/tests/bug46109.phpt
@@ -16,7 +16,7 @@ $mysqli->init();
 echo "done";
 ?>
 --EXPECTF--
-Deprecated: Method mysqli::init() is deprecated in %s on line %d
+Deprecated: Method mysqli::init() is deprecated since 8.1, replace calls to parent::init() with parent::__construct() in %s on line %d
 
-Deprecated: Method mysqli::init() is deprecated in %s on line %d
+Deprecated: Method mysqli::init() is deprecated since 8.1, replace calls to parent::init() with parent::__construct() in %s on line %d
 done

--- a/ext/mysqli/tests/mysqli_get_info_deprecations.phpt
+++ b/ext/mysqli/tests/mysqli_get_info_deprecations.phpt
@@ -24,7 +24,7 @@ print "done!";
 ?>
 --EXPECTF--
 
-Deprecated: Method mysqli::get_client_info() is deprecated in %s
+Deprecated: Method mysqli::get_client_info() is deprecated since 8.1, use mysqli_get_client_info() instead in %s
 client_info = '%s'
 
 Deprecated: mysqli_get_client_info(): Passing connection object as an argument is deprecated in %s

--- a/ext/odbc/odbc.stub.php
+++ b/ext/odbc/odbc.stub.php
@@ -368,7 +368,7 @@ namespace {
 
     function odbc_result(Odbc\Result $statement, string|int $field): string|bool|null {}
 
-    /** @deprecated */
+    #[\Deprecated(since: '8.1')]
     function odbc_result_all(Odbc\Result $statement, string $format = ""): int|false {}
 
     function odbc_free_result(Odbc\Result $statement): true {}

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 34cebf41d91e4dacb8655a935c629ac62f0bb5ab */
+ * Stub hash: 30ed66d5e97f6615a461d39f40f85a18ba618711 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -492,6 +492,13 @@ static void register_odbc_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("SQL_QUICK", SQL_QUICK, CONST_PERSISTENT);
 #endif
 
+
+	zend_attribute *attribute_Deprecated_func_odbc_result_all_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_result_all", sizeof("odbc_result_all") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_odbc_result_all_0_arg0;
+	zend_string *attribute_Deprecated_func_odbc_result_all_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_odbc_result_all_0_arg0, attribute_Deprecated_func_odbc_result_all_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_odbc_result_all_0->args[0].value, &attribute_Deprecated_func_odbc_result_all_0_arg0);
+	attribute_Deprecated_func_odbc_result_all_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_connect", sizeof("odbc_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 

--- a/ext/odbc/tests/bug44618.phpt
+++ b/ext/odbc/tests/bug44618.phpt
@@ -66,7 +66,7 @@ array(3) {
 Warning: odbc_result(): Cannot get data of column #3 (retcode 100) in %s on line %d
 bool(false)
 
-Deprecated: Function odbc_result_all() is deprecated in %s on line %d
+Deprecated: Function odbc_result_all() is deprecated since 8.1 in %s on line %d
 <table><tr><th>ID</th><th>real1</th><th>text1</th></tr>
 <tr><td>1</td><td>10.02</td><td></td></tr></table>
 Warning: odbc_result_all(): Cannot get data of column #3 (retcode 100) in %s on line %d

--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -443,7 +443,7 @@ function openssl_x509_checkpurpose(OpenSSLCertificate|string $certificate, int $
 
 function openssl_x509_read(OpenSSLCertificate|string $certificate): OpenSSLCertificate|false {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0', message: 'as OpenSSLCertificate objects are freed automatically')]
 function openssl_x509_free(OpenSSLCertificate $certificate): void {}
 
 /**
@@ -507,15 +507,13 @@ function openssl_pkey_get_public($public_key): OpenSSLAsymmetricKey|false {}
  */
 function openssl_get_publickey($public_key): OpenSSLAsymmetricKey|false {}
 
-/**
- * @deprecated
- */
+#[\Deprecated(since: '8.0', message: 'as OpenSSLAsymmetricKey objects are freed automatically')]
 function openssl_pkey_free(OpenSSLAsymmetricKey $key): void {}
 
 /**
  * @alias openssl_pkey_free
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'as OpenSSLAsymmetricKey objects are freed automatically')]
 function openssl_free_key(OpenSSLAsymmetricKey $key): void {}
 
 /**

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1867498c895461f81aad433c21cf899ffdb65b3d */
+ * Stub hash: b2af57dc7fedc4305cbae2664331376fe390873f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
@@ -648,6 +648,18 @@ static void register_openssl_symbols(int module_number)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_check_private_key", sizeof("openssl_x509_check_private_key") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
+	zend_attribute *attribute_Deprecated_func_openssl_x509_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_free", sizeof("openssl_x509_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_openssl_x509_free_0_arg0;
+	zend_string *attribute_Deprecated_func_openssl_x509_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_x509_free_0_arg0, attribute_Deprecated_func_openssl_x509_free_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_x509_free_0->args[0].value, &attribute_Deprecated_func_openssl_x509_free_0_arg0);
+	attribute_Deprecated_func_openssl_x509_free_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_openssl_x509_free_0_arg1;
+	zend_string *attribute_Deprecated_func_openssl_x509_free_0_arg1_str = zend_string_init("as OpenSSLCertificate objects are freed automatically", strlen("as OpenSSLCertificate objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_x509_free_0_arg1, attribute_Deprecated_func_openssl_x509_free_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_x509_free_0->args[1].value, &attribute_Deprecated_func_openssl_x509_free_0_arg1);
+	attribute_Deprecated_func_openssl_x509_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
@@ -669,6 +681,30 @@ static void register_openssl_symbols(int module_number)
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_attribute *attribute_Deprecated_func_openssl_pkey_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_free", sizeof("openssl_pkey_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_openssl_pkey_free_0_arg0;
+	zend_string *attribute_Deprecated_func_openssl_pkey_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_pkey_free_0_arg0, attribute_Deprecated_func_openssl_pkey_free_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_pkey_free_0->args[0].value, &attribute_Deprecated_func_openssl_pkey_free_0_arg0);
+	attribute_Deprecated_func_openssl_pkey_free_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_openssl_pkey_free_0_arg1;
+	zend_string *attribute_Deprecated_func_openssl_pkey_free_0_arg1_str = zend_string_init("as OpenSSLAsymmetricKey objects are freed automatically", strlen("as OpenSSLAsymmetricKey objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_pkey_free_0_arg1, attribute_Deprecated_func_openssl_pkey_free_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_pkey_free_0->args[1].value, &attribute_Deprecated_func_openssl_pkey_free_0_arg1);
+	attribute_Deprecated_func_openssl_pkey_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_openssl_free_key_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_free_key", sizeof("openssl_free_key") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_openssl_free_key_0_arg0;
+	zend_string *attribute_Deprecated_func_openssl_free_key_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_free_key_0_arg0, attribute_Deprecated_func_openssl_free_key_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_free_key_0->args[0].value, &attribute_Deprecated_func_openssl_free_key_0_arg0);
+	attribute_Deprecated_func_openssl_free_key_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_openssl_free_key_0_arg1;
+	zend_string *attribute_Deprecated_func_openssl_free_key_0_arg1_str = zend_string_init("as OpenSSLAsymmetricKey objects are freed automatically", strlen("as OpenSSLAsymmetricKey objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_openssl_free_key_0_arg1, attribute_Deprecated_func_openssl_free_key_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_free_key_0->args[1].value, &attribute_Deprecated_func_openssl_free_key_0_arg1);
+	attribute_Deprecated_func_openssl_free_key_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 

--- a/ext/openssl/tests/001.phpt
+++ b/ext/openssl/tests/001.phpt
@@ -74,11 +74,11 @@ Export key to file
 bool(true)
 Load key from file - array syntax
 
-Deprecated: Function openssl_pkey_free() is deprecated in %s on line %d
+Deprecated: Function openssl_pkey_free() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 Load key using direct syntax
 
-Deprecated: Function openssl_pkey_free() is deprecated in %s on line %d
+Deprecated: Function openssl_pkey_free() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 Load key manually and use string syntax
 
-Deprecated: Function openssl_pkey_free() is deprecated in %s on line %d
+Deprecated: Function openssl_pkey_free() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 OK!

--- a/ext/openssl/tests/openssl_free_key.phpt
+++ b/ext/openssl/tests/openssl_free_key.phpt
@@ -65,11 +65,11 @@ Creating private key
 Export key to file
 Load key from file - array syntax
 
-Deprecated: Function openssl_free_key() is deprecated in %s on line %d
+Deprecated: Function openssl_free_key() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 Load key using direct syntax
 
-Deprecated: Function openssl_free_key() is deprecated in %s on line %d
+Deprecated: Function openssl_free_key() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 Load key manually and use string syntax
 
-Deprecated: Function openssl_free_key() is deprecated in %s on line %d
+Deprecated: Function openssl_free_key() is deprecated since 8.0, as OpenSSLAsymmetricKey objects are freed automatically in %s on line %d
 OK!

--- a/ext/openssl/tests/openssl_x509_free_basic.phpt
+++ b/ext/openssl/tests/openssl_x509_free_basic.phpt
@@ -12,6 +12,6 @@ var_dump($res);
 object(OpenSSLCertificate)#1 (0) {
 }
 
-Deprecated: Function openssl_x509_free() is deprecated in %s on line %d
+Deprecated: Function openssl_x509_free() is deprecated since 8.0, as OpenSSLCertificate objects are freed automatically in %s on line %d
 object(OpenSSLCertificate)#1 (0) {
 }

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -480,8 +480,8 @@ namespace {
 
     /**
      * @alias pg_last_error
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_last_error() instead')]
     function pg_errormessage(?PgSql\Connection $connection = null): string {}
 
     /** @refcount 1 */
@@ -552,24 +552,24 @@ namespace {
 
     /**
      * @alias pg_num_rows
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_num_rows() instead')]
     function pg_numrows(PgSql\Result $result): int {}
 
     function pg_num_fields(PgSql\Result $result): int {}
 
     /**
      * @alias pg_num_fields
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_num_fields() instead')]
     function pg_numfields(PgSql\Result $result): int {}
 
     function pg_affected_rows(PgSql\Result $result): int {}
 
     /**
      * @alias pg_affected_rows
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_affected_rows() instead')]
     function pg_cmdtuples(PgSql\Result $result): int {}
 
     function pg_last_notice(PgSql\Connection $connection, int $mode = PGSQL_NOTICE_LAST): array|string|bool {}
@@ -581,24 +581,24 @@ namespace {
 
     /**
      * @alias pg_field_name
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_name() instead')]
     function pg_fieldname(PgSql\Result $result, int $field): string {}
 
     function pg_field_size(PgSql\Result $result, int $field): int {}
 
     /**
      * @alias pg_field_size
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_size() instead')]
     function pg_fieldsize(PgSql\Result $result, int $field): int {}
 
     function pg_field_type(PgSql\Result $result, int $field): string {}
 
     /**
      * @alias pg_field_type
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_type() instead')]
     function pg_fieldtype(PgSql\Result $result, int $field): string {}
 
     /** @refcount 1 */
@@ -608,8 +608,8 @@ namespace {
 
     /**
      * @alias pg_field_num
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_num() instead')]
     function pg_fieldnum(PgSql\Result $result, string $field): int {}
 
     /**
@@ -621,8 +621,8 @@ namespace {
     /**
      * @param string|int $row
      * @alias pg_fetch_result
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_fetch_result() instead')]
     function pg_result(PgSql\Result $result, $row, string|int $field = UNKNOWN): string|false|null {}
 
     /**
@@ -665,8 +665,8 @@ namespace {
 
     /**
      * @param string|int $row
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_prtlen() instead')]
     function pg_fieldprtlen(PgSql\Result $result, $row, string|int $field = UNKNOWN): int|false {}
 
     /** @param string|int|null $row */
@@ -674,16 +674,16 @@ namespace {
 
     /**
      * @param string|int $row
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_field_is_null() instead')]
     function pg_fieldisnull(PgSql\Result $result, $row, string|int $field = UNKNOWN): int|false {}
 
     function pg_free_result(PgSql\Result $result): bool {}
 
     /**
      * @alias pg_free_result
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_free_result() instead')]
     function pg_freeresult(PgSql\Result $result): bool {}
 
     /** @refcount 1 */
@@ -691,8 +691,8 @@ namespace {
 
     /**
      * @alias pg_last_oid
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_last_oid() instead')]
     function pg_getlastoid(PgSql\Result $result): string|int|false {}
 
     function pg_trace(string $filename, string $mode = "w", ?PgSql\Connection $connection = null, int $trace_mode = 0): bool {}
@@ -710,8 +710,8 @@ namespace {
      * @param PgSql\Connection $connection
      * @param string|int $oid
      * @alias pg_lo_create
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_create() instead')]
     function pg_locreate($connection = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
     /**
@@ -724,8 +724,8 @@ namespace {
      * @param PgSql\Connection $connection
      * @param string|int $oid
      * @alias pg_lo_unlink
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_unlink() instead')]
     function pg_lounlink($connection, $oid = UNKNOWN): bool {}
 
     /**
@@ -739,16 +739,16 @@ namespace {
      * @param PgSql\Connection $connection
      * @param string|int $oid
      * @alias pg_lo_open
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_open() instead')]
     function pg_loopen($connection, $oid = UNKNOWN, string $mode = UNKNOWN): PgSql\Lob|false {}
 
     function pg_lo_close(PgSql\Lob $lob): bool {}
 
     /**
      * @alias pg_lo_close
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_close() instead')]
     function pg_loclose(PgSql\Lob $lob): bool {}
 
     /** @refcount 1 */
@@ -756,24 +756,24 @@ namespace {
 
     /**
      * @alias pg_lo_read
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_read() instead')]
     function pg_loread(PgSql\Lob $lob, int $length = 8192): string|false {}
 
     function pg_lo_write(PgSql\Lob $lob, string $data, ?int $length = null): int|false {}
 
     /**
      * @alias pg_lo_write
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_write() instead')]
     function pg_lowrite(PgSql\Lob $lob, string $data, ?int $length = null): int|false {}
 
     function pg_lo_read_all(PgSql\Lob $lob): int {}
 
     /**
      * @alias pg_lo_read_all
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_read_all() instead')]
     function pg_loreadall(PgSql\Lob $lob): int {}
 
     /**
@@ -789,8 +789,8 @@ namespace {
      * @param string|int $filename
      * @param string|int $oid
      * @alias pg_lo_import
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_import() instead')]
     function pg_loimport($connection, $filename = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
     /**
@@ -805,8 +805,8 @@ namespace {
      * @param string|int $oid
      * @param string|int $filename
      * @alias pg_lo_export
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_lo_export() instead')]
     function pg_loexport($connection, $oid = UNKNOWN, $filename = UNKNOWN): bool {}
 
     function pg_lo_seek(PgSql\Lob $lob, int $offset, int $whence = SEEK_CUR): bool {}
@@ -824,16 +824,16 @@ namespace {
     /**
      * @param PgSql\Connection|string $connection
      * @alias pg_set_client_encoding
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_set_client_encoding() instead')]
     function pg_setclientencoding($connection, string $encoding = UNKNOWN): int {}
 
     function pg_client_encoding(?PgSql\Connection $connection = null): string {}
 
     /**
      * @alias pg_client_encoding
-     * @deprecated
      */
+    #[\Deprecated(since: '8.0', message: 'use pg_client_encoding() instead')]
     function pg_clientencoding(?PgSql\Connection $connection = null): string {}
 
     function pg_end_copy(?PgSql\Connection $connection = null): bool {}

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 84535fbc63b6fe9766088d884c89f5c4a4db0ddf */
+ * Stub hash: 0b89a48c27c6682542312391f10a3ab8fb719ef8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -850,6 +850,294 @@ static void register_pgsql_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ERRORS", PQSHOW_CONTEXT_ERRORS, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
 
+
+	zend_attribute *attribute_Deprecated_func_pg_errormessage_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_errormessage", sizeof("pg_errormessage") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_errormessage_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_errormessage_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_errormessage_0_arg0, attribute_Deprecated_func_pg_errormessage_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_errormessage_0->args[0].value, &attribute_Deprecated_func_pg_errormessage_0_arg0);
+	attribute_Deprecated_func_pg_errormessage_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_errormessage_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_errormessage_0_arg1_str = zend_string_init("use pg_last_error() instead", strlen("use pg_last_error() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_errormessage_0_arg1, attribute_Deprecated_func_pg_errormessage_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_errormessage_0->args[1].value, &attribute_Deprecated_func_pg_errormessage_0_arg1);
+	attribute_Deprecated_func_pg_errormessage_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_numrows_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numrows", sizeof("pg_numrows") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_numrows_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_numrows_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_numrows_0_arg0, attribute_Deprecated_func_pg_numrows_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numrows_0->args[0].value, &attribute_Deprecated_func_pg_numrows_0_arg0);
+	attribute_Deprecated_func_pg_numrows_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_numrows_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_numrows_0_arg1_str = zend_string_init("use pg_num_rows() instead", strlen("use pg_num_rows() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_numrows_0_arg1, attribute_Deprecated_func_pg_numrows_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numrows_0->args[1].value, &attribute_Deprecated_func_pg_numrows_0_arg1);
+	attribute_Deprecated_func_pg_numrows_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_numfields_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numfields", sizeof("pg_numfields") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_numfields_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_numfields_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_numfields_0_arg0, attribute_Deprecated_func_pg_numfields_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numfields_0->args[0].value, &attribute_Deprecated_func_pg_numfields_0_arg0);
+	attribute_Deprecated_func_pg_numfields_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_numfields_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_numfields_0_arg1_str = zend_string_init("use pg_num_fields() instead", strlen("use pg_num_fields() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_numfields_0_arg1, attribute_Deprecated_func_pg_numfields_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numfields_0->args[1].value, &attribute_Deprecated_func_pg_numfields_0_arg1);
+	attribute_Deprecated_func_pg_numfields_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_cmdtuples_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_cmdtuples", sizeof("pg_cmdtuples") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_cmdtuples_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_cmdtuples_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_cmdtuples_0_arg0, attribute_Deprecated_func_pg_cmdtuples_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_cmdtuples_0->args[0].value, &attribute_Deprecated_func_pg_cmdtuples_0_arg0);
+	attribute_Deprecated_func_pg_cmdtuples_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_cmdtuples_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_cmdtuples_0_arg1_str = zend_string_init("use pg_affected_rows() instead", strlen("use pg_affected_rows() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_cmdtuples_0_arg1, attribute_Deprecated_func_pg_cmdtuples_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_cmdtuples_0->args[1].value, &attribute_Deprecated_func_pg_cmdtuples_0_arg1);
+	attribute_Deprecated_func_pg_cmdtuples_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldname_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldname", sizeof("pg_fieldname") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldname_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldname_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldname_0_arg0, attribute_Deprecated_func_pg_fieldname_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldname_0->args[0].value, &attribute_Deprecated_func_pg_fieldname_0_arg0);
+	attribute_Deprecated_func_pg_fieldname_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldname_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldname_0_arg1_str = zend_string_init("use pg_field_name() instead", strlen("use pg_field_name() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldname_0_arg1, attribute_Deprecated_func_pg_fieldname_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldname_0->args[1].value, &attribute_Deprecated_func_pg_fieldname_0_arg1);
+	attribute_Deprecated_func_pg_fieldname_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldsize", sizeof("pg_fieldsize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldsize_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldsize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldsize_0_arg0, attribute_Deprecated_func_pg_fieldsize_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldsize_0->args[0].value, &attribute_Deprecated_func_pg_fieldsize_0_arg0);
+	attribute_Deprecated_func_pg_fieldsize_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldsize_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldsize_0_arg1_str = zend_string_init("use pg_field_size() instead", strlen("use pg_field_size() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldsize_0_arg1, attribute_Deprecated_func_pg_fieldsize_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldsize_0->args[1].value, &attribute_Deprecated_func_pg_fieldsize_0_arg1);
+	attribute_Deprecated_func_pg_fieldsize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldtype_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldtype", sizeof("pg_fieldtype") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldtype_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldtype_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldtype_0_arg0, attribute_Deprecated_func_pg_fieldtype_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldtype_0->args[0].value, &attribute_Deprecated_func_pg_fieldtype_0_arg0);
+	attribute_Deprecated_func_pg_fieldtype_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldtype_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldtype_0_arg1_str = zend_string_init("use pg_field_type() instead", strlen("use pg_field_type() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldtype_0_arg1, attribute_Deprecated_func_pg_fieldtype_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldtype_0->args[1].value, &attribute_Deprecated_func_pg_fieldtype_0_arg1);
+	attribute_Deprecated_func_pg_fieldtype_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldnum_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldnum", sizeof("pg_fieldnum") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldnum_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldnum_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldnum_0_arg0, attribute_Deprecated_func_pg_fieldnum_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldnum_0->args[0].value, &attribute_Deprecated_func_pg_fieldnum_0_arg0);
+	attribute_Deprecated_func_pg_fieldnum_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldnum_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldnum_0_arg1_str = zend_string_init("use pg_field_num() instead", strlen("use pg_field_num() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldnum_0_arg1, attribute_Deprecated_func_pg_fieldnum_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldnum_0->args[1].value, &attribute_Deprecated_func_pg_fieldnum_0_arg1);
+	attribute_Deprecated_func_pg_fieldnum_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_result_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_result", sizeof("pg_result") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_result_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_result_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_result_0_arg0, attribute_Deprecated_func_pg_result_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_result_0->args[0].value, &attribute_Deprecated_func_pg_result_0_arg0);
+	attribute_Deprecated_func_pg_result_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_result_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_result_0_arg1_str = zend_string_init("use pg_fetch_result() instead", strlen("use pg_fetch_result() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_result_0_arg1, attribute_Deprecated_func_pg_result_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_result_0->args[1].value, &attribute_Deprecated_func_pg_result_0_arg1);
+	attribute_Deprecated_func_pg_result_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldprtlen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldprtlen", sizeof("pg_fieldprtlen") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldprtlen_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldprtlen_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldprtlen_0_arg0, attribute_Deprecated_func_pg_fieldprtlen_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldprtlen_0->args[0].value, &attribute_Deprecated_func_pg_fieldprtlen_0_arg0);
+	attribute_Deprecated_func_pg_fieldprtlen_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldprtlen_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldprtlen_0_arg1_str = zend_string_init("use pg_field_prtlen() instead", strlen("use pg_field_prtlen() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldprtlen_0_arg1, attribute_Deprecated_func_pg_fieldprtlen_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldprtlen_0->args[1].value, &attribute_Deprecated_func_pg_fieldprtlen_0_arg1);
+	attribute_Deprecated_func_pg_fieldprtlen_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_fieldisnull_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldisnull", sizeof("pg_fieldisnull") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_fieldisnull_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_fieldisnull_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldisnull_0_arg0, attribute_Deprecated_func_pg_fieldisnull_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldisnull_0->args[0].value, &attribute_Deprecated_func_pg_fieldisnull_0_arg0);
+	attribute_Deprecated_func_pg_fieldisnull_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_fieldisnull_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_fieldisnull_0_arg1_str = zend_string_init("use pg_field_is_null() instead", strlen("use pg_field_is_null() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_fieldisnull_0_arg1, attribute_Deprecated_func_pg_fieldisnull_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldisnull_0->args[1].value, &attribute_Deprecated_func_pg_fieldisnull_0_arg1);
+	attribute_Deprecated_func_pg_fieldisnull_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_freeresult_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_freeresult", sizeof("pg_freeresult") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_freeresult_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_freeresult_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_freeresult_0_arg0, attribute_Deprecated_func_pg_freeresult_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_freeresult_0->args[0].value, &attribute_Deprecated_func_pg_freeresult_0_arg0);
+	attribute_Deprecated_func_pg_freeresult_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_freeresult_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_freeresult_0_arg1_str = zend_string_init("use pg_free_result() instead", strlen("use pg_free_result() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_freeresult_0_arg1, attribute_Deprecated_func_pg_freeresult_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_freeresult_0->args[1].value, &attribute_Deprecated_func_pg_freeresult_0_arg1);
+	attribute_Deprecated_func_pg_freeresult_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_getlastoid_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_getlastoid", sizeof("pg_getlastoid") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_getlastoid_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_getlastoid_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_getlastoid_0_arg0, attribute_Deprecated_func_pg_getlastoid_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_getlastoid_0->args[0].value, &attribute_Deprecated_func_pg_getlastoid_0_arg0);
+	attribute_Deprecated_func_pg_getlastoid_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_getlastoid_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_getlastoid_0_arg1_str = zend_string_init("use pg_last_oid() instead", strlen("use pg_last_oid() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_getlastoid_0_arg1, attribute_Deprecated_func_pg_getlastoid_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_getlastoid_0->args[1].value, &attribute_Deprecated_func_pg_getlastoid_0_arg1);
+	attribute_Deprecated_func_pg_getlastoid_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_locreate_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_locreate", sizeof("pg_locreate") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_locreate_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_locreate_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_locreate_0_arg0, attribute_Deprecated_func_pg_locreate_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_locreate_0->args[0].value, &attribute_Deprecated_func_pg_locreate_0_arg0);
+	attribute_Deprecated_func_pg_locreate_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_locreate_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_locreate_0_arg1_str = zend_string_init("use pg_lo_create() instead", strlen("use pg_lo_create() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_locreate_0_arg1, attribute_Deprecated_func_pg_locreate_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_locreate_0->args[1].value, &attribute_Deprecated_func_pg_locreate_0_arg1);
+	attribute_Deprecated_func_pg_locreate_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_lounlink_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lounlink", sizeof("pg_lounlink") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_lounlink_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_lounlink_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_lounlink_0_arg0, attribute_Deprecated_func_pg_lounlink_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lounlink_0->args[0].value, &attribute_Deprecated_func_pg_lounlink_0_arg0);
+	attribute_Deprecated_func_pg_lounlink_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_lounlink_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_lounlink_0_arg1_str = zend_string_init("use pg_lo_unlink() instead", strlen("use pg_lo_unlink() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_lounlink_0_arg1, attribute_Deprecated_func_pg_lounlink_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lounlink_0->args[1].value, &attribute_Deprecated_func_pg_lounlink_0_arg1);
+	attribute_Deprecated_func_pg_lounlink_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loopen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loopen", sizeof("pg_loopen") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loopen_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loopen_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loopen_0_arg0, attribute_Deprecated_func_pg_loopen_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loopen_0->args[0].value, &attribute_Deprecated_func_pg_loopen_0_arg0);
+	attribute_Deprecated_func_pg_loopen_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loopen_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loopen_0_arg1_str = zend_string_init("use pg_lo_open() instead", strlen("use pg_lo_open() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loopen_0_arg1, attribute_Deprecated_func_pg_loopen_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loopen_0->args[1].value, &attribute_Deprecated_func_pg_loopen_0_arg1);
+	attribute_Deprecated_func_pg_loopen_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loclose_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loclose", sizeof("pg_loclose") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loclose_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loclose_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loclose_0_arg0, attribute_Deprecated_func_pg_loclose_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loclose_0->args[0].value, &attribute_Deprecated_func_pg_loclose_0_arg0);
+	attribute_Deprecated_func_pg_loclose_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loclose_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loclose_0_arg1_str = zend_string_init("use pg_lo_close() instead", strlen("use pg_lo_close() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loclose_0_arg1, attribute_Deprecated_func_pg_loclose_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loclose_0->args[1].value, &attribute_Deprecated_func_pg_loclose_0_arg1);
+	attribute_Deprecated_func_pg_loclose_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loread_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loread", sizeof("pg_loread") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loread_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loread_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loread_0_arg0, attribute_Deprecated_func_pg_loread_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loread_0->args[0].value, &attribute_Deprecated_func_pg_loread_0_arg0);
+	attribute_Deprecated_func_pg_loread_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loread_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loread_0_arg1_str = zend_string_init("use pg_lo_read() instead", strlen("use pg_lo_read() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loread_0_arg1, attribute_Deprecated_func_pg_loread_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loread_0->args[1].value, &attribute_Deprecated_func_pg_loread_0_arg1);
+	attribute_Deprecated_func_pg_loread_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_lowrite_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lowrite", sizeof("pg_lowrite") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_lowrite_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_lowrite_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_lowrite_0_arg0, attribute_Deprecated_func_pg_lowrite_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lowrite_0->args[0].value, &attribute_Deprecated_func_pg_lowrite_0_arg0);
+	attribute_Deprecated_func_pg_lowrite_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_lowrite_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_lowrite_0_arg1_str = zend_string_init("use pg_lo_write() instead", strlen("use pg_lo_write() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_lowrite_0_arg1, attribute_Deprecated_func_pg_lowrite_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lowrite_0->args[1].value, &attribute_Deprecated_func_pg_lowrite_0_arg1);
+	attribute_Deprecated_func_pg_lowrite_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loreadall_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loreadall", sizeof("pg_loreadall") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loreadall_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loreadall_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loreadall_0_arg0, attribute_Deprecated_func_pg_loreadall_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loreadall_0->args[0].value, &attribute_Deprecated_func_pg_loreadall_0_arg0);
+	attribute_Deprecated_func_pg_loreadall_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loreadall_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loreadall_0_arg1_str = zend_string_init("use pg_lo_read_all() instead", strlen("use pg_lo_read_all() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loreadall_0_arg1, attribute_Deprecated_func_pg_loreadall_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loreadall_0->args[1].value, &attribute_Deprecated_func_pg_loreadall_0_arg1);
+	attribute_Deprecated_func_pg_loreadall_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loimport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loimport", sizeof("pg_loimport") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loimport_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loimport_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loimport_0_arg0, attribute_Deprecated_func_pg_loimport_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loimport_0->args[0].value, &attribute_Deprecated_func_pg_loimport_0_arg0);
+	attribute_Deprecated_func_pg_loimport_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loimport_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loimport_0_arg1_str = zend_string_init("use pg_lo_import() instead", strlen("use pg_lo_import() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loimport_0_arg1, attribute_Deprecated_func_pg_loimport_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loimport_0->args[1].value, &attribute_Deprecated_func_pg_loimport_0_arg1);
+	attribute_Deprecated_func_pg_loimport_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_loexport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loexport", sizeof("pg_loexport") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_loexport_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_loexport_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loexport_0_arg0, attribute_Deprecated_func_pg_loexport_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loexport_0->args[0].value, &attribute_Deprecated_func_pg_loexport_0_arg0);
+	attribute_Deprecated_func_pg_loexport_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_loexport_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_loexport_0_arg1_str = zend_string_init("use pg_lo_export() instead", strlen("use pg_lo_export() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_loexport_0_arg1, attribute_Deprecated_func_pg_loexport_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loexport_0->args[1].value, &attribute_Deprecated_func_pg_loexport_0_arg1);
+	attribute_Deprecated_func_pg_loexport_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_setclientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_setclientencoding", sizeof("pg_setclientencoding") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_setclientencoding_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_setclientencoding_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_setclientencoding_0_arg0, attribute_Deprecated_func_pg_setclientencoding_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_setclientencoding_0->args[0].value, &attribute_Deprecated_func_pg_setclientencoding_0_arg0);
+	attribute_Deprecated_func_pg_setclientencoding_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_setclientencoding_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_setclientencoding_0_arg1_str = zend_string_init("use pg_set_client_encoding() instead", strlen("use pg_set_client_encoding() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_setclientencoding_0_arg1, attribute_Deprecated_func_pg_setclientencoding_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_setclientencoding_0->args[1].value, &attribute_Deprecated_func_pg_setclientencoding_0_arg1);
+	attribute_Deprecated_func_pg_setclientencoding_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_pg_clientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_clientencoding", sizeof("pg_clientencoding") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_pg_clientencoding_0_arg0;
+	zend_string *attribute_Deprecated_func_pg_clientencoding_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_clientencoding_0_arg0, attribute_Deprecated_func_pg_clientencoding_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_clientencoding_0->args[0].value, &attribute_Deprecated_func_pg_clientencoding_0_arg0);
+	attribute_Deprecated_func_pg_clientencoding_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_pg_clientencoding_0_arg1;
+	zend_string *attribute_Deprecated_func_pg_clientencoding_0_arg1_str = zend_string_init("use pg_client_encoding() instead", strlen("use pg_client_encoding() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_pg_clientencoding_0_arg1, attribute_Deprecated_func_pg_clientencoding_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_clientencoding_0->args[1].value, &attribute_Deprecated_func_pg_clientencoding_0_arg1);
+	attribute_Deprecated_func_pg_clientencoding_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_change_password", sizeof("pg_change_password") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }

--- a/ext/pgsql/tests/98old_api.phpt
+++ b/ext/pgsql/tests/98old_api.phpt
@@ -45,39 +45,39 @@ $db = pg_connect($conn_str);
 pg_query($db, "DROP TABLE IF EXISTS {$table_name}");
 ?>
 --EXPECTF--
-Deprecated: Function pg_numrows() is deprecated in %s on line %d
+Deprecated: Function pg_numrows() is deprecated since 8.0, use pg_num_rows() instead in %s on line %d
 
-Deprecated: Function pg_numfields() is deprecated in %s on line %d
+Deprecated: Function pg_numfields() is deprecated since 8.0, use pg_num_fields() instead in %s on line %d
 
-Deprecated: Function pg_fieldname() is deprecated in %s on line %d
+Deprecated: Function pg_fieldname() is deprecated since 8.0, use pg_field_name() instead in %s on line %d
 
-Deprecated: Function pg_fieldsize() is deprecated in %s on line %d
+Deprecated: Function pg_fieldsize() is deprecated since 8.0, use pg_field_size() instead in %s on line %d
 
-Deprecated: Function pg_fieldtype() is deprecated in %s on line %d
+Deprecated: Function pg_fieldtype() is deprecated since 8.0, use pg_field_type() instead in %s on line %d
 
-Deprecated: Function pg_fieldprtlen() is deprecated in %s on line %d
+Deprecated: Function pg_fieldprtlen() is deprecated since 8.0, use pg_field_prtlen() instead in %s on line %d
 
-Deprecated: Function pg_fieldprtlen() is deprecated in %s on line %d
+Deprecated: Function pg_fieldprtlen() is deprecated since 8.0, use pg_field_prtlen() instead in %s on line %d
 
 Deprecated: pg_fieldprtlen(): Passing null to parameter #2 ($row) of type int is deprecated in %s on line %d
 
-Deprecated: Function pg_fieldisnull() is deprecated in %s on line %d
+Deprecated: Function pg_fieldisnull() is deprecated since 8.0, use pg_field_is_null() instead in %s on line %d
 
-Deprecated: Function pg_fieldisnull() is deprecated in %s on line %d
+Deprecated: Function pg_fieldisnull() is deprecated since 8.0, use pg_field_is_null() instead in %s on line %d
 
 Deprecated: pg_fieldisnull(): Passing null to parameter #2 ($row) of type int is deprecated in %s on line %d
 
-Deprecated: Function pg_result() is deprecated in %s on line %d
+Deprecated: Function pg_result() is deprecated since 8.0, use pg_fetch_result() instead in %s on line %d
 
-Deprecated: Function pg_result() is deprecated in %s on line %d
+Deprecated: Function pg_result() is deprecated since 8.0, use pg_fetch_result() instead in %s on line %d
 
 Deprecated: pg_result(): Passing null to parameter #2 ($row) of type int is deprecated in %s on line %d
 
-Deprecated: Function pg_getlastoid() is deprecated in %s on line %d
+Deprecated: Function pg_getlastoid() is deprecated since 8.0, use pg_last_oid() instead in %s on line %d
 
-Deprecated: Function pg_freeresult() is deprecated in %s on line %d
+Deprecated: Function pg_freeresult() is deprecated since 8.0, use pg_free_result() instead in %s on line %d
 
-Deprecated: Function pg_errormessage() is deprecated in %s on line %d
+Deprecated: Function pg_errormessage() is deprecated since 8.0, use pg_last_error() instead in %s on line %d
 
-Deprecated: Function pg_cmdtuples() is deprecated in %s on line %d
+Deprecated: Function pg_cmdtuples() is deprecated since 8.0, use pg_affected_rows() instead in %s on line %d
 OK

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -127,8 +127,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
 
     /**
      * @tentative-return-type
-     * @deprecated ReflectionFunction can no longer be constructed for disabled functions
      */
+    #[\Deprecated(since: '8.0', message: "as ReflectionFunction can no longer be constructed for disabled functions")]
     public function isDisabled(): bool {}
 
     /** @tentative-return-type */
@@ -593,8 +593,8 @@ class ReflectionParameter implements Reflector
 
     /**
      * @tentative-return-type
-     * @deprecated Use ReflectionParameter::getType() instead
      */
+    #[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]
     public function getClass(): ?ReflectionClass {}
 
     /** @tentative-return-type */
@@ -605,14 +605,14 @@ class ReflectionParameter implements Reflector
 
     /**
      * @tentative-return-type
-     * @deprecated Use ReflectionParameter::getType() instead
      */
+    #[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]
     public function isArray(): bool {}
 
     /**
      * @tentative-return-type
-     * @deprecated Use ReflectionParameter::getType() instead
      */
+    #[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]
     public function isCallable(): bool {}
 
     /** @tentative-return-type */

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 53cb11e3aaa2215f8dbb39778dfbc1bd28f629af */
+ * Stub hash: 9658aab117448d2a2337c749d8c8ccd5835321a6 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -1287,6 +1287,19 @@ static zend_class_entry *register_class_ReflectionFunction(zend_class_entry *cla
 	zend_declare_typed_class_constant(class_entry, const_IS_DEPRECATED_name, &const_IS_DEPRECATED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_DEPRECATED_name);
 
+
+	zend_attribute *attribute_Deprecated_func_isdisabled_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isdisabled", sizeof("isdisabled") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_isdisabled_0_arg0;
+	zend_string *attribute_Deprecated_func_isdisabled_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_isdisabled_0_arg0, attribute_Deprecated_func_isdisabled_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_isdisabled_0->args[0].value, &attribute_Deprecated_func_isdisabled_0_arg0);
+	attribute_Deprecated_func_isdisabled_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_isdisabled_0_arg1;
+	zend_string *attribute_Deprecated_func_isdisabled_0_arg1_str = zend_string_init("as ReflectionFunction can no longer be constructed for disabled functions", strlen("as ReflectionFunction can no longer be constructed for disabled functions"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_isdisabled_0_arg1, attribute_Deprecated_func_isdisabled_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_isdisabled_0->args[1].value, &attribute_Deprecated_func_isdisabled_0_arg1);
+	attribute_Deprecated_func_isdisabled_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
 	return class_entry;
 }
 
@@ -1521,6 +1534,43 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
+
+
+	zend_attribute *attribute_Deprecated_func_getclass_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "getclass", sizeof("getclass") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_getclass_0_arg0;
+	zend_string *attribute_Deprecated_func_getclass_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_getclass_0_arg0, attribute_Deprecated_func_getclass_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_getclass_0->args[0].value, &attribute_Deprecated_func_getclass_0_arg0);
+	attribute_Deprecated_func_getclass_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_getclass_0_arg1;
+	zend_string *attribute_Deprecated_func_getclass_0_arg1_str = zend_string_init("use ReflectionParameter::getType() instead", strlen("use ReflectionParameter::getType() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_getclass_0_arg1, attribute_Deprecated_func_getclass_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_getclass_0->args[1].value, &attribute_Deprecated_func_getclass_0_arg1);
+	attribute_Deprecated_func_getclass_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_isarray_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isarray", sizeof("isarray") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_isarray_0_arg0;
+	zend_string *attribute_Deprecated_func_isarray_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_isarray_0_arg0, attribute_Deprecated_func_isarray_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_isarray_0->args[0].value, &attribute_Deprecated_func_isarray_0_arg0);
+	attribute_Deprecated_func_isarray_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_isarray_0_arg1;
+	zend_string *attribute_Deprecated_func_isarray_0_arg1_str = zend_string_init("use ReflectionParameter::getType() instead", strlen("use ReflectionParameter::getType() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_isarray_0_arg1, attribute_Deprecated_func_isarray_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_isarray_0->args[1].value, &attribute_Deprecated_func_isarray_0_arg1);
+	attribute_Deprecated_func_isarray_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_iscallable_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "iscallable", sizeof("iscallable") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_iscallable_0_arg0;
+	zend_string *attribute_Deprecated_func_iscallable_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_iscallable_0_arg0, attribute_Deprecated_func_iscallable_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_iscallable_0->args[0].value, &attribute_Deprecated_func_iscallable_0_arg0);
+	attribute_Deprecated_func_iscallable_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_iscallable_0_arg1;
+	zend_string *attribute_Deprecated_func_iscallable_0_arg1_str = zend_string_init("use ReflectionParameter::getType() instead", strlen("use ReflectionParameter::getType() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_iscallable_0_arg1, attribute_Deprecated_func_iscallable_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_iscallable_0->args[1].value, &attribute_Deprecated_func_iscallable_0_arg1);
+	attribute_Deprecated_func_iscallable_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	return class_entry;
 }

--- a/ext/reflection/tests/ReflectionClass_isArray.phpt
+++ b/ext/reflection/tests/ReflectionClass_isArray.phpt
@@ -14,14 +14,14 @@ foreach ($reflection->getParameters() as $parameter) {
 }
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)

--- a/ext/reflection/tests/ReflectionFunction_isDisabled_basic.phpt
+++ b/ext/reflection/tests/ReflectionFunction_isDisabled_basic.phpt
@@ -20,5 +20,5 @@ var_dump($rf->isDisabled());
 --EXPECTF--
 Function is_file() does not exist
 
-Deprecated: Method ReflectionFunction::isDisabled() is deprecated in %s on line %d
+Deprecated: Method ReflectionFunction::isDisabled() is deprecated since 8.0, as ReflectionFunction can no longer be constructed for disabled functions in %s on line %d
 bool(false)

--- a/ext/reflection/tests/ReflectionParameter_getClass_self_parent_closure.phpt
+++ b/ext/reflection/tests/ReflectionParameter_getClass_self_parent_closure.phpt
@@ -27,11 +27,11 @@ try {
 
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 Parameter uses "self" as type but function is not a class member
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 Parameter uses "parent" as type but function is not a class member
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 Parameter uses "parent" as type although class does not have a parent

--- a/ext/reflection/tests/bug26695.phpt
+++ b/ext/reflection/tests/bug26695.phpt
@@ -20,5 +20,5 @@ $class = $params[0]->getClass();
 var_dump($class->getName());
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 string(3) "Foo"

--- a/ext/reflection/tests/bug29268.phpt
+++ b/ext/reflection/tests/bug29268.phpt
@@ -22,7 +22,7 @@ foreach($parameters as $parameter)
 echo "ok\n";
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 __autoload(A)
 A
 ok

--- a/ext/reflection/tests/bug39884.phpt
+++ b/ext/reflection/tests/bug39884.phpt
@@ -16,7 +16,7 @@ $refParam = new ReflectionParameter(array('stubParamTest', 'paramTest'), 'param'
 var_dump($refParam->getClass());
 ?>
 --EXPECTF--
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 object(ReflectionClass)#4 (1) {
   ["name"]=>
   string(13) "stubParamTest"

--- a/ext/reflection/tests/bug69802.phpt
+++ b/ext/reflection/tests/bug69802.phpt
@@ -13,7 +13,7 @@ echo $r,"\n";
 --EXPECTF--
 string(1) "x"
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 object(ReflectionClass)#4 (1) {
   ["name"]=>
   string(8) "stdClass"

--- a/ext/reflection/tests/parameters_002.phpt
+++ b/ext/reflection/tests/parameters_002.phpt
@@ -79,11 +79,11 @@ Deprecated: test(): Implicitly marking parameter $opt as nullable is deprecated,
 getName: string(3) "nix"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(false)
@@ -92,11 +92,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(2) "ar"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -105,11 +105,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "ref"
 isPassedByReference: bool(true)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(false)
@@ -118,11 +118,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "std"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: stdClass
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -131,11 +131,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(2) "na"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 Class "NonExistingClass" does not exist
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -144,11 +144,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "opt"
 isPassedByReference: bool(true)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: stdClass
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(true)
@@ -158,11 +158,11 @@ getDefaultValue: NULL
 getName: string(3) "def"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: NULL
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(true)
@@ -173,11 +173,11 @@ getDefaultValue: string(6) "FooBar"
 getName: string(3) "nix"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(false)
@@ -186,11 +186,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(2) "ar"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(true)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -199,11 +199,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "ref"
 isPassedByReference: bool(true)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(false)
@@ -212,11 +212,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "std"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: stdClass
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -225,11 +225,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(2) "na"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 Class "NonExistingClass" does not exist
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(false)
 isOptional: bool(false)
@@ -238,11 +238,11 @@ isDefaultValueAvailable: bool(false)
 getName: string(3) "opt"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: stdClass
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(true)
@@ -252,11 +252,11 @@ getDefaultValue: NULL
 getName: string(3) "def"
 isPassedByReference: bool(false)
 
-Deprecated: Method ReflectionParameter::getClass() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::getClass() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 getClass: NULL
 getDeclaringClass: test
 isArray: 
-Deprecated: Method ReflectionParameter::isArray() is deprecated in %s on line %d
+Deprecated: Method ReflectionParameter::isArray() is deprecated since 8.0, use ReflectionParameter::getType() instead in %s on line %d
 bool(false)
 allowsNull: bool(true)
 isOptional: bool(true)

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -23,6 +23,8 @@
 
 #include "php.h"
 #include "php_shmop.h"
+#include "Zend/zend_attributes.h"
+
 #include "shmop_arginfo.h"
 
 # ifndef PHP_WIN32
@@ -115,6 +117,8 @@ PHP_MINIT_FUNCTION(shmop)
 	shmop_object_handlers.get_constructor = shmop_get_constructor;
 	shmop_object_handlers.clone_obj = NULL;
 	shmop_object_handlers.compare = zend_objects_not_comparable;
+
+	register_shmop_symbols(module_number);
 
 	return SUCCESS;
 }

--- a/ext/shmop/shmop.stub.php
+++ b/ext/shmop/shmop.stub.php
@@ -12,7 +12,7 @@ function shmop_open(int $key, string $mode, int $permissions, int $size): Shmop|
 
 function shmop_read(Shmop $shmop, int $offset, int $size): string {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.0', message: 'as Shmop objects are freed automatically')]
 function shmop_close(Shmop $shmop): void {}
 
 function shmop_size(Shmop $shmop): int {}

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6055f4edb68a7caed517dbb80f4d5265865dd91d */
+ * Stub hash: e7f250077b6721539caee96afe4ed392396018f9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_shmop_open, 0, 4, Shmop, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
@@ -52,6 +52,22 @@ static const zend_function_entry ext_functions[] = {
 static const zend_function_entry class_Shmop_methods[] = {
 	ZEND_FE_END
 };
+
+static void register_shmop_symbols(int module_number)
+{
+
+	zend_attribute *attribute_Deprecated_func_shmop_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "shmop_close", sizeof("shmop_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_shmop_close_0_arg0;
+	zend_string *attribute_Deprecated_func_shmop_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_shmop_close_0_arg0, attribute_Deprecated_func_shmop_close_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_shmop_close_0->args[0].value, &attribute_Deprecated_func_shmop_close_0_arg0);
+	attribute_Deprecated_func_shmop_close_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_shmop_close_0_arg1;
+	zend_string *attribute_Deprecated_func_shmop_close_0_arg1_str = zend_string_init("as Shmop objects are freed automatically", strlen("as Shmop objects are freed automatically"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_shmop_close_0_arg1, attribute_Deprecated_func_shmop_close_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_shmop_close_0->args[1].value, &attribute_Deprecated_func_shmop_close_0_arg1);
+	attribute_Deprecated_func_shmop_close_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+}
 
 static zend_class_entry *register_class_Shmop(void)
 {

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -24,6 +24,7 @@
 #include "ext/standard/flock_compat.h"
 #include "ext/standard/scanf.h"
 #include "ext/standard/php_string.h"
+#include "zend_attributes.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"
 

--- a/ext/spl/spl_directory.stub.php
+++ b/ext/spl/spl_directory.stub.php
@@ -98,9 +98,9 @@ class SplFileInfo implements Stringable
     public function __debugInfo(): array {}
 
     /**
-     * @deprecated
      * @tentative-return-type
      */
+    #[\Deprecated(since: '8.2')]
     final public function _bad_state_ex(): void {}
 }
 

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6212994df4935f42c99080b928b8b5b08bdbe19d */
+ * Stub hash: 3ed3a9f6609e1b8fa642f1e4cfaa1de40e3cc11e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileInfo___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -490,6 +490,14 @@ static zend_class_entry *register_class_SplFileInfo(zend_class_entry *class_entr
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
+
+
+	zend_attribute *attribute_Deprecated_func__bad_state_ex_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "_bad_state_ex", sizeof("_bad_state_ex") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func__bad_state_ex_0_arg0;
+	zend_string *attribute_Deprecated_func__bad_state_ex_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
+	ZVAL_STR(&attribute_Deprecated_func__bad_state_ex_0_arg0, attribute_Deprecated_func__bad_state_ex_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func__bad_state_ex_0->args[0].value, &attribute_Deprecated_func__bad_state_ex_0_arg0);
+	attribute_Deprecated_func__bad_state_ex_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
 	return class_entry;
 }

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2136,9 +2136,9 @@ function crypt(#[\SensitiveParameter] string $string, string $salt): string {}
 #ifdef HAVE_STRPTIME
 /**
  * @return array<string, int|string>|false
- * @deprecated
  * @refcount 1
  */
+#[\Deprecated(since: '8.2', message: 'use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead')]
 function strptime(string $timestamp, string $format): array|false {}
 #endif
 
@@ -2301,7 +2301,7 @@ function get_html_translation_table(int $table = HTML_SPECIALCHARS, int $flags =
 
 function assert(mixed $assertion, Throwable|string|null $description = null): bool {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.3')]
 function assert_options(int $option, mixed $value = UNKNOWN): mixed {}
 
 /* string.c */
@@ -2655,15 +2655,15 @@ function substr_compare(string $haystack, string $needle, int $offset, ?int $len
 /**
  * @compile-time-eval
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.2', message: 'visit the php.net documentation for various alternatives')]
 function utf8_encode(string $string): string {}
 
 /**
  * @compile-time-eval
  * @refcount 1
- * @deprecated
  */
+#[\Deprecated(since: '8.2', message: 'visit the php.net documentation for various alternatives')]
 function utf8_decode(string $string): string {}
 
 /* dir.c */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3a942ebd5d1011a6419217f9aa229b18c2ac0f83 */
+ * Stub hash: 298deeb590d17e5444ca0f76a65f63df9af5330c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -4122,6 +4122,51 @@ static void register_basic_functions_symbols(int module_number)
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "crypt", sizeof("crypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#if defined(HAVE_STRPTIME)
+
+	zend_attribute *attribute_Deprecated_func_strptime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strptime", sizeof("strptime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_strptime_0_arg0;
+	zend_string *attribute_Deprecated_func_strptime_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_strptime_0_arg0, attribute_Deprecated_func_strptime_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_strptime_0->args[0].value, &attribute_Deprecated_func_strptime_0_arg0);
+	attribute_Deprecated_func_strptime_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_strptime_0_arg1;
+	zend_string *attribute_Deprecated_func_strptime_0_arg1_str = zend_string_init("use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead", strlen("use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_strptime_0_arg1, attribute_Deprecated_func_strptime_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_strptime_0->args[1].value, &attribute_Deprecated_func_strptime_0_arg1);
+	attribute_Deprecated_func_strptime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+#endif
+
+	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", sizeof("assert_options") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_assert_options_0_arg0;
+	zend_string *attribute_Deprecated_func_assert_options_0_arg0_str = zend_string_init("8.3", strlen("8.3"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_assert_options_0_arg0, attribute_Deprecated_func_assert_options_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_assert_options_0->args[0].value, &attribute_Deprecated_func_assert_options_0_arg0);
+	attribute_Deprecated_func_assert_options_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_attribute *attribute_Deprecated_func_utf8_encode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_encode", sizeof("utf8_encode") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_utf8_encode_0_arg0;
+	zend_string *attribute_Deprecated_func_utf8_encode_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_utf8_encode_0_arg0, attribute_Deprecated_func_utf8_encode_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_encode_0->args[0].value, &attribute_Deprecated_func_utf8_encode_0_arg0);
+	attribute_Deprecated_func_utf8_encode_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_utf8_encode_0_arg1;
+	zend_string *attribute_Deprecated_func_utf8_encode_0_arg1_str = zend_string_init("visit the php.net documentation for various alternatives", strlen("visit the php.net documentation for various alternatives"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_utf8_encode_0_arg1, attribute_Deprecated_func_utf8_encode_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_encode_0->args[1].value, &attribute_Deprecated_func_utf8_encode_0_arg1);
+	attribute_Deprecated_func_utf8_encode_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_utf8_decode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_decode", sizeof("utf8_decode") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_utf8_decode_0_arg0;
+	zend_string *attribute_Deprecated_func_utf8_decode_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_utf8_decode_0_arg0, attribute_Deprecated_func_utf8_decode_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_decode_0->args[0].value, &attribute_Deprecated_func_utf8_decode_0_arg0);
+	attribute_Deprecated_func_utf8_decode_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_utf8_decode_0_arg1;
+	zend_string *attribute_Deprecated_func_utf8_decode_0_arg1_str = zend_string_init("visit the php.net documentation for various alternatives", strlen("visit the php.net documentation for various alternatives"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_utf8_decode_0_arg1, attribute_Deprecated_func_utf8_decode_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_decode_0->args[1].value, &attribute_Deprecated_func_utf8_decode_0_arg1);
+	attribute_Deprecated_func_utf8_decode_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 

--- a/ext/standard/tests/assert/assert.phpt
+++ b/ext/standard/tests/assert/assert.phpt
@@ -43,23 +43,23 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_ACTIVE is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_WARNING is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assertion failed 21,"assert($a != 0)"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 class assertion failed 24,"assert($a != 0)"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 class assertion failed 28,"assert($a != 0)"

--- a/ext/standard/tests/assert/assert03.phpt
+++ b/ext/standard/tests/assert/assert03.phpt
@@ -38,15 +38,15 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_ACTIVE is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_WARNING is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assertion failed - a - 18,"assert($a != 0)"
 
 Deprecated: ini_set(): assert.callback INI setting is deprecated in %s on line %d

--- a/ext/standard/tests/assert/assert04.phpt
+++ b/ext/standard/tests/assert/assert04.phpt
@@ -31,16 +31,16 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_ACTIVE is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_ACTIVE is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Warning: assert(): assert(0) failed in %s on line %d
 
 Deprecated: Constant ASSERT_BAIL is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Warning: assert(): assert(0) failed in %s on line %d

--- a/ext/standard/tests/assert/assert_basic2.phpt
+++ b/ext/standard/tests/assert/assert_basic2.phpt
@@ -32,7 +32,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f1"
 f1 called
 
@@ -40,12 +40,12 @@ Warning: assert(): assert(0) failed in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f1"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f2"
 f2 called
 

--- a/ext/standard/tests/assert/assert_basic3.phpt
+++ b/ext/standard/tests/assert/assert_basic3.phpt
@@ -25,7 +25,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_BAIL is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 int(0)
 f1 called
 

--- a/ext/standard/tests/assert/assert_basic4.phpt
+++ b/ext/standard/tests/assert/assert_basic4.phpt
@@ -30,22 +30,22 @@ Deprecated: PHP Startup: assert.callback INI setting is deprecated in Unknown on
 
 Deprecated: Constant ASSERT_ACTIVE is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Initial values: assert_options(ASSERT_ACTIVE) => [0]
 
 Deprecated: Constant ASSERT_WARNING is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Initial values: assert_options(ASSERT_WARNING) => [0]
 
 Deprecated: Constant ASSERT_BAIL is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Initial values: assert_options(ASSERT_BAIL) => [0]
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Initial values: assert_options(ASSERT_CALLBACK) => [f1]
 Initial values: ini.get("assert.active") => [0]
 Initial values: ini.get("assert.warning") => [0]

--- a/ext/standard/tests/assert/assert_basic5.phpt
+++ b/ext/standard/tests/assert/assert_basic5.phpt
@@ -30,7 +30,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_WARNING is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 int(0)
 f1 called
 
@@ -40,5 +40,5 @@ bool(true)
 
 Deprecated: Constant ASSERT_WARNING is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 int(1)

--- a/ext/standard/tests/assert/assert_basic6.phpt
+++ b/ext/standard/tests/assert/assert_basic6.phpt
@@ -34,11 +34,11 @@ try {
 --EXPECTF--
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f1"
 foo
 assert(false)
@@ -46,10 +46,10 @@ assert(false)
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 NULL
 assert(false)

--- a/ext/standard/tests/assert/assert_closures.phpt
+++ b/ext/standard/tests/assert/assert_closures.phpt
@@ -15,7 +15,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Hello World!
 
 Warning: assert(): assert(0) failed in %s on line %d

--- a/ext/standard/tests/assert/assert_closures_multiple.phpt
+++ b/ext/standard/tests/assert/assert_closures_multiple.phpt
@@ -34,5 +34,5 @@ DONE
 --EXPECTF--
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 DONE

--- a/ext/standard/tests/assert/assert_error2.phpt
+++ b/ext/standard/tests/assert/assert_error2.phpt
@@ -27,7 +27,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_BAIL is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 int(0)
 f1 called
 

--- a/ext/standard/tests/assert/assert_options_error.phpt
+++ b/ext/standard/tests/assert/assert_options_error.phpt
@@ -10,5 +10,5 @@ try {
 }
 ?>
 --EXPECTF--
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assert_options(): Argument #1 ($option) must be an ASSERT_* constant

--- a/ext/standard/tests/assert/assert_variation.phpt
+++ b/ext/standard/tests/assert/assert_variation.phpt
@@ -87,7 +87,7 @@ Deprecated: PHP Startup: assert.exception INI setting is deprecated in Unknown o
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 Initial values: assert_options(ASSERT_CALLBACK) => [f1]
 Initial values: ini.get("assert.callback") => [f1]
 f1 called
@@ -100,7 +100,7 @@ string(2) "f1"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assert_options(ASSERT_CALLBACK) => [f2]
 ini.get("assert.callback") => [f2]
 f2 called
@@ -110,12 +110,12 @@ Change callback function using assert_options and test return value
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f2"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assert_options(ASSERT_CALLBACK) => [f3]
 ini.get("assert.callback") => [f2]
 f3 called
@@ -125,12 +125,12 @@ Reset the name of the callback routine to a class method
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "f3"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 assert_options(ASSERT_CALLBACK) => [c1]
 ini.get("assert.callback") => [f2]
 Invalid callback c1, function "c1" not found or invalid function name
@@ -139,12 +139,12 @@ Reset callback options to use a class method
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(2) "c1"
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 array(2) {
   [0]=>
   string(2) "c1"
@@ -160,7 +160,7 @@ Reset callback options to use an object method
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 array(2) {
   [0]=>
   string(2) "c1"
@@ -170,7 +170,7 @@ array(2) {
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 array(2) {
   [0]=>
   &object(c1)#2 (0) {
@@ -187,9 +187,9 @@ Set callback to something silly
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 float(3.141)

--- a/ext/standard/tests/assert/bug80290.phpt
+++ b/ext/standard/tests/assert/bug80290.phpt
@@ -14,7 +14,7 @@ assert(false, 'Dynamic message: ' . $x);
 --EXPECTF--
 Deprecated: Constant ASSERT_CALLBACK is deprecated in %s on line %d
 
-Deprecated: Function assert_options() is deprecated in %s on line %d
+Deprecated: Function assert_options() is deprecated since 8.3 in %s on line %d
 string(18) "Dynamic message: x"
 
 Fatal error: Uncaught AssertionError: Dynamic message: x in %s:%d

--- a/ext/standard/tests/strings/bug43957.phpt
+++ b/ext/standard/tests/strings/bug43957.phpt
@@ -5,5 +5,5 @@ Bug #43957 (utf8_decode() bogus conversion on multibyte indicator near end of st
   echo utf8_decode('abc'.chr(0xe0));
 ?>
 --EXPECTF--
-Deprecated: Function utf8_decode() is deprecated in %s on line %d
+Deprecated: Function utf8_decode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 abc?

--- a/ext/standard/tests/strings/bug49687.phpt
+++ b/ext/standard/tests/strings/bug49687.phpt
@@ -14,12 +14,12 @@ foreach ($tests as $t) {
 echo "Done.\n";
 ?>
 --EXPECTF--
-Deprecated: Function utf8_decode() is deprecated in %s on line %d
+Deprecated: Function utf8_decode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 413f3e42
 
-Deprecated: Function utf8_decode() is deprecated in %s on line %d
+Deprecated: Function utf8_decode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 3f22
 
-Deprecated: Function utf8_decode() is deprecated in %s on line %d
+Deprecated: Function utf8_decode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 413f3f423f433f3f
 Done.

--- a/ext/standard/tests/strings/utf8.phpt
+++ b/ext/standard/tests/strings/utf8.phpt
@@ -6,8 +6,8 @@ printf("%s -> %s\n", urlencode("æ"), urlencode(utf8_encode("æ")));
 printf("%s <- %s\n", urlencode(utf8_decode(urldecode("%C3%A6"))), "%C3%A6");
 ?>
 --EXPECTF--
-Deprecated: Function utf8_encode() is deprecated in %s on line %d
+Deprecated: Function utf8_encode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 %E6 -> %C3%A6
 
-Deprecated: Function utf8_decode() is deprecated in %s on line %d
+Deprecated: Function utf8_decode() is deprecated since 8.2, visit the php.net documentation for various alternatives in %s on line %d
 %E6 <- %C3%A6

--- a/ext/standard/tests/time/bug38524.phpt
+++ b/ext/standard/tests/time/bug38524.phpt
@@ -12,7 +12,7 @@ if (str_contains(PHP_OS, 'FreeBSD')) {
     var_dump(strptime('2006-08-20', '%Y-%m-%d'));
 ?>
 --EXPECTF--
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 array(9) {
   ["tm_sec"]=>
   int(0)

--- a/ext/standard/tests/time/strptime_basic.phpt
+++ b/ext/standard/tests/time/strptime_basic.phpt
@@ -34,9 +34,9 @@ setlocale(LC_ALL, $orig);
 --EXPECTF--
 *** Testing strptime() : basic functionality ***
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 array(9) {
   ["tm_sec"]=>
   int(0)
@@ -58,9 +58,9 @@ array(9) {
   string(4) " GMT"
 }
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 array(9) {
   ["tm_sec"]=>
   int(0)
@@ -82,9 +82,9 @@ array(9) {
   string(0) ""
 }
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 array(9) {
   ["tm_sec"]=>
   int(0)

--- a/ext/standard/tests/time/strptime_error.phpt
+++ b/ext/standard/tests/time/strptime_error.phpt
@@ -23,5 +23,5 @@ var_dump( strptime('foo', $format) );
 
 -- Testing strptime() function on failure --
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 bool(false)

--- a/ext/standard/tests/time/strptime_parts.phpt
+++ b/ext/standard/tests/time/strptime_parts.phpt
@@ -50,9 +50,9 @@ setlocale(LC_ALL, $orig);
 --EXPECTF--
 *** Testing strptime() : basic functionality ***
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 int(20)
 int(1)
 int(10)
@@ -60,9 +60,9 @@ int(2)
 int(6)
 int(63)
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 int(20)
 int(1)
 int(10)
@@ -70,9 +70,9 @@ int(2)
 int(6)
 int(163)
 
-Deprecated: Function strftime() is deprecated in %s on line %d
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in %s on line %d
 
-Deprecated: Function strptime() is deprecated in %s on line %d
+Deprecated: Function strptime() is deprecated since 8.2, use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead in %s on line %d
 int(0)
 int(1)
 int(10)

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3168,6 +3168,8 @@ static PHP_MINIT_FUNCTION(zip)
 
 	php_register_url_stream_wrapper("zip", &php_stream_zip_wrapper);
 
+	register_php_zip_symbols(module_number);
+
 	le_zip_dir   = zend_register_list_destructors_ex(php_zip_free_dir,   NULL, le_zip_dir_name,   module_number);
 	le_zip_entry = zend_register_list_destructors_ex(php_zip_free_entry, NULL, le_zip_entry_name, module_number);
 

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -4,64 +4,64 @@
 
 /**
  * @return resource|int|false
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::open() instead')]
 function zip_open(string $filename) {}
 
 /**
  * @param resource $zip
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::close() instead')]
 function zip_close($zip): void {}
 
 /**
  * @param resource $zip
  * @return resource|false
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]
 function zip_read($zip) {}
 
 /**
  * @param resource $zip_dp
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0')]
 function zip_entry_open($zip_dp, $zip_entry, string $mode = "rb"): bool {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0')]
 function zip_entry_close($zip_entry): bool {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::getFromIndex() instead')]
 function zip_entry_read($zip_entry, int $len = 1024): string|false {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]
 function zip_entry_name($zip_entry): string|false {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]
 function zip_entry_compressedsize($zip_entry): int|false {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]
 function zip_entry_filesize($zip_entry): int|false {}
 
 /**
  * @param resource $zip_entry
- * @deprecated
  */
+#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]
 function zip_entry_compressionmethod($zip_entry): string|false {}
 
 class ZipArchive implements Countable
@@ -109,8 +109,8 @@ class ZipArchive implements Countable
 #ifdef ZIP_FL_RECOMPRESS
     /**
      * @cvalue ZIP_FL_RECOMPRESS
-     * @deprecated
      */
+    #[\Deprecated(since: '8.3')]
     public const int FL_RECOMPRESS = UNKNOWN;
 #endif
     /**

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 95564c667a51a548f5d43025c90546b991970ddd */
+ * Stub hash: 2b8e40ec2fc17effac1c0acc97bf860ab7e27399 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -497,6 +497,120 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_FE_END
 };
 
+static void register_php_zip_symbols(int module_number)
+{
+
+	zend_attribute *attribute_Deprecated_func_zip_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_open", sizeof("zip_open") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_open_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_open_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_open_0_arg0, attribute_Deprecated_func_zip_open_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_open_0->args[0].value, &attribute_Deprecated_func_zip_open_0_arg0);
+	attribute_Deprecated_func_zip_open_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_open_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_open_0_arg1_str = zend_string_init("use ZipArchive::open() instead", strlen("use ZipArchive::open() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_open_0_arg1, attribute_Deprecated_func_zip_open_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_open_0->args[1].value, &attribute_Deprecated_func_zip_open_0_arg1);
+	attribute_Deprecated_func_zip_open_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_close", sizeof("zip_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_close_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_close_0_arg0, attribute_Deprecated_func_zip_close_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_close_0->args[0].value, &attribute_Deprecated_func_zip_close_0_arg0);
+	attribute_Deprecated_func_zip_close_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_close_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_close_0_arg1_str = zend_string_init("use ZipArchive::close() instead", strlen("use ZipArchive::close() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_close_0_arg1, attribute_Deprecated_func_zip_close_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_close_0->args[1].value, &attribute_Deprecated_func_zip_close_0_arg1);
+	attribute_Deprecated_func_zip_close_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_read", sizeof("zip_read") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_read_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_read_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_read_0_arg0, attribute_Deprecated_func_zip_read_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_read_0->args[0].value, &attribute_Deprecated_func_zip_read_0_arg0);
+	attribute_Deprecated_func_zip_read_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_read_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_read_0_arg1_str = zend_string_init("use ZipArchive::statIndex() instead", strlen("use ZipArchive::statIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_read_0_arg1, attribute_Deprecated_func_zip_read_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_read_0->args[1].value, &attribute_Deprecated_func_zip_read_0_arg1);
+	attribute_Deprecated_func_zip_read_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_open", sizeof("zip_entry_open") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_zip_entry_open_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_open_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_open_0_arg0, attribute_Deprecated_func_zip_entry_open_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_open_0->args[0].value, &attribute_Deprecated_func_zip_entry_open_0_arg0);
+	attribute_Deprecated_func_zip_entry_open_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_close", sizeof("zip_entry_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_func_zip_entry_close_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_close_0_arg0, attribute_Deprecated_func_zip_entry_close_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_close_0->args[0].value, &attribute_Deprecated_func_zip_entry_close_0_arg0);
+	attribute_Deprecated_func_zip_entry_close_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_read", sizeof("zip_entry_read") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_entry_read_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_read_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_read_0_arg0, attribute_Deprecated_func_zip_entry_read_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_read_0->args[0].value, &attribute_Deprecated_func_zip_entry_read_0_arg0);
+	attribute_Deprecated_func_zip_entry_read_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_entry_read_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_entry_read_0_arg1_str = zend_string_init("use ZipArchive::getFromIndex() instead", strlen("use ZipArchive::getFromIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_read_0_arg1, attribute_Deprecated_func_zip_entry_read_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_read_0->args[1].value, &attribute_Deprecated_func_zip_entry_read_0_arg1);
+	attribute_Deprecated_func_zip_entry_read_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_name", sizeof("zip_entry_name") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_entry_name_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_name_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_name_0_arg0, attribute_Deprecated_func_zip_entry_name_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_name_0->args[0].value, &attribute_Deprecated_func_zip_entry_name_0_arg0);
+	attribute_Deprecated_func_zip_entry_name_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_entry_name_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_entry_name_0_arg1_str = zend_string_init("use ZipArchive::statIndex() instead", strlen("use ZipArchive::statIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_name_0_arg1, attribute_Deprecated_func_zip_entry_name_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_name_0->args[1].value, &attribute_Deprecated_func_zip_entry_name_0_arg1);
+	attribute_Deprecated_func_zip_entry_name_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_compressedsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressedsize", sizeof("zip_entry_compressedsize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_entry_compressedsize_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_compressedsize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressedsize_0_arg0, attribute_Deprecated_func_zip_entry_compressedsize_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_compressedsize_0->args[0].value, &attribute_Deprecated_func_zip_entry_compressedsize_0_arg0);
+	attribute_Deprecated_func_zip_entry_compressedsize_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_entry_compressedsize_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_entry_compressedsize_0_arg1_str = zend_string_init("use ZipArchive::statIndex() instead", strlen("use ZipArchive::statIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressedsize_0_arg1, attribute_Deprecated_func_zip_entry_compressedsize_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_compressedsize_0->args[1].value, &attribute_Deprecated_func_zip_entry_compressedsize_0_arg1);
+	attribute_Deprecated_func_zip_entry_compressedsize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_filesize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_filesize", sizeof("zip_entry_filesize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_entry_filesize_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_filesize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_filesize_0_arg0, attribute_Deprecated_func_zip_entry_filesize_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_filesize_0->args[0].value, &attribute_Deprecated_func_zip_entry_filesize_0_arg0);
+	attribute_Deprecated_func_zip_entry_filesize_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_entry_filesize_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_entry_filesize_0_arg1_str = zend_string_init("use ZipArchive::statIndex() instead", strlen("use ZipArchive::statIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_filesize_0_arg1, attribute_Deprecated_func_zip_entry_filesize_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_filesize_0->args[1].value, &attribute_Deprecated_func_zip_entry_filesize_0_arg1);
+	attribute_Deprecated_func_zip_entry_filesize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_zip_entry_compressionmethod_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressionmethod", sizeof("zip_entry_compressionmethod") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0;
+	zend_string *attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0, attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_compressionmethod_0->args[0].value, &attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0);
+	attribute_Deprecated_func_zip_entry_compressionmethod_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_zip_entry_compressionmethod_0_arg1;
+	zend_string *attribute_Deprecated_func_zip_entry_compressionmethod_0_arg1_str = zend_string_init("use ZipArchive::statIndex() instead", strlen("use ZipArchive::statIndex() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressionmethod_0_arg1, attribute_Deprecated_func_zip_entry_compressionmethod_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_compressionmethod_0->args[1].value, &attribute_Deprecated_func_zip_entry_compressionmethod_0_arg1);
+	attribute_Deprecated_func_zip_entry_compressionmethod_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+}
+
 static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry_Countable)
 {
 	zend_class_entry ce, *class_entry;
@@ -565,7 +679,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_FL_RECOMPRESS_value;
 	ZVAL_LONG(&const_FL_RECOMPRESS_value, ZIP_FL_RECOMPRESS);
 	zend_string *const_FL_RECOMPRESS_name = zend_string_init_interned("FL_RECOMPRESS", sizeof("FL_RECOMPRESS") - 1, 1);
-	zend_declare_typed_class_constant(class_entry, const_FL_RECOMPRESS_name, &const_FL_RECOMPRESS_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_class_constant *const_FL_RECOMPRESS = zend_declare_typed_class_constant(class_entry, const_FL_RECOMPRESS_name, &const_FL_RECOMPRESS_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_RECOMPRESS_name);
 #endif
 
@@ -1277,6 +1391,16 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *property_comment_name = zend_string_init("comment", sizeof("comment") - 1, 1);
 	zend_declare_typed_property(class_entry, property_comment_name, &property_comment_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_comment_name);
+
+#if defined(ZIP_FL_RECOMPRESS)
+
+	zend_attribute *attribute_Deprecated_const_FL_RECOMPRESS_0 = zend_add_class_constant_attribute(class_entry, const_FL_RECOMPRESS, ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
+	zval attribute_Deprecated_const_FL_RECOMPRESS_0_arg0;
+	zend_string *attribute_Deprecated_const_FL_RECOMPRESS_0_arg0_str = zend_string_init("8.3", strlen("8.3"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_FL_RECOMPRESS_0_arg0, attribute_Deprecated_const_FL_RECOMPRESS_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_FL_RECOMPRESS_0->args[0].value, &attribute_Deprecated_const_FL_RECOMPRESS_0_arg0);
+	attribute_Deprecated_const_FL_RECOMPRESS_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setpassword", sizeof("setpassword") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);

--- a/ext/zip/tests/bug7214.phpt
+++ b/ext/zip/tests/bug7214.phpt
@@ -17,13 +17,13 @@ if (strlen($contents) == zip_entry_filesize($entry)) {
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_read() is deprecated in %s on line %d
+Deprecated: Function zip_entry_read() is deprecated since 8.0, use ZipArchive::getFromIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 Ok

--- a/ext/zip/tests/doubleclose.phpt
+++ b/ext/zip/tests/doubleclose.phpt
@@ -38,12 +38,12 @@ Done
 --EXPECTF--
 Procedural
 
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
 NULL
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
 zip_close(): supplied resource is not a valid Zip Directory resource
 Object
 bool(true)

--- a/ext/zip/tests/oo_setcompression.phpt
+++ b/ext/zip/tests/oo_setcompression.phpt
@@ -61,57 +61,57 @@ bool(true)
 bool(true)
 bool(true)
 
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry1.txt: deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry2.txt: deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 dir/entry3.txt: stored
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry4.txt: deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry5.txt: stored
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry6.txt: deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry7.txt: deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_close.phpt
+++ b/ext/zip/tests/zip_close.phpt
@@ -11,7 +11,7 @@ echo "OK";
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
 OK

--- a/ext/zip/tests/zip_entry_close.phpt
+++ b/ext/zip/tests/zip_entry_close.phpt
@@ -17,18 +17,18 @@ zip_close($zip);
 ?>
 Done
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 entry_open:  
-Deprecated: Function zip_entry_open() is deprecated in %s on line %d
+Deprecated: Function zip_entry_open() is deprecated since 8.0 in %s on line %d
 bool(true)
 entry_close: 
-Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+Deprecated: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
 bool(true)
 entry_close: 
-Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+Deprecated: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
 zip_entry_close(): supplied resource is not a valid Zip Entry resource
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
 Done

--- a/ext/zip/tests/zip_entry_compressedsize.phpt
+++ b/ext/zip/tests/zip_entry_compressedsize.phpt
@@ -14,28 +14,28 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 5
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 4
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 0
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressedsize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 24
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_entry_compressionmethod.phpt
+++ b/ext/zip/tests/zip_entry_compressionmethod.phpt
@@ -14,28 +14,28 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 stored
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 stored
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 stored
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_compressionmethod() is deprecated in %s on line %d
+Deprecated: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 deflated
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_entry_filesize.phpt
+++ b/ext/zip/tests/zip_entry_filesize.phpt
@@ -14,28 +14,28 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 5
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 4
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 0
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_filesize() is deprecated in %s on line %d
+Deprecated: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 27
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_entry_name.phpt
+++ b/ext/zip/tests/zip_entry_name.phpt
@@ -14,28 +14,28 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 foo
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 bar
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 foobar/
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+Deprecated: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 foobar/baz
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_entry_open.phpt
+++ b/ext/zip/tests/zip_entry_open.phpt
@@ -12,12 +12,12 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_open() is deprecated in %s on line %d
+Deprecated: Function zip_entry_open() is deprecated since 8.0 in %s on line %d
 OK
-Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+Deprecated: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_entry_read.phpt
+++ b/ext/zip/tests/zip_entry_read.phpt
@@ -13,16 +13,16 @@ zip_close($zip);
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_entry_open() is deprecated in %s on line %d
+Deprecated: Function zip_entry_open() is deprecated since 8.0 in %s on line %d
 
-Deprecated: Function zip_entry_read() is deprecated in %s on line %d
+Deprecated: Function zip_entry_read() is deprecated since 8.0, use ZipArchive::getFromIndex() instead in %s on line %d
 foo
 
 
-Deprecated: Function zip_entry_close() is deprecated in %s on line %d
+Deprecated: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d

--- a/ext/zip/tests/zip_open.phpt
+++ b/ext/zip/tests/zip_open.phpt
@@ -10,5 +10,5 @@ echo is_resource($zip) ? "OK" : "Failure";
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 OK

--- a/ext/zip/tests/zip_open_error.phpt
+++ b/ext/zip/tests/zip_open_error.phpt
@@ -20,9 +20,9 @@ echo is_resource($zip) ? "OK" : "Failure";
 ?>
 --EXPECTF--
 Test case 1:
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 zip_open(): Argument #1 ($filename) cannot be empty
 Test case 2:
 
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 Failure

--- a/ext/zip/tests/zip_read.phpt
+++ b/ext/zip/tests/zip_read.phpt
@@ -15,17 +15,17 @@ echo "$entries entries";
 
 ?>
 --EXPECTF--
-Deprecated: Function zip_open() is deprecated in %s on line %d
+Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_read() is deprecated in %s on line %d
+Deprecated: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
 
-Deprecated: Function zip_close() is deprecated in %s on line %d
+Deprecated: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
 4 entries


### PR DESCRIPTION
This is spun out of and depends on #11293.