### PR TITLE
PHP 8.4 UPGRADING: various tweaks and fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -407,7 +407,7 @@ PHP                                                                        NEWS
 
 - PCNTL:
   . Added pcntl_setns for Linux. (David Carlier)
-  . Added pcntl_getaffinity/pcntl_setaffinity. (David Carlier)
+  . Added pcntl_getcpuaffinity/pcntl_setcpuaffinity. (David Carlier)
   . Updated pcntl_get_signal_handler signal id upper limit to be
     more in line with platforms limits. (David Carlier)
   . Added pcntl_getcpu for Linux/FreeBSD/Solaris/Illumos. (David Carlier)

--- a/UPGRADING
+++ b/UPGRADING
@@ -302,12 +302,25 @@ PHP 8.4 UPGRADE NOTES
     extended to support those keys.
 
 - PDO:
+  . Added support for driver-specific subclasses.
+    RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses
+    This RFC adds subclasses for PDO in order to better support
+    database-specific functionalities. The new classes are
+    instantiatable either via calling the PDO::connect() method
+    or by invoking their constructor directly.
   . Added support for driver specific SQL parsers. The default parser supports:
     - single and double quoted literals, with doubling as escaping mechanism.
     - two-dashes and non-nested C-style comments.
     RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
+- PDO_DBLIB:
+  . Added class Pdo\DbLib.
+
+- PDO_FIREBIRD:
+  . Added class Pdo\Firebird.
+
 - PDO_MYSQL:
+  . Added class Pdo\Mysql.
   . Added custom parser supporting:
     - single and double-quoted literals, with doubling and backslash as escaping
       mechanism
@@ -316,7 +329,11 @@ PHP 8.4 UPGRADE NOTES
       and hash-comments
     RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
+- PDO_ODBC:
+  . Added class Pdo\Odbc.
+
 - PDO_PGSQL:
+  . Added class Pdo\Pgsql.
   . Added custom parser supporting:
     - single and double quoted literals, with doubling as escaping mechanism
     - C-style "escape" string literals (E'string')
@@ -326,6 +343,7 @@ PHP 8.4 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
 - PDO_SQLITE:
+  . Added class Pdo\Sqlite.
   . Added custom parser supporting:
     - single, double quoted, and backtick literals, with doubling as escaping mechanism
     - square brackets quoting for identifiers
@@ -346,32 +364,6 @@ PHP 8.4 UPGRADE NOTES
     as the (?r) mode modifier. When enabled along with the case-insensitive
     modifier ("i"), the expression locks out mixing of ASCII and non-ASCII
     characters.
-
-- PDO:
-  . Added support for driver-specific subclasses.
-    RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses
-    This RFC adds subclasses for PDO in order to better support
-    database-specific functionalities. The new classes are
-    instantiatable either via calling the PDO::connect() method
-    or by invoking their constructor directly.
-
-- PDO_DBLIB:
-  . Added class Pdo\DbLib.
-
-- PDO_FIREBIRD:
-  . Added class Pdo\Firebird.
-
-- PDO_MYSQL:
-  . Added class Pdo\Mysql.
-
-- PDO_ODBC:
-  . Added class Pdo\Odbc.
-
-- PDO_PGSQL:
-  . Added class Pdo\Pgsql.
-
-- PDO_SQLITE:
-  . Added class Pdo\Sqlite.
 
 - POSIX:
   . Added constant POSIX_SC_CHILD_MAX

--- a/UPGRADING
+++ b/UPGRADING
@@ -64,8 +64,8 @@ PHP 8.4 UPGRADE NOTES
     object. This is no longer possible, and cloning a DOMXPath object now throws
     an error.
   . DOMDocument::$actualEncoding, DOMDocument::config, DOMEntity::$actualEncoding,
-    DOMEntity::$encoding, DOMEntity::$version have been deprecated as part of the
-    https://wiki.php.net/rfc/deprecations_php_8_4 RFC.
+    DOMEntity::$encoding, DOMEntity::$version have been deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#formally_deprecate_soft-deprecated_domdocument_and_domentity_properties
 
 - GMP:
   . The GMP class is now final and cannot be extended anymore.
@@ -305,6 +305,7 @@ PHP 8.4 UPGRADE NOTES
   . Added support for driver specific SQL parsers. The default parser supports:
     - single and double quoted literals, with doubling as escaping mechanism.
     - two-dashes and non-nested C-style comments.
+    RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
 - PDO_MYSQL:
   . Added custom parser supporting:
@@ -313,6 +314,7 @@ PHP 8.4 UPGRADE NOTES
     - backtick literal identifiers and with doubling as escaping mechanism
     - two dashes followed by at least 1 whitespace, non-nested C-style comments,
       and hash-comments
