### PR TITLE
Autotools: Sync HAVE_ERASE_EMPTY_LINE help text

### DIFF
--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -14,6 +14,9 @@ else
   php_with_readline=no
 fi
 
+AH_TEMPLATE([HAVE_ERASE_EMPTY_LINE],
+  [Define to 1 if edit/readline library has 'rl_erase_empty_line' variable.])
+
 if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   for i in $PHP_READLINE /usr/local /usr; do
     test -f $i/include/readline/readline.h && READLINE_DIR=$i && break
@@ -76,8 +79,7 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   ])
 
   AC_CHECK_DECL([rl_erase_empty_line],
-    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1],
-      [Define to 1 if readline library has rl_erase_empty_line variable.])],,
+    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1])],,
     [#include <readline/readline.h>])
 
   AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
@@ -139,8 +141,7 @@ elif test "$PHP_LIBEDIT" != "no"; then
   ])
 
   AC_CHECK_DECL([rl_erase_empty_line],
-    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1],
-      [Define to 1 if edit library has rl_erase_empty_line variable.])],,
+    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1])],,
     [#include <editline/readline.h>])
 
   AC_DEFINE(HAVE_LIBEDIT, 1, [ ])


### PR DESCRIPTION
HAVE_ERASE_EMPTY_LINE always gets the last AC_DEFINE help text, so it is simpler to have the same help message for both definitions (readline and editline). First text never got into header via autoheader anyway.