### PR TITLE
Autotools: Obsolete PHP_TEST_BUILD, PHP_BUILD_THREAD_SAFE, and PHP_DEF_HAVE

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -190,6 +190,9 @@ PHP 8.4 INTERNALS UPGRADE NOTES
    - Autoconf macro PHP_SETUP_ICONV doesn't define the HAVE_ICONV symbol
      anymore.
    - Autoconf macro PHP_OUTPUT is obsolete (use AC_CONFIG_FILES).
+   - Autoconf macro PHP_TEST_BUILD is obsolete (use AC_* macros).
+   - Autoconf macro PHP_BUILD_THREAD_SAFE is obsolete (set enable_zts manually).
+   - Autoconf macro PHP_DEF_HAVE is obsolete (use AC_DEFINE).
    - Autoconf macro PHP_PROG_SETUP now accepts an argument to set the minimum
      required PHP version during the build.
    - Autoconf macro PHP_INSTALL_HEADERS arguments can now be also

--- a/build/php.m4
+++ b/build/php.m4
@@ -31,7 +31,9 @@ dnl PHP_DEF_HAVE(what)
 dnl
 dnl Generates 'AC_DEFINE(HAVE_WHAT, 1, [ ])'.
 dnl
-AC_DEFUN([PHP_DEF_HAVE],[AC_DEFINE([HAVE_]translit($1,a-z_.-,A-Z___), 1, [ ])])
+AC_DEFUN([PHP_DEF_HAVE], [m4_warn([obsolete],
+  [The macro 'PHP_DEF_HAVE' is obsolete. Use AC_DEFINE.])
+AC_DEFINE([HAVE_]translit($1,a-z_.-,A-Z___), 1, [ ])])
 
 dnl
 dnl PHP_RUN_ONCE(namespace, variable, code)
@@ -744,7 +746,9 @@ dnl ----------------------------------------------------------------------------
 dnl
 dnl PHP_BUILD_THREAD_SAFE
 dnl
-AC_DEFUN([PHP_BUILD_THREAD_SAFE], [enable_zts=yes])
+AC_DEFUN([PHP_BUILD_THREAD_SAFE], [m4_warn([obsolete],
+  [The macro 'PHP_BUILD_THREAD_SAFE' is obsolete. Set 'enable_zts' manually.])
+  enable_zts=yes])
 
 dnl
 dnl PHP_REQUIRE_CXX
@@ -1510,7 +1514,8 @@ dnl PHP_TEST_BUILD(function, action-if-ok, action-if-not-ok [, extra-libs [, ext
 dnl
 dnl This macro checks whether build works and given function exists.
 dnl
-AC_DEFUN([PHP_TEST_BUILD], [
+AC_DEFUN([PHP_TEST_BUILD], [m4_warn([obsolete],
+  [The macro 'PHP_TEST_BUILD' is obsolete. Use AC_* macros.])
   old_LIBS=$LIBS
   LIBS="$4 $LIBS"
   AC_LINK_IFELSE([AC_LANG_SOURCE([

--- a/sapi/apache2handler/config.m4
+++ b/sapi/apache2handler/config.m4
@@ -112,7 +112,7 @@ if test "$PHP_APXS2" != "no"; then
 
   AS_IF([$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1], [
     APACHE_THREADED_MPM=yes
-    PHP_BUILD_THREAD_SAFE
+    enable_zts=yes
   ], [APACHE_THREADED_MPM=no])
 
 AC_CONFIG_COMMANDS([apache2handler], [AS_VAR_IF([enable_zts], [yes],,


### PR DESCRIPTION
The PHP_BUILD_THREAD_SAFE macro is a simple wrapper around setting the enable_zts variable and can't be used in PHP extensions realistically.

The PHP_TEST_BUILD macro might produce warnings on certain compiler configurations and default AC_* macros like AC_LINK_IFELSE, AC_CHECK_LIB, or AC_CHECK_FUNC are better suited for such checks. Also, a quick browse through the open-source PHP extensions doesn't find usages of this macro except in imap extension where patch is was already sent:
https://github.com/php/pecl-mail-imap/pull/11

PHP_DEF_HAVE is a wrapper around AC_DEFINE and using AC_DEFINE_UNQUOTED and AS_TR_CPP are better suited for this task where also help text can be passed. Edit: Also usages around the open source PHP extensions have been checked and patches sent where found.
