### PR TITLE
Workaraound against false positive GCC array bounds error

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2559,8 +2559,8 @@ static void zend_check_magic_method_no_return_type(
 
 ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce, const zend_function *fptr, zend_string *lcname, int error_type) /* {{{ */
 {
-	if (ZSTR_VAL(fptr->common.function_name)[0] != '_'
-	 || ZSTR_VAL(fptr->common.function_name)[1] != '_') {
+	if (ZSTR_VAL(lcname)[0] != '_'
+	 || ZSTR_VAL(lcname)[1] != '_') {
 		return;
 	}
 


### PR DESCRIPTION
This prevents compilation error when compiling PHP by GCC with "-O2 -g -Wall -Werror"

```
zend_API.c:2754:34: error: array subscript ‘zend_function {aka const union _zend_function}[0]’ is partly outside array bounds of ‘unsigned char[160]’ [-Werror=array-bounds=]

 2754 |         if (ZSTR_VAL(fptr->common.function_name)[0] != '_'
```

This is an alternative to https://github.com/php/php-src/pull/15013