### PR TITLE
Autotools: Trim redundant newlines in PHP_ADD_BUILD_DIR

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -893,11 +893,7 @@ dnl When "create" is given, the provided "dirs" are created immediately upon
 dnl macro invocation, instead of deferring it to the PHP_GEN_BUILD_DIRS.
 dnl
 AC_DEFUN([PHP_ADD_BUILD_DIR],[
-  ifelse($2,,[
-    BUILD_DIR="$BUILD_DIR $1"
-  ], [
-    $php_shtool mkdir -p $1
-  ])
+  ifelse($2,,[BUILD_DIR="$BUILD_DIR $1"], [$php_shtool mkdir -p $1])
 ])
 
 dnl


### PR DESCRIPTION
This reduces redundant newlines in the generated configure script while keeping possible 'dnl' usage before or after this macro call working as before (backwards compatible).