### PR TITLE
Autotools: Fix ffi checks

### DIFF
--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -13,16 +13,14 @@ if test "$PHP_FFI" != "no"; then
 
   AC_CHECK_TYPES([long double])
 
-  AC_DEFUN([PHP_FFI_CHECK_DECL], [
-    CFLAGS_SAVE=$CFLAGS
-    CFLAGS="$CFLAGS $FFI_CFLAGS"
-    AC_CHECK_DECL([$1],
+  AC_DEFUN([PHP_FFI_CHECK_DECL],
+    [AC_CHECK_DECL([$1],
       [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
         [Define to 1 if libffi supports the '$1' calling convention.])],,
-      [#include <ffi.h>])
-    CFLAGS=$CFLAGS_SAVE
-  ])
+      [#include <ffi.h>])])
 
+  CFLAGS_SAVE=$CFLAGS
+  CFLAGS="$CFLAGS $FFI_CFLAGS"
   PHP_FFI_CHECK_DECL([FFI_FASTCALL])
   PHP_FFI_CHECK_DECL([FFI_THISCALL])
   PHP_FFI_CHECK_DECL([FFI_STDCALL])
@@ -30,6 +28,7 @@ if test "$PHP_FFI" != "no"; then
   PHP_FFI_CHECK_DECL([FFI_REGISTER])
   PHP_FFI_CHECK_DECL([FFI_MS_CDECL])
   PHP_FFI_CHECK_DECL([FFI_SYSV])
+  CFLAGS=$CFLAGS_SAVE
 
   PHP_NEW_EXTENSION([ffi],
     [ffi.c ffi_parser.c],

--- a/ext/ffi/config.m4
+++ b/ext/ffi/config.m4
@@ -13,11 +13,15 @@ if test "$PHP_FFI" != "no"; then
 
   AC_CHECK_TYPES([long double])
 
-  AC_DEFUN([PHP_FFI_CHECK_DECL],
-    [AC_CHECK_DECL([$1],
+  AC_DEFUN([PHP_FFI_CHECK_DECL], [
+    CFLAGS_SAVE=$CFLAGS
+    CFLAGS="$CFLAGS $FFI_CFLAGS"
+    AC_CHECK_DECL([$1],
       [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
-        [Whether libffi supports the '$1' calling convention.])],,
-      [#include <ffi.h>])])
+        [Define to 1 if libffi supports the '$1' calling convention.])],,
+      [#include <ffi.h>])
+    CFLAGS=$CFLAGS_SAVE
+  ])
 
   PHP_FFI_CHECK_DECL([FFI_FASTCALL])
   PHP_FFI_CHECK_DECL([FFI_THISCALL])


### PR DESCRIPTION
When libffi is installed on non-default places, also the calling convention check needs adjusted compilation flags to be able to find the ffi.h header file.