### PR TITLE
Generated arginfo header files: combine preprocessor conditional blocks

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -102,8 +102,6 @@ static const func_info_t func_infos[] = {
 	F1("imagecreatetruecolor", MAY_BE_OBJECT|MAY_BE_FALSE),
 #if defined(PHP_WIN32)
 	F1("imagegrabwindow", MAY_BE_OBJECT|MAY_BE_FALSE),
-#endif
-#if defined(PHP_WIN32)
 	F1("imagegrabscreen", MAY_BE_OBJECT|MAY_BE_FALSE),
 #endif
 	F1("imagerotate", MAY_BE_OBJECT|MAY_BE_FALSE),
@@ -137,8 +135,6 @@ static const func_info_t func_infos[] = {
 	F1("imagegetclip", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG),
 #if defined(HAVE_GD_FREETYPE)
 	F1("imageftbbox", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG|MAY_BE_FALSE),
-#endif
-#if defined(HAVE_GD_FREETYPE)
 	F1("imagefttext", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG|MAY_BE_FALSE),
 #endif
 	F1("imagecrop", MAY_BE_OBJECT|MAY_BE_FALSE),
@@ -182,11 +178,7 @@ static const func_info_t func_infos[] = {
 	F1("hash_hkdf", MAY_BE_STRING),
 #if defined(PHP_MHASH_BC)
 	F1("mhash_get_hash_name", MAY_BE_STRING|MAY_BE_FALSE),
-#endif
-#if defined(PHP_MHASH_BC)
 	F1("mhash_keygen_s2k", MAY_BE_STRING|MAY_BE_FALSE),
-#endif
-#if defined(PHP_MHASH_BC)
 	F1("mhash", MAY_BE_STRING|MAY_BE_FALSE),
 #endif
 	F1("iconv_substr", MAY_BE_STRING|MAY_BE_FALSE),
@@ -239,29 +231,13 @@ static const func_info_t func_infos[] = {
 	F1("mb_get_info", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_ARRAY|MAY_BE_STRING|MAY_BE_LONG|MAY_BE_FALSE|MAY_BE_NULL),
 #if defined(HAVE_MBREGEX)
 	F1("mb_regex_encoding", MAY_BE_STRING|MAY_BE_BOOL),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_ereg_replace", MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_eregi_replace", MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_ereg_replace_callback", MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_split", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_FALSE),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_ereg_search_pos", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG|MAY_BE_FALSE),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_ereg_search_regs", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_FALSE|MAY_BE_FALSE),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_ereg_search_getregs", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_FALSE|MAY_BE_FALSE),
-#endif
-#if defined(HAVE_MBREGEX)
 	F1("mb_regex_set_options", MAY_BE_STRING),
 #endif
 	F1("mysqli_affected_rows", MAY_BE_LONG|MAY_BE_STRING),
@@ -402,8 +378,6 @@ static const func_info_t func_infos[] = {
 	FN("sodium_crypto_kx_server_session_keys", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	FN("sodium_crypto_secretstream_xchacha20poly1305_init_push", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	FN("sodium_crypto_secretstream_xchacha20poly1305_pull", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_FALSE),
 #endif
 	F1("class_implements", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_FALSE),
@@ -596,8 +570,6 @@ static const func_info_t func_infos[] = {
 	F1("number_format", MAY_BE_STRING),
 #if defined(HAVE_GETTIMEOFDAY)
 	F1("microtime", MAY_BE_STRING|MAY_BE_DOUBLE),
-#endif
-#if defined(HAVE_GETTIMEOFDAY)
 	F1("gettimeofday", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_DOUBLE),
 #endif
 #if defined(HAVE_GETRUSAGE)
@@ -609,8 +581,6 @@ static const func_info_t func_infos[] = {
 	F1("password_hash", MAY_BE_STRING),
 #if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	F1("proc_open", MAY_BE_RESOURCE|MAY_BE_FALSE),
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	F1("proc_get_status", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_FALSE|MAY_BE_ARRAY_OF_TRUE|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING),
 #endif
 	F1("quoted_printable_decode", MAY_BE_STRING),

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -409,22 +409,16 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_load
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadHTMLFile, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_saveHTML, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, node, DOMNode, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_saveHTMLFile, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -440,22 +434,16 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_sche
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_schemaValidateSource, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_relaxNGValidate, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_relaxNGValidateSource, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -513,42 +501,30 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMXPath___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, document, DOMDocument, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMXPath_evaluate, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, contextNode, DOMNode, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 #define arginfo_class_DOMXPath_query arginfo_class_DOMXPath_evaluate
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMXPath_registerNamespace, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMXPath_registerPhpFunctions, 0, 0, IS_VOID, 0)
 	ZEND_ARG_TYPE_MASK(0, restrict, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DOMXPath_registerPhpFunctionNS, 0, 3, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, callable, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DOMXPath_quote, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -984,22 +960,16 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_Document_schemaValidat
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_Document_schemaValidateSource, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_Document_relaxNgValidate, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_Document_relaxNgValidateSource, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -1129,42 +1099,30 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Dom_XPath___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, document, Dom\\Document, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Dom_XPath_evaluate, 0, 1, Dom\\\116odeList, MAY_BE_NULL|MAY_BE_BOOL|MAY_BE_DOUBLE|MAY_BE_STRING)
 	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, contextNode, Dom\\\116ode, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Dom_XPath_query, 0, 1, Dom\\\116odeList, 0)
 	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, contextNode, Dom\\\116ode, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_XPath_registerNamespace, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Dom_XPath_registerPhpFunctions, 0, 0, IS_VOID, 0)
 	ZEND_ARG_TYPE_MASK(0, restrict, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 #define arginfo_class_Dom_XPath_registerPhpFunctionNS arginfo_class_DOMXPath_registerPhpFunctionNS
-#endif
 
-#if defined(LIBXML_XPATH_ENABLED)
 #define arginfo_class_Dom_XPath_quote arginfo_class_DOMXPath_quote
 #endif
 
@@ -1261,27 +1219,15 @@ ZEND_METHOD(DOMDocument, registerNodeClass);
 ZEND_METHOD(DOMDocument, save);
 #if defined(LIBXML_HTML_ENABLED)
 ZEND_METHOD(DOMDocument, loadHTML);
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_METHOD(DOMDocument, loadHTMLFile);
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_METHOD(DOMDocument, saveHTML);
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_METHOD(DOMDocument, saveHTMLFile);
 #endif
 ZEND_METHOD(DOMDocument, saveXML);
 #if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_METHOD(DOMDocument, schemaValidate);
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_METHOD(DOMDocument, schemaValidateSource);
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_METHOD(DOMDocument, relaxNGValidate);
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_METHOD(DOMDocument, relaxNGValidateSource);
 #endif
 ZEND_METHOD(DOMDocument, validate);
@@ -1299,23 +1245,11 @@ ZEND_METHOD(DOMEntityReference, __construct);
 ZEND_METHOD(DOMProcessingInstruction, __construct);
 #if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, __construct);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, evaluate);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, query);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, registerNamespace);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, registerPhpFunctions);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, registerPhpFunctionNS);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(DOMXPath, quote);
 #endif
 ZEND_METHOD(Dom_Implementation, createDocumentType);
@@ -1384,11 +1318,7 @@ ZEND_METHOD(Dom_TokenList, count);
 ZEND_METHOD(Dom_TokenList, getIterator);
 #if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(Dom_XPath, __construct);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(Dom_XPath, evaluate);
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 ZEND_METHOD(Dom_XPath, query);
 #endif
 
@@ -1555,27 +1485,15 @@ static const zend_function_entry class_DOMDocument_methods[] = {
 	ZEND_ME(DOMDocument, save, arginfo_class_DOMDocument_save, ZEND_ACC_PUBLIC)
 #if defined(LIBXML_HTML_ENABLED)
 	ZEND_ME(DOMDocument, loadHTML, arginfo_class_DOMDocument_loadHTML, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 	ZEND_ME(DOMDocument, loadHTMLFile, arginfo_class_DOMDocument_loadHTMLFile, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 	ZEND_ME(DOMDocument, saveHTML, arginfo_class_DOMDocument_saveHTML, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_HTML_ENABLED)
 	ZEND_ME(DOMDocument, saveHTMLFile, arginfo_class_DOMDocument_saveHTMLFile, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(DOMDocument, saveXML, arginfo_class_DOMDocument_saveXML, ZEND_ACC_PUBLIC)
 #if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_ME(DOMDocument, schemaValidate, arginfo_class_DOMDocument_schemaValidate, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_ME(DOMDocument, schemaValidateSource, arginfo_class_DOMDocument_schemaValidateSource, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_ME(DOMDocument, relaxNGValidate, arginfo_class_DOMDocument_relaxNGValidate, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_ME(DOMDocument, relaxNGValidateSource, arginfo_class_DOMDocument_relaxNGValidateSource, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(DOMDocument, validate, arginfo_class_DOMDocument_validate, ZEND_ACC_PUBLIC)
@@ -1811,14 +1729,8 @@ static const zend_function_entry class_Dom_Document_methods[] = {
 	ZEND_ME(Dom_Document, registerNodeClass, arginfo_class_Dom_Document_registerNodeClass, ZEND_ACC_PUBLIC)
 #if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_RAW_FENTRY("schemaValidate", zim_DOMDocument_schemaValidate, arginfo_class_Dom_Document_schemaValidate, ZEND_ACC_PUBLIC, NULL, NULL)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_RAW_FENTRY("schemaValidateSource", zim_DOMDocument_schemaValidateSource, arginfo_class_Dom_Document_schemaValidateSource, ZEND_ACC_PUBLIC, NULL, NULL)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_RAW_FENTRY("relaxNgValidate", zim_DOMDocument_relaxNGValidate, arginfo_class_Dom_Document_relaxNgValidate, ZEND_ACC_PUBLIC, NULL, NULL)
-#endif
-#if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_RAW_FENTRY("relaxNgValidateSource", zim_DOMDocument_relaxNGValidateSource, arginfo_class_Dom_Document_relaxNgValidateSource, ZEND_ACC_PUBLIC, NULL, NULL)
 #endif
 	ZEND_RAW_FENTRY("append", zim_DOMElement_append, arginfo_class_Dom_Document_append, ZEND_ACC_PUBLIC, NULL, NULL)

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -111,9 +111,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagegrabwindow, 0, 1, GdIma
 	ZEND_ARG_TYPE_INFO(0, handle, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, client_area, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagegrabscreen, 0, 0, GdImage, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 #endif
@@ -483,9 +481,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imageftbbox, 0, 4, MAY_BE_ARRAY|
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_GD_FREETYPE)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imagefttext, 0, 8, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
 	ZEND_ARG_TYPE_INFO(0, size, IS_DOUBLE, 0)
@@ -497,13 +493,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imagefttext, 0, 8, MAY_BE_ARRAY|
 	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_GD_FREETYPE)
 #define arginfo_imagettfbbox arginfo_imageftbbox
-#endif
 
-#if defined(HAVE_GD_FREETYPE)
 #define arginfo_imagettftext arginfo_imagefttext
 #endif
 
@@ -596,8 +588,6 @@ ZEND_FUNCTION(imagecolorexactalpha);
 ZEND_FUNCTION(imagecopyresampled);
 #if defined(PHP_WIN32)
 ZEND_FUNCTION(imagegrabwindow);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(imagegrabscreen);
 #endif
 ZEND_FUNCTION(imagerotate);
@@ -696,8 +686,6 @@ ZEND_FUNCTION(imagesetclip);
 ZEND_FUNCTION(imagegetclip);
 #if defined(HAVE_GD_FREETYPE)
 ZEND_FUNCTION(imageftbbox);
-#endif
-#if defined(HAVE_GD_FREETYPE)
 ZEND_FUNCTION(imagefttext);
 #endif
 ZEND_FUNCTION(imagefilter);
@@ -736,8 +724,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imagecopyresampled, arginfo_imagecopyresampled)
 #if defined(PHP_WIN32)
 	ZEND_FE(imagegrabwindow, arginfo_imagegrabwindow)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(imagegrabscreen, arginfo_imagegrabscreen)
 #endif
 	ZEND_FE(imagerotate, arginfo_imagerotate)
@@ -836,14 +822,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imagegetclip, arginfo_imagegetclip)
 #if defined(HAVE_GD_FREETYPE)
 	ZEND_FE(imageftbbox, arginfo_imageftbbox)
-#endif
-#if defined(HAVE_GD_FREETYPE)
 	ZEND_FE(imagefttext, arginfo_imagefttext)
-#endif
-#if defined(HAVE_GD_FREETYPE)
 	ZEND_RAW_FENTRY("imagettfbbox", zif_imageftbbox, arginfo_imagettfbbox, 0, NULL, NULL)
-#endif
-#if defined(HAVE_GD_FREETYPE)
 	ZEND_RAW_FENTRY("imagettftext", zif_imagefttext, arginfo_imagettftext, 0, NULL, NULL)
 #endif
 	ZEND_FE(imagefilter, arginfo_imagefilter)

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -94,29 +94,21 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mhash_get_block_size, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_MHASH_BC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mhash_get_hash_name, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_MHASH_BC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mhash_keygen_s2k, 0, 4, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, salt, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_MHASH_BC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mhash_count, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_MHASH_BC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mhash, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
@@ -152,17 +144,9 @@ ZEND_FUNCTION(hash_equals);
 ZEND_FUNCTION(hash_hkdf);
 #if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash_get_block_size);
-#endif
-#if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash_get_hash_name);
-#endif
-#if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash_keygen_s2k);
-#endif
-#if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash_count);
-#endif
-#if defined(PHP_MHASH_BC)
 ZEND_FUNCTION(mhash);
 #endif
 ZEND_METHOD(HashContext, __construct);
@@ -188,17 +172,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(hash_hkdf, arginfo_hash_hkdf)
 #if defined(PHP_MHASH_BC)
 	ZEND_RAW_FENTRY("mhash_get_block_size", zif_mhash_get_block_size, arginfo_mhash_get_block_size, ZEND_ACC_DEPRECATED, NULL, NULL)
-#endif
-#if defined(PHP_MHASH_BC)
 	ZEND_RAW_FENTRY("mhash_get_hash_name", zif_mhash_get_hash_name, arginfo_mhash_get_hash_name, ZEND_ACC_DEPRECATED, NULL, NULL)
-#endif
-#if defined(PHP_MHASH_BC)
 	ZEND_RAW_FENTRY("mhash_keygen_s2k", zif_mhash_keygen_s2k, arginfo_mhash_keygen_s2k, ZEND_ACC_DEPRECATED, NULL, NULL)
-#endif
-#if defined(PHP_MHASH_BC)
 	ZEND_RAW_FENTRY("mhash_count", zif_mhash_count, arginfo_mhash_count, ZEND_ACC_DEPRECATED, NULL, NULL)
-#endif
-#if defined(PHP_MHASH_BC)
 	ZEND_RAW_FENTRY("mhash", zif_mhash, arginfo_mhash, ZEND_ACC_DEPRECATED, NULL, NULL)
 #endif
 	ZEND_FE_END
@@ -238,8 +214,6 @@ static void register_hash_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_mhash_get_block_size_0_arg0, attribute_Deprecated_func_mhash_get_block_size_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_block_size_0->args[0].value, &attribute_Deprecated_func_mhash_get_block_size_0_arg0);
 	attribute_Deprecated_func_mhash_get_block_size_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
-#endif
-#if defined(PHP_MHASH_BC)
 
 	zend_attribute *attribute_Deprecated_func_mhash_get_hash_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_hash_name", sizeof("mhash_get_hash_name") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
 	zval attribute_Deprecated_func_mhash_get_hash_name_0_arg0;
@@ -247,8 +221,6 @@ static void register_hash_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_mhash_get_hash_name_0_arg0, attribute_Deprecated_func_mhash_get_hash_name_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_hash_name_0->args[0].value, &attribute_Deprecated_func_mhash_get_hash_name_0_arg0);
 	attribute_Deprecated_func_mhash_get_hash_name_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
-#endif
-#if defined(PHP_MHASH_BC)
 
 	zend_attribute *attribute_Deprecated_func_mhash_keygen_s2k_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_keygen_s2k", sizeof("mhash_keygen_s2k") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
 	zval attribute_Deprecated_func_mhash_keygen_s2k_0_arg0;
@@ -256,8 +228,6 @@ static void register_hash_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_mhash_keygen_s2k_0_arg0, attribute_Deprecated_func_mhash_keygen_s2k_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].value, &attribute_Deprecated_func_mhash_keygen_s2k_0_arg0);
 	attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
-#endif
-#if defined(PHP_MHASH_BC)
 
 	zend_attribute *attribute_Deprecated_func_mhash_count_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_count", sizeof("mhash_count") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
 	zval attribute_Deprecated_func_mhash_count_0_arg0;
@@ -265,8 +235,6 @@ static void register_hash_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_mhash_count_0_arg0, attribute_Deprecated_func_mhash_count_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_count_0->args[0].value, &attribute_Deprecated_func_mhash_count_0_arg0);
 	attribute_Deprecated_func_mhash_count_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
-#endif
-#if defined(PHP_MHASH_BC)
 
 	zend_attribute *attribute_Deprecated_func_mhash_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash", sizeof("mhash") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 1);
 	zval attribute_Deprecated_func_mhash_0_arg0;

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -736,9 +736,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_intltz_get_windows_id, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_intltz_get_id_for_windows_id, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, region, IS_STRING, 1, "null")
@@ -970,8 +968,6 @@ ZEND_FUNCTION(intltz_get_tz_data_version);
 ZEND_FUNCTION(intltz_get_unknown);
 #if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_FUNCTION(intltz_get_windows_id);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_FUNCTION(intltz_get_id_for_windows_id);
 #endif
 ZEND_FUNCTION(intltz_has_same_rules);
@@ -1163,8 +1159,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(intltz_get_unknown, arginfo_intltz_get_unknown)
 #if U_ICU_VERSION_MAJOR_NUM >= 52
 	ZEND_FE(intltz_get_windows_id, arginfo_intltz_get_windows_id)
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 	ZEND_FE(intltz_get_id_for_windows_id, arginfo_intltz_get_id_for_windows_id)
 #endif
 	ZEND_FE(intltz_has_same_rules, arginfo_intltz_has_same_rules)

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -85,9 +85,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_IntlTimeZone_getWindowsID, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_IntlTimeZone_getIDForWindowsID, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, region, IS_STRING, 1, "null")
@@ -129,8 +127,6 @@ ZEND_FUNCTION(intltz_get_tz_data_version);
 ZEND_FUNCTION(intltz_get_unknown);
 #if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_FUNCTION(intltz_get_windows_id);
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 ZEND_FUNCTION(intltz_get_id_for_windows_id);
 #endif
 ZEND_FUNCTION(intltz_has_same_rules);
