### PR TITLE
Autotools: Remove unused PHPDBG_SHARED compile definition

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -92,7 +92,6 @@ if test "$PHP_PHPDBG" != "no"; then
                 \$(EXTRA_LIBS) \
                 \$(PHPDBG_EXTRA_LIBS) \
                 \$(ZEND_EXTRA_LIBS) \
-                \-DPHPDBG_SHARED \
          -o \$(BUILD_SHARED)"
 
   PHP_SUBST([PHPDBG_EXTRA_LIBS])


### PR DESCRIPTION
There was also redundant backslash escaping.