### PR TITLE
Fix GH-14798: Valgrind and address sanitizer are not compatible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1555,12 +1555,18 @@ if test "$PHP_MEMORY_SANITIZER" = "yes"; then
   ], [AC_MSG_ERROR([MemorySanitizer is not available])])
 fi
 
-if test "$PHP_ADDRESS_SANITIZER" = "yes"; then
+AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
+  [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR([m4_normalize([
+    Valgrind and address sanitizer are not compatible. Either disable Valgrind
+    (remove --with-valgrind) or disable address sanitizer (remove
+    --enable-address-sanitizer).
+  ])])])
+
   AX_CHECK_COMPILE_FLAG([-fsanitize=address], [
     CFLAGS="$CFLAGS -fsanitize=address -DZEND_TRACK_ARENA_ALLOC"
     CXXFLAGS="$CXXFLAGS -fsanitize=address -DZEND_TRACK_ARENA_ALLOC"
   ], [AC_MSG_ERROR([AddressSanitizer is not available])])
-fi
+])
 
 if test "$PHP_UNDEFINED_SANITIZER" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-fsanitize=undefined], [


### PR DESCRIPTION
When configuring PHP with:

    ./configure --with-valgrind and --enable-address-sanitizer

configuration now errors now since these two are not compatible configurations.