### PR TITLE
Don't export php_pdo_int.h

### DIFF
--- a/ext/pdo/config.m4
+++ b/ext/pdo/config.m4
@@ -16,7 +16,6 @@ if test "$PHP_PDO" != "no"; then
     pdo_sql_parser.h
     php_pdo_driver.h
     php_pdo_error.h
-    php_pdo_int.h
     php_pdo.h
   ]))
   PHP_ADD_MAKEFILE_FRAGMENT

--- a/ext/pdo/config.w32
+++ b/ext/pdo/config.w32
@@ -10,7 +10,6 @@ if (PHP_PDO != "no") {
 		"pdo_sql_parser.h " +
 		"php_pdo_driver.h " +
 		"php_pdo_error.h " +
-		"php_pdo_int.h " +
 		"php_pdo.h"
 	);
 }

--- a/ext/pdo/pdo_sql_parser.re
+++ b/ext/pdo/pdo_sql_parser.re
@@ -16,7 +16,6 @@
 
 #include "php.h"
 #include "php_pdo_driver.h"
-#include "php_pdo_int.h"
 #include "pdo_sql_parser.h"
 
 static int default_scanner(pdo_scanner_t *s)

--- a/ext/pdo_mysql/mysql_sql_parser.re
+++ b/ext/pdo_mysql/mysql_sql_parser.re
@@ -17,7 +17,6 @@
 
 #include "php.h"
 #include "ext/pdo/php_pdo_driver.h"
-#include "ext/pdo/php_pdo_int.h"
 #include "ext/pdo/pdo_sql_parser.h"
 
 int pdo_mysql_scanner(pdo_scanner_t *s)

--- a/ext/pdo_pgsql/pgsql_sql_parser.re
+++ b/ext/pdo_pgsql/pgsql_sql_parser.re
@@ -17,7 +17,6 @@
 
 #include "php.h"
 #include "ext/pdo/php_pdo_driver.h"
-#include "ext/pdo/php_pdo_int.h"
 #include "ext/pdo/pdo_sql_parser.h"
 
 int pdo_pgsql_scanner(pdo_scanner_t *s)

--- a/ext/pdo_sqlite/sqlite_sql_parser.re
+++ b/ext/pdo_sqlite/sqlite_sql_parser.re
@@ -17,7 +17,6 @@
 
 #include "php.h"
 #include "ext/pdo/php_pdo_driver.h"
-#include "ext/pdo/php_pdo_int.h"
 #include "ext/pdo/pdo_sql_parser.h"
 
 int pdo_sqlite_scanner(pdo_scanner_t *s)


### PR DESCRIPTION
This is, as the name and a comment in the header imply, an internal header which is not supposed to be used by extensions other than PDO (not even by drivers).

Since there is apparently no need to include this header in the parsers of the drivers, we remove these includes, and no longer declare the header to be installed.  Given that the header is only exported for a couple of weeks[1], this is not considered to be a BC break, because it's unlikely that external drivers have already been adjusted to use this header, and otherwise they can still be fixed; PHP 8.4 is still in the pre-release stage.

[1] <https://github.com/php/php-src/pull/14797>