### PR TITLE
ext/dba/tests: sort expected test output

### DIFF
--- a/ext/dba/tests/dba_flatfile.phpt
+++ b/ext/dba/tests/dba_flatfile.phpt
@@ -29,12 +29,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
+[key10]name10: Content String 10
+[key30]name30: Content String 30
 key2: Content String 2
 key4: Another Content String
 key5: The last content string
 name9: Content String 9
-[key10]name10: Content String 10
-[key30]name30: Content String 30
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/dba_gdbm.phpt
+++ b/ext/dba/tests/dba_gdbm.phpt
@@ -35,12 +35,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
-key4: Another Content String
-key2: Content String 2
-key5: The last content string
 [key10]name10: Content String 10
-name9: Content String 9
 [key30]name30: Content String 30
+key2: Content String 2
+key4: Another Content String
+key5: The last content string
+name9: Content String 9
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y
@@ -81,12 +81,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
-key4: Another Content String
-key2: Content String 2
-key5: The last content string
 [key10]name10: Content String 10
-name9: Content String 9
 [key30]name30: Content String 30
+key2: Content String 2
+key4: Another Content String
+key5: The last content string
+name9: Content String 9
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/dba_inifile.phpt
+++ b/ext/dba/tests/dba_inifile.phpt
@@ -30,14 +30,14 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
-key2: Content String 2
-key4: Another Content String
-key5: The last content string
-name9: Content String 9
 [key10]: 
 [key10]name10: Content String 10
 [key30]: 
 [key30]name30: Content String 30
+key2: Content String 2
+key4: Another Content String
+key5: The last content string
+name9: Content String 9
 Total keys: 8
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/dba_ndbm.phpt
+++ b/ext/dba/tests/dba_ndbm.phpt
@@ -36,12 +36,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
-key4: Another Content String
-key2: Content String 2
-key5: The last content string
 [key10]name10: Content String 10
-name9: Content String 9
 [key30]name30: Content String 30
+key2: Content String 2
+key4: Another Content String
+key5: The last content string
+name9: Content String 9
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y
@@ -82,12 +82,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
-key4: Another Content String
-key2: Content String 2
-key5: The last content string
 [key10]name10: Content String 10
-name9: Content String 9
 [key30]name30: Content String 30
+key2: Content String 2
+key4: Another Content String
+key5: The last content string
+name9: Content String 9
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/dba_qdbm.phpt
+++ b/ext/dba/tests/dba_qdbm.phpt
@@ -35,12 +35,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
+[key10]name10: Content String 10
+[key30]name30: Content String 30
 key2: Content String 2
 key4: Another Content String
 key5: The last content string
 name9: Content String 9
-[key10]name10: Content String 10
-[key30]name30: Content String 30
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y
@@ -81,12 +81,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
+[key10]name10: Content String 10
+[key30]name30: Content String 30
 key2: Content String 2
 key4: Another Content String
 key5: The last content string
 name9: Content String 9
-[key10]name10: Content String 10
-[key30]name30: Content String 30
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/dba_tcadb.phpt
+++ b/ext/dba/tests/dba_tcadb.phpt
@@ -30,12 +30,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
+[key10]name10: Content String 10
+[key30]name30: Content String 30
 key2: Content String 2
 key4: Another Content String
 key5: The last content string
 name9: Content String 9
-[key10]name10: Content String 10
-[key30]name30: Content String 30
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y

--- a/ext/dba/tests/setup/setup_dba_tests.inc
+++ b/ext/dba/tests/setup/setup_dba_tests.inc
@@ -102,14 +102,28 @@ function run_standard_tests_ex(string $handler, string $name, LockFlag $lock, bo
     echo 'Try to remove key 1 again', \PHP_EOL;
     var_dump(dba_delete("key1", $db_writer));
 
-    // Fetch data
+    // Fetch and sort data. We sort to guarantee that the output is
+    // always the same across architectures. GDBM in particular does
+    // not guarantee that the insert order is the same as the
+    // iteration order with firstkey() and nextkey(). There is a
+    // Github report (issue 14786) of this actually happening. GDBM's
+    // own test suite sorts its output, suggesting that this is a
+    // reasonable workaround for the issue.
+    $output = [];
+
     $key = dba_firstkey($db_writer);
     $total_keys = 0;
     while ($key) {
-        echo $key, ': ', dba_fetch($key, $db_writer), \PHP_EOL;
+        $output[] = $key . ': ' . dba_fetch($key, $db_writer) . \PHP_EOL;
         $key = dba_nextkey($db_writer);
         $total_keys++;
     }
+
+    sort($output, SORT_STRING);
+    foreach ($output as $line) {
+        echo $line;
+    }
+
     echo 'Total keys: ', $total_keys, \PHP_EOL;
     for ($i = 1; $i < 6; $i++) {
         echo "Key $i exists? ", dba_exists("key$i", $db_writer) ? 'Y' : 'N', \PHP_EOL;

--- a/ext/dba/tests/setup/setup_dba_tests.inc
+++ b/ext/dba/tests/setup/setup_dba_tests.inc
@@ -103,12 +103,13 @@ function run_standard_tests_ex(string $handler, string $name, LockFlag $lock, bo
     var_dump(dba_delete("key1", $db_writer));
 
     // Fetch and sort data. We sort to guarantee that the output is
-    // always the same across architectures. GDBM in particular does
-    // not guarantee that the insert order is the same as the
-    // iteration order with firstkey() and nextkey(). There is a
-    // Github report (issue 14786) of this actually happening. GDBM's
-    // own test suite sorts its output, suggesting that this is a
-    // reasonable workaround for the issue.
+    // consistent across invocations and architectures. When iterating
+    // with firstkey() and nextkey(), several engines (GDBM, LMDB,
+    // QDBM) make no promise about the iteration order. Others (TCADB,
+    // DBM) explicitly state that the order is arbitrary. With GDBM at
+    // least, the order appears platform-dependent -- we have a report
+    // in Github issue 14786. GDBM's own test suite sorts this output,
+    // suggesting that sorting is a reasonable workaround for the issue.
     $output = [];
 
     $key = dba_firstkey($db_writer);

--- a/ext/pgsql/tests/80_bug14383.phpt
+++ b/ext/pgsql/tests/80_bug14383.phpt
@@ -39,12 +39,12 @@ bool(true)
 bool(true)
 Try to remove key 1 again
 bool(false)
+[key10]name10: Content String 10
+[key30]name30: Content String 30
 key2: Content String 2
 key4: Another Content String
 key5: The last content string
 name9: Content String 9
-[key10]name10: Content String 10
-[key30]name30: Content String 30
 Total keys: 6
 Key 1 exists? N
 Key 2 exists? Y


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/14786 by sorting the fetched rows before `echo`ing them, and updating the expected output to reflect the sort order.

I don't have dbm, ndbm, or Oracle db < 4 to test so hopefully the CI does.
