### PR TITLE
Fix GH-15657: Segmentation fault in ext/opcache/jit/ir/dynasm/dasm_x86.h

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2428,8 +2428,21 @@ static zend_class_entry* zend_accel_inheritance_cache_add(zend_class_entry *ce, 
 		} ZEND_HASH_FOREACH_END();
 		ZCG(mem) = (char*)ZCG(mem) + zend_hash_num_elements(dependencies) * sizeof(zend_class_dependency);
 	}
+
+	/* See GH-15657: `zend_persist_class_entry` can JIT property hook code via
+	 * `zend_persist_property_info`, but the inheritance cache should not
+	 * JIT those at this point in time. */
+#ifdef HAVE_JIT
+	bool jit_on_old = JIT_G(on);
+	JIT_G(on) = false;
+#endif
+
 	entry->ce = new_ce = zend_persist_class_entry(ce);
 	zend_update_parent_ce(new_ce);
+
+#ifdef HAVE_JIT
+	JIT_G(on) = jit_on_old;
+#endif
 
 	entry->num_warnings = EG(num_errors);
 	entry->warnings = zend_persist_warnings(EG(num_errors), EG(errors));

--- a/ext/opcache/tests/jit/gh15657.phpt
+++ b/ext/opcache/tests/jit/gh15657.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-15657 (Segmentation fault in ext/opcache/jit/ir/dynasm/dasm_x86.h)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit_buffer_size=64M
+opcache.jit=1101
+--FILE--
+<?php
+// Triggering the inheritance cache via implementing this interface is important to reproduce the bug
+interface I {}
+
+class A implements I {
+    private $_prop;
+    public $prop {
+        get => $this->_prop;
+    }
+}
+echo "Done\n";
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
The crash happens because the zend_persist.c code tries to JIT the hook's op_array while the JIT buffer memory is still protected. This happens in `zend_persist_property_info` called via `zend_persist_class_entry` through the inheritance cache. You can check that this is true by surrounding the JIT call with `zend_jit_unprotect()` and `zend_jit_protect()`.

We shouldn't JIT the property hook code when persisting property info for the inheritance cache.

This is a simple workaround by temporarily disabling the JIT so that the property hook code is not JITted when persisting the property info.

An alternative solution would be to move the JITting of the property hooks to a different place in zend_persist.c by doing an additional pass over the classes.