### PR TITLE
Autotools: Refactor oniguruma invalid KOI8 check

### DIFF
--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -55,20 +55,24 @@ AC_DEFUN([PHP_MBSTRING_SETUP_MBREGEX], [
     PHP_EVAL_LIBLINE($ONIG_LIBS, MBSTRING_SHARED_LIBADD)
     PHP_EVAL_INCLINE($ONIG_CFLAGS)
 
-    save_old_LDFLAGS=$LDFLAGS
-    PHP_EVAL_LIBLINE([$MBSTRING_SHARED_LIBADD], LDFLAGS)
-    AC_MSG_CHECKING([if oniguruma has an invalid entry for KOI8 encoding])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <oniguruma.h>
-    ]], [[
-return (int)(ONIG_ENCODING_KOI8 + 1);
-    ]])], [
-      AC_MSG_RESULT([no])
-    ], [
-      AC_MSG_RESULT([yes])
-      AC_DEFINE([PHP_ONIG_BAD_KOI8_ENTRY], [1], [define to 1 if oniguruma has an invalid entry for KOI8 encoding])
-    ])
-    LDFLAGS=$save_old_LDFLAGS
+    AC_CACHE_CHECK([if oniguruma has an invalid entry for KOI8 encoding],
+      [php_cv_lib_onig_invalid_koi8],
+      [save_old_LDFLAGS=$LDFLAGS
+        save_old_CFLAGS=$CFLAGS
+        CFLAGS="$CFLAGS $ONIG_CFLAGS"
+        PHP_EVAL_LIBLINE([$MBSTRING_SHARED_LIBADD], [LDFLAGS])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([
+          #include <stdint.h>
+          #include <oniguruma.h>
+        ],
+        [return (intptr_t)(ONIG_ENCODING_KOI8 + 1);])],
+        [php_cv_lib_onig_invalid_koi8=no],
+        [php_cv_lib_onig_invalid_koi8=yes])
+        LDFLAGS=$save_old_LDFLAGS
+        CFLAGS=$save_old_CFLAGS])
+    AS_VAR_IF([php_cv_lib_onig_invalid_koi8], [yes],
+      [AC_DEFINE([PHP_ONIG_BAD_KOI8_ENTRY], [1],
+        [Define to 1 if oniguruma has an invalid entry for KOI8 encoding.])])
 
     PHP_MBSTRING_ADD_CFLAG([-DONIG_ESCAPE_UCHAR_COLLISION=1])
     PHP_MBSTRING_ADD_CFLAG([-DUChar=OnigUChar])


### PR DESCRIPTION
- Fixed warning: cast from pointer to integer of different size using the intptr_t instead of int type case
- CS synced
- Check wrapped in AC_CACHE_CHECK
- Over-quoted arguments reduced
- Also the include flags added to the check when building with oniguruma installed on custom places