### PR TITLE
Fix xmlreader extension phpize build

### DIFF
--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -58,7 +58,12 @@ if test "$PHP_DOM" != "no"; then
       $ext_builddir/$LEXBOR_DIR/tag
     ])])
     PHP_SUBST([DOM_SHARED_LIBADD])
-    PHP_INSTALL_HEADERS([ext/dom], [xml_common.h xpath_callbacks.h namespace_compat.h])
+    PHP_INSTALL_HEADERS([ext/dom], [m4_normalize([
+      dom_ce.h
+      namespace_compat.h
+      xml_common.h
+      xpath_callbacks.h
+    ])])
     PHP_ADD_EXTENSION_DEP(dom, libxml)
   ])
 fi

--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -47,7 +47,12 @@ if (PHP_DOM == "yes") {
 				WARNING("dom support can't be enabled, libxml is not found")
 			}
 		}
-		PHP_INSTALL_HEADERS("ext/dom", "xml_common.h xpath_callbacks.h namespace_compat.h");
+		PHP_INSTALL_HEADERS("ext/dom",
+			"dom_ce.h " +
+			"namespace_compat.h " +
+			"xml_common.h " +
+			"xpath_callbacks.h "
+		);
 	} else {
 		WARNING("dom support can't be enabled, libxml is not enabled")
 		PHP_DOM = "no"


### PR DESCRIPTION
When building ext/xmlreader with phpize, also ext/dom/dom_ce.h needs to be installed by dom extension as it is used in
the ext/xmlreader/php_xmlreader.c.

    cd ext/xmlreader
    phpize
    ./configure
    make