### PR TITLE
Fix bug #81481 (xml_get_current_byte_index limited to 32-bit numbers on 64-bit builds)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-14792 (Compilation failure on pdo_* extensions).
     (Peter Kokot)
 
+- XML:
+  . Fixed bug #81481 (xml_get_current_byte_index limited to 32-bit numbers on
+    64-bit builds). (nielsdos)
+
 04 Jul 2024, PHP 8.4.0alpha1
 
 - BCMath:

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -292,6 +292,11 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - The ext/session/php_session.h doesn't transitively include the
      ext/hash/php_hash.h header anymore.
 
+ i. ext/xml
+   - Made the expat compatibility wrapper XML_GetCurrentByteIndex return a long
+     instead of an int. This corresponds to the XML_Index type when
+     XML_LARGE_SIZE is not used in expat.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -686,7 +686,7 @@ XML_GetCurrentColumnNumber(XML_Parser parser)
 	return parser->parser->input->col;
 }
 
-PHP_XML_API int
+PHP_XML_API long
 XML_GetCurrentByteIndex(XML_Parser parser)
 {
 	/* We have to temporarily disable the encoder to satisfy the note from the manual:
@@ -702,16 +702,15 @@ XML_GetCurrentByteIndex(XML_Parser parser)
 	if (encoder) {
 		input->buf->encoder = encoder;
 	}
-	/* TODO: at one point this should return long probably to make sure that files greater than 2 GiB are handled correctly. */
-	return (int) result;
+	return result;
 }
 
 PHP_XML_API int
 XML_GetCurrentByteCount(XML_Parser parser)
 {
-	/* WARNING: this is identical to ByteIndex; it should probably
+	/* TODO: this is identical to ByteIndex; it should probably
 	 * be different */
-	return XML_GetCurrentByteIndex(parser);
+	return (int) XML_GetCurrentByteIndex(parser);
 }
 
 PHP_XML_API const XML_Char *XML_ExpatVersion(void)

--- a/ext/xml/expat_compat.h
+++ b/ext/xml/expat_compat.h
@@ -144,7 +144,7 @@ PHP_XML_API int  XML_GetErrorCode(XML_Parser);
 PHP_XML_API const XML_Char *XML_ErrorString(int);
 PHP_XML_API int  XML_GetCurrentLineNumber(XML_Parser);
 PHP_XML_API int  XML_GetCurrentColumnNumber(XML_Parser);
-PHP_XML_API int  XML_GetCurrentByteIndex(XML_Parser);
+PHP_XML_API long XML_GetCurrentByteIndex(XML_Parser);
 PHP_XML_API int  XML_GetCurrentByteCount(XML_Parser);
 PHP_XML_API const XML_Char *XML_ExpatVersion(void);
 PHP_XML_API void XML_ParserFree(XML_Parser);

--- a/ext/xml/tests/bug81481.phpt
+++ b/ext/xml/tests/bug81481.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #81481 (xml_get_current_byte_index limited to 32-bit numbers on 64-bit builds)
+--CREDITS--
+dev at b65sol dot com
+--EXTENSIONS--
+xml
+--INI--
+memory_limit=-1
+--SKIPIF--
+<?php
+require __DIR__ . '/libxml_expat_skipif.inc';
+skipif(want_expat: false);
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+if (PHP_INT_SIZE != 8) die("skip 64-bit only");
+if (PHP_OS_FAMILY == 'Windows') die('skip not for Windows');
+?>
+--FILE--
+<?php
+$parser = xml_parser_create('UTF-8');
+xml_set_element_handler( $parser, 'startelement', null );
+
+$emptylong = str_repeat(' ', 1024*1024);
+xml_parse($parser, '<root><i></i><b/><ext>Hello</ext>', false);
+for($i = 0; $i < 2200; $i++) {
+    xml_parse($parser, $emptylong, false);
+}
+xml_parse($parser, '<ext></ext><ext></ext></root>', false);
+
+function startelement($parser, $name, $attribute) {
+    if ( $name == 'EXT' ) { echo "Byte Index:", xml_get_current_byte_index($parser), "\n"; }
+}
+?>
+--EXPECT--
+Byte Index:21
+Byte Index:2306867237
+Byte Index:2306867248


### PR DESCRIPTION
The return value is long in both expat and expat2 (with XML_LARGE_SIZE not set).