### PR TITLE
Check for iODBC and unixODBC with pkg-config in PDO_ODBC

### DIFF
--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -23,7 +23,8 @@ AC_DEFUN([PHP_PDO_ODBC_CHECK_HEADER],
     AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
       [Define to 1 if you have the <$1> header file.])
       AC_MSG_RESULT([yes])
-  ], [AC_MSG_RESULT([no])])
+  ],
+  [AC_MSG_RESULT([no])])
 ])
 
 if test "$PHP_PDO_ODBC" != "no"; then

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -73,8 +73,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
   if test ! -z "$pdo_odbc_pkgconfig_module"; then
     AC_MSG_RESULT([$pdo_odbc_flavour using pkg-config])
     PKG_CHECK_MODULES([PDO_ODBC], [$pdo_odbc_pkgconfig_module])
-    PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
-    PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
   else
     if test -n "$pdo_odbc_dir"; then
       PDO_ODBC_INCDIR="$pdo_odbc_dir/include"
@@ -93,10 +91,7 @@ if test "$PHP_PDO_ODBC" != "no"; then
     fi
 
     PDO_ODBC_CFLAGS="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR"
-    PDO_ODBC_LDFLAGS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
-
-    PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
-    PHP_EVAL_LIBLINE([$PDO_ODBC_LDFLAGS], [PDO_ODBC_SHARED_LIBADD])
+    PDO_ODBC_LIBS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
 
     dnl Check first for an ODBC 1.0 function to assert that the libraries work
     PHP_CHECK_LIBRARY($pdo_odbc_def_lib, SQLBindCol,
@@ -110,11 +105,14 @@ Your ODBC library does not appear to be ODBC 3 compatible.
 You should consider using iODBC or unixODBC instead, and loading your
 libraries as a driver in that environment; it will emulate the
 functions required for PDO support.
-])], $PDO_ODBC_LDFLAGS)
+])], $PDO_ODBC_LIBS)
     ],[
       AC_MSG_ERROR([Your ODBC library does not exist or there was an error. Check config.log for more information])
-    ], $PDO_ODBC_LDFLAGS)
+    ], $PDO_ODBC_LIBS)
   fi
+
+  PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
+  PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
 
   OLD_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $PDO_ODBC_CFLAGS"

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -1,11 +1,15 @@
 define([PDO_ODBC_HELP_TEXT],[[
-  The include and lib dirs are looked for under 'dir'. The 'flavour' can be one
-  of: ibm-db2, iODBC, unixODBC, generic. If ',dir' part is omitted, default for
-  the flavour you have selected will be used. e.g.: --with-pdo-odbc=unixODBC
-  will check for unixODBC under /usr/local. You may attempt to use an otherwise
-  unsupported driver using the 'generic' flavour. The syntax for generic ODBC
-  support is: --with-pdo-odbc=generic,dir,libname,ldflags,cflags. When built as
-  'shared' the extension filename is always pdo_odbc.so]])
+  The 'flavour' part determines what driver or driver manager to use; it can be
+  either ibm-db2, iODBC, unixODBC, or generic.
+
+  The include and lib dirs are looked for under 'dir'.  You may attempt to use
+  an otherwise unsupported driver using the 'generic' flavour. The syntax for
+  generic ODBC support is: --with-pdo-odbc=generic,dir,libname,ldflags,cflags.
+  When built as 'shared' the extension filename is always 'pdo_odbc.so'.
+
+  For unixODBC and iODBC, the 'dir' part is ignored and can be omitted, as
+  pkg-config will be searched instead. For ibm-db2, it will search for the DB2
+  driver at that path.]])
 
 PHP_ARG_WITH([pdo-odbc],
   [for ODBC v3 support for PDO],
@@ -48,15 +52,11 @@ if test "$PHP_PDO_ODBC" != "no"; then
         ;;
 
     iODBC|iodbc)
-        pdo_odbc_def_libdir=/usr/local/$PHP_LIBDIR
-        pdo_odbc_def_incdir=/usr/local/include
-        pdo_odbc_def_lib=iodbc
+        pdo_odbc_pkgconfig_module=libiodbc
         ;;
 
     unixODBC|unixodbc)
-        pdo_odbc_def_libdir=/usr/local/$PHP_LIBDIR
-        pdo_odbc_def_incdir=/usr/local/include
-        pdo_odbc_def_lib=odbc
+        pdo_odbc_pkgconfig_module=odbc
         ;;
 
     generic)
