### PR TITLE
Fix indirect readonly error messages

### DIFF
--- a/Zend/tests/enum/no-pass-properties-by-ref.phpt
+++ b/Zend/tests/enum/no-pass-properties-by-ref.phpt
@@ -22,5 +22,5 @@ var_dump(Foo::Bar->value);
 
 ?>
 --EXPECT--
-Cannot modify readonly property Foo::$value
+Cannot indirectly modify readonly property Foo::$value
 int(0)

--- a/Zend/tests/enum/no-return-properties-by-ref.phpt
+++ b/Zend/tests/enum/no-return-properties-by-ref.phpt
@@ -23,5 +23,5 @@ var_dump(Foo::Bar->value);
 
 ?>
 --EXPECT--
-Cannot modify readonly property Foo::$value
+Cannot indirectly modify readonly property Foo::$value
 int(0)

--- a/Zend/tests/enum/no-write-properties-through-foreach-reference.phpt
+++ b/Zend/tests/enum/no-write-properties-through-foreach-reference.phpt
@@ -18,5 +18,5 @@ var_dump(Foo::Bar->value);
 
 ?>
 --EXPECT--
-Cannot modify readonly property Foo::$value
+Cannot indirectly modify readonly property Foo::$value
 int(0)

--- a/Zend/tests/enum/no-write-properties-through-references.phpt
+++ b/Zend/tests/enum/no-write-properties-through-references.phpt
@@ -19,5 +19,5 @@ var_dump(Foo::Bar->value);
 
 ?>
 --EXPECT--
-Cannot modify readonly property Foo::$value
+Cannot indirectly modify readonly property Foo::$value
 int(0)

--- a/Zend/tests/readonly_props/cache_slot.phpt
+++ b/Zend/tests/readonly_props/cache_slot.phpt
@@ -88,35 +88,35 @@ $replaceProp3();
 var_dump($test->prop3);
 
 ?>
---EXPECT--
+--EXPECTF--
 string(1) "a"
 Cannot modify readonly property Test::$prop
 string(1) "a"
 
-Cannot modify readonly property Test::$prop2
-Cannot modify readonly property Test::$prop2
-array(0) {
-}
-
-object(stdClass)#3 (1) {
-  ["foo"]=>
-  int(1)
-}
-object(stdClass)#3 (1) {
-  ["foo"]=>
-  int(1)
-}
-
-Cannot modify readonly property Test::$prop2
+Cannot indirectly modify readonly property Test::$prop2
 Cannot modify readonly property Test::$prop2
 array(0) {
 }
 
-object(stdClass)#5 (1) {
+object(stdClass)#%d (1) {
   ["foo"]=>
   int(1)
 }
-object(stdClass)#5 (1) {
+object(stdClass)#%d (1) {
+  ["foo"]=>
+  int(1)
+}
+
+Cannot indirectly modify readonly property Test::$prop2
+Cannot modify readonly property Test::$prop2
+array(0) {
+}
+
+object(stdClass)#%d (1) {
+  ["foo"]=>
+  int(1)
+}
+object(stdClass)#%d (1) {
   ["foo"]=>
   int(1)
 }

--- a/Zend/tests/readonly_props/cache_slot.phpt
+++ b/Zend/tests/readonly_props/cache_slot.phpt
@@ -108,7 +108,7 @@ object(stdClass)#%d (1) {
 }
 
 Cannot indirectly modify readonly property Test::$prop2
-Cannot modify readonly property Test::$prop2
+Cannot indirectly modify readonly property Test::$prop2
 array(0) {
 }
 

--- a/Zend/tests/readonly_props/readonly_clone_error5.phpt
+++ b/Zend/tests/readonly_props/readonly_clone_error5.phpt
@@ -73,4 +73,4 @@ object(TestSetOnce)#%d (1) {
   }
 }
 Cannot indirectly modify readonly property TestSetTwice::$prop
-Cannot modify readonly property TestSetTwice::$prop
+Cannot indirectly modify readonly property TestSetTwice::$prop

--- a/Zend/tests/readonly_props/readonly_clone_error5.phpt
+++ b/Zend/tests/readonly_props/readonly_clone_error5.phpt
@@ -57,20 +57,20 @@ try {
 }
 
 ?>
---EXPECT--
-object(TestSetOnce)#2 (1) {
+--EXPECTF--
+object(TestSetOnce)#%d (1) {
   ["prop"]=>
   array(1) {
     [0]=>
     int(1)
   }
 }
-object(TestSetOnce)#1 (1) {
+object(TestSetOnce)#%d (1) {
   ["prop"]=>
   array(1) {
     [0]=>
     int(1)
   }
 }
