### PR TITLE
zend_compile.h: `ZEND_ACC_DEPRECATED` can be used for class constants

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -337,7 +337,7 @@ typedef struct _zend_oparray_context {
 /* ==============                                         |     |     |     */
 /*                                                        |     |     |     */
 /* deprecation flag                                       |     |     |     */
-#define ZEND_ACC_DEPRECATED              (1 << 11) /*     |  X  |     |     */
+#define ZEND_ACC_DEPRECATED              (1 << 11) /*     |  X  |     |  X  */
 /*                                                        |     |     |     */
 /* Function returning by reference                        |     |     |     */
 #define ZEND_ACC_RETURN_REFERENCE        (1 << 12) /*     |  X  |     |     */


### PR DESCRIPTION
Support for deprecating class constants was added to implement the PHP 8.3 deprecations in #11615, but the documentation update was missed.

[skip ci]