### PR TITLE
deprecate json_encode() of non-serializable instances

### DIFF
--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -678,7 +678,9 @@ again:
 				return php_json_encode_serializable_enum(buf, val, options, encoder);
 			}
 			if (Z_OBJCE_P(val)->ce_flags & ZEND_ACC_NOT_SERIALIZABLE) {
-				zend_error(E_DEPRECATED, "json_encode() of non-serializable class %s is deprecated", ZSTR_VAL(Z_OBJCE_P(val)->name));
+				if (!(Z_OBJCE_P(val)->ce_flags & ZEND_ACC_ANON_CLASS) || (Z_OBJCE_P(val)->parent && Z_OBJCE_P(val)->parent->ce_flags & ZEND_ACC_NOT_SERIALIZABLE)) {
+					zend_error(E_DEPRECATED, "json_encode() of non-serializable class %s is deprecated", ZSTR_VAL(Z_OBJCE_P(val)->name));
+				}
 			}
 			/* fallthrough -- Non-serializable object */
 			ZEND_FALLTHROUGH;

--- a/tests/classes/json_encode_non_serializable_deprecated.phpt
+++ b/tests/classes/json_encode_non_serializable_deprecated.phpt
@@ -5,11 +5,20 @@ json_encode() on instances of classes market with ZEND_ACC_NOT_SERIALIZABLE
 function a() { for ($i=0; $i < 10; $i++) { yield $i; }};
 $fn = a(...);
 
+$c1 = new class() extends PDOStatement {};
+$c2 = new class() extends stdClass {};
+$c3 = new class() {};
+
 echo json_encode(a());
 echo json_encode($fn);
+echo json_encode($c1);
+echo json_encode($c2);
+echo json_encode($c3);
 ?>
 --EXPECTF--
 Deprecated: json_encode() of non-serializable class Generator is deprecated in %s on line %d
 {}
 Deprecated: json_encode() of non-serializable class Closure is deprecated in %s on line %d
 {}
+Deprecated: json_encode() of non-serializable class PDOStatement@anonymous is deprecated in %s on line %d
+{}{}{}


### PR DESCRIPTION
there's a good reason for classes being marked as non-serializable, so it follows that the same should probably be true for json_encoding them as well.

As this flag is only available to internal classes, no userland code should be affected.

This is the implementation of an RFC I'm currently in the process of authoring after there was some mild agreement about this making sense when I asked on internals.

RFC (in draft): https://wiki.php.net/rfc/deprecate-json_encode-nonserializable