### PR TITLE
Refactor HAVE_SQLDATASOURCES check

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -440,12 +440,13 @@ fi
 
 dnl Extension setup
 if test -n "$ODBC_TYPE"; then
-  if test "$ODBC_TYPE" != "dbmaker"; then
-    PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], ODBC_SHARED_LIBADD)
-    if test "$ODBC_TYPE" != "solid"; then
-      AC_DEFINE(HAVE_SQLDATASOURCES,1,[ ])
-    fi
-  fi
+  AS_VAR_IF([ODBC_TYPE], [dbmaker],, [
+    PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], [ODBC_SHARED_LIBADD])
+    AS_VAR_IF([ODBC_TYPE], [solid],,
+      [AC_DEFINE([HAVE_SQLDATASOURCES], [1],
+        [Define to 1 if ODBC library has 'SQLDataSources', as a function or
+        macro.])])
+  ])
 
   AC_DEFINE([HAVE_UODBC], [1],
     [Define to 1 if the PHP extension 'odbc' is available.])

--- a/ext/odbc/config.w32
+++ b/ext/odbc/config.w32
@@ -9,6 +9,7 @@ if (PHP_ODBC == "yes") {
 	&& CHECK_HEADER_ADD_INCLUDE("sqlext.h", "CFLAGS_ODBC")) {
 		EXTENSION("odbc", "php_odbc.c odbc_utils.c", PHP_ODBC_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_UODBC", 1, "Define to 1 if the PHP extension 'odbc' is available.");
+		AC_DEFINE("HAVE_SQLDATASOURCES", 1, "Define to 1 if ODBC library has 'SQLDataSources', as a function or macro.");
 		if ("no" == PHP_ODBCVER) {
 			AC_DEFINE("ODBCVER", "0x0350", "The highest supported ODBC version", false);
 		} else if ("0" != PHP_ODBCVER) {

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -95,7 +95,6 @@
 #define HAVE_GLOB
 #define PHP_SHLIB_SUFFIX "dll"
 #define PHP_SHLIB_EXT_PREFIX "php_"
-#define HAVE_SQLDATASOURCES
 
 /* Win32 supports socketpair by the emulation in win32/sockets.c */
 #define HAVE_SOCKETPAIR 1


### PR DESCRIPTION
On Windows, this preprocessor macro is moved to odbc extension, in Autotools check CS is synced and some basic help text is added.

This was once present in the main/config.w32.h header file but wasn't moved to the extension when Windows build system was added. Open source code quickly checked and it shouldn't cause issues.