### PR TITLE
ext/random: Optimized `getBytes` loop processing

### DIFF
--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -214,31 +214,4 @@ PHPAPI ZEND_EXTERN_MODULE_GLOBALS(random)
 
 # define RANDOM_G(v)	ZEND_MODULE_GLOBALS_ACCESSOR(random, v)
 
-/* Bytes swap */
-#ifdef _MSC_VER
-#  include <stdlib.h>
-#  define RANDOM_BSWAP64(u) _byteswap_uint64(u)
-#else
-#  ifdef __GNUC__
-#    define RANDOM_BSWAP64(u) __builtin_bswap64(u)
-#  elif defined(__has_builtin)
-#    if __has_builtin(__builtin_bswap64)
-#      define RANDOM_BSWAP64(u) __builtin_bswap64(u)
-#    endif // __has_builtin(__builtin_bswap64)
-#  endif // __GNUC__
-#endif // _MSC_VER
-#ifndef RANDOM_BSWAP64
-static inline uint64_t RANDOM_BSWAP64(uint64_t u)
-{
-   return (((u & 0xff00000000000000ULL) >> 56)
-          | ((u & 0x00ff000000000000ULL) >> 40)
-          | ((u & 0x0000ff0000000000ULL) >> 24)
-          | ((u & 0x000000ff00000000ULL) >>  8)
-          | ((u & 0x00000000ff000000ULL) <<  8)
-          | ((u & 0x0000000000ff0000ULL) << 24)
-          | ((u & 0x000000000000ff00ULL) << 40)
-          | ((u & 0x00000000000000ffULL) << 56));
-}
-#endif
-
 #endif	/* PHP_RANDOM_H */

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -217,30 +217,16 @@ PHPAPI ZEND_EXTERN_MODULE_GLOBALS(random)
 /* Bytes swap */
 #ifdef _MSC_VER
 #  include <stdlib.h>
-#  define RANDOM_BSWAP32(u) _byteswap_ulong(u)
 #  define RANDOM_BSWAP64(u) _byteswap_uint64(u)
 #else
 #  ifdef __GNUC__
-#    define RANDOM_BSWAP32(u) __builtin_bswap32(u)
 #    define RANDOM_BSWAP64(u) __builtin_bswap64(u)
 #  elif defined(__has_builtin)
-#    if __has_builtin(__builtin_bswap32)
-#      define RANDOM_BSWAP32(u) __builtin_bswap32(u)
-#    endif // __has_builtin(__builtin_bswap32)
 #    if __has_builtin(__builtin_bswap64)
 #      define RANDOM_BSWAP64(u) __builtin_bswap64(u)
 #    endif // __has_builtin(__builtin_bswap64)
 #  endif // __GNUC__
 #endif // _MSC_VER
