### PR TITLE
Autotools: Simplify PHP_ALWAYS_SHARED macro

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -659,7 +659,8 @@ no[)]
   ;;
 esac
 
-PHP_ALWAYS_SHARED([$1])
+dnl When using phpize, automatically enable and build extension as shared.
+m4_ifdef([PHP_ALWAYS_SHARED], [PHP_ALWAYS_SHARED([$1])])
 ])
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -76,8 +76,6 @@ PHP_SUBST([PHP_MINOR_VERSION])
 PHP_SUBST([PHP_RELEASE_VERSION])
 PHP_SUBST([PHP_EXTRA_VERSION])
 
-AC_DEFUN([PHP_ALWAYS_SHARED],[])dnl
-
 dnl Setting up the PHP version based on the information above.
 dnl ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Instead of defining an empty M4 macro PHP_ALWAYS_SHARED when configuring extensions in php-src using the main configure.ac, the m4_ifdef can be used to conditionally call the macro when it is defined (when using phpize).