### PR TITLE
Update fuzzer parser dict for property hooks words

### DIFF
--- a/sapi/fuzzer/dict/parser
+++ b/sapi/fuzzer/dict/parser
@@ -81,7 +81,6 @@
 "public"
 "readonly"
 "enum"
-"unset"
 "list"
 "callable"
 "iterable"
@@ -93,3 +92,5 @@
 "__file__"
 "__dir__"
 "__namespace__"
+"get"
+"set"


### PR DESCRIPTION
- adds two words to fuzzer parser dict coming from property hooks feature `set` and `get`
- removes redundant `unset` word