### PR TITLE
Remove driver specific support from ODBC

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,9 @@ PHP                                                                        NEWS
   . Fixed bug GH-11952 (Fix locale strings canonicalization for IntlDateFormatter
     and NumberFormatter). (alexandre-daubois)
 
+- ODBC:
+  . Removed driver-specific build flags and support. (Calvin Buckley)
+
 - Opcache:
   . Fixed bug GH-19486 (Incorrect opline after deoptimization). (Arnaud)
   . Fixed bug GH-19601 (Wrong JIT stack setup on aarch64/clang). (Arnaud)

--- a/UPGRADING
+++ b/UPGRADING
@@ -91,6 +91,9 @@ PHP 8.5 UPGRADE NOTES
 - ODBC:
   . ODBC now assumes that at least ODBC 3.5 functionality is available. The
     ODBCVER definition and build system flags to control it have been removed.
+  . ODBC no longer has build flags to build against specific drivers (except
+    for DB2) and removes special cases for those drivers. It is strongly
+    recommended to use a driver manager like iODBC or unixODBC on non-Windows.
 
 - Opcache:
   . The Opcache extension is now always built into the PHP binary and is always

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -118,9 +118,10 @@ PHP_ARG_WITH([unixODBC],
 
 dnl Extension setup
 if test -n "$ODBC_TYPE"; then
-  AS_VAR_IF([ODBC_TYPE], [dbmaker],, [
-    PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], [ODBC_SHARED_LIBADD])
-  ])
+  PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], [ODBC_SHARED_LIBADD])
+  AC_DEFINE([HAVE_SQLDATASOURCES], [1],
+    [Define to 1 if ODBC library has 'SQLDataSources', as a function or
+    macro.])
 
   AC_DEFINE([HAVE_UODBC], [1],
     [Define to 1 if the PHP extension 'odbc' is available.])

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -8,170 +8,8 @@ AC_DEFUN([PHP_ODBC_CHECK_HEADER],
   [AC_MSG_ERROR([ODBC header file '$ODBC_INCDIR/$1' not found!])])])
 
 dnl
-dnl PHP_ODBC_FIND_SOLID_LIBS(libdir)
-dnl
-dnl Figure out which library file to link with for the Solid support.
-dnl
-AC_DEFUN([PHP_ODBC_FIND_SOLID_LIBS],[
-  AC_MSG_CHECKING([Solid library file])
-  ac_solid_uname_r=$(uname -r 2>/dev/null)
-  ac_solid_uname_s=$(uname -s 2>/dev/null)
-  case $ac_solid_uname_s in
-    AIX) ac_solid_os=a3x;;   # a4x for AIX4/ Solid 2.3/3.0 only
-    HP-UX) ac_solid_os=h9x;; # h1x for hpux11, h0x for hpux10
-    Linux)
-      if ldd -v /bin/sh | grep GLIBC > /dev/null; then
-        ac_solid_os=l2x
-      else
-        ac_solid_os=lux
-      fi
-      AC_DEFINE([SS_LINUX], [1],
-        [Define to 1 to be able to use the obsolete <sqlunix.h> header file on
-        some Linux systems.])
-      ;;
-    SunOS)
-      ac_solid_os=ssx;; # should we deal with SunOS 4?
-    FreeBSD)
-      if test $(expr $ac_solid_uname_r : '\(.\)') -gt "2"; then
-        ac_solid_os=fex
-      else
-        ac_solid_os=fbx
-      fi
-      AC_DEFINE([SS_FBX], [1],
-        [Define to 1 to be able to use the wchar defs in the obsolete
-        <sqlunix.h> header file on some FreeBSD systems.])
-      ;;
-  esac
-
-  if test -f $1/soc${ac_solid_os}35.a; then
-    ac_solid_version=35
-    ac_solid_prefix=soc
-  elif test -f $1/scl${ac_solid_os}30.a; then
-    ac_solid_version=30
-    ac_solid_prefix=scl
-  elif test -f $1/scl${ac_solid_os}23.a; then
-    ac_solid_version=23
-    ac_solid_prefix=scl
-  fi
-
-dnl Check for the library files, and setup the ODBC_LIBS path.
-if test ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so && \
-  test ! -f $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a; then
-  dnl we have an error and should bail out, as we can't find the libs!
-  echo ""
-  echo "*********************************************************************"
-  echo "* Unable to locate $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so or $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a"
-  echo "* Please correct this by creating the following links and reconfiguring:"
-  echo "* $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a -> $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.a"
-  echo "* $1/${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so -> $1/lib${ac_solid_prefix}${ac_solid_os}${ac_solid_version}.so"
-  echo "*********************************************************************"
-else
-  ODBC_LFLAGS=-L$1
-  ODBC_LIBS=-l${ac_solid_prefix}${ac_solid_os}${ac_solid_version}
-fi
-
-  AC_MSG_RESULT([$(echo $ODBC_LIBS | $SED -e 's!.*/!!')])
-])
-
-dnl
-dnl PHP_ODBC_FIND_EMPRESS_LIBS(libdir)
-dnl
-dnl Figure out which library file to link with for the Empress support.
-dnl
-AC_DEFUN([PHP_ODBC_FIND_EMPRESS_LIBS],[
-  AC_MSG_CHECKING([Empress library file])
-  ODBC_LIBS=$(echo $1/libempodbccl.so | cut -d' ' -f1)
-  if test ! -f $ODBC_LIBS; then
-    ODBC_LIBS=$(echo $1/libempodbccl.so | cut -d' ' -f1)
-  fi
-  AC_MSG_RESULT([$(echo $ODBC_LIBS | $SED -e 's!.*/!!')])
-])
-
-dnl
-dnl PHP_ODBC_FIND_EMPRESS_BCS_LIBS(libdir)
-dnl
-dnl Figure out which library file to link with for the Empress local access
-dnl support.
-dnl
-AC_DEFUN([PHP_ODBC_FIND_EMPRESS_BCS_LIBS],[
-  AC_MSG_CHECKING([Empress local access library file])
-  ODBCBCS_LIBS=$(echo $1/libempodbcbcs.a | cut -d' ' -f1)
-  if test ! -f $ODBCBCS_LIBS; then
-    ODBCBCS_LIBS=$(echo $1/libempodbcbcs.a | cut -d' ' -f1)
-  fi
-  AC_MSG_RESULT([$(echo $ODBCBCS_LIBS | $SED -e 's!.*/!!')])
-])
-
-dnl
 dnl configure options
 dnl
