### PR TITLE
ext/core: Deprecate passing E_USER_ERROR to trigger_error()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-15140 (Missing variance check for abstract set with asymmetric
     type). (ilutov)
   . Fixed bug GH-15181 (Disabled output handler is flushed again). (cmb)
+  . Passing E_USER_ERROR to trigger_error() is now deprecated. (Girgias)
 
 - Date:
   . Constants SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, and SUNFUNCS_RET_DOUBLE

--- a/UPGRADING
+++ b/UPGRADING
@@ -401,6 +401,8 @@ PHP 8.4 UPGRADE NOTES
 - Core:
   . Implicitly nullable parameter types are now deprecated.
     RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
+  . Passing E_USER_ERROR to trigger_error() is now deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
 
 - Curl:
   . The CURLOPT_BINARYTRANSFER constant is deprecated.

--- a/Zend/tests/bug33802.phpt
+++ b/Zend/tests/bug33802.phpt
@@ -2,15 +2,15 @@
 Bug #33802 (throw Exception in error handler causes crash)
 --FILE--
 <?php
-set_error_handler('errorHandler', E_USER_ERROR);
-try{
+set_error_handler('errorHandler', E_USER_WARNING);
+try {
     test();
-}catch(Exception $e){
+} catch(Exception $e){
 }
 restore_error_handler();
 
-function test(){
-    trigger_error("error", E_USER_ERROR);
+function test() {
+    trigger_error("error", E_USER_WARNING);
 }
 
 function errorHandler($errno, $errstr, $errfile, $errline) {

--- a/Zend/tests/fibers/fatal-error-in-fiber.phpt
+++ b/Zend/tests/fibers/fatal-error-in-fiber.phpt
@@ -11,4 +11,6 @@ $fiber->start();
 
 ?>
 --EXPECTF--
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Fatal error in fiber in %sfatal-error-in-fiber.php on line %d

--- a/Zend/tests/fibers/fatal-error-in-nested-fiber.phpt
+++ b/Zend/tests/fibers/fatal-error-in-nested-fiber.phpt
@@ -25,4 +25,6 @@ $fiber->resume();
 int(2)
 int(1)
 
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Fatal error in nested fiber in %sfatal-error-in-nested-fiber.php on line %d

--- a/Zend/tests/fibers/fatal-error-with-multiple-fibers.phpt
+++ b/Zend/tests/fibers/fatal-error-with-multiple-fibers.phpt
@@ -25,4 +25,6 @@ $fiber2->resume();
 int(1)
 int(2)
 
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Fatal error in fiber in %sfatal-error-with-multiple-fibers.php on line %d

--- a/Zend/tests/fibers/gh10437.phpt
+++ b/Zend/tests/fibers/gh10437.phpt
@@ -14,5 +14,7 @@ $fiber->start();
 
 ?>
 --EXPECTF--
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Bailout in fiber in %sgh10437.php on line %d
 NULL

--- a/Zend/tests/gh10695_7.phpt
+++ b/Zend/tests/gh10695_7.phpt
@@ -9,7 +9,7 @@ set_error_handler(function ($errno, $errstr) {
     throw new \Exception($errstr);
 });
 register_shutdown_function(function () {
-    trigger_error('main', E_USER_ERROR);
+    trigger_error('main', E_USER_WARNING);
 });
 ?>
 --EXPECT--

--- a/Zend/tests/gh13097_a.phpt
+++ b/Zend/tests/gh13097_a.phpt
@@ -12,4 +12,6 @@ trigger_error(
 
 ?>
 --EXPECTF--
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: class@anonymous%s ...now you don't! in %s on line %d

--- a/Zend/tests/nowdoc_015.phpt
+++ b/Zend/tests/nowdoc_015.phpt
@@ -6,25 +6,25 @@ function error_handler($num, $msg, $file, $line) {
     echo $line,"\n";
 }
 set_error_handler('error_handler');
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<EOF
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<'EOF'
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<EOF
 test
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<'EOF'
 test
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<EOF
 test1
 test2
@@ -34,7 +34,7 @@ test3
 
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 $x = <<<'EOF'
 test1
 test2
@@ -44,7 +44,7 @@ test3
 
 EOF;
 var_dump($x);
-trigger_error("line", E_USER_ERROR);
+trigger_error("line", E_USER_WARNING);
 echo "ok\n";
 ?>
 --EXPECT--

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1214,6 +1214,11 @@ ZEND_FUNCTION(trigger_error)
 
 	switch (error_type) {
 		case E_USER_ERROR:
+			zend_error(E_DEPRECATED, "Passing E_USER_ERROR to trigger_error() is deprecated since 8.4,"
+				" throw an exception or call exit with a string message instead");
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
 		case E_USER_WARNING:
 		case E_USER_NOTICE:
 		case E_USER_DEPRECATED:

--- a/ext/standard/tests/streams/gh8409.phpt
+++ b/ext/standard/tests/streams/gh8409.phpt
@@ -3,7 +3,7 @@ GH-8409: Error in socket creation when error handler does not clean persistent c
 --FILE--
 <?php
 set_error_handler(function (int $errno, string $errstring): never {
-    trigger_error($errstring, E_USER_ERROR);
+    throw new Exception($errstring);
 });
 
 register_shutdown_function(function (): void {
@@ -21,5 +21,10 @@ stream_socket_client('tcp://9999.9999.9999.9999:9999', $error_code, $error_messa
 echo "ERROR: this should not be visible\n";
 ?>
 --EXPECTF--
-Fatal error: stream_socket_client(): %s in %sgh8409.php on line %d
+Fatal error: Uncaught Exception: stream_socket_client(): %s in %sgh8409.php:%d
+Stack trace:
+#0 [internal function]: {closure:%s:%d}(2, 'stream_socket_c...', '%s', %d)
+#1 %s(%d): stream_socket_client('tcp://9999.9999...', 0, '', 0.2, 5)
+#2 {main}
+  thrown in %s on line %d
 OK: persistent stream closed

--- a/ext/zend_test/tests/observer_error_02.phpt
+++ b/ext/zend_test/tests/observer_error_02.phpt
@@ -26,6 +26,8 @@ echo 'You should not see this.';
     <!-- init trigger_error() -->
     <trigger_error>
 
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Foo error in %s on line %d
     </trigger_error:NULL>
   </foo:NULL>

--- a/ext/zend_test/tests/observer_error_05.phpt
+++ b/ext/zend_test/tests/observer_error_05.phpt
@@ -35,6 +35,8 @@ echo 'You should not see this.';
       <!-- init trigger_error() -->
       <trigger_error>
 
+Deprecated: Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead in %s on line %d
+
 Fatal error: Foo error in %s on line %d
       </trigger_error:NULL>
     </{closure:%s:%d}:NULL>

--- a/tests/lang/error_2_exception_001.phpt
+++ b/tests/lang/error_2_exception_001.phpt
@@ -30,11 +30,11 @@ try {
 }
 
 try {
-    trigger_error("I will become an exception", E_USER_ERROR);
+    trigger_error("I will become an exception", E_USER_WARNING);
 } catch (MyException $exception) {
     echo "There was an exception: " . $exception->getErrno() . ", '" . $exception->getErrmsg() . "'\n";
 }
 
 ?>
 --EXPECT--
-There was an exception: 256, 'I will become an exception'
+There was an exception: 512, 'I will become an exception'


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error