### PR TITLE
main/network: Use more appropriate types

### DIFF
--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -37,7 +37,6 @@ PHPAPI PHP_FUNCTION(fpassthru);
 PHP_MINIT_FUNCTION(user_streams);
 
 PHPAPI int php_le_stream_context(void);
-PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
 PHPAPI zend_result php_copy_file(const char *src, const char *dest);
 PHPAPI zend_result php_copy_file_ex(const char *src, const char *dest, int src_flags);
 PHPAPI zend_result php_copy_file_ctx(const char *src, const char *dest, int src_flags, php_stream_context *ctx);

--- a/main/network.c
+++ b/main/network.c
@@ -499,11 +499,11 @@ bound:
 }
 /* }}} */
 
-PHPAPI int php_network_parse_network_address_with_port(const char *addr, zend_long addrlen, struct sockaddr *sa, socklen_t *sl)
+PHPAPI zend_result php_network_parse_network_address_with_port(const char *addr, size_t addrlen, struct sockaddr *sa, socklen_t *sl)
 {
 	char *colon;
 	char *tmp;
-	int ret = FAILURE;
+	zend_result ret = FAILURE;
 	short port;
 	struct sockaddr_in *in4 = (struct sockaddr_in*)sa;
 	struct sockaddr **psal;
@@ -843,7 +843,7 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 				struct sockaddr_in6 in6;
 #endif
 			} local_address = {0};
-			int local_address_len = 0;
+			size_t local_address_len = 0;
 
 			if (sa->sa_family == AF_INET) {
 				if (inet_pton(AF_INET, bindto, &local_address.in4.sin_addr) == 1) {
@@ -974,7 +974,7 @@ PHPAPI void php_any_addr(int family, php_sockaddr_storage *addr, unsigned short 
 /* {{{ php_sockaddr_size
  * Returns the size of struct sockaddr_xx for the family
  */
-PHPAPI int php_sockaddr_size(php_sockaddr_storage *addr)
+PHPAPI socklen_t php_sockaddr_size(php_sockaddr_storage *addr)
 {
 	switch (((struct sockaddr *)addr)->sa_family) {
 	case AF_INET:
@@ -1099,9 +1099,9 @@ PHPAPI php_stream *_php_stream_sock_open_host(const char *host, unsigned short p
 	return stream;
 }
 
-PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block)
+PHPAPI zend_result php_set_sock_blocking(php_socket_t socketd, bool block)
 {
-	int ret = SUCCESS;
+	zend_result ret = SUCCESS;
 
 #ifdef PHP_WIN32
 	u_long flags;
@@ -1253,7 +1253,7 @@ static struct hostent * gethostname_re (const char *host,struct hostent *hostbuf
 		*tmphstbuf = (char *)realloc (*tmphstbuf,*hstbuflen);
 	}
 
-	if (res != SUCCESS) {
+	if (res != 0) {
 		return NULL;
 	}
 
@@ -1295,7 +1295,7 @@ static struct hostent * gethostname_re (const char *host,struct hostent *hostbuf
 	}
 	memset((void *)(*tmphstbuf),0,*hstbuflen);
 
-	if (SUCCESS != gethostbyname_r(host,hostbuf,(struct hostent_data *)*tmphstbuf)) {
+	if (0 != gethostbyname_r(host,hostbuf,(struct hostent_data *)*tmphstbuf)) {
 		return NULL;
 	}
 

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -306,7 +306,7 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
 		);
 
 PHPAPI void php_any_addr(int family, php_sockaddr_storage *addr, unsigned short port);
-PHPAPI int php_sockaddr_size(php_sockaddr_storage *addr);
+PHPAPI socklen_t php_sockaddr_size(php_sockaddr_storage *addr);
 END_EXTERN_C()
 
 struct _php_netstream_data_t	{
@@ -336,12 +336,12 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 		socklen_t *addrlen
 		);
 
-PHPAPI int php_network_parse_network_address_with_port(const char *addr,
-		zend_long addrlen, struct sockaddr *sa, socklen_t *sl);
+PHPAPI zend_result php_network_parse_network_address_with_port(const char *addr,
+		size_t addrlen, struct sockaddr *sa, socklen_t *sl);
 
 PHPAPI struct hostent*	php_network_gethostbyname(const char *name);
 
-PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
+PHPAPI zend_result php_set_sock_blocking(php_socket_t socketd, bool block);
 END_EXTERN_C()
 
 #define php_stream_sock_open_from_socket(socket, persistent)	_php_stream_sock_open_from_socket((socket), (persistent) STREAMS_CC)


### PR DESCRIPTION
And check directly against 0 for success for functions not returning a `zend_result`.

While going through the file, I noticed a few things:

## Signed `socklen_t` on Windows

I don't really understand why `socklen_t` is a signed integer on Windows rather than unsigned.
https://github.com/php/php-src/blob/69d9c12df64e829befd843175bfc9617aabb7450/main/php.h#L192-L198

## `poll(2)` emulation

We define our own `poll` function when `PHP_USE_POLL_2_EMULATION` is set, but I can't seem to find when it is set, is this related to Windows @cmb69 ?

## Usage of `gethostbyname_r()`

It seems like this function is obsolete and
> Applications should use [getaddrinfo(3)](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html), [getnameinfo(3)](https://man7.org/linux/man-pages/man3/getnameinfo.3.html), and [gai_strerror(3)](https://man7.org/linux/man-pages/man3/gai_strerror.3.html) instead. 

according to https://man7.org/linux/man-pages/man3/gethostbyname.3.html

So maybe we should review this code to use more modern functions?

It seems getting rid of them would also allow us to get rid of:
https://github.com/php/php-src/blob/69d9c12df64e829befd843175bfc9617aabb7450/ext/standard/file.h#L106-L110
