### PR TITLE
Add `ReflectionProperty::isDynamic()` as an alternative to `isDefault()`

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -431,6 +431,7 @@ PHP 8.4 UPGRADE NOTES
     - ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE
     - ReflectionClass::SKIP_DESTRUCTOR
     RFC: https://wiki.php.net/rfc/lazy-objects
+  . ReflectionProperty::isDynamic() was introduced.
 
 - SOAP:
   . Added support for clark notation for namespaces in class map.

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5921,8 +5921,7 @@ ZEND_METHOD(ReflectionProperty, isVirtual)
 	_property_check_flag(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_VIRTUAL);
 }
 
-/* {{{ Returns whether this property is default (declared at compilation time). */
-ZEND_METHOD(ReflectionProperty, isDefault)
+static void _property_check_dynamic(INTERNAL_FUNCTION_PARAMETERS, bool dynamicTrue) /* {{{ */
 {
 	reflection_object *intern;
 	property_reference *ref;
@@ -5931,7 +5930,21 @@ ZEND_METHOD(ReflectionProperty, isDefault)
 		RETURN_THROWS();
 	}
 	GET_REFLECTION_OBJECT_PTR(ref);
-	RETURN_BOOL(ref->prop != NULL);
+	bool isDynamic = ref->prop == NULL;
+	RETURN_BOOL(dynamicTrue ? isDynamic : !isDynamic);
+}
+
+/* {{{ Returns whether this property is default (declared at compilation time). */
+ZEND_METHOD(ReflectionProperty, isDefault)
+{
+	_property_check_dynamic(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+}
+/* }}} */
+
+/* {{{ Returns whether this property is dynamic (not declared at compilation time). */
+ZEND_METHOD(ReflectionProperty, isDynamic)
+{
+	_property_check_dynamic(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
 }
 /* }}} */
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5921,7 +5921,7 @@ ZEND_METHOD(ReflectionProperty, isVirtual)
 	_property_check_flag(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_ACC_VIRTUAL);
 }
 
-static void _property_check_dynamic(INTERNAL_FUNCTION_PARAMETERS, bool dynamicTrue) /* {{{ */
+static void _property_check_dynamic(INTERNAL_FUNCTION_PARAMETERS, bool dynamic_true)
 {
 	reflection_object *intern;
 	property_reference *ref;
@@ -5930,8 +5930,8 @@ static void _property_check_dynamic(INTERNAL_FUNCTION_PARAMETERS, bool dynamicTr
 		RETURN_THROWS();
 	}
 	GET_REFLECTION_OBJECT_PTR(ref);
-	bool isDynamic = ref->prop == NULL;
-	RETURN_BOOL(dynamicTrue ? isDynamic : !isDynamic);
+	bool is_dynamic = ref->prop == NULL;
+	RETURN_BOOL(dynamic_true ? is_dynamic : !is_dynamic);
 }
 
 /* {{{ Returns whether this property is default (declared at compilation time). */

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -522,6 +522,8 @@ class ReflectionProperty implements Reflector
     /** @tentative-return-type */
     public function isDefault(): bool {}
 
+    public function isDynamic(): bool {}
+
     public function isAbstract(): bool {}
 
     public function isVirtual(): bool {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 09e21577c53d8b53e30aa30e3208d3807ecd8852 */
+ * Stub hash: 8faf835d31acf3ae3e12a0dfca56f0744b95831b */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -418,6 +418,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionProperty_isReadOnly arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionProperty_isDefault arginfo_class_ReflectionFunctionAbstract_inNamespace
+
+#define arginfo_class_ReflectionProperty_isDynamic arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionProperty_isAbstract arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
@@ -842,6 +844,7 @@ ZEND_METHOD(ReflectionProperty, isProtectedSet);
 ZEND_METHOD(ReflectionProperty, isStatic);
 ZEND_METHOD(ReflectionProperty, isReadOnly);
 ZEND_METHOD(ReflectionProperty, isDefault);
+ZEND_METHOD(ReflectionProperty, isDynamic);
 ZEND_METHOD(ReflectionProperty, isAbstract);
 ZEND_METHOD(ReflectionProperty, isVirtual);
 ZEND_METHOD(ReflectionProperty, isPromoted);
@@ -1135,6 +1138,7 @@ static const zend_function_entry class_ReflectionProperty_methods[] = {
 	ZEND_ME(ReflectionProperty, isStatic, arginfo_class_ReflectionProperty_isStatic, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isReadOnly, arginfo_class_ReflectionProperty_isReadOnly, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isDefault, arginfo_class_ReflectionProperty_isDefault, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, isDynamic, arginfo_class_ReflectionProperty_isDynamic, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isAbstract, arginfo_class_ReflectionProperty_isAbstract, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isVirtual, arginfo_class_ReflectionProperty_isVirtual, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isPromoted, arginfo_class_ReflectionProperty_isPromoted, ZEND_ACC_PUBLIC)

--- a/ext/reflection/tests/ReflectionProperty_isDynamic_basic.phpt
+++ b/ext/reflection/tests/ReflectionProperty_isDynamic_basic.phpt
@@ -1,7 +1,5 @@
 --TEST--
-Test usage of ReflectionProperty methods isDefault(), isDynamic(), getModifiers(), getDeclaringClass() and getDocComment().
---INI--
-opcache.save_comments=1
+Test ReflectionProperty::isDynamic() usage.
 --FILE--
 <?php
 
@@ -10,16 +8,8 @@ function reflectProperty($classOrObj, $property, $className = null) {
     $propInfo = new ReflectionProperty($classOrObj, $property);
     echo "**********************************\n";
     echo "Reflecting on property $className::$property\n\n";
-    echo "isDefault():\n";
-    var_dump($propInfo->isDefault());
     echo "isDynamic():\n";
     var_dump($propInfo->isDynamic());
-    echo "getModifiers():\n";
-    var_dump($propInfo->getModifiers());
-    echo "getDeclaringClass():\n";
-    var_dump($propInfo->getDeclaringClass());
-    echo "getDocComment():\n";
-    var_dump($propInfo->getDocComment());
     echo "\n**********************************\n";
 }
 
@@ -27,9 +17,6 @@ function reflectProperty($classOrObj, $property, $className = null) {
 class TestClass {
     public $pub;
     static public $stat = "static property";
-    /**
-     * This property has a comment.
-     */
     protected $prot = 4;
     private $priv = "keepOut";
 }
@@ -44,96 +31,39 @@ $obj->dyn = 'dynamic';
 reflectProperty($obj, "dyn", "TestClass");
 
 ?>
---EXPECTF--
+--EXPECT--
 **********************************
 Reflecting on property TestClass::pub
 
-isDefault():
-bool(true)
 isDynamic():
-bool(false)
-getModifiers():
-int(1)
-getDeclaringClass():
-object(ReflectionClass)#%d (1) {
-  ["name"]=>
-  string(9) "TestClass"
-}
-getDocComment():
 bool(false)
 
 **********************************
 **********************************
 Reflecting on property TestClass::stat
 
-isDefault():
-bool(true)
 isDynamic():
-bool(false)
-getModifiers():
-int(17)
-getDeclaringClass():
-object(ReflectionClass)#%d (1) {
-  ["name"]=>
-  string(9) "TestClass"
-}
-getDocComment():
 bool(false)
 
 **********************************
 **********************************
 Reflecting on property TestClass::prot
 
-isDefault():
-bool(true)
 isDynamic():
 bool(false)
-getModifiers():
-int(2)
-getDeclaringClass():
-object(ReflectionClass)#%d (1) {
-  ["name"]=>
-  string(9) "TestClass"
-}
-getDocComment():
-string(%d) "/**
-     * This property has a comment.
-     */"
 
 **********************************
 **********************************
 Reflecting on property TestClass::priv
 
-isDefault():
-bool(true)
 isDynamic():
-bool(false)
-getModifiers():
-int(4)
-getDeclaringClass():
-object(ReflectionClass)#%d (1) {
-  ["name"]=>
-  string(9) "TestClass"
-}
-getDocComment():
 bool(false)
 
 **********************************
 **********************************
 Reflecting on property TestClass::dyn
 
-isDefault():
-bool(false)
 isDynamic():
 bool(true)
-getModifiers():
-int(1)
-getDeclaringClass():
-object(ReflectionClass)#%d (1) {
-  ["name"]=>
-  string(9) "TestClass"
-}
-getDocComment():
-bool(false)
 
 **********************************


### PR DESCRIPTION
Dynamic properties are generally referred to as "dynamic" properties, while non-dynamic properties are not commonly referred to as "default" properties. Thus, the existing method `ReflectionProperty::isDefault()` has a non obvious name; while an alias could be added for `isNotDynamic()`, a new `isDynamic()` method seems cleaner. The new method returns the opposite of `isDefault()`; dynamic properties are not present on the class by default, and properties present by default are not added dynamically.

Closes GH-15754