### PR TITLE
Autotools: Move auto_cflags marker to PHP_INIT_BUILD_SYSTEM

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -133,7 +133,7 @@ dnl Create empty Makefile placeholders.
 > Makefile.objects
 > Makefile.fragments
 
-dnl Marker whether the CFLAGS are set to automatic default value by Autoconf, or
+dnl Mark whether the CFLAGS are set to automatic default value by Autoconf, or
 dnl they are manually modified by the environment variable from outside. E.g.
 dnl './configure CFLAGS=...'. Set this before the AC_PROG_CC, where Autoconf
 dnl adjusts the CFLAGS variable, so the checks can modify CFLAGS.

--- a/build/php.m4
+++ b/build/php.m4
@@ -128,10 +128,20 @@ AC_DEFUN([PHP_INIT_BUILD_SYSTEM],
 php_shtool=$srcdir/build/shtool
 T_MD=$($php_shtool echo -n -e %B)
 T_ME=$($php_shtool echo -n -e %b)
+
+dnl Create empty Makefile placeholders.
 > Makefile.objects
 > Makefile.fragments
+
+dnl Marker whether the CFLAGS are set to automatic default value by Autoconf, or
+dnl they are manually modified by the environment variable from outside. E.g.
+dnl './configure CFLAGS=...'. Set this before the AC_PROG_CC, where Autoconf
+dnl adjusts the CFLAGS variable, so the checks can modify CFLAGS.
+AS_VAR_IF([CFLAGS],, [auto_cflags=1])
+
 dnl Required programs.
 PHP_PROG_AWK
+
 dnl Run at the end of the configuration, before creating the config.status.
 AC_CONFIG_COMMANDS_PRE(
 [dnl Directory for storing shared objects of extensions.

--- a/configure.ac
+++ b/configure.ac
@@ -100,9 +100,6 @@ dnl ----------------------------------------------------------------------------
 
 PHP_INIT_BUILD_SYSTEM
 
-dnl We want this one before the checks, so the checks can modify CFLAGS.
-AS_VAR_IF([CFLAGS],, [auto_cflags=1])
-
 abs_srcdir=`(cd $srcdir; pwd)`
 abs_builddir=`pwd`
 

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -26,7 +26,7 @@ AC_DEFUN([PHP_ALWAYS_SHARED],[
   test "[$]$1" = "no" && $1=yes
 ])dnl
 
-AS_VAR_IF([CFLAGS],, [auto_cflags=1])
+PHP_INIT_BUILD_SYSTEM
 
 abs_srcdir=`(cd $srcdir && pwd)`
 abs_builddir=`pwd`
@@ -64,8 +64,6 @@ PHP_EXECUTABLE=`$PHP_CONFIG --php-binary 2>/dev/null`
 
 AS_VAR_IF([prefix],,
   [AC_MSG_ERROR([Cannot find php-config. Please use --with-php-config=PATH])])
-
-PHP_INIT_BUILD_SYSTEM
 
 AC_MSG_CHECKING([for PHP prefix])
 AC_MSG_RESULT([$prefix])


### PR DESCRIPTION
The "hacky" auto_cflags variable is otherwise set only for the Oracle Developer Studio compiler (which is at this point also non-usable) and perhaps might be removed in the future but this is for now moved to the PHP_INIT_BUILD_SYSTEM for consistent settings between the php-src build and phpize.

The PHP_INIT_BUILD_SYSTEM is now also called sooner in phpize to match the php-src build.