### PR TITLE
Zend/tests/assert/expect_015.phpt: fix typo in test name

### DIFF
--- a/Zend/tests/assert/expect_015.phpt
+++ b/Zend/tests/assert/expect_015.phpt
@@ -1,5 +1,5 @@
 --TEST--
-AST pretty-peinter
+AST pretty-printer
 --INI--
 zend.assertions=1
 --FILE--


### PR DESCRIPTION
`peinter` -> `printer`