### PR TITLE
Autotools: Replace AC_MSG_ERROR with AC_MSG_FAILURE

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -157,7 +157,7 @@ dnl as a fallback since AC_CHECK_FUNC cannot detect macros.
 dnl
 AC_CHECK_FUNC([sigsetjmp],,
   [AC_CHECK_DECL([sigsetjmp],,
-    [AC_MSG_ERROR([Required sigsetjmp not found. Please, check config.log])],
+    [AC_MSG_FAILURE([Required sigsetjmp not found.])],
     [#include <setjmp.h>])])
 
 ZEND_CHECK_STACK_DIRECTION
@@ -381,7 +381,7 @@ int main(void)
   [php_cv_align_mm=failed],
   [php_cv_align_mm="(size_t)8 (size_t)3 0"])])
 AS_VAR_IF([php_cv_align_mm], [failed],
-  [AC_MSG_ERROR([ZEND_MM alignment defines failed. Please, check config.log])],
+  [AC_MSG_FAILURE([ZEND_MM alignment defines failed.])],
   [zend_mm_alignment=$(echo $php_cv_align_mm | cut -d ' ' -f 1)
   zend_mm_alignment_log2=$(echo $php_cv_align_mm | cut -d ' ' -f 2)
   zend_mm_8byte_realign=$(echo $php_cv_align_mm | cut -d ' ' -f 3)

--- a/build/php.m4
+++ b/build/php.m4
@@ -1273,7 +1273,7 @@ int main(void) {
   [ac_cv_ebcdic=no],
   [ac_cv_ebcdic=no])])
 AS_VAR_IF([ac_cv_ebcdic], [yes],
-  [AC_MSG_ERROR([PHP does not support EBCDIC targets.])])
+  [AC_MSG_FAILURE([PHP does not support EBCDIC targets.])])
 ])
 
 dnl
