### PR TITLE
Fix crash in hooked iterator on properties array without dynamic properties

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ PHP                                                                        NEWS
     visibility are ignored). (ilutov)
   . Fixed bug GH-15419 (Missing readonly+hook incompatibility check for readonly
     classes). (ilutov)
+  . Fixed bug GH-15187 (Various hooked object iterator issues). (ilutov)
 
 15 Aug 2024, PHP 8.4.0beta3
 

--- a/Zend/tests/property_hooks/foreach.phpt
+++ b/Zend/tests/property_hooks/foreach.phpt
@@ -17,6 +17,11 @@ class ByRef {
           $this->_virtualByRef = $value;
         }
     }
+    public $virtualSetOnly {
+        set {
+            echo __METHOD__, "\n";
+        }
+    }
     public function __construct() {
         $this->dynamic = 'dynamic';
     }

--- a/Zend/tests/property_hooks/gh15187_1.phpt
+++ b/Zend/tests/property_hooks/gh15187_1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-15187: Crash in hooked iterators on properties array without dynamic properties
+--FILE--
+<?php
+
+class Test {
+    public $prop { set => $value; }
+}
+
+$test = new Test();
+var_dump($test);
+foreach ($test as $key => $value) {
+    var_dump($key, $value);
+}
+
+?>
+--EXPECTF--
+object(Test)#%d (1) {
+  ["prop"]=>
+  NULL
+}
+string(4) "prop"
+NULL

--- a/Zend/tests/property_hooks/gh15187_2.phpt
+++ b/Zend/tests/property_hooks/gh15187_2.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-15187: Crash in hooked iterators on properties array without dynamic properties
+--FILE--
+<?php
+
+class Test {
+    public int $prop { set => $value; }
+}
+
+$test = new Test();
+var_dump($test);
+foreach ($test as $key => $value) {
+    var_dump($key, $value);
+}
+
+?>
+--EXPECTF--
+object(Test)#%d (0) {
+  ["prop"]=>
+  uninitialized(int)
+}

--- a/Zend/tests/property_hooks/gh15187_3.phpt
+++ b/Zend/tests/property_hooks/gh15187_3.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-15187: Hooked iterator typed property ref tracking
+--FILE--
+<?php
+
+class C {
+    public $a { set {} }
+    public int $b;
+    public int $c = 1;
+    public $d = 2;
+}
+
+$c = new C();
+
+foreach ($c as $k => &$v) {
+    var_dump($v);
+    if ($k === 'c') {
+        try {
+            $v = 'foo';
+        } catch (Error $e) {
+            echo $e->getMessage(), "\n";
+        }
+    }
+    if ($k === 'd') {
+        $v = 'foo';
+    }
+}
+
+var_dump($c);
+
+?>
+--EXPECTF--
+int(1)
+Cannot assign string to reference held by property C::$c of type int
+int(2)
+object(C)#%d (2) {
+  ["b"]=>
+  uninitialized(int)
+  ["c"]=>
+  int(1)
+  ["d"]=>
+  &string(3) "foo"
+}

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -438,6 +438,8 @@ typedef struct _zend_property_info {
 	((uint32_t)(XtOffsetOf(zend_object, properties_table) + sizeof(zval) * (num)))
 #define OBJ_PROP_TO_NUM(offset) \
 	((offset - OBJ_PROP_TO_OFFSET(0)) / sizeof(zval))
+#define OBJ_PROP_PTR_TO_NUM(obj, prop) \
+	(((char*)prop - (char*)obj->properties_table) / sizeof(zval))
 
 typedef struct _zend_class_constant {
 	zval value; /* flags are stored in u2 */


### PR DESCRIPTION
Also fix incorrect usage of zend_read_property_ex().

Fixes GH-15187