### PR TITLE
Autotools: Move php_shtool variable initialization to PHP_INIT_BUILD_SYSTEM

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -124,8 +124,9 @@ dnl PHP_INIT_BUILD_SYSTEM
 dnl
 dnl Creates build directories and Makefile placeholders.
 dnl
-AC_DEFUN([PHP_INIT_BUILD_SYSTEM],[
-AC_REQUIRE([PHP_CANONICAL_HOST_TARGET])dnl
+AC_DEFUN([PHP_INIT_BUILD_SYSTEM],
+[AC_REQUIRE([PHP_CANONICAL_HOST_TARGET])dnl
+php_shtool=$srcdir/build/shtool
 > Makefile.objects
 > Makefile.fragments
 dnl Run at the end of the configuration, before creating the config.status.

--- a/configure.ac
+++ b/configure.ac
@@ -104,11 +104,10 @@ fi
 dnl Settings we want to make before the checks.
 dnl ----------------------------------------------------------------------------
 
-php_shtool=$srcdir/build/shtool
+PHP_INIT_BUILD_SYSTEM
+
 T_MD=`$php_shtool echo -n -e %B`
 T_ME=`$php_shtool echo -n -e %b`
-
-PHP_INIT_BUILD_SYSTEM
 
 dnl We want this one before the checks, so the checks can modify CFLAGS.
 AS_VAR_IF([CFLAGS],, [auto_cflags=1])

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -65,7 +65,6 @@ PHP_EXECUTABLE=`$PHP_CONFIG --php-binary 2>/dev/null`
 AS_VAR_IF([prefix],,
   [AC_MSG_ERROR([Cannot find php-config. Please use --with-php-config=PATH])])
 
-php_shtool=$srcdir/build/shtool
 PHP_INIT_BUILD_SYSTEM
 
 AC_MSG_CHECKING([for PHP prefix])


### PR DESCRIPTION
As this script is still needed across the PHP build system its path can be also set on once place for both phpize usage and regular php-src's configure.ac.