### PR TITLE
Autotools: Refactor PHP_TIME_R_TYPE check

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1064,9 +1064,10 @@ dnl
 dnl Check type of reentrant time-related functions. Type can be: irix, hpux or
 dnl POSIX.
 dnl
-AC_DEFUN([PHP_TIME_R_TYPE],[
-AC_CACHE_CHECK(for type of reentrant time-related functions, ac_cv_time_r_type,[
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_DEFUN([PHP_TIME_R_TYPE],
+[AC_CACHE_CHECK([for type of reentrant time-related functions],
+  [php_cv_time_r_type],
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>
 
 int main(void) {
@@ -1080,10 +1081,9 @@ r = (int) asctime_r(&t, buf, 26);
 if (r == s && s == 0) return (0);
 return (1);
 }
-]])],[
-  ac_cv_time_r_type=hpux
-],[
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+  ]])],
+  [php_cv_time_r_type=hpux],
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>
 int main(void) {
   struct tm t, *s;
@@ -1095,21 +1095,17 @@ int main(void) {
   if (p == buf && s == &t) return (0);
   return (1);
 }
-  ]])],[
-    ac_cv_time_r_type=irix
-  ],[
-    ac_cv_time_r_type=POSIX
-  ],[
-    ac_cv_time_r_type=POSIX
-  ])
-],[
-  ac_cv_time_r_type=POSIX
+  ]])],
+  [php_cv_time_r_type=irix],
+  [php_cv_time_r_type=POSIX],
+  [php_cv_time_r_type=POSIX])],
+  [php_cv_time_r_type=POSIX])
 ])
-])
-  case $ac_cv_time_r_type in
-  hpux[)] AC_DEFINE(PHP_HPUX_TIME_R,1,[Whether you have HP-UX 10.x]) ;;
-  irix[)] AC_DEFINE(PHP_IRIX_TIME_R,1,[Whether you have IRIX-style functions]) ;;
-  esac
+AS_CASE([php_cv_time_r_type],
+  [hpux], [AC_DEFINE([PHP_HPUX_TIME_R], [1],
+    [Define to 1 if you have HP-UX 10.x.-style reentrant time functions.])]
+  [irix], [AC_DEFINE([PHP_IRIX_TIME_R], [1],
+    [Define to 1 you have IRIX-style reentrant time functions.])])
 ])
 
 dnl


### PR DESCRIPTION
- Synced CS
- Cache variable ac_cv_time_r_type renamed to php_cv_time_r_type