### PR TITLE
Update extension skeleton .gitignore

### DIFF
--- a/ext/skeleton/.gitignore.in
+++ b/ext/skeleton/.gitignore.in
@@ -9,7 +9,7 @@ build
 config.guess
 config.h
 config.h.in
-config.h.in~
+*~
 config.log
 config.nice
 config.status

--- a/ext/skeleton/.gitignore.in
+++ b/ext/skeleton/.gitignore.in
@@ -1,3 +1,4 @@
+*.dep
 *.lo
 *.la
 .libs
@@ -8,11 +9,13 @@ build
 config.guess
 config.h
 config.h.in
+config.h.in~
 config.log
 config.nice
 config.status
 config.sub
 configure
+configure~
 configure.ac
 configure.in
 include

--- a/ext/skeleton/.gitignore.in
+++ b/ext/skeleton/.gitignore.in
@@ -9,13 +9,11 @@ build
 config.guess
 config.h
 config.h.in
-*~
 config.log
 config.nice
 config.status
 config.sub
 configure
-configure~
 configure.ac
 configure.in
 include
@@ -42,3 +40,4 @@ tests/**/*.sh
 tests/**/*.db
 tests/**/*.mem
 tmp-php.ini
+*~


### PR DESCRIPTION
Update .gitignore in ext/skeleton to exclude additional auto-generated files

The .gitignore file in ext/skeleton is not excluding some auto-generated files.