### PR TITLE
Fix GH-15658: Segmentation fault in Zend/zend_vm_execute.h

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3970,7 +3970,13 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 				case ZEND_OP_DATA:
 				case ZEND_SWITCH_LONG:
 				case ZEND_SWITCH_STRING:
+					break;
 				case ZEND_MATCH:
+					/* We have to exit to the VM because the MATCH handler performs an N-way jump for
+					 * which we can't generate simple (opcache.jit=1201) JIT code. */
+					if (!zend_jit_tail_handler(&dasm_state, opline)) {
+						goto jit_failure;
+					}
 					break;
 				case ZEND_JMP:
 					if (JIT_G(opt_level) < ZEND_JIT_LEVEL_INLINE) {

--- a/ext/opcache/tests/jit/gh15658.phpt
+++ b/ext/opcache/tests/jit/gh15658.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-15658 (Segmentation fault in Zend/zend_vm_execute.h)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=0101
+opcache.jit_buffer_size=1024M
+--FILE--
+<?php
+echo match (random_int(1, 2)) {
+    1, 2 => 'foo',
+};
+?>
+--EXPECT--
+foo


### PR DESCRIPTION
Implement a minimal ZEND_MATCH handler using a tail call.