### PR TITLE
Properly support template elements in DOM

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-14801 (Fix build for armv7). (andypost)
 
+- DOM:
+  . Improve support for template elements. (nielsdos)
+
 - GD:
   . Check overflow/underflow for imagescale/imagefilter. (David Carlier)
 

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -27,7 +27,7 @@ if test "$PHP_DOM" != "no"; then
       $LEXBOR_DIR/ns/ns.c \
       $LEXBOR_DIR/tag/tag.c"
     PHP_NEW_EXTENSION(dom, [php_dom.c attr.c document.c infra.c \
-                            xml_document.c html_document.c xml_serializer.c html5_serializer.c html5_parser.c namespace_compat.c \
+                            xml_document.c html_document.c xml_serializer.c html5_serializer.c html5_parser.c namespace_compat.c private_data.c \
                             domexception.c \
                             parentnode/tree.c parentnode/css_selectors.c \
                             processinginstruction.c cdatasection.c \

--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -8,7 +8,7 @@ if (PHP_DOM == "yes") {
 		CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_DOM", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("dom", "php_dom.c attr.c document.c infra.c \
-			xml_document.c html_document.c xml_serializer.c html5_serializer.c html5_parser.c namespace_compat.c \
+			xml_document.c html_document.c xml_serializer.c html5_serializer.c html5_parser.c namespace_compat.c private_data.c \
 			domexception.c processinginstruction.c \
 			cdatasection.c documentfragment.c domimplementation.c element.c  inner_html_mixin.c \
 			node.c characterdata.c documenttype.c \

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -23,6 +23,7 @@
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "xml_serializer.h"
 #include "internal_helpers.h"
 #include "dom_properties.h"

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -23,6 +23,7 @@
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 
 /*
 * class DOMImplementation

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -266,7 +266,8 @@ PHP_METHOD(Dom_Implementation, createDocument)
 
 	xmlDocPtr document = NULL;
 	xmlChar *localname = NULL, *prefix = NULL;
-	php_dom_libxml_ns_mapper *ns_mapper = php_dom_libxml_ns_mapper_create();
+	php_dom_private_data *private_data = php_dom_private_data_create();
+	php_dom_libxml_ns_mapper *ns_mapper = php_dom_ns_mapper_from_private(private_data);
 
 	/* 1. Let document be a new XMLDocument. */
 	document = xmlNewDoc(BAD_CAST "1.0");
@@ -307,7 +308,7 @@ PHP_METHOD(Dom_Implementation, createDocument)
 		NULL
 	);
 	dom_set_xml_class(intern->document);
-	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
+	intern->document->private_data = php_dom_libxml_private_data_header(private_data);
 
 	/* 4. If doctype is non-null, append doctype to document. */
 	if (doctype != NULL) {
@@ -337,7 +338,7 @@ error:
 	xmlFree(localname);
 	xmlFree(prefix);
 	xmlFreeDoc(document);
-	php_dom_libxml_ns_mapper_destroy(ns_mapper);
+	php_dom_private_data_destroy(private_data);
 	RETURN_THROWS();
 }
 /* }}} end dom_domimplementation_create_document */
@@ -366,7 +367,8 @@ PHP_METHOD(Dom_Implementation, createHTMLDocument)
 	/* 3. Append a new doctype, with "html" as its name and with its node document set to doc, to doc. */
 	xmlDtdPtr dtd = xmlCreateIntSubset(doc, BAD_CAST "html", NULL, NULL);
 
-	php_dom_libxml_ns_mapper *ns_mapper = php_dom_libxml_ns_mapper_create();
+	php_dom_private_data *private_data = php_dom_private_data_create();
+	php_dom_libxml_ns_mapper *ns_mapper = php_dom_ns_mapper_from_private(private_data);
 	xmlNsPtr html_ns = php_dom_libxml_ns_mapper_ensure_html_ns(ns_mapper);
 
 	/* 4. Append the result of creating an element given doc, html, and the HTML namespace, to doc. */
@@ -396,7 +398,7 @@ PHP_METHOD(Dom_Implementation, createHTMLDocument)
 	if (UNEXPECTED(dtd == NULL || html_element == NULL || head_element == NULL || (title != NULL && title_element == NULL) || body_element == NULL)) {
 		php_dom_throw_error(INVALID_STATE_ERR, true);
 		xmlFreeDoc(doc);
-		php_dom_libxml_ns_mapper_destroy(ns_mapper);
+		php_dom_private_data_destroy(private_data);
 		RETURN_THROWS();
 	}
 
@@ -408,7 +410,7 @@ PHP_METHOD(Dom_Implementation, createHTMLDocument)
 		NULL
 	);
 	dom_set_xml_class(intern->document);
-	intern->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
+	intern->document->private_data = php_dom_libxml_private_data_header(private_data);
 }
 /* }}} */
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -24,6 +24,7 @@
 #include "zend_enum.h"
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "internal_helpers.h"
 #include "dom_properties.h"
 #include "token_list.h"
@@ -2029,6 +2030,11 @@ PHP_METHOD(Dom_Element, rename)
 				);
 			}
 			goto cleanup;
+		}
+
+		/* If we currently have a template but the new element type won't be a template, then throw away the templated content. */
+		if (is_currently_html_ns && xmlStrEqual(nodep->name, BAD_CAST "template") && !xmlStrEqual(localname, BAD_CAST "template")) {
+			php_dom_remove_templated_content(php_dom_get_private_data(intern), nodep);
 		}
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -24,7 +24,6 @@
 #include "zend_enum.h"
 #include "php_dom.h"
 #include "namespace_compat.h"
-#include "private_data.h"
 #include "internal_helpers.h"
 #include "dom_properties.h"
 #include "token_list.h"
@@ -2034,7 +2033,12 @@ PHP_METHOD(Dom_Element, rename)
 
 		/* If we currently have a template but the new element type won't be a template, then throw away the templated content. */
 		if (is_currently_html_ns && xmlStrEqual(nodep->name, BAD_CAST "template") && !xmlStrEqual(localname, BAD_CAST "template")) {
-			php_dom_remove_templated_content(php_dom_get_private_data(intern), nodep);
+			php_dom_throw_error_with_message(
+				INVALID_MODIFICATION_ERR,
+				"It is not possible to rename the template element because it hosts a document fragment",
+				/* strict */ true
+			);
+			goto cleanup;
 		}
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -24,6 +24,7 @@
 #include "zend_enum.h"
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "internal_helpers.h"
 #include "dom_properties.h"
 #include "token_list.h"

