### PR TITLE
Add benchmark suite to CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,111 @@
+name: Benchmark
+on:
+  schedule:
+    - cron: "0 2 * * *"
+permissions:
+  contents: read
+jobs:
+  BENCHMARK:
+    name: BENCHMARK
+    if: github.repository == 'php/php-src'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install dependencies
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install gpg
+
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update
+          sudo apt install terraform=1.5.7-*
+      - name: Checkout benchmark suite
+        uses: actions/checkout@v4
+        with:
+          repository: 'kocsismate/php-version-benchmarks'
+          ref: 'main'
+          fetch-depth: 1
+          path: 'php-version-benchmarks'
+      - name: Checkout php-src
+        uses: actions/checkout@v4
+        with:
+          repository: 'php/php-src'
+          ref: 'master'
+          fetch-depth: 100
+          path: 'php-version-benchmarks/tmp/php_master'
+      - name: Copy-paste the same repo content for benchmarking JIT
+        run: |
+          set -e
+    
+          cp -r "php-version-benchmarks/tmp/php_master/" "php-version-benchmarks/tmp/php_master_jit"
+      - name: Setup benchmark config
+        run: |
+          set -e
+
+          cp ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini.dist ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
+          ESCAPED_DOCKER_REGISTRY=$(printf '%s\n' "${{ secrets.PHP_VERSION_BENCHMARK_DOCKER_REGISTRY }}" | sed -e 's/[\/&]/\\&/g')
+          sed -i "s/INFRA_DOCKER_REGISTRY=public.ecr.aws\/abcdefgh/INFRA_DOCKER_REGISTRY=$ESCAPED_DOCKER_REGISTRY/g" ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
+
+          cp ./php-version-benchmarks/build/infrastructure/config/aws.tfvars.dist ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+          sed -i 's/access_key = ""/access_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_ACCESS_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+          sed -i 's/secret_key = ""/secret_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_SECRET_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master1.ini
+          YESTERDAY="$(date -d "-2 day 13:00" '+%Y-%m-%d')"
+          YESTERDAY_SHA="$(cd ./php-version-benchmarks/tmp/php_master/ && git --no-pager log --until="$YESTERDAY 23:59:59" -n 1 --pretty='%H')"
+          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - previous master"/g' ./php-version-benchmarks/config/php/master1.ini
+          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_previous/g" ./php-version-benchmarks/config/php/master1.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$YESTERDAY_SHA/g" ./php-version-benchmarks/config/php/master1.ini
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master2.ini
+          cp ./php-version-benchmarks/config/php/master_jit.ini.dist ./php-version-benchmarks/config/php/master2_jit.ini
+
+          cp ./php-version-benchmarks/config/test/1_laravel.ini.dist ./php-version-benchmarks/config/test/1_laravel.ini
+          cp ./php-version-benchmarks/config/test/2_symfony_main.ini.dist ./php-version-benchmarks/config/test/2_symfony_main.ini
+          cp ./php-version-benchmarks/config/test/4_wordpress.ini.dist ./php-version-benchmarks/config/test/4_wordpress.ini
+          cp ./php-version-benchmarks/config/test/5_bench.php.ini.dist ./php-version-benchmarks/config/test/5_bench.php.ini
+          cp ./php-version-benchmarks/config/test/6_micro_bench.php.ini.dist ./php-version-benchmarks/config/test/6_micro_bench.php.ini
+
+          rm -rf ./php-version-benchmarks/docs/results
+      - name: Git setup
+        run: |
+          git config --global user.name "Benchmark"
+          git config --global user.email "benchmark@php.net"
+      - name: Checkout benchmark results
+        uses: actions/checkout@v4
+        with:
+          repository: kocsismate/php-version-benchmark-results
+          ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}
+          path: 'php-version-benchmarks/docs/results'
+      - name: Run benchmark
+        run: ./php-version-benchmarks/benchmark.sh run aws
+      - name: Store results
+        run: |
+          set -ex
+
+          cd ./php-version-benchmarks/docs/results
+          git pull --autostash
+          if [ -e ".git/MERGE_HEAD" ]; then
+            echo "Merging, can't proceed"
+            exit 1
+          fi
+          git add .
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Add result for ${{ github.repository }}@${{ github.sha }}"
+          git push
+      - name: Cleanup
+        if: always()
+        run: |
+          set -ex
+
+          rm -rf ./php-version-benchmarks/tmp/
+          rm -f ./php-version-benchmarks/build/infrastructure/config/*.tfvars
+          rm -rf ./php-version-benchmarks/build/infrastructure/aws/.terraform/
+          rm -f ./php-version-benchmarks/build/infrastructure/aws/.terraform.lock.hcl
+          rm -f ./php-version-benchmarks/build/infrastructure/aws/aws.tfplan
+          rm -f ./php-version-benchmarks/build/infrastructure/aws/terraform.tfstate
+          rm -f ./php-version-benchmarks/build/infrastructure/aws/terraform.tfstate.backup
+          rm -f ./php-version-benchmarks/config/infra/aws/*.ini

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,7 @@
 name: Benchmark
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "30 0 * * *"
 permissions:
   contents: read
 jobs:
@@ -19,8 +19,9 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update
-          sudo apt install terraform=1.5.7-*
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update -y
+          sudo apt-get install -y terraform=1.5.7-*
       - name: Checkout benchmark suite
         uses: actions/checkout@v4
         with:
@@ -32,52 +33,63 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'php/php-src'
-          ref: 'master'
+          ref: '${{ github.sha }}'
           fetch-depth: 100
           path: 'php-version-benchmarks/tmp/php_master'
-      - name: Copy-paste the same repo content for benchmarking JIT
-        run: |
-          set -e
-    
-          cp -r "php-version-benchmarks/tmp/php_master/" "php-version-benchmarks/tmp/php_master_jit"
-      - name: Setup benchmark config
-        run: |
-          set -e
-
-          cp ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini.dist ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
-          ESCAPED_DOCKER_REGISTRY=$(printf '%s\n' "${{ secrets.PHP_VERSION_BENCHMARK_DOCKER_REGISTRY }}" | sed -e 's/[\/&]/\\&/g')
-          sed -i "s/INFRA_DOCKER_REGISTRY=public.ecr.aws\/abcdefgh/INFRA_DOCKER_REGISTRY=$ESCAPED_DOCKER_REGISTRY/g" ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
-
-          cp ./php-version-benchmarks/build/infrastructure/config/aws.tfvars.dist ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
-          sed -i 's/access_key = ""/access_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_ACCESS_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
-          sed -i 's/secret_key = ""/secret_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_SECRET_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
-
-          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master1.ini
-          YESTERDAY="$(date -d "-2 day 13:00" '+%Y-%m-%d')"
-          YESTERDAY_SHA="$(cd ./php-version-benchmarks/tmp/php_master/ && git --no-pager log --until="$YESTERDAY 23:59:59" -n 1 --pretty='%H')"
-          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - previous master"/g' ./php-version-benchmarks/config/php/master1.ini
-          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_previous/g" ./php-version-benchmarks/config/php/master1.ini
-          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$YESTERDAY_SHA/g" ./php-version-benchmarks/config/php/master1.ini
-          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master2.ini
-          cp ./php-version-benchmarks/config/php/master_jit.ini.dist ./php-version-benchmarks/config/php/master2_jit.ini
-
-          cp ./php-version-benchmarks/config/test/1_laravel.ini.dist ./php-version-benchmarks/config/test/1_laravel.ini
-          cp ./php-version-benchmarks/config/test/2_symfony_main.ini.dist ./php-version-benchmarks/config/test/2_symfony_main.ini
-          cp ./php-version-benchmarks/config/test/4_wordpress.ini.dist ./php-version-benchmarks/config/test/4_wordpress.ini
-          cp ./php-version-benchmarks/config/test/5_bench.php.ini.dist ./php-version-benchmarks/config/test/5_bench.php.ini
-          cp ./php-version-benchmarks/config/test/6_micro_bench.php.ini.dist ./php-version-benchmarks/config/test/6_micro_bench.php.ini
-
-          rm -rf ./php-version-benchmarks/docs/results
-      - name: Git setup
+      - name: Setup benchmark results
         run: |
           git config --global user.name "Benchmark"
           git config --global user.email "benchmark@php.net"
+          
+          rm -rf ./php-version-benchmarks/docs/results
       - name: Checkout benchmark results
         uses: actions/checkout@v4
         with:
           repository: kocsismate/php-version-benchmark-results
           ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}
           path: 'php-version-benchmarks/docs/results'
+      - name: Set benchmark config
+        run: |
+          set -e
+
+          # Set infrastructure config
+          cp ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini.dist ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
+          ESCAPED_DOCKER_REGISTRY=$(printf '%s\n' "${{ secrets.PHP_VERSION_BENCHMARK_DOCKER_REGISTRY }}" | sed -e 's/[\/&]/\\&/g')
+          sed -i "s/INFRA_DOCKER_REGISTRY=public.ecr.aws\/abcdefgh/INFRA_DOCKER_REGISTRY=$ESCAPED_DOCKER_REGISTRY/g" ./php-version-benchmarks/config/infra/aws/x86_64-metal.ini
+          cp ./php-version-benchmarks/build/infrastructure/config/aws.tfvars.dist ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+          sed -i 's/access_key = ""/access_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_ACCESS_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+          sed -i 's/secret_key = ""/secret_key = "${{ secrets.PHP_VERSION_BENCHMARK_AWS_SECRET_KEY }}"/g' ./php-version-benchmarks/build/infrastructure/config/aws.tfvars
+
+          YEAR="$(date '+%Y')"
+          DATABASE="./php-version-benchmarks/docs/results/$YEAR/database.tsv"
+          if [ -f "$DATABASE" ]; then
+            LAST_RESULT_SHA="$(tail -n 2 "$DATABASE" | head -n 1 | cut -f 6)"
+          else
+            YESTERDAY="$(date -d "-2 day 23:59:59" '+%Y-%m-%d %H:%M:%S')"
+            LAST_RESULT_SHA="$(cd ./php-version-benchmarks/tmp/php_master/ && git --no-pager log --until="$YESTERDAY" -n 1 --pretty='%H')"
+          fi
+
+          # Set config for the previous PHP version
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master1.ini
+          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - previous master"/g' ./php-version-benchmarks/config/php/master1.ini
+          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_previous/g" ./php-version-benchmarks/config/php/master1.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$LAST_RESULT_SHA/g" ./php-version-benchmarks/config/php/master1.ini
+
+          # Set config for the current PHP version
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master2.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master2.ini
+
+          # Set config for current PHP version with JIT
+          git clone ./php-version-benchmarks/tmp/php_master/ ./php-version-benchmarks/tmp/php_master_jit
+          cp ./php-version-benchmarks/config/php/master_jit.ini.dist ./php-version-benchmarks/config/php/master2_jit.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master2_jit.ini
+
+          # Set test configs
+          cp ./php-version-benchmarks/config/test/1_laravel.ini.dist ./php-version-benchmarks/config/test/1_laravel.ini
+          cp ./php-version-benchmarks/config/test/2_symfony_main.ini.dist ./php-version-benchmarks/config/test/2_symfony_main.ini
+          cp ./php-version-benchmarks/config/test/4_wordpress.ini.dist ./php-version-benchmarks/config/test/4_wordpress.ini
+          cp ./php-version-benchmarks/config/test/5_bench.php.ini.dist ./php-version-benchmarks/config/test/5_bench.php.ini
+          cp ./php-version-benchmarks/config/test/6_micro_bench.php.ini.dist ./php-version-benchmarks/config/test/6_micro_bench.php.ini
       - name: Run benchmark
         run: ./php-version-benchmarks/benchmark.sh run aws
       - name: Store results
@@ -92,7 +104,7 @@ jobs:
           fi
           git add .
           if git diff --cached --quiet; then
-            exit 0
+            exit 1
           fi
           git commit -m "Add result for ${{ github.repository }}@${{ github.sha }}"
           git push

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,20 +69,29 @@ jobs:
             LAST_RESULT_SHA="$(cd ./php-version-benchmarks/tmp/php_master/ && git --no-pager log --until="$YESTERDAY" -n 1 --pretty='%H')"
           fi
 
+          BASELINE_SHA="306a51951f460abc3a7ebf4d196474d4c041b87e"
+          BASELINE_SHORT_SHA="$(echo "$BASELINE_SHA" | cut -c1-4)"
+
+          # Set config for the baseline PHP version
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master_baseline.ini
+          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - baseline@'"$BASELINE_SHORT_SHA"'"/g' ./php-version-benchmarks/config/php/master_baseline.ini
+          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_baseline/g" ./php-version-benchmarks/config/php/master_baseline.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$BASELINE_SHA/g" ./php-version-benchmarks/config/php/master_baseline.ini
+
           # Set config for the previous PHP version
-          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master1.ini
-          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - previous master"/g' ./php-version-benchmarks/config/php/master1.ini
-          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_previous/g" ./php-version-benchmarks/config/php/master1.ini
-          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$LAST_RESULT_SHA/g" ./php-version-benchmarks/config/php/master1.ini
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master_last.ini
+          sed -i 's/PHP_NAME="PHP - master"/PHP_NAME="PHP - previous master"/g' ./php-version-benchmarks/config/php/master_last.ini
+          sed -i "s/PHP_ID=php_master/PHP_ID=php_master_previous/g" ./php-version-benchmarks/config/php/master_last.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=$LAST_RESULT_SHA/g" ./php-version-benchmarks/config/php/master_last.ini
 
           # Set config for the current PHP version
-          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master2.ini
-          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master2.ini
+          cp ./php-version-benchmarks/config/php/master.ini.dist ./php-version-benchmarks/config/php/master_now.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master_now.ini
 
           # Set config for current PHP version with JIT
           git clone ./php-version-benchmarks/tmp/php_master/ ./php-version-benchmarks/tmp/php_master_jit
-          cp ./php-version-benchmarks/config/php/master_jit.ini.dist ./php-version-benchmarks/config/php/master2_jit.ini
-          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master2_jit.ini
+          cp ./php-version-benchmarks/config/php/master_jit.ini.dist ./php-version-benchmarks/config/php/master_now_jit.ini
+          sed -i "s/PHP_COMMIT=/PHP_COMMIT=${{ github.sha }}/g" ./php-version-benchmarks/config/php/master_now_jit.ini
 
           # Set test configs
           cp ./php-version-benchmarks/config/test/1_laravel.ini.dist ./php-version-benchmarks/config/test/1_laravel.ini

--- a/.github/workflows/real-time-benchmark.yml
+++ b/.github/workflows/real-time-benchmark.yml
@@ -42,10 +42,10 @@ jobs:
           git config --global user.email "benchmark@php.net"
           
           rm -rf ./php-version-benchmarks/docs/results
-      - name: Checkout benchmark results
+      - name: Checkout benchmark data
         uses: actions/checkout@v4
         with:
-          repository: php/php-version-benchmark-results
+          repository: php/real-time-benchmark-data
           ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}
           path: 'php-version-benchmarks/docs/results'
       - name: Set benchmark config

--- a/.github/workflows/real-time-benchmark.yml
+++ b/.github/workflows/real-time-benchmark.yml
@@ -1,12 +1,12 @@
-name: Benchmark
+name: Real-time Benchmark
 on:
   schedule:
     - cron: "30 0 * * *"
 permissions:
   contents: read
 jobs:
-  BENCHMARK:
-    name: BENCHMARK
+  REAL_TIME_BENCHMARK:
+    name: REAL_TIME_BENCHMARK
     if: github.repository == 'php/php-src'
     runs-on: ubuntu-22.04
     steps:
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout benchmark results
         uses: actions/checkout@v4
         with:
-          repository: kocsismate/php-version-benchmark-results
+          repository: php/php-version-benchmark-results
           ssh-key: ${{ secrets.PHP_VERSION_BENCHMARK_RESULTS_DEPLOY_KEY }}
           path: 'php-version-benchmarks/docs/results'
       - name: Set benchmark config
@@ -69,7 +69,7 @@ jobs:
             LAST_RESULT_SHA="$(cd ./php-version-benchmarks/tmp/php_master/ && git --no-pager log --until="$YESTERDAY" -n 1 --pretty='%H')"
           fi
 
-          BASELINE_SHA="306a51951f460abc3a7ebf4d196474d4c041b87e"
+          BASELINE_SHA="d5f6e56610c729710073350af318c4ea1b292cfe"
           BASELINE_SHORT_SHA="$(echo "$BASELINE_SHA" | cut -c1-4)"
 
           # Set config for the baseline PHP version


### PR DESCRIPTION
This PR integrates https://github.com/kocsismate/php-version-benchmarks/ into the CI as a nightly job running every day at 12:30 AM. Roughly, the following happens: the benchmark suite spins up an AWS EC2 instance via Terraform, runs the tests according to the configuration, and then the results are committed to the https://github.com/kocsismate/php-version-benchmark-results repository.

In order to have as stable results as possible, the CPU, kernel and other settings of the AWS instance are fine-tuned:

- Hyper-threading is disabled
- Turbo boost is disabled
- C states of the CPU are limited: https://docs.aws.amazon.com/linux/al2/ug/processor_state_control.html#baseline-perf
- The workload is dedicated to a single core by using taskset according to Intel's recommendations (https://web.archive.org/web/20210614053522/https://01.org/node/3774)
- An io2 SSD volume is attached to the instance which has a provisioned IOPS (https://docs.aws.amazon.com/ebs/latest/userguide/provisioned-iops.html#io2-block-express) so that IO performance is nearly constant
- The instance is dedicated so that the noisy neighbor effect is eliminated: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
- ASLR is disabled (https://github.com/php/php-src/pull/13769)

Customizing the CPU is only supported by metal instances among recent instance types according to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html, so at last, a `c7i.metal-24xl` instance is used in the `eu-west-1` region.

The benchmark suite compares the performance of the latest commit of the master branch in the time when the benchmark runs with the last commit of master from the day before yesterday. I.e. if the benchmark runs tomorrow morning at 2 AM, then the performance of the  latest commit will be benchmarked against the last commit pushed yesterday. This makes it possible to spot outstanding regressions (or progressions) in time. Actually, the end goal is to send notifications in case of any significant changes for further analyzation. The reason why the benchmark is run for previous commits as well (while they may have already been measured the day before) is to make the results less sensitive for changes in the environment or the benchmark suite itself. I.e.: if AWS upgrades the OS, or if the code under test is modified, then the numbers will likely be affected, and the previous results will be invalidated).

According to the first two test runs on a metal instance, the following results were measured (without using the dedicated instance feature for now):
- https://github.com/kocsismate/php-version-benchmark-results/commit/ede49f63497ce954c0982e07aef7a1245185a8da?short_path=433ac0d#diff-433ac0d326dd9ad164157417eb9ff76a5885182630d68769a2a8f2621966aa74
- https://github.com/kocsismate/php-version-benchmark-results/commit/b94bd66d26aaf00b38a35a22702e14aab1f0b6a0?short_path=4fd961d#diff-4fd961dbc49408c2126ff6cfc68dae5cea51f87e880be9afff52883061868834

As it can be seen, the difference between the median results of the two runs **have less than `0.001` sec difference** in case of most tests. This is very promising as it suggests that the environment is stable and the results are precise. To have a better understanding of the actual accuracy of the results, I ran the benchmark comparing the very same commits to each other in the hope that the performance diff would be very close to 0. Here are the results:
- https://github.com/kocsismate/php-version-benchmark-results/commit/7a1ff15bab2f275e984e19abaff2821c6ed9c735?short_path=a9d6090#diff-a9d60905b6b553a9889176ea93d928c9d9970d120c9dd146f7035d1dc73c3690

Indeed, real word tests show a maximum of **relative difference of 0.08%**, while the synthetic ones vary by a maximum of 0.35%.

