### PR TITLE
Remove redundant 'zobj->ce->__isset' check

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -2254,7 +2254,7 @@ found:
 	}
 
 	result = false;
-	if ((has_set_exists != ZEND_PROPERTY_EXISTS) && zobj->ce->__isset) {
+	if (has_set_exists != ZEND_PROPERTY_EXISTS) {
 		uint32_t *guard = zend_get_property_guard(zobj, name);
 
 		if (!((*guard) & IN_ISSET)) {


### PR DESCRIPTION
This became unnecessary due to the addition of lazy objects that added the goto when '!zobj->ce->__isset' above.

Removes a static analyser warning.