### PR TITLE
Autotools: Update skeleton extension config.m4 template

### DIFF
--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -10,7 +10,7 @@ dnl   [for %EXTNAME% support],
 dnl   [AS_HELP_STRING([--with-%EXTNAME%],
 dnl     [Include %EXTNAME% support])])
 
-dnl Otherwise use '--enable-%EXTNAME%' configure option:
+dnl Otherwise use the '--enable-%EXTNAME%' configure option:
 PHP_ARG_ENABLE([%EXTNAME%],
   [whether to enable %EXTNAME% support],
   [AS_HELP_STRING([--enable-%EXTNAME%],
@@ -18,7 +18,8 @@ PHP_ARG_ENABLE([%EXTNAME%],
   [no])
 
 AS_VAR_IF([PHP_%EXTNAMECAPS%], [no],, [
-  dnl This is executed when extension is enabled. Adjust and add tests here.
+  dnl This section is executed when extension is enabled with one of the above
+  dnl configure options. Adjust and add tests here.
 
   dnl
   dnl Use and adjust this code block if extension depends on external library
@@ -95,8 +96,8 @@ AS_VAR_IF([PHP_%EXTNAMECAPS%], [no],, [
   dnl Add linked libraries flags for shared extension to the generated Makefile.
   dnl PHP_SUBST([%EXTNAMECAPS%_SHARED_LIBADD])
 
-  dnl Define CPP macro to indicate that extension is available either as a
-  dnl shared module or statically built into PHP.
+  dnl Define a preprocessor macro to indicate that this PHP extension can
+  dnl be dynamically loaded as a shared module or is statically built into PHP.
   AC_DEFINE([HAVE_%EXTNAMECAPS%], [1],
     [Define to 1 if PHP extension '%EXTNAME%' is available.])
 

--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -1,92 +1,108 @@
-dnl config.m4 for extension %EXTNAME%
+dnl Autotools config.m4 for PHP extension %EXTNAME%
 
-dnl Comments in this file start with the string 'dnl'.
+dnl Comments in this file start with the string 'dnl' (discard to next line).
 dnl Remove where necessary.
 
-dnl If your extension references something external, use 'with':
-
+dnl If extension references and depends on an external library package, use
+dnl the '--with-%EXTNAME%' configure option:
 dnl PHP_ARG_WITH([%EXTNAME%],
 dnl   [for %EXTNAME% support],
 dnl   [AS_HELP_STRING([--with-%EXTNAME%],
 dnl     [Include %EXTNAME% support])])
 
-dnl Otherwise use 'enable':
-
+dnl Otherwise use '--enable-%EXTNAME%' configure option:
 PHP_ARG_ENABLE([%EXTNAME%],
   [whether to enable %EXTNAME% support],
   [AS_HELP_STRING([--enable-%EXTNAME%],
     [Enable %EXTNAME% support])],
   [no])
 
-if test "$PHP_%EXTNAMECAPS%" != "no"; then
-  dnl Write more examples of tests here...
+AS_VAR_IF([PHP_%EXTNAMECAPS%], [no],, [
+  dnl This is executed when extension is enabled. Adjust and add tests here.
 
-  dnl Remove this code block if the library does not support pkg-config.
+  dnl
+  dnl Use and adjust this code block if extension depends on external library
+  dnl package which supports pkg-config.
+  dnl
+  dnl Find library package with pkg-config.
   dnl PKG_CHECK_MODULES([LIBFOO], [foo])
-  dnl PHP_EVAL_INCLINE([$LIBFOO_CFLAGS])
-  dnl PHP_EVAL_LIBLINE([$LIBFOO_LIBS], [%EXTNAMECAPS%_SHARED_LIBADD])
-
-  dnl If you need to check for a particular library version using PKG_CHECK_MODULES,
+  dnl
+  dnl Or if you need to check for a particular library version with pkg-config,
   dnl you can use comparison operators. For example:
   dnl PKG_CHECK_MODULES([LIBFOO], [foo >= 1.2.3])
   dnl PKG_CHECK_MODULES([LIBFOO], [foo < 3.4])
   dnl PKG_CHECK_MODULES([LIBFOO], [foo = 1.2.3])
-
-  dnl Remove this code block if the library supports pkg-config.
-  dnl --with-%EXTNAME% -> check with-path
-  dnl SEARCH_PATH="/usr/local /usr"     # you might want to change this
-  dnl SEARCH_FOR="/include/%EXTNAME%.h"  # you most likely want to change this
-  dnl if test -r $PHP_%EXTNAMECAPS%/$SEARCH_FOR; then # path given as parameter
-  dnl   %EXTNAMECAPS%_DIR=$PHP_%EXTNAMECAPS%
-  dnl else # search default path list
-  dnl   AC_MSG_CHECKING([for %EXTNAME% files in default path])
-  dnl   for i in $SEARCH_PATH ; do
-  dnl     if test -r $i/$SEARCH_FOR; then
-  dnl       %EXTNAMECAPS%_DIR=$i
-  dnl       AC_MSG_RESULT([found in $i])
-  dnl     fi
-  dnl   done
-  dnl fi
   dnl
-  dnl if test -z "$%EXTNAMECAPS%_DIR"; then
-  dnl   AC_MSG_RESULT([not found])
-  dnl   AC_MSG_ERROR([Please reinstall the %EXTNAME% distribution])
-  dnl fi
-
-  dnl Remove this code block if the library supports pkg-config.
-  dnl --with-%EXTNAME% -> add include path
-  dnl PHP_ADD_INCLUDE([$%EXTNAMECAPS%_DIR/include])
-
-  dnl Remove this code block if the library supports pkg-config.
-  dnl --with-%EXTNAME% -> check for lib and symbol presence
-  dnl LIBNAME=%EXTNAMECAPS% # you may want to change this
-  dnl LIBSYMBOL=%EXTNAMECAPS% # you most likely want to change this
-
+  dnl Add library compilation and linker flags to extension.
+  dnl PHP_EVAL_INCLINE([$LIBFOO_CFLAGS])
+  dnl PHP_EVAL_LIBLINE([$LIBFOO_LIBS], [%EXTNAMECAPS%_SHARED_LIBADD])
+  dnl
+  dnl Check for library and symbol presence.
+  dnl LIBNAME=%EXTNAME% # you may want to change this
+  dnl LIBSYMBOL=%EXTNAME% # you most likely want to change this
+  dnl
   dnl If you need to check for a particular library function (e.g. a conditional
   dnl or version-dependent feature) and you are using pkg-config:
   dnl PHP_CHECK_LIBRARY([$LIBNAME], [$LIBSYMBOL],
-  dnl   [AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1], [ ])],
+  dnl   [AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1],
+  dnl     [Define to 1 if %EXTNAME% has the 'FEATURE'.])],
   dnl   [AC_MSG_ERROR([FEATURE not supported by your %EXTNAME% library.])],
   dnl   [$LIBFOO_LIBS])
+  dnl
 
+  dnl
+  dnl Or use and adjust this code block if extension depends on external library
+  dnl package, which does not support pkg-config.
+  dnl
+  dnl Path to library package can be given as parameter (--with-%EXTNAME%=<DIR>)
+  dnl SEARCH_PATH="/usr/local /usr" # you might want to change this
+  dnl SEARCH_FOR="/include/%EXTNAME%.h" # you most likely want to change this
+  dnl AS_IF([test -r $PHP_%EXTNAMECAPS%/$SEARCH_FOR],
+  dnl   [%EXTNAMECAPS%_DIR=$PHP_%EXTNAMECAPS%],
+  dnl   [
+  dnl     for i in $SEARCH_PATH; do
+  dnl       AS_IF([test -r $i/$SEARCH_FOR],
+  dnl         [%EXTNAMECAPS%_DIR=$i; break;])
+  dnl     done
+  dnl   ])
+  dnl
+  dnl AC_MSG_CHECKING([for %EXTNAME% library package])
+  dnl AS_VAR_IF([%EXTNAMECAPS%_DIR],, [
+  dnl   AC_MSG_RESULT([not found])
+  dnl   AC_MSG_ERROR([Please reinstall the %EXTNAME% library package])
+  dnl ], [AC_MSG_RESULT([found in $%EXTNAMECAPS%_DIR])])
+  dnl
+  dnl Add include flag where library package headers are located on the system.
+  dnl PHP_ADD_INCLUDE([$%EXTNAMECAPS%_DIR/include])
+  dnl
+  dnl Check for library and symbol presence.
+  dnl LIBNAME=%EXTNAME% # you may want to change this
+  dnl LIBSYMBOL=%EXTNAME% # you most likely want to change this
+  dnl
   dnl If you need to check for a particular library function (e.g. a conditional
   dnl or version-dependent feature) and you are not using pkg-config:
-  dnl PHP_CHECK_LIBRARY([$LIBNAME], [$LIBSYMBOL],
-  dnl   [PHP_ADD_LIBRARY_WITH_PATH([$LIBNAME],
-  dnl     [$%EXTNAMECAPS%_DIR/$PHP_LIBDIR],
-  dnl     [%EXTNAMECAPS%_SHARED_LIBADD])
-  dnl   AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1], [ ])
+  dnl PHP_CHECK_LIBRARY([$LIBNAME], [$LIBSYMBOL], [
+  dnl     PHP_ADD_LIBRARY_WITH_PATH([$LIBNAME],
+  dnl       [$%EXTNAMECAPS%_DIR/$PHP_LIBDIR],
+  dnl       [%EXTNAMECAPS%_SHARED_LIBADD])
+  dnl     AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1],
+  dnl       [Define to 1 if %EXTNAME% has the 'FEATURE'.])
   dnl   ],
   dnl   [AC_MSG_ERROR([FEATURE not supported by your %EXTNAME% library.])],
   dnl   [-L$%EXTNAMECAPS%_DIR/$PHP_LIBDIR -lm])
   dnl
+
+  dnl Add linked libraries flags for shared extension to the generated Makefile.
   dnl PHP_SUBST([%EXTNAMECAPS%_SHARED_LIBADD])
 
-  dnl In case of no dependencies
-  AC_DEFINE(HAVE_%EXTNAMECAPS%, 1, [ Have %EXTNAME% support ])
+  dnl Define CPP macro to indicate that extension is available either as a
+  dnl shared module or statically built into PHP.
+  AC_DEFINE([HAVE_%EXTNAMECAPS%], [1],
+    [Define to 1 if PHP extension '%EXTNAME%' is available.])
 
+  dnl Configure extension sources and compilation flags.
   PHP_NEW_EXTENSION([%EXTNAME%],
     [%EXTNAME%.c],
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
-fi
+])


### PR DESCRIPTION
- Comments refactored to a bit more guide way
- Basic help text added to the HAVE_<EXTENSION>* CPP macro definitions
- Raw shell ifs replaced with AS_VAR_IF M4 macros
- Code wrapped inside the line length of 80 characters
- pkg-config functionality added on top
- non-pkg-config functionality added afterwards
- The loop refactored a bit with a break and check message done afterwards