### PR TITLE
Autotools: Sync CS in ext/dba

### DIFF
--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -1,8 +1,16 @@
+dnl
+dnl PHP_DBA_STD_BEGIN
+dnl
 dnl Suppose we need FlatFile if no support or only CDB is used.
-AC_DEFUN([PHP_DBA_STD_BEGIN],[
-  unset THIS_INCLUDE THIS_LIBS THIS_LFLAGS THIS_PREFIX THIS_RESULT
-])
+dnl
+AC_DEFUN([PHP_DBA_STD_BEGIN],
+  [unset THIS_INCLUDE THIS_LIBS THIS_LFLAGS THIS_PREFIX THIS_RESULT])
 
+dnl
+dnl PHP_TEMP_LDFLAGS(ldflags, libs)
+dnl
+dnl Save and restore linker flags.
+dnl
 AC_DEFUN([PHP_TEMP_LDFLAGS],[
   old_LDFLAGS=$LDFLAGS
   LDFLAGS="$1 $LDFLAGS"
@@ -13,32 +21,45 @@ AC_DEFUN([PHP_TEMP_LDFLAGS],[
   LIBS=$old_LIBS
 ])
 
-dnl Assign INCLUDE/LFLAGS from PREFIX
+dnl
+dnl PHP_DBA_STD_ASSIGN
+dnl
+dnl Assign INCLUDE/LFLAGS from PREFIX.
+dnl
 AC_DEFUN([PHP_DBA_STD_ASSIGN],[
   if test -n "$THIS_PREFIX" && test "$THIS_PREFIX" != "/usr"; then
     THIS_LFLAGS=$THIS_PREFIX/$PHP_LIBDIR
   fi
 ])
 
-dnl Standard check
+dnl
+dnl PHP_DBA_STD_CHECK
+dnl
+dnl Check if includes and libraries are set.
+dnl
 AC_DEFUN([PHP_DBA_STD_CHECK],[
   THIS_RESULT=yes
-  if test -z "$THIS_INCLUDE"; then
-    AC_MSG_ERROR([DBA: Could not find necessary header file(s).])
-  fi
-  if test -z "$THIS_LIBS"; then
-    AC_MSG_ERROR([DBA: Could not find necessary library.])
-  fi
+  AS_VAR_IF([THIS_INCLUDE],,
+    [AC_MSG_ERROR([DBA: Could not find necessary header file(s).])])
+  AS_VAR_IF([THIS_LIBS],,
+    [AC_MSG_ERROR([DBA: Could not find necessary library.])])
 ])
 
-dnl Attach THIS_x to DBA_x
+dnl
+dnl PHP_DBA_STD_ATTACH
+dnl
+dnl Attach THIS_x to DBA_x.
+dnl
 AC_DEFUN([PHP_DBA_STD_ATTACH],[
   PHP_ADD_LIBRARY_WITH_PATH([$THIS_LIBS], [$THIS_LFLAGS], [DBA_SHARED_LIBADD])
   unset THIS_INCLUDE THIS_LIBS THIS_LFLAGS THIS_PREFIX
 ])
 
-dnl Print the result message
-dnl parameters(name [, full name [, empty or error message]])
+dnl
+dnl PHP_DBA_STD_RESULT(name [, full name [, empty or error message]])
+dnl
+dnl Print the result message.
+dnl
 AC_DEFUN([PHP_DBA_STD_RESULT],[
   THIS_NAME=[]translit($1,a-z0-9-,A-Z0-9_)
   if test -n "$2"; then
@@ -167,14 +188,15 @@ if test "$PHP_QDBM" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(qdbm)
+PHP_DBA_STD_RESULT([qdbm])
 
 dnl GDBM
 if test "$PHP_GDBM" != "no"; then
   PHP_DBA_STD_BEGIN
-  if test "$HAVE_QDBM" = "1"; then
-    PHP_DBA_STD_RESULT(gdbm, gdbm, [You cannot combine --with-gdbm with --with-qdbm])
-  fi
+  AS_VAR_IF([HAVE_QDBM], [1],
+    [PHP_DBA_STD_RESULT([gdbm],
+      [gdbm],
+      [You cannot combine --with-gdbm with --with-qdbm])])
   for i in $PHP_GDBM /usr/local /usr; do
     if test -f "$i/include/gdbm.h"; then
       THIS_PREFIX=$i
@@ -197,7 +219,7 @@ if test "$PHP_GDBM" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(gdbm)
+PHP_DBA_STD_RESULT([gdbm])
 
 dnl NDBM
 if test "$PHP_NDBM" != "no"; then
@@ -233,7 +255,7 @@ if test "$PHP_NDBM" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(ndbm)
+PHP_DBA_STD_RESULT([ndbm])
 
 dnl TCADB
 if test "$PHP_TCADB" != "no"; then
@@ -266,7 +288,7 @@ if test "$PHP_TCADB" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(tcadb)
+PHP_DBA_STD_RESULT([tcadb])
 
 dnl LMDB
 if test "$PHP_LMDB" != "no"; then
@@ -299,24 +321,23 @@ if test "$PHP_LMDB" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(lmdb)
+PHP_DBA_STD_RESULT([lmdb])
 
-dnl Berkeley specific (library and version test)
-dnl parameters(version, library list, function)
+dnl
+dnl PHP_DBA_DB_CHECK(version, library list, function)
+dnl
+dnl Berkeley specific (library and version test).
+dnl
 AC_DEFUN([PHP_DBA_DB_CHECK],[
-  if test -z "$THIS_INCLUDE"; then
-    AC_MSG_ERROR([DBA: Could not find necessary header file(s).])
-  fi
+  AS_VAR_IF([THIS_INCLUDE],,
+    [AC_MSG_ERROR([DBA: Could not find necessary header file(s).])])
   for LIB in $2; do
     if test -f $THIS_PREFIX/$PHP_LIBDIR/lib$LIB.a || test -f $THIS_PREFIX/$PHP_LIBDIR/lib$LIB.$SHLIB_SUFFIX_NAME; then
       lib_found="";
-      PHP_TEMP_LDFLAGS(-L$THIS_PREFIX/$PHP_LIBDIR, -l$LIB,[
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include "$THIS_INCLUDE"
-        ]],[[
-          $3;
-        ]])],[
-          AC_EGREP_CPP(yes,[
+      PHP_TEMP_LDFLAGS([-L$THIS_PREFIX/$PHP_LIBDIR], [-l$LIB],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "$THIS_INCLUDE"],
+          [$3;])],
+          [AC_EGREP_CPP([yes], [
 #include "$THIS_INCLUDE"
 #if DB_VERSION_MAJOR == $1 || ($1 == 4 && DB_VERSION_MAJOR == 5)
             yes
@@ -324,45 +345,41 @@ AC_DEFUN([PHP_DBA_DB_CHECK],[
           ],[
             THIS_LIBS=$LIB
             lib_found=1
-          ])
-        ],[])
-      ])
+            ])],
+          [])])
       if test -n "$lib_found"; then
         lib_found="";
         break;
       fi
     fi
   done
