### PR TITLE
Autotools: Sync CS in phpize and configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ T_ME=`$php_shtool echo -n -e %b`
 PHP_INIT_BUILD_SYSTEM
 
 dnl We want this one before the checks, so the checks can modify CFLAGS.
-test -z "$CFLAGS" && auto_cflags=1
+AS_VAR_SET_IF([CFLAGS],, [auto_cflags=1])
 
 abs_srcdir=`(cd $srcdir; pwd)`
 abs_builddir=`pwd`
@@ -1349,10 +1349,10 @@ unset LIBS LDFLAGS
 
 AC_ARG_PROGRAM
 
-test "$prefix" = "NONE" && prefix=/usr/local
-test "$exec_prefix" = "NONE" && exec_prefix='${prefix}'
-test "$program_prefix" = "NONE" && program_prefix=
-test "$program_suffix" = "NONE" && program_suffix=
+AS_VAR_IF([prefix], [NONE], [prefix=/usr/local])
+AS_VAR_IF([exec_prefix], [NONE], [exec_prefix='${prefix}'])
+AS_VAR_IF([program_prefix], [NONE], [program_prefix=])
+AS_VAR_IF([program_suffix], [NONE], [program_suffix=])
 
 orig_libdir=$libdir
 case $libdir in

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -26,7 +26,7 @@ AC_DEFUN([PHP_ALWAYS_SHARED],[
   test "[$]$1" = "no" && $1=yes
 ])dnl
 
-test -z "$CFLAGS" && auto_cflags=1
+AS_VAR_SET_IF([CFLAGS],, [auto_cflags=1])
 
 abs_srcdir=`(cd $srcdir && pwd)`
 abs_builddir=`pwd`
@@ -62,9 +62,8 @@ INCLUDES=`$PHP_CONFIG --includes 2>/dev/null`
 EXTENSION_DIR=`$PHP_CONFIG --extension-dir 2>/dev/null`
 PHP_EXECUTABLE=`$PHP_CONFIG --php-binary 2>/dev/null`
 
-if test -z "$prefix"; then
-  AC_MSG_ERROR([Cannot find php-config. Please use --with-php-config=PATH])
-fi
+AS_VAR_SET_IF([prefix],,
+  [AC_MSG_ERROR([Cannot find php-config. Please use --with-php-config=PATH])])
 
 php_shtool=$srcdir/build/shtool
 PHP_INIT_BUILD_SYSTEM
@@ -167,16 +166,14 @@ CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CFLAGS_CLEAN='$(CFLAGS) -D_GNU_SOURCE'
 CXXFLAGS_CLEAN='$(CXXFLAGS)'
 
-test "$prefix" = "NONE" && prefix="/usr/local"
-test "$exec_prefix" = "NONE" && exec_prefix='$(prefix)'
+AS_VAR_IF([prefix], [NONE], [prefix=/usr/local])
+AS_VAR_IF([exec_prefix], [NONE], [exec_prefix='$(prefix)'])
 
-if test "$cross_compiling" = yes ; then
-  AC_MSG_CHECKING(for native build C compiler)
-  AC_CHECK_PROGS(BUILD_CC, [gcc clang c99 c89 cc cl],none)
-  AC_MSG_RESULT($BUILD_CC)
-else
-  BUILD_CC=$CC
-fi
+AS_VAR_IF([cross_compiling], [yes],
+  [AC_CHECK_PROGS([BUILD_CC], [gcc clang c99 c89 cc cl], [none])
+    AC_MSG_CHECKING([for native build C compiler])
+    AC_MSG_RESULT([$BUILD_CC])],
+  [BUILD_CC=$CC])
 
 PHP_SUBST([PHP_MODULES])
 PHP_SUBST([PHP_ZEND_EX])


### PR DESCRIPTION
- This syncs Autoconf syntax with AS_VAR_* macros in phpize and configure.ac
- The cross-compiling check synced with configure.ac (the check message printed after program check message)
- Some redundant quoting removed