### PR TITLE
Autotools: Normalize PHP_ADD_BUILD_DIR 1st argument

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -186,6 +186,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_INSTALL_HEADERS arguments can now be also
      blank-or-newline-separated lists instead of only separated with whitespace
      or backslash-then-newline.
+   - M4 macro PHP_ADD_BUILD_DIR now also accepts 1st argument as a
+     blank-or-newline-separated separated list.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -911,12 +911,15 @@ AC_DEFUN([PHP_SELECT_SAPI],[
 dnl
 dnl PHP_ADD_BUILD_DIR(dirs [, create])
 dnl
-dnl Add build directories and directories required for the out-of-source builds.
-dnl When "create" is given, the provided "dirs" are created immediately upon
-dnl macro invocation, instead of deferring it to the PHP_GEN_BUILD_DIRS.
+dnl Add blank-or-newline-separated list of build directories or directories
+dnl required for the out-of-source builds. When "create" is given, the provided
+dnl "dirs" are created immediately upon macro invocation, instead of deferring
+dnl them to the PHP_GEN_BUILD_DIRS.
 dnl
-AC_DEFUN([PHP_ADD_BUILD_DIR],[
-  ifelse($2,,[BUILD_DIR="$BUILD_DIR $1"], [$php_shtool mkdir -p $1])
+AC_DEFUN([PHP_ADD_BUILD_DIR],
+[m4_ifblank([$2],
+  [AS_VAR_APPEND([BUILD_DIR], [" m4_normalize(m4_expand([$1]))"])],
+  [$php_shtool mkdir -p m4_normalize(m4_expand([$1]))])
 ])
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1781,7 +1781,7 @@ PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/Zend/Makefile.frag],
 AC_DEFINE([HAVE_BUILD_DEFS_H], [1],
   [Define to 1 if PHP has the <main/build-defs.h> header file.])
 
-PHP_ADD_BUILD_DIR(m4_normalize([
+PHP_ADD_BUILD_DIR([
   main
   main/streams
   scripts
@@ -1790,7 +1790,7 @@ PHP_ADD_BUILD_DIR(m4_normalize([
   Zend
   Zend/asm
   Zend/Optimizer
-]))
+])
 
 AC_CONFIG_FILES([
   main/build-defs.h

--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -765,9 +765,11 @@ AS_VAR_IF([HAVE_DBA], [1], [
     ]),
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
-  PHP_ADD_BUILD_DIR([$ext_builddir/libcdb])
-  PHP_ADD_BUILD_DIR([$ext_builddir/libflatfile])
-  PHP_ADD_BUILD_DIR([$ext_builddir/libinifile])
+  PHP_ADD_BUILD_DIR([
+    $ext_builddir/libcdb
+    $ext_builddir/libflatfile
+    $ext_builddir/libinifile
+  ])
   PHP_SUBST([DBA_SHARED_LIBADD])
 ],
 [AC_MSG_RESULT([no])])

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -227,7 +227,7 @@ if test "$PHP_DOM" != "no"; then
       ]),
       [$ext_shared],,
       [$PHP_LEXBOR_CFLAGS])
-    PHP_ADD_BUILD_DIR(m4_normalize([
+    PHP_ADD_BUILD_DIR([
       $ext_builddir/parentnode
       $ext_builddir/$LEXBOR_DIR/core
       $ext_builddir/$LEXBOR_DIR/css/selectors
@@ -242,7 +242,7 @@ if test "$PHP_DOM" != "no"; then
       $ext_builddir/$LEXBOR_DIR/ports/posix/lexbor/core
       $ext_builddir/$LEXBOR_DIR/selectors-adapted
       $ext_builddir/$LEXBOR_DIR/tag
-    ]))
+    ])
     PHP_SUBST([DOM_SHARED_LIBADD])
     PHP_INSTALL_HEADERS([ext/dom], m4_normalize([
       dom_ce.h

--- a/ext/intl/config.m4
+++ b/ext/intl/config.m4
@@ -108,7 +108,7 @@ if test "$PHP_INTL" != "no"; then
       [shared_objects_intl],
       [yes])])
 
-  PHP_ADD_BUILD_DIR(m4_normalize([
+  PHP_ADD_BUILD_DIR([
     $ext_builddir/breakiterator
     $ext_builddir/calendar
     $ext_builddir/collator
@@ -126,7 +126,7 @@ if test "$PHP_INTL" != "no"; then
     $ext_builddir/timezone
     $ext_builddir/transliterator
     $ext_builddir/uchar
-  ]))
+  ])
 
   PHP_ADD_EXTENSION_DEP(intl, date)
 fi

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -354,8 +354,10 @@ int main(void) {
   fi
 
   AS_VAR_IF([PHP_OPCACHE_JIT], [yes], [
-    PHP_ADD_BUILD_DIR([$ext_builddir/jit])
-    PHP_ADD_BUILD_DIR([$ext_builddir/jit/ir])
+    PHP_ADD_BUILD_DIR([
+      $ext_builddir/jit
+      $ext_builddir/jit/ir
+    ])
     PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/jit/Makefile.frag])
   ])
   PHP_SUBST([OPCACHE_SHARED_LIBADD])

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -506,8 +506,10 @@ if test "$PHP_FPM" != "no"; then
   php_fpm_prefix=$(eval echo $prefix)
   AC_SUBST([php_fpm_prefix])
 
-  PHP_ADD_BUILD_DIR([sapi/fpm/fpm])
-  PHP_ADD_BUILD_DIR([sapi/fpm/fpm/events])
+  PHP_ADD_BUILD_DIR([
+    sapi/fpm/fpm
+    sapi/fpm/fpm/events
+  ])
   AC_CONFIG_FILES([
     sapi/fpm/init.d.php-fpm
     sapi/fpm/php-fpm.8


### PR DESCRIPTION
The m4_normalize(m4_expand([$1])) expands the given argument if it contains M4 macros, and then trims the items together into a space separated string in an intuitive way.

From my tests, I think this is still "safe" to put to PHP-8.4 branch as it already works the same also without m4_normalize() in PHP-8.3 and earlier due to those double quotes used around the 1st argument variable. That's why I'm targeting it already.