### PR TITLE
random: Optimize `Randomizer::getBytesFromString()`

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -431,9 +431,9 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 		mask |= mask >> 1;
 		mask |= mask >> 2;
 		mask |= mask >> 4;
+		// Expand the lowest byte into all bytes.
+		mask *= 0x0101010101010101;
 
-		/* Example: if mask is 0xAB, will be 0xABABABABABABABAB */
-		uint64_t mask_repeat = (~((uint64_t) 0) / 0xff) * mask;
 		int failures = 0;
 		while (total_size < length) {
 			php_random_result result = engine.algo->generate(engine.state);
@@ -442,7 +442,7 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 				RETURN_THROWS();
 			}
 
-			uint64_t offsets = result.result & mask_repeat;
+			uint64_t offsets = result.result & mask;
 			for (size_t i = 0; i < result.size; i++) {
 				uint64_t offset = offsets & 0xff;
 				offsets >>= 8;

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -432,6 +432,8 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 		mask |= mask >> 2;
 		mask |= mask >> 4;
 
+		/* Example: if mask is 0xAB, will be 0xABABABABABABABAB */
+		uint64_t mask_repeat = (~((uint64_t) 0) / 0xff) * mask;
 		int failures = 0;
 		while (total_size < length) {
 			php_random_result result = engine.algo->generate(engine.state);
@@ -440,8 +442,9 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 				RETURN_THROWS();
 			}
 
+			uint64_t offsets = result.result & mask_repeat;
 			for (size_t i = 0; i < result.size; i++) {
-				uint64_t offset = (result.result >> (i * 8)) & mask;
+				uint64_t offset = offsets >> (i * 8) & 0xff;
 
 				if (offset > max_offset) {
 					if (++failures > PHP_RANDOM_RANGE_ATTEMPTS) {

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -444,7 +444,8 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 
 			uint64_t offsets = result.result & mask_repeat;
 			for (size_t i = 0; i < result.size; i++) {
-				uint64_t offset = offsets >> (i * 8) & 0xff;
+				uint64_t offset = offsets & 0xff;
+				offsets >>= 8;
 
 				if (offset > max_offset) {
 					if (++failures > PHP_RANDOM_RANGE_ATTEMPTS) {


### PR DESCRIPTION
## Benchmark codes

Since the description is too long, `<?php` and `use` are omitted.
`$str` is all 256 characters

### Using PcgOneseq128XslRr64

0.php:
```
$r = new Randomizer(new PcgOneseq128XslRr64());
// 256 characters
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 10000000; $i++) {
    $r->getBytesFromString($str, 1);
}
```

1.php:
```
$r = new Randomizer(new PcgOneseq128XslRr64());
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 10000000; $i++) {
    $r->getBytesFromString($str, 16);
}
```

2.php
```
$r = new Randomizer(new PcgOneseq128XslRr64());
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 300000; $i++) {
    $r->getBytesFromString($str, 1024);
}
```

### Omit constructor arguments

n0.php:
```
$r = new Randomizer();
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 1000000; $i++) {
    $r->getBytesFromString($str, 1);
}
```

n1.php:
```
$r = new Randomizer();
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 500000; $i++) {
    $r->getBytesFromString($str, 16);
}
```

n2.php:
```
$r = new Randomizer();
$str = '1GCOFExQwWVNBFxOpGXilQdjcCrS6CxJRbgRf214G6w0bnFdwlmylDIpAQlcHVH5co5heIrarVoodaGeTbMQwWaM16fwXfLr03tjYymp2hg0XI5MqTlEr1taXFyHD5fYNqX7nkFJKOYU3FRMeIUkXAMpqqkIdNXP2od5Wbkra5rvLV4WT1lGN0Yg0AeEXAPq8nRxdePU2M6vQOX7wvJKKrmMAWsopEEDAdOxtrOb8lp7oPI3RjhXMbTFXaPgjljO';

for ($i = 0; $i < 5000; $i++) {
    $r->getBytesFromString($str, 1024);
}
```

## Using PcgOneseq128XslRr64

### before

```
# hyperfine "php /mount/random/fromstr/0.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/0.php
  Time (mean ± σ):     334.1 ms ±   5.6 ms    [User: 329.8 ms, System: 3.4 ms]
  Range (min … max):   327.7 ms … 343.4 ms    10 runs

# hyperfine "php /mount/random/fromstr/1.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/1.php
  Time (mean ± σ):     609.3 ms ±  12.1 ms    [User: 603.4 ms, System: 5.0 ms]
  Range (min … max):   596.2 ms … 632.6 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/2.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/2.php
  Time (mean ± σ):     614.3 ms ±   5.9 ms    [User: 609.0 ms, System: 4.4 ms]
  Range (min … max):   605.6 ms … 621.5 ms    10 runs
```

### after commit 1

```
# hyperfine "php /mount/random/fromstr/0.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/0.php
  Time (mean ± σ):     344.1 ms ±  11.6 ms    [User: 339.6 ms, System: 3.7 ms]
  Range (min … max):   335.1 ms … 374.4 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/1.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/1.php
  Time (mean ± σ):     583.9 ms ±   5.4 ms    [User: 578.8 ms, System: 4.2 ms]
  Range (min … max):   576.8 ms … 597.1 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/2.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/2.php
  Time (mean ± σ):     543.7 ms ±   3.4 ms    [User: 540.0 ms, System: 2.6 ms]
  Range (min … max):   538.6 ms … 549.4 ms    10 runs
```

### after commit 2

```
# hyperfine "php /mount/random/fromstr/0.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/0.php
  Time (mean ± σ):     332.8 ms ±   4.0 ms    [User: 328.4 ms, System: 3.6 ms]
  Range (min … max):   327.3 ms … 338.8 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/1.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/1.php
  Time (mean ± σ):     487.9 ms ±  11.4 ms    [User: 484.5 ms, System: 2.7 ms]
  Range (min … max):   479.6 ms … 514.9 ms    10 runs

# hyperfine "php /mount/random/fromstr/2.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/2.php
  Time (mean ± σ):     349.7 ms ±   8.0 ms    [User: 345.8 ms, System: 3.2 ms]
  Range (min … max):   343.3 ms … 369.7 ms    10 runs
```

## Omit constructor arguments

### before

```
# hyperfine "php /mount/random/fromstr/n0.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n0.php
  Time (mean ± σ):     506.9 ms ±  22.2 ms    [User: 184.3 ms, System: 321.6 ms]
  Range (min … max):   476.7 ms … 536.2 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/n1.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n1.php
  Time (mean ± σ):     479.5 ms ±   5.6 ms    [User: 184.4 ms, System: 294.2 ms]
  Range (min … max):   471.8 ms … 489.1 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/n2.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n2.php
  Time (mean ± σ):     301.7 ms ±   4.8 ms    [User: 104.0 ms, System: 196.9 ms]
  Range (min … max):   296.3 ms … 309.7 ms    10 runs
```

### after

```
# hyperfine "php /mount/random/fromstr/n0.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n0.php
  Time (mean ± σ):     484.7 ms ±   5.2 ms    [User: 181.5 ms, System: 302.4 ms]
  Range (min … max):   475.7 ms … 491.3 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/n1.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n1.php
  Time (mean ± σ):     475.9 ms ±   7.7 ms    [User: 174.4 ms, System: 300.7 ms]
  Range (min … max):   470.2 ms … 495.7 ms    10 runs
 
# hyperfine "php /mount/random/fromstr/n2.php" --warmup 10
Benchmark 1: php /mount/random/fromstr/n2.php
  Time (mean ± σ):     296.1 ms ±   4.8 ms    [User: 98.2 ms, System: 197.1 ms]
  Range (min … max):   289.4 ms … 305.5 ms    10 runs
```