### PR TITLE
Autotools: Replace PHP_DEF_HAVE with AC_DEFINE_UNQUTED

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1453,8 +1453,10 @@ AC_DEFUN([PHP_CHECK_FUNC_LIB],[
 
   if test "$found" = "yes"; then
     PHP_ADD_LIBRARY($2)
-    PHP_DEF_HAVE($1)
-    PHP_DEF_HAVE(lib$2)
+    AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
+      [Define to 1 if you have the '$1' function.])
+    AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_LIB$2]), [1],
+      [Define to 1 if you have the '$2' library (-l$2).])
     ac_cv_func_$1=yes
   else
     PHP_CHECK_FUNC_LIB($1,phpshift(phpshift($@)))
@@ -1478,7 +1480,8 @@ AC_DEFUN([PHP_CHECK_FUNC],[
 
   case $found in
   yes[)]
-    PHP_DEF_HAVE($1)
+    AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
+      [Define to 1 if you have the '$1' function.])
     ac_cv_func_$1=yes
   ;;
   ifelse($#,1,,[


### PR DESCRIPTION
The PHP_DEF_HAVE M4 macro is a simple wrapper around the recommended AC_DEFINE or AC_DEFINE_UNQUOTED (when shell variables are used in arguments). This also adds some basic help texts to macros.