### PR TITLE
Remove unnecessary Windows specific time formatting

### DIFF
--- a/ext/mysqlnd/mysqlnd_debug.c
+++ b/ext/mysqlnd/mysqlnd_debug.c
@@ -76,22 +76,11 @@ MYSQLND_METHOD(mysqlnd_debug, log)(MYSQLND_DEBUG * self,
 	}
 	if (flags & MYSQLND_DEBUG_DUMP_TIME) {
 		/* The following from FF's DBUG library, which is in the public domain */
-#ifdef PHP_WIN32
-		/* FIXME This doesn't give microseconds as in Unix case, and the resolution is
-		in system ticks, 10 ms intervals. See my_getsystime.c for high res */
-		SYSTEMTIME loc_t;
-		GetLocalTime(&loc_t);
-		snprintf(time_buffer, sizeof(time_buffer) - 1,
-				 /* "%04d-%02d-%02d " */
-				 "%02d:%02d:%02d.%06d ",
-				 /*tm_p->tm_year + 1900, tm_p->tm_mon + 1, tm_p->tm_mday,*/
-				 loc_t.wHour, loc_t.wMinute, loc_t.wSecond, loc_t.wMilliseconds);
-		time_buffer[sizeof(time_buffer) - 1 ] = '\0';
-#else
 		struct timeval tv;
 		struct tm *tm_p;
 		if (gettimeofday(&tv, NULL) != -1) {
-			if ((tm_p= localtime((const time_t *)&tv.tv_sec))) {
+			const time_t sec = tv.tv_sec;
+			if ((tm_p = localtime((const time_t *)&sec))) {
 				snprintf(time_buffer, sizeof(time_buffer) - 1,
 						 /* "%04d-%02d-%02d " */
 						 "%02d:%02d:%02d.%06d ",
@@ -99,9 +88,10 @@ MYSQLND_METHOD(mysqlnd_debug, log)(MYSQLND_DEBUG * self,
 						 tm_p->tm_hour, tm_p->tm_min, tm_p->tm_sec,
 						 (int) (tv.tv_usec));
 				time_buffer[sizeof(time_buffer) - 1 ] = '\0';
+			} else {
+				time_buffer[0] = '\0';
 			}
 		}
-#endif
 	}
 	if (flags & MYSQLND_DEBUG_DUMP_FILE) {
 		snprintf(file_buffer, sizeof(file_buffer) - 1, "%14s: ", file);
@@ -173,22 +163,11 @@ MYSQLND_METHOD(mysqlnd_debug, log_va)(MYSQLND_DEBUG *self,
 	}
 	if (flags & MYSQLND_DEBUG_DUMP_TIME) {
 		/* The following from FF's DBUG library, which is in the public domain */
-#ifdef PHP_WIN32
-		/* FIXME This doesn't give microseconds as in Unix case, and the resolution is
-		in system ticks, 10 ms intervals. See my_getsystime.c for high res */
-		SYSTEMTIME loc_t;
-		GetLocalTime(&loc_t);
-		snprintf(time_buffer, sizeof(time_buffer) - 1,
-				 /* "%04d-%02d-%02d " */
-				 "%02d:%02d:%02d.%06d ",
-				 /*tm_p->tm_year + 1900, tm_p->tm_mon + 1, tm_p->tm_mday,*/
-				 loc_t.wHour, loc_t.wMinute, loc_t.wSecond, loc_t.wMilliseconds);
-		time_buffer[sizeof(time_buffer) - 1 ] = '\0';
-#else
 		struct timeval tv;
 		struct tm *tm_p;
 		if (gettimeofday(&tv, NULL) != -1) {
-			if ((tm_p= localtime((const time_t *)&tv.tv_sec))) {
+			const time_t sec = tv.tv_sec;
+			if ((tm_p = localtime((const time_t *)&sec))) {
 				snprintf(time_buffer, sizeof(time_buffer) - 1,
 						 /* "%04d-%02d-%02d " */
 						 "%02d:%02d:%02d.%06d ",
@@ -196,9 +175,10 @@ MYSQLND_METHOD(mysqlnd_debug, log_va)(MYSQLND_DEBUG *self,
 						 tm_p->tm_hour, tm_p->tm_min, tm_p->tm_sec,
 						 (int) (tv.tv_usec));
 				time_buffer[sizeof(time_buffer) - 1 ] = '\0';
+			} else {
+				time_buffer[0] = '\0';
 			}
 		}
-#endif
 	}
 	if (flags & MYSQLND_DEBUG_DUMP_FILE) {
 		snprintf(file_buffer, sizeof(file_buffer) - 1, "%14s: ", file);


### PR DESCRIPTION
`gettimeofday()` is supported by PHP on Windows for ages; and generally `localtime()` is supported on Windows for a long time.  As such, there is no need for the Windows specific formatting code.

However, the general Windows caveat regarding `time_t` applies, namely that it is usually `__time64_t`, unless `_USE_32BIT_TIME_T` is declared, what we do for 32bit architectures, in which case it is `__time32_t`. Now, `struct timeval` is imported from WinSock2.h, where the members are declared as long (i.e. 32bit on both x86 and x64).  That means passing a pointer to `tv_sec` to `localtime()` likely fails on x64, or at least doesn't yield the desired result.  Therefore, we assign `tv_sec` to an appropriate `time_t` variable, and also make sure that the `time_buffer` is zero-terminated even if the `localtime()` call still fails.