### PR TITLE
Autotools: Add min-version argument to PHP_PROG_PHP macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -181,6 +181,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      anymore.
    - M4 macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol anymore.
    - M4 macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
+   - M4 macro PHP_PROG_SETUP now accepts an argument to set the minimum required
+     PHP version during the build.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -1778,28 +1778,26 @@ AC_DEFUN([PHP_PROG_RE2C],[
   PHP_SUBST([RE2C_FLAGS])
 ])
 
-AC_DEFUN([PHP_PROG_PHP],[
-  AC_CHECK_PROG([PHP], [php], [php])
-
-  if test -n "$PHP"; then
-    AC_MSG_CHECKING([for php version])
-    php_version=$($PHP -v | head -n1 | cut -d ' ' -f 2 | cut -d '-' -f 1)
-    if test -z "$php_version"; then
-      php_version=0.0.0
-    fi
-    ac_IFS=$IFS; IFS="."
-    set $php_version
-    IFS=$ac_IFS
-    php_version_num=`expr [$]{1:-0} \* 10000 + [$]{2:-0} \* 100 + [$]{3:-0}`
-    dnl Minimum supported version for gen_stub.php is PHP 7.4.
-    if test "$php_version_num" -lt 70400; then
-      AC_MSG_RESULT([$php_version (too old)])
-      unset PHP
-    else
-      AC_MSG_RESULT([$php_version (ok)])
-    fi
-  fi
-  PHP_SUBST([PHP])
+dnl
+dnl PHP_PROG_PHP([min-version])
+dnl
+dnl Find PHP command-line interface SAPI on the system and check if version is
+dnl greater or equal to "min-version". If suitable version is found, the PHP
+dnl variable is set and substituted to a Makefile variable. Used for generating
+dnl files and running PHP utilities during the build.
+dnl
+AC_DEFUN([PHP_PROG_PHP],
+[m4_if([$1],, [php_required_version=7.4], [php_required_version=$1])
+AC_CHECK_PROG([PHP], [php], [php])
+AS_VAR_IF([PHP],,, [
+AC_MSG_CHECKING([for php version])
+php_version=$($PHP -v | head -n1 | cut -d ' ' -f 2)
+AS_VERSION_COMPARE([$php_version], [$php_required_version], [unset PHP])
+AS_VAR_IF([PHP],,
+  [AC_MSG_RESULT([$php_version (too old, install $php_required_version or later)])],
+  [AC_MSG_RESULT([$php_version (ok)])])
+])
+PHP_SUBST([PHP])
 ])
 
 dnl ----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,8 @@ dnl Checks for some support/generator progs.
 PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
 PHP_PROG_RE2C([1.0.3], [--no-generation-date])
-PHP_PROG_PHP()
+dnl Find installed PHP. Minimum supported version for gen_stub.php is PHP 7.4.
+PHP_PROG_PHP([7.4])
 
 PHP_ARG_ENABLE([re2c-cgoto],
   [whether to enable computed goto extension with re2c],


### PR DESCRIPTION
This makes a bit simpler to use this macro by optionally passing the required minimum PHP version. If version is not passed it falls back to 7.4 as before. Minimum version also added to configure.ac.

Note: I'll retest this change a bit if it works correctly. According to current tests it seems fine.