### PR TITLE
zend_compile.h: `ZEND_ACC_FINAL` can be used for constants

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -226,7 +226,7 @@ typedef struct _zend_oparray_context {
 #define ZEND_ACC_STATIC                  (1 <<  4) /*     |  X  |  X  |     */
 /*                                                        |     |     |     */
 /* Final class or method                                  |     |     |     */
-#define ZEND_ACC_FINAL                   (1 <<  5) /*  X  |  X  |  X  |     */
+#define ZEND_ACC_FINAL                   (1 <<  5) /*  X  |  X  |  X  |  X  */
 /*                                                        |     |     |     */
 /* Abstract method                                        |     |     |     */
 #define ZEND_ACC_ABSTRACT                (1 <<  6) /*  X  |  X  |  X  |     */


### PR DESCRIPTION
There was a whole RFC about this, but the implementation in #6878 seems to have missed updating the documentation