### PR TITLE
Autotools: Add pkg-config support for NET-SNMP library

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -189,6 +189,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Added pkg-config support to find GNU MP library. As a fallback default
      system paths are searched. When a directory argument is provided
      (--with-gmp=DIR), it will be used instead of the pkg-config.
+   - Added optional pkg-config support to find NET-SNMP library. As a fallback
+     net-snmp-config utility is used like before.
    - Removed BC enable_pear variable check due to --enable-pear configure option
      once used (use with_pear variable name).
    - Cache variables synced to php_cv_* naming scheme. If you use them for

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -1,40 +1,48 @@
 PHP_ARG_WITH([snmp],
   [for SNMP support],
   [AS_HELP_STRING([[--with-snmp[=DIR]]],
-    [Include SNMP support])])
+    [Include SNMP support. Use PKG_CONFIG_PATH (or SNMP_CFLAGS and SNMP_LIBS)
+    environment variables, or alternatively the optional DIR argument to
+    customize where to look for the net-snmp-config utility of the NET-SNMP
+    library.])])
 
 if test "$PHP_SNMP" != "no"; then
+  snmp_found=no
+  AS_VAR_IF([PHP_SNMP], [yes],
+    [PKG_CHECK_MODULES([SNMP], [netsnmp >= 5.3], [snmp_found=yes], [:])])
 
-  if test "$PHP_SNMP" = "yes"; then
-    AC_PATH_PROG(SNMP_CONFIG,net-snmp-config,,[/usr/local/bin:$PATH])
-  else
-    SNMP_CONFIG="$PHP_SNMP/bin/net-snmp-config"
-  fi
+  AS_VAR_IF([snmp_found], [no], [
+    AS_VAR_IF([PHP_SNMP], [yes],
+      [AC_PATH_PROG([SNMP_CONFIG], [net-snmp-config],, [/usr/local/bin:$PATH])],
+      [SNMP_CONFIG="$PHP_SNMP/bin/net-snmp-config"])
 
-  if test -x "$SNMP_CONFIG"; then
-    SNMP_LIBS=`$SNMP_CONFIG --netsnmp-libs`
-    SNMP_LIBS="$SNMP_LIBS `$SNMP_CONFIG --external-libs`"
-    SNMP_PREFIX=`$SNMP_CONFIG --prefix`
-    snmp_full_version=`$SNMP_CONFIG --version`
-    ac_IFS=$IFS
-    IFS="."
-    set $snmp_full_version
-    IFS=$ac_IFS
-    SNMP_VERSION=`expr [$]1 \* 1000 + [$]2`
-    if test "$SNMP_VERSION" -ge "5003"; then
-      if test -n "$SNMP_LIBS" && test -n "$SNMP_PREFIX"; then
-        PHP_ADD_INCLUDE([${SNMP_PREFIX}/include])
-        PHP_EVAL_LIBLINE([$SNMP_LIBS], [SNMP_SHARED_LIBADD])
-        SNMP_LIBNAME=netsnmp
-      else
-        AC_MSG_ERROR([Could not find the required paths. Please check your net-snmp installation.])
-      fi
-    else
-      AC_MSG_ERROR([Net-SNMP version 5.3 or greater required (detected $snmp_full_version).])
-    fi
-  else
-    AC_MSG_ERROR([Could not find net-snmp-config binary. Please check your net-snmp installation.])
-  fi
+    AS_IF([test ! -x "$SNMP_CONFIG"],
+      [AC_MSG_ERROR(m4_text_wrap([
+        Could not find net-snmp-config binary. Please check your net-snmp
+        installation.
+      ]))])
+
+    snmp_version=$($SNMP_CONFIG --version)
+    AS_VERSION_COMPARE([$snmp_version], [5.3],
+      [AC_MSG_ERROR(m4_text_wrap([
+        Net-SNMP version 5.3 or greater required (detected $snmp_version).
+      ]))])
+
+    SNMP_PREFIX=$($SNMP_CONFIG --prefix)
+    SNMP_CFLAGS="-I${SNMP_PREFIX}/include"
+    SNMP_LIBS=$($SNMP_CONFIG --netsnmp-libs)
+    SNMP_LIBS="$SNMP_LIBS $($SNMP_CONFIG --external-libs)"
+
+    AS_IF([test -z "$SNMP_LIBS" || test -z "$SNMP_PREFIX"],
+      [AC_MSG_ERROR(m4_text_wrap([
+        Could not find the required paths. Please check your net-snmp
+        installation.
+      ]))])
+  ])
+
+  PHP_EVAL_INCLINE([$SNMP_CFLAGS])
+  PHP_EVAL_LIBLINE([$SNMP_LIBS], [SNMP_SHARED_LIBADD])
+  SNMP_LIBNAME=netsnmp
 
   dnl Test build.
   PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [init_snmp],


### PR DESCRIPTION
This is alternative and a BC compatible implementation to GH-15002 (NET-SNMP pkg-config support).

NET-SNMP has pkg-config support since 5.8.1

This optionally finds the NET-SNMP library using pkg-config or falls back to find library on the system with net-snmp-config. The configure option argument (--with-snmp=DIR) works like before (path to the net-snmp-config).

When explicitly using the DIR argument, the pkg-config check is silently skipped.

When not using DIR argument, the SNMP_CFLAGS and SNMP_LIBS can be also used to find the NET-SNMP library:

    ./configure --with-snmp \
        SNMP_CFLAGS=-I/path/to/net-snmp/include \
        SNMP_LIBS="-L/path/to/net-snmp -lnetsnmp"