### PR TITLE
Fix GH-15501: Windows HAVE_<header>_H macros defined to 1 or undefined

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-15187 (Various hooked object iterator issues). (ilutov)
   . Fixed bug GH-15456 (Crash in get_class_vars() on virtual properties).
     (ilutov)
+  . Fixed bug GH-15501 (Windows HAVE_<header>_H macros defined to 1 or
+    undefined). (Peter Kokot)
 
 15 Aug 2024, PHP 8.4.0beta3
 

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -230,6 +230,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Added configure option --enable-phpdbg-debug to build phpdbg in debug mode.
    - The win32/build/libs_version.txt file has been removed.
    - MSVC builds now use the new preprocessor (/Zc:preprocessor).
+   - The CHECK_HEADER_ADD_INCLUDE function now consistently defines preprocessor
+     macros HAVE_<header>_H either to value 1 or leaves them undefined to match
+     the Autotools headers checks.
 
 ========================
 3. Module changes

--- a/ext/com_dotnet/com_dotnet.c
+++ b/ext/com_dotnet/com_dotnet.c
@@ -20,7 +20,7 @@
 
 #include "php.h"
 
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 # include "php_ini.h"
 # include "ext/standard/info.h"
 # include "php_com_dotnet.h"

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -195,7 +195,7 @@ PHP_MINIT_FUNCTION(com_dotnet)
 	tmp->create_object = php_com_object_new;
 	tmp->get_iterator = php_com_iter_get;
 
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 	tmp = register_class_dotnet(php_com_variant_class_entry);
 	tmp->default_object_handlers = &php_com_object_handlers;
 	tmp->create_object = php_com_object_new;
@@ -216,7 +216,7 @@ PHP_MINIT_FUNCTION(com_dotnet)
 PHP_MSHUTDOWN_FUNCTION(com_dotnet)
 {
 	UNREGISTER_INI_ENTRIES();
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 	if (COMG(dotnet_runtime_stuff)) {
 		php_com_dotnet_mshutdown();
 	}
@@ -239,7 +239,7 @@ PHP_RINIT_FUNCTION(com_dotnet)
 /* {{{ PHP_RSHUTDOWN_FUNCTION */
 PHP_RSHUTDOWN_FUNCTION(com_dotnet)
 {
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 	if (COMG(dotnet_runtime_stuff)) {
 		php_com_dotnet_rshutdown();
 	}
@@ -257,7 +257,7 @@ PHP_MINFO_FUNCTION(com_dotnet)
 	php_info_print_table_row(2, "COM support", "enabled");
 	php_info_print_table_row(2, "DCOM support", COMG(allow_dcom) ? "enabled" : "disabled");
 
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 	php_info_print_table_row(2, ".Net support", "enabled");
 #else
 	php_info_print_table_row(2, ".Net support", "not present in this build");

--- a/ext/com_dotnet/com_extension.stub.php
+++ b/ext/com_dotnet/com_extension.stub.php
@@ -363,7 +363,7 @@ class com extends variant
     public function __construct(string $module_name, array|string|null $server_name = null, int $codepage = CP_ACP, string $typelib = "") {}
 }
 
-#if HAVE_MSCOREE_H
+#ifdef HAVE_MSCOREE_H
 class dotnet extends variant
 {
     public function __construct(string $assembly_name, string $datatype_name, int $codepage = CP_ACP) {}

--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b91206482b5119ce6d7c899e9599acfa2e06ec2a */
+ * Stub hash: 9b2eea541946c291eb002ee98997f3dcad8bdfce */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_variant_set, 0, 2, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, variant, variant, 0)
@@ -123,7 +123,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_com___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, typelib, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-#if HAVE_MSCOREE_H
+#if defined(HAVE_MSCOREE_H)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_dotnet___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, assembly_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, datatype_name, IS_STRING, 0)
@@ -165,7 +165,7 @@ ZEND_FUNCTION(com_message_pump);
 ZEND_FUNCTION(com_load_typelib);
 ZEND_METHOD(variant, __construct);
 ZEND_METHOD(com, __construct);
-#if HAVE_MSCOREE_H
+#if defined(HAVE_MSCOREE_H)
 ZEND_METHOD(dotnet, __construct);
 #endif
 
@@ -215,7 +215,7 @@ static const zend_function_entry class_com_methods[] = {
 	ZEND_FE_END
 };
 
-#if HAVE_MSCOREE_H
+#if defined(HAVE_MSCOREE_H)
 static const zend_function_entry class_dotnet_methods[] = {
 	ZEND_ME(dotnet, __construct, arginfo_class_dotnet___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
@@ -316,7 +316,7 @@ static zend_class_entry *register_class_com(zend_class_entry *class_entry_varian
 	return class_entry;
 }
 
-#if HAVE_MSCOREE_H
+#if defined(HAVE_MSCOREE_H)
 static zend_class_entry *register_class_dotnet(zend_class_entry *class_entry_variant)
 {
 	zend_class_entry ce, *class_entry;

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1040,10 +1040,10 @@ function CHECK_HEADER_ADD_INCLUDE(header_name, flag_name, path_to_check, use_env
 		add_to_flag_only = true;
 	}
 
-	if (typeof(add_to_flag_only) != "undefined") {
+	if (typeof(add_to_flag_only) != "undefined" && have) {
 		ADD_FLAG(flag_name, "/DHAVE_" + sym + "=" + have);
-	} else if (!configure_hdr.Exists('HAVE_' + sym)) {
-		AC_DEFINE("HAVE_" + sym, have, "have the " + header_name + " header file");
+	} else if (!configure_hdr.Exists('HAVE_' + sym) && have) {
+		AC_DEFINE("HAVE_" + sym, have, "Define to 1 if you have the <" + header_name + "> header file.");
 	}
 
 	return p;


### PR DESCRIPTION
I should probably fine tune this explanation to make it easier to understand but anyway...

Previously the CHECK_HEADER_ADD_INCLUDE function defined the `HAVE_<header>_H` preprocessor macros to value 0 or 1 whether the `<header.h>` file was found. This syncs it with Autotools build system where most of these macros are either undefined or defined to 1.

In possible edge cases where such macros might be intentionally used like this without being aware that HAVE_HEADER_H can be 0 or 1 on Windows:

| #ifdef HAVE_HEADER_H
| ...
| #endif

there is backwards incompatibility for PECL extensions in case the header wouldn't exist on Windows such code wouldn't execute. However, this is considered a bug if such case is present. From the Autotools point of view, the check is correct though and should be used with ifdef/defined() checks.

Help text is also synced to Autotools style:
`Define to 1 if you have the <header.h> header file.`