### PR TITLE
Fix odbc_data_source_001.phpt

### DIFF
--- a/ext/odbc/tests/odbc_data_source_001.phpt
+++ b/ext/odbc/tests/odbc_data_source_001.phpt
@@ -17,7 +17,7 @@ include 'config.inc';
 $conn = odbc_connect($dsn, $user, $pass);
 
 try {
-    var_dump(odbc_data_source($conn, NULL));
+    var_dump(odbc_data_source($conn, SQL_FETCH_FIRST + SQL_FETCH_NEXT));
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }


### PR DESCRIPTION
As of PHP 8.1.0, passing `null` to an `int` parameter is deprecated, and as such the deprecation notice breaks the test.  So we instead pass an integer, and to avoid hard-coding a value we just add the two supported constants (which are supposed to have the values `1` and `2`, respectively).

---

Note that [this test is skipped in CI](https://github.com/php/php-src/actions/runs/10265811205/job/28402785672?pr=15253#step:6:436) since no data sources are configured. [Programatically configuring data sources](https://learn.microsoft.com/en-us/cpp/data/odbc/data-source-programmatically-configuring-an-odbc-data-source?view=msvc-170) (file data sources won't work) is possible, but would require some new code in ext/zend_test or fiddling with the registry manually. I don't think that running this test in CI justifies the required effort, though.