### PR TITLE
Update mysql preprocessor macros help texts

### DIFF
--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -18,7 +18,8 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
   done
 
   if test -n "$MYSQL_SOCK"; then
-    AC_DEFINE_UNQUOTED(PHP_MYSQL_UNIX_SOCK_ADDR, "$MYSQL_SOCK", [ ])
+    AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$MYSQL_SOCK"],
+      [The MySQL Unix socket location.])
     AC_MSG_RESULT([$MYSQL_SOCK])
   else
     AC_MSG_RESULT([no])
@@ -52,7 +53,7 @@ if test "$PHP_MYSQLI" != "no"; then
   AC_MSG_CHECKING([for MySQL UNIX socket location])
   if test "$PHP_MYSQL_SOCK" != "no" && test "$PHP_MYSQL_SOCK" != "yes"; then
     MYSQL_SOCK=$PHP_MYSQL_SOCK
-    AC_DEFINE_UNQUOTED(PHP_MYSQL_UNIX_SOCK_ADDR, "$MYSQL_SOCK", [ ])
+    AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$MYSQL_SOCK"])
     AC_MSG_RESULT([$MYSQL_SOCK])
   elif test "$PHP_MYSQL_SOCK" = "yes"; then
     PHP_MYSQL_SOCKET_SEARCH

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -10,7 +10,8 @@ if test "$PHP_PDO_MYSQL" != "no"; then
   AC_MSG_CHECKING([for MySQL UNIX socket location])
   if test "$PHP_MYSQL_SOCK" != "no" && test "$PHP_MYSQL_SOCK" != "yes"; then
     MYSQL_SOCK=$PHP_MYSQL_SOCK
-    AC_DEFINE_UNQUOTED(PHP_MYSQL_UNIX_SOCK_ADDR, "$MYSQL_SOCK", [ ])
+    AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$MYSQL_SOCK"],
+      [The MySQL Unix socket location.])
     AC_MSG_RESULT([$MYSQL_SOCK])
   elif test "$PHP_MYSQL_SOCK" = "yes"; then
     PHP_MYSQL_SOCKET_SEARCH
@@ -83,7 +84,9 @@ if test "$PHP_PDO_MYSQL" != "no"; then
 
   if test -n "$PDO_MYSQL_CONFIG"; then
     PDO_MYSQL_SOCKET=`$PDO_MYSQL_CONFIG --socket`
-    AC_DEFINE_UNQUOTED(PDO_MYSQL_UNIX_ADDR, "$PDO_MYSQL_SOCKET", [ ])
+    AC_DEFINE_UNQUOTED([PDO_MYSQL_UNIX_ADDR], ["$PDO_MYSQL_SOCKET"],
+      [The MySQL Unix socket location as defined by 'mysql_config' for use with
+      the pdo_mysql extension.])
   fi
 
   PHP_NEW_EXTENSION([pdo_mysql],

--- a/ext/pdo_mysql/pdo_mysql.c
+++ b/ext/pdo_mysql/pdo_mysql.c
@@ -43,7 +43,7 @@ ZEND_DECLARE_MODULE_GLOBALS(pdo_mysql)
  The default socket location is sometimes defined by configure.
  With libmysql `mysql_config --socket` will fill PDO_MYSQL_UNIX_ADDR
  and the user can use --with-mysql-sock=SOCKET which will fill
- PDO_MYSQL_UNIX_ADDR. If both aren't set we're using mysqlnd and use
+ PHP_MYSQL_UNIX_SOCK_ADDR. If both aren't set we're using mysqlnd and use
  /tmp/mysql.sock as default on *nix and NULL for Windows (default
  named pipe name is set in mysqlnd).
 */


### PR DESCRIPTION
This adds missing help texts for preprocessor macros defined in mysqli and pdo_mysql extensions.