### PR TITLE
fix: allow negative values for session GC probability for 8.2

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -387,8 +387,12 @@ static zend_long php_session_gc(bool immediate) /* {{{ */
 			PS(mod)->s_gc(&PS(mod_data), PS(gc_maxlifetime), &num);
 			return num;
 		}
-		nrand = (zend_long) ((float) PS(gc_divisor) * php_combined_lcg());
-		if (PS(gc_probability) > 0 && nrand < PS(gc_probability)) {
+		if(PS(gc_divisor) == 0 || PS(gc_probability) == 0) {
+			return num;
+		}
+
+		nrand = (zend_long) ((float) llabs(PS(gc_divisor)) * php_combined_lcg());
+		if (llabs(PS(gc_probability)) > 0 && nrand < llabs(PS(gc_probability))) {
 			PS(mod)->s_gc(&PS(mod_data), PS(gc_maxlifetime), &num);
 		}
 	}

--- a/ext/session/tests/session_gc_probability_ini.phpt
+++ b/ext/session/tests/session_gc_probability_ini.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Test session.gc_probability and session.gc_divisor settings for negative values - always run GC
+--INI--
+session.gc_maxlifetime=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php
+include('skipif.inc');
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+$gc_settings = [
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => -1
+    ],
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => 1
+    ],
+];
+
+ob_start();
+foreach($gc_settings as $gc_setting) {
+    session_start($gc_setting);
+    $_SESSION['test'] = 'test';
+    session_write_close();
+
+    sleep(2);
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_write_close();
+    $_SESSION = [];
+
+    session_start($gc_setting);
+    if(count($_SESSION) !== 0) {
+        echo "\nERROR";
+    }
+    session_destroy();
+}
+ob_end_flush();
+?>
+Done
+--EXPECTF--
+Done

--- a/ext/session/tests/session_gc_probability_ini_2.phpt
+++ b/ext/session/tests/session_gc_probability_ini_2.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Test session.gc_probability and session.gc_divisor settings for negative values - never run GC
+--INI--
+session.gc_maxlifetime=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php
+include('skipif.inc');
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+$gc_settings = [
+    [
+        'gc_probability' => 1,
+        'gc_divisor' => 0
+    ],
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => 0
+    ],
+    [
+        'gc_probability' => 0,
+        'gc_divisor' => 0
+    ],
+];
+
+ob_start();
+foreach($gc_settings as $gc_setting) {
+    session_start($gc_setting);
+    $_SESSION['test'] = 'test';
+    session_write_close();
+
+    sleep(2);
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_write_close();
+    $_SESSION = [];
+
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_destroy();
+}
+ob_end_flush();
+?>
+Done
+--EXPECTF--
+Done


### PR DESCRIPTION
Fix for 8.2 of https://github.com/php/php-src/pull/15284