### PR TITLE
Autotools: Append rt library to FPM_EXTRA_LIBS

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -6,11 +6,17 @@ PHP_ARG_ENABLE([fpm],
   [no])
 
 dnl Configure checks.
-AC_DEFUN([PHP_FPM_CLOCK],
-[AC_CHECK_FUNCS([clock_gettime],,
-  [AC_SEARCH_LIBS([clock_gettime], [rt],
-    [ac_cv_func_clock_gettime=yes
-    AC_DEFINE([HAVE_CLOCK_GETTIME], [1])])])
+AC_DEFUN([PHP_FPM_CLOCK], [
+AC_CHECK_FUNCS([clock_gettime],, [
+  LIBS_save=$LIBS
+  AC_SEARCH_LIBS([clock_gettime], [rt], [
+    ac_cv_func_clock_gettime=yes
+    AC_DEFINE([HAVE_CLOCK_GETTIME], [1])
+    AS_VAR_IF([ac_cv_search_clock_gettime], ["none required"],,
+      [AS_VAR_APPEND([FPM_EXTRA_LIBS], [" $ac_cv_search_clock_gettime"])])
+  ])
+  LIBS=$LIBS_save
+])
 
 AS_VAR_IF([ac_cv_func_clock_gettime], [no],
   [AC_CACHE_CHECK([for clock_get_time], [php_cv_func_clock_get_time],


### PR DESCRIPTION
This appends the possible rt library as needed on Solaris <= 10 to FPM_EXTRA_LIBS instead of the global LIBS variable for all SAPIs to have cleaner build. The possible required rt library for other SAPIs is also checked in the configure.ac.