### PR TITLE
Fix type incompatibility in assignment.

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -56,8 +56,8 @@
 
 PHPAPI ZEND_DECLARE_MODULE_GLOBALS(ps)
 
-static zend_result php_session_rfc1867_callback(unsigned int event, void *event_data, void **extra);
-static zend_result (*php_session_rfc1867_orig_callback)(unsigned int event, void *event_data, void **extra);
+static int php_session_rfc1867_callback(unsigned int event, void *event_data, void **extra);
+static int (*php_session_rfc1867_orig_callback)(unsigned int event, void *event_data, void **extra);
 static void php_session_track_init(void);
 
 /* SessionHandler class */


### PR DESCRIPTION
This partially reverts 0956267c08b8ea8cc8e8e2b31fe0ce12f060e47e, which introduced a type incompatibility where an `int` function is assigned to a `zend_result` function.  That yields a level 1 C4133 warning on MSVC, and usually (e.g. in CI) level 1 warnings are elevated to errors, so the build fails.[1]

The PHP-8.3 branch and up are uneffected by this, so the upward merges should be empty.

[1] <https://github.com/php/php-src/commit/0956267c08b8ea8cc8e8e2b31fe0ce12f060e47e#r144587696>

---

See https://github.com/php/php-src/actions/runs/10078923540/job/27864997876#step:5:897 for detailed info about the build failure.