### PR TITLE
Fix GH-15087 IntlChar::foldCase()'s $option is not optional

### DIFF
--- a/ext/intl/uchar/tests/gh15087.phpt
+++ b/ext/intl/uchar/tests/gh15087.phpt
@@ -1,0 +1,10 @@
+--TEST--
+GH-15087 (IntlChar::foldCase()'s $option is not optional)
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+var_dump(IntlChar::foldCase('I'));
+?>
+--EXPECT--
+string(1) "i"

--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -392,7 +392,7 @@ IC_METHOD(foldCase) {
 	zend_string *string_codepoint;
 	zend_long int_codepoint;
 
-	ZEND_PARSE_PARAMETERS_START(2, 2)
+	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();

--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -394,6 +394,7 @@ IC_METHOD(foldCase) {
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
+		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
 


### PR DESCRIPTION
Since that parameter is supposed to be optional (and has been prior to PHP 8.0.0), we fix the implementation instead of the stub.

---

Note that Windows CI is supposed to fail due to https://github.com/php/php-src/commit/0956267c08b8ea8cc8e8e2b31fe0ce12f060e47e#r144587696. Locally, the intl tests were running fine.