### PR TITLE
ext/standard/tests: 32bit wordwrap tests aren't just for Windows

### DIFF
--- a/ext/standard/tests/strings/wordwrap_memory_limit.phpt
+++ b/ext/standard/tests/strings/wordwrap_memory_limit.phpt
@@ -2,7 +2,7 @@
 No overflow should occur during the memory_limit check for wordwrap()
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN' && PHP_INT_SIZE == 4) die("skip this test is not for 32bit Windows platforms");
+if (PHP_INT_SIZE == 4) die("skip this test is not for 32bit platforms");
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip Zend MM disabled");
 ?>
 --INI--

--- a/ext/standard/tests/strings/wordwrap_memory_limit_32bit.phpt
+++ b/ext/standard/tests/strings/wordwrap_memory_limit_32bit.phpt
@@ -16,4 +16,4 @@ wordwrap($str, 1, $str2);
 
 ?>
 --EXPECTF--
-Fatal error: Possible integer overflow in memory allocation (4294901777 + %d) in %s on line %d
+Fatal error: %rAllowed memory size of %d bytes exhausted%s\(tried to allocate %d bytes\)|Possible integer overflow in memory allocation \(4294901777 \+ %d\)%r in %s on line %d

--- a/ext/standard/tests/strings/wordwrap_memory_limit_32bit.phpt
+++ b/ext/standard/tests/strings/wordwrap_memory_limit_32bit.phpt
@@ -2,7 +2,7 @@
 No overflow should occur during the memory_limit check for wordwrap()
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) != 'WIN' || PHP_INT_SIZE != 4) die("skip this test is for 32bit Windows platforms only");
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
 if (getenv("USE_ZEND_ALLOC") === "0") die("skip Zend MM disabled");
 ?>
 --INI--


### PR DESCRIPTION
The test in `strings/wordwrap_memory_limit.phpt` has a counterpart in `strings/wordwrap_memory_limit_win32.phpt`. The two are conditional on both the OS name and the size of an int (32- versus 64-bits).

A Gentoo Linux user has however reported that the 64-bit test fails on a 32-bit system, with precisely the error message that the "win32" test is expecting. I don't have any 32-bit hardware to test myself, but I think it's reasonable to conclude that the OS name is not an essential part of the test: it's simply 32- versus 64-bit.

This commit drops the conditionals for the OS name. Now one test will be run on 32-bit systems, and the other on 64-bit systems, regardless of the OS name.

Bug: https://bugs.gentoo.org/935382