### PR TITLE
Autotools: Remove obsolete crypt link override due to OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1154,13 +1154,6 @@ case $php_sapi_module in
 esac
 
 EXTRA_LIBS="$EXTRA_LIBS $DLIBS $LIBS"
-
-dnl This has to be here to prevent the openssl crypt() from overriding the
-dnl system provided crypt().
-if test "$ac_cv_lib_crypt_crypt" = "yes"; then
-  EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
-fi
-
 unset LIBS
 
 dnl PEAR


### PR DESCRIPTION
OpenSSL versions before 0.9.7 provided its own crypt() function (and des_* functions) in its Crypto library that interfered with the implementation relying on crypt() from some other crypt library. This is at this point obsolete as crypt and other functions that caused clashes were removed in OpenSSL version 1.1.0.

In OpenSSL 0.9.7 des_old.c and des_old.h files were provided for BC.

In OpenSSL 0.9.8 crypt() function was renamed to _ossl_old_crypt and the crypt macro definition was commented out in the des_old.h header.

In OpenSSL 1.1.0 the old DES API was removed, meaning OpenSSL's crypto library no longer provides crypt() function as it used to.

References:
- Some further historic notes on this: https://www.openldap.org/faq/data/cache/1041.html
- OpenSSL Git commit history and changelogs