### PR TITLE
Autotools: Sync CS in ext/tidy

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -4,40 +4,35 @@ PHP_ARG_WITH([tidy],
     [Include TIDY support])])
 
 if test "$PHP_TIDY" != "no"; then
-
-  if test "$PHP_TIDY" != "yes"; then
-    TIDY_SEARCH_DIRS=$PHP_TIDY
-  else
-    TIDY_SEARCH_DIRS="/usr/local /usr"
-  fi
+  AS_VAR_IF([PHP_TIDY], [yes],
+    [TIDY_SEARCH_DIRS="/usr/local /usr"],
+    [TIDY_SEARCH_DIRS=$PHP_TIDY])
 
   for i in $TIDY_SEARCH_DIRS; do
     for j in tidy tidyp; do
-        if test -f $i/include/$j/$j.h; then
-            TIDY_DIR=$i
-            TIDY_INCDIR=$i/include/$j
-            TIDY_LIB_NAME=$j
-        break
-        elif test -f $i/include/$j.h; then
-            TIDY_DIR=$i
-            TIDY_INCDIR=$i/include
-            TIDY_LIB_NAME=$j
-        break
-        fi
+      AS_IF([test -f $i/include/$j/$j.h], [
+        TIDY_DIR=$i
+        TIDY_INCDIR=$i/include/$j
+        TIDY_LIB_NAME=$j
+        break 2
+      ],
+      [test -f $i/include/$j.h], [
+        TIDY_DIR=$i
+        TIDY_INCDIR=$i/include
+        TIDY_LIB_NAME=$j
+        break 2
+      ])
     done
   done
 
-  if test -z "$TIDY_DIR"; then
-    AC_MSG_ERROR([Cannot find libtidy])
-  else
-    dnl Check for tidybuffio.h (as opposed to simply buffio.h) which indicates
-    dnl that we are building against tidy-html5 and not the legacy htmltidy. The
-    dnl two are compatible, except for with regard to this header file.
-    if test -f "$TIDY_INCDIR/tidybuffio.h"; then
-      AC_DEFINE([HAVE_TIDYBUFFIO_H], [1],
-        [Define to 1 if you have the <tidybuffio.h> header file.])
-    fi
-  fi
+  AS_VAR_IF([TIDY_DIR],, [AC_MSG_ERROR([Cannot find libtidy])])
+
+  dnl Check for tidybuffio.h (as opposed to simply buffio.h) which indicates
+  dnl that we are building against tidy-html5 and not the legacy htmltidy. The
+  dnl two are compatible, except for with regard to this header file.
+  AS_IF([test -f "$TIDY_INCDIR/tidybuffio.h"2],
+    [AC_DEFINE([HAVE_TIDYBUFFIO_H], [1],
+      [Define to 1 if you have the <tidybuffio.h> header file.])])
 
   TIDY_LIBDIR=$TIDY_DIR/$PHP_LIBDIR
   AS_VAR_IF([TIDY_LIB_NAME], [tidyp],

--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -30,7 +30,7 @@ if test "$PHP_TIDY" != "no"; then
   dnl Check for tidybuffio.h (as opposed to simply buffio.h) which indicates
   dnl that we are building against tidy-html5 and not the legacy htmltidy. The
   dnl two are compatible, except for with regard to this header file.
-  AS_IF([test -f "$TIDY_INCDIR/tidybuffio.h"2],
+  AS_IF([test -f "$TIDY_INCDIR/tidybuffio.h"],
     [AC_DEFINE([HAVE_TIDYBUFFIO_H], [1],
       [Define to 1 if you have the <tidybuffio.h> header file.])])
 


### PR DESCRIPTION
- AS_* macros used
- When TIDY_DIR is not set error out in its own "if" sentence
- break 2 used instead of break to exit also the first for loop