### PR TITLE
Use pattern tags for NDBM ext/dba/tests

### DIFF
--- a/ext/dba/tests/dba_ndbm.phpt
+++ b/ext/dba/tests/dba_ndbm.phpt
@@ -26,11 +26,11 @@ cleanup_standard_db($db_name);
 --EXPECT--
 === RUNNING WITH FILE LOCK ===
 
-Notice: dba_open(): Handler ndbm does locking internally in /home/girgias/Dev/php-src/ext/dba/tests/setup/setup_dba_tests.inc on line 40
+Notice: dba_open(): Handler ndbm does locking internally in %s on line %d
 
-Notice: dba_open(): Handler ndbm does locking internally in /home/girgias/Dev/php-src/ext/dba/tests/setup/setup_dba_tests.inc on line 40
+Notice: dba_open(): Handler ndbm does locking internally in %s on line %d
 
-Notice: dba_open(): Handler ndbm does locking internally in /home/girgias/Dev/php-src/ext/dba/tests/setup/setup_dba_tests.inc on line 82
+Notice: dba_open(): Handler ndbm does locking internally in %s on line %d
 Remove key 1 and 3
 bool(true)
 bool(true)
@@ -61,7 +61,7 @@ bool(true)
 Fetch "key2": Content 2 replaced 2nd time
 Fetch "key number 6": The 6th value
 
-Notice: dba_open(): Handler ndbm does locking internally in /home/girgias/Dev/php-src/ext/dba/tests/setup/setup_dba_tests.inc on line 149
+Notice: dba_open(): Handler ndbm does locking internally in %s on line %d
 array(6) {
   ["[key10]name10"]=>
   string(17) "Content String 10"
@@ -122,5 +122,5 @@ array(6) {
 }
 === RUNNING WITH NO LOCK ===
 
-Warning: dba_open(): Locking cannot be disabled for handler ndbm in /home/girgias/Dev/php-src/ext/dba/tests/setup/setup_dba_tests.inc on line 40
+Warning: dba_open(): Locking cannot be disabled for handler ndbm in %s on line %d
 Failed to create DB


### PR DESCRIPTION
Targeting PHP-8.2 branch here. This matches the patterns in other ext/dba tests.