### PR TITLE
Use fast ZPP for ParentNode manipulation methods

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1453,9 +1453,9 @@ PHP_METHOD(DOMElement, after)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 
@@ -1468,9 +1468,9 @@ PHP_METHOD(DOMElement, before)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 
@@ -1486,9 +1486,9 @@ PHP_METHOD(DOMElement, append)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 
@@ -1505,9 +1505,9 @@ PHP_METHOD(DOMElement, prepend)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 
@@ -1524,9 +1524,9 @@ PHP_METHOD(DOMElement, replaceWith)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 
@@ -1543,9 +1543,9 @@ PHP_METHOD(DOMElement, replaceChildren)
 	zval *args;
 	dom_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('*', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_INTERN(intern);
 


### PR DESCRIPTION
These are very common, and parsing variadic arguments takes a very long time, so this optimization makes sense to do.