### PR TITLE
Autotools: Remove dependency related errors

### DIFF
--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -5,11 +5,6 @@ PHP_ARG_ENABLE([dom],
   [yes])
 
 if test "$PHP_DOM" != "no"; then
-
-  if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([DOM extension requires LIBXML extension, add --with-libxml])
-  fi
-
   PHP_SETUP_LIBXML([DOM_SHARED_LIBADD], [
     AC_DEFINE([HAVE_DOM], [1],
       [Define to 1 if the PHP extension 'dom' is available.])

--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -4,15 +4,6 @@ PHP_ARG_WITH([xsl],
     [Build with XSL support])])
 
 if test "$PHP_XSL" != "no"; then
-
-  if test "$PHP_LIBXML" = "no"; then
-    AC_MSG_ERROR([XSL extension requires LIBXML extension, add --with-libxml])
-  fi
-
-  if test "$PHP_DOM" = "no"; then
-    AC_MSG_ERROR([XSL extension requires DOM extension, add --enable-dom])
-  fi
-
   PKG_CHECK_MODULES([XSL], [libxslt >= 1.1.0])
 
   PHP_EVAL_INCLINE([$XSL_CFLAGS])


### PR DESCRIPTION
- ext/dom
- ext/xsl

These use the PHP_ADD_EXTENSION_DEP macro which throws error when one of the dependencies is disabled or not configured properly.

For example:

    ./configure --disable-all --enable-dom

or

    ./configure --disable-all --with-xsl

Will throw default PHP dependency error info, when using PHP_ADD_EXTENSION_DEP.

These errors were once done when PHP_ADD_EXTENSION_DEP macro wasn't yet available.