### PR TITLE
ext/pdo: Fixed parent class of subclass stubs

### DIFF
--- a/ext/pdo_dblib/pdo_dblib.stub.php
+++ b/ext/pdo_dblib/pdo_dblib.stub.php
@@ -8,7 +8,7 @@ namespace Pdo;
  * @strict-properties
  * @not-serializable
  */
-class Dblib extends PDO
+class Dblib extends \PDO
 {
     /** @cvalue PDO_DBLIB_ATTR_CONNECTION_TIMEOUT */
     public const int ATTR_CONNECTION_TIMEOUT = UNKNOWN;

--- a/ext/pdo_dblib/pdo_dblib_arginfo.h
+++ b/ext/pdo_dblib/pdo_dblib_arginfo.h
@@ -1,16 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7589c5d95f17513e35fa7884cd0ac4c6df253d09 */
+ * Stub hash: 95f297028aee0675523d6984c03a518e4fc431df */
 
 static const zend_function_entry class_Pdo_Dblib_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Dblib", class_Pdo_Dblib_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval const_ATTR_CONNECTION_TIMEOUT_value;

--- a/ext/pdo_firebird/pdo_firebird.stub.php
+++ b/ext/pdo_firebird/pdo_firebird.stub.php
@@ -8,7 +8,7 @@ namespace Pdo;
  * @strict-properties
  * @not-serializable
  */
-class Firebird extends PDO
+class Firebird extends \PDO
 {
     /** @cvalue PDO_FB_ATTR_DATE_FORMAT */
     public const int ATTR_DATE_FORMAT = UNKNOWN;

--- a/ext/pdo_firebird/pdo_firebird_arginfo.h
+++ b/ext/pdo_firebird/pdo_firebird_arginfo.h
@@ -1,16 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 84acb963a6d147625c986e66ec313a0927314af2 */
+ * Stub hash: bc0f434e238c1087e292be0d4a7a04aa4718a6bc */
 
 static const zend_function_entry class_Pdo_Firebird_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Firebird", class_Pdo_Firebird_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval const_ATTR_DATE_FORMAT_value;

--- a/ext/pdo_mysql/pdo_mysql.stub.php
+++ b/ext/pdo_mysql/pdo_mysql.stub.php
@@ -8,7 +8,7 @@ namespace Pdo;
  * @strict-properties
  * @not-serializable
  */
-class Mysql extends PDO
+class Mysql extends \PDO
 {
     /** @cvalue PDO_MYSQL_ATTR_USE_BUFFERED_QUERY */
     public const int ATTR_USE_BUFFERED_QUERY = UNKNOWN;

--- a/ext/pdo_mysql/pdo_mysql_arginfo.h
+++ b/ext/pdo_mysql/pdo_mysql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 065388b9ae5ffe9feb14fc4738ea5df66e0cf755 */
+ * Stub hash: 05487a0b7668688c1885a14a8ce02493b96f63bb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Pdo_Mysql_getWarningCount, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -11,12 +11,12 @@ static const zend_function_entry class_Pdo_Mysql_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Mysql", class_Pdo_Mysql_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval const_ATTR_USE_BUFFERED_QUERY_value;

--- a/ext/pdo_odbc/pdo_odbc.stub.php
+++ b/ext/pdo_odbc/pdo_odbc.stub.php
@@ -15,7 +15,7 @@ namespace Pdo {
      * @strict-properties
      * @not-serializable
      */
-    class Odbc extends PDO
+    class Odbc extends \PDO
     {
         /** @cvalue PDO_ODBC_ATTR_USE_CURSOR_LIBRARY */
         public const int ATTR_USE_CURSOR_LIBRARY = UNKNOWN;

--- a/ext/pdo_odbc/pdo_odbc_arginfo.h
+++ b/ext/pdo_odbc/pdo_odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 03226d99e04ac7db352bc8a9561826fa534c1fc7 */
+ * Stub hash: 9136c911494c9e3462c49b3e58f4bcc15ebb2a9c */
 
 static const zend_function_entry class_Pdo_Odbc_methods[] = {
 	ZEND_FE_END
@@ -10,12 +10,12 @@ static void register_pdo_odbc_symbols(int module_number)
 	REGISTER_STRING_CONSTANT("PDO_ODBC_TYPE", PDO_ODBC_TYPE, CONST_PERSISTENT);
 }
 
-static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Odbc", class_Pdo_Odbc_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval const_ATTR_USE_CURSOR_LIBRARY_value;

--- a/ext/pdo_pgsql/pdo_pgsql.stub.php
+++ b/ext/pdo_pgsql/pdo_pgsql.stub.php
@@ -8,7 +8,7 @@ namespace Pdo;
  * @strict-properties
  * @not-serializable
  */
-class Pgsql extends PDO
+class Pgsql extends \PDO
 {
     /** @cvalue PDO_PGSQL_ATTR_DISABLE_PREPARES */
     public const int ATTR_DISABLE_PREPARES = UNKNOWN;

--- a/ext/pdo_pgsql/pdo_pgsql_arginfo.h
+++ b/ext/pdo_pgsql/pdo_pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 92d66416beab5094d0ca70565e691eacc3049d9c */
+ * Stub hash: 225cbb077d441f93b7c6bdb9826ab3e8f634b79d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Pdo_Pgsql_escapeIdentifier, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
@@ -81,12 +81,12 @@ static const zend_function_entry class_Pdo_Pgsql_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Pdo_Pgsql(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Pgsql(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Pgsql", class_Pdo_Pgsql_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval const_ATTR_DISABLE_PREPARES_value;

--- a/ext/pdo_sqlite/pdo_sqlite.stub.php
+++ b/ext/pdo_sqlite/pdo_sqlite.stub.php
@@ -8,7 +8,7 @@ namespace Pdo;
  * @strict-properties
  * @not-serializable
  */
-class Sqlite extends PDO
+class Sqlite extends \PDO
 {
 #ifdef SQLITE_DETERMINISTIC
     /** @cvalue SQLITE_DETERMINISTIC */

--- a/ext/pdo_sqlite/pdo_sqlite_arginfo.h
+++ b/ext/pdo_sqlite/pdo_sqlite_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 89e215924e6e1041d1ddfca6717e4ad2219d0199 */
+ * Stub hash: 4b89b32b7fa966fa1c3f481bc2b322f5b8d03129 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Pdo_Sqlite_createAggregate, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
@@ -53,12 +53,12 @@ static const zend_function_entry class_Pdo_Sqlite_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Pdo_Sqlite(zend_class_entry *class_entry_Pdo_PDO)
+static zend_class_entry *register_class_Pdo_Sqlite(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Sqlite", class_Pdo_Sqlite_methods);
-	class_entry = zend_register_internal_class_ex(&ce, class_entry_Pdo_PDO);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_PDO);
 	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE;
 #if defined(SQLITE_DETERMINISTIC)
 


### PR DESCRIPTION
The parent class was `Pdo\PDO`, so I changed it to `\PDO`.