### PR TITLE
Move ext/snmp to pkg-config

### DIFF
--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -1,74 +1,18 @@
 PHP_ARG_WITH([snmp],
   [for SNMP support],
-  [AS_HELP_STRING([[--with-snmp[=DIR]]],
+  [AS_HELP_STRING([--with-snmp],
     [Include SNMP support])])
 
 if test "$PHP_SNMP" != "no"; then
+  dnl 5.4 includes shutdown_snmp_logging.
+  dnl We used to check for SHA-256, but since PHP needs OpenSSL 1.1.1,
+  dnl and those algorithms' API are always available since then...
+  PKG_CHECK_MODULES([SNMP], [netsnmp >= 5.4])
 
-  if test "$PHP_SNMP" = "yes"; then
-    AC_PATH_PROG(SNMP_CONFIG,net-snmp-config,,[/usr/local/bin:$PATH])
-  else
-    SNMP_CONFIG="$PHP_SNMP/bin/net-snmp-config"
-  fi
+  PHP_EVAL_INCLINE([$SNMP_CFLAGS])
+  PHP_EVAL_LIBLINE([$SNMP_LIBS], [SNMP_SHARED_LIBADD])
 
-  if test -x "$SNMP_CONFIG"; then
-    SNMP_LIBS=`$SNMP_CONFIG --netsnmp-libs`
-    SNMP_LIBS="$SNMP_LIBS `$SNMP_CONFIG --external-libs`"
-    SNMP_PREFIX=`$SNMP_CONFIG --prefix`
-    snmp_full_version=`$SNMP_CONFIG --version`
-    ac_IFS=$IFS
-    IFS="."
-    set $snmp_full_version
-    IFS=$ac_IFS
-    SNMP_VERSION=`expr [$]1 \* 1000 + [$]2`
-    if test "$SNMP_VERSION" -ge "5003"; then
-      if test -n "$SNMP_LIBS" && test -n "$SNMP_PREFIX"; then
-        PHP_ADD_INCLUDE(${SNMP_PREFIX}/include)
-        PHP_EVAL_LIBLINE($SNMP_LIBS, SNMP_SHARED_LIBADD)
-        SNMP_LIBNAME=netsnmp
-      else
-        AC_MSG_ERROR([Could not find the required paths. Please check your net-snmp installation.])
-      fi
-    else
-      AC_MSG_ERROR([Net-SNMP version 5.3 or greater required (detected $snmp_full_version).])
-    fi
-  else
-    AC_MSG_ERROR([Could not find net-snmp-config binary. Please check your net-snmp installation.])
-  fi
-
-  dnl Test build.
-  PHP_CHECK_LIBRARY($SNMP_LIBNAME, init_snmp,
-  [
-    AC_DEFINE(HAVE_SNMP,1,[ ])
-  ], [
-    AC_MSG_ERROR([SNMP sanity check failed. Please check config.log for more information.])
-  ], [
-    $SNMP_SHARED_LIBADD
-  ])
-
-  dnl Check whether shutdown_snmp_logging() exists.
-  PHP_CHECK_LIBRARY($SNMP_LIBNAME, shutdown_snmp_logging,
-  [
-    AC_DEFINE(HAVE_SHUTDOWN_SNMP_LOGGING, 1, [ ])
-  ], [], [
-    $SNMP_SHARED_LIBADD
-  ])
-
-  dnl Check whether usmHMAC192SHA256AuthProtocol exists.
-  PHP_CHECK_LIBRARY($SNMP_LIBNAME, usmHMAC192SHA256AuthProtocol,
-  [
-    AC_DEFINE(HAVE_SNMP_SHA256, 1, [ ])
-  ], [], [
-    $SNMP_SHARED_LIBADD
-  ])
-
-  dnl Check whether usmHMAC384SHA512AuthProtocol exists.
-  PHP_CHECK_LIBRARY($SNMP_LIBNAME, usmHMAC384SHA512AuthProtocol,
-  [
-    AC_DEFINE(HAVE_SNMP_SHA512, 1, [ ])
-  ], [], [
-    $SNMP_SHARED_LIBADD
-  ])
+  AC_DEFINE(HAVE_SNMP,1,[ ])
 
   PHP_NEW_EXTENSION(snmp, snmp.c, $ext_shared)
   PHP_SUBST([SNMP_SHARED_LIBADD])

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -64,17 +64,6 @@
 
 #include "snmp_arginfo.h"
 
-/* For net-snmp prior to 5.4 */
-#ifndef HAVE_SHUTDOWN_SNMP_LOGGING
-extern netsnmp_log_handler *logh_head;
-#define shutdown_snmp_logging() \
-	{ \
-		snmp_disable_log(); \
-		while(NULL != logh_head) \
-			netsnmp_remove_loghandler( logh_head ); \
-	}
-#endif
-
 typedef struct snmp_session php_snmp_session;
 
 #define PHP_SNMP_ADD_PROPERTIES(a, b) \
@@ -930,31 +919,21 @@ static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_strin
 		return true;
 	}
 
-#ifdef HAVE_SNMP_SHA256
 	if (zend_string_equals_literal_ci(prot, "SHA256")) {
 		s->securityAuthProto = usmHMAC192SHA256AuthProtocol;
 		s->securityAuthProtoLen = sizeof(usmHMAC192SHA256AuthProtocol) / sizeof(oid);
 		return true;
 	}
-#endif
 
-#ifdef HAVE_SNMP_SHA512
 	if (zend_string_equals_literal_ci(prot, "SHA512")) {
 		s->securityAuthProto = usmHMAC384SHA512AuthProtocol;
 		s->securityAuthProtoLen = sizeof(usmHMAC384SHA512AuthProtocol) / sizeof(oid);
 		return true;
 	}
-#endif
 
 	smart_string err = {0};
 
-	smart_string_appends(&err, "Authentication protocol must be \"SHA\"");
-#ifdef HAVE_SNMP_SHA256
-	smart_string_appends(&err, " or \"SHA256\"");
-#endif
-#ifdef HAVE_SNMP_SHA512
-	smart_string_appends(&err, " or \"SHA512\"");
-#endif
+	smart_string_appends(&err, "Authentication protocol must be \"SHA\", \"SHA256\", or \"SHA512\"");
 #ifndef DISABLE_MD5
 	smart_string_appends(&err, " or \"MD5\"");
 #endif


### PR DESCRIPTION
This mandates net-snmp 5.4 (which is quite old), and assumes the version of OpenSSL it was built against has EVP_SHA256/512 support (as the version of OpenSSL PHP requires should be guaranteed to have this).

pkg-config support in net-snmp materializes in 5.8.1 (from 2019).