### PR TITLE
Fix building of callgraph including preloaded symbols

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-15432 (Heap corruption when querying a vector). (cmb,
     Kamil Tekiela)
 
+- Opcache:
+  . Fixed bug GH-15490 (Building of callgraph modifies preloaded symbols).
+    (ilutov)
+
 - PDO_MYSQL:
   . mysqlnd: support ER_CLIENT_INTERACTION_TIMEOUT. (Appla)
 

--- a/Zend/Optimizer/zend_call_graph.c
+++ b/Zend/Optimizer/zend_call_graph.c
@@ -79,7 +79,8 @@ ZEND_API void zend_analyze_calls(zend_arena **arena, zend_script *script, uint32
 
 					if (build_flags & ZEND_CALL_TREE) {
 						call_info->next_caller = NULL;
-					} else if (func->type == ZEND_INTERNAL_FUNCTION) {
+					} else if (func->type == ZEND_INTERNAL_FUNCTION
+					 || func->op_array.filename != script->filename) {
 						call_info->next_caller = NULL;
 					} else {
 						zend_func_info *callee_func_info = ZEND_FUNC_INFO(&func->op_array);

--- a/ext/opcache/tests/jit/gh15490.inc
+++ b/ext/opcache/tests/jit/gh15490.inc
@@ -1,0 +1,9 @@
+<?php
+
+function foo() {
+    bar();
+}
+
+function bar() {
+    echo 'Hello world!';
+}

--- a/ext/opcache/tests/jit/gh15490.phpt
+++ b/ext/opcache/tests/jit/gh15490.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-15490: use-after-free when traversing call graph
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.preload={PWD}/gh15490.inc
+opcache.jit=1235
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+foo();
+?>
+--EXPECT--
+Hello world!


### PR DESCRIPTION
This issue was introduced in GH-15021. When building the call graph, we can now see preloaded functions. However, building the call graph involves adding the function to the caller list of the callee, which we don't want to do for functions not coming from the script.

Fixes GH-15490