### PR TITLE
ensure default settings used in test

### DIFF
--- a/Zend/tests/exit/exit_values.phpt
+++ b/Zend/tests/exit/exit_values.phpt
@@ -49,7 +49,7 @@ try {
 TEMPLATE;
 
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
-$command = $php . ' ' . escapeshellarg(FILE_PATH);
+$command = $php . ' --no-php-ini ' . escapeshellarg(FILE_PATH);
 
 foreach ([FILE_CONTENT, str_replace('exit', 'die', FILE_CONTENT)] as $code) {
     foreach ($values as $value) {


### PR DESCRIPTION
Test may fail with a php.ini installed setting not expected options

