### PR TITLE
Remove unused buffer variables

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -622,7 +622,6 @@ static bool zend_call_stack_get_netbsd_vm(zend_call_stack *stack, void **ptr)
 	char *start, *end;
 	struct kinfo_vmentry *entry;
 	size_t len, max_size;
-	char buffer[4096];
 	uintptr_t addr_on_stack = (uintptr_t) zend_call_stack_position();
 	int mib[5] = { CTL_VM, VM_PROC, VM_PROC_MAP, getpid(), sizeof(struct kinfo_vmentry) };
 	bool found = false;
@@ -704,7 +703,6 @@ static bool zend_call_stack_get_solaris_pthread(zend_call_stack *stack)
 #ifdef HAVE_LIBPROC_H
 static bool zend_call_stack_get_solaris_proc_maps(zend_call_stack *stack)
 {
-	char buffer[4096];
 	uintptr_t addr_on_stack = (uintptr_t) zend_call_stack_position();
 	bool found = false, r = false;
 	struct ps_prochandle *proc;


### PR DESCRIPTION
These emit warning: unused variable 'buffer'.