### PR TITLE
Autotools: Fix config.status script syntax

### DIFF
--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -110,11 +110,13 @@ if test "$PHP_APXS2" != "no"; then
     ;;
   esac
 
-  APACHE_THREADED_MPM=$($APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes')
-  AS_VAR_IF([APACHE_THREADED_MPM],,, [PHP_BUILD_THREAD_SAFE])
+  AS_IF([$APXS_HTTPD -V 2>/dev/null | grep -q 'threaded:.*yes'], [
+    APACHE_THREADED_MPM=yes
+    PHP_BUILD_THREAD_SAFE
+  ], [APACHE_THREADED_MPM=no])
 
 AC_CONFIG_COMMANDS([apache2handler], [AS_VAR_IF([enable_zts], [yes],,
-  [AS_VAR_IF([APACHE_THREADED_MPM],,
+  [AS_VAR_IF([APACHE_THREADED_MPM], [no],
     [AC_MSG_WARN([
 +--------------------------------------------------------------------+
 |                        *** WARNING ***                             |

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -124,5 +124,5 @@ AC_CONFIG_COMMANDS([apache2handler], [AS_VAR_IF([enable_zts], [yes],,
 | PHP with --enable-zts                                              |
 +--------------------------------------------------------------------+
   ])])])],
-  [APACHE_THREADED_MPM=$APACHE_THREADED_MPM; enable_zts=$enable_zts])
+  [APACHE_THREADED_MPM="$APACHE_THREADED_MPM"; enable_zts="$enable_zts"])
 fi

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -110,7 +110,7 @@ if test "$PHP_APXS2" != "no"; then
     ;;
   esac
 
-  AS_IF([$APXS_HTTPD -V 2>/dev/null | grep -q 'threaded:.*yes'], [
+  AS_IF([$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1], [
     APACHE_THREADED_MPM=yes
     PHP_BUILD_THREAD_SAFE
   ], [APACHE_THREADED_MPM=no])


### PR DESCRIPTION
The init-cmds argument is appended to the config.status script with cat command and variables $var are replaced during the cat step to their values, so quoting these values fixes the syntax errors.

Fixes report in GH-14872