@@ -163,8 +159,6 @@ static const zend_function_entry class_IntlTimeZone_methods[] = {
 	ZEND_RAW_FENTRY("getUnknown", zif_intltz_get_unknown, arginfo_class_IntlTimeZone_getUnknown, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, NULL)
 #if U_ICU_VERSION_MAJOR_NUM >= 52
 	ZEND_RAW_FENTRY("getWindowsID", zif_intltz_get_windows_id, arginfo_class_IntlTimeZone_getWindowsID, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, NULL)
-#endif
-#if U_ICU_VERSION_MAJOR_NUM >= 52
 	ZEND_RAW_FENTRY("getIDForWindowsID", zif_intltz_get_id_for_windows_id, arginfo_class_IntlTimeZone_getIDForWindowsID, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, NULL)
 #endif
 	ZEND_RAW_FENTRY("hasSameRules", zif_intltz_has_same_rules, arginfo_class_IntlTimeZone_hasSameRules, ZEND_ACC_PUBLIC, NULL, NULL)

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -206,9 +206,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_rename, 0, 5, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, delete_old_rdn, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAP\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
@@ -217,39 +215,29 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAP\
 	ZEND_ARG_TYPE_INFO(0, delete_old_rdn, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_option, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, value, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_set_option, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 1)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_references, 0, 2, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
@@ -299,9 +287,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_t61_to_8859, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(STR_TRANSLATION)
 #define arginfo_ldap_8859_to_t61 arginfo_ldap_t61_to_8859
 #endif
 
@@ -314,9 +300,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_exop, 0, 2, LDAP\\Resul
 	ZEND_ARG_INFO(1, response_data)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, response_oid, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_exop_sync, 0, 2, LDAP\\Result, MAY_BE_BOOL)
 	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, request_oid, IS_STRING, 0)
