### PR TITLE
Fix AS_VAR_* checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ T_ME=`$php_shtool echo -n -e %b`
 PHP_INIT_BUILD_SYSTEM
 
 dnl We want this one before the checks, so the checks can modify CFLAGS.
-AS_VAR_SET_IF([CFLAGS],, [auto_cflags=1])
+AS_VAR_IF([CFLAGS],, [auto_cflags=1])
 
 abs_srcdir=`(cd $srcdir; pwd)`
 abs_builddir=`pwd`

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -106,5 +106,5 @@ if test "$PHP_APXS2" != "no"; then
   esac
 
   APACHE_THREADED_MPM=$($APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes')
-  AS_VAR_SET_IF([APACHE_THREADED_MPM], [PHP_BUILD_THREAD_SAFE])
+  AS_VAR_IF([APACHE_THREADED_MPM],,, [PHP_BUILD_THREAD_SAFE])
 fi

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -26,7 +26,7 @@ AC_DEFUN([PHP_ALWAYS_SHARED],[
   test "[$]$1" = "no" && $1=yes
 ])dnl
 
-AS_VAR_SET_IF([CFLAGS],, [auto_cflags=1])
+AS_VAR_IF([CFLAGS],, [auto_cflags=1])
 
 abs_srcdir=`(cd $srcdir && pwd)`
 abs_builddir=`pwd`
@@ -62,7 +62,7 @@ INCLUDES=`$PHP_CONFIG --includes 2>/dev/null`
 EXTENSION_DIR=`$PHP_CONFIG --extension-dir 2>/dev/null`
 PHP_EXECUTABLE=`$PHP_CONFIG --php-binary 2>/dev/null`
 
-AS_VAR_SET_IF([prefix],,
+AS_VAR_IF([prefix],,
   [AC_MSG_ERROR([Cannot find php-config. Please use --with-php-config=PATH])])
 
 php_shtool=$srcdir/build/shtool


### PR DESCRIPTION
AS_VAR_SET_IF doesn't behave the same as "test -n" and/or "test -z", which becomes an issue for Apache's ZTS automatic enabling and CFLAGS edge case where it would be explicitly set to empty value. It is safer to use AS_VAR_IF instead of AS_VAR_SET_IF in these cases.

My bad for introducing that AS_VAR_SET_IF. Haven't noticed the issue behind it. Now is fixed.