### PR TITLE
Disallow enums in ArrayObject

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1091,6 +1091,12 @@ static void spl_array_set_array(zval *object, spl_array_object *intern, zval *ar
 					ZSTR_VAL(Z_OBJCE_P(array)->name), ZSTR_VAL(intern->std.ce->name));
 				return;
 			}
+			if (UNEXPECTED(Z_OBJCE_P(array)->ce_flags & ZEND_ACC_ENUM)) {
+				zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
+					"Enum %s is not compatible with %s",
+					ZSTR_VAL(Z_OBJCE_P(array)->name), ZSTR_VAL(intern->std.ce->name));
+				return;
+			}
 			zval_ptr_dtor(&intern->array);
 			ZVAL_COPY(&intern->array, array);
 		}

--- a/ext/spl/tests/ArrayObject_enum.phpt
+++ b/ext/spl/tests/ArrayObject_enum.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Enums are not compatible with ArrayObject
+--FILE--
+<?php
+
+enum Foo {
+    case Bar;
+}
+
+new ArrayObject(Foo::Bar);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught InvalidArgumentException: Enum Foo is not compatible with ArrayObject in %s:%d
+%a


### PR DESCRIPTION
We should probably disallow objects in `ArrayObject` altogether. It allows overriding `readonly` properties which can break engine assumptions.