### PR TITLE
Support AVX-512 builds on Windows

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -393,7 +393,7 @@ ARG_WITH("test-ini-ext-exclude", "Comma separated list of shared extensions to \
 		be excluded from the test.ini", "no");
 
 ARG_ENABLE("native-intrinsics", "Comma separated list of intrinsic optimizations to enable. \
-	Available instruction set names are sse, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2. \
+	Available instruction set names are sse, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512. \
 	SSE and SSE2 are enabled by default. The best instruction set specified will \
 	automatically enable all the older instruction sets. Note, that the produced binary \
 	might not work properly, if the chosen instruction sets are not available on the target \

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3331,8 +3331,6 @@ function toolset_setup_common_cflags()
 function toolset_setup_intrinsic_cflags()
 {
 	var default_enabled = "sse2";
-	/* XXX AVX and above needs to be reflected in /arch, for now SSE4.2 is
-		the best possible optimization.*/
 	var avail = WScript.CreateObject("Scripting.Dictionary");
 	avail.Add("sse", "__SSE__");
 	avail.Add("sse2", "__SSE2__");
@@ -3341,7 +3339,7 @@ function toolset_setup_intrinsic_cflags()
 	avail.Add("sse4.1", "__SSE4_1__");
 	avail.Add("sse4.2", "__SSE4_2__");
 	/* From oldest to newest. */
-	var scale = new Array("sse", "sse2", "sse3", "ssse3", "sse4.1", "sse4.2", "avx", "avx2");
+	var scale = new Array("sse", "sse2", "sse3", "ssse3", "sse4.1", "sse4.2", "avx", "avx2", "avx512");
 
 	if (VS_TOOLSET) {
 		if ("disabled" == PHP_NATIVE_INTRINSICS) {
@@ -3367,9 +3365,9 @@ function toolset_setup_intrinsic_cflags()
 				AC_DEFINE(avail.Item(list[i]), 1);
 			}
 
-			/* All means all. __AVX__ and __AVX2__ are defined by compiler. */
-			ADD_FLAG("CFLAGS","/arch:AVX2");
-			configure_subst.Add("PHP_SIMD_SCALE", "AVX2");
+			/* All means all. __AVX__, __AVX2__, and __AVX512*__ are defined by compiler. */
+			ADD_FLAG("CFLAGS","/arch:AVX512");
+			configure_subst.Add("PHP_SIMD_SCALE", "AVX512");
 		} else {
 			var list = PHP_NATIVE_INTRINSICS.split(",");
 			var j = 0;
@@ -3378,7 +3376,7 @@ function toolset_setup_intrinsic_cflags()
 					var it = list[i].toLowerCase();
 					if (scale[k] == it) {
 						j = k > j ? k : j;
-					} else if (!avail.Exists(it) && "avx2" != it && "avx" != it) {
+					} else if (!avail.Exists(it) && "avx512" != it && "avx2" != it && "avx" != it) {
 						WARNING("Unknown intrinsic name '" + it + "' ignored");
 					}
 				}
@@ -3395,7 +3393,10 @@ function toolset_setup_intrinsic_cflags()
 			/* There is no explicit way to enable intrinsics between SSE3 and SSE4.2.
 				The declared macros therefore won't affect the code generation,
 				but will enable the guarded code parts. */
-			if ("avx2" == scale[j]) {
+			if ("avx512" == scale[j]) {
+				ADD_FLAG("CFLAGS","/arch:AVX512");
+				j -= 3;
+			} else if ("avx2" == scale[j]) {
 				ADD_FLAG("CFLAGS","/arch:AVX2");
 				j -= 2;
 			} else if ("avx" == scale[j]) {


### PR DESCRIPTION
"Since limited support for `/arch:AVX512` was added in Visual Studio 2017, and expanded in Visual Studio 2019"[1], we can safely offer this option, since PHP 8.4 is supposed to build with Visual Studio 2022, and it is unlikely that someone tries to build PHP 8.4 with Visual Studio, requesting AVX-512 support.

[1] <https://learn.microsoft.com/en-us/cpp/build/reference/arch-x64?view=msvc-170>

---

Note that this merely enables people to build for AVX-512; it doesn't change the default (that is still used for official Windows builds), nor does it update CI (which uses AVX2; I don't think AVX-512 is supported on hosted GH runners).

Also note that a full PHP build for AVX-512 succeeded, but apparently not even `php -i` can be run. Coreinfo reports here:
````
AVX-512-F       -       Supports AVX-512 Foundation instructions
AVX-512-DQ      -       Supports AVX-512 double and quadword instructions
AVX-512-IFAMA   -       Supports AVX-512 integer Fused multiply-add instructions
AVX-512-PF      -       Supports AVX-512 prefetch instructions
AVX-512-ER      -       Supports AVX-512 exponential and reciprocal instructions
AVX-512-CD      -       Supports AVX-512 conflict detection instructions
AVX-512-BW      -       Supports AVX-512 byte and word instructions
AVX-512-VL      -       Supports AVX-512 vector length instructions
````
I'll look into this.