### PR TITLE
Support SHA256_Transform_shani() with MSVC

### DIFF
--- a/ext/hash/hash_sha_ni.c
+++ b/ext/hash/hash_sha_ni.c
@@ -31,7 +31,7 @@
 
 # include <immintrin.h>
 
-# if PHP_HASH_INTRIN_SHA_RESOLVER
+# if defined(HAVE_FUNC_ATTRIBUTE_TARGET)
 static __m128i be32dec_128(const uint8_t * src)  __attribute__((target("ssse3")));
 void SHA256_Transform_shani(uint32_t state[PHP_STATIC_RESTRICT 8], const uint8_t block[PHP_STATIC_RESTRICT 64])  __attribute__((target("ssse3,sha")));
 # endif

--- a/ext/hash/hash_sha_ni.c
+++ b/ext/hash/hash_sha_ni.c
@@ -31,7 +31,7 @@
 
 # include <immintrin.h>
 
-# if defined(HAVE_FUNC_ATTRIBUTE_TARGET)
+# if  defined(PHP_HASH_INTRIN_SHA_RESOLVER) && defined(HAVE_FUNC_ATTRIBUTE_TARGET)
 static __m128i be32dec_128(const uint8_t * src)  __attribute__((target("ssse3")));
 void SHA256_Transform_shani(uint32_t state[PHP_STATIC_RESTRICT 8], const uint8_t block[PHP_STATIC_RESTRICT 64])  __attribute__((target("ssse3,sha")));
 # endif

--- a/ext/hash/php_hash_sha.h
+++ b/ext/hash/php_hash_sha.h
@@ -55,10 +55,10 @@ PHP_HASH_API void PHP_SHA256Update(PHP_SHA256_CTX *, const unsigned char *, size
 void SHA256_Transform_sse2(uint32_t state[PHP_STATIC_RESTRICT 8], const uint8_t block[PHP_STATIC_RESTRICT 64], uint32_t W[PHP_STATIC_RESTRICT 64], uint32_t S[PHP_STATIC_RESTRICT 8]);
 #endif
 
-#if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IMMINTRIN_H)
+#if ((defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IMMINTRIN_H)) || defined(_M_X64) || defined(_M_IX86)
 # if defined(__SSSE3__) && defined(__SHA__)
 #  define PHP_HASH_INTRIN_SHA_NATIVE 1
-# elif defined(HAVE_FUNC_ATTRIBUTE_TARGET)
+# elif defined(HAVE_FUNC_ATTRIBUTE_TARGET) || defined(_M_X64) || defined(_M_IX86)
 #  define PHP_HASH_INTRIN_SHA_RESOLVER 1
 # endif
 #endif


### PR DESCRIPTION
This requires https://github.com/php/php-src/issues/15292 to be fixed; I've used the same macro guards as proposed by https://github.com/php/php-src/pull/15301.

I've only did most minimal cleanup; given that the implementation apparently does not rely on `HAVE_FUNC_ATTRIBUTE_TARGET`, I've removed the forward declaration and changed the guard.

As is, this does not support compile time `__SHA__` detection, because that macro is apparently never defined on Windows. We would need to work around that in confutils.js like with other non standard MSVC macros:

https://github.com/php/php-src/blob/bd77462c7c71c096843c624f3f2ad9f589299ecf/win32/build/confutils.js#L3341-L3346

However, I wouldn't know where to insert `__SHA__`; likely this is "non-linear", and as such the whole `--enable-native-intrinsics` might need to be changed, or an extra configure option be introduced. Probably low priority, since official builds only use SSE(2) anyway.

Note also that the current implementation appears to be suboptimal since there is ~~neither proper support for `HAVE_FUNC_ATTRIBUTE_TARGET` (which is not available with MSVC anyway)~~, nor for `ZEND_INTRIN_*_FUNC_PTR` style which is likely supported everywhere.

@TimWolla might want to have a look at this, although for now it's just a draft.