### PR TITLE
Export OPcache header files

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -343,6 +343,13 @@ int main(void) {
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $JIT_CFLAGS],,
     [yes])
 
+  PHP_INSTALL_HEADERS([ext/opcache], m4_normalize([
+    ZendAccelerator.h
+    zend_accelerator_debug.h
+    zend_accelerator_hash.h
+    zend_shared_alloc.h
+  ]))
+
   PHP_ADD_EXTENSION_DEP(opcache, date)
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -18,6 +18,8 @@ if (PHP_OPCACHE != "no") {
 		zend_shared_alloc.c \
 		shared_alloc_win32.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
+	PHP_INSTALL_HEADERS("ext/opcache", "ZendAccelerator.h zend_accelerator_debug.h zend_accelerator_hash.h zend_shared_alloc.h");
+
 	ADD_EXTENSION_DEP('opcache', 'date');
 	ADD_EXTENSION_DEP('opcache', 'hash');
 	ADD_EXTENSION_DEP('opcache', 'pcre');


### PR DESCRIPTION
See https://github.com/php/php-src/pull/15592#issuecomment-2311779054
Export headers for OPcache so it is easier to use https://github.com/php/php-src/pull/15543 

CC: @arnaud-lb / @cmb69 