### PR TITLE
zend_enum: Rename try parameter to avoid conflict with C++

### DIFF
--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -279,7 +279,7 @@ static ZEND_NAMED_FUNCTION(zend_enum_cases_func)
 	} ZEND_HASH_FOREACH_END();
 }
 
-ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try)
+ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try_from)
 {
 	if (ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
 		if (zend_update_class_constants(ce) == FAILURE) {
@@ -303,7 +303,7 @@ ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_clas
 
 	if (case_name_zv == NULL) {
 not_found:
-		if (try) {
+		if (try_from) {
 			*result = NULL;
 			return SUCCESS;
 		}
@@ -333,7 +333,7 @@ not_found:
 	return SUCCESS;
 }
 
-static void zend_enum_from_base(INTERNAL_FUNCTION_PARAMETERS, bool try)
+static void zend_enum_from_base(INTERNAL_FUNCTION_PARAMETERS, bool try_from)
 {
 	zend_class_entry *ce = execute_data->func->common.scope;
 	bool release_string = false;
@@ -368,12 +368,12 @@ static void zend_enum_from_base(INTERNAL_FUNCTION_PARAMETERS, bool try)
 	}
 
 	zend_object *case_obj;
-	if (zend_enum_get_case_by_value(&case_obj, ce, long_key, string_key, try) == FAILURE) {
+	if (zend_enum_get_case_by_value(&case_obj, ce, long_key, string_key, try_from) == FAILURE) {
 		goto throw;
 	}
 
 	if (case_obj == NULL) {
-		ZEND_ASSERT(try);
+		ZEND_ASSERT(try_from);
 		goto return_null;
 	}
 

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -41,7 +41,7 @@ ZEND_API void zend_enum_add_case(zend_class_entry *ce, zend_string *case_name, z
 ZEND_API void zend_enum_add_case_cstr(zend_class_entry *ce, const char *name, zval *value);
 ZEND_API zend_object *zend_enum_get_case(zend_class_entry *ce, zend_string *name);
 ZEND_API zend_object *zend_enum_get_case_cstr(zend_class_entry *ce, const char *name);
-ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try);
+ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try_from);
 
 static zend_always_inline zval *zend_enum_fetch_case_name(zend_object *zobj)
 {


### PR DESCRIPTION
`try` is a keyword in C++, and as such C++ code including <zend_enum.h> fails to compile unless a workaround is in place.  To resolve this, we simply rename the parameter.

We choose `try_from` to make it clear that this parameter is true when the function is called from `BackedEnum::tryFrom()`.  For consistency, we also rename the `try` parameter of `zend_enum_from_base()`, although that function is not exported.

---

Note that this is a follow-up on #15235, which has been closed for unknown reasons, but has been a valid request.