@@ -71,20 +71,56 @@ if test "$PHP_PDO_ODBC" != "no"; then
         ;;
   esac
 
-  if test -n "$pdo_odbc_dir"; then
-    PDO_ODBC_INCDIR="$pdo_odbc_dir/include"
-    PDO_ODBC_LIBDIR="$pdo_odbc_dir/$PHP_LIBDIR"
+  if test ! -z "$pdo_odbc_pkgconfig_module"; then
+    AC_MSG_RESULT([$pdo_odbc_flavour using pkg-config])
+    PKG_CHECK_MODULES([PDO_ODBC], [$pdo_odbc_pkgconfig_module])
+    dnl PHP_ODBC_INCDIR is only used by PHP_PDO_ODBC_CHECK_HEADER
+    dnl when using pkg-config, so snarf the includedir from it.
+    PDO_ODBC_INCDIR=$($PKG_CONFIG --variable=includedir $pdo_odbc_pkgconfig_module)
+    PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
+    PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
+    PDO_ODBC_INCLUDE="$PDO_ODBC_CFLAGS -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
   else
-    PDO_ODBC_INCDIR="$pdo_odbc_def_incdir"
-    PDO_ODBC_LIBDIR="$pdo_odbc_def_libdir"
-  fi
+    if test -n "$pdo_odbc_dir"; then
+      PDO_ODBC_INCDIR="$pdo_odbc_dir/include"
+      PDO_ODBC_LIBDIR="$pdo_odbc_dir/$PHP_LIBDIR"
+    else
+      PDO_ODBC_INCDIR="$pdo_odbc_def_incdir"
+      PDO_ODBC_LIBDIR="$pdo_odbc_def_libdir"
+    fi
 
-  AC_MSG_RESULT([$pdo_odbc_flavour
-          libs       $PDO_ODBC_LIBDIR,
-          headers    $PDO_ODBC_INCDIR])
+    AC_MSG_RESULT([$pdo_odbc_flavour
+            libs       $PDO_ODBC_LIBDIR,
+            headers    $PDO_ODBC_INCDIR])
 
-  if test ! -d "$PDO_ODBC_LIBDIR" ; then
-    AC_MSG_WARN([library dir $PDO_ODBC_LIBDIR does not exist])
+    if test ! -d "$PDO_ODBC_LIBDIR" ; then
+      AC_MSG_WARN([library dir $PDO_ODBC_LIBDIR does not exist])
+    fi
+
+    AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
+      [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])
+
+    PDO_ODBC_INCLUDE="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
+    PDO_ODBC_LDFLAGS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
+
+    PHP_EVAL_LIBLINE([$PDO_ODBC_LDFLAGS], [PDO_ODBC_SHARED_LIBADD])
+
+    dnl Check first for an ODBC 1.0 function to assert that the libraries work
+    PHP_CHECK_LIBRARY($pdo_odbc_def_lib, SQLBindCol,
+    [
+      dnl And now check for an ODBC 3.0 function to assert that they're *good*
+      dnl libraries.
+      PHP_CHECK_LIBRARY($pdo_odbc_def_lib, SQLAllocHandle,
+      [], [
+        AC_MSG_ERROR([
+Your ODBC library does not appear to be ODBC 3 compatible.
+You should consider using iODBC or unixODBC instead, and loading your
+libraries as a driver in that environment; it will emulate the
+functions required for PDO support.
+])], $PDO_ODBC_LDFLAGS)
+    ],[
+      AC_MSG_ERROR([Your ODBC library does not exist or there was an error. Check config.log for more information])
+    ], $PDO_ODBC_LDFLAGS)
   fi
 
   PHP_PDO_ODBC_CHECK_HEADER([cli0cli.h])
@@ -104,31 +140,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
   PHP_PDO_ODBC_CHECK_HEADER([sqlucode.h])
   PHP_PDO_ODBC_CHECK_HEADER([sqlunix.h])
   PHP_PDO_ODBC_CHECK_HEADER([udbcext.h])
