### PR TITLE
Implement GH-15711: Allow SoapClient to use the backing value during response serialization

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -850,6 +850,30 @@ static zend_string *get_serialization_string_from_zval(zval *data)
 	}
 }
 
+static zend_long get_serialization_long_from_zval(zval *data)
+{
+	switch (Z_TYPE_P(data)) {
+		case IS_OBJECT:
+			if (Z_OBJCE_P(data)->ce_flags & ZEND_ACC_ENUM) {
+				if (UNEXPECTED(Z_OBJCE_P(data)->enum_backing_type != IS_LONG)) {
+					if (Z_OBJCE_P(data)->enum_backing_type == IS_UNDEF) {
+						zend_value_error("Non-backed enums have no default serialization");
+					} else {
+						zend_value_error("String-backed enum cannot be serialized as int");
+					}
+					return 0;
+				} else {
+					zval *value = zend_enum_fetch_case_value(Z_OBJ_P(data));
+					ZEND_ASSERT(Z_TYPE_P(value) == IS_LONG);
+					return Z_LVAL_P(value);
+				}
+			}
+			ZEND_FALLTHROUGH;
+		default:
+			return zval_get_long(data);
+	}
+}
+
 static xmlNodePtr to_xml_string(encodeTypePtr type, zval *data, int style, xmlNodePtr parent)
 {
 	xmlNodePtr ret, text;
@@ -1075,7 +1099,7 @@ static xmlNodePtr to_xml_long(encodeTypePtr type, zval *data, int style, xmlNode
 		snprintf(s, sizeof(s), "%0.0F",floor(Z_DVAL_P(data)));
 		xmlNodeSetContent(ret, BAD_CAST(s));
 	} else {
-		zend_string *str = zend_long_to_str(zval_get_long(data));
+		zend_string *str = zend_long_to_str(get_serialization_long_from_zval(data));
 		xmlNodeSetContentLen(ret, BAD_CAST(ZSTR_VAL(str)), ZSTR_LEN(str));
 		zend_string_release_ex(str, 0);
 	}

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -924,19 +924,14 @@ static xmlNodePtr to_xml_string(encodeTypePtr type, zval *data, int style, xmlNo
 static xmlNodePtr to_xml_base64(encodeTypePtr type, zval *data, int style, xmlNodePtr parent)
 {
 	xmlNodePtr ret, text;
-	zend_string *str;
 
 	ret = xmlNewNode(NULL, BAD_CAST("BOGUS"));
 	xmlAddChild(parent, ret);
 	FIND_ZVAL_NULL(data, ret, style);
 
-	if (Z_TYPE_P(data) == IS_STRING) {
-		str = php_base64_encode((unsigned char*)Z_STRVAL_P(data), Z_STRLEN_P(data));
-	} else {
-		zend_string *tmp = zval_get_string_func(data);
-		str = php_base64_encode((unsigned char*) ZSTR_VAL(tmp), ZSTR_LEN(tmp));
-		zend_string_release_ex(tmp, 0);
-	}
+	zend_string *serialization = get_serialization_string_from_zval(data);
+	zend_string *str = php_base64_encode((unsigned char *) ZSTR_VAL(serialization), ZSTR_LEN(serialization));
+	zend_string_release(serialization);
 
 	text = xmlNewTextLen(BAD_CAST(ZSTR_VAL(str)), ZSTR_LEN(str));
 	xmlAddChild(ret, text);
@@ -961,7 +956,7 @@ static xmlNodePtr to_xml_hexbin(encodeTypePtr type, zval *data, int style, xmlNo
 	FIND_ZVAL_NULL(data, ret, style);
 
 	if (Z_TYPE_P(data) != IS_STRING) {
-		ZVAL_STR(&tmp, zval_get_string_func(data));
+		ZVAL_STR(&tmp, get_serialization_string_from_zval(data));
 		data = &tmp;
 	}
 	str = (unsigned char *) safe_emalloc(Z_STRLEN_P(data) * 2, sizeof(char), 1);
@@ -3032,7 +3027,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 		smart_str list = {0};
 
 		if (Z_TYPE_P(data) != IS_STRING) {
-			ZVAL_STR(&tmp, zval_get_string_func(data));
+			ZVAL_STR(&tmp, get_serialization_string_from_zval(data));
 			data = &tmp;
 		}
 		str = estrndup(Z_STRVAL_P(data), Z_STRLEN_P(data));
@@ -3141,13 +3136,10 @@ static xmlNodePtr to_xml_any(encodeTypePtr type, zval *data, int style, xmlNodeP
 		} ZEND_HASH_FOREACH_END();
 		return ret;
 	}
-	if (Z_TYPE_P(data) == IS_STRING) {
-		ret = xmlNewTextLen(BAD_CAST(Z_STRVAL_P(data)), Z_STRLEN_P(data));
-	} else {
-		zend_string *tmp = zval_get_string_func(data);
-		ret = xmlNewTextLen(BAD_CAST(ZSTR_VAL(tmp)), ZSTR_LEN(tmp));
-		zend_string_release_ex(tmp, 0);
-	}
+
+	zend_string *serialization = get_serialization_string_from_zval(data);
+	ret = xmlNewTextLen(BAD_CAST(ZSTR_VAL(serialization)), ZSTR_LEN(serialization));
+	zend_string_release_ex(serialization, false);
 
 	ret->name = xmlStringTextNoenc;
 	ret->parent = parent;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -834,6 +834,17 @@ static zval *to_zval_hexbin(zval *ret, encodeTypePtr type, xmlNodePtr data)
 static zend_string *get_serialization_string_from_zval(zval *data)
 {
 	switch (Z_TYPE_P(data)) {
+		case IS_OBJECT:
+			if (Z_OBJCE_P(data)->ce_flags & ZEND_ACC_ENUM) {
+				if (UNEXPECTED(Z_OBJCE_P(data)->enum_backing_type == IS_UNDEF)) {
+					zend_value_error("Non-backed enums have no default serialization");
+					return zend_empty_string;
+				} else {
+					zval *value = zend_enum_fetch_case_value(Z_OBJ_P(data));
+					return zval_get_string_func(value);
+				}
+			}
+			ZEND_FALLTHROUGH;
 		default:
 			return zval_get_string_func(data);
 	}

--- a/ext/soap/tests/gh15711.phpt
+++ b/ext/soap/tests/gh15711.phpt
@@ -1,0 +1,66 @@
+--TEST--
+GH-15711 (SoapClient can't convert BackedEnum to scalar value)
+--EXTENSIONS--
+soap
+--INI--
+soap.wsdl_cache_enabled=0
+--FILE--
+<?php
+
+enum TestBackedEnum: string
+{
+    case First = 'BackingValue1';
+    case Second = 'BackingValue2';
+    case Third = 'BackingValue3';
+    case Fourth = 'BackingValue4';
+    case Fifth = 'BackingValue5';
+}
+
+enum TestNonBackedEnum
+{
+    case First;
+}
+
+class TestSoapClient extends SoapClient {
+    function __doRequest($request, $location, $action, $version, $one_way = 0): ?string {
+        echo $request;
+    }
+}
+
+$client = new TestSoapClient('ext/soap/tests/gh15711.wsdl', ['classmap' => ['book' => 'book']]);
+
+echo "--- Test with backed enum ---\n";
+
+$book = new stdClass();
+$book->base64 = TestBackedEnum::First;
+$book->string = TestBackedEnum::Second;
+$book->any = TestBackedEnum::Third;
+$book->hexbin = TestBackedEnum::Fourth;
+$book->nmtokens = TestBackedEnum::Fifth;
+
+try {
+    $client->dotest($book);
+} catch (Throwable) {}
+
+echo "--- Test with non-backed enum ---\n";
+
+$book = new stdClass();
+$book->base64 = TestNonBackedEnum::First;
+$book->string = TestNonBackedEnum::First;
+$book->any = TestNonBackedEnum::First;
+$book->hexbin = TestNonBackedEnum::First;
+$book->nmtokens = TestNonBackedEnum::First;
+
+try {
+    $client->dotest($book);
+} catch (ValueError $e) {
+    echo "ValueError: ", $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+--- Test with backed enum ---
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://schemas.nothing.com" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:dotest><dotestReturn xsi:type="ns1:book"><base64 xsi:type="xsd:base64Binary">QmFja2luZ1ZhbHVlMQ==</base64><string xsi:type="xsd:string">BackingValue2</string><any xsi:type="xsd:any"><name xsi:type="xsd:string">Third</name><value xsi:type="xsd:string">BackingValue3</value></any><hexbin xsi:type="xsd:hexBinary">4261636B696E6756616C756534</hexbin><nmtokens>BackingValue5</nmtokens></dotestReturn></ns1:dotest></SOAP-ENV:Body></SOAP-ENV:Envelope>
+--- Test with non-backed enum ---
+ValueError: Non-backed enums have no default serialization

--- a/ext/soap/tests/gh15711.phpt
+++ b/ext/soap/tests/gh15711.phpt
@@ -7,7 +7,7 @@ soap.wsdl_cache_enabled=0
 --FILE--
 <?php
 
-enum TestBackedEnum: string
+enum StringBackedEnum: string
 {
     case First = 'BackingValue1';
     case Second = 'BackingValue2';
@@ -16,7 +16,13 @@ enum TestBackedEnum: string
     case Fifth = 'BackingValue5';
 }
 
-enum TestNonBackedEnum
+enum IntBackedEnum: int
+{
+    case First = 1;
+    case Second = 2;
+}
+
+enum NonBackedEnum
 {
     case First;
 }
@@ -32,11 +38,13 @@ $client = new TestSoapClient('ext/soap/tests/gh15711.wsdl', ['classmap' => ['boo
 echo "--- Test with backed enum ---\n";
 
 $book = new stdClass();
-$book->base64 = TestBackedEnum::First;
-$book->string = TestBackedEnum::Second;
-$book->any = TestBackedEnum::Third;
-$book->hexbin = TestBackedEnum::Fourth;
-$book->nmtokens = TestBackedEnum::Fifth;
+$book->base64 = StringBackedEnum::First;
+$book->string = StringBackedEnum::Second;
+$book->any = StringBackedEnum::Third;
+$book->hexbin = StringBackedEnum::Fourth;
+$book->nmtokens = StringBackedEnum::Fifth;
+$book->integer = IntBackedEnum::First;
+$book->short = IntBackedEnum::Second;
 
 try {
     $client->dotest($book);
@@ -45,12 +53,24 @@ try {
 echo "--- Test with non-backed enum ---\n";
 
 $book = new stdClass();
-$book->base64 = TestNonBackedEnum::First;
-$book->string = TestNonBackedEnum::First;
-$book->any = TestNonBackedEnum::First;
-$book->hexbin = TestNonBackedEnum::First;
-$book->nmtokens = TestNonBackedEnum::First;
+$book->base64 = NonBackedEnum::First;
+$book->string = NonBackedEnum::First;
+$book->any = NonBackedEnum::First;
+$book->hexbin = NonBackedEnum::First;
+$book->nmtokens = NonBackedEnum::First;
+$book->integer = NonBackedEnum::First;
+$book->short = NonBackedEnum::First;
 
+try {
+    $client->dotest($book);
+} catch (ValueError $e) {
+    echo "ValueError: ", $e->getMessage(), "\n";
+}
+
+echo "--- Test with mismatched enum backing type ---\n";
+
+$book->integer = StringBackedEnum::First;
+$book->short = StringBackedEnum::First;
 try {
     $client->dotest($book);
 } catch (ValueError $e) {
@@ -61,6 +81,8 @@ try {
 --EXPECT--
 --- Test with backed enum ---
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://schemas.nothing.com" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:dotest><dotestReturn xsi:type="ns1:book"><base64 xsi:type="xsd:base64Binary">QmFja2luZ1ZhbHVlMQ==</base64><string xsi:type="xsd:string">BackingValue2</string><any xsi:type="xsd:any"><name xsi:type="xsd:string">Third</name><value xsi:type="xsd:string">BackingValue3</value></any><hexbin xsi:type="xsd:hexBinary">4261636B696E6756616C756534</hexbin><nmtokens>BackingValue5</nmtokens></dotestReturn></ns1:dotest></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://schemas.nothing.com" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:dotest><dotestReturn xsi:type="ns1:book"><base64 xsi:type="xsd:base64Binary">QmFja2luZ1ZhbHVlMQ==</base64><string xsi:type="xsd:string">BackingValue2</string><any xsi:type="xsd:any"><name xsi:type="xsd:string">Third</name><value xsi:type="xsd:string">BackingValue3</value></any><hexbin xsi:type="xsd:hexBinary">4261636B696E6756616C756534</hexbin><nmtokens>BackingValue5</nmtokens><integer xsi:type="xsd:integer">1</integer><short xsi:type="xsd:short">2</short></dotestReturn></ns1:dotest></SOAP-ENV:Body></SOAP-ENV:Envelope>
 --- Test with non-backed enum ---
 ValueError: Non-backed enums have no default serialization
+--- Test with mismatched enum backing type ---
+ValueError: String-backed enum cannot be serialized as int

--- a/ext/soap/tests/gh15711.wsdl
+++ b/ext/soap/tests/gh15711.wsdl
@@ -1,0 +1,37 @@
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.nothing.com" targetNamespace="http://schemas.nothing.com">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://schemas.nothing.com">
+			<xsd:complexType name="book">
+				<xsd:all>
+					<xsd:element name="base64" type="xsd:base64Binary"/>
+					<xsd:element name="string" type="xsd:string"/>
+                    <xsd:element name="any" type="xsd:any"/>
+                    <xsd:element name="hexbin" type="xsd:hexBinary"/>
+                    <xsd:element name="nmtokens" type="xsd:NMTOKENS"/>
+				</xsd:all>
+			</xsd:complexType>
+  </xsd:schema>
+	</wsdl:types>
+	<message name="dotestRequest">
+		<part name="dotestReturn" type="tns:book"/>
+  </message>
+	<portType name="testPortType">
+		<operation name="dotest">
+			<input message="tns:dotestRequest"/>
+		</operation>
+	</portType>
+	<binding name="testBinding" type="tns:testPortType">
+		<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="dotest">
+			<soap:operation soapAction="http://localhost:81/test/interface.php?class=test/dotest" style="rpc"/>
+			<input>
+				<soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="http://schemas.nothing.com"/>
+			</input>
+		</operation>
+	</binding>
+	<service name="test">
+		<port name="testPort" binding="tns:testBinding">
+			<soap:address location="http://localhost:81/test/interface.php?class=test"/>
+		</port>
+	</service>
+</wsdl:definitions>

--- a/ext/soap/tests/gh15711.wsdl
+++ b/ext/soap/tests/gh15711.wsdl
@@ -8,6 +8,8 @@
                     <xsd:element name="any" type="xsd:any"/>
                     <xsd:element name="hexbin" type="xsd:hexBinary"/>
                     <xsd:element name="nmtokens" type="xsd:NMTOKENS"/>
+                    <xsd:element name="integer" type="xsd:integer"/>
+                    <xsd:element name="short" type="xsd:short"/>
 				</xsd:all>
 			</xsd:complexType>
   </xsd:schema>


### PR DESCRIPTION
See individual commits, some code had to be adapted first.