@@ -407,23 +391,11 @@ ZEND_FUNCTION(ldap_err2str);
 ZEND_FUNCTION(ldap_compare);
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_rename);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_rename_ext);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_get_option);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_set_option);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_count_references);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_first_reference);
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_FUNCTION(ldap_next_reference);
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_REFERENCE)
@@ -441,14 +413,10 @@ ZEND_FUNCTION(ldap_start_tls);
 ZEND_FUNCTION(ldap_escape);
 #if defined(STR_TRANSLATION)
 ZEND_FUNCTION(ldap_t61_to_8859);
-#endif
-#if defined(STR_TRANSLATION)
 ZEND_FUNCTION(ldap_8859_to_t61);
 #endif
 #if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 ZEND_FUNCTION(ldap_exop);
-#endif
-#if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 ZEND_FUNCTION(ldap_exop_sync);
 #endif
 #if defined(HAVE_LDAP_PASSWD)
@@ -515,23 +483,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(ldap_compare, arginfo_ldap_compare)
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_rename, arginfo_ldap_rename)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_rename_ext, arginfo_ldap_rename_ext)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_get_option, arginfo_ldap_get_option)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_set_option, arginfo_ldap_set_option)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_count_references, arginfo_ldap_count_references)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_first_reference, arginfo_ldap_first_reference)
-#endif
-#if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 	ZEND_FE(ldap_next_reference, arginfo_ldap_next_reference)
 #endif
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_REFERENCE)
@@ -549,14 +505,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(ldap_escape, arginfo_ldap_escape)
 #if defined(STR_TRANSLATION)
 	ZEND_FE(ldap_t61_to_8859, arginfo_ldap_t61_to_8859)
-#endif
-#if defined(STR_TRANSLATION)
 	ZEND_FE(ldap_8859_to_t61, arginfo_ldap_8859_to_t61)
 #endif
 #if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 	ZEND_FE(ldap_exop, arginfo_ldap_exop)
-#endif
-#if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 	ZEND_FE(ldap_exop_sync, arginfo_ldap_exop_sync)
 #endif
 #if defined(HAVE_LDAP_PASSWD)

--- a/ext/mbstring/mbstring_arginfo.h
+++ b/ext/mbstring/mbstring_arginfo.h
@@ -224,101 +224,71 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_regex_encoding, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, matches, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 #define arginfo_mb_eregi arginfo_mb_ereg
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_ereg_replace, 0, 3, MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, replacement, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 #define arginfo_mb_eregi_replace arginfo_mb_ereg_replace
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_ereg_replace_callback, 0, 3, MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_split, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg_match, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg_search, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_ereg_search_pos, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 #define arginfo_mb_ereg_search_regs arginfo_mb_ereg_search_pos
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg_search_init, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_ereg_search_getregs, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg_search_getpos, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_ereg_search_setpos, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_MBREGEX)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mb_regex_set_options, 0, 0, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
@@ -375,50 +345,20 @@ ZEND_FUNCTION(mb_chr);
 ZEND_FUNCTION(mb_str_pad);
 #if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_regex_encoding);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_eregi);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_replace);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_eregi_replace);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_replace_callback);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_split);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_match);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_pos);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_regs);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_init);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_getregs);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_getpos);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_ereg_search_setpos);
-#endif
-#if defined(HAVE_MBREGEX)
 ZEND_FUNCTION(mb_regex_set_options);
 #endif
 
@@ -474,50 +414,20 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mb_str_pad, arginfo_mb_str_pad)
 #if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_regex_encoding, arginfo_mb_regex_encoding)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg, arginfo_mb_ereg)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_eregi, arginfo_mb_eregi)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_replace, arginfo_mb_ereg_replace)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_eregi_replace, arginfo_mb_eregi_replace)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_replace_callback, arginfo_mb_ereg_replace_callback)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_split, arginfo_mb_split)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_match, arginfo_mb_ereg_match)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search, arginfo_mb_ereg_search)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_pos, arginfo_mb_ereg_search_pos)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_regs, arginfo_mb_ereg_search_regs)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_init, arginfo_mb_ereg_search_init)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_getregs, arginfo_mb_ereg_search_getregs)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_getpos, arginfo_mb_ereg_search_getpos)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_ereg_search_setpos, arginfo_mb_ereg_search_setpos)
-#endif
-#if defined(HAVE_MBREGEX)
 	ZEND_FE(mb_regex_set_options, arginfo_mb_regex_set_options)
 #endif
 	ZEND_FE_END

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -44,9 +44,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_fetch_object, 0, 1, std
 	ZEND_ARG_INFO(0, statement)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_fetch_array, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, statement)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
@@ -184,18 +182,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_procedurecolumns, 0, 1,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, procedure, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, column, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_procedures, 0, 1, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, catalog, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, schema, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, procedure, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_foreignkeys, 0, 7, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, pk_catalog, IS_STRING, 1)
@@ -233,9 +227,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_tableprivileges, 0, 4, 
 	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_odbc_columnprivileges, 0, 5, Odbc\\Result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, odbc, Odbc\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, catalog, IS_STRING, 1)
@@ -267,8 +259,6 @@ ZEND_FUNCTION(odbc_data_source);
 ZEND_FUNCTION(odbc_exec);
 #if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_FUNCTION(odbc_fetch_object);