--- a/ext/dom/html5_parser.c
+++ b/ext/dom/html5_parser.c
@@ -171,15 +171,17 @@ static lexbor_libxml2_bridge_status lexbor_libxml2_bridge_convert(
 			xmlNodePtr lxml_child_parent = lxml_element;
 			lxb_dom_node_t *child_node = element->node.last_child;
 			if (lxb_html_tree_node_is(&element->node, LXB_TAG_TEMPLATE)) {
-				lxml_child_parent = xmlNewDocFragment(lxml_doc);
-				if (UNEXPECTED(lxml_child_parent == NULL)) {
-					retval = LEXBOR_LIBXML2_BRIDGE_STATUS_OOM;
-					break;
-				}
+				if (create_default_ns) {
+					lxml_child_parent = xmlNewDocFragment(lxml_doc);
+					if (UNEXPECTED(lxml_child_parent == NULL)) {
+						retval = LEXBOR_LIBXML2_BRIDGE_STATUS_OOM;
+						break;
+					}
 
-				lxml_child_parent->parent = lxml_element;
-				dom_add_element_ns_hook(private_data, lxml_element);
-				php_dom_add_templated_content(private_data, lxml_element, lxml_child_parent);
+					lxml_child_parent->parent = lxml_element;
+					dom_add_element_ns_hook(private_data, lxml_element);
+					php_dom_add_templated_content(private_data, lxml_element, lxml_child_parent);
+				}
 
 				lxb_html_template_element_t *template = lxb_html_interface_template(&element->node);
 				if (template->content != NULL) {

--- a/ext/dom/html5_parser.h
+++ b/ext/dom/html5_parser.h
@@ -71,7 +71,7 @@ lexbor_libxml2_bridge_status lexbor_libxml2_bridge_convert_document(
     xmlDocPtr *doc_out,
     bool compact_text_nodes,
     bool create_default_ns,
-    php_dom_libxml_ns_mapper *ns_mapper
+    php_dom_private_data *private_data
 );
 lexbor_libxml2_bridge_status lexbor_libxml2_bridge_convert_fragment(
     lxb_dom_node_t *start_node,
@@ -79,7 +79,7 @@ lexbor_libxml2_bridge_status lexbor_libxml2_bridge_convert_fragment(
     xmlNodePtr *fragment_out,
     bool compact_text_nodes,
     bool create_default_ns,
-    php_dom_libxml_ns_mapper *ns_mapper
+    php_dom_private_data *private_data
 );
 void lexbor_libxml2_bridge_report_errors(
     const lexbor_libxml2_bridge_parse_context *ctx,

--- a/ext/dom/html5_serializer.c
+++ b/ext/dom/html5_serializer.c
@@ -289,14 +289,26 @@ static zend_result dom_html5_serialize_node(dom_html5_serialize_context *ctx, co
 
 			case XML_ELEMENT_NODE: {
 				TRY(dom_html5_serialize_element_start(ctx, node));
-				if (node->children) {
+				const xmlNode *children = node->children;
+				if (php_dom_ns_is_fast(node, php_dom_ns_is_html_magic_token) && xmlStrEqual(node->name, BAD_CAST "template")) {
+					children = php_dom_retrieve_templated_content(ctx->private_data, node);
+				}
+				if (children) {
 					if (!dom_html5_serializes_as_void(node)) {
-						node = node->children;
+						node = children;
 						continue;
 					}
 				} else {
 					/* Not descended, so wouldn't put the closing tag as it's normally only done when going back upwards. */
 					TRY(dom_html5_serialize_element_end(ctx, node));
+				}
+				break;
+			}
+
+			case XML_DOCUMENT_FRAG_NODE: {
+				if (node->children) {
+					node = node->children;
+					continue;
 				}
 				break;
 			}
@@ -346,10 +358,15 @@ zend_result dom_html5_serialize(dom_html5_serialize_context *ctx, const xmlNode 
 	}
 
 	/* Step 2 not needed because we're not using a string to store the serialized data */
-	/* Step 3 not needed because we don't support template contents yet */
+
+	/* Step 3. If the node is a template element, then let the node instead be the template element's template contents (a DocumentFragment node). */
+	xmlNodePtr children = php_dom_retrieve_templated_content(ctx->private_data, node);
+	if (!children) {
+		children = node->children;
+	}
 
 	/* Step 4 */
-	return dom_html5_serialize_node(ctx, node->children, node);
+	return dom_html5_serialize_node(ctx, children, node);
 }
 
 /* Variant on the above that is equivalent to the "outer HTML". */

--- a/ext/dom/html5_serializer.h
+++ b/ext/dom/html5_serializer.h
@@ -19,11 +19,13 @@
 
 #include <Zend/zend_types.h>
 #include <libxml/tree.h>
+#include "private_data.h"
 
 typedef struct {
 	zend_result (*write_string)(void *application_data, const char *buf);
 	zend_result (*write_string_len)(void *application_data, const char *buf, size_t len);
 	void *application_data;
+	php_dom_private_data *private_data;
 } dom_html5_serialize_context;
 
 zend_result dom_html5_serialize(dom_html5_serialize_context *ctx, const xmlNode *node);

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1644,4 +1644,19 @@ zend_result dom_html_document_title_write(dom_object *obj, zval *newval)
 	return SUCCESS;
 }
 
+#if ZEND_DEBUG
+PHP_METHOD(Dom_HTMLDocument, debugGetTemplateCount)
+{
+	xmlDocPtr doc;
+	dom_object *intern;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	DOM_GET_OBJ(doc, ZEND_THIS, xmlDocPtr, intern);
+	ZEND_IGNORE_VALUE(doc);
+
+	RETURN_LONG(php_dom_get_template_count((const php_dom_private_data *) intern->document->private_data));
+}
+#endif
+
 #endif  /* HAVE_LIBXML && HAVE_DOM */

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -25,6 +25,7 @@
 #include "html5_parser.h"
 #include "html5_serializer.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "dom_properties.h"
 #include <Zend/zend_smart_string.h>
 #include <lexbor/html/encoding.h>
@@ -879,7 +880,6 @@ PHP_METHOD(Dom_HTMLDocument, createFromString)
 	}
 
 	php_dom_private_data *private_data = php_dom_private_data_create();
-	php_dom_libxml_ns_mapper *ns_mapper = php_dom_ns_mapper_from_private(private_data);
 
 	xmlDocPtr lxml_doc;
 	lexbor_libxml2_bridge_status bridge_status = lexbor_libxml2_bridge_convert_document(
@@ -887,7 +887,7 @@ PHP_METHOD(Dom_HTMLDocument, createFromString)
 		&lxml_doc,
 		options & XML_PARSE_COMPACT,
 		!(options & DOM_HTML_NO_DEFAULT_NS),
-		ns_mapper
+		private_data
 	);
 	lexbor_libxml2_bridge_copy_observations(parser->tree, &ctx.observations);
 	if (UNEXPECTED(bridge_status != LEXBOR_LIBXML2_BRIDGE_STATUS_OK)) {
@@ -1071,7 +1071,6 @@ PHP_METHOD(Dom_HTMLDocument, createFromFile)
 	}
 
 	private_data = php_dom_private_data_create();
-	php_dom_libxml_ns_mapper *ns_mapper = php_dom_ns_mapper_from_private(private_data);
 
 	xmlDocPtr lxml_doc;
 	lexbor_libxml2_bridge_status bridge_status = lexbor_libxml2_bridge_convert_document(
@@ -1079,7 +1078,7 @@ PHP_METHOD(Dom_HTMLDocument, createFromFile)
 		&lxml_doc,
 		options & XML_PARSE_COMPACT,
 		!(options & DOM_HTML_NO_DEFAULT_NS),
-		ns_mapper
+		private_data
 	);
 	lexbor_libxml2_bridge_copy_observations(parser->tree, &ctx.observations);
 	if (UNEXPECTED(bridge_status != LEXBOR_LIBXML2_BRIDGE_STATUS_OK)) {
@@ -1206,7 +1205,7 @@ static zend_result dom_saveHTML_write_string(void *application_data, const char 
 	return dom_saveHTML_write_string_len(application_data, buf, strlen(buf));
 }
 
-static zend_result dom_common_save(dom_output_ctx *output_ctx, const xmlDoc *docp, const xmlNode *node)
+static zend_result dom_common_save(dom_output_ctx *output_ctx, dom_object *intern, const xmlDoc *docp, const xmlNode *node)
 {
 	/* Initialize everything related to encoding & decoding */
 	const lxb_encoding_data_t *decoding_data = lxb_encoding_data(LXB_ENCODING_UTF_8);
@@ -1239,6 +1238,7 @@ static zend_result dom_common_save(dom_output_ctx *output_ctx, const xmlDoc *doc
 	ctx.write_string_len = dom_saveHTML_write_string_len;
 	ctx.write_string = dom_saveHTML_write_string;
 	ctx.application_data = output_ctx;
+	ctx.private_data = php_dom_get_private_data(intern);
 	if (UNEXPECTED(dom_html5_serialize_outer(&ctx, node) != SUCCESS)) {
 		return FAILURE;
 	}
@@ -1297,7 +1297,7 @@ PHP_METHOD(Dom_HTMLDocument, saveHtmlFile)
 	dom_output_ctx output_ctx;
 	output_ctx.output_data = stream;
 	output_ctx.write_output = dom_write_output_stream;
-	if (UNEXPECTED(dom_common_save(&output_ctx, docp, (const xmlNode *) docp) != SUCCESS)) {
+	if (UNEXPECTED(dom_common_save(&output_ctx, intern, docp, (const xmlNode *) docp) != SUCCESS)) {
 		php_stream_close(stream);
 		RETURN_FALSE;
 	}
@@ -1336,7 +1336,7 @@ PHP_METHOD(Dom_HTMLDocument, saveHtml)
 	output_ctx.output_data = &buf;
 	output_ctx.write_output = dom_write_output_smart_str;
 	/* Can't fail because dom_write_output_smart_str() can't fail. */
-	zend_result result = dom_common_save(&output_ctx, docp, node);
+	zend_result result = dom_common_save(&output_ctx, intern, docp, node);
 	ZEND_ASSERT(result == SUCCESS);
 
 	RETURN_STR(smart_str_extract(&buf));

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1655,7 +1655,7 @@ PHP_METHOD(Dom_HTMLDocument, debugGetTemplateCount)
 	DOM_GET_OBJ(doc, ZEND_THIS, xmlDocPtr, intern);
 	ZEND_IGNORE_VALUE(doc);
 
-	RETURN_LONG(php_dom_get_template_count((const php_dom_private_data *) intern->document->private_data));
+	RETURN_LONG((zend_long) php_dom_get_template_count((const php_dom_private_data *) intern->document->private_data));
 }
 #endif
 

--- a/ext/dom/inner_html_mixin.c
+++ b/ext/dom/inner_html_mixin.c
@@ -351,9 +351,12 @@ zend_result dom_element_inner_html_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
-	xmlNodePtr template_content = php_dom_retrieve_templated_content(php_dom_get_private_data(obj), context_node);
-	if (template_content != NULL) {
-		context_node = template_content;
+	if (php_dom_ns_is_fast(context_node, php_dom_ns_is_html_magic_token) && xmlStrEqual(context_node->name, BAD_CAST "template")) {
+		context_node = php_dom_ensure_templated_content(php_dom_get_private_data(obj), context_node);
+		if (context_node == NULL) {
+			xmlFreeNode(fragment);
+			return FAILURE;
+		}
 	}
 
 	/* We skip the steps involving the template element as context node since we don't do special handling for that. */

--- a/ext/dom/internal_helpers.h
+++ b/ext/dom/internal_helpers.h
@@ -89,4 +89,12 @@ static zend_always_inline bool dom_is_document_cache_modified_since_parsing(php_
 	return !doc_ptr || doc_ptr->cache_tag.modification_nr > dom_minimum_modification_nr_since_parsing(doc_ptr);
 }
 
+static zend_always_inline zend_long dom_mangle_pointer_for_key(const void *ptr)
+{
+	zend_ulong value = (zend_ulong) (uintptr_t) ptr;
+	/* Rotate 3/4 bits for better hash distribution because the low 3/4 bits are normally 0. */
+	const size_t rol_amount = (SIZEOF_ZEND_LONG == 8) ? 4 : 3;
+	return (value >> rol_amount) | (value << (sizeof(value) * 8 - rol_amount));
+}
+
 #endif

--- a/ext/dom/namespace_compat.h
+++ b/ext/dom/namespace_compat.h
@@ -33,6 +33,12 @@ typedef struct php_dom_ns_magic_token php_dom_ns_magic_token;
 struct php_dom_libxml_ns_mapper;
 typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
 
+struct php_dom_private_data;
+typedef struct php_dom_private_data php_dom_private_data;
+
+typedef struct php_libxml_private_data_header php_libxml_private_data_header;
+struct php_libxml_private_data_header;
+
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_html_magic_token;
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_mathml_magic_token;
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_svg_magic_token;
@@ -40,21 +46,20 @@ PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_xlink_magic_to
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_xml_magic_token;
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_xmlns_magic_token;
 
-typedef struct php_libxml_private_data_header php_libxml_private_data_header;
-struct php_libxml_private_data_header;
-
 /* These functions make it possible to make a namespace declaration also visible as an attribute by
  * creating an equivalent attribute node. */
 
-PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_libxml_ns_mapper_create(void);
-PHP_DOM_EXPORT void php_dom_libxml_ns_mapper_destroy(php_dom_libxml_ns_mapper *mapper);
+PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void);
+PHP_DOM_EXPORT void php_dom_private_data_destroy(php_dom_private_data *data);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_ensure_html_ns(php_dom_libxml_ns_mapper *mapper);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_ensure_prefixless_xmlns_ns(php_dom_libxml_ns_mapper *mapper);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns(php_dom_libxml_ns_mapper *mapper, zend_string *prefix, zend_string *uri);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns_raw_prefix_string(php_dom_libxml_ns_mapper *mapper, const xmlChar *prefix, size_t prefix_len, zend_string *uri);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns_raw_strings_nullsafe(php_dom_libxml_ns_mapper *mapper, const char *prefix, const char *uri);
 
-PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_ns_mapper_header(php_dom_libxml_ns_mapper *mapper);
+PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data);
+PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_get_ns_mapper(dom_object *object);
+PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data);
 PHP_DOM_EXPORT void php_dom_ns_compat_mark_attribute_list(php_dom_libxml_ns_mapper *mapper, xmlNodePtr node);
 PHP_DOM_EXPORT void php_dom_libxml_reconcile_modern(php_dom_libxml_ns_mapper *ns_mapper, xmlNodePtr node);
 PHP_DOM_EXPORT void php_dom_reconcile_attribute_namespace_after_insertion(xmlAttrPtr attrp);

--- a/ext/dom/namespace_compat.h
+++ b/ext/dom/namespace_compat.h
@@ -33,12 +33,6 @@ typedef struct php_dom_ns_magic_token php_dom_ns_magic_token;
 struct php_dom_libxml_ns_mapper;
 typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
 
-struct php_dom_private_data;
-typedef struct php_dom_private_data php_dom_private_data;
-
-typedef struct php_libxml_private_data_header php_libxml_private_data_header;
-struct php_libxml_private_data_header;
-
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_html_magic_token;
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_mathml_magic_token;
 PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_svg_magic_token;
@@ -49,17 +43,13 @@ PHP_DOM_EXPORT extern const php_dom_ns_magic_token *php_dom_ns_is_xmlns_magic_to
 /* These functions make it possible to make a namespace declaration also visible as an attribute by
  * creating an equivalent attribute node. */
 
-PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void);
-PHP_DOM_EXPORT void php_dom_private_data_destroy(php_dom_private_data *data);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_ensure_html_ns(php_dom_libxml_ns_mapper *mapper);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_ensure_prefixless_xmlns_ns(php_dom_libxml_ns_mapper *mapper);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns(php_dom_libxml_ns_mapper *mapper, zend_string *prefix, zend_string *uri);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns_raw_prefix_string(php_dom_libxml_ns_mapper *mapper, const xmlChar *prefix, size_t prefix_len, zend_string *uri);
 PHP_DOM_EXPORT xmlNsPtr php_dom_libxml_ns_mapper_get_ns_raw_strings_nullsafe(php_dom_libxml_ns_mapper *mapper, const char *prefix, const char *uri);
 
-PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data);
 PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_get_ns_mapper(dom_object *object);
-PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data);
 PHP_DOM_EXPORT void php_dom_ns_compat_mark_attribute_list(php_dom_libxml_ns_mapper *mapper, xmlNodePtr node);
 PHP_DOM_EXPORT void php_dom_libxml_reconcile_modern(php_dom_libxml_ns_mapper *ns_mapper, xmlNodePtr node);
 PHP_DOM_EXPORT void php_dom_reconcile_attribute_namespace_after_insertion(xmlAttrPtr attrp);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -23,6 +23,7 @@
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "internal_helpers.h"
 #include "dom_properties.h"
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -593,21 +593,21 @@ static zend_object *dom_objects_store_clone_obj(zend_object *zobject) /* {{{ */
 	if (instanceof_function(intern->std.ce, dom_node_class_entry) || instanceof_function(intern->std.ce, dom_modern_node_class_entry)) {
 		xmlNodePtr node = (xmlNodePtr)dom_object_get_node(intern);
 		if (node != NULL) {
-			php_dom_libxml_ns_mapper *ns_mapper = NULL;
+			php_dom_private_data *private_data = NULL;
 			if (php_dom_follow_spec_intern(intern)) {
 				if (node->type == XML_DOCUMENT_NODE || node->type == XML_HTML_DOCUMENT_NODE) {
-					ns_mapper = php_dom_libxml_ns_mapper_create();
+					private_data = php_dom_private_data_create();
 				} else {
-					ns_mapper = php_dom_get_ns_mapper(intern);
+					private_data = php_dom_get_private_data(intern);
 				}
 			}
 
-			xmlNodePtr cloned_node = dom_clone_node(ns_mapper, node, node->doc, true);
+			xmlNodePtr cloned_node = dom_clone_node(php_dom_ns_mapper_from_private(private_data), node, node->doc, true);
 			if (cloned_node != NULL) {
 				dom_update_refcount_after_clone(intern, node, clone, cloned_node);
 			}
-			if (ns_mapper != NULL) {
-				clone->document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
+			if (private_data != NULL) {
+				clone->document->private_data = php_dom_libxml_private_data_header(private_data);
 			}
 		}
 	}

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1395,15 +1395,6 @@ void dom_objects_free_storage(zend_object *object)
 		xmlNodePtr node = ptr->node;
 
 		if (node->type != XML_DOCUMENT_NODE && node->type != XML_HTML_DOCUMENT_NODE) {
-			/* Destroy associated template content. */
-			php_dom_private_data *private_data;
-			if (node->type == XML_ELEMENT_NODE
-				&& ptr->refcount == 1
-				&& intern->document != NULL
-				&& (private_data = php_dom_get_private_data(intern))) {
-				php_dom_remove_templated_content(private_data, node);
-			}
-
 			php_libxml_node_decrement_resource((php_libxml_node_object *) intern);
 		} else {
 			php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -27,6 +27,7 @@
 #include "nodelist.h"
 #include "html_collection.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 #include "internal_helpers.h"
 #include "php_dom_arginfo.h"
 #include "dom_properties.h"
@@ -1389,8 +1390,20 @@ void dom_objects_free_storage(zend_object *object)
 
 	zend_object_std_dtor(&intern->std);
 
-	if (intern->ptr != NULL && ((php_libxml_node_ptr *)intern->ptr)->node != NULL) {
-		if (((xmlNodePtr) ((php_libxml_node_ptr *)intern->ptr)->node)->type != XML_DOCUMENT_NODE && ((xmlNodePtr) ((php_libxml_node_ptr *)intern->ptr)->node)->type != XML_HTML_DOCUMENT_NODE) {
+	php_libxml_node_ptr *ptr = intern->ptr;
+	if (ptr != NULL && ptr->node != NULL) {
+		xmlNodePtr node = ptr->node;
+
+		if (node->type != XML_DOCUMENT_NODE && node->type != XML_HTML_DOCUMENT_NODE) {
+			/* Destroy associated template content. */
+			php_dom_private_data *private_data;
+			if (node->type == XML_ELEMENT_NODE
+				&& ptr->refcount == 1
+				&& intern->document != NULL
+				&& (private_data = php_dom_get_private_data(intern))) {
+				php_dom_remove_templated_content(private_data, node);
+			}
+
 			php_libxml_node_decrement_resource((php_libxml_node_object *) intern);
 		} else {
 			php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -114,6 +114,9 @@ typedef enum dom_iterator_type {
 	DOM_HTMLCOLLECTION,
 } dom_iterator_type;
 
+struct php_dom_libxml_ns_mapper;
+typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
+
 static inline dom_object_namespace_node *php_dom_namespace_node_obj_from_obj(zend_object *obj) {
 	return (dom_object_namespace_node*)((char*)(obj) - XtOffsetOf(dom_object_namespace_node, dom.std));
 }

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1643,6 +1643,10 @@ namespace Dom
         public function saveHtml(?Node $node = null): string {}
 
         public function saveHtmlFile(string $filename): int|false {}
+
+#if ZEND_DEBUG
+        public function debugGetTemplateCount(): int {}
+#endif
     }
 
     final class XMLDocument extends Document

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1af73c3b63ebeb5e59948990892dcf6b627a1671 */
+ * Stub hash: 9a1e6842b2c5b891e11087d40aa8c9f56a2269a3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -1059,6 +1059,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Dom_HTMLDocument_saveHtmlF
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if ZEND_DEBUG
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_HTMLDocument_debugGetTemplateCount, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Dom_XMLDocument_createEmpty, 0, 0, Dom\\XMLDocument, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, version, IS_STRING, 0, "\"1.0\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 0, "\"UTF-8\"")
@@ -1367,6 +1372,9 @@ ZEND_METHOD(Dom_HTMLDocument, createFromString);
 ZEND_METHOD(Dom_XMLDocument, saveXml);
 ZEND_METHOD(Dom_HTMLDocument, saveHtml);
 ZEND_METHOD(Dom_HTMLDocument, saveHtmlFile);
+#if ZEND_DEBUG
+ZEND_METHOD(Dom_HTMLDocument, debugGetTemplateCount);
+#endif
 ZEND_METHOD(Dom_XMLDocument, createEmpty);
 ZEND_METHOD(Dom_XMLDocument, createFromFile);
 ZEND_METHOD(Dom_XMLDocument, createFromString);
@@ -1885,6 +1893,9 @@ static const zend_function_entry class_Dom_HTMLDocument_methods[] = {
 	ZEND_RAW_FENTRY("saveXmlFile", zim_DOMDocument_save, arginfo_class_Dom_HTMLDocument_saveXmlFile, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(Dom_HTMLDocument, saveHtml, arginfo_class_Dom_HTMLDocument_saveHtml, ZEND_ACC_PUBLIC)
 	ZEND_ME(Dom_HTMLDocument, saveHtmlFile, arginfo_class_Dom_HTMLDocument_saveHtmlFile, ZEND_ACC_PUBLIC)
+#if ZEND_DEBUG
+	ZEND_ME(Dom_HTMLDocument, debugGetTemplateCount, arginfo_class_Dom_HTMLDocument_debugGetTemplateCount, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_FE_END
 };
 

--- a/ext/dom/private_data.c
+++ b/ext/dom/private_data.c
@@ -142,7 +142,7 @@ void php_dom_remove_templated_content(php_dom_private_data *private_data, const 
 	}
 }
 
-zend_long php_dom_get_template_count(const php_dom_private_data *private_data)
+uint32_t php_dom_get_template_count(const php_dom_private_data *private_data)
 {
 	if (private_data->template_fragments != NULL) {
 		return zend_hash_num_elements(private_data->template_fragments);

--- a/ext/dom/private_data.c
+++ b/ext/dom/private_data.c
@@ -107,6 +107,19 @@ xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data
 	return zend_hash_index_find_ptr(private_data->template_fragments, dom_mangle_pointer_for_key(template_node));
 }
 
+xmlNodePtr php_dom_ensure_templated_content(php_dom_private_data *private_data, xmlNodePtr template_node)
+{
+	xmlNodePtr result = php_dom_retrieve_templated_content(private_data, template_node);
+	if (result == NULL) {
+		result = xmlNewDocFragment(template_node->doc);
+		if (EXPECTED(result != NULL)) {
+			result->parent = template_node;
+			php_dom_add_templated_content(private_data, template_node, result);
+		}
+	}
+	return result;
+}
+
 void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node)
 {
 	if (private_data->template_fragments != NULL) {

--- a/ext/dom/private_data.c
+++ b/ext/dom/private_data.c
@@ -1,0 +1,127 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Niels Dossche <nielsdos@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "php.h"
+#if defined(HAVE_LIBXML) && defined(HAVE_DOM)
+#include "php_dom.h"
+#include "private_data.h"
+#include "internal_helpers.h"
+
+typedef struct php_dom_private_data {
+	php_libxml_private_data_header header;
+	struct php_dom_libxml_ns_mapper ns_mapper;
+	HashTable *template_fragments;
+} php_dom_private_data;
+
+static void php_dom_libxml_private_data_destroy(php_libxml_private_data_header *header)
+{
+	php_dom_private_data_destroy((php_dom_private_data *) header);
+}
+
+PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data)
+{
+	return private_data == NULL ? NULL : &private_data->header;
+}
+
+PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data)
+{
+	return private_data == NULL ? NULL : &private_data->ns_mapper;
+}
+
+PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void)
+{
+	php_dom_private_data *mapper = emalloc(sizeof(*mapper));
+	mapper->header.dtor = php_dom_libxml_private_data_destroy;
+	mapper->ns_mapper.html_ns = NULL;
+	mapper->ns_mapper.prefixless_xmlns_ns = NULL;
+	zend_hash_init(&mapper->ns_mapper.uri_to_prefix_map, 0, NULL, ZVAL_PTR_DTOR, false);
+	mapper->template_fragments = NULL;
+	return mapper;
+}
+
+void php_dom_private_data_destroy(php_dom_private_data *data)
+{
+	zend_hash_destroy(&data->ns_mapper.uri_to_prefix_map);
+	if (data->template_fragments != NULL) {
+		zend_hash_destroy(data->template_fragments);
+		FREE_HASHTABLE(data->template_fragments);
+	}
+	efree(data);
+}
+
+static void php_dom_free_templated_content(php_dom_private_data *private_data, xmlNodePtr base)
+{
+	/* Note: it's not possible to obtain a userland reference to these yet, so we can just free them without worrying
+	 *       about their proxies.
+	 * Note 2: it's possible to have nested template content. */
+
+	if (zend_hash_num_elements(private_data->template_fragments) > 0) {
+		/* There's more templated content, try to free it. */
+		xmlNodePtr current = base->children;
+		while (current != NULL) {
+			if (current->type == XML_ELEMENT_NODE) {
+				php_dom_remove_templated_content(private_data, current);
+			}
+
+			current = php_dom_next_in_tree_order(current, base);
+		}
+	}
+
+	xmlFreeNode(base);
+}
+
+void php_dom_add_templated_content(php_dom_private_data *private_data, const xmlNode *template_node, xmlNodePtr fragment)
+{
+	if (private_data->template_fragments == NULL) {
+		ALLOC_HASHTABLE(private_data->template_fragments);
+		zend_hash_init(private_data->template_fragments, 0, NULL, NULL, false);
+		zend_hash_real_init_mixed(private_data->template_fragments);
+	}
+
+	zend_hash_index_add_new_ptr(private_data->template_fragments, dom_mangle_pointer_for_key(template_node), fragment);
+}
+
+xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data, const xmlNode *template_node)
+{
+	if (private_data->template_fragments == NULL) {
+		return NULL;
+	}
+
+	return zend_hash_index_find_ptr(private_data->template_fragments, dom_mangle_pointer_for_key(template_node));
+}
+
+void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node)
+{
+	if (private_data->template_fragments != NULL) {
+		/* Deletion needs to be done not via a destructor because we can't access private_data from there. */
+		zval *zv = zend_hash_index_find(private_data->template_fragments, dom_mangle_pointer_for_key(template_node));
+		if (zv != NULL) {
+			xmlNodePtr node = Z_PTR_P(zv);
+			ZEND_ASSERT(offsetof(Bucket, val) == 0 && "Type cast only works if this is true");
+			Bucket* bucket = (Bucket*) zv;
+			/* First remove it from the bucket before freeing the content, otherwise recursion could make the bucket
+			 * pointer invalid due to hash table structure changes. */
+			zend_hash_del_bucket(private_data->template_fragments, bucket);
+			php_dom_free_templated_content(private_data, node);
+		}
+	}
+}
+
+#endif  /* HAVE_LIBXML && HAVE_DOM */

--- a/ext/dom/private_data.h
+++ b/ext/dom/private_data.h
@@ -27,11 +27,6 @@ struct php_dom_libxml_ns_mapper {
 	HashTable uri_to_prefix_map;
 };
 
-struct dom_ns_hook_token {
-	int tag;
-	struct php_dom_private_data *private_data;
-};
-
 typedef struct php_dom_private_data {
 	php_libxml_private_data_header header;
 	struct php_dom_libxml_ns_mapper ns_mapper;
@@ -55,7 +50,7 @@ void php_dom_add_templated_content(php_dom_private_data *private_data, const xml
 xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
 xmlNodePtr php_dom_ensure_templated_content(php_dom_private_data *private_data, xmlNodePtr template_node);
 void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
-zend_long php_dom_get_template_count(const php_dom_private_data *private_data);
+uint32_t php_dom_get_template_count(const php_dom_private_data *private_data);
 void dom_add_element_ns_hook(php_dom_private_data *private_data, xmlNodePtr element);
 
 #endif

--- a/ext/dom/private_data.h
+++ b/ext/dom/private_data.h
@@ -42,6 +42,7 @@ PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void);
 void php_dom_private_data_destroy(php_dom_private_data *data);
 void php_dom_add_templated_content(php_dom_private_data *private_data, const xmlNode *template_node, xmlNodePtr fragment);
 xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
+xmlNodePtr php_dom_ensure_templated_content(php_dom_private_data *private_data, xmlNodePtr template_node);
 void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
 
 #endif

--- a/ext/dom/private_data.h
+++ b/ext/dom/private_data.h
@@ -1,0 +1,47 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Niels Dossche <nielsdos@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef PRIVATE_DATA_H
+#define PRIVATE_DATA_H
+
+#include "xml_common.h"
+
+struct php_dom_libxml_ns_mapper {
+	/* This is used almost all the time for HTML documents, so it makes sense to cache this. */
+	xmlNsPtr html_ns;
+	/* Used for every prefixless namespace declaration in XML, so also very common. */
+	xmlNsPtr prefixless_xmlns_ns;
+	HashTable uri_to_prefix_map;
+};
+
+typedef struct php_libxml_private_data_header php_libxml_private_data_header;
+struct php_libxml_private_data_header;
+
+struct php_dom_private_data;
+typedef struct php_dom_private_data php_dom_private_data;
+
+struct php_dom_libxml_ns_mapper;
+typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
+
+PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data);
+PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data);
+PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void);
+void php_dom_private_data_destroy(php_dom_private_data *data);
+void php_dom_add_templated_content(php_dom_private_data *private_data, const xmlNode *template_node, xmlNodePtr fragment);
+xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
+void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
+
+#endif

--- a/ext/dom/private_data.h
+++ b/ext/dom/private_data.h
@@ -27,6 +27,17 @@ struct php_dom_libxml_ns_mapper {
 	HashTable uri_to_prefix_map;
 };
 
+struct dom_ns_hook_token {
+	int tag;
+	struct php_dom_private_data *private_data;
+};
+
+typedef struct php_dom_private_data {
+	php_libxml_private_data_header header;
+	struct php_dom_libxml_ns_mapper ns_mapper;
+	HashTable *template_fragments;
+} php_dom_private_data;
+
 typedef struct php_libxml_private_data_header php_libxml_private_data_header;
 struct php_libxml_private_data_header;
 
@@ -36,13 +47,15 @@ typedef struct php_dom_private_data php_dom_private_data;
 struct php_dom_libxml_ns_mapper;
 typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
 
-PHP_DOM_EXPORT php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data);
-PHP_DOM_EXPORT php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data);
-PHP_DOM_EXPORT php_dom_private_data *php_dom_private_data_create(void);
+php_libxml_private_data_header *php_dom_libxml_private_data_header(php_dom_private_data *private_data);
+php_dom_libxml_ns_mapper *php_dom_ns_mapper_from_private(php_dom_private_data *private_data);
+php_dom_private_data *php_dom_private_data_create(void);
 void php_dom_private_data_destroy(php_dom_private_data *data);
 void php_dom_add_templated_content(php_dom_private_data *private_data, const xmlNode *template_node, xmlNodePtr fragment);
 xmlNodePtr php_dom_retrieve_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
 xmlNodePtr php_dom_ensure_templated_content(php_dom_private_data *private_data, xmlNodePtr template_node);
 void php_dom_remove_templated_content(php_dom_private_data *private_data, const xmlNode *template_node);
