### PR TITLE
Autotools: Move HAVE_DTRACE to configure.ac

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2387,7 +2387,6 @@ EOF
     ;;
   esac
 
-AC_DEFINE([HAVE_DTRACE], [1], [Define to 1 if DTrace support is enabled.])
 PHP_SUBST([PHP_DTRACE_OBJS])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1013,15 +1013,17 @@ PHP_ARG_ENABLE([dtrace],
   [no],
   [no])
 
-AS_VAR_IF([PHP_DTRACE], [yes],
-  [PHP_INIT_DTRACE([Zend/zend_dtrace.d], [Zend/zend_dtrace_gen.h], [
+AS_VAR_IF([PHP_DTRACE], [yes], [
+  PHP_INIT_DTRACE([Zend/zend_dtrace.d], [Zend/zend_dtrace_gen.h], [
     main/main.c
     Zend/zend_API.c
     Zend/zend_dtrace.c
     Zend/zend_exceptions.c
     Zend/zend_execute.c
     Zend/zend.c
-  ])])
+  ])
+  AC_DEFINE([HAVE_DTRACE], [1], [Define to 1 if DTrace support is enabled.])
+])
 
 AC_MSG_CHECKING([how big to make fd sets])
 PHP_ARG_ENABLE([fd-setsize],,


### PR DESCRIPTION
Following 32210ce967e169845c8e226286d5f736421953f0 and 9ea290b72b8ba5413c3d9737cd05dfc71ed938d2, this moves the HAVE_DTRACE preprocessor macro definition back to configure.ac so that PHP_INIT_DTRACE Autoconf macro can be used in extensions without redefinition interference.