-
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([adabas],
-  [for Adabas support],
-  [AS_HELP_STRING([[--with-adabas[=DIR]]],
-    [Include Adabas D support [/usr/local]])])
-
-  AS_VAR_IF([PHP_ADABAS], [no], [], [
-    AS_VAR_IF([PHP_ADABAS], [yes], [PHP_ADABAS=/usr/local])
-    PHP_ADD_INCLUDE([$PHP_ADABAS/incl])
-    PHP_ADD_LIBPATH([$PHP_ADABAS/$PHP_LIBDIR])
-    ODBC_OBJS="$PHP_ADABAS/$PHP_LIBDIR/odbclib.a"
-    ODBC_LIB="$abs_builddir/ext/odbc/libodbc_adabas.a"
-    $srcdir/build/shtool mkdir -f -p ext/odbc
-    rm -f "$ODBC_LIB"
-    cp "$ODBC_OBJS" "$ODBC_LIB"
-    PHP_ADD_LIBRARY([sqlptc])
-    PHP_ADD_LIBRARY([sqlrte])
-    PHP_ADD_LIBRARY_WITH_PATH([odbc_adabas], [$abs_builddir/ext/odbc])
-    ODBC_TYPE=adabas
-    ODBC_INCDIR=$PHP_ADABAS/incl
-    PHP_ODBC_CHECK_HEADER([sqlext.h])
-    AC_DEFINE([HAVE_ADABAS], [1],
-      [Define to 1 if the odbc extension uses the Adabas D.])
-  ])
-])
-
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([sapdb],
-  [for SAP DB support],
-  [AS_HELP_STRING([[--with-sapdb[=DIR]]],
-    [Include SAP DB support [/usr/local]])])
-
-  AS_VAR_IF([PHP_SAPDB], [no], [], [
-    AS_VAR_IF([PHP_SAPDB], [yes], [PHP_SAPDB=/usr/local])
-    PHP_ADD_INCLUDE([$PHP_SAPDB/incl])
-    PHP_ADD_LIBPATH([$PHP_SAPDB/$PHP_LIBDIR])
-    PHP_ADD_LIBRARY([sqlod])
-    ODBC_TYPE=sapdb
-    AC_DEFINE([HAVE_SAPDB], [1],
-      [Define to 1 if the odbc extension uses the SAP DB.])
-  ])
-])
-
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([solid],
-  [for Solid support],
-  [AS_HELP_STRING([[--with-solid[=DIR]]],
-    [Include Solid support [/usr/local/solid]])])
-
-  AS_VAR_IF([PHP_SOLID], [no], [], [
-    AS_VAR_IF([PHP_SOLID], [yes], [PHP_SOLID=/usr/local/solid])
-    ODBC_INCDIR=$PHP_SOLID/include
-    ODBC_LIBDIR=$PHP_SOLID/$PHP_LIBDIR
-    ODBC_CFLAGS=-I$ODBC_INCDIR
-    ODBC_TYPE=solid
-    if test -f $ODBC_LIBDIR/soc*35.a; then
-      AC_DEFINE([HAVE_SOLID_35], [1], [Define to 1 if Solid DB 3.5 is used.])
-    elif test -f $ODBC_LIBDIR/scl*30.a; then
-      AC_DEFINE([HAVE_SOLID_30], [1], [Define to 1 if Solid DB 3.0 is used.])
-    elif test -f $ODBC_LIBDIR/scl*23.a; then
-      AC_DEFINE([HAVE_SOLID], [1],
-        [Define to 1 if the odbc extension uses the Solid DB.])
-    fi
-    PHP_ODBC_FIND_SOLID_LIBS([$ODBC_LIBDIR])
-  ])
-])
 
 AS_VAR_IF([ODBC_TYPE],, [
 PHP_ARG_WITH([ibm-db2],
@@ -207,70 +45,6 @@ PHP configure:
 # . \$IBM_DB2/db2profile
 ])])
     LIBS=$old_LIBS
