### PR TITLE
[ci skip] Clarify usage of C99 standard

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -9,9 +9,12 @@ rewritten to comply with these rules.
 
 1. Document your code in source files and the manual. (tm)
 
-1. PHP is implemented in C99.  The optional fixed-width integers from
+1. PHP is implemented in C99.
+    For instance, the optional fixed-width integers from
     stdint.h (int8_t, int16_t, int32_t, int64_t and their unsigned
-    counterparts) must be available.
+    counterparts) are supposed to be available.
+    However, some features (most notably variable-length arrays) which are not
+    supported by all relevant compilers, must not be used.
 
 1. Functions that are given pointers to resources should not free them.
 


### PR DESCRIPTION
This is mostly about mentioning that VLAs which are a required part of C99 conforming implementations (although made optional in the C11 standard) must not be used in php-src.

---

This may help to prevent issues such as #13933.