+    RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
 - PDO_PGSQL:
   . Added custom parser supporting:
@@ -321,12 +323,14 @@ PHP 8.4 UPGRADE NOTES
     - dollar-quoted string literals
     - two-dashes and C-style comments (non-nested)
     - support for "??" as escape sequence for the "?" operator
+    RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
 - PDO_SQLITE:
   . Added custom parser supporting:
     - single, double quoted, and backtick literals, with doubling as escaping mechanism
     - square brackets quoting for identifiers
     - two-dashes and C-style comments (non-nested)
+    RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers
 
 - Phar:
   . Added support for the unix timestamp extension for zip archives.
@@ -443,7 +447,7 @@ PHP 8.4 UPGRADE NOTES
   . Constants SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, and
     SUNFUNCS_RET_DOUBLE are now deprecated, following the deprecation of
     the associated date_sunset() and date_sunrise() functions in PHP 8.1.
-    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#constants_sunfuncs_ret_string_sunfuncs_ret_double_sunfuncs_ret_timestamp
 
 - DBA:
   . Passing null or false to dba_key_split() is deprecated.
@@ -455,7 +459,7 @@ PHP 8.4 UPGRADE NOTES
 
 - Hash:
   . Deprecated passing incorrect data types for options to ext/hash functions.
-    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_incorrect_data_types_for_options_to_exthash_functions
 
 - Intl:
   . Calling intlcal_set() as well as calling IntlCalendar::set() with
@@ -505,7 +509,7 @@ PHP 8.4 UPGRADE NOTES
 - Random:
   . lcg_value() is deprecated, as the function is broken in multiple ways.
     Use \Random\Randomizer::getFloat() instead.
-    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_lcg_value
 
 - Reflection:
   . Calling ReflectionMethod::__construct() with 1 argument is deprecated.
@@ -517,7 +521,7 @@ PHP 8.4 UPGRADE NOTES
   . Changing the INI settings session.sid_length and session.sid_bits_per_character
     is deprecated. Update the session storage backend to accept 32 character
     hexadecimal session IDs and stop changing these two INI settings.
-    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character
 
 - SOAP:
   . Passing an int to SoapServer::addFunction() is now deprecated.
@@ -543,7 +547,7 @@ PHP 8.4 UPGRADE NOTES
   . Raising zero to the power of negative number is deprecated.
     RFC: https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number
   . Unserializing strings using the uppercase 'S' tag is deprecated.
-    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4#unserialize_s_s_tag
   . Passing a non-empty string for the $enclosure parameter of:
     - fputcsv()
     - fgetcsv()
@@ -683,11 +687,9 @@ PHP 8.4 UPGRADE NOTES
     earlier PHP versions.
   . The $mode parameter of the round() function has been widened to RoundingMode|int,
     accepting instances of a new RoundingMode enum.
-
     RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum
   . Four new modes have been added to the round() function: RoundingMode::PositiveInfinity,
     RoundingMode::NegativeInfinity, RoundingMode::TowardsZero, RoundingMode::AwayFromZero.
-
     RFC: https://wiki.php.net/rfc/new_rounding_modes_to_round_function
   . Fixed a bug caused by "pre-rounding" of the round() function. Previously, using
     "pre-rounding" to treat a value like 0.285 (actually 0.28499999999999998) as a
@@ -699,7 +701,6 @@ PHP 8.4 UPGRADE NOTES
     but now returns `4503599627370496`.
   . The default value of the 'cost' option for PASSWORD_BCRYPT for password_hash()
     has been increased from '10' to '12'.
-
     RFC: https://wiki.php.net/rfc/bcrypt_cost_2023
   . debug_zval_dump() now indicates whether an array is packed.
   . long2ip() now returns string instead of string|false.

--- a/UPGRADING
+++ b/UPGRADING
@@ -739,8 +739,8 @@ PHP 8.4 UPGRADE NOTES
 - PCNTL:
   . Added pcntl_setns allowing a process to be reassociated with a namespace in order
     to share resources with other processes within this context.
-  . Added pcntl_getaffinity to get the cpu(s) bound to a process and
-    pcntl_setaffinity to bind 1 or more cpus to a process.
+  . Added pcntl_getcpuaffinity to get the cpu(s) bound to a process and
+    pcntl_setcpuaffinity to bind 1 or more cpus to a process.
   . Added pcntl_getcpu to get the cpu id from where the current process runs.
   . Added pcntl_getqos_class to get the QoS level (aka performance and related
     energy consumption) of the current process and pcntl_setqos_class to set it.