-
-  AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
-    [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])
-
-  PDO_ODBC_INCLUDE="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
-  PDO_ODBC_LDFLAGS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
-
-  PHP_EVAL_LIBLINE([$PDO_ODBC_LDFLAGS], [PDO_ODBC_SHARED_LIBADD])
-
-  dnl Check first for an ODBC 1.0 function to assert that the libraries work
-  PHP_CHECK_LIBRARY($pdo_odbc_def_lib, SQLBindCol,
-  [
-    dnl And now check for an ODBC 3.0 function to assert that they're *good*
-    dnl libraries.
-    PHP_CHECK_LIBRARY($pdo_odbc_def_lib, SQLAllocHandle,
-    [], [
-      AC_MSG_ERROR([
-Your ODBC library does not appear to be ODBC 3 compatible.
-You should consider using iODBC or unixODBC instead, and loading your
-libraries as a driver in that environment; it will emulate the
-functions required for PDO support.
-])], $PDO_ODBC_LDFLAGS)
-  ],[
-    AC_MSG_ERROR([Your ODBC library does not exist or there was an error. Check config.log for more information])
-  ], $PDO_ODBC_LDFLAGS)
 
   PHP_NEW_EXTENSION(pdo_odbc, pdo_odbc.c odbc_driver.c odbc_stmt.c, $ext_shared,, $PDO_ODBC_INCLUDE)
   PHP_SUBST([PDO_ODBC_SHARED_LIBADD])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -97,9 +97,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
       AC_MSG_WARN([library dir $PDO_ODBC_LIBDIR does not exist])
     fi
 
-    AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
-      [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])
-
     PDO_ODBC_INCLUDE="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
     PDO_ODBC_LDFLAGS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
 
@@ -140,6 +137,9 @@ functions required for PDO support.
   PHP_PDO_ODBC_CHECK_HEADER([sqlucode.h])
   PHP_PDO_ODBC_CHECK_HEADER([sqlunix.h])
   PHP_PDO_ODBC_CHECK_HEADER([udbcext.h])
+
+  AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
+    [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])
 
   PHP_NEW_EXTENSION(pdo_odbc, pdo_odbc.c odbc_driver.c odbc_stmt.c, $ext_shared,, $PDO_ODBC_INCLUDE)
   PHP_SUBST([PDO_ODBC_SHARED_LIBADD])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -71,7 +71,7 @@ if test "$PHP_PDO_ODBC" != "no"; then
         ;;
   esac
 
-  if test ! -z "$pdo_odbc_pkgconfig_module"; then
+  if test -n "$pdo_odbc_pkgconfig_module"; then
     AC_MSG_RESULT([$pdo_odbc_flavour using pkg-config])
     PKG_CHECK_MODULES([PDO_ODBC], [$pdo_odbc_pkgconfig_module])
   else
@@ -115,7 +115,7 @@ functions required for PDO support.
   PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
   PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
 
-  OLD_CPPFLAGS="$CPPFLAGS"
+  OLD_CPPFLAGS=$CPPFLAGS
   CPPFLAGS="$CPPFLAGS $PDO_ODBC_CFLAGS"
   PHP_PDO_ODBC_CHECK_HEADER([cli0cli.h])
   PHP_PDO_ODBC_CHECK_HEADER([cli0core.h])
@@ -134,7 +134,7 @@ functions required for PDO support.
   PHP_PDO_ODBC_CHECK_HEADER([sqlucode.h])
   PHP_PDO_ODBC_CHECK_HEADER([sqlunix.h])
   PHP_PDO_ODBC_CHECK_HEADER([udbcext.h])
-  CPPFLAGS="$OLD_CPPFLAGS"
+  CPPFLAGS=$OLD_CPPFLAGS
 
   AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
     [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -17,14 +17,13 @@ PHP_ARG_WITH([pdo-odbc],
     [PDO: Support for 'flavour' ODBC driver.]PDO_ODBC_HELP_TEXT)])
 
 AC_DEFUN([PHP_PDO_ODBC_CHECK_HEADER],
-[AC_MSG_CHECKING([for $1 in $PDO_ODBC_INCDIR])
-  AS_IF([test -f "$PDO_ODBC_INCDIR/$1"], [
+[AC_MSG_CHECKING([for $1])
+  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([#include <$1>], [])], [
     php_pdo_odbc_have_header=yes
     AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
       [Define to 1 if you have the <$1> header file.])
-    AC_MSG_RESULT([yes])
-  ],
-  [AC_MSG_RESULT([no])])
+      AC_MSG_RESULT([yes])
+  ], [AC_MSG_RESULT([no])])
 ])
 
 if test "$PHP_PDO_ODBC" != "no"; then
@@ -74,9 +73,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
   if test ! -z "$pdo_odbc_pkgconfig_module"; then
     AC_MSG_RESULT([$pdo_odbc_flavour using pkg-config])
     PKG_CHECK_MODULES([PDO_ODBC], [$pdo_odbc_pkgconfig_module])