@@ -2016,13 +2016,11 @@ AS_VAR_IF([found_pgsql], [yes], [dnl
   PHP_EVAL_INCLINE([$PGSQL_CFLAGS])
   PHP_EVAL_LIBLINE([$PGSQL_LIBS], [$1])
 dnl PostgreSQL minimum version sanity check.
-  PHP_CHECK_LIBRARY([pq], [PQencryptPasswordConn],, [AC_MSG_ERROR(m4_normalize([
-    PostgreSQL check failed: libpq 10.0 or later is required, please see
-    config.log for details.
-  ]))],
+  PHP_CHECK_LIBRARY([pq], [PQencryptPasswordConn],,
+    [AC_MSG_FAILURE([PostgreSQL check failed: libpq 10.0 or later is required.])],
   [$PGSQL_LIBS])
 $2],
-[m4_default([$3], [AC_MSG_ERROR(m4_normalize([
+[m4_default([$3], [AC_MSG_FAILURE(m4_normalize([
   Cannot find libpq-fe.h or pq library (libpq). Please specify the correct
   PostgreSQL installation path with environment variables PGSQL_CFLAGS and
   PGSQL_LIBS or provide the PostgreSQL installation directory.
@@ -2251,7 +2249,7 @@ AS_VAR_IF([php_cv_crypt_r_style], [struct_crypt_data_gnu_source],
     [Define to 1 if struct crypt_data requires _GNU_SOURCE.])])
 
 AS_VAR_IF([php_cv_crypt_r_style], [none],
-  [AC_MSG_ERROR([Unable to detect data struct used by crypt_r.])])
+  [AC_MSG_FAILURE([Unable to detect data struct used by crypt_r.])])
 ])
 
 dnl
@@ -2293,7 +2291,7 @@ dnl extensions.
 dnl
 AC_DEFUN([PHP_INIT_DTRACE],
 [AC_CHECK_HEADER([sys/sdt.h],,
-  [AC_MSG_ERROR([Cannot find sys/sdt.h which is required for DTrace support.])])
+  [AC_MSG_FAILURE([Cannot find required <sys/sdt.h> to enable DTrace support.])])
 
 dnl Set paths properly when called from extension.
   case "$4" in

--- a/configure.ac
+++ b/configure.ac
@@ -602,8 +602,8 @@ AC_CHECK_FUNCS(m4_normalize([
   vasprintf
 ]))
 
-AC_CHECK_FUNC([inet_ntop],,[AC_MSG_ERROR([Required inet_ntop not found.])])
-AC_CHECK_FUNC([inet_pton],,[AC_MSG_ERROR([Required inet_pton not found.])])
+AC_CHECK_FUNC([inet_ntop],, [AC_MSG_FAILURE([Required inet_ntop not found.])])
+AC_CHECK_FUNC([inet_pton],, [AC_MSG_FAILURE([Required inet_pton not found.])])
 
 dnl Check for strerror_r, and if its a POSIX-compatible or a GNU specific version.
 AC_FUNC_STRERROR_R
@@ -856,7 +856,7 @@ fi
 
 AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [
   AS_VAR_IF([pthreads_working], [yes], [],
-    [AC_MSG_ERROR(m4_normalize([
+    [AC_MSG_FAILURE(m4_normalize([
       Unable to verify system support for POSIX Threads, which are required for
       PHP thread safety (ZTS) build.
     ]))])
@@ -978,7 +978,7 @@ AS_VAR_IF([PHP_DMALLOC], [yes],
     [PHP_ADD_LIBRARY([dmalloc])
       AC_DEFINE([HAVE_DMALLOC], [1], [Define to 1 if you have dmalloc.])
       AS_VAR_APPEND([CPPFLAGS], [" -DDMALLOC_FUNC_CHECK"])],
-    [AC_MSG_ERROR([Problem with enabling dmalloc. Please, check config.log for details.])])])
+    [AC_MSG_FAILURE([The dmalloc check failed. Cannot enable dmalloc.])])])
 
 PHP_ARG_ENABLE([ipv6],
   [whether to enable IPv6 support],
@@ -1312,7 +1312,7 @@ else
   AC_CHECK_HEADER([ucontext.h],
     [AC_DEFINE([ZEND_FIBER_UCONTEXT], [1],
       [Define to 1 if Zend fiber uses ucontext instead of boost context.])],
-    [AC_MSG_ERROR([fibers not available on this platform])])
+    [AC_MSG_FAILURE([fibers not available on this platform])])
 fi
 
 ZEND_INIT

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -24,7 +24,7 @@ if test "$PHP_BZ2" != "no"; then
     AC_DEFINE([HAVE_BZ2], [1],
       [Define to 1 if the PHP extension 'bz2' is available.])
     ],
-    [AC_MSG_FAILURE([bz2 module requires libbz2 >= 1.0.0])],
+    [AC_MSG_FAILURE([The bz2 extension requires libbz2 >= 1.0.0])],
     [-L$BZIP_DIR/$PHP_LIBDIR])
 
   PHP_NEW_EXTENSION([bz2], [bz2.c bz2_filter.c], [$ext_shared])

--- a/ext/bz2/config.m4
+++ b/ext/bz2/config.m4
@@ -24,7 +24,7 @@ if test "$PHP_BZ2" != "no"; then
     AC_DEFINE([HAVE_BZ2], [1],
       [Define to 1 if the PHP extension 'bz2' is available.])
     ],
-    [AC_MSG_ERROR([bz2 module requires libbz2 >= 1.0.0])],
+    [AC_MSG_FAILURE([bz2 module requires libbz2 >= 1.0.0])],
     [-L$BZIP_DIR/$PHP_LIBDIR])
 
   PHP_NEW_EXTENSION([bz2], [bz2.c bz2_filter.c], [$ext_shared])

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -75,7 +75,7 @@ if test "$PHP_CURL" != "no"; then
     [curl_easy_perform],
     [AC_DEFINE([HAVE_CURL], [1],
       [Define to 1 if the PHP extension 'curl' is available.])],
-    [AC_MSG_ERROR([The libcurl check failed. Please, check config.log for details.])],
+    [AC_MSG_FAILURE([The libcurl check failed.])],
     [$CURL_LIBS])
 
   PHP_NEW_EXTENSION([curl],

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -274,10 +274,11 @@ dnl Various checks for GD features
 
     PHP_INSTALL_HEADERS([ext/gd], [php_gd.h libgd/])
 
-    PHP_TEST_BUILD(foobar, [], [
-      AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
-    ], [ $GD_SHARED_LIBADD ], [char foobar(void) { return '\0'; }])
-
+    PHP_TEST_BUILD([foobar],
+      [],
+      [AC_MSG_FAILURE([GD library build test failed.])],
+      [$GD_SHARED_LIBADD],
+      [char foobar(void) { return '\0'; }])
   else
     extra_sources="gd_compat.c"
     PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
@@ -290,7 +291,7 @@ dnl Various checks for GD features
     PHP_INSTALL_HEADERS([ext/gd], [php_gd.h])
     PHP_CHECK_LIBRARY([gd], [gdImageCreate],
       [],
-      [AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])],
+      [AC_MSG_FAILURE([GD library build test failed.])],
       [$GD_SHARED_LIBADD])
   fi
 

--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -25,7 +25,7 @@ if test "$PHP_GETTEXT" != "no"; then
       GETTEXT_LIBS=
       GETTEXT_CHECK_IN_LIB=c
       ],
-      [AC_MSG_ERROR([Unable to find required gettext library])])])
+      [AC_MSG_FAILURE([Unable to find required intl library for gettext.])])])
 
   AC_DEFINE([HAVE_LIBINTL], [1], [Define to 1 if you have the 'intl' library.])
   PHP_NEW_EXTENSION([gettext], [gettext.c], [$ext_shared])

