### PR TITLE
sapi/apache: AP_MPMQ_MAX_THREADS is always available.

### DIFF
--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -486,13 +486,9 @@ php_apache_server_startup(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 	}
 #ifdef ZTS
 	int expected_threads;
-#ifdef AP_MPMQ_MAX_THREADS
 	if (ap_mpm_query(AP_MPMQ_MAX_THREADS, &expected_threads) != APR_SUCCESS) {
 		expected_threads = 1;
 	}
-#else
-	expected_threads = 1;
-#endif
 
 	php_tsrm_startup_ex(expected_threads);
 # ifdef PHP_WIN32


### PR DESCRIPTION
since we upgraded the minimum with 2.4, AP_MPMQ_MAX_THREADS is always available (since 2.3) and all MPM return a value, including prefork.