+zend_long php_dom_get_template_count(const php_dom_private_data *private_data);
+void dom_add_element_ns_hook(php_dom_private_data *private_data, xmlNodePtr element);
 
 #endif

--- a/ext/dom/tests/modern/common/template_cloning.phpt
+++ b/ext/dom/tests/modern/common/template_cloning.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Template cloning
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$dom = Dom\HTMLDocument::createFromString('<template>x</template>', LIBXML_NOERROR);
+$a = $dom->head->firstChild->cloneNode(false);
+echo $dom->saveXML($a), "\n";
+echo $dom->saveHTML($a), "\n";
+?>
+--EXPECT--
+<template xmlns="http://www.w3.org/1999/xhtml"></template>
+<template></template>

--- a/ext/dom/tests/modern/common/template_indirect_removal.phpt
+++ b/ext/dom/tests/modern/common/template_indirect_removal.phpt
@@ -1,0 +1,22 @@
+--TEST--
+template content indirect removal
+--EXTENSIONS--
+dom
+--SKIPIF--
+<?php
+if (!PHP_DEBUG) { die ("skip only for debug build"); }
+?>
+--FILE--
+<?php
+$dom = Dom\HTMLDocument::createFromString('<template>foo<template>nested</template></template>', LIBXML_NOERROR);
+$head = $dom->head;
+var_dump($dom->debugGetTemplateCount());
+$head->remove();
+var_dump($dom->debugGetTemplateCount());
+unset($head);
+var_dump($dom->debugGetTemplateCount());
+?>
+--EXPECT--
+int(2)
+int(2)
+int(0)

