### PR TITLE
ext/bcmath: bcpow() performance improvement

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -149,9 +149,9 @@ bc_num bc_multiply(bc_num n1, bc_num n2, size_t scale);
 bc_num bc_square(bc_num n1, size_t scale);
 
 #define bc_square_ex(n1, result, scale_min) do {	\
-	bc_num square_ex = bc_square(n1, scale_min); \
-	bc_free_num (result);                           \
-	*(result) = square_ex;                             \
+	bc_num square_ex = bc_square(n1, scale_min);	\
+	bc_free_num (result);							\
+	*(result) = square_ex;							\
 } while (0)
 
 bool bc_divide(bc_num n1, bc_num n2, bc_num *quot, size_t scale);

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -148,12 +148,6 @@ bc_num bc_multiply(bc_num n1, bc_num n2, size_t scale);
 
 bc_num bc_square(bc_num n1, size_t scale);
 
-#define bc_square_ex(n1, result, scale_min) do {	\
-	bc_num square_ex = bc_square(n1, scale_min);	\
-	bc_free_num (result);							\
-	*(result) = square_ex;							\
-} while (0)
-
 bool bc_divide(bc_num n1, bc_num n2, bc_num *quot, size_t scale);
 
 bool bc_modulo(bc_num num1, bc_num num2, bc_num *resul, size_t scale);

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -146,6 +146,14 @@ bc_num bc_multiply(bc_num n1, bc_num n2, size_t scale);
 	*(result) = mul_ex;                             \
 } while (0)
 
+bc_num bc_square(bc_num n1, size_t scale);
+
+#define bc_square_ex(n1, result, scale_min) do {	\
+	bc_num square_ex = bc_square(n1, scale_min); \
+	bc_free_num (result);                           \
+	*(result) = square_ex;                             \
+} while (0)
+
 bool bc_divide(bc_num n1, bc_num n2, bc_num *quot, size_t scale);
 
 bool bc_modulo(bc_num num1, bc_num num2, bc_num *resul, size_t scale);

--- a/ext/bcmath/libbcmath/src/raise.c
+++ b/ext/bcmath/libbcmath/src/raise.c
@@ -34,13 +34,16 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+void bc_square_ex(bc_num n1, bc_num *result, size_t scale_min) {
+	bc_num square_ex = bc_square(n1, scale_min);
+	bc_free_num(result);
+	*(result) = square_ex;
+}
 
 /* Raise NUM1 to the NUM2 power.  The result is placed in RESULT.
    Maximum exponent is LONG_MAX.  If a NUM2 is not an integer,
    only the integer part is used.  */
-
-void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
-{
+void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale) {
 	bc_num temp, power;
 	size_t rscale;
 	size_t pwrscale;
@@ -102,8 +105,7 @@ void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
 }
 
 /* This is used internally by BCMath */
-void bc_raise_bc_exponent(bc_num base, bc_num expo, bc_num *result, size_t scale)
-{
+void bc_raise_bc_exponent(bc_num base, bc_num expo, bc_num *result, size_t scale) {
 	/* Exponent must not have fractional part */
 	assert(expo->n_scale == 0);
 

--- a/ext/bcmath/libbcmath/src/raise.c
+++ b/ext/bcmath/libbcmath/src/raise.c
@@ -69,7 +69,7 @@ void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
 	pwrscale = num1->n_scale;
 	while ((exponent & 1) == 0) {
 		pwrscale = 2 * pwrscale;
-		bc_multiply_ex(power, power, &power, pwrscale);
+		bc_square_ex(power, &power, pwrscale);
 		exponent = exponent >> 1;
 	}
 	temp = bc_copy_num(power);
@@ -79,7 +79,7 @@ void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
 	/* Do the calculation. */
 	while (exponent > 0) {
 		pwrscale = 2 * pwrscale;
-		bc_multiply_ex(power, power, &power, pwrscale);
+		bc_square_ex(power, &power, pwrscale);
 		if ((exponent & 1) == 1) {
 			calcscale = pwrscale + calcscale;
 			bc_multiply_ex(temp, power, &temp, calcscale);

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -186,7 +186,7 @@ static void bc_standard_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len, bc
 		}
 	}
 
-	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod);
+	bc_mul_finish_from_vector(prod_vector, prod_arr_size, prodlen, prod);
 
 	efree(buf);
 }
