### PR TITLE
Drop support for building with old Visual Studio versions

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1249,16 +1249,12 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir)
 		if (PHP_DEBUG != "yes" && PHP_PGI == "yes") {
 			ADD_FLAG('CFLAGS_' + SAPI, "/GL /O2");
 			ADD_FLAG('LDFLAGS_' + SAPI, "/LTCG /GENPROFILE");
-			if (VCVERS >= 1914) {
-				ADD_FLAG('LDFLAGS_' + SAPI, "/d2:-FuncCache1");
-			}
+			ADD_FLAG('LDFLAGS_' + SAPI, "/d2:-FuncCache1");
 		}
 		else if (PHP_DEBUG != "yes" && PHP_PGO != "no") {
 			ADD_FLAG('CFLAGS_' + SAPI, "/GL /O2");
 			ADD_FLAG('LDFLAGS_' + SAPI, "/LTCG /USEPROFILE");
-			if (VCVERS >= 1914) {
-				ADD_FLAG('LDFLAGS_' + SAPI, "/d2:-FuncCache1");
-			}
+			ADD_FLAG('LDFLAGS_' + SAPI, "/d2:-FuncCache1");
 		}
 
 		ldflags += " /PGD:$(PGOPGD_DIR)\\" + makefiletarget.substring(0, makefiletarget.indexOf(".")) + ".pgd";
@@ -1461,15 +1457,11 @@ function EXTENSION(extname, file_list, shared, cflags, dllname, obj_dir)
 			// Add compiler and link flags if PGO options are selected
 			if (PHP_DEBUG != "yes" && PHP_PGI == "yes") {
 				ADD_FLAG('LDFLAGS_' + EXT, "/LTCG /GENPROFILE");
-				if (VCVERS >= 1914) {
-					ADD_FLAG('LDFLAGS_' + EXT, "/d2:-FuncCache1");
-				}
+				ADD_FLAG('LDFLAGS_' + EXT, "/d2:-FuncCache1");
 			}
 			else if (PHP_DEBUG != "yes" && PHP_PGO != "no") {
 				ADD_FLAG('LDFLAGS_' + EXT, "/LTCG /USEPROFILE");
-				if (VCVERS >= 1914) {
-					ADD_FLAG('LDFLAGS_' + EXT, "/d2:-FuncCache1");
-				}
+				ADD_FLAG('LDFLAGS_' + EXT, "/d2:-FuncCache1");
 			}
 
 			ADD_FLAG('CFLAGS_' + EXT, "/GL /O2");
@@ -3064,7 +3056,8 @@ function toolset_get_compiler_version()
 
 	if (VS_TOOLSET) {
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
-		if (version < 1910) {
+		ERROR(version);
+		if (version < 1920) {
 			ERROR("Building with MSC_VER " + version + " is no longer supported");
 		}
 		return version;
@@ -3273,17 +3266,8 @@ function toolset_setup_common_cflags()
 			ADD_FLAG('CFLAGS', ' /RTC1 ');
 		} else {
 			if (PHP_DEBUG == "no" && PHP_SECURITY_FLAGS == "yes") {
-				/* Mitigations for CVE-2017-5753.
-			  	   TODO backport for all supported VS versions when they release it. */
-				if (VCVERS >= 1912) {
-					var subver1912 = probe_binary(PHP_CL).substr(6);
-					if (VCVERS >= 1913 || 1912 == VCVERS && subver1912 >= 25835) {
-						ADD_FLAG('CFLAGS', "/Qspectre");
-					} else {
-						/* Undocumented. */
-						ADD_FLAG('CFLAGS', "/d2guardspecload");
-					}
-				}
+				/* Mitigations for CVE-2017-5753. */
+				ADD_FLAG('CFLAGS', "/Qspectre");
 			}
 			if (PHP_SECURITY_FLAGS == "yes") {
 				ADD_FLAG('CFLAGS', "/guard:cf");
@@ -3297,14 +3281,10 @@ function toolset_setup_common_cflags()
 			}
 		}
 
-		if (VCVERS >= 1914) {
-			/* This is only in effect for CXX sources, __cplusplus is not defined in C sources. */
-			ADD_FLAG("CFLAGS", "/Zc:__cplusplus");
-		}
+		/* This is only in effect for CXX sources, __cplusplus is not defined in C sources. */
+		ADD_FLAG("CFLAGS", "/Zc:__cplusplus");
 
-		if (VCVERS >= 1914) {
-			ADD_FLAG("CFLAGS", "/d2FuncCache1");
-		}
+		ADD_FLAG("CFLAGS", "/d2FuncCache1");
 
 		if (VCVERS >= 1930) {
 			ADD_FLAG("CFLAGS", "/Zc:preprocessor");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3099,7 +3099,7 @@ function toolset_get_compiler_name(short)
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
 
 		if (version >= 1950) {
-			return name;
+			// skip
 		} else if (version >= 1930) {
 			name = short ? "VS17" : "Visual C++ 2022";
 		} else if (version >= 1920) {
@@ -3110,12 +3110,6 @@ function toolset_get_compiler_name(short)
 						When new versions are introduced, adapt also checks in
 						php_win32_image_compatible(), if needed. */
 			name = short ? "VS16" : "Visual C++ 2019";
-		} else if (version >= 1910) {
-			name = short ? "VC15" : "Visual C++ 2017";
-		} else if (version >= 1900) {
-			name = short ? "VC14" : "Visual C++ 2015";
-		} else {
-			ERROR("Unsupported Visual C++ compiler " + version);
 		}
 
 		return name;
@@ -3123,7 +3117,7 @@ function toolset_get_compiler_name(short)
 		var command = 'cmd /c ""' + PHP_CL + '" -v"';
 		var full = execute(command + '" 2>&1"');
 
-		return full.split(/\n/)[0].replace(/\s/g, ' ');
+		ERROR(full.split(/\n/)[0].replace(/\s/g, ' '));
 	}
 
 	WARNING("Unsupported toolset");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3056,7 +3056,6 @@ function toolset_get_compiler_version()
 
 	if (VS_TOOLSET) {
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
-		ERROR(version);
 		if (version < 1920) {
 			ERROR("Building with MSC_VER " + version + " is no longer supported");
 		}

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3064,7 +3064,9 @@ function toolset_get_compiler_version()
 
 	if (VS_TOOLSET) {
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
-
+		if (version < 1900) {
+			ERROR("Building with MSC_VER " + version + " is no longer supported");
+		}
 		return version;
 	} else if (CLANG_TOOLSET) {
 		var command = 'cmd /c ""' + PHP_CL + '" -v"';
@@ -3288,19 +3290,15 @@ function toolset_setup_common_cflags()
 					}
 				}
 			}