--- a/ext/dom/tests/modern/common/template_manual.phpt
+++ b/ext/dom/tests/modern/common/template_manual.phpt
@@ -1,0 +1,36 @@
+--TEST--
+<template> element manual creation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+echo "=== After creation ===\n";
+
+$dom = Dom\HTMLDocument::createEmpty();
+$template = $dom->appendChild($dom->createElement("template"));
+var_dump($template->innerHTML);
+echo $dom->saveXML(), "\n";
+echo $dom->saveHTML(), "\n";
+
+echo "=== After setting content ===\n";
+
+$template->innerHTML = "<p>hello</template></p>";
+var_dump($template->innerHTML);
+var_dump($template->firstChild);
+echo $dom->saveXML(), "\n";
+echo $dom->saveHTML(), "\n";
+
+?>
+--EXPECT--
+=== After creation ===
+string(0) ""
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<template xmlns="http://www.w3.org/1999/xhtml"></template>
+<template></template>
+=== After setting content ===
+string(12) "<p>hello</p>"
+NULL
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<template xmlns="http://www.w3.org/1999/xhtml"><p>hello</p></template>
+<template><p>hello</p></template>

--- a/ext/dom/tests/modern/common/template_nested.phpt
+++ b/ext/dom/tests/modern/common/template_nested.phpt
@@ -1,0 +1,29 @@
+--TEST--
+<template> element nesting
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html>
+    <body>
+        <template>foo<template>bar</template></template>
+    </body>
+</html>
+HTML;
+$dom = Dom\HTMLDocument::createFromString($html);
+$template = $dom->body->firstElementChild;
+var_dump($template->innerHTML);
+echo $dom->saveXML();
+
+?>
+--EXPECT--
+string(27) "foo<template>bar</template>"
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>
+        <template>foo<template>bar</template></template>
+    
+</body></html>