-  ])
-])
-
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([empress],
-  [for Empress support],
-  [AS_HELP_STRING([[--with-empress[=DIR]]],
-    [Include Empress support $EMPRESSPATH (Empress Version >= 8.60
-    required)])])
-
-  AS_VAR_IF([PHP_EMPRESS], [no], [], [
-    AS_VAR_IF([PHP_EMPRESS], [yes], [
-      ODBC_INCDIR=$EMPRESSPATH/include/odbc
-      ODBC_LIBDIR=$EMPRESSPATH/shlib
-    ], [
-      ODBC_INCDIR=$PHP_EMPRESS/include/odbc
-      ODBC_LIBDIR=$PHP_EMPRESS/shlib
-    ])
-    ODBC_CFLAGS=-I$ODBC_INCDIR
-    ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_TYPE=empress
-    AC_DEFINE([HAVE_EMPRESS], [1],
-      [Define to 1 if the odbc extension uses the Empress.])
-    PHP_ODBC_FIND_EMPRESS_LIBS([$ODBC_LIBDIR])
-  ])
-])
-
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([empress-bcs],
-  [for Empress local access support],
-  [AS_HELP_STRING([[--with-empress-bcs[=DIR]]],
-    [Include Empress Local Access support $EMPRESSPATH (Empress Version >=
-    8.60 required)])])
-
-  AS_VAR_IF([PHP_EMPRESS_BCS], [no], [], [
-    AS_VAR_IF([PHP_EMPRESS_BCS], [yes], [
-      ODBC_INCDIR=$EMPRESSPATH/include/odbc
-      ODBC_LIBDIR=$EMPRESSPATH/shlib
-    ], [
-      ODBC_INCDIR=$PHP_EMPRESS_BCS/include/odbc
-      ODBC_LIBDIR=$PHP_EMPRESS_BCS/shlib
-    ])
-    CC="empocc -bcs";export CC;
-    LD="empocc -bcs";export LD;
-    ODBC_CFLAGS=-I$ODBC_INCDIR
-    ODBC_LFLAGS=-L$ODBC_LIBDIR
-    LIST=$(empocc -listlines -bcs -o a a.c)
-
-    NEWLIST=
-    for I in $LIST
-    do
-      case $I in
-        $EMPRESSPATH/odbccl/lib/* | \
-        $EMPRESSPATH/rdbms/lib/* | \
-        $EMPRESSPATH/common/lib/*)
-              NEWLIST="$NEWLIST $I"
-              ;;
-      esac
-    done
-    ODBC_LIBS="-lempphpbcs -lms -lmscfg -lbasic -lbasic_os -lnlscstab -lnlsmsgtab -lm -ldl -lcrypt"
-    ODBC_TYPE=empress-bcs
-    AC_DEFINE([HAVE_EMPRESS], [1],
-      [Define to 1 if the odbc extension uses the Empress.])
-    PHP_ODBC_FIND_EMPRESS_BCS_LIBS([$ODBC_LIBDIR])
   ])
 ])
 
@@ -314,25 +88,6 @@ PHP_ARG_WITH([iodbc],
 ])
 
 AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([esoob],
-  [for Easysoft ODBC-ODBC Bridge support],
-  [AS_HELP_STRING([[--with-esoob[=DIR]]],
-    [Include Easysoft OOB support [/usr/local/easysoft/oob/client]])])
-
-  AS_VAR_IF([PHP_ESOOB], [no], [], [
-    AS_VAR_IF([PHP_ESOOB], [yes], [PHP_ESOOB=/usr/local/easysoft/oob/client])
-    ODBC_INCDIR=$PHP_ESOOB/include
-    ODBC_LIBDIR=$PHP_ESOOB/$PHP_LIBDIR
-    ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_CFLAGS=-I$ODBC_INCDIR
-    ODBC_LIBS=-lesoobclient
-    ODBC_TYPE=esoob
-    AC_DEFINE([HAVE_ESOOB], [1],
-      [Define to 1 if the odbc extension uses the Easysoft OOB.])
-  ])
-])
-
-AS_VAR_IF([ODBC_TYPE],, [
 PHP_ARG_WITH([unixODBC],
   [whether to build with unixODBC support],
   [AS_HELP_STRING([[--with-unixODBC[=DIR]]],
@@ -360,57 +115,11 @@ PHP_ARG_WITH([unixODBC],
   ])
 ])
 
-AS_VAR_IF([ODBC_TYPE],, [
-PHP_ARG_WITH([dbmaker],
-  [for DBMaker support],
-  [AS_HELP_STRING([[--with-dbmaker[=DIR]]],
-    [Include DBMaker support])])
-
-  AS_VAR_IF([PHP_DBMAKER], [no], [], [
-    AS_VAR_IF([PHP_DBMAKER], [yes], [
-      dnl Find dbmaker home directory
-      DBMAKER_HOME=$(grep "^dbmaker:" /etc/passwd | $AWK -F: '{print $6}')
-
-      dnl check DBMaker version (from 5.0 to 2.0)
-      DBMAKER_VERSION=5.0
-
-      while test ! -d $DBMAKER_HOME/$DBMAKER_VERSION && test "$DBMAKER_VERSION" != "2.9"; do
-        DM_VER=$(echo $DBMAKER_VERSION | $SED -e 's/\.//' | $AWK '{ print $1-1;}')
-        MAJOR_V=$(echo $DM_VER | $AWK '{ print $1/10; }'  | $AWK -F. '{ print $1; }')
-        MINOR_V=$(echo $DM_VER | $AWK '{ print $1%10; }')
-        DBMAKER_VERSION=$MAJOR_V.$MINOR_V
-      done
-
-      AS_VAR_IF([DBMAKER_VERSION], [2.9],
-        [PHP_DBMAKER=$DBMAKER_HOME],
-        [PHP_DBMAKER=$DBMAKER_HOME/$DBMAKER_VERSION])
-    ])
-
-    ODBC_INCDIR=$PHP_DBMAKER/include
-    ODBC_LIBDIR=$PHP_DBMAKER/$PHP_LIBDIR
-    ODBC_CFLAGS=-I$ODBC_INCDIR
-    ODBC_LFLAGS=-L$ODBC_LIBDIR
-    ODBC_LIBS="-ldmapic -lc"
-    ODBC_TYPE=dbmaker
-
-    AC_DEFINE([HAVE_DBMAKER], [1],
-      [Define to 1 if the odbc extension uses the DBMaker.])
-
-    AS_VAR_IF([ext_shared], [yes], [ODBC_LIBS="-ldmapic -lc -lm"], [
-      PHP_ADD_LIBRARY_WITH_PATH([dmapic], [$ODBC_LIBDIR])
-      PHP_ADD_INCLUDE([$ODBC_INCDIR])
-    ])
-  ])
-])
 
 dnl Extension setup
 if test -n "$ODBC_TYPE"; then
   AS_VAR_IF([ODBC_TYPE], [dbmaker],, [
     PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], [ODBC_SHARED_LIBADD])
-    AS_VAR_IF([ODBC_TYPE], [solid],,
-      [AC_DEFINE([HAVE_SQLDATASOURCES], [1],
-        [Define to 1 if ODBC library has 'SQLDataSources', as a function or
-        macro.])])
   ])
 
   AC_DEFINE([HAVE_UODBC], [1],

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -119,9 +119,6 @@ PHP_ARG_WITH([unixODBC],
 dnl Extension setup
 if test -n "$ODBC_TYPE"; then
   PHP_EVAL_LIBLINE([$ODBC_LFLAGS $ODBC_LIBS], [ODBC_SHARED_LIBADD])
-  AC_DEFINE([HAVE_SQLDATASOURCES], [1],
-    [Define to 1 if ODBC library has 'SQLDataSources', as a function or
-    macro.])
 
   AC_DEFINE([HAVE_UODBC], [1],
     [Define to 1 if the PHP extension 'odbc' is available.])

--- a/ext/odbc/config.w32
+++ b/ext/odbc/config.w32
@@ -8,7 +8,6 @@ if (PHP_ODBC == "yes") {
 	&& CHECK_HEADER_ADD_INCLUDE("sqlext.h", "CFLAGS_ODBC")) {
 		EXTENSION("odbc", "php_odbc.c odbc_utils.c", PHP_ODBC_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_UODBC", 1, "Define to 1 if the PHP extension 'odbc' is available.");
-		AC_DEFINE("HAVE_SQLDATASOURCES", 1, "Define to 1 if ODBC library has 'SQLDataSources', as a function or macro.");
 	} else {
 		WARNING("odbc support can't be enabled, libraries or header are missing (SDK)")
 		PHP_ODBC = "no"

--- a/ext/odbc/odbc.stub.php
+++ b/ext/odbc/odbc.stub.php
@@ -344,11 +344,9 @@ namespace {
     /** @alias odbc_exec */
     function odbc_do(Odbc\Connection $odbc, string $query): Odbc\Result|false {}
 
-#ifdef PHP_ODBC_HAVE_FETCH_HASH
     function odbc_fetch_object(Odbc\Result $statement, ?int $row = null): stdClass|false {}
 
     function odbc_fetch_array(Odbc\Result $statement, ?int $row = null): array|false {}
-#endif
 
     /**
      * @param array $array

--- a/ext/odbc/odbc.stub.php
+++ b/ext/odbc/odbc.stub.php
@@ -374,9 +374,7 @@ namespace {
 
     function odbc_num_rows(Odbc\Result $statement): int {}
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30)
     function odbc_next_result(Odbc\Result $statement): bool {}
-#endif
 
     function odbc_num_fields(Odbc\Result $statement): int {}
 
@@ -413,23 +411,19 @@ namespace {
 
     function odbc_primarykeys(Odbc\Connection $odbc, ?string $catalog, string $schema, string $table): Odbc\Result|false {}
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
     function odbc_procedurecolumns(Odbc\Connection $odbc, ?string $catalog = null, ?string $schema = null, ?string $procedure = null, ?string $column = null): Odbc\Result|false {}
 
     function odbc_procedures(Odbc\Connection $odbc, ?string $catalog = null, ?string $schema = null, ?string $procedure = null): Odbc\Result|false {}
 
     function odbc_foreignkeys(Odbc\Connection $odbc, ?string $pk_catalog, string $pk_schema, string $pk_table, string $fk_catalog, string $fk_schema, string $fk_table): Odbc\Result|false {}
-#endif
 
     function odbc_specialcolumns(Odbc\Connection $odbc, int $type, ?string $catalog, string $schema, string $table, int $scope, int $nullable): Odbc\Result|false {}
 
     function odbc_statistics(Odbc\Connection $odbc, ?string $catalog, string $schema, string $table, int $unique, int $accuracy): Odbc\Result|false {}
 
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
     function odbc_tableprivileges(Odbc\Connection $odbc, ?string $catalog, string $schema, string $table): Odbc\Result|false {}
 
     function odbc_columnprivileges(Odbc\Connection $odbc, ?string $catalog, string $schema, string $table, string $column): Odbc\Result|false {}
-#endif
 
     /* odbc_utils.c */
 

--- a/ext/odbc/odbc.stub.php
+++ b/ext/odbc/odbc.stub.php
@@ -337,9 +337,7 @@ namespace {
 
     function odbc_cursor(Odbc\Result $statement): string|false {}
 
-#ifdef HAVE_SQLDATASOURCES
     function odbc_data_source(Odbc\Connection $odbc, int $fetch_type): array|null|false {}
-#endif
 
     function odbc_exec(Odbc\Connection $odbc, string $query): Odbc\Result|false {}
 

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2a788e343c154d2f29adeab45d5507f73de1b6bf */
+ * Stub hash: 64703cfd8e2706e1cc3f1525c847f12b32fc4fc6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -93,11 +93,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_num_rows, 0, 1, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
 ZEND_END_ARG_INFO()
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_next_result, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 #define arginfo_odbc_num_fields arginfo_odbc_num_rows
 
@@ -174,7 +172,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_primarykeys, 0, 4, Odbc
 	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_procedurecolumns, 0, 1, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, catalog, IS_STRING, 1, "null")
@@ -199,7 +196,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_foreignkeys, 0, 7, Odbc
 	ZEND_ARG_TYPE_INFO(0, fk_schema, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, fk_table, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_specialcolumns, 0, 7, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
@@ -220,13 +216,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_statistics, 0, 6, Odbc\
 	ZEND_ARG_TYPE_INFO(0, accuracy, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_tableprivileges, 0, 4, Odbc\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
-	ZEND_ARG_TYPE_INFO(0, catalog, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_odbc_tableprivileges arginfo_odbc_primarykeys
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_columnprivileges, 0, 5, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
@@ -235,7 +225,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_columnprivileges, 0, 5,
 	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, column, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_connection_string_is_quoted, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
@@ -270,9 +259,7 @@ ZEND_FUNCTION(odbc_connect);
 ZEND_FUNCTION(odbc_pconnect);
 ZEND_FUNCTION(odbc_close);
 ZEND_FUNCTION(odbc_num_rows);
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30)
 ZEND_FUNCTION(odbc_next_result);
-#endif
 ZEND_FUNCTION(odbc_num_fields);
 ZEND_FUNCTION(odbc_field_name);
 ZEND_FUNCTION(odbc_field_type);
@@ -289,17 +276,13 @@ ZEND_FUNCTION(odbc_tables);
 ZEND_FUNCTION(odbc_columns);
 ZEND_FUNCTION(odbc_gettypeinfo);
 ZEND_FUNCTION(odbc_primarykeys);
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_procedurecolumns);
 ZEND_FUNCTION(odbc_procedures);
 ZEND_FUNCTION(odbc_foreignkeys);
-#endif
 ZEND_FUNCTION(odbc_specialcolumns);
 ZEND_FUNCTION(odbc_statistics);
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_tableprivileges);
 ZEND_FUNCTION(odbc_columnprivileges);
-#endif
 ZEND_FUNCTION(odbc_connection_string_is_quoted);
 ZEND_FUNCTION(odbc_connection_string_should_quote);
 ZEND_FUNCTION(odbc_connection_string_quote);
@@ -329,9 +312,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(odbc_pconnect, arginfo_odbc_pconnect)
 	ZEND_FE(odbc_close, arginfo_odbc_close)
 	ZEND_FE(odbc_num_rows, arginfo_odbc_num_rows)
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30)
 	ZEND_FE(odbc_next_result, arginfo_odbc_next_result)
-#endif
 	ZEND_FE(odbc_num_fields, arginfo_odbc_num_fields)
 	ZEND_FE(odbc_field_name, arginfo_odbc_field_name)
 	ZEND_FE(odbc_field_type, arginfo_odbc_field_type)
@@ -349,17 +330,13 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(odbc_columns, arginfo_odbc_columns)
 	ZEND_FE(odbc_gettypeinfo, arginfo_odbc_gettypeinfo)
 	ZEND_FE(odbc_primarykeys, arginfo_odbc_primarykeys)
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_procedurecolumns, arginfo_odbc_procedurecolumns)
 	ZEND_FE(odbc_procedures, arginfo_odbc_procedures)
 	ZEND_FE(odbc_foreignkeys, arginfo_odbc_foreignkeys)
