### PR TITLE
Deprecate Soft-deprecated DOMDocument and DOMEntity properties

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -56,6 +56,9 @@ PHP 8.4 UPGRADE NOTES
   . Previously, DOMXPath objects could be cloned, but resulted in an unusable
     object. This is no longer possible, and cloning a DOMXPath object now throws
     an error.
+  . DOMDocument::$actualEncoding, DOMDocument::config, DOMEntity::$actualEncoding,
+    DOMEntity::$encoding, DOMEntity::$version have been deprecated as part of the
+    https://wiki.php.net/rfc/deprecations_php_8_4 RFC.
 
 - GMP:
   . The GMP class is now final and cannot be extended anymore.

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -105,6 +105,16 @@ zend_result dom_document_encoding_read(dom_object *obj, zval *retval)
 	return SUCCESS;
 }
 
+zend_result dom_document_actual_encoding_read(dom_object *obj, zval *retval)
+{
+	zend_error(E_DEPRECATED, "Property DOMDocument::$actualEncoding is deprecated");
+	if (UNEXPECTED(EG(exception))) {
+		return FAILURE;
+	}
+
+	return dom_document_encoding_read(obj, retval);
+}
+
 zend_result dom_document_encoding_write(dom_object *obj, zval *newval)
 {
 	DOM_PROP_NODE(xmlDocPtr, docp, obj);
@@ -409,6 +419,11 @@ Since: DOM Level 3
 */
 zend_result dom_document_config_read(dom_object *obj, zval *retval)
 {
+	zend_error(E_DEPRECATED, "Property DOMDocument::$config is deprecated");
+	if (UNEXPECTED(EG(exception))) {
+		return FAILURE;
+	}
+
 	ZVAL_NULL(retval);
 	return SUCCESS;
 }

--- a/ext/dom/dom_properties.h
+++ b/ext/dom/dom_properties.h
@@ -37,6 +37,7 @@ zend_result dom_document_implementation_read(dom_object *obj, zval *retval);
 zend_result dom_modern_document_implementation_read(dom_object *obj, zval *retval);
 zend_result dom_document_document_element_read(dom_object *obj, zval *retval);
 zend_result dom_document_encoding_read(dom_object *obj, zval *retval);
+zend_result dom_document_actual_encoding_read(dom_object *obj, zval *retval);
 zend_result dom_document_encoding_write(dom_object *obj, zval *newval);
 zend_result dom_document_standalone_read(dom_object *obj, zval *retval);
 zend_result dom_document_standalone_write(dom_object *obj, zval *newval);

--- a/ext/dom/entity.c
+++ b/ext/dom/entity.c
@@ -104,6 +104,11 @@ Since: DOM Level 3
 */
 zend_result dom_entity_actual_encoding_read(dom_object *obj, zval *retval)
 {
+	zend_error(E_DEPRECATED, "Property DOMEntity::$actualEncoding is deprecated");
+	if (UNEXPECTED(EG(exception))) {
+		return FAILURE;
+	}
+
 	ZVAL_NULL(retval);
 	return SUCCESS;
 }
@@ -117,6 +122,11 @@ Since: DOM Level 3
 */
 zend_result dom_entity_encoding_read(dom_object *obj, zval *retval)
 {
+	zend_error(E_DEPRECATED, "Property DOMEntity::$encoding is deprecated");
+	if (UNEXPECTED(EG(exception))) {
+		return FAILURE;
+	}
+
 	ZVAL_NULL(retval);
 	return SUCCESS;
 }
@@ -130,6 +140,11 @@ Since: DOM Level 3
 */
 zend_result dom_entity_version_read(dom_object *obj, zval *retval)
 {
+	zend_error(E_DEPRECATED, "Property DOMEntity::$version is deprecated");
+	if (UNEXPECTED(EG(exception))) {
+		return FAILURE;
+	}
+
 	ZVAL_NULL(retval);
 	return SUCCESS;
 }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -894,7 +894,7 @@ PHP_MINIT_FUNCTION(dom)
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "doctype", dom_document_doctype_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "implementation", dom_document_implementation_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "documentElement", dom_document_document_element_read, NULL);
-	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "actualEncoding", dom_document_encoding_read, NULL);
+	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "actualEncoding", dom_document_actual_encoding_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "encoding", dom_document_encoding_read, dom_document_encoding_write);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "xmlEncoding", dom_document_encoding_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "standalone", dom_document_standalone_read, dom_document_standalone_write);

--- a/ext/dom/tests/DOMDocument_config_basic.phpt
+++ b/ext/dom/tests/DOMDocument_config_basic.phpt
@@ -19,8 +19,10 @@ var_dump( $test );
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
 DOMDocument created
+
+Deprecated: Property DOMDocument::$config is deprecated in %s on line %d
 Read config:
 NULL
 Done

--- a/ext/dom/tests/DOMEntity_fields.phpt
+++ b/ext/dom/tests/DOMEntity_fields.phpt
@@ -42,59 +42,101 @@ foreach ($entities as $entity) {
     echo "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 Entity name: sampleExternalPublicWithNotationName1
 publicId: string(9) "public id"
 systemId: string(14) "external.stuff"
 notationName: string(5) "stuff"
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleExternalPublicWithNotationName2
 publicId: string(0) ""
 systemId: string(14) "external.stuff"
 notationName: string(5) "stuff"
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleExternalPublicWithoutNotationName1
 publicId: string(9) "public id"
 systemId: string(14) "external.stuff"
 notationName: string(0) ""
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleExternalPublicWithoutNotationName2
 publicId: string(0) ""
 systemId: string(14) "external.stuff"
 notationName: string(0) ""
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleExternalSystemWithNotationName
 publicId: NULL
 systemId: string(14) "external.stuff"
 notationName: string(5) "stuff"
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleExternalSystemWithoutNotationName
 publicId: NULL
 systemId: string(14) "external.stuff"
 notationName: string(0) ""
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL
 
 Entity name: sampleInternalEntity
 publicId: NULL
 systemId: NULL
 notationName: NULL
-actualEncoding: NULL
-encoding: NULL
-version: NULL
+actualEncoding: 
+Deprecated: Property DOMEntity::$actualEncoding is deprecated in %s on line %d
+NULL
+encoding: 
+Deprecated: Property DOMEntity::$encoding is deprecated in %s on line %d
+NULL
+version: 
+Deprecated: Property DOMEntity::$version is deprecated in %s on line %d
+NULL

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -16,6 +16,10 @@ var_dump($d);
 ?>
 --EXPECTF--
 Deprecated: Creation of dynamic property DOMDocument::$dynamicProperty is deprecated in %s on line %d
+
+Deprecated: Property DOMDocument::$actualEncoding is deprecated in %s on line %d
+
+Deprecated: Property DOMDocument::$config is deprecated in %s on line %d
 object(DOMDocument)#1 (41) {
   ["dynamicProperty"]=>
   object(stdClass)#2 (0) {


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_4#formally_deprecate_soft-deprecated_domdocument_and_domentity_properties