### PR TITLE
Fix UAF when removing doctype and using foreach iteration

### DIFF
--- a/ext/dom/dom_iterators.c
+++ b/ext/dom/dom_iterators.c
@@ -295,7 +295,7 @@ zend_object_iterator *php_dom_get_iterator(zend_class_entry *ce, zval *object, i
 					if (objmap->nodetype == XML_ATTRIBUTE_NODE) {
 						curnode = (xmlNodePtr) nodep->properties;
 					} else {
-						curnode = (xmlNodePtr) nodep->children;
+						curnode = dom_nodelist_iter_start_first_child(nodep);
 					}
 				} else {
 					if (nodep->type == XML_DOCUMENT_NODE || nodep->type == XML_HTML_DOCUMENT_NODE) {

--- a/ext/dom/nodelist.c
+++ b/ext/dom/nodelist.c
@@ -31,7 +31,7 @@
 * Since:
 */
 
-static xmlNodePtr dom_nodelist_iter_start_first_child(xmlNodePtr nodep)
+xmlNodePtr dom_nodelist_iter_start_first_child(xmlNodePtr nodep)
 {
 	if (nodep->type == XML_ENTITY_REF_NODE) {
 		/* See entityreference.c */

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -156,6 +156,7 @@ void php_dom_named_node_map_get_item_into_zval(dom_nnodemap_object *objmap, zend
 void php_dom_nodelist_get_item_into_zval(dom_nnodemap_object *objmap, zend_long index, zval *return_value);
 int php_dom_get_namednodemap_length(dom_object *obj);
 int php_dom_get_nodelist_length(dom_object *obj);
+xmlNodePtr dom_nodelist_iter_start_first_child(xmlNodePtr nodep);
 
 #define DOM_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_DOMOBJ_P(__id); \

--- a/ext/dom/tests/uaf_doctype_iterator.phpt
+++ b/ext/dom/tests/uaf_doctype_iterator.phpt
@@ -1,0 +1,26 @@
+--TEST--
+UAF when removing doctype and iterating over the child nodes
+--EXTENSIONS--
+dom
+--CREDITS--
+Yuancheng Jiang
+--FILE--
+<?php
+$dom = new DOMDocument;
+$dom->loadXML(<<<XML
+<!DOCTYPE foo [
+    <!ENTITY foo1 "bar1">
+]>
+<foo>&foo1;</foo>
+XML);
+$ref = $dom->documentElement->firstChild;
+$nodes = $ref->childNodes;
+$dom->removeChild($dom->doctype);
+foreach($nodes as $str) {}
+var_dump($nodes);
+?>
+--EXPECTF--
+object(DOMNodeList)#%d (1) {
+  ["length"]=>
+  int(0)
+}


### PR DESCRIPTION
This is an old bug, but this is pretty easy to fix. It's basically applying the same fix as I did for e878b9f. Reported by YuanchengJiang.