### PR TITLE
Fix GH-15292: Dynamic AVX detection is broken for MSVC

### DIFF
--- a/Zend/zend_cpuinfo.c
+++ b/Zend/zend_cpuinfo.c
@@ -73,7 +73,7 @@ static void __zend_cpuid(uint32_t func, uint32_t subfunc, zend_cpu_info *cpuinfo
 }
 #endif
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86)
 /* Function based on compiler-rt implementation. */
 static unsigned get_xcr0_eax(void) {
 # if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170 For x64, either _M_X64 or _M_AMD64 would work but I'm going with what's already used in php-src.