### PR TITLE
[PHP next] Support --enable-debug-assertions configure option on Windows

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -32,6 +32,10 @@ ARG_ENABLE('debug-pack', 'Release binaries with external debug symbols (--enable
 if (PHP_DEBUG == "yes" && PHP_DEBUG_PACK == "yes") {
 	ERROR("Use of both --enable-debug and --enable-debug-pack not allowed.");
 }
+ARG_ENABLE('debug-assertions', 'Release binaries with debug assertions (--enable-debug must not be specified)', "no");
+if (PHP_DEBUG == "yes" && PHP_DEBUG_ASSERTIONS == "yes") {
+	ERROR("Use of both --enable-debug and --enable-debug-assertions not allowed.");
+}
 
 if (PHP_DEBUG == "yes") {
 	ADD_FLAG("CFLAGS"," /Wall ");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -456,7 +456,7 @@ can be built that way. \
 	var snapshot_build_exclusions = new Array(
 		'debug', 'lzf-better-compression', 'php-build', 'snapshot-template', 'zts',
 		'ipv6', 'fd-setsize', 'pgi', 'pgo', 'all-shared', 'config-profile', 'sanitizer',
-		'phpdbg-debug'
+		'phpdbg-debug', 'debug-assertions'
 	);
 	var force;
 
@@ -3475,10 +3475,15 @@ function toolset_setup_build_mode()
 		}
 		ADD_FLAG("CFLAGS", "/LD /MD");
 		if (PHP_SANITIZER == "yes" && CLANG_TOOLSET) {
-			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
+			ADD_FLAG("CFLAGS", "/Od /D NDebug /D ZEND_WIN32_NEVER_INLINE");
 		} else {
 			// Equivalent to Release_TSInline build -> best optimization
-			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /GF /D ZEND_DEBUG=0");
+			ADD_FLAG("CFLAGS", "/Ox /D NDebug /GF");
+		}
+		if (PHP_DEBUG_ASSERTIONS == "yes") {
+			ADD_FLAG("CFLAGS", "/D ZEND_DEBUG=1");
+		} else {
+			ADD_FLAG("CFLAGS", "/D ZEND_DEBUG=0 /D NDEBUG");
 		}
 
 		// if you have VS.Net /GS hardens the binary against buffer overruns

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -486,7 +486,7 @@ PHP_WINUTIL_API BOOL php_win32_crt_compatible(char **err)
 {/*{{{*/
 #if PHP_LINKER_MAJOR == 14
 	/* Extend for other CRT if needed. */
-# if PHP_DEBUG
+# if _DEBUG
 	const char *crt_name = "vcruntime140d.dll";
 # else
 	const char *crt_name = "vcruntime140.dll";


### PR DESCRIPTION
This has been introduced for non Windows system years ago[1] mainly to
improve fuzzer SAPI.  While this is still not available on Windows, the
option can still make sense, particularly for CI runs or other
environments where full debugging support would be useless, but where
enabled assertions would be helpful.

[1] <https://github.com/php/php-src/commit/c4e2ca607f49d37564aaf34f5a48c5e59aca12a6>

---

Thanks to @arnaud-lb for telling me about this configuration option!

Note that a couple of ext/ffi test [are failing if this is enabled](https://github.com/php/php-src/actions/runs/10498650502/job/29083989504?pr=15361#step:6:412), due to

https://github.com/php/php-src/blob/c79e723725083b53002e06c44c7f9b271146385e/ext/ffi/tests/utils.inc#L12-L19

One may argue that the userland `PHP_DEBUG` shouldn't be set to true for `--enable-debug-assertions`, but since it is on non Windows systems, it's probably okay.

(The issue with the other failing test has been resolved in this PR.)

Still unresolved:

* [ ] fix the failing FFI tests
* [ ] check whether everything works as intended for phpize builds
* [ ] check clang on Windows

Oh, and while I was working on this, I've noticed that setting or not setting the `NDEBUG` macro shouldn't be necessary, due to

https://github.com/php/php-src/blob/c79e723725083b53002e06c44c7f9b271146385e/main/php.h#L112-L118

However, that doesn't affect Zend/, most notably zend_vm_execute.h will not grab that, so maybe this should be revised.

And I'm not sure about

https://github.com/php/php-src/blob/c79e723725083b53002e06c44c7f9b271146385e/ext/zend_test/test.c#L41-L45

While that worked for me, can we be sure that the inclusion of assert.h isn't guarded, so that this will not necessarily work? It might make more sense to run (some) CI jobs with `--enable-debug-assertions` instead. /cc @realFlowControl 

And I'm not sure what to do with the `NDebug` and `_DEBUG` symbols; the latter is supposed to be automatically set by the compiler, so there is likely no need to set it manually. And regarding the former (which is apparently there since the beginning of the new Windows build infrastructure, 05b9b20ed8e2f98b3fb71a227e49e11bdf7b9c6b), I have no idea what it's supposed to do (maybe support for some ancient compiler?)