### PR TITLE
Sync Zend/asm/*_x86_64_sysv_elf_gas.S with upstream

### DIFF
--- a/Zend/asm/jump_x86_64_sysv_elf_gas.S
+++ b/Zend/asm/jump_x86_64_sysv_elf_gas.S
@@ -73,14 +73,6 @@ jump_fcontext:
     /* read the current SSP and store it */
     rdsspq  %rcx
     movq  %rcx, (%rsp)
-#endif
-
-#if BOOST_CONTEXT_SHADOW_STACK
-    /* grow the stack to reserve space for shadow stack pointer(SSP) */
-    leaq  -0x8(%rsp), %rsp
-    /* read the current SSP and store it */
-    rdsspq  %rcx
-    movq  %rcx, (%rsp)
 # endif
 
     /* store RSP (pointing to context-data) in RAX */

--- a/Zend/asm/make_x86_64_sysv_elf_gas.S
+++ b/Zend/asm/make_x86_64_sysv_elf_gas.S
@@ -92,35 +92,6 @@ make_fcontext:
     movq  %rcx, 0x38(%rax)
 
 #if BOOST_CONTEXT_SHADOW_STACK
-    /* Populate the shadow stack and normal stack */
-    /* get original SSP */
-    rdsspq  %r8
-    /* restore new shadow stack */
-    rstorssp  -0x8(%r9)
-    /* save the restore token on the original shadow stack */
-    saveprevssp
-    /* push the address of "jmp trampoline" to the new shadow stack */
-    /* as well as the stack */
-    call  1f
-    jmp  trampoline
-1:
-    /* save address of "jmp trampoline" as return-address */
-    /* for context-function */
-    pop 0x38(%rax)
-    /* Get the new SSP.  */
-    rdsspq  %r9
-    /* restore original shadow stack */
-    rstorssp  -0x8(%r8)
-    /* save the restore token on the new shadow stack.  */
-    saveprevssp
-
-    /* reserve space for the new SSP */
-    leaq  -0x8(%rax), %rax
-    /* save the new SSP to this fcontext */
-    movq  %r9, (%rax)
-#endif
-
-#if BOOST_CONTEXT_SHADOW_STACK
     /* Populate the shadow stack */
 
     /* get original SSP */


### PR DESCRIPTION
If I'm not mistaken there are duplicate code blocks in the php-src in these files. This looks ok or is this intentional that php-src doesn't have these synced with upstream?