### PR TITLE
zend: fix msan

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -183,7 +183,7 @@ static bool zend_call_stack_get_linux_proc_maps(zend_call_stack *stack)
 	FILE *f;
 	char buffer[4096];
 	uintptr_t addr_on_stack = (uintptr_t) zend_call_stack_position();
-	uintptr_t start, end, prev_end = 0;
+	uintptr_t start = 0, end = 0, prev_end = 0;
 	size_t max_size;
 	bool found = false;
 	struct rlimit rlim;


### PR DESCRIPTION
The code in the master branch triggers warnings with Clang's MemorySanitizer (version 18 or newer).
There are instances where uninitialized values are being compared in if statements.

```
]# php -v
==114==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xaaaac6ceafc0 in zend_call_stack_get_linux_proc_maps /php-src/Zend/zend_call_stack.c:227:30
    #1 0xaaaac6cea5a4 in zend_call_stack_get_linux /php-src/Zend/zend_call_stack.c:268:10
    #2 0xaaaac6ce9b28 in zend_call_stack_get /php-src/Zend/zend_call_stack.c:796:6
    #3 0xaaaac6ce91d0 in zend_call_stack_init /php-src/Zend/zend_call_stack.c:84:7
    #4 0xaaaac7ac845c in zend_post_startup /php-src/Zend/zend.c:1135:2
    #5 0xaaaac64f3904 in php_module_startup /php-src/main/main.c:2324:6
    #6 0xaaaac7aece04 in php_cli_startup /php-src/sapi/cli/php_cli.c:397:9
    #7 0xaaaac7ae502c in main /php-src/sapi/cli/php_cli.c:1276:6
    #8 0xffffa32e2298  (/lib/aarch64-linux-gnu/libc.so.6+0x22298) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #9 0xffffa32e236c in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x2236c) (BuildId: 59a6cf3f027666659833681bc2039e9781f3c188)
    #10 0xaaaac3eb8d2c in _start (/usr/local/bin/php+0x138d2c) (BuildId: 91d91469db462fc0d04b60823916bcb08195ccf3)

  Uninitialized value was created by an allocation of 'start' in the stack frame
    #0 0xaaaac6ceac0c in zend_call_stack_get_linux_proc_maps /php-src/Zend/zend_call_stack.c:186:2

SUMMARY: MemorySanitizer: use-of-uninitialized-value /php-src/Zend/zend_call_stack.c:227:30 in zend_call_stack_get_linux_proc_maps
Exiting
```