### PR TITLE
Fix GH-15137: Unexpected null pointer in Zend/zend_smart_str.h

### DIFF
--- a/ext/dom/tests/gh15137.phpt
+++ b/ext/dom/tests/gh15137.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-15137: Unexpected null pointer in Zend/zend_smart_str.h
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+var_dump(new DOMText()->wholeText);
+?>
+--EXPECT--
+string(0) ""
+

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -77,7 +77,9 @@ zend_result dom_text_whole_text_read(dom_object *obj, zval *retval)
 
 	/* concatenate all adjacent text and cdata nodes */
 	while (node && ((node->type == XML_TEXT_NODE) || (node->type == XML_CDATA_SECTION_NODE))) {
-		smart_str_appends(&str, (const char *) node->content);
+		if (node->content) {
+			smart_str_appends(&str, (const char *) node->content);
+		}
 		node = node->next;
 	}
 


### PR DESCRIPTION
This regressed when I optimized $wholeText. The previous code used xmlStrcat which implicitly checked for a NULL argument, but now it's a direct memcpy which you shouldn't pass null pointers to, although it won't result in a crash because memcpy doesn't do anything if the length is 0.