### PR TITLE
Fix GH-15752: `finfo_file()` - parameter validation error messages

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -373,12 +373,14 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 			php_stream_wrapper *wrap;
 			php_stream_statbuf ssb;
 
+			// Implementation is used for both finfo_file() and mimetype_emu()
+			int buffer_param_num = (mimetype_emu ? 1 : 2);
 			if (buffer == NULL || buffer_len == 0) {
-				zend_argument_value_error(1, "cannot be empty");
+				zend_argument_value_error(buffer_param_num, "cannot be empty");
 				goto clean;
 			}
 			if (CHECK_NULL_PATH(buffer, buffer_len)) {
-				zend_argument_type_error(1, "must not contain any null bytes");
+				zend_argument_type_error(buffer_param_num, "must not contain any null bytes");
 				goto clean;
 			}
 

--- a/ext/fileinfo/tests/finfo_file_001.phpt
+++ b/ext/fileinfo/tests/finfo_file_001.phpt
@@ -21,8 +21,8 @@ var_dump(finfo_file($fp, '&'));
 
 ?>
 --EXPECTF--
-finfo_file(): Argument #1 ($finfo) must not contain any null bytes
-finfo_file(): Argument #1 ($finfo) cannot be empty
+finfo_file(): Argument #2 ($filename) must not contain any null bytes
+finfo_file(): Argument #2 ($filename) cannot be empty
 string(9) "directory"
 
 Warning: finfo_file(&): Failed to open stream: No such file or directory in %s on line %d

--- a/ext/fileinfo/tests/finfo_file_basic.phpt
+++ b/ext/fileinfo/tests/finfo_file_basic.phpt
@@ -25,4 +25,4 @@ try {
 string(28) "text/x-php; charset=us-ascii"
 string(22) "PHP script, ASCII text"
 string(28) "text/plain; charset=us-ascii"
-finfo_file(): Argument #1 ($finfo) must not contain any null bytes
+finfo_file(): Argument #2 ($filename) must not contain any null bytes


### PR DESCRIPTION
Show the correct parameter names and numbers - the errors are caused by the
second parameter being empty or having null bytes, not the first.