### PR TITLE
Fixed GH-15547: curl_multi_wait expects a signed int for timeout.

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -189,7 +189,9 @@ PHP_FUNCTION(curl_multi_select)
 
 	if (!(timeout >= 0.0 && timeout <= ((double)INT_MAX / 1000.0))) {
 		php_error_docref(NULL, E_WARNING, "timeout must be between 0 and %d", (int)ceilf((double)INT_MAX / 1000));
+#ifdef CURLM_BAD_FUNCTION_ARGUMENT
 		SAVE_CURLM_ERROR(mh, CURLM_BAD_FUNCTION_ARGUMENT);
+#endif
 		RETURN_LONG(-1);
 	}
 

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -187,7 +187,12 @@ PHP_FUNCTION(curl_multi_select)
 
 	mh = Z_CURL_MULTI_P(z_mh);
 
-	error = curl_multi_wait(mh->multi, NULL, 0, (unsigned long) (timeout * 1000.0), &numfds);
+	if (!(timeout >= ((double)INT_MIN / 1000.0) && timeout <= ((double)INT_MAX / 1000.0))) {
+		php_error_docref(NULL, E_WARNING, "timeout must be between %d and %d", (INT_MIN / 1000), (INT_MAX / 1000));
+		RETURN_LONG(-1);
+	}
+
+	error = curl_multi_wait(mh->multi, NULL, 0, (int) (timeout * 1000.0), &numfds);
 	if (CURLM_OK != error) {
 		SAVE_CURLM_ERROR(mh, error);
 		RETURN_LONG(-1);

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -189,6 +189,7 @@ PHP_FUNCTION(curl_multi_select)
 
 	if (!(timeout >= 0.0 && timeout <= ((double)INT_MAX / 1000.0))) {
 		php_error_docref(NULL, E_WARNING, "timeout must be between 0 and %d", (int)ceilf((double)INT_MAX / 1000));
+		SAVE_CURLM_ERROR(mh, CURLM_BAD_FUNCTION_ARGUMENT);
 		RETURN_LONG(-1);
 	}
 

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -187,8 +187,8 @@ PHP_FUNCTION(curl_multi_select)
 
 	mh = Z_CURL_MULTI_P(z_mh);
 
-	if (!(timeout >= ((double)INT_MIN / 1000.0) && timeout <= ((double)INT_MAX / 1000.0))) {
-		php_error_docref(NULL, E_WARNING, "timeout must be between %d and %d", (INT_MIN / 1000), (INT_MAX / 1000));
+	if (!(timeout >= 0.0 && timeout <= ((double)INT_MAX / 1000.0))) {
+		php_error_docref(NULL, E_WARNING, "timeout must be between 0 and %d", (int)ceilf((double)INT_MAX / 1000));
 		RETURN_LONG(-1);
 	}
 

--- a/ext/curl/tests/gh15547.phpt
+++ b/ext/curl/tests/gh15547.phpt
@@ -11,9 +11,9 @@ var_dump(curl_multi_select($mh, 2500000));
 var_dump(curl_multi_select($mh, 1000000));
 ?>
 --EXPECTF--
-Warning: curl_multi_select(): timeout must be between %s and %s in %s on line %d
+Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
 
-Warning: curl_multi_select(): timeout must be between %s and %s in %s on line %d
+Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
 int(0)

--- a/ext/curl/tests/gh15547.phpt
+++ b/ext/curl/tests/gh15547.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-15547 - overflow on timeout argument
+GH-15547 - curl_multi_select overflow on timeout argument
 --EXTENSIONS--
 curl
 --FILE--
@@ -7,13 +7,23 @@ curl
 
 $mh = curl_multi_init();
 var_dump(curl_multi_select($mh, -2500000));
+var_dump(curl_multi_strerror(curl_multi_errno($mh)));
+curl_multi_close($mh);
+$mh = curl_multi_init();
 var_dump(curl_multi_select($mh, 2500000));
+var_dump(curl_multi_strerror(curl_multi_errno($mh)));
+curl_multi_close($mh);
+$mh = curl_multi_init();
 var_dump(curl_multi_select($mh, 1000000));
+var_dump(curl_multi_strerror(curl_multi_errno($mh)));
 ?>
 --EXPECTF--
 Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
+string(43) "A libcurl function was given a bad argument"
 
 Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
+string(43) "A libcurl function was given a bad argument"
 int(0)
+string(8) "No error"

--- a/ext/curl/tests/gh15547.phpt
+++ b/ext/curl/tests/gh15547.phpt
@@ -20,10 +20,10 @@ var_dump(curl_multi_strerror(curl_multi_errno($mh)));
 --EXPECTF--
 Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
-string(43) "A libcurl function was given a bad argument"
+%s
 
 Warning: curl_multi_select(): timeout must be between 0 and %d in %s on line %d
 int(-1)
-string(43) "A libcurl function was given a bad argument"
+%s
 int(0)
 string(8) "No error"

--- a/ext/curl/tests/gh15547.phpt
+++ b/ext/curl/tests/gh15547.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-15547 - overflow on timeout argument
+--EXTENSIONS--
+curl
+--FILE--
+<?php
+
+$mh = curl_multi_init();
+var_dump(curl_multi_select($mh, -2500000));
+var_dump(curl_multi_select($mh, 2500000));
+var_dump(curl_multi_select($mh, 1000000));
+?>
+--EXPECTF--
+Warning: curl_multi_select(): timeout must be between %s and %s in %s on line %d
+int(-1)
+
+Warning: curl_multi_select(): timeout must be between %s and %s in %s on line %d
+int(-1)
+int(0)


### PR DESCRIPTION
confusion might come from the previous argument type. PHP expects ms so we check it fits integer boundaries before the cast. Raising a warning at least for stable branches.