### PR TITLE
gai_strerror() is not thread-safe on Windows

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -143,6 +143,22 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
 }
 /* }}} */
 
+#ifdef HAVE_GETADDRINFO
+static zend_always_inline report_getaddrinfo_failure(const char *host, int errcode, zend_string **error_string)
+{
+	zend_string *msg = strpprintf(0, "php_network_getaddresses: getaddrinfo for %s failed: %s", host, PHP_GAI_STRERROR(errcode));
+	if (error_string) {
+		/* free error string received during previous iteration (if any) */
+		if (*error_string) {
+			zend_string_release_ex(*error_string, 0);
+		}
+		*error_string = zend_string_copy(msg);
+	}
+	php_error_docref(NULL, E_WARNING, "%s", ZSTR_VAL(msg));
+	zend_string_release_ex(msg, 0);
+}
+#endif
+
 /* {{{ php_network_getaddresses
  * Returns number of addresses, 0 for none/error
  */
@@ -191,16 +207,7 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 # endif
 
 	if ((n = getaddrinfo(host, NULL, &hints, &res))) {
-		if (error_string) {
-			/* free error string received during previous iteration (if any) */
-			if (*error_string) {
-				zend_string_release_ex(*error_string, 0);
-			}
-			*error_string = strpprintf(0, "php_network_getaddresses: getaddrinfo for %s failed: %s", host, PHP_GAI_STRERROR(n));
-			php_error_docref(NULL, E_WARNING, "%s", ZSTR_VAL(*error_string));
-		} else {
-			php_error_docref(NULL, E_WARNING, "php_network_getaddresses: getaddrinfo for %s failed: %s", host, PHP_GAI_STRERROR(n));
-		}
+		report_getaddrinfo_failure(host, n, error_string);
 		return 0;
 	} else if (res == NULL) {
 		if (error_string) {

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -324,7 +324,7 @@ STDOUT.WriteBlankLines(1);
 ARG_ENABLE("ipv6", "Disable IPv6 support (default is turn it on if available)", "yes");
 
 AC_DEFINE('HAVE_GAI_STRERROR', 1);
-if (PHP_IPV6) {
+if (PHP_IPV6 == "yes") {
 	STDOUT.WriteLine("Enabling IPv6 support");
 	AC_DEFINE('HAVE_IPV6', 1);
 }

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -323,13 +323,9 @@ STDOUT.WriteBlankLines(1);
 /* Can we build with IPv6 support? */
 ARG_ENABLE("ipv6", "Disable IPv6 support (default is turn it on if available)", "yes");
 
-var main_network_has_ipv6 = 0;
-if (PHP_IPV6 == "yes") {
-	main_network_has_ipv6 = CHECK_HEADER_ADD_INCLUDE("wspiapi.h", "CFLAGS") ? 1 : 0;
-}
-if (main_network_has_ipv6) {
+AC_DEFINE('HAVE_GAI_STRERROR', 1);
+if (PHP_IPV6) {
 	STDOUT.WriteLine("Enabling IPv6 support");
-	AC_DEFINE('HAVE_GAI_STRERROR', 1);
 	AC_DEFINE('HAVE_IPV6', 1);
 }
 


### PR DESCRIPTION
This PR is mainly about avoiding `gai_strerror()` on Windows, because the function is not thread-safe there[1].

However, it also fixes the IPv6 configuration on Windows where `HAVE_GAI_STRERROR` only was defined if IPv6 support is requested (the default; can be disabled with `--disable-ipv6`), although that function is generally available. For BC, we define `HAVE_GAI_STRERROR` but do no longer use it internally. If extensions use it, they should be fixed (if necessary), but we don't want to break them that late in the pre-release cycle of PHP 8.4.

Note that I'm fine with dropping the changes to config.w32, but the 5th commit should be merged (maybe in a different form; code is not nice as is).

[1] <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-gai_strerrora>

---

WSPiApi.h has been created in 2000, so we can safely assume that it is available everywhere nowadays.  Furthermore, `gai_strerror()` is available regardless of whether there is IPv6 support.

---

This came up in #15567, and solves the easy part. Not using `gai_strerror()` on Windows, because it is not thread-safe would be as simple as `define PHP_GAI_STRERROR(x) (php_win32_error_to_msg(x))`if there wasn't a memory leak because the returned buffer needs to be freed by the caller. Any suggestions on how to solve this in a clean way are welcome!