### PR TITLE
Fix bogus fallthrough path in firebird_handle_get_attribute()

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -977,8 +977,7 @@ static int firebird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 				ZVAL_STRING(val, tmp);
 				return 1;
 			}
-			/* TODO Check this is correct? */
-			ZEND_FALLTHROUGH;
+			return -1;
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
 			ZVAL_BOOL(val, H->fetch_table_names);


### PR DESCRIPTION
If getting the version fails, we should return -1 according to php_pdo_driver.h:259, not fall through to another attribute.