### PR TITLE
Cater to raised requirement of fbclient 3.0+ for pdo_firebird

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -148,7 +148,8 @@ PHP 8.4 UPGRADE NOTES
 
 - PDO_FIREBIRD:
   . Since some Firebird C++ APIs are used now, this extension requires a C++
-    compiler to be built.
+    compiler to be built. This also implies that the extension has to be built
+    against fbclient 3.0 or higher.
   . getAttribute, ATTR_AUTOCOMMIT has been changed to get the value as a bool.
 
 - PDO_MYSQL:

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -28,13 +28,7 @@ if test "$PHP_PDO_FIREBIRD" != "no"; then
 
     PHP_CHECK_LIBRARY([fbclient], [isc_detach_database],
       [FIREBIRD_LIBNAME=fbclient],
-      [PHP_CHECK_LIBRARY([gds], [isc_detach_database],
-        [FIREBIRD_LIBNAME=gds],
-        [PHP_CHECK_LIBRARY([ib_util], [isc_detach_database],
-          [FIREBIRD_LIBNAME=ib_util],
-          [AC_MSG_FAILURE([libfbclient, libgds or libib_util not found.])],
-          [$FIREBIRD_LIBDIR_FLAG])],
-        [$FIREBIRD_LIBDIR_FLAG])],
+      [AC_MSG_FAILURE([libfbclient not found.])],
       [$FIREBIRD_LIBDIR_FLAG])
     PHP_ADD_LIBRARY_WITH_PATH([$FIREBIRD_LIBNAME],
       [$FIREBIRD_LIBDIR],

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -13,6 +13,8 @@ if test "$PHP_PDO_FIREBIRD" != "no"; then
     FB_LIBDIR=$($FB_CONFIG --libs)
     FB_VERSION=$($FB_CONFIG --version)
     AC_MSG_RESULT([version $FB_VERSION])
+    AS_VERSION_COMPARE([$FB_VERSION], [3.0],
+      [AC_MSG_ERROR([Firebird required version is at least 3.0])])
     PHP_EVAL_LIBLINE([$FB_LIBDIR], [PDO_FIREBIRD_SHARED_LIBADD])
     PHP_EVAL_INCLINE([$FB_CFLAGS])
   else

--- a/ext/pdo_firebird/config.m4
+++ b/ext/pdo_firebird/config.m4
@@ -28,11 +28,11 @@ if test "$PHP_PDO_FIREBIRD" != "no"; then
       FIREBIRD_LIBDIR_FLAG=-L$FIREBIRD_LIBDIR
     ])
 
-    PHP_CHECK_LIBRARY([fbclient], [isc_detach_database],
-      [FIREBIRD_LIBNAME=fbclient],
+    PHP_CHECK_LIBRARY([fbclient], [fb_get_master_interface],
+      [],
       [AC_MSG_FAILURE([libfbclient not found.])],
       [$FIREBIRD_LIBDIR_FLAG])
-    PHP_ADD_LIBRARY_WITH_PATH([$FIREBIRD_LIBNAME],
+    PHP_ADD_LIBRARY_WITH_PATH([fbclient],
       [$FIREBIRD_LIBDIR],
       [PDO_FIREBIRD_SHARED_LIBADD])
     PHP_ADD_INCLUDE([$FIREBIRD_INCDIR])

--- a/ext/pdo_firebird/config.w32
+++ b/ext/pdo_firebird/config.w32
@@ -4,11 +4,12 @@ ARG_WITH("pdo-firebird", "Firebird support for PDO", "no");
 
 if (PHP_PDO_FIREBIRD != "no") {
 
-	if ((CHECK_LIB("fbclient_ms.lib", "pdo_firebird", PHP_PHP_BUILD + "\\interbase\\lib_ms;" + PHP_PDO_FIREBIRD)
-			|| CHECK_LIB("gds32_ms.lib", "pdo_firebird", PHP_PHP_BUILD + "\\interbase\\lib_ms;" + PHP_PDO_FIREBIRD)
-		) && CHECK_HEADER_ADD_INCLUDE("ibase.h", "CFLAGS_PDO_FIREBIRD",
-				PHP_PHP_BUILD + "\\include\\interbase;" + PHP_PHP_BUILD + "\\interbase\\include;" + PHP_PDO_FIREBIRD)
-		) {
+	if (CHECK_LIB("fbclient_ms.lib", "pdo_firebird", PHP_PHP_BUILD + "\\interbase\\lib_ms;" + PHP_PDO_FIREBIRD)
+		&& CHECK_HEADER_ADD_INCLUDE("ibase.h", "CFLAGS_PDO_FIREBIRD",
+			PHP_PHP_BUILD + "\\include\\interbase;" + PHP_PHP_BUILD + "\\interbase\\include;" + PHP_PDO_FIREBIRD)
+		&& CHECK_HEADER_ADD_INCLUDE("firebird\\Interface.h", "CFLAGS_PDO_FIREBIRD",
+			PHP_PHP_BUILD + "\\include\\interbase;" + PHP_PHP_BUILD + "\\interbase\\include;" + PHP_PDO_FIREBIRD)
+	) {
 
 		EXTENSION("pdo_firebird", "pdo_firebird.c firebird_driver.c firebird_statement.c pdo_firebird_utils.cpp");
 		ADD_FLAG("CFLAGS_PDO_FIREBIRD", "/EHsc");


### PR DESCRIPTION
The recently [introduced support for proper formatting of the new timezone data types](https://github.com/php/php-src/pull/15230), which also required a C++ compiler to build pdo_firebird, also requires at least fbclient 3.0.

Given that [Firebird 2.5 has been discontinued on 24 Jun 2019](https://firebirdsql.org/en/discontinued-versions/), and even the now discontinued Debian 10 LTS shipped with fbclient 3 by default, and since classic CentOS has also been discontinued, there shouldn't be a problem to require fbclient 3.0 or higher.

It should be noted that Firebird 2.5 *servers* are still supported, though.

TODO:

- [x] Document fbclient 3.0+ version requirement
- [x] Check existence of Interface.h in config.w32
- [x] Check version in config.m4