### PR TITLE
Autotools: Refactor mysqli extension checks

### DIFF
--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -17,13 +17,11 @@ AC_DEFUN([PHP_MYSQL_SOCKET_SEARCH], [
     fi
   done
 
-  if test -n "$MYSQL_SOCK"; then
+  AS_VAR_IF([MYSQL_SOCK],, [AC_MSG_RESULT([no])], [
     AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$MYSQL_SOCK"],
       [The MySQL Unix socket location.])
     AC_MSG_RESULT([$MYSQL_SOCK])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 PHP_ARG_WITH([mysqli],
@@ -33,39 +31,42 @@ PHP_ARG_WITH([mysqli],
 
 dnl ext/pdo_mysql/config.m4 also depends on this configure option.
 PHP_ARG_WITH([mysql-sock],
-  [for specified location of the MySQL UNIX socket],
+  [for specified location of the MySQL Unix socket],
   [AS_HELP_STRING([[--with-mysql-sock[=SOCKPATH]]],
-    [MySQLi/PDO_MYSQL: Location of the MySQL unix socket pointer. If unspecified,
-    the default locations are searched])],
+    [MySQLi/PDO_MYSQL: Location of the MySQL Unix socket pointer. If
+    unspecified, the default locations are searched])],
   [no],
   [no])
 
-if test "$PHP_MYSQLI" = "yes" || test "$PHP_MYSQLI" = "mysqlnd"; then
-  dnl This needs to be set in any extension which wishes to use mysqlnd
-  PHP_MYSQLND_ENABLED=yes
-
-elif test "$PHP_MYSQLI" != "no"; then
-  AC_MSG_ERROR([Linking mysqli against external library is no longer supported])
-fi
-
-dnl Build extension
 if test "$PHP_MYSQLI" != "no"; then
-  AC_MSG_CHECKING([for MySQL UNIX socket location])
-  if test "$PHP_MYSQL_SOCK" != "no" && test "$PHP_MYSQL_SOCK" != "yes"; then
-    MYSQL_SOCK=$PHP_MYSQL_SOCK
-    AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$MYSQL_SOCK"])
-    AC_MSG_RESULT([$MYSQL_SOCK])
-  elif test "$PHP_MYSQL_SOCK" = "yes"; then
-    PHP_MYSQL_SOCKET_SEARCH
-  else
-    AC_MSG_RESULT([no])
-  fi
+  dnl The PHP_MYSQLND_ENABLED variable enables the mysqlnd extension.
+  AS_CASE([$PHP_MYSQLI],
+    [yes|mysqlnd], [PHP_MYSQLND_ENABLED=yes],
+    [AC_MSG_ERROR(m4_text_wrap([
+      Linking mysqli against external library is no longer supported. Replace
+      '--with-mysqli=$PHP_MYSQLI' with '--with-mysqli'.
+    ]))])
 
-  mysqli_sources="mysqli.c mysqli_api.c mysqli_prop.c mysqli_nonapi.c \
-                  mysqli_report.c mysqli_driver.c mysqli_warning.c \
-                  mysqli_exception.c mysqli_result_iterator.c"
-  PHP_NEW_EXTENSION([mysqli],
-    [$mysqli_sources],
+  AC_MSG_CHECKING([for MySQL Unix socket location])
+  AS_CASE([$PHP_MYSQL_SOCK],
+    [yes], [PHP_MYSQL_SOCKET_SEARCH],
+    [no], [AC_MSG_RESULT([no])],
+    [
+      AC_DEFINE_UNQUOTED([PHP_MYSQL_UNIX_SOCK_ADDR], ["$PHP_MYSQL_SOCK"])
+      AC_MSG_RESULT([$PHP_MYSQL_SOCK])
+    ])
+
+  PHP_NEW_EXTENSION([mysqli], m4_normalize([
+      mysqli_api.c
+      mysqli_driver.c
+      mysqli_exception.c
+      mysqli_nonapi.c
+      mysqli_prop.c
+      mysqli_report.c
+      mysqli_result_iterator.c
+      mysqli_warning.c
+      mysqli.c
+    ]),
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
   PHP_INSTALL_HEADERS([ext/mysqli], [php_mysqli_structs.h mysqli_mysqlnd.h])


### PR DESCRIPTION
- AS_* macros used
- s/UNIX/Unix
- The --with-mysql result value moved into the check when extension is enabled
- List of source files normalized with m4_normalize
- Redundant variables omitted
- CS synced