### PR TITLE
test: add SKIP_DOCKER env in tests

### DIFF
--- a/sapi/cli/tests/php_cli_server_pdeathsig.phpt
+++ b/sapi/cli/tests/php_cli_server_pdeathsig.phpt
@@ -8,7 +8,7 @@ include "skipif.inc";
 if (!(str_contains(PHP_OS, 'Linux') || str_contains(PHP_OS, 'FreeBSD'))) {
     die('skip PDEATHSIG is only supported on Linux and FreeBSD');
 }
-if (@file_exists('/.dockerenv')) die("skip Broken in Docker");
+if (getenv('SKIP_DOCKER') || @file_exists('/.dockerenv')) die("skip Broken in Docker");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Docker environment detection can also be can be environment variables.