### PR TITLE
Autotools: Refactor thread safety checks

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -163,8 +163,12 @@ ZEND_DLSYM_CHECK
 ZEND_CHECK_GLOBAL_REGISTER_VARIABLES
 ZEND_CHECK_CPUID_COUNT
 
-AC_MSG_CHECKING([whether to enable thread-safety])
+AC_MSG_CHECKING([whether to enable thread safety])
 AC_MSG_RESULT([$ZEND_ZTS])
+AS_VAR_IF([ZEND_ZTS], [yes], [
+  AC_DEFINE([ZTS], [1], [Define to 1 if thread safety (ZTS) is enabled.])
+  AS_VAR_APPEND([CFLAGS], [" -DZTS"])
+])
 
 AC_MSG_CHECKING([whether to enable Zend debugging])
 AC_MSG_RESULT([$ZEND_DEBUG])
@@ -190,11 +194,6 @@ AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], CFLAGS="-Wstrict-prototypes $CFLAGS
 AX_CHECK_COMPILE_FLAG([-fno-common], CFLAGS="-fno-common $CFLAGS", , [-Werror])
 
 AS_VAR_IF([DEBUG_CFLAGS],,, [AS_VAR_APPEND([CFLAGS], [" $DEBUG_CFLAGS"])])
-
-if test "$ZEND_ZTS" = "yes"; then
-  AC_DEFINE(ZTS,1,[ ])
-  CFLAGS="$CFLAGS -DZTS"
-fi
 
 ZEND_CHECK_ALIGNMENT
 ZEND_CHECK_SIGNALS

--- a/configure.ac
+++ b/configure.ac
@@ -295,9 +295,10 @@ if test -z "$PHP_INSTALLED_SAPIS"; then
   AC_MSG_ERROR([Nothing to build.])
 fi
 
-dnl Force ZTS.
-if test "$enable_zts" = "yes"; then
-  dnl Add pthreads linker and compiler flags.
+dnl Add POSIX threads compilation and linker flags when thread safety is enabled
+dnl with either the '--enable-zts' configure option or automatically enabled by
+dnl PHP SAPIs. For example, Apache SAPI.
+AS_VAR_IF([enable_zts], [yes], [
   if test -n "$ac_cv_pthreads_lib"; then
     LIBS="$LIBS -l$ac_cv_pthreads_lib"
   fi
@@ -306,7 +307,7 @@ if test "$enable_zts" = "yes"; then
   fi
 
   PTHREADS_FLAGS
-fi
+])
 
 dnl Starting system checks.
 dnl ----------------------------------------------------------------------------
@@ -847,12 +848,7 @@ AC_ARG_ENABLE([zts],
   [ZEND_ZTS=$enableval],
   [ZEND_ZTS=no])
 
-if test "$ZEND_ZTS" = "yes"; then
-  AC_DEFINE(ZTS, 1,[ ])
-  PHP_THREAD_SAFETY=yes
-else
-  PHP_THREAD_SAFETY=no
-fi
+AS_VAR_IF([ZEND_ZTS], [yes], [PHP_THREAD_SAFETY=yes], [PHP_THREAD_SAFETY=no])
 
 AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [
   AS_VAR_IF([pthreads_working], [yes], [],
@@ -1368,17 +1364,11 @@ if test -z "$EXTENSION_DIR"; then
   extbasedir=$ZEND_MODULE_API_NO
   if test "$oldstyleextdir" = "yes"; then
     AS_VAR_IF([PHP_DEBUG], [1], [part1=debug], [part1=no-debug])
-    if test "$enable_zts" = "yes"; then
-      part2=zts
-    else
-      part2=non-zts
-    fi
+    AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [part2=zts], [part2=non-zts])
     extbasedir=$part1-$part2-$extbasedir
     EXTENSION_DIR=$libdir/extensions/$extbasedir
   else
-    if test "$enable_zts" = "yes"; then
-      extbasedir=$extbasedir-zts
-    fi
+    AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [extbasedir=$extbasedir-zts])
     AS_VAR_IF([PHP_DEBUG], [1], [extbasedir=$extbasedir-debug])
     EXTENSION_DIR=$libdir/$extbasedir
   fi

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -91,19 +91,17 @@ php_debug_is_enabled
 CPPFLAGS=$old_CPPFLAGS
 AC_MSG_RESULT([$PHP_DEBUG])
 
-AC_MSG_CHECKING([if zts is enabled])
+AC_MSG_CHECKING([if PHP is built with thread safety (ZTS)])
 old_CPPFLAGS=$CPPFLAGS
 CPPFLAGS="-I$phpincludedir"
-AC_EGREP_CPP(php_zts_is_enabled,[
+AC_EGREP_CPP([php_zts_is_enabled], [
 #include <main/php_config.h>
 #ifdef ZTS
 php_zts_is_enabled
 #endif
-],[
-  PHP_THREAD_SAFETY=yes
-],[
-  PHP_THREAD_SAFETY=no
-])
+],
+  [PHP_THREAD_SAFETY=yes],
+  [PHP_THREAD_SAFETY=no])
 CPPFLAGS=$old_CPPFLAGS
 AC_MSG_RESULT([$PHP_THREAD_SAFETY])
 

--- a/win32/php_win32_globals.h
+++ b/win32/php_win32_globals.h
@@ -17,7 +17,7 @@
 #ifndef PHP_WIN32_GLOBALS_H
 #define PHP_WIN32_GLOBALS_H
 
-/* misc globals for thread-safety under win32 */
+/* misc globals for thread safety under win32 */
 
 #include "win32/sendmail.h"
 


### PR DESCRIPTION
- The ZTS is defined on only one place
- Added help text for ZTS preprocessor macro
- The 'enable_zts' variable replaced with PHP_THREAD_SAFETY in configure.ac.
- Nits fixed.