### PR TITLE
Autotools: Quote RE2C_FLAGS argument

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1740,7 +1740,7 @@ AC_DEFUN([PHP_PROG_RE2C],[
   esac
 
   PHP_SUBST([RE2C])
-  AS_VAR_SET([RE2C_FLAGS], [m4_normalize([$2])])
+  AS_VAR_SET([RE2C_FLAGS], [m4_normalize(["$2"])])
   PHP_SUBST([RE2C_FLAGS])
 ])
 


### PR DESCRIPTION
This enables and simplifies adding blank-or-newline-separated global re2c flags to the PHP_PROG_RE2C macro possibly at some point. Fixed just in case, so this works normally:

    PHP_PROG_RE2C([1.0.3], [--no-generation-date -W -foo])