### PR TITLE
CI: Add 60-minute timeouts to GitHub Actions and Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,7 @@ env:
 
 freebsd_task:
   name: FREEBSD_DEBUG_NTS
+  timeout_in: 50m
   freebsd_instance:
     image_family: freebsd-13-3
   env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -77,6 +77,7 @@ jobs:
             asan: true
     name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}${{ matrix.asan && '_ASAN' || '' }}"
     runs-on: ubuntu-${{ !matrix.asan && '22' || '20' }}.04
+    timeout-minutes: 50
     container:
       image: ${{ matrix.asan && 'ubuntu:23.04' || null }}
     steps:
@@ -146,6 +147,7 @@ jobs:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     name: LINUX_X32_DEBUG_ZTS
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     container:
       image: ubuntu:20.04
     env:
@@ -199,6 +201,7 @@ jobs:
             arch: ARM64
     name: MACOS_${{ matrix.arch }}_DEBUG_NTS
     runs-on: macos-${{ matrix.os }}
+    timeout-minutes: 50
     steps:
       - name: git checkout
         uses: actions/checkout@v4
@@ -233,6 +236,7 @@ jobs:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     name: WINDOWS_X64_ZTS
     runs-on: windows-2022
+    timeout-minutes: 50
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
@@ -259,6 +263,7 @@ jobs:
     name: BENCHMARKING
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
+    timeout-minutes: 50
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently, there are no explicit timeouts set for CI jobs, which means the CI jobs will keep running until they are terminated by the task runner. The current defaults of each provider are:

 - GitHub Actions: 360 minutes[^1]
 - Cirrus CI: 60 minutes[^2]
 - Travis CI: 50 minutes[^3]

On Travis, the timeout is not configurable, and given that our test suite usually completes within 20 minutes, this commit explicitly sets timeouts for Cirrus CI and GitHub Actions to 50 minutes as well.

[^1]: [GitHub Actions Workflow Syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)
[^2]: [Cirrus CI FAQ](https://cirrus-ci.org/faq/#instance-timed-out)
[^3]: [Travis docs - customizing the build](https://docs.travis-ci.com/user/customizing-the-build#build-timeouts)