### PR TITLE
Autotools: Replace uname with host_alias for finding Solaris

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1305,17 +1305,14 @@ dnl
 dnl Some systems, notably Solaris, cause getcwd() or realpath to fail if a
 dnl component of the path has execute but not read permissions.
 dnl
-AC_DEFUN([PHP_BROKEN_GETCWD],[
-  AC_MSG_CHECKING([for broken getcwd])
-  os=$(uname -sr 2>/dev/null)
-  case $os in
-    SunOS*[)]
-      AC_DEFINE([HAVE_BROKEN_GETCWD], [1],
-        [Define to 1 if system has a broken 'getcwd'.])
-      AC_MSG_RESULT([yes]);;
-    *[)]
-      AC_MSG_RESULT([no]);;
-  esac
+AC_DEFUN([PHP_BROKEN_GETCWD], [
+AC_CACHE_CHECK([for broken getcwd], [php_cv_func_getcwd_broken],
+  [AS_CASE([$host_alias],
+    [*solaris*], [php_cv_func_getcwd_broken=yes],
+    [php_cv_func_getcwd_broken=no])])
+AS_VAR_IF([php_cv_func_getcwd_broken], [yes],
+  [AC_DEFINE([HAVE_BROKEN_GETCWD], [1],
+    [Define to 1 if system has a broken 'getcwd'.])])
 ])
 
 dnl

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -9,14 +9,14 @@ if test "$PHP_CGI" != "no"; then
   dnl BSD systems.
   AC_CHECK_MEMBERS([struct sockaddr_un.sun_len],,,[#include <sys/un.h>])
 
-  AC_MSG_CHECKING([whether cross-process locking is required by accept()])
-  AS_CASE([$(uname -sr)],
-    [SunOS\ 5.*], [
-      AC_MSG_RESULT([yes])
-      AC_DEFINE([USE_LOCKING], [1],
-        [Define to 1 if cross-process locking is required by 'accept()'.])
-    ],
-    [AC_MSG_RESULT([no])])
+  AC_CACHE_CHECK([whether cross-process locking is required by accept()],
+    [php_cv_have_cross_process_locking],
+    [AS_CASE([$host_alias],
+      [*solaris*], [php_cv_have_cross_process_locking=yes],
+      [php_cv_have_cross_process_locking=no])])
+  AS_VAR_IF([php_cv_have_cross_process_locking], [yes],
+    [AC_DEFINE([USE_LOCKING], [1],
+      [Define to 1 if cross-process locking is required by 'accept()'.])])
 
   PHP_ADD_MAKEFILE_FRAGMENT([$abs_srcdir/sapi/cgi/Makefile.frag])
 


### PR DESCRIPTION
This wraps checks in AC_CACHE_CHECK and replaces the "uname -sr" command with simpler $host_alias as it is already set by the config.guess script properly.