### PR TITLE
Fix nightly Windows builds regarding CRT and runners

### DIFF
--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -76,17 +76,23 @@ function get_matrix_include(array $branches) {
 function get_windows_matrix_include(array $branches) {
     $jobs = [];
     foreach ($branches as $branch) {
+        $crt = $branch['name'] === 'master' ? 'vs17' : 'vs16';
+        $runner = $crt === 'vs17' ? 'windows-2022' : 'windows-2019';
         $jobs[] = [
             'branch' => $branch,
             'x64' => true,
             'zts' => true,
             'opcache' => true,
+            'crt' => $crt,
+            'runner' => $runner,
         ];
         $jobs[] = [
             'branch' => $branch,
             'x64' => false,
             'zts' => false,
             'opcache' => false,
+            'crt' => $crt,
+            'runner' => $runner,
         ];
     }
     return $jobs;

--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -76,23 +76,17 @@ function get_matrix_include(array $branches) {
 function get_windows_matrix_include(array $branches) {
     $jobs = [];
     foreach ($branches as $branch) {
-        $crt = $branch['name'] === 'master' ? 'vs17' : 'vs16';
-        $runner = $crt === 'vs17' ? 'windows-2022' : 'windows-2019';
         $jobs[] = [
             'branch' => $branch,
             'x64' => true,
             'zts' => true,
             'opcache' => true,
-            'crt' => $crt,
-            'runner' => $runner,
         ];
         $jobs[] = [
             'branch' => $branch,
             'x64' => false,
             'zts' => false,
             'opcache' => false,
-            'crt' => $crt,
-            'runner' => $runner,
         ];
     }
     return $jobs;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -883,13 +883,13 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.windows-matrix-include) }}
     name: "${{ matrix.branch.name }}_WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: vs17
+      PHP_BUILD_CRT: ${{ matrix.crt }}
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -883,13 +883,13 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.windows-matrix-include) }}
     name: "${{ matrix.branch.name }}_WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ (matrix.branch.version.minor >= 4) && 'windows-2022' || 'windows-2019' }}
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: ${{ matrix.crt }}
+      PHP_BUILD_CRT: ${{ (matrix.branch.version.minor >= 4) && 'vs17' || 'vs16' }}
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"


### PR DESCRIPTION
Only the master branch should use vs17; older branches still should stick with vs16.  And while not strictly necessary, older branches should better stick with windows-2019 runners.

---

Note that `$crt = $branch['name'] === 'master' ? 'vs17' : 'vs16';` is obviously brittle, but it should do for a first check if this patch fixes the nightly Windows builds.