### PR TITLE
Remove redundant HAVE_LIBREADLINE check

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -830,7 +830,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 			goto err;
 		}
 
-#if defined(PHP_WIN32) && !defined(PHP_CLI_WIN32_NO_CONSOLE) && (defined(HAVE_LIBREADLINE) || defined(HAVE_LIBEDIT)) && !defined(COMPILE_DL_READLINE)
+#if defined(PHP_WIN32) && !defined(PHP_CLI_WIN32_NO_CONSOLE) && defined(HAVE_LIBEDIT) && !defined(COMPILE_DL_READLINE)
 		if (!interactive) {
 		/* The -a option was not passed. If there is no file, it could
 		 	still make sense to run interactively. The presence of a file


### PR DESCRIPTION
The HAVE_LIBREADLINE is at this point only defined by Autotools and this check is for Windows only where only HAVE_LIBEDIT is defined.