### PR TITLE
Support somewhat recent clang versions on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3070,7 +3070,7 @@ function toolset_get_compiler_version()
 		var command = 'cmd /c ""' + PHP_CL + '" -v"';
 		var full = execute(command + '" 2>&1"');
 
-		if (full.match(/clang version ([\d\.]+) \((.*)\)/)) {
+		if (full.match(/clang version ([\d\.]+)/)) {
 			version = RegExp.$1;
 			version = version.replace(/\./g, '');
 			version = version/100 < 1 ? version*10 : version;
@@ -3324,7 +3324,9 @@ function toolset_setup_common_cflags()
 		} else {
 			ADD_FLAG('CFLAGS', '-m64');
 		}
-		ADD_FLAG("CFLAGS", " /fallback ");
+		if (CLANGVERS < 1300) {
+			ADD_FLAG("CFLAGS", " /fallback ");
+		}
 		ADD_FLAG("CFLAGS", "-Xclang -fmodules");
 
 		var vc_ver = probe_binary(PATH_PROG('cl', null));


### PR DESCRIPTION
Prior to clang 10.0.0, `clang-cl -v` apparently always appended some fine grained version information in parentheses[1]; this is no longer the case, so the build fails early because the compiler version could not be detected.  Since we never used this fine grained version info, we no longer check for it.

As of clang 13.0.0, the `/fallback` command option has been removed[2], so we only set the flag for older clang versions.

[1] <https://github.com/php/php-src/pull/11313#discussion_r1712097627>
[2] <https://releases.llvm.org/13.0.0/tools/clang/docs/ReleaseNotes.html#removed-compiler-flags>

---

With these changes I've managed to have a successful minimal build (`--with-toolset=clang --disable-all --enable-cli`) with clang 18.1.8 on x64 Windows (didn't try x86 so far), if I set `CFLAGS=-Wno-implicit-function-declaration`. I'm going to follow up with a patch for the undeclared functions.