### PR TITLE
Generate deprecation warning box for the manual

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1873,7 +1873,7 @@ ENDCOMMENT
         /* Creation of <refsynopsisdiv> */
         $refsynopsisDiv = $doc->createElement('refsynopsisdiv');
         $deprecationEntity = $doc->createEntityReference(
-            'warn.deprecated.' . (isset($aliasMap[$this->name->__toString()]) ? 'alias' : 'function-') .
+            'warn.deprecated.' . (isset($aliasMap[$this->name->__toString()]) ? 'alias' : 'function') . '-' .
             str_replace(".", "-", $this->deprecatedSince) . "-0"
         );
         $refsynopsisDiv->appendChild(new DOMText("\n  "));


### PR DESCRIPTION
By using the information available by the newly added `Deprecated` property, the deprecation warning boxes in the manual can now be generated when not exists. (if it already exists, the box may contain different alternative suggestion than what's written in the stub, so this case is not handled).