### PR TITLE
ext/pdo_firebird: Fixed segmentation fault when attribute value was not set

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1193,15 +1193,15 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			return 1;
 
 		case PDO_FB_ATTR_DATE_FORMAT:
-			ZVAL_STRING(val, H->date_format);
+			ZVAL_STRING(val, H->date_format ? H->date_format : PDO_FB_DEF_DATE_FMT);
 			return 1;
 
 		case PDO_FB_ATTR_TIME_FORMAT:
-			ZVAL_STRING(val, H->time_format);
+			ZVAL_STRING(val, H->time_format ? H->time_format : PDO_FB_DEF_TIME_FMT);
 			return 1;
 
 		case PDO_FB_ATTR_TIMESTAMP_FORMAT:
-			ZVAL_STRING(val, H->timestamp_format);
+			ZVAL_STRING(val, H->timestamp_format ? H->timestamp_format : PDO_FB_DEF_TIMESTAMP_FMT);
 			return 1;
 
 		case PDO_FB_TRANSACTION_ISOLATION_LEVEL:

--- a/ext/pdo_firebird/tests/attr_datetime_format.phpt
+++ b/ext/pdo_firebird/tests/attr_datetime_format.phpt
@@ -1,0 +1,40 @@
+--TEST--
+PDO_Firebird: attr date, time, and timestamp formats
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+require("testdb.inc");
+$dbh = getDbConnection();
+
+echo "== Default state with nothing set. ==\n";
+echo 'ATTR_DATE_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_DATE_FORMAT), "\n";
+echo 'ATTR_TIME_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_TIME_FORMAT), "\n";
+echo 'ATTR_TIMESTAMP_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_TIMESTAMP_FORMAT), "\n";
+
+$dbh->setAttribute(Pdo\firebird::ATTR_DATE_FORMAT, 'Y----m----d');
+$dbh->setAttribute(Pdo\firebird::ATTR_TIME_FORMAT, 'H::::i::::s');
+$dbh->setAttribute(Pdo\firebird::ATTR_TIMESTAMP_FORMAT, 'Y----m----d....H::::i::::s');
+
+echo "\n";
+
+echo "== State after setting value. ==\n";
+echo 'ATTR_DATE_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_DATE_FORMAT), "\n";
+echo 'ATTR_TIME_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_TIME_FORMAT), "\n";
+echo 'ATTR_TIMESTAMP_FORMAT: ', $dbh->getAttribute(Pdo\firebird::ATTR_TIMESTAMP_FORMAT), "\n";
+?>
+--EXPECT--
+== Default state with nothing set. ==
+ATTR_DATE_FORMAT: %Y-%m-%d
+ATTR_TIME_FORMAT: %H:%M:%S
+ATTR_TIMESTAMP_FORMAT: %Y-%m-%d %H:%M:%S
+
+== State after setting value. ==
+ATTR_DATE_FORMAT: Y----m----d
+ATTR_TIME_FORMAT: H::::i::::s
+ATTR_TIMESTAMP_FORMAT: Y----m----d....H::::i::::s


### PR DESCRIPTION
Fixed an issue where a segmentation fault would occur if tried to get a value with getAttribute when `ATTR_DATE_FORMAT`, `ATTR_TIME_FORMAT` or `ATTR_TIMESTAMP_FORMAT` were not set.