### PR TITLE
Autotools: Sync CS in opcache extension

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -79,11 +79,7 @@ if test "$PHP_OPCACHE" != "no"; then
         DASM_FLAGS="-D X64=1"
         DASM_ARCH="x86"
       ],
-      [[i[34567]86*]], [
-        IR_TARGET=IR_TARGET_X86
-        DASM_ARCH="x86"
-      ],
-      [x86*], [
+      [[i[34567]86*|x86*]], [
         IR_TARGET=IR_TARGET_X86
         DASM_ARCH="x86"
       ],

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -26,7 +26,6 @@ PHP_ARG_WITH([capstone],
   [no])
 
 if test "$PHP_OPCACHE" != "no"; then
-
   dnl Always build as shared extension
   ext_shared=yes
 
@@ -34,22 +33,21 @@ if test "$PHP_OPCACHE" != "no"; then
     [AC_DEFINE([HAVE_HUGE_CODE_PAGES], [1],
       [Define to 1 to enable copying PHP CODE pages into HUGE PAGES.])])
 
-  if test "$PHP_OPCACHE_JIT" = "yes"; then
-    case $host_cpu in
-      i[[34567]]86*|x86*|aarch64|amd64)
-        ;;
-      *)
+  AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
+    AS_CASE([$host_cpu],
+      [[i[34567]86*|x86*|aarch64|amd64]], [],
+      [
         AC_MSG_WARN([JIT not supported by host architecture])
         PHP_OPCACHE_JIT=no
-        ;;
-    esac
+      ])
+
     if test "$host_vendor" = "apple" && test "$host_cpu" = "aarch64" && test "$PHP_THREAD_SAFETY" = "yes"; then
       AC_MSG_WARN([JIT not supported on Apple Silicon with ZTS])
       PHP_OPCACHE_JIT=no
     fi
-  fi
+  ])
 
-  if test "$PHP_OPCACHE_JIT" = "yes" ; then
+  AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
     AC_DEFINE([HAVE_JIT], [1], [Define to 1 to enable JIT.])
     ZEND_JIT_SRC=m4_normalize(["
       jit/ir/ir_cfg.c
@@ -70,30 +68,29 @@ if test "$PHP_OPCACHE" != "no"; then
     "])
 
     dnl Find out which ABI we are using.
-    case $host_alias in
-      x86_64-*-darwin*)
+    AS_CASE([$host_alias],
+      [x86_64-*-darwin*], [
         IR_TARGET=IR_TARGET_X64
         DASM_FLAGS="-D X64APPLE=1 -D X64=1"
         DASM_ARCH="x86"
-        ;;
-      *x86_64*|amd64-*-freebsd*)
+      ],
+      [*x86_64*|amd64-*-freebsd*], [
         IR_TARGET=IR_TARGET_X64
         DASM_FLAGS="-D X64=1"
         DASM_ARCH="x86"
-        ;;
-      i[[34567]]86*)
+      ],
+      [[i[34567]86*]], [
         IR_TARGET=IR_TARGET_X86
         DASM_ARCH="x86"
-        ;;
-      x86*)
+      ],
+      [x86*], [
         IR_TARGET=IR_TARGET_X86
         DASM_ARCH="x86"
-        ;;
-      aarch64*)
+      ],
+      [aarch64*], [
         IR_TARGET=IR_TARGET_AARCH64
         DASM_ARCH="aarch64"
-        ;;
-     esac
+      ])
 
     AS_VAR_IF([PHP_CAPSTONE], [yes],
       [PKG_CHECK_MODULES([CAPSTONE], [capstone >= 3.0.0], [
@@ -109,12 +106,12 @@ if test "$PHP_OPCACHE" != "no"; then
 
     JIT_CFLAGS="-I@ext_builddir@/jit/ir -D$IR_TARGET -DIR_PHP"
     AS_VAR_IF([ZEND_DEBUG], [yes], [JIT_CFLAGS="$JIT_CFLAGS -DIR_DEBUG"])
-  fi
+  ])
 
   AC_CHECK_FUNCS([mprotect shm_create_largepage])
 
   AC_CACHE_CHECK([for sysvipc shared memory support], [php_cv_shm_ipc],
-    [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    [AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/ipc.h>
@@ -178,7 +175,7 @@ int main(void) {
   }
   return 0;
 }
-]])],
+])],
 [php_cv_shm_ipc=yes],
 [php_cv_shm_ipc=no],
 [php_cv_shm_ipc=no])])
@@ -188,7 +185,7 @@ AS_VAR_IF([php_cv_shm_ipc], [yes],
 
   AC_CACHE_CHECK([for mmap() using MAP_ANON shared memory support],
   [php_cv_shm_mmap_anon],
-  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
@@ -234,7 +231,7 @@ int main(void) {
   }
   return 0;
 }
-]])],
+])],
 [php_cv_shm_mmap_anon=yes],
 [php_cv_shm_mmap_anon=no],
 [AS_CASE([$host_alias],
@@ -248,7 +245,7 @@ AS_VAR_IF([php_cv_shm_mmap_anon], [yes],
   dnl needed: rt (older Linux and Solaris <= 10). Most systems have it in the C
   dnl standard library (newer Linux, illumos, Solaris 11.4, macOS, BSD-based
   dnl systems...). Haiku has it in the root library, which is linked by default.
-  LIBS_save="$LIBS"
+  LIBS_save=$LIBS
   LIBS=
   AC_SEARCH_LIBS([shm_open], [rt],
     [AC_CACHE_CHECK([for mmap() using shm_open() shared memory support],
@@ -321,14 +318,14 @@ int main(void) {
       [php_cv_shm_mmap_posix=no])
     ])
 
-    if test "$php_cv_shm_mmap_posix" = "yes"; then
+    AS_VAR_IF([php_cv_shm_mmap_posix], [yes], [
       AS_VAR_IF([ac_cv_search_shm_open], ["none required"],,
         [OPCACHE_SHARED_LIBADD="$OPCACHE_SHARED_LIBADD $ac_cv_search_shm_open"])
       AC_DEFINE([HAVE_SHM_MMAP_POSIX], [1],
         [Define to 1 if you have the POSIX mmap() SHM support.])
-    fi
+    ])
   ])
-  LIBS="$LIBS_save"
+  LIBS=$LIBS_save
 
   PHP_NEW_EXTENSION([opcache], m4_normalize([
       shared_alloc_mmap.c
@@ -356,10 +353,10 @@ int main(void) {
     AC_MSG_FAILURE([No supported shared memory caching support was found when configuring opcache.])
   fi
 
-  if test "$PHP_OPCACHE_JIT" = "yes"; then
+  AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
     PHP_ADD_BUILD_DIR([$ext_builddir/jit])
     PHP_ADD_BUILD_DIR([$ext_builddir/jit/ir])
     PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/jit/Makefile.frag])
-  fi
+  ])
   PHP_SUBST([OPCACHE_SHARED_LIBADD])
 fi


### PR DESCRIPTION
- AS_* macros used
- Overquoted AC_RUN_IFELSE macros arguments reduced
- Redundant double quoted single variables assignments removed