-Cannot modify readonly property TestSetTwice::$prop
+Cannot indirectly modify readonly property TestSetTwice::$prop
 Cannot modify readonly property TestSetTwice::$prop

--- a/Zend/tests/readonly_props/readonly_modification.phpt
+++ b/Zend/tests/readonly_props/readonly_modification.phpt
@@ -73,10 +73,10 @@ Cannot modify readonly property Test::$prop
 Cannot modify readonly property Test::$prop
 Cannot modify readonly property Test::$prop
 Cannot modify readonly property Test::$prop
-Cannot modify readonly property Test::$prop
-Cannot modify readonly property Test::$prop
-Cannot modify readonly property Test::$prop
+Cannot indirectly modify readonly property Test::$prop
+Cannot indirectly modify readonly property Test::$prop
+Cannot indirectly modify readonly property Test::$prop
 array(0) {
 }
-Cannot modify readonly property Test::$prop2
-Cannot modify readonly property Test::$prop2
+Cannot indirectly modify readonly property Test::$prop2
+Cannot indirectly modify readonly property Test::$prop2

--- a/Zend/tests/readonly_props/variation.phpt
+++ b/Zend/tests/readonly_props/variation.phpt
@@ -95,13 +95,13 @@ foreach ([true, false] as $init) {
 Init: 1, scope: 1, op: r: 1
 Init: 1, scope: 1, op: w: Cannot modify readonly property Test::$prop
 Init: 1, scope: 1, op: rw: Cannot modify readonly property Test::$prop
-Init: 1, scope: 1, op: im: Cannot modify readonly property Test::$prop
+Init: 1, scope: 1, op: im: Cannot indirectly modify readonly property Test::$prop
 Init: 1, scope: 1, op: is: 1
 Init: 1, scope: 1, op: us: Cannot unset readonly property Test::$prop
 Init: 1, scope: 0, op: r: 1
 Init: 1, scope: 0, op: w: Cannot modify readonly property Test::$prop
 Init: 1, scope: 0, op: rw: Cannot modify readonly property Test::$prop
-Init: 1, scope: 0, op: im: Cannot modify readonly property Test::$prop
+Init: 1, scope: 0, op: im: Cannot indirectly modify readonly property Test::$prop
 Init: 1, scope: 0, op: is: 1
 Init: 1, scope: 0, op: us: Cannot unset readonly property Test::$prop
 Init: 0, scope: 1, op: r: Typed property Test::$prop must not be accessed before initialization

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3367,7 +3367,7 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 						} else if (Z_PROP_FLAG_P(ptr) & IS_PROP_REINITABLE) {
 							Z_PROP_FLAG_P(ptr) &= ~IS_PROP_REINITABLE;
 						} else {
-							zend_readonly_property_modification_error(prop_info);
+							zend_readonly_property_indirect_modification_error(prop_info);
 							ZVAL_ERROR(result);
 						}
 						return;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -697,7 +697,7 @@ try_again:
 				} else if (Z_PROP_FLAG_P(retval) & IS_PROP_REINITABLE) {
 					Z_PROP_FLAG_P(retval) &= ~IS_PROP_REINITABLE;
 				} else {
-					zend_readonly_property_modification_error(prop_info);
+					zend_readonly_property_indirect_modification_error(prop_info);
 					retval = &EG(uninitialized_zval);
 				}
 			}

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -13959,7 +13959,7 @@ static int zend_jit_fetch_obj(zend_jit_ctx         *jit,
 			ir_IF_FALSE(if_reinitable);
 
 			jit_SET_EX_OPLINE(jit, opline);
-			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_readonly_property_modification_error), prop_info_ref);
+			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_readonly_property_indirect_modification_error), prop_info_ref);
 			jit_set_Z_TYPE_INFO(jit, res_addr, _IS_ERROR);
 			ir_END_list(end_inputs);
 
@@ -14033,7 +14033,7 @@ static int zend_jit_fetch_obj(zend_jit_ctx         *jit,
 
 			ir_IF_FALSE(if_reinitable);
 			jit_SET_EX_OPLINE(jit, opline);
-			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_readonly_property_modification_error), ir_CONST_ADDR(prop_info));
+			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_readonly_property_indirect_modification_error), ir_CONST_ADDR(prop_info));
 			jit_set_Z_TYPE_INFO(jit, res_addr, _IS_ERROR);
 			ir_END_list(end_inputs);
 


### PR DESCRIPTION
`$obj->ro[] = 42;`, `passByRef($obj->ro);` and the likes should emit an indirect modification error message. This message already existed but was used inconsistently.