### PR TITLE
Revert fix for GH-14930: truncating readdir output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -81,6 +81,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-15028 (Memory leak in ext/phar/stream.c). (nielsdos)
   . Fixed bug GH-15034 (Integer overflow on stream_notification_callback
     byte_max parameter with files bigger than 2GB). (nielsdos)
+  . Reverted fix for GH-14930 (Custom stream wrapper dir_readdir output
+    truncated to 255 characters). (Jakub Zelenka)
 
 - Tidy:
   . Fix memory leaks in ext/tidy basedir restriction code. (nielsdos)

--- a/ext/standard/tests/streams/gh14930.phpt
+++ b/ext/standard/tests/streams/gh14930.phpt
@@ -1,5 +1,7 @@
 --TEST--
 GH-14930: Custom stream wrapper dir_readdir output truncated to 255 characters in PHP 8.3
+--XFAIL--
+Fix is an ABI break so reverted from 8.3
 --FILE--
 <?php
 

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -107,7 +107,11 @@ typedef struct _php_stream_statbuf {
 } php_stream_statbuf;
 
 typedef struct _php_stream_dirent {
+#ifdef NAME_MAX
+	char d_name[NAME_MAX + 1];
+#else
 	char d_name[MAXPATHLEN];
+#endif
 	unsigned char d_type;
 } php_stream_dirent;
 


### PR DESCRIPTION
The fix was an ABI break so it needs to be reverted from 8.3.