### PR TITLE
Declare that `tests/output/gh14808.phpt` needs iconv extension

### DIFF
--- a/tests/output/gh14808.phpt
+++ b/tests/output/gh14808.phpt
@@ -1,5 +1,7 @@
 --TEST--
 GH-14808 (Unexpected null pointer in Zend/zend_string.h with empty output buffer)
+--EXTENSIONS--
+iconv
 --FILE--
 <?php
 var_dump($args);


### PR DESCRIPTION
Otherwise it would fail with the usual recommended ./configure invocation used for RMs testing (i.e. --disable-all).