### PR TITLE
Add a test for setting the innerHTML on a prefixed XML element

### DIFF
--- a/ext/dom/tests/modern/xml/Element_innerHTML_prefixed_writing.phpt
+++ b/ext/dom/tests/modern/xml/Element_innerHTML_prefixed_writing.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test setting innerHTML on a prefixed element
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$dom = Dom\XMLDocument::createFromString('<x:root xmlns:x="urn:x"/>');
+$dom->documentElement->innerHTML = '<child><x:subchild/></child>';
+echo $dom->saveXML();
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<x:root xmlns:x="urn:x"><child><x:subchild/></child></x:root>


### PR DESCRIPTION
This code path was previously uncovered in `dom_xml_parser_tag_name`