-#ifndef RANDOM_BSWAP32
-static inline uint32_t RANDOM_BSWAP32(uint32_t u)
-{
-  return (((u & 0xff000000) >> 24)
-          | ((u & 0x00ff0000) >>  8)
-          | ((u & 0x0000ff00) <<  8)
-          | ((u & 0x000000ff) << 24));
-}
-#endif
 #ifndef RANDOM_BSWAP64
 static inline uint64_t RANDOM_BSWAP64(uint64_t u)
 {

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -214,4 +214,45 @@ PHPAPI ZEND_EXTERN_MODULE_GLOBALS(random)
 
 # define RANDOM_G(v)	ZEND_MODULE_GLOBALS_ACCESSOR(random, v)
 
+/* Bytes swap */
+#ifdef _MSC_VER
+#  include <stdlib.h>
+#  define RANDOM_BSWAP32(u) _byteswap_ulong(u)
+#  define RANDOM_BSWAP64(u) _byteswap_uint64(u)
+#else
+#  ifdef __GNUC__
+#    define RANDOM_BSWAP32(u) __builtin_bswap32(u)
+#    define RANDOM_BSWAP64(u) __builtin_bswap64(u)
+#  elif defined(__has_builtin)
+#    if __has_builtin(__builtin_bswap32)
+#      define RANDOM_BSWAP32(u) __builtin_bswap32(u)
+#    endif // __has_builtin(__builtin_bswap32)
+#    if __has_builtin(__builtin_bswap64)
+#      define RANDOM_BSWAP64(u) __builtin_bswap64(u)
+#    endif // __has_builtin(__builtin_bswap64)
+#  endif // __GNUC__
+#endif // _MSC_VER
+#ifndef RANDOM_BSWAP32
+static inline uint32_t RANDOM_BSWAP32(uint32_t u)
+{
+  return (((u & 0xff000000) >> 24)
+          | ((u & 0x00ff0000) >>  8)
+          | ((u & 0x0000ff00) <<  8)
+          | ((u & 0x000000ff) << 24));
+}
+#endif
+#ifndef RANDOM_BSWAP64
+static inline uint64_t RANDOM_BSWAP64(uint64_t u)
+{
+   return (((u & 0xff00000000000000ULL) >> 56)
+          | ((u & 0x00ff000000000000ULL) >> 40)
+          | ((u & 0x0000ff0000000000ULL) >> 24)
+          | ((u & 0x000000ff00000000ULL) >>  8)
+          | ((u & 0x00000000ff000000ULL) <<  8)
+          | ((u & 0x0000000000ff0000ULL) << 24)
+          | ((u & 0x000000000000ff00ULL) << 40)
+          | ((u & 0x00000000000000ffULL) << 56));
+}
+#endif
+
 #endif	/* PHP_RANDOM_H */

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -26,6 +26,7 @@
 
 #include "Zend/zend_enum.h"
 #include "Zend/zend_exceptions.h"
+#include "zend_portability.h"
 
 static inline void randomizer_common_init(php_random_randomizer *randomizer, zend_object *engine_object) {
 	if (engine_object->ce->type == ZEND_INTERNAL_CLASS) {
@@ -302,7 +303,7 @@ PHP_METHOD(Random_Randomizer, getBytes)
 		uint64_t tmp_ret = result.result;
 		if (to_read >= sizeof(uint64_t) && result.size == sizeof(uint64_t)) {
 #ifdef WORDS_BIGENDIAN
-			tmp_ret = RANDOM_BSWAP64(tmp_ret);
+			tmp_ret = ZEND_BYTES_SWAP64(tmp_ret);
 #endif
 			memcpy(rptr, &tmp_ret, sizeof(uint64_t));
 			to_read -= sizeof(uint64_t);

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -298,8 +298,10 @@ PHP_METHOD(Random_Randomizer, getBytes)
 			zend_string_free(retval);
 			RETURN_THROWS();
 		}
+		uint64_t tmp_ret = result.result;
 		for (size_t i = 0; i < result.size; i++) {
-			ZSTR_VAL(retval)[total_size++] = (result.result >> (i * 8)) & 0xff;
+			ZSTR_VAL(retval)[total_size++] = tmp_ret & 0xff;
+			tmp_ret >>= 8;
 			if (total_size >= length) {
 				break;
 			}


### PR DESCRIPTION
All measurement results are from the latest commit.

## Benchmark codes

Since the description is too long, `<?php` and `use` are omitted.

### Using PcgOneseq128XslRr64

0.php:
```
$r = new Randomizer(new PcgOneseq128XslRr64());

for ($i = 0; $i < 10000000; $i++) {
    $r->getBytes(1);
}
```

1.php:
```
$r = new Randomizer(new PcgOneseq128XslRr64());

for ($i = 0; $i < 10000000; $i++) {
    $r->getBytes(16);
}
```

2.php
```
$r = new Randomizer(new PcgOneseq128XslRr64());

for ($i = 0; $i < 500000; $i++) {
    $r->getBytes(1024);
}
```

### Omit constructor arguments

n0.php:
```
$r = new Randomizer();

for ($i = 0; $i < 1000000; $i++) {
    $r->getBytes(1);
}
```

n1.php:
```
$r = new Randomizer();

for ($i = 0; $i < 500000; $i++) {
    $r->getBytes(16);
}
```

n2.php:
```
$r = new Randomizer();

for ($i = 0; $i < 5000; $i++) {
    $r->getBytes(1024);
}
```

## Using PcgOneseq128XslRr64

### before

```
# hyperfine "php /mount/random/0.php" --warmup 10
Benchmark 1: php /mount/random/0.php
  Time (mean ± σ):     278.7 ms ±   2.5 ms    [User: 274.0 ms, System: 4.0 ms]
  Range (min … max):   275.0 ms … 283.1 ms    10 runs
 
# hyperfine "php /mount/random/1.php" --warmup 10
Benchmark 1: php /mount/random/1.php
  Time (mean ± σ):     425.6 ms ±  12.5 ms    [User: 422.3 ms, System: 2.5 ms]
  Range (min … max):   413.2 ms … 457.5 ms    10 runs
 
# hyperfine "php /mount/random/2.php" --warmup 10
Benchmark 1: php /mount/random/2.php
  Time (mean ± σ):     561.9 ms ±   5.2 ms    [User: 558.2 ms, System: 3.0 ms]
  Range (min … max):   556.5 ms … 572.7 ms    10 runs
```

### after Optimized bit shifting

```
# hyperfine "php /mount/random/0.php" --warmup 10
Benchmark 1: php /mount/random/0.php
  Time (mean ± σ):     267.0 ms ±  13.4 ms    [User: 263.3 ms, System: 3.0 ms]
  Range (min … max):   257.9 ms … 302.5 ms    11 runs
 
# hyperfine "php /mount/random/1.php" --warmup 10
Benchmark 1: php /mount/random/1.php
  Time (mean ± σ):     409.1 ms ±  33.2 ms    [User: 405.3 ms, System: 3.1 ms]
  Range (min … max):   385.3 ms … 476.4 ms    10 runs
 
# hyperfine "php /mount/random/2.php" --warmup 10
Benchmark 1: php /mount/random/2.php
  Time (mean ± σ):     499.8 ms ±   7.8 ms    [User: 496.3 ms, System: 2.9 ms]
  Range (min … max):   491.3 ms … 515.6 ms    10 runs
```

### after Using memcpy

```
# hyperfine "php /mount/random/0.php" --warmup 10
Benchmark 1: php /mount/random/0.php
  Time (mean ± σ):     295.5 ms ±   9.3 ms    [User: 290.9 ms, System: 3.9 ms]
  Range (min … max):   287.6 ms … 318.5 ms    10 runs
 
# hyperfine "php /mount/random/1.php" --warmup 10
Benchmark 1: php /mount/random/1.php
  Time (mean ± σ):     327.9 ms ±   3.8 ms    [User: 323.6 ms, System: 3.5 ms]
  Range (min … max):   323.0 ms … 332.2 ms    10 runs
 
# hyperfine "php /mount/random/2.php" --warmup 10
Benchmark 1: php /mount/random/2.php
  Time (mean ± σ):     260.5 ms ±   3.0 ms    [User: 256.2 ms, System: 3.7 ms]
  Range (min … max):   255.9 ms … 265.3 ms    11 runs
```

### after Loop optimization

```
# hyperfine "php /mount/random/0.php" --warmup 10
Benchmark 1: php /mount/random/0.php
  Time (mean ± σ):     268.8 ms ±   2.5 ms    [User: 265.3 ms, System: 2.7 ms]
  Range (min … max):   264.9 ms … 273.9 ms    11 runs

# hyperfine "php /mount/random/1.php" --warmup 10
Benchmark 1: php /mount/random/1.php
  Time (mean ± σ):     323.7 ms ±  13.5 ms    [User: 320.0 ms, System: 3.0 ms]
  Range (min … max):   314.9 ms … 354.8 ms    10 runs
  
# hyperfine "php /mount/random/2.php" --warmup 10
Benchmark 1: php /mount/random/2.php
  Time (mean ± σ):     265.2 ms ±   3.6 ms    [User: 260.7 ms, System: 3.7 ms]
  Range (min … max):   260.3 ms … 273.6 ms    11 runs
```

## Omit constructor arguments

### before

```
# hyperfine "php /mount/random/n0.php" --warmup 10
Benchmark 1: php /mount/random/n0.php
  Time (mean ± σ):     478.8 ms ±   5.0 ms    [User: 177.2 ms, System: 300.8 ms]
  Range (min … max):   474.9 ms … 489.1 ms    10 runs

# hyperfine "php /mount/random/n1.php" --warmup 10
Benchmark 1: php /mount/random/n1.php
  Time (mean ± σ):     475.6 ms ±   6.7 ms    [User: 172.3 ms, System: 302.6 ms]
  Range (min … max):   470.9 ms … 493.4 ms    10 runs

# hyperfine "php /mount/random/n2.php" --warmup 10
Benchmark 1: php /mount/random/n2.php
  Time (mean ± σ):     297.1 ms ±   4.4 ms    [User: 101.6 ms, System: 194.7 ms]
  Range (min … max):   292.2 ms … 307.0 ms    10 runs
```

### after

```
# hyperfine "php /mount/random/n0.php" --warmup 10
Benchmark 1: php /mount/random/n0.php
  Time (mean ± σ):     478.0 ms ±   4.5 ms    [User: 175.8 ms, System: 301.4 ms]
  Range (min … max):   469.3 ms … 483.8 ms    10 runs
  
# hyperfine "php /mount/random/n1.php" --warmup 10
Benchmark 1: php /mount/random/n1.php
  Time (mean ± σ):     473.6 ms ±  12.5 ms    [User: 171.3 ms, System: 301.5 ms]
  Range (min … max):   463.2 ms … 501.3 ms    10 runs

# hyperfine "php /mount/random/n2.php" --warmup 10
Benchmark 1: php /mount/random/n2.php
  Time (mean ± σ):     297.5 ms ±   9.0 ms    [User: 95.5 ms, System: 201.3 ms]
  Range (min … max):   286.2 ms … 317.8 ms    10 runs
```