### PR TITLE
Autotools: Add pkg-config for GMP library

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -183,6 +183,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      used instead of the pkg-config search.
    - Added pkg-config support to find unixODBC and iODBC for the pdo_odbc
      extension.
+   - Added pkg-config support to find GNU MP library. As a fallback default
+     system paths are searched. When a directory argument is provided
+     (--with-gmp=DIR), it will be used instead of the pkg-config.
    - Removed BC enable_pear variable check due to --enable-pear configure option
      once used (use with_pear variable name).
    - Cache variables synced to php_cv_* naming scheme. If you use them for

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -1,9 +1,9 @@
 PHP_ARG_WITH([gmp],
   [for GNU MP support],
   [AS_HELP_STRING([[--with-gmp[=DIR]]],
-    [Include GNU MP support. Optional DIR is the library installation directory.
-    Also, the GMP_CFLAGS and GMP_LIBS environment variables can be used instead
-    of the DIR argument to customize the GMP paths.])])
+    [Include GNU MP support. Use PKG_CONFIG_PATH (or GMP_CFLAGS and GMP_LIBS)
+    environment variables, or alternatively the optional DIR argument to
+    customize where to look for the GNU MP library.])])
 
 if test "$PHP_GMP" != "no"; then
   gmp_found=no
@@ -20,14 +20,13 @@ if test "$PHP_GMP" != "no"; then
   LIBS_SAVED=$LIBS
   CFLAGS="$CFLAGS $GMP_CFLAGS"
   LIBS="$LIBS $GMP_LIBS"
-  gmp_check=
-  AC_CHECK_HEADER([gmp.h], [AC_CHECK_FUNC([__gmpz_rootrem], [gmp_check=ok])])
+  gmp_check=no
+  AC_CHECK_HEADER([gmp.h], [AC_CHECK_FUNC([__gmpz_rootrem], [gmp_check=yes])])
   CFLAGS=$CFLAGS_SAVED
   LIBS=$LIBS_SAVED
 
-  AS_VAR_IF([gmp_check], [ok],, [AC_MSG_ERROR([
-    GNU MP library check failed. GNU MP Library version 4.2 or greater required.
-    Please, check config.log for details.
+  AS_VAR_IF([gmp_check], [no], [AC_MSG_FAILURE([
+    The required GNU MP library version 4.2 or greater not found.
   ])])
 
   PHP_EVAL_LIBLINE([$GMP_LIBS], [GMP_SHARED_LIBADD])

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -1,30 +1,37 @@
 PHP_ARG_WITH([gmp],
   [for GNU MP support],
   [AS_HELP_STRING([[--with-gmp[=DIR]]],
-    [Include GNU MP support])])
+    [Include GNU MP support. Optional DIR is the library installation directory.
+    Also, the GMP_CFLAGS and GMP_LIBS environment variables can be used instead
+    of the DIR argument to customize the GMP paths.])])
 
 if test "$PHP_GMP" != "no"; then
-  if test "$PHP_GMP" = "yes"; then
-    PHP_CHECK_LIBRARY([gmp], [__gmpz_rootrem],
-      [],
-      [AC_MSG_FAILURE([GNU MP Library version 4.2 or greater required.])])
+  gmp_found=no
+  AS_VAR_IF([PHP_GMP], [yes],
+    [PKG_CHECK_MODULES([GMP], [gmp >= 4.2], [gmp_found=yes], [:])])
 
-    PHP_ADD_LIBRARY([gmp],, [GMP_SHARED_LIBADD])
-  else
-    if test ! -f $PHP_GMP/include/gmp.h; then
-      AC_MSG_ERROR([Unable to locate gmp.h])
-    fi
+  AS_VAR_IF([gmp_found], [no], [AS_VAR_IF([PHP_GMP], [yes], [GMP_LIBS=-lgmp], [
+    GMP_LIBS="-L$PHP_GMP/$PHP_LIBDIR -lgmp"
+    GMP_CFLAGS="-I$PHP_GMP/include"
+  ])])
 
-    PHP_CHECK_LIBRARY([gmp], [__gmpz_rootrem],
-      [],
-      [AC_MSG_FAILURE([GNU MP Library version 4.2 or greater required.])],
-      [-L$PHP_GMP/$PHP_LIBDIR])
+  dnl Sanity check.
+  CFLAGS_SAVED=$CFLAGS
+  LIBS_SAVED=$LIBS
+  CFLAGS="$CFLAGS $GMP_CFLAGS"
+  LIBS="$LIBS $GMP_LIBS"
+  gmp_check=
+  AC_CHECK_HEADER([gmp.h], [AC_CHECK_FUNC([__gmpz_rootrem], [gmp_check=ok])])
+  CFLAGS=$CFLAGS_SAVED
+  LIBS=$LIBS_SAVED
 
-    PHP_ADD_LIBRARY_WITH_PATH([gmp],
-      [$PHP_GMP/$PHP_LIBDIR],
-      [GMP_SHARED_LIBADD])
-    PHP_ADD_INCLUDE([$PHP_GMP/include])
-  fi
+  AS_VAR_IF([gmp_check], [ok],, [AC_MSG_ERROR([
+    GNU MP library check failed. GNU MP Library version 4.2 or greater required.
+    Please, check config.log for details.
+  ])])
+
+  PHP_EVAL_LIBLINE([$GMP_LIBS], [GMP_SHARED_LIBADD])
+  PHP_EVAL_INCLINE([$GMP_CFLAGS])
 
   PHP_INSTALL_HEADERS([ext/gmp], [php_gmp_int.h])
 


### PR DESCRIPTION
This can also wait for the next PHP version or perhaps for PHP 8.4 beta otherwise it seems to be working fine. 

GMP has pkg-config integration since 2019-08-22 (version ~6.2.0).

This optionally finds the GMP library using pkg-config or falls back to find library on the system or with the provided configure option argument (--with-gmp=DIR).

When using DIR argument, the pkg-config check is silently skipped.

When not using DIR argument, the GMP_CFLAGS and GMP_LIBS can be also used to find the GMP library:

     ./configure --with-gmp \
         GMP_CFLAGS=-I/path/to/gmp/include \
         GMP_LIBS="-L/path/to/gmp -lgmp" \