### PR TITLE
Autotools: Move abs_srcdir and abs_builddir to init macro

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -142,6 +142,9 @@ AS_VAR_IF([CFLAGS],, [auto_cflags=1])
 dnl Required programs.
 PHP_PROG_AWK
 
+abs_srcdir=$(cd $srcdir && pwd)
+abs_builddir=$(pwd)
+
 dnl Run at the end of the configuration, before creating the config.status.
 AC_CONFIG_COMMANDS_PRE(
 [dnl Directory for storing shared objects of extensions.

--- a/configure.ac
+++ b/configure.ac
@@ -100,9 +100,6 @@ dnl ----------------------------------------------------------------------------
 
 PHP_INIT_BUILD_SYSTEM
 
-abs_srcdir=`(cd $srcdir; pwd)`
-abs_builddir=`pwd`
-
 dnl Because `make install` is often performed by the superuser, we create the
 dnl libs subdirectory as the user who configures PHP. Otherwise, the current
 dnl user will not be able to delete libs or the contents of libs.

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -28,9 +28,6 @@ AC_DEFUN([PHP_ALWAYS_SHARED],[
 
 PHP_INIT_BUILD_SYSTEM
 
-abs_srcdir=`(cd $srcdir && pwd)`
-abs_builddir=`pwd`
-
 PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
 PHP_DETECT_ICC


### PR DESCRIPTION
This syncs the abs_srcdir and abs_builddir variables assignments between the php-src build and phpize. The `&&` was picked over `;` as it is more rigorous - the pwd command would fail if cd fails for some reason. The obsolete backticks are replaced with the recommended `$(...)`. 