--- a/ext/gmp/config.m4
+++ b/ext/gmp/config.m4
@@ -7,7 +7,7 @@ if test "$PHP_GMP" != "no"; then
   if test "$PHP_GMP" = "yes"; then
     PHP_CHECK_LIBRARY([gmp], [__gmpz_rootrem],
       [],
-      [AC_MSG_ERROR([GNU MP Library version 4.2 or greater required.])])
+      [AC_MSG_FAILURE([GNU MP Library version 4.2 or greater required.])])
 
     PHP_ADD_LIBRARY([gmp],, [GMP_SHARED_LIBADD])
   else
@@ -17,7 +17,7 @@ if test "$PHP_GMP" != "no"; then
 
     PHP_CHECK_LIBRARY([gmp], [__gmpz_rootrem],
       [],
-      [AC_MSG_ERROR([GNU MP Library version 4.2 or greater required.])],
+      [AC_MSG_FAILURE([GNU MP Library version 4.2 or greater required.])],
       [-L$PHP_GMP/$PHP_LIBDIR])
 
     PHP_ADD_LIBRARY_WITH_PATH([gmp],

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -6,7 +6,7 @@ PHP_ARG_WITH([iconv],
 
 if test "$PHP_ICONV" != "no"; then
   PHP_SETUP_ICONV([ICONV_SHARED_LIBADD],,
-    [AC_MSG_ERROR([The iconv not found. Please, check config.log for details.])])
+    [AC_MSG_FAILURE([The iconv not found.])])
 
     save_LDFLAGS="$LDFLAGS"
     save_CFLAGS="$CFLAGS"
@@ -93,7 +93,7 @@ int main(void) {
     [php_cv_iconv_errno=no],
     [php_cv_iconv_errno=yes])])
     AS_VAR_IF([php_cv_iconv_errno], [yes],,
-      [AC_MSG_ERROR([iconv does not support errno])])
+      [AC_MSG_FAILURE([The iconv check failed, 'errno' is missing.])])
 
     AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore],
       [AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -144,7 +144,7 @@ if test "$PHP_LDAP" != "no"; then
   dnl Sanity check
   AC_CHECK_FUNC([ldap_sasl_bind_s],,
     [AC_CHECK_FUNC([ldap_simple_bind_s],,
-      [AC_MSG_ERROR([LDAP build check failed. Please check config.log for details.])])])
+      [AC_MSG_ERROR([LDAP library build check failed.])])])
 
   dnl Restore original values
   CPPFLAGS=$_SAVE_CPPFLAGS

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -197,19 +197,18 @@ PHP_ARG_WITH([ibm-db2],,
     ODBC_TYPE=ibm-db2
     ODBC_LIBS=-ldb2
 
-    PHP_TEST_BUILD(SQLExecute, [
+    PHP_TEST_BUILD([SQLExecute], [
       AC_DEFINE(HAVE_IBMDB2,1,[ ])
       AC_MSG_RESULT([$ext_output])
     ], [
       AC_MSG_RESULT([no])
-      AC_MSG_ERROR([
-build test failed. Please check the config.log for details.
-You need to source your DB2 environment before running PHP configure:
+      AC_MSG_FAILURE([
+ODBC build test failed. You need to source your DB2 environment before running
+PHP configure:
 # . \$IBM_DB2/db2profile
 ])
-    ], [
-      $ODBC_LFLAGS $ODBC_LIBS
-    ])
+    ],
+    [$ODBC_LFLAGS $ODBC_LIBS])
   else
     AC_MSG_RESULT([no])
   fi

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -353,7 +353,7 @@ int main(void) {
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 
   if test "$php_cv_shm_ipc" != "yes" && test "$php_cv_shm_mmap_posix" != "yes" && test "$php_cv_shm_mmap_anon" != "yes"; then
-    AC_MSG_ERROR([No supported shared memory caching support was found when configuring opcache. Check config.log for any errors or missing dependencies.])
+    AC_MSG_FAILURE([No supported shared memory caching support was found when configuring opcache.])
   fi
 
   if test "$PHP_OPCACHE_JIT" = "yes"; then

--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -6,7 +6,7 @@ PHP_ARG_ENABLE([pcntl],
 if test "$PHP_PCNTL" != "no"; then
   for function in fork sigaction waitpid; do
     AC_CHECK_FUNC([$function],,
-      [AC_MSG_ERROR([ext/pcntl: required function $function() not found.])])
+      [AC_MSG_FAILURE([ext/pcntl: required function $function() not found.])])
   done
 
   AC_CHECK_FUNCS(m4_normalize([

--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -14,7 +14,7 @@ if test "$PHP_PDO_DBLIB" != "no"; then
     dnl Only perform a sanity check that this is really the case.
     PHP_CHECK_LIBRARY([sybdb], [dbsqlexec],
       [],
-      [AC_MSG_ERROR([Cannot find FreeTDS in known installation directories])])
+      [AC_MSG_FAILURE([Cannot find FreeTDS in known installation directories.])])
     PHP_ADD_LIBRARY([sybdb],, [PDO_DBLIB_SHARED_LIBADD])
   elif test "$PHP_PDO_DBLIB" != "no"; then
 

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -38,7 +38,7 @@ if test "$PHP_PDO_FIREBIRD" != "no"; then
         [FIREBIRD_LIBNAME=gds],
         [PHP_CHECK_LIBRARY([ib_util], [isc_detach_database],
           [FIREBIRD_LIBNAME=ib_util],
-          [AC_MSG_ERROR([libfbclient, libgds or libib_util not found! Check config.log for more information.])],
+          [AC_MSG_FAILURE([libfbclient, libgds or libib_util not found.])],
           [$FIREBIRD_LIBDIR_FLAG])],
         [$FIREBIRD_LIBDIR_FLAG])],
       [$FIREBIRD_LIBDIR_FLAG])

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -100,14 +100,14 @@ if test "$PHP_PDO_ODBC" != "no"; then
     PHP_CHECK_LIBRARY([$pdo_odbc_def_lib], [SQLBindCol],
       [PHP_CHECK_LIBRARY([$pdo_odbc_def_lib], [SQLAllocHandle],
         [],
-        [AC_MSG_ERROR([
+        [AC_MSG_FAILURE([
 Your ODBC library does not appear to be ODBC 3 compatible.
 You should consider using iODBC or unixODBC instead, and loading your
 libraries as a driver in that environment; it will emulate the
 functions required for PDO support.
 ])],
         [$PDO_ODBC_LIBS])],
-      [AC_MSG_ERROR([Your ODBC library does not exist or there was an error. Check config.log for more information])],
+      [AC_MSG_FAILURE([Your ODBC library does not exist or there was an error.])],
       [$PDO_ODBC_LIBS])
   fi
 

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -43,12 +43,12 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
     [PHP_ADD_LIBRARY_WITH_PATH([readline],
       [$READLINE_DIR/$PHP_LIBDIR],
       [READLINE_SHARED_LIBADD])],
-    [AC_MSG_ERROR([readline library not found])],
+    [AC_MSG_FAILURE([The readline library not found.])],
     [-L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS])
 
   PHP_CHECK_LIBRARY([readline], [rl_pending_input],
     [],
-    [AC_MSG_ERROR([invalid readline installation detected. Try --with-libedit instead.])],
+    [AC_MSG_FAILURE([Invalid readline installation detected. Try --with-libedit instead.])],
     [-L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS])
 
   PHP_CHECK_LIBRARY([readline], [rl_callback_read_char],
@@ -98,7 +98,7 @@ elif test "$PHP_LIBEDIT" != "no"; then
 
   PHP_CHECK_LIBRARY([edit], [readline],
     [],
-    [AC_MSG_ERROR([edit library required by readline not found])],
+    [AC_MSG_FAILURE([The edit library required by readline extension not found.])],
     [$READLINE_SHARED_LIBADD])
 
   PHP_CHECK_LIBRARY([edit], [rl_callback_read_char],

--- a/ext/skeleton/config.m4.in
+++ b/ext/skeleton/config.m4.in
@@ -47,7 +47,7 @@ AS_VAR_IF([PHP_%EXTNAMECAPS%], [no],, [
   dnl PHP_CHECK_LIBRARY([$LIBNAME], [$LIBSYMBOL],
   dnl   [AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1],
   dnl     [Define to 1 if %EXTNAME% has the 'FEATURE'.])],
-  dnl   [AC_MSG_ERROR([FEATURE not supported by your %EXTNAME% library.])],
+  dnl   [AC_MSG_FAILURE([FEATURE not supported by your %EXTNAME% library.])],
   dnl   [$LIBFOO_LIBS])
   dnl
 
@@ -89,7 +89,7 @@ AS_VAR_IF([PHP_%EXTNAMECAPS%], [no],, [
   dnl     AC_DEFINE([HAVE_%EXTNAMECAPS%_FEATURE], [1],
   dnl       [Define to 1 if %EXTNAME% has the 'FEATURE'.])
   dnl   ],
-  dnl   [AC_MSG_ERROR([FEATURE not supported by your %EXTNAME% library.])],
+  dnl   [AC_MSG_FAILURE([FEATURE not supported by your %EXTNAME% library.])],
   dnl   [-L$%EXTNAMECAPS%_DIR/$PHP_LIBDIR -lm])
   dnl
 

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -40,7 +40,7 @@ if test "$PHP_SNMP" != "no"; then
   PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [init_snmp],
     [AC_DEFINE([HAVE_SNMP], [1],
       [Define to 1 if the PHP extension 'snmp' is available.])],
-    [AC_MSG_ERROR([SNMP sanity check failed. Please check config.log for more information.])],
+    [AC_MSG_FAILURE([SNMP sanity check failed.])],
     [$SNMP_SHARED_LIBADD])
 
   dnl Check whether shutdown_snmp_logging() exists.

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -94,12 +94,12 @@ AS_VAR_IF([PHP_EXTERNAL_LIBCRYPT], [no], [
 AC_SEARCH_LIBS([crypt], [crypt],
   [AC_DEFINE([HAVE_CRYPT], [1],
     [Define to 1 if you have the 'crypt' function.])],
-  [AC_MSG_ERROR([Cannot use external libcrypt as crypt() is missing.])])
+  [AC_MSG_FAILURE([Cannot use external libcrypt as crypt() is missing.])])
 
 AC_SEARCH_LIBS([crypt_r], [crypt],
   [AC_DEFINE([HAVE_CRYPT_R], [1],
     [Define to 1 if you have the 'crypt_r' function.])],
-  [AC_MSG_ERROR([Cannot use external libcrypt as crypt_r() is missing.])])
+  [AC_MSG_FAILURE([Cannot use external libcrypt as crypt_r() is missing.])])
 
 PHP_CRYPT_R_STYLE
 AC_CHECK_HEADERS([crypt.h])
@@ -279,7 +279,7 @@ int main(void) {
 
 
   if test "$ac_cv_crypt_blowfish" = "no" || test "$ac_cv_crypt_des" = "no" || test "$ac_cv_crypt_ext_des" = "no" || test "$ac_cv_crypt_md5" = "no" || test "$ac_cv_crypt_sha512" = "no" || test "$ac_cv_crypt_sha256" = "no"; then
-    AC_MSG_ERROR([Cannot use external libcrypt as some algo are missing])
+    AC_MSG_FAILURE([Cannot use external libcrypt as some algo are missing.])
   fi
 
   AC_DEFINE([PHP_USE_PHP_CRYPT_R], [0])

--- a/ext/sysvmsg/config.m4
+++ b/ext/sysvmsg/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE([sysvmsg],
 
 if test "$PHP_SYSVMSG" != "no"; then
   AC_CHECK_HEADER([sys/msg.h],,
-    [AC_MSG_ERROR([Cannot enable System V IPC support, sys/msg.h is missing])])
+    [AC_MSG_FAILURE([Cannot enable System V IPC support, sys/msg.h is missing.])])
 
   AC_DEFINE([HAVE_SYSVMSG], [1],
     [Define to 1 if the PHP extension 'sysvmsg' is available.])

--- a/ext/sysvmsg/config.m4
+++ b/ext/sysvmsg/config.m4
@@ -5,7 +5,10 @@ PHP_ARG_ENABLE([sysvmsg],
 
 if test "$PHP_SYSVMSG" != "no"; then
   AC_CHECK_HEADER([sys/msg.h],,
-    [AC_MSG_FAILURE([Cannot enable System V IPC support, sys/msg.h is missing.])])
+    [AC_MSG_FAILURE(m4_normalize([
+      Cannot enable System V IPC support. Required <sys/msg.h> header file not
+      found.
+    ]))])
 
   AC_DEFINE([HAVE_SYSVMSG], [1],
     [Define to 1 if the PHP extension 'sysvmsg' is available.])

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -413,7 +413,7 @@ if test "$PHP_FPM" != "no"; then
     CFLAGS_save=$CFLAGS
     CFLAGS="$INCLUDES $CFLAGS"
     AC_CHECK_HEADER([systemd/sd-daemon.h],,
-      [AC_MSG_ERROR([Required systemd/sd-daemon.h not found.])])
+      [AC_MSG_FAILURE([Required systemd/sd-daemon.h not found.])])
     CFLAGS=$CFLAGS_save
   ])
 
@@ -454,7 +454,7 @@ if test "$PHP_FPM" != "no"; then
       [PHP_EVAL_INCLINE([$APPARMOR_CFLAGS])],
       [AC_CHECK_LIB([apparmor], [aa_change_profile],
         [APPARMOR_LIBS=-lapparmor],
-        [AC_MSG_ERROR([libapparmor required but not found.])])])
+        [AC_MSG_FAILURE([libapparmor required but not found.])])])
     PHP_EVAL_LIBLINE([$APPARMOR_LIBS], [FPM_EXTRA_LIBS], [yes])
 
     dnl Sanity check.
