### PR TITLE
Deprecate using "_" as a class name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-15181 (Disabled output handler is flushed again). (cmb)
   . Passing E_USER_ERROR to trigger_error() is now deprecated. (Girgias)
   . Fixed bug GH-15292 (Dynamic AVX detection is broken for MSVC). (nielsdos)
+  . Using "_" as a class name is now deprecated. (Girgias)
 
 - Date:
   . Constants SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, and SUNFUNCS_RET_DOUBLE

--- a/UPGRADING
+++ b/UPGRADING
@@ -408,6 +408,8 @@ PHP 8.4 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
   . Passing E_USER_ERROR to trigger_error() is now deprecated.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
+  . Using "_" as a class name is now deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name
 
 - Curl:
   . The CURLOPT_BINARYTRANSFER constant is deprecated.

--- a/Zend/tests/class_underscore_as_name.phpt
+++ b/Zend/tests/class_underscore_as_name.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Using "_" as a class name is deprecated
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class _ {}
+}
+
+namespace {
+    class _ {}
+}
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -243,6 +243,9 @@ void zend_assert_valid_class_name(const zend_string *name) /* {{{ */
 		zend_error_noreturn(E_COMPILE_ERROR,
 			"Cannot use '%s' as class name as it is reserved", ZSTR_VAL(name));
 	}
+	if (zend_string_equals_literal(name, "_")) {
+		zend_error(E_DEPRECATED, "Using \"_\" as a class name is deprecated since 8.4");
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name