### PR TITLE
Update ci actions/checkout to v4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -166,7 +166,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: apt
         uses: ./.github/actions/apt-x32
       - name: ccache


### PR DESCRIPTION
> [LINUX_X32_DEBUG_ZTS](https://github.com/php/php-src/actions/runs/10150594501/job/28068046379)
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/