### PR TITLE
Add OPcache restart hook

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -94,6 +94,7 @@ ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
 ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 ZEND_API zend_result (*zend_post_startup_cb)(void) = NULL;
 ZEND_API void (*zend_post_shutdown_cb)(void) = NULL;
+ZEND_API void (*zend_accel_schedule_restart_hook)(int reason) = NULL;
 ZEND_ATTRIBUTE_NONNULL ZEND_API zend_result (*zend_random_bytes)(void *bytes, size_t size, char *errstr, size_t errstr_size) = NULL;
 ZEND_ATTRIBUTE_NONNULL ZEND_API void (*zend_random_bytes_insecure)(zend_random_bytes_insecure_state *state, void *bytes, size_t size) = NULL;
 

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -362,6 +362,8 @@ extern ZEND_ATTRIBUTE_NONNULL ZEND_API void (*zend_random_bytes_insecure)(
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);
 extern ZEND_API void (*zend_post_shutdown_cb)(void);
 
+extern ZEND_API void (*zend_accel_schedule_restart_hook)(int reason);
+
 ZEND_API ZEND_COLD void zend_error(int type, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn_unchecked(int type, const char *format, ...);

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -26,6 +26,7 @@
 #include "zend_compile.h"
 #include "ZendAccelerator.h"
 #include "zend_persist.h"
+#include "zend_portability.h"
 #include "zend_shared_alloc.h"
 #include "zend_accelerator_module.h"
 #include "zend_accelerator_blacklist.h"
@@ -3410,6 +3411,8 @@ void accel_shutdown(void)
 	}
 }
 
+ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason);
+
 void zend_accel_schedule_restart(zend_accel_restart_reason reason)
 {
 	const char *zend_accel_restart_reason_text[ACCEL_RESTART_USER + 1] = {
@@ -3417,6 +3420,10 @@ void zend_accel_schedule_restart(zend_accel_restart_reason reason)
 		"hash overflow",
 		"user",
 	};
+
+	if (UNEXPECTED(zend_accel_schedule_restart_hook)) {
+		zend_accel_schedule_restart_hook(reason);
+	}
 
 	if (ZCSG(restart_pending)) {
 		/* don't schedule twice */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -26,7 +26,6 @@
 #include "zend_compile.h"
 #include "ZendAccelerator.h"
 #include "zend_persist.h"
-#include "zend_portability.h"
 #include "zend_shared_alloc.h"
 #include "zend_accelerator_module.h"
 #include "zend_accelerator_blacklist.h"
@@ -3410,8 +3409,6 @@ void accel_shutdown(void)
 		ini_entry->on_modify = orig_include_path_on_modify;
 	}
 }
-
-ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason) = NULL;
 
 void zend_accel_schedule_restart(zend_accel_restart_reason reason)
 {

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3421,14 +3421,15 @@ void zend_accel_schedule_restart(zend_accel_restart_reason reason)
 		"user",
 	};
 
-	if (UNEXPECTED(zend_accel_schedule_restart_hook)) {
-		zend_accel_schedule_restart_hook(reason);
-	}
-
 	if (ZCSG(restart_pending)) {
 		/* don't schedule twice */
 		return;
 	}
+
+	if (UNEXPECTED(zend_accel_schedule_restart_hook)) {
+		zend_accel_schedule_restart_hook(reason);
+	}
+
 	zend_accel_error(ACCEL_LOG_DEBUG, "Restart Scheduled! Reason: %s",
 			zend_accel_restart_reason_text[reason]);
 

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3411,7 +3411,7 @@ void accel_shutdown(void)
 	}
 }
 
-ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason);
+ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason) = NULL;
 
 void zend_accel_schedule_restart(zend_accel_restart_reason reason)
 {

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -311,8 +311,9 @@ extern const char *zps_api_failure_reason;
 BEGIN_EXTERN_C()
 
 void accel_shutdown(void);
-zend_result  accel_activate(INIT_FUNC_ARGS);
+zend_result accel_activate(INIT_FUNC_ARGS);
 zend_result accel_post_deactivate(void);
+extern ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason);
 void zend_accel_schedule_restart(zend_accel_restart_reason reason);
 void zend_accel_schedule_restart_if_necessary(zend_accel_restart_reason reason);
 accel_time_t zend_get_file_handle_timestamp(zend_file_handle *file_handle, size_t *size);

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -313,7 +313,6 @@ BEGIN_EXTERN_C()
 void accel_shutdown(void);
 zend_result accel_activate(INIT_FUNC_ARGS);
 zend_result accel_post_deactivate(void);
-extern ZEND_EXT_API void (*zend_accel_schedule_restart_hook)(zend_accel_restart_reason reason);
 void zend_accel_schedule_restart(zend_accel_restart_reason reason);
 void zend_accel_schedule_restart_if_necessary(zend_accel_restart_reason reason);
 accel_time_t zend_get_file_handle_timestamp(zend_file_handle *file_handle, size_t *size);


### PR DESCRIPTION
Hey folks,

adding to #15543 which allows access to OPcache shared globals, this hook will allow observing extensions to observe the actual OPcache restart using this code snippet:

```C
void restart_hook(zend_accel_restart_reason reason)
{
    printf("IT HAPPENED\n");
}

void call_during_minit() {
    // assume you have the `opcache_handle` available
    void (**opcache_restart_hook)(zend_accel_restart_reason reason);
    opcache_restart_hook = DL_FETCH_SYMBOL(opcache_handle, "zend_accel_schedule_restart_hook");
    // do proper error handling ;-)
    *opcache_restart_hook = restart_hook;
}
```

CC: @arnaud-lb 
