### PR TITLE
Autotools: Fix SNMP checks

### DIFF
--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -58,21 +58,33 @@ if test "$PHP_SNMP" != "no"; then
     [],
     [$SNMP_SHARED_LIBADD])
 
-  dnl Check whether usmHMAC192SHA256AuthProtocol exists.
-  PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [usmHMAC192SHA256AuthProtocol],
+  CFLAGS_SAVE=$CFLAGS
+  LIBS_SAVE=$LIBS
+  CFLAGS="$CFLAGS $SNMP_CFLAGS"
+  LIBS="$LIBS $SNMP_LIBS"
+
+  AC_CHECK_DECL([usmHMAC192SHA256AuthProtocol],
     [AC_DEFINE([HAVE_SNMP_SHA256], [1],
       [Define to 1 if SNMP library has the 'usmHMAC192SHA256AuthProtocol'
       array.])],
     [],
-    [$SNMP_SHARED_LIBADD])
+    [
+      #include <net-snmp/net-snmp-config.h>
+      #include <net-snmp/net-snmp-includes.h>
+    ])
 
-  dnl Check whether usmHMAC384SHA512AuthProtocol exists.
-  PHP_CHECK_LIBRARY([$SNMP_LIBNAME], [usmHMAC384SHA512AuthProtocol],
+  AC_CHECK_DECL([usmHMAC384SHA512AuthProtocol],
     [AC_DEFINE([HAVE_SNMP_SHA512], [1],
       [Define to 1 if SNMP library has the 'usmHMAC384SHA512AuthProtocol'
       array.])],
     [],
-    [$SNMP_SHARED_LIBADD])
+    [
+      #include <net-snmp/net-snmp-config.h>
+      #include <net-snmp/net-snmp-includes.h>
+    ])
+
+  CFLAGS=$CFLAGS_SAVE
+  LIBS=$LIBS_SAVE
 
   PHP_NEW_EXTENSION([snmp], [snmp.c], [$ext_shared])
   PHP_SUBST([SNMP_SHARED_LIBADD])


### PR DESCRIPTION
This is a follow-up of GH-15242
(0b25e26b4ec15dbd7ef69e89c1cda05fa005b4e6)

because the `usmHMAC192SHA256AuthProtocol` and `usmHMAC384SHA512AuthProtocol` are not functions but arrays. The AC_CHECK_DECL might be more appropriate and portable way to find these.

Pending GH-15261 to recheck and then this check can be adjusted based on that.