### PR TITLE
Autotools: Sync CS in XML related extensions

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -171,6 +171,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
    - M4 macro PHP_EVAL_LIBLINE got a new 3rd argument to override the ext_shared
      checks.
+   - M4 macro PHP_SETUP_LIBXML doesn't define the redundant HAVE_LIBXML symbol
+     anymore.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -1892,12 +1892,9 @@ dnl Common setup macro for libxml.
 dnl
 AC_DEFUN([PHP_SETUP_LIBXML], [
   PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0])
-
   PHP_EVAL_INCLINE([$LIBXML_CFLAGS])
   PHP_EVAL_LIBLINE([$LIBXML_LIBS], [$1])
-
-  AC_DEFINE(HAVE_LIBXML, 1, [ ])
-
+  AC_DEFINE([HAVE_LIBXML], [1], [Define to 1 if libxml2 library is available.])
   $2
 ])
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -1894,7 +1894,6 @@ AC_DEFUN([PHP_SETUP_LIBXML], [
   PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0])
   PHP_EVAL_INCLINE([$LIBXML_CFLAGS])
   PHP_EVAL_LIBLINE([$LIBXML_LIBS], [$1])
-  AC_DEFINE([HAVE_LIBXML], [1], [Define to 1 if libxml2 library is available.])
   $2
 ])
 

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -10,8 +10,8 @@ if test "$PHP_DOM" != "no"; then
     AC_MSG_ERROR([DOM extension requires LIBXML extension, add --with-libxml])
   fi
 
