### PR TITLE
Fix GH-14741: Segmentation fault in Zend/zend_types.h

### DIFF
--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -666,6 +666,7 @@ ZEND_API void zend_register_interfaces(void)
 
 	memcpy(&zend_internal_iterator_handlers, zend_get_std_object_handlers(),
 		sizeof(zend_object_handlers));
+	zend_internal_iterator_handlers.clone_obj = NULL;
 	zend_internal_iterator_handlers.free_obj = zend_internal_iterator_free;
 }
 /* }}} */

--- a/ext/zend_test/tests/gh14741.phpt
+++ b/ext/zend_test/tests/gh14741.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-14741 (Segmentation fault in Zend/zend_types.h)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$subject = new \ZendTest\Iterators\TraversableTest();
+$it = $subject->getIterator();
+try {
+    clone $it;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Trying to clone an uncloneable object of class InternalIterator
+TraversableTest::drop


### PR DESCRIPTION
The create_obj handler of InternalIterator is overwritten, but not the clone_obj handler. This is not allowed.
In PHP 8.2 this didn't cause a segfault because the standard object handler was used for the clone instead of the internal handler. So then it allocates and frees the object using the standard object handlers. In 8.3 however, the object is created using the standard object handler and freed using the custom handler, resulting in the buffer overflow. Even though bisect points to 1e1ea4f this only reveals the bug.