### PR TITLE
Autotools: Quote AC_CHECK_LIB arguments

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1404,7 +1404,7 @@ AC_DEFUN([PHP_CHECK_FRAMEWORK], [
   dnl Supplying "c" to AC_CHECK_LIB is technically cheating, but rewriting
   dnl AC_CHECK_LIB is overkill and this only affects the "checking.." output
   dnl anyway.
-  AC_CHECK_LIB(c,[$2],[
+  AC_CHECK_LIB([c],[$2],[
     LDFLAGS=$save_old_LDFLAGS
     $3
   ],[

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -17,30 +17,34 @@ if test "$PHP_GETTEXT" != "no"; then
 
   O_LDFLAGS=$LDFLAGS
   LDFLAGS="$LDFLAGS -L$GETTEXT_LIBDIR"
-  AC_CHECK_LIB(intl, bindtextdomain, [
+  AC_CHECK_LIB([intl], [bindtextdomain], [
     GETTEXT_LIBS=intl
     GETTEXT_CHECK_IN_LIB=intl
     ],
-    [
-    AC_CHECK_LIB(c, bindtextdomain, [
+    [AC_CHECK_LIB([c], [bindtextdomain], [
       GETTEXT_LIBS=
       GETTEXT_CHECK_IN_LIB=c
-    ],[
-      AC_MSG_ERROR([Unable to find required gettext library])
-    ])
-  ]
-  )
+      ],
+      [AC_MSG_ERROR([Unable to find required gettext library])])])
 
-  AC_DEFINE(HAVE_LIBINTL,1,[ ])
+  AC_DEFINE([HAVE_LIBINTL], [1], [Define to 1 if you have the 'intl' library.])
   PHP_NEW_EXTENSION(gettext, gettext.c, $ext_shared)
   PHP_SUBST([GETTEXT_SHARED_LIBADD])
 
   PHP_ADD_INCLUDE([$GETTEXT_INCDIR])
 
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, ngettext,  [AC_DEFINE(HAVE_NGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dngettext,  [AC_DEFINE(HAVE_DNGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dcngettext,  [AC_DEFINE(HAVE_DCNGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, bind_textdomain_codeset,  [AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1, [ ])])
+  AC_CHECK_LIB([$GETTEXT_CHECK_IN_LIB], [ngettext],
+    [AC_DEFINE([HAVE_NGETTEXT], [1],
+      [Define to 1 if you have the 'ngettext' function.])])
+  AC_CHECK_LIB([$GETTEXT_CHECK_IN_LIB], [dngettext],
+    [AC_DEFINE([HAVE_DNGETTEXT], [1],
+      [Define to 1 if you have the 'dngettext' function.])])
+  AC_CHECK_LIB([$GETTEXT_CHECK_IN_LIB], [dcngettext],
+    [AC_DEFINE([HAVE_DCNGETTEXT], [1],
+      [Define to 1 if you have the 'dcngettext' function.])])
+  AC_CHECK_LIB([$GETTEXT_CHECK_IN_LIB], [bind_textdomain_codeset],
+    [AC_DEFINE([HAVE_BIND_TEXTDOMAIN_CODESET], [1],
+      [Define to 1 if you have the 'bind_textdomain_codeset' function.])])
   LDFLAGS=$O_LDFLAGS
 
   if test -n "$GETTEXT_LIBS"; then

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -29,13 +29,11 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   PHP_ADD_INCLUDE([$READLINE_DIR/include])
 
   PHP_READLINE_LIBS=""
-  AC_CHECK_LIB(ncurses, tgetent,
-  [
+  AC_CHECK_LIB([ncurses], [tgetent], [
     PHP_ADD_LIBRARY([ncurses],, [READLINE_SHARED_LIBADD])
     PHP_READLINE_LIBS="$PHP_READLINE_LIBS -lncurses"
-  ],[
-    AC_CHECK_LIB(termcap, tgetent,
-    [
+    ],
+    [AC_CHECK_LIB([termcap], [tgetent], [
       PHP_ADD_LIBRARY([termcap],, [READLINE_SHARED_LIBADD])
       PHP_READLINE_LIBS="$PHP_READLINE_LIBS -ltermcap"
     ])
@@ -101,9 +99,9 @@ elif test "$PHP_LIBEDIT" != "no"; then
   PHP_EVAL_LIBLINE([$EDIT_LIBS], [READLINE_SHARED_LIBADD])
   PHP_EVAL_INCLINE([$EDIT_CFLAGS])
 
-  AC_CHECK_LIB(ncurses, tgetent,
+  AC_CHECK_LIB([ncurses], [tgetent],
     [PHP_ADD_LIBRARY([ncurses],, [READLINE_SHARED_LIBADD])],
-    [AC_CHECK_LIB(termcap, tgetent,
+    [AC_CHECK_LIB([termcap], [tgetent],
       [PHP_ADD_LIBRARY([termcap],, [READLINE_SHARED_LIBADD])])])
 
   PHP_CHECK_LIBRARY(edit, readline,


### PR DESCRIPTION
This syncs CS for AC_CHECK_LIB where possible, and adds minor help texts to gettext extension AC_DEFINE symbols, including the HAVE_LIBINTL.