### PR TITLE
Display two digits after decimal point for test result percentages

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -3056,30 +3056,30 @@ Number of tests : ' . sprintf('%5d', $n_total) . '          ' . sprintf('%8d', $
 
     if ($sum_results['BORKED']) {
         $summary .= '
-Tests borked    : ' . sprintf('%5d (%5.1f%%)', $sum_results['BORKED'], $percent_results['BORKED']) . ' --------';
+Tests borked    : ' . sprintf('%5d (%6.2f%%)', $sum_results['BORKED'], $percent_results['BORKED']) . ' ---------';
     }
 
     $summary .= '
-Tests skipped   : ' . sprintf('%5d (%5.1f%%)', $sum_results['SKIPPED'], $percent_results['SKIPPED']) . ' --------
-Tests warned    : ' . sprintf('%5d (%5.1f%%)', $sum_results['WARNED'], $percent_results['WARNED']) . ' ' . sprintf('(%5.1f%%)', $x_warned) . '
-Tests failed    : ' . sprintf('%5d (%5.1f%%)', $sum_results['FAILED'], $percent_results['FAILED']) . ' ' . sprintf('(%5.1f%%)', $x_failed);
+Tests skipped   : ' . sprintf('%5d (%6.2f%%)', $sum_results['SKIPPED'], $percent_results['SKIPPED']) . ' ---------
+Tests warned    : ' . sprintf('%5d (%6.2f%%)', $sum_results['WARNED'], $percent_results['WARNED']) . ' ' . sprintf('(%6.2f%%)', $x_warned) . '
+Tests failed    : ' . sprintf('%5d (%6.2f%%)', $sum_results['FAILED'], $percent_results['FAILED']) . ' ' . sprintf('(%6.2f%%)', $x_failed);
 
     if ($sum_results['XFAILED']) {
         $summary .= '
-Expected fail   : ' . sprintf('%5d (%5.1f%%)', $sum_results['XFAILED'], $percent_results['XFAILED']) . ' ' . sprintf('(%5.1f%%)', $x_xfailed);
+Expected fail   : ' . sprintf('%5d (%6.2f%%)', $sum_results['XFAILED'], $percent_results['XFAILED']) . ' ' . sprintf('(%6.2f%%)', $x_xfailed);
     }
 
     if ($valgrind) {
         $summary .= '
-Tests leaked    : ' . sprintf('%5d (%5.1f%%)', $sum_results['LEAKED'], $percent_results['LEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_leaked);
+Tests leaked    : ' . sprintf('%5d (%6.2f%%)', $sum_results['LEAKED'], $percent_results['LEAKED']) . ' ' . sprintf('(%6.2f%%)', $x_leaked);
         if ($sum_results['XLEAKED']) {
             $summary .= '
-Expected leak   : ' . sprintf('%5d (%5.1f%%)', $sum_results['XLEAKED'], $percent_results['XLEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_xleaked);
+Expected leak   : ' . sprintf('%5d (%6.2f%%)', $sum_results['XLEAKED'], $percent_results['XLEAKED']) . ' ' . sprintf('(%6.2f%%)', $x_xleaked);
         }
     }
 
     $summary .= '
-Tests passed    : ' . sprintf('%5d (%5.1f%%)', $sum_results['PASSED'], $percent_results['PASSED']) . ' ' . sprintf('(%5.1f%%)', $x_passed) . '
+Tests passed    : ' . sprintf('%5d (%6.2f%%)', $sum_results['PASSED'], $percent_results['PASSED']) . ' ' . sprintf('(%6.2f%%)', $x_passed) . '
 ---------------------------------------------------------------------
 Time taken      : ' . sprintf('%5.3f seconds', ($end_time - $start_time) / 1e9) . '
 =====================================================================


### PR DESCRIPTION
At [CakeFest 2024](https://cakefest.org/) last week,  Florian Engelbart presented "[Growing the PHP core - One Test at a Time](https://speakerdeck.com/realflowcontrol/growing-the-php-core-one-test-at-a-time-at-laraconeu-2021)", which is also available as [blog post](https://dev.to/realflowcontrol/growing-the-php-core-one-test-at-a-time-4g4k).

During the [demo](https://www.youtube.com/live/GWDtf-YeCDw?si=8vqhHBxkKp3d52lW&t=21224), I noticed that the percentages of the test results were shown with one digit after the decima point, only.

![grafik](https://github.com/user-attachments/assets/e89aec2f-d1cd-4b65-9829-716aa3e25127)

Since there are almost 20 thousand tests by now, any small test result number gets represented quite unprecise percentage.
Especially small changes to these numbers, e.g. one failed test fixed, would likely not be noticable in the percentages.

Thus, I thought adding one precision point more would be sensible and helpful.

Before (example):

````
Number of tests : 19409             13853
Tests skipped   :  5556 ( 28.6%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Expected fail   :     8 (  0.0%) (  0.1%)
Tests passed    : 13845 ( 71.3%) ( 99.9%)
---------------------------------------------------------------------
Time taken      : 246.705 seconds
=====================================================================
````

After (example):

````
Number of tests : 19409             13853
Tests skipped   :  5556 ( 28.63%) ---------
Tests warned    :     0 (  0.00%) (  0.00%)
Tests failed    :     0 (  0.00%) (  0.00%)
Expected fail   :     8 (  0.04%) (  0.06%)
Tests passed    : 13845 ( 71.33%) ( 99.94%)
---------------------------------------------------------------------
Time taken      : 206.058 seconds
=====================================================================
````