### PR TITLE
Autotools: Quote PHP_NEW_EXTENSION arguments

### DIFF
--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -149,6 +149,10 @@ fi
 
 if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then
   dnl Add -Wno-strict-prototypes as depends on user libs
-  PHP_NEW_EXTENSION(readline, readline.c readline_cli.c, $ext_shared, cli, "-Wno-strict-prototypes")
+  PHP_NEW_EXTENSION([readline],
+    [readline.c readline_cli.c],
+    [$ext_shared],
+    [cli],
+    [-Wno-strict-prototypes])
   PHP_SUBST([READLINE_SHARED_LIBADD])
 fi


### PR DESCRIPTION
This removes redundant shell double quotes as PHP_NEW_EXTENSION macro already wraps the flags argument in quotes.