### PR TITLE
Forbid a-vis on unilateral virtual prop

### DIFF
--- a/Zend/tests/asymmetric_visibility/virtual_get_only.phpt
+++ b/Zend/tests/asymmetric_visibility/virtual_get_only.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Get-only virtual property must not specify asymmetric visibility
+--FILE--
+<?php
+
+class Foo {
+    public private(set) int $bar {
+        get => 42;
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Unilateral virtual property Foo::$bar must not specify asymmetric visibility in %s on line %d

--- a/Zend/tests/asymmetric_visibility/virtual_set_only.phpt
+++ b/Zend/tests/asymmetric_visibility/virtual_set_only.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Set-only virtual property must not specify asymmetric visibility
+--FILE--
+<?php
+
+class Foo {
+    public private(set) int $bar {
+        set {}
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Unilateral virtual property Foo::$bar must not specify asymmetric visibility in %s on line %d


### PR DESCRIPTION
The get-only case is obvious, there is no set operation so specifying its visibility is senseless. The set-only case is also questionable, since there is no operation other than set, so changing the visibility of the entire property is preferable.

This change was forgotten during the implementation.