-  PHP_SETUP_LIBXML(DOM_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_DOM,1,[ ])
+  PHP_SETUP_LIBXML([DOM_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_DOM], [1], [Define to 1 if dom extension is available.])
     PHP_LEXBOR_CFLAGS="-I@ext_srcdir@/lexbor -DLEXBOR_STATIC"
     LEXBOR_DIR="lexbor/lexbor"
     LEXBOR_SOURCES=m4_normalize(["

--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -38,7 +38,7 @@ if (PHP_DOM == "yes") {
 		ADD_SOURCES("ext/dom/lexbor/lexbor/tag", "tag.c", "dom");
 		ADD_FLAG("CFLAGS_DOM", "/D LEXBOR_STATIC ");
 
-		AC_DEFINE("HAVE_DOM", 1, "DOM support");
+		AC_DEFINE("HAVE_DOM", 1, "Define to 1 if dom extension is available.");
 
 		if (!PHP_DOM_SHARED) {
 			ADD_FLAG("CFLAGS_DOM", "/D LIBXML_STATIC ");

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -10,7 +10,7 @@ if (PHP_LIBXML == "yes") {
 			ADD_EXTENSION_DEP('libxml', 'iconv')) {
 
 		EXTENSION("libxml", "libxml.c mime_sniff.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE("HAVE_LIBXML", 1, "Define to 1 if libxml2 library is available.");
+		AC_DEFINE("HAVE_LIBXML", 1, "Define to 1 if libxml extension is available.");
 		ADD_FLAG("CFLAGS_LIBXML", "/D LIBXML_STATIC /D LIBXML_STATIC_FOR_DLL /D HAVE_WIN32_THREADS ");
 		if (!PHP_LIBXML_SHARED) {
 			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -10,7 +10,7 @@ if (PHP_LIBXML == "yes") {
 			ADD_EXTENSION_DEP('libxml', 'iconv')) {
 
 		EXTENSION("libxml", "libxml.c mime_sniff.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE("HAVE_LIBXML", 1, "LibXML support");
+		AC_DEFINE("HAVE_LIBXML", 1, "Define to 1 if libxml2 library is available.");
 		ADD_FLAG("CFLAGS_LIBXML", "/D LIBXML_STATIC /D LIBXML_STATIC_FOR_DLL /D HAVE_WIN32_THREADS ");
 		if (!PHP_LIBXML_SHARED) {
 			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -9,9 +9,11 @@ if test "$PHP_LIBXML" != "no"; then
   dnl This extension can not be build as shared
   ext_shared=no
 
-  PHP_SETUP_LIBXML(LIBXML_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_LIBXML,1,[ ])
-    PHP_NEW_EXTENSION(libxml, [libxml.c mime_sniff.c], $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_SETUP_LIBXML([LIBXML_SHARED_LIBADD], [
+    PHP_NEW_EXTENSION([libxml],
+      [libxml.c mime_sniff.c],
+      [$ext_shared],,
+      [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_INSTALL_HEADERS([ext/libxml], [php_libxml.h])
   ])
 fi

--- a/ext/libxml/config0.m4
+++ b/ext/libxml/config0.m4
@@ -10,6 +10,8 @@ if test "$PHP_LIBXML" != "no"; then
   ext_shared=no
 
   PHP_SETUP_LIBXML([LIBXML_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_LIBXML], [1],
+      [Define to 1 if libxml extension is available.])
     PHP_NEW_EXTENSION([libxml],
       [libxml.c mime_sniff.c],
       [$ext_shared],,

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -5,9 +5,10 @@ PHP_ARG_ENABLE([simplexml],
   [yes])
 
 if test "$PHP_SIMPLEXML" != "no"; then
-  PHP_SETUP_LIBXML(SIMPLEXML_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_SIMPLEXML,1,[ ])
-    PHP_NEW_EXTENSION(simplexml, simplexml.c, $ext_shared)
+  PHP_SETUP_LIBXML([SIMPLEXML_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_SIMPLEXML], [1],
+      [Define to 1 if simplexml extension is available.])
+    PHP_NEW_EXTENSION([simplexml], [simplexml.c], [$ext_shared])
     PHP_ADD_EXTENSION_DEP(simplexml, libxml)
     PHP_ADD_EXTENSION_DEP(simplexml, spl)
     PHP_INSTALL_HEADERS([ext/simplexml], [php_simplexml.h php_simplexml_exports.h])

--- a/ext/simplexml/config.w32
+++ b/ext/simplexml/config.w32
@@ -9,7 +9,7 @@ if (PHP_SIMPLEXML == "yes") {
 		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SIMPLEXML", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("simplexml", "simplexml.c");
-		AC_DEFINE("HAVE_SIMPLEXML", 1, "Simple XML support");
+		AC_DEFINE("HAVE_SIMPLEXML", 1, "Define to 1 if simplexml extension is available.");
 		if (!PHP_SIMPLEXML_SHARED) {
 			ADD_FLAG("CFLAGS_SIMPLEXML", "/D LIBXML_STATIC");
 		} else {

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -4,9 +4,19 @@ PHP_ARG_ENABLE([soap],
     [Enable SOAP support])])
 
 if test "$PHP_SOAP" != "no"; then
-  PHP_SETUP_LIBXML(SOAP_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_SOAP,1,[ ])
-    PHP_NEW_EXTENSION(soap, soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_SETUP_LIBXML([SOAP_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_SOAP], [1], [Define to 1 if soap extension is available.])
+    PHP_NEW_EXTENSION([soap], m4_normalize([
+        php_encoding.c
+        php_http.c
+        php_packet_soap.c
+        php_schema.c
+        php_sdl.c
+        php_xml.c
+        soap.c
+      ]),
+      [$ext_shared],,
+      [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_SUBST([SOAP_SHARED_LIBADD])
   ])
   PHP_ADD_EXTENSION_DEP(soap, libxml)

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -9,7 +9,7 @@ if (PHP_SOAP != "no") {
 		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2")
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE('HAVE_SOAP', 1, "SOAP support");
+		AC_DEFINE('HAVE_SOAP', 1, "Define to 1 if soap extension is available.");
 		ADD_EXTENSION_DEP('soap', 'session', true);
 
 		if (!PHP_SOAP_SHARED) {

--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -22,7 +22,7 @@ if test "$PHP_XML" != "no"; then
       AC_MSG_ERROR([XML extension requires LIBXML extension, add --with-libxml])
     fi
 
-    PHP_SETUP_LIBXML(XML_SHARED_LIBADD, [
+    PHP_SETUP_LIBXML([XML_SHARED_LIBADD], [
       xml_extra_sources="compat.c"
       PHP_ADD_EXTENSION_DEP(xml, libxml)
     ])
@@ -30,8 +30,11 @@ if test "$PHP_XML" != "no"; then
     PHP_SETUP_EXPAT([XML_SHARED_LIBADD])
   fi
 
-  PHP_NEW_EXTENSION(xml, xml.c $xml_extra_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_NEW_EXTENSION([xml],
+    [xml.c $xml_extra_sources],
+    [$ext_shared],,
+    [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
   PHP_SUBST([XML_SHARED_LIBADD])
   PHP_INSTALL_HEADERS([ext/xml], [expat_compat.h php_xml.h])
-  AC_DEFINE(HAVE_XML, 1, [ ])
+  AC_DEFINE([HAVE_XML], [1], [Define to 1 if xml extension is available.])
 fi

--- a/ext/xml/config.w32
+++ b/ext/xml/config.w32
@@ -9,7 +9,7 @@ if (PHP_XML == "yes") {
 		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_XML", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("xml", "xml.c compat.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE("HAVE_XML", 1, "XML support");
+		AC_DEFINE("HAVE_XML", 1, "Define to 1 if xml extension is available.");
 		if (!PHP_XML_SHARED) {
 			ADD_FLAG("CFLAGS_XML", "/D LIBXML_STATIC ");
 		}

--- a/ext/xmlreader/config.m4
+++ b/ext/xmlreader/config.m4
@@ -5,9 +5,10 @@ PHP_ARG_ENABLE([xmlreader],
   [yes])
 
 if test "$PHP_XMLREADER" != "no"; then
-  PHP_SETUP_LIBXML(XMLREADER_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_XMLREADER,1,[ ])
-    PHP_NEW_EXTENSION(xmlreader, php_xmlreader.c, $ext_shared)
+  PHP_SETUP_LIBXML([XMLREADER_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_XMLREADER], [1],
+      [Define to 1 if xmlreader extension is available.])
+    PHP_NEW_EXTENSION([xmlreader], [php_xmlreader.c], [$ext_shared])
     PHP_ADD_EXTENSION_DEP(xmlreader, dom, true)
     PHP_ADD_EXTENSION_DEP(xmlreader, libxml)
     PHP_SUBST([XMLREADER_SHARED_LIBADD])

--- a/ext/xmlreader/config.w32
+++ b/ext/xmlreader/config.w32
@@ -8,7 +8,7 @@ if (PHP_XMLREADER == "yes" &&
 	CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_XMLREADER", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 	EXTENSION("xmlreader", "php_xmlreader.c");
-	AC_DEFINE("HAVE_XMLREADER", 1, "XMLReader support");
+	AC_DEFINE("HAVE_XMLREADER", 1, "Define to 1 if xmlreader extension is available.");
 	if (!PHP_XMLREADER_SHARED) {
 		ADD_FLAG("CFLAGS_XMLREADER", "/D LIBXML_STATIC");
 	}

--- a/ext/xmlwriter/config.m4
+++ b/ext/xmlwriter/config.m4
@@ -5,9 +5,10 @@ PHP_ARG_ENABLE([xmlwriter],
   [yes])
 
 if test "$PHP_XMLWRITER" != "no"; then
-  PHP_SETUP_LIBXML(XMLWRITER_SHARED_LIBADD, [
-    AC_DEFINE(HAVE_XMLWRITER,1,[ ])
-    PHP_NEW_EXTENSION(xmlwriter, php_xmlwriter.c, $ext_shared)
+  PHP_SETUP_LIBXML([XMLWRITER_SHARED_LIBADD], [
+    AC_DEFINE([HAVE_XMLWRITER], [1],
+      [Define to 1 if xmlwriter extension is available.])
+    PHP_NEW_EXTENSION([xmlwriter], [php_xmlwriter.c], [$ext_shared])
     PHP_ADD_EXTENSION_DEP(xmlwriter, libxml)
     PHP_SUBST([XMLWRITER_SHARED_LIBADD])
   ])

--- a/ext/xmlwriter/config.w32
+++ b/ext/xmlwriter/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("xmlwriter", "XMLWriter support", "yes");
 if (PHP_XMLWRITER == "yes" && PHP_LIBXML == "yes") {
 	if (CHECK_HEADER_ADD_INCLUDE('libxml/xmlwriter.h', 'CFLAGS_XMLWRITER', PHP_XMLWRITER + ";" + PHP_PHP_BUILD + "\\include\\libxml2")) {
 		EXTENSION("xmlwriter", "php_xmlwriter.c");
-		AC_DEFINE("HAVE_XMLWRITER", 1, "XMLWriter support");
+		AC_DEFINE("HAVE_XMLWRITER", 1, "Define to 1 if xmlwriter extension is available.");
 		if (!PHP_XMLWRITER_SHARED) {
 			ADD_FLAG("CFLAGS_XMLWRITER", "/D LIBXML_STATIC");
 		}


### PR DESCRIPTION
- PHP_SETUP_LIBXML arguments quoted
- Help texts updated for HAVE_LIBXML, HAVE_DOM, HAVE_XMLREADER, HAVE_XMLWRITER, HAVE_SOAP, HAVE_SIMPLEXML, and HAVE_XML CPP macros
- Duplicate HAVE_LIBXML symbol definition in libxml extenstion removed