### PR TITLE
Fix GH-14775: range overflow on negative step.

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2887,6 +2887,10 @@ PHP_FUNCTION(range)
 			step = Z_LVAL_P(user_step);
 			/* We only want positive step values. */
 			if (step < 0) {
+				if (UNEXPECTED(step == ZEND_LONG_MIN)) {
+					zend_argument_value_error(3, "must be greater than " ZEND_LONG_FMT, step);
+					RETURN_THROWS();
+				}
 				is_step_negative = true;
 				step *= -1;
 			}

--- a/ext/standard/tests/array/gh14775.phpt
+++ b/ext/standard/tests/array/gh14775.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-14775: Range negative step overflow
+--FILE--
+<?php
+$var = -PHP_INT_MAX - 1;
+try {
+	range($var,1,$var);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+--EXPECTF--
+range(): Argument #3 ($step) must be greater than %s


### PR DESCRIPTION
overflow occurs since we only deal with positive steps.