### PR TITLE
ext/curl: No-op `CURLOPT_DNS_USE_GLOBAL_CACHE` constant

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,9 @@ PHP                                                                        NEWS
   . Fixed bug GH-15693 (Unnecessary include in main.c bloats binary).
     (nielsdos)
 
+- Curl:
+  . The CURLOPT_DNS_USE_GLOBAL_CACHE option is now silently ignored. (Ayesh Karunaratne)
+
 - DOM:
   . Fixed bug GH-13988 (Storing DOMElement consume 4 times more memory in
     PHP 8.1 than in PHP 8.0). (nielsdos)

--- a/UPGRADING
+++ b/UPGRADING
@@ -930,6 +930,9 @@ PHP 8.4 UPGRADE NOTES
 
 - Curl:
   . The Curl extension now requires at least libcurl 7.61.0.
+  . The CURLOPT_DNS_USE_GLOBAL_CACHE Curl option no longer has any
+    effect, and is silently ignored. This underlying feature was
+    deprecated in libcurl 7.11.1 and removed in 7.62.0.
 
 - Date:
   . The class constants are typed now.

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1165,9 +1165,6 @@ static void _php_curl_set_default_options(php_curl *ch)
 	curl_easy_setopt(ch->cp, CURLOPT_INFILE,            (void *) ch);
 	curl_easy_setopt(ch->cp, CURLOPT_HEADERFUNCTION,    curl_write_header);
 	curl_easy_setopt(ch->cp, CURLOPT_WRITEHEADER,       (void *) ch);
-#ifndef ZTS
-	curl_easy_setopt(ch->cp, CURLOPT_DNS_USE_GLOBAL_CACHE, 1);
-#endif
 	curl_easy_setopt(ch->cp, CURLOPT_DNS_CACHE_TIMEOUT, 120);
 	curl_easy_setopt(ch->cp, CURLOPT_MAXREDIRS, 20); /* prevent infinite redirects */
 
@@ -1657,7 +1654,6 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 		case CURLOPT_COOKIESESSION:
 		case CURLOPT_CRLF:
 		case CURLOPT_DNS_CACHE_TIMEOUT:
-		case CURLOPT_DNS_USE_GLOBAL_CACHE:
 		case CURLOPT_FAILONERROR:
 		case CURLOPT_FILETIME:
 		case CURLOPT_FORBID_REUSE:
@@ -1806,12 +1802,6 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 					php_error_docref(NULL, E_WARNING, "CURLPROTO_FILE cannot be activated when an open_basedir is set");
 					return FAILURE;
 			}
-# if defined(ZTS)
-			if (option == CURLOPT_DNS_USE_GLOBAL_CACHE && lval) {
-				php_error_docref(NULL, E_WARNING, "CURLOPT_DNS_USE_GLOBAL_CACHE cannot be activated when thread safety is enabled");
-				return FAILURE;
-			}
-# endif
 			error = curl_easy_setopt(ch->cp, option, lval);
 			break;
 		case CURLOPT_SAFE_UPLOAD:
@@ -2146,6 +2136,7 @@ static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue
 		}
 
 		case CURLOPT_BINARYTRANSFER:
+		case CURLOPT_DNS_USE_GLOBAL_CACHE:
 			/* Do nothing, just backward compatibility */
 			break;
 

--- a/ext/curl/tests/bug71144.phpt
+++ b/ext/curl/tests/bug71144.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Bug #71144 (Sementation fault when using cURL with ZTS)
+--DESCRIPTION--
+Since Curl 7.62, CURLOPT_DNS_USE_GLOBAL_CACHE has no effect, and is
+silently ignored.
 --EXTENSIONS--
 curl
---SKIPIF--
-<?php if (!PHP_ZTS) { print "skip only for zts build"; } ?>
 --FILE--
 <?php
 $ch = curl_init();
 var_dump(curl_setopt($ch, CURLOPT_DNS_USE_GLOBAL_CACHE, 1));
 ?>
 --EXPECTF--
-Warning: curl_setopt(): CURLOPT_DNS_USE_GLOBAL_CACHE cannot be activated when thread safety is enabled in %sbug71144.php on line %d
-bool(false)
+bool(true)


### PR DESCRIPTION
~Libcurl `CURLOPT_DNS_USE_GLOBAL_CACHE` constant is no longer supported since libcurl[^1] 7.62. This feature is also not thread-safe, and we have special handling to emit warnings if it's used in ZTS builds.~

~Impact: Close to 1,100 hits on GitHub code search[^2]~

Libcurl `CURLOPT_DNS_USE_GLOBAL_CACHE` constant is no longer supported since libcurl[^1] 7.62. This no-ops the constant, but without causing any deprecation notices.

[^1]: [CURLOPT_DNS_USE_GLOBAL_CACHE](https://curl.se/libcurl/c/CURLOPT_DNS_USE_GLOBAL_CACHE.html)
[^2]: [GitHub code search: `CURLOPT_DNS_USE_GLOBAL_CACHE`](https://github.com/search?q=CURLOPT_DNS_USE_GLOBAL_CACHE+language%3APHP+++NOT+is%3Aarchived+NOT+path%3A%2F%5Eext%5C%2F%2F&type=code)