### PR TITLE
php_reflection.c: remove unneeded do-while in `DUMP_CONST_FLAG` macro

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -556,13 +556,11 @@ static void _const_string(smart_str *str, char *name, zval *value, char *indent)
 		smart_str_appends(str, "<");
 
 #define DUMP_CONST_FLAG(flag, output) \
-	do { \
-		if (flags & flag) { \
-			if (!first) smart_str_appends(str, ", "); \
-			smart_str_appends(str, output); \
-			first = false; \
-		} \
-	} while (0)
+	if (flags & flag) { \
+		if (!first) smart_str_appends(str, ", "); \
+		smart_str_appends(str, output); \
+		first = false; \
+	}
 		DUMP_CONST_FLAG(CONST_PERSISTENT, "persistent");
 		DUMP_CONST_FLAG(CONST_NO_FILE_CACHE, "no_file_cache");
 		DUMP_CONST_FLAG(CONST_DEPRECATED, "deprecated");


### PR DESCRIPTION
The do-while trick is used to allow including multiple statements where only one is expected, but in this case we know that the uses on the next few lines permit including multiple statements, so the extra do-while wrapper is unneeded.