### PR TITLE
Suppress deprecation notices when ext/dom properties are accessed by the get_debug_info handler

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -107,10 +107,7 @@ zend_result dom_document_encoding_read(dom_object *obj, zval *retval)
 
 zend_result dom_document_actual_encoding_read(dom_object *obj, zval *retval)
 {
-	zend_error(E_DEPRECATED, "Property DOMDocument::$actualEncoding is deprecated");
-	if (UNEXPECTED(EG(exception))) {
-		return FAILURE;
-	}
+	PHP_DOM_DEPRECATED_PROPERTY("Property DOMDocument::$actualEncoding is deprecated");
 
 	return dom_document_encoding_read(obj, retval);
 }
@@ -419,10 +416,7 @@ Since: DOM Level 3
 */
 zend_result dom_document_config_read(dom_object *obj, zval *retval)
 {
-	zend_error(E_DEPRECATED, "Property DOMDocument::$config is deprecated");
-	if (UNEXPECTED(EG(exception))) {
-		return FAILURE;
-	}
+	PHP_DOM_DEPRECATED_PROPERTY("Property DOMDocument::$config is deprecated");
 
 	ZVAL_NULL(retval);
 	return SUCCESS;

--- a/ext/dom/entity.c
+++ b/ext/dom/entity.c
@@ -104,10 +104,7 @@ Since: DOM Level 3
 */
 zend_result dom_entity_actual_encoding_read(dom_object *obj, zval *retval)
 {
-	zend_error(E_DEPRECATED, "Property DOMEntity::$actualEncoding is deprecated");
-	if (UNEXPECTED(EG(exception))) {
-		return FAILURE;
-	}
+	PHP_DOM_DEPRECATED_PROPERTY("Property DOMEntity::$actualEncoding is deprecated");
 
 	ZVAL_NULL(retval);
 	return SUCCESS;
@@ -122,10 +119,7 @@ Since: DOM Level 3
 */
 zend_result dom_entity_encoding_read(dom_object *obj, zval *retval)
 {
-	zend_error(E_DEPRECATED, "Property DOMEntity::$encoding is deprecated");
-	if (UNEXPECTED(EG(exception))) {
-		return FAILURE;
-	}
+	PHP_DOM_DEPRECATED_PROPERTY("Property DOMEntity::$encoding is deprecated");
 
 	ZVAL_NULL(retval);
 	return SUCCESS;
@@ -140,10 +134,7 @@ Since: DOM Level 3
 */
 zend_result dom_entity_version_read(dom_object *obj, zval *retval)
 {
-	zend_error(E_DEPRECATED, "Property DOMEntity::$version is deprecated");
-	if (UNEXPECTED(EG(exception))) {
-		return FAILURE;
-	}
+	PHP_DOM_DEPRECATED_PROPERTY("Property DOMEntity::$version is deprecated");
 
 	ZVAL_NULL(retval);
 	return SUCCESS;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -474,6 +474,8 @@ static HashTable* dom_get_debug_info_helper(zend_object *object, int *is_temp) /
 		return debug_info;
 	}
 
+	DOM_G(suppress_warnings) = true;
+
 	object_str = ZSTR_INIT_LITERAL("(object value omitted)", false);
 
 	ZEND_HASH_MAP_FOREACH_STR_KEY_PTR(prop_handlers, string_key, entry) {
@@ -481,12 +483,9 @@ static HashTable* dom_get_debug_info_helper(zend_object *object, int *is_temp) /
 
 		ZEND_ASSERT(string_key != NULL);
 
-		DOM_G(suppress_warnings) = true;
 		if (entry->read_func(obj, &value) == FAILURE) {
-			DOM_G(suppress_warnings) = false;
 			continue;
 		}
-		DOM_G(suppress_warnings) = false;
 
 		if (Z_TYPE(value) == IS_OBJECT) {
 			zval_ptr_dtor(&value);
@@ -498,6 +497,8 @@ static HashTable* dom_get_debug_info_helper(zend_object *object, int *is_temp) /
 	} ZEND_HASH_FOREACH_END();
 
 	zend_string_release_ex(object_str, false);
+
+	DOM_G(suppress_warnings) = false;
 
 	return debug_info;
 }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -203,6 +203,16 @@ static const libxml_doc_props default_doc_props = {
 	.classmap = NULL,
 };
 
+ZEND_DECLARE_MODULE_GLOBALS(dom)
+
+static PHP_GINIT_FUNCTION(dom)
+{
+#if defined(COMPILE_DL_DOM) && defined(ZTS)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
+	dom_globals->suppress_warnings = false;
+}
+
 /* {{{ dom_get_doc_props() */
 dom_doc_propsptr dom_get_doc_props(php_libxml_ref_obj *document)
 {
@@ -471,9 +481,12 @@ static HashTable* dom_get_debug_info_helper(zend_object *object, int *is_temp) /
 
 		ZEND_ASSERT(string_key != NULL);
 
+		DOM_G(suppress_warnings) = true;
 		if (entry->read_func(obj, &value) == FAILURE) {
+			DOM_G(suppress_warnings) = false;
 			continue;
 		}
+		DOM_G(suppress_warnings) = false;
 
 		if (Z_TYPE(value) == IS_OBJECT) {
 			zval_ptr_dtor(&value);
@@ -668,7 +681,11 @@ zend_module_entry dom_module_entry = { /* {{{ */
 	NULL,
 	PHP_MINFO(dom),
 	DOM_API_VERSION, /* Extension versionnumber */
-	STANDARD_MODULE_PROPERTIES
+	PHP_MODULE_GLOBALS(dom),
+	PHP_GINIT(dom),
+	NULL,
+	NULL,
+	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -300,6 +300,23 @@ static zend_always_inline const xmlChar *php_dom_get_content_or_empty(const xmlN
 	return node->content ? node->content : BAD_CAST "";
 }
 
+#define PHP_DOM_DEPRECATED_PROPERTY(message) do { \
+    if (EXPECTED(!DOM_G(suppress_warnings))) {\
+        zend_error(E_DEPRECATED, message); \
+        if (UNEXPECTED(EG(exception))) { \
+            return FAILURE; \
+        } \
+    } \
+} while (0)
+
+ZEND_BEGIN_MODULE_GLOBALS(dom)
+	bool suppress_warnings;
+ZEND_END_MODULE_GLOBALS(dom)
+
+ZEND_EXTERN_MODULE_GLOBALS(dom)
+
+#define DOM_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(dom, v)
+
 PHP_MINIT_FUNCTION(dom);
 PHP_MSHUTDOWN_FUNCTION(dom);
 PHP_MINFO_FUNCTION(dom);

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -16,10 +16,6 @@ var_dump($d);
 ?>
 --EXPECTF--
 Deprecated: Creation of dynamic property DOMDocument::$dynamicProperty is deprecated in %s on line %d
-
-Deprecated: Property DOMDocument::$actualEncoding is deprecated in %s on line %d
-
-Deprecated: Property DOMDocument::$config is deprecated in %s on line %d
 object(DOMDocument)#1 (41) {
   ["dynamicProperty"]=>
   object(stdClass)#2 (0) {


### PR DESCRIPTION
relates to https://github.com/php/php-src/pull/15369#issuecomment-2292648759