### PR TITLE
[skip ci] Sync CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,14 @@
-# The following volunteers have self-identified as subject matter experts or
-# interested parties in a particular area of the php-src source code. While
-# requesting a review from someone does not obligate that person to review a
-# pull request, these reviewers might have valuable knowledge of the problem
-# area and could aid in deciding whether a pull request is ready for merging.
+# The following volunteers have self-identified as subject matter experts
+# or interested parties over a particular area of the php-src source code.
+# While requesting a review from someone does not obligate that person to
+# review a pull request, these reviewers might have valuable knowledge of
+# the problem area and could aid in deciding whether a pull request is ready
+# for merging.
 #
 # When changing this file, please make sure to commit the changes to the
 # earliest supported PHP branch (PHP-X.Y) and not only to the master branch.
 # GitHub reads the CODEOWNERS file from the pull request's targeted branch.
+# Commit changes here like bug fixes.
 #
 # For more information, see the GitHub CODEOWNERS documentation:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,40 +1,54 @@
-# The following volunteers have self-identified as subject matter experts
-# or interested parties over a particular area of the php-src source code.
-# While requesting a review from someone does not obligate that person to
-# review a pull request, these reviewers might have valuable knowledge of
-# the problem area and could aid in deciding whether a pull request is ready
-# for merging.
+# The following volunteers have self-identified as subject matter experts or
+# interested parties in a particular area of the php-src source code. While
+# requesting a review from someone does not obligate that person to review a
+# pull request, these reviewers might have valuable knowledge of the problem
+# area and could aid in deciding whether a pull request is ready for merging.
+#
+# When changing this file, please make sure to commit the changes to the
+# earliest supported PHP branch (PHP-X.Y) and not only to the master branch.
+# GitHub reads the CODEOWNERS file from the pull request's targeted branch.
 #
 # For more information, see the GitHub CODEOWNERS documentation:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 /.github @iluuu1994 @TimWolla
 /build/gen_stub.php @kocsismate
-/ext/bcmath @Girgias
+/ext/bcmath @Girgias @nielsdos @SakiTakamachi
 /ext/curl @adoy
 /ext/date @derickr
 /ext/dba @Girgias
 /ext/dom @nielsdos
 /ext/ffi @dstogov
+/ext/gd @devnexen
 /ext/gettext @devnexen
 /ext/gmp @Girgias
 /ext/imap @Girgias
 /ext/intl @devnexen
 /ext/json @bukka
 /ext/libxml @nielsdos
-/ext/mbstring @alexdowad
+/ext/mbstring @alexdowad @youkidearitai
+/ext/mysqlnd @SakiTakamachi
 /ext/odbc @NattyNarwhal
 /ext/opcache @dstogov @iluuu1994
 /ext/openssl @bukka
-/ext/pdo_odbc @NattyNarwhal
-/ext/pdo_pgsql @devnexen
+/ext/pcntl @devnexen
+/ext/pdo @SakiTakamachi
+/ext/pdo_dblib @SakiTakamachi
+/ext/pdo_firebird @SakiTakamachi
+/ext/pdo_mysql @SakiTakamachi
+/ext/pdo_odbc @NattyNarwhal @SakiTakamachi
+/ext/pdo_pgsql @devnexen @SakiTakamachi
+/ext/pdo_sqlite @SakiTakamachi
 /ext/pgsql @devnexen
 /ext/random @TimWolla @zeriyoshi
 /ext/session @Girgias
+/ext/simplexml @nielsdos
 /ext/sockets @devnexen
 /ext/spl @Girgias
 /ext/standard @bukka
+/ext/xml @nielsdos
 /ext/xmlreader @nielsdos
+/ext/xmlwriter @nielsdos
 /ext/xsl @nielsdos
 /main @bukka
 /sapi/fpm @bukka
@@ -44,6 +58,8 @@
 /Zend/zend_API.* @dstogov @iluuu1994
 /Zend/zend_call_stack.* @arnaud-lb
 /Zend/zend_closures.* @dstogov
+/Zend/zend_compile.* @iluuu1994
+/Zend/zend_enum.* @iluuu1994
 /Zend/zend_execute.* @dstogov @iluuu1994
 /Zend/zend_execute_API.c @dstogov @iluuu1994
 /Zend/zend_gc.* @dstogov @arnaud-lb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,8 @@
 # When changing this file, please make sure to commit the changes to the
 # earliest supported PHP branch (PHP-X.Y) and not only to the master branch.
 # GitHub reads the CODEOWNERS file from the pull request's targeted branch.
-# Commit changes here like bug fixes.
+# Commit changes here similar to bug fixes:
+# https://github.com/php/php-src/blob/master/CONTRIBUTING.md#pull-requests
 #
 # For more information, see the GitHub CODEOWNERS documentation:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
This repeats the sync as noted in the GH-13591 and the discussion https://news-web.php.net/php.internals/124472

The CODEOWNERS file is related to the targeted branch in the pull request and not only the master branch.

- CS style comments synced (80 columns length)
- Added a note to change the earliest supported PHP branch and not only master branch
- Synced GitHub ID's and paths across the PHP-8.2, PHP-8.3 and master branches