--- a/ext/dom/tests/modern/common/template_no_default_ns.phpt
+++ b/ext/dom/tests/modern/common/template_no_default_ns.phpt
@@ -1,0 +1,24 @@
+--TEST--
+<template> element no default namespace
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html>
+    <body>
+        <template>a<div>foo</div>b</template>
+    </body>
+</html>
+HTML;
+$dom = Dom\HTMLDocument::createFromString($html, Dom\HTML_NO_DEFAULT_NS);
+$template = $dom->getElementsByTagName('template')[0];
+var_dump($template->innerHTML);
+var_dump($template->firstElementChild->tagName);
+
+?>
+--EXPECT--
+string(16) "a<div>foo</div>b"
+string(3) "div"

--- a/ext/dom/tests/modern/common/template_participation.phpt
+++ b/ext/dom/tests/modern/common/template_participation.phpt
@@ -1,0 +1,83 @@
+--TEST--
+<template> element contents do not participate in DOM
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html>
+    <body>
+        <template>a<div>foo</div>b</template>
+    </body>
+</html>
+HTML;
+$dom = Dom\HTMLDocument::createFromString($html);
+$template = $dom->body->firstElementChild;
+
+echo "=== Manipulation ===\n";
+
+echo "First child of template: ";
+var_dump($template->firstChild?->nodeName);
+$template->append($dom->createElement('invisible'));
+
+echo "First child of template after appending: ";
+var_dump($template->firstChild->nodeName);
+$template->innerHTML = $template->innerHTML;
+echo "Inner HTML after idempotent modification: ";
+var_dump($template->innerHTML);
+echo "Selector should not find div element in shadow DOM: ";
+var_dump($template->querySelector('div'));
+
+echo "XPath should not find div element in shadow DOM:\n";
+$xpath = new Dom\XPath($dom);
+var_dump($xpath->query('//div'));
+
+echo "=== HTML serialization ===\n";
+echo $dom->saveHTML(), "\n";
+echo "=== HTML serialization of <template> ===\n";
+echo $dom->saveHTML($template), "\n";
+echo "=== XML serialization ===\n";
+echo $dom->saveXML(), "\n";
+echo "=== XML serialization of <template> ===\n";
+echo $dom->saveXML($template), "\n";
+
+// Should not crash
+$template->remove();
+unset($template);
+
+echo "=== Creating a new template should not leak the old contents ===\n";
+$template = $dom->createElement('template');
+var_dump($template->innerHTML);
+
+?>
+--EXPECT--
+=== Manipulation ===
+First child of template: NULL
+First child of template after appending: string(9) "INVISIBLE"
+Inner HTML after idempotent modification: string(16) "a<div>foo</div>b"
+Selector should not find div element in shadow DOM: NULL
+XPath should not find div element in shadow DOM:
+object(Dom\NodeList)#4 (1) {
+  ["length"]=>
+  int(0)
+}
+=== HTML serialization ===
+<!DOCTYPE html><html><head></head><body>
+        <template>a<div>foo</div>b</template>
+    
+</body></html>
+=== HTML serialization of <template> ===
+<template>a<div>foo</div>b</template>
+=== XML serialization ===
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>
+        <template>a<div>foo</div>b</template>
+    
+</body></html>
+=== XML serialization of <template> ===
+<template xmlns="http://www.w3.org/1999/xhtml">a<div>foo</div>b</template>
+=== Creating a new template should not leak the old contents ===
+string(0) ""

