### PR TITLE
PHP 8.4 | Exit as function: fix incorrect parameter name

### DIFF
--- a/Zend/tests/exit/die_string_cast_exception.phpt
+++ b/Zend/tests/exit/die_string_cast_exception.phpt
@@ -11,4 +11,4 @@ try {
 
 ?>
 --EXPECT--
-exit(): Argument #1 ($code) must be of type string|int, stdClass given
+exit(): Argument #1 ($status) must be of type string|int, stdClass given

--- a/Zend/tests/exit/exit_as_function.phpt
+++ b/Zend/tests/exit/exit_as_function.phpt
@@ -27,7 +27,7 @@ object(Closure)#1 (2) {
   string(4) "exit"
   ["parameter"]=>
   array(1) {
-    ["$code"]=>
+    ["$status"]=>
     string(10) "<optional>"
   }
 }
@@ -36,7 +36,7 @@ object(Closure)#2 (2) {
   string(4) "exit"
   ["parameter"]=>
   array(1) {
-    ["$code"]=>
+    ["$status"]=>
     string(10) "<optional>"
   }
 }

--- a/Zend/tests/exit/exit_named_arg.phpt
+++ b/Zend/tests/exit/exit_named_arg.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Using exit()/die() as function call with a named argument
+--FILE--
+<?php
+
+$values = [
+    12,
+    "Goodbye!",
+];
+
+const FILE_PATH = __DIR__ . '/exit_named_arg_test.php';
+const FILE_CONTENT = <<<'TEMPLATE'
+<?php
+try {
+    exit(status: VALUE);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+TEMPLATE;
+
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$command = $php . ' --no-php-ini ' . escapeshellarg(FILE_PATH);
+
+foreach ([FILE_CONTENT, str_replace('exit', 'die', FILE_CONTENT)] as $code) {
+    foreach ($values as $value) {
+        echo 'Using ', var_export($value, true), ' as value:', PHP_EOL;
+        $output = [];
+        $content = str_replace('VALUE', var_export($value, true), $code);
+        file_put_contents(FILE_PATH, $content);
+        exec($command, $output, $exit_status);
+        echo 'Exit status is: ', $exit_status, PHP_EOL,
+             'Output is:', PHP_EOL, join($output), PHP_EOL;
+    }
+}
+
+?>
+--CLEAN--
+<?php
+const FILE_PATH = __DIR__ . '/exit_named_arg_test.php';
+@unlink(FILE_PATH);
+?>
+--EXPECT--
+Using 12 as value:
+Exit status is: 12
+Output is:
+
+Using 'Goodbye!' as value:
+Exit status is: 0
+Output is:
+Goodbye!
+Using 12 as value:
+Exit status is: 12
+Output is:
+
+Using 'Goodbye!' as value:
+Exit status is: 0
+Output is:
+Goodbye!

--- a/Zend/tests/exit/exit_values.phpt
+++ b/Zend/tests/exit/exit_values.phpt
@@ -80,7 +80,7 @@ const FILE_PATH = __DIR__ . '/exit_values_test.php';
 Using NULL as value:
 Exit status is: 0
 Output is:
-Deprecated: exit(): Passing null to parameter #1 ($code) of type string|int is deprecated in %s on line %d
+Deprecated: exit(): Passing null to parameter #1 ($status) of type string|int is deprecated in %s on line %d
 Using false as value:
 Exit status is: 0
 Output is:
@@ -116,23 +116,23 @@ Hello world
 Using [] as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, array given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, array given
 Using STDERR as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, resource given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, resource given
 Using new stdClass() as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, stdClass given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, stdClass given
 As a statement:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, stdClass given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, stdClass given
 Using NULL as value:
 Exit status is: 0
 Output is:
-Deprecated: exit(): Passing null to parameter #1 ($code) of type string|int is deprecated in %s on line %d
+Deprecated: exit(): Passing null to parameter #1 ($status) of type string|int is deprecated in %s on line %d
 Using false as value:
 Exit status is: 0
 Output is:
@@ -168,16 +168,16 @@ Hello world
 Using [] as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, array given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, array given
 Using STDERR as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, resource given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, resource given
 Using new stdClass() as value:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, stdClass given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, stdClass given
 As a statement:
 Exit status is: 0
 Output is:
-TypeError: exit(): Argument #1 ($code) must be of type string|int, stdClass given
+TypeError: exit(): Argument #1 ($status) must be of type string|int, stdClass given

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -72,11 +72,11 @@ zend_result zend_startup_builtin_functions(void) /* {{{ */
 ZEND_FUNCTION(exit)
 {
 	zend_string *str = NULL;
-	zend_long code = 0;
+	zend_long status = 0;
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_STR_OR_LONG(str, code)
+		Z_PARAM_STR_OR_LONG(str, status)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (str) {
@@ -89,7 +89,7 @@ ZEND_FUNCTION(exit)
 			}
 		}
 	} else {
-		EG(exit_status) = code;
+		EG(exit_status) = status;
 	}
 
 	ZEND_ASSERT(!EG(exception));

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -7,10 +7,10 @@ class stdClass
 {
 }
 
-function exit(string|int $code = 0): never {}
+function exit(string|int $status = 0): never {}
 
 /** @alias exit */
-function die(string|int $code = 0): never {}
+function die(string|int $status = 0): never {}
 
 /** @refcount 1 */
 function zend_version(): string {}

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a6d7e59d6b7875ddc28ce828ae240c7dfd852023 */
+ * Stub hash: 3dbc84896823c9aaa9ac8aeef8841266920c3e50 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_exit, 0, 0, IS_NEVER, 0)
-	ZEND_ARG_TYPE_MASK(0, code, MAY_BE_STRING|MAY_BE_LONG, "0")
+	ZEND_ARG_TYPE_MASK(0, status, MAY_BE_STRING|MAY_BE_LONG, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_die arginfo_exit


### PR DESCRIPTION
Follow up on #13483

As previously reported in https://github.com/php/php-src/pull/13483#discussion_r1718546927:

> The parameter names seem to be incorrect.
>
> It should be `$status`, not `$code`.
>
> The RFC explicitly uses that parameter name in the proposal: https://wiki.php.net/rfc/exit-as-function#proposal
>
> It is also the name already used in the [manual](https://www.php.net/exit).
>
> Lastly, the parameter name `$status` better covers what can be passed: either a status _message_ or a status _code_.
> While `$code` would read pretty weird when passing a message:
> ```php
> exit(code: 'message');
> ```

This commit attempts to fix this.

Includes adding a test for exit/die using a named argument.

---

P.S.: I hope I got it right, but can't test locally, so I'm opening this in draft to see the CI results and keeping my :crossed_fingers:.