### PR TITLE
Autotools: Enable adding a list of paths in PHP_ADD_INCLUDE

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -200,6 +200,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Autoconf macros PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X,
      PHP_SELECT_SAPI now have the source files and flags arguments normalized so
      the list of items can be passed as a blank-or-newline-separated list.
+   - Autoconf macro PHP_ADD_INCLUDE now takes also a blank-or-newline-separated
+     list of include directories instead of a single directory.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -201,7 +201,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      PHP_SELECT_SAPI now have the source files and flags arguments normalized so
      the list of items can be passed as a blank-or-newline-separated list.
    - Autoconf macro PHP_ADD_INCLUDE now takes also a blank-or-newline-separated
-     list of include directories instead of a single directory.
+     list of include directories instead of a single directory. The "prepend"
+     argument is validated at Autoconf compile time.
    - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and

--- a/build/php.m4
+++ b/build/php.m4
@@ -473,9 +473,9 @@ dnl Add blank-or-newline-separated list of include paths. If "before" is given,
 dnl paths are prepended to the beginning of INCLUDES.
 dnl
 AC_DEFUN([PHP_ADD_INCLUDE], [
-for path in m4_normalize(m4_expand([$1])); do
-  AS_IF([test "$path" != "/usr/include"], [
-    PHP_EXPAND_PATH([$path], [ai_p])
+for include_path in m4_normalize(m4_expand([$1])); do
+  AS_IF([test "$include_path" != "/usr/include"], [
+    PHP_EXPAND_PATH([$include_path], [ai_p])
     PHP_RUN_ONCE([INCLUDEPATH], [$ai_p], [m4_ifnblank([$2],
       [INCLUDES="-I$ai_p $INCLUDES"],
       [INCLUDES="$INCLUDES -I$ai_p"])])

--- a/build/php.m4
+++ b/build/php.m4
@@ -467,9 +467,9 @@ AC_DEFUN([PHP_UTILIZE_RPATHS],[
 ])
 
 dnl
-dnl PHP_ADD_INCLUDE(paths [,before])
+dnl PHP_ADD_INCLUDE(paths [,prepend])
 dnl
-dnl Add blank-or-newline-separated list of include paths. If "before" is given,
+dnl Add blank-or-newline-separated list of include paths. If "prepend" is given,
 dnl paths are prepended to the beginning of INCLUDES.
 dnl
 AC_DEFUN([PHP_ADD_INCLUDE], [

--- a/build/php.m4
+++ b/build/php.m4
@@ -467,21 +467,20 @@ AC_DEFUN([PHP_UTILIZE_RPATHS],[
 ])
 
 dnl
-dnl PHP_ADD_INCLUDE(path [,before])
+dnl PHP_ADD_INCLUDE(paths [,before])
 dnl
-dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+dnl Add blank-or-newline-separated list of include paths. If "before" is given,
+dnl paths are prepended to the beginning of INCLUDES.
 dnl
-AC_DEFUN([PHP_ADD_INCLUDE],[
-  if test "$1" != "/usr/include"; then
-    PHP_EXPAND_PATH($1, ai_p)
-    PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
-      if test "$2"; then
-        INCLUDES="-I$ai_p $INCLUDES"
-      else
-        INCLUDES="$INCLUDES -I$ai_p"
-      fi
-    ])
-  fi
+AC_DEFUN([PHP_ADD_INCLUDE], [
+for path in m4_normalize(m4_expand([$1])); do
+  AS_IF([test "$path" != "/usr/include"], [
+    PHP_EXPAND_PATH([$path], [ai_p])
+    PHP_RUN_ONCE([INCLUDEPATH], [$ai_p], [m4_ifnblank([$2],
+      [INCLUDES="-I$ai_p $INCLUDES"],
+      [INCLUDES="$INCLUDES -I$ai_p"])])
+  ])
+done
 ])
 
 dnl


### PR DESCRIPTION
This enables adding multiple include paths. For example:

    PHP_ADD_INCLUDE([
      $abs_srcdir
      $abs_builddir
      $abs_srcdir/main
      $abs_builddir/main
    ], [1])