### PR TITLE
Deduplicate NULL checks in ext/dom

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -163,12 +163,8 @@ zend_result dom_attr_owner_element_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	xmlNodePtr nodeparent = nodep->parent;
-	if (!nodeparent) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object(nodeparent, retval, obj);
+	php_dom_create_nullable_object(nodeparent, retval, obj);
 	return SUCCESS;
 }
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -50,12 +50,8 @@ zend_result dom_document_doctype_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlDocPtr, docp, obj);
 
 	xmlDtdPtr dtdptr = xmlGetIntSubset(docp);
-	if (!dtdptr) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object((xmlNodePtr) dtdptr, retval, obj);
+	php_dom_create_nullable_object((xmlNodePtr) dtdptr, retval, obj);
 	return SUCCESS;
 }
 
@@ -83,12 +79,8 @@ zend_result dom_document_document_element_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlDocPtr, docp, obj);
 
 	xmlNodePtr root = xmlDocGetRootElement(docp);
-	if (!root) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object(root, retval, obj);
+	php_dom_create_nullable_object(root, retval, obj);
 	return SUCCESS;
 }
 

--- a/ext/dom/entityreference.c
+++ b/ext/dom/entityreference.c
@@ -85,12 +85,8 @@ zend_result dom_entity_reference_child_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	xmlEntityPtr entity = dom_entity_reference_fetch_and_sync_declaration(nodep);
-	if (entity == NULL) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object((xmlNodePtr) entity, retval, obj);
+	php_dom_create_nullable_object((xmlNodePtr) entity, retval, obj);
 	return SUCCESS;
 }
 

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1386,11 +1386,7 @@ zend_result dom_html_document_element_read_helper(dom_object *obj, zval *retval,
 	DOM_PROP_NODE(const xmlDoc *, docp, obj);
 
 	const xmlNode *element = dom_html_document_element_read_raw(docp, accept);
-	if (element == NULL) {
-		ZVAL_NULL(retval);
-	} else {
-		php_dom_create_object((xmlNodePtr) element, retval, obj);
-	}
+	php_dom_create_nullable_object((xmlNodePtr) element, retval, obj);
 
 	return SUCCESS;
 }

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -304,12 +304,7 @@ zend_result dom_node_first_child_read(dom_object *obj, zval *retval)
 		first = nodep->children;
 	}
 
-	if (!first) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(first, retval, obj);
+	php_dom_create_nullable_object(first, retval, obj);
 	return SUCCESS;
 }
 
@@ -329,12 +324,7 @@ zend_result dom_node_last_child_read(dom_object *obj, zval *retval)
 		last = nodep->last;
 	}
 
-	if (!last) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(last, retval, obj);
+	php_dom_create_nullable_object(last, retval, obj);
 	return SUCCESS;
 }
 
@@ -350,12 +340,8 @@ zend_result dom_node_previous_sibling_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	xmlNodePtr prevsib = nodep->prev;
-	if (!prevsib) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object(prevsib, retval, obj);
+	php_dom_create_nullable_object(prevsib, retval, obj);
 	return SUCCESS;
 }
 
@@ -371,12 +357,8 @@ zend_result dom_node_next_sibling_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	xmlNodePtr nextsib = nodep->next;
-	if (!nextsib) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
 
-	php_dom_create_object(nextsib, retval, obj);
+	php_dom_create_nullable_object(nextsib, retval, obj);
 	return SUCCESS;
 }
 
@@ -397,12 +379,7 @@ zend_result dom_node_previous_element_sibling_read(dom_object *obj, zval *retval
 		prevsib = prevsib->prev;
 	}
 
-	if (!prevsib) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(prevsib, retval, obj);
+	php_dom_create_nullable_object(prevsib, retval, obj);
 	return SUCCESS;
 }
 
@@ -423,12 +400,7 @@ zend_result dom_node_next_element_sibling_read(dom_object *obj, zval *retval)
 		nextsib = nextsib->next;
 	}
 
-	if (!nextsib) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(nextsib, retval, obj);
+	php_dom_create_nullable_object(nextsib, retval, obj);
 	return SUCCESS;
 }
 

--- a/ext/dom/parentnode/tree.c
+++ b/ext/dom/parentnode/tree.c
@@ -39,12 +39,7 @@ zend_result dom_parent_node_first_element_child_read(dom_object *obj, zval *retv
 		first = first->next;
 	}
 
-	if (!first) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(first, retval, obj);
+	php_dom_create_nullable_object(first, retval, obj);
 	return SUCCESS;
 }
 /* }}} */
@@ -63,12 +58,7 @@ zend_result dom_parent_node_last_element_child_read(dom_object *obj, zval *retva
 		last = last->prev;
 	}
 
-	if (!last) {
-		ZVAL_NULL(retval);
-		return SUCCESS;
-	}
-
-	php_dom_create_object(last, retval, obj);
+	php_dom_create_nullable_object(last, retval, obj);
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1606,6 +1606,16 @@ static zend_always_inline zend_class_entry *dom_get_element_ce(const xmlNode *no
 	}
 }
 
+bool php_dom_create_nullable_object(xmlNodePtr obj, zval *return_value, dom_object *domobj)
+{
+	if (!obj) {
+		ZVAL_NULL(return_value);
+		return false;
+	}
+
+	return php_dom_create_object(obj, return_value, domobj);
+}
+
 /* {{{ php_dom_create_object */
 PHP_DOM_EXPORT bool php_dom_create_object(xmlNodePtr obj, zval *return_value, dom_object *domobj)
 {

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -179,6 +179,7 @@ const char *dom_locate_a_namespace(const xmlNode *node, const zend_string *prefi
 void dom_mark_namespaces_as_attributes_too(php_dom_libxml_ns_mapper *ns_mapper, xmlDocPtr doc);
 bool dom_compare_value(const xmlAttr *attr, const xmlChar *value);
 void dom_attr_value_will_change(dom_object *obj, xmlAttrPtr attrp);
+bool php_dom_create_nullable_object(xmlNodePtr obj, zval *return_value, dom_object *domobj);
 
 typedef enum {
 	DOM_LOAD_STRING = 0,


### PR DESCRIPTION
This introduces a new helper php_dom_create_nullable_object() that does the NULL check and puts NULL in return_value. Otherwise it runs php_dom_create_object(). This deduplicates a bit of code.