### PR TITLE
Sync CPP macros in ext/iconv

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1825,6 +1825,8 @@ dnl
 AC_DEFUN([PHP_SETUP_ICONV], [
   found_iconv=no
   unset ICONV_DIR
+  AH_TEMPLATE([HAVE_LIBICONV],
+    [Define to 1 if you have the 'libiconv' function.])
 
   dnl Check libc first if no path is provided in --with-iconv.
   if test "$PHP_ICONV" = "yes"; then
@@ -1835,7 +1837,7 @@ AC_DEFUN([PHP_SETUP_ICONV], [
       found_iconv=yes
     ],[
       AC_CHECK_FUNC([libiconv], [
-        AC_DEFINE(HAVE_LIBICONV, 1, [ ])
+        AC_DEFINE([HAVE_LIBICONV], [1])
         found_iconv=yes
       ])
     ])
@@ -1869,9 +1871,9 @@ AC_DEFUN([PHP_SETUP_ICONV], [
     then
       PHP_CHECK_LIBRARY([$iconv_lib_name], [libiconv], [
         found_iconv=yes
-        AC_DEFINE([HAVE_LIBICONV], [1], [ ])
+        AC_DEFINE([HAVE_LIBICONV], [1])
         AC_DEFINE([ICONV_ALIASED_LIBICONV], [1],
-          [iconv() is aliased to libiconv() in -liconv])
+          [Define to 1 if 'iconv()' is aliased to 'libiconv()'.])
         ],
         [PHP_CHECK_LIBRARY([$iconv_lib_name], [iconv],
           [found_iconv=yes],

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -51,25 +51,24 @@ if test "$PHP_ICONV" != "no"; then
       ])
     fi
 
-    case "$iconv_impl_name" in
-      gnu_libiconv [)]
-        AC_DEFINE([PHP_ICONV_IMPL],["libiconv"],[Which iconv implementation to use])
-        AC_DEFINE([HAVE_LIBICONV],1,[Whether libiconv is used])
-        ;;
+  AH_TEMPLATE([PHP_ICONV_IMPL], [The iconv implementation.])
 
-      bsd [)]
-        AC_DEFINE([PHP_ICONV_IMPL],["BSD iconv"],[Which iconv implementation to use])
-        ;;
-
-      glibc [)]
-        AC_DEFINE([HAVE_GLIBC_ICONV],1,[glibc's iconv implementation])
-        AC_DEFINE([PHP_ICONV_IMPL],["glibc"],[Which iconv implementation to use])
-        ;;
-      ibm [)]
-        AC_DEFINE([HAVE_IBM_ICONV],1,[IBM iconv implementation])
-        AC_DEFINE([PHP_ICONV_IMPL],["IBM iconv"],[Which iconv implementation to use])
-        ;;
-    esac
+  AS_CASE([$iconv_impl_name],
+    [gnu_libiconv], [
+      AC_DEFINE([PHP_ICONV_IMPL], ["libiconv"])
+      AC_DEFINE([HAVE_LIBICONV], [1])
+    ],
+    [bsd], [AC_DEFINE([PHP_ICONV_IMPL], ["BSD iconv"])],
+    [glibc], [
+      AC_DEFINE([HAVE_GLIBC_ICONV], [1],
+        [Define to 1 if iconv implementation is glibc.])
+      AC_DEFINE([PHP_ICONV_IMPL], ["glibc"])
+    ],
+    [ibm], [
+      AC_DEFINE([HAVE_IBM_ICONV], [1],
+        [Define to 1 if iconv implementation is IBM.])
+      AC_DEFINE([PHP_ICONV_IMPL], ["IBM iconv"])
+    ])
 
     AC_CACHE_CHECK([if iconv supports errno], [php_cv_iconv_errno],
     [AC_RUN_IFELSE([AC_LANG_SOURCE([
@@ -122,7 +121,8 @@ int main(void) {
       [php_cv_iconv_ignore=no])])
 
     AS_VAR_IF([php_cv_iconv_ignore], [no],
-      [AC_DEFINE([ICONV_BROKEN_IGNORE], [1], [Whether iconv has broken IGNORE.])])
+      [AC_DEFINE([ICONV_BROKEN_IGNORE], [1],
+        [Define to 1 if iconv has broken IGNORE.])])
 
     LDFLAGS="$save_LDFLAGS"
     CFLAGS="$save_CFLAGS"

--- a/ext/iconv/config.w32
+++ b/ext/iconv/config.w32
@@ -10,9 +10,9 @@ if (PHP_ICONV != "no") {
 		EXTENSION("iconv", "iconv.c", PHP_ICONV_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
 		AC_DEFINE("HAVE_ICONV", 1, "Define to 1 if PHP extension 'iconv' is available.");
-		AC_DEFINE("HAVE_LIBICONV", 1, "Define if libiconv is available");
-		AC_DEFINE("ICONV_ALIASED_LIBICONV", 1, "The iconv function is called iconv() in libiconv");
-		AC_DEFINE("PHP_ICONV_IMPL", "\"libiconv\"", "Which iconv implementation to use");
+		AC_DEFINE("HAVE_LIBICONV", 1, "Define to 1 if you have the 'libiconv' function.");
+		AC_DEFINE("ICONV_ALIASED_LIBICONV", 1, "Define to 1 if 'iconv()' is aliased to 'libiconv()'.");
+		AC_DEFINE("PHP_ICONV_IMPL", "\"libiconv\"", "The iconv implementation.");
 		ADD_FLAG("CFLAGS_ICONV", "/D PHP_ICONV_EXPORTS ");
 		if (!PHP_ICONV_SHARED) {
 			ADD_DEF_FILE("ext\\iconv\\php_iconv.def");


### PR DESCRIPTION
This syncs and adds help texts for CPP macros defined when iconv extension is configured.