### PR TITLE
Fix bug #51558: shared readline build fails

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,9 @@ PHP                                                                        NEWS
 - Random:
   . lcg_value() is now deprecated. (timwolla)
 
+- Readline:
+  . Fixed bug #51558 (Shared readline build fails). (Peter Kokot)
+
 - Session:
   . INI settings session.sid_length and session.sid_bits_per_character are now
     deprecated. (timwolla)

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -46,11 +46,6 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
     [AC_MSG_FAILURE([The readline library not found.])],
     [-L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS])
 
-  PHP_CHECK_LIBRARY([readline], [rl_pending_input],
-    [],
-    [AC_MSG_FAILURE([Invalid readline installation detected. Try --with-libedit instead.])],
-    [-L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS])
-
   PHP_CHECK_LIBRARY([readline], [rl_callback_read_char],
     [AC_DEFINE([HAVE_RL_CALLBACK_READ_CHAR], [1], [ ])],
     [],
@@ -72,6 +67,13 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   CFLAGS="$CFLAGS $INCLUDES"
   LDFLAGS="$LDFLAGS -L$READLINE_DIR/$PHP_LIBDIR"
   LIBS="$LIBS -lreadline"
+
+  dnl Sanity check if readline library has variable rl_pending_input.
+  AC_CHECK_DECL([rl_pending_input],, [AC_MSG_FAILURE([
+      Invalid readline installation detected. Try --with-libedit instead.
+    ])],
+    [#include <readline/readline.h>])
+
   AC_CHECK_DECL([rl_erase_empty_line],
     [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1])],,
     [#include <readline/readline.h>])

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -68,7 +68,8 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   LDFLAGS="$LDFLAGS -L$READLINE_DIR/$PHP_LIBDIR"
   LIBS="$LIBS -lreadline"
 
-  dnl Sanity check if readline library has variable rl_pending_input.
+  dnl Sanity and minimum version check if readline library has variable
+  dnl rl_pending_input.
   AC_CHECK_DECL([rl_pending_input],, [AC_MSG_FAILURE([
       Invalid readline installation detected. Try --with-libedit instead.
     ])], [

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -71,12 +71,16 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   dnl Sanity check if readline library has variable rl_pending_input.
   AC_CHECK_DECL([rl_pending_input],, [AC_MSG_FAILURE([
       Invalid readline installation detected. Try --with-libedit instead.
-    ])],
-    [#include <readline/readline.h>])
+    ])], [
+      #include <stdio.h>
+      #include <readline/readline.h>
+    ])
 
   AC_CHECK_DECL([rl_erase_empty_line],
-    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1])],,
-    [#include <readline/readline.h>])
+    [AC_DEFINE([HAVE_ERASE_EMPTY_LINE], [1])],, [
+      #include <stdio.h>
+      #include <readline/readline.h>
+    ])
   CFLAGS=$CFLAGS_SAVE
   LDFLAGS=$LDFLAGS_SAVE
   LIBS=$LIBS_SAVE


### PR DESCRIPTION
The 'rl_pending_input' is a variable in Readline library and checking it with PHP_CHECK_LIBRARY wouldn't find it on some systems. This should fix the build on systems where this caused issues, such as AIX.

Which works on most systems but not on AIX mentioned in the bug as it exports variables and functions differently whereas the linker couldn't resolve the variable as a function.

The library check:

```c
char rl_pending_input ();
int main (void) {
    return rl_pending_input ();
}
```

The declaration check:

```c
#include <stdio.h>
#include <readline/readline.h>
int main (void) {
#ifndef rl_pending_input
#ifdef __cplusplus
    (void) rl_pending_input;
#else
    (void) rl_pending_input;
#endif
#endif
;
    return 0;
}
```

Closes https://bugs.php.net/51558