### PR TITLE
Use php_error_docref() instead of zend_error() in session.c

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -752,7 +752,7 @@ static PHP_INI_MH(OnUpdateSidLength) /* {{{ */
 	SESSION_CHECK_OUTPUT_STATE;
 	val = ZEND_STRTOL(ZSTR_VAL(new_value), &endptr, 10);
 	if (val != 32) {
-		zend_error(E_DEPRECATED, "session.sid_length INI setting is deprecated");
+		php_error_docref("session.configuration", E_DEPRECATED, "session.sid_length INI setting is deprecated");
 	}
 	if (endptr && (*endptr == '\0')
 		&& val >= 22 && val <= PS_MAX_SID_LENGTH) {
@@ -775,7 +775,7 @@ static PHP_INI_MH(OnUpdateSidBits) /* {{{ */
 	SESSION_CHECK_OUTPUT_STATE;
 	val = ZEND_STRTOL(ZSTR_VAL(new_value), &endptr, 10);
 	if (val != 4) {
-		zend_error(E_DEPRECATED, "session.sid_bits_per_character INI setting is deprecated");
+		php_error_docref("session.configuration", E_DEPRECATED, "session.sid_bits_per_character INI setting is deprecated");
 	}
 	if (endptr && (*endptr == '\0')
 		&& val >= 4 && val <=6) {
@@ -2113,7 +2113,7 @@ PHP_FUNCTION(session_set_save_handler)
 		RETURN_TRUE;
 	}
 
-	zend_error(E_DEPRECATED, "Calling session_set_save_handler() with more than 2 arguments is deprecated");
+	php_error_docref(NULL, E_DEPRECATED, "Calling session_set_save_handler() with more than 2 arguments is deprecated");
 	if (UNEXPECTED(EG(exception))) {
 		RETURN_THROWS();
 	}

--- a/ext/session/tests/bug68063.phpt
+++ b/ext/session/tests/bug68063.phpt
@@ -22,6 +22,6 @@ var_dump(session_start());
 var_dump(session_id());
 ?>
 --EXPECTF--
-Deprecated: session.sid_length INI setting is deprecated in Unknown on line 0
+Deprecated: PHP Startup: session.sid_length INI setting is deprecated in Unknown on line 0
 bool(true)
 string(40) "%s"

--- a/ext/session/tests/session_id_basic2.phpt
+++ b/ext/session/tests/session_id_basic2.phpt
@@ -29,11 +29,11 @@ echo "Done";
 --EXPECTF--
 *** Testing session_id() : basic functionality ***
 
-Deprecated: session.sid_bits_per_character INI setting is deprecated in %s on line %d
+Deprecated: ini_set(): session.sid_bits_per_character INI setting is deprecated in %s on line %d
 
-Deprecated: session.sid_length INI setting is deprecated in %s on line %d
+Deprecated: ini_set(): session.sid_length INI setting is deprecated in %s on line %d
 string(120) "%s"
 
-Deprecated: session.sid_length INI setting is deprecated in %s on line %d
+Deprecated: ini_set(): session.sid_length INI setting is deprecated in %s on line %d
 string(22) "%s"
 Done

--- a/ext/session/tests/user_session_module/bug31454.phpt
+++ b/ext/session/tests/user_session_module/bug31454.phpt
@@ -21,6 +21,6 @@ try {
 echo "Done\n";
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #1 ($open) must be a valid callback, first array member is not a valid class name or object
 Done

--- a/ext/session/tests/user_session_module/bug60634_error_3.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_3.phpt
@@ -42,7 +42,7 @@ session_start();
 
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 write: goodbye cruel world
 
 Fatal error: Uncaught Error: Call to undefined function undefined_function() in %s:%d

--- a/ext/session/tests/user_session_module/bug60634_error_4.phpt
+++ b/ext/session/tests/user_session_module/bug60634_error_4.phpt
@@ -37,7 +37,7 @@ session_start();
 
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 write: goodbye cruel world
 
 Fatal error: Uncaught Exception in %s

--- a/ext/session/tests/user_session_module/bug80889a.phpt
+++ b/ext/session/tests/user_session_module/bug80889a.phpt
@@ -31,7 +31,7 @@ $setHandler = ini_get('session.save_handler');
 var_dump($initHandler, $setHandler);
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Warning: session_set_save_handler(): Session save handler cannot be changed after headers have already been sent in %s on line %d
 string(8) "whatever"

--- a/ext/session/tests/user_session_module/gh7787.phpt
+++ b/ext/session/tests/user_session_module/gh7787.phpt
@@ -82,7 +82,7 @@ Warning: session_write_close(): Failed to write session data using user defined 
 
 Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: MySessionHandler::updateTimestamp) in %s on line %d
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: write) in %s on line %d
 

