### PR TITLE
Fix bug71162.phpt xfail message

### DIFF
--- a/ext/session/tests/user_session_module/bug71162.phpt
+++ b/ext/session/tests/user_session_module/bug71162.phpt
@@ -5,7 +5,7 @@ session
 --INI--
 session.use_strict_mode=0
 --XFAIL--
-Current session module is designed to write empty session always. In addition, current session module only supports SessionHandlerInterface only from PHP 7.0.
+Current session module is designed to write empty session always.
 --FILE--
 <?php
 class MySessionHandler extends SessionHandler implements SessionUpdateTimestampHandlerInterface


### PR DESCRIPTION
The test failure is unlikely to be caused by `SessionHandlerInterface` not being available.

---

Since this test is about a rather [old bug report](https://bugs.php.net/bug.php?id=71162), maybe it makes sense to have a closer look at it. Might be a WONTFIX, or documentation issue.