### PR TITLE
Use new MSVC preprocessor for VS 17 builds

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3313,6 +3313,10 @@ function toolset_setup_common_cflags()
 			ADD_FLAG("CFLAGS", "/d2FuncCache1");
 		}
 
+		if (VCVERS >= 1930) {
+			ADD_FLAG("CFLAGS", "/Zc:preprocessor");
+		}
+
 		ADD_FLAG("CFLAGS", "/Zc:wchar_t");
 	} else if (CLANG_TOOLSET) {
 		if (TARGET_ARCH == 'x86') {


### PR DESCRIPTION
From the documentation[1]:

| We're updating the Microsoft C++ preprocessor to improve standards | conformance, fix longstanding bugs, and change some behaviors that | are officially undefined. We've also added new diagnostics to warn | on errors in macro definitions.

Thus it appears to be sensible to switch to the new preprocessor for all VS17 builds.  Note that although the new preprocessor is available as of VS16.5 (i.e. `version >= 1925`), we don't want to potentially break older builds, and as such use the new preprocessor only for VS17 builds.  Users who wish to use the new preprocessor with VS16, can still `set CFLAGS=/Zc:preprocessor` before running `buildconf`/`phpize`.

[1] <https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170>

---

Note that I was reminded of this when re-checking https://github.com/krakjoe/cmark/issues/20, and the new preprocessor was quite helpful in directly triggering a useful [C5101](https://learn.microsoft.com/de-de/cpp/error-messages/compiler-warnings/compiler-warnings-by-compiler-version?view=msvc-170) diagnostic, instead of triggering [C2121](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2121?view=msvc-170) and [C2059](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2059?view=msvc-170).

This change might break builds of older PHP versions with VS17, but those users can counteract via `set CFLAGS=/Zc:preprocessor-`, or just fix the code for best (forward) compatibility.