### PR TITLE
Autotools: Add PHP_PUSH and PHP_POP

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -30,6 +30,32 @@ dnl Build system helper macros.
 dnl ----------------------------------------------------------------------------
 
 dnl
+dnl PHP_PUSH([namespace])
+dnl
+dnl Save a state of the common compilation and linker flag variables (CFLAGS,
+dnl CPPFLAGS, LIBS and LDFLAGS) to temporary variables. Optional "namespace" is
+dnl a prefix for temporary variable names.
+dnl
+AC_DEFUN([PHP_PUSH],
+[AS_VAR_COPY([$1_php_save_CFLAGS],   [CFLAGS])
+AS_VAR_COPY([$1_php_save_CPPFLAGS],  [CPPFLAGS])
+AS_VAR_COPY([$1_php_save_LDFLAGS],   [LDFLAGS])
+AS_VAR_COPY([$1_php_save_LIBS],      [LIBS])])
+
+dnl
+dnl PHP_POP([namespace])
+dnl
+dnl Restore the state of the common compilation and linker flag variables to the
+dnl last pushed state using PHP_PUSH. When using "namespace" it will restore the
+dnl variables of the last PHP_PUSH([namespace]) call.
+dnl
+AC_DEFUN([PHP_POP],
+[AS_VAR_COPY([CFLAGS],    [$1_php_save_CFLAGS])
+AS_VAR_COPY([CPPFLAGS], [$1_php_save_CPPFLAGS])
+AS_VAR_COPY([LDFLAGS],   [$1_php_save_LDFLAGS])
+AS_VAR_COPY([LIBS],      [$1_php_save_LIBS])])
+
+dnl
 dnl PHP_DEF_HAVE(what)
 dnl
 dnl Generates 'AC_DEFINE(HAVE_WHAT, 1, [ ])'.

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -454,7 +454,7 @@ if test "$PHP_FPM" != "no"; then
     AC_CHECK_HEADERS([sys/acl.h])
 
     dnl *BSD has acl_* built into libc, macOS doesn't have user/group support.
-    LIBS_save=$LIBS
+    PHP_PUSH([fpm_acl])
     AC_SEARCH_LIBS([acl_free], [acl],
     [AC_CACHE_CHECK([for ACL user/group permissions support],
       [php_cv_lib_acl_user_group],
@@ -477,7 +477,7 @@ if test "$PHP_FPM" != "no"; then
           [AS_VAR_APPEND([FPM_EXTRA_LIBS], [" $ac_cv_search_acl_free"])])
       ])
     ])
-    LIBS=$LIBS_save
+    PHP_POP([fpm_acl])
   ])
 
   if test "x$PHP_FPM_APPARMOR" != "xno" ; then


### PR DESCRIPTION
There is common use case where CPPFLAGS, CFLAGS, LIBS and LDFLAGS variables need to be adjusted during some check test and then must be restored back to their initial values. This adds two new macros PHP_PUSH and PHP_POP that store mentioned variables current values to temporary variables and then after the test restore them back.

This is similar implementation to AX_SAVE_FLAGS, AX_RESTORE_FLAGS, AX_SAVE_FLAGS_WITH_PREFIX and AX_RESTORE_FLAGS_WITH_PREFIX from the Autoconf Archive collection.

Usage:

```m4
PHP_PUSH([foo])
CFLAGS="$CFLAGS $LIBFOO_CFLAGS"
LIBS="$LIBS $LIBFOO_LIBS"
dnl Check for some libfoo feature.
PHP_POP([foo])
```

Initial example is added to PHP-FPM SAPI.