### PR TITLE
Add assertion to error path in streams.c

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2211,6 +2211,7 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 			options &= ~USE_PATH;
 		}
 		if (EG(exception)) {
+			ZEND_ASSERT(resolved_path == NULL);
 			return NULL;
 		}
 	}


### PR DESCRIPTION
This makes the developer intent clear and should prevent some false reports.
See GH-15026.