### PR TITLE
Refactor HAVE_GETIFADDRS checks

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2191,7 +2191,7 @@ function getmxrr(string $hostname, &$hosts, &$weights = null): bool {}
 
 /* net.c */
 
-#if (defined(PHP_WIN32) || HAVE_GETIFADDRS || defined(__PASE__))
+#if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
 function net_get_interfaces(): array|false {}
 #endif
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7d588414e84ed62088cd5b1c668b29c0e51d406f */
+ * Stub hash: 3a942ebd5d1011a6419217f9aa229b18c2ac0f83 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -674,7 +674,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_getmxrr arginfo_dns_get_mx
 #endif
 
-#if (defined(PHP_WIN32) || HAVE_GETIFADDRS || defined(__PASE__))
+#if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_net_get_interfaces, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 #endif
@@ -2516,7 +2516,7 @@ ZEND_FUNCTION(dns_get_record);
 #if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_FUNCTION(dns_get_mx);
 #endif
-#if (defined(PHP_WIN32) || HAVE_GETIFADDRS || defined(__PASE__))
+#if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
 ZEND_FUNCTION(net_get_interfaces);
 #endif
 #if defined(HAVE_FTOK)
@@ -3154,7 +3154,7 @@ static const zend_function_entry ext_functions[] = {
 #if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_RAW_FENTRY("getmxrr", zif_dns_get_mx, arginfo_getmxrr, 0, NULL, NULL)
 #endif
-#if (defined(PHP_WIN32) || HAVE_GETIFADDRS || defined(__PASE__))
+#if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
 	ZEND_FE(net_get_interfaces, arginfo_net_get_interfaces)
 #endif
 #if defined(HAVE_FTOK)

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -390,22 +390,21 @@ AC_CHECK_HEADERS([net/if.h],,, [dnl
   #endif
 ])
 
-AC_MSG_CHECKING([for usable getifaddrs])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+AC_CACHE_CHECK([for usable getifaddrs], [php_cv_func_getifaddrs],
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([
   #include <sys/types.h>
   #include <ifaddrs.h>
-]],[[
+], [
   struct ifaddrs *interfaces;
   if (!getifaddrs(&interfaces)) {
-      freeifaddrs(interfaces);
+    freeifaddrs(interfaces);
   }
-]])], [ac_have_getifaddrs=yes], [ac_have_getifaddrs=no])
-if test "$ac_have_getifaddrs" = "yes" ; then
-  AC_DEFINE(HAVE_GETIFADDRS, 1, [whether getifaddrs is present and usable])
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
-fi
+])],
+[php_cv_func_getifaddrs=yes],
+[php_cv_func_getifaddrs=no])])
+AS_VAR_IF([php_cv_func_getifaddrs], [yes],
+  [AC_DEFINE([HAVE_GETIFADDRS], [1],
+    [Define to 1 if you have the 'getifaddrs' function.])])
 
 dnl
 dnl Setup extension sources

--- a/ext/standard/net.c
+++ b/ext/standard/net.c
@@ -261,7 +261,7 @@ PHP_FUNCTION(net_get_interfaces) {
 	FREE(pAddresses);
 #undef MALLOC
 #undef FREE
-#elif HAVE_GETIFADDRS || defined(__PASE__) /* !PHP_WIN32 */
+#elif defined(HAVE_GETIFADDRS) || defined(__PASE__) /* !PHP_WIN32 */
 	struct ifaddrs *addrs = NULL, *p;
 
 	ZEND_PARSE_PARAMETERS_NONE();


### PR DESCRIPTION
- AC_CACHE used with php_cv_func_getifaddrs cache variable
- Synced #if/ifdef/defined checks for HAVE_GETIFADDRS as it is either defined to 1 or undefined