### PR TITLE
Mark gd14930.phpt as dynamic xfail

### DIFF
--- a/ext/standard/tests/streams/gh14930.phpt
+++ b/ext/standard/tests/streams/gh14930.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GH-14930: Custom stream wrapper dir_readdir output truncated to 255 characters in PHP 8.3
---XFAIL--
-Fix is an ABI break so reverted from 8.3
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== "Windows") die("xfail Fix is an ABI break so reverted from 8.3");
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
This test only fails when `NAME_MAX` is defined, which is never the case on Windows, so we let the test pass there.  This could be extended to other environments where `NAME_MAX` is not defined.

---

Note that merging up into `master` should be empty (the test is supposed to succeed there always).