### PR TITLE
Autotools: Add PHP_EXTRA_CFLAGS environment variable

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -221,6 +221,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
        - ac_cv_write_stdout                -> php_cv_have_write_stdout
      and all other checks wrapped with their belonging cache variables (see *.m4
      source files for details).
+   - New configure-phase environment variable PHP_EXTRA_CFLAGS to append
+     additional build-time CFLAGS to the PHP build.
 
  c. Windows build system changes
    - The configure options --with-oci8-11g, --with-oci8-12c, --with-oci8-19,

--- a/configure.ac
+++ b/configure.ac
@@ -1431,6 +1431,12 @@ AS_VAR_IF([PHP_BUILD_ARCH],,,
   [AC_DEFINE_UNQUOTED([PHP_BUILD_ARCH], ["$PHP_BUILD_ARCH"],
     [The build architecture.])])
 
+AC_ARG_VAR([PHP_EXTRA_CFLAGS],
+  [Additional build-phase compilation options appended to CFLAGS when building
+  PHP; these are isolated from the Autoconf configure checks and its CFLAGS])
+AS_VAR_IF([PHP_EXTRA_CFLAGS],,, [EXTRA_CFLAGS=$PHP_EXTRA_CFLAGS])
+
+PHP_SUBST([EXTRA_CFLAGS])
 PHP_SUBST([PHP_FASTCGI_OBJS])
 PHP_SUBST([PHP_SAPI_OBJS])
 PHP_SUBST([PHP_BINARY_OBJS])


### PR DESCRIPTION
This adds a new configure-phase environment variable PHP_EXTRA_CFLAGS which are appended to the CFLAGS in the Makefile rules. It sets the already present undocumented EXTRA_CFLAGS Makefile variable to not introduce issues with EXTRA_CFLAGS usage in the existing PECL extensions.

This enables setting configure-and-build-phase CFLAGS and build-phase PHP_EXTRA_CFLAGS separately to not affect configure checks:

    ./configure CFLAGS=... PHP_EXTRA_CFLAGS=...


Follow-up of https://github.com/php/php-src/pull/12050