### PR TITLE
Fix GH-15690: ext-dba failures on 32-bit

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -309,7 +309,7 @@ static void dba_close_connection(dba_connection *connection)
 
 static zend_object *dba_connection_create_object(zend_class_entry *class_type)
 {
-	dba_connection *intern = zend_object_alloc(sizeof(dba_info), class_type);
+	dba_connection *intern = zend_object_alloc(sizeof(dba_connection), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);


### PR DESCRIPTION
The wrong type was used in the size calculation. On 64-bit this coincidentally doesn't cause issues, but on 32-bit it does because of different padding vs 64-bit resulting in a different size.

Regressed in 2097237.