### PR TITLE
Fix HAVE_LIBGD usage

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -253,7 +253,8 @@ if test "$PHP_GD" != "no"; then
     "])
 
 dnl These are always available with bundled library
-    AC_DEFINE(HAVE_GD_BUNDLED,          1, [ ])
+    AC_DEFINE([HAVE_GD_BUNDLED], [1],
+      [Define to 1 if gd extension uses GD library bundled in PHP.])
     AC_DEFINE(HAVE_GD_PNG,              1, [ ])
     AC_DEFINE(HAVE_GD_BMP,              1, [ ])
     AC_DEFINE(HAVE_GD_TGA,              1, [ ])
@@ -284,7 +285,8 @@ dnl Various checks for GD features
     PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])
     PHP_EVAL_LIBLINE([$GDLIB_LIBS], [GD_SHARED_LIBADD])
     PHP_EVAL_INCLINE([$GDLIB_CFLAGS])
-    AC_DEFINE(HAVE_LIBGD, 1, [ ])
+    AC_DEFINE([HAVE_LIBGD], [1],
+      [Define to 1 gd extension uses external system GD library.])
     PHP_GD_CHECK_VERSION
 
     PHP_NEW_EXTENSION([gd], [gd.c $extra_sources], [$ext_shared])

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -55,8 +55,7 @@ if (PHP_GD != "no") {
 			gdtables.c gd_topal.c gd_wbmp.c gdxpm.c wbmp.c gd_xbm.c gd_security.c gd_transform.c \
 			gd_filter.c gd_pixelate.c gd_rotate.c gd_color_match.c gd_webp.c gd_avif.c \
 			gd_crop.c gd_interpolation.c gd_matrix.c gd_bmp.c gd_tga.c", "gd");
-		AC_DEFINE('HAVE_LIBGD', 1, 'GD support');
-		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Bundled GD");
+		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Define to 1 if gd extension uses GD library bundled in PHP.");
 		AC_DEFINE('HAVE_GD_PNG', 1, "PNG support");
 		AC_DEFINE('HAVE_GD_BMP', 1, "BMP support");
 		AC_DEFINE('HAVE_GD_TGA', 1, "TGA support");


### PR DESCRIPTION
When PHP gd extension uses the external system GD library, the HAVE_LIBGD preprocessor macro gets defined in Autotools. On Windows it was previously always defined when bundled library is used. This fixes the usage and adds help texts.