### PR TITLE
Improve open/close tag handling for phpdbg + stdin

### DIFF
--- a/sapi/phpdbg/tests/stdin_002.phpt
+++ b/sapi/phpdbg/tests/stdin_002.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test stdin input with strict types
+--PHPDBG--
+stdin foo
+<?php
+declare(strict_types=1);
+echo "Hello, world!\n";
+foo
+b 3
+r
+c
+r
+q
+--EXPECT--
+prompt> [Successful compilation of stdin input]
+prompt> [Breakpoint #0 added at Standard input code:3]
+prompt> [Breakpoint #0 at Standard input code:3, hits: 1]
+>00003: echo "Hello, world!\n";
+ 00004: 
+prompt> Hello, world!
+[Script ended normally]
+prompt> [Breakpoint #0 at Standard input code:3, hits: 1]
+>00003: echo "Hello, world!\n";
+ 00004: 
+prompt> 


### PR DESCRIPTION
/cc @devnexen

phpdbg currently always compiles scripts with the `ZEND_COMPILE_POSITION_AFTER_OPEN_TAG` flag. To allow loading scripts through stdin that start with `<?php`, it would prepend a `?>` to the source. This would implicitly turn into `?>` into `;`, which are not allowed before `declare(strict_types=1)`.