### PR TITLE
ext/curl: curl_error using curl_easy_strerror if CURLOPT_ERRORBUFFER

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2626,7 +2626,11 @@ PHP_FUNCTION(curl_error)
 
 	if (ch->err.no) {
 		ch->err.str[CURL_ERROR_SIZE] = 0;
-		RETURN_STRING(ch->err.str);
+		if (strlen(ch->err.str) > 0) {
+			RETURN_STRING(ch->err.str);
+		} else {
+			RETURN_STRING(curl_easy_strerror(ch->err.no));
+		}
 	} else {
 		RETURN_EMPTY_STRING();
 	}


### PR DESCRIPTION
did not fill the error buffer.