-#endif
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 ZEND_FUNCTION(odbc_fetch_array);
 #endif
 ZEND_FUNCTION(odbc_fetch_into);
@@ -301,19 +291,13 @@ ZEND_FUNCTION(odbc_gettypeinfo);
 ZEND_FUNCTION(odbc_primarykeys);
 #if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_procedurecolumns);
-#endif
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_procedures);
-#endif
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_foreignkeys);
 #endif
 ZEND_FUNCTION(odbc_specialcolumns);
 ZEND_FUNCTION(odbc_statistics);
 #if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_tableprivileges);
-#endif
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 ZEND_FUNCTION(odbc_columnprivileges);
 #endif
 ZEND_FUNCTION(odbc_connection_string_is_quoted);
@@ -334,8 +318,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("odbc_do", zif_odbc_exec, arginfo_odbc_do, 0, NULL, NULL)
 #if defined(PHP_ODBC_HAVE_FETCH_HASH)
 	ZEND_FE(odbc_fetch_object, arginfo_odbc_fetch_object)
-#endif
-#if defined(PHP_ODBC_HAVE_FETCH_HASH)
 	ZEND_FE(odbc_fetch_array, arginfo_odbc_fetch_array)
 #endif
 	ZEND_FE(odbc_fetch_into, arginfo_odbc_fetch_into)
@@ -369,19 +351,13 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(odbc_primarykeys, arginfo_odbc_primarykeys)
 #if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_procedurecolumns, arginfo_odbc_procedurecolumns)
-#endif
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_procedures, arginfo_odbc_procedures)
-#endif
-#if !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) && !defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_foreignkeys, arginfo_odbc_foreignkeys)
 #endif
 	ZEND_FE(odbc_specialcolumns, arginfo_odbc_specialcolumns)
 	ZEND_FE(odbc_statistics, arginfo_odbc_statistics)
 #if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_tableprivileges, arginfo_odbc_tableprivileges)
-#endif
-#if !defined(HAVE_DBMAKER) && !defined(HAVE_SOLID) && !defined(HAVE_SOLID_30) &&!defined(HAVE_SOLID_35)
 	ZEND_FE(odbc_columnprivileges, arginfo_odbc_columnprivileges)
 #endif
 	ZEND_FE(odbc_connection_string_is_quoted, arginfo_odbc_connection_string_is_quoted)

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -394,9 +394,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_password_hash, 0, 2, IS_
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_OPENSSL_ARGON2)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_password_verify, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
@@ -469,8 +467,6 @@ ZEND_FUNCTION(openssl_spki_export_challenge);
 ZEND_FUNCTION(openssl_get_cert_locations);
 #if defined(HAVE_OPENSSL_ARGON2)
 ZEND_FUNCTION(openssl_password_hash);
-#endif
-#if defined(HAVE_OPENSSL_ARGON2)
 ZEND_FUNCTION(openssl_password_verify);
 #endif
 
@@ -543,8 +539,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(openssl_get_cert_locations, arginfo_openssl_get_cert_locations)
 #if defined(HAVE_OPENSSL_ARGON2)
 	ZEND_FE(openssl_password_hash, arginfo_openssl_password_hash)
-#endif
-#if defined(HAVE_OPENSSL_ARGON2)
 	ZEND_FE(openssl_password_verify, arginfo_openssl_password_verify)
 #endif
 	ZEND_FE_END
@@ -778,8 +772,6 @@ static void register_openssl_symbols(int module_number)
 #if defined(HAVE_OPENSSL_ARGON2)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_hash", sizeof("openssl_password_hash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(HAVE_OPENSSL_ARGON2)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_verify", sizeof("openssl_password_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -52,9 +52,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_sigwaitinfo, 0, 1, MAY_BE_
 	ZEND_ARG_TYPE_INFO(0, signals, IS_ARRAY, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, info, "[]")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_sigtimedwait, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, signals, IS_ARRAY, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, info, "[]")
@@ -152,9 +150,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pcntl_getcpuaffinity, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_SCHED_SETAFFINITY)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setcpuaffinity, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, process_id, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cpu_ids, IS_ARRAY, 0, "[]")
@@ -169,9 +165,7 @@ ZEND_END_ARG_INFO()
 #if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_pcntl_getqos_class, 0, 0, Pcntl\\QosClass, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pcntl_setqos_class, 0, 0, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, qos_class, Pcntl\\QosClass, 0, "Pcntl\\QosClass::Default")
 ZEND_END_ARG_INFO()
@@ -191,8 +185,6 @@ ZEND_FUNCTION(pcntl_sigprocmask);
 #endif
 #if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_FUNCTION(pcntl_sigwaitinfo);
-#endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 ZEND_FUNCTION(pcntl_sigtimedwait);
 #endif
 ZEND_FUNCTION(pcntl_wifexited);
@@ -229,8 +221,6 @@ ZEND_FUNCTION(pcntl_setns);
 #endif
 #if defined(HAVE_SCHED_SETAFFINITY)
 ZEND_FUNCTION(pcntl_getcpuaffinity);
-#endif
-#if defined(HAVE_SCHED_SETAFFINITY)
 ZEND_FUNCTION(pcntl_setcpuaffinity);
 #endif
 #if defined(HAVE_SCHED_GETCPU)
@@ -238,8 +228,6 @@ ZEND_FUNCTION(pcntl_getcpu);
 #endif
 #if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 ZEND_FUNCTION(pcntl_getqos_class);
-#endif
-#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 ZEND_FUNCTION(pcntl_setqos_class);
 #endif
 
@@ -258,8 +246,6 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 	ZEND_FE(pcntl_sigwaitinfo, arginfo_pcntl_sigwaitinfo)
-#endif
-#if defined(HAVE_STRUCT_SIGINFO_T) && (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
 	ZEND_FE(pcntl_sigtimedwait, arginfo_pcntl_sigtimedwait)
 #endif
 	ZEND_FE(pcntl_wifexited, arginfo_pcntl_wifexited)
@@ -297,8 +283,6 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_SCHED_SETAFFINITY)
 	ZEND_FE(pcntl_getcpuaffinity, arginfo_pcntl_getcpuaffinity)
-#endif
-#if defined(HAVE_SCHED_SETAFFINITY)
 	ZEND_FE(pcntl_setcpuaffinity, arginfo_pcntl_setcpuaffinity)
 #endif
 #if defined(HAVE_SCHED_GETCPU)