@@ -463,7 +463,7 @@ if test "$PHP_FPM" != "no"; then
     AC_CHECK_HEADER([sys/apparmor.h],
       [AC_DEFINE([HAVE_APPARMOR], [1],
         [Define to 1 if AppArmor confinement is available for PHP-FPM.])],
-      [AC_MSG_ERROR([Required sys/apparmor.h not found.])])
+      [AC_MSG_FAILURE([Required sys/apparmor.h not found.])])
     CFLAGS=$CFLAGS_save
   ])
 
@@ -472,7 +472,7 @@ if test "$PHP_FPM" != "no"; then
       [PHP_EVAL_INCLINE([$SELINUX_CFLAGS])],
       [AC_CHECK_LIB([selinux], [security_setenforce],
         [SELINUX_LIBS=-lselinux],
-        [AC_MSG_ERROR([Required SELinux library not found.])])])
+        [AC_MSG_FAILURE([Required SELinux library not found.])])])
     PHP_EVAL_LIBLINE([$SELINUX_LIBS], [FPM_EXTRA_LIBS], [yes])
 
     dnl Sanity check.
@@ -481,7 +481,7 @@ if test "$PHP_FPM" != "no"; then
     AC_CHECK_HEADER([selinux/selinux.h],
       [AC_DEFINE([HAVE_SELINUX], [1],
         [Define to 1 if SELinux is available in PHP-FPM.])],
-      [AC_MSG_ERROR([Required selinux/selinux.h not found.])])
+      [AC_MSG_FAILURE([Required selinux/selinux.h not found.])])
     CFLAGS=$CFLAGS_save
   ])
 

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -413,7 +413,7 @@ if test "$PHP_FPM" != "no"; then
     CFLAGS_save=$CFLAGS
     CFLAGS="$INCLUDES $CFLAGS"
     AC_CHECK_HEADER([systemd/sd-daemon.h],,
-      [AC_MSG_FAILURE([Required systemd/sd-daemon.h not found.])])
+      [AC_MSG_FAILURE([Required <systemd/sd-daemon.h> header file not found.])])
     CFLAGS=$CFLAGS_save
   ])
 
