### PR TITLE
Autotools: Check for crypt and crypt_r with AC_* macros

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -152,6 +152,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbol HAVE_PHPDBG has been removed.
    - Symbols PHP_HAVE_AVX512_SUPPORTS and PHP_HAVE_AVX512_VBMI_SUPPORTS are now
      either defined to 1 or undefined.
+   - Symbol HAVE_LIBCRYPT has been removed.
    - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
    - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
    - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -85,14 +85,18 @@ AS_VAR_IF([PHP_EXTERNAL_LIBCRYPT], [no], [
   PHP_ADD_SOURCES([PHP_EXT_DIR([standard])],
     [crypt_freesec.c crypt_blowfish.c crypt_sha512.c crypt_sha256.c php_crypt_r.c])
 ], [
-  PHP_CHECK_FUNC(crypt, crypt)
-  PHP_CHECK_FUNC(crypt_r, crypt)
-  AC_CHECK_HEADERS([crypt.h])
-  AS_VAR_IF([ac_cv_func_crypt], [yes],,
-    [AC_MSG_ERROR([Cannot use external libcrypt as crypt() is missing.])])
-  AS_VAR_IF([ac_cv_func_crypt_r], [yes],
-    [PHP_CRYPT_R_STYLE],
-    [AC_MSG_ERROR([Cannot use external libcrypt as crypt_r() is missing.])])
+AC_SEARCH_LIBS([crypt], [crypt],
+  [AC_DEFINE([HAVE_CRYPT], [1],
+    [Define to 1 if you have the 'crypt' function.])],
+  [AC_MSG_ERROR([Cannot use external libcrypt as crypt() is missing.])])
+
+AC_SEARCH_LIBS([crypt_r], [crypt],
+  [AC_DEFINE([HAVE_CRYPT_R], [1],
+    [Define to 1 if you have the 'crypt_r' function.])],
+  [AC_MSG_ERROR([Cannot use external libcrypt as crypt_r() is missing.])])
+
+PHP_CRYPT_R_STYLE
+AC_CHECK_HEADERS([crypt.h])
 
   AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
This checks if crypt and crypt_r functions are available on the system in default libraries or in the crypt library with the AC_SEARCH_LIBS. The redundant HAVE_LIBCRYPT symbol is removed.