@@ -231,7 +231,7 @@ static void bc_standard_square(bc_num n1, size_t n1len, bc_num *prod)
 		}
 	}
 
-	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod);
+	bc_mul_finish_from_vector(prod_vector, prod_arr_size, prodlen, prod);
 
 	efree(buf);
 }

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -292,19 +292,16 @@ bc_num bc_square(bc_num n1, size_t scale)
 {
 	bc_num prod;
 
-	/* Initialize things. */
 	size_t len1 = n1->n_len + n1->n_scale;
 	size_t full_scale = n1->n_scale + n1->n_scale;
 	size_t prod_scale = MIN(full_scale, MAX(scale, n1->n_scale));
 
-	/* Do the square */
 	if (len1 <= BC_VECTOR_SIZE) {
 		bc_fast_square(n1, len1, &prod);
 	} else {
 		bc_standard_square(n1, len1, &prod);
 	}
 
-	/* Assign to prod and clean up the number. */
 	prod->n_sign = PLUS;
 	prod->n_len -= full_scale;
 	prod->n_scale = prod_scale;

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -94,8 +94,9 @@ static inline void bc_fast_square(bc_num n1, size_t n1len, bc_num *prod)
 	}
 }
 
-/** Common part of functions bc_standard_mul and bc_standard_square */
-static inline void bc_standard_mul_common(BC_VECTOR *prod_vector, size_t prod_arr_size, size_t prodlen, bc_num *prod, BC_VECTOR *buf) {
+/* Common part of functions bc_standard_mul and bc_standard_square
+ * that takes a vector and converts it to a bc_num 	*/
+static inline void bc_mul_finish_from_vector(BC_VECTOR *prod_vector, size_t prod_arr_size, size_t prodlen, bc_num *prod) {
 	/*
 	 * Move a value exceeding 4/8 digits by carrying to the next digit.
 	 * However, the last digit does nothing.
@@ -127,8 +128,6 @@ static inline void bc_standard_mul_common(BC_VECTOR *prod_vector, size_t prod_ar
 		*pend-- = prod_vector[i] % BASE;
 		prod_vector[i] /= BASE;
 	}
-
-	efree(buf);
 }
 
 /*
@@ -187,7 +186,9 @@ static void bc_standard_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len, bc
 		}
 	}
 
-	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod, buf);
+	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod);
+
+	efree(buf);
 }
 
 /** This is bc_standard_mul implementation for square */
@@ -230,7 +231,9 @@ static void bc_standard_square(bc_num n1, size_t n1len, bc_num *prod)
 		}
 	}
 
-	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod, buf);
+	bc_standard_mul_common(prod_vector, prod_arr_size, prodlen, prod);
+
+	efree(buf);
 }
 
 /* The multiply routine. N2 times N1 is put int PROD with the scale of

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -72,6 +72,10 @@ static inline void bc_fast_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len,
 	}
 }
 
+/*
+ * Equivalent of bc_fast_mul for small numbers to perform computations
+ * without using array.
+ */
 static inline void bc_fast_square(bc_num n1, size_t n1len, bc_num *prod)
 {
 	const char *n1end = n1->n_value + n1len - 1;

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -72,6 +72,24 @@ static inline void bc_fast_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len,
 	}
 }
 