-  if test -z "$THIS_LIBS"; then
-    AC_MSG_CHECKING([for DB$1 major version])
-    AC_MSG_ERROR([Header contains different version])
-  fi
+
+  AS_VAR_IF([THIS_LIBS],, [AC_MSG_FAILURE(m4_text_wrap([
+    DB$1 major version check failed: header contains different version
+  ]))])
+
   if test "$1" = "4"; then
     AC_MSG_CHECKING([for DB4 minor version and patch level])
-    AC_EGREP_CPP(yes,[
+    AC_EGREP_CPP([yes], [
 #include "$THIS_INCLUDE"
 #if DB_VERSION_MAJOR > 4 || (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR != 1) || (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 1 && DB_VERSION_PATCH >= 25)
       yes
 #endif
-    ],[
-      AC_MSG_RESULT([ok])
-    ],[
-      AC_MSG_ERROR([Version 4.1 requires patch level 25])
-    ])
+    ],
+    [AC_MSG_RESULT([ok])],
+    [AC_MSG_ERROR([Version 4.1 requires patch level 25])])
   fi
-  if test "$ext_shared" = "yes"; then
+  AS_VAR_IF([ext_shared], [yes], [
     AC_MSG_CHECKING([if dba can be used as shared extension])
-    AC_EGREP_CPP(yes,[
+    AC_EGREP_CPP([yes], [
 #include "$THIS_INCLUDE"
 #if DB_VERSION_MAJOR > 3 || (DB_VERSION_MAJOR == 3 && DB_VERSION_MINOR > 2)
       yes
 #endif
-    ],[
-      AC_MSG_RESULT([yes])
-    ],[
-      AC_MSG_ERROR([At least version 3.3 is required])
-    ])
-  fi
+    ],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_ERROR([At least version 3.3 is required])])
+  ])
   if test -n "$THIS_LIBS"; then
     AC_DEFINE_UNQUOTED([DBA_DB$1], [1],
       [Define to 1 if the dba extension uses the Berkeley DB version $1 (DB$1)
@@ -444,14 +461,15 @@ if test "$PHP_DB4" != "no"; then
   done
   PHP_DBA_DB_CHECK(4, db-5.3 db-5.1 db-5.0 db-4.8 db-4.7 db-4.6 db-4.5 db-4.4 db-4.3 db-4.2 db-4.1 db-4.0 db-4 db4 db, [(void)db_create((DB**)0, (DB_ENV*)0, 0)])
 fi
-PHP_DBA_STD_RESULT(db4,Berkeley DB4)
+PHP_DBA_STD_RESULT([db4], [Berkeley DB4])
 
 dnl DB3
 if test "$PHP_DB3" != "no"; then
   PHP_DBA_STD_BEGIN
-  if test "$HAVE_DB4" = "1"; then
-    PHP_DBA_STD_RESULT(db3, Berkeley DB3, [You cannot combine --with-db3 with --with-db4])
-  fi
+  AS_VAR_IF([HAVE_DB4], [1],
+    [PHP_DBA_STD_RESULT([db3],
+      [Berkeley DB3],
+      [You cannot combine --with-db3 with --with-db4])])
   for i in $PHP_DB3 /usr/local/BerkeleyDB.3.3 /usr/local/BerkeleyDB.3.2 /usr/local/BerkeleyDB.3.1 /usr/local/BerkeleyDB.3.0 /usr/local /usr; do
     if test -f "$i/db3/db.h"; then
       THIS_PREFIX=$i
@@ -477,13 +495,15 @@ if test "$PHP_DB3" != "no"; then
   done
   PHP_DBA_DB_CHECK(3, db-3.3 db-3.2 db-3.1 db-3.0 db-3 db3 db, [(void)db_create((DB**)0, (DB_ENV*)0, 0)])
 fi
-PHP_DBA_STD_RESULT(db3,Berkeley DB3)
+PHP_DBA_STD_RESULT([db3], [Berkeley DB3])
 
 dnl DB2
 if test "$PHP_DB2" != "no"; then
   PHP_DBA_STD_BEGIN
   if test "$HAVE_DB3" = "1" || test "$HAVE_DB4" = "1"; then
-    PHP_DBA_STD_RESULT(db2, Berkeley DB2, [You cannot combine --with-db2 with --with-db3 or --with-db4])
+    PHP_DBA_STD_RESULT([db2],
+      [Berkeley DB2],
+      [You cannot combine --with-db2 with --with-db3 or --with-db4])
   fi
   for i in $PHP_DB2 $PHP_DB2/BerkeleyDB /usr/BerkeleyDB /usr/local /usr; do
     if test -f "$i/db2/db.h"; then
@@ -510,7 +530,7 @@ if test "$PHP_DB2" != "no"; then
   done
   PHP_DBA_DB_CHECK(2, db-2 db2 db,  [(void)db_appinit("", NULL, (DB_ENV*)0, 0)])
 fi
-PHP_DBA_STD_RESULT(db2, Berkeley DB2)
+PHP_DBA_STD_RESULT([db2], [Berkeley DB2])
 
 dnl DB1
 if test "$PHP_DB1" != "no"; then
@@ -562,35 +582,31 @@ if test "$PHP_DB1" != "no"; then
   AC_MSG_CHECKING([for DB1 in header])
   AC_MSG_RESULT([$THIS_INCLUDE])
   if test -n "$THIS_INCLUDE"; then
-    PHP_TEMP_LDFLAGS(-L$THIS_PREFIX/$PHP_LIBDIR, -l$THIS_LIBS,[
-      AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include "$THIS_INCLUDE"
-      ]],[[
-        DB * dbp = dbopen("", 0, 0, DB_HASH, 0);
-      ]])],[
-        AC_DEFINE_UNQUOTED([DB1_INCLUDE_FILE], ["$THIS_INCLUDE"],
+    PHP_TEMP_LDFLAGS([-L$THIS_PREFIX/$PHP_LIBDIR], [-l$THIS_LIBS],
+      [AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "$THIS_INCLUDE"],
+        [DB * dbp = dbopen("", 0, 0, DB_HASH, 0);])],
+        [AC_DEFINE_UNQUOTED([DB1_INCLUDE_FILE], ["$THIS_INCLUDE"],
           [The DB1 handler header file.])
         AC_DEFINE([DBA_DB1], [1],
           [Define to 1 if the dba extension uses the Berkeley DB version 1 (DB1)
           handler.])
         THIS_RESULT=yes
-      ],[
-        THIS_RESULT=no
-      ])
-    ])
+        ],
+        [THIS_RESULT=no])])
   fi
   PHP_DBA_STD_ASSIGN
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(db1, DB1)
+PHP_DBA_STD_RESULT([db1], [DB1])
 
 dnl DBM
 if test "$PHP_DBM" != "no"; then
   PHP_DBA_STD_BEGIN