--- a/ext/dom/tests/modern/common/template_rename.phpt
+++ b/ext/dom/tests/modern/common/template_rename.phpt
@@ -1,0 +1,29 @@
+--TEST--
+<template> element renaming
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html>
+    <body>
+        <template>a<div>foo</div>b</template>
+    </body>
+</html>
+HTML;
+$dom = Dom\HTMLDocument::createFromString($html);
+$template = $dom->body->firstElementChild;
+var_dump($template->innerHTML);
+
+$template->rename($template->namespaceURI, 'screwthis');
+var_dump($template->innerHTML);
+$template->rename($template->namespaceURI, 'template');
+var_dump($template->innerHTML);
+
+?>
+--EXPECT--
+string(16) "a<div>foo</div>b"
+string(0) ""
+string(0) ""

--- a/ext/dom/tests/modern/common/template_rename.phpt
+++ b/ext/dom/tests/modern/common/template_rename.phpt
@@ -17,13 +17,19 @@ $dom = Dom\HTMLDocument::createFromString($html);
 $template = $dom->body->firstElementChild;
 var_dump($template->innerHTML);
 
-$template->rename($template->namespaceURI, 'screwthis');
-var_dump($template->innerHTML);
-$template->rename($template->namespaceURI, 'template');
+try {
+    $template->rename($template->namespaceURI, 'screwthis');
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// These shouldn't be changed!
+var_dump($template->nodeName);
 var_dump($template->innerHTML);
 
 ?>
 --EXPECT--
 string(16) "a<div>foo</div>b"
-string(0) ""
-string(0) ""
+It is not possible to rename the template element because it hosts a document fragment
+string(8) "TEMPLATE"
+string(16) "a<div>foo</div>b"

--- a/ext/dom/tests/modern/common/template_simplexml.phpt
+++ b/ext/dom/tests/modern/common/template_simplexml.phpt
@@ -1,0 +1,30 @@
+--TEST--
+SimpleXML and template content
+--EXTENSIONS--
+dom
+simplexml
+--SKIPIF--
+<?php
+if (!PHP_DEBUG) { die ("skip only for debug build"); }
+?>
+--FILE--
+<?php
+$dom = Dom\HTMLDocument::createFromString('<template>foo<template>nested</template></template>', LIBXML_NOERROR);
+$head = $dom->head;
+$head_sxe = simplexml_import_dom($head);
+var_dump($head_sxe);
+var_dump($dom->debugGetTemplateCount());
+unset($head_sxe->template);
+var_dump($head_sxe);
+var_dump($dom->debugGetTemplateCount());
+?>
+--EXPECTF--
+object(SimpleXMLElement)#%d (1) {
+  ["template"]=>
+  object(SimpleXMLElement)#%d (0) {
+  }
+}
+int(2)
+object(SimpleXMLElement)#%d (0) {
+}
+int(0)

