### PR TITLE
Autotools: Fix gd extension -I flag for bundled libgd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -279,8 +279,10 @@ dnl Various checks for GD features
     PHP_GD_FREETYPE2
     PHP_GD_JISX0208
 
-    GD_CFLAGS="-Wno-strict-prototypes -I$ext_srcdir/libgd $GD_CFLAGS"
-    PHP_NEW_EXTENSION([gd], [gd.c $extra_sources], [$ext_shared],, [$GD_CFLAGS])
+    PHP_NEW_EXTENSION([gd],
+      [gd.c $extra_sources],
+      [$ext_shared],,
+      [-Wno-strict-prototypes -I@ext_srcdir@/libgd])
     PHP_ADD_BUILD_DIR([$ext_builddir/libgd])
 
     PHP_INSTALL_HEADERS([ext/gd], [php_gd.h libgd/])


### PR DESCRIPTION
The ext_srcdir variable is at time of writing set only after calling the PHP_NEW_EXTENSION. Other extensions also use @ext_srcdir@ template placeholder for these cases. This fixes wrongly set include flag even though build also works without libgd include flag.