-#endif
 	ZEND_FE(odbc_specialcolumns, arginfo_odbc_specialcolumns)
 	ZEND_FE(odbc_statistics, arginfo_odbc_statistics)
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_tableprivileges, arginfo_odbc_tableprivileges)
 	ZEND_FE(odbc_columnprivileges, arginfo_odbc_columnprivileges)
-#endif
 	ZEND_FE(odbc_connection_string_is_quoted, arginfo_odbc_connection_string_is_quoted)
 	ZEND_FE(odbc_connection_string_should_quote, arginfo_odbc_connection_string_should_quote)
 	ZEND_FE(odbc_connection_string_quote, arginfo_odbc_connection_string_quote)

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1ac486a9c572384af6b7134cd4116989b596cada */
+ * Stub hash: f9ba28767b256dbcea087a65aa4bb5f5b509d6f3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -37,7 +37,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_odbc_do arginfo_odbc_prepare
 
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_fetch_object, 0, 1, stdClass, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
@@ -47,7 +46,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_fetch_array, 0, 1, MAY_BE_A
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_fetch_into, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
@@ -242,10 +240,8 @@ ZEND_FUNCTION(odbc_execute);
 ZEND_FUNCTION(odbc_cursor);
 ZEND_FUNCTION(odbc_data_source);
 ZEND_FUNCTION(odbc_exec);
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_FUNCTION(odbc_fetch_object);
 ZEND_FUNCTION(odbc_fetch_array);
