### PR TITLE
ext/gd: enable avif tests on GH-Actions

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -39,6 +39,7 @@ runs:
           libsqlite3-dev \
           libsqlite3-mod-spatialite \
           libwebp-dev \
+          libavif-dev \
           libonig-dev \
           libcurl4-openssl-dev \
           libxml2-dev \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -28,6 +28,7 @@ runs:
           --enable-gd \
           --with-jpeg \
           --with-webp \
+          --with-avif \
           --with-freetype \
           --with-xpm \
           --enable-exif \


### PR DESCRIPTION
When the avif support was first added (GH-7026), php-src did not use GitHub Actions. When we moved to GitHub Actions for CI, the `--with-avif` option nor the `libavif-dev` dependencies were not added.

Cirrus CI still runs the tests, and now that we no longer use Travis CI, this brings parity to test avif on x64 tests on GitHub Actions as well.

`libavif-dev` package's x86 builds seem to be missing[^1][^2] on older Ubuntu versions, so this commit only adds it for x64 builds.

[^1]: https://packages.ubuntu.com/jammy/libavif-dev
[^2]: https://packages.ubuntu.com/noble/libavif-dev