### PR TITLE
Update MSVC compiler version detection

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3104,7 +3104,7 @@ function toolset_get_compiler_name(short)
 
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
 
-		if (version >= 1940) {
+		if (version >= 1950) {
 			return name;
 		} else if (version >= 1930) {
 			name = short ? "VS17" : "Visual C++ 2022";


### PR DESCRIPTION
As of Visual Studio 2015, the major version of the compiler (`cl.exe`) is 19, and the minor version increases by steps of 10.  However, the latest Visual Studio 2022 release has the version `19.40`, so that Visual Studio version is not properly detected.  This is not a big deal regarding the reported compiler version (`php -v` etc.), but the filenames of the builds would no longer match the expectations (instead of `vs17` there is now `19.40.33811` or another build number).  This implies that the files would have to be renamed manually to be properly handled by windows.php.net (or that code would have to be adapted).

Therefore we update the version detection to detect all versions < 1950 as Visual Studio 2022, assuming that "For major releases, the minor version increases by 10."[1] still holds in the future.

[1] <https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170#visual-studio-2017-and-later>

---

Note that I have targeted `PHP-8.3` since there may be custom builds which use Visual Studio 2022, so they get a "proper" compiler detection, although that might break some build scripts. Thus, it might be best to only apply this patch to `master`, because in my opinion PHP 8.4 should be built with Visual Studio 2022, although [Visual Studio 2019 still has extended support until 2029-04-10](https://learn.microsoft.com/en-us/lifecycle/products/visual-studio-2019).