### PR TITLE
userland_declaration_error_class_const.phpt: fix test name

### DIFF
--- a/Zend/tests/parameter_default_values/userland_declaration_error_class_const.phpt
+++ b/Zend/tests/parameter_default_values/userland_declaration_error_class_const.phpt
@@ -1,5 +1,5 @@
 --TEST--
-The default value is a constant in the parent class method's signature.
+The default value is a class constant in the parent class method's signature.
 --FILE--
 <?php
 


### PR DESCRIPTION
Unlike the `userland_declaration_error_const.phpt` test, the point of this test is to demonstrate using a class constant as the default parameter. See also the corresponding internal_declaration_* tests.

[skip ci]