### PR TITLE
zend build making sigjmp_buf and api check as mandatory.

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -151,11 +151,16 @@ AC_CHECK_FUNCS(m4_normalize([
   pthread_stackseg_np
 ]))
 
-dnl Check for sigsetjmp. If it's defined as a macro, AC_CHECK_FUNCS won't work.
-AC_CHECK_FUNCS([sigsetjmp],,
-  [AC_CHECK_DECL([sigsetjmp],
-    [AC_DEFINE([HAVE_SIGSETJMP], [1])],,
-    [#include <setjmp.h>])])
+dnl
+dnl ZEND_CHECK_SIGSETJMP
+dnl
+dnl Check for sigsetjmp. If sigsetjmp is defined as a macro, use AC_CHECK_DECL
+dnl as a fallback since AC_CHECK_FUNC cannot detect macros.
+dnl
+AC_CHECK_FUNC([sigsetjmp],,
+  [AC_CHECK_DECL([sigsetjmp],,
+    [AC_MSG_ERROR([Required sigsetjmp not found. Please, check config.log])],
+    [#include <setjmp.h>])]) 
 
 ZEND_CHECK_STACK_DIRECTION
 ZEND_CHECK_FLOAT_PRECISION

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -152,8 +152,6 @@ AC_CHECK_FUNCS(m4_normalize([
 ]))
 
 dnl
-dnl ZEND_CHECK_SIGSETJMP
-dnl
 dnl Check for sigsetjmp. If sigsetjmp is defined as a macro, use AC_CHECK_DECL
 dnl as a fallback since AC_CHECK_FUNC cannot detect macros.
 dnl

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -394,7 +394,7 @@ char *alloca();
 # define XtOffsetOf(s_type, field) offsetof(s_type, field)
 #endif
 
-#ifdef HAVE_SIGSETJMP
+#ifndef ZEND_WIN32
 # define SETJMP(a) sigsetjmp(a, 0)
 # define LONGJMP(a,b) siglongjmp(a, b)
 # define JMP_BUF sigjmp_buf


### PR DESCRIPTION
all unixes support it since long time, the few which don't do not meet the requirements to build php anyway (minix, dietlibc, ...).