### PR TITLE
Move ext/tidy to pkg-config

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -26,17 +26,8 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 
-#ifdef HAVE_TIDY_H
 #include "tidy.h"
-#elif defined(HAVE_TIDYP_H)
-#include "tidyp.h"
-#endif
-
-#ifdef HAVE_TIDYBUFFIO_H
 #include "tidybuffio.h"
-#else
-#include "buffio.h"
-#endif
 
 #include "tidy_arginfo.h"
 


### PR DESCRIPTION
It seems most distributions i.e. Debian/Gentoo/Fedora have all moved over to html-tidy as the tidy library they ship. It ships a pkg-config file, so we can just simply check for that and omit the various alternatives to check for.

I'm not sure if the checks for library functionality are needed anymore if we assume the html5 tidy fork either.