-#endif
 ZEND_FUNCTION(odbc_fetch_into);
 ZEND_FUNCTION(odbc_fetch_row);
 ZEND_FUNCTION(odbc_result);
@@ -293,10 +289,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(odbc_data_source, arginfo_odbc_data_source)
 	ZEND_FE(odbc_exec, arginfo_odbc_exec)
 	ZEND_RAW_FENTRY("odbc_do", zif_odbc_exec, arginfo_odbc_do, 0, NULL, NULL)
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 	ZEND_FE(odbc_fetch_object, arginfo_odbc_fetch_object)
 	ZEND_FE(odbc_fetch_array, arginfo_odbc_fetch_array)
-#endif
 	ZEND_FE(odbc_fetch_into, arginfo_odbc_fetch_into)
 	ZEND_FE(odbc_fetch_row, arginfo_odbc_fetch_row)
 	ZEND_FE(odbc_result, arginfo_odbc_result)

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 64703cfd8e2706e1cc3f1525c847f12b32fc4fc6 */
+ * Stub hash: 1ac486a9c572384af6b7134cd4116989b596cada */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -28,12 +28,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_cursor, 0, 1, MAY_BE_STRING
 	ZEND_ARG_OBJ_INFO(0, statement, Odbc\\Result, 0)
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_SQLDATASOURCES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_data_source, 0, 2, MAY_BE_ARRAY|MAY_BE_NULL|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, fetch_type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 #define arginfo_odbc_exec arginfo_odbc_prepare
 
