### PR TITLE
Remove HAVE_STRPTIME_DECL_FAILS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -140,6 +140,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbols HAVE_LIBRT and HAVE_TIMER_CREATE removed.
    - Symbols PHP_FPM_SYSTEMD, PHP_FPM_USER, and PHP_FPM_GROUP removed.
    - Symbol PTHREADS has been removed.
+   - Symbol HAVE_STRPTIME_DECL_FAILS has been removed (use HAVE_DECL_STRPTIME).
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -341,23 +341,14 @@ PHP_CHECK_FUNC(res_search, resolv, socket)
 AC_CHECK_FUNCS([posix_spawn_file_actions_addchdir_np])
 
 dnl
-dnl Check for strptime()
+dnl Obsolete check for strptime() declaration. The strptime, where available,
+dnl needs the _GNU_SOURCE defined or compiler flag -std=gnuXX appended to be
+dnl declared in time.h. PHP's strptime is also deprecated as of PHP 8.1.
 dnl
-AC_CACHE_CHECK([whether strptime is declared],
-[php_cv_have_decl_strptime],
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <time.h>], [
-#ifndef HAVE_STRPTIME
-#error no strptime() on this platform
-#else
-/* use invalid strptime() declaration to see if it fails to compile */
-int strptime(const char *s, const char *format, struct tm *tm);
-#endif
-])],
-[php_cv_have_decl_strptime=no],
-[php_cv_have_decl_strptime=yes])])
-AS_VAR_IF([php_cv_have_decl_strptime], [yes],
-  [AC_DEFINE([HAVE_STRPTIME_DECL_FAILS], [1],
-    [Define to 1 if 'strptime' has declaration.])])
+AC_CHECK_DECL([strptime],
+  [AC_DEFINE([HAVE_DECL_STRPTIME], [1],
+    [Define to 1 if you have the declaration of 'strptime'.])],,
+  [#include <time.h>])
 
 dnl
 dnl Check for argon2

--- a/ext/standard/datetime.c
+++ b/ext/standard/datetime.c
@@ -63,7 +63,7 @@ PHPAPI char *php_std_date(time_t t)
 /* }}} */
 
 #ifdef HAVE_STRPTIME
-#ifndef HAVE_STRPTIME_DECL_FAILS
+#ifndef HAVE_DECL_STRPTIME
 char *strptime(const char *s, const char *format, struct tm *tm);
 #endif
 


### PR DESCRIPTION
The strptime, where available, needs the _GNU_SOURCE defined or compiler flag -std=gnuXX appended to be declared in time.h. PHP's strptime is also deprecated as of PHP 8.1.

This removes the HAVE_STRPTIME_DECL_FAILS in favor of a simpler AC_CHECK_DECL check and HAVE_DECL_STRPTIME CPP macro.