--- a/UPGRADING
+++ b/UPGRADING
@@ -490,7 +490,7 @@ PHP 8.4 UPGRADE NOTES
     is no longer necessary to escape question marks inside them.
 
 - PgSQL:
-  . Calling pgsql_fetch_result() with 2 arguments is deprecated. Use the
+  . Calling pg_fetch_result() with 2 arguments is deprecated. Use the
     3-parameter signature with a null $row parameter instead.
   . Calling pg_field_prtlen() with 2 arguments is deprecated. Use the
     3-parameter signature with a null $row parameter instead.

--- a/UPGRADING
+++ b/UPGRADING
@@ -961,6 +961,9 @@ PHP 8.4 UPGRADE NOTES
   . P_SID (NetBSD/FreeBSD only).
   . P_JAILID (FreeBSD only).
 
+- PgSQL:
+  . PGSQL_TUPLES_CHUNK
+
 - Sockets:
   . SO_EXCLUSIVEADDRUSE (Windows only).
   . SOCK_CONN_DGRAM (NetBSD only).

--- a/UPGRADING
+++ b/UPGRADING
@@ -126,6 +126,22 @@ PHP 8.4 UPGRADE NOTES
     has changed. Consult https://github.com/PCRE2Project/pcre2/blob/master/NEWS
     for a full changelog.
 
+- PCNTL:
+  . The functions pcntl_sigprocmask(), pcntl_sigwaitinfo() and
+    pcntl_sigtimedwait() now throw:
+    - A ValueError if the $signals array is empty (except for
+      pcntl_sigprocmask() if the $mode is SIG_SETMASK).
+    - A TypeError if a value of the $signals array is not an integer
+    - A ValueError if a value of the $signals array is not a valid signal number
+    Moreover, those functions now always return false on failure.
+    In some case previously it could return the value -1.
+  . The function pcntl_sigprocmask() will also now throw:
+    - A ValueError if $mode is not one of SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
+  . The function pcntl_sigtimedwait() will also now throw:
+    - A ValueError if $seconds is less than 0
+    - A ValueError if $nanoseconds is less than 0 or greater than 1e9
+    - A ValueError if both $seconds and $nanoseconds are 0
+
 - PDO_DBLIB:
   . setAttribute, DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER and DBLIB_ATTR_DATETIME_CONVERT
     have been changed to set value as a bool.
@@ -142,22 +158,6 @@ PHP 8.4 UPGRADE NOTES
 - PDO_PGSQL:
   . The DSN's credentials, when set, are given priority over their PDO
     constructor counterparts, being closer to the documentation states.
-
-- PCNTL:
-  . The functions pcntl_sigprocmask(), pcntl_sigwaitinfo() and
-    pcntl_sigtimedwait() now throw:
-    - A ValueError if the $signals array is empty (except for
-      pcntl_sigprocmask() if the $mode is SIG_SETMASK).
-    - A TypeError if a value of the $signals array is not an integer
-    - A ValueError if a value of the $signals array is not a valid signal number
-    Moreover, those functions now always return false on failure.
-    In some case previously it could return the value -1.
-  . The function pcntl_sigprocmask() will also now throw:
-    - A ValueError if $mode is not one of SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
-  . The function pcntl_sigtimedwait() will also now throw:
-    - A ValueError if $seconds is less than 0
-    - A ValueError if $nanoseconds is less than 0 or greater than 1e9
-    - A ValueError if both $seconds and $nanoseconds are 0
 
 - SimpleXML:
   . Get methods called, or casting to a string on a SimpleXMLElement will no
@@ -301,6 +301,18 @@ PHP 8.4 UPGRADE NOTES
     openssl_pkey_get_details as well as openssl_sign and openssl_verify were
     extended to support those keys.
 
+- PCRE:
+  . The bundled pcre2lib has been updated to version 10.44.
+    As a consequence, LoongArch JIT support has been added, spaces
+    are now allowed between braces in Perl-compatible items, and
+    variable-length lookbehind assertions are now supported.
+  . With pcre2lib version 10.44, the maximum length of named capture groups
+    has changed from 32 to 128.
+  . Added support for the "r" (PCRE2_EXTRA_CASELESS_RESTRICT) modifier, as well
+    as the (?r) mode modifier. When enabled along with the case-insensitive
+    modifier ("i"), the expression locks out mixing of ASCII and non-ASCII
+    characters.
+
 - PDO:
   . Added support for driver-specific subclasses.
     RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses
@@ -352,18 +364,6 @@ PHP 8.4 UPGRADE NOTES
 
 - Phar:
   . Added support for the unix timestamp extension for zip archives.
