### PR TITLE
Use a common function for "cannot be empty" ValueError

### DIFF
--- a/Zend/tests/property_hooks/invalid_empty_hooks.phpt
+++ b/Zend/tests/property_hooks/invalid_empty_hooks.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Property hook list cannot be empty
+Property hook list must not be empty
 --FILE--
 <?php
 
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Property hook list cannot be empty in %s on line %d
+Fatal error: Property hook list must not be empty in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -439,9 +439,9 @@ ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *
 }
 /* }}} */
 
-ZEND_API ZEND_COLD void zend_argument_cannot_be_empty_error(uint32_t arg_num)
+ZEND_API ZEND_COLD void zend_argument_must_not_be_empty_error(uint32_t arg_num)
 {
-	zend_argument_value_error(arg_num, "cannot be empty");
+	zend_argument_value_error(arg_num, "must not be empty");
 }
 
 ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string *new_name, zend_class_entry *old_ce)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -439,6 +439,11 @@ ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *
 }
 /* }}} */
 
+ZEND_API ZEND_COLD void zend_argument_cannot_be_empty_error(uint32_t arg_num)
+{
+	zend_argument_value_error(arg_num, "cannot be empty");
+}
+
 ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string *new_name, zend_class_entry *old_ce)
 {
 	if (old_ce->type == ZEND_INTERNAL_CLASS) {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1564,7 +1564,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_en
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...);
-ZEND_API ZEND_COLD void zend_argument_cannot_be_empty_error(uint32_t arg_num);
+ZEND_API ZEND_COLD void zend_argument_must_not_be_empty_error(uint32_t arg_num);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, zend_class_entry *old_ce);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string *new_name, zend_class_entry *old_ce);
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1564,6 +1564,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_en
 ZEND_API ZEND_COLD void zend_argument_error(zend_class_entry *error_ce, uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_type_error(uint32_t arg_num, const char *format, ...);
 ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *format, ...);
