### PR TITLE
Don't skip tests which are supposed to fail; mark them as xfail

### DIFF
--- a/ext/mysqli/tests/mysqli_change_user_get_lock.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_get_lock.phpt
@@ -5,8 +5,9 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-die("skip - is the server still buggy?");
 ?>
+--XFAIL--
+The server is still buggy
 --INI--
 max_execution_time=240
 --FILE--

--- a/ext/mysqli/tests/mysqli_change_user_locks_temporary.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_locks_temporary.phpt
@@ -5,8 +5,9 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-die("skip - is the server still buggy?");
 ?>
+--XFAIL--
+The server is still buggy
 --FILE--
 <?php
     require_once 'connect.inc';

--- a/ext/mysqli/tests/mysqli_stmt_attr_get_prefetch.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_get_prefetch.phpt
@@ -5,8 +5,9 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-die("SKIP: prefetch isn't supported at the moment");
 ?>
+--XFAIL--
+prefetch isn't supported at the moment
 --FILE--
 <?php
     require 'table.inc';

--- a/ext/mysqli/tests/mysqli_stmt_result_metadata_sqltests.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_result_metadata_sqltests.phpt
@@ -5,9 +5,9 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-die("skip Check again when the Klingons visit earth - http://bugs.mysql.com/bug.php?id=42490");
 ?>
+--XFAIL--
+http://bugs.mysql.com/bug.php?id=42490
 --FILE--
 <?php
     require 'table.inc';


### PR DESCRIPTION
Especially regarding buggy server behavior, we should not skip those tests, because it is unlikely that fixes to the server's behavior will even be noticed.  Instead we mark these tests as xfail, so we get a warning if the test succeeds, and can act appropriately.

---

Note that mysqli_stmt_attr_get_prefetch.phpt passes for me with MySQL 5.6, 8.0 and 9.0.

