### PR TITLE
Fix ZEND_EXT_API wrt accessibility of OPcache symbols on Windows

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -65,7 +65,11 @@
 
 #ifndef ZEND_EXT_API
 # ifdef ZEND_WIN32
-#  define ZEND_EXT_API __declspec(dllexport)
+#  ifdef ZEND_EXT_EXPORTS
+#   define ZEND_EXT_API __declspec(dllexport)
+#  else
+#   define ZEND_EXT_API __declspec(dllimport)
+#  endif
 # elif defined(__GNUC__) && __GNUC__ >= 4
 #  define ZEND_EXT_API __attribute__ ((visibility("default")))
 # else

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -62,7 +62,7 @@ if (PHP_OPCACHE != "no") {
 		}
 	}
 
-	ADD_FLAG('CFLAGS_OPCACHE', "/I " + configure_module_dirname);
+	ADD_FLAG('CFLAGS_OPCACHE', "/I " + configure_module_dirname + " /D ZEND_EXT_EXPORTS");
 
 }
 


### PR DESCRIPTION
When building a DLL which exports symbols these need to be explicitly exported like on other platforms.  When building a DLL which accesses these symbols, they should be imported for performance reasons if the symbols are referring to functions, and *have* *to* be imported if the symbols are referring to data.[1]

So we do the common dllexport/dllimport "dance" depending on a macro which is only set when building OPcache.

[1] <https://learn.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport?view=msvc-170>

---

This should solve @dstogov's concerns from PR #15543, and makes it possible to statically link to `smm_shared_globals` in the import library of php_opcache.dll.

cc @bwoebi, @realFlowControl, maybe you want to test this.

One problem remains, though, namely that apparently none of the OPcache headers are exported (aka. installed), so phpize builds can't use these (easily). Is there any particular reason for that?

Also note that almost all extensions doesn't handle the export/import on Windows properly; even if only function symbols are exported, accessing them without dllimport has a small performance impact. Maybe we should improve that over time.
