### PR TITLE
Autotools: Move AWK finder to PHP_INIT_BUILD_SYSTEM

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -130,6 +130,8 @@ T_MD=$($php_shtool echo -n -e %B)
 T_ME=$($php_shtool echo -n -e %b)
 > Makefile.objects
 > Makefile.fragments
+dnl Required programs.
+PHP_PROG_AWK
 dnl Run at the end of the configuration, before creating the config.status.
 AC_CONFIG_COMMANDS_PRE(
 [dnl Directory for storing shared objects of extensions.

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,6 @@ dnl Check for -R, etc. switch.
 PHP_RUNPATH_SWITCH
 
 dnl Checks for some support/generator progs.
-PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
 PHP_PROG_RE2C([1.0.3], [--no-generation-date])
 PHP_PROG_PHP()

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -136,9 +136,6 @@ AS_VAR_IF([PHP_DEBUG], [yes], [
 dnl Always shared.
 PHP_BUILD_SHARED
 
-dnl Required programs.
-PHP_PROG_AWK
-
 PHP_HELP_SEPARATOR([Extension:])
 PHP_CONFIGURE_PART([Configuring extension])
 


### PR DESCRIPTION
This calls the PHP_PROG_AWK from a single place for php-src build and phpize.