### PR TITLE
Fix rename_variation12*.phpt parallel test conflicts

### DIFF
--- a/ext/standard/tests/file/rename_variation12-win32.phpt
+++ b/ext/standard/tests/file/rename_variation12-win32.phpt
@@ -11,8 +11,8 @@ if (substr(PHP_OS, 0, 3) != 'WIN') die('skip..  for Windows');
 /* Creating unique files in various dirs by passing relative paths to $dir arg */
 
 echo "*** Testing rename() with absolute and relative paths ***\n";
-$mainDir = "renameVar11";
-$subDir = "renameVar11Sub";
+$mainDir = "renameVar12";
+$subDir = "renameVar12Sub";
 $absMainDir = __DIR__."/".$mainDir;
 mkdir($absMainDir);
 $absSubDir = $absMainDir."/".$subDir;
@@ -83,12 +83,12 @@ bool(true)
 
 -- Iteration 5 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/renameMe.tmp,%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
+Warning: rename(%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/renameMe.tmp,%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 6 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/BADDIR/renameMe.tmp,%s/renameVar11/renameVar11Sub/BADDIR/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
+Warning: rename(%s/renameVar12/renameVar12Sub/BADDIR/renameMe.tmp,%s/renameVar12/renameVar12Sub/BADDIR/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 7 --

--- a/ext/standard/tests/file/rename_variation12.phpt
+++ b/ext/standard/tests/file/rename_variation12.phpt
@@ -11,8 +11,8 @@ if (substr(PHP_OS, 0, 3) == 'WIN') die('skip..  not for Windows');
 /* Creating unique files in various dirs by passing relative paths to $dir arg */
 
 echo "*** Testing rename() with absolute and relative paths ***\n";
-$mainDir = "renameVar11";
-$subDir = "renameVar11Sub";
+$mainDir = "renameVar12";
+$subDir = "renameVar12Sub";
 $absMainDir = __DIR__."/".$mainDir;
 mkdir($absMainDir);
 $absSubDir = $absMainDir."/".$subDir;
@@ -83,12 +83,12 @@ bool(true)
 
 -- Iteration 5 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/renameMe.tmp,%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/IwasRenamed.tmp): %s in %s on line %d
+Warning: rename(%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/renameMe.tmp,%s/renameVar12/renameVar12Sub/..///renameVar12Sub//..//../renameVar12Sub/IwasRenamed.tmp): %s in %s on line %d
 bool(false)
 
 -- Iteration 6 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/BADDIR/renameMe.tmp,%s/renameVar11/renameVar11Sub/BADDIR/IwasRenamed.tmp): %s in %s on line %d
+Warning: rename(%s/renameVar12/renameVar12Sub/BADDIR/renameMe.tmp,%s/renameVar12/renameVar12Sub/BADDIR/IwasRenamed.tmp): %s in %s on line %d
 bool(false)
 
 -- Iteration 7 --


### PR DESCRIPTION
For rename_variation12.phpt this is actually not necessary, since there is no rename_variation11.phpt, but we still fix it to be in sync with rename_variation12-win32.phpt which actually is prone to parallel conflicts.

---

Noticed due to https://github.com/php/php-src/actions/runs/10476631022/job/29015969409?pr=15510.