### PR TITLE
pdo_firebird: Cleanup code.

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -989,12 +989,6 @@ static int php_firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const zend_string *sq
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
 	char *new_sql;
 
-	/* Firebird allows SQL statements up to 64k, so bail if it doesn't fit */
-	if (ZSTR_LEN(sql) > 65536) {
-		php_firebird_error_with_info(dbh, "01004", strlen("01004"), NULL, 0);
-		return 0;
-	}
-
 	/* allocate the statement */
 	if (isc_dsql_allocate_statement(H->isc_status, &H->db, s)) {
 		php_firebird_error(dbh);

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -463,53 +463,6 @@ static int php_firebird_preprocess(const zend_string* sql, char* sql_out, HashTa
 
 #if FB_API_VER >= 40
 /* set coercing a data type */
-static void set_coercing_input_data_types(XSQLDA* sqlda)
-{
-	/* Data types introduced in Firebird 4.0 are difficult to process using the Firebird Legacy API. */ 
-	/* These data types include DECFLOAT(16), DECFLOAT(34), INT128 (NUMERIC/DECIMAL(38, x)), */
-	/* TIMESTAMP WITH TIME ZONE, and TIME WITH TIME ZONE. */
-	/* This function allows you to ensure minimal performance */ 
-	/* of queries if they contain parameters of the above types. */
-	unsigned int i;
-	short dtype;
-	short nullable;
-	XSQLVAR* var;
-	for (i=0, var = sqlda->sqlvar; i < sqlda->sqld; i++, var++) {
-		dtype = (var->sqltype & ~1); /* drop flag bit  */
-		nullable = (var->sqltype & 1); 
-		switch(dtype) {
-			case SQL_INT128:
-				var->sqltype = SQL_VARYING + nullable;
-				var->sqllen = 46;
-				var->sqlscale = 0;
-				break;
-
-			case SQL_DEC16:
-				var->sqltype = SQL_VARYING + nullable;
-				var->sqllen = 24;
-				break;
-
-			case SQL_DEC34:
-			    var->sqltype = SQL_VARYING + nullable;
-				var->sqllen = 43;
-				break;
-
-			case SQL_TIMESTAMP_TZ:
-				var->sqltype = SQL_VARYING + nullable;
-				var->sqllen = 58;
-				break;
-
-			case SQL_TIME_TZ:
-				var->sqltype = SQL_VARYING + nullable;
-				var->sqllen = 46;
-				break;
-
-			default:
-				break;
-		}
-	}	
-}
-
 static void set_coercing_output_data_types(XSQLDA* sqlda)
 {
 	/* Data types introduced in Firebird 4.0 are difficult to process using the Firebird Legacy API. */ 
@@ -728,11 +681,6 @@ static bool firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
 			if (isc_dsql_describe_bind(H->isc_status, &s, PDO_FB_SQLDA_VERSION, S->in_sqlda)) {
 				break;
 			}
-
-#if FB_API_VER >= 40
-			/* set coercing a data type */
-			set_coercing_input_data_types(S->in_sqlda);
-#endif
 		}
 
 		stmt->driver_data = S;

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -602,14 +602,12 @@ void php_firebird_set_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *state,
 		einfo->errmsg_length = read_len;
 		einfo->errmsg = pestrndup(buf, read_len, dbh->is_persistent);
 
-#if FB_API_VER >= 25
 		char sqlstate[sizeof(pdo_error_type)];
 		fb_sqlstate(sqlstate, H->isc_status);
 		if (sqlstate != NULL && strlen(sqlstate) < sizeof(pdo_error_type)) {
 			strcpy(*error_code, sqlstate);
 			goto end;
 		}
-#endif
 	} else if (msg && msg_len) {
 		einfo->errmsg_length = msg_len;
 		einfo->errmsg = pestrndup(msg, einfo->errmsg_length, dbh->is_persistent);
@@ -1333,7 +1331,6 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 }
 /* }}} */
 
-#if FB_API_VER >= 30
 /* called by PDO to check liveness */
 static zend_result pdo_firebird_check_liveness(pdo_dbh_t *dbh) /* {{{ */
 {
@@ -1343,7 +1340,6 @@ static zend_result pdo_firebird_check_liveness(pdo_dbh_t *dbh) /* {{{ */
 	return fb_ping(H->isc_status, &H->db) ? FAILURE : SUCCESS;
 }
 /* }}} */
-#endif
 
 /* called by PDO to retrieve driver-specific information about an error that has occurred */
 static void pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
@@ -1383,11 +1379,7 @@ static const struct pdo_dbh_methods firebird_methods = { /* {{{ */
 	NULL, /* last_id not supported */
 	pdo_firebird_fetch_error_func,
 	pdo_firebird_get_attribute,
-#if FB_API_VER >= 30
 	pdo_firebird_check_liveness,
-#else
-	NULL,
-#endif
 	NULL, /* get driver methods */
 	NULL, /* request shutdown */
 	pdo_firebird_in_manually_transaction,

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -822,6 +822,13 @@ static int pdo_firebird_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param
 						case SQL_TIMESTAMP:
 						case SQL_TYPE_DATE:
 						case SQL_TYPE_TIME:
+#if FB_API_VER >= 40
+						case SQL_INT128:
+						case SQL_DEC16:
+						case SQL_DEC34:
+						case SQL_TIMESTAMP_TZ:
+						case SQL_TIME_TZ:
+#endif
 							force_null = (Z_STRLEN_P(parameter) == 0);
 					}
 					if (!force_null) {

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -349,11 +349,9 @@ static int pdo_firebird_stmt_get_column_meta(pdo_stmt_t *stmt, zend_long colno, 
 #endif
 				param_type = PDO_PARAM_INT;
 				break;
-#ifdef SQL_BOOLEAN
 			case SQL_BOOLEAN:
 				param_type = PDO_PARAM_BOOL;
 				break;
-#endif
 			default:
 				param_type = PDO_PARAM_STR;
 				break;
@@ -542,11 +540,9 @@ static int pdo_firebird_stmt_get_col(
 					/* TODO: Why is this not returned as the native type? */
 					ZVAL_STR(result, zend_strpprintf_unchecked(0, "%.16H", php_get_double_from_sqldata(var->sqldata)));
 					break;
-#ifdef SQL_BOOLEAN
 				case SQL_BOOLEAN:
 					ZVAL_BOOL(result, *(FB_BOOLEAN*)var->sqldata);
 					break;
-#endif
 				case SQL_TYPE_DATE:
 					isc_decode_sql_date((ISC_DATE*)var->sqldata, &t);
 					fmt = S->H->date_format ? S->H->date_format : PDO_FB_DEF_DATE_FMT;
@@ -744,7 +740,6 @@ static int pdo_firebird_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param
 				}
 			}
 
-#ifdef SQL_BOOLEAN
 			/* keep native BOOLEAN type */
 			if ((var->sqltype & ~1) == SQL_BOOLEAN) {
 				switch (Z_TYPE_P(parameter)) {
@@ -797,8 +792,6 @@ static int pdo_firebird_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param
 				}
 				break;
 			}
-#endif
-
 
 			/* check if a NULL should be inserted */
 			switch (Z_TYPE_P(parameter)) {


### PR DESCRIPTION
Since Firebird PDO now requires fbclient 3.0+ to compile, some conditional compilation directives are no longer needed in the code.