### PR TITLE
Fix GH-15179: Segmentation fault (null pointer dereference) in ext/standard/url_scanner_ex.re

### DIFF
--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -736,6 +736,7 @@ static inline int php_url_scanner_add_var_impl(const char *name, size_t name_len
 	zend_string *encoded;
 	url_adapt_state_ex_t *url_state;
 	php_output_handler_func_t handler;
+	bool should_start = false;
 
 	if (type) {
 		url_state = &BG(url_adapt_session_ex);
@@ -747,7 +748,7 @@ static inline int php_url_scanner_add_var_impl(const char *name, size_t name_len
 
 	if (!url_state->active) {
 		php_url_scanner_ex_activate(type);
-		php_output_start_internal(ZEND_STRL("URL-Rewriter"), handler, 0, PHP_OUTPUT_HANDLER_STDFLAGS);
+		should_start = true;
 		url_state->active = 1;
 	}
 
@@ -785,6 +786,10 @@ static inline int php_url_scanner_add_var_impl(const char *name, size_t name_len
 	smart_str_free(&svalue);
 	smart_str_free(&hname);
 	smart_str_free(&hvalue);
+
+	if (should_start) {
+		php_output_start_internal(ZEND_STRL("URL-Rewriter"), handler, 0, PHP_OUTPUT_HANDLER_STDFLAGS);
+	}
 
 	return SUCCESS;
 }

--- a/tests/output/gh15179.phpt
+++ b/tests/output/gh15179.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-15179 (Segmentation fault (null pointer dereference) in ext/standard/url_scanner_ex.re)
+--CREDITS--
+YuanchengJiang
+--INI--
+memory_limit=64M
+--SKIPIF--
+<?php
+if (getenv("USE_ZEND_ALLOC") === "0") die("skip requires ZendMM");
+?>
+--FILE--
+<?php
+$var = str_repeat('a', 20 * 1024 * 1024);
+
+output_add_rewrite_var($var, $var);
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted %s


### PR DESCRIPTION
Based on analysis by Ilija: https://github.com/php/php-src/issues/15179#issuecomment-2261546902

Only enable it when the object is in a fully initialized state.