### PR TITLE
Fix MSan false-positive in zend_max_execution_timer

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -802,6 +802,8 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	executor_globals->num_errors = 0;
 	executor_globals->errors = NULL;
 #ifdef ZEND_MAX_EXECUTION_TIMERS
+	memset(&executor_globals->max_execution_timer_timer, 0,
+		sizeof(executor_globals->max_execution_timer_timer));
 	executor_globals->pid = 0;
 	executor_globals->oldact = (struct sigaction){0};
 #endif

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -802,8 +802,6 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	executor_globals->num_errors = 0;
 	executor_globals->errors = NULL;
 #ifdef ZEND_MAX_EXECUTION_TIMERS
-	memset(&executor_globals->max_execution_timer_timer, 0,
-		sizeof(executor_globals->max_execution_timer_timer));
 	executor_globals->pid = 0;
 	executor_globals->oldact = (struct sigaction){0};
 #endif


### PR DESCRIPTION
ZEND_MAX_EXECUTION_TIMER is always enabled in PHP 8.3 and later ZTS builds, but accesses uninitialized memory.
Detected at clang-20 with MSan.

```
$ CC=clang CXX=clang++ CFLAGS="-DZEND_TRACK_ARENA_ALLOC" ./configure --enable-debug --enable-zts --enable-memory-sanitizer
$ make -j"$(nproc)"
~~~
==284762==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xaaaaafdafc04 in zend_max_execution_timer_settime /usr/src/php-fixed/Zend/zend_max_execution_timer.c:101:6
    #1 0xaaaaaf3f1bfc in zend_set_timeout_ex /usr/src/php-fixed/Zend/zend_execute_API.c:1567:2
    #2 0xaaaaaf3f1f60 in zend_set_timeout /usr/src/php-fixed/Zend/zend_execute_API.c:1636:2
    #3 0xaaaaaeac7c98 in php_request_startup /usr/src/php-fixed/main/main.c:1847:4
    #4 0xaaaaaff87168 in do_cli /usr/src/php-fixed/sapi/cli/php_cli.c:903:7
    #5 0xaaaaaff82988 in main /usr/src/php-fixed/sapi/cli/php_cli.c:1309:18
    #6 0xffffb9e7777c in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 0xffffb9e77854 in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 0xaaaaac45ffec in _start (/usr/src/php-fixed/sapi/cli/php+0x14ffec) (BuildId: 27f7688a26e0107ad93e8e90a4bde71027f24c40)

  Uninitialized value was stored to memory at
    #0 0xaaaaafdafc00 in zend_max_execution_timer_settime /usr/src/php-fixed/Zend/zend_max_execution_timer.c:101:20
    #1 0xaaaaaf3f1bfc in zend_set_timeout_ex /usr/src/php-fixed/Zend/zend_execute_API.c:1567:2
    #2 0xaaaaaf3f1f60 in zend_set_timeout /usr/src/php-fixed/Zend/zend_execute_API.c:1636:2
    #3 0xaaaaaeac7c98 in php_request_startup /usr/src/php-fixed/main/main.c:1847:4
    #4 0xaaaaaff87168 in do_cli /usr/src/php-fixed/sapi/cli/php_cli.c:903:7
    #5 0xaaaaaff82988 in main /usr/src/php-fixed/sapi/cli/php_cli.c:1309:18
    #6 0xffffb9e7777c in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 0xffffb9e77854 in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 0xaaaaac45ffec in _start (/usr/src/php-fixed/sapi/cli/php+0x14ffec) (BuildId: 27f7688a26e0107ad93e8e90a4bde71027f24c40)

  Uninitialized value was stored to memory at
    #0 0xaaaaafdafa1c in zend_max_execution_timer_settime /usr/src/php-fixed/Zend/zend_max_execution_timer.c:86:10
    #1 0xaaaaaf3f1bfc in zend_set_timeout_ex /usr/src/php-fixed/Zend/zend_execute_API.c:1567:2
    #2 0xaaaaaf3f1f60 in zend_set_timeout /usr/src/php-fixed/Zend/zend_execute_API.c:1636:2
    #3 0xaaaaaeac7c98 in php_request_startup /usr/src/php-fixed/main/main.c:1847:4
    #4 0xaaaaaff87168 in do_cli /usr/src/php-fixed/sapi/cli/php_cli.c:903:7
    #5 0xaaaaaff82988 in main /usr/src/php-fixed/sapi/cli/php_cli.c:1309:18
    #6 0xffffb9e7777c in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 0xffffb9e77854 in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 0xaaaaac45ffec in _start (/usr/src/php-fixed/sapi/cli/php+0x14ffec) (BuildId: 27f7688a26e0107ad93e8e90a4bde71027f24c40)

  Uninitialized value was created by a heap allocation
    #0 0xaaaaac49a744 in malloc (/usr/src/php-fixed/sapi/cli/php+0x18a744) (BuildId: 27f7688a26e0107ad93e8e90a4bde71027f24c40)
    #1 0xaaaaaea9e4a4 in allocate_new_resource /usr/src/php-fixed/TSRM/TSRM.c:381:47
    #2 0xaaaaaea9d4d4 in ts_resource_ex /usr/src/php-fixed/TSRM/TSRM.c:451:3
    #3 0xaaaaaeadc8d4 in php_tsrm_startup_ex /usr/src/php-fixed/main/main.c:2759:8
    #4 0xaaaaaeadc938 in php_tsrm_startup /usr/src/php-fixed/main/main.c:2766:9
    #5 0xaaaaaff81a4c in main /usr/src/php-fixed/sapi/cli/php_cli.c:1202:2
    #6 0xffffb9e7777c in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 0xffffb9e77854 in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 0xaaaaac45ffec in _start (/usr/src/php-fixed/sapi/cli/php+0x14ffec) (BuildId: 27f7688a26e0107ad93e8e90a4bde71027f24c40)
```