### PR TITLE
Fix GH-13437: FPM: ERROR: scoreboard: failed to lock (already locked)

### DIFF
--- a/sapi/fpm/fpm/fpm_atomic.h
+++ b/sapi/fpm/fpm/fpm_atomic.h
@@ -156,6 +156,25 @@ static inline int fpm_spinlock(atomic_t *lock, int try_once) /* {{{ */
 }
 /* }}} */
 
+static inline int fpm_spinlock_with_max_retries(atomic_t *lock, unsigned int max_retries)
+{
+    unsigned int retries = 0;
+
+    for (;;) {
+        if (atomic_cmp_set(lock, 0, 1)) {
+            return 1;
+        }
+
+        sched_yield();
+
+        if (++retries > max_retries) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 #define fpm_unlock(lock) lock = 0
 
 #endif

--- a/sapi/fpm/fpm/fpm_scoreboard.h
+++ b/sapi/fpm/fpm/fpm_scoreboard.h
@@ -18,6 +18,8 @@
 #define FPM_SCOREBOARD_LOCK_HANG 0
 #define FPM_SCOREBOARD_LOCK_NOHANG 1
 
+#define FPM_SCOREBOARD_SPINLOCK_MAX_RETRIES 50000
+
 struct fpm_scoreboard_proc_s {
 	union {
 		atomic_t lock;
@@ -52,6 +54,8 @@ struct fpm_scoreboard_s {
 		atomic_t lock;
 		char dummy[16];
 	};
+	atomic_t writer_active;
+	unsigned int reader_count;
 	char pool[32];
 	int pm;
 	time_t start_epoch;


### PR DESCRIPTION
This changes locking for scoreboard to reduce contention between readers and adds retries for acquiring scoreboard for read.
