### PR TITLE
Autotools: Add ZEND_ENABLE_STATIC_TSRMLS_CACHE to skeleton

### DIFF
--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -90,5 +90,8 @@ if test "$PHP_%EXTNAMECAPS%" != "no"; then
   dnl In case of no dependencies
   AC_DEFINE(HAVE_%EXTNAMECAPS%, 1, [ Have %EXTNAME% support ])
 
-  PHP_NEW_EXTENSION(%EXTNAME%, %EXTNAME%.c, $ext_shared)
+  PHP_NEW_EXTENSION([%EXTNAME%],
+    [%EXTNAME%.c],
+    [$ext_shared],,
+    [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 fi


### PR DESCRIPTION
This enables "Thread Safety Resource Manager Local Storage" static cache for skeleton template for Autotools build.