### PR TITLE
Fix broken GCC compatibility

### DIFF
--- a/Zend/zend_max_execution_timer.c
+++ b/Zend/zend_max_execution_timer.c
@@ -24,12 +24,13 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 
+#include "zend.h"
+#include "zend_globals.h"
+#include "zend_portability.h"
+
 #if __has_feature(memory_sanitizer)
 # include <sanitizer/msan_interface.h>
 #endif
-
-#include "zend.h"
-#include "zend_globals.h"
 
 // Musl Libc defines this macro, glibc does not
 // According to "man 2 timer_create" this field should always be available, but it's not: https://sourceware.org/bugzilla/show_bug.cgi?id=27417
@@ -53,8 +54,8 @@ ZEND_API void zend_max_execution_timer_init(void) /* {{{ */
 
 #if __has_feature(memory_sanitizer)
 	/* MSan does not intercept timer_create() */
-		__msan_unpoison(&EG(max_execution_timer_timer),
-						sizeof(EG(max_execution_timer_timer)));
+	__msan_unpoison(&EG(max_execution_timer_timer),
+					sizeof(EG(max_execution_timer_timer)));
 #endif
 
 	// Measure wall time instead of CPU time as originally planned now that it is possible https://github.com/php/php-src/pull/6504#issuecomment-1370303727


### PR DESCRIPTION
since #15408, ZTS builds now fail in GCC.

The cause is a header inclusion omission, which will be fixed.

Indentation format has also been fixed.
