### PR TITLE
standard: Stop using `php_combined_lcg()` in `uniqid()`

### DIFF
--- a/ext/standard/uniqid.c
+++ b/ext/standard/uniqid.c
@@ -75,10 +75,9 @@ PHP_FUNCTION(uniqid)
 		uint32_t bytes;
 		double seed;
 		if (php_random_bytes_silent(&bytes, sizeof(uint32_t)) == FAILURE) {
-			seed = php_combined_lcg() * 10;
-		} else {
-			seed = ((double) bytes / UINT32_MAX) * 10.0;
+			bytes = php_random_generate_fallback_seed();
 		}
+		seed = ((double) bytes / UINT32_MAX) * 10.0;
 		uniqid = strpprintf(0, "%s%08x%05x%.8F", prefix, sec, usec, seed);
 	} else {
 		uniqid = strpprintf(0, "%s%08x%05x", prefix, sec, usec);


### PR DESCRIPTION
Fall back to the fallback generator if the CSPRNG fails instead. This removes the last internal user of `php_combined_lcg()`.