### PR TITLE
Sync preprocessor macros help texts

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -118,14 +118,11 @@ dnl Ugly hack to check if dlsym() requires a leading underscore in symbol name.
 dnl
 AC_DEFUN([ZEND_DLSYM_CHECK], [dnl
 AC_MSG_CHECKING([whether dlsym() requires a leading underscore in symbol names])
-_LT_AC_TRY_DLOPEN_SELF([
-  AC_MSG_RESULT([no])
-], [
+_LT_AC_TRY_DLOPEN_SELF([AC_MSG_RESULT([no])], [
   AC_MSG_RESULT([yes])
-  AC_DEFINE(DLSYM_NEEDS_UNDERSCORE, 1, [Define if dlsym() requires a leading underscore in symbol names. ])
-], [
-  AC_MSG_RESULT([no])
-], [])
+  AC_DEFINE([DLSYM_NEEDS_UNDERSCORE], [1],
+    [Define to 1 if 'dlsym()' requires a leading underscore in symbol names.])
+], [AC_MSG_RESULT([no])], [])
 ])
 
 dnl

--- a/ext/ffi/config.w32
+++ b/ext/ffi/config.w32
@@ -6,15 +6,15 @@ if (PHP_FFI != 'no') {
 		AC_DEFINE('HAVE_FFI', 1, "Define to 1 if the PHP extension 'ffi' is available.");
 
 		if (!X64) {
-		    AC_DEFINE('HAVE_FFI_FASTCALL', 1 ,'libffi supports fastcall calling convention');
-		    AC_DEFINE('HAVE_FFI_THISCALL', 1 ,'libffi supports thiscall calling convention');
-		    AC_DEFINE('HAVE_FFI_STDCALL', 1 ,'libffi supports stdcall calling convention');
-		    AC_DEFINE('HAVE_FFI_MS_CDECL', 1 ,'libffi supports ms_cdecl calling convention');
-		    AC_DEFINE('HAVE_FFI_SYSV', 1 ,'libffi supports sysv calling convention');
+			AC_DEFINE('HAVE_FFI_FASTCALL', 1 , 'Define to 1 if libffi supports the fastcall calling convention.');
+			AC_DEFINE('HAVE_FFI_THISCALL', 1 , 'Define to 1 if libffi supports the thiscall calling convention.');
+			AC_DEFINE('HAVE_FFI_STDCALL', 1 , 'Define to 1 if libffi supports the stdcall calling convention.');
+			AC_DEFINE('HAVE_FFI_MS_CDECL', 1 , 'Define to 1 if libffi supports the ms_cdecl calling convention.');
+			AC_DEFINE('HAVE_FFI_SYSV', 1 , 'Define to 1 if libffi supports the sysv calling convention.');
 		}
 		// Available in https://github.com/winlibs/libffi.
 		if (GREP_HEADER("ffitarget.h", "FFI_VECTORCALL_PARTIAL", PHP_PHP_BUILD + "\\include")) {
-			AC_DEFINE('HAVE_FFI_VECTORCALL_PARTIAL', 1 ,'libffi partially supports vectorcall calling convention');
+			AC_DEFINE('HAVE_FFI_VECTORCALL_PARTIAL', 1 , 'Define to 1 if libffi partially supports the vectorcall calling convention.');
 		}
 
 		EXTENSION('ffi', 'ffi.c ffi_parser.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');

--- a/ext/ffi/config.w32
+++ b/ext/ffi/config.w32
@@ -6,15 +6,15 @@ if (PHP_FFI != 'no') {
 		AC_DEFINE('HAVE_FFI', 1, "Define to 1 if the PHP extension 'ffi' is available.");
 
 		if (!X64) {
-			AC_DEFINE('HAVE_FFI_FASTCALL', 1 , 'Define to 1 if libffi supports the fastcall calling convention.');
-			AC_DEFINE('HAVE_FFI_THISCALL', 1 , 'Define to 1 if libffi supports the thiscall calling convention.');
-			AC_DEFINE('HAVE_FFI_STDCALL', 1 , 'Define to 1 if libffi supports the stdcall calling convention.');
-			AC_DEFINE('HAVE_FFI_MS_CDECL', 1 , 'Define to 1 if libffi supports the ms_cdecl calling convention.');
-			AC_DEFINE('HAVE_FFI_SYSV', 1 , 'Define to 1 if libffi supports the sysv calling convention.');
+			AC_DEFINE('HAVE_FFI_FASTCALL', 1, 'Define to 1 if libffi supports the fastcall calling convention.');
+			AC_DEFINE('HAVE_FFI_THISCALL', 1, 'Define to 1 if libffi supports the thiscall calling convention.');
+			AC_DEFINE('HAVE_FFI_STDCALL', 1, 'Define to 1 if libffi supports the stdcall calling convention.');
+			AC_DEFINE('HAVE_FFI_MS_CDECL', 1, 'Define to 1 if libffi supports the ms_cdecl calling convention.');
+			AC_DEFINE('HAVE_FFI_SYSV', 1, 'Define to 1 if libffi supports the sysv calling convention.');
 		}
 		// Available in https://github.com/winlibs/libffi.
 		if (GREP_HEADER("ffitarget.h", "FFI_VECTORCALL_PARTIAL", PHP_PHP_BUILD + "\\include")) {
-			AC_DEFINE('HAVE_FFI_VECTORCALL_PARTIAL', 1 , 'Define to 1 if libffi partially supports the vectorcall calling convention.');
+			AC_DEFINE('HAVE_FFI_VECTORCALL_PARTIAL', 1, 'Define to 1 if libffi partially supports the vectorcall calling convention.');
 		}
 
 		EXTENSION('ffi', 'ffi.c ffi_parser.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -8,6 +8,9 @@ AC_DEFUN([PHP_LDAP_CHECKS], [
     LDAP_INCDIR=$1/ldap/public
     LDAP_LIBDIR=$1/$PHP_LIBDIR
   else
+    dnl Note that Oracle Instant Client lacks LDAP features implemented in PHP
+    dnl ldap extension and cannot be built. Use OpenLDAP on Solaris.
+    dnl See: https://github.com/php/php-src/issues/15051
 
     dnl Find Oracle Instant Client RPM header location corresponding to the
     dnl given lib path e.g. for --with-ldap=/usr/lib/oracle/12.1/client64/lib
@@ -71,6 +74,9 @@ if test "$PHP_LDAP" != "no"; then
   dnl -pc removal is a hack for clang
   MACHINE_INCLUDES=$($CC -dumpmachine | $SED 's/-pc//')
 
+  AH_TEMPLATE([HAVE_ORALDAP],
+    [Define to 1 if the ldap extension uses the Oracle Instant Client.])
+
   if test -f $LDAP_LIBDIR/liblber.a || test -f $LDAP_LIBDIR/liblber.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.a || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/liblber.$SHLIB_SUFFIX_NAME; then
     PHP_ADD_LIBRARY_WITH_PATH([lber], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
     PHP_ADD_LIBRARY_WITH_PATH([ldap], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
@@ -80,15 +86,15 @@ if test "$PHP_LDAP" != "no"; then
 
   elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.12.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.12.1; then
     PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-    AC_DEFINE(HAVE_ORALDAP,1,[ ])
+    AC_DEFINE([HAVE_ORALDAP], [1])
 
   elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME.11.1 || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME.11.1; then
     PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-    AC_DEFINE(HAVE_ORALDAP,1,[ ])
+    AC_DEFINE([HAVE_ORALDAP], [1])
 
   elif test -f $LDAP_LIBDIR/libclntsh.$SHLIB_SUFFIX_NAME || test -f $LDAP_LIBDIR/$MACHINE_INCLUDES/libclntsh.$SHLIB_SUFFIX_NAME; then
      PHP_ADD_LIBRARY_WITH_PATH([clntsh], [$LDAP_LIBDIR], [LDAP_SHARED_LIBADD])
-     AC_DEFINE(HAVE_ORALDAP,1,[ ])
+     AC_DEFINE([HAVE_ORALDAP], [1])
 
   else
     AC_MSG_ERROR([Cannot find ldap libraries in $LDAP_LIBDIR.])
@@ -132,14 +138,13 @@ if test "$PHP_LDAP" != "no"; then
   ]))
 
   dnl SASL check
-  if test "$PHP_LDAP_SASL" != "no"; then
+  AS_VAR_IF([PHP_LDAP_SASL], [no],, [
     PKG_CHECK_MODULES([SASL], [libsasl2])
-
     PHP_EVAL_INCLINE([$SASL_CFLAGS])
     PHP_EVAL_LIBLINE([$SASL_LIBS], [LDAP_SHARED_LIBADD])
-
-    AC_DEFINE(HAVE_LDAP_SASL, 1, [LDAP SASL support])
-  fi
+    AC_DEFINE([HAVE_LDAP_SASL], [1],
+      [Define to 1 if the ldap extension has SASL support enabled.])
+  ])
 
   dnl Sanity check
   AC_CHECK_FUNC([ldap_sasl_bind_s],,

--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -16,7 +16,7 @@ if (PHP_LDAP != "no") {
 		AC_DEFINE('HAVE_LDAP_PARSE_REFERENCE', 1);
 		AC_DEFINE('HAVE_LDAP_START_TLS_S', 1);
 		AC_DEFINE('HAVE_LDAP', 1, "Define to 1 if the PHP extension 'ldap' is available.");
-		AC_DEFINE('HAVE_LDAP_SASL', 1);
+		AC_DEFINE('HAVE_LDAP_SASL', 1, 'Define to 1 if the ldap extension has SASL support enabled.');
 		AC_DEFINE('HAVE_LDAP_CONTROL_FIND', 1);
 		AC_DEFINE('HAVE_LDAP_PARSE_EXTENDED_RESULT', 1);
 		AC_DEFINE('HAVE_LDAP_EXTENDED_OPERATION_S', 1);

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -325,7 +325,7 @@ int main(void) {
       AS_VAR_IF([ac_cv_search_shm_open], ["none required"],,
         [OPCACHE_SHARED_LIBADD="$OPCACHE_SHARED_LIBADD $ac_cv_search_shm_open"])
       AC_DEFINE([HAVE_SHM_MMAP_POSIX], [1],
-        [Define if you have POSIX mmap() SHM support])
+        [Define to 1 if you have the POSIX mmap() SHM support.])
     fi
   ])
   LIBS="$LIBS_save"

--- a/ext/pcre/config.w32
+++ b/ext/pcre/config.w32
@@ -5,14 +5,14 @@ EXTENSION("pcre", "php_pcre.c", false /* never shared */,
 ADD_SOURCES("ext/pcre/pcre2lib", "pcre2_auto_possess.c pcre2_chartables.c pcre2_compile.c pcre2_config.c pcre2_context.c pcre2_chkdint.c pcre2_dfa_match.c pcre2_error.c pcre2_jit_compile.c pcre2_maketables.c pcre2_match.c pcre2_match_data.c pcre2_newline.c pcre2_ord2utf.c pcre2_pattern_info.c pcre2_serialize.c pcre2_string_utils.c pcre2_study.c pcre2_substitute.c  pcre2_substring.c pcre2_tables.c pcre2_ucd.c pcre2_valid_utf.c pcre2_xclass.c pcre2_find_bracket.c pcre2_convert.c pcre2_extuni.c pcre2_script_run.c", "pcre");
 ADD_DEF_FILE("ext\\pcre\\php_pcre.def");
 
-AC_DEFINE('HAVE_BUNDLED_PCRE', 1, 'Using bundled PCRE library');
-AC_DEFINE('PCRE2_CODE_UNIT_WIDTH', 8, 'Have PCRE library');
-AC_DEFINE("PCRE2_STATIC", 1, "");
+AC_DEFINE('HAVE_BUNDLED_PCRE', 1, 'Define to 1 if PHP uses the bundled PCRE library.');
+AC_DEFINE('PCRE2_CODE_UNIT_WIDTH', 8, 'Number of bits in non-UTF mode for PCRE library.');
+AC_DEFINE("PCRE2_STATIC", 1, "Define to 1 if PCRE library is built statically.");
 PHP_PCRE="yes";
 PHP_INSTALL_HEADERS("ext/pcre", "php_pcre.h pcre2lib/");
 ADD_FLAG("CFLAGS_PCRE", " /D HAVE_CONFIG_H /D HAVE_MEMMOVE");
 
 ARG_WITH("pcre-jit", "Enable PCRE JIT support", "yes");
 if (PHP_PCRE_JIT != "no") {
-	AC_DEFINE('HAVE_PCRE_JIT_SUPPORT', 1, 'PCRE library');
+	AC_DEFINE('HAVE_PCRE_JIT_SUPPORT', 1, 'Define to 1 if PCRE JIT is enabled and supported.');
 }

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -13,6 +13,8 @@ PHP_ARG_WITH([pcre-jit],
   [yes],
   [no])
 
+AH_TEMPLATE([PCRE2_CODE_UNIT_WIDTH],
+  [Number of bits in non-UTF mode for PCRE library.])
 AH_TEMPLATE([HAVE_PCRE_JIT_SUPPORT],
   [Define to 1 if PCRE JIT is enabled and supported.])
 
@@ -21,7 +23,7 @@ if test "$PHP_EXTERNAL_PCRE" != "no"; then
 
   PHP_EVAL_INCLINE([$PCRE2_CFLAGS])
   PHP_EVAL_LIBLINE([$PCRE2_LIBS])
-  AC_DEFINE(PCRE2_CODE_UNIT_WIDTH, 8, [ ])
+  AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8])
 
   AS_VAR_IF([PHP_PCRE_JIT], [no],,
     [AC_CACHE_CHECK([whether external PCRE2 library has JIT supported],
@@ -89,8 +91,9 @@ else
     [-Werror])
 
   PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-  AC_DEFINE(HAVE_BUNDLED_PCRE, 1, [ ])
-  AC_DEFINE(PCRE2_CODE_UNIT_WIDTH, 8, [ ])
+  AC_DEFINE([HAVE_BUNDLED_PCRE], [1],
+    [Define to 1 if PHP uses the bundled PCRE library.])
+  AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8])
 
   AS_VAR_IF([PHP_PCRE_JIT], [no],,
     [AC_DEFINE([HAVE_PCRE_JIT_SUPPORT], [1])

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -39,7 +39,8 @@ if test "$PHP_PDO_MYSQL" != "no"; then
   if test "$PHP_PDO_MYSQL" = "yes" || test "$PHP_PDO_MYSQL" = "mysqlnd"; then
     dnl enables build of mysqnd library
     PHP_MYSQLND_ENABLED=yes
-    AC_DEFINE([PDO_USE_MYSQLND], 1, [Whether pdo_mysql uses mysqlnd])
+    AC_DEFINE([PDO_USE_MYSQLND], [1],
+      [Define to 1 if the pdo_mysql extension uses mysqlnd.])
   else
     AC_MSG_CHECKING([for mysql_config])
     if test -n "$PDO_MYSQL_CONFIG"; then

--- a/ext/pdo_mysql/config.w32
+++ b/ext/pdo_mysql/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("pdo-mysql", "MySQL support for PDO", "no");
 
 if (PHP_PDO_MYSQL != "no") {
 	if (PHP_PDO_MYSQL == "yes" || PHP_PDO_MYSQL == "mysqlnd") {
-		AC_DEFINE('PDO_USE_MYSQLND', 1, 'Using MySQL native driver');
+		AC_DEFINE('PDO_USE_MYSQLND', 1, 'Define to 1 if the pdo_mysql extension uses mysqlnd.');
 		STDOUT.WriteLine("INFO: mysqlnd build");
 		EXTENSION("pdo_mysql", "pdo_mysql.c mysql_driver.c mysql_statement.c mysql_sql_parser.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		ADD_EXTENSION_DEP('pdo_mysql', 'pdo');

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -80,7 +80,8 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   LIBS=$LIBS_SAVE
 
   AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
-  AC_DEFINE(HAVE_LIBREADLINE, 1, [ ])
+  AC_DEFINE([HAVE_LIBREADLINE], [1],
+    [Define to 1 if readline extension uses the 'readline' library.])
 
 elif test "$PHP_LIBEDIT" != "no"; then
   if test "$PHP_LIBEDIT" != "yes"; then
@@ -131,7 +132,8 @@ elif test "$PHP_LIBEDIT" != "no"; then
   CFLAGS=$CFLAGS_SAVE
   LIBS=$LIBS_SAVE
 
-  AC_DEFINE(HAVE_LIBEDIT, 1, [ ])
+  AC_DEFINE([HAVE_LIBEDIT], [1],
+    [Define to 1 if readline extension uses the 'libedit' library.])
 fi
 
 if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -17,7 +17,7 @@ if (PHP_PASSWORD_ARGON2 != "no") {
 ARG_WITH("config-file-scan-dir", "Dir to check for additional php ini files", "");
 
 AC_DEFINE("PHP_CONFIG_FILE_SCAN_DIR", PHP_CONFIG_FILE_SCAN_DIR);
-AC_DEFINE("PHP_USE_PHP_CRYPT_R", 1);
+AC_DEFINE("PHP_USE_PHP_CRYPT_R", 1, "Define to 1 if PHP uses its own crypt_r, and to 0 if using the external crypt library.");
 
 CHECK_HEADER_ADD_INCLUDE("timelib_config.h", "CFLAGS_STANDARD", "ext/date/lib");
 


### PR DESCRIPTION
This partially syncs help texts a bit further for:
- ext/ffi
- ext/ldap
- ext/opcache
- ext/pcre
- ext/pdo_mysql
- ext/readline
- ext/standard