### PR TITLE
standard: Fix Msan warning

### DIFF
--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -594,7 +594,7 @@ PHP_FUNCTION(password_needs_rehash)
 	const php_password_algo *old_algo, *new_algo;
 	zend_string *hash;
 	zend_string *new_algo_str;
-	zend_long new_algo_long;
+	zend_long new_algo_long = 0;
 	bool new_algo_is_null;
 	zend_array *options = 0;
 
@@ -642,7 +642,7 @@ PHP_FUNCTION(password_hash)
 {
 	zend_string *password, *digest = NULL;
 	zend_string *algo_str;
-	zend_long algo_long;
+	zend_long algo_long = 0;
 	bool algo_is_null;
 	const php_password_algo *algo;
 	zend_array *options = NULL;


### PR DESCRIPTION
Fix MSan uninitialized warning, assign `0` as the initial value.

Detected when registering a new algorithm from an extension: https://github.com/zeriyoshi/php-xpass/actions/runs/10635999247/job/29486840808