### PR TITLE
Fix use-after-free in property coercion with __toString()

### DIFF
--- a/Zend/tests/gh14969.phpt
+++ b/Zend/tests/gh14969.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-14969: Crash on coercion with throwing __toString()
+--FILE--
+<?php
+
+class C {
+    public function __toString() {
+        global $c;
+        $c = [];
+        throw new Exception(__METHOD__);
+    }
+}
+
+class D {
+    public string $prop;
+}
+
+$c = new C();
+$d = new D();
+try {
+    $d->prop = $c;
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($d);
+
+$c = new C();
+$d->prop = 'foo';
+try {
+    $d->prop = $c;
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($d);
+
+?>
+--EXPECTF--
+C::__toString
+object(D)#%d (0) {
+  ["prop"]=>
+  uninitialized(string)
+}
+C::__toString
+object(D)#2 (1) {
+  ["prop"]=>
+  string(3) "foo"
+}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -819,7 +819,7 @@ ZEND_API zval *zend_std_write_property(zend_object *zobj, zend_string *name, zva
 
 				ZVAL_COPY_VALUE(&tmp, value);
 				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, property_uses_strict_types()))) {
-					Z_TRY_DELREF_P(value);
+					zval_ptr_dtor(&tmp);
 					variable_ptr = &EG(error_zval);
 					goto exit;
 				}
@@ -890,7 +890,7 @@ write_std_property:
 
 				ZVAL_COPY_VALUE(&tmp, value);
 				if (UNEXPECTED(!zend_verify_property_type(prop_info, &tmp, property_uses_strict_types()))) {
-					zval_ptr_dtor(value);
+					zval_ptr_dtor(&tmp);
 					goto exit;
 				}
 				value = &tmp;


### PR DESCRIPTION
This was only partially fixed in PHP-8.3. Backports and fixes the case for both initialized and uninitialized property writes.

Closes GH-14969