@@ -242,9 +240,7 @@ ZEND_FUNCTION(odbc_longreadlen);
 ZEND_FUNCTION(odbc_prepare);
 ZEND_FUNCTION(odbc_execute);
 ZEND_FUNCTION(odbc_cursor);
-#if defined(HAVE_SQLDATASOURCES)
 ZEND_FUNCTION(odbc_data_source);
-#endif
 ZEND_FUNCTION(odbc_exec);
 #if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_FUNCTION(odbc_fetch_object);
@@ -294,9 +290,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(odbc_prepare, arginfo_odbc_prepare)
 	ZEND_FE(odbc_execute, arginfo_odbc_execute)
 	ZEND_FE(odbc_cursor, arginfo_odbc_cursor)
-#if defined(HAVE_SQLDATASOURCES)
 	ZEND_FE(odbc_data_source, arginfo_odbc_data_source)
-#endif
 	ZEND_FE(odbc_exec, arginfo_odbc_exec)
 	ZEND_RAW_FENTRY("odbc_do", zif_odbc_exec, arginfo_odbc_do, 0, NULL, NULL)
 #if defined(PHP_ODBC_HAVE_FETCH_HASH)

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1306,7 +1306,6 @@ PHP_FUNCTION(odbc_exec)
 }
 /* }}} */
 
-#ifdef PHP_ODBC_HAVE_FETCH_HASH
 #define ODBC_NUM  1
 #define ODBC_OBJECT  2
 
@@ -1458,7 +1457,6 @@ PHP_FUNCTION(odbc_fetch_array)
 	php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAM_PASSTHRU, ODBC_OBJECT);
 }
 /* }}} */
-#endif
 
 /* {{{ Fetch one result row into an array */
 PHP_FUNCTION(odbc_fetch_into)

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -690,14 +690,6 @@ void odbc_bindcols(odbc_result *result)
 			case SQL_WLONGVARCHAR:
 				result->values[i].value = NULL;
 				break;
