### PR TITLE
Autotools: Sync CS across the configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,16 +281,12 @@ AC_MSG_RESULT([$PHP_SAPI])
 
 dnl Show which binaries were selected.
 AC_MSG_CHECKING([for executable SAPI binaries])
-if test "$PHP_BINARIES"; then
-  AC_MSG_RESULT([$PHP_BINARIES])
-else
-  AC_MSG_RESULT([none])
-fi
+AS_VAR_IF([PHP_BINARIES],,
+  [AC_MSG_RESULT([none])],
+  [AC_MSG_RESULT([$PHP_BINARIES])])
 
 dnl Exit early.
-if test -z "$PHP_INSTALLED_SAPIS"; then
-  AC_MSG_ERROR([Nothing to build.])
-fi
+AS_VAR_IF([PHP_INSTALLED_SAPIS],, [AC_MSG_ERROR([Nothing to build.])])
 
 dnl Add POSIX threads compilation and linker flags when thread safety is enabled
 dnl with either the '--enable-zts' configure option or automatically enabled by
@@ -763,10 +759,8 @@ PHP_ARG_ENABLE([gcov],
   [no])
 
 if test "$PHP_GCOV" = "yes"; then
-
-  if test "$GCC" != "yes"; then
-    AC_MSG_ERROR([GCC is required for --enable-gcov])
-  fi
+  AS_VAR_IF([GCC], [yes],,
+    [AC_MSG_ERROR([GNU C compatible compiler is required for --enable-gcov])])
 
   dnl Check if ccache is being used.
   case `$php_shtool path $CC` in
@@ -877,14 +871,7 @@ PHP_ARG_WITH([layout],
   [PHP],
   [no])
 
