### PR TITLE
Update the php-sdk-binary-tools to php-sdk-2.3.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -657,7 +657,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.2.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -182,7 +182,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.2.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs16
       PLATFORM: x64
       THREAD_SAFE: "1"


### PR DESCRIPTION
The Windows CI of the `PHP-8.1` to `PHP-8.3` branches still use the `php-sdk-2.2.0` which is almost five years old, and does not fetch the updated dependencies from https://downloads.php.net/~windows.

The `master` branch CI uses `php_downloads_server_migration_v1`, which has been superseded a few months ago[1].  So switching to the `php-sdk-2.3.0` makes sense there, too.

[1] <php/php-sdk-binary-tools@19c8ccb>