### PR TITLE
Fix GH-15837: Segmentation fault in ext/simplexml/simplexml.c

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2547,6 +2547,11 @@ static void php_sxe_iterator_current_key(zend_object_iterator *iter, zval *key) 
 {
 	php_sxe_iterator *iterator = (php_sxe_iterator *)iter;
 	zval *curobj = &iterator->sxe->iter.data;
+	if (Z_ISUNDEF_P(curobj)) {
+		ZVAL_NULL(key);
+		return;
+	}
+
 	php_sxe_object *intern = Z_SXEOBJ_P(curobj);
 
 	xmlNodePtr curnode = NULL;

--- a/ext/simplexml/tests/gh15837.phpt
+++ b/ext/simplexml/tests/gh15837.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-15837 (Segmentation fault in ext/simplexml/simplexml.c)
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$xml =<<<EOF
+<xml>
+<fieldset1>
+</fieldset1>
+<fieldset2>
+<options>
+</options>
+</fieldset2>
+</xml>
+EOF;
+$sxe = new SimpleXMLIterator($xml);
+$rit = new RecursiveIteratorIterator($sxe, RecursiveIteratorIterator::LEAVES_ONLY);
+foreach ($rit as $child) {
+    $ancestry = $child->xpath('ancestor-or-self::*');
+    // Exhaust internal iterator
+    foreach ($ancestry as $ancestor) {
+    }
+}
+var_dump($rit->valid());
+var_dump($rit->key());
+?>
+--EXPECT--
+bool(false)
+NULL


### PR DESCRIPTION
We should check if the iterator data is still valid, because if it isn't, then the type info is UNDEF, but the pointer value may be dangling.