### PR TITLE
Autotools: Normalize PHP_INSTALL_HEADERS arguments

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -183,6 +183,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
    - M4 macro PHP_PROG_SETUP now accepts an argument to set the minimum required
      PHP version during the build.
+   - M4 macro PHP_INSTALL_HEADERS arguments can now be also
+     blank-or-newline-separated lists instead of only separated with whitespace
+     or backslash-then-newline.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -2030,24 +2030,25 @@ dnl Misc. macros
 dnl ----------------------------------------------------------------------------
 
 dnl
-dnl PHP_INSTALL_HEADERS(path [, file ...])
+dnl PHP_INSTALL_HEADERS(path [, files ...])
 dnl
-dnl PHP header files to be installed.
+dnl Add PHP header files to the list to be installed on the system. The "files"
+dnl argument is a blank-or-newline-separated list of header files or directories
+dnl located in the "path". If 2nd argument is not given, it installs header
+dnl files in all paths from the blank-or-newline-separated "path" argument.
 dnl
-AC_DEFUN([PHP_INSTALL_HEADERS],[
-  ifelse([$2],[],[
-    for header_file in $1; do
-      PHP_RUN_ONCE(INSTALLHEADERS, $header_file, [
-        INSTALL_HEADERS="$INSTALL_HEADERS $header_file"
-      ])
+AC_DEFUN([PHP_INSTALL_HEADERS],
+  [m4_ifblank([$2], [
+    for header_file in m4_normalize(m4_expand([$1])); do
+      PHP_RUN_ONCE([INSTALLHEADERS], [$header_file],
+        [INSTALL_HEADERS="$INSTALL_HEADERS $header_file"])
     done
   ], [
     header_path=$1
-    for header_file in $2; do
+    for header_file in m4_normalize(m4_expand([$2])); do
       hp_hf="$header_path/$header_file"
-      PHP_RUN_ONCE(INSTALLHEADERS, $hp_hf, [
-        INSTALL_HEADERS="$INSTALL_HEADERS $hp_hf"
-      ])
+      PHP_RUN_ONCE([INSTALLHEADERS], [$hp_hf],
+        [INSTALL_HEADERS="$INSTALL_HEADERS $hp_hf"])
     done
   ])
 ])


### PR DESCRIPTION
The m4_normalize(m4_expand([...])) simplifies working with a list of header files. The m4_normalize() is at this point still used in the php-src config.m4 files because of copy/paste probability to community extensions where the arguments still need to be done in the old style to support phpize in PHP-8.3 and earlier. For example:

```m4
PHP_INSTALL_HEADERS([ext/dom], m4_normalize([
  dom_ce.h
  namespace_compat.h
  xml_common.h
  xpath_callbacks.h
]))
```

When PHP 8.4 will be the minimum supported PHP version, the headers can be installed without using m4_normalize() in PECL extensions. For example:

```m4
PHP_INSTALL_HEADERS([ext/dom], [
  dom_ce.h
  namespace_compat.h
  xml_common.h
  xpath_callbacks.h
])
```