### PR TITLE
imageloadfont: Fix font loading in opposite endianness format

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-15192 (Segmentation fault in dom extension
     (html5_serializer)). (nielsdos)
 
+- GD:
+  . Fixed imageloadfont() when loading font files for the opposite endianness,
+    including those with non-zero offset field. (Giovanni Giacobbi)
+
 - PHPDBG:
   . array out of bounds, stack overflow handled for segfault handler on windows.
     (David Carlier)

--- a/ext/gd/tests/imageloadfont_endianness.phpt
+++ b/ext/gd/tests/imageloadfont_endianness.phpt
@@ -1,0 +1,66 @@
+--TEST--
+imageloadfont() detects endianness correctly
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+$file_LE = __DIR__ .  '/imageloadfont_endianness_LE.gdf';
+$fp = fopen($file_LE, 'wb');
+fwrite($fp,
+  "\x01\x00\x00\x00" .  // one char
+  "\x20\x00\x00\x00" .  // at position 32 (space)
+  "\x04\x00\x00\x00" .  // width = 4
+  "\x01\x00\x00\x00" .  // height = 1
+  "\x01\x00\x01\x01");  // char: [x xx]
+fclose($fp);
+
+$file_BE = __DIR__ .  '/imageloadfont_endianness_BE.gdf';
+$fp = fopen($file_BE, 'wb');
+fwrite($fp,
+  "\x00\x00\x00\x01" .  // one char
+  "\x00\x00\x00\x20" .  // at position 32 (space)
+  "\x00\x00\x00\x04" .  // width = 4
+  "\x00\x00\x00\x01" .  // height = 1
+  "\x01\x00\x01\x01");  // char: [x xx]
+fclose($fp);
+
+foreach (array("LE" => $file_LE, "BE" => $file_BE) as $key => $file) {
+  print "\n=== $key ===\n";
+  $font = imageloadfont($file);
+  print "width = "; var_dump(imagefontwidth($font));
+  print "height = "; var_dump(imagefontheight($font));
+  $im = imagecreate(4, 1);
+  imagecolorallocate($im, 255, 255, 255);
+  imagechar($im, $font, 0, 0, ' ', imagecolorallocate($im, 0, 0, 0));
+  print "pixels = "; var_export(array(
+    imagecolorat($im, 0, 0),
+    imagecolorat($im, 1, 0),
+    imagecolorat($im, 2, 0),
+    imagecolorat($im, 3, 0)));
+  print "\n";
+  imagedestroy($im);
+}
+unlink($file_BE);
+unlink($file_LE);
+?>
+--EXPECT--
+
+=== LE ===
+width = int(4)
+height = int(1)
+pixels = array (
+  0 => 1,
+  1 => 0,
+  2 => 1,
+  3 => 1,
+)
+
+=== BE ===
+width = int(4)
+height = int(1)
+pixels = array (
+  0 => 1,
+  1 => 0,
+  2 => 1,
+  3 => 1,
+)


### PR DESCRIPTION
The ability to load fonts of the opposite endianness used to work until php 7.4.0 due to commit 88b603768f8e5074ad5cbdccc1e0779089fac9d0. The same commit introduced a vulnerability due to a missing overflow check that was fixed later in commit d50532be91f054ef9beb1afca2ea94f4a70f7c4d, but the feature remains broken due to the early overflow check.

Furthermore, the initial implementation was missing the conversion (`FLIPWORD` macro) for the offset field, thus only fonts with zero offset (starting character) could be loaded correctly.

Note that the missed conversion of the offset endianness is not exploitable as there is no way to craft a font that passes the overflow checks before and after the endianness swapping.

This patch fixes the functionality in a secure way, by guessing the endianness based on the number of characters (typically 256), and then performing the overflow check.
