### PR TITLE
Add configure phase dependencies to mysqlnd extension

### DIFF
--- a/ext/mysqlnd/config.w32
+++ b/ext/mysqlnd/config.w32
@@ -38,6 +38,7 @@ if (PHP_MYSQLND != "no") {
 			AC_DEFINE("MYSQLND_SSL_SUPPORTED", 1, "Define to 1 if mysqlnd core SSL is enabled.");
 			if (CHECK_LIB("crypt32.lib", "mysqlnd")) {
 				AC_DEFINE("MYSQLND_HAVE_SSL", 1, "Define to 1 if mysqlnd extended SSL is enabled through OpenSSL.");
+				ADD_EXTENSION_DEP('mysqlnd', 'hash');
 			}
 		}
 		PHP_INSTALL_HEADERS("", "ext/mysqlnd");

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -36,11 +36,6 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
   AC_DEFINE([MYSQLND_SSL_SUPPORTED], [1],
     [Define to 1 if mysqlnd core SSL is enabled.])
 
-  AS_VAR_IF([PHP_MYSQLND_SSL], [no],,
-    [PHP_SETUP_OPENSSL([MYSQLND_SHARED_LIBADD],
-      [AC_DEFINE([MYSQLND_HAVE_SSL], [1],
-        [Define to 1 if mysqlnd extended SSL is enabled through OpenSSL.])])])
-
   PHP_NEW_EXTENSION([mysqlnd], m4_normalize([
     mysqlnd_alloc.c
     mysqlnd_auth.c
@@ -67,6 +62,13 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
   ]),
   [$ext_shared],,
   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
+  AS_VAR_IF([PHP_MYSQLND_SSL], [no],,
+    [PHP_SETUP_OPENSSL([MYSQLND_SHARED_LIBADD], [
+      AC_DEFINE([MYSQLND_HAVE_SSL], [1],
+        [Define to 1 if mysqlnd extended SSL is enabled through OpenSSL.])
+      PHP_ADD_EXTENSION_DEP(mysqlnd, hash)
+    ])])
 
   PHP_INSTALL_HEADERS([ext/mysqlnd/])
   PHP_SUBST([MYSQLND_SHARED_LIBADD])


### PR DESCRIPTION
The hash extension is required in mysqlnd extension for using sha functions when extended SSL is enabled (MYSQLND_HAVE_SSL).