### PR TITLE
Autotools: Fix stack direction check

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -223,16 +223,17 @@ AC_DEFUN([ZEND_CHECK_STACK_DIRECTION],
   [AC_RUN_IFELSE([AC_LANG_SOURCE([dnl
 #include <stdint.h>
 
+#ifdef __has_builtin
+# if __has_builtin(__builtin_frame_address)
+#  define builtin_frame_address __builtin_frame_address(0)
+# endif
+#endif
+
 int (*volatile f)(uintptr_t);
 
 int stack_grows_downwards(uintptr_t arg) {
-#ifdef __has_builtin
-# if __has_builtin(__builtin_frame_address)
-    uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
-# else
-    int local;
-    uintptr_t addr = (uintptr_t)&local;
-# endif
+#ifdef builtin_frame_address
+  uintptr_t addr = (uintptr_t)builtin_frame_address;
 #else
   int local;
   uintptr_t addr = (uintptr_t)&local;
@@ -242,13 +243,8 @@ int stack_grows_downwards(uintptr_t arg) {
 }
 
 int main(void) {
-#ifdef __has_builtin
-# if __has_builtin(__builtin_frame_address)
-    uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
-# else
-    int local;
-    uintptr_t addr = (uintptr_t)&local;
-# endif
+#ifdef builtin_frame_address
+  uintptr_t addr = (uintptr_t)builtin_frame_address;
 #else
   int local;
   uintptr_t addr = (uintptr_t)&local;

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -226,7 +226,7 @@ AC_DEFUN([ZEND_CHECK_STACK_DIRECTION],
 int (*volatile f)(uintptr_t);
 
 int stack_grows_downwards(uintptr_t arg) {
-#if defined(__has_builtin)
+#ifdef __has_builtin
 # if __has_builtin(__builtin_frame_address)
     uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
 # else
@@ -242,7 +242,7 @@ int stack_grows_downwards(uintptr_t arg) {
 }
 
 int main(void) {
-#if defined(__has_builtin)
+#ifdef __has_builtin
 # if __has_builtin(__builtin_frame_address)
     uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
 # else

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -226,8 +226,13 @@ AC_DEFUN([ZEND_CHECK_STACK_DIRECTION],
 int (*volatile f)(uintptr_t);
 
 int stack_grows_downwards(uintptr_t arg) {
-#if defined(__has_builtin) && __has_builtin(__builtin_frame_address)
-  uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
+#if defined(__has_builtin)
+# if __has_builtin(__builtin_frame_address)
+    uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
+# else
+    int local;
+    uintptr_t addr = (uintptr_t)&local;
+# endif
 #else
   int local;
   uintptr_t addr = (uintptr_t)&local;
@@ -237,8 +242,13 @@ int stack_grows_downwards(uintptr_t arg) {
 }
 
 int main(void) {
-#if defined(__has_builtin) && __has_builtin(__builtin_frame_address)
-  uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
+#if defined(__has_builtin)
+# if __has_builtin(__builtin_frame_address)
+    uintptr_t addr = (uintptr_t)__builtin_frame_address(0);
+# else
+    int local;
+    uintptr_t addr = (uintptr_t)&local;
+# endif
 #else
   int local;
   uintptr_t addr = (uintptr_t)&local;


### PR DESCRIPTION
On Solaris 10 and GCC 4.9 this check failed with error in config.log: error: missing binary operator before token "("

The __has_builtin must be checked in its own `#if`. Is this correct?