### PR TITLE
Drop support for OpenSSL < 1.1.0 on Windows

### DIFF
--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -15,7 +15,7 @@ if (PHP_CURL != "no") {
 
 	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "curl", PHP_CURL) &&
 		CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_CURL") &&
-		SETUP_OPENSSL("curl", PHP_CURL) > 0 &&
+		SETUP_OPENSSL("curl", PHP_CURL) >= 2 &&
 		CHECK_LIB("winmm.lib", "curl", PHP_CURL) &&
 		CHECK_LIB("wldap32.lib", "curl", PHP_CURL) &&
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "curl", PHP_CURL))) ||

--- a/ext/ftp/config.w32
+++ b/ext/ftp/config.w32
@@ -8,7 +8,7 @@ if (PHP_FTP != "no") {
 
 	var ret = SETUP_OPENSSL("ftp", PHP_FTP);
 
-	if (ret > 0) {
+	if (ret >= 2) {
 		MESSAGE("Enabling SSL support for ext\\ftp");
 		AC_DEFINE('HAVE_FTP_SSL', 1, 'Have FTP over SSL support');
 	}

--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -6,7 +6,7 @@ if (PHP_LDAP != "no") {
 
 	if (CHECK_HEADER_ADD_INCLUDE("ldap.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
 			CHECK_HEADER_ADD_INCLUDE("lber.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
-			SETUP_OPENSSL("ldap", PHP_LDAP) > 0 &&
+			SETUP_OPENSSL("ldap", PHP_LDAP) >= 2 &&
 			CHECK_LIB("oldap32_a.lib", "ldap", PHP_LDAP) &&
 			CHECK_LIB("olber32_a.lib", "ldap", PHP_LDAP)&&
 			CHECK_LIB("libsasl.lib", "ldap", PHP_LDAP)) {

--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("openssl", "OpenSSL support", "no,shared");
 if (PHP_OPENSSL != "no") {
 	var ret = SETUP_OPENSSL("openssl", PHP_OPENSSL);
 
-	if (ret > 0) {
+	if (ret >= 2) {
 		EXTENSION("openssl", "openssl.c xp_ssl.c");
 		AC_DEFINE("HAVE_OPENSSL_EXT", 1, "Define to 1 if the openssl extension is available.");
 	}

--- a/ext/snmp/config.w32
+++ b/ext/snmp/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("snmp", "SNMP support", "no");
 
 if (PHP_SNMP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("snmp.h", "CFLAGS_SNMP", PHP_PHP_BUILD + "\\include\\net-snmp;" + PHP_SNMP) &&
-		SETUP_OPENSSL("snmp", PHP_SNMP) > 0) {
+		SETUP_OPENSSL("snmp", PHP_SNMP) >= 2) {
 		if (CHECK_LIB("netsnmp.lib", "snmp", PHP_SNMP)) {
 			EXTENSION('snmp', 'snmp.c');
 			AC_DEFINE('HAVE_SNMP', 1);

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3664,14 +3664,8 @@ function SETUP_OPENSSL(target, path_to_check, common_name, use_env, add_dir_part
 			CHECK_LIB("libssl.lib", target, path_to_check) &&
 			CHECK_LIB("crypt32.lib", target, path_to_check, common_name) &&
 			CHECK_HEADER_ADD_INCLUDE("openssl/ssl.h", cflags_var, path_to_check, use_env, add_dir_part, add_to_flag_only)) {
-		/* Openssl 1.1.x */
+		/* Openssl 1.1.x or later */
 		return 2;
-	} else if (CHECK_LIB("ssleay32.lib", target, path_to_check, common_name) &&
-			CHECK_LIB("libeay32.lib", target, path_to_check, common_name) &&
-			CHECK_LIB("crypt32.lib", target, path_to_check, common_name) &&
-			CHECK_HEADER_ADD_INCLUDE("openssl/ssl.h", cflags_var, path_to_check, use_env, add_dir_part, add_to_flag_only)) {
-		/* Openssl 1.0.x and lower */
-		return 1;
 	}
 
 	return ret;


### PR DESCRIPTION
PR #13498 bumped the required OpenSSL version to 1.1.1, but apparently only for non Windows system.  We catch up somewhat by dropping support for OpenSSL < 1.1.0 on Windows; besides completely removing detection of old OpenSSL versions in `SETUP_OPENSSL`, we also ensure that all bundled extension using this function do no longer accept OpenSSL < 1.1.0, to avoid to still be able to build these extensions with older `phpize` scripts.

We do not cater to `--phar-native-ssl` yet; that might better be addressed by #14578.