### PR TITLE
Explicitly drop support for old clang versions on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3074,7 +3074,9 @@ function toolset_get_compiler_version()
 			version = RegExp.$1;
 			version = version.replace(/\./g, '');
 			version = version/100 < 1 ? version*10 : version;
-
+			if (version < 400) {
+				ERROR("Building with clang " + version + " is no longer supported");
+			}
 			return version;
 		}
 	} else if (ICC_TOOLSET) {

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3073,7 +3073,6 @@ function toolset_get_compiler_version()
 		if (full.match(/clang version ([\d\.]+)/)) {
 			version = RegExp.$1;
 			version = version.replace(/\./g, '');
-			version = version/100 < 1 ? version*10 : version;
 			if (version < 400) {
 				ERROR("Building with clang " + version + " is no longer supported");
 			}


### PR DESCRIPTION
This ensures compatibility with the typedef redefinitions we use, and makes it clear during the `configure` stage that old compiler versions are not supported.

See <https://releases.llvm.org/> regarding the release history of clang.

---

Note that clang 3.1.0 added support for C11, and that *may* include support for typedef redefinitions, but I'm not sure about that. And the oldest clang I've managed to install on my machine is 4.0.0. I did a minimal PHP build successfully, so I'm reasonable sure that the typedef redifinition won't cause an issue as of clang 4.0.0. And frankly, I don't see much point in claiming support for even older clang versions, while clang 4.0.0 has been released on 2017-03-13, and I'm not even sure that newer clang versions are fully supported with PHP on Windows.