### PR TITLE
Add pcre dependency as required to ext/filter

### DIFF
--- a/ext/filter/config.w32
+++ b/ext/filter/config.w32
@@ -4,5 +4,6 @@ ARG_ENABLE("filter", "Filter Support", "yes");
 
 if (PHP_FILTER == "yes") {
 	EXTENSION("filter", "filter.c sanitizing_filters.c logical_filters.c callback_filter.c", PHP_FILTER_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	ADD_EXTENSION_DEP('filter', 'pcre');
 	PHP_INSTALL_HEADERS("ext/filter", "php_filter.h");
 }


### PR DESCRIPTION
This is configure phase dependency synced with already present Autotools pcre dependency check.