@@ -306,8 +290,6 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 	ZEND_FE(pcntl_getqos_class, arginfo_pcntl_getqos_class)
-#endif
-#if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
 	ZEND_FE(pcntl_setqos_class, arginfo_pcntl_setqos_class)
 #endif
 	ZEND_FE_END

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -37,19 +37,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_handler_instal
 	ZEND_ARG_TYPE_INFO(0, prompt, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_read_char, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_callback_handler_remove, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 #define arginfo_readline_redisplay arginfo_readline_callback_read_char
 #endif
 
@@ -70,14 +64,8 @@ ZEND_FUNCTION(readline_write_history);
 ZEND_FUNCTION(readline_completion_function);
 #if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_FUNCTION(readline_callback_handler_install);
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_FUNCTION(readline_callback_read_char);
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_FUNCTION(readline_callback_handler_remove);
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 ZEND_FUNCTION(readline_redisplay);
 #endif
 #if defined(HAVE_RL_CALLBACK_READ_CHAR) && defined(HAVE_RL_ON_NEW_LINE)
@@ -97,14 +85,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(readline_completion_function, arginfo_readline_completion_function)
 #if defined(HAVE_RL_CALLBACK_READ_CHAR)
 	ZEND_FE(readline_callback_handler_install, arginfo_readline_callback_handler_install)
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 	ZEND_FE(readline_callback_read_char, arginfo_readline_callback_read_char)
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 	ZEND_FE(readline_callback_handler_remove, arginfo_readline_callback_handler_remove)
-#endif
-#if defined(HAVE_RL_CALLBACK_READ_CHAR)
 	ZEND_FE(readline_redisplay, arginfo_readline_redisplay)
 #endif
 #if defined(HAVE_RL_CALLBACK_READ_CHAR) && defined(HAVE_RL_ON_NEW_LINE)

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -201,15 +201,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_wsaprotocol_info_export, 
 	ZEND_ARG_OBJ_INFO(0, socket, Socket, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_socket_wsaprotocol_info_import, 0, 1, Socket, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, info_id, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_socket_wsaprotocol_info_release, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, info_id, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -258,11 +254,7 @@ ZEND_FUNCTION(socket_addrinfo_bind);
 ZEND_FUNCTION(socket_addrinfo_explain);
 #if defined(PHP_WIN32)
 ZEND_FUNCTION(socket_wsaprotocol_info_export);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(socket_wsaprotocol_info_import);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(socket_wsaprotocol_info_release);
 #endif
 
@@ -312,11 +304,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(socket_addrinfo_explain, arginfo_socket_addrinfo_explain)
 #if defined(PHP_WIN32)
 	ZEND_FE(socket_wsaprotocol_info_export, arginfo_socket_wsaprotocol_info_export)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(socket_wsaprotocol_info_import, arginfo_socket_wsaprotocol_info_import)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(socket_wsaprotocol_info_release, arginfo_socket_wsaprotocol_info_release)
 #endif
 	ZEND_FE_END

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -11,18 +11,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_aes256gcm_dec
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_AESGCM)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aes256gcm_encrypt, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_AESGCM)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aes256gcm_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -34,18 +30,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_aegis128l_dec
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis128l_encrypt, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis128l_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -57,18 +49,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_aegis256_decr
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_aegis256_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis256_encrypt, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_aegis256_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis256_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -103,14 +91,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_xchacha20poly
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_xchacha20poly1305_ietf_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
@@ -180,61 +164,37 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_core_ristretto255_
 	ZEND_ARG_TYPE_INFO(0, p, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, q, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_core_ristretto255_from_hash, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, s, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_core_ristretto255_is_valid_point, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, s, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_core_ristretto255_random, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_core_ristretto255_scalar_add, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, x, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, y, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_complement arginfo_sodium_crypto_core_ristretto255_from_hash
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_invert arginfo_sodium_crypto_core_ristretto255_from_hash
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_mul arginfo_sodium_crypto_core_ristretto255_scalar_add
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_negate arginfo_sodium_crypto_core_ristretto255_from_hash
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_random arginfo_sodium_crypto_core_ristretto255_random
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_reduce arginfo_sodium_crypto_core_ristretto255_from_hash
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_scalar_sub arginfo_sodium_crypto_core_ristretto255_scalar_add
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 #define arginfo_sodium_crypto_core_ristretto255_sub arginfo_sodium_crypto_core_ristretto255_add
 #endif
 
@@ -297,17 +257,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash, 0, 5, IS_S
 	ZEND_ARG_TYPE_INFO(0, memlimit, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, algo, IS_LONG, 0, "SODIUM_CRYPTO_PWHASH_ALG_DEFAULT")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_pwhash_SALTBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash_str, 0, 3, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, opslimit, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, memlimit, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_pwhash_SALTBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash_str_verify, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, hash, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
@@ -330,17 +286,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash_scryptsalsa
 	ZEND_ARG_TYPE_INFO(0, opslimit, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, memlimit, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash_scryptsalsa208sha256_str, 0, 3, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, opslimit, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, memlimit, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_pwhash_scryptsalsa208sha256_str_verify, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, hash, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
@@ -357,9 +309,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_scalarmult_ristret
 	ZEND_ARG_TYPE_INFO(0, n, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, p, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_scalarmult_ristretto255_base, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, n, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -382,39 +332,29 @@ ZEND_END_ARG_INFO()
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_init_push, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_push, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(1, state, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, additional_data, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_MESSAGE")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_init_pull, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, header, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_pull, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, state, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ciphertext, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, additional_data, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_secretstream_xchacha20poly1305_rekey, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(1, state, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -476,22 +416,16 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_stream_xchacha20, 
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_stream_xchacha20_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_stream_xchacha20_xor, 0, 3, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_stream_xchacha20_xor_ic, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
@@ -539,9 +473,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_bin2base64, 0, 2, IS_STRI
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(sodium_base64_VARIANT_ORIGINAL)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_base642bin, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, id, IS_LONG, 0)
@@ -554,29 +486,17 @@ ZEND_END_ARG_INFO()
 ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_is_available);
 #if defined(HAVE_AESGCM)
 ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_decrypt);
-#endif
-#if defined(HAVE_AESGCM)
 ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt);
-#endif
-#if defined(HAVE_AESGCM)
 ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_keygen);
 #endif
 #if defined(crypto_aead_aegis128l_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis128l_decrypt);
-#endif
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis128l_encrypt);
-#endif
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis128l_keygen);
 #endif
 #if defined(crypto_aead_aegis256_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis256_decrypt);
-#endif
-#if defined(crypto_aead_aegis256_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis256_encrypt);
-#endif
-#if defined(crypto_aead_aegis256_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_aegis256_keygen);
 #endif
 ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt);
@@ -587,11 +507,7 @@ ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_encrypt);
 ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_keygen);
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt);
-#endif
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_keygen);
-#endif
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 ZEND_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt);
 #endif
 ZEND_FUNCTION(sodium_crypto_auth);
@@ -609,41 +525,17 @@ ZEND_FUNCTION(sodium_crypto_box_seal_open);
 ZEND_FUNCTION(sodium_crypto_box_secretkey);
 #if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_add);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_from_hash);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_is_valid_point);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_random);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_add);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_complement);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_invert);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_mul);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_negate);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_random);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_reduce);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_scalar_sub);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_core_ristretto255_sub);
 #endif
 ZEND_FUNCTION(sodium_crypto_kx_keypair);
@@ -661,11 +553,7 @@ ZEND_FUNCTION(sodium_crypto_kdf_derive_from_key);
 ZEND_FUNCTION(sodium_crypto_kdf_keygen);
 #if defined(crypto_pwhash_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash);
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash_str);
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash_str_verify);
 #endif
 #if SODIUM_LIBRARY_VERSION_MAJOR > 9 || (SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR >= 6)
@@ -673,18 +561,12 @@ ZEND_FUNCTION(sodium_crypto_pwhash_str_needs_rehash);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256);
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str);
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 ZEND_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify);
 #endif
 ZEND_FUNCTION(sodium_crypto_scalarmult);
 #if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_scalarmult_ristretto255);
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 ZEND_FUNCTION(sodium_crypto_scalarmult_ristretto255_base);
 #endif
 ZEND_FUNCTION(sodium_crypto_secretbox);
@@ -692,20 +574,10 @@ ZEND_FUNCTION(sodium_crypto_secretbox_keygen);
 ZEND_FUNCTION(sodium_crypto_secretbox_open);
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_keygen);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_init_push);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_push);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_init_pull);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_pull);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 ZEND_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_rekey);
 #endif
 ZEND_FUNCTION(sodium_crypto_shorthash);
@@ -727,14 +599,8 @@ ZEND_FUNCTION(sodium_crypto_stream_keygen);
 ZEND_FUNCTION(sodium_crypto_stream_xor);
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_stream_xchacha20);
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_stream_xchacha20_keygen);
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_stream_xchacha20_xor);
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 ZEND_FUNCTION(sodium_crypto_stream_xchacha20_xor_ic);
 #endif
 ZEND_FUNCTION(sodium_add);
@@ -748,8 +614,6 @@ ZEND_FUNCTION(sodium_bin2hex);
 ZEND_FUNCTION(sodium_hex2bin);
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 ZEND_FUNCTION(sodium_bin2base64);
-#endif
-#if defined(sodium_base64_VARIANT_ORIGINAL)
 ZEND_FUNCTION(sodium_base642bin);
 #endif
 
@@ -757,29 +621,17 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_aead_aes256gcm_is_available, arginfo_sodium_crypto_aead_aes256gcm_is_available)
 #if defined(HAVE_AESGCM)
 	ZEND_FE(sodium_crypto_aead_aes256gcm_decrypt, arginfo_sodium_crypto_aead_aes256gcm_decrypt)
-#endif
-#if defined(HAVE_AESGCM)
 	ZEND_FE(sodium_crypto_aead_aes256gcm_encrypt, arginfo_sodium_crypto_aead_aes256gcm_encrypt)
-#endif
-#if defined(HAVE_AESGCM)
 	ZEND_FE(sodium_crypto_aead_aes256gcm_keygen, arginfo_sodium_crypto_aead_aes256gcm_keygen)
 #endif
 #if defined(crypto_aead_aegis128l_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis128l_decrypt, arginfo_sodium_crypto_aead_aegis128l_decrypt)
-#endif
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis128l_encrypt, arginfo_sodium_crypto_aead_aegis128l_encrypt)
-#endif
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis128l_keygen, arginfo_sodium_crypto_aead_aegis128l_keygen)
 #endif
 #if defined(crypto_aead_aegis256_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis256_decrypt, arginfo_sodium_crypto_aead_aegis256_decrypt)
-#endif
-#if defined(crypto_aead_aegis256_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis256_encrypt, arginfo_sodium_crypto_aead_aegis256_encrypt)
-#endif
-#if defined(crypto_aead_aegis256_KEYBYTES)
 	ZEND_FE(sodium_crypto_aead_aegis256_keygen, arginfo_sodium_crypto_aead_aegis256_keygen)
 #endif
 	ZEND_FE(sodium_crypto_aead_chacha20poly1305_decrypt, arginfo_sodium_crypto_aead_chacha20poly1305_decrypt)
