### PR TITLE
Autotools: Use a no-op command in PKG_CHECK_MODULES

### DIFF
--- a/ext/xsl/config.m4
+++ b/ext/xsl/config.m4
@@ -15,7 +15,7 @@ if test "$PHP_XSL" != "no"; then
     PHP_EVAL_LIBLINE([$EXSLT_LIBS], [XSL_SHARED_LIBADD])
     AC_DEFINE([HAVE_XSL_EXSLT], [1],
       [Define to 1 if the system has the EXSLT extension library for XSLT.])
-  ], [ ])
+  ], [:])
 
   AC_DEFINE([HAVE_XSL], [1],
     [Define to 1 if the PHP extension 'xsl' is available.])


### PR DESCRIPTION
Instead of using a space for the "do nothing" command in the PKG_CHECK_MODULES 2nd argument when libexslt is not found, the no-op command ":" is perhaps a bit clearer and is in most cases used in such scenarios and macro arguments.