### PR TITLE
Fix some -Wimplicit-function-declaration errors on Windows

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -23,6 +23,9 @@
 #include "SAPI.h"
 #include "main/php_network.h"
 #include "zend_smart_str.h"
+#ifdef PHP_WIN32
+# include "win32/sockets.h"
+#endif
 
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -24,6 +24,7 @@
 #ifdef PHP_WIN32
 # include <process.h>
 # include <io.h>
+# include "win32/console.h"
 # include "win32/time.h"
 # include "win32/signal.h"
 # include "win32/php_registry.h"


### PR DESCRIPTION
While clang is picky about these, MSVC doesn't seem to care and would only report the calls to undeclared functions as errors during link time.  Still, obviously, MSVC is fine with having the declarations during compile time.

---

Note that these fixes all such errors for a full build of all self-contained extensions (i.e. those which don't require external libraries), except for ext/com_dotnet (which throws link errors), and the undeclared `_AddressOfReturnAddress()` in zend_call_stack.h which is due to 36857ab52b8cafc91650ccc55053abe6b517f092 (need to figure out what that is about).