### PR TITLE
Autotools: Quote and fix PHP_SELECT_SAPI arguments

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -843,10 +843,16 @@ EOF
 ])
 
 dnl
-dnl PHP_SELECT_SAPI(name, type[, sources [, extra-cflags [, build-target]]])
+dnl PHP_SELECT_SAPI(name, type[, sources [, extra-cflags]])
 dnl
-dnl Selects the SAPI name and type (static, shared, bundle, program) and
-dnl optionally also the source-files for the SAPI-specific objects.
+dnl When developing PHP SAPI modules, this macro specifies the SAPI "name" by
+dnl its "type", how PHP is supposed to be built (static, shared, bundle, or
+dnl program). It optionially adds the source files "sources" and compilation
+dnl flags "extra-cflags" to build the SAPI-specific objects. For example:
+dnl   PHP_SELECT_SAPI([apache2handler],
+dnl     [shared],
+dnl     [<sources...>],
+dnl     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 dnl
 AC_DEFUN([PHP_SELECT_SAPI],[
   if test "$2" = "program"; then

--- a/build/php.m4
+++ b/build/php.m4
@@ -847,7 +847,7 @@ dnl PHP_SELECT_SAPI(name, type[, sources [, extra-cflags]])
 dnl
 dnl When developing PHP SAPI modules, this macro specifies the SAPI "name" by
 dnl its "type", how PHP is supposed to be built (static, shared, bundle, or
-dnl program). It optionially adds the source files "sources" and compilation
+dnl program). It optionally adds the source files "sources" and compilation
 dnl flags "extra-cflags" to build the SAPI-specific objects. For example:
 dnl   PHP_SELECT_SAPI([apache2handler],
 dnl     [shared],

--- a/docs-old/unix-build-system.md
+++ b/docs-old/unix-build-system.md
@@ -92,23 +92,6 @@ Make sure to prefix *all* relative paths correctly with either `$(builddir)` or
 anymore, we must use either absolute paths or relative ones to the top
 build-directory. Correct prefixing ensures that.
 
-### SAPI developers
-
-Instead of using `PHP_SAPI=foo/PHP_BUILD_XYZ`, you will need to type
-
-```m4
-PHP_SELECT_SAPI(name, type, sources.c)
-```
-
-I.e. specify the source-code files as above and also pass the information
-regarding how PHP is supposed to be built (shared module, program, etc).
-
-For example for APXS:
-
-```m4
-PHP_SELECT_SAPI(apache, shared, sapi_apache.c mod_php.c php_apache.c)
-```
-
 ## General info
 
 The foundation for the new system is the flexible handling of sources and their

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -85,7 +85,10 @@ if test "$PHP_APXS2" != "no"; then
   case $host_alias in
   *aix*)
     EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-brtl -Wl,-bI:$APXS_LIBEXECDIR/httpd.exp"
-    PHP_SELECT_SAPI(apache2handler, shared, mod_php.c sapi_apache2.c apache_config.c php_functions.c, $APACHE_CFLAGS)
+    PHP_SELECT_SAPI([apache2handler],
+      [shared],
+      [mod_php.c sapi_apache2.c apache_config.c php_functions.c],
+      [$APACHE_CFLAGS])
     INSTALL_IT="$INSTALL_IT $SAPI_LIBTOOL"
     ;;
   *darwin*)
@@ -100,12 +103,18 @@ if test "$PHP_APXS2" != "no"; then
     fi
     MH_BUNDLE_FLAGS="-bundle -bundle_loader $APXS_HTTPD $MH_BUNDLE_FLAGS"
     PHP_SUBST([MH_BUNDLE_FLAGS])
-    PHP_SELECT_SAPI(apache2handler, bundle, mod_php.c sapi_apache2.c apache_config.c php_functions.c, $APACHE_CFLAGS)
+    PHP_SELECT_SAPI([apache2handler],
+      [bundle],
+      [mod_php.c sapi_apache2.c apache_config.c php_functions.c],
+      [$APACHE_CFLAGS])
     SAPI_SHARED=libs/libphp.so
     INSTALL_IT="$INSTALL_IT $SAPI_SHARED"
     ;;
   *)
-    PHP_SELECT_SAPI(apache2handler, shared, mod_php.c sapi_apache2.c apache_config.c php_functions.c, $APACHE_CFLAGS)
+    PHP_SELECT_SAPI([apache2handler],
+      [shared],
+      [mod_php.c sapi_apache2.c apache_config.c php_functions.c],
+      [$APACHE_CFLAGS])
     INSTALL_IT="$INSTALL_IT $SAPI_LIBTOOL"
     ;;
   esac

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -34,7 +34,10 @@ if test "$PHP_CGI" != "no"; then
     esac
 
     dnl Select SAPI.
