### PR TITLE
Make internal run_time_cache a persistent allocation

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -735,6 +735,7 @@ static void compiler_globals_ctor(zend_compiler_globals *compiler_globals) /* {{
 	compiler_globals->map_ptr_base = ZEND_MAP_PTR_BIASED_BASE(NULL);
 	compiler_globals->map_ptr_size = 0;
 	compiler_globals->map_ptr_last = global_map_ptr_last;
+	compiler_globals->internal_run_time_cache = 0;
 	if (compiler_globals->map_ptr_last) {
 		/* Allocate map_ptr table */
 		compiler_globals->map_ptr_size = ZEND_MM_ALIGNED_SIZE_EX(compiler_globals->map_ptr_last, 4096);
@@ -2028,11 +2029,11 @@ ZEND_API void *zend_map_ptr_new_static(void)
 		zend_map_ptr_static_size += 4096;
 		/* Grow map_ptr table */
 		CG(map_ptr_size) = ZEND_MM_ALIGNED_SIZE_EX(CG(map_ptr_last), 4096);
-		/* Note: there are no used non-static map_ptrs yet, hence we don't need to move the whole thing */
 		CG(map_ptr_real_base) = perealloc(CG(map_ptr_real_base), CG(map_ptr_size) * sizeof(void*), 1);
+		memmove((char*)CG(map_ptr_real_base) + 4096 * sizeof(void *), CG(map_ptr_real_base), (CG(map_ptr_last) - 4096) * sizeof(void *));
 		CG(map_ptr_base) = ZEND_MAP_PTR_BIASED_BASE(CG(map_ptr_real_base));
 	}
