### PR TITLE
Autotools: Normalize headers arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1634,16 +1634,17 @@ PHP_SUBST([install_targets])
 PHP_SUBST([install_binary_targets])
 
 PHP_INSTALL_HEADERS([Zend/ TSRM/ main/ main/streams/])
-PHP_INSTALL_HEADERS([Zend/Optimizer], [ \
-    zend_call_graph.h \
-    zend_cfg.h \
-    zend_dfg.h \
-    zend_dump.h \
-    zend_func_info.h \
-    zend_inference.h \
-    zend_optimizer.h \
-    zend_ssa.h \
-    zend_worklist.h])
+PHP_INSTALL_HEADERS([Zend/Optimizer], m4_normalize([
+  zend_call_graph.h
+  zend_cfg.h
+  zend_dfg.h
+  zend_dump.h
+  zend_func_info.h
+  zend_inference.h
+  zend_optimizer.h
+  zend_ssa.h
+  zend_worklist.h
+]))
 
 PHP_ADD_SOURCES(TSRM, TSRM.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -37,13 +37,26 @@ EXT_HASH_SOURCES="hash.c hash_md.c hash_sha.c hash_ripemd.c hash_haval.c \
   hash_tiger.c hash_gost.c hash_snefru.c hash_whirlpool.c hash_adler32.c \
   hash_crc32.c hash_fnv.c hash_joaat.c $EXT_HASH_SHA3_SOURCES
   murmur/PMurHash.c murmur/PMurHash128.c hash_murmur.c hash_xxhash.c"
-EXT_HASH_HEADERS="php_hash.h php_hash_md.h php_hash_sha.h php_hash_ripemd.h \
-  php_hash_haval.h php_hash_tiger.h php_hash_gost.h php_hash_snefru.h \
-  php_hash_whirlpool.h php_hash_adler32.h php_hash_crc32.h \
-  php_hash_fnv.h php_hash_joaat.h php_hash_sha3.h php_hash_murmur.h \
-  php_hash_xxhash.h xxhash/xxhash.h"
 
 PHP_NEW_EXTENSION(hash, $EXT_HASH_SOURCES, 0,,$PHP_HASH_CFLAGS)
 PHP_ADD_BUILD_DIR([$ext_builddir/murmur])
 AS_VAR_IF([SHA3_DIR],,, [PHP_ADD_BUILD_DIR([$ext_builddir/$SHA3_DIR])])
-PHP_INSTALL_HEADERS([ext/hash], [$EXT_HASH_HEADERS])
+PHP_INSTALL_HEADERS([ext/hash], m4_normalize([
+  php_hash_adler32.h
+  php_hash_crc32.h
+  php_hash_fnv.h
+  php_hash_gost.h
+  php_hash_haval.h
+  php_hash_joaat.h
+  php_hash_md.h
+  php_hash_murmur.h
+  php_hash_ripemd.h
+  php_hash_sha.h
+  php_hash_sha3.h
+  php_hash_snefru.h
+  php_hash_tiger.h
+  php_hash_whirlpool.h
+  php_hash_xxhash.h
+  php_hash.h
+  xxhash/xxhash.h
+]))

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -6,5 +6,9 @@ PHP_NEW_EXTENSION([json], m4_normalize([
   ]),
   [no],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
-PHP_INSTALL_HEADERS([ext/json], [php_json.h php_json_parser.h php_json_scanner.h])
+PHP_INSTALL_HEADERS([ext/json], m4_normalize([
+  php_json_parser.h
+  php_json_scanner.h
+  php_json.h
+]))
 PHP_ADD_MAKEFILE_FRAGMENT

--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -30,4 +30,8 @@ PHP_NEW_EXTENSION([random], m4_normalize([
   ]),
   [no],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
-PHP_INSTALL_HEADERS([ext/random], [php_random.h php_random_csprng.h php_random_uint128.h])
+PHP_INSTALL_HEADERS([ext/random], m4_normalize([
+  php_random_csprng.h
+  php_random_uint128.h
+  php_random.h
+]))

--- a/ext/simplexml/config.m4
+++ b/ext/simplexml/config.m4
@@ -11,7 +11,10 @@ if test "$PHP_SIMPLEXML" != "no"; then
     PHP_NEW_EXTENSION([simplexml], [simplexml.c], [$ext_shared])
     PHP_ADD_EXTENSION_DEP(simplexml, libxml)
     PHP_ADD_EXTENSION_DEP(simplexml, spl)
-    PHP_INSTALL_HEADERS([ext/simplexml], [php_simplexml.h php_simplexml_exports.h])
+    PHP_INSTALL_HEADERS([ext/simplexml], m4_normalize([
+      php_simplexml_exports.h
+      php_simplexml.h
+    ]))
     PHP_SUBST([SIMPLEXML_SHARED_LIBADD])
   ])
 fi

--- a/ext/spl/config.m4
+++ b/ext/spl/config.m4
@@ -12,7 +12,18 @@ PHP_NEW_EXTENSION([spl], m4_normalize([
   ]),
   [no],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
-PHP_INSTALL_HEADERS([ext/spl], [php_spl.h spl_array.h spl_directory.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h])
+PHP_INSTALL_HEADERS([ext/spl], m4_normalize([
+  php_spl.h
+  spl_array.h
+  spl_directory.h
+  spl_dllist.h
+  spl_exceptions.h
+  spl_fixedarray.h
+  spl_functions.h
+  spl_heap.h
+  spl_iterators.h
+  spl_observer.h
+]))
 PHP_ADD_EXTENSION_DEP(spl, pcre, true)
 PHP_ADD_EXTENSION_DEP(spl, standard, true)
 PHP_ADD_EXTENSION_DEP(spl, json)


### PR DESCRIPTION
Refactor all "long" arguments into blank-or-newline-separated list of files with m4_normalize.