### PR TITLE
Update the php-sdk-binary-tools to latest

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -860,7 +860,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.2.0
+      PHP_BUILD_SDK_BRANCH: master
       PHP_BUILD_CRT: vs16
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -860,7 +860,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: 2.3.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -860,7 +860,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: master
+      PHP_BUILD_SDK_BRANCH: 2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -222,7 +222,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: master
+      PHP_BUILD_SDK_BRANCH: 2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: x64
       THREAD_SAFE: "1"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -222,7 +222,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.2.0
+      PHP_BUILD_SDK_BRANCH: master
       PHP_BUILD_CRT: vs16
       PLATFORM: x64
       THREAD_SAFE: "1"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -222,7 +222,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: 2.3.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: x64
       THREAD_SAFE: "1"


### PR DESCRIPTION
The `PHP-8.3` branch CI still uses the tag `php-sdk-2.2.0` which is almost five years old, so may have missed some important updates.  The `master` branch CI uses the `php_downloads_server_migration_v1` branch, which has been superseded a few months ago[1].  To always get the latest updates, we switch to the `master` branch of the php-sdk-binary-tools.

[1] <https://github.com/php/php-sdk-binary-tools/commit/19c8ccbf072370b0ed99bd8734ed09926549d16f>

---

An alternative would be to create a new tag for [php-sdk-binary-tools](https://github.com/php/php-sdk-binary-tools), but I'm not really convinced that this makes much sense, since there have mostly been a couple of updates regarding new PHP versions and URL changes over the last years, and switching to the `master` branch avoids having to update the Windows CI for each such small change.