### PR TITLE
Autotools: Sync CS in ext/pcntl

### DIFF
--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -31,7 +31,16 @@ if test "$PHP_PCNTL" != "no"; then
     [AC_CHECK_DECL([WIFCONTINUED], [AC_DEFINE([HAVE_WIFCONTINUED], [1])],,
       [#include <sys/wait.h>])])
 
-  AC_CHECK_DECLS([WCONTINUED, WEXITED, WSTOPPED, WNOWAIT, P_ALL, P_PIDFD, P_UID, P_JAILID],,,
+  AC_CHECK_DECLS(m4_normalize([
+      WCONTINUED,
+      WEXITED,
+      WSTOPPED,
+      WNOWAIT,
+      P_ALL,
+      P_PIDFD,
+      P_UID,
+      P_JAILID
+    ]),,,
     [#include <sys/wait.h>])
 
   dnl if unsupported, -1 means automatically ENOSYS in this context
@@ -52,7 +61,8 @@ int main(void) {
     [AC_DEFINE([HAVE_SCHED_GETCPU], [1],
       [Define to 1 if the 'sched_getcpu' function is properly supported.])])
 
-  AC_CHECK_TYPE([siginfo_t],[PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,[#include <signal.h>])
+  AC_CHECK_TYPE([siginfo_t], [PCNTL_CFLAGS="-DHAVE_STRUCT_SIGINFO_T"],,
+    [#include <signal.h>])
 
   PHP_NEW_EXTENSION([pcntl],
     [pcntl.c php_signal.c],


### PR DESCRIPTION
- AC_CHECK_TYPE long list of arguments split into a newline
- Long lists in AC_CHECK_DECLS can be split across multiple lines, even without m4_normalize, but the end quote needs to be done properly after the last item without space or newline. Here the m4_normalize ensures all trailing blanks are trimmed and having the possibility to put the ending quotes on newlines also