### PR TITLE
Fix GH-15094: php_random_default_engine() is not C++ conforming

### DIFF
--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -167,10 +167,10 @@ PHPAPI void *php_random_default_status(void);
 
 static inline php_random_algo_with_state php_random_default_engine(void)
 {
-	return (php_random_algo_with_state){
-		.algo = php_random_default_algo(),
-		.state = php_random_default_status(),
-	};
+	php_random_algo_with_state raws;
+	raws.algo = php_random_default_algo();
+	raws.state = php_random_default_status();
+	return raws;
 }
 
 PHPAPI zend_string *php_random_bin2hex_le(const void *ptr, const size_t len);


### PR DESCRIPTION
Using compound literals is conforming to C99 (and up), but not with any C++ standard.  Since the code is in a public header, it might be used by C++ extensions.  Unfortunately, we cannot even used designated initializers, because these are a C++20 feature, so we stick with classic C/C++ code.