### PR TITLE
Add missing cstddef include for C++ builds

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -791,9 +791,13 @@ extern "C++" {
 # define ZEND_STATIC_ASSERT(c, m)
 #endif
 
-#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) /* C11 */ \
-  || (defined(__cplusplus) && __cplusplus >= 201103L) /* C++11 */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) /* C11 */
 typedef max_align_t zend_max_align_t;
+#elif (defined(__cplusplus) && __cplusplus >= 201103L) /* C++11 */
+extern "C++" {
+# include <cstddef>
+}
+typedef std::max_align_t zend_max_align_t;
 #else
 typedef union {
 	char c;


### PR DESCRIPTION
I've noticed this while trying to build [sqlsrv](https://pecl.php.net/package/sqlsrv) (a C++ extension) for PHP 8.4.0alpha2 with Visual Studio 2022. While my C++ knowledge is rather limited, I think this is the proper way to make `max_align_t` available. At least, MSVC wouldn't know it without the include, and error out.

@arnaud-lb, since you've written that code, could you please have look?