### PR TITLE
Update ext/tidy preprocessor macros help texts

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -34,26 +34,28 @@ if test "$PHP_TIDY" != "no"; then
     dnl that we are building against tidy-html5 and not the legacy htmltidy. The
     dnl two are compatible, except for with regard to this header file.
     if test -f "$TIDY_INCDIR/tidybuffio.h"; then
-      AC_DEFINE(HAVE_TIDYBUFFIO_H,1,[defined if tidybuffio.h exists])
+      AC_DEFINE([HAVE_TIDYBUFFIO_H], [1],
+        [Define to 1 if you have the <tidybuffio.h> header file.])
     fi
   fi
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR
-  if test "$TIDY_LIB_NAME" == 'tidyp'; then
-    AC_DEFINE(HAVE_TIDYP_H,1,[defined if tidyp.h exists])
-  else
-    AC_DEFINE(HAVE_TIDY_H,1,[defined if tidy.h exists])
-  fi
-
+  AS_VAR_IF([TIDY_LIB_NAME], [tidyp],
+    [AC_DEFINE([HAVE_TIDYP_H], [1],
+      [Define to 1 if you have the <tidyp.h> header file.])],
+    [AC_DEFINE([HAVE_TIDY_H], [1],
+      [Define to 1 if you have the <tidy.h> header file.])])
 
   PHP_CHECK_LIBRARY([$TIDY_LIB_NAME], [tidyOptGetDoc],
-    [AC_DEFINE([HAVE_TIDYOPTGETDOC], [1], [ ])],
+    [AC_DEFINE([HAVE_TIDYOPTGETDOC], [1],
+      [Define to 1 if Tidy library has the 'tidyOptGetDoc' function.])],
     [PHP_CHECK_LIBRARY([tidy5], [tidyOptGetDoc],
       [TIDY_LIB_NAME=tidy5
-      AC_DEFINE([HAVE_TIDYOPTGETDOC], [1], [ ])])])
+      AC_DEFINE([HAVE_TIDYOPTGETDOC], [1])])])
 
   PHP_CHECK_LIBRARY([$TIDY_LIB_NAME], [tidyReleaseDate],
-    [AC_DEFINE([HAVE_TIDYRELEASEDATE], [1], [ ])])
+    [AC_DEFINE([HAVE_TIDYRELEASEDATE], [1],
+      [Define to 1 if Tidy library has the 'tidyReleaseDate' function.])])
 
   PHP_ADD_LIBRARY_WITH_PATH([$TIDY_LIB_NAME],
     [$TIDY_LIBDIR],

--- a/ext/tidy/config.w32
+++ b/ext/tidy/config.w32
@@ -13,14 +13,14 @@ if (PHP_TIDY != "no") {
 			)) {
 
 		if (CHECK_HEADER_ADD_INCLUDE("tidybuffio.h", "CFLAGS_TIDY")) {
-			AC_DEFINE('HAVE_TIDYBUFFIO_H', 1, 'Have tidybuffio.h header file');
+			AC_DEFINE('HAVE_TIDYBUFFIO_H', 1, 'Define to 1 if you have the <tidybuffio.h> header file.');
 		}
 
 		EXTENSION("tidy", "tidy.c");
 		AC_DEFINE('HAVE_TIDY', 1, "Define to 1 if the PHP extension 'tidy' is available.");
-		AC_DEFINE('HAVE_TIDY_H', 1, "tidy include header")
-		AC_DEFINE('HAVE_TIDYOPTGETDOC', 1, "tidy_get_opt_doc function")
-		AC_DEFINE('HAVE_TIDYRELEASEDATE', 1, "tidy release date function")
+		AC_DEFINE('HAVE_TIDY_H', 1, "Define to 1 if you have the <tidy.h> header file.")
+		AC_DEFINE('HAVE_TIDYOPTGETDOC', 1, "Define to 1 if Tidy library has the 'tidyOptGetDoc' function.")
+		AC_DEFINE('HAVE_TIDYRELEASEDATE', 1, "Define to 1 if Tidy library has the 'tidyReleaseDate' function.")
 		ADD_FLAG('CFLAGS_TIDY', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 		if (!PHP_TIDY_SHARED) {
 			ADD_DEF_FILE("ext\\tidy\\php_tidy.def");


### PR DESCRIPTION
This is a follow-up of AC_DEFINEs syncs for the tidy extension. And also one bash-style equal operator synced to a shell style. 

For the tidy and pkg-config stuff, I'll check in the next PRs.