### PR TITLE
Fix GH-15534: Build failure for libxml2 2.9.0 - 2.9.3

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -872,8 +872,7 @@ PHP 8.4 UPGRADE NOTES
     INTL_IDNA_VARIANT_UTS46.
 
 - LibXML:
-  . The libxml extension and PHP_SETUP_LIBXML Autoconf macro now require at
-    least libxml2 2.9.4.
+  . The libxml extension now requires at least libxml2 2.9.4.
 
 - MBString:
   . Unicode data tables have been updated to Unicode 15.1.

--- a/UPGRADING
+++ b/UPGRADING
@@ -871,6 +871,10 @@ PHP 8.4 UPGRADE NOTES
     $domain name is empty or too long, and if $variant is not
     INTL_IDNA_VARIANT_UTS46.
 
+- LibXML:
+  . The libxml extension and PHP_SETUP_LIBXML Autoconf macro now require at
+    least libxml2 2.9.4.
+
 - MBString:
   . Unicode data tables have been updated to Unicode 15.1.
 

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -178,7 +178,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_EVAL_LIBLINE got a new 3rd argument to override the ext_shared
      checks.
    - M4 macro PHP_SETUP_LIBXML doesn't define the redundant HAVE_LIBXML symbol
-     anymore.
+     anymore and requires at least libxml2 2.9.4.
    - M4 macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol anymore.
    - M4 macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.

--- a/build/php.m4
+++ b/build/php.m4
@@ -1934,7 +1934,7 @@ dnl
 dnl Common setup macro for libxml.
 dnl
 AC_DEFUN([PHP_SETUP_LIBXML], [
-  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0])
+  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.4])
   PHP_EVAL_INCLINE([$LIBXML_CFLAGS])
   PHP_EVAL_LIBLINE([$LIBXML_LIBS], [$1])
   $2

--- a/ext/dom/lexbor/lexbor/selectors-adapted/selectors.c
+++ b/ext/dom/lexbor/lexbor/selectors-adapted/selectors.c
@@ -6,7 +6,6 @@
  * Based on Lexbor 2.4.0 (upstream commit e9d35f6384de7bd8c1b79e7111bc3a44f8822967)
  */
 
-#include <libxml/tree.h>
 #include <libxml/xmlstring.h>
 #include <libxml/dict.h>
 #include <Zend/zend.h>

--- a/ext/dom/lexbor/lexbor/selectors-adapted/selectors.c
+++ b/ext/dom/lexbor/lexbor/selectors-adapted/selectors.c
@@ -6,6 +6,7 @@
  * Based on Lexbor 2.4.0 (upstream commit e9d35f6384de7bd8c1b79e7111bc3a44f8822967)
  */
 
+#include <libxml/tree.h>
 #include <libxml/xmlstring.h>
 #include <libxml/dict.h>
 #include <Zend/zend.h>

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -9,13 +9,19 @@ if (PHP_LIBXML == "yes") {
 			CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
 			ADD_EXTENSION_DEP('libxml', 'iconv')) {
 
-		EXTENSION("libxml", "libxml.c mime_sniff.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-		AC_DEFINE("HAVE_LIBXML", 1, "Define to 1 if the PHP extension 'libxml' is available.");
-		ADD_FLAG("CFLAGS_LIBXML", "/D LIBXML_STATIC /D LIBXML_STATIC_FOR_DLL /D HAVE_WIN32_THREADS ");
-		if (!PHP_LIBXML_SHARED) {
-			ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");
+		if (GREP_HEADER("libxml/xmlversion.h", "#define\\s+LIBXML_VERSION\\s+(\\d+)", PHP_PHP_BUILD + "\\include\\libxml2") &&
+				+RegExp.$1 >= 20904) {
+
+			EXTENSION("libxml", "libxml.c mime_sniff.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+			AC_DEFINE("HAVE_LIBXML", 1, "Define to 1 if the PHP extension 'libxml' is available.");
+			ADD_FLAG("CFLAGS_LIBXML", "/D LIBXML_STATIC /D LIBXML_STATIC_FOR_DLL /D HAVE_WIN32_THREADS ");
+			if (!PHP_LIBXML_SHARED) {
+				ADD_DEF_FILE("ext\\libxml\\php_libxml2.def");
+			}
+			PHP_INSTALL_HEADERS("ext/libxml", "php_libxml.h");
+		} else {
+			WARNING("libxml support can't be enabled, libxml version >= 2.9.4 required");
 		}
-		PHP_INSTALL_HEADERS("ext/libxml", "php_libxml.h");
 	} else {
 		WARNING("libxml support can't be enabled, iconv or libxml are missing")
 		PHP_LIBXML = "no"


### PR DESCRIPTION
The xmlDictPtr was moved before the includes in libxml2 2.9.4 so the <libxml/dict.h> can be included directly but for earlier versions the <libxml/tree.h> needs to be included before. Since PHP requires libxml2 2.9.0 or later and this also fixes builds on Solaris 10.