### PR TITLE
ext/pdo: Security Fix - Memory leak inside PDO could lead to a DoS

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2111,6 +2111,10 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 	pdo_stmt_reset_columns(stmt);
 
 	if (!Z_ISUNDEF(stmt->fetch.into) && stmt->default_fetch_type == PDO_FETCH_INTO) {
+		/* For circular references, decrement the ref count by one. */
+		if (UNEXPECTED(Z_TYPE(stmt->fetch.into) == IS_OBJECT && Z_OBJ(stmt->fetch.into) == &stmt->std)) {
+			Z_DELREF_P(&stmt->fetch.into);
+		}
 		zval_ptr_dtor(&stmt->fetch.into);
 		ZVAL_UNDEF(&stmt->fetch.into);
 	}

--- a/ext/pdo/tests/ghsa_5fcx_f85c_x9mc.phpt
+++ b/ext/pdo/tests/ghsa_5fcx_f85c_x9mc.phpt
@@ -1,0 +1,43 @@
+--TEST--
+PDO Common: GHSA-5fcx-f85c-x9mc (Memory leak inside PDO could lead to a DoS)
+--EXTENSIONS--
+pdo
+--SKIPIF--
+<?php
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+// see https://github.com/php/php-src/security/advisories/GHSA-5fcx-f85c-x9mc
+
+class TestStmt extends PDOStatement
+{
+    public $name;
+}
+
+$db = new PDO(
+    'mysql:host=db.sakiot.com;dbname=db;',
+    'saki',
+    'password',
+    [PDO::ATTR_STATEMENT_CLASS => [TestStmt::class]],
+);
+
+$db->exec('CREATE TABLE ghsa_5fcx_f85c_x9mc (name varchar(255))');
+$db->exec('INSERT INTO ghsa_5fcx_f85c_x9mc (name) VALUES ("test_name")');
+
+$stmt = $db->query('SELECT name FROM ghsa_5fcx_f85c_x9mc');
+$t = $stmt;
+$stmt->setFetchMode(PDO::FETCH_INTO, $stmt);
+$stmt->fetch();
+echo "done!\n";
+?>
+--CLEAN--
+<?php
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+PDOTest::dropTableIfExists($db, 'ghsa_5fcx_f85c_x9mc');
+?>
+--EXPECT--
+done!


### PR DESCRIPTION
Related: https://github.com/php/php-src/security/advisories/GHSA-5fcx-f85c-x9mc

The case of circular references, the zval's ref count will not go to 0 and will leak.
So, in case of circular references, I reduced the reference count by 2

Note that the test is for leak detection, so any test that does not check for leaks will always pass.