### PR TITLE
Fix AArch64 MSan warnings

### DIFF
--- a/ext/standard/base64.c
+++ b/ext/standard/base64.c
@@ -891,6 +891,7 @@ PHPAPI zend_string *php_base64_encode(const unsigned char *str, size_t length)
 	zend_string *result;
 
 	result = zend_string_safe_alloc(((length + 2) / 3), 4 * sizeof(char), 0, 0);
+	memset(ZSTR_VAL(result), 0, ZSTR_LEN(result));
 	p = (unsigned char *)ZSTR_VAL(result);
 
 	p = php_base64_encode_impl(str, length, p);
@@ -912,6 +913,7 @@ PHPAPI zend_string *php_base64_decode_ex(const unsigned char *str, size_t length
 	size_t outl = 0;
 
 	result = zend_string_alloc(length, 0);
+	memset(ZSTR_VAL(result), 0, ZSTR_LEN(result));
 
 	if (!php_base64_decode_impl(str, length, (unsigned char*)ZSTR_VAL(result), &outl, strict)) {
 		zend_string_efree(result);

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1190,7 +1190,7 @@ PHP_FUNCTION(usleep)
 PHP_FUNCTION(time_nanosleep)
 {
 	zend_long tv_sec, tv_nsec;
-	struct timespec php_req, php_rem;
+	struct timespec php_req, php_rem = {0};
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_LONG(tv_sec)


### PR DESCRIPTION
Clang 18 (stable) on AArch64 generates warnings about uninitialized values when using MSan.

This PR fixes the issue, but it's likely a false positive.
I'm not yet sure how to properly address the false positive, but I'm creating this draft PR for now.