### PR TITLE
GH-14286 (ffi enum type (when enum has no name) make memory leak)

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -3544,7 +3544,7 @@ ZEND_METHOD(FFI, scope) /* {{{ */
 }
 /* }}} */
 
-static void zend_ffi_cleanup_dcl(zend_ffi_dcl *dcl) /* {{{ */
+void zend_ffi_cleanup_dcl(zend_ffi_dcl *dcl) /* {{{ */
 {
 	if (dcl) {
 		zend_ffi_type_dtor(dcl->type);

--- a/ext/ffi/ffi.g
+++ b/ext/ffi/ffi.g
@@ -98,7 +98,7 @@ declarations:
 			)*
 		|
 			/* empty */
-			{if (common_dcl.flags & ZEND_FFI_DCL_ENUM) zend_ffi_cleanup_dcl(&common_dcl);}
+			{if (common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STRUCT | ZEND_FFI_DCL_UNION)) zend_ffi_cleanup_dcl(&common_dcl);}
 		)
 		";"
 	)*

--- a/ext/ffi/ffi.g
+++ b/ext/ffi/ffi.g
@@ -70,7 +70,6 @@ static void yy_error_sym(const char *msg, int sym);
 declarations:
 	(
 		{zend_ffi_dcl common_dcl = ZEND_FFI_ATTR_INIT;}
-		{bool has_name = false;}
 		"__extension__"?
 		declaration_specifiers(&common_dcl)
 		(
@@ -87,7 +86,6 @@ declarations:
 				/*TODO*/
 				")"
 			)?
-			{has_name = true;}
 			attributes(&dcl)?
 			initializer?
 			{zend_ffi_declare(name, name_len, &dcl);}
@@ -98,8 +96,10 @@ declarations:
 				initializer?
 				{zend_ffi_declare(name, name_len, &dcl);}
 			)*
