### PR TITLE
Add pcre as a configure step dependency to fileinfo

### DIFF
--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -41,6 +41,7 @@ if test "$PHP_FILEINFO" != "no"; then
     [$ext_shared],,
     [-I@ext_srcdir@/libmagic])
   PHP_ADD_BUILD_DIR([$ext_builddir/libmagic])
+  PHP_ADD_EXTENSION_DEP(fileinfo, pcre)
 
   AC_CHECK_FUNCS([utimes strndup])
 

--- a/ext/fileinfo/config.w32
+++ b/ext/fileinfo/config.w32
@@ -11,5 +11,6 @@ if (PHP_FILEINFO != 'no') {
 			strcasestr.c buffer.c is_csv.c";
 
 	EXTENSION('fileinfo', 'fileinfo.c php_libmagic.c', true, "/I" + configure_module_dirname + "/libmagic /I" + configure_module_dirname);
+	ADD_EXTENSION_DEP('fileinfo', 'pcre');
 	ADD_SOURCES(configure_module_dirname + '\\libmagic', LIBMAGIC_SOURCES, "fileinfo");
 }


### PR DESCRIPTION
The pcre is a required dependency in fileinfo extenstion. This marks it as a configure step dependency for consistency with other extensions and to have extensions properly sorted in the generated internal_functions* files.