### PR TITLE
Autotools: Patch apache2handler version check

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -189,6 +189,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      symbol anymore and requires at least libxml2 2.9.4.
    - Autoconf macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol
      anymore.
+   - Autoconf macro PHP_AP_EXTRACT_VERSION is obsolete (use the
+     'apxs -q HTTPD_VERSION').
    - Autoconf macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
    - Autoconf macro PHP_PROG_SETUP now accepts an argument to set the minimum
      required PHP version during the build.

--- a/build/php.m4
+++ b/build/php.m4
@@ -2030,7 +2030,8 @@ dnl PHP_AP_EXTRACT_VERSION(/path/httpd)
 dnl
 dnl This macro is used to get a comparable version for Apache.
 dnl
-AC_DEFUN([PHP_AP_EXTRACT_VERSION],[
+AC_DEFUN([PHP_AP_EXTRACT_VERSION], [m4_warn([obsolete],
+  [The macro 'PHP_AP_EXTRACT_VERSION' is obsolete. Use 'apxs -q HTTPD_VERSION'])
 AS_IF([test -x "$1"], [
   ac_output=$($1 -v 2>&1 | grep version | $SED -e 's/Oracle-HTTP-//')
   ac_IFS=$IFS

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -53,9 +53,19 @@ if test "$PHP_APXS2" != "no"; then
     AS_CASE([$flag], [-D*], [APACHE_CPPFLAGS="$APACHE_CPPFLAGS $flag"])
   done
 
-  dnl Check Apache version.
-  PHP_AP_EXTRACT_VERSION([$APXS_HTTPD])
-  AS_VERSION_COMPARE([$APACHE_VERSION], [2004000],
+  dnl Check Apache version. The HTTPD_VERSION was added in Apache 2.4.17.
+  dnl Earlier versions can use the Apache HTTP Server command-line utility.
+  APACHE_VERSION=$($APXS -q HTTPD_VERSION 2>/dev/null)
+  AS_VAR_IF([APACHE_VERSION],, [
+    ac_output=$($APXS_HTTPD -v 2>&1 | grep version | $SED -e 's/Oracle-HTTP-//')
+    ac_IFS=$IFS
+    IFS="- /.
+"
+    set $ac_output
+    IFS=$ac_IFS
+    APACHE_VERSION="$4.$5.$6"
+  ])
+  AS_VERSION_COMPARE([$APACHE_VERSION], [2.4.0],
     [AC_MSG_ERROR([Please note that Apache version >= 2.4 is required])])
 
   APXS_LIBEXECDIR='$(INSTALL_ROOT)'$($APXS -q LIBEXECDIR)


### PR DESCRIPTION
Since Apache 2.4.17 there is HTTPD_VERSION variable available with the `apxs -q` Apache extension tool itself. Here are appended two commits:

1st commit makes the PHP_AP_EXTRACT_VERSION macro obsolete

and the

2nd commit removes the PHP_AP_EXTRACT_VERSION macro.

I've quickly checked the open source extensions out there and none seem to use this macro. However, the removal can also wait for PHP 9.

I'm not sure if removing these M4 macros at this point can be done for PHP-8.4.