### PR TITLE
Correctly specify secret instead of seed in ext/hash deprecation message

### DIFF
--- a/ext/hash/hash_xxhash.c
+++ b/ext/hash/hash_xxhash.c
@@ -183,7 +183,7 @@ zend_always_inline static void _PHP_XXH3_Init(PHP_XXH3_64_CTX *ctx, HashTable *a
 			return;
 		} else if (_secret) {
 			if (IS_STRING != Z_TYPE_P(_secret)) {
-				php_error_docref(NULL, E_DEPRECATED, "Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs");
+				php_error_docref(NULL, E_DEPRECATED, "Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs");
 			}
 			zend_string *secret_string = zval_try_get_string(_secret);
 			if (UNEXPECTED(!secret_string)) {

--- a/ext/hash/tests/xxh3_convert_secret_to_string.phpt
+++ b/ext/hash/tests/xxh3_convert_secret_to_string.phpt
@@ -8,7 +8,7 @@ try {
 var_dump($x);
 ?>
 --EXPECTF--
-Deprecated: hash_init(): Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
+Deprecated: hash_init(): Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
 array(1) {
   ["secret"]=>
   int(4)

--- a/ext/hash/tests/xxhash_secret.phpt
+++ b/ext/hash/tests/xxhash_secret.phpt
@@ -49,13 +49,13 @@ foreach (["xxh3", "xxh128"] as $a) {
 --EXPECTF--
 string(67) "xxh3: Only one of seed or secret is to be passed for initialization"
 
-Deprecated: hash_init(): Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
+Deprecated: hash_init(): Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
 string(23) "exception in __toString"
 string(57) "xxh3: Secret length must be >= 136 bytes, 17 bytes passed"
 8028aa834c03557a == 8028aa834c03557a == true
 string(69) "xxh128: Only one of seed or secret is to be passed for initialization"
 
-Deprecated: hash_init(): Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
+Deprecated: hash_init(): Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
 string(23) "exception in __toString"
 string(59) "xxh128: Secret length must be >= 136 bytes, 17 bytes passed"
 54279097795e7218093a05d4d781cbb9 == 54279097795e7218093a05d4d781cbb9 == true

--- a/ext/hash/tests/xxhash_seed_deprecation.phpt
+++ b/ext/hash/tests/xxhash_seed_deprecation.phpt
@@ -23,6 +23,6 @@ Deprecated: hash_init(): Passing a seed of a type other than int is deprecated b
 
 Deprecated: hash_init(): Passing a seed of a type other than int is deprecated because it is ignored in %s on line %d
 
-Deprecated: hash_init(): Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
+Deprecated: hash_init(): Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
 
-Deprecated: hash_init(): Passing a seed of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d
+Deprecated: hash_init(): Passing a secret of a type other than string is deprecated because it implicitly converts to a string, potentially hiding bugs in %s on line %d


### PR DESCRIPTION
Reference: https://github.com/php/php-src/commit/74eff98c84b26a8088fb56b5be748a3e0e1da419#r145528001