### PR TITLE
Autotools: Fix xml extension dependency

### DIFF
--- a/ext/xml/config.m4
+++ b/ext/xml/config.m4
@@ -5,35 +5,27 @@ PHP_ARG_ENABLE([xml],
   [yes])
 
 PHP_ARG_WITH([expat],
-  [whether to build with expat support],
+  [whether to build with Expat support],
   [AS_HELP_STRING([--with-expat],
-    [XML: use expat instead of libxml2])],
+    [XML: use Expat library instead of libxml2 in the xml extension])],
   [no],
   [no])
 
 if test "$PHP_XML" != "no"; then
-
-  dnl
   dnl Default to libxml2 if --with-expat is not specified.
-  dnl
-  if test "$PHP_EXPAT" = "no"; then
-
-    if test "$PHP_LIBXML" = "no"; then
-      AC_MSG_ERROR([XML extension requires LIBXML extension, add --with-libxml])
-    fi
-
-    PHP_SETUP_LIBXML([XML_SHARED_LIBADD], [
-      xml_extra_sources="compat.c"
-      PHP_ADD_EXTENSION_DEP(xml, libxml)
-    ])
-  else
-    PHP_SETUP_EXPAT([XML_SHARED_LIBADD])
-  fi
+  AS_VAR_IF([PHP_EXPAT], [no],
+    [PHP_SETUP_LIBXML([XML_SHARED_LIBADD], [xml_extra_sources="compat.c"])],
+    [PHP_SETUP_EXPAT([XML_SHARED_LIBADD])])
 
   PHP_NEW_EXTENSION([xml],
     [xml.c $xml_extra_sources],
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
+  AS_VAR_IF([PHP_EXPAT], [no], [
+    PHP_ADD_EXTENSION_DEP(xml, libxml)
+  ])
+
   PHP_SUBST([XML_SHARED_LIBADD])
   PHP_INSTALL_HEADERS([ext/xml], [expat_compat.h php_xml.h])
   AC_DEFINE([HAVE_XML], [1], [Define to 1 if xml extension is available.])


### PR DESCRIPTION
The PHP_ADD_EXTENSION_DEP Autoconf macro needs to be called after PHP_NEW_EXTENSION to be fully effective. This simplifies the code and checks. Also, due to the current order_by_dep.awk script implementation it needs to be on its own line with arguments unquoted so that awk can parse the config.m4 file. Until order_by_dep.awk script is fixed.