### PR TITLE
Drop superfluous LONG_MAX/LONG_MIN fallback definitions

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -444,14 +444,6 @@ char *alloca();
 # define ZTS_V 0
 #endif
 
-#ifndef LONG_MAX
-# define LONG_MAX 2147483647L
-#endif
-
-#ifndef LONG_MIN
-# define LONG_MIN (- LONG_MAX - 1)
-#endif
-
 #define MAX_LENGTH_OF_DOUBLE 32
 
 #undef MIN

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -292,10 +292,6 @@ static double private_mem[PRIVATE_mem], *pmem_next = private_mem;
 #define DBL_MAX 1.7014118346046923e+38
 #endif
 
-#ifndef LONG_MAX
-#define LONG_MAX 2147483647
-#endif
-
 #else /* ifndef Bad_float_h */
 #include "float.h"
 #endif /* Bad_float_h */

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -74,11 +74,6 @@ typedef struct bc_struct {
 #define MAX(a, b)      ((a)>(b)?(a):(b))
 #define MIN(a, b)      ((a)>(b)?(b):(a))
 
-#ifndef LONG_MAX
-#define LONG_MAX 0x7fffffff
-#endif
-
-
 /* Function Prototypes */
 
 void bc_init_numbers(void);

--- a/main/php.h
+++ b/main/php.h
@@ -225,14 +225,6 @@ typedef unsigned int socklen_t;
 
 #include <limits.h>
 
-#ifndef LONG_MAX
-#define LONG_MAX 2147483647L
-#endif
-
-#ifndef LONG_MIN
-#define LONG_MIN (- LONG_MAX - 1)
-#endif
-
 #ifndef INT_MAX
 #define INT_MAX 2147483647
 #endif


### PR DESCRIPTION
Both macros are supposed to be defined in limits.h (C99) and as such it is superfluous to provide fallback definitions.  Even worse, because these fallback definitions didn't cater to LP64, ILP64 and SILP64 data models (and maybe some rather uncommon ones), but just assumed ILP32, they are confusing.

---

To not forget about [that removal](https://github.com/php/php-src/pull/15663#issuecomment-2321983389), which should be postponed to PHP 8.5/9.0.