### PR TITLE
Fix GH-14792: Compilation failure on pdo_* extensions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.0alpha2
 
+- PDO
+  . Fixed bug GH-14792 (Compilation failure on pdo_* extensions).
+    (Peter Kokot)
 
 04 Jul 2024, PHP 8.4.0alpha1
 

--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -11,6 +11,12 @@ if test "$PHP_PDO" != "no"; then
 
   PHP_NEW_EXTENSION(pdo, pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c, $ext_shared)
   PHP_ADD_EXTENSION_DEP(pdo, spl)
-  PHP_INSTALL_HEADERS([ext/pdo], [php_pdo.h php_pdo_driver.h php_pdo_error.h])
+  PHP_INSTALL_HEADERS([ext/pdo], m4_normalize([
+    pdo_sql_parser.h
+    php_pdo_driver.h
+    php_pdo_error.h
+    php_pdo_int.h
+    php_pdo.h
+  ]))
   PHP_ADD_MAKEFILE_FRAGMENT
 fi

--- a/ext/pdo/config.w32
+++ b/ext/pdo/config.w32
@@ -6,5 +6,11 @@ if (PHP_PDO != "no") {
 	EXTENSION('pdo', 'pdo.c pdo_dbh.c pdo_stmt.c pdo_sql_parser.c pdo_sqlstate.c', false /* force static, PHP_PDO_SHARED is broken yet somehow */);
 	ADD_EXTENSION_DEP('pdo', 'spl');
 	ADD_MAKEFILE_FRAGMENT();
-	PHP_INSTALL_HEADERS("ext/pdo", "php_pdo.h php_pdo_driver.h php_pdo_error.h");
+	PHP_INSTALL_HEADERS("ext/pdo",
+		"pdo_sql_parser.h " +
+		"php_pdo_driver.h " +
+		"php_pdo_error.h " +
+		"php_pdo_int.h " +
+		"php_pdo.h"
+	);
 }


### PR DESCRIPTION
When building pdo_mysql, pdo_pgsql, or pdo_sqlite from downloaded PHP 8.4 archive, also pdo_sql_parser.h and php_pdo_int.h need to be installed.