### PR TITLE
Autotools: Sync CS in sapi/fuzzer

### DIFF
--- a/sapi/fuzzer/config.m4
+++ b/sapi/fuzzer/config.m4
@@ -8,13 +8,15 @@ PHP_ARG_ENABLE([fuzzer],
 dnl For newer Clang versions see https://llvm.org/docs/LibFuzzer.html#fuzzer-usage
 dnl for relevant flags.
 
-dnl Macro to define fuzzing target
+dnl
 dnl PHP_FUZZER_TARGET(name, target-var)
+dnl
+dnl Macro to define the fuzzing target.
 dnl
 AC_DEFUN([PHP_FUZZER_TARGET], [
   PHP_FUZZER_BINARIES="$PHP_FUZZER_BINARIES $SAPI_FUZZER_PATH/php-fuzz-$1"
   PHP_SUBST([$2])
-  PHP_ADD_SOURCES_X([sapi/fuzzer],[fuzzer-$1.c],[],$2)
+  PHP_ADD_SOURCES_X([sapi/fuzzer], [fuzzer-$1.c], [], [$2])
   $2="[$]$2 $FUZZER_COMMON_OBJS"
 ])
 
@@ -30,19 +32,18 @@ if test "$PHP_FUZZER" != "no"; then
   PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/fuzzer/Makefile.frag])
   SAPI_FUZZER_PATH=sapi/fuzzer
   PHP_SUBST([SAPI_FUZZER_PATH])
-  if test -z "$LIB_FUZZING_ENGINE"; then
+  AS_VAR_IF([LIB_FUZZING_ENGINE],, [
     FUZZING_LIB="-fsanitize=fuzzer"
-    FUZZING_CC="$CC"
+    FUZZING_CC=$CC
     AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link], [
       CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link"
       CXXFLAGS="$CXXFLAGS -fsanitize=fuzzer-no-link"
-    ],[
-      AC_MSG_ERROR([Compiler doesn't support -fsanitize=fuzzer-no-link])
-    ])
-  else
-    FUZZING_LIB="$LIB_FUZZING_ENGINE"
+    ],
+    [AC_MSG_ERROR([Compiler doesn't support -fsanitize=fuzzer-no-link])])
+  ], [
+    FUZZING_LIB=$LIB_FUZZING_ENGINE
     FUZZING_CC="$CXX -stdlib=libc++"
-  fi
+  ])
   PHP_SUBST([FUZZING_LIB])
   PHP_SUBST([FUZZING_CC])
 
@@ -55,21 +56,21 @@ if test "$PHP_FUZZER" != "no"; then
 
   PHP_ADD_SOURCES_X([sapi/fuzzer], [fuzzer-sapi.c], [], [FUZZER_COMMON_OBJS])
 
-  PHP_FUZZER_TARGET([parser], PHP_FUZZER_PARSER_OBJS)
-  PHP_FUZZER_TARGET([execute], PHP_FUZZER_EXECUTE_OBJS)
-  PHP_FUZZER_TARGET([function-jit], PHP_FUZZER_FUNCTION_JIT_OBJS)
-  PHP_FUZZER_TARGET([tracing-jit], PHP_FUZZER_TRACING_JIT_OBJS)
-  PHP_FUZZER_TARGET([unserialize], PHP_FUZZER_UNSERIALIZE_OBJS)
-  PHP_FUZZER_TARGET([unserializehash], PHP_FUZZER_UNSERIALIZEHASH_OBJS)
-  PHP_FUZZER_TARGET([json], PHP_FUZZER_JSON_OBJS)
+  PHP_FUZZER_TARGET([parser], [PHP_FUZZER_PARSER_OBJS])
+  PHP_FUZZER_TARGET([execute], [PHP_FUZZER_EXECUTE_OBJS])
+  PHP_FUZZER_TARGET([function-jit], [PHP_FUZZER_FUNCTION_JIT_OBJS])
+  PHP_FUZZER_TARGET([tracing-jit], [PHP_FUZZER_TRACING_JIT_OBJS])
+  PHP_FUZZER_TARGET([unserialize], [PHP_FUZZER_UNSERIALIZE_OBJS])
+  PHP_FUZZER_TARGET([unserializehash], [PHP_FUZZER_UNSERIALIZEHASH_OBJS])
+  PHP_FUZZER_TARGET([json], [PHP_FUZZER_JSON_OBJS])
 
   if test -n "$enable_exif" && test "$enable_exif" != "no"; then
-    PHP_FUZZER_TARGET([exif], PHP_FUZZER_EXIF_OBJS)
+    PHP_FUZZER_TARGET([exif], [PHP_FUZZER_EXIF_OBJS])
   fi
   if test -n "$enable_mbstring" && test "$enable_mbstring" != "no"; then
-    PHP_FUZZER_TARGET([mbstring], PHP_FUZZER_MBSTRING_OBJS)
+    PHP_FUZZER_TARGET([mbstring], [PHP_FUZZER_MBSTRING_OBJS])
     if test -n "$enable_mbregex" && test "$enable_mbregex" != "no"; then
-      PHP_FUZZER_TARGET([mbregex], PHP_FUZZER_MBREGEX_OBJS)
+      PHP_FUZZER_TARGET([mbregex], [PHP_FUZZER_MBREGEX_OBJS])
     fi
   fi
 


### PR DESCRIPTION
- AS_VAR_IF macro used
- redundant quotes removed
- PHP_FUZZER_TARGET macro body synced with the rest of the macros in php-src
- PHP_FUZZER_TARGET arguments quoted