### PR TITLE
Fix Solaris 10 build: missing libproc.h

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -133,7 +133,10 @@ dnl
 AC_DEFUN([ZEND_INIT], [dnl
 AC_REQUIRE([AC_PROG_CC])
 
-AC_CHECK_HEADERS([cpuid.h])
+AC_CHECK_HEADERS(m4_normalize([
+  cpuid.h
+  libproc.h
+]))
 
 dnl Check for library functions.
 AC_CHECK_FUNCS(m4_normalize([

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -64,9 +64,9 @@ typedef int boolean_t;
 #include <sys/syscall.h>
 #endif
 #ifdef __sun
+# include <sys/lwp.h>
 # ifdef HAVE_LIBPROC_H
 #  define _STRUCTURED_PROC 1
-#  include <sys/lwp.h>
 #  include <sys/procfs.h>
 #  include <libproc.h>
 # endif

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -64,10 +64,10 @@ typedef int boolean_t;
 #include <sys/syscall.h>
 #endif
 #ifdef __sun
-#define _STRUCTURED_PROC 1
-#include <sys/lwp.h>
-#include <sys/procfs.h>
 # ifdef HAVE_LIBPROC_H
+#  define _STRUCTURED_PROC 1
+#  include <sys/lwp.h>
+#  include <sys/procfs.h>
 #  include <libproc.h>
 # endif
 #include <thread.h>

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -701,9 +701,9 @@ static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
 	return true;
 }
 
+#ifdef HAVE_LIBPROC_H
 static bool zend_call_stack_get_solaris_proc_maps(zend_call_stack *stack)
 {
-#ifdef HAVE_LIBPROC_H
 	char buffer[4096];
 	uintptr_t addr_on_stack = (uintptr_t) zend_call_stack_position();
 	bool found = false, r = false;
@@ -773,16 +773,16 @@ end:
 	Prelease(proc, 0);
 	close(fd);
 	return r;
-#else
-	return false;
-#endif
 }
+#endif
 
 static bool zend_call_stack_get_solaris(zend_call_stack *stack)
 {
+#ifdef HAVE_LIBPROC_H
 	if (_lwp_self() == 1) {
 		return zend_call_stack_get_solaris_proc_maps(stack);
 	}
+#endif
 	return zend_call_stack_get_solaris_pthread(stack);
 }
 #else

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -703,6 +703,7 @@ static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
 
 static bool zend_call_stack_get_solaris_proc_maps(zend_call_stack *stack)
 {
+#ifdef HAVE_LIBPROC_H
 	char buffer[4096];
 	uintptr_t addr_on_stack = (uintptr_t) zend_call_stack_position();
 	bool found = false, r = false;
@@ -772,6 +773,9 @@ end:
 	Prelease(proc, 0);
 	close(fd);
 	return r;
+#else
+	return false;
+#endif
 }
 
 static bool zend_call_stack_get_solaris(zend_call_stack *stack)

--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -67,7 +67,9 @@ typedef int boolean_t;
 #define _STRUCTURED_PROC 1
 #include <sys/lwp.h>
 #include <sys/procfs.h>
-#include <libproc.h>
+# ifdef HAVE_LIBPROC_H
+#  include <libproc.h>
+# endif
 #include <thread.h>
 #endif
 


### PR DESCRIPTION
The libproc.h header file was added on Solaris as of 11.4.