### PR TITLE
ext/pcntl: pcntl_exec add open_basedir restriction check.

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -42,6 +42,8 @@ ZEND_API zend_class_entry *zend_ce_value_error;
 ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 ZEND_API zend_class_entry *zend_ce_unhandled_match_error;
+ZEND_API zend_class_entry *zend_ce_access_error;
+ZEND_API zend_class_entry *zend_ce_openbasedir_access_error;
 ZEND_API zend_class_entry *zend_ce_request_parse_body_exception;
 
 /* Internal pseudo-exception that is not exposed to userland. Throwing this exception *does not* execute finally blocks. */
@@ -787,6 +789,12 @@ void zend_register_default_exception(void) /* {{{ */
 
 	zend_ce_unhandled_match_error = register_class_UnhandledMatchError(zend_ce_error);
 	zend_init_exception_class_entry(zend_ce_unhandled_match_error);
+
+	zend_ce_access_error = register_class_AccessError(zend_ce_error);
+	zend_init_exception_class_entry(zend_ce_access_error);
+
+	zend_ce_openbasedir_access_error = register_class_OpenbasedirAccessError(zend_ce_access_error);
+	zend_init_exception_class_entry(zend_ce_openbasedir_access_error);
 
 	zend_ce_request_parse_body_exception = register_class_RequestParseBodyException(zend_ce_exception);
 	zend_init_exception_class_entry(zend_ce_request_parse_body_exception);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -38,6 +38,8 @@ extern ZEND_API zend_class_entry *zend_ce_value_error;
 extern ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 extern ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 extern ZEND_API zend_class_entry *zend_ce_unhandled_match_error;
+extern ZEND_API zend_class_entry *zend_ce_access_error;
+extern ZEND_API zend_class_entry *zend_ce_openbasedir_access_error;
 extern ZEND_API zend_class_entry *zend_ce_request_parse_body_exception;
 
 ZEND_API void zend_exception_set_previous(zend_object *exception, zend_object *add_previous);

--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -171,6 +171,14 @@ class UnhandledMatchError extends Error
 {
 }
 
+class AccessError extends Error
+{
+}
+
+class OpenbasedirAccessError extends AccessError
+{
+}
+
 class RequestParseBodyException extends Exception
 {
 }

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ba1562ca8fe2fe48c40bc52d10545aa989afd86c */
+ * Stub hash: 53cd20dcbbc630997ed07c00c52d79676d562438 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -171,6 +171,14 @@ static const zend_function_entry class_DivisionByZeroError_methods[] = {
 };
 
 static const zend_function_entry class_UnhandledMatchError_methods[] = {
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_AccessError_methods[] = {
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_OpenbasedirAccessError_methods[] = {
 	ZEND_FE_END
 };
 
@@ -389,6 +397,26 @@ static zend_class_entry *register_class_UnhandledMatchError(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "UnhandledMatchError", class_UnhandledMatchError_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_Error);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_AccessError(zend_class_entry *class_entry_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "AccessError", class_AccessError_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_Error);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_OpenbasedirAccessError(zend_class_entry *class_entry_AccessError)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "OpenbasedirAccessError", class_OpenbasedirAccessError_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_AccessError);
 
 	return class_entry;
 }

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -599,6 +599,11 @@ PHP_FUNCTION(pcntl_exec)
 		Z_PARAM_ARRAY(envs)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (php_check_open_basedir_ex(path, 0)) {
+		zend_argument_value_error(1, "open_basedir restriction in effect.");
+		RETURN_THROWS();
+	}
+
 	if (ZEND_NUM_ARGS() > 1) {
 		/* Build argument list */
 		SEPARATE_ARRAY(args);

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -32,6 +32,7 @@
 #include "php_pcntl.h"
 #include "php_signal.h"
 #include "php_ticks.h"
+#include "zend_exceptions.h"
 #include "zend_fibers.h"
 
 #if defined(HAVE_GETPRIORITY) || defined(HAVE_SETPRIORITY) || defined(HAVE_WAIT3)
@@ -600,7 +601,8 @@ PHP_FUNCTION(pcntl_exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (php_check_open_basedir_ex(path, 0)) {
-		zend_argument_value_error(1, "open_basedir restriction in effect.");
+		// TODO we may generalise the following with a new handy specialised call
+		zend_argument_error(zend_ce_openbasedir_access_error, 1, "open_basedir restriction in effect for the path `%s`.", path);
 		RETURN_THROWS();
 	}
 

--- a/ext/pcntl/tests/pcntl_exec_restrict.phpt
+++ b/ext/pcntl/tests/pcntl_exec_restrict.phpt
@@ -1,0 +1,21 @@
+--TEST--
+pcntl_exec() - Testing with open_basedir restriction.
+--EXTENSIONS--
+pcntl
+--INI--
+open_basedir=${HOME}/bin
+--SKIPIF--
+<?php
+if (!getenv("TEST_PHP_EXECUTABLE") || !is_executable(getenv("TEST_PHP_EXECUTABLE"))) die("skip TEST_PHP_EXECUTABLE not set");
+?>
+--FILE--
+<?php
+try {
+    pcntl_exec(getenv("TEST_PHP_EXECUTABLE"), ['-n', new stdClass()]);
+} catch (Error $error) {
+    echo $error->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+pcntl_exec(): Argument #1 ($path) open_basedir restriction in effect.

--- a/ext/pcntl/tests/pcntl_exec_restrict.phpt
+++ b/ext/pcntl/tests/pcntl_exec_restrict.phpt
@@ -3,7 +3,7 @@ pcntl_exec() - Testing with open_basedir restriction.
 --EXTENSIONS--
 pcntl
 --INI--
-open_basedir=${HOME}/bin
+open_basedir=${HOME}/authorizedbins
 --SKIPIF--
 <?php
 if (!getenv("TEST_PHP_EXECUTABLE") || !is_executable(getenv("TEST_PHP_EXECUTABLE"))) die("skip TEST_PHP_EXECUTABLE not set");
@@ -12,10 +12,10 @@ if (!getenv("TEST_PHP_EXECUTABLE") || !is_executable(getenv("TEST_PHP_EXECUTABLE
 <?php
 try {
     pcntl_exec(getenv("TEST_PHP_EXECUTABLE"), ['-n', new stdClass()]);
-} catch (Error $error) {
-    echo $error->getMessage() . "\n";
+} catch (OpenbasedirAccessError $error) {
+    echo $error->getMessage();
 }
 
 ?>
---EXPECT--
-pcntl_exec(): Argument #1 ($path) open_basedir restriction in effect.
+--EXPECTF--
+pcntl_exec(): Argument #1 ($path) open_basedir restriction in effect for the path `%s`.


### PR DESCRIPTION
if the admin wants to disallow relative path or other unauthorized accesses.