### PR TITLE
ext/standard: Add `get_declared_enums` function

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -61,7 +61,7 @@ PHP 8.5 UPGRADE NOTES
 ========================================
 
 - Zlib:
-  . The "use_include_path" argument for the 
+  . The "use_include_path" argument for the
     gzfile, gzopen and readgzfile functions had been changed
     from int to boolean.
 
@@ -82,6 +82,10 @@ PHP 8.5 UPGRADE NOTES
   . pg_close_stmt offers an alternative way to close a prepared
     statement from the DEALLOCATE sql command in that we can reuse
     its name afterwards.
+
+- Standard:
+  . Added get_declared_enums() function that returns a list of declared enums. The
+    existing get_declared_classes() function continues to include enums.
 
 ========================================
 7. New Classes and Interfaces

--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -11,6 +11,7 @@ static const func_info_t func_infos[] = {
 	F1("get_declared_classes", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 	F1("get_declared_traits", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 	F1("get_declared_interfaces", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
+	F1("get_declared_enums", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 	F1("get_defined_functions", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_ARRAY),
 	F1("get_defined_vars", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF),
 	F1("get_resource_type", MAY_BE_STRING),

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1382,7 +1382,7 @@ static inline void get_declared_class_impl(INTERNAL_FUNCTION_PARAMETERS, int fla
 	ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(return_value)) {
 		ZEND_HASH_MAP_FOREACH_STR_KEY_VAL(EG(class_table), key, zv) {
 			ce = Z_PTR_P(zv);
-			if ((ce->ce_flags & (ZEND_ACC_LINKED|ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT)) == flags
+			if ((ce->ce_flags & (flags|ZEND_ACC_LINKED|ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT)) == flags
 			 && key
 			 && ZSTR_VAL(key)[0] != 0) {
 				ZEND_HASH_FILL_GROW();
@@ -1417,6 +1417,13 @@ ZEND_FUNCTION(get_declared_classes)
 ZEND_FUNCTION(get_declared_interfaces)
 {
 	get_declared_class_impl(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_LINKED | ZEND_ACC_INTERFACE);
+}
+/* }}} */
+
+/* {{{ Returns an array of all declared enums. */
+ZEND_FUNCTION(get_declared_enums)
+{
+	get_declared_class_impl(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_LINKED | ZEND_ACC_ENUM);
 }
 /* }}} */
 

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -141,6 +141,12 @@ function get_declared_traits(): array {}
 function get_declared_interfaces(): array {}
 
 /**
+ * @return array<int, string>
+ * @refcount 1
+ */
+function get_declared_enums(): array {}
+
+/**
  * @return array<string, array>
  * @refcount 1
  */

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3dbc84896823c9aaa9ac8aeef8841266920c3e50 */
+ * Stub hash: 3437a70925f1bb521ee264aba4a5b32af42c2f17 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_exit, 0, 0, IS_NEVER, 0)
 	ZEND_ARG_TYPE_MASK(0, status, MAY_BE_STRING|MAY_BE_LONG, "0")
@@ -160,6 +160,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_get_declared_interfaces arginfo_func_get_args
 
+#define arginfo_get_declared_enums arginfo_func_get_args
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_defined_functions, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, exclude_disabled, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
@@ -277,6 +279,7 @@ ZEND_FUNCTION(restore_exception_handler);
 ZEND_FUNCTION(get_declared_classes);
 ZEND_FUNCTION(get_declared_traits);
 ZEND_FUNCTION(get_declared_interfaces);
+ZEND_FUNCTION(get_declared_enums);
 ZEND_FUNCTION(get_defined_functions);
 ZEND_FUNCTION(get_defined_vars);
 ZEND_FUNCTION(get_resource_type);
@@ -341,6 +344,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(get_declared_classes, arginfo_get_declared_classes)
 	ZEND_FE(get_declared_traits, arginfo_get_declared_traits)
 	ZEND_FE(get_declared_interfaces, arginfo_get_declared_interfaces)
+	ZEND_FE(get_declared_enums, arginfo_get_declared_enums)
 	ZEND_FE(get_defined_functions, arginfo_get_defined_functions)
 	ZEND_FE(get_defined_vars, arginfo_get_defined_vars)
 	ZEND_FE(get_resource_type, arginfo_get_resource_type)

--- a/ext/standard/tests/class_object/get_declared_enums_basic.phpt
+++ b/ext/standard/tests/class_object/get_declared_enums_basic.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Test get_declared_enums() function
+--FILE--
+<?php
+
+enum MyUnitEnum {}
+enum MyStringBackedEnum: string {
+    case FOO = 'test';
+}
+enum MyIntBackedEnum: int {
+    case FOO = 1;
+}
+enum MyEnumImplementation implements Countable {
+    use TraitWithNoProperties;
+    public function count(): int {
+        return 0;
+    }
+}
+
+trait TraitWithNoProperties {}
+
+$enumsList = get_declared_enums();
+$classesList = get_declared_classes();
+var_dump($enumsList);
+
+foreach ($enumsList as $enum) {
+    if (!enum_exists($enum)) {
+        echo "Error: $enum is not a valid enum.\n";
+    }
+}
+
+echo "Ensure all enums are included.\n";
+
+var_dump(in_array('MyUnitEnum', $enumsList));
+var_dump(in_array('MyStringBackedEnum', $enumsList));
+var_dump(in_array('MyIntBackedEnum', $enumsList));
+var_dump(in_array('MyEnumImplementation', $enumsList));
+
+echo "Ensure interfaces are not included.\n";
+var_dump(!in_array('Throwable', $enumsList));
+var_dump(!in_array('IntBackedEnum', $enumsList));
+
+echo "Ensure traits are not included.\n";
+var_dump(!in_array('TraitWithNoProperties', $enumsList));
+
+echo "Ensure classes are not included.\n";
+var_dump(!in_array('stdClass', $enumsList));
+var_dump(!in_array('Exception', $enumsList));
+
+echo "Ensure enums are included in get_declared_classes().\n";
+var_dump(in_array('MyUnitEnum', $classesList));
+var_dump(in_array('MyStringBackedEnum', $classesList));
+var_dump(in_array('MyIntBackedEnum', $classesList));
+var_dump(in_array('MyEnumImplementation', $classesList));
+echo "Done";
+?>
+--EXPECTF--
+array(%d) {
+%a
+}
+Ensure all enums are included.
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Ensure interfaces are not included.
+bool(true)
+bool(true)
+Ensure traits are not included.
+bool(true)
+Ensure classes are not included.
+bool(true)
+bool(true)
+Ensure enums are included in get_declared_classes().
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done


### PR DESCRIPTION
Adds a `get_declared_enums()` function that returns a list of declared Enums. This function is similar to the existing `get_declared_(classes|interfaces|traits)` functions.

RFC: https://wiki.php.net/rfc/get_declared_enums