### PR TITLE
ext/standard/tests: use %d instead of bytes in an overflow message

### DIFF
--- a/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
@@ -17,4 +17,4 @@ var_dump(chunk_split($a,$b,$c));
 --EXPECTF--
 *** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
 
-Fatal error: %rAllowed memory size of %d bytes exhausted%s\(tried to allocate %d bytes\)|Possible integer overflow in memory allocation \(4294901777 \+ 2097152\)%r in %s on line %d
+Fatal error: %rAllowed memory size of %d bytes exhausted%s\(tried to allocate %d bytes\)|Possible integer overflow in memory allocation \(4294901777 \+ %d\)%r in %s on line %d


### PR DESCRIPTION
In `strings/chunk_split_variation1_32bit.phpt`, we have a test that is expected to fail on x32 with a possible integer overflow error. The message reports the exact number of bytes -- a number big enough to overflow an int on x32 -- stemming from a memory allocation in `chunk_split()`.

This number appears unpredictable, and is not the point of the test. We replace it with `%d` to make the test independent of the allocation details.

(This fixes half of https://bugs.gentoo.org/935382)