### PR TITLE
Support --with-openssl-argon2 on Windows

### DIFF
--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -4,14 +4,25 @@ ARG_WITH("openssl", "OpenSSL support", "no,shared");
 
 ARG_WITH("openssl-legacy-provider", "OPENSSL: Load legacy algorithm provider in addition to default provider", "no");
 
+ARG_WITH("openssl-argon2", "OPENSSL: Enable argon2 password hashing (requires OpenSSL >= 3.2)", "no");
+
 if (PHP_OPENSSL != "no") {
 	var ret = SETUP_OPENSSL("openssl", PHP_OPENSSL);
 
 	if (ret >= 2) {
-		EXTENSION("openssl", "openssl.c xp_ssl.c");
+		EXTENSION("openssl", "openssl.c openssl_pwhash.c xp_ssl.c");
 		AC_DEFINE("HAVE_OPENSSL_EXT", 1, "Define to 1 if the PHP extension 'openssl' is available.");
 		if (PHP_OPENSSL_LEGACY_PROVIDER != "no") {
 			AC_DEFINE("LOAD_OPENSSL_LEGACY_PROVIDER", 1, "Define to 1 to load the OpenSSL legacy algorithm provider in addition to the default provider.");
+		}
+		if (PHP_OPENSSL_ARGON2 != "no") {
+			if (PHP_ZTS != "no") {
+				WARNING("OpenSSL argon2 hashing not supported in ZTS mode for now");
+			} else if (!CHECK_FUNC_IN_HEADER("openssl/thread.h", "OSSL_set_max_threads", PHP_PHP_BUILD + "\\include")) {
+				WARNING("OpenSSL argon2 hashing requires OpenSSL >= 3.2");
+			} else {
+				AC_DEFINE("HAVE_OPENSSL_ARGON2", 1, "Define to 1 to enable OpenSSL argon2 password hashing.");
+			}
 		}
 	}
 }


### PR DESCRIPTION
We change the error for ZTS builds to a warning, to not break snapshot builds which automatically will try to enable OpenSSL password hashing.

We also change some messages to better fit building on Windows.

And of course, we cannot easily check whether `OSSL_set_max_threads()` is actually available; instead we're looking up the function declaration in its header file.

---

Note that we're still using OpenSSL 3.0 for the `master` branch, so even if attempted, enabling of OpenSSL argon2 password hashing is not supposed to work (besides that in regular CI we only test ZTS builds). I tested locally with OpenSSL 3.2.2, though, and everything appears to be fine.

While not directly related to this PR, we should consider to update our OpenSSL on Windows. PHP 8.4 is supposed to be supported until 31st Dec 2028, but OpenSSL 3.0 will only be supported until 7th September 2026. This might even be an issue for PHP 8.3. Unfortunately, even OpenSSL 3.3 support ends on 9th April 2026 (thus even earlier than 3.0), but we likely need to update to more recent OpenSSL minor versions. Maybe you can comment about the stability, @bukka.

cc @remicollet since you implemented the feature (thanks!)

PS: OpenSSL 3.2.2 builds for Windows (build against PHP 8.3, but work for PHP 8.4, too) are available at https://github.com/winlibs/winlib-builder/actions/runs/10668521738.

PPS: original feature via #13635.