### PR TITLE
ext/bcmath: Removed unnecessary bc_free_num and bc_init_num

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -162,7 +162,6 @@ PHP_FUNCTION(bcadd)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL, result = NULL;
 	int scale;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -183,24 +182,24 @@ PHP_FUNCTION(bcadd)
 
 	BC_ARENA_SETUP;
 
+	bc_num first = NULL, second = NULL;
 	if (php_str2num(&first, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&second, right) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
-	result = bc_add (first, second, scale);
+	bc_num result = bc_add (first, second, scale);
 
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -212,7 +211,6 @@ PHP_FUNCTION(bcsub)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL, result = NULL;
 	int scale;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -233,24 +231,24 @@ PHP_FUNCTION(bcsub)
 
 	BC_ARENA_SETUP;
 
+	bc_num first = NULL, second = NULL;
 	if (php_str2num(&first, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&second, right) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
-	result = bc_sub (first, second, scale);
+	bc_num result = bc_sub (first, second, scale);
 
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -262,7 +260,6 @@ PHP_FUNCTION(bcmul)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL, result = NULL;
 	int scale;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -283,24 +280,24 @@ PHP_FUNCTION(bcmul)
 
 	BC_ARENA_SETUP;
 
+	bc_num first = NULL, second = NULL;
 	if (php_str2num(&first, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&second, right) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
-	result = bc_multiply (first, second, scale);
+	bc_num result = bc_multiply (first, second, scale);
 
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -312,7 +309,6 @@ PHP_FUNCTION(bcdiv)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL, result;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -333,18 +329,17 @@ PHP_FUNCTION(bcdiv)
 
 	BC_ARENA_SETUP;
 
-	bc_init_num(&result);
-
+	bc_num first = NULL, second = NULL;
 	if (php_str2num(&first, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&second, right) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
+	bc_num result = NULL;
 	if (!bc_divide(first, second, &result, scale)) {
 		zend_throw_exception_ex(zend_ce_division_by_zero_error, 0, "Division by zero");
 		goto cleanup;
@@ -353,9 +348,13 @@ PHP_FUNCTION(bcdiv)
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
+		if (second != NULL) {
+			bc_free_num(&second);
+		}
+		/* If bc_divide is false, result will remain NULL, so there is no need to free it. */
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -367,7 +366,6 @@ PHP_FUNCTION(bcmod)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL, result;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -388,18 +386,17 @@ PHP_FUNCTION(bcmod)
 
 	BC_ARENA_SETUP;
 
-	bc_init_num(&result);
-
+	bc_num first = NULL, second = NULL;
 	if (php_str2num(&first, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&second, right) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
+	bc_num result = NULL;
 	if (!bc_modulo(first, second, &result, scale)) {
 		zend_throw_exception_ex(zend_ce_division_by_zero_error, 0, "Modulo by zero");
 		goto cleanup;
@@ -408,9 +405,13 @@ PHP_FUNCTION(bcmod)
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
+		if (second != NULL) {
+			bc_free_num(&second);
+		}
+		/* If bc_modulo is false, result will remain NULL, so there is no need to free it. */
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -422,7 +423,6 @@ PHP_FUNCTION(bcpowmod)
 	zend_string *base_str, *exponent_str, *modulus_str;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num bc_base = NULL, bc_expo = NULL, bc_modulus = NULL, result;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(3, 4)
@@ -444,8 +444,7 @@ PHP_FUNCTION(bcpowmod)
 
 	BC_ARENA_SETUP;
 
-	bc_init_num(&result);
-
+	bc_num bc_base = NULL, bc_expo = NULL, bc_modulus = NULL;
 	if (php_str2num(&bc_base, base_str) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
@@ -461,6 +460,7 @@ PHP_FUNCTION(bcpowmod)
 		goto cleanup;
 	}
 
+	bc_num result = NULL;
 	raise_mod_status status = bc_raisemod(bc_base, bc_expo, bc_modulus, &result, scale);
 	switch (status) {
 		case BASE_HAS_FRACTIONAL:
@@ -485,10 +485,16 @@ PHP_FUNCTION(bcpowmod)
 	}
 
 	cleanup: {
-		bc_free_num(&bc_base);
-		bc_free_num(&bc_expo);
-		bc_free_num(&bc_modulus);
-		bc_free_num(&result);
+		if (bc_base != NULL) {
+			bc_free_num(&bc_base);
+		}
+		if (bc_expo != NULL) {
+			bc_free_num(&bc_expo);
+		}
+		if (bc_modulus != NULL) {
+			bc_free_num(&bc_modulus);
+		}
+		/* If raise_mod_status is not OK, result will remain NULL, so there is no need to free it. */
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -500,7 +506,6 @@ PHP_FUNCTION(bcpow)
 	zend_string *base_str, *exponent_str;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, bc_exponent = NULL, result;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -521,13 +526,11 @@ PHP_FUNCTION(bcpow)
 
 	BC_ARENA_SETUP;
 
-	bc_init_num(&result);
-
+	bc_num first = NULL, bc_exponent = NULL;
 	if (php_str2num(&first, base_str) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (php_str2num(&bc_exponent, exponent_str) == FAILURE) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
@@ -544,14 +547,18 @@ PHP_FUNCTION(bcpow)
 		goto cleanup;
 	}
 
+	bc_num result = NULL;
 	bc_raise(first, exponent, &result, scale);
 
 	RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&bc_exponent);
-		bc_free_num(&result);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
+		if (bc_exponent != NULL) {
+			bc_free_num(&bc_exponent);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -563,7 +570,6 @@ PHP_FUNCTION(bcsqrt)
 	zend_string *left;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num result = NULL;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -583,6 +589,7 @@ PHP_FUNCTION(bcsqrt)
 
 	BC_ARENA_SETUP;
 
+	bc_num result = NULL;
 	if (php_str2num(&result, left) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
@@ -595,7 +602,6 @@ PHP_FUNCTION(bcsqrt)
 	}
 
 	cleanup: {
-		bc_free_num(&result);
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -607,7 +613,6 @@ PHP_FUNCTION(bccomp)
 	zend_string *left, *right;
 	zend_long scale_param;
 	bool scale_param_is_null = 1;
-	bc_num first = NULL, second = NULL;
 	int scale = BCG(bc_precision);
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
@@ -628,11 +633,11 @@ PHP_FUNCTION(bccomp)
 
 	BC_ARENA_SETUP;
 
+	bc_num first = NULL, second = NULL;
 	if (!bc_str2num(&first, ZSTR_VAL(left), ZSTR_VAL(left) + ZSTR_LEN(left), scale, false)) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
-
 	if (!bc_str2num(&second, ZSTR_VAL(right), ZSTR_VAL(right) + ZSTR_LEN(right), scale, false)) {
 		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
@@ -641,8 +646,9 @@ PHP_FUNCTION(bccomp)
 	RETVAL_LONG(bc_compare(first, second, scale));
 
 	cleanup: {
-		bc_free_num(&first);
-		bc_free_num(&second);
+		if (first != NULL) {
+			bc_free_num(&first);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -652,7 +658,6 @@ PHP_FUNCTION(bccomp)
 static void bcfloor_or_bcceil(INTERNAL_FUNCTION_PARAMETERS, bool is_floor)
 {
 	zend_string *numstr;
-	bc_num num = NULL, result = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STR(numstr)
@@ -660,17 +665,19 @@ static void bcfloor_or_bcceil(INTERNAL_FUNCTION_PARAMETERS, bool is_floor)
 
 	BC_ARENA_SETUP;
 
+	bc_num num = NULL;
 	if (php_str2num(&num, numstr) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
-	result = bc_floor_or_ceil(num, is_floor);
+	bc_num result = bc_floor_or_ceil(num, is_floor);
 	RETVAL_NEW_STR(bc_num2str_ex(result, 0));
 
 	cleanup: {
-		bc_free_num(&num);
-		bc_free_num(&result);
+		if (num != NULL) {
+			bc_free_num(&num);
+		}
 		BC_ARENA_TEARDOWN;
 	};
 }
@@ -697,7 +704,6 @@ PHP_FUNCTION(bcround)
 	zend_long precision = 0;
 	zend_long mode = PHP_ROUND_HALF_UP;
 	zend_object *mode_object = NULL;
-	bc_num num = NULL, result;
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
 		Z_PARAM_STR(numstr)
@@ -728,19 +734,17 @@ PHP_FUNCTION(bcround)
 
 	BC_ARENA_SETUP;
 
-	bc_init_num(&result);
-
+	bc_num num = NULL;
 	if (php_str2num(&num, numstr) == FAILURE) {
 		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
+	bc_num result = NULL;
 	bc_round(num, precision, mode, &result);
 	RETVAL_NEW_STR(bc_num2str_ex(result, result->n_scale));
 
 	cleanup: {
-		bc_free_num(&num);
-		bc_free_num(&result);
 		BC_ARENA_TEARDOWN;
 	};
 }

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -335,7 +335,9 @@ bool bc_divide(bc_num numerator, bc_num divisor, bc_num *quot, size_t scale)
 		return false;
 	}
 
-	bc_free_num(quot);
+	if (*quot != NULL) {
+		bc_free_num(quot);
+	}
 
 	/* If numerator is zero, the quotient is always zero. */
 	if (bc_is_zero(numerator)) {

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -134,7 +134,7 @@ bool bc_str2num(bc_num *num, const char *str, const char *end, size_t scale, boo
 
 	/* If a non-digit and non-decimal-point indicator is in the string, i.e. an invalid character */
 	if (UNEXPECTED(!decimal_point && *ptr != '\0')) {
-		goto fail;
+		return false;
 	}
 
 	/* search and validate fractional end if exists */
@@ -150,7 +150,7 @@ bool bc_str2num(bc_num *num, const char *str, const char *end, size_t scale, boo
 		fractional_end = bc_count_digits(fractional_ptr, end);
 		if (UNEXPECTED(*fractional_end != '\0')) {
 			/* invalid num */
-			goto fail;
+			return false;
 		}
 
 		/* Exclude trailing zeros. */
@@ -204,8 +204,4 @@ after_fractional:
 zero:
 	*num = bc_copy_num(BCG(_zero_));
 	return true;
-
-fail:
-	*num = bc_copy_num(BCG(_zero_));
-	return false;
 }


### PR DESCRIPTION
Removed unnecessary `bc_free_num()` and `bc_init_num()`.

When `str2num` failed, used to copy `BCG(_ZERO_)` to num, so stopped doing that.
This eliminates the need to call `bc_free_num` on failure.