### PR TITLE
Fix SoapFault property destruction

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -529,6 +529,13 @@ static void soap_fault_dtor_properties(zval *obj)
 	zval_ptr_dtor(Z_FAULT_DETAIL_P(obj));
 	zval_ptr_dtor(Z_FAULT_NAME_P(obj));
 	zval_ptr_dtor(Z_FAULT_HEADERFAULT_P(obj));
+	ZVAL_EMPTY_STRING(Z_FAULT_STRING_P(obj));
+	ZVAL_NULL(Z_FAULT_CODE_P(obj));
+	ZVAL_NULL(Z_FAULT_CODENS_P(obj));
+	ZVAL_NULL(Z_FAULT_ACTOR_P(obj));
+	ZVAL_NULL(Z_FAULT_DETAIL_P(obj));
+	ZVAL_NULL(Z_FAULT_NAME_P(obj));
+	ZVAL_NULL(Z_FAULT_HEADERFAULT_P(obj));
 }
 
 /* {{{ SoapFault constructor */
@@ -550,9 +557,6 @@ PHP_METHOD(SoapFault, __construct)
 		Z_PARAM_ZVAL_OR_NULL(headerfault)
 	ZEND_PARSE_PARAMETERS_END();
 
-	/* Delete previously set properties */
-	soap_fault_dtor_properties(ZEND_THIS);
-
 	if (code_str) {
 		fault_code = ZSTR_VAL(code_str);
 		fault_code_len = ZSTR_LEN(code_str);
@@ -570,6 +574,9 @@ PHP_METHOD(SoapFault, __construct)
 		zend_argument_value_error(1, "is not a valid fault code");
 		RETURN_THROWS();
 	}
+
+	/* Delete previously set properties */
+	soap_fault_dtor_properties(ZEND_THIS);
 
 	if (name != NULL && name_len == 0) {
 		name = NULL;

--- a/ext/soap/tests/SoapFault/gh14586.phpt
+++ b/ext/soap/tests/SoapFault/gh14586.phpt
@@ -6,7 +6,17 @@ soap
 <?php
 $sf = new SoapFault(null, "x");
 $sf->__construct(null, "x");
+try {
+    $sf->__construct("", "");
+} catch (ValueError) {}
+$sf->__construct(null, "x", headerFault: []);
+var_dump($sf->headerfault);
+$sf->__construct(null, "x");
+var_dump($sf->headerfault);
 ?>
 DONE
 --EXPECT--
+array(0) {
+}
+NULL
 DONE


### PR DESCRIPTION
Two issues:
1) We should not modify the object when we pass invalid values
2) We should reset the properties to their default value otherwise we
   get a UAF.

Regressed in df219ccf9d6be8302eef3ab6e26fd00fbd2fef71