### PR TITLE
Autotools: Wrap long texts with m4_text_wrap

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1697,7 +1697,10 @@ AC_DEFUN([PHP_PROG_BISON], [
   case $php_bison_check in
     ""|invalid[)]
       if test ! -f "$abs_srcdir/Zend/zend_language_parser.h" || test ! -f "$abs_srcdir/Zend/zend_language_parser.c"; then
-        AC_MSG_ERROR([bison $php_bison_required_version or newer is required to generate PHP parsers (excluded versions: $php_bison_excluded_versions).])
+        AC_MSG_ERROR(m4_text_wrap([
+          bison $php_bison_required_version or newer is required to generate PHP
+          parsers (excluded versions: $php_bison_excluded_versions).
+        ]))
       fi
 
       YACC="exit 0;"
@@ -1757,7 +1760,10 @@ AC_DEFUN([PHP_PROG_RE2C],[
   case $php_re2c_check in
     ""|invalid[)]
       if test ! -f "$abs_srcdir/Zend/zend_language_scanner.c"; then
-        AC_MSG_ERROR([re2c $php_re2c_required_version or newer is required to generate PHP lexers.])
+        AC_MSG_ERROR(m4_text_wrap([
+          re2c $php_re2c_required_version or newer is required to generate PHP
+          lexers.
+        ]))
       fi
 
       RE2C="exit 0;"
@@ -2019,7 +2025,7 @@ dnl PostgreSQL minimum version sanity check.
     [AC_MSG_FAILURE([PostgreSQL check failed: libpq 10.0 or later is required.])],
   [$PGSQL_LIBS])
 $2],
-[m4_default([$3], [AC_MSG_FAILURE(m4_normalize([
+[m4_default([$3], [AC_MSG_FAILURE(m4_text_wrap([
   Cannot find libpq-fe.h or pq library (libpq). Please specify the correct
   PostgreSQL installation path with environment variables PGSQL_CFLAGS and
   PGSQL_LIBS or provide the PostgreSQL installation directory.

--- a/configure.ac
+++ b/configure.ac
@@ -769,7 +769,10 @@ if test "$PHP_GCOV" = "yes"; then
   esac
 
   if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
-    AC_MSG_ERROR([ccache must be disabled when --enable-gcov option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
+    AC_MSG_ERROR(m4_text_wrap([
+      ccache must be disabled when --enable-gcov option is used. You can disable
+      ccache by setting environment variable CCACHE_DISABLE=1.
+    ]))
   fi
 
   AC_DEFINE([HAVE_GCOV], [1], [Define to 1 if GCOV code coverage is enabled.])
@@ -843,7 +846,7 @@ AS_VAR_IF([ZEND_ZTS], [yes], [PHP_THREAD_SAFETY=yes], [PHP_THREAD_SAFETY=no])
 
 AS_VAR_IF([PHP_THREAD_SAFETY], [yes], [
   AS_VAR_IF([pthreads_working], [yes], [],
-    [AC_MSG_FAILURE(m4_normalize([
+    [AC_MSG_FAILURE(m4_text_wrap([
       Unable to verify system support for POSIX Threads, which are required for
       PHP thread safety (ZTS) build.
     ]))])
@@ -1140,7 +1143,7 @@ AS_VAR_IF([PHP_PEAR], [no],, [
   AC_MSG_WARN([The --with-pear option is deprecated])
 
   dnl PEAR dependencies.
-  AS_VAR_IF([PHP_XML], [no], [AC_MSG_ERROR(m4_normalize([
+  AS_VAR_IF([PHP_XML], [no], [AC_MSG_ERROR(m4_text_wrap([
     PEAR requires XML to be enabled. Add '--enable-xml' to the configure line,
     or disable PEAR (--without-pear).
   ]))])
@@ -1494,7 +1497,7 @@ AS_VAR_IF([PHP_MEMORY_SANITIZER], [yes],
 ])
 
 AS_VAR_IF([PHP_ADDRESS_SANITIZER], [yes],
-  [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR(m4_normalize([
+  [AS_VAR_IF([PHP_VALGRIND], [no],, [AC_MSG_ERROR(m4_text_wrap([
     Valgrind and address sanitizer are not compatible. Either disable Valgrind
     (remove --with-valgrind) or disable address sanitizer (remove
     --enable-address-sanitizer).

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -346,7 +346,10 @@ int main(void) {
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 
   if test "$php_cv_shm_ipc" != "yes" && test "$php_cv_shm_mmap_posix" != "yes" && test "$php_cv_shm_mmap_anon" != "yes"; then
-    AC_MSG_FAILURE([No supported shared memory caching support was found when configuring opcache.])
+    AC_MSG_FAILURE(m4_text_wrap([
+      No supported shared memory caching support was found when configuring
+      opcache.
+    ]))
   fi
 
   AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [

--- a/ext/sysvmsg/config.m4
+++ b/ext/sysvmsg/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE([sysvmsg],
 
 if test "$PHP_SYSVMSG" != "no"; then
   AC_CHECK_HEADER([sys/msg.h],,
-    [AC_MSG_FAILURE(m4_normalize([
+    [AC_MSG_FAILURE(m4_text_wrap([
       Cannot enable System V IPC support. Required <sys/msg.h> header file not
       found.
     ]))])

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -34,7 +34,7 @@ if test "$PHP_APXS2" != "no"; then
 
   APXS_INCLUDEDIR=`$APXS -q INCLUDEDIR`
   APXS_HTTPD=`$APXS -q SBINDIR`/`$APXS -q TARGET`
-  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR(m4_normalize([
+  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR(m4_text_wrap([
     $APXS_HTTPD executable not found. Please, install Apache HTTP Server
     command-line utility.
   ]))])

--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -19,7 +19,7 @@ AC_DEFUN([PHP_FUZZER_TARGET], [
 ])
 
 if test "$PHP_FUZZER" != "no"; then
-  AS_VAR_IF([enable_zts], [yes], [AC_MSG_ERROR(m4_normalize([
+  AS_VAR_IF([enable_zts], [yes], [AC_MSG_ERROR(m4_text_wrap([
     Thread safety (--enable-zts) is not supported when building fuzzing module
     (--enable-fuzzer). Please build fuzzer without ZTS.
   ]))])


### PR DESCRIPTION
The m4_text_wrap macro wraps the text into a single space separated string which is wrapped to not exceed the line lenght of 79 characters by default.