-    dnl PHP_ODBC_INCDIR is only used by PHP_PDO_ODBC_CHECK_HEADER
-    dnl when using pkg-config, so snarf the includedir from it.
-    PDO_ODBC_INCDIR=$($PKG_CONFIG --variable=includedir $pdo_odbc_pkgconfig_module)
     PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
     PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
     PDO_ODBC_INCLUDE="$PDO_ODBC_CFLAGS -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
@@ -120,6 +116,8 @@ functions required for PDO support.
     ], $PDO_ODBC_LDFLAGS)
   fi
 
+  OLD_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $PDO_ODBC_INCLUDE"
   PHP_PDO_ODBC_CHECK_HEADER([cli0cli.h])
   PHP_PDO_ODBC_CHECK_HEADER([cli0core.h])
   PHP_PDO_ODBC_CHECK_HEADER([cli0defs.h])
@@ -137,6 +135,7 @@ functions required for PDO support.
   PHP_PDO_ODBC_CHECK_HEADER([sqlucode.h])
   PHP_PDO_ODBC_CHECK_HEADER([sqlunix.h])
   PHP_PDO_ODBC_CHECK_HEADER([udbcext.h])
+  CPPFLAGS="$OLD_CPPFLAGS"
 
   AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
     [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -75,7 +75,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
     PKG_CHECK_MODULES([PDO_ODBC], [$pdo_odbc_pkgconfig_module])
     PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
     PHP_EVAL_LIBLINE([$PDO_ODBC_LIBS], [PDO_ODBC_SHARED_LIBADD])
-    PDO_ODBC_INCLUDE="$PDO_ODBC_CFLAGS -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
   else
     if test -n "$pdo_odbc_dir"; then
       PDO_ODBC_INCDIR="$pdo_odbc_dir/include"
@@ -93,9 +92,10 @@ if test "$PHP_PDO_ODBC" != "no"; then
       AC_MSG_WARN([library dir $PDO_ODBC_LIBDIR does not exist])
     fi
 
-    PDO_ODBC_INCLUDE="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR -DPDO_ODBC_TYPE=\\\"$pdo_odbc_flavour\\\""
+    PDO_ODBC_CFLAGS="$pdo_odbc_def_cflags -I$PDO_ODBC_INCDIR"
     PDO_ODBC_LDFLAGS="$pdo_odbc_def_ldflags -L$PDO_ODBC_LIBDIR -l$pdo_odbc_def_lib"
 
+    PHP_EVAL_INCLINE([$PDO_ODBC_CFLAGS])
     PHP_EVAL_LIBLINE([$PDO_ODBC_LDFLAGS], [PDO_ODBC_SHARED_LIBADD])
 
     dnl Check first for an ODBC 1.0 function to assert that the libraries work
@@ -117,7 +117,7 @@ functions required for PDO support.
   fi
 
   OLD_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS $PDO_ODBC_INCLUDE"
+  CPPFLAGS="$CPPFLAGS $PDO_ODBC_CFLAGS"
   PHP_PDO_ODBC_CHECK_HEADER([cli0cli.h])
   PHP_PDO_ODBC_CHECK_HEADER([cli0core.h])
   PHP_PDO_ODBC_CHECK_HEADER([cli0defs.h])
@@ -140,7 +140,10 @@ functions required for PDO support.
   AS_VAR_IF([php_pdo_odbc_have_header], [yes],,
     [AC_MSG_ERROR([Cannot find header file(s) for pdo_odbc.])])
 
-  PHP_NEW_EXTENSION(pdo_odbc, pdo_odbc.c odbc_driver.c odbc_stmt.c, $ext_shared,, $PDO_ODBC_INCLUDE)
+  AC_DEFINE_UNQUOTED([PDO_ODBC_TYPE], ["$pdo_odbc_flavour"],
+    [Define to the ODBC driver or driver manager value.])
+
+  PHP_NEW_EXTENSION(pdo_odbc, pdo_odbc.c odbc_driver.c odbc_stmt.c, $ext_shared)
   PHP_SUBST([PDO_ODBC_SHARED_LIBADD])
   PHP_ADD_EXTENSION_DEP(pdo_odbc, pdo)
 fi


### PR DESCRIPTION
PDO_ODBC required that these backends had their path specified manually, which was clumsy and contrary to how procedural ODBC checked it. This adds a pkg-config based path to check for these backends that ignores the 'dir' part of the flag, so i.e. `--with-pdo-odbc=unixODBC` should pick it up from the correct location.

Generic and the special ibm-db2 usecase should be unaffected. The header situation is unfortunately ugly, and has a workaround; this should also be cleaned up.