### PR TITLE
ext/dba: Deprecate passing null|false to dba_key_split()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,9 @@ PHP                                                                        NEWS
   . Constants SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, and SUNFUNCS_RET_DOUBLE
     are now deprecated. (Jorg Sowa)
 
+- DBA:
+  . Passing null or false to dba_key_split() is deprecated. (Grigias)
+
 - DOM:
   . Fixed bug GH-15192 (Segmentation fault in dom extension
     (html5_serializer)). (nielsdos)

--- a/UPGRADING
+++ b/UPGRADING
@@ -409,6 +409,10 @@ PHP 8.4 UPGRADE NOTES
     the associated date_sunset() and date_sunrise() functions in PHP 8.1.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_4
 
+- DBA:
+  . Passing null or false to dba_key_split() is deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split
+
 - DOM:
   . Deprecated DOM_PHP_ERR constant.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_dom_php_err_constant

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1108,6 +1108,7 @@ PHP_FUNCTION(dba_key_split)
 	}
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "z", &zkey) == SUCCESS) {
 		if (Z_TYPE_P(zkey) == IS_NULL || (Z_TYPE_P(zkey) == IS_FALSE)) {
+			php_error_docref(NULL, E_DEPRECATED, "Passing false or null is deprecated since 8.4");
 			RETURN_FALSE;
 		}
 	}

--- a/ext/dba/tests/dba_split.phpt
+++ b/ext/dba/tests/dba_split.phpt
@@ -17,8 +17,11 @@ var_dump(dba_key_split("[key1]name1[key2]name2"));
 var_dump(dba_key_split("[key1]name1"));
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: dba_key_split(): Passing false or null is deprecated since 8.4 in %s on line %d
 bool(false)
+
+Deprecated: dba_key_split(): Passing false or null is deprecated since 8.4 in %s on line %d
 bool(false)
 array(2) {
   [0]=>


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split