### PR TITLE
Autotools: Enhance PHP_EVAL_LIBLINE M4 macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -160,6 +160,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
+   - M4 macro PHP_EVAL_LIBLINE got a new 3rd argument to override the ext_shared
+     checks.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -341,12 +341,21 @@ AC_DEFUN([PHP_REMOVE_USR_LIB],[
 ])
 
 dnl
-dnl PHP_EVAL_LIBLINE(libline, SHARED-LIBADD)
+dnl PHP_EVAL_LIBLINE(libline, [libs-variable], [not-extension])
 dnl
-dnl Use this macro, if you need to add libraries and or library search paths to
-dnl the PHP build system which are only given in compiler notation.
+dnl Use this macro to add libraries and/or library search paths to the PHP build
+dnl system when specified in compiler notation. Libraries (-l) are appended
+dnl either to the global Autoconf LIBS variable or to the specified
+dnl "libs-variable" (e.g., *_SHARED_LIBADD) when the extension is shared
+dnl (ext_shared=yes). If "not-extension" is set to a non-blank value, the
+dnl libraries are appended to "libs-variable" unconditionally. This is
+dnl particularly useful when working with SAPIs. The -L flags are appended to
+dnl the LDFLAGS.
 dnl
-AC_DEFUN([PHP_EVAL_LIBLINE],[
+AC_DEFUN([PHP_EVAL_LIBLINE],
+[m4_ifnblank([$3], [m4_ifblank([$2],
+  [m4_warn([syntax], [Missing 2nd argument when skipping extension check])],
+  [_php_ext_shared_saved=$ext_shared; ext_shared=yes])])
   for ac_i in $1; do
     case $ac_i in
     -pthread[)]
@@ -368,6 +377,7 @@ AC_DEFUN([PHP_EVAL_LIBLINE],[
     ;;
     esac
   done
+m4_ifnblank([$3], [m4_ifnblank([$2], [ext_shared=$_php_ext_shared_saved])])dnl
 ])
 
 dnl

--- a/build/php.m4
+++ b/build/php.m4
@@ -348,8 +348,8 @@ dnl system when specified in compiler notation. Libraries (-l) are appended
 dnl either to the global Autoconf LIBS variable or to the specified
 dnl "libs-variable" (e.g., *_SHARED_LIBADD) when the extension is shared
 dnl (ext_shared=yes). If "not-extension" is set to a non-blank value, the
-dnl libraries are appended to "libs-variable" unconditionally. This is
-dnl particularly useful when working with SAPIs. The -L flags are appended to
+dnl libraries are appended to "libs-variable" unconditionally (this is
+dnl particularly useful when working with SAPIs). The -L flags are appended to
 dnl the LDFLAGS.
 dnl
 AC_DEFUN([PHP_EVAL_LIBLINE],


### PR DESCRIPTION
PHP_EVAL_LIBALINE macro processes the given libraries flags (-l) and/or library paths flags (-L) and appends the -l flags to either LIBS or the given *_SHARED_LIBADD variables. The -L flags are appended to the LDFLAGS. The new 3rd argument enables appending libraries to the given variable in the 2nd argument without manual setting whether the extension is shared. For example, to simplify usage in SAPIs where additional libraries need to be appended but they shouldn't go to the global LIBS. This can be then used in PHP-FPM SAPI to link apparmor, SELinux, systemd, etc.

This will simplify these PRs:
* https://github.com/php/php-src/pull/14885
* https://github.com/php/php-src/pull/14884
* https://github.com/php/php-src/pull/14883
