### PR TITLE
Ensure proper alignment of zend_accel_shared_globals.interned_strings

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -280,7 +280,7 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 
 	/* Interned Strings Support (must be the last element) */
-	zend_string_table interned_strings;
+	ZEND_SET_ALIGNED(ZEND_STRING_TABLE_POS_ALIGNMENT, zend_string_table interned_strings);
 } zend_accel_shared_globals;
 
 #ifdef ZEND_WIN32


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/15348

https://github.com/php/php-src/pull/13676 adds a assertion to check that `zend_accel_shared_globals.interned_strings.start` is 8 bytes aligned, which in hindsight was not guaranteed. What is guaranteed is that the size of zend_strings in the buffer is a multiple of 8.

Here I ensure that `zend_accel_shared_globals.interned_strings`, and thus `zend_accel_shared_globals.interned_strings.start`, are 8-bytes aligned.

