### PR TITLE
Autotools: Fix iconv shared build with external library

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-15330 (Do not scan generator frames more than once). (Arnaud)
   . Fixed bug GH-15644 (Asymmetric visibility doesn't work with hooks). (ilutov)
   . Implemented lazy objects RFC. (Arnaud)
+  . Fixed bug GH-15686 (Building shared iconv with external iconv library).
+    (Peter Kokot, zeriyoshi)
 
 - DOM:
   . Fixed bug GH-13988 (Storing DOMElement consume 4 times more memory in

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -8,9 +8,9 @@ if test "$PHP_ICONV" != "no"; then
   PHP_SETUP_ICONV([ICONV_SHARED_LIBADD],,
     [AC_MSG_FAILURE([The iconv not found.])])
 
-  save_LDFLAGS=$LDFLAGS
+  save_LIBS=$LIBS
   save_CFLAGS=$CFLAGS
-  LDFLAGS="$ICONV_SHARED_LIBADD $LDFLAGS"
+  LIBS="$LIBS $ICONV_SHARED_LIBADD"
   CFLAGS="$INCLUDES $CFLAGS"
 
   AC_CACHE_CHECK([for iconv implementation], [php_cv_iconv_implementation], [
@@ -111,7 +111,7 @@ int main(void) {
     [AC_DEFINE([ICONV_BROKEN_IGNORE], [1],
       [Define to 1 if iconv has broken IGNORE.])])
 
-  LDFLAGS=$save_LDFLAGS
+  LIBS=$save_LIBS
   CFLAGS=$save_CFLAGS
 
   AC_DEFINE([HAVE_ICONV], [1],


### PR DESCRIPTION
When building:

    ./configure --with-iconv=shared,/path/to/libiconv

the iconv couldn't be found due to linker error

Autoconf places LDFLAGS before the conftest.c file in the test compile command and LIBS after it. GCC also requires this.

Similar issue discovered at
https://github.com/remicollet/php-xpass/pull/1