### PR TITLE
Zend/tests/return_types/never_generator.phpt: fix test name

### DIFF
--- a/Zend/tests/return_types/never_generator.phpt
+++ b/Zend/tests/return_types/never_generator.phpt
@@ -1,5 +1,5 @@
 --TEST--
-never return type: not valid as a parameter type
+never return type: not valid for a generator
 --FILE--
 <?php
 


### PR DESCRIPTION
The test is unrelated to parameter types, likely left over from a copy-paste with never_parameter.phpt