### PR TITLE
Change YIELD/YIELD_FROM to do not increment opline

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -83,6 +83,8 @@ PHP                                                                        NEWS
   . Added missing cstddef include for C++ builds. (cmb)
   . Fixed bug GH-15108 (Segfault when destroying generator during shutdown).
     (Arnaud)
+  . Fixed bug GH-15275 (Crash during GC of suspended generator delegate).
+    (Arnaud)
 
 - BCMath:
   . Adjust bcround()'s $mode parameter to only accept the RoundingMode

--- a/Zend/tests/gh15275-001.phpt
+++ b/Zend/tests/gh15275-001.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-15275 001: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        Fiber::suspend();
+        var_dump("not executed");
+    }
+}
+
+function f() {
+    var_dump(yield from new It());
+}
+
+$iterable = f();
+
+$fiber = new Fiber(function () use ($iterable) {
+    var_dump($iterable->current());
+    $iterable->next();
+    var_dump("not executed");
+});
+
+$ref = $fiber;
+
+$fiber->start();
+
+gc_collect_cycles();
+
+?>
+==DONE==
+--EXPECT--
+string(3) "foo"
+==DONE==

--- a/Zend/tests/gh15275-002.phpt
+++ b/Zend/tests/gh15275-002.phpt
@@ -1,0 +1,57 @@
+--TEST--
+GH-15275 002: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        try {
+            Fiber::suspend();
+        } finally {
+            var_dump(__METHOD__);
+        }
+        var_dump("not executed");
+    }
+}
+
+function f() {
+    try {
+        var_dump(new stdClass, yield from new It());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+function g() {
+    try {
+        var_dump(new stdClass, yield from f());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+$gen = g();
+
+$fiber = new Fiber(function () use ($gen) {
+    var_dump($gen->current());
+    $gen->next();
+    var_dump("not executed");
+});
+
+$ref = $fiber;
+
+$fiber->start();
+
+gc_collect_cycles();
+
+?>
+==DONE==
+--EXPECT--
+string(3) "foo"
+==DONE==
+string(15) "It::getIterator"
+string(1) "f"
+string(1) "g"

--- a/Zend/tests/gh15275-003.phpt
+++ b/Zend/tests/gh15275-003.phpt
@@ -1,0 +1,51 @@
+--TEST--
+GH-15275 003: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        throw new \Exception();
+        var_dump("not executed");
+    }
+}
+
+function f() {
+    try {
+        var_dump(new stdClass, yield from new It());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+function g() {
+    try {
+        var_dump(new stdClass, yield from f());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+$gen = g();
+
+var_dump($gen->current());
+$gen->next();
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+string(1) "f"
+string(1) "g"
+
+Fatal error: Uncaught Exception in %s:8
+Stack trace:
+#0 %s(15): It->getIterator()
+#1 %s(23): f()
+#2 [internal function]: g()
+#3 %s(32): Generator->next()
+#4 {main}
+  thrown in %s on line 8

--- a/Zend/tests/gh15275-004.phpt
+++ b/Zend/tests/gh15275-004.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-15275 004: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        echo "baz\n";
+        throw new \Exception();
+    }
+
+    public function __destruct()
+    {
+        gc_collect_cycles();
+    }
+}
+
+function f() {
+    var_dump(new stdClass, yield from new It());
+}
+
+$gen = f();
+
+var_dump($gen->current());
+$gen->next();
+
+gc_collect_cycles();
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+baz
+
+Fatal error: Uncaught Exception in %s:9
+Stack trace:
+#0 %s(19): It->getIterator()
+#1 [internal function]: f()
+#2 %s(25): Generator->next()
+#3 {main}
+  thrown in %s on line 9

--- a/Zend/tests/gh15275-005.phpt
+++ b/Zend/tests/gh15275-005.phpt
@@ -1,0 +1,51 @@
+--TEST--
+GH-15275 005: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        throw new \Exception();
+        var_dump("not executed");
+    }
+}
+
+function f() {
+    try {
+        var_dump(new stdClass, yield from new It());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+function g() {
+    try {
+        var_dump(new stdClass, yield from f());
+    } finally {
+        var_dump(__FUNCTION__);
+    }
+}
+
+$gen = g();
+
+var_dump($gen->current());
+$gen->next();
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+string(1) "f"
+string(1) "g"
+
+Fatal error: Uncaught Exception in %s:8
+Stack trace:
+#0 %s(15): It->getIterator()
+#1 %s(23): f()
+#2 [internal function]: g()
+#3 %s(32): Generator->next()
+#4 {main}
+  thrown in %s on line 8

--- a/Zend/tests/gh15275-006.phpt
+++ b/Zend/tests/gh15275-006.phpt
@@ -1,0 +1,51 @@
+--TEST--
+GH-15275 006: Crash during GC of suspended generator delegate
+--FILE--
+<?php
+
+class It implements \IteratorAggregate
+{
+    public function getIterator(): \Generator
+    {
+        yield 'foo';
+        echo "baz\n";
+        throw new \Exception();
+    }
+
+    public function __destruct()
+    {
+        throw new \Exception();
+    }
+}
+
+function f() {
+    var_dump(new stdClass, yield from new It());
+}
+
+$gen = f();
+
+var_dump($gen->current());
+$gen->next();
+
+gc_collect_cycles();
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+baz
+
+Fatal error: Uncaught Exception in %s:9
+Stack trace:
+#0 %s(19): It->getIterator()
+#1 [internal function]: f()
+#2 %s(25): Generator->next()
+#3 {main}
+
+Next Exception in %s:14
+Stack trace:
+#0 %s(19): It->__destruct()
+#1 [internal function]: f()
+#2 %s(25): Generator->next()
+#3 {main}
+  thrown in %s on line 14

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4762,7 +4762,13 @@ ZEND_API HashTable *zend_unfinished_execution_gc_ex(zend_execute_data *execute_d
 	}
 
 	if (call) {
-		uint32_t op_num = execute_data->opline - op_array->opcodes;
+		uint32_t op_num;
+		if (UNEXPECTED(execute_data->opline->opcode == ZEND_HANDLE_EXCEPTION)) {
+			op_num = EG(opline_before_exception) - op_array->opcodes;
+		} else {
+			op_num = execute_data->opline - op_array->opcodes;
+		}
+		ZEND_ASSERT(op_num < op_array->last);
 		if (suspended_by_yield) {
 			/* When the execution was suspended by yield, EX(opline) points to
 			 * next opline to execute. Otherwise, it points to the opline that

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -26,6 +26,7 @@
 #include "zend_closures.h"
 #include "zend_generators_arginfo.h"
 #include "zend_observer.h"
+#include "zend_vm_opcodes.h"
 
 ZEND_API zend_class_entry *zend_ce_generator;
 ZEND_API zend_class_entry *zend_ce_ClosedGeneratorException;
@@ -516,6 +517,8 @@ static void zend_generator_throw_exception(zend_generator *generator, zval *exce
 	 * to pretend the exception happened during the YIELD opcode. */
 	EG(current_execute_data) = generator->execute_data;
 	generator->execute_data->opline--;
+	ZEND_ASSERT(generator->execute_data->opline->opcode == ZEND_YIELD
+			|| generator->execute_data->opline->opcode == ZEND_YIELD_FROM);
 	generator->execute_data->prev_execute_data = original_execute_data;
 
 	if (exception) {
@@ -524,13 +527,14 @@ static void zend_generator_throw_exception(zend_generator *generator, zval *exce
 		zend_rethrow_exception(EG(current_execute_data));
 	}
 
+	generator->execute_data->opline++;
+
 	/* if we don't stop an array/iterator yield from, the exception will only reach the generator after the values were all iterated over */
 	if (UNEXPECTED(Z_TYPE(generator->values) != IS_UNDEF)) {
 		zval_ptr_dtor(&generator->values);
 		ZVAL_UNDEF(&generator->values);
 	}
 
-	generator->execute_data->opline++;
 	EG(current_execute_data) = original_execute_data;
 }
 
@@ -660,8 +664,6 @@ ZEND_API zend_generator *zend_generator_update_current(zend_generator *generator
 
 static zend_result zend_generator_get_next_delegated_value(zend_generator *generator) /* {{{ */
 {
-	--generator->execute_data->opline;
-
 	zval *value;
 	if (Z_TYPE(generator->values) == IS_ARRAY) {
 		HashTable *ht = Z_ARR(generator->values);
@@ -743,14 +745,12 @@ static zend_result zend_generator_get_next_delegated_value(zend_generator *gener
 		}
 	}
 
-	++generator->execute_data->opline;
 	return SUCCESS;
 
 failure:
 	zval_ptr_dtor(&generator->values);
 	ZVAL_UNDEF(&generator->values);
 
-	++generator->execute_data->opline;
 	return FAILURE;
 }
 /* }}} */
@@ -814,6 +814,15 @@ try_again:
 			orig_generator->flags &= ~(ZEND_GENERATOR_DO_INIT | ZEND_GENERATOR_IN_FIBER);
 			generator->flags &= ~ZEND_GENERATOR_IN_FIBER;
 			return;
+		}
+		if (UNEXPECTED(EG(exception))) {
+			/* Decrementing opline_before_exception to pretend the exception
+			 * happened during the YIELD_FROM opcode. */
+			if (generator->execute_data) {
+				ZEND_ASSERT(generator->execute_data->opline == EG(exception_op));
+				ZEND_ASSERT((EG(opline_before_exception)-1)->opcode == ZEND_YIELD_FROM);
+				EG(opline_before_exception)--;
+			}
 		}
 		/* If there are no more delegated values, resume the generator
 		 * after the "yield from" expression. */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4609,7 +4609,7 @@ ZEND_VM_HANDLER(139, ZEND_GENERATOR_CREATE, ANY, ANY)
 		generator->execute_fake.prev_execute_data = NULL;
 		ZVAL_OBJ(&generator->execute_fake.This, (zend_object *) generator);
 
-		gen_execute_data->opline = opline + 1;
+		gen_execute_data->opline = opline;
 		/* EX(return_value) keeps pointer to zend_object (not a real zval) */
 		gen_execute_data->return_value = (zval*)generator;
 		call_info = Z_TYPE_INFO(EX(This));
@@ -8416,10 +8416,6 @@ ZEND_VM_HANDLER(160, ZEND_YIELD, CONST|TMP|VAR|CV|UNUSED, CONST|TMPVAR|CV|UNUSED
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -8521,10 +8517,6 @@ ZEND_VM_C_LABEL(yield_from_try_again):
 
 	/* This generator has no send target (though the generator we delegate to might have one) */
 	generator->send_target = NULL;
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2222,7 +2222,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_GENERATOR_CREATE_SPEC_HANDLER(
 		generator->execute_fake.prev_execute_data = NULL;
 		ZVAL_OBJ(&generator->execute_fake.This, (zend_object *) generator);
 
-		gen_execute_data->opline = opline + 1;
+		gen_execute_data->opline = opline;
 		/* EX(return_value) keeps pointer to zend_object (not a real zval) */
 		gen_execute_data->return_value = (zval*)generator;
 		call_info = Z_TYPE_INFO(EX(This));
@@ -5866,10 +5866,6 @@ yield_from_try_again:
 	/* This generator has no send target (though the generator we delegate to might have one) */
 	generator->send_target = NULL;
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -8097,10 +8093,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CONST_CONST_HANDLER
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -10429,10 +10421,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CONST_TMPVAR_HANDLE
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -11276,10 +11264,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CONST_UNUSED_HANDLE
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -12916,10 +12900,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CONST_CV_HANDLER(ZE
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -15464,10 +15444,6 @@ yield_from_try_again:
 
 	/* This generator has no send target (though the generator we delegate to might have one) */
 	generator->send_target = NULL;
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -20930,10 +20906,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_TMP_CONST_HANDLER(Z
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -21374,10 +21346,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_TMP_TMPVAR_HANDLER(
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -21835,10 +21803,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_TMP_UNUSED_HANDLER(
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -22238,10 +22202,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_TMP_CV_HANDLER(ZEND
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -26243,10 +26203,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_VAR_CONST_HANDLER(Z
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -28736,10 +28692,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_VAR_TMPVAR_HANDLER(
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -30690,10 +30642,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_VAR_UNUSED_HANDLER(
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -33161,10 +33109,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_VAR_CV_HANDLER(ZEND
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -35442,10 +35386,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_UNUSED_CONST_HANDLE
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -37415,10 +37355,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_UNUSED_TMPVAR_HANDL
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -37955,10 +37891,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_UNUSED_UNUSED_HANDL
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -40037,10 +39969,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_UNUSED_CV_HANDLER(Z
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -41395,10 +41323,6 @@ yield_from_try_again:
 
 	/* This generator has no send target (though the generator we delegate to might have one) */
 	generator->send_target = NULL;
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -45469,10 +45393,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CV_CONST_HANDLER(ZE
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -49157,10 +49077,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CV_TMPVAR_HANDLER(Z
 		generator->send_target = NULL;
 	}
 
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
-
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
 	SAVE_OPLINE();
@@ -51013,10 +50929,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CV_UNUSED_HANDLER(Z
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */
@@ -54727,10 +54639,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_YIELD_SPEC_CV_CV_HANDLER(ZEND_
 	} else {
 		generator->send_target = NULL;
 	}
-
-	/* We increment to the next op, so we are at the correct position when the
-	 * generator is resumed. */
-	ZEND_VM_INC_OPCODE();
 
 	/* The GOTO VM uses a local opline variable. We need to set the opline
 	 * variable in execute_data so we don't resume at an old position. */

--- a/ext/reflection/tests/ReflectionGenerator_isClosed.phpt
+++ b/ext/reflection/tests/ReflectionGenerator_isClosed.phpt
@@ -32,15 +32,15 @@ foreach ($gens as $gen) {
 }
 
 ?>
---EXPECTF--
-int(10)
+--EXPECT--
+int(9)
 bool(false)
-int(10)
+int(9)
 bool(true)
 Cannot fetch information from a closed Generator
 
-int(4)
+int(3)
 bool(false)
-int(4)
+int(3)
 bool(true)
 Cannot fetch information from a closed Generator

--- a/ext/reflection/tests/ReflectionGenerator_isClosed_002.phpt
+++ b/ext/reflection/tests/ReflectionGenerator_isClosed_002.phpt
@@ -30,11 +30,11 @@ foreach ($gens as $gen) {
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(false)
 bool(true)
 bool(false)
-int(11)
+int(10)
 
 bool(false)
 bool(false)


### PR DESCRIPTION
This is an alternative of https://github.com/php/php-src/pull/15275

`YIELD` and `YIELD_FROM` increment opline before returning, but in most places we need the opline to point to the `YIELD` and `YIELD_FROM`.

Here I change `YIELD`/`YIELD_FROM` to not increment opline. This simplifies the code a fixes a few crashes.