### PR TITLE
Remove deprecated typedef and useless includes due to those typedefs

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -338,6 +338,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      the caller now.
    - The php_info_html_esc() function has been removed, use
      php_escape_html_entities() with ENT_QUOTES directly instead.
+   - The deprecated php_uint32 and php_int32 typedefs have been removed from
+     ext/standard/basic_functions.h. Use the standard uint32_t and int32_t
+     types instead.
 
  h. ext/session
    - Added the php_get_session_status() API to get the session status, which is

--- a/ext/hash/php_hash_adler32.h
+++ b/ext/hash/php_hash_adler32.h
@@ -17,8 +17,6 @@
 #ifndef PHP_HASH_ADLER32_H
 #define PHP_HASH_ADLER32_H
 
-#include "ext/standard/basic_functions.h"
-
 typedef struct {
 	uint32_t state;
 } PHP_ADLER32_CTX;

--- a/ext/hash/php_hash_gost.h
+++ b/ext/hash/php_hash_gost.h
@@ -17,8 +17,6 @@
 #ifndef PHP_HASH_GOST_H
 #define PHP_HASH_GOST_H
 
-#include "ext/standard/basic_functions.h"
-
 /* GOST context */
 typedef struct {
 	uint32_t state[16];

--- a/ext/hash/php_hash_haval.h
+++ b/ext/hash/php_hash_haval.h
@@ -17,7 +17,6 @@
 #ifndef PHP_HASH_HAVAL_H
 #define PHP_HASH_HAVAL_H
 
-#include "ext/standard/basic_functions.h"
 /* HAVAL context. */
 typedef struct {
 	uint32_t state[8];

--- a/ext/hash/php_hash_ripemd.h
+++ b/ext/hash/php_hash_ripemd.h
@@ -16,7 +16,6 @@
 
 #ifndef PHP_HASH_RIPEMD_H
 #define PHP_HASH_RIPEMD_H
-#include "ext/standard/basic_functions.h"
 
 /* RIPEMD context. */
 typedef struct {

--- a/ext/hash/php_hash_sha.h
+++ b/ext/hash/php_hash_sha.h
@@ -19,7 +19,6 @@
 #define PHP_HASH_SHA_H
 
 #include "ext/standard/sha1.h"
-#include "ext/standard/basic_functions.h"
 
 /* SHA224 context. */
 typedef struct {

--- a/ext/hash/php_hash_sha3.h
+++ b/ext/hash/php_hash_sha3.h
@@ -17,8 +17,6 @@
 #ifndef PHP_HASH_SHA3_H
 #define PHP_HASH_SHA3_H
 
-#include "php.h"
-
 typedef struct {
 #ifdef HAVE_SLOW_HASH3
 	unsigned char state[200]; // 5 * 5 * sizeof(uint64)

--- a/ext/hash/php_hash_snefru.h
+++ b/ext/hash/php_hash_snefru.h
@@ -21,8 +21,6 @@
  * AKA "Xerox Secure Hash Function"
  */
 
-#include "ext/standard/basic_functions.h"
-
 /* SNEFRU context */
 typedef struct {
 	uint32_t state[16];

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -29,6 +29,7 @@
 #ifdef ZEND_WIN32
 #include "ext/standard/md5.h"
 #endif
+#include "ext/standard/php_filestat.h"
 
 #include "ZendAccelerator.h"
 #include "zend_file_cache.h"

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -51,10 +51,6 @@ PHPAPI int _php_error_log(int opt_err, const char *message, const char *opt, con
 PHPAPI int _php_error_log_ex(int opt_err, const char *message, size_t message_len, const char *opt, const char *headers);
 PHPAPI int php_prefix_varname(zval *result, zend_string *prefix, const char *var_name, size_t var_name_len, bool add_underscore);
 
-/* Deprecated type aliases -- use the standard types instead */
-typedef uint32_t php_uint32;
-typedef int32_t php_int32;
-
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 	HashTable putenv_ht;

--- a/ext/standard/md5.h
+++ b/ext/standard/md5.h
@@ -21,8 +21,6 @@
 PHPAPI void make_digest(char *md5str, const unsigned char *digest);
 PHPAPI void make_digest_ex(char *md5str, const unsigned char *digest, int len);
 
-#include "ext/standard/basic_functions.h"
-
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security,
  * Inc. MD5 Message-Digest Algorithm (RFC 1321).

--- a/ext/standard/sha1.h
+++ b/ext/standard/sha1.h
@@ -17,8 +17,6 @@
 #ifndef SHA1_H
 #define SHA1_H
 
-#include "ext/standard/basic_functions.h"
-
 /* SHA1 context. */
 typedef struct {
 	uint32_t state[5];		/* state (ABCD) */


### PR DESCRIPTION
It is highly likely the reason for those headers to include basic_functions.h was for the uint32 types.