### PR TITLE
Avoid string duplications in simplexml

### DIFF
--- a/ext/simplexml/php_simplexml.h
+++ b/ext/simplexml/php_simplexml.h
@@ -56,8 +56,8 @@ typedef struct {
 	HashTable *properties;
 	xmlXPathContextPtr xpath;
 	struct {
-		xmlChar               *name;
-		xmlChar               *nsprefix;
+		zend_string           *name;
+		zend_string           *nsprefix;
 		int                   isprefix;
 		SXE_ITER              type;
 		zval                  data;


### PR DESCRIPTION
Switch to zend_string which allows us to use zend_string_copy.