### PR TITLE
Fix GH-15268: heap buffer overflow in phpdbg (zend_hash_num_elements() Zend/zend_hash.h)

### DIFF
--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -403,12 +403,15 @@ PHPDBG_INFO(classes) /* {{{ */
 		phpdbg_print_class_name(ce);
 
 		if (ce->parent) {
-			zend_class_entry *pce;
-			pce = ce->parent;
-			do {
-				phpdbg_out("|-------- ");
-				phpdbg_print_class_name(pce);
-			} while ((pce = pce->parent));
+			if (ce->ce_flags & ZEND_ACC_LINKED) {
+				zend_class_entry *pce = ce->parent;
+				do {
+					phpdbg_out("|-------- ");
+					phpdbg_print_class_name(pce);
+				} while ((pce = pce->parent));
+			} else {
+				phpdbg_writeln("|-------- User Class %s (not yet linked because declaration for parent was not encountered when declaring the class)", ZSTR_VAL(ce->parent_name));
+			}
 		}
 
 		if (ce->info.user.filename) {

--- a/sapi/phpdbg/tests/gh15268.phpt
+++ b/sapi/phpdbg/tests/gh15268.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-15268 (heap buffer overflow in phpdbg (zend_hash_num_elements() Zend/zend_hash.h))
+--SKIPIF--
+<?php
+if (function_exists('opcache_get_status')) die('skip not for opcache because it will link');
+?>
+--FILE--
+<?php
+class B extends A {
+}
+class A {
+}
+?>
+--PHPDBG--
+i classes
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [User Classes (2)]
+User Class B (0)
+|-------- User Class A (not yet linked because declaration for parent was not encountered when declaring the class)
+|---- in %s on line %d
+User Class A (0)
+|---- in %s on line %d
+prompt>


### PR DESCRIPTION
The class is not yet linked, so we cannot access `parent`, but only `parent_name`.