### PR TITLE
Fix GH-15670: Polymorphic cache slot issue in DOM

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -370,13 +370,14 @@ static zend_always_inline const dom_prop_handler *dom_get_prop_handler(const dom
 	const dom_prop_handler *hnd = NULL;
 
 	if (obj->prop_handler != NULL) {
-		if (cache_slot) {
-			hnd = *cache_slot;
+		if (cache_slot && *cache_slot == obj->prop_handler) {
+			hnd = *(cache_slot + 1);
 		}
 		if (!hnd) {
 			hnd = zend_hash_find_ptr(obj->prop_handler, name);
 			if (cache_slot) {
-				*cache_slot = (void *) hnd;
+				*cache_slot = obj->prop_handler;
+				*(cache_slot + 1) = (void *) hnd;
 			}
 		}
 	}
@@ -419,12 +420,13 @@ zval *dom_write_property(zend_object *object, zend_string *name, zval *value, vo
 
 		zend_property_info *prop = NULL;
 		if (cache_slot) {
-			prop = *(cache_slot + 1);
+			ZEND_ASSERT(*cache_slot == obj->prop_handler);
+			prop = *(cache_slot + 2);
 		}
 		if (!prop) {
 			prop = zend_get_property_info(object->ce, name, /* silent */ true);
 			if (cache_slot) {
-				*(cache_slot + 1) = prop;
+				*(cache_slot + 2) = prop;
 			}
 		}
 

--- a/ext/dom/tests/gh15670.phpt
+++ b/ext/dom/tests/gh15670.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-15670 (Polymorphic cache slot issue in DOM)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadHTML('<p id=x>foo</p>');
+$dom = DOM\XMLDocument::createFromString('<root/>');
+$child = $dom->documentElement->appendChild($dom->createElementNS('urn:a', 'child'));
+function test($child, $html) {
+    try {
+        $child->innerHTML = $html;
+    } catch (DOMException $e) {
+    }
+}
+test($child, '--></root><!--');
+test($doc, '<');
+echo $doc->saveXML(), "\n";
+echo $dom->saveXML(), "\n";
+?>
+--EXPECTF--
+Deprecated: Creation of dynamic property DOMDocument::$innerHTML is deprecated in %s on line %d
+<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p id="x">foo</p></body></html>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<root><child xmlns="urn:a"/></root>


### PR DESCRIPTION
A cache slot can be hit with different DOM object types, so we should check if we're still handling the same type.