### PR TITLE
Reset seen symbols when ending namespace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ PHP                                                                        NEWS
   . Passing E_USER_ERROR to trigger_error() is now deprecated. (Girgias)
   . Fixed bug GH-15292 (Dynamic AVX detection is broken for MSVC). (nielsdos)
   . Using "_" as a class name is now deprecated. (Girgias)
+  . Exiting a namespace now clears seen symbols. (ilutov)
 
 - Curl:
   . Added constants CURL_HTTP_VERSION_3 (libcurl 7.66) and CURL_HTTP_VERSION_3ONLY

--- a/UPGRADING
+++ b/UPGRADING
@@ -248,6 +248,10 @@ PHP 8.4 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecated_attribute
   . Implemented property hooks.
     RFC: https://wiki.php.net/rfc/property-hooks
+  . Exiting a namespace now clears seen symbols. This allows using a symbol in a
+    namespace block, even if a previous namespace block declared a symbol with
+    the same name.
+    See Zend/tests/use_function/ns_end_resets_seen_symbols_1.phpt.
 
 - Curl:
   . curl_version() returns an additional feature_list value, which is an

--- a/Zend/tests/use_function/ns_end_resets_seen_symbols_1.phpt
+++ b/Zend/tests/use_function/ns_end_resets_seen_symbols_1.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Namespace end resets seen function symbols
+--FILE--
+<?php
+
+namespace {
+    function f() {
+        echo __FUNCTION__, "\n";
+    }
+    f();
+}
+
+namespace Ns {
+    function f() {
+        echo __FUNCTION__, "\n";
+    }
+    f();
+}
+
+namespace {
+    use function Ns\f;
+    f();
+}
+
+namespace Ns {
+    use function f;
+    f();
+}
+
+namespace {
+    f();
+}
+
+namespace Ns {
+    f();
+}
+
+namespace {
+    use function f;
+    f();
+}
+
+namespace Ns {
+    use function Ns\f;
+    f();
+}
+
+?>
+--EXPECTF--
+Warning: The use statement with non-compound name 'f' has no effect in %s on line 36
+f
+Ns\f
+Ns\f
+f
+f
+Ns\f
+f
+Ns\f

--- a/Zend/tests/use_function/ns_end_resets_seen_symbols_2.phpt
+++ b/Zend/tests/use_function/ns_end_resets_seen_symbols_2.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Namespace end resets seen class symbols
+--FILE--
+<?php
+
+namespace {
+    class C {}
+    var_dump(new C);
+}
+
+namespace Ns {
+    class C {}
+    var_dump(new C);
+}
+
+namespace {
+    use Ns\C;
+    var_dump(new C);
+}
+
+namespace Ns {
+    use C;
+    var_dump(new C);
+}
+
+namespace {
+    var_dump(new C);
+}
+
+namespace Ns {
+    var_dump(new C);
+}
+
+namespace {
+    use C;
+    var_dump(new C);
+}
+
+namespace Ns {
+    use Ns\C;
+    var_dump(new C);
+}
+
+?>
+--EXPECTF--
+Warning: The use statement with non-compound name 'C' has no effect in %s on line 32
+object(C)#%d (0) {
+}
+object(Ns\C)#1 (0) {
+}
+object(Ns\C)#1 (0) {
+}
+object(C)#%d (0) {
+}
+object(C)#%d (0) {
+}
+object(Ns\C)#1 (0) {
+}
+object(C)#%d (0) {
+}
+object(Ns\C)#1 (0) {
+}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -377,6 +377,8 @@ static void zend_reset_import_tables(void) /* {{{ */
 		efree(FC(imports_const));
 		FC(imports_const) = NULL;
 	}
+
+	zend_hash_clean(&FC(seen_symbols));
 }
 /* }}} */
 


### PR DESCRIPTION
Previously, seen symbols were never cleaned during the compilation of a single file. This makes it impossible to use a class or function from a different namespace if such a symbol is also declared within the same file. This is inconsistent with how it would work when split into different files.