### PR TITLE
Add API to exempt function from being traced in JIT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,7 @@ PHP                                                                        NEWS
 
 - Opcache:
   . Fixed bug GH-15657 (Segmentation fault in dasm_x86.h). (nielsdos)
+  . Added opcache_jit_blacklist() function. (Bob)
 
 - PHPDBG:
   . Fixed bug GH-15901 (phpdbg: Assertion failure on i funcs). (cmb)

--- a/UPGRADING
+++ b/UPGRADING
@@ -815,6 +815,10 @@ PHP 8.4 UPGRADE NOTES
   . Added mb_ucfirst and mb_lcfirst functions.
     RFC: https://wiki.php.net/rfc/mb_ucfirst
 
+- OPCache:
+  . Added opcache_jit_blacklist function. It allows skipping the tracing JIT
+    execution of select functions.
+
 - PCNTL:
   . Added pcntl_setns allowing a process to be reassociated with a namespace in order
     to share resources with other processes within this context.

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -706,7 +706,7 @@ static bool zend_may_be_dynamic_property(zend_class_entry *ce, zend_string *memb
 # endif
 #endif
 
-void zend_jit_status(zval *ret)
+ZEND_EXT_API void zend_jit_status(zval *ret)
 {
 	zval stats;
 	array_init(&stats);

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -162,7 +162,8 @@ void zend_jit_startup(void *jit_buffer, size_t size, bool reattached);
 void zend_jit_shutdown(void);
 void zend_jit_activate(void);
 void zend_jit_deactivate(void);
-void zend_jit_status(zval *ret);
+ZEND_EXT_API void zend_jit_status(zval *ret);
+ZEND_EXT_API void zend_jit_blacklist_function(zend_op_array *op_array);
 void zend_jit_restart(void);
 
 #define ZREG_LOAD           (1<<0)

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -10102,6 +10102,22 @@ static int zend_jit_do_fcall(zend_jit_ctx *jit, const zend_op *opline, const zen
 				ir_STORE(jit_EX(opline), jit_IP(jit));
 			}
 			jit_observer_fcall_begin(jit, rx, observer_handler);
+
+			if (trace) {
+				int32_t exit_point = zend_jit_trace_get_exit_point(opline, ZEND_JIT_EXIT_TO_VM);
+
+				exit_addr = zend_jit_trace_get_exit_addr(exit_point);
+				if (!exit_addr) {
+					return 0;
+				}
+			} else {
+				exit_addr = NULL;
+			}
+
+			if (!zend_jit_check_timeout(jit, NULL /* we're inside the called function */, exit_addr)) {
+				return 0;
+			}
+
 			jit_observer_fcall_is_unobserved_end(jit, &unobserved_data);
 		}
 

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -10114,9 +10114,7 @@ static int zend_jit_do_fcall(zend_jit_ctx *jit, const zend_op *opline, const zen
 				exit_addr = NULL;
 			}
 
-			if (!zend_jit_check_timeout(jit, NULL /* we're inside the called function */, exit_addr)) {
-				return 0;
-			}
+			zend_jit_check_timeout(jit, NULL /* we're inside the called function */, exit_addr);
 
 			jit_observer_fcall_is_unobserved_end(jit, &unobserved_data);
 		}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7656,6 +7656,23 @@ static void zend_jit_blacklist_root_trace(const zend_op *opline, size_t offset)
 	zend_shared_alloc_unlock();
 }
 
