### PR TITLE
Fix OPcache tests under specific conditions

### DIFF
--- a/ext/opcache/tests/bug78185.phpt
+++ b/ext/opcache/tests/bug78185.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Bug #78185: file cache only no longer works
 --INI--
+opcache.enable=1
 opcache.enable_cli=1
 opcache.optimization_level=-1
 opcache.file_cache={PWD}

--- a/ext/opcache/tests/gh9259_003.phpt
+++ b/ext/opcache/tests/gh9259_003.phpt
@@ -9,6 +9,7 @@ if (getenv('SKIP_ASAN')) die('xleak Leaks memory with ASAN');
 --INI--
 opcache.interned_strings_buffer=500
 opcache.enable_cli=1
+opcache.enable=1
 --FILE--
 <?php
 

--- a/ext/opcache/tests/opcache_invalidate_deleted_file.phpt
+++ b/ext/opcache/tests/opcache_invalidate_deleted_file.phpt
@@ -3,6 +3,7 @@ opcache_invalidate() should invalidate deleted file
 --EXTENSIONS--
 opcache
 --INI--
+opcache.enable=1
 opcache.enable_cli=1
 opcache.validate_timestamps=0
 --FILE--


### PR DESCRIPTION
These tests will always fail when `run-tests.php` is executed with `-d opcache.enable=0` . Add `opcache.enable=1` to the INI section to ensure it's always overridden.