### PR TITLE
Autotools: Normalize ext/fileinfo sources

### DIFF
--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -5,14 +5,27 @@ PHP_ARG_ENABLE([fileinfo],
   [yes])
 
 if test "$PHP_FILEINFO" != "no"; then
-
-  libmagic_sources=" \
-    libmagic/apprentice.c libmagic/apptype.c libmagic/ascmagic.c \
-    libmagic/cdf.c libmagic/cdf_time.c libmagic/compress.c \
-    libmagic/encoding.c libmagic/fsmagic.c libmagic/funcs.c \
-    libmagic/is_json.c libmagic/is_tar.c libmagic/is_simh.c libmagic/magic.c libmagic/print.c \
-    libmagic/readcdf.c libmagic/softmagic.c libmagic/der.c \
-    libmagic/buffer.c libmagic/is_csv.c"
+  libmagic_sources=m4_normalize(["
+    libmagic/apprentice.c
+    libmagic/apptype.c
+    libmagic/ascmagic.c
+    libmagic/buffer.c
+    libmagic/cdf_time.c
+    libmagic/cdf.c
+    libmagic/compress.c
+    libmagic/der.c
+    libmagic/encoding.c
+    libmagic/fsmagic.c
+    libmagic/funcs.c
+    libmagic/is_csv.c
+    libmagic/is_json.c
+    libmagic/is_simh.c
+    libmagic/is_tar.c
+    libmagic/magic.c
+    libmagic/print.c
+    libmagic/readcdf.c
+    libmagic/softmagic.c
+  "])
 
   AC_CHECK_HEADERS([sys/sysmacros.h])
 
@@ -23,7 +36,10 @@ if test "$PHP_FILEINFO" != "no"; then
 
   AX_GCC_FUNC_ATTRIBUTE([visibility])
 
-  PHP_NEW_EXTENSION(fileinfo, fileinfo.c php_libmagic.c $libmagic_sources, $ext_shared,,-I@ext_srcdir@/libmagic)
+  PHP_NEW_EXTENSION([fileinfo],
+    [fileinfo.c php_libmagic.c $libmagic_sources],
+    [$ext_shared],,
+    [-I@ext_srcdir@/libmagic])
   PHP_ADD_BUILD_DIR([$ext_builddir/libmagic])
 
   AC_CHECK_FUNCS([utimes strndup])


### PR DESCRIPTION
This makes a list of files a bit more readable and have an overview of the bundled libmagic files.