### PR TITLE
Fix GREP_HEADER on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -965,14 +965,19 @@ function GREP_HEADER(header_name, regex, path_to_check)
 
 	if (!c) {
 		/* look in the include path */
+		if (path_to_check == null) {
+			path_to_check = php_usual_include_suspects;
+		} else {
+			path_to_check += ";" + php_usual_include_suspects;
+		}
 
 		var p = search_paths(header_name, path_to_check, "INCLUDE");
 		if (typeof(p) == "string") {
-			c = file_get_contents(p);
+			c = file_get_contents(p + "\\" + header_name);
 		} else if (p == false) {
 			p = search_paths(header_name, PHP_EXTRA_INCLUDES, null);
 			if (typeof(p) == "string") {
-				c = file_get_contents(p);
+				c = file_get_contents(p + "\\" + header_name);
 			}
 		}
 		if (!c) {


### PR DESCRIPTION
I still need to retest this a bit if it covers all cases correctly. This check never actually worked properly as the filename needs to be appended to the file_get_contents path.

This fixes the libxml version check when the libxml/xmlversion.h is located elsewhere than libxml2 include directory.

Fixes https://github.com/php/php-src/pull/15536#discussion_r1734708148

