### PR TITLE
Autotools: Fix phpdbg build

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -64,7 +64,7 @@ if test "$PHP_PHPDBG" != "no"; then
 
   PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/phpdbg/Makefile.frag],
     [$abs_srcdir/sapi/phpdbg],
-    [$abs_builddir/sapi/phpdbg])
+    [sapi/phpdbg])
   PHP_SELECT_SAPI([phpdbg],
     [program],
     m4_normalize([


### PR DESCRIPTION
With 04a67cd86c6b18f04b7f359b2dd3f4daeb6583ac the list of source files are now added alphabetically. Previously the phpdbg_parser.c was added before the phpdbg_lexer.c. Which caused the
"sapi/phpdbg/phpdbg_lexer.l:8:10: fatal error: 'phpdbg_parser.h' file not found" error.

To make the order of source files irrelevant, the Makefile substitutions needs to be fixed - the 3rd argument of PHP_ADD_MAKEFILE_FRAGMENT macro, which is the substitution of the `$(builddir)` Make variable. The `$(builddir)/phpdbg_lexer.lo` was previously substituted to an absolute path. And the relative should be used, for Make to be able to find the dependent target.

Fixes https://github.com/SjonHortensius/3v4l_org/issues/22