### PR TITLE
Autotools: Enhance phpdbg readline enabling

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -21,25 +21,29 @@ PHP_ARG_ENABLE([phpdbg-readline],
   [no])
 
 if test "$PHP_PHPDBG" != "no"; then
+  AS_VAR_IF([PHP_PHPDBG_READLINE], [yes], [
+    AC_MSG_CHECKING([if readline can be enabled in phpdbg])
+    phpdbg_readline="no (readline extension is not enabled)"
+    AS_IF(m4_normalize([
+      (test -n "$with_readline" && test "x$with_readline" != xno) ||
+      (test -n "$with_libedit" && test "x$with_libedit" != xno)
+    ]), [phpdbg_readline=yes])
+    AS_CASE([$with_readline], [*shared*],
+      [phpdbg_readline="no (shared readline extension not supported)"])
+    AS_CASE([$with_libedit], [*shared*],
+      [phpdbg_readline="no (shared readline extension not supported)"])
+    AS_VAR_IF([phpdbg_readline], [yes], [
+      AC_DEFINE([HAVE_PHPDBG_READLINE], [1],
+        [Define to 1 if the phpdbg SAPI has libedit/readline integration.])
+    ])
+    AC_MSG_RESULT([$phpdbg_readline])
+  ])
+
   AC_HEADER_TIOCGWINSZ
 
   PHP_PHPDBG_CFLAGS="-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
   AS_VAR_IF([PHP_PHPDBG_DEBUG], [no],,
     [AS_VAR_APPEND([PHP_PHPDBG_CFLAGS], [" -DPHPDBG_DEBUG=1"])])
-
-  AC_MSG_CHECKING([for phpdbg and readline integration])
-  if test "$PHP_PHPDBG_READLINE" = "yes"; then
-    if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then
-      AC_DEFINE([HAVE_PHPDBG_READLINE], [1],
-        [Define to 1 if the phpdbg SAPI has libedit/readline integration.])
-      PHPDBG_EXTRA_LIBS="$PHP_READLINE_LIBS"
-      AC_MSG_RESULT([ok])
-    else
-      AC_MSG_RESULT([readline is not available])
-    fi
-  else
-    AC_MSG_RESULT([disabled])
-  fi
 
   AH_TEMPLATE([HAVE_USERFAULTFD_WRITEFAULT],
     [Define to 1 if faulting on write-protected memory support can be compiled


### PR DESCRIPTION
PHP_READLINE, PHP_LIBEDIT, and PHP_READLINE_LIBS variables are not available in sapi before the extensions arguments get processed by the configure script. But the Autoconf raw default variables with_readline and with_libedit are. This checks if readline support can be enabled in phpdbg

This is partial fix towards the more proper GH-13184 or similar in the future to make phpdbg readline integration easier to use.

Previous check silently enabled the phpdbg readline integration when readline is built as shared and failed on the make step:

    undefined reference to 'readline'
    undefined reference to 'add_history'

These cases enable it:

    ./configure --enable-phpdbg-readline --with-libedit
    ./configure --enable-phpdbg-readline --with-readline

These cases don't enable it:

    ./configure --enable-phpdbg-readline
    ./configure --enable-phpdbg-readline --with-libedit=shared
    ./configure --enable-phpdbg-readline --with-readline=shared