### PR TITLE
Close-GH 15685: improve proc_open error reporting on Windows

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1317,7 +1317,9 @@ PHP_FUNCTION(proc_open)
 	if (newprocok == FALSE) {
 		DWORD dw = GetLastError();
 		close_all_descriptors(descriptors, ndesc);
-		php_error_docref(NULL, E_WARNING, "CreateProcess failed, error code: %u", dw);
+		char *msg = php_win32_error_to_msg(dw);
+		php_error_docref(NULL, E_WARNING, "CreateProcess failed: %s", msg);
+		php_win32_error_msg_free(msg);
 		goto exit_fail;
 	}
 

--- a/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_001.phpt
+++ b/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_001.phpt
@@ -4,6 +4,9 @@ GHSA-9fcc-425m-g385 - bypass CVE-2024-1874 - batch file variation
 <?php
 if( substr(PHP_OS, 0, 3) != "WIN" )
   die('skip Run only on Windows');
+if (!str_contains(shell_exec("does_not_exist.exe 2>&1"), "is not recognized as an internal or external command")) {
+  die("skip English locale required");
+}
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--

--- a/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_001.phpt
+++ b/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_001.phpt
@@ -49,7 +49,7 @@ operable program or batch file.
 '"%sghsa-9fcc-425m-g385_001.bat. ... . ."' is not recognized as an internal or external command,
 operable program or batch file.
 
-Warning: proc_open(): CreateProcess failed, error code: 2 in %s on line %d
+Warning: proc_open(): CreateProcess failed: The system cannot find the file specified in %s on line %d
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/ghsa-9fcc-425m-g385_001.bat');

--- a/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_002.phpt
+++ b/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_002.phpt
@@ -4,6 +4,9 @@ GHSA-9fcc-425m-g385 - bypass CVE-2024-1874 - cmd.exe variation
 <?php
 if( substr(PHP_OS, 0, 3) != "WIN" )
   die('skip Run only on Windows');
+if (!str_contains(shell_exec("does_not_exist.exe 2>&1"), "is not recognized as an internal or external command")) {
+  die("skip English locale required");
+}
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--

--- a/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_002.phpt
+++ b/ext/standard/tests/general_functions/ghsa-9fcc-425m-g385_002.phpt
@@ -49,17 +49,17 @@ $proc = proc_open(["\\cmd. ...  ", "/c", $batch_file_path, "\"&notepad.exe"], $d
 %sghsa-9fcc-425m-g385_002.bat
 "&notepad.exe
 
-Warning: proc_open(): CreateProcess failed, error code: 2 in %s on line %d
+Warning: proc_open(): CreateProcess failed: The system cannot find the file specified in %s on line %d
 %sghsa-9fcc-425m-g385_002.bat
 "&notepad.exe
 %sghsa-9fcc-425m-g385_002.bat
 "&notepad.exe
 
-Warning: proc_open(): CreateProcess failed, error code: 2 in %s on line %d
+Warning: proc_open(): CreateProcess failed: The system cannot find the file specified in %s on line %d
 
-Warning: proc_open(): CreateProcess failed, error code: 2 in %s on line %d
+Warning: proc_open(): CreateProcess failed: The system cannot find the file specified in %s on line %d
 
-Warning: proc_open(): CreateProcess failed, error code: 2 in %s on line %d
+Warning: proc_open(): CreateProcess failed: The system cannot find the file specified in %s on line %d
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/ghsa-9fcc-425m-g385_002.bat');


### PR DESCRIPTION
While similar errors are already reported via `strerror()` on other platforms, this has apparently overlooked for Windows, where only the error code has been reported so far.