### PR TITLE
Throw an exception when using the namespace axis in XPath in modern DOM

### DIFF
--- a/ext/dom/tests/modern/xml/XMLDocument_xpath.phpt
+++ b/ext/dom/tests/modern/xml/XMLDocument_xpath.phpt
@@ -43,7 +43,11 @@ foreach ($result as $item) {
 echo "--- Get a namespace node ---\n";
 
 // Namespace nodes don't exist in modern day DOM.
-var_dump($xpath->evaluate("//*/namespace::*"));
+try {
+    var_dump($xpath->evaluate("//*/namespace::*"));
+} catch (DOMException $e) {
+    echo $e->getCode(), ": ", $e->getMessage(), "\n";
+}
 
 ?>
 --EXPECT--
@@ -67,7 +71,4 @@ string(4) "data"
 string(11) "Dom\Comment"
 string(9) " comment "
 --- Get a namespace node ---
-object(Dom\NodeList)#5 (1) {
-  ["length"]=>
-  int(0)
-}
+9: The namespace axis is not well-defined in the living DOM specification. Use Dom\Element::getInScopeNamespaces() or Dom\Element::getDescendantNamespaces() instead.

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -338,7 +338,14 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type, bool modern) 
 
 					if (node->type == XML_NAMESPACE_DECL) {
 						if (modern) {
-							continue;
+							if (!EG(exception)) {
+								php_dom_throw_error_with_message(NOT_SUPPORTED_ERR,
+									"The namespace axis is not well-defined in the living DOM specification. "
+									"Use Dom\\Element::getInScopeNamespaces() or Dom\\Element::getDescendantNamespaces() instead.",
+									/* strict */ true
+								);
+							}
+							break;
 						}
 
 						xmlNodePtr nsparent = node->_private;


### PR DESCRIPTION
This was specified in https://wiki.php.net/rfc/dom_additions_84, under the "NamespaceInfo" section, but was not implemented yet.