### PR TITLE
Fix GH-14834: Error installing PHP when --with-pear is used

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -375,7 +375,7 @@ _get_entity(void *user, const xmlChar *name)
 		if (ret == NULL)
 			ret = xmlGetDocEntity(parser->parser->myDoc, name);
 
-		if (ret == NULL || (parser->parser->instate != XML_PARSER_ENTITY_VALUE && parser->parser->instate != XML_PARSER_ATTRIBUTE_VALUE)) {
+		if (ret == NULL || parser->parser->instate == XML_PARSER_CONTENT) {
 			if (ret == NULL || ret->etype == XML_INTERNAL_GENERAL_ENTITY || ret->etype == XML_INTERNAL_PARAMETER_ENTITY || ret->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
 				/* Predefined entities will expand unless no cdata handler is present */
 				if (parser->h_default && ! (ret && ret->etype == XML_INTERNAL_PREDEFINED_ENTITY && parser->h_cdata)) {

--- a/ext/xml/tests/gh14834.phpt
+++ b/ext/xml/tests/gh14834.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-14834 (Error installing PHP when --with-pear is used)
+--EXTENSIONS--
+xml
+--FILE--
+<?php
+$xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root [
+    <!ENTITY foo "ent">
+]>
+<root>
+  <element hint="hello&apos;world">&foo;<![CDATA[ &amp; ]]><?x &amp; ?></element>
+</root>
+XML;
+
+$parser = xml_parser_create();
+xml_set_character_data_handler($parser, function($_, $data) {
+    var_dump($data);
+});
+xml_parse($parser, $xml, true);
+?>
+--EXPECT--
+string(3) "
+  "
+string(3) "ent"
+string(7) " &amp; "
+string(1) "
+"


### PR DESCRIPTION
libxml2 2.13 makes changes to how the parsing state is set, update our code accordingly. In particular, it started reporting entities within attributes, while it should only report entities inside text nodes.