### PR TITLE
Fix run-tests.php to propagate status code on Windows

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1177,7 +1177,7 @@ function system_with_timeout(
     // and on Windows quotes are discarded, this is a fix to honor the quotes and allow values containing
     // spaces like '"C:\Program Files\PHP\php.exe"' to be passed as 1 argument correctly
     if (IS_WINDOWS) {
-        $commandline = 'start "" /b /wait ' . $commandline;
+        $commandline = 'start "" /b /wait ' . $commandline . ' & exit';
     }
 
     $data = '';


### PR DESCRIPTION
There is now a workaround in `system_with_timeout()` to avoid issues with quotes and spaces in the filenames of the executable by using `start`[1].  However, calling `start` will not propagate the process status of the actual process.  Thus, calling `proc_get_status()` is pretty meaningless, and especially Microsoft errors cannot be detected (typically, access violations etc.), and as such no "Termsig" message is output.

We fix this by executing `exit` after the started command has finished.

[1] <https://github.com/php/php-src/blob/a6d7d5234b05582d3a333c0f2646fdeae44b4728/run-tests.php#L1157-L1162>

---

Given the `proc_open()` escaping fixes that have been done in the meantime, it may also be possible to drop the `start` workaround on Windows altogether; a quick test worked as expected, but I haven't done extensive testing.