### PR TITLE
Update ext/mbstring and ext/snmp dependencies

### DIFF
--- a/ext/mbstring/config.m4
+++ b/ext/mbstring/config.m4
@@ -178,4 +178,5 @@ if test "$PHP_MBSTRING" != "no"; then
   dnl libmbfl is required
   PHP_MBSTRING_SETUP_LIBMBFL
   PHP_MBSTRING_EXTENSION
+  PHP_ADD_EXTENSION_DEP(mbstring, pcre)
 fi

--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -7,6 +7,7 @@ if (PHP_MBSTRING != "no") {
 
 	if (CHECK_HEADER_ADD_INCLUDE("mbstring.h", "CFLAGS_MBSTRING", PHP_MBSTRING + ";" + PHP_PHP_BUILD + "\\include")) {
 		EXTENSION("mbstring", "mbstring.c php_unicode.c mb_gpc.c", PHP_MBSTRING_SHARED);
+		ADD_EXTENSION_DEP('mbstring', 'pcre');
 
 		STDOUT.WriteLine("Using bundled libmbfl...");
 

--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -87,5 +87,6 @@ if test "$PHP_SNMP" != "no"; then
   LIBS=$LIBS_SAVE
 
   PHP_NEW_EXTENSION([snmp], [snmp.c], [$ext_shared])
+  PHP_ADD_EXTENSION_DEP(snmp, spl)
   PHP_SUBST([SNMP_SHARED_LIBADD])
 fi

--- a/ext/snmp/config.w32
+++ b/ext/snmp/config.w32
@@ -7,6 +7,7 @@ if (PHP_SNMP != "no") {
 		SETUP_OPENSSL("snmp", PHP_SNMP) >= 2) {
 		if (CHECK_LIB("netsnmp.lib", "snmp", PHP_SNMP)) {
 			EXTENSION('snmp', 'snmp.c');
+			ADD_EXTENSION_DEP('snmp', 'spl');
 			AC_DEFINE('HAVE_SNMP', 1, "Define to 1 if the PHP extension 'snmp' is available.");
 		} else {
 			WARNING("snmp not enabled; libraries and headers not found");


### PR DESCRIPTION
The mbstring extension requires the pcre extension and snmp extension requires the spl extension.