+static inline void bc_fast_square(bc_num n1, size_t n1len, bc_num *prod)
+{
+	const char *n1end = n1->n_value + n1len - 1;
+
+	BC_VECTOR n1_vector = bc_partial_convert_to_vector(n1end, n1len);
+	BC_VECTOR prod_vector = n1_vector * n1_vector;
+
+	size_t prodlen = n1len + n1len;
+	*prod = bc_new_num_nonzeroed(prodlen, 0);
+	char *pptr = (*prod)->n_value;
+	char *pend = pptr + prodlen - 1;
+
+	while (pend >= pptr) {
+		*pend-- = prod_vector % BASE;
+		prod_vector /= BASE;
+	}
+}
+
 /*
  * Converts the BCD of bc_num by 4 (32 bits) or 8 (64 bits) digits to an array of BC_VECTOR.
  * The array is generated starting with the smaller digits.
@@ -163,7 +181,82 @@ static void bc_standard_mul(bc_num n1, size_t n1len, bc_num n2, size_t n2len, bc
 	efree(buf);
 }
 
-/* The multiply routine.  N2 times N1 is put int PROD with the scale of
+/** This is bc_standard_mul implementation for square */
+static void bc_standard_square(bc_num n1, size_t n1len, bc_num *prod)
+{
+	size_t i;
+	const char *n1end = n1->n_value + n1len - 1;
+	size_t prodlen = n1len + n1len;
+
+	size_t n1_arr_size = (n1len + BC_VECTOR_SIZE - 1) / BC_VECTOR_SIZE;
+	size_t prod_arr_size = (prodlen + BC_VECTOR_SIZE - 1) / BC_VECTOR_SIZE;
+
+	BC_VECTOR *buf = safe_emalloc(n1_arr_size + n1_arr_size + prod_arr_size, sizeof(BC_VECTOR), 0);
+
+	BC_VECTOR *n1_vector = buf;
+	BC_VECTOR *prod_vector = n1_vector + n1_arr_size + n1_arr_size;
+
+	for (i = 0; i < prod_arr_size; i++) {
+		prod_vector[i] = 0;
+	}
+
+	/* Convert to BC_VECTOR[] */
+	bc_convert_to_vector(n1_vector, n1end, n1len);
+
+	/* Multiplication and addition */
+	size_t count = 0;
+	for (i = 0; i < n1_arr_size; i++) {
+		/*
+		 * This calculation adds the result multiple times to the array entries.
+		 * When multiplying large numbers of digits, there is a possibility of
+		 * overflow, so digit adjustment is performed beforehand.
+		 */
+		if (UNEXPECTED(count >= BC_VECTOR_NO_OVERFLOW_ADD_COUNT)) {
+			bc_mul_carry_calc(prod_vector, prod_arr_size);
+			count = 0;
+		}
+		count++;
+		for (size_t j = 0; j < n1_arr_size; j++) {
+			prod_vector[i + j] += n1_vector[i] * n1_vector[j];
+		}
+	}
+
+	/*
+	 * Move a value exceeding 4/8 digits by carrying to the next digit.
+	 * However, the last digit does nothing.
+	 */
+	bc_mul_carry_calc(prod_vector, prod_arr_size);
+
+	/* Convert to bc_num */
+	*prod = bc_new_num_nonzeroed(prodlen, 0);
+	char *pptr = (*prod)->n_value;
+	char *pend = pptr + prodlen - 1;
+	i = 0;
+	while (i < prod_arr_size - 1) {
+#if BC_VECTOR_SIZE == 4
+		bc_write_bcd_representation(prod_vector[i], pend - 3);
+		pend -= 4;
+#else
+		bc_write_bcd_representation(prod_vector[i] / 10000, pend - 7);
+		bc_write_bcd_representation(prod_vector[i] % 10000, pend - 3);
+		pend -= 8;
+#endif
+		i++;
+	}
+
+	/*
+	 * The last digit may carry over.
+	 * Also need to fill it to the end with zeros, so loop until the end of the string.
+	 */
+	while (pend >= pptr) {
+		*pend-- = prod_vector[i] % BASE;
+		prod_vector[i] /= BASE;
+	}
+
+	efree(buf);
+}
+
+/* The multiply routine. N2 times N1 is put int PROD with the scale of
    the result being MIN(N2 scale+N1 scale, MAX (SCALE, N2 scale, N1 scale)).
    */
 
@@ -192,5 +285,30 @@ bc_num bc_multiply(bc_num n1, bc_num n2, size_t scale)
 	if (bc_is_zero(prod)) {
 		prod->n_sign = PLUS;
 	}
