### PR TITLE
Remove unused SMART_STR_PREALLOC

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -53,8 +53,6 @@
 #endif /* ZTS && HAVE_CURL_OLD_OPENSSL */
 /* }}} */
 
-#define SMART_STR_PREALLOC 4096
-
 #include "zend_smart_str.h"
 #include "ext/standard/info.h"
 #include "ext/standard/file.h"

--- a/ext/mysqlnd/mysqlnd_alloc.c
+++ b/ext/mysqlnd/mysqlnd_alloc.c
@@ -323,7 +323,6 @@ static char * _mysqlnd_pestrndup(const char * const ptr, size_t length, bool per
 
 
 #define SMART_STR_START_SIZE 2048
-#define SMART_STR_PREALLOC 512
 #include "zend_smart_str.h"
 
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -26,8 +26,6 @@
 #include <config.h>
 #endif
 
-#define SMART_STR_PREALLOC 512
-
 #include "php.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"


### PR DESCRIPTION
Unless I'm missing something and these still have some "documentation-alike" value...