### PR TITLE
Fix test race condition

### DIFF
--- a/ext/openssl/tests/gh13860.phpt
+++ b/ext/openssl/tests/gh13860.phpt
@@ -18,8 +18,8 @@ $serverCode = <<<'CODE'
 
     $client = @stream_socket_accept($server);
     if ($client) {
-        fwrite($client, "xx");
         phpt_wait();
+        fwrite($client, "xx");
         fclose($client);
         phpt_notify();
     }


### PR DESCRIPTION
There is a race condition in https://github.com/php/php-src/blob/ec277ce7fe1e7b7f98e270198826fc1432cdcb3d/ext/openssl/tests/gh13860.phpt: If the first `fread($fp, 2);` (line 36) is executed after `fwrite($client, "xx");`, the test hangs indefinitely in the loop: https://github.com/php/php-src/blob/ec277ce7fe1e7b7f98e270198826fc1432cdcb3d/ext/openssl/tests/gh13860.phpt#L39C1-L41C6

I've observed this on Alpine with a ZTS + ASAN build, in https://github.com/php/php-src/pull/13925, but adding a sleep() before the first fread() will also reproduce the issue.

Moving the `phpt_wait()` before `fwrite()` fixes the hang by ensuring that `fread($fp, 2);` executes before `fwrite()`. However I'm not sure this is still testing the right thing (although the test fails if I revert https://github.com/php/php-src/commit/2aae14c8a97d37239298b7c939c0cca5daeb4c9a).