### PR TITLE
Declare gdImageGetInterpolationMethod() for bundled GD

### DIFF
--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -878,6 +878,7 @@ gdImagePtr gdImageCropAuto(gdImagePtr im, const unsigned int mode);
 gdImagePtr gdImageCropThreshold(gdImagePtr im, const unsigned int color, const float threshold);
 
 int gdImageSetInterpolationMethod(gdImagePtr im, gdInterpolationMethod id);
+gdInterpolationMethod gdImageGetInterpolationMethod(gdImagePtr im);
 
 gdImagePtr gdImageScaleBilinear(gdImagePtr im, const unsigned int new_width, const unsigned int new_height);
 gdImagePtr gdImageScaleBicubic(gdImagePtr src_img, const unsigned int new_width, const unsigned int new_height);


### PR DESCRIPTION
When this function has been added to our bundled GD[1], it had been overlooked to also declare it in gd.h, like it's done in libgd.  While MSVC doesn't have any issues with this, clang reports an error.

[1] <https://github.com/php/php-src/commit/03bd4333f62d89047ba4e9ce3625e44c063391de>

---

See also https://github.com/php/php-src/pull/15296#discussion_r171132417..