### PR TITLE
opcache: Set up symbols when disassembly is enabled at runtime

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3728,4 +3728,10 @@ ZEND_EXT_API void zend_jit_restart(void)
 	}
 }
 
+ZEND_EXT_API void zend_jit_enable_disasm(void)
+{
+	if (ZCG(enabled) && JIT_G(enabled)) {
+		zend_jit_setup_disasm();
+	}
+}
 #endif /* HAVE_JIT */

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -164,6 +164,7 @@ ZEND_EXT_API void zend_jit_activate(void);
 ZEND_EXT_API void zend_jit_deactivate(void);
 ZEND_EXT_API void zend_jit_status(zval *ret);
 ZEND_EXT_API void zend_jit_restart(void);
+ZEND_EXT_API void zend_jit_enable_disasm(void);
 
 #define ZREG_LOAD           (1<<0)
 #define ZREG_STORE          (1<<1)

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -350,6 +350,8 @@ static void** zend_jit_stub_handlers = NULL;
 static void* zend_jit_stub_handlers[sizeof(zend_jit_stubs) / sizeof(zend_jit_stubs[0])];
 #endif
 
+static zend_atomic_bool zend_jit_disasm_setup_done = ZEND_ATOMIC_BOOL_INITIALIZER(false);
+
 #if defined(IR_TARGET_AARCH64)
 
 # ifdef __FreeBSD__
@@ -2901,6 +2903,10 @@ static void zend_jit_setup_stubs(void)
 static void zend_jit_setup_disasm(void)
 {
 #ifdef HAVE_CAPSTONE
+	bool done = zend_atomic_bool_exchange_ex(&zend_jit_disasm_setup_done, true);
+	if (done) {
+		return;
+	}
 	ir_disasm_init();
 
 	if (zend_vm_kind() == ZEND_VM_KIND_HYBRID) {
@@ -2958,7 +2964,9 @@ static void zend_jit_setup_disasm(void)
 		zend_vm_set_opcode_handler(&opline);
 		ir_disasm_add_symbol("ZEND_RETURN_SPEC_CV_LABEL", (uint64_t)(uintptr_t)opline.handler, sizeof(void*));
 
-		ir_disasm_add_symbol("ZEND_HYBRID_HALT_LABEL", (uint64_t)(uintptr_t)zend_jit_halt_op->handler, sizeof(void*));
+		if (zend_jit_halt_op) {
+			ir_disasm_add_symbol("ZEND_HYBRID_HALT_LABEL", (uint64_t)(uintptr_t)zend_jit_halt_op->handler, sizeof(void*));
+		}
 	}
 
 	REGISTER_DATA(zend_jit_profile_counter);
@@ -3379,9 +3387,7 @@ static void zend_jit_shutdown_ir(void)
 	}
 #endif
 #ifdef HAVE_CAPSTONE
-	if (JIT_G(debug) & (ZEND_JIT_DEBUG_ASM|ZEND_JIT_DEBUG_ASM_STUBS)) {
-		ir_disasm_free();
-	}
+	ir_disasm_free();
 #endif
 }
 

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -200,6 +200,11 @@ static ZEND_INI_MH(OnUpdateJitDebug)
 
 	if (zend_jit_debug_config(*p, val, stage) == SUCCESS) {
 		*p = val;
+
+		if (val & (ZEND_JIT_DEBUG_ASM|ZEND_JIT_DEBUG_ASM_STUBS)) {
+			zend_jit_enable_disasm();
+		}
+
 		return SUCCESS;
 	}
 	return FAILURE;


### PR DESCRIPTION
opcache.jit_debug can be modified at runtime, which is a handy way to dump specific functions. However, the initialisation of symbols was missed when disassembly was not enabled at startup. So, load symbols when ini_set() is called, if they weren't loaded already.

Also free the symbol table on shutdown even if disassembly is disabled on shutdown.

Calling zend_jit_setup_disasm() when zend_jit_setup() wasn't previously called caused dereference of the null pointer zend_jit_halt_op, so I guarded against that in two ways.