### PR TITLE
getaddrinfo conversion

### DIFF
--- a/ext/sockets/sockaddr_conv.c
+++ b/ext/sockets/sockaddr_conv.c
@@ -11,24 +11,24 @@
 
 extern zend_result php_string_to_if_index(const char *val, unsigned *out);
 
-#ifdef HAVE_IPV6
-/* Sets addr by hostname, or by ip in string form (AF_INET6) */
-int php_set_inet6_addr(struct sockaddr_in6 *sin6, char *string, php_socket *php_sock) /* {{{ */
+int php_set_common_addr(struct sockaddr *sin, int family, char *string, php_socket *php_sock) /* {{{ */
 {
-	struct in6_addr tmp;
 #ifdef HAVE_GETADDRINFO
+	struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)sin;
+	struct sockaddr_in *sin4 = (struct sockaddr_in*)sin;
+	struct in6_addr tmp6;
+	struct in_addr tmp4;
+
 	struct addrinfo hints;
 	struct addrinfo *addrinfo = NULL;
-#endif
-	char *scope = strchr(string, '%');
 
-	if (inet_pton(AF_INET6, string, &tmp)) {
-		memcpy(&(sin6->sin6_addr.s6_addr), &(tmp.s6_addr), sizeof(struct in6_addr));
+	if (family == AF_INET6 && inet_pton(AF_INET6, string, &tmp6)) {
+		memcpy(&(sin6->sin6_addr.s6_addr), &(tmp6.s6_addr), sizeof(struct in6_addr));
+	} else if (family == AF_INET && inet_pton(AF_INET, string, &tmp4)) {
+		sin4->sin_addr.s_addr = tmp4.s_addr;
 	} else {
-#ifdef HAVE_GETADDRINFO
-
 		memset(&hints, 0, sizeof(struct addrinfo));
-		hints.ai_family = AF_INET6;
+		hints.ai_family = family;
 #ifdef AI_V4MAPPED
 		hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
 #else
@@ -43,21 +43,37 @@ int php_set_inet6_addr(struct sockaddr_in6 *sin6, char *string, php_socket *php_
 #endif
 			return 0;
 		}
-		if (addrinfo->ai_family != PF_INET6 || addrinfo->ai_addrlen != sizeof(struct sockaddr_in6)) {
-			php_error_docref(NULL, E_WARNING, "Host lookup failed: Non AF_INET6 domain returned on AF_INET6 socket");
+		if (addrinfo->ai_family != family) {
+			php_error_docref(NULL, E_WARNING, "Host lookup failed: Wrong address family returned for socket");
 			freeaddrinfo(addrinfo);
 			return 0;
 		}
 
-		memcpy(&(sin6->sin6_addr.s6_addr), ((struct sockaddr_in6*)(addrinfo->ai_addr))->sin6_addr.s6_addr, sizeof(struct in6_addr));
+		if (addrinfo->ai_family == AF_INET6) {
+			memcpy(&(sin6->sin6_addr.s6_addr), ((struct sockaddr_in6*)(addrinfo->ai_addr))->sin6_addr.s6_addr, sizeof(struct in6_addr));
+		} else if (addrinfo->ai_family == AF_INET) {
+			memcpy(&(sin4->sin_addr.s_addr), &((struct sockaddr_in*)(addrinfo->ai_addr))->sin_addr.s_addr, sizeof(struct in_addr));
+		}
 		freeaddrinfo(addrinfo);
+	}
 
+	return 1;
 #else
-		/* No IPv6 specific hostname resolution is available on this system? */
-		php_error_docref(NULL, E_WARNING, "Host lookup failed: getaddrinfo() not available on this system");
-		return 0;
+	php_error_docref(NULL, E_WARNING, "Host lookup failed: getaddrinfo() not available on this system");
+	return 0;
 #endif
+}
+/* }}} */
 
+#ifdef HAVE_IPV6
+/* Sets addr by hostname, or by ip in string form (AF_INET6) */
+int php_set_inet6_addr(struct sockaddr_in6 *sin6, char *string, php_socket *php_sock) /* {{{ */
+{
+	char *scope = strchr(string, '%');
+
+	int ret = php_set_common_addr((struct sockaddr*)sin6, AF_INET6, string, php_sock);
+	if (!ret) {
+		return 0;
 	}
 
 	if (scope) {
@@ -86,29 +102,7 @@ int php_set_inet6_addr(struct sockaddr_in6 *sin6, char *string, php_socket *php_
 /* Sets addr by hostname, or by ip in string form (AF_INET)  */
 int php_set_inet_addr(struct sockaddr_in *sin, char *string, php_socket *php_sock) /* {{{ */
 {
-	struct in_addr tmp;
-	struct hostent *host_entry;
-
-	if (inet_pton(AF_INET, string, &tmp)) {
-		sin->sin_addr.s_addr = tmp.s_addr;
-	} else {
-		if (strlen(string) > MAXFQDNLEN || ! (host_entry = php_network_gethostbyname(string))) {
-			/* Note: < -10000 indicates a host lookup error */
-#ifdef PHP_WIN32
-			PHP_SOCKET_ERROR(php_sock, "Host lookup failed", WSAGetLastError());
-#else
-			PHP_SOCKET_ERROR(php_sock, "Host lookup failed", (-10000 - h_errno));
-#endif
-			return 0;
-		}
-		if (host_entry->h_addrtype != AF_INET) {
-			php_error_docref(NULL, E_WARNING, "Host lookup failed: Non AF_INET domain returned on AF_INET socket");
-			return 0;
-		}
-		memcpy(&(sin->sin_addr.s_addr), host_entry->h_addr_list[0], host_entry->h_length);
-	}
-
-	return 1;
+	return php_set_common_addr((struct sockaddr*)sin, AF_INET, string, php_sock);
 }
 /* }}} */
 

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -233,11 +233,7 @@ PHP_FUNCTION(gethostbyname)
 	}
 
 	php_sockaddr_storage resolved;
-	zend_string *gai_error = NULL;
-	int address_count = php_network_getaddress(&resolved, hostname, 0, AF_INET, 0, &gai_error);
-	if (gai_error) {
-		zend_string_release_ex(gai_error, 0);
-	}
+	int address_count = php_network_getaddress(&resolved, hostname, 0, AF_INET, 0, NULL);
 	if (address_count == 0) {
 		/* don't need to docref here, getaddresses E_WARNINGs for us */
 		RETURN_STRINGL(hostname, hostname_len);
@@ -280,11 +276,7 @@ PHP_FUNCTION(gethostbynamel)
 	}
 
 	struct sockaddr **addresses = NULL;
-	zend_string *gai_error = NULL;
-	int address_count = php_network_getaddresses(hostname, 0, &addresses, &gai_error);
-	if (gai_error) {
-		zend_string_release_ex(gai_error, 0);
-	}
+	int address_count = php_network_getaddresses(hostname, 0, &addresses, NULL);
 	if (address_count == 0) {
 		/* don't need to docref here, getaddresses E_WARNINGs for us */
 		RETURN_FALSE;

--- a/ext/standard/tests/network/gethostbyname_error003.phpt
+++ b/ext/standard/tests/network/gethostbyname_error003.phpt
@@ -6,5 +6,6 @@ gethostbyname() function - basic type return error test
 <?php
     var_dump(is_string(gethostbyname("asdfasdf")));
 ?>
---EXPECT--
+--EXPECTF--
+Warning: gethostbyname(): php_network_getaddresses: getaddrinfo for asdfasdf failed: nodename nor servname provided, or not known in %s on line %d
 bool(true)

--- a/ext/standard/tests/network/gethostbyname_error006.phpt
+++ b/ext/standard/tests/network/gethostbyname_error006.phpt
@@ -6,5 +6,6 @@ gethostbyname() function - basic invalid parameter test
 <?php
     var_dump(gethostbyname(".toto.toto.toto"));
 ?>
---EXPECT--
+--EXPECTF--
+Warning: gethostbyname(): php_network_getaddresses: getaddrinfo for .toto.toto.toto failed: nodename nor servname provided, or not known in %s on line %d
 string(15) ".toto.toto.toto"

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -688,11 +688,7 @@ int fcgi_listen(const char *path, int backlog)
 				if (strlen(host) > MAXFQDNLEN) {
 					address_count = 0;
 				} else {
-					zend_string *gai_error = NULL;
-					address_count = php_network_getaddress(&resolved, host, 0, AF_INET, 0, &gai_error);
-					if (gai_error) {
-						zend_string_release_ex(gai_error, 0);
-					}
+					address_count = php_network_getaddress(&resolved, host, 0, AF_INET, 0, NULL);
 				}
 				if (address_count == 0 || resolved.ss_family != AF_INET) {
 					fcgi_log(FCGI_ERROR, "Cannot resolve host name '%s'!\n", host);

--- a/main/network.c
+++ b/main/network.c
@@ -143,10 +143,10 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
 }
 /* }}} */
 
-/* {{{ php_network_getaddresses
+/* {{{ php_network_getaddresses_ex
  * Returns number of addresses, 0 for none/error
  */
-PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+PHPAPI int php_network_getaddresses_ex(const char *host, int socktype, int family, int ai_flags, struct sockaddr ***sal, zend_string **error_string)
 {
 	struct sockaddr **sap;
 	int n;
@@ -168,6 +168,7 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 
 	hints.ai_family = AF_INET; /* default to regular inet (see below) */
 	hints.ai_socktype = socktype;
+	hints.ai_flags = ai_flags;
 
 # ifdef HAVE_IPV6
 	/* probe for a working IPv6 stack; even if detected as having v6 at compile
@@ -187,7 +188,7 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 			closesocket(s);
 		}
 	}
-	hints.ai_family = ipv6_borked ? AF_INET : AF_UNSPEC;
+	hints.ai_family = ipv6_borked ? AF_INET : family;
 # endif
 
 	if ((n = getaddrinfo(host, NULL, &hints, &res))) {
@@ -266,6 +267,15 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 
 	*sap = NULL;
 	return n;
+}
+/* }}} */
+
+/* {{{ php_network_getaddresses
+ * Returns number of addresses, 0 for none/error
+ */
+PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+{
+	return php_network_getaddresses_ex(host, socktype, AF_UNSPEC, 0, sal, error_string);
 }
 /* }}} */
 

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -261,6 +261,7 @@ typedef struct {
 
 BEGIN_EXTERN_C()
 PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string);
+PHPAPI int php_network_getaddresses_ex(const char *host, int socktype, int family, int ai_flags, struct sockaddr ***sal, zend_string **error_string);
 PHPAPI void php_network_freeaddresses(struct sockaddr **sal);
 
 PHPAPI php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short port,

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -263,6 +263,7 @@ BEGIN_EXTERN_C()
 PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string);
 PHPAPI int php_network_getaddresses_ex(const char *host, int socktype, int family, int ai_flags, struct sockaddr ***sal, zend_string **error_string);
 PHPAPI void php_network_freeaddresses(struct sockaddr **sal);
+PHPAPI int php_network_getaddress(php_sockaddr_storage *sockaddr, const char *host, int socktype, int family, int ai_flags, zend_string **error_string);
 
 PHPAPI php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short port,
 		int socktype, int asynchronous, struct timeval *timeout, zend_string **error_string,


### PR DESCRIPTION
Probably perilous. Tested only on my Mac so far. Concerns:

- This adds some new functions out of convenience (`php_network_getaddress`, for common situations like resolving `localhost` - we only want just the one) and necessity (`php_network_getaddresses_ex` - exposes more of `getaddrinfo` like address family).
- There are quite a few spots that are IPv4 only. Some of them are because the function is documented as returning IPv4 addresses (this sucks, but too late in cycle to fix?), some are because it's just kinda assumed (i.e. FastCGI)?
- `sockaddr_conv.c` should probably be converted to `bool` returns, though I'm not sure if it's an ABI break (since it can be represented differently). It's a little ugly anyways...
- `socket_addrinfo_lookup` calls `getaddrinfo` directly. It could call `php_network_getaddresses_ex`, though we'd need to expose service there too.
- This doesn't drop `php_network_gethostbyname` and the associated detritus just yet, since it's an ABI break. We could do it before RC1...
  - As previously mentioned, big build system simplification.
- Does `HAVE_IPV6` or building without it even make sense anymore? We kinda assume `inet_ntop` for example, so assuming `getaddrinfo` also makes sense.
- Userland function `gethostbyaddr` actually calls the modern `gethostbyname` equivalent already when possible. The fallback path to the legacy function can be removed with `gethostbyname`.

Fixes GH-15531