-
-- PCRE:
-  . The bundled pcre2lib has been updated to version 10.44.
-    As a consequence, LoongArch JIT support has been added, spaces
-    are now allowed between braces in Perl-compatible items, and
-    variable-length lookbehind assertions are now supported.
-  . With pcre2lib version 10.44, the maximum length of named capture groups
-    has changed from 32 to 128.
-  . Added support for the "r" (PCRE2_EXTRA_CASELESS_RESTRICT) modifier, as well
-    as the (?r) mode modifier. When enabled along with the case-insensitive
-    modifier ("i"), the expression locks out mixing of ASCII and non-ASCII
-    characters.
 
 - POSIX:
   . Added constant POSIX_SC_CHILD_MAX
@@ -602,6 +602,12 @@ PHP 8.4 UPGRADE NOTES
   . The behavior of mb_strcut is more consistent now on invalid UTF-8 and UTF-16
     strings. (For valid UTF-8 and UTF-16 strings, there is no change.)
 
+- ODBC:
+  . Parameter $row of odbc_fetch_object(), odbc_fetch_array(), and
+    odbc_fetch_into() now has a default value of null, consistent with
+    odbc_fetch_row(). Previously, the default values were -1, -1, and 0,
+    respectively.
+
 - OpenSSL:
   . The extra_attributes parameter in openssl_csr_new sets CSR attributes
     instead of subject DN which was incorrectly done previously.
@@ -612,12 +618,6 @@ PHP 8.4 UPGRADE NOTES
   . Parsing ASN.1 UTCTime by openssl_x509_parse fails if seconds are omitted
     for OpenSSL version below 3.2 (-1 is returned for such fields). The
     OpenSSL version 3.3+ does not load such certificates already.
-
-- ODBC:
-  . Parameter $row of odbc_fetch_object(), odbc_fetch_array(), and
-    odbc_fetch_into() now has a default value of null, consistent with
-    odbc_fetch_row(). Previously, the default values were -1, -1, and 0,
-    respectively.
 
 - Output:
   . Output handler status flags passed to the flags parameter of ob_start
@@ -869,7 +869,7 @@ PHP 8.4 UPGRADE NOTES
 - MBString:
   . Unicode data tables have been updated to Unicode 15.1.
 
-- mysqli:
+- Mysqli:
   . The unused and undocumented constant MYSQLI_SET_CHARSET_DIR
     has been removed.
 
@@ -879,10 +879,10 @@ PHP 8.4 UPGRADE NOTES
 - PDO:
   . The class constants are typed now.
 
-- pdo_pgsql:
+- PDO_PGSQL:
   . The pdo_pgsql extension now requires at least libpq 10.0.
 
-- pgsql:
+- PgSQL:
   . The pgsql extension now requires at least libpq 10.0.
 
 - Reflection:

--- a/UPGRADING
+++ b/UPGRADING
@@ -365,6 +365,9 @@ PHP 8.4 UPGRADE NOTES
 - Phar:
   . Added support for the unix timestamp extension for zip archives.
 
+- PgSQL:
+  . Added pg_result_memory_size to get the visibility the memory used by a query result.
+
 - POSIX:
   . Added constant POSIX_SC_CHILD_MAX
   . Added constant POSIX_SC_CLK_TCK
@@ -496,7 +499,6 @@ PHP 8.4 UPGRADE NOTES
     3-parameter signature with a null $row parameter instead.
   . Calling pg_field_is_null() with 2 arguments is deprecated. Use the
     3-parameter signature with a null $row parameter instead.
-  . Added pg_result_memory_size to get the visibility the memory used by a query result.
 
 - Random:
   . lcg_value() is deprecated, as the function is broken in multiple ways.


### PR DESCRIPTION
### 8.4 | UPGRADING: add missing RFC links

Includes fixing up existing (deprecations) RFC links which didn't directly link to the section within the RFC.

### 8.4 | UPGRADING: join PDO entries

There were multiple headers for the same PDO extensions in the "New features" section.

This joins these together.

### 8.4 | UPGRADING: fix extension order

A number of times, extensions were not listed in alphabetic order.

Fixed now.

Includes a few minor fixes where extension names were using inconsistent casing across the file.

### 8.4 | UPGRADING: fix typo

### 8.4 | UPGRADING: move new function to correct section

The `pg_result_memory_size()` function is a new feature, not a deprecated feature.

### 8.4 | UPGRADING: fix incorrect function names

Ref: 1cf8291#diff-d22d5ad00ee9f000cb8c8f9a5cfb905a8de91e7dc4a633896e2c5ab4ad1513d1

### 8.4 | UPGRADING: add missing constant

Ref: 564914a#diff-c5961ea04ab805b0059964fac68d6e159095a4b56aaaded0b1b941b8768c0f52