-	ptr = (void**)CG(map_ptr_real_base) + zend_map_ptr_static_last;
+	ptr = (void**)CG(map_ptr_real_base) + (zend_map_ptr_static_last & 4095);
 	*ptr = NULL;
 	zend_map_ptr_static_last++;
 	return ZEND_MAP_PTR_PTR2OFFSET(ptr);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2958,7 +2958,7 @@ ZEND_API zend_result zend_register_functions(zend_class_entry *scope, const zend
 		if (EG(active)) { // at run-time: this ought to only happen if registered with dl() or somehow temporarily at runtime
 			ZEND_MAP_PTR_INIT(internal_function->run_time_cache, zend_arena_calloc(&CG(arena), 1, zend_internal_run_time_cache_reserved_size()));
 		} else {
-			ZEND_MAP_PTR_NEW(internal_function->run_time_cache);
+			ZEND_MAP_PTR_NEW_STATIC(internal_function->run_time_cache);
 		}
 		if (ptr->flags) {
 			if (!(ptr->flags & ZEND_ACC_PPP_MASK)) {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2958,7 +2958,11 @@ ZEND_API zend_result zend_register_functions(zend_class_entry *scope, const zend
 		if (EG(active)) { // at run-time: this ought to only happen if registered with dl() or somehow temporarily at runtime
 			ZEND_MAP_PTR_INIT(internal_function->run_time_cache, zend_arena_calloc(&CG(arena), 1, zend_internal_run_time_cache_reserved_size()));
 		} else {
+#if ZTS
 			ZEND_MAP_PTR_NEW_STATIC(internal_function->run_time_cache);
+#else
+			ZEND_MAP_PTR_INIT(internal_function->run_time_cache, NULL);
+#endif
 		}
 		if (ptr->flags) {
 			if (!(ptr->flags & ZEND_ACC_PPP_MASK)) {

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -421,7 +421,11 @@ static void zend_enum_register_func(zend_class_entry *ce, zend_known_string_id n
     if (EG(active)) { // at run-time
 		ZEND_MAP_PTR_INIT(zif->run_time_cache, zend_arena_calloc(&CG(arena), 1, zend_internal_run_time_cache_reserved_size()));
 	} else {
+#if ZTS
 		ZEND_MAP_PTR_NEW_STATIC(zif->run_time_cache);
+#else
+		ZEND_MAP_PTR_INIT(zif->run_time_cache, NULL);
+#endif
 	}
 
 	if (!zend_hash_add_ptr(&ce->function_table, name, zif)) {

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -421,7 +421,7 @@ static void zend_enum_register_func(zend_class_entry *ce, zend_known_string_id n
     if (EG(active)) { // at run-time
 		ZEND_MAP_PTR_INIT(zif->run_time_cache, zend_arena_calloc(&CG(arena), 1, zend_internal_run_time_cache_reserved_size()));
 	} else {
-		ZEND_MAP_PTR_NEW(zif->run_time_cache);
+		ZEND_MAP_PTR_NEW_STATIC(zif->run_time_cache);
 	}
 
 	if (!zend_hash_add_ptr(&ce->function_table, name, zif)) {

--- a/Zend/zend_extensions.c
+++ b/Zend/zend_extensions.c
@@ -331,24 +331,33 @@ ZEND_API void zend_init_internal_run_time_cache(void) {
 			functions += zend_hash_num_elements(&ce->function_table);
 		} ZEND_HASH_FOREACH_END();
 
-		char *ptr = zend_arena_calloc(&CG(arena), functions, rt_size);
+		size_t alloc_size = functions * rt_size;
+		char *ptr = pemalloc(alloc_size, 1);
+
+		CG(internal_run_time_cache) = ptr;
+		CG(internal_run_time_cache_size) = alloc_size;
+
 		zend_internal_function *zif;
 		ZEND_HASH_MAP_FOREACH_PTR(CG(function_table), zif) {
-			if (!ZEND_USER_CODE(zif->type) && ZEND_MAP_PTR_GET(zif->run_time_cache) == NULL)
-			{
+			if (!ZEND_USER_CODE(zif->type) && ZEND_MAP_PTR_GET(zif->run_time_cache) == NULL) {
 				ZEND_MAP_PTR_SET(zif->run_time_cache, (void *)ptr);
 				ptr += rt_size;
 			}
 		} ZEND_HASH_FOREACH_END();
 		ZEND_HASH_MAP_FOREACH_PTR(CG(class_table), ce) {
 			ZEND_HASH_MAP_FOREACH_PTR(&ce->function_table, zif) {
-				if (!ZEND_USER_CODE(zif->type) && ZEND_MAP_PTR_GET(zif->run_time_cache) == NULL)
-				{
+				if (!ZEND_USER_CODE(zif->type) && ZEND_MAP_PTR_GET(zif->run_time_cache) == NULL) {
 					ZEND_MAP_PTR_SET(zif->run_time_cache, (void *)ptr);
 					ptr += rt_size;
 				}
 			} ZEND_HASH_FOREACH_END();
 		} ZEND_HASH_FOREACH_END();
+	}
+}
+
+ZEND_API void zend_reset_internal_run_time_cache(void) {
+	if (CG(internal_run_time_cache)) {
+		memset(CG(internal_run_time_cache), 0, CG(internal_run_time_cache_size));
 	}
 }
 

--- a/Zend/zend_extensions.h
+++ b/Zend/zend_extensions.h
@@ -149,6 +149,7 @@ void zend_shutdown_extensions(void);
 
 ZEND_API size_t zend_internal_run_time_cache_reserved_size(void);
 ZEND_API void zend_init_internal_run_time_cache(void);
+ZEND_API void zend_reset_internal_run_time_cache(void);
 
 BEGIN_EXTERN_C()
 ZEND_API zend_result zend_load_extension(const char *path);

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -154,6 +154,9 @@ struct _zend_compiler_globals {
 
 	uint32_t rtd_key_counter;
 
+	void *internal_run_time_cache;
+	uint32_t internal_run_time_cache_size;
+
 	zend_stack short_circuiting_opnums;
 #ifdef ZTS
 	uint32_t copied_functions_count;

--- a/Zend/zend_map_ptr.h
+++ b/Zend/zend_map_ptr.h
@@ -48,7 +48,7 @@ typedef struct _zend_string zend_string;
 
 #if ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR_OR_OFFSET
 # define ZEND_MAP_PTR_NEW_OFFSET() \
-	((uint32_t)(intptr_t)zend_map_ptr_new())
+	((uint32_t)(uintptr_t)zend_map_ptr_new())
 # define ZEND_MAP_PTR_IS_OFFSET(ptr) \
 	(((uintptr_t)ZEND_MAP_PTR(ptr)) & 1L)
 # define ZEND_MAP_PTR_GET(ptr) \

--- a/Zend/zend_map_ptr.h
+++ b/Zend/zend_map_ptr.h
@@ -42,10 +42,13 @@ typedef struct _zend_string zend_string;
 #define ZEND_MAP_PTR_NEW(ptr) do { \
 		ZEND_MAP_PTR(ptr) = zend_map_ptr_new(); \
 	} while (0)
+#define ZEND_MAP_PTR_NEW_STATIC(ptr) do { \
+		ZEND_MAP_PTR(ptr) = zend_map_ptr_new_static(); \
+	} while (0)
 
 #if ZEND_MAP_PTR_KIND == ZEND_MAP_PTR_KIND_PTR_OR_OFFSET
 # define ZEND_MAP_PTR_NEW_OFFSET() \
-	((uint32_t)(uintptr_t)zend_map_ptr_new())
+	((uint32_t)(intptr_t)zend_map_ptr_new())
 # define ZEND_MAP_PTR_IS_OFFSET(ptr) \
 	(((uintptr_t)ZEND_MAP_PTR(ptr)) & 1L)
 # define ZEND_MAP_PTR_GET(ptr) \
@@ -53,7 +56,7 @@ typedef struct _zend_string zend_string;
 		ZEND_MAP_PTR_GET_IMM(ptr) : \
 		((void*)(ZEND_MAP_PTR(ptr)))))
 # define ZEND_MAP_PTR_GET_IMM(ptr) \
-	(*ZEND_MAP_PTR_OFFSET2PTR((uintptr_t)ZEND_MAP_PTR(ptr)))
+	(*ZEND_MAP_PTR_OFFSET2PTR((intptr_t)ZEND_MAP_PTR(ptr)))
 # define ZEND_MAP_PTR_SET(ptr, val) do { \
 		if (ZEND_MAP_PTR_IS_OFFSET(ptr)) { \
 			ZEND_MAP_PTR_SET_IMM(ptr, val); \
@@ -62,11 +65,11 @@ typedef struct _zend_string zend_string;
 		} \
 	} while (0)
 # define ZEND_MAP_PTR_SET_IMM(ptr, val) do { \
-		void **__p = ZEND_MAP_PTR_OFFSET2PTR((uintptr_t)ZEND_MAP_PTR(ptr)); \
+		void **__p = ZEND_MAP_PTR_OFFSET2PTR((intptr_t)ZEND_MAP_PTR(ptr)); \
 		*__p = (val); \
 	} while (0)
 # define ZEND_MAP_PTR_BIASED_BASE(real_base) \
-	((void*)(((uintptr_t)(real_base)) - 1))
+	((void*)(((uintptr_t)(real_base)) + zend_map_ptr_static_size * sizeof(void *) - 1))
 #else
 # error "Unknown ZEND_MAP_PTR_KIND"
 #endif
@@ -75,8 +78,12 @@ BEGIN_EXTERN_C()
 
 ZEND_API void  zend_map_ptr_reset(void);
 ZEND_API void *zend_map_ptr_new(void);
+ZEND_API void *zend_map_ptr_new_static(void);
 ZEND_API void  zend_map_ptr_extend(size_t last);
 ZEND_API void zend_alloc_ce_cache(zend_string *type_name);
+
+ZEND_API extern size_t zend_map_ptr_static_last;
+ZEND_API extern size_t zend_map_ptr_static_size;
 
 END_EXTERN_C()
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -842,7 +842,7 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 #define ZSTR_GET_CE_CACHE(s)		ZSTR_GET_CE_CACHE_EX(s, 1)
 #define ZSTR_SET_CE_CACHE(s, ce)	ZSTR_SET_CE_CACHE_EX(s, ce, 1)
 
-#define ZSTR_VALID_CE_CACHE(s)		EXPECTED((GC_REFCOUNT(s)-1)/sizeof(void *) < CG(map_ptr_last) - zend_map_ptr_static_size)
+#define ZSTR_VALID_CE_CACHE(s)		EXPECTED((GC_REFCOUNT(s)-1)/sizeof(void *) < CG(map_ptr_last))
 
 #define ZSTR_GET_CE_CACHE_EX(s, validate) \
 	((!(validate) || ZSTR_VALID_CE_CACHE(s)) ? GET_CE_CACHE(GC_REFCOUNT(s)) : NULL)

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -842,7 +842,7 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 #define ZSTR_GET_CE_CACHE(s)		ZSTR_GET_CE_CACHE_EX(s, 1)
 #define ZSTR_SET_CE_CACHE(s, ce)	ZSTR_SET_CE_CACHE_EX(s, ce, 1)
 
-#define ZSTR_VALID_CE_CACHE(s)		EXPECTED((GC_REFCOUNT(s)-1)/sizeof(void *) < CG(map_ptr_last))
+#define ZSTR_VALID_CE_CACHE(s)		EXPECTED((GC_REFCOUNT(s)-1)/sizeof(void *) < CG(map_ptr_last) - zend_map_ptr_static_size)
 
 #define ZSTR_GET_CE_CACHE_EX(s, validate) \
 	((!(validate) || ZSTR_VALID_CE_CACHE(s)) ? GET_CE_CACHE(GC_REFCOUNT(s)) : NULL)

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -5393,6 +5393,11 @@ static zend_result ffi_fixup_temporaries(void) {
 		++zend_ffi_cast_fn.T;
 		++zend_ffi_type_fn.T;
 	}
+#if !ZTS
+	ZEND_MAP_PTR(zend_ffi_new_fn.run_time_cache) = ZEND_MAP_PTR(((zend_internal_function *)zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "new", sizeof("new")-1))->run_time_cache);
+	ZEND_MAP_PTR(zend_ffi_cast_fn.run_time_cache) = ZEND_MAP_PTR(((zend_internal_function *)zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "cast", sizeof("cast")-1))->run_time_cache);
+	ZEND_MAP_PTR(zend_ffi_type_fn.run_time_cache) = ZEND_MAP_PTR(((zend_internal_function *)zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "type", sizeof("type")-1))->run_time_cache);
+#endif
 	if (prev_zend_post_startup_cb) {
 		return prev_zend_post_startup_cb();
 	}

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -4534,8 +4534,12 @@ static struct jit_observer_fcall_is_unobserved_data jit_observer_fcall_is_unobse
 	if (func && (func->common.fn_flags & ZEND_ACC_CLOSURE) == 0 && ZEND_MAP_PTR_IS_OFFSET(func->common.run_time_cache)) {
 		// JIT: ZEND_MAP_PTR_GET_IMM(func->common.runtime_cache)
 		run_time_cache = ir_LOAD_A(ir_ADD_OFFSET(ir_LOAD_A(jit_CG(map_ptr_base)), (uintptr_t)ZEND_MAP_PTR(func->common.run_time_cache)));
+#if !ZTS
+	} else if (func && rx == IS_UNUSED) { // happens for internal functions only
+		ZEND_ASSERT(!ZEND_USER_CODE(func->type));
+		run_time_cache = ir_LOAD_A(ir_ADD_OFFSET(ir_CONST_ADDR(func), offsetof(zend_op_array, run_time_cache__ptr)));
+#endif
 	} else {
-		ZEND_ASSERT(rx != IR_UNUSED);
 		// Closures may be duplicated and have a different runtime cache. Use the regular run_time_cache access pattern for these
 		if (func && ZEND_USER_CODE(func->type)) { // not a closure and definitely not an internal function
 			run_time_cache = ir_LOAD_A(jit_CALL(rx, run_time_cache));

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -1276,6 +1276,10 @@ static zend_result xmlreader_fixup_temporaries(void) {
 		++xmlreader_open_fn.T;
 		++xmlreader_xml_fn.T;
 	}
+#if !ZTS
+	ZEND_MAP_PTR(xmlreader_open_fn.run_time_cache) = ZEND_MAP_PTR(((zend_internal_function *)zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "open", sizeof("open")-1))->run_time_cache);
+	ZEND_MAP_PTR(xmlreader_xml_fn.run_time_cache) = ZEND_MAP_PTR(((zend_internal_function *)zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "xml", sizeof("xml")-1))->run_time_cache);
+#endif
 	if (prev_zend_post_startup_cb) {
 		return prev_zend_post_startup_cb();
 	}

--- a/main/main.c
+++ b/main/main.c
@@ -2316,6 +2316,9 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	/* freeze the list of observer fcall_init handlers */
 	zend_observer_post_startup();
 
+	/* freeze the list of persistent internal functions */
+	zend_init_internal_run_time_cache();
+
 	/* Extensions that add engine hooks after this point do so at their own peril */
 	zend_finalize_system_id();
 


### PR DESCRIPTION
We also add zend_map_ptr_static, so that we do not incur the overhead of constantly recreating the internal run_time_cache pointers on each request when observers are enabled.

Additionally it saves a bit of zeroing of the map_ptrs on each request, independently of whether observers are actually enabled or not, given that they're below the zend_map_ptr_static_size threshold now.

Comparing instruction counts, it shows about 0.1% improvement without observers.

This mechanism might be extended for mutable_data of internal classes too. And possibly also for preloaded code.