### PR TITLE
Autotools: Sync shared argument CS

### DIFF
--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -38,7 +38,7 @@ EXT_HASH_SOURCES="hash.c hash_md.c hash_sha.c hash_ripemd.c hash_haval.c \
   hash_crc32.c hash_fnv.c hash_joaat.c $EXT_HASH_SHA3_SOURCES
   murmur/PMurHash.c murmur/PMurHash128.c hash_murmur.c hash_xxhash.c"
 
-PHP_NEW_EXTENSION(hash, $EXT_HASH_SOURCES, 0,,$PHP_HASH_CFLAGS)
+PHP_NEW_EXTENSION([hash], [$EXT_HASH_SOURCES], [no],, [$PHP_HASH_CFLAGS])
 PHP_ADD_BUILD_DIR([$ext_builddir/murmur])
 AS_VAR_IF([SHA3_DIR],,, [PHP_ADD_BUILD_DIR([$ext_builddir/$SHA3_DIR])])
 PHP_INSTALL_HEADERS([ext/hash], m4_normalize([

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -467,7 +467,8 @@ PHP_NEW_EXTENSION([standard], m4_normalize([
     var.c
     versioning.c
     $php_ext_standard_sources
-  ]),,,
+  ]),
+  [no],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
 PHP_ADD_BUILD_DIR([$ext_builddir/libavifinfo])


### PR DESCRIPTION
The 3rd argument of the PHP_NEW_EXTENSION can be "shared" or "yes" to mark the extension as shared, or anything else to mark that extension as not shared. This syncs the argument values across the build system to be "no" as in other always-enabled extensions.