### PR TITLE
Simplify document standalone setter

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -155,8 +155,8 @@ zend_result dom_document_standalone_write(dom_object *obj, zval *newval)
 {
 	DOM_PROP_NODE(xmlDocPtr, docp, obj);
 
-	zend_long standalone = zval_get_long(newval);
-	docp->standalone = ZEND_NORMALIZE_BOOL(standalone);
+	ZEND_ASSERT(Z_TYPE_P(newval) == IS_TRUE || Z_TYPE_P(newval) == IS_FALSE);
+	docp->standalone = Z_TYPE_P(newval) == IS_TRUE;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
The logic was very weird as it just should check whether the boolean is true or not. And in fact the code is equivalent because zval_get_long() will only return 0/1 because the type is a bool, and ZEND_NORMALIZE_BOOL won't change that value.