### PR TITLE
Fix GH-15381: Autotools: Refactor main/internal_functions commands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1796,6 +1796,18 @@ AC_CONFIG_FILES([
 
 AC_CONFIG_COMMANDS_PRE([PHP_PATCH_CONFIG_HEADERS([main/php_config.h.in])])
 
+AC_CONFIG_COMMANDS([main/internal_functions.c], [], [
+  AWK="$AWK" $SHELL $srcdir/build/genif.sh \
+    $srcdir/main/internal_functions.c.in \
+    "$EXT_STATIC" > main/internal_functions.c
+])
+
+AC_CONFIG_COMMANDS([main/internal_functions_cli.c], [], [
+  AWK="$AWK" $SHELL $srcdir/build/genif.sh \
+    $srcdir/main/internal_functions.c.in \
+    "$EXT_CLI_STATIC" > main/internal_functions_cli.c
+])
+
 AC_CONFIG_COMMANDS([default],[
 cat <<X
 
@@ -1817,11 +1829,5 @@ dnl ----------------------------------------------------------------------------
 cat >Zend/zend_config.h <<FEO
 #include <../main/php_config.h>
 FEO
-
-echo "creating main/internal_functions.c"
-AWK="$AWK" sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in "$EXT_STATIC" > main/internal_functions.c
-
-echo "creating main/internal_functions_cli.c"
-AWK="$AWK" sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in "$EXT_CLI_STATIC" > main/internal_functions_cli.c
 ])
 AC_OUTPUT


### PR DESCRIPTION
This wraps generation of main/internal_functions* files into a separate AC_CONFIG_COMMANDS and uses a SHELL variable instead of sh command. Autoconf sets the SHELL variable to a suitable current shell the configure is running in.

Instead of putting the commands into the 2nd argument the 3rd initialization argument is used like before because it is easier to read and work with variables (AWK, EXT_STATIC and EXT_CLI_STATIC), which would need to be assigned again for the 2nd argument.

This simplifies the configure usage on Solaris 10 C shell and KornShell without issuing errors when executing genif.sh script.