### PR TITLE
ext/standard: disable one ipv2long test.

### DIFF
--- a/ext/standard/tests/network/ip2long_variation2_x64.phpt
+++ b/ext/standard/tests/network/ip2long_variation2_x64.phpt
@@ -8,6 +8,7 @@ Test ip2long() function : usage variation 2, 64 bit
      otherwise, the number is interpreted as decimal).
 */
 if(PHP_OS == 'Darwin') die("skip - inet_pton behaves differently on Darwin");
+if(PHP_OS == 'OpenBSD') die("skip - inet_pton accepts leading zeros on OpenBSD");
 if(PHP_INT_SIZE != 8) {die('skip 64 bit only');}
 ?>
 --FILE--


### PR DESCRIPTION
atypical leading zeros are accepted on this platform.