### PR TITLE
Autotools: s/M4 macros/Autoconf macros

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -140,15 +140,16 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - COOKIE_IO_FUNCTIONS_T symbol has been removed (use cookie_io_functions_t).
    - HAVE_SOCKADDR_UN_SUN_LEN symbol renamed to HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.
    - HAVE_UTSNAME_DOMAINNAME symbol renamed to HAVE_STRUCT_UTSNAME_DOMAINNAME.
-   - PHP_CHECK_IN_ADDR_T M4 macro and 'in_addr_t' fallback definition to 'u_int'
-     removed (use AC_CHECK_TYPES Autoconf macro instead).
+   - PHP_CHECK_IN_ADDR_T Autoconf macro and 'in_addr_t' fallback definition to
+     'u_int' removed (use AC_CHECK_TYPES Autoconf macro instead).
    - HAVE_ODBC2 symbol has been removed in ext/odbc.
    - Removed linking with obsolete dnet_stub library in ext/pdo_dblib.
    - Removed checking and linking with obsolete libbind for some functions.
    - Symbol HAVE_JSON has been removed (ext/json is always available since PHP
      8.0).
    - Symbol DARWIN has been removed (use __APPLE__ to target Darwin systems).
-   - Symbol MISSING_FCLOSE_DECL and M4 macro PHP_MISSING_FCLOSE_DECL removed.
+   - Symbol MISSING_FCLOSE_DECL and Autoconf macro PHP_MISSING_FCLOSE_DECL were
+     removed.
    - Symbol HAVE_BSD_ICONV has been removed.
    - Symbol ZEND_FIBER_ASM has been removed.
    - Symbols HAVE_DLOPEN and HAVE_DLSYM have been removed.
@@ -164,39 +165,42 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Symbols PHP_HAVE_AVX512_SUPPORTS and PHP_HAVE_AVX512_VBMI_SUPPORTS are now
      either defined to 1 or undefined.
    - Symbol HAVE_LIBCRYPT has been removed.
-   - M4 macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and config.h).
-   - M4 macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
-   - M4 macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
-   - M4 macro PHP_SOCKADDR_CHECKS has been removed (use AC_CHECK_TYPES and
+   - Autoconf macro PHP_DEFINE (atomic includes) removed (use AC_DEFINE and
+     config.h).
+   - Autoconf macro PHP_WITH_SHARED has been removed (use PHP_ARG_WITH).
+   - Autoconf macro PHP_STRUCT_FLOCK has been removed (use AC_CHECK_TYPES).
+   - Autoconf macro PHP_SOCKADDR_CHECKS has been removed (use AC_CHECK_TYPES and
      AC_CHECK_MEMBERS).
-   - M4 macro PHP_CHECK_GCC_ARG has been removed since PHP 8.0 (use
+   - Autoconf macro PHP_CHECK_GCC_ARG has been removed since PHP 8.0 (use
      AX_CHECK_COMPILE_FLAG).
-   - M4 macro PHP_PROG_RE2C got a new 2nd argument to define common default re2c
-     command-line options substituted to the Makefile RE2C_FLAGS variable.
-   - M4 macros PHP_CHECK_BUILTIN_* have been removed in favor of
+   - Autoconf macro PHP_PROG_RE2C got a new 2nd argument to define common
+     default re2c command-line options substituted to the Makefile RE2C_FLAGS
+     variable.
+   - Autoconf macros PHP_CHECK_BUILTIN_* have been removed in favor of
      PHP_CHECK_BUILTIN and all PHP_HAVE_BUILTIN_* symbols changed to be either
      undefined or defined to 1 whether compiler supports the builtin.
    - Added php-config --lib-dir and --lib-embed options for PHP embed SAPI.
    - PDO extensions in php-src don't have the include flag -I$pdo_cv_inc_path
      directory anymore.
-   - M4 macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
-   - M4 macro PHP_EVAL_LIBLINE got a new 3rd argument to override the ext_shared
-     checks.
-   - M4 macro PHP_SETUP_LIBXML doesn't define the redundant HAVE_LIBXML symbol
-     anymore and requires at least libxml2 2.9.4.
-   - M4 macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol anymore.
-   - M4 macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
-   - M4 macro PHP_PROG_SETUP now accepts an argument to set the minimum required
-     PHP version during the build.
-   - M4 macro PHP_INSTALL_HEADERS arguments can now be also
+   - Autoconf macro PHP_SETUP_OPENSSL doesn't accept the 3rd argument anymore.
+   - Autoconf macro PHP_EVAL_LIBLINE got a new 3rd argument to override the
+     ext_shared checks.
+   - Autoconf macro PHP_SETUP_LIBXML doesn't define the redundant HAVE_LIBXML
+     symbol anymore and requires at least libxml2 2.9.4.
+   - Autoconf macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol
+     anymore.
+   - Autoconf macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
+   - Autoconf macro PHP_PROG_SETUP now accepts an argument to set the minimum
+     required PHP version during the build.
+   - Autoconf macro PHP_INSTALL_HEADERS arguments can now be also
      blank-or-newline-separated lists instead of only separated with whitespace
      or backslash-then-newline.
-   - M4 macro PHP_ADD_BUILD_DIR now also accepts 1st argument as a
+   - Autoconf macro PHP_ADD_BUILD_DIR now also accepts 1st argument as a
      blank-or-newline-separated separated list.
-   - M4 macros PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X,
+   - Autoconf macros PHP_NEW_EXTENSION, PHP_ADD_SOURCES, PHP_ADD_SOURCES_X,
      PHP_SELECT_SAPI now have the source files and flags arguments normalized so
      the list of items can be passed as a blank-or-newline-separated list.
-   - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS M4 macro have been removed.
+   - TSRM/tsrm.m4 file and its TSRM_CHECK_PTHREADS macro have been removed.
    - Added pkg-config support to find libpq for the pdo_pgsql and pgsql
      extensions. The libpq paths can be customized with the PGSQL_CFLAGS and
      PGSQL_LIBS environment variables. When a directory argument is provided to


### PR DESCRIPTION
M4 macros would mean macros for M4 language like m4_normalize() and similar. Macros defined with AC_DEFUN are better called simply Auotoconf macros.

[skip ci]