### PR TITLE
Improve link styling in PHPInfo

### DIFF
--- a/ext/standard/css.c
+++ b/ext/standard/css.c
@@ -21,8 +21,8 @@ PHPAPI ZEND_COLD void php_info_print_css(void) /* {{{ */
 {
 	PUTS("body {background-color: #fff; color: #222; font-family: sans-serif;}\n");
 	PUTS("pre {margin: 0; font-family: monospace;}\n");
-	PUTS("a:link {color: #009; text-decoration: none; background-color: #fff;}\n");
-	PUTS("a:hover {text-decoration: underline;}\n");
+	PUTS("a {color: inherit;}\n");
+	PUTS("a:hover {text-decoration: none;}\n");
 	PUTS("table {border-collapse: collapse; border: 0; width: 934px; box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.2);}\n");
 	PUTS(".center {text-align: center;}\n");
 	PUTS(".center table {margin: 1em auto; text-align: left;}\n");
@@ -31,7 +31,6 @@ PHPAPI ZEND_COLD void php_info_print_css(void) /* {{{ */
 	PUTS("th {position: sticky; top: 0; background: inherit;}\n");
 	PUTS("h1 {font-size: 150%;}\n");
 	PUTS("h2 {font-size: 125%;}\n");
-	PUTS("h2 a:link, h2 a:visited{color: inherit; background: inherit;}\n");
 	PUTS(".p {text-align: left;}\n");
 	PUTS(".e {background-color: #ccf; width: 300px; font-weight: bold;}\n");
 	PUTS(".h {background-color: #99c; font-weight: bold;}\n");

--- a/ext/standard/css.c
+++ b/ext/standard/css.c
@@ -31,6 +31,8 @@ PHPAPI ZEND_COLD void php_info_print_css(void) /* {{{ */
 	PUTS("th {position: sticky; top: 0; background: inherit;}\n");
 	PUTS("h1 {font-size: 150%;}\n");
 	PUTS("h2 {font-size: 125%;}\n");
+	PUTS("h2 > a {text-decoration: none;}\n");
+	PUTS("h2 > a:hover {text-decoration: underline;}\n");
 	PUTS(".p {text-align: left;}\n");
 	PUTS(".e {background-color: #ccf; width: 300px; font-weight: bold;}\n");
 	PUTS(".h {background-color: #99c; font-weight: bold;}\n");


### PR DESCRIPTION
The previous styling with the fixed background color didn't work well in dark mode. Remove the background and make links inherit the regular text color. To make them visually detectable the underlining behavior is reversed. The underline is now shown when not hovering and hidden when hovering.

-----------

Before (linking the “Zend Scripting” text as an example):

![image](https://github.com/user-attachments/assets/5958c03b-0d1f-46c2-837b-64cdad358e61)
![image](https://github.com/user-attachments/assets/1a38e1c0-0ed9-4b2d-b495-c25a9f9d1f62)

After:

![image](https://github.com/user-attachments/assets/c371cf70-8a8e-4f34-9547-96cf617634f8)
![image](https://github.com/user-attachments/assets/45de5468-4f55-4369-97ba-79336df12bce)

/cc @Ayesh who made the latest change to the CSS.