### PR TITLE
Access long value directly for call to count() in simplexml

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1923,8 +1923,8 @@ static zend_result sxe_count_elements(zend_object *object, zend_long *count) /* 
 		zval rv;
 		zend_call_method_with_0_params(object, intern->zo.ce, &intern->fptr_count, "count", &rv);
 		if (!Z_ISUNDEF(rv)) {
-			*count = zval_get_long(&rv);
-			zval_ptr_dtor(&rv);
+			ZEND_ASSERT(Z_TYPE(rv) == IS_LONG);
+			*count = Z_LVAL(rv);
 			return SUCCESS;
 		}
 		return FAILURE;


### PR DESCRIPTION
Because the signature is checked at compile time, we know that the only possible return value (if there is no exception) is IS_LONG. So we can avoid some work.