### PR TITLE
Autotools: Simplify SAPI configure log check messages

### DIFF
--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -1,11 +1,10 @@
-PHP_ARG_WITH([apxs2],,
+PHP_ARG_WITH([apxs2],
+  [whether to build Apache 2 handler module support via DSO through APXS],
   [AS_HELP_STRING([[--with-apxs2[=FILE]]],
     [Build shared Apache 2 handler module. FILE is the optional pathname to
     the Apache apxs tool [apxs]])],
   [no],
   [no])
-
-AC_MSG_CHECKING([for Apache 2 handler module support via DSO through APXS])
 
 if test "$PHP_APXS2" != "no"; then
   if test "$PHP_APXS2" = "yes"; then
@@ -118,7 +117,4 @@ if test "$PHP_APXS2" != "no"; then
       PHP_BUILD_THREAD_SAFE
     fi
   fi
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
 fi

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -1,14 +1,11 @@
-PHP_ARG_ENABLE([cgi],,
+PHP_ARG_ENABLE([cgi],
+  [for CGI build],
   [AS_HELP_STRING([--disable-cgi],
     [Disable building CGI version of PHP])],
   [yes],
   [no])
 
-dnl CGI setup.
-AC_MSG_CHECKING(for CGI build)
 if test "$PHP_CGI" != "no"; then
-    AC_MSG_RESULT(yes)
-
     dnl BSD systems.
     AC_CHECK_MEMBERS([struct sockaddr_un.sun_len],,,[#include <sys/un.h>])
 
@@ -59,6 +56,4 @@ if test "$PHP_CGI" != "no"; then
     PHP_SUBST([BUILD_CGI])
 
     PHP_OUTPUT(sapi/cgi/php-cgi.1)
-else
-  AC_MSG_RESULT(no)
 fi

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -1,4 +1,5 @@
-PHP_ARG_ENABLE([cli],,
+PHP_ARG_ENABLE([cli],
+  [for CLI build],
   [AS_HELP_STRING([--disable-cli],
     [Disable building CLI version of PHP (this forces --without-pear)])],
   [yes],
@@ -20,7 +21,6 @@ if test "$cli_cv_var_PS_STRINGS" = yes ; then
   AC_DEFINE([HAVE_PS_STRINGS], [], [Define to 1 if the PS_STRINGS thing exists.])
 fi
 
-AC_MSG_CHECKING(for CLI build)
 if test "$PHP_CLI" != "no"; then
   PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/cli/Makefile.frag)
 
@@ -57,4 +57,3 @@ if test "$PHP_CLI" != "no"; then
 
   PHP_INSTALL_HEADERS([sapi/cli], [cli.h])
 fi
-AC_MSG_RESULT($PHP_CLI)

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -31,5 +31,5 @@ if test "$PHP_EMBED" != "no"; then
   AC_MSG_RESULT([$PHP_EMBED_TYPE])
   AC_SUBST([PHP_EMBED_TYPE])
 else
-  AC_MSG_RESULT(no)
+  AC_MSG_RESULT([no])
 fi

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -1,4 +1,5 @@
-PHP_ARG_ENABLE([fpm],,
+PHP_ARG_ENABLE([fpm],
+  [for FPM build],
   [AS_HELP_STRING([--enable-fpm],
     [Enable building of the fpm SAPI executable])],
   [no],
@@ -416,10 +417,7 @@ AS_VAR_IF([php_cv_have_select], [yes],
     [Define to 1 if system has a working 'select' function.])])
 ])
 
-AC_MSG_CHECKING(for FPM build)
 if test "$PHP_FPM" != "no"; then
-  AC_MSG_RESULT($PHP_FPM)
-
   PHP_FPM_CLOCK
   PHP_FPM_TRACE
   PHP_FPM_BUILTIN_ATOMIC
@@ -635,7 +633,4 @@ if test "$PHP_FPM" != "no"; then
 
   PHP_SUBST([SAPI_FPM_PATH])
   PHP_SUBST([BUILD_FPM])
-
-else
-  AC_MSG_RESULT(no)
 fi

--- a/sapi/litespeed/config.m4
+++ b/sapi/litespeed/config.m4
@@ -1,6 +1,5 @@
-AC_MSG_CHECKING(for LiteSpeed support)
-
-PHP_ARG_ENABLE([litespeed],,
+PHP_ARG_ENABLE([litespeed],
+  [for LiteSpeed support],
   [AS_HELP_STRING([--enable-litespeed],
     [Build PHP as litespeed module])],
   [no])
@@ -25,5 +24,3 @@ if test "$PHP_LITESPEED" != "no"; then
   PHP_SUBST([SAPI_LITESPEED_PATH])
   PHP_SUBST([BUILD_LITESPEED])
 fi
-
-AC_MSG_RESULT($PHP_LITESPEED)


### PR DESCRIPTION
The PHP_ARG_ENABLE and PHP_ARG_WITH 2nd argument is the check message in the configure log output.