### PR TITLE
Autotools: Improve --with-mm configure option check

### DIFF
--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -18,32 +18,36 @@ if test "$PHP_SESSION" != "no"; then
     [mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c],
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
   dnl https://bugs.php.net/53141
   PHP_ADD_EXTENSION_DEP(session, spl, true)
+
   PHP_SUBST([SESSION_SHARED_LIBADD])
   PHP_INSTALL_HEADERS([ext/session], [php_session.h mod_files.h mod_user.h])
   AC_DEFINE([HAVE_PHP_SESSION], [1],
     [Define to 1 if the PHP extension 'session' is available.])
-fi
 
-if test "$PHP_MM" != "no"; then
-  for i in $PHP_MM /usr/local /usr; do
-    test -f "$i/include/mm.h" && MM_DIR=$i && break
-  done
+  AS_VAR_IF([PHP_MM], [no],, [
+    for i in $PHP_MM /usr/local /usr; do
+      AS_IF([test -f "$i/include/mm.h"], [MM_DIR=$i; break;])
+    done
 
-  if test -z "$MM_DIR" ; then
-    AC_MSG_ERROR([cannot find mm library])
-  fi
+    AS_VAR_IF([MM_DIR],,
+      [AC_MSG_ERROR([Cannot find the 'mm' library, <mm.h> header file not found.])])
 
-  if test "$PHP_THREAD_SAFETY" = "yes"; then
-    dnl The mm library is not thread-safe, and mod_mm.c refuses to compile.
-    AC_MSG_ERROR([--with-mm cannot be combined with --enable-zts])
-  fi
+    AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [AC_MSG_ERROR(m4_text_wrap([
+      The configure option '--with-mm' cannot be combined with '--enable-zts'.
+      The mm library is not thread-safe, and mod_mm.c refuses to compile. Either
+      remove the '--with-mm', or build without thread safety (remove the
+      '--enable-zts').
+    ]))])
 
-  PHP_ADD_LIBRARY_WITH_PATH([mm],
-    [$MM_DIR/$PHP_LIBDIR],
-    [SESSION_SHARED_LIBADD])
-  PHP_ADD_INCLUDE([$MM_DIR/include])
-  PHP_INSTALL_HEADERS([ext/session], [mod_mm.h])
-  AC_DEFINE([HAVE_LIBMM], [1], [Define to 1 if the system has the 'mm' library.])
+    PHP_ADD_LIBRARY_WITH_PATH([mm],
+      [$MM_DIR/$PHP_LIBDIR],
+      [SESSION_SHARED_LIBADD])
+    PHP_ADD_INCLUDE([$MM_DIR/include])
+    PHP_INSTALL_HEADERS([ext/session], [mod_mm.h])
+    AC_DEFINE([HAVE_LIBMM], [1],
+      [Define to 1 if the system has the 'mm' library.])
+  ])
 fi

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -38,8 +38,8 @@ if test "$PHP_SESSION" != "no"; then
     AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [AC_MSG_ERROR(m4_text_wrap([
       The configure option '--with-mm' cannot be combined with '--enable-zts'.
       The mm library is not thread-safe, and mod_mm.c refuses to compile. Either
-      remove the '--with-mm', or build without thread safety (remove the
-      '--enable-zts').
+      remove the '--with-mm' option, or build without thread safety (remove the
+      '--enable-zts' option).
     ]))])
 
     PHP_ADD_LIBRARY_WITH_PATH([mm],


### PR DESCRIPTION
The mm check code block needs to done only when session is enabled to prevent redundant mm library linkage in edge case mistakes like:

    ./configure --disable-session --with-mm

CS is synced with AC_* macros. The 'm4_text_wrap' macro joins the given text with single space characters and limits it to 79 characters width.