### PR TITLE
Avoid multiple connects in SKIPIF sections

### DIFF
--- a/ext/mysqli/tests/045.phpt
+++ b/ext/mysqli/tests/045.phpt
@@ -4,10 +4,8 @@ mysqli_stmt_bind_result (SHOW)
 mysqli
 --SKIPIF--
 <?php
-    require_once 'skipifconnectfailure.inc';
-
-    $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
-
+    require_once __DIR__ . '/test_setup/test_helpers.inc';
+    $link = mysqli_connect_or_skip();
     $stmt = mysqli_prepare($link, "SHOW VARIABLES LIKE 'port'");
     mysqli_stmt_execute($stmt);
 

--- a/ext/mysqli/tests/gh9590.phpt
+++ b/ext/mysqli/tests/gh9590.phpt
@@ -5,11 +5,8 @@ mysqli
 posix
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip cannot connect");
-
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (mysqli_get_server_version($link) < 50012)
     die("skip Test needs SQL function SLEEP() available as of MySQL 5.0.12");
 

--- a/ext/mysqli/tests/mysqli_begin_transaction.phpt
+++ b/ext/mysqli/tests/mysqli_begin_transaction.phpt
@@ -4,12 +4,8 @@ mysqli_begin_transaction()
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-require_once 'connect.inc';
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
-
+require_once __DIR__ . '/test_setup/test_helpers.inc';;
+$link = mysqli_connect_or_skip();
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>

--- a/ext/mysqli/tests/mysqli_change_user_old.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_old.phpt
@@ -4,12 +4,8 @@ mysqli_change_user(), MySQL < 5.6
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("SKIP Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
-        $host, $user, $db, $port, $socket));
-
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (mysqli_get_server_version($link) >= 50600 && mysqli_get_server_version($link) < 10_00_00)
     die("SKIP For MySQL < 5.6.0");
 ?>

--- a/ext/mysqli/tests/mysqli_fetch_assoc_bit.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc_bit.phpt
@@ -4,9 +4,8 @@ mysqli_fetch_assoc() - BIT
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-require_once 'table.inc';
+require_once __DIR__ . '/test_setup/test_helpers.inc';;
+$link = mysqli_connect_or_skip();
 if (mysqli_get_server_version($link) < 50003)
     // b'001' syntax not supported before 5.0.3
     die("skip Syntax used for test not supported with MySQL Server before 5.0.3");

--- a/ext/mysqli/tests/mysqli_query_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_query_unicode.phpt
@@ -4,12 +4,10 @@ mysqli_query() - unicode (cyrillic)
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-require_once 'table.inc';
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE 'utf8'"))
     die("skip UTF8 chatset seems not available");
-mysqli_free_result($res);
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_query_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_query_unicode.phpt
@@ -4,10 +4,7 @@ mysqli_query() - unicode (cyrillic)
 mysqli
 --SKIPIF--
 <?php
-require_once __DIR__ . '/test_setup/test_helpers.inc';
-$link = mysqli_connect_or_skip();
-if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE 'utf8'"))
-    die("skip UTF8 chatset seems not available");
+require_once 'skipifconnectfailure.inc';
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_big5.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_big5.phpt
@@ -4,16 +4,10 @@ mysqli_real_escape_string() - big5
 mysqli
 --SKIPIF--
 <?php
-
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'big5'))
     die(sprintf("skip Cannot set charset 'big5'"));
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_eucjpms.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_eucjpms.phpt
@@ -4,16 +4,10 @@ mysqli_real_escape_string() - eucjpms
 mysqli
 --SKIPIF--
 <?php
-
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'eucjpms'))
     die(sprintf("skip Cannot set charset 'eucjpms'"));
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_euckr.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_euckr.phpt
@@ -4,16 +4,10 @@ mysqli_real_escape_string() - euckr
 mysqli
 --SKIPIF--
 <?php
-
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'euckr'))
     die(sprintf("skip Cannot set charset 'euckr'"));
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_gb2312.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_gb2312.phpt
@@ -4,16 +4,10 @@ mysqli_real_escape_string() - gb2312
 mysqli
 --SKIPIF--
 <?php
-
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'gb2312'))
     die(sprintf("skip Cannot set charset 'gb2312'"));
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_gbk.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_gbk.phpt
@@ -4,16 +4,10 @@ mysqli_real_escape_string() - gbk
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'gbk'))
     die(sprintf("skip Cannot set charset 'gbk'"));
-
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_real_escape_string_sjis.phpt
+++ b/ext/mysqli/tests/mysqli_real_escape_string_sjis.phpt
@@ -4,15 +4,10 @@ mysqli_real_escape_string() - sjis
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
-
-if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Cannot connect to MySQL, [%d] %s\n",
-        mysqli_connect_errno(), mysqli_connect_error()));
-}
+require_once __DIR__ . '/test_setup/test_helpers.inc';
+$link = mysqli_connect_or_skip();
 if (!mysqli_set_charset($link, 'sjis'))
     die(sprintf("skip Cannot set charset 'sjis'"));
-mysqli_close($link);
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/test_setup/test_helpers.inc
+++ b/ext/mysqli/tests/test_setup/test_helpers.inc
@@ -112,11 +112,10 @@ function mysqli_check_skip_test(): void {
 }
 function mysqli_connect_or_skip() {
     try {
-        default_mysqli_connect();
+        return default_mysqli_connect();
     } catch (\mysqli_sql_exception) {
         die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
     }
-    return $link;
 }
 function have_innodb(mysqli $link): bool {
     $res = $link->query("SELECT SUPPORT FROM INFORMATION_SCHEMA.ENGINES WHERE ENGINE = 'InnoDB'");

--- a/ext/mysqli/tests/test_setup/test_helpers.inc
+++ b/ext/mysqli/tests/test_setup/test_helpers.inc
@@ -108,11 +108,15 @@ function default_mysqli_connect(): \mysqli{
     );
 }
 function mysqli_check_skip_test(): void {
+    mysqli_connect_or_skip();
+}
+function mysqli_connect_or_skip() {
     try {
         default_mysqli_connect();
     } catch (\mysqli_sql_exception) {
         die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
     }
+    return $link;
 }
 function have_innodb(mysqli $link): bool {
     $res = $link->query("SELECT SUPPORT FROM INFORMATION_SCHEMA.ENGINES WHERE ENGINE = 'InnoDB'");


### PR DESCRIPTION
Besides checking for the ability to connect to the MySQL server, some tests require additional checks (e.g. to be able to check for the server's version) as skip condition.  There is no need, though, to connect twice; instead we introduce `mysqli_connect_or_skip()` in test_helpers.inc, which `die()`s with an appropriate error message, if the connection can't be established, or returns the connection link otherwise.