### PR TITLE
Autotools: Remove too basic optimization flag cleanup

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -177,9 +177,6 @@ AH_TEMPLATE([ZEND_DEBUG],
 AS_VAR_IF([ZEND_DEBUG], [yes], [
   AC_DEFINE([ZEND_DEBUG], [1])
   echo " $CFLAGS" | grep ' -g' >/dev/null || DEBUG_CFLAGS="-g"
-  if test "$CFLAGS" = "-g -O2"; then
-    CFLAGS=-g
-  fi
 ], [AC_DEFINE([ZEND_DEBUG], [0])])
 
 test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare $CFLAGS"


### PR DESCRIPTION
The optimization flags are removed in configure.ac when using --enable-debug. When using --enable-debug-assertions the optimization flags shouldn't ideally be removed and this case never actually happen because the CFLAGS at this point in ZEND_INIT contain all sorts of other flags also, so it's redundant as it never gets executed.