### PR TITLE
Autotools: Sync CS for PHP_RUNPATH_SWITCH

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -298,33 +298,29 @@ dnl
 dnl Checks for -R, etc. switch.
 dnl
 AC_DEFUN([PHP_RUNPATH_SWITCH],[
-AC_MSG_CHECKING([if compiler supports -Wl,-rpath,])
-AC_CACHE_VAL(php_cv_cc_rpath,[
+AC_CACHE_CHECK([if compiler supports -Wl,-rpath,], [php_cv_cc_rpath], [
   SAVE_LIBS=$LIBS
   LIBS="-Wl,-rpath,/usr/$PHP_LIBDIR $LIBS"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],[php_cv_cc_rpath=yes],[php_cv_cc_rpath=no])
-  LIBS=$SAVE_LIBS])
-AC_MSG_RESULT([$php_cv_cc_rpath])
-if test $php_cv_cc_rpath = "yes"; then
-  ld_runpath_switch=-Wl,-rpath,
-else
-  AC_MSG_CHECKING([if compiler supports -R])
-  AC_CACHE_VAL(php_cv_cc_dashr,[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+    [php_cv_cc_rpath=yes],
+    [php_cv_cc_rpath=no])
+  LIBS=$SAVE_LIBS
+])
+AS_VAR_IF([php_cv_cc_rpath], [yes],
+  [ld_runpath_switch=-Wl,-rpath,],
+  [AC_CACHE_CHECK([if compiler supports -R], [php_cv_cc_dashr], [
     SAVE_LIBS=$LIBS
     LIBS="-R /usr/$PHP_LIBDIR $LIBS"
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],[php_cv_cc_dashr=yes],[php_cv_cc_dashr=no])
-    LIBS=$SAVE_LIBS])
-  AC_MSG_RESULT([$php_cv_cc_dashr])
-  if test $php_cv_cc_dashr = "yes"; then
-    ld_runpath_switch=-R
-  else
-    dnl Something innocuous.
-    ld_runpath_switch=-L
-  fi
-fi
-if test "$PHP_RPATH" = "no"; then
-  ld_runpath_switch=
-fi
+    AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+      [php_cv_cc_dashr=yes],
+      [php_cv_cc_dashr=no])
+    LIBS=$SAVE_LIBS
+  ])
+  AS_VAR_IF([php_cv_cc_dashr], [yes],
+    [ld_runpath_switch=-R],
+    [ld_runpath_switch=-L])
+])
+AS_VAR_IF([PHP_RPATH], [no], [ld_runpath_switch=])
 ])
 
 dnl
@@ -465,10 +461,10 @@ AC_DEFUN([PHP_UTILIZE_RPATHS],[
     NATIVE_RPATHS="$NATIVE_RPATHS $ld_runpath_switch$i"
   done
 
-  if test "$PHP_RPATH" = "no"; then
+  AS_VAR_IF([PHP_RPATH], [no], [
     unset PHP_RPATHS
     unset NATIVE_RPATHS
-  fi
+  ])
 ])
 
 dnl


### PR DESCRIPTION
- AS_VAR_IF macros used
- AC_CACHE_VAL and AC_MSG_CHECKING replaced with AC_CACHE_CHECK
- arguments quoted