### PR TITLE
Autotools: Normalize 2nd arg in PHP_ADD_SOURCES_X

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -188,6 +188,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      or backslash-then-newline.
    - M4 macro PHP_ADD_BUILD_DIR now also accepts 1st argument as a
      blank-or-newline-separated separated list.
+   - M4 macros PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X,
+     PHP_SELECT_SAPI now have the source files arguments normalized so the list
+     of files can be passed as blank-or-newline-separated list (including
+     newlines, backslash-then-newline, or any sequence of spaces or tabs).
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -197,9 +197,10 @@ dnl
 dnl PHP_ADD_SOURCES(source-path, sources [, special-flags [, type]])
 dnl
 dnl Adds sources which are located relative to source-path to the array of type
-dnl type. Sources are processed with optional special-flags which are passed to
-dnl the compiler. Sources can be either written in C or C++ (filenames shall end
-dnl in .c or .cpp, respectively).
+dnl type. The blank-or-newline separated list of "sources" are processed with
+dnl optional special-flags which are passed to the compiler. Sources can be
+dnl either written in C or C++ (filenames shall end in .c or .cpp,
+dnl respectively).
 dnl
 dnl Note: If source-path begins with a "/", the "/" is removed and the path is
 dnl interpreted relative to the top build-directory.
@@ -239,7 +240,8 @@ dnl PHP_ADD_SOURCES_X(source-path, sources[, special-flags[, target-var[, shared
 dnl
 dnl Additional to PHP_ADD_SOURCES (see above), this lets you set the name of the
 dnl array target-var directly, as well as whether shared objects will be built
-dnl from the sources. Should not be used directly.
+dnl from the blank-or-newline-separated list of "sources". Should not be used
+dnl directly.
 dnl
 AC_DEFUN([PHP_ADD_SOURCES_X],[
 dnl Relative to source- or build-directory?
@@ -255,7 +257,7 @@ dnl how to build .. shared or static?
 
 dnl Iterate over the sources.
   old_IFS=[$]IFS
-  for ac_src in $2; do
+  for ac_src in m4_normalize(m4_expand([$2])); do
 
 dnl Remove the suffix.
       IFS=.
@@ -864,8 +866,9 @@ dnl PHP_SELECT_SAPI(name, type[, sources [, extra-cflags]])
 dnl
 dnl When developing PHP SAPI modules, this macro specifies the SAPI "name" by
 dnl its "type", how PHP is supposed to be built (static, shared, bundle, or
-dnl program). It optionally adds the source files "sources" and compilation
-dnl flags "extra-cflags" to build the SAPI-specific objects. For example:
+dnl program). It optionally adds the blank-or-newline-separated source files
+dnl "sources" and compilation flags "extra-cflags" to build the SAPI-specific
+dnl objects. For example:
 dnl   PHP_SELECT_SAPI([apache2handler],
 dnl     [shared],
 dnl     [<sources...>],
@@ -936,8 +939,8 @@ dnl
 dnl Includes an extension in the build.
 dnl
 dnl "extname" is the name of the extension.
-dnl "sources" is a list of files relative to the subdir which are used to build
-dnl the extension.
+dnl "sources" is a blank-or-newline-separated list of source files relative to
+dnl the subdir which are used to build the extension.
 dnl "shared" can be set to "shared" or "yes" to build the extension as a
 dnl dynamically loadable library. Optional parameter "sapi_class" can be set to
 dnl "cli" to mark extension build only with CLI or CGI sapi's. "extra-cflags"


### PR DESCRIPTION
By using `m4_normalize(m4_expand([...]))`, the arguments can be split into newlines without using backslashes and it makes working with lists of files a bit easier.

Tested:
- variables inside the argument
- M4 macro expansions
- dnl comments
- newlines, leading and trailing spaces and tabs, sequences of backslash-then-newline, multiple spaces, tabs, newlines, backslash-then-newline, empty spaces
- quoted/unquoted arguments
- ...

Unfortunately, this wasn't ready sooner... But I'm not yet sure if to target PHP-8.4 so probably it's safer to target version after PHP-8.4.