### PR TITLE
Autotools: Sync PHP_ADD_MAKEFILE_FRAGMENT

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -160,13 +160,16 @@ EOF
 ])
 
 dnl
-dnl PHP_ADD_MAKEFILE_FRAGMENT([srcfile [, ext_srcdir [, ext_builddir]]])
+dnl PHP_ADD_MAKEFILE_FRAGMENT([makefile [, srcdir [, builddir]]])
 dnl
 dnl Processes a file called Makefile.frag in the source directory of the most
 dnl recently added extension. $(srcdir) and $(builddir) are substituted with the
 dnl proper paths. Can be used to supply custom rules and/or additional targets.
+dnl For extensions, call this macro after the PHP_NEW_EXTENSION to get these
+dnl variables substituted automatically, elsewhere pass the Makefile path
+dnl "makefile" and optionally adjust "srcdir" and "builddir".
 dnl
-AC_DEFUN([PHP_ADD_MAKEFILE_FRAGMENT],[
+AC_DEFUN([PHP_ADD_MAKEFILE_FRAGMENT], [dnl
   ifelse($1,,src=$ext_srcdir/Makefile.frag,src=$1)
   ifelse($2,,ac_srcdir=$ext_srcdir,ac_srcdir=$2)
   ifelse($3,,ac_builddir=$ext_builddir,ac_builddir=$3)

--- a/configure.ac
+++ b/configure.ac
@@ -814,7 +814,7 @@ if test "$PHP_GCOV" = "yes"; then
   fi
 
   AC_DEFINE(HAVE_GCOV, 1, [Whether you have gcov])
-  PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/build/Makefile.gcov, $abs_srcdir)
+  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/build/Makefile.gcov], [$abs_srcdir])
 
   dnl Remove all optimization flags from CFLAGS.
   changequote({,})
@@ -1781,8 +1781,12 @@ PHP_ADD_SOURCES([Zend], [m4_normalize([
 ])],
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $fiber_asm_cflag])
 
-PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/scripts/Makefile.frag,$abs_srcdir/scripts,scripts)
-PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Zend/Makefile.frag,$abs_srcdir/Zend,Zend)
+PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/scripts/Makefile.frag],
+  [$abs_srcdir/scripts],
+  [scripts])
+PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/Zend/Makefile.frag],
+  [$abs_srcdir/Zend],
+  [Zend])
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -5,4 +5,4 @@ PHP_NEW_EXTENSION(json,
   json_scanner.c,
   no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
-PHP_ADD_MAKEFILE_FRAGMENT()
+PHP_ADD_MAKEFILE_FRAGMENT

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -348,7 +348,7 @@ int main(void) {
   if test "$PHP_OPCACHE_JIT" = "yes"; then
     PHP_ADD_BUILD_DIR([$ext_builddir/jit], 1)
     PHP_ADD_BUILD_DIR([$ext_builddir/jit/ir], 1)
-    PHP_ADD_MAKEFILE_FRAGMENT($ext_srcdir/jit/Makefile.frag)
+    PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/jit/Makefile.frag])
   fi
   PHP_SUBST(OPCACHE_SHARED_LIBADD)
 fi

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -24,7 +24,7 @@ if test "$PHP_CGI" != "no"; then
       ;;
     esac
 
-    PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/cgi/Makefile.frag)
+    PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/cgi/Makefile.frag])
 
     dnl Set filename.
     case $host_alias in

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -22,7 +22,7 @@ fi
 
 AC_MSG_CHECKING(for CLI build)
 if test "$PHP_CLI" != "no"; then
-  PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/cli/Makefile.frag)
+  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/cli/Makefile.frag])
 
   dnl Set filename.
   SAPI_CLI_PATH=sapi/cli/php

--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -27,7 +27,7 @@ if test "$PHP_FUZZER" != "no"; then
   dnl Don't use PHP_REQUIRE_CXX() to avoid unnecessarily pulling in -lstdc++
   AC_PROG_CXX
   AC_PROG_CXXCPP
-  PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/fuzzer/Makefile.frag)
+  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/fuzzer/Makefile.frag])
   SAPI_FUZZER_PATH=sapi/fuzzer
   PHP_SUBST([SAPI_FUZZER_PATH])
   if test -z "$LIB_FUZZING_ENGINE"; then

--- a/sapi/litespeed/config.m4
+++ b/sapi/litespeed/config.m4
@@ -6,7 +6,9 @@ PHP_ARG_ENABLE([litespeed],,
   [no])
 
 if test "$PHP_LITESPEED" != "no"; then
-  PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/sapi/litespeed/Makefile.frag,$abs_srcdir/sapi/litespeed,sapi/litespeed)
+  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/litespeed/Makefile.frag],
+    [$abs_srcdir/sapi/litespeed],
+    [sapi/litespeed])
   SAPI_LITESPEED_PATH=sapi/litespeed/php
   PHP_SELECT_SAPI(litespeed, program, lsapi_main.c lsapilib.c, "", '$(SAPI_LITESPEED_PATH)')
   case $host_alias in

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -67,7 +67,9 @@ if test "$PHP_PHPDBG" != "no"; then
     fi
   ],,[#include <linux/userfaultfd.h>])
 
-  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/phpdbg/Makefile.frag], [$abs_srcdir/sapi/phpdbg], [$abs_builddir/sapi/phpdbg])
+  PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/phpdbg/Makefile.frag],
+    [$abs_srcdir/sapi/phpdbg],
+    [$abs_builddir/sapi/phpdbg])
   PHP_SELECT_SAPI(phpdbg, program, $PHP_PHPDBG_FILES, $PHP_PHPDBG_CFLAGS, [$(SAPI_PHPDBG_PATH)])
 
   BUILD_BINARY="sapi/phpdbg/phpdbg"


### PR DESCRIPTION
- Macro help text updated for extensions and general usage
- Arguments quoted
- dnl removes redundant newlines in the generated configure script