### PR TITLE
Autotools: Refactor PHP_TEST_BUILD checks

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -287,11 +287,17 @@ dnl Various checks for GD features
 
     PHP_INSTALL_HEADERS([ext/gd], [php_gd.h libgd/])
 
-    PHP_TEST_BUILD([foobar],
-      [],
-      [AC_MSG_FAILURE([GD library build test failed.])],
-      [$GD_SHARED_LIBADD],
-      [char foobar(void) { return '\0'; }])
+    dnl Sanity check.
+    AC_CACHE_CHECK([whether build works], [php_cv_lib_gd_works], [
+      LIBS_SAVED=$LIBS
+      LIBS="$GD_SHARED_LIBADD $LIBS"
+      AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+        [php_cv_lib_gd_works=yes],
+        [php_cv_lib_gd_works=no])
+      LIBS=$LIBS_SAVED
+    ])
+    AS_VAR_IF([php_cv_lib_gd_works], [yes],,
+      [AC_MSG_FAILURE([GD library build test failed.])])
   else
     extra_sources="gd_compat.c"
     PKG_CHECK_MODULES([GDLIB], [gdlib >= 2.1.0])

--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -202,15 +202,18 @@ PHP_ARG_WITH([ibm-db2],
     ODBC_TYPE=ibm-db2
     ODBC_LIBS=-ldb2
 
-    PHP_TEST_BUILD([SQLExecute],
+    dnl Sanity check.
+    old_LIBS=$LIBS
+    LIBS="$ODBC_LFLAGS $ODBC_LIBS $LIBS"
+    AC_CHECK_FUNC([SQLExecute],
       [AC_DEFINE([HAVE_IBMDB2], [1],
         [Define to 1 if the odbc extension uses the IBM DB2.])],
       [AC_MSG_FAILURE([
 ODBC build test failed. You need to source your DB2 environment before running
 PHP configure:
 # . \$IBM_DB2/db2profile
-])],
-    [$ODBC_LFLAGS $ODBC_LIBS])
+])])
+    LIBS=$old_LIBS
   ])
 ])
 


### PR DESCRIPTION
- The libgd sanity check is there only to check whether all current linked libraries for the bundled libgd work together, otherwise it is probably even redundant a bit; this refactors it to a simpler AC_LINK_IFELSE check with default empty C program by Autoconf
- The IBM DB2 sanity check is simplified with AC_CHECK_FUNC instead