### PR TITLE
Fix / implement GH-15287: add a lazy fetch to Pdo\PgSql

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ PHP                                                                        NEWS
 
 - PDO_PGSQL:
   . Added Iterable support for PDO::pgsqlCopyFromArray. (KentarouTakeda)
+  . Implement GH-15387 Pdo\Pgsql::setAttribute(PDO::ATTR_PREFETCH, 0) or
+    Pdo\PgSql::prepare(…, [ PDO::ATTR_PREFETCH => 0 ]) make fetch() lazy
+    instead of storing the whole result set in memory (Guillaume Outters)
+    /!\ In this mode statements cannot be run parallely
 
 - Random:
   . Moves from /dev/urandom usage to arc4random_buf on Haiku. (David Carlier)

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -198,6 +198,7 @@ stmt_retry:
 					/* it worked */
 					S->is_prepared = 1;
 					PQclear(S->result);
+					S->result = NULL;
 					break;
 				default: {
 					char *sqlstate = pdo_pgsql_sqlstate(S->result);

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -99,18 +99,18 @@ static void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode)
 	if (S->stmt_name && S->is_prepared && (fin_mode & FIN_CLOSE)) {
 		PGresult *res;
 #ifndef HAVE_PQCLOSEPREPARED
-			// TODO (??) libpq does not support close statement protocol < postgres 17
-			// check if we can circumvent this.
-			char *q = NULL;
-			spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
-			res = PQexec(H->server, q);
-			efree(q);
+		// TODO (??) libpq does not support close statement protocol < postgres 17
+		// check if we can circumvent this.
+		char *q = NULL;
+		spprintf(&q, 0, "DEALLOCATE %s", S->stmt_name);
+		res = PQexec(H->server, q);
+		efree(q);
 #else
-			res = PQclosePrepared(H->server, S->stmt_name);
+		res = PQclosePrepared(H->server, S->stmt_name);
 #endif
-			if (res) {
-				PQclear(res);
-			}
+		if (res) {
+			PQclear(res);
+		}
 
 		S->is_prepared = false;
 		if (H->running_stmt == S) {
@@ -284,7 +284,7 @@ stmt_retry:
 					S->param_formats,
 					0);
 		} else {
-		S->result = PQexecPrepared(H->server, S->stmt_name,
+			S->result = PQexecPrepared(H->server, S->stmt_name,
 				stmt->bound_params ?
 					zend_hash_num_elements(stmt->bound_params) :
 					0,
@@ -304,7 +304,7 @@ stmt_retry:
 					S->param_formats,
 					0);
 		} else {
-		S->result = PQexecParams(H->server, ZSTR_VAL(S->query),
+			S->result = PQexecParams(H->server, ZSTR_VAL(S->query),
 				stmt->bound_params ? zend_hash_num_elements(stmt->bound_params) : 0,
 				S->param_types,
 				(const char**)S->param_values,
@@ -317,7 +317,7 @@ stmt_retry:
 		if (S->is_unbuffered) {
 			dispatch_result = PQsendQuery(H->server, ZSTR_VAL(stmt->active_query_string));
 		} else {
-		S->result = PQexec(H->server, ZSTR_VAL(stmt->active_query_string));
+			S->result = PQexec(H->server, ZSTR_VAL(stmt->active_query_string));
 		}
 	}
 

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -34,6 +34,8 @@ typedef struct {
 	char *errmsg;
 } pdo_pgsql_error_info;
 
+typedef struct pdo_pgsql_stmt pdo_pgsql_stmt;
+
 /* stuff we use in a pgsql database handle */
 typedef struct {
 	PGconn		*server;
@@ -49,13 +51,15 @@ typedef struct {
 	bool		disable_prepares;
 	HashTable       *lob_streams;
 	zend_fcall_info_cache *notice_callback;
+	bool		default_fetching_laziness;
+	pdo_pgsql_stmt  *running_stmt;
 } pdo_pgsql_db_handle;
 
 typedef struct {
 	Oid          pgsql_type;
 } pdo_pgsql_column;
 
-typedef struct {
+struct pdo_pgsql_stmt {
 	pdo_pgsql_db_handle     *H;
 	PGresult                *result;
 	pdo_pgsql_column        *cols;
@@ -68,7 +72,9 @@ typedef struct {
 	Oid *param_types;
 	int                     current_row;
 	bool is_prepared;
-} pdo_pgsql_stmt;
+	bool is_unbuffered;
+	bool is_running_unbuffered;
+};
 
 typedef struct {
 	Oid     oid;

--- a/ext/pdo_pgsql/tests/gh15287.phpt
+++ b/ext/pdo_pgsql/tests/gh15287.phpt
@@ -1,0 +1,183 @@
+--TEST--
+PDO PgSQL #15287 (Pdo\Pgsql has no real lazy fetch mode)
+--EXTENSIONS--
+pdo
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require  __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+
+require  __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+// We need a dataset of several KB so that memory gain is significant.
+// See https://www.postgresql.org/message-id/1140652.1687950987%40sss.pgh.pa.us
+$pdo->exec("create temp table t (n int, t text)");
+$pdo->exec("insert into t values (0, 'original')");
+for ($i = -1; ++$i < 8;) {
+	$pdo->exec("insert into t select n + 1, 'non '||t from t");
+}
+
+$reqOf3 = 'select 79 n union all select 80 union all select 81';
+$reqOfBig = 'select * from t';
+
+function display($res)
+{
+	echo implode("\n", array_map(fn($row) => implode("\t", $row), $res))."\n";
+}
+
+echo "=== non regression ===\n";
+
+// libpq explicitely requires single-row-mode statements to run one at a time (one stmt must
+// be fully read, or aborted, before another one can be launched).
+// Ensure that integration does not break the ability of the traditional, prefetched mode,
+// to mix fetching of multiple statements' result.
+$stmt1 = $pdo->query($reqOf3);
+$stmt2 = $pdo->query("select * from ($reqOf3) t order by n desc");
+for ($i = -1; ++$i < 3;) {
+	display([ $stmt1->fetch() ]);
+	display([ $stmt2->fetch() ]);
+}
+
+echo "=== mem test ===\n";
+
+// First execute without lazy fetching, as a reference and non-regression;
+// execute twice: in case warmup reduces memory consumption, we want the stabilized consumption.
+for ($i = -1; ++$i < 5;) {
+	$attrs = [];
+	$lazy = false;
+	switch ($i) {
+		case 0:
+		case 3:
+			echo "Without lazy fetching:\n";
+			break;
+		case 2:
+			echo "With statement-scoped lazy fetching:\n";
+			$attrs = [ PDO::ATTR_PREFETCH => 0 ];
+			$lazy = true;
+			break;
+		case 4:
+			echo "With connection-scoped lazy fetching:\n";
+			$pdo->setAttribute(PDO::ATTR_PREFETCH, 0);
+			$lazy = true;
+			break;
+	}
+	$stmt = $pdo->prepare($reqOfBig, $attrs);
+	$stmt->execute();
+	$res = [];
+	// No fetchAll because we want the memory of the result of the FORElast call (the last one is empty).
+	while (($re = $stmt->fetch())) {
+		$res[] = $re;
+		// Memory introspection relies on an optionally-compiled constant.
+		if (defined('PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE')) {
+			$mem = $stmt->getAttribute(PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE);
+		} else {
+			// If not there emulate a return value which validates our test.
+			$mem = $lazy ? 0 : 1;
+		}
+	}
+	echo "ResultSet is $mem bytes long\n";
+	if ($i >= 2) {
+		echo "ResultSet is " . ($mem > $mem0 ? "longer" : ($mem == $mem0 ? "not shorter" : ($mem <= $mem0 / 2 ? "more than twice shorter" : "a bit shorter"))) . " than without lazy fetching\n";
+	} else {
+		$mem0 = $mem;
+	}
+}
+
+$pdo->setAttribute(PDO::ATTR_PREFETCH, 0);
+
+foreach ([
+	[ 'query', 'fetch' ],
+	[ 'query', 'fetchAll' ],
+	[ 'prepare', 'fetch' ],
+	[ 'prepare', 'fetchAll' ],
+] as $mode) {
+	echo "=== with " . implode(' / ', $mode). " ===\n";
+	switch ($mode[0]) {
+		case 'query':
+			$stmt = $pdo->query($reqOf3);
+			break;
+		case 'prepare':
+			$stmt = $pdo->prepare($reqOf3);
+			$stmt->execute();
+			break;
+	}
+	switch ($mode[1]) {
+		case 'fetch':
+			$res = [];
+			while (($re = $stmt->fetch())) {
+				$res[] = $re;
+			}
+			break;
+		case 'fetchAll':
+			$res = $stmt->fetchAll();
+			break;
+	}
+	display($res);
+}
+echo "DML works too:\n";
+$pdo->exec("create temp table t2 as select 678 n, 'ok' status");
+echo "multiple calls to the same prepared statement, some interrupted before having read all results:\n";
+$stmt = $pdo->prepare("select :1 n union all select :1 + 1 union all select :1 + 2 union all select :1 + 3");
+$stmt->execute([ 32 ]);
+$res = []; for ($i = -1; ++$i < 2;) $res[] = $stmt->fetch(); display($res);
+$stmt->execute([ 15 ]);
+$res = []; while (($re = $stmt->fetch())) $res[] = $re; display($res);
+$stmt->execute([ 0 ]);
+$res = []; for ($i = -1; ++$i < 2;) $res[] = $stmt->fetch(); display($res);
+display($pdo->query("select * from t2")->fetchAll());
+?>
+--EXPECTF--
+=== non regression ===
+79
+81
+80
+80
+81
+79
+=== mem test ===
+Without lazy fetching:
+ResultSet is %d bytes long
+ResultSet is %d bytes long
+With statement-scoped lazy fetching:
+ResultSet is %d bytes long
+ResultSet is more than twice shorter than without lazy fetching
+Without lazy fetching:
+ResultSet is %d bytes long
+ResultSet is not shorter than without lazy fetching
+With connection-scoped lazy fetching:
+ResultSet is %d bytes long
+ResultSet is more than twice shorter than without lazy fetching
+=== with query / fetch ===
+79
+80
+81
+=== with query / fetchAll ===
+79
+80
+81
+=== with prepare / fetch ===
+79
+80
+81
+=== with prepare / fetchAll ===
+79
+80
+81
+DML works too:
+multiple calls to the same prepared statement, some interrupted before having read all results:
+32
+33
+15
+16
+17
+18
+0
+1
+678	ok


### PR DESCRIPTION
Make `Pdo\PgSql` accept `Pdo::setAttribute(PDO::ATTR_PREFETCH, 0)` to enter libpq's [single row mode](https://www.postgresql.org/docs/current/libpq-single-row-mode.html).
This avoids storing the whole result set in memory before being able to call the first `fetch()`.