### PR TITLE
CI: gh-actions - add gh at apt-x64 step

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -70,4 +70,5 @@ runs:
           libqdbm-dev \
           libjpeg-dev \
           libpng-dev \
-          libfreetype6-dev
+          libfreetype6-dev \
+          gh # to use in setup-caddy action


### PR DESCRIPTION
Related: GH-13296.
ASAN builds use a different base image on GitHub Actions, which does not have the `gh` binary installed. This adds `gh` to the `apt install` list to make sure it's available on all builds.