-
-#ifdef HAVE_ADABAS
-			case SQL_TIMESTAMP:
-				result->values[i].value = (char *)emalloc(27);
-				SQLBindCol(result->stmt, (SQLUSMALLINT)(i+1), SQL_C_CHAR, result->values[i].value,
-							27, &result->values[i].vallen);
-				break;
-#endif /* HAVE_ADABAS */
 			case SQL_CHAR:
 			case SQL_VARCHAR:
 			case SQL_WCHAR:

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1186,7 +1186,6 @@ PHP_FUNCTION(odbc_cursor)
 }
 /* }}} */
 
-#ifdef HAVE_SQLDATASOURCES
 /* {{{ Return information about the currently connected data source */
 PHP_FUNCTION(odbc_data_source)
 {
@@ -1242,7 +1241,6 @@ PHP_FUNCTION(odbc_data_source)
 
 }
 /* }}} */
-#endif /* HAVE_SQLDATASOURCES */
 
 /* {{{ Prepare and execute an SQL statement */
 /* XXX Use flags */

--- a/ext/odbc/php_odbc.h
+++ b/ext/odbc/php_odbc.h
@@ -31,7 +31,7 @@ extern zend_module_entry odbc_module_entry;
 #include "php_version.h"
 #define PHP_ODBC_VERSION PHP_VERSION
 
-#if defined(HAVE_DBMAKER) || defined(PHP_WIN32) || defined(HAVE_IBMDB2) || defined(HAVE_UNIXODBC) || defined(HAVE_IODBC)
+#if defined(PHP_WIN32) || defined(HAVE_IBMDB2) || defined(HAVE_UNIXODBC) || defined(HAVE_IODBC)
 # define PHP_ODBC_HAVE_FETCH_HASH 1
 #endif
 

--- a/ext/odbc/php_odbc.h
+++ b/ext/odbc/php_odbc.h
@@ -31,10 +31,6 @@ extern zend_module_entry odbc_module_entry;
 #include "php_version.h"
 #define PHP_ODBC_VERSION PHP_VERSION
 
-#if defined(PHP_WIN32) || defined(HAVE_IBMDB2) || defined(HAVE_UNIXODBC) || defined(HAVE_IODBC)
-# define PHP_ODBC_HAVE_FETCH_HASH 1
-#endif
-
 /* user functions */
 PHP_MINIT_FUNCTION(odbc);
 PHP_MSHUTDOWN_FUNCTION(odbc);

--- a/ext/odbc/php_odbc_includes.h
+++ b/ext/odbc/php_odbc_includes.h
@@ -25,28 +25,12 @@
 
 #if defined(HAVE_IODBC) /* iODBC library */
 
-#ifdef CHAR
-#undef CHAR
-#endif
-
-#ifdef SQLCHAR
-#undef SQLCHAR
-#endif
-
 #define ODBC_TYPE "iODBC"
 #include <sql.h>
 #include <sqlext.h>
 #include <iodbcext.h>
 
 #elif defined(HAVE_UNIXODBC) /* unixODBC library */
-
-#ifdef CHAR
-#undef CHAR
-#endif
-
-#ifdef SQLCHAR
-#undef SQLCHAR
-#endif
 
 #define ODBC_TYPE "unixODBC"
 #include <sql.h>

--- a/ext/odbc/php_odbc_includes.h
+++ b/ext/odbc/php_odbc_includes.h
@@ -23,59 +23,7 @@
 
 /* checking in the same order as in configure.ac */
 
-#if defined(HAVE_SOLID) || defined(HAVE_SOLID_30) || defined(HAVE_SOLID_35) /* Solid Server */
-
-#define ODBC_TYPE "Solid"
-#if defined(HAVE_SOLID)
-# include <cli0core.h>
-# include <cli0ext1.h>
-# include <cli0env.h>
-#elif defined(HAVE_SOLID_30)
-# include <cli0cli.h>
-# include <cli0defs.h>
-# include <cli0env.h>
-#elif defined(HAVE_SOLID_35)
-# include <sqlunix.h>
-# include <sqltypes.h>
-# include <sqlucode.h>
-# include <sqlext.h>
-# include <sql.h>
-#endif	/* end: #if defined(HAVE_SOLID) */
-#undef HAVE_SQL_EXTENDED_FETCH
-#define SQLSMALLINT SWORD
-#define SQLUSMALLINT UWORD
-#ifndef SQL_SUCCEEDED
-#define SQL_SUCCEEDED(rc) (((rc)&(~1))==0)
-#endif
-
-#elif defined(HAVE_EMPRESS) /* Empress */
-
-#define ODBC_TYPE "Empress"
-#include <sql.h>
-#include <sqlext.h>
-#undef HAVE_SQL_EXTENDED_FETCH
-
-#elif defined(HAVE_ADABAS) /* Adabas D */
-
-#define ODBC_TYPE "Adabas D"
-#include <WINDOWS.H>
-#include <sql.h>
-#include <sqlext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
-#define SQL_SUCCEEDED(rc) (((rc)&(~1))==0)
-#define SQLINTEGER ULONG
-#define SQLUSMALLINT USHORT
-
-#elif defined(HAVE_SAPDB) /* SAP DB */
-
-#define ODBC_TYPE "SAP DB"
-#include <WINDOWS.H>
-#include <sql.h>
-#include <sqlext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
-#define SQL_SUCCEEDED(rc) (((rc)&(~1))==0)
-
-#elif defined(HAVE_IODBC) /* iODBC library */
+#if defined(HAVE_IODBC) /* iODBC library */
 
 #ifdef CHAR
 #undef CHAR
