### PR TITLE
Fix GH-14808: Unexpected null pointer in Zend/zend_string.h with empty output buffer

### DIFF
--- a/main/output.c
+++ b/main/output.c
@@ -380,7 +380,11 @@ PHPAPI int php_output_get_level(void)
 PHPAPI int php_output_get_contents(zval *p)
 {
 	if (OG(active)) {
-		ZVAL_STRINGL(p, OG(active)->buffer.data, OG(active)->buffer.used);
+		if (OG(active)->buffer.used) {
+			ZVAL_STRINGL(p, OG(active)->buffer.data, OG(active)->buffer.used);
+		} else {
+			ZVAL_EMPTY_STRING(p);
+		}
 		return SUCCESS;
 	} else {
 		ZVAL_NULL(p);

--- a/tests/output/gh14808.phpt
+++ b/tests/output/gh14808.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-14808 (Unexpected null pointer in Zend/zend_string.h with empty output buffer)
+--FILE--
+<?php
+var_dump($args);
+ob_start('ob_iconv_handler');
+ob_clean();
+var_dump(ob_get_contents());
+?>
+--EXPECTF--
+Warning: Undefined variable $args in %s on line %d
+NULL
+string(0) ""


### PR DESCRIPTION
The output buffer can be NULL when the number of bytes is zero.