### PR TITLE
Add date extension to dependencies

### DIFF
--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -127,4 +127,6 @@ if test "$PHP_INTL" != "no"; then
     $ext_builddir/transliterator
     $ext_builddir/uchar
   ]))
+
+  PHP_ADD_EXTENSION_DEP(intl, date)
 fi

--- a/ext/intl/config.w32
+++ b/ext/intl/config.w32
@@ -8,6 +8,7 @@ if (PHP_INTL != "no") {
 		// always build as shared - zend_strtod.c/ICU type conflict
 		EXTENSION("intl", "php_intl.c intl_convert.c intl_convertcpp.cpp intl_error.c ", true,
 								"/I \"" + configure_module_dirname + "\" /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+		ADD_EXTENSION_DEP('intl', 'date');
 		ADD_SOURCES(configure_module_dirname + "/collator", "\
 				collator_attr.c \
 				collator_class.c \

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -343,6 +343,7 @@ int main(void) {
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $JIT_CFLAGS],,
     [yes])
 
+  PHP_ADD_EXTENSION_DEP(opcache, date)
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 
   if test "$php_cv_shm_ipc" != "yes" && test "$php_cv_shm_mmap_posix" != "yes" && test "$php_cv_shm_mmap_anon" != "yes"; then

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -18,6 +18,7 @@ if (PHP_OPCACHE != "no") {
 		zend_shared_alloc.c \
 		shared_alloc_win32.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
+	ADD_EXTENSION_DEP('opcache', 'date');
 	ADD_EXTENSION_DEP('opcache', 'hash');
 	ADD_EXTENSION_DEP('opcache', 'pcre');
 

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -19,6 +19,7 @@ if test "$PHP_SESSION" != "no"; then
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
+  PHP_ADD_EXTENSION_DEP(session, date)
   dnl https://bugs.php.net/53141
   PHP_ADD_EXTENSION_DEP(session, spl, true)
 

--- a/ext/session/config.w32
+++ b/ext/session/config.w32
@@ -4,6 +4,7 @@ ARG_ENABLE("session", "session support", "yes");
 
 if (PHP_SESSION == "yes") {
 	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	ADD_EXTENSION_DEP('session', 'date');
 	// https://bugs.php.net/53141
 	ADD_EXTENSION_DEP('session', 'spl', true);
 	AC_DEFINE("HAVE_PHP_SESSION", 1, "Define to 1 if the PHP extension 'session' is available.");

--- a/ext/soap/config.m4
+++ b/ext/soap/config.m4
@@ -20,6 +20,7 @@ if test "$PHP_SOAP" != "no"; then
       [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
     PHP_SUBST([SOAP_SHARED_LIBADD])
   ])
+  PHP_ADD_EXTENSION_DEP(soap, date)
   PHP_ADD_EXTENSION_DEP(soap, hash)
   PHP_ADD_EXTENSION_DEP(soap, libxml)
   PHP_ADD_EXTENSION_DEP(soap, session, true)

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -10,6 +10,7 @@ if (PHP_SOAP != "no") {
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_SOAP', 1, "Define to 1 if the PHP extension 'soap' is available.");
+		ADD_EXTENSION_DEP('soap', 'date');
 		ADD_EXTENSION_DEP('soap', 'hash');
 		ADD_EXTENSION_DEP('soap', 'session', true);
 


### PR DESCRIPTION
This is at this point only meta-data information for extensions to depend also on date extension. This is a configure phase dependency for consistency.