### PR TITLE
Autotools: Remove obsolete config.status invocations

### DIFF
--- a/scripts/Makefile.frag
+++ b/scripts/Makefile.frag
@@ -33,7 +33,7 @@ install-build:
 	$(INSTALL) $(BUILD_FILES_EXEC) $(INSTALL_ROOT)$(phpbuilddir) && \
 	$(INSTALL_DATA) $(BUILD_FILES) $(INSTALL_ROOT)$(phpbuilddir))
 
-install-programs: $(builddir)/phpize $(builddir)/php-config
+install-programs:
 	@echo "Installing helper programs:       $(INSTALL_ROOT)$(bindir)/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
 	@for prog in $(bin_SCRIPTS); do \
@@ -46,9 +46,3 @@ install-programs: $(builddir)/phpize $(builddir)/php-config
 		echo "  page: $(program_prefix)$${page}$(program_suffix).1"; \
 		$(INSTALL_DATA) $(builddir)/man1/$${page}.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)$${page}$(program_suffix).1; \
 	done
-
-$(builddir)/phpize: $(srcdir)/phpize.in $(top_builddir)/config.status
-	(CONFIG_FILES=$@ CONFIG_HEADERS= $(top_builddir)/config.status)
-
-$(builddir)/php-config: $(srcdir)/php-config.in $(top_builddir)/config.status
-	(CONFIG_FILES=$@ CONFIG_HEADERS= $(top_builddir)/config.status)


### PR DESCRIPTION
This was once added to fix the bug https://bugs.php.net/13561 because the phpize and php-config scripts were located in the pear subdirectory and were installed only when --with-pear option was used. Then in the 20c43285f78f745f88faf70062b04ed26a8c3c11 scripts were moved to scripts subdirectory with this mechanism used in the generated Makefile when running 'make install' command.

Before the AC_CONFIG_FILES was introduced to Autoconf AC_OUTPUT once accepted arguments. This signature is obsolete in current Autoconf versions.

The old obsolete config.status invocation:
  CONFIG_FILES=... ./config.status

And the new invocation is (if used with AC_CONFIG_FILES in the code):
  ./config.status --file=...

Instead, this simply removes the redundant phpize and php-config generation with the old obsolete config.status invocations as these files are always generated in the php-src build context.