--- a/ext/session/tests/user_session_module/session_set_save_handler_basic.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_basic.phpt
@@ -75,7 +75,7 @@ bool(false)
 Warning: session_module_name(): Session handler module "foo" cannot be found in %s on line %d
 bool(false)
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(3) {
@@ -98,7 +98,7 @@ array(3) {
 }
 Starting session again..!
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(3) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_002.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_002.phpt
@@ -87,7 +87,7 @@ session_unset();
 --EXPECTF--
 *** Testing session_set_save_handler() : full handler implementation ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 string(%d) "%s"
 string(4) "user"
 array(1) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_closures.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_closures.phpt
@@ -62,7 +62,7 @@ bool(false)
 Warning: session_module_name(): Session handler module "foo" cannot be found in %s on line %d
 bool(false)
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(3) {
@@ -85,7 +85,7 @@ array(3) {
 }
 Starting session again..!
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(4) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_error3.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_error3.phpt
@@ -29,7 +29,7 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_set_save_handler() : error functionality ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Fatal error: Uncaught Exception: Do something bad..! in %s:%d
 Stack trace:

--- a/ext/session/tests/user_session_module/session_set_save_handler_error4.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_error4.phpt
@@ -55,24 +55,24 @@ ob_end_flush();
 --EXPECTF--
 *** Testing session_set_save_handler() : error functionality ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #2 ($close) must be a valid callback, function "echo" not found or invalid function name
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #3 ($read) must be a valid callback, function "echo" not found or invalid function name
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #4 ($write) must be a valid callback, function "echo" not found or invalid function name
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #5 ($destroy) must be a valid callback, function "echo" not found or invalid function name
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 session_set_save_handler(): Argument #6 ($gc) must be a valid callback, function "echo" not found or invalid function name
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
 bool(false)

--- a/ext/session/tests/user_session_module/session_set_save_handler_iface_001.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_iface_001.phpt
@@ -83,7 +83,7 @@ session_unset();
 --EXPECTF--
 *** Testing session_set_save_handler() function: interface ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 string(%d) "%s"
 string(4) "user"
 array(1) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_iface_002.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_iface_002.phpt
@@ -81,7 +81,7 @@ session_start();
 --EXPECTF--
 *** Testing session_set_save_handler() function: interface wrong ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 bool(true)
 session_set_save_handler(): Argument #1 ($open) must be of type SessionHandlerInterface, MySession2 given
 good handler writing

--- a/ext/session/tests/user_session_module/session_set_save_handler_multiple.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_multiple.phpt
@@ -73,7 +73,7 @@ session_write_close();
 ob_end_flush();
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open
 Create SID OLD
 Read
@@ -81,7 +81,7 @@ Write
 Close
 New handlers:
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open
 Validate ID
 Read

--- a/ext/session/tests/user_session_module/session_set_save_handler_sid_001.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_sid_001.phpt
@@ -73,7 +73,7 @@ var_dump($_SESSION);
 --EXPECTF--
 *** Testing session_set_save_handler() function: create_sid ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 string(32) "session_set_save_handler_sid_001"
 string(4) "user"
 array(1) {

--- a/ext/session/tests/user_session_module/session_set_save_handler_type_error.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_type_error.phpt
@@ -43,19 +43,19 @@ ob_end_flush();
 
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Session callback must have a return value of type bool, array returned
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Deprecated: session_start(): Session callback must have a return value of type bool, int returned in %s on line %d
 
 Warning: session_start(): Failed to read session data: user (%s) in %s on line %d
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Session callback must have a return value of type bool, array returned
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Deprecated: session_start(): Session callback must have a return value of type bool, int returned in %s on line %d
 

--- a/ext/session/tests/user_session_module/session_set_save_handler_type_error2.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_type_error2.phpt
@@ -28,8 +28,8 @@ ob_end_flush();
 
 ?>
 --EXPECTF--
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Session callback must have a return value of type bool, null returned
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Session callback must have a return value of type bool, int returned

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation2.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation2.phpt
@@ -28,7 +28,7 @@ rmdir($path);
 *** Testing session_set_save_handler() : variation ***
 bool(true)
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active in %s on line %d
 bool(false)

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation3.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation3.phpt
@@ -31,7 +31,7 @@ int(2)
 
 Warning: session_save_path(): Session save path cannot be changed when a session is active in %s on line %d
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 
 Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active in %s on line %d
 bool(false)

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation4.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation4.phpt
@@ -51,7 +51,7 @@ rmdir($path);
 --EXPECTF--
 *** Testing session_set_save_handler() : variation ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 GC [0]
@@ -68,7 +68,7 @@ Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;]
 Close [%s,PHPSESSID]
 bool(true)
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 GC [0]

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation5.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation5.phpt
@@ -59,7 +59,7 @@ rmdir($path);
 string(0) ""
 *** Without lazy_write ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 bool(true)
 Open [%s,PHPSESSID]
 CreateID [PHPT-%d]
@@ -75,7 +75,7 @@ string(%d) "PHPT-%d"
 *** With lazy_write ***
 string(%d) "PHPT-%d"
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 bool(true)
 Open [%s,PHPSESSID]
 ValidateID [%s,PHPT-%d]

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation6.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation6.phpt
@@ -63,7 +63,7 @@ rmdir($path);
 --EXPECTF--
 *** Testing session_set_save_handler() : test write short circuit ***
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 CreateID [PHPT-%s]
 Read [%s,%s]
@@ -87,7 +87,7 @@ array(3) {
 }
 Starting session again..!
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(3) {
@@ -102,7 +102,7 @@ Write [%s,%s,Blah|s:12:"Hello World!";Foo|b:0;Guff|i:1234567890;Bar|s:3:"Foo";]
 Close [%s,PHPSESSID]
 Starting session again..!
 
-Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: session_set_save_handler(): Calling session_set_save_handler() with more than 2 arguments is deprecated in %s on line %d
 Open [%s,PHPSESSID]
 Read [%s,%s]
 array(4) {


### PR DESCRIPTION
Using `php_error_docref()` is preferable since it outputs additional details (which function has been called and whether it is a startup or shutdown error), uses HTML markup, and also provides a link to the documentation, if configured.

Since these deprecation warnings have been introduced recently[1][2], i.e. for PHP 8.4, there are no BC concerns.

[1] <https://github.com/php/php-src/commit/e8ff7c70f9669f1a54c47c018ccc0f80bc0c929b>
[2] <https://github.com/php/php-src/commit/b36eac94d26bdced150d9d2178f6209893d9961f>

---

See also https://github.com/php/php-src/commit/e8ff7c70f9669f1a54c47c018ccc0f80bc0c929b#r145516647.

/cc @kocsismate and @TimWolla.