### PR TITLE
Fix build for armv7

### DIFF
--- a/main/debug_gdb_scripts.c
+++ b/main/debug_gdb_scripts.c
@@ -7,7 +7,7 @@
  * See https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
  */
 asm(
-    ".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+    ".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
     ".byte 4 /* Python Text */\n"
     ".ascii \"gdb.inlined-script\\n\"\n"
     ".ascii \"gdb.execute('''\\n\"\n"

--- a/scripts/gdb/debug_gdb_scripts_gen.php
+++ b/scripts/gdb/debug_gdb_scripts_gen.php
@@ -28,7 +28,7 @@ $ccode = sprintf(
      * See https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
      */
     asm(
-        ".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+        ".pushsection \".debug_gdb_scripts\", \"MS\",%%progbits,1\n"
         ".byte 4 /* Python Text */\n"
         ".ascii \"gdb.inlined-script\\n\"\n"
         %s


### PR DESCRIPTION
Started packaging 8.4_alpha1 for Alpinelinux and faced build failure for armv7 and [armhf](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/68651#note_418224) using **clang 18..1.8**

```
<inline asm>:1:41: error: expected '%<type>' or "<type>"
    1 | .pushsection ".debug_gdb_scripts", "MS",@progbits,1
      |                                         ^
<inline asm>:1008:12: error: .popsection without corresponding .pushsection
 1008 | .popsection
      |            ^
2 errors generated.
make: *** [Makefile:3100: main/debug_gdb_scripts.lo] Error 1
```

quick grep showed that other sections has `%progbits` instead of `@progbits`