### PR TITLE
Add hash extension to soap dependencies

### DIFF
--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -20,6 +20,7 @@ if test "$PHP_SOAP" != "no"; then
       [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_SUBST([SOAP_SHARED_LIBADD])
   ])
+  PHP_ADD_EXTENSION_DEP(soap, hash)
   PHP_ADD_EXTENSION_DEP(soap, libxml)
   PHP_ADD_EXTENSION_DEP(soap, session, true)
 fi

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -10,6 +10,7 @@ if (PHP_SOAP != "no") {
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_SOAP', 1, "Define to 1 if the PHP extension 'soap' is available.");
+		ADD_EXTENSION_DEP('soap', 'hash');
 		ADD_EXTENSION_DEP('soap', 'session', true);
 
 		if (!PHP_SOAP_SHARED) {


### PR DESCRIPTION
This adds the hash extension to the configure phase as a required dependency.