### PR TITLE
Fix iconv_open basic test

### DIFF
--- a/ext/iconv/tests/iconv_basic_001.phpt
+++ b/ext/iconv/tests/iconv_basic_001.phpt
@@ -21,5 +21,5 @@ $string_out = iconv($in_charset, $out_charset, $string_to_translate);
 
 var_dump($string_out);
 ?>
---EXPECT--
-string(15) "Zlutoucky kun\n"
+--EXPECTF--
+string(1%d) "Zlutouck%Sy kun\n"


### PR DESCRIPTION
Transliteration works differently across the iconv implementations and the system. When using GNU libiconv the output in this test is: string(16) "Zlutouck'y kun\n"
(like on Windows). On glibc's built-in iconv output is: string(15) "Zlutoucky kun\n"

Targeting PHP-8.2 to have this resolved also on current maintained branches.