### PR TITLE
Fix stack limit under valgrind

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -71,6 +71,10 @@ typedef int boolean_t;
 #include <thread.h>
 #endif
 
+#ifdef HAVE_VALGRIND
+# include <valgrind/valgrind.h>
+#endif
+
 #ifdef ZEND_CHECK_STACK_LIMIT
 
 /* Called once per process or thread */
@@ -237,6 +241,13 @@ static bool zend_call_stack_get_linux_proc_maps(zend_call_stack *stack)
 	}
 
 	max_size = rlim.rlim_cur;
+
+#ifdef HAVE_VALGRIND
+	/* Under Valgrind, the last page is not useable */
+	if (RUNNING_ON_VALGRIND) {
+		max_size -= zend_get_page_size();
+	}
+#endif
 
 	/* Previous mapping may prevent the stack from growing */
 	if (end - max_size < prev_end) {


### PR DESCRIPTION
Valgrind creates a stack mapping that can grow up to RLIMIT_STACK, but the last page is never useable.

This fixes `Zend/tests/stack_limit/stack_limit_009.phpt` and `Zend/tests/arginfo_zpp_mismatch.phpt` when running under valgrind, as long as php is compiled with `--with-valgrind`.