### PR TITLE
ext/opcache/ZendAccelerator.c: Restrict MD5 header include to Windows

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -47,10 +47,11 @@
 #include "zend_accelerator_hash.h"
 #include "zend_file_cache.h"
 #include "ext/pcre/php_pcre.h"
-#include "ext/standard/md5.h"
+#include "ext/standard/basic_functions.h"
 
 #ifdef ZEND_WIN32
 # include "ext/hash/php_hash.h"
+# include "ext/standard/md5.h"
 #endif
 
 #ifdef HAVE_JIT


### PR DESCRIPTION
As it is only ever used in accel_gen_uname_id() which is Windows only