### PR TITLE
Improve readonly avis error

### DIFF
--- a/Zend/tests/asymmetric_visibility/readonly.phpt
+++ b/Zend/tests/asymmetric_visibility/readonly.phpt
@@ -57,6 +57,6 @@ test();
 ?>
 --EXPECT--
 Cannot modify private(set) property P::$pPrivate from scope C
-Cannot modify protected(set) property P::$pDefault from global scope
+Cannot modify protected(set) readonly property P::$pDefault from global scope
 Cannot modify private(set) property P::$pPrivate from global scope
-Cannot modify protected(set) property P::$pProtected from global scope
+Cannot modify protected(set) readonly property P::$pProtected from global scope

--- a/Zend/tests/readonly_props/initialization_scope.phpt
+++ b/Zend/tests/readonly_props/initialization_scope.phpt
@@ -59,7 +59,7 @@ var_dump($test);
 
 ?>
 --EXPECTF--
-Cannot modify protected(set) property A::$prop from global scope
+Cannot modify protected(set) readonly property A::$prop from global scope
 object(B)#%d (1) {
   ["prop"]=>
   int(2)

--- a/Zend/tests/readonly_props/magic_get_set.phpt
+++ b/Zend/tests/readonly_props/magic_get_set.phpt
@@ -64,8 +64,8 @@ try {
 --EXPECT--
 bool(false)
 Typed property Test::$prop must not be accessed before initialization
-Cannot modify protected(set) property Test::$prop from global scope
-Cannot unset protected(set) property Test::$prop from global scope
+Cannot modify protected(set) readonly property Test::$prop from global scope
+Cannot unset protected(set) readonly property Test::$prop from global scope
 Test::__isset(prop)
 bool(true)
 Test::__get(prop)

--- a/Zend/tests/readonly_props/unset.phpt
+++ b/Zend/tests/readonly_props/unset.phpt
@@ -61,4 +61,4 @@ Test2::__get
 int(1)
 int(1)
 Cannot unset readonly property Test2::$prop
-Cannot unset protected(set) property Test3::$prop from global scope
+Cannot unset protected(set) readonly property Test3::$prop from global scope

--- a/Zend/tests/readonly_props/variation.phpt
+++ b/Zend/tests/readonly_props/variation.phpt
@@ -126,9 +126,9 @@ Init: 0, scope: 1, op: is: 0
 Init: 0, scope: 1, op: us: done
 Init: 0, scope: 1, op: us_dim: done
 Init: 0, scope: 0, op: r: Typed property Test::$prop must not be accessed before initialization
-Init: 0, scope: 0, op: w: Cannot modify protected(set) property Test::$prop from global scope
+Init: 0, scope: 0, op: w: Cannot modify protected(set) readonly property Test::$prop from global scope
 Init: 0, scope: 0, op: rw: Typed property Test::$prop must not be accessed before initialization
 Init: 0, scope: 0, op: im: Cannot indirectly modify readonly property Test::$prop
 Init: 0, scope: 0, op: is: 0
-Init: 0, scope: 0, op: us: Cannot unset protected(set) property Test::$prop from global scope
+Init: 0, scope: 0, op: us: Cannot unset protected(set) readonly property Test::$prop from global scope
 Init: 0, scope: 0, op: us_dim: done

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -930,7 +930,11 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_asymmetric_visibility_property_modifi
 		visibility = "private(set)";
 	} else {
 		ZEND_ASSERT(prop_info->flags & ZEND_ACC_PROTECTED_SET);
-		visibility = "protected(set)";
+		if (prop_info->flags & ZEND_ACC_READONLY) {
+			visibility = "protected(set) readonly";
+		} else {
+			visibility = "protected(set)";
+		}
 	}
 
 	zend_throw_error(NULL, "Cannot %s %s property %s::$%s from %s%s",


### PR DESCRIPTION
We don't track whether protected(set) is implicit, so for now always point out when the property is readonly in the error message.

/cc @SakiTakamachi I'm not sure if this helps.