### PR TITLE
Fix GH-15515: Configure error grep illegal option q

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-15408 (MSan false-positve on zend_max_execution_timer).
     (zeriyoshi)
+  . Fixed bug GH-15515 (Configure error grep illegal option q). (Peter Kokot)
 
 - MySQLnd:
   . Fixed bug GH-15432 (Heap corruption when querying a vector). (cmb,

--- a/configure.ac
+++ b/configure.ac
@@ -262,7 +262,7 @@ esac
 
 dnl Detect musl libc
 AC_MSG_CHECKING([whether we are using musl libc])
-if command -v ldd >/dev/null && ldd --version 2>&1 | grep -q ^musl
+if command -v ldd >/dev/null && ldd --version 2>&1 | grep ^musl >/dev/null 2>&1
 then
   AC_MSG_RESULT(yes)
   AC_DEFINE([__MUSL__], [1], [Define when using musl libc])


### PR DESCRIPTION
On Solaris default grep doesn't support the -q option. In such cases the grep output can be redirected to /dev/null and the exit status is checked.