### PR TITLE
Sync Zend/*_i386_sysv_elf_gas.S with upstream

### DIFF
--- a/Zend/asm/jump_i386_sysv_elf_gas.S
+++ b/Zend/asm/jump_i386_sysv_elf_gas.S
@@ -24,6 +24,10 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#ifdef __x86_64__
+#include "jump_x86_64_sysv_elf_gas.S"
+#else
+
 .file "jump_i386_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
@@ -91,3 +95,5 @@ jump_fcontext:
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits
+
+#endif

--- a/Zend/asm/make_i386_sysv_elf_gas.S
+++ b/Zend/asm/make_i386_sysv_elf_gas.S
@@ -24,6 +24,10 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#ifdef __x86_64__
+#include "make_x86_64_sysv_elf_gas.S"
+#else
+
 .file "make_i386_sysv_elf_gas.S"
 .text
 .globl make_fcontext
@@ -111,3 +115,5 @@ finish:
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits
+
+#endif


### PR DESCRIPTION
This is a sync with upstream already fixed in early 2024 which fixes 64-bit builds on 32-bit hosts. PHP's bundled config.guess sets the host_alias, for example, on Solaris systems to 64-bit if the compiler supports it even though the architecture is actually 32-bit. These assembly files resolve this situation in a build-system-agnostic way by including the architecture file that is supported by the compiler.