### PR TITLE
Autotools: Normalize flags arguments

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -192,9 +192,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - M4 macro PHP_ADD_BUILD_DIR now also accepts 1st argument as a
      blank-or-newline-separated separated list.
    - M4 macros PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X,
-     PHP_SELECT_SAPI now have the source files arguments normalized so the list
-     of files can be passed as blank-or-newline-separated list (including
-     newlines, backslash-then-newline, or any sequence of spaces or tabs).
+     PHP_SELECT_SAPI now have the source files and flags arguments normalized so
+     the list of items can be passed as a blank-or-newline-separated list.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -270,10 +270,10 @@ dnl Append to the array which has been dynamically chosen at m4 time.
 
 dnl Choose the right compiler/flags/etc. for the source-file.
       case $ac_src in
-        *.c[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
-        *.s[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
-        *.S[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
-        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_cxx_post" ;;
+        *.c[)] ac_comp="$b_c_pre $ac_inc $b_c_meta m4_normalize(m4_expand([$3])) -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.s[)] ac_comp="$b_c_pre $ac_inc $b_c_meta m4_normalize(m4_expand([$3])) -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.S[)] ac_comp="$b_c_pre $ac_inc $b_c_meta m4_normalize(m4_expand([$3])) -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta m4_normalize(m4_expand([$3])) -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_cxx_post" ;;
       esac
 
 dnl Generate Makefiles with dependencies
@@ -953,7 +953,7 @@ AC_DEFUN([PHP_NEW_EXTENSION],[
   ext_srcdir=[]PHP_EXT_SRCDIR()
   ext_dir=[]PHP_EXT_DIR()
 
-  ifelse($5,,ac_extra=,[ac_extra=$(echo "$5"|$SED s#@ext_srcdir@#$ext_srcdir#g|$SED s#@ext_builddir@#$ext_builddir#g)])
+  ifelse($5,,ac_extra=,[ac_extra=$(echo "m4_normalize(m4_expand([$5]))"|$SED s#@ext_srcdir@#$ext_srcdir#g|$SED s#@ext_builddir@#$ext_builddir#g)])
 
   if test "$3" != "shared" && test "$3" != "yes" && test "$4" != "cli"; then
 dnl ---------------------------------------------- Static module

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -53,8 +53,6 @@ if test "$PHP_APXS2" != "no"; then
     AS_CASE([$flag], [-D*], [APACHE_CPPFLAGS="$APACHE_CPPFLAGS $flag"])
   done
 
-  APACHE_CFLAGS="$APACHE_CPPFLAGS -I$APXS_INCLUDEDIR $APR_CFLAGS $APU_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-
   dnl Check Apache version.
   PHP_AP_EXTRACT_VERSION([$APXS_HTTPD])
   AS_VERSION_COMPARE([$APACHE_VERSION], [2004000],
@@ -104,7 +102,13 @@ if test "$PHP_APXS2" != "no"; then
   PHP_SELECT_SAPI([apache2handler],
     [$php_sapi_apache2handler_type],
     [mod_php.c sapi_apache2.c apache_config.c php_functions.c],
-    [$APACHE_CFLAGS])
+    [
+      $APACHE_CPPFLAGS
+      -I$APXS_INCLUDEDIR
+      $APR_CFLAGS
+      $APU_CFLAGS
+      -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1
+    ])
 
   AS_IF([$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1], [
     APACHE_THREADED_MPM=yes

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -526,8 +526,6 @@ if test "$PHP_FPM" != "no"; then
     [AS_IF([test -f "$abs_srcdir/sapi/fpm/fpm/fpm_trace_$fpm_trace_type.c"],
       [PHP_FPM_TRACE_FILES="fpm/fpm_trace.c fpm/fpm_trace_$fpm_trace_type.c"])])
 
-  PHP_FPM_CFLAGS="-I$abs_srcdir/sapi/fpm -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
-
   PHP_FPM_FILES="fpm/fpm.c \
     fpm/fpm_children.c \
     fpm/fpm_cleanup.c \
@@ -560,7 +558,7 @@ if test "$PHP_FPM" != "no"; then
   PHP_SELECT_SAPI([fpm],
     [program],
     [$PHP_FPM_FILES $PHP_FPM_TRACE_FILES $PHP_FPM_SD_FILES],
-    [$PHP_FPM_CFLAGS])
+    [-I$abs_srcdir/sapi/fpm -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
   AS_CASE([$host_alias],
     [*aix*], [


### PR DESCRIPTION
This is a follow up of 7edb9a07d750a92ceea9371588f10ff2f05df40f that provides passing compilation options to PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X, and PHP_SELECT_SAPI as a blank-or-newline-separated argument.

Unlike with PHP_NEW_EXTENSION cases, the Apache example in the commit is added directly to PHP-8.4 as PHP_SELECT_SAPI is not used that widely outside of php-src.