--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -80,13 +80,13 @@ PHP_DOM_EXPORT xmlNodePtr dom_object_get_node(dom_object *obj);
 	__id = ZEND_THIS; \
 	DOM_GET_OBJ(__ptr, __id, __prtype, __intern);
 
-struct php_dom_libxml_ns_mapper;
-typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
+struct php_dom_private_data;
+typedef struct php_dom_private_data php_dom_private_data;
 
-static zend_always_inline php_dom_libxml_ns_mapper *php_dom_get_ns_mapper(dom_object *intern)
+static zend_always_inline php_dom_private_data *php_dom_get_private_data(dom_object *intern)
 {
 	ZEND_ASSERT(intern->document != NULL);
-	return (php_dom_libxml_ns_mapper *) intern->document->private_data;
+	return (php_dom_private_data *) intern->document->private_data;
 }
 
 static zend_always_inline xmlNodePtr php_dom_next_in_tree_order(const xmlNode *nodep, const xmlNode *basep)

--- a/ext/dom/xml_document.c
+++ b/ext/dom/xml_document.c
@@ -122,7 +122,7 @@ PHP_METHOD(Dom_XMLDocument, createEmpty)
 		NULL
 	);
 	dom_set_xml_class(intern->document);
-	intern->document->private_data = php_dom_libxml_ns_mapper_header(php_dom_libxml_ns_mapper_create());
+	intern->document->private_data = php_dom_libxml_private_data_header(php_dom_private_data_create());
 	return;
 
 oom:
