### PR TITLE
Make bug49278.phpt more resilient

### DIFF
--- a/ext/soap/tests/bugs/bug49278.phpt
+++ b/ext/soap/tests/bugs/bug49278.phpt
@@ -44,7 +44,7 @@ string(0) ""
 string(%d) "POST / HTTP/1.1
 Host: %s
 Connection: Keep-Alive
-User-Agent: PHP-SOAP/8.4.%s
+User-Agent: PHP-SOAP/%s
 Content-Type: text/xml; charset=utf-8
 SOAPAction: "Add"
 Content-Length: %d
@@ -54,6 +54,6 @@ string(%s) "HTTP/1.1 200 OK
 Host: %s
 Date: %s
 Connection: close
-X-Powered-By: PHP/8.4.%s
+X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
 "

--- a/ext/soap/tests/bugs/bug49278.phpt
+++ b/ext/soap/tests/bugs/bug49278.phpt
@@ -41,19 +41,19 @@ var_dump($client->__getLastResponseHeaders());
 --EXPECTF--
 string(0) ""
 string(0) ""
-string(177) "POST / HTTP/1.1
+string(%d) "POST / HTTP/1.1
 Host: %s
 Connection: Keep-Alive
-User-Agent: PHP-SOAP/8.4.0-dev
+User-Agent: PHP-SOAP/8.4.%s
 Content-Type: text/xml; charset=utf-8
 SOAPAction: "Add"
 Content-Length: %d
 
 "
-string(165) "HTTP/1.1 200 OK
+string(%s) "HTTP/1.1 200 OK
 Host: %s
 Date: %s
 Connection: close
-X-Powered-By: PHP/8.4.0-dev
+X-Powered-By: PHP/8.4.%s
 Content-type: text/html; charset=UTF-8
 "


### PR DESCRIPTION
Due to the hard-coded PHP version, that test easily fails[1], so we relax the test expectations.

[1] e.g. <https://github.com/cmb69/php-ftw/actions/runs/9784934000/job/27016894692#step:5:66>

---

Regarding future minor/major PHP versions, it might be even better to completey replace the `8.4` with the wildcard.