@@ -790,11 +642,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_aead_chacha20poly1305_ietf_keygen, arginfo_sodium_crypto_aead_chacha20poly1305_ietf_keygen)
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 	ZEND_FE(sodium_crypto_aead_xchacha20poly1305_ietf_decrypt, arginfo_sodium_crypto_aead_xchacha20poly1305_ietf_decrypt)
-#endif
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 	ZEND_FE(sodium_crypto_aead_xchacha20poly1305_ietf_keygen, arginfo_sodium_crypto_aead_xchacha20poly1305_ietf_keygen)
-#endif
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 	ZEND_FE(sodium_crypto_aead_xchacha20poly1305_ietf_encrypt, arginfo_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt)
 #endif
 	ZEND_FE(sodium_crypto_auth, arginfo_sodium_crypto_auth)
@@ -812,41 +660,17 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_box_secretkey, arginfo_sodium_crypto_box_secretkey)
 #if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_add, arginfo_sodium_crypto_core_ristretto255_add)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_from_hash, arginfo_sodium_crypto_core_ristretto255_from_hash)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_is_valid_point, arginfo_sodium_crypto_core_ristretto255_is_valid_point)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_random, arginfo_sodium_crypto_core_ristretto255_random)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_add, arginfo_sodium_crypto_core_ristretto255_scalar_add)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_complement, arginfo_sodium_crypto_core_ristretto255_scalar_complement)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_invert, arginfo_sodium_crypto_core_ristretto255_scalar_invert)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_mul, arginfo_sodium_crypto_core_ristretto255_scalar_mul)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_negate, arginfo_sodium_crypto_core_ristretto255_scalar_negate)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_random, arginfo_sodium_crypto_core_ristretto255_scalar_random)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_reduce, arginfo_sodium_crypto_core_ristretto255_scalar_reduce)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_scalar_sub, arginfo_sodium_crypto_core_ristretto255_scalar_sub)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_core_ristretto255_sub, arginfo_sodium_crypto_core_ristretto255_sub)
 #endif
 	ZEND_FE(sodium_crypto_kx_keypair, arginfo_sodium_crypto_kx_keypair)
@@ -864,11 +688,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_kdf_keygen, arginfo_sodium_crypto_kdf_keygen)
 #if defined(crypto_pwhash_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash, arginfo_sodium_crypto_pwhash)
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash_str, arginfo_sodium_crypto_pwhash_str)
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash_str_verify, arginfo_sodium_crypto_pwhash_str_verify)
 #endif
 #if SODIUM_LIBRARY_VERSION_MAJOR > 9 || (SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR >= 6)
@@ -876,18 +696,12 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash_scryptsalsa208sha256, arginfo_sodium_crypto_pwhash_scryptsalsa208sha256)
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash_scryptsalsa208sha256_str, arginfo_sodium_crypto_pwhash_scryptsalsa208sha256_str)
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 	ZEND_FE(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify, arginfo_sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 #endif
 	ZEND_FE(sodium_crypto_scalarmult, arginfo_sodium_crypto_scalarmult)
 #if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_scalarmult_ristretto255, arginfo_sodium_crypto_scalarmult_ristretto255)
-#endif
-#if defined(crypto_core_ristretto255_HASHBYTES)
 	ZEND_FE(sodium_crypto_scalarmult_ristretto255_base, arginfo_sodium_crypto_scalarmult_ristretto255_base)
 #endif
 	ZEND_FE(sodium_crypto_secretbox, arginfo_sodium_crypto_secretbox)
@@ -895,20 +709,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_secretbox_open, arginfo_sodium_crypto_secretbox_open)
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_keygen, arginfo_sodium_crypto_secretstream_xchacha20poly1305_keygen)
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_init_push, arginfo_sodium_crypto_secretstream_xchacha20poly1305_init_push)
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_push, arginfo_sodium_crypto_secretstream_xchacha20poly1305_push)
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_init_pull, arginfo_sodium_crypto_secretstream_xchacha20poly1305_init_pull)
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_pull, arginfo_sodium_crypto_secretstream_xchacha20poly1305_pull)
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 	ZEND_FE(sodium_crypto_secretstream_xchacha20poly1305_rekey, arginfo_sodium_crypto_secretstream_xchacha20poly1305_rekey)
 #endif
 	ZEND_FE(sodium_crypto_shorthash, arginfo_sodium_crypto_shorthash)
@@ -930,14 +734,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_crypto_stream_xor, arginfo_sodium_crypto_stream_xor)
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 	ZEND_FE(sodium_crypto_stream_xchacha20, arginfo_sodium_crypto_stream_xchacha20)
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 	ZEND_FE(sodium_crypto_stream_xchacha20_keygen, arginfo_sodium_crypto_stream_xchacha20_keygen)
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 	ZEND_FE(sodium_crypto_stream_xchacha20_xor, arginfo_sodium_crypto_stream_xchacha20_xor)
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 	ZEND_FE(sodium_crypto_stream_xchacha20_xor_ic, arginfo_sodium_crypto_stream_xchacha20_xor_ic)
 #endif
 	ZEND_FE(sodium_add, arginfo_sodium_add)
@@ -951,8 +749,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sodium_hex2bin, arginfo_sodium_hex2bin)
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 	ZEND_FE(sodium_bin2base64, arginfo_sodium_bin2base64)
-#endif
-#if defined(sodium_base64_VARIANT_ORIGINAL)
 	ZEND_FE(sodium_base642bin, arginfo_sodium_base642bin)
 #endif
 	ZEND_RAW_FENTRY("sodium_crypto_scalarmult_base", zif_sodium_crypto_box_publickey_from_secretkey, arginfo_sodium_crypto_scalarmult_base, 0, NULL, NULL)
@@ -1173,8 +969,6 @@ static void register_libsodium_symbols(int module_number)
 #if defined(HAVE_AESGCM)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_decrypt", sizeof("sodium_crypto_aead_aes256gcm_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(HAVE_AESGCM)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
@@ -1183,8 +977,6 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_aead_aegis128l_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_decrypt", sizeof("sodium_crypto_aead_aegis128l_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_aead_aegis128l_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", sizeof("sodium_crypto_aead_aegis128l_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
@@ -1193,8 +985,6 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_aead_aegis256_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_decrypt", sizeof("sodium_crypto_aead_aegis256_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_aead_aegis256_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", sizeof("sodium_crypto_aead_aegis256_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
@@ -1215,8 +1005,6 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
@@ -1265,24 +1053,16 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_pwhash_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash", sizeof("sodium_crypto_pwhash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str", sizeof("sodium_crypto_pwhash_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_pwhash_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str_verify", sizeof("sodium_crypto_pwhash_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str_verify", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
@@ -1295,12 +1075,8 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_push") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_push") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_pull", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_pull") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
@@ -1331,14 +1107,10 @@ static void register_libsodium_symbols(int module_number)
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20", sizeof("sodium_crypto_stream_xchacha20") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(crypto_stream_xchacha20_KEYBYTES)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
@@ -1365,8 +1137,6 @@ static void register_libsodium_symbols(int module_number)
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2base64", sizeof("sodium_bin2base64") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(sodium_base64_VARIANT_ORIGINAL)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_base642bin", sizeof("sodium_base642bin") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -155,9 +155,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_GlobIterator___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_GLOB)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_GlobIterator_count, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -326,8 +324,6 @@ ZEND_METHOD(RecursiveDirectoryIterator, getSubPath);
 ZEND_METHOD(RecursiveDirectoryIterator, getSubPathname);
 #if defined(HAVE_GLOB)
 ZEND_METHOD(GlobIterator, __construct);
-#endif
-#if defined(HAVE_GLOB)
 ZEND_METHOD(GlobIterator, count);
 #endif
 ZEND_METHOD(SplFileObject, __construct);

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -432,9 +432,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_time_nanosleep, 0, 2, MAY_BE_ARR
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, nanoseconds, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_NANOSLEEP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_time_sleep_until, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
@@ -646,13 +644,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dns_check_record, 0, 1, _IS_BOOL
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_STRING, 0, "\"MX\"")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 #define arginfo_checkdnsrr arginfo_dns_check_record
-#endif
 
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_dns_get_record, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "DNS_ANY")
@@ -660,17 +654,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_dns_get_record, 0, 1, MAY_BE_ARR
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, additional_records, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, raw, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dns_get_mx, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
 	ZEND_ARG_INFO(1, hosts)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, weights, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 #define arginfo_getmxrr arginfo_dns_get_mx
 #endif
 
