### PR TITLE
Autotools: Remove PDO dependency related errors

### DIFF
--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -4,10 +4,6 @@ PHP_ARG_WITH([pdo-dblib],
     [PDO: DBLIB-DB support. DIR is the FreeTDS home directory])])
 
 if test "$PHP_PDO_DBLIB" != "no"; then
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   if test "$PHP_PDO_DBLIB" = "yes"; then
     dnl FreeTDS must be on the default system include/library path.
     dnl Only perform a sanity check that this is really the case.

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -5,10 +5,6 @@ PHP_ARG_WITH([pdo-firebird],
     [/opt/firebird]])])
 
 if test "$PHP_PDO_FIREBIRD" != "no"; then
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   AC_PATH_PROG([FB_CONFIG], [fb_config], [no])
 
   if test -x "$FB_CONFIG" && test "$PHP_PDO_FIREBIRD" = "yes"; then

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -17,10 +17,6 @@ if test "$PHP_PDO_MYSQL" != "no"; then
       AC_MSG_RESULT([$PHP_MYSQL_SOCK])
     ])
 
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   dnl Whether to build with the mysqlnd extension or with the MySQL library.
   AS_CASE([$PHP_PDO_MYSQL], [yes|mysqlnd], [
     PHP_MYSQLND_ENABLED=yes

--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -28,11 +28,6 @@ AC_DEFUN([PHP_PDO_ODBC_CHECK_HEADER],
 ])
 
 if test "$PHP_PDO_ODBC" != "no"; then
-
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   PHP_CHECK_PDO_INCLUDES
 
   AC_MSG_CHECKING([for selected PDO ODBC flavour])

--- a/ext/pdo_pgsql/config.m4
+++ b/ext/pdo_pgsql/config.m4
@@ -7,10 +7,6 @@ PHP_ARG_WITH([pdo-pgsql],
     the libpq paths.])])
 
 if test "$PHP_PDO_PGSQL" != "no"; then
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   PHP_SETUP_PGSQL([PDO_PGSQL_SHARED_LIBADD],,, [$PHP_PDO_PGSQL])
   PHP_SUBST([PDO_PGSQL_SHARED_LIBADD])
 

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -5,11 +5,6 @@ PHP_ARG_WITH([pdo-sqlite],
   [$PHP_PDO])
 
 if test "$PHP_PDO_SQLITE" != "no"; then
-
-  if test "$PHP_PDO" = "no" && test "$ext_shared" = "no"; then
-    AC_MSG_ERROR([PDO is not enabled! Add --enable-pdo to your configure line.])
-  fi
-
   PHP_CHECK_PDO_INCLUDES
 
   PHP_SETUP_SQLITE([PDO_SQLITE_SHARED_LIBADD])


### PR DESCRIPTION
Follow-up of GH-15344 (687eb9125abf39b32512f2b001e3163f5fb5f45e)

This removes the customized error messages in PDO extensions when PDO is not enabled (--disable-all or --disable-pdo) in favor of the default error done by PHP_ADD_EXTENSION_DEP.