### PR TITLE
PDO_Firebird: Set session timezone in connection properties

### DIFF
--- a/ext/pdo_firebird/pdo_firebird.stub.php
+++ b/ext/pdo_firebird/pdo_firebird.stub.php
@@ -34,5 +34,8 @@ class Firebird extends \PDO
     /** @cvalue PDO_FB_WRITABLE_TRANSACTION */
     public const int WRITABLE_TRANSACTION = UNKNOWN;
 
+    /** @cvalue PDO_FB_SESSION_TIMEZONE */
+    public const int SESSION_TIMEZONE = UNKNOWN;    
+
     public static function getApiVersion(): int {}
 }

--- a/ext/pdo_firebird/pdo_firebird_arginfo.h
+++ b/ext/pdo_firebird/pdo_firebird_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d36b2055abc48ae91c3442dda68fa2a28eb6d25b */
+ * Stub hash: 50db19699b572bf8653790782327f05bbada9575 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Pdo_Firebird_getApiVersion, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -65,6 +65,12 @@ static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_ent
 	zend_string *const_WRITABLE_TRANSACTION_name = zend_string_init_interned("WRITABLE_TRANSACTION", sizeof("WRITABLE_TRANSACTION") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_WRITABLE_TRANSACTION_name, &const_WRITABLE_TRANSACTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WRITABLE_TRANSACTION_name);
+
+	zval const_SESSION_TIMEZONE_value;
+	ZVAL_LONG(&const_SESSION_TIMEZONE_value, PDO_FB_SESSION_TIMEZONE);
+	zend_string *const_SESSION_TIMEZONE_name = zend_string_init_interned("SESSION_TIMEZONE", sizeof("SESSION_TIMEZONE") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_SESSION_TIMEZONE_name, &const_SESSION_TIMEZONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_SESSION_TIMEZONE_name);
 
 	return class_entry;
 }

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -154,6 +154,9 @@ enum {
 
 	/* transaction access mode */
 	PDO_FB_WRITABLE_TRANSACTION,
+
+	/* session time zone */
+	PDO_FB_SESSION_TIMEZONE,
 };
 
 #endif	/* PHP_PDO_FIREBIRD_INT_H */

--- a/ext/pdo_firebird/tests/set_timezone.phpt
+++ b/ext/pdo_firebird/tests/set_timezone.phpt
@@ -1,0 +1,55 @@
+--TEST--
+PDO_Firebird: Set session timezone in connection properties
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); 
+if (Pdo\Firebird::getApiVersion() < 40) {
+	die('skip: Firebird API version must be greater than or equal to 40');
+}
+require_once 'testdb.inc';
+$dbh = getDbConnection();
+$stmt = $dbh->query("SELECT RDB\$get_context('SYSTEM', 'ENGINE_VERSION') AS VERSION FROM RDB\$DATABASE");
+$data = $stmt->fetch(\PDO::FETCH_ASSOC);
+if (!$data || !array_key_exists('VERSION', $data) || version_compare($data['VERSION'], '4.0.0') < 0) {
+	die("skip Firebird Server version must be greater than or equal to 4.0.0");
+}
+unset($stmt);
+unset($dbh);
+?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+require_once 'testdb.inc';
+
+$sql = <<<'SQL'
+SELECT 
+  rdb$get_context('SYSTEM', 'SESSION_TIMEZONE') as tz,
+  trim(replace(current_timestamp, localtimestamp, '')) as tz1,
+  trim(replace(current_time, localtime, '')) as tz2
+FROM rdb$database
+SQL;
+
+$attr = [
+      Pdo\Firebird::SESSION_TIMEZONE => 'Europe/Rome'
+];
+
+$dbh = connectToDb($attr);
+
+$stmt = $dbh->prepare($sql);
+$stmt->execute();
+$data = $stmt->fetch(\PDO::FETCH_ASSOC);
+$stmt->closeCursor();
+$str = json_encode($data, JSON_PRETTY_PRINT);
+echo $str;
+echo "\ndone\n";
+?>
+--EXPECT--
+{
+    "TZ": "Europe\/Rome",
+    "TZ1": "Europe\/Rome",
+    "TZ2": "Europe\/Rome"
+}
+done

--- a/ext/pdo_firebird/tests/testdb.inc
+++ b/ext/pdo_firebird/tests/testdb.inc
@@ -21,8 +21,8 @@ function getDbConnection($class = PDO::class): PDO {
     return new $class(PDO_FIREBIRD_TEST_DSN, PDO_FIREBIRD_TEST_USER, PDO_FIREBIRD_TEST_PASS);
 }
 
-function connectToDb(): Pdo\Firebird {
-    return Pdo\Firebird::connect(PDO_FIREBIRD_TEST_DSN, PDO_FIREBIRD_TEST_USER, PDO_FIREBIRD_TEST_PASS);
+function connectToDb(array $options = []): Pdo\Firebird {
+    return Pdo\Firebird::connect(PDO_FIREBIRD_TEST_DSN, PDO_FIREBIRD_TEST_USER, PDO_FIREBIRD_TEST_PASS, $options);
 }
 
 ?>


### PR DESCRIPTION
This feature allows you to set the session time zone when connecting to the database. An alternative is to set the time zone after the connection is established using the query:

```php
$dbh->exec("SET TIME ZONE '$timezone'");
```