### PR TITLE
main: fix msan

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -469,7 +469,7 @@ int php_init_config(void)
 		 */
 
 		search_path_size = MAXPATHLEN * 4 + (int)strlen(env_location) + 3 + 1;
-		php_ini_search_path = (char *) emalloc(search_path_size);
+		php_ini_search_path = (char *) ecalloc(1, search_path_size);
 		free_ini_search_path = 1;
 		php_ini_search_path[0] = 0;
 


### PR DESCRIPTION
The code is using `estrdup` on uninitialized memory allocated by `emalloc`. While this likely doesn't cause harm, it triggers a warning from MemorySanitizer on clang  >= 18.

(I still have a lot of things I don't understand about this field. Please let me know if I'm mistaken.)

```
 ./sapi/cli/php -v
Uninitialized bytes in __interceptor_strlen at offset 1 inside [0xe29000000000, 33)
==16649==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xaaaad8a67124 in _estrdup /php-src/Zend/zend_alloc.c:2678:11
    #1 0xaaaad87809e4 in php_fopen_with_path /php-src/main/fopen_wrappers.c:688:13
    #2 0xaaaad878c330 in php_init_config /php-src/main/php_ini.c:587:9
    #3 0xaaaad8738098 in php_module_startup /php-src/main/main.c:2229:6
    #4 0xaaaad9c18c98 in php_cli_startup /php-src/sapi/cli/php_cli.c:410:9
    #5 0xaaaad9c10e5c in main /php-src/sapi/cli/php_cli.c:1300:6
    #6 0xffff95d22298  (/lib/aarch64-linux-gnu/libc.so.6+0x22298) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #7 0xffff95d2236c in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x2236c) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #8 0xaaaad68591ec in _start (/php-src/sapi/cli/php+0x1091ec) (BuildId: 2f336b1641ebcbb92eeab39fdd34febcbdc7a760)

  Uninitialized value was created by a heap allocation
    #0 0xaaaad688d5ac in malloc (/php-src/sapi/cli/php+0x13d5ac) (BuildId: 2f336b1641ebcbb92eeab39fdd34febcbdc7a760)
    #1 0xaaaad8a51f1c in tracked_malloc /php-src/Zend/zend_alloc.c:2832:14
    #2 0xaaaad8a62aa0 in _malloc_custom /php-src/Zend/zend_alloc.c:2477:10
    #3 0xaaaad8a622f8 in _emalloc /php-src/Zend/zend_alloc.c:2596:10
    #4 0xaaaad878af24 in php_init_config /php-src/main/php_ini.c:472:34
    #5 0xaaaad8738098 in php_module_startup /php-src/main/main.c:2229:6
    #6 0xaaaad9c18c98 in php_cli_startup /php-src/sapi/cli/php_cli.c:410:9
    #7 0xaaaad9c10e5c in main /php-src/sapi/cli/php_cli.c:1300:6
    #8 0xffff95d22298  (/lib/aarch64-linux-gnu/libc.so.6+0x22298) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #9 0xffff95d2236c in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x2236c) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #10 0xaaaad68591ec in _start (/php-src/sapi/cli/php+0x1091ec) (BuildId: 2f336b1641ebcbb92eeab39fdd34febcbdc7a760)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /php-src/Zend/zend_alloc.c:2678:11 in _estrdup
Exiting
```