### PR TITLE
Export `zend_accel_shared_globals`

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -53,7 +53,7 @@
 static const zend_shared_memory_handlers *g_shared_alloc_handler = NULL;
 static const char *g_shared_model;
 /* pointer to globals allocated in SHM and shared across processes */
-zend_smm_shared_globals *smm_shared_globals;
+ZEND_EXT_API zend_smm_shared_globals *smm_shared_globals;
 
 #ifndef ZEND_WIN32
 #ifdef ZTS

--- a/ext/opcache/zend_shared_alloc.h
+++ b/ext/opcache/zend_shared_alloc.h
@@ -119,7 +119,7 @@ typedef struct _zend_smm_shared_globals {
 	size_t                     reserved_size;
 } zend_smm_shared_globals;
 
-extern zend_smm_shared_globals *smm_shared_globals;
+ZEND_EXT_API extern zend_smm_shared_globals *smm_shared_globals;
 
 #define ZSMMG(element)		(smm_shared_globals->element)
 


### PR DESCRIPTION
Hey folks 👋 

I could not find any other way to access this information from an extension:
https://github.com/php/php-src/blob/35fbb0061d92f41ee028e18ac99b28fffa929e7f/ext/opcache/ZendAccelerator.h#L244-L284

There is a user land function `opcache_get_status()` but this does way more, especially unnecessary things when not using the data in PHP, but in another C/Rust extension.

I'd like to add a bit more observability to the OPcache. IIRC @arnaud-lb is working on OPcache, is that right?