### PR TITLE
Fix skip condition of gh13082.phpt

### DIFF
--- a/ext/gd/tests/gh13082.phpt
+++ b/ext/gd/tests/gh13082.phpt
@@ -3,7 +3,7 @@ GH-13082 - imagefontwidth/height unexpectedly throwing an exception on a valid G
 --EXTENSIONS--
 gd
 --SKIPIF--
-<?php if (getenv('TRAVIS')) die('skip Currently fails on Travis'); ?>
+<?php if (pack('i', 0x01020304) !== "\x04\x03\x02\x01") die('skip unsupported platform'); ?>
 --FILE--
 <?php
     $font = imageloadfont(__DIR__ . "/gh13082.gdf");


### PR DESCRIPTION
The test failure is not particularly related to Travis, but rather is caused by the GD font file to only be suitable for platforms where `int` stores 32bit values in little endian byte order.  This platform dependence is documented in the source code[1].  Thus we fix the skip condition and skip reason accordingly.

An alternative would be to dynamically create the font file just before running the test, but that appears to be overkill.

[1] <https://github.com/php/php-src/blob/d59691c02fa77b65855ebbcd5f50aaac034ab75d/ext/gd/gd.c#L545-L556>

---

Note that this is a follow up to https://github.com/php/php-src/pull/13208.

The skip reason might be improved; I've kept it as short as possible for now.