### PR TITLE
Autotools: Use FPM_EXTRA_LIBS for SELinux library

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -425,7 +425,8 @@ if test "$PHP_FPM" != "no"; then
     [no],
     [no])
 
-  PHP_ARG_WITH([fpm-selinux],,
+  PHP_ARG_WITH([fpm-selinux],
+    [whether to enable SELinux support in PHP-FPM],
     [AS_HELP_STRING([--with-fpm-selinux],
       [Support SELinux policy library])],
     [no],
@@ -498,23 +499,23 @@ if test "$PHP_FPM" != "no"; then
     CFLAGS="$CFLAGS_save"
   fi
 
-  if test "x$PHP_FPM_SELINUX" != "xno" ; then
-    PKG_CHECK_MODULES([SELINUX], [libselinux], [
-      PHP_EVAL_LIBLINE([$SELINUX_LIBS])
-      PHP_EVAL_INCLINE([$SELINUX_CFLAGS])
-    ],
+  AS_VAR_IF([PHP_FPM_SELINUX], [no],, [
+    PKG_CHECK_MODULES([SELINUX], [libselinux],
+      [PHP_EVAL_INCLINE([$SELINUX_CFLAGS])],
       [AC_CHECK_LIB([selinux], [security_setenforce],
-        [PHP_ADD_LIBRARY([selinux])],
+        [SELINUX_LIBS=-lselinux],
         [AC_MSG_ERROR([Required SELinux library not found.])])])
+    PHP_EVAL_LIBLINE([$SELINUX_LIBS], [FPM_EXTRA_LIBS], [yes])
 
     dnl Sanity check.
-    CFLAGS_save="$CFLAGS"
+    CFLAGS_save=$CFLAGS
     CFLAGS="$INCLUDES $CFLAGS"
     AC_CHECK_HEADER([selinux/selinux.h],
-      [AC_DEFINE([HAVE_SELINUX], [1], [Whether SELinux is available.])],
+      [AC_DEFINE([HAVE_SELINUX], [1],
+        [Define to 1 if SELinux is available in PHP-FPM.])],
       [AC_MSG_ERROR([Required selinux/selinux.h not found.])])
-    CFLAGS="$CFLAGS_save"
-  fi
+    CFLAGS=$CFLAGS_save
+  ])
 
   AC_SUBST([php_fpm_systemd])
 


### PR DESCRIPTION
Instead of appending -lselinux to global LIBS variable, this adds it as needed only to FPM_EXTRA_LIBS as it was already used in the BUILD_FPM invocation.

Follow-up of GH-14881