### PR TITLE
zend_compile: Fully remove `ZEND_DIM_ALTERNATIVE_SYNTAX`

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3026,9 +3026,6 @@ static inline void zend_emit_assign_znode(zend_ast *var_ast, znode *value_node) 
 
 static zend_op *zend_delayed_compile_dim(znode *result, zend_ast *ast, uint32_t type, bool by_ref)
 {
-	if (ast->attr == ZEND_DIM_ALTERNATIVE_SYNTAX) {
-		zend_error(E_COMPILE_ERROR, "Array and string offset access syntax with curly braces is no longer supported");
-	}
 	zend_ast *var_ast = ast->child[0];
 	zend_ast *dim_ast = ast->child[1];
 	zend_op *opline;
@@ -11761,11 +11758,6 @@ static void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 
 			if (ast->child[1] == NULL) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Cannot use [] for reading");
-			}
-
-			if (ast->attr & ZEND_DIM_ALTERNATIVE_SYNTAX) {
-				ast->attr &= ~ZEND_DIM_ALTERNATIVE_SYNTAX; /* remove flag to avoid duplicate warning */
-				zend_error(E_COMPILE_ERROR, "Array and string offset access syntax with curly braces is no longer supported");
 			}
 
 			/* Set isset fetch indicator here, opcache disallows runtime altering of the AST */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1090,11 +1090,10 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 	((ZEND_TYPE_FULL_MASK((arg_info)->type) & _ZEND_IS_TENTATIVE_BIT) != 0)
 
 #define ZEND_DIM_IS					(1 << 0) /* isset fetch needed for null coalesce. Set in zend_compile.c for ZEND_AST_DIM nested within ZEND_AST_COALESCE. */
-#define ZEND_DIM_ALTERNATIVE_SYNTAX	(1 << 1) /* deprecated curly brace usage */
 
 /* Attributes for ${} encaps var in strings (ZEND_AST_DIM or ZEND_AST_VAR node) */
 /* ZEND_AST_VAR nodes can have any of the ZEND_ENCAPS_VAR_* flags */
-/* ZEND_AST_DIM flags can have ZEND_DIM_ALTERNATIVE_SYNTAX or ZEND_ENCAPS_VAR_DOLLAR_CURLY during the parse phase (ZEND_DIM_ALTERNATIVE_SYNTAX is a thrown fatal error). */
+/* ZEND_AST_DIM flags can have ZEND_ENCAPS_VAR_DOLLAR_CURLY during the parse phase. */
 #define ZEND_ENCAPS_VAR_DOLLAR_CURLY (1 << 0)
 #define ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR (1 << 1)
 


### PR DESCRIPTION
This flag is longer set since the merge of property hooks in 780a8280d23453ebab5df0dbc35ac897c07c1f0d. This patch removes it completely, because the corresponding error messages are unreachable.