### PR TITLE
Fix violation of the one definition rule in ext/com_dotnet

### DIFF
--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -66,7 +66,7 @@ static inline bool php_com_is_valid_object(zval *zv)
 } while(0)
 
 /* com_extension.c */
-zend_class_entry *php_com_variant_class_entry, *php_com_exception_class_entry, *php_com_saproxy_class_entry;
+extern zend_class_entry *php_com_variant_class_entry, *php_com_exception_class_entry, *php_com_saproxy_class_entry;
 
 /* com_handlers.c */
 zend_object* php_com_object_new(zend_class_entry *ce);


### PR DESCRIPTION
The definition of the class entries in the internal header file is not correct, since that file is included several times, and even the comment above the definition hints at com_extension.c where the actual definition is.  We fix this by declaring these variables as `extern`.

---

Note that I found this when compiling with clang, which fails with [LNK2005](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk2005?view=msvc-170); I have no idea why MSVC compiles do not trigger this error.