### PR TITLE
Fix GH-15712: overflow on float print with precision ini large value.

### DIFF
--- a/Zend/tests/gh15712.phpt
+++ b/Zend/tests/gh15712.phpt
@@ -1,0 +1,9 @@
+--TEST--
+GH-15712: overflow on real number printing
+--FILE--
+<?php
+ini_set('precision', 1100000000);
+echo  -1 * (2 ** -10);
+?>
+--EXPECTF--
+%s

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3613,11 +3613,11 @@ rv_alloc(i) int i;
 rv_alloc(int i)
 #endif
 {
-	int j, k, *r;
+	int k, *r;
 
-	j = sizeof(ULong);
+	size_t j = sizeof(ULong);
 	for(k = 0;
-		sizeof(Bigint) - sizeof(ULong) - sizeof(int) + (size_t)j <= (size_t)i;
+		sizeof(Bigint) - sizeof(ULong) - sizeof(int) + j <= (size_t)i;
 		j <<= 1)
 			k++;
 	r = (int*)Balloc(k);


### PR DESCRIPTION
When allocating enough room for floats, the allocator used overflows with
large ndigits/EG(precision) value which used an signed integer to
increase the size of thebuffer.
Testing with the zend operator directly is enough to trigger
the issue rather than higher level math interface.