### PR TITLE
Fix GH-15034: Integer overflow on stream_notification_callback byte_max parameter with files bigger than 2GB

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -795,11 +795,12 @@ finish:
 				const char *ptr = http_header_value;
 				/* must contain only digits, no + or - symbols */
 				if (*ptr >= '0' && *ptr <= '9') {
-					char* endptr = NULL;
+					char *endptr = NULL;
 					size_t parsed = ZEND_STRTOUL(ptr, &endptr, 10);
 					/* check whether there was no garbage in the header value and the conversion was successful */
 					if (endptr && !*endptr) {
-						file_size = parsed;
+						/* truncate for 32-bit such that no negative file sizes occur */
+						file_size = MIN(parsed, ZEND_LONG_MAX);
 						php_stream_notify_file_size(context, file_size, http_header_line, 0);
 					}
 				}

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -791,8 +791,18 @@ finish:
 			} else if (!strncasecmp(http_header_line, "Content-Type:", sizeof("Content-Type:")-1)) {
 				php_stream_notify_info(context, PHP_STREAM_NOTIFY_MIME_TYPE_IS, http_header_value, 0);
 			} else if (!strncasecmp(http_header_line, "Content-Length:", sizeof("Content-Length:")-1)) {
-				file_size = atoi(http_header_value);
-				php_stream_notify_file_size(context, file_size, http_header_line, 0);
+				/* https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length */
+				const char *ptr = http_header_value;
+				/* must contain only digits, no + or - symbols */
+				if (*ptr >= '0' && *ptr <= '9') {
+					char* endptr = NULL;
+					size_t parsed = ZEND_STRTOUL(ptr, &endptr, 10);
+					/* check whether there was no garbage in the header value and the conversion was successful */
+					if (endptr && !*endptr) {
+						file_size = parsed;
+						php_stream_notify_file_size(context, file_size, http_header_line, 0);
+					}
+				}
 			} else if (
 				!strncasecmp(http_header_line, "Transfer-Encoding:", sizeof("Transfer-Encoding:")-1)
 				&& !strncasecmp(http_header_value, "Chunked", sizeof("Chunked")-1)

--- a/ext/standard/tests/http/gh15034.phpt
+++ b/ext/standard/tests/http/gh15034.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-15034 (Integer overflow on stream_notification_callback byte_max parameter with files bigger than 2GB)
+--SKIPIF--
+<?php
+require 'server.inc';
+http_server_skipif();
+if (PHP_INT_SIZE != 8) die("skip 64-bit only");
+?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+require 'server.inc';
+
+$responses = [
+    "data://text/plain,HTTP/1.1 200 OK\r\n"
+    . "Content-Type: text/plain\r\n"
+    . "Content-Length: 3000000000\r\n\r\n"
+    . "foo\n",
+];
+['pid' => $pid, 'uri' => $uri] = http_server($responses);
+
+$params = ['notification' => function(
+    int $notification_code,
+    int $severity,
+    ?string $message,
+    int $message_code,
+    int $bytes_transferred,
+    int $bytes_max
+) {
+    global $max;
+    $max = $bytes_max;
+}];
+$contextResource = stream_context_create([], $params);
+
+$resource = fopen($uri, 'r', false, $contextResource);
+fclose($resource);
+
+http_server_kill($pid);
+
+var_dump($max);
+?>
+--EXPECT--
+int(3000000000)


### PR DESCRIPTION
We were using atoi, which is only for integers. When the size does not fit in an integer this breaks. Use ZEND_STRTOUL instead. Also make sure invalid data isn't accidentally parsed into a file size.