### PR TITLE
libtool: Don't remove gcov *.gcno file

### DIFF
--- a/build/ltmain.sh
+++ b/build/ltmain.sh
@@ -3467,7 +3467,7 @@ EOF
 	tempremovelist=`$echo "$output_objdir/*"`
 	for p in $tempremovelist; do
 	  case $p in
-	    *.$objext)
+	    *.$objext|*.gcno)
 	       ;;
 	    $output_objdir/$outputname | $output_objdir/$libname.* | $output_objdir/${libname}${release}.*)
 	       if test "X$precious_files_regex" != "X"; then

--- a/build/ltmain.sh
+++ b/build/ltmain.sh
@@ -3467,7 +3467,7 @@ EOF
 	tempremovelist=`$echo "$output_objdir/*"`
 	for p in $tempremovelist; do
 	  case $p in
-	    *.$objext|*.gcno)
+	    *.$objext | *.gcno)
 	       ;;
 	    $output_objdir/$outputname | $output_objdir/$libname.* | $output_objdir/${libname}${release}.*)
 	       if test "X$precious_files_regex" != "X"; then


### PR DESCRIPTION
The libtool bundled with PHP is outdated and deletes `*.gcno` files used by gcov during the build process.

While this issue has already been resolved [upstream](https://github.com/autotools-mirror/libtool/blob/master/NEWS#L605), incorporating the fix at this point may not be practical. Therefore, we attempt to apply a fix to the current version.

This change will enable proper coverage output for third-party PHP Extensions.