### PR TITLE
Autotools: Refactor curl config.m4

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -7,30 +7,26 @@ if test "$PHP_CURL" != "no"; then
   PKG_CHECK_MODULES([CURL], [libcurl >= 7.61.0])
   PKG_CHECK_VAR([CURL_FEATURES], [libcurl], [supported_features])
 
-  PHP_EVAL_LIBLINE($CURL_LIBS, CURL_SHARED_LIBADD)
-  PHP_EVAL_INCLINE($CURL_CFLAGS)
+  PHP_EVAL_LIBLINE([$CURL_LIBS], [CURL_SHARED_LIBADD])
+  PHP_EVAL_INCLINE([$CURL_CFLAGS])
 
   AC_MSG_CHECKING([for SSL support in libcurl])
-  AS_CASE([$CURL_FEATURES],
-    [*SSL*], [
-      CURL_SSL=yes
-      AC_MSG_RESULT([yes])
-    ], [
-      CURL_SSL=no
-      AC_MSG_RESULT([no])
-    ])
+  AS_CASE([$CURL_FEATURES], [*SSL*], [CURL_SSL=yes], [CURL_SSL=no])
+  AC_MSG_RESULT([$CURL_SSL])
 
-  AS_IF([test "$PHP_THREAD_SAFETY" = yes && test "$CURL_SSL" = yes], [
-    save_LDFLAGS="$LDFLAGS"
-    LDFLAGS="$LDFLAGS $CURL_LIBS"
+  AS_IF([test "x$PHP_THREAD_SAFETY" = xyes && test "x$CURL_SSL" = xyes],
+    [AC_CACHE_CHECK([whether libcurl is linked against old OpenSSL < 1.1],
+      [php_cv_lib_curl_ssl], [
+      save_LIBS=$LIBS
+      save_CFLAGS=$CFLAGS
+      LIBS="$LIBS $CURL_SHARED_LIBADD"
+      CFLAGS="$CFLAGS $CURL_CFLAGS"
 
-    AC_CACHE_CHECK([for libcurl linked against old OpenSSL < 1.1],
-      [php_cv_lib_curl_ssl],
-      [AC_RUN_IFELSE([AC_LANG_PROGRAM([
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([
 #include <stdio.h>
 #include <strings.h>
 #include <curl/curl.h>
-      ], [
+], [
   curl_version_info_data *data = curl_version_info(CURLVERSION_NOW);
 
   if (data && data->ssl_version && *data->ssl_version) {
@@ -60,29 +56,31 @@ if test "$PHP_CURL" != "no"; then
   /* No SSL support */
   return 1;
 ])],
-    [php_cv_lib_curl_ssl=yes],
-    [php_cv_lib_curl_ssl=no],
-    [php_cv_lib_curl_ssl=no])])
+      [php_cv_lib_curl_ssl=yes],
+      [php_cv_lib_curl_ssl=no],
+      [php_cv_lib_curl_ssl=no])
+      LIBS=$save_LIBS
+      CFLAGS=$save_CFLAGS
+    ])
 
     AS_VAR_IF([php_cv_lib_curl_ssl], [yes], [
-      AC_DEFINE([HAVE_CURL_OLD_OPENSSL], [1], [Have cURL with old OpenSSL])
+      AC_DEFINE([HAVE_CURL_OLD_OPENSSL], [1],
+        [Define to 1 if libcurl is linked against old OpenSSL < 1.1.])
       PHP_SETUP_OPENSSL([CURL_SHARED_LIBADD],
         [AC_CHECK_HEADERS([openssl/crypto.h])])
     ])
-
-    LDFLAGS="$save_LDFLAGS"
   ])
 
-  PHP_CHECK_LIBRARY(curl,curl_easy_perform,
-  [
-    AC_DEFINE(HAVE_CURL,1,[ ])
-  ],[
-    AC_MSG_ERROR(There is something wrong. Please check config.log for more information.)
-  ],[
-    $CURL_LIBS
-  ])
+  PHP_CHECK_LIBRARY([curl],
+    [curl_easy_perform],
+    [AC_DEFINE([HAVE_CURL], [1],
+      [Define to 1 if curl extension is available.])],
+    [AC_MSG_ERROR([The libcurl check failed. Please, check config.log for details.])],
+    [$CURL_LIBS])
 
-  PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
+  PHP_NEW_EXTENSION([curl],
+    [interface.c multi.c share.c curl_file.c],
+    [$ext_shared])
   PHP_INSTALL_HEADERS([ext/curl], [php_curl.h])
   PHP_SUBST([CURL_SHARED_LIBADD])
 fi

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -26,7 +26,7 @@ if (PHP_CURL != "no") {
 		 CHECK_LIB("nghttp2.lib", "curl", PHP_CURL))
 		) {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
-		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
+		AC_DEFINE('HAVE_CURL', 1, 'Define to 1 if curl extension is available.');
 		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB /D PHP_CURL_EXPORTS=1");
 		PHP_INSTALL_HEADERS("ext/curl", "php_curl.h");
 	} else {


### PR DESCRIPTION
- CS synced
- When checking for libcurl linked against old OpenSSL the LIBS can be used instead of LDFLAGS to put -lcurl to proper place. Also, flags manipulation variables are wrapped in the AC_CACHE_CHECK commands because there is also OpenSSL setup done later in the code which changes LDFLAGS, LIBS and/or CFLAGS.
- CFLAGS added to the check to have edge case of -I flags of custom installation paths taken into consideration
- All macro arguments quoted
- SSL check simplified a bit
- The HAVE_CURL symbol help text synced