### PR TITLE
Autotools: Fix ext/standard sources

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -80,10 +80,16 @@ AH_TEMPLATE([PHP_USE_PHP_CRYPT_R],
   [Define to 1 if PHP uses its own crypt_r, and to 0 if using the external crypt
   library.])
 
+php_ext_standard_sources=
 AS_VAR_IF([PHP_EXTERNAL_LIBCRYPT], [no], [
   AC_DEFINE([PHP_USE_PHP_CRYPT_R], [1])
-  PHP_ADD_SOURCES([PHP_EXT_DIR([standard])],
-    [crypt_freesec.c crypt_blowfish.c crypt_sha512.c crypt_sha256.c php_crypt_r.c])
+  php_ext_standard_sources=m4_normalize(["
+    crypt_blowfish.c
+    crypt_freesec.c
+    crypt_sha256.c
+    crypt_sha512.c
+    php_crypt_r.c
+  "])
 ], [
 AC_SEARCH_LIBS([crypt], [crypt],
   [AC_DEFINE([HAVE_CRYPT], [1],
@@ -460,6 +466,7 @@ PHP_NEW_EXTENSION([standard], m4_normalize([
   var_unserializer.c
   var.c
   versioning.c
+  $php_ext_standard_sources
 ]),,,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 


### PR DESCRIPTION
This appends source files to the PHP_NEW_EXTENSION call and adds the possible compilation flag -DZEND_ENABLE_STATIC_TSRMLS_CACHE when building objects as done on all ext/standard sources already. Also, the PHP_EXT_DIR Autoconf macro doesn't accept any argument.

This is changed to not have any possible side effects due to possible mismatched compilation flags.

Makefile diff:

```diff
1761,1775d1760
< -include ext/standard/crypt_freesec.dep
< ext/standard/crypt_freesec.lo: /php-src/ext/standard/crypt_freesec.c
< 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  -c /php-src/ext/standard/crypt_freesec.c -o ext/standard/crypt_freesec.lo  -MMD -MF ext/standard/crypt_freesec.dep -MT ext/standard/crypt_freesec.lo
< -include ext/standard/crypt_blowfish.dep
< ext/standard/crypt_blowfish.lo: /php-src/ext/standard/crypt_blowfish.c
< 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  -c /php-src/ext/standard/crypt_blowfish.c -o ext/standard/crypt_blowfish.lo  -MMD -MF ext/standard/crypt_blowfish.dep -MT ext/standard/crypt_blowfish.lo
< -include ext/standard/crypt_sha512.dep
< ext/standard/crypt_sha512.lo: /php-src/ext/standard/crypt_sha512.c
< 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  -c /php-src/ext/standard/crypt_sha512.c -o ext/standard/crypt_sha512.lo  -MMD -MF ext/standard/crypt_sha512.dep -MT ext/standard/crypt_sha512.lo
< -include ext/standard/crypt_sha256.dep
< ext/standard/crypt_sha256.lo: /php-src/ext/standard/crypt_sha256.c
< 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  -c /php-src/ext/standard/crypt_sha256.c -o ext/standard/crypt_sha256.lo  -MMD -MF ext/standard/crypt_sha256.dep -MT ext/standard/crypt_sha256.lo
< -include ext/standard/php_crypt_r.dep
< ext/standard/php_crypt_r.lo: /php-src/ext/standard/php_crypt_r.c
< 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  -c /php-src/ext/standard/php_crypt_r.c -o ext/standard/php_crypt_r.lo  -MMD -MF ext/standard/php_crypt_r.dep -MT ext/standard/php_crypt_r.lo
1964a1950,1964
> -include ext/standard/crypt_blowfish.dep
> ext/standard/crypt_blowfish.lo: /php-src/ext/standard/crypt_blowfish.c
> 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c /php-src/ext/standard/crypt_blowfish.c -o ext/standard/crypt_blowfish.lo  -MMD -MF ext/standard/crypt_blowfish.dep -MT ext/standard/crypt_blowfish.lo
> -include ext/standard/crypt_freesec.dep
> ext/standard/crypt_freesec.lo: /php-src/ext/standard/crypt_freesec.c
> 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c /php-src/ext/standard/crypt_freesec.c -o ext/standard/crypt_freesec.lo  -MMD -MF ext/standard/crypt_freesec.dep -MT ext/standard/crypt_freesec.lo
> -include ext/standard/crypt_sha256.dep
> ext/standard/crypt_sha256.lo: /php-src/ext/standard/crypt_sha256.c
> 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c /php-src/ext/standard/crypt_sha256.c -o ext/standard/crypt_sha256.lo  -MMD -MF ext/standard/crypt_sha256.dep -MT ext/standard/crypt_sha256.lo
> -include ext/standard/crypt_sha512.dep
> ext/standard/crypt_sha512.lo: /php-src/ext/standard/crypt_sha512.c
> 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c /php-src/ext/standard/crypt_sha512.c -o ext/standard/crypt_sha512.lo  -MMD -MF ext/standard/crypt_sha512.dep -MT ext/standard/crypt_sha512.lo
> -include ext/standard/php_crypt_r.dep
> ext/standard/php_crypt_r.lo: /php-src/ext/standard/php_crypt_r.c
> 	$(LIBTOOL) --tag=CC --mode=compile $(CC) -Iext/standard/ -I/php-src/ext/standard/ $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c /php-src/ext/standard/php_crypt_r.c -o ext/standard/php_crypt_r.lo  -MMD -MF ext/standard/php_crypt_r.dep -MT ext/standard/php_crypt_r.lo

```