@@ -105,35 +53,6 @@
 #include <sql.h>
 #include <sqlext.h>
 #define HAVE_SQL_EXTENDED_FETCH 1
-
-#elif defined(HAVE_ESOOB) /* Easysoft ODBC-ODBC Bridge library */
-
-#define ODBC_TYPE "ESOOB"
-#include <sql.h>
-#include <sqlext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
-
-#elif defined(HAVE_OPENLINK) /* OpenLink ODBC drivers */
-
-#define ODBC_TYPE "Openlink"
-#include <iodbc.h>
-#include <isql.h>
-#include <isqlext.h>
-#include <udbcext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
-#ifndef SQLSMALLINT
-#define SQLSMALLINT SWORD
-#endif
-#ifndef SQLUSMALLINT
-#define SQLUSMALLINT UWORD
-#endif
-
-#elif defined(HAVE_DBMAKER) /* DBMaker */
-
-#define ODBC_TYPE "DBMaker"
-#define HAVE_SQL_EXTENDED_FETCH 1
-#include <odbc.h>
-
 
 #elif defined(HAVE_CODBC) /* Custom ODBC */
 
@@ -173,10 +92,6 @@
 #define ODBC_SQL_ENV_T SQLHANDLE
 #define ODBC_SQL_CONN_T SQLHANDLE
 #define ODBC_SQL_STMT_T SQLHANDLE
-#elif defined( HAVE_SOLID_35 ) || defined( HAVE_SAPDB ) || defined ( HAVE_EMPRESS )
-#define ODBC_SQL_ENV_T SQLHENV
-#define ODBC_SQL_CONN_T SQLHDBC
-#define ODBC_SQL_STMT_T SQLHSTMT
 #else
 #define ODBC_SQL_ENV_T HENV
 #define ODBC_SQL_CONN_T HDBC

--- a/ext/odbc/php_odbc_includes.h
+++ b/ext/odbc/php_odbc_includes.h
@@ -65,10 +65,6 @@
 #define ODBC_TYPE "IBM DB2 CLI"
 #define HAVE_SQL_EXTENDED_FETCH 1
 #include <sqlcli1.h>
-#ifdef DB268K
-/* Need to include ASLM for 68K applications */
-#include <LibraryManager.h>
-#endif
 
 #else /* MS ODBC */
 

--- a/ext/odbc/php_odbc_includes.h
+++ b/ext/odbc/php_odbc_includes.h
@@ -37,7 +37,6 @@
 #include <sql.h>
 #include <sqlext.h>
 #include <iodbcext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
 
 #elif defined(HAVE_UNIXODBC) /* unixODBC library */
 
@@ -52,23 +51,19 @@
 #define ODBC_TYPE "unixODBC"
 #include <sql.h>
 #include <sqlext.h>
-#define HAVE_SQL_EXTENDED_FETCH 1
 
 #elif defined(HAVE_CODBC) /* Custom ODBC */
 
 #define ODBC_TYPE "Custom ODBC"
-#define HAVE_SQL_EXTENDED_FETCH 1
 #include <odbc.h>
 
 #elif defined(HAVE_IBMDB2) /* DB2 CLI */
 
 #define ODBC_TYPE "IBM DB2 CLI"
-#define HAVE_SQL_EXTENDED_FETCH 1
 #include <sqlcli1.h>
 
 #else /* MS ODBC */
 
-#define HAVE_SQL_EXTENDED_FETCH 1
 #include <WINDOWS.H>
 #include <sql.h>
 #include <sqlext.h>
@@ -128,9 +123,7 @@ typedef struct odbc_result {
 	odbc_result_value *values;
 	SQLSMALLINT numcols;
 	SQLSMALLINT numparams;
-# ifdef HAVE_SQL_EXTENDED_FETCH
 	int fetch_abs;
-# endif
 	zend_long longreadlen;
 	int binmode;
 	int fetched;


### PR DESCRIPTION
See GH-15630 for motivation and some concerns. Looks like we can get rid of a bunch of ifdefs!

Additional ones I've had since this:

* Should we remove the Db2 special casing?
* ~~There's some redundancy with the various fetch functions; this could be made into a common interface that the PHP functions call into.~~ I will likely do a refactor of this in a separate PR.
* ~~It seems fetch hash works with all the driver managers, but not the custom ones.~~ We can probably assume any modern ODBC driver will support these.
* ~~`SQL_TIMESTAMP` is gated behind Adabas for some reason (in `odbc_bindcols`), even though it seems general? May need to look into how it gets converted to `SQL_C_CHAR` per [ODBC ref](https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/sql-to-c-timestamp?view=sql-server-ver16).~~ This seems unneeded; `SQL_C_CHAR` binding should be correct based on display size.
* ~~`HAVE_SQLDATASOURCES` only gets set on Windows, need to test or assume on Unix~~ ahahaha accidentally deleted it in a cleanup, added back