### PR TITLE
Generated arginfo header files: remove empty zend_function_entry arrays

### DIFF
--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -364,15 +364,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_stdClass_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_stdClass(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "stdClass", class_stdClass_methods);
+	INIT_CLASS_ENTRY(ce, "stdClass", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 
 	zend_string *attribute_name_AllowDynamicProperties_class_stdClass_0 = zend_string_init_interned("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -142,42 +142,6 @@ static const zend_function_entry class_Error_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_CompileError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ParseError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_TypeError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ArgumentCountError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ValueError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ArithmeticError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DivisionByZeroError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_UnhandledMatchError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_RequestParseBodyException_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_Throwable(zend_class_entry *class_entry_Stringable)
 {
 	zend_class_entry ce, *class_entry;
@@ -317,7 +281,7 @@ static zend_class_entry *register_class_CompileError(zend_class_entry *class_ent
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "CompileError", class_CompileError_methods);
+	INIT_CLASS_ENTRY(ce, "CompileError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -327,7 +291,7 @@ static zend_class_entry *register_class_ParseError(zend_class_entry *class_entry
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ParseError", class_ParseError_methods);
+	INIT_CLASS_ENTRY(ce, "ParseError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_CompileError, 0);
 
 	return class_entry;
@@ -337,7 +301,7 @@ static zend_class_entry *register_class_TypeError(zend_class_entry *class_entry_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "TypeError", class_TypeError_methods);
+	INIT_CLASS_ENTRY(ce, "TypeError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -347,7 +311,7 @@ static zend_class_entry *register_class_ArgumentCountError(zend_class_entry *cla
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ArgumentCountError", class_ArgumentCountError_methods);
+	INIT_CLASS_ENTRY(ce, "ArgumentCountError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_TypeError, 0);
 
 	return class_entry;
@@ -357,7 +321,7 @@ static zend_class_entry *register_class_ValueError(zend_class_entry *class_entry
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ValueError", class_ValueError_methods);
+	INIT_CLASS_ENTRY(ce, "ValueError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -367,7 +331,7 @@ static zend_class_entry *register_class_ArithmeticError(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ArithmeticError", class_ArithmeticError_methods);
+	INIT_CLASS_ENTRY(ce, "ArithmeticError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -377,7 +341,7 @@ static zend_class_entry *register_class_DivisionByZeroError(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DivisionByZeroError", class_DivisionByZeroError_methods);
+	INIT_CLASS_ENTRY(ce, "DivisionByZeroError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ArithmeticError, 0);
 
 	return class_entry;
@@ -387,7 +351,7 @@ static zend_class_entry *register_class_UnhandledMatchError(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "UnhandledMatchError", class_UnhandledMatchError_methods);
+	INIT_CLASS_ENTRY(ce, "UnhandledMatchError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -397,7 +361,7 @@ static zend_class_entry *register_class_RequestParseBodyException(zend_class_ent
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "RequestParseBodyException", class_RequestParseBodyException_methods);
+	INIT_CLASS_ENTRY(ce, "RequestParseBodyException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/Zend/zend_generators_arginfo.h
+++ b/Zend/zend_generators_arginfo.h
@@ -50,10 +50,6 @@ static const zend_function_entry class_Generator_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_ClosedGeneratorException_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_Generator(zend_class_entry *class_entry_Iterator)
 {
 	zend_class_entry ce, *class_entry;
@@ -69,7 +65,7 @@ static zend_class_entry *register_class_ClosedGeneratorException(zend_class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ClosedGeneratorException", class_ClosedGeneratorException_methods);
+	INIT_CLASS_ENTRY(ce, "ClosedGeneratorException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/Zend/zend_interfaces_arginfo.h
+++ b/Zend/zend_interfaces_arginfo.h
@@ -69,10 +69,6 @@ ZEND_METHOD(InternalIterator, next);
 ZEND_METHOD(InternalIterator, valid);
 ZEND_METHOD(InternalIterator, rewind);
 
-static const zend_function_entry class_Traversable_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_IteratorAggregate_methods[] = {
 	ZEND_RAW_FENTRY("getIterator", NULL, arginfo_class_IteratorAggregate_getIterator, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_FE_END
@@ -125,7 +121,7 @@ static zend_class_entry *register_class_Traversable(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "Traversable", class_Traversable_methods);
+	INIT_CLASS_ENTRY(ce, "Traversable", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	return class_entry;

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -5104,9 +5104,7 @@ function generateArgInfoCode(
             }
         );
 
-        if (!empty($fileInfo->funcInfos)) {
-            $code .= generateFunctionEntries(null, $fileInfo->funcInfos);
-        }
+        $code .= generateFunctionEntries(null, $fileInfo->funcInfos);
 
         foreach ($fileInfo->classInfos as $classInfo) {
             $code .= generateFunctionEntries($classInfo->name, $classInfo->funcInfos, $classInfo->cond);
@@ -5157,8 +5155,8 @@ function generateClassEntryCode(FileInfo $fileInfo, array $allConstInfos): strin
 
 /** @param FuncInfo[] $funcInfos */
 function generateFunctionEntries(?Name $className, array $funcInfos, ?string $cond = null): string {
-    // No need to add anything if there are no function entries for a class
-    if ($className !== null && $funcInfos === []) {
+    // No need to add anything if there are no function entries
+    if ($funcInfos === []) {
         return '';
     }
 

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3285,11 +3285,12 @@ class ClassInfo {
         $flagCodes = generateVersionDependentFlagCode("%s", $this->getFlagsByPhpVersion(), $this->phpVersionIdMinimumCompatibility);
         $flags = implode("", $flagCodes);
 
+        $classMethods = ($this->funcInfos === []) ? 'NULL' : "class_{$escapedName}_methods";
         if ($this->type === "enum") {
             $name = addslashes((string) $this->name);
             $backingType = $this->enumBackingType
                 ? $this->enumBackingType->toTypeCode() : "IS_UNDEF";
-            $code .= "\tzend_class_entry *class_entry = zend_register_internal_enum(\"$name\", $backingType, class_{$escapedName}_methods);\n";
+            $code .= "\tzend_class_entry *class_entry = zend_register_internal_enum(\"$name\", $backingType, $classMethods);\n";
             if ($flags !== "") {
                 $code .= "\tclass_entry->ce_flags |= $flags\n";
             }
@@ -3299,9 +3300,9 @@ class ClassInfo {
                 $className = $this->name->getLast();
                 $namespace = addslashes((string) $this->name->slice(0, -1));
 
-                $code .= "\tINIT_NS_CLASS_ENTRY(ce, \"$namespace\", \"$className\", class_{$escapedName}_methods);\n";
+                $code .= "\tINIT_NS_CLASS_ENTRY(ce, \"$namespace\", \"$className\", $classMethods);\n";
             } else {
-                $code .= "\tINIT_CLASS_ENTRY(ce, \"$this->name\", class_{$escapedName}_methods);\n";
+                $code .= "\tINIT_CLASS_ENTRY(ce, \"$this->name\", $classMethods);\n";
             }
 
             if ($this->type === "class" || $this->type === "trait") {
@@ -5156,6 +5157,11 @@ function generateClassEntryCode(FileInfo $fileInfo, array $allConstInfos): strin
 
 /** @param FuncInfo[] $funcInfos */
 function generateFunctionEntries(?Name $className, array $funcInfos, ?string $cond = null): string {
+    // No need to add anything if there are no function entries for a class
+    if ($className !== null && $funcInfos === []) {
+        return '';
+    }
+
     $code = "\n";
 
     if ($cond) {

--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -222,14 +222,6 @@ static const zend_function_entry class_dotnet_methods[] = {
 };
 #endif
 
-static const zend_function_entry class_com_safearray_proxy_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_com_exception_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_com_extension_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("CLSCTX_INPROC_SERVER", CLSCTX_INPROC_SERVER, CONST_PERSISTENT);
@@ -331,7 +323,7 @@ static zend_class_entry *register_class_com_safearray_proxy(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "com_safearray_proxy", class_com_safearray_proxy_methods);
+	INIT_CLASS_ENTRY(ce, "com_safearray_proxy", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
 	return class_entry;
@@ -341,7 +333,7 @@ static zend_class_entry *register_class_com_exception(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "com_exception", class_com_exception_methods);
+	INIT_CLASS_ENTRY(ce, "com_exception", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_FINAL);
 
 	return class_entry;

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -213,18 +213,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_CurlHandle_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_CurlMultiHandle_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_CurlShareHandle_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_curl_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("CURLOPT_AUTOREFERER", CURLOPT_AUTOREFERER, CONST_PERSISTENT);
@@ -1108,7 +1096,7 @@ static zend_class_entry *register_class_CurlHandle(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "CurlHandle", class_CurlHandle_methods);
+	INIT_CLASS_ENTRY(ce, "CurlHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1118,7 +1106,7 @@ static zend_class_entry *register_class_CurlMultiHandle(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "CurlMultiHandle", class_CurlMultiHandle_methods);
+	INIT_CLASS_ENTRY(ce, "CurlMultiHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1128,7 +1116,7 @@ static zend_class_entry *register_class_CurlShareHandle(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "CurlShareHandle", class_CurlShareHandle_methods);
+	INIT_CLASS_ENTRY(ce, "CurlShareHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -780,42 +780,6 @@ static const zend_function_entry class_DatePeriod_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_DateError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateObjectError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateRangeError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateInvalidTimeZoneException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateInvalidOperationException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateMalformedStringException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateMalformedIntervalStringException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DateMalformedPeriodStringException_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_php_date_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("DATE_ATOM", DATE_FORMAT_RFC3339, CONST_PERSISTENT);
@@ -1205,7 +1169,7 @@ static zend_class_entry *register_class_DateError(zend_class_entry *class_entry_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateError", class_DateError_methods);
+	INIT_CLASS_ENTRY(ce, "DateError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1215,7 +1179,7 @@ static zend_class_entry *register_class_DateObjectError(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateObjectError", class_DateObjectError_methods);
+	INIT_CLASS_ENTRY(ce, "DateObjectError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1225,7 +1189,7 @@ static zend_class_entry *register_class_DateRangeError(zend_class_entry *class_e
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateRangeError", class_DateRangeError_methods);
+	INIT_CLASS_ENTRY(ce, "DateRangeError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1235,7 +1199,7 @@ static zend_class_entry *register_class_DateException(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateException", class_DateException_methods);
+	INIT_CLASS_ENTRY(ce, "DateException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1245,7 +1209,7 @@ static zend_class_entry *register_class_DateInvalidTimeZoneException(zend_class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateInvalidTimeZoneException", class_DateInvalidTimeZoneException_methods);
+	INIT_CLASS_ENTRY(ce, "DateInvalidTimeZoneException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1255,7 +1219,7 @@ static zend_class_entry *register_class_DateInvalidOperationException(zend_class
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateInvalidOperationException", class_DateInvalidOperationException_methods);
+	INIT_CLASS_ENTRY(ce, "DateInvalidOperationException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1265,7 +1229,7 @@ static zend_class_entry *register_class_DateMalformedStringException(zend_class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateMalformedStringException", class_DateMalformedStringException_methods);
+	INIT_CLASS_ENTRY(ce, "DateMalformedStringException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1275,7 +1239,7 @@ static zend_class_entry *register_class_DateMalformedIntervalStringException(zen
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateMalformedIntervalStringException", class_DateMalformedIntervalStringException_methods);
+	INIT_CLASS_ENTRY(ce, "DateMalformedIntervalStringException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -1285,7 +1249,7 @@ static zend_class_entry *register_class_DateMalformedPeriodStringException(zend_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DateMalformedPeriodStringException", class_DateMalformedPeriodStringException_methods);
+	INIT_CLASS_ENTRY(ce, "DateMalformedPeriodStringException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;

--- a/ext/dba/dba_arginfo.h
+++ b/ext/dba/dba_arginfo.h
@@ -95,10 +95,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Dba_Connection_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_dba_symbols(int module_number)
 {
 #if defined(DBA_LMDB)
@@ -113,7 +109,7 @@ static zend_class_entry *register_class_Dba_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dba", "Connection", class_Dba_Connection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dba", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1398,10 +1398,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_DOMDocumentType_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_DOMCdataSection_methods[] = {
 	ZEND_ME(DOMCdataSection, __construct, arginfo_class_DOMCdataSection___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
@@ -1591,10 +1587,6 @@ static const zend_function_entry class_DOMDocument_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_DOMException_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_DOMText_methods[] = {
 	ZEND_ME(DOMText, __construct, arginfo_class_DOMText___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMText, isWhitespaceInElementContent, arginfo_class_DOMText_isWhitespaceInElementContent, ZEND_ACC_PUBLIC)
@@ -1612,16 +1604,8 @@ static const zend_function_entry class_DOMNamedNodeMap_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_DOMEntity_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_DOMEntityReference_methods[] = {
 	ZEND_ME(DOMEntityReference, __construct, arginfo_class_DOMEntityReference___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DOMNotation_methods[] = {
 	ZEND_FE_END
 };
 
@@ -1726,10 +1710,6 @@ static const zend_function_entry class_Dom_HTMLCollection_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Dom_AdjacentPosition_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Dom_Element_methods[] = {
 	ZEND_RAW_FENTRY("hasAttributes", zim_DOMNode_hasAttributes, arginfo_class_Dom_Element_hasAttributes, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getAttributeNames", zim_DOMElement_getAttributeNames, arginfo_class_Dom_Element_getAttributeNames, ZEND_ACC_PUBLIC, NULL, NULL)
@@ -1771,10 +1751,6 @@ static const zend_function_entry class_Dom_Element_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Dom_HTMLElement_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Dom_Attr_methods[] = {
 	ZEND_RAW_FENTRY("isId", zim_DOMAttr_isId, arginfo_class_Dom_Attr_isId, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("rename", zim_Dom_Element_rename, arginfo_class_Dom_Attr_rename, ZEND_ACC_PUBLIC, NULL, NULL)
@@ -1799,18 +1775,6 @@ static const zend_function_entry class_Dom_Text_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Dom_CDATASection_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Dom_ProcessingInstruction_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Dom_Comment_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Dom_DocumentType_methods[] = {
 	ZEND_RAW_FENTRY("remove", zim_DOMElement_remove, arginfo_class_Dom_DocumentType_remove, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("before", zim_DOMElement_before, arginfo_class_Dom_DocumentType_before, ZEND_ACC_PUBLIC, NULL, NULL)
@@ -1826,18 +1790,6 @@ static const zend_function_entry class_Dom_DocumentFragment_methods[] = {
 	ZEND_RAW_FENTRY("replaceChildren", zim_DOMElement_replaceChildren, arginfo_class_Dom_DocumentFragment_replaceChildren, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("querySelector", zim_Dom_Element_querySelector, arginfo_class_Dom_DocumentFragment_querySelector, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("querySelectorAll", zim_Dom_Element_querySelectorAll, arginfo_class_Dom_DocumentFragment_querySelectorAll, ZEND_ACC_PUBLIC, NULL, NULL)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Dom_Entity_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Dom_EntityReference_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Dom_Notation_methods[] = {
 	ZEND_FE_END
 };
 
@@ -2005,7 +1957,7 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DOMDocumentType", class_DOMDocumentType_methods);
+	INIT_CLASS_ENTRY(ce, "DOMDocumentType", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
 
 	zval property_name_default_value;
@@ -2682,7 +2634,7 @@ static zend_class_entry *register_class_DOMException(zend_class_entry *class_ent
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DOMException", class_DOMException_methods);
+	INIT_CLASS_ENTRY(ce, "DOMException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_FINAL);
 	zend_register_class_alias("Dom\\DOMException", class_entry);
 
@@ -2732,7 +2684,7 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DOMEntity", class_DOMEntity_methods);
+	INIT_CLASS_ENTRY(ce, "DOMEntity", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
 
 	zval property_publicId_default_value;
@@ -2788,7 +2740,7 @@ static zend_class_entry *register_class_DOMNotation(zend_class_entry *class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DOMNotation", class_DOMNotation_methods);
+	INIT_CLASS_ENTRY(ce, "DOMNotation", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
 
 	zval property_publicId_default_value;
@@ -3091,7 +3043,7 @@ static zend_class_entry *register_class_Dom_HTMLCollection(zend_class_entry *cla
 
 static zend_class_entry *register_class_Dom_AdjacentPosition(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("Dom\\AdjacentPosition", IS_STRING, class_Dom_AdjacentPosition_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("Dom\\AdjacentPosition", IS_STRING, NULL);
 
 	zval enum_case_BeforeBegin_value;
 	zend_string *enum_case_BeforeBegin_value_str = zend_string_init("beforebegin", strlen("beforebegin"), 1);
@@ -3227,7 +3179,7 @@ static zend_class_entry *register_class_Dom_HTMLElement(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "HTMLElement", class_Dom_HTMLElement_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "HTMLElement", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Element, 0);
 
 	return class_entry;
@@ -3343,7 +3295,7 @@ static zend_class_entry *register_class_Dom_CDATASection(zend_class_entry *class
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "CDATASection", class_Dom_CDATASection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "CDATASection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Text, 0);
 
 	return class_entry;
@@ -3353,7 +3305,7 @@ static zend_class_entry *register_class_Dom_ProcessingInstruction(zend_class_ent
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "ProcessingInstruction", class_Dom_ProcessingInstruction_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "ProcessingInstruction", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_CharacterData, 0);
 
 	zval property_target_default_value;
@@ -3369,7 +3321,7 @@ static zend_class_entry *register_class_Dom_Comment(zend_class_entry *class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "Comment", class_Dom_Comment_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "Comment", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_CharacterData, 0);
 
 	return class_entry;
@@ -3459,7 +3411,7 @@ static zend_class_entry *register_class_Dom_Entity(zend_class_entry *class_entry
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "Entity", class_Dom_Entity_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "Entity", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
 
 	zval property_publicId_default_value;
@@ -3487,7 +3439,7 @@ static zend_class_entry *register_class_Dom_EntityReference(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "EntityReference", class_Dom_EntityReference_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "EntityReference", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
 
 	return class_entry;
@@ -3497,7 +3449,7 @@ static zend_class_entry *register_class_Dom_Notation(zend_class_entry *class_ent
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Dom", "Notation", class_Dom_Notation_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Dom", "Notation", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
 
 	zval property_publicId_default_value;

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -146,14 +146,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_EnchantBroker_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_EnchantDictionary_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_enchant_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("ENCHANT_MYSPELL", PHP_ENCHANT_MYSPELL, CONST_PERSISTENT | CONST_DEPRECATED);
@@ -230,7 +222,7 @@ static zend_class_entry *register_class_EnchantBroker(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "EnchantBroker", class_EnchantBroker_methods);
+	INIT_CLASS_ENTRY(ce, "EnchantBroker", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -240,7 +232,7 @@ static zend_class_entry *register_class_EnchantDictionary(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "EnchantDictionary", class_EnchantDictionary_methods);
+	INIT_CLASS_ENTRY(ce, "EnchantDictionary", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -176,10 +176,6 @@ static const zend_function_entry class_FFI_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_FFI_CData_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_FFI_CType_methods[] = {
 	ZEND_ME(FFI_CType, getName, arginfo_class_FFI_CType_getName, ZEND_ACC_PUBLIC)
 	ZEND_ME(FFI_CType, getKind, arginfo_class_FFI_CType_getKind, ZEND_ACC_PUBLIC)
@@ -197,14 +193,6 @@ static const zend_function_entry class_FFI_CType_methods[] = {
 	ZEND_ME(FFI_CType, getFuncReturnType, arginfo_class_FFI_CType_getFuncReturnType, ZEND_ACC_PUBLIC)
 	ZEND_ME(FFI_CType, getFuncParameterCount, arginfo_class_FFI_CType_getFuncParameterCount, ZEND_ACC_PUBLIC)
 	ZEND_ME(FFI_CType, getFuncParameterType, arginfo_class_FFI_CType_getFuncParameterType, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_FFI_Exception_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_FFI_ParserException_methods[] = {
 	ZEND_FE_END
 };
 
@@ -228,7 +216,7 @@ static zend_class_entry *register_class_FFI_CData(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "FFI", "CData", class_FFI_CData_methods);
+	INIT_NS_CLASS_ENTRY(ce, "FFI", "CData", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -478,7 +466,7 @@ static zend_class_entry *register_class_FFI_Exception(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "FFI", "Exception", class_FFI_Exception_methods);
+	INIT_NS_CLASS_ENTRY(ce, "FFI", "Exception", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -488,7 +476,7 @@ static zend_class_entry *register_class_FFI_ParserException(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "FFI", "ParserException", class_FFI_ParserException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "FFI", "ParserException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FFI_Exception, ZEND_ACC_FINAL);
 
 	return class_entry;

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -273,10 +273,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_FTP_Connection_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_ftp_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("FTP_ASCII", FTPTYPE_ASCII, CONST_PERSISTENT);
@@ -299,7 +295,7 @@ static zend_class_entry *register_class_FTP_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "FTP", "Connection", class_FTP_Connection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "FTP", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -862,14 +862,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_GdImage_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_GdFont_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_gd_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("IMG_AVIF", PHP_IMG_AVIF, CONST_PERSISTENT);
@@ -995,7 +987,7 @@ static zend_class_entry *register_class_GdImage(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "GdImage", class_GdImage_methods);
+	INIT_CLASS_ENTRY(ce, "GdImage", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1005,7 +997,7 @@ static zend_class_entry *register_class_GdFont(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "GdFont", class_GdFont_methods);
+	INIT_CLASS_ENTRY(ce, "GdFont", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1183,10 +1183,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_IntlException_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_php_intl_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("INTL_MAX_LOCALE_LEN", INTL_MAX_LOCALE_LEN, CONST_PERSISTENT);
@@ -1249,7 +1245,7 @@ static zend_class_entry *register_class_IntlException(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "IntlException", class_IntlException_methods);
+	INIT_CLASS_ENTRY(ce, "IntlException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -49,10 +49,6 @@ static const zend_function_entry class_JsonSerializable_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_JsonException_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_json_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("JSON_HEX_TAG", PHP_JSON_HEX_TAG, CONST_PERSISTENT);
@@ -100,7 +96,7 @@ static zend_class_entry *register_class_JsonException(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "JsonException", class_JsonException_methods);
+	INIT_CLASS_ENTRY(ce, "JsonException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -574,18 +574,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_LDAP_Connection_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_LDAP_Result_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_LDAP_ResultEntry_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_ldap_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("LDAP_DEREF_NEVER", LDAP_DEREF_NEVER, CONST_PERSISTENT);
@@ -891,7 +879,7 @@ static zend_class_entry *register_class_LDAP_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Connection", class_LDAP_Connection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -901,7 +889,7 @@ static zend_class_entry *register_class_LDAP_Result(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Result", class_LDAP_Result_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -911,7 +899,7 @@ static zend_class_entry *register_class_LDAP_ResultEntry(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "LDAP", "ResultEntry", class_LDAP_ResultEntry_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "ResultEntry", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -50,10 +50,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_LibXMLError_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_libxml_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("LIBXML_VERSION", LIBXML_VERSION, CONST_PERSISTENT);
@@ -108,7 +104,7 @@ static zend_class_entry *register_class_LibXMLError(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LibXMLError", class_LibXMLError_methods);
+	INIT_CLASS_ENTRY(ce, "LibXMLError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_level_default_value;

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -929,10 +929,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_mysqli_driver_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_ME(mysqli, __construct, arginfo_class_mysqli___construct, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("autocommit", zif_mysqli_autocommit, arginfo_class_mysqli_autocommit, ZEND_ACC_PUBLIC, NULL, NULL)
@@ -1197,7 +1193,7 @@ static zend_class_entry *register_class_mysqli_driver(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "mysqli_driver", class_mysqli_driver_methods);
+	INIT_CLASS_ENTRY(ce, "mysqli_driver", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
 	zval property_client_info_default_value;

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -390,14 +390,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Odbc_Connection_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Odbc_Result_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_odbc_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("ODBC_TYPE", PHP_ODBC_TYPE, CONST_PERSISTENT);
@@ -509,7 +501,7 @@ static zend_class_entry *register_class_Odbc_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Connection", class_Odbc_Connection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -519,7 +511,7 @@ static zend_class_entry *register_class_Odbc_Result(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Result", class_Odbc_Result_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -522,18 +522,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_OpenSSLCertificate_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_OpenSSLCertificateSigningRequest_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_OpenSSLAsymmetricKey_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_openssl_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("OPENSSL_VERSION_TEXT", OPENSSL_VERSION_TEXT, CONST_PERSISTENT);
@@ -765,7 +753,7 @@ static zend_class_entry *register_class_OpenSSLCertificate(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OpenSSLCertificate", class_OpenSSLCertificate_methods);
+	INIT_CLASS_ENTRY(ce, "OpenSSLCertificate", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -775,7 +763,7 @@ static zend_class_entry *register_class_OpenSSLCertificateSigningRequest(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OpenSSLCertificateSigningRequest", class_OpenSSLCertificateSigningRequest_methods);
+	INIT_CLASS_ENTRY(ce, "OpenSSLCertificateSigningRequest", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -785,7 +773,7 @@ static zend_class_entry *register_class_OpenSSLAsymmetricKey(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OpenSSLAsymmetricKey", class_OpenSSLAsymmetricKey_methods);
+	INIT_CLASS_ENTRY(ce, "OpenSSLAsymmetricKey", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -313,10 +313,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Pcntl_QosClass_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_pcntl_symbols(int module_number)
 {
 #if defined(WNOHANG)
@@ -712,7 +708,7 @@ static void register_pcntl_symbols(int module_number)
 
 static zend_class_entry *register_class_Pcntl_QosClass(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("Pcntl\\QosClass", IS_UNDEF, class_Pcntl_QosClass_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("Pcntl\\QosClass", IS_UNDEF, NULL);
 
 	zend_enum_add_case_cstr(class_entry, "UserInteractive", NULL);
 

--- a/ext/pdo/pdo_arginfo.h
+++ b/ext/pdo/pdo_arginfo.h
@@ -11,15 +11,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_PDOException_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_PDOException(zend_class_entry *class_entry_RuntimeException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "PDOException", class_PDOException_methods);
+	INIT_CLASS_ENTRY(ce, "PDOException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	zval property_code_default_value;

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -132,10 +132,6 @@ static const zend_function_entry class_PDOStatement_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_PDORow_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_PDOStatement(zend_class_entry *class_entry_IteratorAggregate)
 {
 	zend_class_entry ce, *class_entry;
@@ -157,7 +153,7 @@ static zend_class_entry *register_class_PDORow(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "PDORow", class_PDORow_methods);
+	INIT_CLASS_ENTRY(ce, "PDORow", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval property_queryString_default_value;

--- a/ext/pdo_dblib/pdo_dblib_arginfo.h
+++ b/ext/pdo_dblib/pdo_dblib_arginfo.h
@@ -1,15 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: 95f297028aee0675523d6984c03a518e4fc431df */
 
-static const zend_function_entry class_Pdo_Dblib_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_PDO)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Dblib", class_Pdo_Dblib_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Dblib", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_CONNECTION_TIMEOUT_value;

--- a/ext/pdo_odbc/pdo_odbc_arginfo.h
+++ b/ext/pdo_odbc/pdo_odbc_arginfo.h
@@ -1,10 +1,6 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: 9136c911494c9e3462c49b3e58f4bcc15ebb2a9c */
 
-static const zend_function_entry class_Pdo_Odbc_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_pdo_odbc_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("PDO_ODBC_TYPE", PDO_ODBC_TYPE, CONST_PERSISTENT);
@@ -14,7 +10,7 @@ static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_P
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Odbc", class_Pdo_Odbc_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Odbc", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_USE_CURSOR_LIBRARY_value;

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -729,18 +729,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_PgSql_Connection_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_PgSql_Result_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_PgSql_Lob_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_pgsql_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("PGSQL_LIBPQ_VERSION", pgsql_libpq_version, CONST_PERSISTENT);
@@ -1146,7 +1134,7 @@ static zend_class_entry *register_class_PgSql_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Connection", class_PgSql_Connection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1156,7 +1144,7 @@ static zend_class_entry *register_class_PgSql_Result(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Result", class_PgSql_Result_methods);
+	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1166,7 +1154,7 @@ static zend_class_entry *register_class_PgSql_Lob(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Lob", class_PgSql_Lob_methods);
+	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Lob", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -465,10 +465,6 @@ ZEND_METHOD(PharFileInfo, isCompressed);
 ZEND_METHOD(PharFileInfo, isCRCChecked);
 ZEND_METHOD(PharFileInfo, setMetadata);
 
-static const zend_function_entry class_PharException_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Phar_methods[] = {
 	ZEND_ME(Phar, __construct, arginfo_class_Phar___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(Phar, __destruct, arginfo_class_Phar___destruct, ZEND_ACC_PUBLIC)
@@ -612,7 +608,7 @@ static zend_class_entry *register_class_PharException(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "PharException", class_PharException_methods);
+	INIT_CLASS_ENTRY(ce, "PharException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -207,10 +207,6 @@ static const zend_function_entry class_Random_Engine_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Random_CryptoSafeEngine_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Random_Randomizer_methods[] = {
 	ZEND_ME(Random_Randomizer, __construct, arginfo_class_Random_Randomizer___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, nextInt, arginfo_class_Random_Randomizer_nextInt, ZEND_ACC_PUBLIC)
@@ -224,22 +220,6 @@ static const zend_function_entry class_Random_Randomizer_methods[] = {
 	ZEND_ME(Random_Randomizer, pickArrayKeys, arginfo_class_Random_Randomizer_pickArrayKeys, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, __serialize, arginfo_class_Random_Randomizer___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, __unserialize, arginfo_class_Random_Randomizer___unserialize, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Random_IntervalBoundary_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Random_RandomError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Random_BrokenRandomEngineError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Random_RandomException_methods[] = {
 	ZEND_FE_END
 };
 
@@ -320,7 +300,7 @@ static zend_class_entry *register_class_Random_CryptoSafeEngine(zend_class_entry
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Random", "CryptoSafeEngine", class_Random_CryptoSafeEngine_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Random", "CryptoSafeEngine", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 	zend_class_implements(class_entry, 1, class_entry_Random_Engine);
 
@@ -346,7 +326,7 @@ static zend_class_entry *register_class_Random_Randomizer(void)
 
 static zend_class_entry *register_class_Random_IntervalBoundary(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("Random\\IntervalBoundary", IS_UNDEF, class_Random_IntervalBoundary_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("Random\\IntervalBoundary", IS_UNDEF, NULL);
 
 	zend_enum_add_case_cstr(class_entry, "ClosedOpen", NULL);
 
@@ -363,7 +343,7 @@ static zend_class_entry *register_class_Random_RandomError(zend_class_entry *cla
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomError", class_Random_RandomError_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -373,7 +353,7 @@ static zend_class_entry *register_class_Random_BrokenRandomEngineError(zend_clas
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Random", "BrokenRandomEngineError", class_Random_BrokenRandomEngineError_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Random", "BrokenRandomEngineError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Random_RandomError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;
@@ -383,7 +363,7 @@ static zend_class_entry *register_class_Random_RandomException(zend_class_entry 
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomException", class_Random_RandomException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -956,16 +956,8 @@ ZEND_METHOD(ReflectionConstant, getValue);
 ZEND_METHOD(ReflectionConstant, isDeprecated);
 ZEND_METHOD(ReflectionConstant, __toString);
 
-static const zend_function_entry class_ReflectionException_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_Reflection_methods[] = {
 	ZEND_ME(Reflection, getModifierNames, arginfo_class_Reflection_getModifierNames, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Reflector_methods[] = {
 	ZEND_FE_END
 };
 
@@ -1120,10 +1112,6 @@ static const zend_function_entry class_ReflectionClass_methods[] = {
 
 static const zend_function_entry class_ReflectionObject_methods[] = {
 	ZEND_ME(ReflectionObject, __construct, arginfo_class_ReflectionObject___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_PropertyHookType_methods[] = {
 	ZEND_FE_END
 };
 
@@ -1334,7 +1322,7 @@ static zend_class_entry *register_class_ReflectionException(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ReflectionException", class_ReflectionException_methods);
+	INIT_CLASS_ENTRY(ce, "ReflectionException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;
@@ -1354,7 +1342,7 @@ static zend_class_entry *register_class_Reflector(zend_class_entry *class_entry_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "Reflector", class_Reflector_methods);
+	INIT_CLASS_ENTRY(ce, "Reflector", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
@@ -1534,7 +1522,7 @@ static zend_class_entry *register_class_ReflectionObject(zend_class_entry *class
 
 static zend_class_entry *register_class_PropertyHookType(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("PropertyHookType", IS_STRING, class_PropertyHookType_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("PropertyHookType", IS_STRING, NULL);
 
 	zval enum_case_Get_value;
 	zend_string *enum_case_Get_value_str = zend_string_init("get", strlen("get"), 1);

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -49,10 +49,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Shmop_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_shmop_symbols(int module_number)
 {
 
@@ -73,7 +69,7 @@ static zend_class_entry *register_class_Shmop(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "Shmop", class_Shmop_methods);
+	INIT_CLASS_ENTRY(ce, "Shmop", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/simplexml/simplexml_arginfo.h
+++ b/ext/simplexml/simplexml_arginfo.h
@@ -156,10 +156,6 @@ static const zend_function_entry class_SimpleXMLElement_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SimpleXMLIterator_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_SimpleXMLElement(zend_class_entry *class_entry_Stringable, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_RecursiveIterator)
 {
 	zend_class_entry ce, *class_entry;
@@ -175,7 +171,7 @@ static zend_class_entry *register_class_SimpleXMLIterator(zend_class_entry *clas
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SimpleXMLIterator", class_SimpleXMLIterator_methods);
+	INIT_CLASS_ENTRY(ce, "SimpleXMLIterator", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SimpleXMLElement, 0);
 
 	return class_entry;

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -236,10 +236,6 @@ static const zend_function_entry class_SNMP_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SNMPException_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_snmp_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("SNMP_OID_OUTPUT_SUFFIX", NETSNMP_OID_OUTPUT_SUFFIX, CONST_PERSISTENT);
@@ -399,7 +395,7 @@ static zend_class_entry *register_class_SNMPException(zend_class_entry *class_en
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SNMPException", class_SNMPException_methods);
+	INIT_CLASS_ENTRY(ce, "SNMPException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -173,14 +173,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Soap_Url_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_Soap_Sdl_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_SoapParam_methods[] = {
 	ZEND_ME(SoapParam, __construct, arginfo_class_SoapParam___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
@@ -322,7 +314,7 @@ static zend_class_entry *register_class_Soap_Url(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Soap", "Url", class_Soap_Url_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Soap", "Url", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -332,7 +324,7 @@ static zend_class_entry *register_class_Soap_Sdl(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "Soap", "Sdl", class_Soap_Sdl_methods);
+	INIT_NS_CLASS_ENTRY(ce, "Soap", "Sdl", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -322,14 +322,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_Socket_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_AddressInfo_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_sockets_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("AF_UNIX", AF_UNIX, CONST_PERSISTENT);
@@ -1089,7 +1081,7 @@ static zend_class_entry *register_class_Socket(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "Socket", class_Socket_methods);
+	INIT_CLASS_ENTRY(ce, "Socket", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -1099,7 +1091,7 @@ static zend_class_entry *register_class_AddressInfo(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "AddressInfo", class_AddressInfo_methods);
+	INIT_CLASS_ENTRY(ce, "AddressInfo", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -959,10 +959,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SodiumException_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_libsodium_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("SODIUM_LIBRARY_VERSION", SODIUM_LIBRARY_VERSION(), CONST_PERSISTENT);
@@ -1382,7 +1378,7 @@ static zend_class_entry *register_class_SodiumException(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SodiumException", class_SodiumException_methods);
+	INIT_CLASS_ENTRY(ce, "SodiumException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;

--- a/ext/spl/spl_dllist_arginfo.h
+++ b/ext/spl/spl_dllist_arginfo.h
@@ -146,10 +146,6 @@ static const zend_function_entry class_SplQueue_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SplStack_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_SplDoublyLinkedList(zend_class_entry *class_entry_Iterator, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_ArrayAccess, zend_class_entry *class_entry_Serializable)
 {
 	zend_class_entry ce, *class_entry;
@@ -199,7 +195,7 @@ static zend_class_entry *register_class_SplStack(zend_class_entry *class_entry_S
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SplStack", class_SplStack_methods);
+	INIT_CLASS_ENTRY(ce, "SplStack", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplDoublyLinkedList, 0);
 
 	return class_entry;

--- a/ext/spl/spl_exceptions_arginfo.h
+++ b/ext/spl/spl_exceptions_arginfo.h
@@ -1,63 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
  * Stub hash: 07475caecc81ab3b38a04905f874615af1126289 */
 
-static const zend_function_entry class_LogicException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_BadFunctionCallException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_BadMethodCallException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DomainException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_InvalidArgumentException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_LengthException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_OutOfRangeException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_RuntimeException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_OutOfBoundsException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_OverflowException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_RangeException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_UnderflowException_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_UnexpectedValueException_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_LogicException(zend_class_entry *class_entry_Exception)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LogicException", class_LogicException_methods);
+	INIT_CLASS_ENTRY(ce, "LogicException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;
@@ -67,7 +15,7 @@ static zend_class_entry *register_class_BadFunctionCallException(zend_class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "BadFunctionCallException", class_BadFunctionCallException_methods);
+	INIT_CLASS_ENTRY(ce, "BadFunctionCallException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
 
 	return class_entry;
@@ -77,7 +25,7 @@ static zend_class_entry *register_class_BadMethodCallException(zend_class_entry 
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "BadMethodCallException", class_BadMethodCallException_methods);
+	INIT_CLASS_ENTRY(ce, "BadMethodCallException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_BadFunctionCallException, 0);
 
 	return class_entry;
@@ -87,7 +35,7 @@ static zend_class_entry *register_class_DomainException(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DomainException", class_DomainException_methods);
+	INIT_CLASS_ENTRY(ce, "DomainException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
 
 	return class_entry;
@@ -97,7 +45,7 @@ static zend_class_entry *register_class_InvalidArgumentException(zend_class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "InvalidArgumentException", class_InvalidArgumentException_methods);
+	INIT_CLASS_ENTRY(ce, "InvalidArgumentException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
 
 	return class_entry;
@@ -107,7 +55,7 @@ static zend_class_entry *register_class_LengthException(zend_class_entry *class_
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LengthException", class_LengthException_methods);
+	INIT_CLASS_ENTRY(ce, "LengthException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
 
 	return class_entry;
@@ -117,7 +65,7 @@ static zend_class_entry *register_class_OutOfRangeException(zend_class_entry *cl
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OutOfRangeException", class_OutOfRangeException_methods);
+	INIT_CLASS_ENTRY(ce, "OutOfRangeException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
 
 	return class_entry;
@@ -127,7 +75,7 @@ static zend_class_entry *register_class_RuntimeException(zend_class_entry *class
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "RuntimeException", class_RuntimeException_methods);
+	INIT_CLASS_ENTRY(ce, "RuntimeException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;
@@ -137,7 +85,7 @@ static zend_class_entry *register_class_OutOfBoundsException(zend_class_entry *c
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OutOfBoundsException", class_OutOfBoundsException_methods);
+	INIT_CLASS_ENTRY(ce, "OutOfBoundsException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;
@@ -147,7 +95,7 @@ static zend_class_entry *register_class_OverflowException(zend_class_entry *clas
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "OverflowException", class_OverflowException_methods);
+	INIT_CLASS_ENTRY(ce, "OverflowException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;
@@ -157,7 +105,7 @@ static zend_class_entry *register_class_RangeException(zend_class_entry *class_e
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "RangeException", class_RangeException_methods);
+	INIT_CLASS_ENTRY(ce, "RangeException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;
@@ -167,7 +115,7 @@ static zend_class_entry *register_class_UnderflowException(zend_class_entry *cla
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "UnderflowException", class_UnderflowException_methods);
+	INIT_CLASS_ENTRY(ce, "UnderflowException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;
@@ -177,7 +125,7 @@ static zend_class_entry *register_class_UnexpectedValueException(zend_class_entr
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "UnexpectedValueException", class_UnexpectedValueException_methods);
+	INIT_CLASS_ENTRY(ce, "UnexpectedValueException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
 
 	return class_entry;

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -210,10 +210,6 @@ ZEND_METHOD(SQLite3Result, fetchArray);
 ZEND_METHOD(SQLite3Result, reset);
 ZEND_METHOD(SQLite3Result, finalize);
 
-static const zend_function_entry class_SQLite3Exception_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_SQLite3_methods[] = {
 	ZEND_RAW_FENTRY("__construct", zim_SQLite3_open, arginfo_class_SQLite3___construct, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(SQLite3, open, arginfo_class_SQLite3_open, ZEND_ACC_PUBLIC)
@@ -293,7 +289,7 @@ static zend_class_entry *register_class_SQLite3Exception(zend_class_entry *class
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SQLite3Exception", class_SQLite3Exception_methods);
+	INIT_CLASS_ENTRY(ce, "SQLite3Exception", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	return class_entry;

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -3607,18 +3607,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class___PHP_Incomplete_Class_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_AssertionError_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_RoundingMode_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_basic_functions_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("EXTR_OVERWRITE", PHP_EXTR_OVERWRITE, CONST_PERSISTENT);
@@ -4177,7 +4165,7 @@ static zend_class_entry *register_class___PHP_Incomplete_Class(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "__PHP_Incomplete_Class", class___PHP_Incomplete_Class_methods);
+	INIT_CLASS_ENTRY(ce, "__PHP_Incomplete_Class", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 
 	zend_string *attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0 = zend_string_init_interned("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
@@ -4191,7 +4179,7 @@ static zend_class_entry *register_class_AssertionError(zend_class_entry *class_e
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "AssertionError", class_AssertionError_methods);
+	INIT_CLASS_ENTRY(ce, "AssertionError", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
 
 	return class_entry;
@@ -4199,7 +4187,7 @@ static zend_class_entry *register_class_AssertionError(zend_class_entry *class_e
 
 static zend_class_entry *register_class_RoundingMode(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("RoundingMode", IS_UNDEF, class_RoundingMode_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("RoundingMode", IS_UNDEF, NULL);
 
 	zend_enum_add_case_cstr(class_entry, "HalfAwayFromZero", NULL);
 

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -25,10 +25,6 @@ static const zend_function_entry class_php_user_filter_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_StreamBucket_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_user_filters_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("PSFS_PASS_ON", PSFS_PASS_ON, CONST_PERSISTENT);
@@ -71,7 +67,7 @@ static zend_class_entry *register_class_StreamBucket(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "StreamBucket", class_StreamBucket_methods);
+	INIT_CLASS_ENTRY(ce, "StreamBucket", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
 	zval property_bucket_default_value;

--- a/ext/sysvmsg/sysvmsg_arginfo.h
+++ b/ext/sysvmsg/sysvmsg_arginfo.h
@@ -62,10 +62,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SysvMessageQueue_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_sysvmsg_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("MSG_IPC_NOWAIT", PHP_MSG_IPC_NOWAIT, CONST_PERSISTENT);
@@ -79,7 +75,7 @@ static zend_class_entry *register_class_SysvMessageQueue(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SysvMessageQueue", class_SysvMessageQueue_methods);
+	INIT_CLASS_ENTRY(ce, "SysvMessageQueue", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/sysvsem/sysvsem_arginfo.h
+++ b/ext/sysvsem/sysvsem_arginfo.h
@@ -32,15 +32,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SysvSemaphore_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_SysvSemaphore(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SysvSemaphore", class_SysvSemaphore_methods);
+	INIT_CLASS_ENTRY(ce, "SysvSemaphore", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/sysvshm/sysvshm_arginfo.h
+++ b/ext/sysvshm/sysvshm_arginfo.h
@@ -50,15 +50,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_SysvSharedMemory_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_SysvSharedMemory(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "SysvSharedMemory", class_SysvSharedMemory_methods);
+	INIT_CLASS_ENTRY(ce, "SysvSharedMemory", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -131,10 +131,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_XMLParser_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_xml_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("XML_ERROR_NONE", XML_ERROR_NONE, CONST_PERSISTENT);
@@ -184,7 +180,7 @@ static zend_class_entry *register_class_XMLParser(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "XMLParser", class_XMLParser_methods);
+	INIT_CLASS_ENTRY(ce, "XMLParser", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;

--- a/ext/zend_test/object_handlers_arginfo.h
+++ b/ext/zend_test/object_handlers_arginfo.h
@@ -40,10 +40,6 @@ static const zend_function_entry class_NumericCastableNoOperations_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_DimensionHandlersNoArrayAccess_methods[] = {
-	ZEND_FE_END
-};
-
 static zend_class_entry *register_class_DoOperationNoCast(void)
 {
 	zend_class_entry ce, *class_entry;
@@ -112,7 +108,7 @@ static zend_class_entry *register_class_DimensionHandlersNoArrayAccess(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DimensionHandlersNoArrayAccess", class_DimensionHandlersNoArrayAccess_methods);
+	INIT_CLASS_ENTRY(ce, "DimensionHandlersNoArrayAccess", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_read_default_value;

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -448,10 +448,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class__ZendTestInterface_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class__ZendTestClass_methods[] = {
 	ZEND_ME(_ZendTestClass, is_object, arginfo_class__ZendTestClass_is_object, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(_ZendTestClass, __toString, arginfo_class__ZendTestClass___toString, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
@@ -482,16 +478,8 @@ static const zend_function_entry class__ZendTestTrait_methods[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_ZendTestAttribute_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_ZendTestAttributeWithArguments_methods[] = {
 	ZEND_ME(ZendTestAttributeWithArguments, __construct, arginfo_class_ZendTestAttributeWithArguments___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ZendTestRepeatableAttribute_methods[] = {
 	ZEND_FE_END
 };
 
@@ -516,25 +504,9 @@ static const zend_function_entry class_ZendTestChildClassWithMethodWithParameter
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_ZendTestClassWithPropertyAttribute_methods[] = {
-	ZEND_FE_END
-};
-
 static const zend_function_entry class_ZendTestForbidDynamicCall_methods[] = {
 	ZEND_ME(ZendTestForbidDynamicCall, call, arginfo_class_ZendTestForbidDynamicCall_call, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZendTestForbidDynamicCall, callStatic, arginfo_class_ZendTestForbidDynamicCall_callStatic, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ZendTestUnitEnum_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ZendTestStringEnum_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_ZendTestIntEnum_methods[] = {
 	ZEND_FE_END
 };
 
@@ -602,7 +574,7 @@ static zend_class_entry *register_class__ZendTestInterface(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "_ZendTestInterface", class__ZendTestInterface_methods);
+	INIT_CLASS_ENTRY(ce, "_ZendTestInterface", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	zval const_DUMMY_value;
@@ -871,7 +843,7 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ZendTestAttribute", class_ZendTestAttribute_methods);
+	INIT_CLASS_ENTRY(ce, "ZendTestAttribute", NULL);
 #if (PHP_VERSION_ID >= 80400)
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 #else
@@ -925,7 +897,7 @@ static zend_class_entry *register_class_ZendTestRepeatableAttribute(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ZendTestRepeatableAttribute", class_ZendTestRepeatableAttribute_methods);
+	INIT_CLASS_ENTRY(ce, "ZendTestRepeatableAttribute", NULL);
 #if (PHP_VERSION_ID >= 80400)
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 #else
@@ -1061,7 +1033,7 @@ static zend_class_entry *register_class_ZendTestClassWithPropertyAttribute(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "ZendTestClassWithPropertyAttribute", class_ZendTestClassWithPropertyAttribute_methods);
+	INIT_CLASS_ENTRY(ce, "ZendTestClassWithPropertyAttribute", NULL);
 #if (PHP_VERSION_ID >= 80400)
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 #else
@@ -1100,7 +1072,7 @@ static zend_class_entry *register_class_ZendTestForbidDynamicCall(void)
 #if (PHP_VERSION_ID >= 80100)
 static zend_class_entry *register_class_ZendTestUnitEnum(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestUnitEnum", IS_UNDEF, class_ZendTestUnitEnum_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestUnitEnum", IS_UNDEF, NULL);
 
 	zend_enum_add_case_cstr(class_entry, "Foo", NULL);
 
@@ -1113,7 +1085,7 @@ static zend_class_entry *register_class_ZendTestUnitEnum(void)
 #if (PHP_VERSION_ID >= 80100)
 static zend_class_entry *register_class_ZendTestStringEnum(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestStringEnum", IS_STRING, class_ZendTestStringEnum_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestStringEnum", IS_STRING, NULL);
 
 	zval enum_case_Foo_value;
 	zend_string *enum_case_Foo_value_str = zend_string_init("Test1", strlen("Test1"), 1);
@@ -1142,7 +1114,7 @@ static zend_class_entry *register_class_ZendTestStringEnum(void)
 #if (PHP_VERSION_ID >= 80100)
 static zend_class_entry *register_class_ZendTestIntEnum(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestIntEnum", IS_LONG, class_ZendTestIntEnum_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestIntEnum", IS_LONG, NULL);
 
 	zval enum_case_Foo_value;
 	ZVAL_LONG(&enum_case_Foo_value, 1);

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -196,14 +196,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE_END
 };
 
-static const zend_function_entry class_InflateContext_methods[] = {
-	ZEND_FE_END
-};
-
-static const zend_function_entry class_DeflateContext_methods[] = {
-	ZEND_FE_END
-};
-
 static void register_zlib_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("FORCE_GZIP", PHP_ZLIB_ENCODING_GZIP, CONST_PERSISTENT);
@@ -239,7 +231,7 @@ static zend_class_entry *register_class_InflateContext(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "InflateContext", class_InflateContext_methods);
+	INIT_CLASS_ENTRY(ce, "InflateContext", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
@@ -249,7 +241,7 @@ static zend_class_entry *register_class_DeflateContext(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "DeflateContext", class_DeflateContext_methods);
+	INIT_CLASS_ENTRY(ce, "DeflateContext", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;


### PR DESCRIPTION
When a class (or enum) has no methods, rather than using an array that only contains `ZEND_FE_END`, use `NULL` for the functions. The implementation of class registration for internal classes, `do_register_internal_class()` in zend_API.c, already skips classes where the functions are `NULL`. By removing these unneeded arrays, we can reduce the size of the header files, while also removing an unneeded call to zend_register_functions() for each internal class with no extra methods.