### PR TITLE
Autotools: Normalize DTrace sources argument

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2268,6 +2268,11 @@ AS_VAR_IF([php_cv_have_write_stdout], [yes],
 dnl
 dnl PHP_INIT_DTRACE(providerdesc, header-file, sources [, module])
 dnl
+dnl Initialize the DTrace support using the DTrace "providerdesc" file and
+dnl generate "header-file". The "sources" is a blank-or-newline-separated list
+dnl of files. The optional "module" is PHP extension name or path when used in
+dnl extensions.
+dnl
 AC_DEFUN([PHP_INIT_DTRACE],
 [AC_CHECK_HEADER([sys/sdt.h],,
   [AC_MSG_ERROR([Cannot find sys/sdt.h which is required for DTrace support.])])
@@ -2306,7 +2311,7 @@ dnl Add providerdesc.o or .lo into global objects when needed.
 
 dnl DTrace objects.
   old_IFS=[$]IFS
-  for ac_src in $3; do
+  for ac_src in m4_normalize([$3]); do
     IFS=.
     set $ac_src
     ac_obj=[$]1

--- a/configure.ac
+++ b/configure.ac
@@ -1020,11 +1020,14 @@ PHP_ARG_ENABLE([dtrace],
   [no])
 
 AS_VAR_IF([PHP_DTRACE], [yes],
-  [PHP_INIT_DTRACE([Zend/zend_dtrace.d],
-    [Zend/zend_dtrace_gen.h],
-    [main/main.c Zend/zend_API.c \
-      Zend/zend_execute.c Zend/zend_exceptions.c \
-      Zend/zend_dtrace.c Zend/zend.c])])
+  [PHP_INIT_DTRACE([Zend/zend_dtrace.d], [Zend/zend_dtrace_gen.h], [
+    main/main.c
+    Zend/zend_API.c
+    Zend/zend_dtrace.c
+    Zend/zend_exceptions.c
+    Zend/zend_execute.c
+    Zend/zend.c
+  ])])
 
 AC_MSG_CHECKING([how big to make fd sets])
 PHP_ARG_ENABLE([fd-setsize],,


### PR DESCRIPTION
Using the m4_normalize, the source files can be added more intuitively using blank-or-newline delimited list of files. This adds also some basic help text.