-		)?
-		{if (!has_name && ((common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(&common_dcl);}
+		|
+			/* empty */
+			{if (common_dcl.flags & ZEND_FFI_DCL_ENUM) zend_ffi_cleanup_dcl(&common_dcl);}
+		)
 		";"
 	)*
 ;

--- a/ext/ffi/ffi.g
+++ b/ext/ffi/ffi.g
@@ -137,6 +137,7 @@ declaration_specifiers(zend_ffi_dcl *dcl):
 		|	attributes(dcl)
 		|	type_qualifier(dcl)
 		|	type_specifier(dcl)
+			{if (((dcl->flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(dcl);}
 		)
 	)+
 ;

--- a/ext/ffi/ffi.g
+++ b/ext/ffi/ffi.g
@@ -70,6 +70,7 @@ static void yy_error_sym(const char *msg, int sym);
 declarations:
 	(
 		{zend_ffi_dcl common_dcl = ZEND_FFI_ATTR_INIT;}
+		{bool has_name = false;}
 		"__extension__"?
 		declaration_specifiers(&common_dcl)
 		(
@@ -86,6 +87,7 @@ declarations:
 				/*TODO*/
 				")"
 			)?
+			{has_name = true;}
 			attributes(&dcl)?
 			initializer?
 			{zend_ffi_declare(name, name_len, &dcl);}
@@ -97,6 +99,7 @@ declarations:
 				{zend_ffi_declare(name, name_len, &dcl);}
 			)*
 		)?
+		{if (!has_name && ((common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(&common_dcl);}
 		";"
 	)*
 ;
@@ -137,7 +140,6 @@ declaration_specifiers(zend_ffi_dcl *dcl):
 		|	attributes(dcl)
 		|	type_qualifier(dcl)
 		|	type_specifier(dcl)
-			{if (((dcl->flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(dcl);}
 		)
 	)+
 ;

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -2012,7 +2012,6 @@ static int synpred_6(int sym) {
 static int parse_declarations(int sym) {
 	while (YY_IN_SET(sym, (YY___EXTENSION__,YY_TYPEDEF,YY_EXTERN,YY_STATIC,YY_AUTO,YY_REGISTER,YY_INLINE,YY___INLINE,YY___INLINE__,YY__NORETURN,YY__ALIGNAS,YY___ATTRIBUTE,YY___ATTRIBUTE__,YY___DECLSPEC,YY___CDECL,YY___STDCALL,YY___FASTCALL,YY___THISCALL,YY___VECTORCALL,YY_CONST,YY___CONST,YY___CONST__,YY_RESTRICT,YY___RESTRICT,YY___RESTRICT__,YY_VOLATILE,YY___VOLATILE,YY___VOLATILE__,YY__ATOMIC,YY_VOID,YY_CHAR,YY_SHORT,YY_INT,YY_LONG,YY_FLOAT,YY_DOUBLE,YY_SIGNED,YY_UNSIGNED,YY__BOOL,YY__COMPLEX,YY_COMPLEX,YY___COMPLEX,YY___COMPLEX__,YY_STRUCT,YY_UNION,YY_ENUM,YY_ID), "\202\377\377\377\377\107\360\017\000\000\000\002\000")) {
 		zend_ffi_dcl common_dcl = ZEND_FFI_ATTR_INIT;
-		bool has_name = false;
 		if (sym == YY___EXTENSION__) {
 			sym = get_sym();
 		}
@@ -2038,7 +2037,6 @@ static int parse_declarations(int sym) {
 				}
 				sym = get_sym();
 			}
-			has_name = true;
 			if (YY_IN_SET(sym, (YY___ATTRIBUTE,YY___ATTRIBUTE__,YY___DECLSPEC,YY___CDECL,YY___STDCALL,YY___FASTCALL,YY___THISCALL,YY___VECTORCALL), "\000\000\000\000\000\000\360\017\000\000\000\000\000")) {
 				sym = parse_attributes(sym, &dcl);
 			}
@@ -2058,8 +2056,11 @@ static int parse_declarations(int sym) {
 				}
 				zend_ffi_declare(name, name_len, &dcl);
 			}
+		} else if (sym == YY__SEMICOLON) {
+			if (common_dcl.flags & ZEND_FFI_DCL_ENUM) zend_ffi_cleanup_dcl(&common_dcl);
+		} else {
+			yy_error_sym("unexpected", sym);
 		}
-		if (!has_name && ((common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(&common_dcl);
 		if (sym != YY__SEMICOLON) {
 			yy_error_sym("';' expected, got", sym);
 		}

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -2166,6 +2166,7 @@ static int parse_declaration_specifiers(int sym, zend_ffi_dcl *dcl) {
 			case YY_ENUM:
 			case YY_ID:
 				sym = parse_type_specifier(sym, dcl);
+				if (((dcl->flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(dcl);
 				break;
 			default:
 				yy_error_sym("unexpected", sym);

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -2012,6 +2012,7 @@ static int synpred_6(int sym) {
 static int parse_declarations(int sym) {
 	while (YY_IN_SET(sym, (YY___EXTENSION__,YY_TYPEDEF,YY_EXTERN,YY_STATIC,YY_AUTO,YY_REGISTER,YY_INLINE,YY___INLINE,YY___INLINE__,YY__NORETURN,YY__ALIGNAS,YY___ATTRIBUTE,YY___ATTRIBUTE__,YY___DECLSPEC,YY___CDECL,YY___STDCALL,YY___FASTCALL,YY___THISCALL,YY___VECTORCALL,YY_CONST,YY___CONST,YY___CONST__,YY_RESTRICT,YY___RESTRICT,YY___RESTRICT__,YY_VOLATILE,YY___VOLATILE,YY___VOLATILE__,YY__ATOMIC,YY_VOID,YY_CHAR,YY_SHORT,YY_INT,YY_LONG,YY_FLOAT,YY_DOUBLE,YY_SIGNED,YY_UNSIGNED,YY__BOOL,YY__COMPLEX,YY_COMPLEX,YY___COMPLEX,YY___COMPLEX__,YY_STRUCT,YY_UNION,YY_ENUM,YY_ID), "\202\377\377\377\377\107\360\017\000\000\000\002\000")) {
 		zend_ffi_dcl common_dcl = ZEND_FFI_ATTR_INIT;
+		bool has_name = false;
 		if (sym == YY___EXTENSION__) {
 			sym = get_sym();
 		}
@@ -2037,6 +2038,7 @@ static int parse_declarations(int sym) {
 				}
 				sym = get_sym();
 			}
+			has_name = true;
 			if (YY_IN_SET(sym, (YY___ATTRIBUTE,YY___ATTRIBUTE__,YY___DECLSPEC,YY___CDECL,YY___STDCALL,YY___FASTCALL,YY___THISCALL,YY___VECTORCALL), "\000\000\000\000\000\000\360\017\000\000\000\000\000")) {
 				sym = parse_attributes(sym, &dcl);
 			}
@@ -2057,6 +2059,7 @@ static int parse_declarations(int sym) {
 				zend_ffi_declare(name, name_len, &dcl);
 			}
 		}
+		if (!has_name && ((common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(&common_dcl);
 		if (sym != YY__SEMICOLON) {
 			yy_error_sym("';' expected, got", sym);
 		}
@@ -2166,7 +2169,6 @@ static int parse_declaration_specifiers(int sym, zend_ffi_dcl *dcl) {
 			case YY_ENUM:
 			case YY_ID:
 				sym = parse_type_specifier(sym, dcl);
-				if (((dcl->flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STORAGE_CLASS)) == ZEND_FFI_DCL_ENUM)) zend_ffi_cleanup_dcl(dcl);
 				break;
 			default:
 				yy_error_sym("unexpected", sym);

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -2057,7 +2057,7 @@ static int parse_declarations(int sym) {
 				zend_ffi_declare(name, name_len, &dcl);
 			}
 		} else if (sym == YY__SEMICOLON) {
-			if (common_dcl.flags & ZEND_FFI_DCL_ENUM) zend_ffi_cleanup_dcl(&common_dcl);
+			if (common_dcl.flags & (ZEND_FFI_DCL_ENUM | ZEND_FFI_DCL_STRUCT | ZEND_FFI_DCL_UNION)) zend_ffi_cleanup_dcl(&common_dcl);
 		} else {
 			yy_error_sym("unexpected", sym);
 		}

--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -208,6 +208,7 @@ typedef struct _zend_ffi_val {
 
 zend_result zend_ffi_parse_decl(const char *str, size_t len);
 zend_result zend_ffi_parse_type(const char *str, size_t len, zend_ffi_dcl *dcl);
+void zend_ffi_cleanup_dcl(zend_ffi_dcl *dcl);
 
 /* parser callbacks */
 void ZEND_NORETURN zend_ffi_parser_error(const char *msg, ...);

--- a/ext/ffi/tests/gh14286.phpt
+++ b/ext/ffi/tests/gh14286.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-14286 (ffi enum type (when enum has no name) make memory leak)
+--EXTENSIONS--
+ffi
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$ffi = FFI::cdef("
+    enum {
+        TEST_ONE=1,
+        TEST_TWO=2,
+    };
+    enum TestEnum {
+        TEST_THREE=3,
+    };
+    struct TestStruct {
+        enum {
+            TEST_FOUR=4,
+        } test1;
+        enum TestEnum2 {
+            TEST_FIVE=5,
+        } test2;
+    };
+    typedef enum { TEST_SIX=6 } TestEnum3;
+");
+var_dump($ffi->TEST_ONE);
+var_dump($ffi->TEST_TWO);
+var_dump($ffi->TEST_THREE);
+var_dump($ffi->TEST_FOUR);
+var_dump($ffi->TEST_FIVE);
+var_dump($ffi->TEST_SIX);
+?>
+--EXPECT--
+int(1)
+int(2)
+int(3)
+int(4)
+int(5)
+int(6)

--- a/ext/ffi/tests/gh14286.phpt
+++ b/ext/ffi/tests/gh14286.phpt
@@ -30,6 +30,17 @@ var_dump($ffi->TEST_THREE);
 var_dump($ffi->TEST_FOUR);
 var_dump($ffi->TEST_FIVE);
 var_dump($ffi->TEST_SIX);
+
+try {
+    $ffi = FFI::cdef("
+        enum {
+            TEST_ONE=1,
+            TEST_TWO=2,
+        } x;
+    ");
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
 int(1)
@@ -38,3 +49,4 @@ int(3)
 int(4)
 int(5)
 int(6)
+Failed resolving C variable 'x'

--- a/ext/ffi/tests/gh14286_1.phpt
+++ b/ext/ffi/tests/gh14286_1.phpt
@@ -30,17 +30,6 @@ var_dump($ffi->TEST_THREE);
 var_dump($ffi->TEST_FOUR);
 var_dump($ffi->TEST_FIVE);
 var_dump($ffi->TEST_SIX);
-
-try {
-    $ffi = FFI::cdef("
-        enum {
-            TEST_ONE=1,
-            TEST_TWO=2,
-        } x;
-    ");
-} catch (Throwable $e) {
-    echo $e->getMessage(), "\n";
-}
 ?>
 --EXPECT--
 int(1)
@@ -49,4 +38,3 @@ int(3)
 int(4)
 int(5)
 int(6)
-Failed resolving C variable 'x'

--- a/ext/ffi/tests/gh14286_1.phpt
+++ b/ext/ffi/tests/gh14286_1.phpt
@@ -23,6 +23,12 @@ $ffi = FFI::cdef("
         } test2;
     };
     typedef enum { TEST_SIX=6 } TestEnum3;
+    struct {
+        int x;
+    };
+    union {
+        int x;
+    };
 ");
 var_dump($ffi->TEST_ONE);
 var_dump($ffi->TEST_TWO);

--- a/ext/ffi/tests/gh14286_2.phpt
+++ b/ext/ffi/tests/gh14286_2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-14286 (ffi enum type (when enum has no name) make memory leak)
+--EXTENSIONS--
+ffi
+--SKIPIF--
+<?php
+if (PHP_DEBUG || getenv('SKIP_ASAN')) die("xfail: FFI cleanup after parser error is nor implemented");
+?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+try {
+    $ffi = FFI::cdef("
+        enum {
+            TEST_ONE=1,
+            TEST_TWO=2,
+        } x;
+    ");
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Failed resolving C variable 'x'


### PR DESCRIPTION
For top-level anonymous type definition we never store the declaration anywhere else nor the type anywhere else.
The declaration keeps owning the type and it goes out of scope. For anonymous fields this gets handled by the add_anonymous_field code that removes the type from the declaration.
This patch does something similar in the parsing code when it is detected we're dealing with an anonymous enum in a top-level declaration.