### PR TITLE
Sync required phar dependencies

### DIFF
--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -17,8 +17,8 @@ if test "$PHP_PHAR" != "no"; then
       AC_MSG_RESULT([no])
     fi
   fi
-  PHP_ADD_EXTENSION_DEP(phar, hash, true)
-  PHP_ADD_EXTENSION_DEP(phar, spl, true)
+  PHP_ADD_EXTENSION_DEP(phar, hash)
+  PHP_ADD_EXTENSION_DEP(phar, spl)
   PHP_ADD_MAKEFILE_FRAGMENT
 
   PHP_INSTALL_HEADERS([ext/phar], [php_phar.h])

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -34,7 +34,8 @@ if (PHP_PHAR != "no") {
 			STDOUT.WriteLine('        Native OpenSSL support in Phar disabled');
 		}
 	}
-	ADD_EXTENSION_DEP('phar', 'spl', true);
+	ADD_EXTENSION_DEP('phar', 'hash');
+	ADD_EXTENSION_DEP('phar', 'spl');
 	PHP_INSTALL_HEADERS("ext/phar", "php_phar.h");
 
 	ADD_MAKEFILE_FRAGMENT();


### PR DESCRIPTION
Required extensions hash and spl are added to the configure phase as required. They are also already noted as ZEND_MOD_REQUIRED.