### PR TITLE
Sync HAVE_ICONV preprocessor macro usage

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -173,6 +173,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      checks.
    - M4 macro PHP_SETUP_LIBXML doesn't define the redundant HAVE_LIBXML symbol
      anymore.
+   - M4 macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol anymore.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -1883,7 +1883,6 @@ AC_DEFUN([PHP_SETUP_ICONV], [
   fi
 
   if test "$found_iconv" = "yes"; then
-    AC_DEFINE(HAVE_ICONV,1,[ ])
     if test -n "$ICONV_DIR"; then
       PHP_ADD_LIBRARY_WITH_PATH([$iconv_lib_name],
         [$ICONV_DIR/$PHP_LIBDIR],

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -127,6 +127,9 @@ int main(void) {
     LDFLAGS="$save_LDFLAGS"
     CFLAGS="$save_CFLAGS"
 
+    AC_DEFINE([HAVE_ICONV], [1],
+      [Define to 1 if PHP extension 'iconv' is available.])
+
     PHP_NEW_EXTENSION([iconv],
       [iconv.c],
       [$ext_shared],,

--- a/ext/iconv/config.w32
+++ b/ext/iconv/config.w32
@@ -9,7 +9,7 @@ if (PHP_ICONV != "no") {
 
 		EXTENSION("iconv", "iconv.c", PHP_ICONV_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-		AC_DEFINE("HAVE_ICONV", 1, "Define if iconv extension is enabled");
+		AC_DEFINE("HAVE_ICONV", 1, "Define to 1 if PHP extension 'iconv' is available.");
 		AC_DEFINE("HAVE_LIBICONV", 1, "Define if libiconv is available");
 		AC_DEFINE("ICONV_ALIASED_LIBICONV", 1, "The iconv function is called iconv() in libiconv");
 		AC_DEFINE("PHP_ICONV_IMPL", "\"libiconv\"", "Which iconv implementation to use");


### PR DESCRIPTION
HAVE_ICONV marks that PHP extension 'iconv' is available, and not only that iconv library or its functions/headers are available.