### PR TITLE
ext/standard: change `highlight_string()`/`print_r` stub return type from `string|bool` to `string|true`

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -566,6 +566,7 @@ PHP 8.4 UPGRADE NOTES
   . output_add_rewrite_var() now uses url_rewriter.hosts instead of
     session.trans_sid_hosts for selecting hosts that will be rewritten.
   . highlight_string() now has a return type of string|true instead of string|bool.
+  . print_r() now has a return type of string|true instead of string|bool.
 
 ========================================
 6. New Functions

--- a/UPGRADING
+++ b/UPGRADING
@@ -565,6 +565,7 @@ PHP 8.4 UPGRADE NOTES
     one digit.
   . output_add_rewrite_var() now uses url_rewriter.hosts instead of
     session.trans_sid_hosts for selecting hosts that will be rewritten.
+  . highlight_string() now has a return type of string|true instead of string|bool.
 
 ========================================
 6. New Functions

--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -456,7 +456,7 @@ static const func_info_t func_infos[] = {
 	F1("error_get_last", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_NULL),
 	F1("highlight_file", MAY_BE_STRING|MAY_BE_BOOL),
 	F1("php_strip_whitespace", MAY_BE_STRING),
-	F1("highlight_string", MAY_BE_STRING|MAY_BE_BOOL),
+	F1("highlight_string", MAY_BE_STRING|MAY_BE_TRUE),
 	F1("ini_get_all", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_ARRAY|MAY_BE_ARRAY_OF_NULL|MAY_BE_FALSE),
 	F1("set_include_path", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("get_include_path", MAY_BE_STRING|MAY_BE_FALSE),

--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -460,7 +460,7 @@ static const func_info_t func_infos[] = {
 	F1("ini_get_all", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_ARRAY|MAY_BE_ARRAY_OF_NULL|MAY_BE_FALSE),
 	F1("set_include_path", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("get_include_path", MAY_BE_STRING|MAY_BE_FALSE),
-	F1("print_r", MAY_BE_STRING|MAY_BE_BOOL),
+	F1("print_r", MAY_BE_STRING|MAY_BE_TRUE),
 #if defined(HAVE_GETSERVBYPORT)
 	F1("getservbyport", MAY_BE_STRING|MAY_BE_FALSE),
 #endif

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2050,7 +2050,7 @@ function set_include_path(string $include_path): string|false {}
 function get_include_path(): string|false {}
 
 /** @refcount 1 */
-function print_r(mixed $value, bool $return = false): string|bool {}
+function print_r(mixed $value, bool $return = false): string|true {}
 
 function connection_aborted(): int {}
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2024,7 +2024,7 @@ function show_source(string $filename, bool $return = false): string|bool {}
 function php_strip_whitespace(string $filename): string {}
 
 /** @refcount 1 */
-function highlight_string(string $string, bool $return = false): string|bool {}
+function highlight_string(string $string, bool $return = false): string|true {}
 
 function ini_get(string $option): string|false {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 298deeb590d17e5444ca0f76a65f63df9af5330c */
+ * Stub hash: 9394c9db6592d623d9361d22fd39381fcbd8a677 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -489,7 +489,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_php_strip_whitespace, 0, 1, IS_S
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_highlight_string, 0, 1, MAY_BE_STRING|MAY_BE_BOOL)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_highlight_string, 0, 1, MAY_BE_STRING|MAY_BE_TRUE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, return, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9394c9db6592d623d9361d22fd39381fcbd8a677 */
+ * Stub hash: e3a7bf1e9f0df3e38f6280f91af70e54ce492a60 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -524,7 +524,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_get_include_path arginfo_ob_get_flush
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_print_r, 0, 1, MAY_BE_STRING|MAY_BE_BOOL)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_print_r, 0, 1, MAY_BE_STRING|MAY_BE_TRUE)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, return, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
`highlight_string` either returns `string` if the `$return` parameter is `true`, or always returns `true`. We can now reflect this in the stubs.