### PR TITLE
use libedit instead of readline for CI

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -44,7 +44,7 @@ runs:
           libxml2-dev \
           libxslt1-dev \
           libpq-dev \
-          libreadline-dev \
+          libedit-dev \
           libldap2-dev \
           libsodium-dev \
           libargon2-0-dev \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -41,7 +41,7 @@ runs:
           --enable-sysvshm \
           --enable-shmop \
           --enable-pcntl \
-          --with-readline \
+          --without-readline --with-libedit \
           --enable-mbstring \
           --with-curl \
           --with-gettext \


### PR DESCRIPTION
Related to recent failure (8.4.0alpha3) because of libedit/readline incompatible

For memory, readline license (GPL) is not compatible with PHP License, so should not be used
