### PR TITLE
fix: deprecate negative values for session GC probability

### DIFF
--- a/ext/session/tests/session_gc_probability_ini.phpt
+++ b/ext/session/tests/session_gc_probability_ini.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Test session.gc_probability and session.gc_divisor settings for negative values - always run GC
+--INI--
+session.gc_maxlifetime=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php
+include('skipif.inc');
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+$gc_settings = [
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => -1
+    ],
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => 1
+    ],
+];
+
+ob_start();
+foreach($gc_settings as $gc_setting) {
+    session_start($gc_setting);
+    $_SESSION['test'] = 'test';
+    session_write_close();
+
+    sleep(2);
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_write_close();
+    $_SESSION = [];
+
+    session_start($gc_setting);
+    if(count($_SESSION) !== 0) {
+        echo "\nERROR";
+    }
+    session_destroy();
+}
+ob_end_flush();
+?>
+Done
+--EXPECTF--
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+Done

--- a/ext/session/tests/session_gc_probability_ini_2.phpt
+++ b/ext/session/tests/session_gc_probability_ini_2.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Test session.gc_probability and session.gc_divisor settings for negative values - never run GC
+--INI--
+session.gc_maxlifetime=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php
+include('skipif.inc');
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+$gc_settings = [
+    [
+        'gc_probability' => -1,
+        'gc_divisor' => 0
+    ],
+    [
+        'gc_probability' => 1,
+        'gc_divisor' => 0
+    ],
+    [
+        'gc_probability' => 0,
+        'gc_divisor' => 0
+    ],
+];
+
+ob_start();
+foreach($gc_settings as $gc_setting) {
+    session_start($gc_setting);
+    $_SESSION['test'] = 'test';
+    session_write_close();
+
+    sleep(2);
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_write_close();
+    $_SESSION = [];
+
+    session_start($gc_setting);
+    if(count($_SESSION) === 0) {
+        echo "\nERROR";
+    }
+    session_destroy();
+}
+ob_end_flush();
+?>
+Done
+--EXPECTF--
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_probability lower than 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+
+Deprecated: session.gc_divisor lower than or equal 0 is deprecated. GC on each request is disabled. in %s on line %d
+Done


### PR DESCRIPTION
Deprecation PR for https://github.com/php/php-src/pull/15284