+ZEND_API ZEND_COLD void zend_argument_cannot_be_empty_error(uint32_t arg_num);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error(int type, zend_class_entry *old_ce);
 ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string *new_name, zend_class_entry *old_ce);
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8383,7 +8383,7 @@ static void zend_compile_property_hooks(
 	zend_class_entry *ce = CG(active_class_entry);
 
 	if (hooks->children == 0) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Property hook list cannot be empty");
+		zend_error_noreturn(E_COMPILE_ERROR, "Property hook list must not be empty");
 	}
 
 	for (uint32_t i = 0; i < hooks->children; i++) {

--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -349,7 +349,7 @@ PHP_FUNCTION(bzopen)
 	/* If it's not a resource its a string containing the filename to open */
 	if (Z_TYPE_P(file) == IS_STRING) {
 		if (Z_STRLEN_P(file) == 0) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			RETURN_THROWS();
 		}
 

--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -349,7 +349,7 @@ PHP_FUNCTION(bzopen)
 	/* If it's not a resource its a string containing the filename to open */
 	if (Z_TYPE_P(file) == IS_STRING) {
 		if (Z_STRLEN_P(file) == 0) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			RETURN_THROWS();
 		}
 

--- a/ext/bz2/tests/001.phpt
+++ b/ext/bz2/tests/001.phpt
@@ -42,8 +42,8 @@ var_dump(bzopen($fp, "r"));
 
 ?>
 --EXPECTF--
-bzopen(): Argument #1 ($file) cannot be empty
-bzopen(): Argument #1 ($file) cannot be empty
+bzopen(): Argument #1 ($file) must not be empty
+bzopen(): Argument #1 ($file) must not be empty
 bzopen(): Argument #2 ($mode) must be either "r" or "w"
 bzopen(): Argument #2 ($mode) must be either "r" or "w"
 bzopen(): Argument #2 ($mode) must be either "r" or "w"

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -547,15 +547,15 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 	}
 
 	if (ZSTR_LEN(path) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(mode) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 	if (handler_str && ZSTR_LEN(handler_str) == 0) {
-		zend_argument_value_error(3, "cannot be empty");
+		zend_argument_cannot_be_empty_error(3);
 		RETURN_THROWS();
 	}
 	// TODO Check Value for permission
@@ -640,7 +640,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 	// bool is_file_lock = false;
 
 	if (ZSTR_LEN(mode) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		efree(resource_key);
 		RETURN_THROWS();
 	}

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -639,11 +639,6 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 	bool is_lock_ignored = false;
 	// bool is_file_lock = false;
 
-	if (ZSTR_LEN(mode) == 0) {
-		zend_argument_cannot_be_empty_error(2);
-		efree(resource_key);
-		RETURN_THROWS();
-	}
 	if (ZSTR_LEN(mode) > 3) {
 		zend_argument_value_error(2, "must be at most 3 characters");
 		efree(resource_key);

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -547,15 +547,15 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 	}
 
 	if (ZSTR_LEN(path) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(mode) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 	if (handler_str && ZSTR_LEN(handler_str) == 0) {
-		zend_argument_cannot_be_empty_error(3);
+		zend_argument_must_not_be_empty_error(3);
 		RETURN_THROWS();
 	}
 	// TODO Check Value for permission

--- a/ext/dba/tests/value_errors_open.phpt
+++ b/ext/dba/tests/value_errors_open.phpt
@@ -121,9 +121,9 @@ object(Dba\Connection)#%d (%d) {
 
 Warning: dba_open(): Handler "bogus" is not available in %s on line %d
 bool(false)
-dba_open(): Argument #1 ($path) cannot be empty
-dba_open(): Argument #2 ($mode) cannot be empty
-dba_open(): Argument #3 ($handler) cannot be empty
+dba_open(): Argument #1 ($path) must not be empty
+dba_open(): Argument #2 ($mode) must not be empty
+dba_open(): Argument #3 ($handler) must not be empty
 dba_open(): Argument #2 ($mode) first character must be one of "r", "w", "c", or "n"
 dba_open(): Argument #2 ($mode) second character must be one of "d", "l", "-", or "t"
 dba_open(): Argument #2 ($mode) third character must be "t"
@@ -133,9 +133,9 @@ dba_open(): Argument #5 ($map_size) must be greater than or equal to 0
 
 Warning: dba_popen(): Handler "bogus" is not available in %s on line %d
 bool(false)
-dba_popen(): Argument #1 ($path) cannot be empty
-dba_popen(): Argument #2 ($mode) cannot be empty
-dba_popen(): Argument #3 ($handler) cannot be empty
+dba_popen(): Argument #1 ($path) must not be empty
+dba_popen(): Argument #2 ($mode) must not be empty
+dba_popen(): Argument #3 ($handler) must not be empty
 dba_popen(): Argument #2 ($mode) first character must be one of "r", "w", "c", or "n"
 dba_popen(): Argument #2 ($mode) second character must be one of "d", "l", "-", or "t"
 dba_popen(): Argument #2 ($mode) third character must be "t"

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1525,7 +1525,7 @@ static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZEND_SIZE_T_INT_OVFL(source_len)) {
@@ -1579,7 +1579,7 @@ PHP_METHOD(DOMDocument, save)
 	}
 
 	if (file_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1883,7 +1883,7 @@ static void dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type)
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1992,7 +1992,7 @@ static void dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2085,7 +2085,7 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2162,7 +2162,7 @@ PHP_METHOD(DOMDocument, saveHTMLFile)
 	}
 
 	if (file_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1525,7 +1525,7 @@ static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZEND_SIZE_T_INT_OVFL(source_len)) {
@@ -1579,7 +1579,7 @@ PHP_METHOD(DOMDocument, save)
 	}
 
 	if (file_len == 0) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1883,7 +1883,7 @@ static void dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type)
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1992,7 +1992,7 @@ static void dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2085,7 +2085,7 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2162,7 +2162,7 @@ PHP_METHOD(DOMDocument, saveHTMLFile)
 	}
 
 	if (file_len == 0) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -64,7 +64,7 @@ PHP_METHOD(DOMImplementation, createDocumentType)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -64,7 +64,7 @@ PHP_METHOD(DOMImplementation, createDocumentType)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -411,7 +411,7 @@ PHP_METHOD(DOMElement, setAttribute)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -903,7 +903,7 @@ PHP_METHOD(DOMElement, getAttributeNS)
 static void dom_set_attribute_ns_legacy(dom_object *intern, xmlNodePtr elemp, char *uri, size_t uri_len, char *name, size_t name_len, const char *value)
 {
 	if (name_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		return;
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -411,7 +411,7 @@ PHP_METHOD(DOMElement, setAttribute)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -903,7 +903,7 @@ PHP_METHOD(DOMElement, getAttributeNS)
 static void dom_set_attribute_ns_legacy(dom_object *intern, xmlNodePtr elemp, char *uri, size_t uri_len, char *name, size_t name_len, const char *value)
 {
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		return;
 	}
 

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1283,7 +1283,7 @@ PHP_METHOD(Dom_HTMLDocument, saveHtmlFile)
 	}
 
 	if (file_len == 0) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/html_document.c
+++ b/ext/dom/html_document.c
@@ -1283,7 +1283,7 @@ PHP_METHOD(Dom_HTMLDocument, saveHtmlFile)
 	}
 
 	if (file_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
@@ -14,4 +14,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadHTML(): Argument #1 ($source) cannot be empty
+DOMDocument::loadHTML(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
@@ -14,4 +14,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadHTML(): Argument #1 ($source) must not be empty
+DOMDocument::loadHTML(): Argument #1 ($source) cannot be empty

--- a/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
@@ -23,5 +23,5 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not be empty
+DOMDocument::loadHTMLFile(): Argument #1 ($filename) cannot be empty
 DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
@@ -23,5 +23,5 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadHTMLFile(): Argument #1 ($filename) cannot be empty
+DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not be empty
 DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/dom/tests/DOMDocument_loadXML_error6.phpt
+++ b/ext/dom/tests/DOMDocument_loadXML_error6.phpt
@@ -13,4 +13,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadXML(): Argument #1 ($source) cannot be empty
+DOMDocument::loadXML(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_loadXML_error6.phpt
+++ b/ext/dom/tests/DOMDocument_loadXML_error6.phpt
@@ -13,4 +13,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::loadXML(): Argument #1 ($source) must not be empty
+DOMDocument::loadXML(): Argument #1 ($source) cannot be empty

--- a/ext/dom/tests/DOMDocument_load_error6.phpt
+++ b/ext/dom/tests/DOMDocument_load_error6.phpt
@@ -22,6 +22,6 @@ try {
 var_dump($dom->load(str_repeat(" ", PHP_MAXPATHLEN + 1)));
 ?>
 --EXPECT--
-DOMDocument::load(): Argument #1 ($filename) must not be empty
+DOMDocument::load(): Argument #1 ($filename) cannot be empty
 DOMDocument::load(): Argument #1 ($filename) must not contain any null bytes
 bool(false)

--- a/ext/dom/tests/DOMDocument_load_error6.phpt
+++ b/ext/dom/tests/DOMDocument_load_error6.phpt
@@ -22,6 +22,6 @@ try {
 var_dump($dom->load(str_repeat(" ", PHP_MAXPATHLEN + 1)));
 ?>
 --EXPECT--
-DOMDocument::load(): Argument #1 ($filename) cannot be empty
+DOMDocument::load(): Argument #1 ($filename) must not be empty
 DOMDocument::load(): Argument #1 ($filename) must not contain any null bytes
 bool(false)

--- a/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
@@ -24,4 +24,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::saveHTMLFile(): Argument #1 ($filename) must not be empty
+DOMDocument::saveHTMLFile(): Argument #1 ($filename) cannot be empty

--- a/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
@@ -24,4 +24,4 @@ try {
 }
 ?>
 --EXPECT--
-DOMDocument::saveHTMLFile(): Argument #1 ($filename) cannot be empty
+DOMDocument::saveHTMLFile(): Argument #1 ($filename) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
@@ -20,4 +20,4 @@ try {
 
 ?>
 --EXPECT--
-DOMDocument::schemaValidateSource(): Argument #1 ($source) must not be empty
+DOMDocument::schemaValidateSource(): Argument #1 ($source) cannot be empty

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
@@ -20,4 +20,4 @@ try {
 
 ?>
 --EXPECT--
-DOMDocument::schemaValidateSource(): Argument #1 ($source) cannot be empty
+DOMDocument::schemaValidateSource(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
@@ -20,4 +20,4 @@ try {
 
 ?>
 --EXPECT--
-DOMDocument::schemaValidate(): Argument #1 ($filename) cannot be empty
+DOMDocument::schemaValidate(): Argument #1 ($filename) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
@@ -20,4 +20,4 @@ try {
 
 ?>
 --EXPECT--
-DOMDocument::schemaValidate(): Argument #1 ($filename) must not be empty
+DOMDocument::schemaValidate(): Argument #1 ($filename) cannot be empty

--- a/ext/dom/tests/modern/html/interactions/HTMLDocument_saveHTMLFile_empty_path.phpt
+++ b/ext/dom/tests/modern/html/interactions/HTMLDocument_saveHTMLFile_empty_path.phpt
@@ -11,7 +11,7 @@ $dom->saveHtmlFile("");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: Dom\HTMLDocument::saveHtmlFile(): Argument #1 ($filename) must not be empty in %s:%d
+Fatal error: Uncaught ValueError: Dom\HTMLDocument::saveHtmlFile(): Argument #1 ($filename) cannot be empty in %s:%d
 Stack trace:
 #0 %s(%d): Dom\HTMLDocument->saveHtmlFile('')
 #1 {main}

--- a/ext/dom/tests/modern/html/interactions/HTMLDocument_saveHTMLFile_empty_path.phpt
+++ b/ext/dom/tests/modern/html/interactions/HTMLDocument_saveHTMLFile_empty_path.phpt
@@ -11,7 +11,7 @@ $dom->saveHtmlFile("");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: Dom\HTMLDocument::saveHtmlFile(): Argument #1 ($filename) cannot be empty in %s:%d
+Fatal error: Uncaught ValueError: Dom\HTMLDocument::saveHtmlFile(): Argument #1 ($filename) must not be empty in %s:%d
 Stack trace:
 #0 %s(%d): Dom\HTMLDocument->saveHtmlFile('')
 #1 {main}

--- a/ext/dom/tests/modern/html/parser/HTMLDocument_fromFile_empty_path.phpt
+++ b/ext/dom/tests/modern/html/parser/HTMLDocument_fromFile_empty_path.phpt
@@ -9,7 +9,7 @@ $dom = Dom\HTMLDocument::createFromFile("");
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: Path cannot be empty in %s:%d
+Fatal error: Uncaught ValueError: Path must not be empty in %s:%d
 Stack trace:
 #0 %s(%d): Dom\HTMLDocument::createFromFile('')
 #1 {main}

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -447,7 +447,7 @@ PHP_FUNCTION(enchant_broker_request_dict)
 	PHP_ENCHANT_GET_BROKER;
 
 	if (taglen == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -447,7 +447,7 @@ PHP_FUNCTION(enchant_broker_request_dict)
 	PHP_ENCHANT_GET_BROKER;
 
 	if (taglen == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/enchant/tests/broker_request_dict_error_on_empty_tag.phpt
+++ b/ext/enchant/tests/broker_request_dict_error_on_empty_tag.phpt
@@ -18,4 +18,4 @@ try {
 
 ?>
 --EXPECT--
-enchant_broker_request_dict(): Argument #2 ($tag) cannot be empty
+enchant_broker_request_dict(): Argument #2 ($tag) must not be empty

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4550,7 +4550,7 @@ PHP_FUNCTION(exif_read_data)
 		}
 
 		if (!Z_STRLEN_P(stream)) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			RETURN_THROWS();
 		}
 
@@ -4727,7 +4727,7 @@ PHP_FUNCTION(exif_thumbnail)
 		}
 
 		if (!Z_STRLEN_P(stream)) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			RETURN_THROWS();
 		}
 

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -4550,7 +4550,7 @@ PHP_FUNCTION(exif_read_data)
 		}
 
 		if (!Z_STRLEN_P(stream)) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			RETURN_THROWS();
 		}
 
@@ -4727,7 +4727,7 @@ PHP_FUNCTION(exif_thumbnail)
 		}
 
 		if (!Z_STRLEN_P(stream)) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			RETURN_THROWS();
 		}
 

--- a/ext/exif/tests/filename_empty.phpt
+++ b/ext/exif/tests/filename_empty.phpt
@@ -31,7 +31,7 @@ try {
 
 ?>
 --EXPECT--
-exif_read_data(): Argument #1 ($file) cannot be empty
-exif_thumbnail(): Argument #1 ($file) cannot be empty
+exif_read_data(): Argument #1 ($file) must not be empty
+exif_thumbnail(): Argument #1 ($file) must not be empty
 exif_read_data(): Argument #1 ($file) must not contain any null bytes
 exif_thumbnail(): Argument #1 ($file) must not contain any null bytes

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -374,7 +374,7 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 			php_stream_statbuf ssb;
 
 			if (buffer == NULL || buffer_len == 0) {
-				zend_argument_value_error(1, "cannot be empty");
+				zend_argument_cannot_be_empty_error(1);
 				goto clean;
 			}
 			if (CHECK_NULL_PATH(buffer, buffer_len)) {

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -374,7 +374,7 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 			php_stream_statbuf ssb;
 
 			if (buffer == NULL || buffer_len == 0) {
-				zend_argument_cannot_be_empty_error(1);
+				zend_argument_must_not_be_empty_error(1);
 				goto clean;
 			}
 			if (CHECK_NULL_PATH(buffer, buffer_len)) {

--- a/ext/fileinfo/tests/finfo_file_001.phpt
+++ b/ext/fileinfo/tests/finfo_file_001.phpt
@@ -22,7 +22,7 @@ var_dump(finfo_file($fp, '&'));
 ?>
 --EXPECTF--
 finfo_file(): Argument #1 ($finfo) must not contain any null bytes
-finfo_file(): Argument #1 ($finfo) cannot be empty
+finfo_file(): Argument #1 ($finfo) must not be empty
 string(9) "directory"
 
 Warning: finfo_file(&): Failed to open stream: No such file or directory in %s on line %d

--- a/ext/fileinfo/tests/mime_content_type_001.phpt
+++ b/ext/fileinfo/tests/mime_content_type_001.phpt
@@ -47,5 +47,5 @@ mime_content_type(): Argument #1 ($filename) must be of type resource|string, st
 mime_content_type(): Argument #1 ($filename) must be of type resource|string, array given
 
 Warning: mime_content_type(foo/inexistent): Failed to open stream: No such file or directory in %s on line %d
-mime_content_type(): Argument #1 ($filename) cannot be empty
+mime_content_type(): Argument #1 ($filename) must not be empty
 mime_content_type(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -382,7 +382,7 @@ void php_filter_float(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 
 	if (thousand_set) {
 		if (thousand_len < 1) {
-			zend_value_error("%s(): \"thousand\" option cannot be empty", get_active_function_name());
+			zend_value_error("%s(): \"thousand\" option must not be empty", get_active_function_name());
 			RETURN_VALIDATION_FAILED
 		} else {
 			tsd_sep = thousand;

--- a/ext/filter/tests/bug51368.phpt
+++ b/ext/filter/tests/bug51368.phpt
@@ -21,4 +21,4 @@ try {
 --EXPECT--
 float(1000)
 float(1234.567)
-filter_var(): "thousand" option cannot be empty
+filter_var(): "thousand" option must not be empty

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -646,7 +646,7 @@ PHP_FUNCTION(imagesetstyle)
 
 	num_styles = zend_hash_num_elements(Z_ARRVAL_P(styles));
 	if (num_styles == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -646,7 +646,7 @@ PHP_FUNCTION(imagesetstyle)
 
 	num_styles = zend_hash_num_elements(Z_ARRVAL_P(styles));
 	if (num_styles == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/tests/bug72709.phpt
+++ b/ext/gd/tests/bug72709.phpt
@@ -18,5 +18,5 @@ imagedestroy($im);
 ?>
 ====DONE====
 --EXPECT--
-imagesetstyle(): Argument #2 ($style) cannot be empty
+imagesetstyle(): Argument #2 ($style) must not be empty
 ====DONE====

--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -55,7 +55,7 @@ ZEND_GET_MODULE(php_gettext)
 		zend_argument_value_error(_arg_num, "is too long"); \
 		RETURN_THROWS(); \
 	} else if (domain_len == 0) { \
-		zend_argument_cannot_be_empty_error(_arg_num); \
+		zend_argument_must_not_be_empty_error(_arg_num); \
 		RETURN_THROWS(); \
 	}
 

--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -55,7 +55,7 @@ ZEND_GET_MODULE(php_gettext)
 		zend_argument_value_error(_arg_num, "is too long"); \
 		RETURN_THROWS(); \
 	} else if (domain_len == 0) { \
-		zend_argument_value_error(_arg_num, "cannot be empty"); \
+		zend_argument_cannot_be_empty_error(_arg_num); \
 		RETURN_THROWS(); \
 	}
 
@@ -191,7 +191,7 @@ PHP_FUNCTION(bindtextdomain)
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
 
 	if (!ZSTR_LEN(domain)) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -313,7 +313,7 @@ PHP_FUNCTION(bind_textdomain_codeset)
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
 
 	if (!ZSTR_LEN(domain)) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/gettext/gettext.c
+++ b/ext/gettext/gettext.c
@@ -190,11 +190,6 @@ PHP_FUNCTION(bindtextdomain)
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
 
-	if (!ZSTR_LEN(domain)) {
-		zend_argument_cannot_be_empty_error(1);
-		RETURN_THROWS();
-	}
-
 	if (dir == NULL) {
 		RETURN_STRING(bindtextdomain(ZSTR_VAL(domain), NULL));
 	}
@@ -311,11 +306,6 @@ PHP_FUNCTION(bind_textdomain_codeset)
 	ZEND_PARSE_PARAMETERS_END();
 
 	PHP_GETTEXT_DOMAIN_LENGTH_CHECK(1, ZSTR_LEN(domain))
-
-	if (!ZSTR_LEN(domain)) {
-		zend_argument_cannot_be_empty_error(1);
-		RETURN_THROWS();
-	}
 
 	retval = bind_textdomain_codeset(ZSTR_VAL(domain), codeset ? ZSTR_VAL(codeset) : NULL);
 

--- a/ext/gettext/tests/dcngettext.phpt
+++ b/ext/gettext/tests/dcngettext.phpt
@@ -33,6 +33,6 @@ string(1) "1"
 string(4) "test"
 string(4) "test"
 string(4) "test"
-dcngettext(): Argument #1 ($domain) cannot be empty
-dcngettext(): Argument #1 ($domain) cannot be empty
+dcngettext(): Argument #1 ($domain) must not be empty
+dcngettext(): Argument #1 ($domain) must not be empty
 Done

--- a/ext/gettext/tests/gettext_bind_textdomain_codeset-retval.phpt
+++ b/ext/gettext/tests/gettext_bind_textdomain_codeset-retval.phpt
@@ -20,8 +20,8 @@ gettext
     echo "Done\n";
 ?>
 --EXPECT--
-bind_textdomain_codeset(): Argument #1 ($domain) cannot be empty
-bind_textdomain_codeset(): Argument #1 ($domain) cannot be empty
+bind_textdomain_codeset(): Argument #1 ($domain) must not be empty
+bind_textdomain_codeset(): Argument #1 ($domain) must not be empty
 string(5) "UTF-8"
 Done
 --CREDITS--

--- a/ext/gettext/tests/gettext_bindtextdomain-emptydomain.phpt
+++ b/ext/gettext/tests/gettext_bindtextdomain-emptydomain.phpt
@@ -15,7 +15,7 @@ try {
 
 ?>
 --EXPECT--
-bindtextdomain(): Argument #1 ($domain) cannot be empty
+bindtextdomain(): Argument #1 ($domain) must not be empty
 --CREDITS--
 Till Klampaeckel, till@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/gettext/tests/gettext_textdomain-retval.phpt
+++ b/ext/gettext/tests/gettext_textdomain-retval.phpt
@@ -36,7 +36,7 @@ test
 test
 foo
 textdomain(): Argument #1 ($domain) cannot be zero
-textdomain(): Argument #1 ($domain) cannot be empty
+textdomain(): Argument #1 ($domain) must not be empty
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -635,7 +635,7 @@ PHP_FUNCTION(hash_init)
 		}
 		if (!key || (ZSTR_LEN(key) == 0)) {
 			/* Note: a zero length key is no key at all */
-			zend_argument_value_error(3, "cannot be empty when HMAC is requested");
+			zend_argument_value_error(3, "must not be empty when HMAC is requested");
 			RETURN_THROWS();
 		}
 	}
@@ -914,7 +914,7 @@ PHP_FUNCTION(hash_hkdf)
 	}
 
 	if (ZSTR_LEN(ikm) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -914,7 +914,7 @@ PHP_FUNCTION(hash_hkdf)
 	}
 
 	if (ZSTR_LEN(ikm) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/hash/tests/hash_hkdf_error.phpt
+++ b/ext/hash/tests/hash_hkdf_error.phpt
@@ -61,6 +61,6 @@ trycatch_dump(
 [ValueError] hash_hkdf(): Argument #1 ($algo) must be a valid cryptographic hashing algorithm
 
 -- Testing hash_hkdf() function with invalid parameters --
-[ValueError] hash_hkdf(): Argument #2 ($key) cannot be empty
+[ValueError] hash_hkdf(): Argument #2 ($key) must not be empty
 [ValueError] hash_hkdf(): Argument #3 ($length) must be greater than or equal to 0
 [ValueError] hash_hkdf(): Argument #3 ($length) must be less than or equal to 5100

--- a/ext/hash/tests/hash_init_error.phpt
+++ b/ext/hash/tests/hash_init_error.phpt
@@ -47,7 +47,7 @@ hash_init(): Argument #1 ($algo) must be a valid hashing algorithm
 hash_init(): Argument #1 ($algo) must be a cryptographic hashing algorithm if HMAC is requested
 
 -- Testing hash_init() function with HASH_HMAC and no key --
-hash_init(): Argument #3 ($key) cannot be empty when HMAC is requested
+hash_init(): Argument #3 ($key) must not be empty when HMAC is requested
 
 Deprecated: hash_init(): Passing null to parameter #3 ($key) of type string is deprecated in %s on line %d
-hash_init(): Argument #3 ($key) cannot be empty when HMAC is requested
+hash_init(): Argument #3 ($key) must not be empty when HMAC is requested

--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -125,7 +125,7 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(domain) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(domain) > INT32_MAX - 1) {

--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -125,7 +125,7 @@ static void php_intl_idn_handoff(INTERNAL_FUNCTION_PARAMETERS, int mode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(domain) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(domain) > INT32_MAX - 1) {

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -186,7 +186,7 @@ static zval *resource_bundle_array_fetch(
 	if (offset_str) {
 		if (UNEXPECTED(ZSTR_LEN(offset_str) == 0)) {
 			if (offset_arg_num) {
-				zend_argument_value_error(offset_arg_num, "cannot be empty");
+				zend_argument_cannot_be_empty_error(offset_arg_num);
 			} else {
 				zend_value_error("Offset cannot be empty");
 			}

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -186,9 +186,9 @@ static zval *resource_bundle_array_fetch(
 	if (offset_str) {
 		if (UNEXPECTED(ZSTR_LEN(offset_str) == 0)) {
 			if (offset_arg_num) {
-				zend_argument_cannot_be_empty_error(offset_arg_num);
+				zend_argument_must_not_be_empty_error(offset_arg_num);
 			} else {
-				zend_value_error("Offset cannot be empty");
+				zend_value_error("Offset must not be empty");
 			}
 			return NULL;
 		}

--- a/ext/intl/tests/idn_uts46_errors.phpt
+++ b/ext/intl/tests/idn_uts46_errors.phpt
@@ -48,7 +48,7 @@ var_dump($foo["errors"]==IDNA_ERROR_CONTEXTJ);
 bad variant:
 ValueError: idn_to_ascii(): Argument #2 ($flags) must be INTL_IDNA_VARIANT_UTS46
 empty domain:
-ValueError: idn_to_ascii(): Argument #1 ($domain) cannot be empty
+ValueError: idn_to_ascii(): Argument #1 ($domain) must not be empty
 with error, but no details arg:
 bool(false)
 with error, with details arg:

--- a/ext/intl/tests/resourcebundle_dimension_errors.phpt
+++ b/ext/intl/tests/resourcebundle_dimension_errors.phpt
@@ -57,5 +57,5 @@ Error: Cannot use object of type ResourceBundle as array
 string(7) "default"
 TypeError: Cannot access offset of type float on ResourceBundle
 TypeError: Cannot access offset of type stdClass on ResourceBundle
-ValueError: Offset cannot be empty
+ValueError: Offset must not be empty
 ValueError: Index must be between -2147483648 and 2147483647

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1501,7 +1501,7 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 
 		nlinks = zend_hash_num_elements(Z_ARRVAL_P(link));
 		if (nlinks == 0) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			ret = 0;
 			goto cleanup;
 		}

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1501,7 +1501,7 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 
 		nlinks = zend_hash_num_elements(Z_ARRVAL_P(link));
 		if (nlinks == 0) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			ret = 0;
 			goto cleanup;
 		}
@@ -2696,7 +2696,7 @@ PHP_FUNCTION(ldap_modify_batch)
 					zend_hash_internal_pointer_reset(Z_ARRVAL_P(modinfo));
 					num_modvals = zend_hash_num_elements(Z_ARRVAL_P(modinfo));
 					if (num_modvals == 0) {
-						zend_value_error("%s(): Option \"" LDAP_MODIFY_BATCH_VALUES "\" cannot be empty", get_active_function_name());
+						zend_value_error("%s(): Option \"" LDAP_MODIFY_BATCH_VALUES "\" must not be empty", get_active_function_name());
 						RETURN_THROWS();
 					}
 

--- a/ext/ldap/tests/ldap_search_error.phpt
+++ b/ext/ldap/tests/ldap_search_error.phpt
@@ -59,7 +59,7 @@ bool(false)
 
 Warning: ldap_search(): Array initialization wrong in %s on line %d
 bool(false)
-ldap_search(): Argument #1 ($ldap) cannot be empty
+ldap_search(): Argument #1 ($ldap) must not be empty
 ldap_search(): Argument #2 ($base) must have the same number of elements as the links array
 ldap_search(): Argument #3 ($filter) must have the same number of elements as the links array
 ldap_search(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP instance

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2238,7 +2238,7 @@ PHP_FUNCTION(mb_substr_count)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(needle) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -2278,7 +2278,7 @@ PHP_FUNCTION(mb_substr_count)
 		if (ZSTR_LEN(needle_u8) == 0) {
 			zend_string_free(haystack_u8);
 			zend_string_free(needle_u8);
-			zend_argument_cannot_be_empty_error(2);
+			zend_argument_must_not_be_empty_error(2);
 			RETURN_THROWS();
 		}
 	}
@@ -5673,7 +5673,7 @@ PHP_FUNCTION(mb_ord)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (str_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -5810,7 +5810,7 @@ PHP_FUNCTION(mb_str_pad)
 	}
 
 	if (ZSTR_LEN(pad) == 0) {
-		zend_argument_cannot_be_empty_error(3);
+		zend_argument_must_not_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2238,7 +2238,7 @@ PHP_FUNCTION(mb_substr_count)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(needle) == 0) {
-		zend_argument_value_error(2, "must not be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -2278,7 +2278,7 @@ PHP_FUNCTION(mb_substr_count)
 		if (ZSTR_LEN(needle_u8) == 0) {
 			zend_string_free(haystack_u8);
 			zend_string_free(needle_u8);
-			zend_argument_value_error(2, "must not be empty");
+			zend_argument_cannot_be_empty_error(2);
 			RETURN_THROWS();
 		}
 	}
@@ -5673,7 +5673,7 @@ PHP_FUNCTION(mb_ord)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (str_len == 0) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -5810,7 +5810,7 @@ PHP_FUNCTION(mb_str_pad)
 	}
 
 	if (ZSTR_LEN(pad) == 0) {
-		zend_argument_value_error(3, "must be a non-empty string");
+		zend_argument_cannot_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -900,7 +900,7 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	}
 
 	if (arg_pattern_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1468,7 +1468,7 @@ PHP_FUNCTION(mb_ereg_search_init)
 	}
 
 	if (arg_pattern && arg_pattern_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -900,7 +900,7 @@ static void _php_mb_regex_ereg_exec(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	}
 
 	if (arg_pattern_len == 0) {
-		zend_argument_value_error(1, "must not be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1468,7 +1468,7 @@ PHP_FUNCTION(mb_ereg_search_init)
 	}
 
 	if (arg_pattern && arg_pattern_len == 0) {
-		zend_argument_value_error(2, "must not be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/mbstring/tests/bug43994.phpt
+++ b/ext/mbstring/tests/bug43994.phpt
@@ -43,28 +43,28 @@ foreach($inputs as $input) {
 --EXPECT--
 -- Iteration 1 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 NULL
 
 -- Iteration 2 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 NULL
 
 -- Iteration 3 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 NULL
 
 -- Iteration 4 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) cannot be empty
+mb_ereg(): Argument #1 ($pattern) must not be empty
 NULL

--- a/ext/mbstring/tests/bug43994.phpt
+++ b/ext/mbstring/tests/bug43994.phpt
@@ -43,28 +43,28 @@ foreach($inputs as $input) {
 --EXPECT--
 -- Iteration 1 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 NULL
 
 -- Iteration 2 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 NULL
 
 -- Iteration 3 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 NULL
 
 -- Iteration 4 --
 Without $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 With $regs arg:
-mb_ereg(): Argument #1 ($pattern) must not be empty
+mb_ereg(): Argument #1 ($pattern) cannot be empty
 NULL

--- a/ext/mbstring/tests/empty_pattern.phpt
+++ b/ext/mbstring/tests/empty_pattern.phpt
@@ -25,5 +25,5 @@ try {
 
 ?>
 --EXPECT--
-mb_ereg_search_init(): Argument #2 ($pattern) must not be empty
+mb_ereg_search_init(): Argument #2 ($pattern) cannot be empty
 No pattern was provided

--- a/ext/mbstring/tests/empty_pattern.phpt
+++ b/ext/mbstring/tests/empty_pattern.phpt
@@ -25,5 +25,5 @@ try {
 
 ?>
 --EXPECT--
-mb_ereg_search_init(): Argument #2 ($pattern) cannot be empty
+mb_ereg_search_init(): Argument #2 ($pattern) must not be empty
 No pattern was provided

--- a/ext/mbstring/tests/mb_ereg1.phpt
+++ b/ext/mbstring/tests/mb_ereg1.phpt
@@ -35,7 +35,7 @@ array(3) {
   array(0) {
   }
 }
-ValueError: mb_ereg(): Argument #1 ($pattern) cannot be empty
+ValueError: mb_ereg(): Argument #1 ($pattern) must not be empty
 array(3) {
   [0]=>
   string(0) ""

--- a/ext/mbstring/tests/mb_ereg1.phpt
+++ b/ext/mbstring/tests/mb_ereg1.phpt
@@ -35,7 +35,7 @@ array(3) {
   array(0) {
   }
 }
-ValueError: mb_ereg(): Argument #1 ($pattern) must not be empty
+ValueError: mb_ereg(): Argument #1 ($pattern) cannot be empty
 array(3) {
   [0]=>
   string(0) ""

--- a/ext/mbstring/tests/mb_ord.phpt
+++ b/ext/mbstring/tests/mb_ord.phpt
@@ -56,7 +56,7 @@ try {
 bool(true)
 bool(true)
 bool(true)
-mb_ord(): Argument #1 ($string) must not be empty
+mb_ord(): Argument #1 ($string) cannot be empty
 mb_ord(): Argument #2 ($encoding) must be a valid encoding, "typo" given
 mb_ord(): Argument #2 ($encoding) must be a valid encoding, "pass" given
 mb_ord() does not support the "JIS" encoding

--- a/ext/mbstring/tests/mb_ord.phpt
+++ b/ext/mbstring/tests/mb_ord.phpt
@@ -56,7 +56,7 @@ try {
 bool(true)
 bool(true)
 bool(true)
-mb_ord(): Argument #1 ($string) cannot be empty
+mb_ord(): Argument #1 ($string) must not be empty
 mb_ord(): Argument #2 ($encoding) must be a valid encoding, "typo" given
 mb_ord(): Argument #2 ($encoding) must be a valid encoding, "pass" given
 mb_ord() does not support the "JIS" encoding

--- a/ext/mbstring/tests/mb_str_pad.phpt
+++ b/ext/mbstring/tests/mb_str_pad.phpt
@@ -9,27 +9,27 @@ echo "--- Error conditions ---\n";
 try {
     var_dump(mb_str_pad('▶▶', 6, '', STR_PAD_RIGHT));
 } catch (ValueError $e) {
-    var_dump($e->getMessage());
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 try {
     var_dump(mb_str_pad('▶▶', 6, '', STR_PAD_LEFT));
 } catch (ValueError $e) {
-    var_dump($e->getMessage());
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 try {
     var_dump(mb_str_pad('▶▶', 6, '', STR_PAD_BOTH));
 } catch (ValueError $e) {
-    var_dump($e->getMessage());
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 try {
     var_dump(mb_str_pad('▶▶', 6, ' ', 123456));
 } catch (ValueError $e) {
-    var_dump($e->getMessage());
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 try {
-    var_dump(mb_str_pad('▶▶', 6, ' ', STR_PAD_BOTH, 'unexisting'));
+    var_dump(mb_str_pad('▶▶', 6, ' ', STR_PAD_BOTH, 'non-existing'));
 } catch (ValueError $e) {
-    var_dump($e->getMessage());
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
 echo "--- Simple ASCII strings ---\n";
@@ -87,11 +87,11 @@ foreach ($tests as $encoding => $test) {
 ?>
 --EXPECT--
 --- Error conditions ---
-string(66) "mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string"
-string(66) "mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string"
-string(66) "mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string"
-string(90) "mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH"
-string(82) "mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "unexisting" given"
+ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
+ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
+ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
+ValueError: mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH
+ValueError: mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "non-existing" given
 --- Simple ASCII strings ---
 string(7) "+Hello+"
 string(10) "+-World+-+"

--- a/ext/mbstring/tests/mb_str_pad.phpt
+++ b/ext/mbstring/tests/mb_str_pad.phpt
@@ -87,9 +87,9 @@ foreach ($tests as $encoding => $test) {
 ?>
 --EXPECT--
 --- Error conditions ---
-ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
-ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
-ValueError: mb_str_pad(): Argument #3 ($pad_string) cannot be empty
+ValueError: mb_str_pad(): Argument #3 ($pad_string) must not be empty
+ValueError: mb_str_pad(): Argument #3 ($pad_string) must not be empty
+ValueError: mb_str_pad(): Argument #3 ($pad_string) must not be empty
 ValueError: mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH
 ValueError: mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "non-existing" given
 --- Simple ASCII strings ---

--- a/ext/mbstring/tests/mb_substr_count.phpt
+++ b/ext/mbstring/tests/mb_substr_count.phpt
@@ -69,9 +69,9 @@ output_handler=
 ?>
 --EXPECT--
 == Empty needle should raise an error ==
-mb_substr_count(): Argument #2 ($needle) must not be empty
-mb_substr_count(): Argument #2 ($needle) must not be empty
-mb_substr_count(): Argument #2 ($needle) must not be empty
+mb_substr_count(): Argument #2 ($needle) cannot be empty
+mb_substr_count(): Argument #2 ($needle) cannot be empty
+mb_substr_count(): Argument #2 ($needle) cannot be empty
 == Return value for empty haystack should always be zero ==
 int(0)
 int(0)

--- a/ext/mbstring/tests/mb_substr_count.phpt
+++ b/ext/mbstring/tests/mb_substr_count.phpt
@@ -69,9 +69,9 @@ output_handler=
 ?>
 --EXPECT--
 == Empty needle should raise an error ==
-mb_substr_count(): Argument #2 ($needle) cannot be empty
-mb_substr_count(): Argument #2 ($needle) cannot be empty
-mb_substr_count(): Argument #2 ($needle) cannot be empty
+mb_substr_count(): Argument #2 ($needle) must not be empty
+mb_substr_count(): Argument #2 ($needle) must not be empty
+mb_substr_count(): Argument #2 ($needle) must not be empty
 == Return value for empty haystack should always be zero ==
 int(0)
 int(0)

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -139,7 +139,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	if (!types_len) {
-		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
+		zend_argument_must_not_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -139,7 +139,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	if (!types_len) {
-		zend_argument_value_error(ERROR_ARG_POS(2), "cannot be empty");
+		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -572,7 +572,7 @@ PHP_FUNCTION(mysqli_query)
 	}
 
 	if (!query_len) {
-		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
+		zend_argument_must_not_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 	if ((resultmode & ~MYSQLI_ASYNC) != MYSQLI_USE_RESULT &&
@@ -1013,7 +1013,7 @@ PHP_FUNCTION(mysqli_begin_transaction)
 		RETURN_THROWS();
 	}
 	if (name && !name_len) {
-		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(3));
+		zend_argument_must_not_be_empty_error(ERROR_ARG_POS(3));
 		RETURN_THROWS();
 	}
 
@@ -1037,7 +1037,7 @@ PHP_FUNCTION(mysqli_savepoint)
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
+		zend_argument_must_not_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 
@@ -1061,7 +1061,7 @@ PHP_FUNCTION(mysqli_release_savepoint)
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
+		zend_argument_must_not_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 	if (FAIL == mysqlnd_release_savepoint(mysql->mysql, name)) {

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -572,7 +572,7 @@ PHP_FUNCTION(mysqli_query)
 	}
 
 	if (!query_len) {
-		zend_argument_value_error(ERROR_ARG_POS(2), "cannot be empty");
+		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 	if ((resultmode & ~MYSQLI_ASYNC) != MYSQLI_USE_RESULT &&
@@ -1013,7 +1013,7 @@ PHP_FUNCTION(mysqli_begin_transaction)
 		RETURN_THROWS();
 	}
 	if (name && !name_len) {
-		zend_argument_value_error(ERROR_ARG_POS(3), "cannot be empty");
+		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(3));
 		RETURN_THROWS();
 	}
 
@@ -1037,7 +1037,7 @@ PHP_FUNCTION(mysqli_savepoint)
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 	if (name_len == 0) {
-		zend_argument_value_error(ERROR_ARG_POS(2), "cannot be empty");
+		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 
@@ -1061,7 +1061,7 @@ PHP_FUNCTION(mysqli_release_savepoint)
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 	if (name_len == 0) {
-		zend_argument_value_error(ERROR_ARG_POS(2), "cannot be empty");
+		zend_argument_cannot_be_empty_error(ERROR_ARG_POS(2));
 		RETURN_THROWS();
 	}
 	if (FAIL == mysqlnd_release_savepoint(mysql->mysql, name)) {

--- a/ext/mysqli/tests/mysqli_query.phpt
+++ b/ext/mysqli/tests/mysqli_query.phpt
@@ -114,7 +114,7 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS test"))
 mysqli_close($link);
 ?>
 --EXPECTF--
-mysqli_query(): Argument #2 ($query) cannot be empty
+mysqli_query(): Argument #2 ($query) must not be empty
 array(1) {
   ["valid"]=>
   string(30) "this is sql but with semicolon"

--- a/ext/mysqli/tests/mysqli_release_savepoint.phpt
+++ b/ext/mysqli/tests/mysqli_release_savepoint.phpt
@@ -61,7 +61,7 @@ if (!have_innodb($link))
 require_once 'clean_table.inc';
 ?>
 --EXPECT--
-mysqli_release_savepoint(): Argument #2 ($name) cannot be empty
+mysqli_release_savepoint(): Argument #2 ($name) must not be empty
 array(1) {
   ["id"]=>
   string(1) "1"

--- a/ext/mysqli/tests/mysqli_savepoint.phpt
+++ b/ext/mysqli/tests/mysqli_savepoint.phpt
@@ -52,5 +52,5 @@ if (!have_innodb($link))
 require_once 'clean_table.inc';
 ?>
 --EXPECT--
-mysqli_savepoint(): Argument #2 ($name) cannot be empty
+mysqli_savepoint(): Argument #2 ($name) must not be empty
 done!

--- a/ext/mysqli/tests/mysqli_stmt_bind_param.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_param.phpt
@@ -413,7 +413,7 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECT--
 The number of variables must match the number of parameters in the prepared statement
-mysqli_stmt_bind_param(): Argument #2 ($types) cannot be empty
+mysqli_stmt_bind_param(): Argument #2 ($types) must not be empty
 The number of elements in the type definition string must match the number of bind variables
 The number of variables must match the number of parameters in the prepared statement
 The number of elements in the type definition string must match the number of bind variables

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7243,7 +7243,7 @@ PHP_FUNCTION(openssl_seal)
 	pubkeysht = Z_ARRVAL_P(pubkeys);
 	nkeys = pubkeysht ? zend_hash_num_elements(pubkeysht) : 0;
 	if (!nkeys) {
-		zend_argument_cannot_be_empty_error(4);
+		zend_argument_must_not_be_empty_error(4);
 		RETURN_THROWS();
 	}
 
@@ -8017,7 +8017,7 @@ PHP_FUNCTION(openssl_decrypt)
 	}
 
 	if (!method_len) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -8059,7 +8059,7 @@ PHP_FUNCTION(openssl_cipher_iv_length)
 	}
 
 	if (ZSTR_LEN(method) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -8088,7 +8088,7 @@ PHP_FUNCTION(openssl_cipher_key_length)
 	}
 
 	if (ZSTR_LEN(method) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7243,7 +7243,7 @@ PHP_FUNCTION(openssl_seal)
 	pubkeysht = Z_ARRVAL_P(pubkeys);
 	nkeys = pubkeysht ? zend_hash_num_elements(pubkeysht) : 0;
 	if (!nkeys) {
-		zend_argument_value_error(4, "cannot be empty");
+		zend_argument_cannot_be_empty_error(4);
 		RETURN_THROWS();
 	}
 
@@ -8017,7 +8017,7 @@ PHP_FUNCTION(openssl_decrypt)
 	}
 
 	if (!method_len) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -8059,7 +8059,7 @@ PHP_FUNCTION(openssl_cipher_iv_length)
 	}
 
 	if (ZSTR_LEN(method) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -8088,7 +8088,7 @@ PHP_FUNCTION(openssl_cipher_key_length)
 	}
 
 	if (ZSTR_LEN(method) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/openssl/tests/openssl_cipher_iv_length_error.phpt
+++ b/ext/openssl/tests/openssl_cipher_iv_length_error.phpt
@@ -18,4 +18,4 @@ try {
 
 Warning: openssl_cipher_iv_length(): Unknown cipher algorithm in %s on line %d
 bool(false)
-openssl_cipher_iv_length(): Argument #1 ($cipher_algo) cannot be empty
+openssl_cipher_iv_length(): Argument #1 ($cipher_algo) must not be empty

--- a/ext/openssl/tests/openssl_cipher_key_length_error.phpt
+++ b/ext/openssl/tests/openssl_cipher_key_length_error.phpt
@@ -18,4 +18,4 @@ try {
 
 Warning: openssl_cipher_key_length(): Unknown cipher algorithm in %s on line %d
 bool(false)
-openssl_cipher_key_length(): Argument #1 ($cipher_algo) cannot be empty
+openssl_cipher_key_length(): Argument #1 ($cipher_algo) must not be empty

--- a/ext/openssl/tests/openssl_seal_basic.phpt
+++ b/ext/openssl/tests/openssl_seal_basic.phpt
@@ -40,13 +40,13 @@ var_dump(openssl_seal($data, $sealed, $ekeys, array($wrong), $method));
 --EXPECTF--
 Warning: openssl_seal(): Not a public key (1th member of pubkeys) in %s on line %d
 bool(false)
-openssl_seal(): Argument #4 ($public_key) cannot be empty
+openssl_seal(): Argument #4 ($public_key) must not be empty
 int(32)
 int(32)
 
 Warning: openssl_seal(): Not a public key (2th member of pubkeys) in %s on line %d
 bool(false)
-openssl_seal(): Argument #4 ($public_key) cannot be empty
+openssl_seal(): Argument #4 ($public_key) must not be empty
 
 Warning: openssl_seal(): Not a public key (1th member of pubkeys) in %s on line %d
 bool(false)

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -860,7 +860,7 @@ static bool php_pcntl_set_user_signal_infos(
 	bool allow_empty_signal_array
 ) {
 	if (!allow_empty_signal_array && zend_hash_num_elements(user_signals) == 0) {
-		zend_argument_cannot_be_empty_error(arg_num);
+		zend_argument_must_not_be_empty_error(arg_num);
 		return false;
 	}
 
@@ -1695,7 +1695,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 
 	// TODO Why are the arguments optional?
 	if (!hmask || zend_hash_num_elements(Z_ARRVAL_P(hmask)) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1693,8 +1693,9 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 		Z_PARAM_ARRAY(hmask)
 	ZEND_PARSE_PARAMETERS_END();
 
+	// TODO Why are the arguments optional?
 	if (!hmask || zend_hash_num_elements(Z_ARRVAL_P(hmask)) == 0) {
-		zend_argument_value_error(2, "must not be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -860,7 +860,7 @@ static bool php_pcntl_set_user_signal_infos(
 	bool allow_empty_signal_array
 ) {
 	if (!allow_empty_signal_array && zend_hash_num_elements(user_signals) == 0) {
-		zend_argument_value_error(arg_num, "cannot be empty");
+		zend_argument_cannot_be_empty_error(arg_num);
 		return false;
 	}
 

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -60,7 +60,7 @@ array(0) {
 array(0) {
 }
 bool(true)
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cannot be empty
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) must not be empty
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid value (def)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (%d)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (-1024)

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -60,7 +60,7 @@ array(0) {
 array(0) {
 }
 bool(true)
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) must not be empty
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cannot be empty
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid value (def)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (%d)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (-1024)

--- a/ext/pcntl/tests/pcntl_sigprocmask_errors.phpt
+++ b/ext/pcntl/tests/pcntl_sigprocmask_errors.phpt
@@ -60,7 +60,7 @@ try {
 ?>
 --EXPECTF--
 ValueError: pcntl_sigprocmask(): Argument #1 ($mode) must be one of SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
-ValueError: pcntl_sigprocmask(): Argument #2 ($signals) cannot be empty
+ValueError: pcntl_sigprocmask(): Argument #2 ($signals) must not be empty
 ValueError: pcntl_sigprocmask(): Argument #2 ($signals) signals must be between 1 and %d
 ValueError: pcntl_sigprocmask(): Argument #2 ($signals) signals must be between 1 and %d
 TypeError: pcntl_sigprocmask(): Argument #2 ($signals) signals must be of type int, string given

--- a/ext/pcntl/tests/pcntl_sigtimedwait_errors.phpt
+++ b/ext/pcntl/tests/pcntl_sigtimedwait_errors.phpt
@@ -86,7 +86,7 @@ try {
 
 ?>
 --EXPECTF--
-ValueError: pcntl_sigtimedwait(): Argument #1 ($signals) cannot be empty
+ValueError: pcntl_sigtimedwait(): Argument #1 ($signals) must not be empty
 ValueError: pcntl_sigtimedwait(): Argument #1 ($signals) signals must be between 1 and %d
 ValueError: pcntl_sigtimedwait(): Argument #1 ($signals) signals must be between 1 and %d
 ValueError: pcntl_sigtimedwait(): Argument #1 ($signals) signals must be between 1 and %d

--- a/ext/pcntl/tests/pcntl_sigwaitinfo_errors.phpt
+++ b/ext/pcntl/tests/pcntl_sigwaitinfo_errors.phpt
@@ -51,7 +51,7 @@ try {
 }
 ?>
 --EXPECTF--
-ValueError: pcntl_sigwaitinfo(): Argument #1 ($signals) cannot be empty
+ValueError: pcntl_sigwaitinfo(): Argument #1 ($signals) must not be empty
 ValueError: pcntl_sigwaitinfo(): Argument #1 ($signals) signals must be between 1 and %d
 ValueError: pcntl_sigwaitinfo(): Argument #1 ($signals) signals must be between 1 and %d
 TypeError: pcntl_sigwaitinfo(): Argument #1 ($signals) signals must be of type int, string given

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -563,7 +563,7 @@ PHP_METHOD(PDO, prepare)
 	PDO_CONSTRUCT_CHECK;
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1030,7 +1030,7 @@ PHP_METHOD(PDO, exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1166,7 +1166,7 @@ PHP_METHOD(PDO, query)
 	PDO_CONSTRUCT_CHECK;
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -563,7 +563,7 @@ PHP_METHOD(PDO, prepare)
 	PDO_CONSTRUCT_CHECK;
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1030,7 +1030,7 @@ PHP_METHOD(PDO, exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1166,7 +1166,7 @@ PHP_METHOD(PDO, query)
 	PDO_CONSTRUCT_CHECK;
 
 	if (ZSTR_LEN(statement) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1423,7 +1423,7 @@ static void register_bound_param(INTERNAL_FUNCTION_PARAMETERS, int is_param) /* 
 
 	if (param.name) {
 		if (ZSTR_LEN(param.name) == 0) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			RETURN_THROWS();
 		}
 		param.paramno = -1;
@@ -1471,7 +1471,7 @@ PHP_METHOD(PDOStatement, bindValue)
 
 	if (param.name) {
 		if (ZSTR_LEN(param.name) == 0) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 			RETURN_THROWS();
 		}
 		param.paramno = -1;

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1423,7 +1423,7 @@ static void register_bound_param(INTERNAL_FUNCTION_PARAMETERS, int is_param) /* 
 
 	if (param.name) {
 		if (ZSTR_LEN(param.name) == 0) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			RETURN_THROWS();
 		}
 		param.paramno = -1;
@@ -1471,7 +1471,7 @@ PHP_METHOD(PDOStatement, bindValue)
 
 	if (param.name) {
 		if (ZSTR_LEN(param.name) == 0) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 			RETURN_THROWS();
 		}
 		param.paramno = -1;

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated.phpt
@@ -162,7 +162,7 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_emulated');
 ?>
 --EXPECTF--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 array(1) {
   ["one"]=>
   string(1) "1"

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_anonymous_placeholders.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_anonymous_placeholders.phpt
@@ -161,7 +161,7 @@ $db = MySQLPDOTest::factory();
 $db->query('DROP TABLE IF EXISTS test_prepare_emulated_anonymous_placeholder');
 ?>
 --EXPECTF--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam.phpt
@@ -152,5 +152,5 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_emulated_myisam');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam_index.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam_index.phpt
@@ -164,5 +164,5 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_emulated_myisam_index');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native.phpt
@@ -165,7 +165,7 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_native');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_anonymous_placeholder.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_anonymous_placeholder.phpt
@@ -243,7 +243,7 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_native_anonymous_placeholder');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam.phpt
@@ -155,5 +155,5 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_native_myisam');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam_index.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam_index.phpt
@@ -175,5 +175,5 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_prepare_native_myisam_index');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($query) cannot be empty
+PDO::prepare(): Argument #1 ($query) must not be empty
 done!

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -627,7 +627,7 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 	}
 
 	if (!zend_hash_num_elements(Z_ARRVAL_P(pg_rows))) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -627,7 +627,7 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 	}
 
 	if (!zend_hash_num_elements(Z_ARRVAL_P(pg_rows))) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -82,7 +82,7 @@ PHP_METHOD(Pdo_Sqlite, loadExtension)
 	}
 
 	if (extension_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -82,7 +82,7 @@ PHP_METHOD(Pdo_Sqlite, loadExtension)
 	}
 
 	if (extension_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -4613,7 +4613,7 @@ PHP_FUNCTION(pg_meta_data)
 
 	/* php_pgsql_meta_data() asserts that table_name is not empty */
 	if (ZSTR_LEN(table_name) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5405,7 +5405,7 @@ PHP_FUNCTION(pg_convert)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table_name) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5618,7 +5618,7 @@ PHP_FUNCTION(pg_insert)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5840,7 +5840,7 @@ PHP_FUNCTION(pg_update)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5939,7 +5939,7 @@ PHP_FUNCTION(pg_delete)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -6095,7 +6095,7 @@ PHP_FUNCTION(pg_select)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -6143,13 +6143,13 @@ PHP_FUNCTION(pg_change_password)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(user) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
 	/* it is technically possible, but better to disallow it */
 	if (ZSTR_LEN(passwd) == 0) {
-		zend_argument_value_error(3, "cannot be empty");
+		zend_argument_cannot_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -4613,7 +4613,7 @@ PHP_FUNCTION(pg_meta_data)
 
 	/* php_pgsql_meta_data() asserts that table_name is not empty */
 	if (ZSTR_LEN(table_name) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -4799,7 +4799,7 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 	ZEND_ASSERT(Z_TYPE_P(result) == IS_ARRAY);
 	ZEND_ASSERT(!(opt & ~PGSQL_CONV_OPTS));
 	ZEND_ASSERT(table_name);
-	/* Table name cannot be empty for php_pgsql_meta_data() */
+	/* Table name must not be empty for php_pgsql_meta_data() */
 	ZEND_ASSERT(ZSTR_LEN(table_name) != 0);
 
 	array_init(&meta);
@@ -5405,7 +5405,7 @@ PHP_FUNCTION(pg_convert)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table_name) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5618,7 +5618,7 @@ PHP_FUNCTION(pg_insert)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5840,7 +5840,7 @@ PHP_FUNCTION(pg_update)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5939,7 +5939,7 @@ PHP_FUNCTION(pg_delete)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -6095,7 +6095,7 @@ PHP_FUNCTION(pg_select)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(table) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -6143,13 +6143,13 @@ PHP_FUNCTION(pg_change_password)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(user) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
 	/* it is technically possible, but better to disallow it */
 	if (ZSTR_LEN(passwd) == 0) {
-		zend_argument_cannot_be_empty_error(3);
+		zend_argument_must_not_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/pgsql/tests/changepassword.phpt
+++ b/ext/pgsql/tests/changepassword.phpt
@@ -24,6 +24,6 @@ try {
 var_dump(pg_change_password($conn, "inexistent_user", "postitpwd"));
 ?>
 --EXPECT--
-pg_change_password(): Argument #2 ($user) cannot be empty
-pg_change_password(): Argument #3 ($password) cannot be empty
+pg_change_password(): Argument #2 ($user) must not be empty
+pg_change_password(): Argument #3 ($password) must not be empty
 bool(false)

--- a/ext/pgsql/tests/pg_insert_002.phpt
+++ b/ext/pgsql/tests/pg_insert_002.phpt
@@ -21,7 +21,7 @@ foreach (array('', '.', '..') as $table) {
 ?>
 Done
 --EXPECTF--
-pg_insert(): Argument #2 ($table_name) cannot be empty
+pg_insert(): Argument #2 ($table_name) must not be empty
 pg_insert(): Argument #2 ($table_name) must be specified (.)
 pg_insert(): Argument #2 ($table_name) must be specified (..)
 Done

--- a/ext/phar/tests/create_path_error.phpt
+++ b/ext/phar/tests/create_path_error.phpt
@@ -65,10 +65,10 @@ foreach($checks as $check)
 --EXPECTF--
 string(5) "query"
 string(5) "query"
-1:Error: file_put_contents(phar://%s//): Failed to open stream: phar error: file "" in phar "%s" cannot be empty
-2:Error: file_put_contents(phar://%s/.): Failed to open stream: phar error: file "" in phar "%s" cannot be empty
-3:Error: file_put_contents(phar://%s/../): Failed to open stream: phar error: file "" in phar "%s" cannot be empty
-4:Error: file_put_contents(phar://%s/a/..): Failed to open stream: phar error: file "" in phar "%s" cannot be empty
+1:Error: file_put_contents(phar://%s//): Failed to open stream: phar error: file "" in phar "%s" must not be empty
+2:Error: file_put_contents(phar://%s/.): Failed to open stream: phar error: file "" in phar "%s" must not be empty
+3:Error: file_put_contents(phar://%s/../): Failed to open stream: phar error: file "" in phar "%s" must not be empty
+4:Error: file_put_contents(phar://%s/a/..): Failed to open stream: phar error: file "" in phar "%s" must not be empty
 5:
 6:
 7:

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -380,7 +380,7 @@ int phar_get_entry_data(phar_entry_data **ret, char *fname, size_t fname_len, ch
 
 	if (!path_len) {
 		if (error) {
-			spprintf(error, 4096, "phar error: file \"\" in phar \"%s\" cannot be empty", fname);
+			spprintf(error, 4096, "phar error: file \"\" in phar \"%s\" must not be empty", fname);
 		}
 		return FAILURE;
 	}

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -746,7 +746,7 @@ PHP_FUNCTION(posix_eaccess)
 
 	path = expand_filepath(filename, NULL);
 	if (!path) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1285,7 +1285,7 @@ PHP_FUNCTION(posix_pathconf)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (path_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	} else if (php_check_open_basedir(path)) {
 		php_error_docref(NULL, E_WARNING, "Invalid path supplied: %s", path);

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -746,7 +746,7 @@ PHP_FUNCTION(posix_eaccess)
 
 	path = expand_filepath(filename, NULL);
 	if (!path) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1285,7 +1285,7 @@ PHP_FUNCTION(posix_pathconf)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (path_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	} else if (php_check_open_basedir(path)) {
 		php_error_docref(NULL, E_WARNING, "Invalid path supplied: %s", path);

--- a/ext/posix/tests/posix_eaccess.phpt
+++ b/ext/posix/tests/posix_eaccess.phpt
@@ -17,4 +17,4 @@ try {
 
 ?>
 --EXPECT--
-posix_eaccess(): Argument #1 ($filename) cannot be empty
+posix_eaccess(): Argument #1 ($filename) must not be empty

--- a/ext/posix/tests/posix_pathconf.phpt
+++ b/ext/posix/tests/posix_pathconf.phpt
@@ -18,7 +18,7 @@ var_dump(posix_errno() != 0);
 var_dump(posix_pathconf(sys_get_temp_dir(), POSIX_PC_PATH_MAX));
 ?>
 --EXPECTF--
-posix_pathconf(): Argument #1 ($path) cannot be empty
+posix_pathconf(): Argument #1 ($path) must not be empty
 bool(false)
 bool(true)
 int(%d)

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -434,7 +434,7 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 	const size_t max_offset = source_length - 1;
 
 	if (source_length < 1) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -434,7 +434,7 @@ PHP_METHOD(Random_Randomizer, getBytesFromString)
 	const size_t max_offset = source_length - 1;
 
 	if (source_length < 1) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/random/tests/03_randomizer/methods/getBytesFromString_error.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytesFromString_error.phpt
@@ -24,5 +24,5 @@ try {
 
 ?>
 --EXPECTF--
-Random\Randomizer::getBytesFromString(): Argument #1 ($string) cannot be empty
+Random\Randomizer::getBytesFromString(): Argument #1 ($string) must not be empty
 Random\Randomizer::getBytesFromString(): Argument #2 ($length) must be greater than 0

--- a/ext/random/tests/03_randomizer/methods/pickArrayKeys_error.phpt
+++ b/ext/random/tests/03_randomizer/methods/pickArrayKeys_error.phpt
@@ -43,7 +43,7 @@ try {
 ?>
 --EXPECTF--
 Random\Randomizer::pickArrayKeys(): Argument #1 ($array) must be of type array, string given
-Random\Randomizer::pickArrayKeys(): Argument #1 ($array) cannot be empty
+Random\Randomizer::pickArrayKeys(): Argument #1 ($array) must not be empty
 Random\Randomizer::pickArrayKeys(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
 Random\Randomizer::pickArrayKeys(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
 Random\Randomizer::pickArrayKeys(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1667,7 +1667,7 @@ PHP_METHOD(SimpleXMLElement, addChild)
 	}
 
 	if (qname_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1734,7 +1734,7 @@ PHP_METHOD(SimpleXMLElement, addAttribute)
 	}
 
 	if (qname_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1667,7 +1667,7 @@ PHP_METHOD(SimpleXMLElement, addChild)
 	}
 
 	if (qname_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1734,7 +1734,7 @@ PHP_METHOD(SimpleXMLElement, addAttribute)
 	}
 
 	if (qname_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/simplexml/tests/SimpleXMLElement_addAttribute_required_attribute_name.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_addAttribute_required_attribute_name.phpt
@@ -18,6 +18,6 @@ try {
 echo $a->asXML();
 ?>
 --EXPECT--
-SimpleXMLElement::addAttribute(): Argument #1 ($qualifiedName) cannot be empty
+SimpleXMLElement::addAttribute(): Argument #1 ($qualifiedName) must not be empty
 <?xml version="1.0"?>
 <php>testfest</php>

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -668,7 +668,7 @@ static bool php_snmp_parse_oid(
 		objid_query->count++;
 	} else if (oid_ht) { /* we got objid array */
 		if (zend_hash_num_elements(oid_ht) == 0) {
-			zend_value_error("Array of object IDs cannot be empty");
+			zend_value_error("Array of object IDs must not be empty");
 			return false;
 		}
 		objid_query->vars = (snmpobjarg *)safe_emalloc(sizeof(snmpobjarg), zend_hash_num_elements(oid_ht), 0);

--- a/ext/snmp/tests/snmp2_get.phpt
+++ b/ext/snmp/tests/snmp2_get.phpt
@@ -54,7 +54,7 @@ var_dump(snmp2_get($hostname, $community, array('.1.3.6.1.2.1.1.1.0', '.1.3.6.1.
 --EXPECTF--
 Checking error handling
 Empty OID array
-Array of object IDs cannot be empty
+Array of object IDs must not be empty
 Checking working
 Single OID
 string(%d) "%s"

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -571,7 +571,7 @@ PHP_METHOD(SoapParam, __construct)
 	}
 
 	if (ZSTR_LEN(name) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -602,11 +602,11 @@ PHP_METHOD(SoapHeader, __construct)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(ns) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(name) == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -571,7 +571,7 @@ PHP_METHOD(SoapParam, __construct)
 	}
 
 	if (ZSTR_LEN(name) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -602,11 +602,11 @@ PHP_METHOD(SoapHeader, __construct)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(ns) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (ZSTR_LEN(name) == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/soap/tests/bugs/bug31755.phpt
+++ b/ext/soap/tests/bugs/bug31755.phpt
@@ -26,6 +26,6 @@ $response= $client->__soapCall('function', array(), null, $header);
 print $client->__getLastRequest();
 ?>
 --EXPECT--
-SoapHeader::__construct(): Argument #1 ($namespace) cannot be empty
+SoapHeader::__construct(): Argument #1 ($namespace) must not be empty
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="myNS" xmlns:ns2="namespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Header><ns2:foo>bar</ns2:foo></SOAP-ENV:Header><SOAP-ENV:Body><ns1:function/></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -662,7 +662,7 @@ static void from_zval_write_sun_path(const zval *path, char *sockaddr_un_c, ser_
 	 * this is not required, at least on linux for abstract paths. It also
 	 * assumes that the path is not empty */
 	if (ZSTR_LEN(path_str) == 0) {
-		do_from_zval_err(ctx, "%s", "the path is cannot be empty");
+		do_from_zval_err(ctx, "%s", "the path is must not be empty");
 		zend_tmp_string_release(tmp_path_str);
 		return;
 	}

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -696,7 +696,7 @@ static void spl_filesystem_object_construct(INTERNAL_FUNCTION_PARAMETERS, zend_l
 	}
 
 	if (ZSTR_LEN(path) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1227,7 +1227,7 @@ PHP_METHOD(SplFileInfo, getLinkTarget)
 	}
 #if defined(PHP_WIN32) || defined(HAVE_SYMLINK)
 	if (intern->file_name == NULL) {
-		zend_value_error("Filename cannot be empty");
+		zend_value_error("Filename must not be empty");
 		RETURN_THROWS();
 	}
 	if (!IS_ABSOLUTE_PATH(ZSTR_VAL(intern->file_name), ZSTR_LEN(intern->file_name))) {

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -696,7 +696,7 @@ static void spl_filesystem_object_construct(INTERNAL_FUNCTION_PARAMETERS, zend_l
 	}
 
 	if (ZSTR_LEN(path) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/spl/tests/DirectoryIterator_empty_constructor.phpt
+++ b/ext/spl/tests/DirectoryIterator_empty_constructor.phpt
@@ -12,4 +12,4 @@ try {
 }
 ?>
 --EXPECT--
-DirectoryIterator::__construct(): Argument #1 ($directory) cannot be empty
+DirectoryIterator::__construct(): Argument #1 ($directory) must not be empty

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -421,7 +421,7 @@ PHP_METHOD(SQLite3, loadExtension)
 	}
 
 	if (extension_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -421,7 +421,7 @@ PHP_METHOD(SQLite3, loadExtension)
 	}
 
 	if (extension_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
+++ b/ext/sqlite3/tests/sqlite3_33_load_extension_param.phpt
@@ -26,4 +26,4 @@ try {
 
 ?>
 --EXPECTF--
-string(61) "SQLite3::loadExtension(): Argument #1 ($name) cannot be empty"
+string(63) "SQLite3::loadExtension(): Argument #1 ($name) must not be empty"

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6211,7 +6211,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 
 	if (num_avail == 0) {
 		if (!silent) {
-			zend_argument_cannot_be_empty_error(1);
+			zend_argument_must_not_be_empty_error(1);
 		}
 		return false;
 	}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6211,7 +6211,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 
 	if (num_avail == 0) {
 		if (!silent) {
-			zend_argument_value_error(1, "cannot be empty");
+			zend_argument_cannot_be_empty_error(1);
 		}
 		return false;
 	}

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2500,7 +2500,7 @@ PHP_FUNCTION(parse_ini_file)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2500,7 +2500,7 @@ PHP_FUNCTION(parse_ini_file)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -467,7 +467,7 @@ PHP_FUNCTION(scandir)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (dirn_len < 1) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -467,7 +467,7 @@ PHP_FUNCTION(scandir)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (dirn_len < 1) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -388,7 +388,7 @@ PHP_FUNCTION(dns_check_record)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (hostname_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -388,7 +388,7 @@ PHP_FUNCTION(dns_check_record)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (hostname_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -108,7 +108,7 @@ PHP_FUNCTION(dns_check_record)
 	}
 
 	if (hostname_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -108,7 +108,7 @@ PHP_FUNCTION(dns_check_record)
 	}
 
 	if (hostname_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -514,15 +514,11 @@ PHP_FUNCTION(shell_exec)
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STRING(command, command_len)
+		Z_PARAM_PATH(command, command_len)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!command_len) {
 		zend_argument_cannot_be_empty_error(1);
-		RETURN_THROWS();
-	}
-	if (strlen(command) != command_len) {
-		zend_argument_value_error(1, "must not contain any null bytes");
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -218,7 +218,7 @@ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!cmd_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (strlen(cmd) != cmd_len) {
@@ -518,7 +518,7 @@ PHP_FUNCTION(shell_exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!command_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -218,7 +218,7 @@ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!cmd_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (strlen(cmd) != cmd_len) {
@@ -518,7 +518,7 @@ PHP_FUNCTION(shell_exec)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!command_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (strlen(command) != command_len) {

--- a/ext/standard/ftok.c
+++ b/ext/standard/ftok.c
@@ -40,7 +40,7 @@ PHP_FUNCTION(ftok)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (pathname_len == 0){
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/ftok.c
+++ b/ext/standard/ftok.c
@@ -40,7 +40,7 @@ PHP_FUNCTION(ftok)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (pathname_len == 0){
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -87,7 +87,7 @@ PHPAPI zend_result php_setcookie(zend_string *name, zend_string *value, time_t e
 	smart_str buf = {0};
 
 	if (!ZSTR_LEN(name)) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		return FAILURE;
 	}
 	if (strpbrk(ZSTR_VAL(name), "=,; \t\r\n\013\014") != NULL) {   /* man isspace for \013 and \014 */

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -87,7 +87,7 @@ PHPAPI zend_result php_setcookie(zend_string *name, zend_string *value, time_t e
 	smart_str buf = {0};
 
 	if (!ZSTR_LEN(name)) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		return FAILURE;
 	}
 	if (strpbrk(ZSTR_VAL(name), "=,; \t\r\n\013\014") != NULL) {   /* man isspace for \013 and \014 */

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -724,7 +724,7 @@ PHP_FUNCTION(wordwrap)
 	}
 
 	if (breakchar_len == 0) {
-		zend_argument_value_error(3, "cannot be empty");
+		zend_argument_cannot_be_empty_error(3);
 		RETURN_THROWS();
 	}
 
@@ -930,7 +930,7 @@ PHP_FUNCTION(explode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(delim) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1277,7 +1277,7 @@ PHP_FUNCTION(str_increment)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(str) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (!zend_string_only_has_ascii_alphanumeric(str)) {
@@ -1333,7 +1333,7 @@ PHP_FUNCTION(str_decrement)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(str) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (!zend_string_only_has_ascii_alphanumeric(str)) {
@@ -5727,7 +5727,7 @@ PHP_FUNCTION(substr_count)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -724,7 +724,7 @@ PHP_FUNCTION(wordwrap)
 	}
 
 	if (breakchar_len == 0) {
-		zend_argument_cannot_be_empty_error(3);
+		zend_argument_must_not_be_empty_error(3);
 		RETURN_THROWS();
 	}
 
@@ -930,7 +930,7 @@ PHP_FUNCTION(explode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(delim) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1277,7 +1277,7 @@ PHP_FUNCTION(str_increment)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(str) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (!zend_string_only_has_ascii_alphanumeric(str)) {
@@ -1333,7 +1333,7 @@ PHP_FUNCTION(str_decrement)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(str) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (!zend_string_only_has_ascii_alphanumeric(str)) {
@@ -5727,7 +5727,7 @@ PHP_FUNCTION(substr_count)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (needle_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -5802,7 +5802,7 @@ PHP_FUNCTION(str_pad)
 	}
 
 	if (pad_str_len == 0) {
-		zend_argument_cannot_be_empty_error(3);
+		zend_argument_must_not_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5802,7 +5802,7 @@ PHP_FUNCTION(str_pad)
 	}
 
 	if (pad_str_len == 0) {
-		zend_argument_value_error(3, "must be a non-empty string");
+		zend_argument_cannot_be_empty_error(3);
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/tests/array/array_rand.phpt
+++ b/ext/standard/tests/array/array_rand.phpt
@@ -38,8 +38,8 @@ var_dump(array_rand(array(1,2,3), 2));
 
 ?>
 --EXPECTF--
-array_rand(): Argument #1 ($array) cannot be empty
-array_rand(): Argument #1 ($array) cannot be empty
+array_rand(): Argument #1 ($array) must not be empty
+array_rand(): Argument #1 ($array) must not be empty
 array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
 array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
 array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)

--- a/ext/standard/tests/dir/bug41693.phpt
+++ b/ext/standard/tests/dir/bug41693.phpt
@@ -11,4 +11,4 @@ try {
 
 ?>
 --EXPECT--
-scandir(): Argument #1 ($directory) cannot be empty
+scandir(): Argument #1 ($directory) must not be empty

--- a/ext/standard/tests/file/file_get_contents_variation8-win32.phpt
+++ b/ext/standard/tests/file/file_get_contents_variation8-win32.phpt
@@ -55,10 +55,10 @@ Warning: file_get_contents(1): Failed to open stream: No such file or directory 
 bool(false)
 
 -- Filename: FALSE --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: "" --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: " " --
 

--- a/ext/standard/tests/file/file_get_contents_variation8.phpt
+++ b/ext/standard/tests/file/file_get_contents_variation8.phpt
@@ -52,9 +52,9 @@ bool(false)
 Warning: file_get_contents(1): Failed to open stream: No such file or directory in %s on line %d
 bool(false)
 -- Iteration 2 --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- Iteration 3 --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- Iteration 4 --
 
 Warning: file_get_contents( ): Failed to open stream: No such file or directory in %s on line %d

--- a/ext/standard/tests/file/file_put_contents_variation8-win32.phpt
+++ b/ext/standard/tests/file/file_put_contents_variation8-win32.phpt
@@ -55,10 +55,10 @@ foreach($names_arr as $key =>$value) {
 9 bytes written to: '1'
 
 -- Filename: FALSE --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: "" --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: " " --
 

--- a/ext/standard/tests/file/file_put_contents_variation8.phpt
+++ b/ext/standard/tests/file/file_put_contents_variation8.phpt
@@ -64,9 +64,9 @@ rmdir($dir);
 -- Iteration 1 --
 9 bytes written to: '1'
 -- Iteration 2 --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- Iteration 3 --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- Iteration 4 --
 9 bytes written to: ' '
 -- Iteration 5 --

--- a/ext/standard/tests/file/readfile_error.phpt
+++ b/ext/standard/tests/file/readfile_error.phpt
@@ -29,8 +29,8 @@ echo "Done\n";
 *** Test readfile(): error conditions ***
 
 -- Testing readfile() with invalid arguments --
-Path cannot be empty
-Path cannot be empty
+Path must not be empty
+Path must not be empty
 
 -- Testing readfile() with non-existent file --
 

--- a/ext/standard/tests/file/readfile_variation10-win32.phpt
+++ b/ext/standard/tests/file/readfile_variation10-win32.phpt
@@ -51,10 +51,10 @@ Warning: readfile(-1): Failed to open stream: No such file or directory in %s on
 Warning: readfile(1): Failed to open stream: No such file or directory in %s on line %d
 
 -- Filename: FALSE --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: "" --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 
 -- Filename: " " --
 

--- a/ext/standard/tests/file/readfile_variation10.phpt
+++ b/ext/standard/tests/file/readfile_variation10.phpt
@@ -49,9 +49,9 @@ Warning: readfile(-1): Failed to open stream: %s in %s on line %d
 
 Warning: readfile(1): Failed to open stream: %s in %s on line %d
 -- testing '' --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- testing '' --
-ValueError: Path cannot be empty
+ValueError: Path must not be empty
 -- testing ' ' --
 
 Warning: readfile( ): Failed to open stream: %s in %s on line %d

--- a/ext/standard/tests/network/bug69523.phpt
+++ b/ext/standard/tests/network/bug69523.phpt
@@ -9,4 +9,4 @@ try {
 }
 ?>
 --EXPECT--
-setcookie(): Argument #1 ($name) cannot be empty
+setcookie(): Argument #1 ($name) must not be empty

--- a/ext/standard/tests/network/dns_check_record_error_conditions.phpt
+++ b/ext/standard/tests/network/dns_check_record_error_conditions.phpt
@@ -15,5 +15,5 @@ try {
 }
 ?>
 --EXPECT--
-dns_check_record(): Argument #1 ($hostname) cannot be empty
+dns_check_record(): Argument #1 ($hostname) must not be empty
 dns_check_record(): Argument #2 ($type) must be a valid DNS record type

--- a/ext/standard/tests/network/setcookie_error.phpt
+++ b/ext/standard/tests/network/setcookie_error.phpt
@@ -50,7 +50,7 @@ var_dump(headers_list());
 --EXPECTHEADERS--
 
 --EXPECTF--
-setcookie(): Argument #1 ($name) cannot be empty
+setcookie(): Argument #1 ($name) must not be empty
 setcookie(): Argument #1 ($name) cannot contain "=", ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
 setcookie(): "path" option cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
 setcookie(): "domain" option cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"

--- a/ext/standard/tests/network/setrawcookie_error.phpt
+++ b/ext/standard/tests/network/setrawcookie_error.phpt
@@ -50,7 +50,7 @@ var_dump(headers_list());
 --EXPECTHEADERS--
 
 --EXPECTF--
-setrawcookie(): Argument #1 ($name) cannot be empty
+setrawcookie(): Argument #1 ($name) must not be empty
 setrawcookie(): Argument #1 ($name) cannot contain "=", ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
 setrawcookie(): Argument #2 ($value) cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
 setrawcookie(): "path" option cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"

--- a/ext/standard/tests/strings/explode.phpt
+++ b/ext/standard/tests/strings/explode.phpt
@@ -62,9 +62,9 @@ array (
   4 => 'd',
 )
 d6bee42a771449205344c0938ad4f035
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
 array(1) {
   [0]=>
   string(0) ""
@@ -79,7 +79,7 @@ array(1) {
   [0]=>
   string(0) ""
 }
-explode(): Argument #1 ($separator) cannot be empty
+explode(): Argument #1 ($separator) must not be empty
 array(1) {
   [0]=>
   string(3) "acb"

--- a/ext/standard/tests/strings/explode1.phpt
+++ b/ext/standard/tests/strings/explode1.phpt
@@ -91,15 +91,15 @@ var_dump( explode("b", $obj) );
 --EXPECT--
 *** Testing explode() for basic operations ***
 -- Iteration 1 --
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
 -- Iteration 2 --
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
 -- Iteration 3 --
 array(1) {
   [0]=>
@@ -201,10 +201,10 @@ array(2) {
   string(56) "234NULL23abcd00000TRUEFALSE-11.234444true-11.24%PHP%ZEND"
 }
 -- Iteration 7 --
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
-explode(): Argument #1 ($separator) cannot be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
+explode(): Argument #1 ($separator) must not be empty
 -- Iteration 8 --
 array(2) {
   [0]=>

--- a/ext/standard/tests/strings/md5_file.phpt
+++ b/ext/standard/tests/strings/md5_file.phpt
@@ -64,7 +64,7 @@ echo "\nDone";
 ?>
 --EXPECTF--
 *** Testing for error conditions ***
-Path cannot be empty
+Path must not be empty
 
 Warning: md5_file(aZrq16u): Failed to open stream: No such file or directory in %s on line %d
 bool(false)

--- a/ext/standard/tests/strings/sha1_file.phpt
+++ b/ext/standard/tests/strings/sha1_file.phpt
@@ -74,7 +74,7 @@ unlink("EmptyFileSHA1.txt");
 *** Testing for error conditions ***
 
 -- No filename --
-Path cannot be empty
+Path must not be empty
 
 -- invalid filename --
 
@@ -89,7 +89,7 @@ bool(false)
 -- NULL as filename --
 
 Deprecated: sha1_file(): Passing null to parameter #1 ($filename) of type string is deprecated in %s on line %d
-Path cannot be empty
+Path must not be empty
 
 -- Hexadecimal Output for Empty file as Argument --
 string(40) "da39a3ee5e6b4b0d3255bfef95601890afd80709"

--- a/ext/standard/tests/strings/str_decrement_errors.phpt
+++ b/ext/standard/tests/strings/str_decrement_errors.phpt
@@ -37,7 +37,7 @@ foreach ($strings as $s) {
 
 ?>
 --EXPECT--
-str_decrement(): Argument #1 ($string) cannot be empty
+str_decrement(): Argument #1 ($string) must not be empty
 str_decrement(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters
 str_decrement(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters
 str_decrement(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters

--- a/ext/standard/tests/strings/str_decrement_underflow.phpt
+++ b/ext/standard/tests/strings/str_decrement_underflow.phpt
@@ -23,7 +23,7 @@ foreach ($strings as $s) {
 
 ?>
 --EXPECT--
-str_decrement(): Argument #1 ($string) cannot be empty
+str_decrement(): Argument #1 ($string) must not be empty
 str_decrement(): Argument #1 ($string) "0" is out of decrement range
 str_decrement(): Argument #1 ($string) "a" is out of decrement range
 str_decrement(): Argument #1 ($string) "A" is out of decrement range

--- a/ext/standard/tests/strings/str_increment_errors.phpt
+++ b/ext/standard/tests/strings/str_increment_errors.phpt
@@ -37,7 +37,7 @@ foreach ($strings as $s) {
 
 ?>
 --EXPECT--
-str_increment(): Argument #1 ($string) cannot be empty
+str_increment(): Argument #1 ($string) must not be empty
 str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters
 str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters
 str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters

--- a/ext/standard/tests/strings/str_pad.phpt
+++ b/ext/standard/tests/strings/str_pad.phpt
@@ -302,5 +302,5 @@ string(16) "\t\variation\t\t"
 #### error conditions ####
 
 --- empty padding string ---
-str_pad(): Argument #3 ($pad_string) cannot be empty
+str_pad(): Argument #3 ($pad_string) must not be empty
 str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH

--- a/ext/standard/tests/strings/str_pad.phpt
+++ b/ext/standard/tests/strings/str_pad.phpt
@@ -302,5 +302,5 @@ string(16) "\t\variation\t\t"
 #### error conditions ####
 
 --- empty padding string ---
-str_pad(): Argument #3 ($pad_string) must be a non-empty string
+str_pad(): Argument #3 ($pad_string) cannot be empty
 str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH

--- a/ext/standard/tests/strings/substr_count_basic.phpt
+++ b/ext/standard/tests/strings/substr_count_basic.phpt
@@ -34,8 +34,8 @@ var_dump(substr_count($a, "bca", -200, -50));
 ?>
 --EXPECT--
 ***Testing basic operations ***
-substr_count(): Argument #2 ($needle) cannot be empty
-substr_count(): Argument #2 ($needle) cannot be empty
+substr_count(): Argument #2 ($needle) must not be empty
+substr_count(): Argument #2 ($needle) must not be empty
 int(0)
 int(0)
 int(0)

--- a/ext/standard/tests/strings/wordwrap.phpt
+++ b/ext/standard/tests/strings/wordwrap.phpt
@@ -53,4 +53,4 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-wordwrap(): Argument #3 ($break) cannot be empty
+wordwrap(): Argument #3 ($break) must not be empty

--- a/ext/sysvshm/tests/001.phpt
+++ b/ext/sysvshm/tests/001.phpt
@@ -35,7 +35,7 @@ var_dump(ftok(__FILE__,"q"));
 echo "Done\n";
 ?>
 --EXPECTF--
-ftok(): Argument #1 ($filename) cannot be empty
+ftok(): Argument #1 ($filename) must not be empty
 ftok(): Argument #2 ($project_id) must be a single character
 ftok(): Argument #2 ($project_id) must be a single character
 

--- a/ext/tidy/tests/019.phpt
+++ b/ext/tidy/tests/019.phpt
@@ -37,6 +37,6 @@ Warning: tidy_repair_string(): Could not load the Tidy configuration file "" in 
 Warning: tidy_repair_string(): Could not load the Tidy configuration file "1" in %s on line %d
 
 Warning: tidy_repair_string(): Could not set encoding "1" in %s on line %d
-Path cannot be empty
-Path cannot be empty
+Path must not be empty
+Path must not be empty
 Done

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -382,7 +382,7 @@ static void php_xmlreader_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlreader_rea
 	}
 
 	if (!name_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -467,7 +467,7 @@ static void php_xmlreader_set_relaxng_schema(INTERNAL_FUNCTION_PARAMETERS, int t
 	}
 
 	if (source != NULL && !source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -574,12 +574,12 @@ PHP_METHOD(XMLReader, getAttributeNs)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
 	if (ns_uri_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -655,7 +655,7 @@ PHP_METHOD(XMLReader, moveToAttribute)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -715,12 +715,12 @@ PHP_METHOD(XMLReader, moveToAttributeNs)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
 	if (ns_uri_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -860,7 +860,7 @@ static void xml_reader_from_uri(INTERNAL_FUNCTION_PARAMETERS, zend_class_entry *
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1027,7 +1027,7 @@ PHP_METHOD(XMLReader, setSchema)
 	}
 
 	if (source != NULL && !source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1132,7 +1132,7 @@ static void xml_reader_from_string(INTERNAL_FUNCTION_PARAMETERS, zend_class_entr
 	}
 
 	if (!source_len) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -382,7 +382,7 @@ static void php_xmlreader_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlreader_rea
 	}
 
 	if (!name_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -467,7 +467,7 @@ static void php_xmlreader_set_relaxng_schema(INTERNAL_FUNCTION_PARAMETERS, int t
 	}
 
 	if (source != NULL && !source_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -574,12 +574,12 @@ PHP_METHOD(XMLReader, getAttributeNs)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
 	if (ns_uri_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -655,7 +655,7 @@ PHP_METHOD(XMLReader, moveToAttribute)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -715,12 +715,12 @@ PHP_METHOD(XMLReader, moveToAttributeNs)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
 	if (ns_uri_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -860,7 +860,7 @@ static void xml_reader_from_uri(INTERNAL_FUNCTION_PARAMETERS, zend_class_entry *
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1027,7 +1027,7 @@ PHP_METHOD(XMLReader, setSchema)
 	}
 
 	if (source != NULL && !source_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1132,7 +1132,7 @@ static void xml_reader_from_string(INTERNAL_FUNCTION_PARAMETERS, zend_class_entr
 	}
 
 	if (!source_len) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/xmlreader/tests/001.phpt
+++ b/ext/xmlreader/tests/001.phpt
@@ -28,4 +28,4 @@ try {
 --EXPECT--
 books
 books
-XMLReader::XML(): Argument #1 ($source) cannot be empty
+XMLReader::XML(): Argument #1 ($source) must not be empty

--- a/ext/xmlreader/tests/002.phpt
+++ b/ext/xmlreader/tests/002.phpt
@@ -36,6 +36,6 @@ unlink($filename);
 
 ?>
 --EXPECT--
-XMLReader::open(): Argument #1 ($uri) cannot be empty
+XMLReader::open(): Argument #1 ($uri) must not be empty
 books
 books

--- a/ext/xmlreader/tests/003-get-errors.phpt
+++ b/ext/xmlreader/tests/003-get-errors.phpt
@@ -69,7 +69,7 @@ unlink(__DIR__.'/003-get-errors.xml');
 book
 bool(true)
 num: 1
-XMLReader::getAttribute(): Argument #1 ($name) cannot be empty
+XMLReader::getAttribute(): Argument #1 ($name) must not be empty
 num: 1
 NULL
 num: 1

--- a/ext/xmlreader/tests/003-move-errors.phpt
+++ b/ext/xmlreader/tests/003-move-errors.phpt
@@ -68,7 +68,7 @@ unlink(__DIR__.'/003-move-errors.xml');
 book
 bool(true)
 num: 1
-XMLReader::moveToAttribute(): Argument #1 ($name) cannot be empty
+XMLReader::moveToAttribute(): Argument #1 ($name) must not be empty
 num: 1
 bool(false)
 num: 1

--- a/ext/xmlreader/tests/003.phpt
+++ b/ext/xmlreader/tests/003.phpt
@@ -88,4 +88,4 @@ num: 1
 idx: 2
 bool(false)
 bool(false)
-XMLReader::moveToAttribute(): Argument #1 ($name) cannot be empty
+XMLReader::moveToAttribute(): Argument #1 ($name) must not be empty

--- a/ext/xmlreader/tests/007.phpt
+++ b/ext/xmlreader/tests/007.phpt
@@ -53,4 +53,4 @@ $reader->close();
 --EXPECT--
 file relaxNG: ok
 string relaxNG: ok
-XMLReader::setRelaxNGSchema(): Argument #1 ($filename) cannot be empty
+XMLReader::setRelaxNGSchema(): Argument #1 ($filename) must not be empty

--- a/ext/xmlreader/tests/015-get-errors.phpt
+++ b/ext/xmlreader/tests/015-get-errors.phpt
@@ -47,5 +47,5 @@ unlink(__DIR__.'/015-get-errors.xml');
 ?>
 --EXPECTF--
 Deprecated: XMLReader::getAttributeNs(): Passing null to parameter #2 ($namespace) of type string is deprecated in %s on line %d
-XMLReader::getAttributeNs(): Argument #2 ($namespace) cannot be empty
+XMLReader::getAttributeNs(): Argument #2 ($namespace) must not be empty
 ns1:num: 1

--- a/ext/xmlreader/tests/015-move-errors.phpt
+++ b/ext/xmlreader/tests/015-move-errors.phpt
@@ -42,4 +42,4 @@ unlink(__DIR__.'/015-move-errors.xml');
 ?>
 --EXPECTF--
 Deprecated: XMLReader::moveToAttributeNs(): Passing null to parameter #2 ($namespace) of type string is deprecated in %s on line %d
-XMLReader::moveToAttributeNs(): Argument #2 ($namespace) cannot be empty
+XMLReader::moveToAttributeNs(): Argument #2 ($namespace) must not be empty

--- a/ext/xmlreader/tests/setSchema_error.phpt
+++ b/ext/xmlreader/tests/setSchema_error.phpt
@@ -37,7 +37,7 @@ var_dump(@$reader->setSchema('schema-bad.xsd'));
 $reader->close();
 ?>
 --EXPECT--
-XMLReader::setSchema(): Argument #1 ($filename) cannot be empty
+XMLReader::setSchema(): Argument #1 ($filename) must not be empty
 Schema must be set prior to reading
 Schema must be set prior to reading
 bool(false)

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -817,7 +817,7 @@ PHP_FUNCTION(xmlwriter_open_uri)
 	}
 
 	if (source_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -858,7 +858,7 @@ PHP_METHOD(XMLWriter, toUri)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (source_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -817,7 +817,7 @@ PHP_FUNCTION(xmlwriter_open_uri)
 	}
 
 	if (source_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -858,7 +858,7 @@ PHP_METHOD(XMLWriter, toUri)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (source_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 

--- a/ext/xmlwriter/tests/xmlwriter_open_uri_error_001.phpt
+++ b/ext/xmlwriter/tests/xmlwriter_open_uri_error_001.phpt
@@ -15,4 +15,4 @@ Koen Kuipers koenk82@gmail.com
 Theo van der Zee
 #Test Fest Utrecht 09-05-2009
 --EXPECT--
-xmlwriter_open_uri(): Argument #1 ($uri) cannot be empty
+xmlwriter_open_uri(): Argument #1 ($uri) must not be empty

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -56,7 +56,7 @@ static int le_zip_entry;
 	This is always used for the first argument*/
 #define PHP_ZIP_STAT_PATH(za, path, path_len, flags, sb) \
 	if (path_len == 0) { \
-		zend_argument_cannot_be_empty_error(1); \
+		zend_argument_must_not_be_empty_error(1); \
 		RETURN_THROWS(); \
 	} \
 	if (zip_stat(za, path, flags, &sb) != 0) { \
@@ -417,7 +417,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 		}
 
 		if (Z_STRLEN_P(option) == 0) {
-			zend_value_error("Option \"remove_path\" cannot be empty");
+			zend_value_error("Option \"remove_path\" must not be empty");
 			return -1;
 		}
 
@@ -437,7 +437,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 		}
 
 		if (Z_STRLEN_P(option) == 0) {
-			zend_value_error("Option \"add_path\" cannot be empty");
+			zend_value_error("Option \"add_path\" must not be empty");
 			return -1;
 		}
 
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(zip_open)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1466,7 +1466,7 @@ PHP_METHOD(ZipArchive, open)
 	ze_obj = Z_ZIP_P(self);
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1753,7 +1753,7 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 	}
 
 	if (ZSTR_LEN(pattern) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (options && zend_hash_num_elements(options) > 0 && (php_zip_parse_options(options, &opts) < 0)) {
@@ -1871,7 +1871,7 @@ PHP_METHOD(ZipArchive, addFile)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1904,7 +1904,7 @@ PHP_METHOD(ZipArchive, replaceFile)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2168,7 +2168,7 @@ PHP_METHOD(ZipArchive, setCommentName)
 	}
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2235,7 +2235,7 @@ PHP_METHOD(ZipArchive, setExternalAttributesName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2296,7 +2296,7 @@ PHP_METHOD(ZipArchive, getExternalAttributesName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2363,7 +2363,7 @@ PHP_METHOD(ZipArchive, setEncryptionName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2424,7 +2424,7 @@ PHP_METHOD(ZipArchive, getCommentName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2480,7 +2480,7 @@ PHP_METHOD(ZipArchive, setCompressionName)
 	ZIP_FROM_OBJECT(intern, this);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2540,7 +2540,7 @@ PHP_METHOD(ZipArchive, setMtimeName)
 	ZIP_FROM_OBJECT(intern, this);
 
 	if (name_len == 0) {
-		zend_argument_cannot_be_empty_error(1);
+		zend_argument_must_not_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2654,7 +2654,7 @@ PHP_METHOD(ZipArchive, renameIndex)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (new_name_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -2682,7 +2682,7 @@ PHP_METHOD(ZipArchive, renameName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (new_name_len == 0) {
-		zend_argument_cannot_be_empty_error(2);
+		zend_argument_must_not_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -56,7 +56,7 @@ static int le_zip_entry;
 	This is always used for the first argument*/
 #define PHP_ZIP_STAT_PATH(za, path, path_len, flags, sb) \
 	if (path_len == 0) { \
-		zend_argument_value_error(1, "cannot be empty"); \
+		zend_argument_cannot_be_empty_error(1); \
 		RETURN_THROWS(); \
 	} \
 	if (zip_stat(za, path, flags, &sb) != 0) { \
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(zip_open)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1466,7 +1466,7 @@ PHP_METHOD(ZipArchive, open)
 	ze_obj = Z_ZIP_P(self);
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1753,7 +1753,7 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 	}
 
 	if (ZSTR_LEN(pattern) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 	if (options && zend_hash_num_elements(options) > 0 && (php_zip_parse_options(options, &opts) < 0)) {
@@ -1871,7 +1871,7 @@ PHP_METHOD(ZipArchive, addFile)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -1904,7 +1904,7 @@ PHP_METHOD(ZipArchive, replaceFile)
 	}
 
 	if (ZSTR_LEN(filename) == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2168,7 +2168,7 @@ PHP_METHOD(ZipArchive, setCommentName)
 	}
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2235,7 +2235,7 @@ PHP_METHOD(ZipArchive, setExternalAttributesName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2296,7 +2296,7 @@ PHP_METHOD(ZipArchive, getExternalAttributesName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2363,7 +2363,7 @@ PHP_METHOD(ZipArchive, setEncryptionName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2424,7 +2424,7 @@ PHP_METHOD(ZipArchive, getCommentName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2480,7 +2480,7 @@ PHP_METHOD(ZipArchive, setCompressionName)
 	ZIP_FROM_OBJECT(intern, this);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2540,7 +2540,7 @@ PHP_METHOD(ZipArchive, setMtimeName)
 	ZIP_FROM_OBJECT(intern, this);
 
 	if (name_len == 0) {
-		zend_argument_value_error(1, "cannot be empty");
+		zend_argument_cannot_be_empty_error(1);
 		RETURN_THROWS();
 	}
 
@@ -2654,7 +2654,7 @@ PHP_METHOD(ZipArchive, renameIndex)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (new_name_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 
@@ -2682,7 +2682,7 @@ PHP_METHOD(ZipArchive, renameName)
 	ZIP_FROM_OBJECT(intern, self);
 
 	if (new_name_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
+		zend_argument_cannot_be_empty_error(2);
 		RETURN_THROWS();
 	}
 

--- a/ext/zip/tests/oo_getcomment.phpt
+++ b/ext/zip/tests/oo_getcomment.phpt
@@ -30,4 +30,4 @@ $zip->close();
 Zip archive comment
 string(11) "foo comment"
 string(11) "foo comment"
-ZipArchive::getCommentName(): Argument #1 ($name) cannot be empty
+ZipArchive::getCommentName(): Argument #1 ($name) must not be empty

--- a/ext/zip/tests/oo_getexternalattributesname_error.phpt
+++ b/ext/zip/tests/oo_getexternalattributesname_error.phpt
@@ -20,4 +20,4 @@ try {
 }
 ?>
 --EXPECT--
-ZipArchive::getExternalAttributesName(): Argument #1 ($name) cannot be empty
+ZipArchive::getExternalAttributesName(): Argument #1 ($name) must not be empty

--- a/ext/zip/tests/oo_open.phpt
+++ b/ext/zip/tests/oo_open.phpt
@@ -42,5 +42,5 @@ if ($zip->status == ZIPARCHIVE::ER_OK) {
 --EXPECT--
 ER_OPEN: ok
 create: ok
-ZipArchive::open(): Argument #1 ($filename) cannot be empty
+ZipArchive::open(): Argument #1 ($filename) must not be empty
 OK

--- a/ext/zip/tests/zip_open_error.phpt
+++ b/ext/zip/tests/zip_open_error.phpt
@@ -21,7 +21,7 @@ echo is_resource($zip) ? "OK" : "Failure";
 --EXPECTF--
 Test case 1:
 Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
-zip_open(): Argument #1 ($filename) cannot be empty
+zip_open(): Argument #1 ($filename) must not be empty
 Test case 2:
 
 Deprecated: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2194,7 +2194,7 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 	}
 
 	if (!path || !*path) {
-		zend_value_error("Path cannot be empty");
+		zend_value_error("Path must not be empty");
 		return NULL;
 	}
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -1605,7 +1605,7 @@ zend.assertions = 1
 ; With mbstring support this will automatically be converted into the encoding
 ; given by corresponding encode setting. When empty mbstring.internal_encoding
 ; is used. For the decode settings you can distinguish between motorola and
-; intel byte order. A decode setting cannot be empty.
+; intel byte order. A decode setting must not be empty.
 ; https://php.net/exif.encode-unicode
 ;exif.encode_unicode = ISO-8859-15
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -1607,7 +1607,7 @@ zend.assertions = -1
 ; With mbstring support this will automatically be converted into the encoding
 ; given by corresponding encode setting. When empty mbstring.internal_encoding
 ; is used. For the decode settings you can distinguish between motorola and
-; intel byte order. A decode setting cannot be empty.
+; intel byte order. A decode setting must not be empty.
 ; https://php.net/exif.encode-unicode
 ;exif.encode_unicode = ISO-8859-15
 


### PR DESCRIPTION
Commits should be reviewed individually.

Some extensions were not using the standard wording, so changed it by using the new helper.
There are also some drive-by refactoring that I noticed while changing the code to use the helper.