### PR TITLE
Fix GH-15381 (getrandom part).

### DIFF
--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -15,6 +15,11 @@ AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h], [], [],
 ])
 
 dnl
+dnl Mostly for non Linux systems
+dnl
+AC_CHECK_FUNCS([getrandom])
+
+dnl
 dnl Setup extension
 dnl
 PHP_NEW_EXTENSION(random,

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -48,7 +48,7 @@
 
 #if HAVE_SYS_PARAM_H
 # include <sys/param.h>
-# if (__FreeBSD__ && __FreeBSD_version > 1200000) || (__DragonFly__ && __DragonFly_version >= 500700) || defined(__sun)
+# if (__FreeBSD__ && __FreeBSD_version > 1200000) || (__DragonFly__ && __DragonFly_version >= 500700) || (defined(__sun) && defined(HAVE_GETRANDOM))
 #  include <sys/random.h>
 # endif
 #endif
@@ -511,7 +511,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 #else
 	size_t read_bytes = 0;
 	ssize_t n;
-# if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || defined(__sun)
+# if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || (defined(__sun) && defined(HAVE_GETRANDOM))
 	/* Linux getrandom(2) syscall or FreeBSD/DragonFlyBSD getrandom(2) function*/
 	/* Keep reading until we get enough entropy */
 	while (read_bytes < size) {


### PR DESCRIPTION
gcc nor clang provides a constant to distinguish illumos and solaris nor the system provides a kernel version stamp like the BSD. thus, we simply check the symbol and remaining purposely conservative in the existing logic, using it only for solaris to avoid possible unexpected breakages for other systems. would need a different fix for higher branches.