### PR TITLE
Use APPLY_STOP in pcre_clean_cache()

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -521,8 +521,10 @@ static int pcre_clean_cache(zval *data, void *arg)
 	pcre_cache_entry *pce = (pcre_cache_entry *) Z_PTR_P(data);
 	int *num_clean = (int *)arg;
 
-	if (*num_clean > 0 && !pce->refcount) {
-		(*num_clean)--;
+	if (!pce->refcount) {
+		if (--(*num_clean) == 0) {
+			return ZEND_HASH_APPLY_REMOVE|ZEND_HASH_APPLY_STOP;
+		}
 		return ZEND_HASH_APPLY_REMOVE;
 	} else {
 		return ZEND_HASH_APPLY_KEEP;


### PR DESCRIPTION
Once num_clean has reached 0, we never remove any more elements anyway.

Found while looking at https://github.com/php/php-src/pull/15205.

- [x] *Edit*: Ah, actually we shouldn't stop when only `!pce->refcount` is true. I'll fix that in a sec.