### PR TITLE
Autotools: Use SED variable for sed command

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2102,7 +2102,7 @@ EOF
     if test -n "$val"; then
       echo "$var='$val' \\" >> $1
       if test `expr "X$ac_configure_args" : ".*${var}.*"` != 0; then
-        clean_configure_args=$(echo $clean_configure_args | sed -e "s#'$var=$val'##")
+        clean_configure_args=$(echo $clean_configure_args | $SED -e "s#'$var=$val'##")
       fi
     fi
   done

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -70,7 +70,7 @@ else
   ODBC_LIBS=-l${ac_solid_prefix}${ac_solid_os}${ac_solid_version}
 fi
 
-  AC_MSG_RESULT([$(echo $ODBC_LIBS | sed -e 's!.*/!!')])
+  AC_MSG_RESULT([$(echo $ODBC_LIBS | $SED -e 's!.*/!!')])
 ])
 
 dnl
@@ -84,7 +84,7 @@ AC_DEFUN([PHP_ODBC_FIND_EMPRESS_LIBS],[
   if test ! -f $ODBC_LIBS; then
     ODBC_LIBS=$(echo $1/libempodbccl.so | cut -d' ' -f1)
   fi
-  AC_MSG_RESULT([$(echo $ODBC_LIBS | sed -e 's!.*/!!')])
+  AC_MSG_RESULT([$(echo $ODBC_LIBS | $SED -e 's!.*/!!')])
 ])
 
 dnl
@@ -99,7 +99,7 @@ AC_DEFUN([PHP_ODBC_FIND_EMPRESS_BCS_LIBS],[
   if test ! -f $ODBCBCS_LIBS; then
     ODBCBCS_LIBS=$(echo $1/libempodbcbcs.a | cut -d' ' -f1)
   fi
-  AC_MSG_RESULT([$(echo $ODBCBCS_LIBS | sed -e 's!.*/!!')])
+  AC_MSG_RESULT([$(echo $ODBCBCS_LIBS | $SED -e 's!.*/!!')])
 ])
 
 dnl
@@ -410,7 +410,7 @@ PHP_ARG_WITH([dbmaker],,
       DBMAKER_VERSION=5.0
 
       while test ! -d $DBMAKER_HOME/$DBMAKER_VERSION && test "$DBMAKER_VERSION" != "2.9"; do
-        DM_VER=$(echo $DBMAKER_VERSION | sed -e 's/\.//' | $AWK '{ print $1-1;}')
+        DM_VER=$(echo $DBMAKER_VERSION | $SED -e 's/\.//' | $AWK '{ print $1-1;}')
         MAJOR_V=$(echo $DM_VER | $AWK '{ print $1/10; }'  | $AWK -F. '{ print $1; }')
         MINOR_V=$(echo $DM_VER | $AWK '{ print $1%10; }')
         DBMAKER_VERSION=$MAJOR_V.$MINOR_V


### PR DESCRIPTION
This syncs sed usages across the build system as SED variable is set to a suitable sed program on the system.