### PR TITLE
Update Windows CI to build with vs17

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -883,13 +883,13 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.windows-matrix-include) }}
     name: "${{ matrix.branch.name }}_WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: vs16
+      PHP_BUILD_CRT: vs17
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -236,13 +236,13 @@ jobs:
   WINDOWS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     name: WINDOWS_X64_ZTS
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: vs16
+      PHP_BUILD_CRT: vs17
       PLATFORM: x64
       THREAD_SAFE: "1"
       INTRINSICS: AVX2

--- a/Zend/tests/gh8841.phpt
+++ b/Zend/tests/gh8841.phpt
@@ -2,8 +2,9 @@
 GH-8841 (php-cli core dump calling a badly formed function)
 --SKIPIF--
 <?php
-$jit = opcache_get_configuration()["directives"]["opcache.jit"];
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $jit === "tracing") {
+$tracing = extension_loaded("Zend OPcache")
+    && opcache_get_configuration()["directives"]["opcache.jit"] === "tracing";
+if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
     $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
     die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
 }

--- a/Zend/tests/gh8841.phpt
+++ b/Zend/tests/gh8841.phpt
@@ -1,5 +1,13 @@
 --TEST--
 GH-8841 (php-cli core dump calling a badly formed function)
+--SKIPIF--
+<?php
+$jit = opcache_get_configuration()["directives"]["opcache.jit"];
+if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $jit === "tracing") {
+    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
+    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
+}
+?>
 --FILE--
 <?php
 register_shutdown_function(function() {

--- a/Zend/tests/gh8841.phpt
+++ b/Zend/tests/gh8841.phpt
@@ -3,7 +3,9 @@ GH-8841 (php-cli core dump calling a badly formed function)
 --SKIPIF--
 <?php
 $tracing = extension_loaded("Zend OPcache")
-    && opcache_get_configuration()["directives"]["opcache.jit"] === "tracing";
+    && ($conf = opcache_get_configuration()["directives"])
+    && array_key_exists("opcache.jit", $conf)
+    &&  $conf["opcache.jit"] === "tracing";
 if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
     $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
     die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");


### PR DESCRIPTION
PHP 8.4 is supposed to be built with vs17 (aka. Visual Studio 2022)[1], so we also do this for CI.

[1] <https://windows.php.net/>