### PR TITLE
Add comments about internal headers

### DIFF
--- a/Zend/zend_strtod_int.h
+++ b/Zend/zend_strtod_int.h
@@ -16,6 +16,8 @@
    +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed; FIXME but unfortunately is */
+
 #ifndef ZEND_STRTOD_INT_H
 #define ZEND_STRTOD_INT_H
 

--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -1,3 +1,5 @@
+/* interface header; needs to be installed; FIXME rename? */
+
 #ifndef incl_PHP_GMP_INT_H
 #define incl_PHP_GMP_INT_H
 

--- a/ext/pdo_dblib/php_pdo_dblib_int.h
+++ b/ext/pdo_dblib/php_pdo_dblib_int.h
@@ -15,6 +15,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed */
+
 #ifndef PHP_PDO_DBLIB_INT_H
 #define PHP_PDO_DBLIB_INT_H
 

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -14,6 +14,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed */
+
 #ifndef PHP_PDO_FIREBIRD_INT_H
 #define PHP_PDO_FIREBIRD_INT_H
 

--- a/ext/pdo_mysql/php_pdo_mysql_int.h
+++ b/ext/pdo_mysql/php_pdo_mysql_int.h
@@ -16,6 +16,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed */
+
 #ifndef PHP_PDO_MYSQL_INT_H
 #define PHP_PDO_MYSQL_INT_H
 

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -14,6 +14,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed */
+
 #ifdef PHP_WIN32
 # define PDO_ODBC_TYPE	"Win32"
 #endif

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -16,6 +16,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed */
+
 #ifndef PHP_PDO_PGSQL_INT_H
 #define PHP_PDO_PGSQL_INT_H
 

--- a/ext/standard/php_dir_int.h
+++ b/ext/standard/php_dir_int.h
@@ -12,6 +12,8 @@
    +----------------------------------------------------------------------+
  */
 
+/* internal header; not supposed to be installed; FIXME but unfortunately is */
+
 #ifndef PHP_DIR_INT_H
 #define PHP_DIR_INT_H
 

--- a/main/streams/php_streams_int.h
+++ b/main/streams/php_streams_int.h
@@ -14,6 +14,8 @@
   +----------------------------------------------------------------------+
 */
 
+/* internal header; not supposed to be installed; FIXME but unfortunately is */
+
 #if ZEND_DEBUG
 
 #define emalloc_rel_orig(size)	\


### PR DESCRIPTION
A common convention is to name internal C header files as `*_int.h`. Since a couple of these are actually installed, we add comments that this is not supposed to happen, (a) to avoid installing further internal headers, and (b) to pave the way to fix this in the next major PHP version.

Somewhat special is php_gmp_int.h, where "int" is meant as abbreviation for "interface".

Another common convention is appending `_priv` or `_private`, but since there have not been any issues regarding these headers so far, we refrain from adding respective comments to these headers.

Anyhow, it might be a good idea to introduce some common naming convention for such internal/private headers.

---

See also #15688.