### PR TITLE
Support --openssl-legacy-providers on Windows, too

### DIFF
--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -2,11 +2,16 @@
 
 ARG_WITH("openssl", "OpenSSL support", "no,shared");
 
+ARG_WITH("openssl-legacy-provider", "OPENSSL: Load legacy algorithm provider in addition to default provider", "no");
+
 if (PHP_OPENSSL != "no") {
 	var ret = SETUP_OPENSSL("openssl", PHP_OPENSSL);
 
 	if (ret >= 2) {
 		EXTENSION("openssl", "openssl.c xp_ssl.c");
 		AC_DEFINE("HAVE_OPENSSL_EXT", 1, "Define to 1 if the PHP extension 'openssl' is available.");
+		if (PHP_OPENSSL_LEGACY_PROVIDER != "no") {
+			AC_DEFINE("LOAD_OPENSSL_LEGACY_PROVIDER", 1, "Define to 1 to load the OpenSSL legacy algorithm provider in addition to the default provider.");
+		}
 	}
 }

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -456,7 +456,7 @@ can be built that way. \
 	var snapshot_build_exclusions = new Array(
 		'debug', 'lzf-better-compression', 'php-build', 'snapshot-template', 'zts',
 		'ipv6', 'fd-setsize', 'pgi', 'pgo', 'all-shared', 'config-profile', 'sanitizer',
-		'phpdbg-debug'
+		'phpdbg-debug', 'openssl-legacy-provider'
 	);
 	var force;
 


### PR DESCRIPTION
This is not necessarily useful for Windows (few use custom builds on that platform), but for feature parity with other platforms it seems reasonable to support it on Windows.

We make sure, though, that the feature is not enabled for snapshot builds by adding the option to the build exclusions.

---

cc @petk 