### PR TITLE
Add PHP_SETUP_RE2C

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -140,6 +140,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbols HAVE_LIBRT and HAVE_TIMER_CREATE removed.
    - Symbols PHP_FPM_SYSTEMD, PHP_FPM_USER, and PHP_FPM_GROUP removed.
    - Symbol PTHREADS has been removed.
+   - New M4 macro PHP_SETUP_RE2C to use re2c lexer generator tool in PHP and
+     "phpized" extensions. M4 macro PHP_PROG_RE2C got a new 2nd argument to
+     define common default re2c command-line options substituted to the Makefile
+     RE2C_FLAGS variable.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
@@ -147,8 +151,6 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      AC_CHECK_MEMBERS).
    - M4 macro PHP_CHECK_GCC_ARG has been removed since PHP 8.0 (use
      AX_CHECK_COMPILE_FLAG).
-   - M4 macro PHP_PROG_RE2C got a new 2nd argument to define common default re2c
-     command-line options substituted to the Makefile RE2C_FLAGS variable.
    - Added php-config --lib-dir and --lib-embed options for PHP embed SAPI.
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.

--- a/build/php.m4
+++ b/build/php.m4
@@ -2019,6 +2019,46 @@ $2],
 ])])])])
 ])
 
+dnl
+dnl PHP_SETUP_RE2C
+dnl
+dnl Common setup macro for using re2c across the php-src build system and in
+dnl "phpized" extensions. Defined as one-shot macro (it is called only once).
+dnl Macro also adds a configure option --enable-re2c-cgoto which can append the
+dnl re2c's --computed-gotos (-g) option to optimize conditional jumps in lexer
+dnl files.
+dnl
+AC_DEFUN_ONCE([PHP_SETUP_RE2C], [dnl
+PHP_PROG_RE2C([1.0.3], [--no-generation-date])
+
+PHP_ARG_ENABLE([re2c-cgoto],
+  [whether to enable computed goto extension with re2c],
+  [AS_HELP_STRING([--enable-re2c-cgoto],
+    [Enable re2c -g flag to optimize conditional jumps using computed goto
+    extension, if supported by the compiler])],
+  [no],
+  [no])
+
+AS_VAR_IF([PHP_RE2C_CGOTO], [yes],
+[AC_CACHE_CHECK([whether re2c -g works], [php_cv_have_re2c_cgoto],
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+int main(void)
+{
+label1:
+  ;
+label2:
+  ;
+  static void *adr[] = { &&label1, &&label2 };
+  goto *adr[0];
+  return 0;
+}]])],
+  [php_cv_have_re2c_cgoto=yes],
+  [php_cv_have_re2c_cgoto=no])])
+AS_VAR_IF([php_cv_have_re2c_cgoto], [yes],
+  [AS_VAR_APPEND([RE2C_FLAGS], [" -g"])])
+])
+])
+
 dnl ----------------------------------------------------------------------------
 dnl Misc. macros
 dnl ----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -165,35 +165,8 @@ PHP_RUNPATH_SWITCH
 dnl Checks for some support/generator progs.
 PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
-PHP_PROG_RE2C([1.0.3], [--no-generation-date])
+PHP_SETUP_RE2C
 PHP_PROG_PHP()