@@ -454,7 +454,7 @@ if test "$PHP_FPM" != "no"; then
       [PHP_EVAL_INCLINE([$APPARMOR_CFLAGS])],
       [AC_CHECK_LIB([apparmor], [aa_change_profile],
         [APPARMOR_LIBS=-lapparmor],
-        [AC_MSG_FAILURE([libapparmor required but not found.])])])
+        [AC_MSG_FAILURE([Required libapparmor library not found.])])])
     PHP_EVAL_LIBLINE([$APPARMOR_LIBS], [FPM_EXTRA_LIBS], [yes])
 
     dnl Sanity check.
@@ -463,7 +463,7 @@ if test "$PHP_FPM" != "no"; then
     AC_CHECK_HEADER([sys/apparmor.h],
       [AC_DEFINE([HAVE_APPARMOR], [1],
         [Define to 1 if AppArmor confinement is available for PHP-FPM.])],
-      [AC_MSG_FAILURE([Required sys/apparmor.h not found.])])
+      [AC_MSG_FAILURE([Required <sys/apparmor.h> header file not found.])])
     CFLAGS=$CFLAGS_save
   ])
 
@@ -481,7 +481,7 @@ if test "$PHP_FPM" != "no"; then
     AC_CHECK_HEADER([selinux/selinux.h],
       [AC_DEFINE([HAVE_SELINUX], [1],
         [Define to 1 if SELinux is available in PHP-FPM.])],
-      [AC_MSG_FAILURE([Required selinux/selinux.h not found.])])
+      [AC_MSG_FAILURE([Required <selinux/selinux.h> header file not found.])])
     CFLAGS=$CFLAGS_save
   ])
 


### PR DESCRIPTION
This replaces the AC_MSG_ERROR with AC_MSG_FAILURE, where appropriate.

The AC_MSG_ERROR outputs given message and exits the configure step. The AC_MSG_FAILURE does the same but also automatically outputs additional message "See 'config.log' for more details." which might help directing the user where to look further.

The AC_MSG_ERROR is used for errors where current test step isn't logged in the config.log and wouldn't make sense, and AC_MSG_FAILURE is mostly used in cases of library checks, compilation tests, headers checked with AC_CHECK_HEADER* and similar tests that are also logged in the config.log.

AC_MSG_ERROR([Sanity check failed.]) output:

```
configure: error: Sanity check failed.
```

AC_MSG_FAILURE([Sanity check failed.]) output:

```
configure: error: in '/path/to/php-src':
configure: error: Sanity check failed.
See 'config.log' for more details
```