### PR TITLE
ext/bcmath: Fixed LONG_MAX

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -75,7 +75,7 @@ typedef struct bc_struct {
 #define MIN(a, b)      ((a)>(b)?(b):(a))
 
 #ifndef LONG_MAX
-#define LONG_MAX 0x7ffffff
+#define LONG_MAX 0x7fffffff
 #endif
 
 


### PR DESCRIPTION
One `f` is missing.

However, `LONG_MAX` is predefined in php.h, so this macro will probably never be used....
TBH, I think it's okay to delete it...