+	return prod;
+}
+
+bc_num bc_square(bc_num n1, size_t scale)
+{
+	bc_num prod;
+
+	/* Initialize things. */
+	size_t len1 = n1->n_len + n1->n_scale;
+	size_t full_scale = n1->n_scale + n1->n_scale;
+	size_t prod_scale = MIN(full_scale, MAX(scale, n1->n_scale));
+
+	/* Do the square */
+	if (len1 <= BC_VECTOR_SIZE) {
+		bc_fast_square(n1, len1, &prod);
+	} else {
+		bc_standard_square(n1, len1, &prod);
+	}
+
+	/* Assign to prod and clean up the number. */
+	prod->n_sign = PLUS;
+	prod->n_len -= full_scale;
+	prod->n_scale = prod_scale;
+	_bc_rm_leading_zeros(prod);
+
 	return prod;
 }


### PR DESCRIPTION
This PR improves the performance of the BCMath function `bcpow`.

We don't need to perform the usual multiplication when we raise a number to a specific set of numbers. I modified the content of `bc_mulitply` and removed all the redundant operations for the same number.

For small exponents, there is neglectable improvement, but for bigger there is up to 5%. However, I'm not quite happy with this benchmark and I need to use something else.

Benchmark:
```
<?php

$numbers = ['10', '2.1234567', '2'];
$exponents = [1, 2, 10, 64, 100];

foreach($numbers as $number) {
    foreach($exponents as $exponent) {
        echo "Number: $number, Exponent: $exponent = ";
        $start = microtime(true);
        for ($i = 0; $i < 1000000; $i++) {
            bcpow($number, $exponent, 20);
        }
        echo microtime(true) - $start . PHP_EOL;
    }
}
```


| Number        | Exponent      | Before            | After             | Difference    |
| ------------- | ------------- | ----------------- | ----------------- | ------------- |
| 10            | 1             | 0.369961977005    | 0.3674750328064   | -0.67 %       |
| 10            | 2             | 0.39027285575867  | 0.38206386566162  | -2.14 %       |
| 10            | 10            | 0.73798298835754  | 0.70764207839966  | -4.28 %       |
| 10            | 64            | 1.6131219863892   | 1.4904029369354   | -8.23 %       |
| 10            | 100           | 2.5796089172363   | 2.4571402072906   | -4.98 %       |
| 2.1234567     | 1             | 0.36139988899231  | 0.36435699462891  | +0.82 %       |
| 2.1234567     | 2             | 0.448086977005    | 0.44263195991516  | -1.23 %       |
| 2.1234567     | 10            | 1.6505491733551   | 1.5602447986603   | -5.78 %       |
| 2.1234567     | 64            | 6.6499609947205   | 6.3584640026093   | -4.58 %       |
| 2.1234567     | 100           | 14.168872833252   | 13.804186105728   | -2.64 %       |
| 2             | 1             | 0.33516597747803  | 0.32968902587891  | -1.66 %       |
| 2             | 2             | 0.38029599189758  | 0.36791205406189  | -3.36 %       |
| 2             | 10            | 0.59442806243896  | 0.5603358745575   | -6.08 %       |
| 2             | 64            | 0.94932103157043  | 0.86743497848511  | -9.44 %       |
| 2             | 100           | 1.4967222213745   | 1.39244389534     | -7.48 %       |

Edit: 
Benchmark using hyperfine:
0. Benchmark script
```
foreach($numbers as $number) {
    foreach($exponents as $exponent) {
        echo "Number: $number, Exponent: $exponent = ";
        $start = microtime(true);
        for ($i = 0; $i < 10000; $i++) {
            bcpow($number, $exponent, 20);
        }
        echo microtime(true) - $start . PHP_EOL;
    }
}
```
1. Float numbers, small exp
```
$numbers = ['1.0432151', '2.1234567', '0.798432'];
$exponents = [2, 5, 7, 8, 10];
```

> Benchmark 1: sapi/cli/php test_float_numbers_small_exp.php
>   Time (mean ± σ):     168.0 ms ±   1.1 ms    [User: 164.3 ms, System: 1.8 ms]
>   Range (min … max):   166.8 ms … 171.4 ms    17 runs
>  
> Benchmark 2: sapi/cli/php_bc/bin/php test_float_numbers_small_exp.php
>   Time (mean ± σ):     160.1 ms ±   1.1 ms    [User: 156.1 ms, System: 1.8 ms]
>   Range (min … max):   158.3 ms … 161.9 ms    18 runs
>  
> Summary
>   sapi/cli/php_bc/bin/php test_float_numbers_small_exp.php ran
>     1.05 ± 0.01 times faster than sapi/cli/php test_float_numbers_small_exp.php

