### PR TITLE
Fix GH-15102: ext/pgsql use after free on persistent connection renewal.

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -682,7 +682,6 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 
 		/* try to find if we already have this link in our persistent list */
 		if ((le = zend_hash_find_ptr(&EG(persistent_list), str.s)) == NULL) {  /* we don't */
-newpconn:
 			if (PGG(max_links) != -1 && PGG(num_links) >= PGG(max_links)) {
 				php_error_docref(NULL, E_WARNING,
 								 "Cannot create new link. Too many open links (" ZEND_LONG_FMT ")", PGG(num_links));
@@ -720,11 +719,7 @@ newpconn:
 				while ((pg_result = PQgetResult(le->ptr))) {
 					PQclear(pg_result);
 				}
-				PQfinish(le->ptr);
-				le->ptr = NULL;
-				PGG(num_links)--;
-				PGG(num_persistent)--;
-				goto newpconn;
+				PQreset(le->ptr);
 			}
 			/* ensure that the link did not die */
 			if (PGG(auto_reset_persistent) & 1) {


### PR DESCRIPTION
simplifying the workflow by just using PQreset which force a new connection internally, connection process ids ought to be different,
 and let the existing checks do the rest.