+ZEND_EXT_API void zend_jit_blacklist_function(zend_op_array *op_array) {
+	zend_jit_op_array_trace_extension *jit_extension = (zend_jit_op_array_trace_extension *)ZEND_FUNC_INFO(op_array);
+	if (!jit_extension) {
+		return;
+	}
+
+	// First not-skipped op
+	zend_op *opline = op_array->opcodes;
+	if (!(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
+		while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
+			opline++;
+		}
+	}
+
+	zend_jit_blacklist_root_trace(opline, jit_extension->offset);
+}
+
 static bool zend_jit_trace_is_bad_root(const zend_op *opline, zend_jit_trace_stop stop, size_t offset)
 {
 	const zend_op **cache_opline = JIT_G(bad_root_cache_opline);

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7658,16 +7658,18 @@ static void zend_jit_blacklist_root_trace(const zend_op *opline, size_t offset)
 
 ZEND_EXT_API void zend_jit_blacklist_function(zend_op_array *op_array) {
 	zend_jit_op_array_trace_extension *jit_extension = (zend_jit_op_array_trace_extension *)ZEND_FUNC_INFO(op_array);
-	if (!jit_extension || !(jit_extension->func_info.flags & ZEND_JIT_ON_HOT_TRACE)) {
+	if (!jit_extension || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)) {
 		return;
 	}
 
 	zend_shared_alloc_lock();
 	SHM_UNPROTECT();
+	zend_jit_unprotect();
 
 	zend_jit_stop_persistent_op_array(op_array);
 	jit_extension->func_info.flags &= ~ZEND_FUNC_JIT_ON_HOT_TRACE;
 
+	zend_jit_protect();
 	SHM_PROTECT();
 	zend_shared_alloc_unlock();
 }

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7662,6 +7662,8 @@ ZEND_EXT_API void zend_jit_blacklist_function(zend_op_array *op_array) {
 		return;
 	}
 
+	zend_jit_stop_persistent_op_array(op_array);
+
 	// First not-skipped op
 	zend_op *opline = op_array->opcodes;
 	if (!(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7658,21 +7658,18 @@ static void zend_jit_blacklist_root_trace(const zend_op *opline, size_t offset)
 
 ZEND_EXT_API void zend_jit_blacklist_function(zend_op_array *op_array) {
 	zend_jit_op_array_trace_extension *jit_extension = (zend_jit_op_array_trace_extension *)ZEND_FUNC_INFO(op_array);
-	if (!jit_extension) {
+	if (!jit_extension || !(jit_extension->func_info.flags & ZEND_JIT_ON_HOT_TRACE)) {
 		return;
 	}
 
+	zend_shared_alloc_lock();
+	SHM_UNPROTECT();
+
 	zend_jit_stop_persistent_op_array(op_array);
+	jit_extension->func_info.flags &= ~ZEND_FUNC_JIT_ON_HOT_TRACE;
 
-	// First not-skipped op
-	zend_op *opline = op_array->opcodes;
-	if (!(op_array->fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
-		while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
-			opline++;
-		}
-	}
-
-	zend_jit_blacklist_root_trace(opline, jit_extension->offset);
+	SHM_PROTECT();
+	zend_shared_alloc_unlock();
 }
 
 static bool zend_jit_trace_is_bad_root(const zend_op *opline, zend_jit_trace_stop stop, size_t offset)

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -521,16 +521,27 @@ static int zend_jit_trace_record_fake_init_call_ex(zend_execute_data *call, zend
 		 && (func->op_array.fn_flags & (ZEND_ACC_CLOSURE|ZEND_ACC_FAKE_CLOSURE))) {
 			return -1;
 		}
-		if (func->type == ZEND_USER_FUNCTION
-		 && (func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+		if (func->type == ZEND_USER_FUNCTION) {
 			jit_extension =
 				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&func->op_array);
-			if (UNEXPECTED(!jit_extension
-			 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
-			 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
+            if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
+				if (UNEXPECTED(!jit_extension
+				 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
+				 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
+					return -1;
+				}
+				func = (zend_function*)jit_extension->op_array;
+			}
+			// First not-skipped op
+			zend_op *opline = func->op_array.opcodes;
+			if (!(func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
+				while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
+					opline++;
+				}
+			}
+			if (jit_extension && ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
 				return -1;
 			}
-			func = (zend_function*)jit_extension->op_array;
 		}
 		if (is_megamorphic == ZEND_JIT_EXIT_POLYMORPHISM
 		 /* TODO: use more accurate check ??? */
@@ -986,6 +997,11 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 					break;
 				}
 
+				if (jit_extension && ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
+					stop = ZEND_JIT_TRACE_STOP_BLACK_LIST;
+					break;
+				}
+
 				TRACE_RECORD(ZEND_JIT_TRACE_ENTER,
 					EX(return_value) != NULL ? ZEND_JIT_TRACE_RETURN_VALUE_USED : 0,
 					op_array);
@@ -1100,17 +1116,29 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 					stop = ZEND_JIT_TRACE_STOP_BAD_FUNC;
 					break;
 				}
-				if (func->type == ZEND_USER_FUNCTION
-				 && (func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+				if (func->type == ZEND_USER_FUNCTION) {
 					jit_extension =
 						(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&func->op_array);
-					if (UNEXPECTED(!jit_extension)
-					 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
-					 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
-						stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
+					if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
+						if (UNEXPECTED(!jit_extension
+						 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
+						 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
+							stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
+							break;
+						}
+						func = (zend_function*)jit_extension->op_array;
+					}
+					// First not-skipped op
+					zend_op *opline = func->op_array.opcodes;
+					if (!(func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
+						while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
+							opline++;
+						}
+					}
+					if (jit_extension && ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
+						stop = ZEND_JIT_TRACE_STOP_BLACK_LIST;
 						break;
 					}
-					func = (zend_function*)jit_extension->op_array;
 				}
 
 #ifndef HAVE_GCC_GLOBAL_REGS

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -524,9 +524,9 @@ static int zend_jit_trace_record_fake_init_call_ex(zend_execute_data *call, zend
 		if (func->type == ZEND_USER_FUNCTION) {
 			jit_extension =
 				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&func->op_array);
-			if (UNEXPECTED(!jit_extension
-			 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
-			 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
+            if (UNEXPECTED(!jit_extension && (func->op_array.fn_flags & ZEND_ACC_CLOSURE))
+			 || (jit_extension && !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE))
+			 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
 				return -1;
 			}
 			if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
@@ -1104,25 +1104,14 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 				if (func->type == ZEND_USER_FUNCTION) {
 					jit_extension =
 						(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&func->op_array);
-					if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
-						if (UNEXPECTED(!jit_extension
-						 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
-						 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
-							stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
-							break;
-						}
-						func = (zend_function*)jit_extension->op_array;
-					}
-					// First not-skipped op
-					zend_op *opline = func->op_array.opcodes;
-					if (!(func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
-						while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
-							opline++;
-						}
-					}
-					if (jit_extension && ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
-						stop = ZEND_JIT_TRACE_STOP_BLACK_LIST;
+					if (UNEXPECTED(!jit_extension && (func->op_array.fn_flags & ZEND_ACC_CLOSURE))
+					 || (jit_extension && !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE))
+					 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
+						stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
 						break;
+					}
+					if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
+						func = (zend_function*)jit_extension->op_array;
 					}
 				}
 

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -524,23 +524,13 @@ static int zend_jit_trace_record_fake_init_call_ex(zend_execute_data *call, zend
 		if (func->type == ZEND_USER_FUNCTION) {
 			jit_extension =
 				(zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(&func->op_array);
-            if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
-				if (UNEXPECTED(!jit_extension
-				 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
-				 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
-					return -1;
-				}
-				func = (zend_function*)jit_extension->op_array;
-			}
-			// First not-skipped op
-			zend_op *opline = func->op_array.opcodes;
-			if (!(func->op_array.fn_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
-				while (opline->opcode == ZEND_RECV || opline->opcode == ZEND_RECV_INIT) {
-					opline++;
-				}
-			}
-			if (jit_extension && ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
+			if (UNEXPECTED(!jit_extension
+			 || !(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)
+			 || (func->op_array.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
 				return -1;
+			}
+			if (func->op_array.fn_flags & ZEND_ACC_CLOSURE) {
+				func = (zend_function*)jit_extension->op_array;
 			}
 		}
 		if (is_megamorphic == ZEND_JIT_EXIT_POLYMORPHISM
@@ -994,11 +984,6 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 				if (EX(func)->op_array.prop_info) {
 					/* TODO: Can we continue recording ??? */
 					stop = ZEND_JIT_TRACE_STOP_PROP_HOOK_CALL;
-					break;
-				}
-
-				if (jit_extension && ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED) {
-					stop = ZEND_JIT_TRACE_STOP_BLACK_LIST;
 					break;
 				}
 

--- a/ext/opcache/opcache.stub.php
+++ b/ext/opcache/opcache.stub.php
@@ -14,6 +14,8 @@ function opcache_compile_file(string $filename): bool {}
 
 function opcache_invalidate(string $filename, bool $force = false): bool {}
 
+function opcache_jit_blacklist(Closure $closure): void {}
+
 /**
  * @return array<string, mixed>|false
  * @refcount 1

--- a/ext/opcache/opcache_arginfo.h
+++ b/ext/opcache/opcache_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 81f337ea4ac5361ca4a0873fcd3b033beaf524c6 */
+ * Stub hash: c416c231c5d1270b7e5961f84cc3ca3e29db4959 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_opcache_reset, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -17,6 +17,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_opcache_invalidate, 0, 1, _IS_BO
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, force, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_opcache_jit_blacklist, 0, 1, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_opcache_get_configuration, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
@@ -26,6 +30,7 @@ ZEND_FUNCTION(opcache_reset);
 ZEND_FUNCTION(opcache_get_status);
 ZEND_FUNCTION(opcache_compile_file);
 ZEND_FUNCTION(opcache_invalidate);
+ZEND_FUNCTION(opcache_jit_blacklist);
 ZEND_FUNCTION(opcache_get_configuration);
 ZEND_FUNCTION(opcache_is_script_cached);
 
@@ -34,6 +39,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(opcache_get_status, arginfo_opcache_get_status)
 	ZEND_FE(opcache_compile_file, arginfo_opcache_compile_file)
 	ZEND_FE(opcache_invalidate, arginfo_opcache_invalidate)
+	ZEND_FE(opcache_jit_blacklist, arginfo_opcache_jit_blacklist)
 	ZEND_FE(opcache_get_configuration, arginfo_opcache_get_configuration)
 	ZEND_FE(opcache_is_script_cached, arginfo_opcache_is_script_cached)
 	ZEND_FE_END

--- a/ext/opcache/tests/jit/opcache_jit_blacklist.phpt
+++ b/ext/opcache/tests/jit/opcache_jit_blacklist.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Basic usage of opcache_jit_blacklist()
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.protect_memory=1
+opcache.jit=tracing
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+function foo() {
+    $x = 1;
+    $x += 0;
+    ++$x;
+    var_dump($x);
+}
+opcache_jit_blacklist(foo(...));
+foo();
+?>
+--EXPECT--
+int(2)

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -928,13 +928,13 @@ ZEND_FUNCTION(opcache_invalidate)
 /* {{{ Prevents JIT on function. Call it before the first invocation of the given function. */
 ZEND_FUNCTION(opcache_jit_blacklist)
 {
-	zend_object *closure;
+	zval *closure;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &closure, zend_ce_closure) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	const zend_function *func = zend_get_closure_method_def(closure);
+	const zend_function *func = zend_get_closure_method_def(Z_OBJ_P(closure));
 	if (ZEND_USER_CODE(func->type)) {
 		zend_jit_blacklist_function((zend_op_array *)&func->op_array);
 	}

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -24,6 +24,7 @@
 #include "php.h"
 #include "ZendAccelerator.h"
 #include "zend_API.h"
+#include "zend_closures.h"
 #include "zend_shared_alloc.h"
 #include "zend_accelerator_blacklist.h"
 #include "php_ini.h"
@@ -921,6 +922,21 @@ ZEND_FUNCTION(opcache_invalidate)
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;
+	}
+}
+
+/* {{{ Prevents JIT on function. Call it before the first invocation of the given function. */
+ZEND_FUNCTION(opcache_jit_blacklist)
+{
+	zend_object *closure;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &closure, zend_ce_closure) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	const zend_function *func = zend_get_closure_method_def(closure);
+	if (ZEND_USER_CODE(func->type)) {
+		zend_jit_blacklist_function((zend_op_array *)&func->op_array);
 	}
 }
 


### PR DESCRIPTION
Sometimes extensions need to do hideous stuff which is incompatible with JIT.
As such, I propose a simple API function to mark an op_array as blacklisted.

In the past we've been maintaining our own (https://github.com/DataDog/dd-trace-php/blob/master/zend_abstract_interface/jit_utils/jit_blacklist.c) solution to work around it, with a lot of dlsym and relying on JIT internals.

It would be great if that could be part of API of JIT itself.