### PR TITLE
Autotools: Sync CS in opcache Capstone check

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -18,9 +18,10 @@ PHP_ARG_ENABLE([opcache-jit],
   [yes],
   [no])
 
-PHP_ARG_WITH([capstone],,
+PHP_ARG_WITH([capstone],
+  [whether to support opcache JIT dissasembly through Capstone],
   [AS_HELP_STRING([--with-capstone],
-    [support opcache JIT disassembly through capstone])],
+    [Support opcache JIT disassembly through Capstone])],
   [no],
   [no])
 
@@ -81,16 +82,13 @@ if test "$PHP_OPCACHE" != "no"; then
         ;;
      esac
 
-    AS_IF([test x"$with_capstone" = "xyes"],[
-      PKG_CHECK_MODULES([CAPSTONE],[capstone >= 3.0.0],[
-        AC_DEFINE([HAVE_CAPSTONE], [1], [Capstone is available])
+    AS_VAR_IF([PHP_CAPSTONE], [yes],
+      [PKG_CHECK_MODULES([CAPSTONE], [capstone >= 3.0.0], [
+        AC_DEFINE([HAVE_CAPSTONE], [1], [Define to 1 if Capstone is available.])
         PHP_EVAL_LIBLINE([$CAPSTONE_LIBS], [OPCACHE_SHARED_LIBADD])
         PHP_EVAL_INCLINE([$CAPSTONE_CFLAGS])
         ZEND_JIT_SRC="$ZEND_JIT_SRC jit/ir/ir_disasm.c"
-      ],[
-        AC_MSG_ERROR([capstone >= 3.0 required but not found])
-      ])
-    ])
+      ])])
 
     PHP_SUBST([IR_TARGET])
     PHP_SUBST([DASM_FLAGS])

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -41,7 +41,7 @@ if (PHP_OPCACHE != "no") {
 
 			if (CHECK_HEADER_ADD_INCLUDE("capstone\\capstone.h", "CFLAGS_OPCACHE", PHP_OPCACHE+ ";" + PHP_PHP_BUILD + "\\include") &&
 				CHECK_LIB("capstone.lib", "opcache", PHP_OPCACHE)) {
-				AC_DEFINE('HAVE_CAPSTONE', 1, 'capstone support enabled');
+				AC_DEFINE('HAVE_CAPSTONE', 1, 'Define to 1 if Capstone is available.');
 				ir_src += " ir_disasm.c";
 			}
 


### PR DESCRIPTION
- Added Capstone check message in configure log
- PKG_CHECK_MODULES already errors out by default if Capstone is not found with a bit more informative message
- Autoconf syntax used
- HAVE_CAPSTONE help text synced and updated