### PR TITLE
Fix GH-15181: Disabled output handler is flushed again

### DIFF
--- a/main/output.c
+++ b/main/output.c
@@ -925,6 +925,10 @@ static inline php_output_handler_status_t php_output_handler_op(php_output_handl
 	);
 #endif
 
+	if (handler->flags & PHP_OUTPUT_HANDLER_DISABLED) {
+		return PHP_OUTPUT_HANDLER_FAILURE;
+	}
+
 	if (php_output_lock_error(context->op)) {
 		/* fatal error */
 		return PHP_OUTPUT_HANDLER_FAILURE;

--- a/tests/output/gh15181.phpt
+++ b/tests/output/gh15181.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Fix GH-15181 (Disabled output handler is flushed again)
+--FILE--
+<?php
+ob_start(function () {
+    throw new Exception('ob_start');
+});
+try {
+    ob_flush();
+} catch (Throwable) {}
+ob_flush();
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
When an `PHP_OUTPUT_HANDLER_FAILURE` occurs, the output handler becomes disabled (i.e. the `PHP_OUTPUT_HANDLER_DISABLED` flag is set).  However, there is no guard for disabled handlers in `php_output_handler_op()` what may cause serious issues (as reported, UB due to passing `NULL` as the 2nd argument of `memcpy`, because the handler's buffer has already been `NULL`ed).  Therefore, we add a respective guard for disabled handlers, and return `PHP_OUTPUT_HANDLER_FAILURE` right away.

---

Note that older PHP versions are affected by this (confirmed with PHP-8.3, but might be a long-standing issue), and although the behavior is obviously a bug, I'm still reluctant to deploy the fix to lower branches, given the complexities of PHP's output handling, and certain user expectations.  For the given test scripts, unpatched PHP-8.3/master would output the fatal error and the respective stack backtrace.