-			if (VCVERS >= 1900) {
-				if (PHP_SECURITY_FLAGS == "yes") {
-					ADD_FLAG('CFLAGS', "/guard:cf");
-				}
+			if (PHP_SECURITY_FLAGS == "yes") {
+				ADD_FLAG('CFLAGS', "/guard:cf");
 			}
-			if (VCVERS >= 1800) {
-				if (PHP_PGI != "yes" && PHP_PGO != "yes") {
-					ADD_FLAG('CFLAGS', "/Zc:inline");
-				}
-				/* We enable /opt:icf only with the debug pack, so /Gw only makes sense there, too. */
-				if (PHP_DEBUG_PACK == "yes") {
-					ADD_FLAG('CFLAGS', "/Gw");
-				}
+			if (PHP_PGI != "yes" && PHP_PGO != "yes") {
+				ADD_FLAG('CFLAGS', "/Zc:inline");
+			}
+			/* We enable /opt:icf only with the debug pack, so /Gw only makes sense there, too. */
+			if (PHP_DEBUG_PACK == "yes") {
+				ADD_FLAG('CFLAGS', "/Gw");
 			}
 		}
 
@@ -3436,10 +3434,8 @@ function toolset_setup_common_ldlags()
 	ADD_FLAG("PHP_LDFLAGS", "/nodefaultlib:libcmt");
 
 	if (VS_TOOLSET) {
-		if (VCVERS >= 1900) {
-			if (PHP_SECURITY_FLAGS == "yes") {
-				ADD_FLAG('LDFLAGS', "/GUARD:CF");
-			}
+		if (PHP_SECURITY_FLAGS == "yes") {
+			ADD_FLAG('LDFLAGS', "/GUARD:CF");
 		}
 		if (PHP_VS_LINK_COMPAT != "no") {
 			// Allow compatible IL versions, do not require an exact match.
@@ -3610,13 +3606,8 @@ function add_extra_dirs()
 		for (i = 0; i < path.length; i++) {
 			f = FSO.GetAbsolutePathName(path[i]);
 			if (FSO.FolderExists(f)) {
-				if (VS_TOOLSET && VCVERS <= 1200 && f.indexOf(" ") >= 0) {
-					ADD_FLAG("LDFLAGS", '/libpath:"\\"' + f + '\\"" ');
-					ADD_FLAG("ARFLAGS", '/libpath:"\\"' + f + '\\"" ');
-				} else {
-					ADD_FLAG("LDFLAGS", '/libpath:"' + f + '" ');
-					ADD_FLAG("ARFLAGS", '/libpath:"' + f + '" ');
-				}
+				ADD_FLAG("LDFLAGS", '/libpath:"' + f + '" ');
+				ADD_FLAG("ARFLAGS", '/libpath:"' + f + '" ');
 			}
 		}
 	}

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3064,7 +3064,7 @@ function toolset_get_compiler_version()
 
 	if (VS_TOOLSET) {
 		version = probe_binary(PHP_CL).substr(0, 5).replace('.', '');
-		if (version < 1900) {
+		if (version < 1910) {
 			ERROR("Building with MSC_VER " + version + " is no longer supported");
 		}
 		return version;
@@ -3282,11 +3282,6 @@ function toolset_setup_common_cflags()
 					} else {
 						/* Undocumented. */
 						ADD_FLAG('CFLAGS', "/d2guardspecload");
-					}
-				} else if (1900 == VCVERS) {
-					var subver1900 = probe_binary(PHP_CL).substr(6);
-					if (subver1900 >= 24241) {
-						ADD_FLAG('CFLAGS', "/Qspectre");
 					}
 				}
 			}


### PR DESCRIPTION
The first commit requires users to have at least Visual Studio 2015; the second commit raises that to Visual Studio 2017 RTW; the third commit even raises that to Visual Studio 2019 RTW 16.0.

Note that building with Visual Studio 2017 15.9.64 (latest version) fails on

https://github.com/php/php-src/blob/d100caa476f62a9f6576dcf2c5d8dbb88ed9c57e/ext/bcmath/libbcmath/src/convert.h#L22

because the `restrict` keyword is not supported. Thus, if we still want to support Visual Studio 2017, we would need to fix this (and maybe more; I haven't done a full snapshot build).

However, I think we should (or even need to) raise the bar even further. Builds with Visual Studio 2019 16.11.38 (latest version) appear to work flawlessly, but I'm not sure whether somewhat older Visual Studio 2019 versions would work (and I don't think I can test this since going back to older Visual Studio 2019 version is impossible, to my knowledge; you don't need to update, but you can't install an older version).

For details regarding the versioning details, see https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170.
