### PR TITLE
ext/standard/php_string.h: Remove declarations that have no implementation

### DIFF
--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -58,10 +58,6 @@ PHPAPI void php_explode(const zend_string *delim, zend_string *str, zval *return
 PHPAPI size_t php_strspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
 PHPAPI size_t php_strcspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
 
-PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, bool case_insensitive);
-PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);
-PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
-
 PHPAPI bool php_binary_string_shuffle(php_random_algo_with_state engine, char *str, zend_long len);
 
 #ifdef _REENTRANT


### PR DESCRIPTION
I am very confused about those, we don't actually implement those declarations.

Am I missing something @cmb69 or is this just some old cruft?