@@ -236,8 +236,9 @@ static void load_from_helper(INTERNAL_FUNCTION_PARAMETERS, int mode)
 
 void dom_document_convert_to_modern(php_libxml_ref_obj *document, xmlDocPtr lxml_doc)
 {
-	php_dom_libxml_ns_mapper *ns_mapper = php_dom_libxml_ns_mapper_create();
-	document->private_data = php_dom_libxml_ns_mapper_header(ns_mapper);
+	php_dom_private_data *private_data = php_dom_private_data_create();
+	php_dom_libxml_ns_mapper *ns_mapper = php_dom_ns_mapper_from_private(private_data);
+	document->private_data = php_dom_libxml_private_data_header(private_data);
 	dom_mark_namespaces_as_attributes_too(ns_mapper, lxml_doc);
 }
 

--- a/ext/dom/xml_serializer.h
+++ b/ext/dom/xml_serializer.h
@@ -22,6 +22,9 @@
 #include <libxml/xmlsave.h>
 #include <libxml/xmlIO.h>
 
-int dom_xml_serialize(xmlSaveCtxtPtr ctx, xmlOutputBufferPtr out, xmlNodePtr node, bool format, bool require_well_formed);
+struct php_dom_private_data;
+typedef struct php_dom_private_data php_dom_private_data;
+
+int dom_xml_serialize(xmlSaveCtxtPtr ctx, xmlOutputBufferPtr out, xmlNodePtr node, bool format, bool require_well_formed, php_dom_private_data *private_data);
 
 #endif

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -23,6 +23,7 @@
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 #include "namespace_compat.h"
+#include "private_data.h"
 
 #define PHP_DOM_XPATH_QUERY 0
 #define PHP_DOM_XPATH_EVALUATE 1

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1368,6 +1368,9 @@ PHP_LIBXML_API int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *doc
 {
 	int ret_refcount = --document->refcount;
 	if (ret_refcount == 0) {
+		if (document->private_data != NULL) {
+			document->private_data->dtor(document->private_data);
+		}
 		if (document->ptr != NULL) {
 			xmlFreeDoc((xmlDoc *) document->ptr);
 		}
@@ -1377,9 +1380,6 @@ PHP_LIBXML_API int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *doc
 				FREE_HASHTABLE(document->doc_props->classmap);
 			}
 			efree(document->doc_props);
-		}
-		if (document->private_data != NULL) {
-			document->private_data->dtor(document->private_data);
 		}
 		efree(document);
 	}

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -39,6 +39,8 @@ extern zend_module_entry libxml_module_entry;
 
 #define LIBXML_SAVE_NOEMPTYTAG 1<<2
 
+#define LIBXML_NS_TAG_HOOK 1
+
 ZEND_BEGIN_MODULE_GLOBALS(libxml)
 	zval stream_context;
 	smart_str error_buffer;
@@ -67,6 +69,7 @@ typedef struct {
 
 typedef struct php_libxml_private_data_header {
 	void (*dtor)(struct php_libxml_private_data_header *);
+	void (*ns_hook)(struct php_libxml_private_data_header *, xmlNodePtr);
 	/* extra fields */
 } php_libxml_private_data_header;
 


### PR DESCRIPTION
The template element in HTML 5 is special in the sense that it does not
add its contents into the DOM tree, but instead keeps them in a separate
shadow DOM document fragment. Interacting with the DOM tree cannot touch
the elements in the document fragment.