### PR TITLE
fix: add missing `PHPAPI`

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -304,7 +304,7 @@ PHP_FUNCTION(floor)
 }
 /* }}} */
 
-int php_math_round_mode_from_enum(zend_object *mode)
+PHPAPI int php_math_round_mode_from_enum(zend_object *mode)
 {
 	zval *case_name = zend_enum_fetch_case_name(mode);
 	zend_string *mode_name = Z_STR_P(case_name);

--- a/ext/standard/php_math_round_mode.h
+++ b/ext/standard/php_math_round_mode.h
@@ -52,4 +52,4 @@
 
 extern PHPAPI zend_class_entry *rounding_mode_ce;
 
-int php_math_round_mode_from_enum(zend_object *mode);
+PHPAPI int php_math_round_mode_from_enum(zend_object *mode);


### PR DESCRIPTION
Issue introduced in commit https://github.com/php/php-src/commit/5905857fd2652585989ed03e5a5b0beea89ab18e from PR https://github.com/php/php-src/pull/14833

See more context at https://github.com/php/php-src/pull/14833#issuecomment-2254558013