### PR TITLE
Fix GH-15552: Signed integer overflow in ext/standard/scanf.c

### DIFF
--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -361,8 +361,7 @@ PHPAPI int ValidateFormat(char *format, int numVars, int *totalSubs)
 			if (gotSequential) {
 				goto mixedXPG;
 			}
-			objIndex = value - 1;
-			if ((objIndex < 0) || (numVars && (objIndex >= numVars))) {
+			if ((value < 1) || (numVars && (value > numVars))) {
 				goto badIndex;
 			} else if (numVars == 0) {
 				/*
@@ -382,6 +381,7 @@ PHPAPI int ValidateFormat(char *format, int numVars, int *totalSubs)
 
 				xpgSize = (xpgSize > value) ? xpgSize : value;
 			}
+			objIndex = value - 1;
 			goto xpgCheckDone;
 		}
 

--- a/ext/standard/tests/strings/gh15552.phpt
+++ b/ext/standard/tests/strings/gh15552.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug GH-15552 (Signed integer overflow in ext/standard/scanf.c)
+--FILE--
+<?php
+var_dump(sscanf('hello','%2147483648$s'));
+?>
+--EXPECTF--
+Fatal error: Uncaught ValueError: "%n$" argument index out of range in %s:%d
+Stack trace:%A


### PR DESCRIPTION
We ensure that the argnum `value` is in the allowed range, *before* mapping it to the `objIndex`, not *afterwards*.