@@ -720,14 +710,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openlog, 0, 3, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, facility, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_SYSLOG_H)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_closelog, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_SYSLOG_H)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_syslog, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_TYPE_INFO(0, priority, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
@@ -1428,9 +1414,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lchown, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, user, MAY_BE_STRING|MAY_BE_LONG, NULL)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_LCHOWN)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lchgrp, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, group, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -1587,22 +1571,16 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_readlink, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_linkinfo, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_symlink, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, link, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 #define arginfo_link arginfo_symlink
 #endif
 
@@ -1752,9 +1730,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_microtime, 0, 0, MAY_BE_STRING|MAY_BE_DOUBLE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, as_float, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_GETTIMEOFDAY)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_gettimeofday, 0, 0, MAY_BE_ARRAY|MAY_BE_DOUBLE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, as_float, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
@@ -1806,22 +1782,16 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_proc_open, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, env_vars, IS_ARRAY, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_proc_close, 0, 1, IS_LONG, 0)
 	ZEND_ARG_INFO(0, process)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_proc_terminate, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, process)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, signal, IS_LONG, 0, "15")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_proc_get_status, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_INFO(0, process)
 ZEND_END_ARG_INFO()
@@ -2024,9 +1994,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_set_timeout, 0, 2, _IS_BO
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if (defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32))
 #define arginfo_socket_set_timeout arginfo_stream_set_timeout
 #endif
 
