### PR TITLE
Autotools: Expand m4_normalize sooner

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1741,7 +1741,7 @@ AC_DEFUN([PHP_PROG_RE2C],[
   esac
 
   PHP_SUBST([RE2C])
-  AS_VAR_SET([RE2C_FLAGS], [m4_normalize(["$2"])])
+  AS_VAR_SET([RE2C_FLAGS], m4_normalize(["$2"]))
   PHP_SUBST([RE2C_FLAGS])
 ])
 
@@ -1998,17 +1998,17 @@ AS_VAR_IF([found_pgsql], [yes], [dnl
   PHP_EVAL_INCLINE([$PGSQL_CFLAGS])
   PHP_EVAL_LIBLINE([$PGSQL_LIBS], [$1])
 dnl PostgreSQL minimum version sanity check.
-  PHP_CHECK_LIBRARY([pq], [PQencryptPasswordConn],, [AC_MSG_ERROR([m4_normalize([
+  PHP_CHECK_LIBRARY([pq], [PQencryptPasswordConn],, [AC_MSG_ERROR(m4_normalize([
     PostgreSQL check failed: libpq 10.0 or later is required, please see
     config.log for details.
-  ])])],
+  ]))],
   [$PGSQL_LIBS])
 $2],
-[m4_default([$3], [AC_MSG_ERROR([m4_normalize([
+[m4_default([$3], [AC_MSG_ERROR(m4_normalize([
   Cannot find libpq-fe.h or pq library (libpq). Please specify the correct
   PostgreSQL installation path with environment variables PGSQL_CFLAGS and
   PGSQL_LIBS or provide the PostgreSQL installation directory.
-])])])])
+]))])])
 ])
 
 dnl ----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -861,10 +861,10 @@ fi
 
 AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [
   AS_VAR_IF([pthreads_working], [yes], [],
-    [AC_MSG_ERROR([m4_normalize([
+    [AC_MSG_ERROR(m4_normalize([
       Unable to verify system support for POSIX Threads, which are required for
       PHP thread safety (ZTS) build.
-    ])])])
+    ]))])
 
   AC_MSG_CHECKING([for POSIX threads])
   AC_MSG_RESULT([yes])
