### PR TITLE
ext/gd/tests/gh10614.phpt: skip if no PNG support

### DIFF
--- a/ext/gd/tests/gh10614.phpt
+++ b/ext/gd/tests/gh10614.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.4', '>=')) die("skip test requires GD 2.3.4 or older");
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
This test uses `imagecreatefrompng()`, which won't be there if libgd was built without PNG support.