### PR TITLE
Autotools: Add libtool --silent option to phpize

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ PHP                                                                        NEWS
   . Implemented lazy objects RFC. (Arnaud)
   . Fixed bug GH-15686 (Building shared iconv with external iconv library).
     (Peter Kokot, zeriyoshi)
+  . The Libtool --silent option is set to on in phpize. (Peter Kokot)
 
 - DOM:
   . Fixed bug GH-13988 (Storing DOMElement consume 4 times more memory in

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -221,6 +221,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
        - ac_cv_write_stdout                -> php_cv_have_write_stdout
      and all other checks wrapped with their belonging cache variables (see *.m4
      source files for details).
+   - The libtool now has the --silent option set in phpize as in php-src.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19,

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -153,6 +153,8 @@ AC_PROVIDE_IFELSE([PHP_REQUIRE_CXX], [], [
 ])
 AC_PROG_LIBTOOL
 
+PHP_SET_LIBTOOL_VARIABLE([--silent])
+
 all_targets='$(PHP_MODULES) $(PHP_ZEND_EX)'
 install_targets="install-modules install-headers"
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"


### PR DESCRIPTION
When building PHP extensions with phpize there is a lot of additional log output done by libtool in the make step that cannot be turned off. This syncs the php-src build and phpize by enabling the Libtool --silent option.

This can wait for PHP after 8.4 version, otherwise the default output by `make` is almost always sufficient. The php-src's configure.ac already has this option set but phpize didn't have it yet.