### PR TITLE
Autotools: Fix external PCRE JIT check

### DIFF
--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -28,7 +28,12 @@ if test "$PHP_EXTERNAL_PCRE" != "no"; then
   AS_VAR_IF([PHP_PCRE_JIT], [no],,
     [AC_CACHE_CHECK([whether external PCRE2 library has JIT supported],
       [php_cv_have_pcre2_jit],
-      [AC_RUN_IFELSE([AC_LANG_SOURCE([
+      [
+        CFLAGS_SAVE=$CFLAGS
+        LIBS_SAVE=$LIBS
+        CFLAGS="$CFLAGS $PCRE2_CFLAGS"
+        LIBS="$LIBS $PCRE2_LIBS"
+        AC_RUN_IFELSE([AC_LANG_SOURCE([
           #include <pcre2.h>
           #include <stdlib.h>
           int main(void) {
@@ -42,7 +47,10 @@ if test "$PHP_EXTERNAL_PCRE" != "no"; then
         [AS_CASE([$host_cpu],
           [arm*|i[[34567]]86|x86_64|mips*|powerpc*|sparc],
             [php_cv_have_pcre2_jit=yes],
-          [php_cv_have_pcre2_jit=no])])])
+          [php_cv_have_pcre2_jit=no])])
+        CFLAGS=$CFLAGS_SAVE
+        LIBS=$LIBS_SAVE
+      ])
     AS_VAR_IF([php_cv_have_pcre2_jit], [yes],
       [AC_DEFINE([HAVE_PCRE_JIT_SUPPORT], [1])])
   ])


### PR DESCRIPTION
If using a custom PCRE library installation, also CFLAGS and LIBS variables need to be adapted for the JIT check to be able to find it.