### PR TITLE
GH-14930: Revert "Reserve less file space if possible in a directory entry" 

### DIFF
--- a/ext/standard/tests/streams/gh14930.phpt
+++ b/ext/standard/tests/streams/gh14930.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-14930: Custom stream wrapper dir_readdir output truncated to 255 characters in PHP 8.3
+--FILE--
+<?php
+
+class DummyWrapper
+{
+    public $context;
+
+    public function dir_opendir($url, $options)
+    {
+        return true;
+    }
+
+    public function dir_readdir()
+    {
+        return 'very-long-filename-ieNoquiaC6ijeiy9beejaiphoriejo2cheehooGou8uhoh7eh0gefahyuQuohd7eec9auso9eeFah2Maedohsemi1eetoo5fo5biePh5eephai7SiuguipouLeemequ2oope9aigoQu5efak2aLeri9ithaiJ9eew3dianaiHoo1aexaighiitee6geghiequ5nohhiikahwee8ohk2Soip2Aikeithohdeitiedeiku7DiTh2eep3deitiedeiku7DiTh2ee.txt';
+    }
+}
+
+stream_wrapper_register('dummy', DummyWrapper::class);
+
+$dh = opendir('dummy://', stream_context_create());
+var_dump(readdir($dh));
+?>
+--EXPECT--
+string(288) "very-long-filename-ieNoquiaC6ijeiy9beejaiphoriejo2cheehooGou8uhoh7eh0gefahyuQuohd7eec9auso9eeFah2Maedohsemi1eetoo5fo5biePh5eephai7SiuguipouLeemequ2oope9aigoQu5efak2aLeri9ithaiJ9eew3dianaiHoo1aexaighiitee6geghiequ5nohhiikahwee8ohk2Soip2Aikeithohdeitiedeiku7DiTh2eep3deitiedeiku7DiTh2ee.txt"

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -107,11 +107,7 @@ typedef struct _php_stream_statbuf {
 } php_stream_statbuf;
 
 typedef struct _php_stream_dirent {
-#ifdef NAME_MAX
-	char d_name[NAME_MAX + 1];
-#else
 	char d_name[MAXPATHLEN];
-#endif
 	unsigned char d_type;
 } php_stream_dirent;
 


### PR DESCRIPTION
This reverts 00c1e7bf0f1c7244589ce8756f0367497cf1ce15 from https://github.com/php/php-src/pull/11577 which fixes #14930 . 