### PR TITLE
Port "gd2: use existing overflow2() rather than ad-hoc version"

### DIFF
--- a/ext/gd/libgd/gd_gd2.c
+++ b/ext/gd/libgd/gd_gd2.c
@@ -137,7 +137,7 @@ static int _gd2GetHeader(gdIOCtxPtr in, int *sx, int *sy, int *cs, int *vers, in
 	GD2_DBG(gd_error("%d Chunks vertically", *ncy));
 
 	if (gd2_compressed(*fmt)) {
-		if (*ncx <= 0 || *ncy <= 0 || *ncx > INT_MAX / *ncy) {
+		if (overflow2(*ncx, *ncy)) {
 			GD2_DBG(printf ("Illegal chunk counts: %d * %d\n", *ncx, *ncy));
 			goto fail1;
 		}

--- a/ext/gd/tests/bug73869.phpt
+++ b/ext/gd/tests/bug73869.phpt
@@ -14,8 +14,10 @@ var_dump(imagecreatefromgd2(__DIR__ . DIRECTORY_SEPARATOR . 'bug73869a.gd2'));
 var_dump(imagecreatefromgd2(__DIR__ . DIRECTORY_SEPARATOR . 'bug73869b.gd2'));
 ?>
 --EXPECTF--
+%A
 Warning: imagecreatefromgd2(): "%s" is not a valid GD2 file in %s on line %d
 bool(false)
 
+%A
 Warning: imagecreatefromgd2(): "%s" is not a valid GD2 file in %s on line %d
 bool(false)


### PR DESCRIPTION
We port this modification[1] from libgd into our bundled libgd, because the change makes sense, and we want the code bases to stay in sync as close as possible.

We also apply a quick fix to the respective test.

[1] <https://github.com/libgd/libgd/commit/f0a059be6c36a0b2fce42b3c195d2d87f3d3420d>