### PR TITLE
Fix GH-14443: Cross-compiling with external GD library

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ PHP                                                                        NEWS
     (nielsdos)
   . Fixed OSS-Fuzz #69765. (nielsdos)
   . Fixed bug GH-14741 (Segmentation fault in Zend/zend_types.h). (nielsdos)
+  . Fixed bug GH-14443 (Cross-compiling with external GD library). (Peter Kokot)
 
 - Dom:
   . Fixed bug GH-14702 (DOMDocument::xinclude() crash). (nielsdos)

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -147,14 +147,15 @@ dnl that gd defines "junk" versions of each gdImageCreateFromFoo function
 dnl even when it does not support the Foo format. Those junk functions
 dnl display a warning but eventually return normally, making a simple link
 dnl or run test insufficient.
-AC_DEFUN([PHP_GD_CHECK_FORMAT],[
-  old_LIBS="${LIBS}"
-  LIBS="${LIBS} ${GD_SHARED_LIBADD}"
-  old_CFLAGS="${CFLAGS}"
-  CFLAGS="${CFLAGS} ${GDLIB_CFLAGS}"
-  AC_MSG_CHECKING([for working gdImageCreateFrom$1 in libgd])
-  AC_LANG_PUSH([C])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([
+AC_DEFUN([PHP_GD_CHECK_FORMAT],
+[AS_VAR_PUSHDEF([php_var], [php_cv_lib_gd_gdImageCreateFrom$1])
+old_LIBS=$LIBS
+LIBS="$LIBS $GD_SHARED_LIBADD"
+old_CFLAGS=$CFLAGS
+CFLAGS="$CFLAGS $GDLIB_CFLAGS"
+AC_LANG_PUSH([C])
+AC_CACHE_CHECK([for working gdImageCreateFrom$1 in libgd], [php_var],
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <unistd.h>
 #include <gd.h>
@@ -173,17 +174,17 @@ int main(int argc, char** argv) {
   gdSetErrorMethod(exit1);
   gdImagePtr p = gdImageCreateFrom$1(f);
   return 0;
-}])],[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE($2, 1, [Does gdImageCreateFrom$1 work?])
-  ],[
-    AC_MSG_RESULT([no])
-  ],[
-    AC_MSG_RESULT([no])
-  ])
-  AC_LANG_POP([C])
-  CFLAGS="${old_CFLAGS}"
-  LIBS="${old_LIBS}"
+}])],
+  [AS_VAR_SET([php_var], [yes])],
+  [AS_VAR_SET([php_var], [no])],
+  [AS_VAR_SET([php_var], [no])])])
+AS_VAR_IF([php_var], [yes],
+  [AC_DEFINE_UNQUOTED([$2], [1],
+    [Define to 1 if GD library has the 'gdImageCreateFrom$1' function.])])
+AC_LANG_POP([C])
+CFLAGS=$old_CFLAGS
+LIBS=$old_LIBS
+AS_VAR_POPDEF([php_var])
 ])
 
 AC_DEFUN([PHP_GD_CHECK_VERSION],[


### PR DESCRIPTION
This enables cross-compiling simplifications when using external GD library as requested in GH-14443 using cache variables:

* php_cv_lib_gd_gdImageCreateFromPng
* php_cv_lib_gd_gdImageCreateFromAvif
* php_cv_lib_gd_gdImageCreateFromWebp
* php_cv_lib_gd_gdImageCreateFromJpeg
* php_cv_lib_gd_gdImageCreateFromXpm
* php_cv_lib_gd_gdImageCreateFromBmp
* php_cv_lib_gd_gdImageCreateFromTga

For example:

    ./configure --host=... --build=... --enable-gd --with-external-gd \
        php_cv_lib_gd_gdImageCreateFromPng=yes

Note that this has already been implemented in master branch (PHP-8.4-dev) and this one is targeting PHP-8.2.