-  if test "$HAVE_QDBM" = "1"; then
-    PHP_DBA_STD_RESULT(dbm, dbm, [You cannot combine --with-dbm with --with-qdbm])
-  fi
+  AS_VAR_IF([HAVE_QDBM], [1],
+    [PHP_DBA_STD_RESULT([dbm],
+      [dbm],
+      [You cannot combine --with-dbm with --with-qdbm])])
   for i in $PHP_DBM /usr/local /usr; do
     if test -f "$i/include/dbm.h"; then
       THIS_PREFIX=$i
@@ -632,7 +648,7 @@ if test "$PHP_DBM" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(dbm)
+PHP_DBA_STD_RESULT([dbm])
 
 dnl Bundled modules that should be enabled by default if any other option is
 dnl enabled
@@ -697,7 +713,7 @@ elif test "$PHP_CDB" != "no"; then
   PHP_DBA_STD_CHECK
   PHP_DBA_STD_ATTACH
 fi
-PHP_DBA_STD_RESULT(cdb)
+PHP_DBA_STD_RESULT([cdb])
 
 dnl INIFILE
 if test "$PHP_INIFILE" != "no"; then
@@ -706,7 +722,7 @@ if test "$PHP_INIFILE" != "no"; then
   ini_sources="libinifile/inifile.c"
   THIS_RESULT="builtin"
 fi
