### PR TITLE
Fix GH-14873: PHP 8.4 min function fails on typed integer

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1552,6 +1552,8 @@ ZEND_API void zend_frameless_observed_call(zend_execute_data *execute_data)
 	uint8_t num_args = ZEND_FLF_NUM_ARGS(opline->opcode);
 	zend_function *fbc = ZEND_FLF_FUNC(opline);
 	zval *result = EX_VAR(opline->result.var);
+	zval tmp_result;
+	ZVAL_NULL(&tmp_result);
 
 	zend_execute_data *call = zend_vm_stack_push_call_frame_ex(zend_vm_calc_used_stack(num_args, fbc), ZEND_CALL_NESTED_FUNCTION, fbc, num_args, NULL);
 	call->prev_execute_data = execute_data;
@@ -1565,7 +1567,8 @@ ZEND_API void zend_frameless_observed_call(zend_execute_data *execute_data)
 	EG(current_execute_data) = call;
 
 	zend_observer_fcall_begin_prechecked(call, ZEND_OBSERVER_DATA(fbc));
-	fbc->internal_function.handler(call, result);
+	fbc->internal_function.handler(call, &tmp_result);
+	ZVAL_COPY_VALUE(result, &tmp_result);
 	zend_observer_fcall_end(call, result);
 
 	EG(current_execute_data) = execute_data;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9638,9 +9638,9 @@ ZEND_VM_HANDLER(205, ZEND_FRAMELESS_ICALL_1, ANY, UNUSED, SPEC(OBSERVER))
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP1();
 		HANDLE_EXCEPTION();
 	}
@@ -9651,8 +9651,11 @@ ZEND_VM_HANDLER(205, ZEND_FRAMELESS_ICALL_1, ANY, UNUSED, SPEC(OBSERVER))
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
-		function(result, arg1);
+		function(&tmp_result, arg1);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 	FREE_OP1();
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -9664,10 +9667,10 @@ ZEND_VM_HANDLER(206, ZEND_FRAMELESS_ICALL_2, ANY, ANY, SPEC(OBSERVER))
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_R);
 	zval *arg2 = GET_OP2_ZVAL_PTR_DEREF(BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP1();
 		FREE_OP2();
 		HANDLE_EXCEPTION();
@@ -9679,8 +9682,11 @@ ZEND_VM_HANDLER(206, ZEND_FRAMELESS_ICALL_2, ANY, ANY, SPEC(OBSERVER))
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2);
+		function(&tmp_result, arg1, arg2);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP1();
@@ -9698,11 +9704,11 @@ ZEND_VM_HANDLER(207, ZEND_FRAMELESS_ICALL_3, ANY, ANY, SPEC(OBSERVER))
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = GET_OP1_ZVAL_PTR_DEREF(BP_VAR_R);
 	zval *arg2 = GET_OP2_ZVAL_PTR_DEREF(BP_VAR_R);
 	zval *arg3 = GET_OP_DATA_ZVAL_PTR_DEREF(BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP1();
 		FREE_OP2();
 		FREE_OP_DATA();
@@ -9715,8 +9721,11 @@ ZEND_VM_HANDLER(207, ZEND_FRAMELESS_ICALL_3, ANY, ANY, SPEC(OBSERVER))
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2, arg3);
+		function(&tmp_result, arg1, arg2, arg3);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP1();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3738,10 +3738,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_HANDLER
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	zval *arg2 = get_zval_ptr_deref(opline->op2_type, opline->op2, BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		FREE_OP(opline->op2_type, opline->op2.var);
 		HANDLE_EXCEPTION();
@@ -3753,8 +3753,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_HANDLER
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2);
+		function(&tmp_result, arg1, arg2);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -3772,10 +3775,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_OBSERVE
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	zval *arg2 = get_zval_ptr_deref(opline->op2_type, opline->op2, BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		FREE_OP(opline->op2_type, opline->op2.var);
 		HANDLE_EXCEPTION();
@@ -3787,8 +3790,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_2_SPEC_OBSERVE
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_2 function = (zend_frameless_function_2)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2);
+		function(&tmp_result, arg1, arg2);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -3806,11 +3812,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_HANDLER
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	zval *arg2 = get_zval_ptr_deref(opline->op2_type, opline->op2, BP_VAR_R);
 	zval *arg3 = get_op_data_zval_ptr_deref_r((opline+1)->op1_type, (opline+1)->op1);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		FREE_OP(opline->op2_type, opline->op2.var);
 		FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
@@ -3823,8 +3829,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_HANDLER
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2, arg3);
+		function(&tmp_result, arg1, arg2, arg3);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -3846,11 +3855,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_OBSERVE
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	zval *arg2 = get_zval_ptr_deref(opline->op2_type, opline->op2, BP_VAR_R);
 	zval *arg3 = get_op_data_zval_ptr_deref_r((opline+1)->op1_type, (opline+1)->op1);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		FREE_OP(opline->op2_type, opline->op2.var);
 		FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
@@ -3863,8 +3872,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_3_SPEC_OBSERVE
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_3 function = (zend_frameless_function_3)ZEND_FLF_HANDLER(opline);
-		function(result, arg1, arg2, arg3);
+		function(&tmp_result, arg1, arg2, arg3);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 
 	FREE_OP(opline->op1_type, opline->op1.var);
@@ -4275,9 +4287,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_UNUSED_
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		HANDLE_EXCEPTION();
 	}
@@ -4288,8 +4300,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_UNUSED_
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
-		function(result, arg1);
+		function(&tmp_result, arg1);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 	FREE_OP(opline->op1_type, opline->op1.var);
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -4301,9 +4316,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_OBSERVE
 	SAVE_OPLINE();
 
 	zval *result = EX_VAR(opline->result.var);
-	ZVAL_NULL(result);
 	zval *arg1 = get_zval_ptr_deref(opline->op1_type, opline->op1, BP_VAR_R);
 	if (EG(exception)) {
+		ZVAL_NULL(result);
 		FREE_OP(opline->op1_type, opline->op1.var);
 		HANDLE_EXCEPTION();
 	}
@@ -4314,8 +4329,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FRAMELESS_ICALL_1_SPEC_OBSERVE
 	} else
 #endif
 	{
+		zval tmp_result;
+		ZVAL_NULL(&tmp_result);
 		zend_frameless_function_1 function = (zend_frameless_function_1)ZEND_FLF_HANDLER(opline);
-		function(result, arg1);
+		function(&tmp_result, arg1);
+		ZVAL_COPY_VALUE(result, &tmp_result);
 	}
 	FREE_OP(opline->op1_type, opline->op1.var);
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();

--- a/ext/standard/tests/array/gh14873.phpt
+++ b/ext/standard/tests/array/gh14873.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-14873 (PHP 8.4 min function fails on typed integer)
+--FILE--
+<?php
+
+function testTrim1(string $value): string {
+	$value = trim($value);
+	return $value;
+}
+
+function testMin2(int $value): int {
+	$value = min($value, 100);
+	return $value;
+}
+
+function testMin3(int $value): int {
+	$value = min($value, 100, 200);
+	return $value;
+}
+
+var_dump(testTrim1(" boo "));
+var_dump(testMin2(5));
+var_dump(testMin3(5));
+
+?>
+--EXPECT--
+string(3) "boo"
+int(5)
+int(5)


### PR DESCRIPTION
The DFA pass may cause the op1 and result argument to be equal to each other. In the VM we always use ZVAL_NULL(result) first, which will also destroy the first argument. Use a temporary result to fix the issue.