### PR TITLE
Support building ext/gd without libxpm on Windows

### DIFF
--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -17,11 +17,15 @@ if (PHP_GD != "no") {
 		(CHECK_LIB("libiconv_a.lib;libiconv.lib", "gd", PHP_GD) || CHECK_LIB("iconv_a.lib;iconv.lib", "gd", PHP_GD)) &&
 		 CHECK_HEADER_ADD_INCLUDE("iconv.h", "CFLAGS_GD", PHP_GD) &&
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "gd", PHP_GD) )) ||
-			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "gd", PHP_GD)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))) &&
-		CHECK_LIB("libXpm_a.lib", "gd", PHP_GD) &&
-		CHECK_HEADER_ADD_INCLUDE("xpm.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\X11")
+			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "gd", PHP_GD)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED)))
 		) {
 
+		if (CHECK_LIB("libXpm_a.lib", "gd", PHP_GD) &&
+			CHECK_HEADER_ADD_INCLUDE("xpm.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\X11")
+		) {
+			AC_DEFINE('HAVE_XPM', 1, "Define to 1 if you have the xpm library.");
+			AC_DEFINE('HAVE_GD_XPM', 1, "Define to 1 if gd extension has XPM support.");
+		}
 		if (PHP_LIBWEBP != "no") {
 			if ((CHECK_LIB("libwebp_a.lib", "gd", PHP_GD) || CHECK_LIB("libwebp.lib", "gd", PHP_GD)) &&
 				CHECK_HEADER_ADD_INCLUDE("decode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp") &&
@@ -62,8 +66,6 @@ if (PHP_GD != "no") {
 		AC_DEFINE('HAVE_LIBPNG', 1, "Define to 1 if you have the libpng library.");
 		AC_DEFINE('HAVE_LIBJPEG', 1, "Define to 1 if you have the libjpeg library.");
 		AC_DEFINE('HAVE_GD_JPG', 1, "Define to 1 if gd extension has JPEG support.");
-		AC_DEFINE('HAVE_XPM', 1, "Define to 1 if you have the xpm library.");
-		AC_DEFINE('HAVE_GD_XPM', 1, "Define to 1 if gd extension has XPM support.");
 		AC_DEFINE('HAVE_LIBFREETYPE', 1, "Define to 1 if you have the FreeType library.");
 		AC_DEFINE('HAVE_GD_FREETYPE', 1, "Define to 1 if gd extension has FreeType support.");
 		ADD_FLAG("CFLAGS_GD", " \


### PR DESCRIPTION
For GD, libxpm is an optional dependency, and we should treat it as such, i.e. if the library is not found, we build ext/gd without XPM support.

This should also be done for other optional dependencies (like libjpeg), but since we're close to PHP 8.4.0RC1, we postpone that.  However, wrt libxpm[1] we're taking action immediately, so that we can ship builds without XPM support, or at least custom builds without XPM support are possible without modifying the sources.

[1] <https://news-web.php.net/php.internals/125502>