### PR TITLE
Make ext/fileinfo/generate_patch.sh simpler to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ php
 # ------------------------------------------------------------------------------
 
 # Miscellaneous extensions files
+/ext/fileinfo/libmagic.orig/
 /ext/opcache/jit/zend_jit_x86.c
 /ext/opcache/jit/zend_jit_arm64.c
 /ext/opcache/minilua

--- a/ext/fileinfo/generate_patch.sh
+++ b/ext/fileinfo/generate_patch.sh
@@ -1,8 +1,16 @@
+#!/bin/sh
+
 VERSION=5.45
-if [[ ! -d libmagic.orig ]]; then
+
+# Go to fileinfo extension directory.
+cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+if [ ! -d libmagic.orig ]; then
   mkdir libmagic.orig
   wget -O - ftp://ftp.astron.com/pub/file/file-$VERSION.tar.gz \
     | tar -xz --strip-components=2 -C libmagic.orig file-$VERSION/src
 fi
-sed -e "s/X\.YY/${VERSION//.}/g" libmagic.orig/magic.h.in > libmagic.orig/magic.h
+
+version_number=$(echo "$VERSION" | sed 's/\.//g')
+sed -e "s/X\.YY/$version_number/g" libmagic.orig/magic.h.in > libmagic.orig/magic.h
 diff -u libmagic.orig libmagic | grep -v '^Only in' > libmagic.patch


### PR DESCRIPTION
- Shebang added so it can be called with ./generate_patch.sh
- Script changes its working directory to ext/fileinfo (where it is located) so it can be also called as ./ext/fileinfo/generate_patch.sh
- Syntax adjusted a bit for using Bourne or a compatible shell (/bin/sh)
- Downloaded files added to .gitignore