### PR TITLE
Autotools: Fix pdo_mysql build with mysql client library

### DIFF
--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -65,8 +65,8 @@ if test "$PHP_PDO_MYSQL" != "no"; then
         AC_MSG_ERROR([Unable to find your mysql installation])
       fi
 
-      PHP_ADD_INCLUDE([$PDO_MYSQL_INC_DIR])
       PDO_MYSQL_INCLUDE=-I$PDO_MYSQL_INC_DIR
+      PDO_MYSQL_LIBS="-L$PDO_MYSQL_LIB_DIR -lmysqlclient"
     else
       AC_MSG_RESULT([not found])
       AC_MSG_ERROR([Unable to find your mysql installation])


### PR DESCRIPTION
When using --with-pdo-mysql=DIR and for some reason DIR wouldn't have the executable DIR/bin/mysql_config available the 3rd option was so far to guess the mysql client library locations and pass the include directory further. The library directory and library name to link was missing. This fixes this case for consistency reasons. And in the future also the pkg-config could be a reliable alternative to mysql_config in that case. The PDO_MYSQL_INC_DIR is already processed PHP_EVAL_INCLINE so redundant PHP_ADD_INCLUDE is removed.