-case $PHP_LAYOUT in
-  GNU)
-    oldstyleextdir=no
-    ;;
-  *)
-    oldstyleextdir=yes
-    ;;
-esac
+AS_CASE([$PHP_LAYOUT], [GNU], [oldstyleextdir=no], [oldstyleextdir=yes])
 
 PHP_ARG_WITH([config-file-path],
   [path to configuration file],
@@ -893,16 +880,10 @@ PHP_ARG_WITH([config-file-path],
   [DEFAULT],
   [no])
 
-if test "$PHP_CONFIG_FILE_PATH" = "DEFAULT"; then
-  case $PHP_LAYOUT in
-    GNU)
-      PHP_CONFIG_FILE_PATH=$sysconfdir
-      ;;
-    *)
-      PHP_CONFIG_FILE_PATH=$libdir
-      ;;
-  esac
-fi
+AS_VAR_IF([PHP_CONFIG_FILE_PATH], [DEFAULT],
+  [AS_CASE([$PHP_LAYOUT],
+    [GNU], [PHP_CONFIG_FILE_PATH=$sysconfdir],
+    [PHP_CONFIG_FILE_PATH=$libdir])])
 
 AC_MSG_CHECKING([where to scan for configuration files])
 PHP_ARG_WITH([config-file-scan-dir],,
@@ -911,9 +892,7 @@ PHP_ARG_WITH([config-file-scan-dir],,
   [DEFAULT],
   [no])
 
-if test "$PHP_CONFIG_FILE_SCAN_DIR" = "DEFAULT"; then
-  PHP_CONFIG_FILE_SCAN_DIR=
-fi
+AS_VAR_IF([PHP_CONFIG_FILE_SCAN_DIR], [DEFAULT], [PHP_CONFIG_FILE_SCAN_DIR=])
 AC_MSG_RESULT([$PHP_CONFIG_FILE_SCAN_DIR])
 
 PHP_ARG_ENABLE([sigchild],
@@ -936,14 +915,13 @@ PHP_ARG_ENABLE([libgcc],
   [no],
   [no])
 
-if test "$PHP_LIBGCC" = "yes"; then
+AS_VAR_IF([PHP_LIBGCC], [yes], [
   PHP_LIBGCC_LIBPATH([gcc])
-  if test -z "$libgcc_libpath"; then
-    AC_MSG_ERROR([Cannot locate libgcc. Make sure that gcc is in your path])
-  fi
+  AS_VAR_IF([libgcc_libpath],,
+    [AC_MSG_ERROR([Cannot locate libgcc. Make sure that gcc is in your path])])
   PHP_ADD_LIBPATH([$libgcc_libpath])
   PHP_ADD_LIBRARY([gcc], [yes])
-fi
+])
 
 PHP_ARG_ENABLE([short-tags],
   [whether to enable short tags by default],
@@ -1028,16 +1006,14 @@ PHP_ARG_ENABLE([fd-setsize],,
   [no],
   [no])
 
-if test "$PHP_FD_SETSIZE" != "no"; then
+AS_VAR_IF([PHP_FD_SETSIZE], [no], [AC_MSG_RESULT([using system default])], [
   if test "0$PHP_FD_SETSIZE" -gt 0 2>/dev/null; then
     CPPFLAGS="$CPPFLAGS -DFD_SETSIZE=$PHP_FD_SETSIZE"
     AC_MSG_RESULT([using $PHP_FD_SETSIZE])
   else
     AC_MSG_ERROR([Invalid value passed to --enable-fd-setsize!])
   fi
-else
-  AC_MSG_RESULT([using system default])
-fi
+])
 
 PHP_ARG_ENABLE([werror],,
   [AS_HELP_STRING([--enable-werror],
@@ -1356,28 +1332,23 @@ datadir=`eval eval echo $datadir`
 dnl Build extension directory path.
 ZEND_MODULE_API_NO=`$EGREP '#define ZEND_MODULE_API_NO ' $srcdir/Zend/zend_modules.h|"${SED}" 's/#define ZEND_MODULE_API_NO //'`
 
-if test -z "$EXTENSION_DIR"; then
+AS_VAR_IF([EXTENSION_DIR],, [
   extbasedir=$ZEND_MODULE_API_NO
-  if test "$oldstyleextdir" = "yes"; then
+  AS_VAR_IF([oldstyleextdir], [yes], [
     AS_VAR_IF([PHP_DEBUG], [1], [part1=debug], [part1=no-debug])
     AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [part2=zts], [part2=non-zts])
     extbasedir=$part1-$part2-$extbasedir
     EXTENSION_DIR=$libdir/extensions/$extbasedir
-  else
+  ], [
     AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [extbasedir=$extbasedir-zts])
     AS_VAR_IF([PHP_DEBUG], [1], [extbasedir=$extbasedir-debug])
     EXTENSION_DIR=$libdir/$extbasedir
-  fi
-fi
+  ])
+])
 
-case $PHP_LAYOUT in
-  GNU)
-    datarootdir=$prefix/share
-    ;;
-  *)
-    datarootdir=$prefix/php
-    ;;
-esac
+AS_CASE([$PHP_LAYOUT],
+  [GNU], [datarootdir=$prefix/share],
+  [datarootdir=$prefix/php])
 
 dnl Expand all directory names for use in macros/constants.
 EXPANDED_PEAR_INSTALLDIR=`eval echo $PEAR_INSTALLDIR`
@@ -1504,10 +1475,10 @@ if test "$PHP_THREAD_SAFETY" = "yes" && test -n "$ac_cv_pthreads_cflags"; then
 fi
 
 dnl Enable -Werror late, because it may break configure checks throwing warnings.
-if test "$PHP_WERROR" = "yes"; then
+AS_VAR_IF([PHP_WERROR], [yes], [
   CFLAGS="$CFLAGS -Werror"
   CXXFLAGS="$CXXFLAGS -Werror"
-fi
+])
 
 if test "$PHP_MEMORY_SANITIZER" = "yes" &&
    test "$PHP_ADDRESS_SANITIZER" = "yes"; then
@@ -1515,12 +1486,12 @@ if test "$PHP_MEMORY_SANITIZER" = "yes" &&
 fi
 
 dnl Enable -fsanitize=memory late, because interceptors may break linking detection.
-if test "$PHP_MEMORY_SANITIZER" = "yes"; then
-  AX_CHECK_COMPILE_FLAG([-fsanitize=memory -fsanitize-memory-track-origins], [
+AS_VAR_IF([PHP_MEMORY_SANITIZER], [yes],
+  [AX_CHECK_COMPILE_FLAG([-fsanitize=memory -fsanitize-memory-track-origins], [
     CFLAGS="$CFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
     CXXFLAGS="$CXXFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
   ], [AC_MSG_ERROR([MemorySanitizer is not available])])
-fi
+])
 
 AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
   [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR(m4_normalize([
@@ -1535,8 +1506,8 @@ AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
   ], [AC_MSG_ERROR([AddressSanitizer is not available])])
 ])
 
-if test "$PHP_UNDEFINED_SANITIZER" = "yes"; then
-  AX_CHECK_COMPILE_FLAG([-fsanitize=undefined], [
+AS_VAR_IF([PHP_UNDEFINED_SANITIZER], [yes],
+  [AX_CHECK_COMPILE_FLAG([-fsanitize=undefined], [
     CFLAGS="$CFLAGS -fsanitize=undefined -fno-sanitize-recover=undefined"
     CXXFLAGS="$CXXFLAGS -fsanitize=undefined -fno-sanitize-recover=undefined"
     AX_CHECK_COMPILE_FLAG([-fno-sanitize=object-size], [
@@ -1548,23 +1519,27 @@ if test "$PHP_UNDEFINED_SANITIZER" = "yes"; then
 
     dnl Clang 17 adds stricter function pointer compatibility checks where pointer args cannot be
     dnl cast to void*. In that case, set -fno-sanitize=function.
-    OLD_CFLAGS="$CFLAGS"
+    OLD_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -fno-sanitize-recover=undefined"
-    AC_CACHE_CHECK([whether to add -fno-sanitize=function],[php_cv_ubsan_no_function],[
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    AC_CACHE_CHECK([whether to add -fno-sanitize=function],
+    [php_cv_ubsan_no_function],
+    [AC_RUN_IFELSE([AC_LANG_SOURCE([
 void foo(char *string) {}
 int main(void) {
   void (*f)(void *) = (void (*)(void *))foo;
   f("foo");
 }
-    ]])],[php_cv_ubsan_no_function=no],[php_cv_ubsan_no_function=yes],[php_cv_ubsan_no_function=no])])
-    CFLAGS="$OLD_CFLAGS"
-    if test "$php_cv_ubsan_no_function" = yes; then
+    ])],
+    [php_cv_ubsan_no_function=no],
+    [php_cv_ubsan_no_function=yes],
+    [php_cv_ubsan_no_function=no])])
+    CFLAGS=$OLD_CFLAGS
+    AS_VAR_IF([php_cv_ubsan_no_function], [yes], [
       CFLAGS="$CFLAGS -fno-sanitize=function"
       CXXFLAGS="$CFLAGS -fno-sanitize=function"
-    fi
+    ])
   ], [AC_MSG_ERROR([UndefinedBehaviorSanitizer is not available])])
-fi
+])
 
 if test "$PHP_MEMORY_SANITIZER" = "yes" ||
    test "$PHP_ADDRESS_SANITIZER" = "yes" ||


### PR DESCRIPTION
- AS_* macros used where it makes it easier to read
- Redundant double quotes removed (Autoconf and shell script don't need these on these places directly)
- Overquoted arguments reduced in AC_RUN_IFELSE