### PR TITLE
Skip tests calling wmic if it is not available

### DIFF
--- a/Zend/tests/bug55509.phpt
+++ b/Zend/tests/bug55509.phpt
@@ -49,8 +49,11 @@ elseif (PHP_OS == 'FreeBSD') {
     die('skip Not enough memory.');
   }
 } elseif (PHP_OS == "WINNT") {
-  $s = trim(shell_exec("wmic OS get FreeVirtualMemory /Value 2>nul"));
-  $freeMemory = explode('=', $s)[1]*1;
+  $s = shell_exec("wmic OS get FreeVirtualMemory /Value 2>nul");
+  if (!$s) {
+    die('skip wmic not available');
+  }
+  $freeMemory = explode('=', trim($s))[1]*1;
 
   if ($freeMemory < 2.1*1024*1024) {
     die('skip Not enough memory.');

--- a/ext/standard/tests/general_functions/proc_nice_basic-win.phpt
+++ b/ext/standard/tests/general_functions/proc_nice_basic-win.phpt
@@ -11,6 +11,10 @@ if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
 if (getenv('SKIP_SLOW_TESTS')) {
     die('skip: Slow test');
 }
+
+if (!shell_exec("where wmic 2>nul")) {
+    die('skip wmic not available');
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
The WMIC utitlity is deprecated as of Windows 10 21H1, and a feature on demand which is enabled by default in Windows 11 22H2 and 23H2, but will be disabled by default in the next release of Windows.[1]

Therefore, we ensure that tests which rely on wmic.exe are properly skipped if it is not available.

[1] <https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features#deprecated-features>