-
-PHP_ARG_ENABLE([re2c-cgoto],
-  [whether to enable computed goto extension with re2c],
-  [AS_HELP_STRING([--enable-re2c-cgoto],
-    [Enable re2c -g flag to optimize conditional jumps using computed goto
-    extension, if supported by the compiler])],
-  [no],
-  [no])
-
-AS_VAR_IF([PHP_RE2C_CGOTO], [no],,
-[AC_CACHE_CHECK([whether re2c -g works], [php_cv_have_re2c_cgoto],
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-int main(void)
-{
-label1:
-  ;
-label2:
-  ;
-  static void *adr[] = { &&label1, &&label2 };
-  goto *adr[0];
-  return 0;
-}]])],
-  [php_cv_have_re2c_cgoto=yes],
-  [php_cv_have_re2c_cgoto=no])])
-AS_VAR_IF([php_cv_have_re2c_cgoto], [yes],
-  [AS_VAR_APPEND([RE2C_FLAGS], [" -g"])])
-])
 
 dnl Platform-specific compile settings.
 dnl ----------------------------------------------------------------------------

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -6,3 +6,4 @@ PHP_NEW_EXTENSION(json,
   no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
 PHP_ADD_MAKEFILE_FRAGMENT
+PHP_SETUP_RE2C

--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -11,6 +11,13 @@ if test "$PHP_PDO" != "no"; then
 
   PHP_NEW_EXTENSION(pdo, pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c, $ext_shared)
   PHP_ADD_EXTENSION_DEP(pdo, spl)
-  PHP_INSTALL_HEADERS([ext/pdo], [php_pdo.h php_pdo_driver.h php_pdo_error.h])
+  PHP_INSTALL_HEADERS([ext/pdo], m4_normalize([
+    pdo_sql_parser.h
+    php_pdo_driver.h
+    php_pdo_error.h
+    php_pdo_int.h
+    php_pdo.h
+  ]))
   PHP_ADD_MAKEFILE_FRAGMENT
+  PHP_SETUP_RE2C
 fi

--- a/ext/pdo/config.w32
+++ b/ext/pdo/config.w32
@@ -6,5 +6,11 @@ if (PHP_PDO != "no") {
 	EXTENSION('pdo', 'pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c', false /* force static, PHP_PDO_SHARED is broken yet somehow */);
 	ADD_EXTENSION_DEP('pdo', 'spl');
 	ADD_MAKEFILE_FRAGMENT();
-	PHP_INSTALL_HEADERS("ext/pdo", "php_pdo.h php_pdo_driver.h php_pdo_error.h");
+	PHP_INSTALL_HEADERS("ext/pdo",
+		"pdo_sql_parser.h " +
+		"php_pdo_driver.h " +
+		"php_pdo_error.h " +
+		"php_pdo_int.h " +
+		"php_pdo.h"
+	);
 }

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -89,6 +89,7 @@ if test "$PHP_PDO_MYSQL" != "no"; then
 
   PHP_ADD_EXTENSION_DEP(pdo_mysql, pdo)
   PHP_ADD_MAKEFILE_FRAGMENT
+  PHP_SETUP_RE2C
 
   if test "$PHP_PDO_MYSQL" = "yes" || test "$PHP_PDO_MYSQL" = "mysqlnd"; then
     PHP_ADD_EXTENSION_DEP(pdo_mysql, mysqlnd)

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -25,4 +25,5 @@ if test "$PHP_PDO_PGSQL" != "no"; then
   PHP_NEW_EXTENSION(pdo_pgsql, pdo_pgsql.c pgsql_driver.c pgsql_statement.c pgsql_sql_parser.c, $ext_shared)
   PHP_ADD_EXTENSION_DEP(pdo_pgsql, pdo)
   PHP_ADD_MAKEFILE_FRAGMENT
+  PHP_SETUP_RE2C
 fi

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -34,4 +34,5 @@ if test "$PHP_PDO_SQLITE" != "no"; then
 
   PHP_ADD_EXTENSION_DEP(pdo_sqlite, pdo)
   PHP_ADD_MAKEFILE_FRAGMENT
+  PHP_SETUP_RE2C
 fi

--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -20,6 +20,7 @@ if test "$PHP_PHAR" != "no"; then
   PHP_ADD_EXTENSION_DEP(phar, hash, true)
   PHP_ADD_EXTENSION_DEP(phar, spl, true)
   PHP_ADD_MAKEFILE_FRAGMENT
+  PHP_SETUP_RE2C
 
   PHP_INSTALL_HEADERS([ext/phar], [php_phar.h])
 

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -480,4 +480,5 @@ PHP_NEW_EXTENSION([standard], [m4_normalize([
 PHP_ADD_BUILD_DIR($ext_builddir/libavifinfo)
 
 PHP_ADD_MAKEFILE_FRAGMENT
+PHP_SETUP_RE2C
 PHP_INSTALL_HEADERS([ext/standard/])

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -70,6 +70,7 @@ if test "$PHP_PHPDBG" != "no"; then
   PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/phpdbg/Makefile.frag],
     [$abs_srcdir/sapi/phpdbg],
     [$abs_builddir/sapi/phpdbg])
+  PHP_SETUP_RE2C
   PHP_SELECT_SAPI(phpdbg, program, $PHP_PHPDBG_FILES, $PHP_PHPDBG_CFLAGS, [$(SAPI_PHPDBG_PATH)])
 
   BUILD_BINARY="sapi/phpdbg/phpdbg"


### PR DESCRIPTION
This enables building extensions that require re2c lexer generator. In testing and probably needs few more adjustments.

Additionally, the ext/pdo headers are installed with a bit extended set of headers (pdo_sql_parser.h and php_pdo_int.h) for using them in other pdo extensions.

Fixes #14792