@@ -2184,35 +2152,25 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_cp_set, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, codepage, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_cp_get, 0, 0, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, kind, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_cp_conv, 0, 3, IS_STRING, 1)
 	ZEND_ARG_TYPE_MASK(0, in_codepage, MAY_BE_LONG|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_MASK(0, out_codepage, MAY_BE_LONG|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO(0, subject, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_cp_is_utf8, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_set_ctrl_handler, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, handler, IS_CALLABLE, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, add, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_generate_ctrl_event, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, event, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pid, IS_LONG, 0, "0")
@@ -2443,8 +2401,6 @@ ZEND_FUNCTION(sleep);
 ZEND_FUNCTION(usleep);
 #if defined(HAVE_NANOSLEEP)
 ZEND_FUNCTION(time_nanosleep);
-#endif
-#if defined(HAVE_NANOSLEEP)
 ZEND_FUNCTION(time_sleep_until);
 #endif
 ZEND_FUNCTION(get_current_user);
@@ -2509,11 +2465,7 @@ ZEND_FUNCTION(gethostbyname);
 ZEND_FUNCTION(gethostbynamel);
 #if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_FUNCTION(dns_check_record);
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_FUNCTION(dns_get_record);
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 ZEND_FUNCTION(dns_get_mx);
 #endif
 #if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
@@ -2534,11 +2486,7 @@ ZEND_FUNCTION(sha1);
 ZEND_FUNCTION(sha1_file);
 #if defined(HAVE_SYSLOG_H)
 ZEND_FUNCTION(openlog);
-#endif
-#if defined(HAVE_SYSLOG_H)
 ZEND_FUNCTION(closelog);
-#endif
-#if defined(HAVE_SYSLOG_H)
 ZEND_FUNCTION(syslog);
 #endif
 ZEND_FUNCTION(inet_ntop);
@@ -2715,8 +2663,6 @@ ZEND_FUNCTION(chown);
 ZEND_FUNCTION(chgrp);
 #if defined(HAVE_LCHOWN)
 ZEND_FUNCTION(lchown);
-#endif
-#if defined(HAVE_LCHOWN)
 ZEND_FUNCTION(lchgrp);
 #endif
 ZEND_FUNCTION(chmod);
@@ -2756,14 +2702,8 @@ ZEND_FUNCTION(iptcparse);
 ZEND_FUNCTION(levenshtein);
 #if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_FUNCTION(readlink);
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_FUNCTION(linkinfo);
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_FUNCTION(symlink);
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 ZEND_FUNCTION(link);
 #endif
 ZEND_FUNCTION(mail);
@@ -2812,8 +2752,6 @@ ZEND_FUNCTION(fdiv);
 ZEND_FUNCTION(fpow);
 #if defined(HAVE_GETTIMEOFDAY)
 ZEND_FUNCTION(microtime);
-#endif
-#if defined(HAVE_GETTIMEOFDAY)
 ZEND_FUNCTION(gettimeofday);
 #endif
 #if defined(HAVE_GETRUSAGE)
@@ -2828,14 +2766,8 @@ ZEND_FUNCTION(password_verify);
 ZEND_FUNCTION(password_algos);
 #if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_FUNCTION(proc_open);
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_FUNCTION(proc_close);
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_FUNCTION(proc_terminate);
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 ZEND_FUNCTION(proc_get_status);
 #endif
 ZEND_FUNCTION(quoted_printable_decode);
@@ -2934,20 +2866,10 @@ ZEND_FUNCTION(memory_reset_peak_usage);
 ZEND_FUNCTION(version_compare);
 #if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_cp_set);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_cp_get);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_cp_conv);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_cp_is_utf8);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_set_ctrl_handler);
-#endif
-#if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_generate_ctrl_event);
 #endif
 
@@ -3073,8 +2995,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(usleep, arginfo_usleep)
 #if defined(HAVE_NANOSLEEP)
 	ZEND_FE(time_nanosleep, arginfo_time_nanosleep)
-#endif
-#if defined(HAVE_NANOSLEEP)
 	ZEND_FE(time_sleep_until, arginfo_time_sleep_until)
 #endif
 	ZEND_FE(get_current_user, arginfo_get_current_user)
@@ -3141,17 +3061,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(gethostbynamel, arginfo_gethostbynamel)
 #if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_FE(dns_check_record, arginfo_dns_check_record)
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_RAW_FENTRY("checkdnsrr", zif_dns_check_record, arginfo_checkdnsrr, 0, NULL, NULL)
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_FE(dns_get_record, arginfo_dns_get_record)
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_FE(dns_get_mx, arginfo_dns_get_mx)
-#endif
-#if (defined(PHP_WIN32) || defined(HAVE_DNS_SEARCH_FUNC))
 	ZEND_RAW_FENTRY("getmxrr", zif_dns_get_mx, arginfo_getmxrr, 0, NULL, NULL)
 #endif
 #if (defined(PHP_WIN32) || defined(HAVE_GETIFADDRS) || defined(__PASE__))
@@ -3172,11 +3084,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sha1_file, arginfo_sha1_file)
 #if defined(HAVE_SYSLOG_H)
 	ZEND_FE(openlog, arginfo_openlog)
-#endif
-#if defined(HAVE_SYSLOG_H)
 	ZEND_FE(closelog, arginfo_closelog)
-#endif
-#if defined(HAVE_SYSLOG_H)
 	ZEND_FE(syslog, arginfo_syslog)
 #endif
 	ZEND_FE(inet_ntop, arginfo_inet_ntop)
@@ -3358,8 +3266,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(chgrp, arginfo_chgrp)
 #if defined(HAVE_LCHOWN)
 	ZEND_FE(lchown, arginfo_lchown)
-#endif
-#if defined(HAVE_LCHOWN)
 	ZEND_FE(lchgrp, arginfo_lchgrp)
 #endif
 	ZEND_FE(chmod, arginfo_chmod)
@@ -3400,14 +3306,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(levenshtein, arginfo_levenshtein)
 #if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 	ZEND_FE(readlink, arginfo_readlink)
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 	ZEND_FE(linkinfo, arginfo_linkinfo)
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 	ZEND_FE(symlink, arginfo_symlink)
-#endif
-#if (defined(HAVE_SYMLINK) || defined(PHP_WIN32))
 	ZEND_FE(link, arginfo_link)
 #endif
 	ZEND_FE(mail, arginfo_mail)
@@ -3456,8 +3356,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("fpow", zif_fpow, arginfo_fpow, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 #if defined(HAVE_GETTIMEOFDAY)
 	ZEND_FE(microtime, arginfo_microtime)
-#endif
-#if defined(HAVE_GETTIMEOFDAY)
 	ZEND_FE(gettimeofday, arginfo_gettimeofday)
 #endif
 #if defined(HAVE_GETRUSAGE)
@@ -3472,14 +3370,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("password_algos", zif_password_algos, arginfo_password_algos, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 #if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	ZEND_FE(proc_open, arginfo_proc_open)
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	ZEND_FE(proc_close, arginfo_proc_close)
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	ZEND_FE(proc_terminate, arginfo_proc_terminate)
-#endif
-#if defined(PHP_CAN_SUPPORT_PROC_OPEN)
 	ZEND_FE(proc_get_status, arginfo_proc_get_status)
 #endif
 	ZEND_RAW_FENTRY("quoted_printable_decode", zif_quoted_printable_decode, arginfo_quoted_printable_decode, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
@@ -3532,8 +3424,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(stream_set_chunk_size, arginfo_stream_set_chunk_size)
 #if (defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32))
 	ZEND_FE(stream_set_timeout, arginfo_stream_set_timeout)
-#endif
-#if (defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32))
 	ZEND_RAW_FENTRY("socket_set_timeout", zif_stream_set_timeout, arginfo_socket_set_timeout, 0, NULL, NULL)
 #endif
 	ZEND_RAW_FENTRY("gettype", zif_gettype, arginfo_gettype, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
@@ -3588,20 +3478,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("version_compare", zif_version_compare, arginfo_version_compare, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 #if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_cp_set, arginfo_sapi_windows_cp_set)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_cp_get, arginfo_sapi_windows_cp_get)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_cp_conv, arginfo_sapi_windows_cp_conv)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_cp_is_utf8, arginfo_sapi_windows_cp_is_utf8)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_set_ctrl_handler, arginfo_sapi_windows_set_ctrl_handler)
-#endif
-#if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_generate_ctrl_event, arginfo_sapi_windows_generate_ctrl_event)
 #endif
 	ZEND_FE_END

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -117,9 +117,7 @@ ZEND_END_ARG_INFO()
 #if defined(ZEND_CHECK_STACK_LIMIT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_zend_call_stack_get, 0, 0, IS_ARRAY, 1)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(ZEND_CHECK_STACK_LIMIT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_zend_call_stack_use_all, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -281,8 +279,6 @@ static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity);
 static ZEND_FUNCTION(zend_test_zend_ini_str);
 #if defined(ZEND_CHECK_STACK_LIMIT)
 static ZEND_FUNCTION(zend_test_zend_call_stack_get);
-#endif
-#if defined(ZEND_CHECK_STACK_LIMIT)
 static ZEND_FUNCTION(zend_test_zend_call_stack_use_all);
 #endif
 static ZEND_FUNCTION(zend_test_is_string_marked_as_valid_utf8);
@@ -386,8 +382,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_test_zend_ini_str, arginfo_zend_test_zend_ini_str)
 #if defined(ZEND_CHECK_STACK_LIMIT)
 	ZEND_FE(zend_test_zend_call_stack_get, arginfo_zend_test_zend_call_stack_get)
-#endif
-#if defined(ZEND_CHECK_STACK_LIMIT)
 	ZEND_FE(zend_test_zend_call_stack_use_all, arginfo_zend_test_zend_call_stack_use_all)
 #endif
 	ZEND_FE(zend_test_is_string_marked_as_valid_utf8, arginfo_zend_test_is_string_marked_as_valid_utf8)

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -144,9 +144,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setMt
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_SET_MTIME)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setMtimeName, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, timestamp, IS_LONG, 0)
@@ -235,27 +233,21 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setEx
 	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setExternalAttributesIndex, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, opsys, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_getExternalAttributesName, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_INFO(1, opsys)
 	ZEND_ARG_INFO(1, attr)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_getExternalAttributesIndex, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_INFO(1, opsys)
@@ -282,9 +274,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setEn
 	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_ENCRYPTION)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_setEncryptionIndex, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
@@ -310,9 +300,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_isCompressionMe
 	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enc, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAVE_METHOD_SUPPORTED)
 #define arginfo_class_ZipArchive_isEncryptionMethodSupported arginfo_class_ZipArchive_isCompressionMethodSupported
 #endif
 
@@ -348,8 +336,6 @@ ZEND_METHOD(ZipArchive, setCommentIndex);
 ZEND_METHOD(ZipArchive, setCommentName);
 #if defined(HAVE_SET_MTIME)
 ZEND_METHOD(ZipArchive, setMtimeIndex);
-#endif
-#if defined(HAVE_SET_MTIME)
 ZEND_METHOD(ZipArchive, setMtimeName);
 #endif
 ZEND_METHOD(ZipArchive, getCommentIndex);
@@ -372,22 +358,14 @@ ZEND_METHOD(ZipArchive, getStreamName);
 ZEND_METHOD(ZipArchive, getStream);
 #if defined(ZIP_OPSYS_DEFAULT)
 ZEND_METHOD(ZipArchive, setExternalAttributesName);
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_METHOD(ZipArchive, setExternalAttributesIndex);
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_METHOD(ZipArchive, getExternalAttributesName);
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 ZEND_METHOD(ZipArchive, getExternalAttributesIndex);
 #endif
 ZEND_METHOD(ZipArchive, setCompressionName);
 ZEND_METHOD(ZipArchive, setCompressionIndex);
 #if defined(HAVE_ENCRYPTION)
 ZEND_METHOD(ZipArchive, setEncryptionName);
-#endif
-#if defined(HAVE_ENCRYPTION)
 ZEND_METHOD(ZipArchive, setEncryptionIndex);
 #endif
 #if defined(HAVE_PROGRESS_CALLBACK)
@@ -398,8 +376,6 @@ ZEND_METHOD(ZipArchive, registerCancelCallback);
 #endif
 #if defined(HAVE_METHOD_SUPPORTED)
 ZEND_METHOD(ZipArchive, isCompressionMethodSupported);
-#endif
-#if defined(HAVE_METHOD_SUPPORTED)
 ZEND_METHOD(ZipArchive, isEncryptionMethodSupported);
 #endif
 
@@ -440,8 +416,6 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_ME(ZipArchive, setCommentName, arginfo_class_ZipArchive_setCommentName, ZEND_ACC_PUBLIC)
 #if defined(HAVE_SET_MTIME)
 	ZEND_ME(ZipArchive, setMtimeIndex, arginfo_class_ZipArchive_setMtimeIndex, ZEND_ACC_PUBLIC)
-#endif
-#if defined(HAVE_SET_MTIME)
 	ZEND_ME(ZipArchive, setMtimeName, arginfo_class_ZipArchive_setMtimeName, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(ZipArchive, getCommentIndex, arginfo_class_ZipArchive_getCommentIndex, ZEND_ACC_PUBLIC)
@@ -464,22 +438,14 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_ME(ZipArchive, getStream, arginfo_class_ZipArchive_getStream, ZEND_ACC_PUBLIC)
 #if defined(ZIP_OPSYS_DEFAULT)
 	ZEND_ME(ZipArchive, setExternalAttributesName, arginfo_class_ZipArchive_setExternalAttributesName, ZEND_ACC_PUBLIC)
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 	ZEND_ME(ZipArchive, setExternalAttributesIndex, arginfo_class_ZipArchive_setExternalAttributesIndex, ZEND_ACC_PUBLIC)
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 	ZEND_ME(ZipArchive, getExternalAttributesName, arginfo_class_ZipArchive_getExternalAttributesName, ZEND_ACC_PUBLIC)
-#endif
-#if defined(ZIP_OPSYS_DEFAULT)
 	ZEND_ME(ZipArchive, getExternalAttributesIndex, arginfo_class_ZipArchive_getExternalAttributesIndex, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(ZipArchive, setCompressionName, arginfo_class_ZipArchive_setCompressionName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, setCompressionIndex, arginfo_class_ZipArchive_setCompressionIndex, ZEND_ACC_PUBLIC)
 #if defined(HAVE_ENCRYPTION)
 	ZEND_ME(ZipArchive, setEncryptionName, arginfo_class_ZipArchive_setEncryptionName, ZEND_ACC_PUBLIC)
-#endif
-#if defined(HAVE_ENCRYPTION)
 	ZEND_ME(ZipArchive, setEncryptionIndex, arginfo_class_ZipArchive_setEncryptionIndex, ZEND_ACC_PUBLIC)
 #endif
 #if defined(HAVE_PROGRESS_CALLBACK)
@@ -490,8 +456,6 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 #endif
 #if defined(HAVE_METHOD_SUPPORTED)
 	ZEND_ME(ZipArchive, isCompressionMethodSupported, arginfo_class_ZipArchive_isCompressionMethodSupported, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if defined(HAVE_METHOD_SUPPORTED)
 	ZEND_ME(ZipArchive, isEncryptionMethodSupported, arginfo_class_ZipArchive_isEncryptionMethodSupported, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 #endif
 	ZEND_FE_END
@@ -1407,8 +1371,6 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 #if defined(HAVE_ENCRYPTION)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionname", sizeof("setencryptionname") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
-#endif
-#if defined(HAVE_ENCRYPTION)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", sizeof("setencryptionindex") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif


### PR DESCRIPTION
When functions' or class methods' availability is based on some preprocessor condition, the generated arginfo header files wrap the declarations in the preprocessor `#if` conditional blocks, one per declaration, even if they are in the same conditional block based on comments in the stub file. Instead of having multiple conditional blocks one after the other with the same condition, combine them into a single conditional block.