@@ -1170,10 +1170,10 @@ AS_VAR_IF([PHP_PEAR], [no],, [
   AC_MSG_WARN([The --with-pear option is deprecated])
 
   dnl PEAR dependencies.
-  AS_VAR_IF([PHP_XML], [no], [AC_MSG_ERROR([m4_normalize([
+  AS_VAR_IF([PHP_XML], [no], [AC_MSG_ERROR(m4_normalize([
     PEAR requires XML to be enabled. Add '--enable-xml' to the configure line,
     or disable PEAR (--without-pear).
-  ])])])
+  ]))])
 
   install_pear=install-pear
 
@@ -1535,11 +1535,11 @@ if test "$PHP_MEMORY_SANITIZER" = "yes"; then
 fi
 
 AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
-  [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR([m4_normalize([
+  [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR(m4_normalize([
     Valgrind and address sanitizer are not compatible. Either disable Valgrind
     (remove --with-valgrind) or disable address sanitizer (remove
     --enable-address-sanitizer).
-  ])])])
+  ]))])
 
   AX_CHECK_COMPILE_FLAG([-fsanitize=address], [
     CFLAGS="$CFLAGS -fsanitize=address -DZEND_TRACK_ARENA_ALLOC"
@@ -1678,7 +1678,7 @@ PHP_ADD_SOURCES(main/streams, streams.c cast.c memory.c filter.c \
 PHP_ADD_SOURCES(/main, internal_functions.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, sapi)
 PHP_ADD_SOURCES_X(/main, internal_functions_cli.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, PHP_BINARY_OBJS)
 
-PHP_ADD_SOURCES([Zend], [m4_normalize([
+PHP_ADD_SOURCES([Zend], m4_normalize([
   Optimizer/block_pass.c
   Optimizer/compact_literals.c
   Optimizer/compact_vars.c
@@ -1760,7 +1760,7 @@ PHP_ADD_SOURCES([Zend], [m4_normalize([
   zend_vm_opcodes.c
   zend_weakrefs.c
   zend.c
-])],
+]),
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $fiber_asm_cflag])
 
 PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/scripts/Makefile.frag],
@@ -1772,7 +1772,7 @@ PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/Zend/Makefile.frag],
 
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 
-PHP_ADD_BUILD_DIR([m4_normalize([
+PHP_ADD_BUILD_DIR(m4_normalize([
   main
   main/streams
   scripts
@@ -1781,7 +1781,7 @@ PHP_ADD_BUILD_DIR([m4_normalize([
   Zend
   Zend/asm
   Zend/Optimizer
-])])
+]))
 
 ALL_OUTPUT_FILES="main/build-defs.h \
 scripts/phpize scripts/man1/phpize.1 \

--- a/ext/bcmath/config.m4
+++ b/ext/bcmath/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_ENABLE([bcmath],
     [Enable bc style precision math functions])])
 
 if test "$PHP_BCMATH" != "no"; then
-  PHP_NEW_EXTENSION([bcmath], [m4_normalize([
+  PHP_NEW_EXTENSION([bcmath], m4_normalize([
     bcmath.c
     libbcmath/src/add.c
     libbcmath/src/compare.c
@@ -28,7 +28,7 @@ if test "$PHP_BCMATH" != "no"; then
     libbcmath/src/str2num.c
     libbcmath/src/sub.c
     libbcmath/src/zero.c
-  ])],
+  ]),
   [$ext_shared],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
   PHP_ADD_BUILD_DIR([$ext_builddir/libbcmath/src])

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -41,7 +41,7 @@ if test "$PHP_DOM" != "no"; then
                             namednodemap.c xpath_callbacks.c \
                             $LEXBOR_SOURCES],
                             $ext_shared,,$PHP_LEXBOR_CFLAGS)
-    PHP_ADD_BUILD_DIR([m4_normalize([
+    PHP_ADD_BUILD_DIR(m4_normalize([
       $ext_builddir/parentnode
       $ext_builddir/$LEXBOR_DIR/core
       $ext_builddir/$LEXBOR_DIR/css/selectors
@@ -56,14 +56,14 @@ if test "$PHP_DOM" != "no"; then
       $ext_builddir/$LEXBOR_DIR/ports/posix/lexbor/core
       $ext_builddir/$LEXBOR_DIR/selectors-adapted
       $ext_builddir/$LEXBOR_DIR/tag
-    ])])
+    ]))
     PHP_SUBST([DOM_SHARED_LIBADD])
-    PHP_INSTALL_HEADERS([ext/dom], [m4_normalize([
+    PHP_INSTALL_HEADERS([ext/dom], m4_normalize([
       dom_ce.h
       namespace_compat.h
       xml_common.h
       xpath_callbacks.h
-    ])])
+    ]))
     PHP_ADD_EXTENSION_DEP(dom, libxml)
   ])
 fi

--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -100,7 +100,7 @@ if test "$PHP_INTL" != "no"; then
     PHP_ADD_SOURCES_X(PHP_EXT_DIR(intl), $PHP_INTL_CXX_SOURCES, $PHP_INTL_CXX_FLAGS, shared_objects_intl, yes)
   fi
 
-  PHP_ADD_BUILD_DIR([m4_normalize([
+  PHP_ADD_BUILD_DIR(m4_normalize([
     $ext_builddir/breakiterator
     $ext_builddir/calendar
     $ext_builddir/collator
@@ -118,5 +118,5 @@ if test "$PHP_INTL" != "no"; then
     $ext_builddir/timezone
     $ext_builddir/transliterator
     $ext_builddir/uchar
-  ])])
+  ]))
 fi

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -38,7 +38,7 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
     PHP_SETUP_OPENSSL(MYSQLND_SHARED_LIBADD, [AC_DEFINE(MYSQLND_HAVE_SSL,1,[Enable mysqlnd code that uses OpenSSL directly])])
   fi
 
-  PHP_NEW_EXTENSION([mysqlnd], [m4_normalize([
+  PHP_NEW_EXTENSION([mysqlnd], m4_normalize([
     mysqlnd_alloc.c
     mysqlnd_auth.c
     mysqlnd_block_alloc.c
@@ -61,7 +61,7 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
     mysqlnd_vio.c
     mysqlnd_wireprotocol.c
     php_mysqlnd.c
-  ])],
+  ]),
   [$ext_shared],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -377,7 +377,7 @@ AS_VAR_IF([php_cv_func_getifaddrs], [yes],
 dnl
 dnl Setup extension sources
 dnl
-PHP_NEW_EXTENSION([standard], [m4_normalize([
+PHP_NEW_EXTENSION([standard], m4_normalize([
   array.c
   assert.c
   base64.c
@@ -441,7 +441,7 @@ PHP_NEW_EXTENSION([standard], [m4_normalize([
   var_unserializer.c
   var.c
   versioning.c
-])],,,
+]),,,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
 PHP_ADD_BUILD_DIR([$ext_builddir/libavifinfo])

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -34,10 +34,10 @@ if test "$PHP_APXS2" != "no"; then
 
   APXS_INCLUDEDIR=`$APXS -q INCLUDEDIR`
   APXS_HTTPD=`$APXS -q SBINDIR`/`$APXS -q TARGET`
-  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR([m4_normalize([
+  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR(m4_normalize([
     $APXS_HTTPD executable not found. Please, install Apache HTTP Server
     command-line utility.
-  ])])])
+  ]))])
 
   APXS_CFLAGS=`$APXS -q CFLAGS`
   APU_BINDIR=`$APXS -q APU_BINDIR`


### PR DESCRIPTION
Quoted m4_normalize will expand and change its argument later in the macro call when M4 is processing the `*.m4` sources. Without quotes the already normalized string is passed to the macro directly. In these specific cases generated configure script is the same. This is more for consistency to have this synced and not repeat the pattern too much in the future when copy/pasting. Note, that many `AC_*` macros require similar behavior already (for example, AC_CHECK_FUNCS.)