### PR TITLE
Fix ZEND_FASTCALL definition wrt. x64 Windows clang builds

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -306,7 +306,7 @@ char *alloca();
 # define ZEND_FASTCALL __attribute__((fastcall))
 #elif defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER == 1700
 # define ZEND_FASTCALL __fastcall
-#elif defined(_MSC_VER) && _MSC_VER >= 1800 && !defined(__clang__)
+#elif defined(_MSC_VER) && _MSC_VER >= 1800
 # define ZEND_FASTCALL __vectorcall
 #else
 # define ZEND_FASTCALL


### PR DESCRIPTION
As is, MSVC uses `__vectorcall`, but clang uses `__cdecl`.  This obviously is bad for interoperability (and causes link issues), and is likely worse for FFI which offers some limited (but likely sufficient for our purposes) support for `__vectorcall` on Windows.

Since clang claims to support `__vectorcall` as of 3.6.0, and we bumped the requirements to clang 4.0.0 already, there shouldn't be any issues.

---

I've did a minimal x64 clang 4.0.0 build on Windows (`configure --disable-all --enable-cli --with-toolset=clang`) and didn't notice any issues (tests/ where running fine, and the function names where mangled appropriately).

For some more details see also https://github.com/php/php-src/pull/15415#issuecomment-2291173915.