### PR TITLE
Fix GH-15718: ReflectionProperty::get{Hook,Hooks}(): handle dynamic properties

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6505,7 +6505,8 @@ ZEND_METHOD(ReflectionProperty, getHooks)
 
 	GET_REFLECTION_OBJECT_PTR(ref);
 
-	if (!ref->prop->hooks) {
+	// ref->prop can be missing for dynamic properties
+	if (!ref->prop || !ref->prop->hooks) {
 		RETURN_EMPTY_ARRAY();
 	}
 
@@ -6536,11 +6537,16 @@ ZEND_METHOD(ReflectionProperty, getHook)
 
 	GET_REFLECTION_OBJECT_PTR(ref);
 
+	// ref->prop can be missing for dynamic properties
+	if (!ref->prop || !ref->prop->hooks) {
+		RETURN_NULL();
+	}
+
 	zend_function *hook;
 	if (zend_string_equals_literal(Z_STR_P(zend_enum_fetch_case_name(type)), "Get")) {
-		hook = ref->prop->hooks ? ref->prop->hooks[ZEND_PROPERTY_HOOK_GET] : NULL;
+		hook = ref->prop->hooks[ZEND_PROPERTY_HOOK_GET];
 	} else {
-		hook = ref->prop->hooks ? ref->prop->hooks[ZEND_PROPERTY_HOOK_SET] : NULL;
+		hook = ref->prop->hooks[ZEND_PROPERTY_HOOK_SET];
 	}
 
 	if (!hook) {

--- a/ext/reflection/tests/property_hooks/gh15718.phpt
+++ b/ext/reflection/tests/property_hooks/gh15718.phpt
@@ -1,0 +1,48 @@
+--TEST--
+ReflectionProperty::get{Hook,Hooks}() crashes on dynamic properties
+--FILE--
+<?php
+
+#[\AllowDynamicProperties]
+class MyDynamicClass {
+
+}
+
+class NonDynamicClass {
+
+}
+
+$cases = [ MyDynamicClass::class, stdClass::class, NonDynamicClass::class ];
+
+foreach ( $cases as $c ) {
+    echo "$c:" . PHP_EOL;
+    $obj = new $c();
+    $obj->prop = 'foo';
+    $prop = new ReflectionProperty($obj, 'prop');
+    var_dump( $prop->getHooks() );
+    var_dump( $prop->getHook( PropertyHookType::Get ) );
+    var_dump( $prop->getHook( PropertyHookType::Set ) );
+    echo PHP_EOL;
+}
+
+?>
+--EXPECTF--
+MyDynamicClass:
+array(0) {
+}
+NULL
+NULL
+
+stdClass:
+array(0) {
+}
+NULL
+NULL
+
+NonDynamicClass:
+
+Deprecated: Creation of dynamic property NonDynamicClass::$prop is deprecated in %sgh15718.php on line %d
+array(0) {
+}
+NULL
+NULL


### PR DESCRIPTION
For dynamic properties, instead of crashing with a segmentation fault, just say that there are no hooks. Also includes a test to prevent regression.