### PR TITLE
Autotools: Check for cross_compiling=yes

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -285,9 +285,10 @@ int main(void) {
   AC_DEFINE([PHP_USE_PHP_CRYPT_R], [0])
 ])
 
-AS_VAR_IF([cross_compiling], [no], [AC_FUNC_FNMATCH],
+AS_VAR_IF([cross_compiling], [yes],
   [AS_CASE([$host_alias], [*linux*],
-    [AC_DEFINE([HAVE_FNMATCH], [1])])])
+    [AC_DEFINE([HAVE_FNMATCH], [1])])],
+  [AC_FUNC_FNMATCH])
 
 dnl
 dnl Check if there is a support means of creating a new process and defining


### PR DESCRIPTION
The cross_compiling variable can initially be "yes", "no", or "maybe" (when only --host option is added). Autoconf otherwise after AC_PROG_CC resets it to "no" in such case but to be sure, this checks for value "yes" instead. The HAVE_FNMATCH template can be also set after the AC_DEFINE as autoheader scans the templates overall the source code.