### PR TITLE
Add TSRM free thread handlers

### DIFF
--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -115,8 +115,9 @@ TSRM_API void ts_apply_for_id(ts_rsrc_id id, void (*cb)(void *));
 
 typedef void (*tsrm_thread_begin_func_t)(THREAD_T thread_id);
 typedef void (*tsrm_thread_end_func_t)(THREAD_T thread_id);
+typedef void (*tsrm_thread_free_begin_func_t)(THREAD_T thread_id);
+typedef void (*tsrm_thread_free_end_func_t)(THREAD_T thread_id);
 typedef void (*tsrm_shutdown_func_t)(void);
-
 
 TSRM_API int tsrm_error(int level, const char *format, ...);
 TSRM_API void tsrm_error_set(int level, const char *debug_filename);
@@ -133,6 +134,8 @@ TSRM_API int tsrm_sigmask(int how, const sigset_t *set, sigset_t *oldset);
 
 TSRM_API void *tsrm_set_new_thread_begin_handler(tsrm_thread_begin_func_t new_thread_begin_handler);
 TSRM_API void *tsrm_set_new_thread_end_handler(tsrm_thread_end_func_t new_thread_end_handler);
+TSRM_API void *tsrm_set_free_thread_begin_handler(tsrm_thread_free_begin_func_t free_thread_begin_handler);
+TSRM_API void *tsrm_set_free_thread_end_handler(tsrm_thread_free_end_func_t free_thread_end_handler);
 TSRM_API void *tsrm_set_shutdown_handler(tsrm_shutdown_func_t shutdown_handler);
 
 TSRM_API void *tsrm_get_ls_cache(void);


### PR DESCRIPTION
Hey folks,

I needed to observe new thread initialisation and found (thanks to the help of @bwoebi) that there are `tsrm_set_new_thread_begin_handler` and `tsrm_set_new_thread_end_handler` functions that I could use. Now I see that there is no handler for when the thread gets freed (and joined), just a `tsrm_set_shutdown_handler` for when the TSRM shuts down.

This PR aim is to add the missing free thread handlers.

Alternative considered: I am working on an extension that does not have globals, so `globals_ctor` and `globals_dtor` won't be called, I could fake create globals that I do not use in order to get `GINIT`/`GSHUTDOWN` working, but that seems just wrong, although technically working 😉