### PR TITLE
Autotools: Mark always-shared extensions with ext_shared variable

### DIFF
--- a/ext/dl_test/config.m4
+++ b/ext/dl_test/config.m4
@@ -4,8 +4,11 @@ PHP_ARG_ENABLE([dl-test],
     [Enable dl_test extension])])
 
 if test "$PHP_DL_TEST" != "no"; then
+  dnl Always build as shared extension.
+  ext_shared=yes
+
   PHP_NEW_EXTENSION([dl_test],
     [dl_test.c],
-    [shared],,
+    [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 fi

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -26,7 +26,7 @@ PHP_ARG_WITH([capstone],
   [no])
 
 if test "$PHP_OPCACHE" != "no"; then
-  dnl Always build as shared extension
+  dnl Always build as shared extension.
   ext_shared=yes
 
   AS_VAR_IF([PHP_HUGE_CODE_PAGES], [yes],
@@ -339,7 +339,7 @@ int main(void) {
       ZendAccelerator.c
       $ZEND_JIT_SRC
     ]),
-    [shared],,
+    [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $JIT_CFLAGS],,
     [yes])
 


### PR DESCRIPTION
This makes future config.m4 files changes simpler in case of adding additional checks, macro calls etc. Or if these extensions configuration would change at some point.