### PR TITLE
Fix #78757: Enhance sendmail log notice

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1579,10 +1579,11 @@ dnl PHP_PROG_SENDMAIL
 dnl
 dnl Search for the sendmail binary.
 dnl
-AC_DEFUN([PHP_PROG_SENDMAIL], [
-  PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
-  AC_PATH_PROG(PROG_SENDMAIL, sendmail, /usr/sbin/sendmail, $PATH:$PHP_ALT_PATH)
-])
+AC_DEFUN([PHP_PROG_SENDMAIL],
+[PHP_ALT_PATH=/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib
+AC_PATH_PROG([PROG_SENDMAIL], [sendmail], [], [$PATH:$PHP_ALT_PATH])
+AS_VAR_IF([PROG_SENDMAIL],, [PROG_SENDMAIL=/usr/sbin/sendmail
+AC_MSG_NOTICE([default sendmail_path INI directive set to $PROG_SENDMAIL])])])
 
 dnl
 dnl PHP_PROG_AWK


### PR DESCRIPTION
The sendmail is set to default value of /usr/sbin/sendmail if not found on the host system. This was already properly fixed via GH-5548 (commit 517431892b292b039784c64decfb161f4a0664e9). This change now also outputs "no" when searching for sendmail and a minimalistic notice that default send_mail INI directive has been set to /usr/sbin/sendmail.

Fixes and closes: https://bugs.php.net/78757