### PR TITLE
Fix references in request_parse_body() options array

### DIFF
--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -244,6 +244,7 @@ static zend_result cache_request_parse_body_option(HashTable *options, zval *opt
 {
 	if (option) {
 		zend_long result;
+		ZVAL_DEREF(option);
 		if (Z_TYPE_P(option) == IS_STRING) {
 			zend_string *errstr;
 			result = zend_ini_parse_quantity(Z_STR_P(option), &errstr);

--- a/ext/standard/tests/http/request_parse_body/options_array_references.phpt
+++ b/ext/standard/tests/http/request_parse_body/options_array_references.phpt
@@ -1,0 +1,14 @@
+--TEST--
+request_parse_body: reference in options array
+--FILE--
+<?php
+$options = ['post_max_size' => '128M'];
+foreach ($options as $k => &$v) {}
+try {
+    request_parse_body($options);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Request does not provide a content type


### PR DESCRIPTION
Otherwise we get funny messages like
"Invalid string value in $options argument".