### PR TITLE
Autotools: Refactor ODBC type checks

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -114,12 +114,12 @@ PHP_ARG_WITH([odbcver],,
   [0x0350])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([adabas],,
+PHP_ARG_WITH([adabas],
+  [for Adabas support],
   [AS_HELP_STRING([[--with-adabas[=DIR]]],
     [Include Adabas D support [/usr/local]])])
 
-  AC_MSG_CHECKING([for Adabas support])
-  if test "$PHP_ADABAS" != "no"; then
+  AS_VAR_IF([PHP_ADABAS], [no], [], [
     AS_VAR_IF([PHP_ADABAS], [yes], [PHP_ADABAS=/usr/local])
     PHP_ADD_INCLUDE([$PHP_ADABAS/incl])
     PHP_ADD_LIBPATH([$PHP_ADABAS/$PHP_LIBDIR])
@@ -136,19 +136,16 @@ PHP_ARG_WITH([adabas],,
     PHP_ODBC_CHECK_HEADER([sqlext.h])
     AC_DEFINE([HAVE_ADABAS], [1],
       [Define to 1 if the odbc extension uses the Adabas D.])
-    AC_MSG_RESULT([$ext_output])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([sapdb],,
+PHP_ARG_WITH([sapdb],
+  [for SAP DB support],
   [AS_HELP_STRING([[--with-sapdb[=DIR]]],
     [Include SAP DB support [/usr/local]])])
 
-  AC_MSG_CHECKING([for SAP DB support])
-  if test "$PHP_SAPDB" != "no"; then
+  AS_VAR_IF([PHP_SAPDB], [no], [], [
     AS_VAR_IF([PHP_SAPDB], [yes], [PHP_SAPDB=/usr/local])
     PHP_ADD_INCLUDE([$PHP_SAPDB/incl])
     PHP_ADD_LIBPATH([$PHP_SAPDB/$PHP_LIBDIR])
@@ -156,19 +153,16 @@ PHP_ARG_WITH([sapdb],,
     ODBC_TYPE=sapdb
     AC_DEFINE([HAVE_SAPDB], [1],
       [Define to 1 if the odbc extension uses the SAP DB.])
-    AC_MSG_RESULT([$ext_output])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([solid],,
+PHP_ARG_WITH([solid],
+  [for Solid support],
   [AS_HELP_STRING([[--with-solid[=DIR]]],
     [Include Solid support [/usr/local/solid]])])
 
-  AC_MSG_CHECKING([for Solid support])
-  if test "$PHP_SOLID" != "no"; then
+  AS_VAR_IF([PHP_SOLID], [no], [], [
     AS_VAR_IF([PHP_SOLID], [yes], [PHP_SOLID=/usr/local/solid])
     ODBC_INCDIR=$PHP_SOLID/include
     ODBC_LIBDIR=$PHP_SOLID/$PHP_LIBDIR
@@ -182,27 +176,24 @@ PHP_ARG_WITH([solid],,
       AC_DEFINE([HAVE_SOLID], [1],
         [Define to 1 if the odbc extension uses the Solid DB.])
     fi
-    AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_SOLID_LIBS([$ODBC_LIBDIR])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([ibm-db2],,
+PHP_ARG_WITH([ibm-db2],
+  [for IBM DB2 support],
   [AS_HELP_STRING([[--with-ibm-db2[=DIR]]],
     [Include IBM DB2 support [/home/db2inst1/sqllib]])])
 
-  AC_MSG_CHECKING([for IBM DB2 support])
-  if test "$PHP_IBM_DB2" != "no"; then
-    if test "$PHP_IBM_DB2" = "yes"; then
+  AS_VAR_IF([PHP_IBM_DB2], [no], [], [
+    AS_VAR_IF([PHP_IBM_DB2], [yes], [
       ODBC_INCDIR=/home/db2inst1/sqllib/include
       ODBC_LIBDIR=/home/db2inst1/sqllib/lib
-    else
+    ], [
       ODBC_INCDIR=$PHP_IBM_DB2/include
       ODBC_LIBDIR=$PHP_IBM_DB2/$PHP_LIBDIR
-    fi
+    ])
 
     PHP_ODBC_CHECK_HEADER([sqlcli1.h])
 
@@ -211,66 +202,57 @@ PHP_ARG_WITH([ibm-db2],,
     ODBC_TYPE=ibm-db2
     ODBC_LIBS=-ldb2
 
-    PHP_TEST_BUILD([SQLExecute], [
-      AC_DEFINE([HAVE_IBMDB2], [1],
-        [Define to 1 if the odbc extension uses the IBM DB2.])
-      AC_MSG_RESULT([$ext_output])
-    ], [
-      AC_MSG_RESULT([no])
-      AC_MSG_FAILURE([
+    PHP_TEST_BUILD([SQLExecute],
+      [AC_DEFINE([HAVE_IBMDB2], [1],
+        [Define to 1 if the odbc extension uses the IBM DB2.])],
+      [AC_MSG_FAILURE([
 ODBC build test failed. You need to source your DB2 environment before running
 PHP configure:
 # . \$IBM_DB2/db2profile
-])
-    ],
+])],
     [$ODBC_LFLAGS $ODBC_LIBS])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([empress],,
+PHP_ARG_WITH([empress],
+  [for Empress support],
   [AS_HELP_STRING([[--with-empress[=DIR]]],
     [Include Empress support $EMPRESSPATH (Empress Version >= 8.60
     required)])])
 
-  AC_MSG_CHECKING([for Empress support])
-  if test "$PHP_EMPRESS" != "no"; then
-    if test "$PHP_EMPRESS" = "yes"; then
+  AS_VAR_IF([PHP_EMPRESS], [no], [], [
+    AS_VAR_IF([PHP_EMPRESS], [yes], [
       ODBC_INCDIR=$EMPRESSPATH/include/odbc
       ODBC_LIBDIR=$EMPRESSPATH/shlib
-    else
+    ], [
       ODBC_INCDIR=$PHP_EMPRESS/include/odbc
       ODBC_LIBDIR=$PHP_EMPRESS/shlib
-    fi
+    ])
     ODBC_CFLAGS=-I$ODBC_INCDIR
     ODBC_LFLAGS=-L$ODBC_LIBDIR
     ODBC_TYPE=empress
     AC_DEFINE([HAVE_EMPRESS], [1],
       [Define to 1 if the odbc extension uses the Empress.])
-    AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_EMPRESS_LIBS([$ODBC_LIBDIR])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([empress-bcs],,
+PHP_ARG_WITH([empress-bcs],
+  [for Empress local access support],
   [AS_HELP_STRING([[--with-empress-bcs[=DIR]]],
     [Include Empress Local Access support $EMPRESSPATH (Empress Version >=
     8.60 required)])])
 
-  AC_MSG_CHECKING([for Empress local access support])
-  if test "$PHP_EMPRESS_BCS" != "no"; then
-    if test "$PHP_EMPRESS_BCS" = "yes"; then
+  AS_VAR_IF([PHP_EMPRESS_BCS], [no], [], [
+    AS_VAR_IF([PHP_EMPRESS_BCS], [yes], [
       ODBC_INCDIR=$EMPRESSPATH/include/odbc
       ODBC_LIBDIR=$EMPRESSPATH/shlib
-    else
+    ], [
       ODBC_INCDIR=$PHP_EMPRESS_BCS/include/odbc
       ODBC_LIBDIR=$PHP_EMPRESS_BCS/shlib
-    fi
+    ])
     CC="empocc -bcs";export CC;
     LD="empocc -bcs";export LD;
     ODBC_CFLAGS=-I$ODBC_INCDIR
@@ -292,15 +274,13 @@ PHP_ARG_WITH([empress-bcs],,
     ODBC_TYPE=empress-bcs
     AC_DEFINE([HAVE_EMPRESS], [1],
       [Define to 1 if the odbc extension uses the Empress.])
-    AC_MSG_RESULT([$ext_output])
     PHP_ODBC_FIND_EMPRESS_BCS_LIBS([$ODBC_LIBDIR])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([custom-odbc],,
+PHP_ARG_WITH([custom-odbc],
+  [for a custom ODBC support],
   [AS_HELP_STRING([[--with-custom-odbc[=DIR]]],
     [Include user defined ODBC support. DIR is ODBC install base directory
     [/usr/local]. Make sure to define CUSTOM_ODBC_LIBS and have some odbc.h in
@@ -309,8 +289,7 @@ PHP_ARG_WITH([custom-odbc],,
     CPPFLAGS="-DODBC_QNX -DSQLANY_BUG" LDFLAGS=-lunix
     CUSTOM_ODBC_LIBS="-ldblib -lodbc"])])
 
-  AC_MSG_CHECKING([for a custom ODBC support])
-  if test "$PHP_CUSTOM_ODBC" != "no"; then
+  AS_VAR_IF([PHP_CUSTOM_ODBC], [no], [], [
     AS_VAR_IF([PHP_CUSTOM_ODBC], [yes], [PHP_CUSTOM_ODBC=/usr/local])
     ODBC_INCDIR=$PHP_CUSTOM_ODBC/include
     ODBC_LIBDIR=$PHP_CUSTOM_ODBC/$PHP_LIBDIR
@@ -320,37 +299,31 @@ PHP_ARG_WITH([custom-odbc],,
     ODBC_TYPE=custom-odbc
     AC_DEFINE([HAVE_CODBC], [1],
       [Define to 1 if the odbc extension uses custom ODBC installation.])
-    AC_MSG_RESULT([$ext_output])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([iodbc],,
+PHP_ARG_WITH([iodbc],
+  [whether to build with iODBC support],
   [AS_HELP_STRING([--with-iodbc],
     [Include iODBC support])])
 
-  AC_MSG_CHECKING([whether to build with iODBC support])
-  if test "$PHP_IODBC" != "no"; then
-    AC_MSG_RESULT([yes])
+  AS_VAR_IF([PHP_IODBC], [no], [], [
     PKG_CHECK_MODULES([ODBC], [libiodbc])
     PHP_EVAL_INCLINE([$ODBC_CFLAGS])
     ODBC_TYPE=iodbc
     AC_DEFINE([HAVE_IODBC], [1],
       [Define to 1 if the odbc extension uses the iODBC.])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([esoob],,
+PHP_ARG_WITH([esoob],
+  [for Easysoft ODBC-ODBC Bridge support],
   [AS_HELP_STRING([[--with-esoob[=DIR]]],
     [Include Easysoft OOB support [/usr/local/easysoft/oob/client]])])
 
-  AC_MSG_CHECKING([for Easysoft ODBC-ODBC Bridge support])
-  if test "$PHP_ESOOB" != "no"; then
+  AS_VAR_IF([PHP_ESOOB], [no], [], [
     AS_VAR_IF([PHP_ESOOB], [yes], [PHP_ESOOB=/usr/local/easysoft/oob/client])
     ODBC_INCDIR=$PHP_ESOOB/include
     ODBC_LIBDIR=$PHP_ESOOB/$PHP_LIBDIR
@@ -360,24 +333,22 @@ PHP_ARG_WITH([esoob],,
     ODBC_TYPE=esoob
     AC_DEFINE([HAVE_ESOOB], [1],
       [Define to 1 if the odbc extension uses the Easysoft OOB.])
-    AC_MSG_RESULT([$ext_output])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([unixODBC],,
-  [AS_HELP_STRING([--with-unixODBC],
-    [Include unixODBC support])])
+PHP_ARG_WITH([unixODBC],
+  [whether to build with unixODBC support],
+  [AS_HELP_STRING([[--with-unixODBC[=DIR]]],
+    [Include unixODBC support. Use PKG_CONFIG_PATH (or ODBC_CFLAGS and
+    ODBC_LIBS) environment variables, or alternatively the optional DIR argument
+    to customize where to look for the unixODBC library.])])
 
-  AC_MSG_CHECKING([whether to build with unixODBC support])
-  if test "$PHP_UNIXODBC" != "no"; then
-    if test "$PHP_UNIXODBC" = "yes"; then
-      AC_MSG_RESULT([yes from pkgconfig])
+  AS_VAR_IF([PHP_UNIXODBC], [no], [], [
+    AS_VAR_IF([PHP_UNIXODBC], [yes], [
       PKG_CHECK_MODULES([ODBC], [odbc])
       PHP_EVAL_INCLINE([$ODBC_CFLAGS])
-    else
+    ], [
       dnl keep old DIR way for old version without libodbc.pc
       ODBC_INCDIR=$PHP_UNIXODBC/include
       ODBC_LIBDIR=$PHP_UNIXODBC/$PHP_LIBDIR
@@ -385,25 +356,23 @@ PHP_ARG_WITH([unixODBC],,
       ODBC_CFLAGS=-I$ODBC_INCDIR
       ODBC_LIBS=-lodbc
       PHP_ODBC_CHECK_HEADER([sqlext.h])
-      AC_MSG_RESULT([yes in $PHP_UNIXODBC])
-    fi
+      AC_MSG_NOTICE([Using unixODBC in $PHP_UNIXODBC])
+    ])
     ODBC_TYPE=unixODBC
     AC_DEFINE([HAVE_UNIXODBC], [1],
       [Define to 1 if the odbc extension uses the unixODBC.])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([dbmaker],,
+PHP_ARG_WITH([dbmaker],
+  [for DBMaker support],
   [AS_HELP_STRING([[--with-dbmaker[=DIR]]],
     [Include DBMaker support])])
 
-  AC_MSG_CHECKING([for DBMaker support])
-  if test "$PHP_DBMAKER" != "no"; then
-    if test "$PHP_DBMAKER" = "yes"; then
-      dnl Find dbmaker's home directory
+  AS_VAR_IF([PHP_DBMAKER], [no], [], [
+    AS_VAR_IF([PHP_DBMAKER], [yes], [
+      dnl Find dbmaker home directory
       DBMAKER_HOME=$(grep "^dbmaker:" /etc/passwd | $AWK -F: '{print $6}')
 
       dnl check DBMaker version (from 5.0 to 2.0)
@@ -416,12 +385,10 @@ PHP_ARG_WITH([dbmaker],,
         DBMAKER_VERSION=$MAJOR_V.$MINOR_V
       done
 
-      if test "$DBMAKER_VERSION" = "2.9"; then
-        PHP_DBMAKER=$DBMAKER_HOME
-      else
-        PHP_DBMAKER=$DBMAKER_HOME/$DBMAKER_VERSION
-      fi
-    fi
+      AS_VAR_IF([DBMAKER_VERSION], [2.9],
+        [PHP_DBMAKER=$DBMAKER_HOME],
+        [PHP_DBMAKER=$DBMAKER_HOME/$DBMAKER_VERSION])
+    ])
 
     ODBC_INCDIR=$PHP_DBMAKER/include
     ODBC_LIBDIR=$PHP_DBMAKER/$PHP_LIBDIR
@@ -433,19 +400,11 @@ PHP_ARG_WITH([dbmaker],,
     AC_DEFINE([HAVE_DBMAKER], [1],
       [Define to 1 if the odbc extension uses the DBMaker.])
 
-    AS_VAR_IF([ext_shared], [yes], [
-      AC_MSG_RESULT([yes (shared)])
-      ODBC_LIBS="-ldmapic -lc -lm"
-      ODBC_SHARED="odbc.la"
-    ], [
-      AC_MSG_RESULT([yes (static)])
+    AS_VAR_IF([ext_shared], [yes], [ODBC_LIBS="-ldmapic -lc -lm"], [
       PHP_ADD_LIBRARY_WITH_PATH([dmapic], [$ODBC_LIBDIR])
       PHP_ADD_INCLUDE([$ODBC_INCDIR])
-      ODBC_STATIC="libphpext_odbc.la"
     ])
-  else
-    AC_MSG_RESULT([no])
-  fi
+  ])
 ])
 
 AH_TEMPLATE([ODBCVER], [The highest supported ODBC version.])


### PR DESCRIPTION
- AS_VAR_IF macros used
- All check messages moved to the PHP_ARG_WITH 2nd argument and results simplified where possible (the ext_output variable and result message is done automatically when using PHP_ARG_* macros)
- Unusued ODBC_SHARED and ODBC_STATIC shell variables for DBMaker removed
- Help text for --with-unixodbc (and/or --with-unixODBC) configure option synced with current Autotools code. It is still possible to bypass the pkg-config search with optional DIR argument