### PR TITLE
Skip fb4_datatypes*.phpt for Firebird server < 4.0.0

### DIFF
--- a/ext/pdo_firebird/tests/fb4_datatypes.phpt
+++ b/ext/pdo_firebird/tests/fb4_datatypes.phpt
@@ -7,6 +7,13 @@ pdo_firebird
 if (Pdo\Firebird::getApiVersion() < 40) {
 	die('skip: Firebird API version must be greater than or equal to 40');
 }
+require 'testdb.inc';
+$dbh = getDbConnection();
+$stmt = $dbh->query("SELECT RDB\$get_context('SYSTEM', 'ENGINE_VERSION') AS VERSION FROM RDB\$DATABASE");
+$data = $stmt->fetch(\PDO::FETCH_ASSOC);
+if (!$data || !array_key_exists('VERSION', $data) || version_compare($data['VERSION'], '4.0.0') < 0) {
+	die("skip Firebird Server version must be greater than or equal to 4.0.0");
+}
 ?>
 --XLEAK--
 A bug in firebird causes a memory leak when calling `isc_attach_database()`.

--- a/ext/pdo_firebird/tests/fb4_datatypes_params.phpt
+++ b/ext/pdo_firebird/tests/fb4_datatypes_params.phpt
@@ -7,6 +7,13 @@ pdo_firebird
 if (Pdo\Firebird::getApiVersion() < 40) {
 	die('skip: Firebird API version must be greater than or equal to 40');
 }
+require 'testdb.inc';
+$dbh = getDbConnection();
+$stmt = $dbh->query("SELECT RDB\$get_context('SYSTEM', 'ENGINE_VERSION') AS VERSION FROM RDB\$DATABASE");
+$data = $stmt->fetch(\PDO::FETCH_ASSOC);
+if (!$data || !array_key_exists('VERSION', $data) || version_compare($data['VERSION'], '4.0.0') < 0) {
+	die("skip Firebird Server version must be greater than or equal to 4.0.0");
+}
 ?>
 --XLEAK--
 A bug in firebird causes a memory leak when calling `isc_attach_database()`.


### PR DESCRIPTION
Using a newer fbclient version with an older server is generally supported, and as such we must not only skip these tests for older fbclients, but also for older servers.

In lack of some readily available function, we're querying the server to find its version.