### PR TITLE
Remove bogus tree setting code from parentnode/tree.c

### DIFF
--- a/ext/dom/parentnode/tree.c
+++ b/ext/dom/parentnode/tree.c
@@ -377,8 +377,7 @@ xmlNode* dom_zvals_to_single_node(php_libxml_ref_obj *document, xmlNode *context
 				xmlUnlinkNode(newNode);
 			}
 
-			newNodeObj->document = document;
-			xmlSetTreeDoc(newNode, documentNode);
+			ZEND_ASSERT(newNodeObj->document == document);
 
 			if (newNode->type == XML_DOCUMENT_FRAG_NODE) {
 				/* Unpack document fragment nodes, the behaviour differs for different libxml2 versions. */


### PR DESCRIPTION
I don't know why this code was here in the first place, it is present since the initial implementation. It doesn't make sense because:
1. It would require updating the refcounts if the document wasn't actually already set.
2. We enforce that the document is the same as the target document by this point, so setting the tree is pointless.