### PR TITLE
Fix memory leak in tidy_repair_file()

### DIFF
--- a/ext/tidy/tests/parsing_file_too_large.phpt
+++ b/ext/tidy/tests/parsing_file_too_large.phpt
@@ -47,6 +47,12 @@ try {
 } catch (\Throwable $e) {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
+
+try {
+    tidy_repair_file($path);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
 --CLEAN--
 <?php
@@ -58,3 +64,4 @@ int(0)
 ValueError: Input string is too long
 ValueError: Input string is too long
 ValueError: Input string is too long
+ValueError: tidy_repair_file(): Argument #1 ($filename) Input string is too long

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -304,7 +304,12 @@ static void php_tidy_quick_repair(INTERNAL_FUNCTION_PARAMETERS, bool is_file)
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(data))) {
-		zend_argument_value_error(1, "is too long");
+		if (is_file) {
+			zend_string_release_ex(data, false);
+			zend_argument_value_error(1, "Input string is too long");
+		} else {
+			zend_argument_value_error(1, "is too long");
+		}
 		RETURN_THROWS();
 	}
 


### PR DESCRIPTION
When dealing with a file, we must free the contents if the function fails. While here, also fix the error message because previously it sounded like the filename was too long while in fact the file itself is too large. The error message is now consistent with the other ones for when loading a too large file.

Detected with an experimental static analyser I'm working on.