### PR TITLE
Autotools: Sync CS in ext/phar

### DIFF
--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -18,17 +18,16 @@ if test "$PHP_PHAR" != "no"; then
     ]),
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+
   AC_MSG_CHECKING([for phar openssl support])
-  if test "$PHP_OPENSSL_SHARED" = "yes"; then
-    AC_MSG_RESULT([no (shared openssl)])
-  else
-    if test "$PHP_OPENSSL" = "yes"; then
+  AS_VAR_IF([PHP_OPENSSL_SHARED], [yes],
+    [AC_MSG_RESULT([no (shared openssl)])],
+    [AS_VAR_IF([PHP_OPENSSL], [yes], [
       AC_MSG_RESULT([yes])
-      AC_DEFINE(PHAR_HAVE_OPENSSL,1,[ ])
-    else
-      AC_MSG_RESULT([no])
-    fi
-  fi
+      AC_DEFINE([PHAR_HAVE_OPENSSL], [1],
+        [Define to 1 if phar extension has native OpenSSL support.])
+    ], [AC_MSG_RESULT([no])])])
+
   PHP_ADD_EXTENSION_DEP(phar, hash)
   PHP_ADD_EXTENSION_DEP(phar, spl)
   PHP_ADD_MAKEFILE_FRAGMENT


### PR DESCRIPTION
As there is a high chance that https://github.com/php/php-src/pull/15574 and https://github.com/php/php-src/pull/14578 will only get resolved in version after the PHP-8.4, this syncs CS for PHP-8.4.