-PHP_DBA_STD_RESULT(inifile, [INI File])
+PHP_DBA_STD_RESULT([inifile], [INI File])
 
 dnl FLATFILE
 if test "$PHP_FLATFILE" != "no"; then
@@ -715,18 +731,17 @@ if test "$PHP_FLATFILE" != "no"; then
   flat_sources="libflatfile/flatfile.c"
   THIS_RESULT="builtin"
 fi
-PHP_DBA_STD_RESULT(FlatFile, FlatFile)
+PHP_DBA_STD_RESULT([FlatFile], [FlatFile])
 
 dnl
 dnl Extension setup
 dnl
 AC_MSG_CHECKING([whether to enable DBA interface])
-if test "$HAVE_DBA" = "1"; then
-  if test "$ext_shared" = "yes"; then
-    AC_MSG_RESULT([yes, shared])
-  else
-    AC_MSG_RESULT([yes])
-  fi
+AS_VAR_IF([HAVE_DBA], [1], [
+  AS_VAR_IF([ext_shared], [yes],
+    [AC_MSG_RESULT([yes, shared])],
+    [AC_MSG_RESULT([yes])])
+
   AC_DEFINE([HAVE_DBA], [1],
     [Define to 1 if the PHP extension 'dba' is available.])
   PHP_NEW_EXTENSION([dba], m4_normalize([
@@ -754,6 +769,5 @@ if test "$HAVE_DBA" = "1"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/libflatfile])
   PHP_ADD_BUILD_DIR([$ext_builddir/libinifile])
   PHP_SUBST([DBA_SHARED_LIBADD])
-else
-  AC_MSG_RESULT([no])
-fi
+],
+[AC_MSG_RESULT([no])])


### PR DESCRIPTION
- Macro headers synced with current PHP style (a minor description added and parameters)
- macro arguments quoted
- redundant double quotes reduces
- AS_VAR_IF macros used
- Redundant check message removed because there is already error thrown right after it