### PR TITLE
`#[AllowDynamicProperties]` validation: improve error messages

### DIFF
--- a/Zend/tests/allow_dynamic_properties_on_interface.phpt
+++ b/Zend/tests/allow_dynamic_properties_on_interface.phpt
@@ -8,4 +8,4 @@ interface Test {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot apply #[AllowDynamicProperties] to interface in %s on line %d
+Fatal error: Cannot apply #[AllowDynamicProperties] to interface Test in %s on line %d

--- a/Zend/tests/allow_dynamic_properties_on_trait.phpt
+++ b/Zend/tests/allow_dynamic_properties_on_trait.phpt
@@ -8,4 +8,4 @@ trait Test {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot apply #[AllowDynamicProperties] to trait in %s on line %d
+Fatal error: Cannot apply #[AllowDynamicProperties] to trait Test in %s on line %d

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -72,10 +72,14 @@ static void validate_allow_dynamic_properties(
 		zend_attribute *attr, uint32_t target, zend_class_entry *scope)
 {
 	if (scope->ce_flags & ZEND_ACC_TRAIT) {
-		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to trait");
+		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to trait %s",
+			ZSTR_VAL(scope->name)
+		);
 	}
 	if (scope->ce_flags & ZEND_ACC_INTERFACE) {
-		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to interface");
+		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to interface %s",
+			ZSTR_VAL(scope->name)
+		);
 	}
 	if (scope->ce_flags & ZEND_ACC_READONLY_CLASS) {
 		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to readonly class %s",


### PR DESCRIPTION
For traits and interfaces, include the name of the relevant trait (or interface) in the error message, the same way it is included for readonly classes.