2. Float numbers, big exp
```
$numbers = ['1.0432151', '2.1234567', '0.798432'];
$exponents = [32, 64, 67, 100];
```

> Benchmark 1: sapi/cli/php test_float_numbers_big_exp.php
>   Time (mean ± σ):     943.9 ms ±   5.2 ms    [User: 934.5 ms, System: 2.2 ms]
>   Range (min … max):   936.8 ms … 952.4 ms    10 runs
>  
> Benchmark 2: sapi/cli/php_bc/bin/php test_float_numbers_big_exp.php
>   Time (mean ± σ):     872.4 ms ±   1.7 ms    [User: 865.4 ms, System: 2.1 ms]
>   Range (min … max):   870.8 ms … 876.0 ms    10 runs
>  
> Summary
>   sapi/cli/php_bc/bin/php test_float_numbers_big_exp.php ran
>     1.08 ± 0.01 times faster than sapi/cli/php test_float_numbers_big_exp.php
> 

3. Int numbers, small exp
```
$numbers = ['10', '72', '11', '99'];
$exponents = [2, 5, 7, 8, 10];
```

> Benchmark 1: sapi/cli/php test_int_numbers_small_exp.php
>   Time (mean ± σ):     118.1 ms ±   0.5 ms    [User: 114.9 ms, System: 1.7 ms]
>   Range (min … max):   117.4 ms … 119.5 ms    24 runs
>  
> Benchmark 2: sapi/cli/php_bc/bin/php test_int_numbers_small_exp.php
>   Time (mean ± σ):     112.9 ms ±   0.4 ms    [User: 109.9 ms, System: 1.6 ms]
>   Range (min … max):   112.5 ms … 114.1 ms    26 runs
>  
> Summary
>   sapi/cli/php_bc/bin/php test_int_numbers_small_exp.php ran
>     1.05 ± 0.01 times faster than sapi/cli/php test_int_numbers_small_exp.php
> 
> 

4. Int numbers, big exp
```
$numbers = ['10', '72', '11', '99'];
$exponents = [32, 64, 67, 100];
```
> Benchmark 1: sapi/cli/php test_int_numbers_big_exp.php
>   Time (mean ± σ):     355.1 ms ±   0.8 ms    [User: 350.9 ms, System: 1.8 ms]
>   Range (min … max):   353.7 ms … 356.2 ms    10 runs
>  
> Benchmark 2: sapi/cli/php_bc/bin/php test_int_numbers_big_exp.php
>   Time (mean ± σ):     331.5 ms ±   0.4 ms    [User: 327.1 ms, System: 1.8 ms]
>   Range (min … max):   330.9 ms … 332.1 ms    10 runs
>  
> Summary
>   sapi/cli/php_bc/bin/php test_int_numbers_big_exp.php ran
>     1.07 ± 0.00 times faster than sapi/cli/php test_int_numbers_big_exp.php
> 

5. Large numbers
```
$numbers = ['5614987514.43124124321', '21318945190.432132591','954319523410491'];
$exponents = [2, 5, 7, 8, 10];
```

> Benchmark 1: sapi/cli/php test_large_numbers.php
>   Time (mean ± σ):     303.0 ms ±   1.3 ms    [User: 298.8 ms, System: 1.8 ms]
>   Range (min … max):   300.9 ms … 305.6 ms    10 runs
>  
> Benchmark 2: sapi/cli/php_bc/bin/php test_large_numbers.php
>   Time (mean ± σ):     285.7 ms ±   2.5 ms    [User: 281.0 ms, System: 1.9 ms]
>   Range (min … max):   283.3 ms … 292.0 ms    10 runs
>  
> Summary
>   sapi/cli/php_bc/bin/php test_large_numbers.php ran
>     1.06 ± 0.01 times faster than sapi/cli/php test_large_numbers.php