-    PHP_SELECT_SAPI(cgi, program, cgi_main.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, '$(SAPI_CGI_PATH)')
+    PHP_SELECT_SAPI([cgi],
+      [program],
+      [cgi_main.c],
+      [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
     case $host_alias in
       *aix*)

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -27,7 +27,10 @@ if test "$PHP_CLI" != "no"; then
   SAPI_CLI_PATH=sapi/cli/php
 
   dnl Select SAPI.
-  PHP_SELECT_SAPI(cli, program, php_cli.c php_http_parser.c php_cli_server.c ps_title.c php_cli_process_title.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, '$(SAPI_CLI_PATH)')
+  PHP_SELECT_SAPI([cli],
+    [program],
+    [php_cli.c php_http_parser.c php_cli_server.c ps_title.c php_cli_process_title.c],
+    [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
   case $host_alias in
   *aix*)

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -25,7 +25,10 @@ if test "$PHP_EMBED" != "no"; then
   esac
   if test "$PHP_EMBED_TYPE" != "no"; then
     PHP_SUBST([LIBPHP_CFLAGS])
-    PHP_SELECT_SAPI(embed, $PHP_EMBED_TYPE, php_embed.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+    PHP_SELECT_SAPI([embed],
+      [$PHP_EMBED_TYPE],
+      [php_embed.c],
+      [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_INSTALL_HEADERS([sapi/embed], [php_embed.h])
   fi
   AC_MSG_RESULT([$PHP_EMBED_TYPE])

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -548,7 +548,10 @@ if test "$PHP_FPM" != "no"; then
     fpm/events/port.c \
   "
 
-  PHP_SELECT_SAPI(fpm, program, $PHP_FPM_FILES $PHP_FPM_TRACE_FILES $PHP_FPM_SD_FILES, $PHP_FPM_CFLAGS, '$(SAPI_FPM_PATH)')
+  PHP_SELECT_SAPI([fpm],
+    [program],
+    [$PHP_FPM_FILES $PHP_FPM_TRACE_FILES $PHP_FPM_SD_FILES],
+    [$PHP_FPM_CFLAGS])
 
   case $host_alias in
       *aix*)

--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -46,7 +46,7 @@ if test "$PHP_FUZZER" != "no"; then
   PHP_SUBST([FUZZING_LIB])
   PHP_SUBST([FUZZING_CC])
 
-  dnl PHP_SELECT_SAPI(fuzzer-parser, program, $FUZZER_SOURCES, , '$(SAPI_FUZZER_PATH)')
+  dnl PHP_SELECT_SAPI([fuzzer-parser], [program], [$FUZZER_SOURCES])
 
   PHP_ADD_BUILD_DIR([sapi/fuzzer])
   PHP_FUZZER_BINARIES=""

--- a/sapi/litespeed/config.m4
+++ b/sapi/litespeed/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_LITESPEED" != "no"; then
     [$abs_srcdir/sapi/litespeed],
     [sapi/litespeed])
   SAPI_LITESPEED_PATH=sapi/litespeed/php
-  PHP_SELECT_SAPI(litespeed, program, lsapi_main.c lsapilib.c, "", '$(SAPI_LITESPEED_PATH)')
+  PHP_SELECT_SAPI([litespeed], [program], [lsapi_main.c lsapilib.c])
   case $host_alias in
   *darwin*)
     BUILD_LITESPEED="\$(CC) \$(CFLAGS_CLEAN) \$(EXTRA_CFLAGS) \$(EXTRA_LDFLAGS_PROGRAM) \$(LDFLAGS) \$(NATIVE_RPATHS) \$(PHP_GLOBAL_OBJS:.lo=.o) \$(PHP_BINARY_OBJS:.lo=.o) \$(PHP_LITESPEED_OBJS:.lo=.o) \$(PHP_FRAMEWORKS) \$(EXTRA_LIBS) \$(ZEND_EXTRA_LIBS) -o \$(SAPI_LITESPEED_PATH)"

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -66,7 +66,10 @@ if test "$PHP_PHPDBG" != "no"; then
   PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/phpdbg/Makefile.frag],
     [$abs_srcdir/sapi/phpdbg],
     [$abs_builddir/sapi/phpdbg])
-  PHP_SELECT_SAPI(phpdbg, program, $PHP_PHPDBG_FILES, $PHP_PHPDBG_CFLAGS, [$(SAPI_PHPDBG_PATH)])
+  PHP_SELECT_SAPI([phpdbg],
+    [program],
+    [$PHP_PHPDBG_FILES],
+    [$PHP_PHPDBG_CFLAGS])
 
   BUILD_BINARY="sapi/phpdbg/phpdbg"
   BUILD_SHARED="sapi/phpdbg/libphpdbg.la"


### PR DESCRIPTION
This macro once had also the 5th argument (the build target), which was removed via 2a6da0f24cbd04361c044c1cdf6b6b30d08a245e. This quotes all PHP_SELECT_SAPI arguments and removes the redundant ones. The basic macro usage help text is moved to the macros section from the obsolete docs file.