### PR TITLE
 Fix missing variance check for abstract set with asymmetric type

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Updated build system scripts config.guess to 2024-07-27 and config.sub to
     2024-05-27. (Peter Kokot)
   . Fixed bug GH-15240 (Infinite recursion in trait hook). (ilutov)
+  . Fixed bug GH-15140 (Missing variance check for abstract set with asymmetric
+    type). (ilutov)
 
 - Date:
   . Constants SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, and SUNFUNCS_RET_DOUBLE

--- a/Zend/tests/property_hooks/gh15140.phpt
+++ b/Zend/tests/property_hooks/gh15140.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-15140: Asymmetric set type cannot be satisfied by plain property
+--FILE--
+<?php
+
+interface I {
+    public string $prop {
+        set(int|string $value);
+    }
+}
+class C implements I {
+    public string $prop;
+}
+
+?>
+--EXPECTF--
+Fatal error: Set type of C::$prop must be supertype of string|int (as in interface I) in %s on line %d


### PR DESCRIPTION
Closes GH-15140

The first commit is a cleanup and fix of a related issue, in preparation of the actual fix in the second commit. The check is a bit out of place. I also thought about inheriting the abstract method and removing it during inheritance when the check succeeds, but this would 1. require delaying the abstract checks after variance checks, and 2. require dealing with freeing of potentially duplicated static methods and the hooks list.

Anyway, I'll think about this again in some more detail.