### PR TITLE
Autotools: Fix Autoconf syntax (erroneous dnl)

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -377,7 +377,7 @@ AC_DEFUN([PHP_EVAL_LIBLINE],
     ;;
     esac
   done
-m4_ifnblank([$3], [m4_ifnblank([$2], [ext_shared=$_php_ext_shared_saved])])dnl
+m4_ifnblank([$3], [m4_ifnblank([$2], [ext_shared=$_php_ext_shared_saved])])[]dnl
 ])
 
 dnl


### PR DESCRIPTION
M4 interprets the dnl in this combination of m4_ifnblank as part of the preceding text so the [] can be used to avoid this issue.