### PR TITLE
hash: Consistently check for PHP_HASH_INTRIN_SHA_* to guard compilation of SHA256_Transform_shani

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,9 @@ PHP                                                                        NEWS
     As such, passing invalid types to exit/die may now result in a TypeError
     being thrown. (Girgias)
 
+- Hash:
+  . Fix GH-15384 (Build fails on Alpine / Musl for amd64). (timwolla)
+
 - Standard:
   . php_uname() now throws ValueErrors on invalid inputs. (Girgias)
 

--- a/ext/hash/hash_sha_ni.c
+++ b/ext/hash/hash_sha_ni.c
@@ -27,7 +27,7 @@
 #include "php_hash.h"
 #include "php_hash_sha.h"
 
-#if (defined(__i386__) || defined(__x86_64__)) && defined(HAVE_IMMINTRIN_H)
+#if defined(PHP_HASH_INTRIN_SHA_NATIVE) || defined(PHP_HASH_INTRIN_SHA_RESOLVER)
 
 # include <immintrin.h>
 

--- a/ext/hash/php_hash_sha.h
+++ b/ext/hash/php_hash_sha.h
@@ -62,7 +62,9 @@ void SHA256_Transform_sse2(uint32_t state[PHP_STATIC_RESTRICT 8], const uint8_t 
 # elif defined(HAVE_FUNC_ATTRIBUTE_TARGET)
 #  define PHP_HASH_INTRIN_SHA_RESOLVER 1
 # endif
+#endif
 
+#if defined(PHP_HASH_INTRIN_SHA_NATIVE) || defined(PHP_HASH_INTRIN_SHA_RESOLVER)
 void SHA256_Transform_shani(uint32_t state[PHP_STATIC_RESTRICT 8], const uint8_t block[PHP_STATIC_RESTRICT 64]);
 #endif
 


### PR DESCRIPTION
This fixes the build for amd64 platforms that do not have `HAVE_FUNC_ATTRIBUTE_TARGET`, specifically Alpine/Musl as of now.

Closes GH-15384.
Related to GH-15312.