### PR TITLE
Fix oss-fuzz #71382

### DIFF
--- a/Zend/tests/lazy_objects/oss_fuzz_71382.phpt
+++ b/Zend/tests/lazy_objects/oss_fuzz_71382.phpt
@@ -1,0 +1,27 @@
+--TEST--
+oss-fuzz #71382
+--FILE--
+<?php
+
+class C {
+    public $a;
+    public $b {
+        get {
+        }
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+$obj = $reflector->newLazyGhost(function() {
+    throw new \Exception('initializer');
+});
+
+try {
+    foreach($obj as $a) {
+    }
+} catch (Exception $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+--EXPECT--
+Exception: initializer

--- a/Zend/zend_property_hooks.c
+++ b/Zend/zend_property_hooks.c
@@ -54,7 +54,7 @@ static zend_array *zho_build_properties_ex(zend_object *zobj, bool check_access,
 	if (UNEXPECTED(zend_lazy_object_must_init(zobj))) {
 		zobj = zend_lazy_object_init(zobj);
 		if (UNEXPECTED(!zobj)) {
-			return (zend_array*) &zend_empty_array;
+			return zend_new_array(0);
 		}
 	}
 


### PR DESCRIPTION
The return value of `zho_build_properties_ex()` is passed to `ZVAL_ARR()`, which sets the `IS_TYPE_REFCOUNTED` flag. Returning `&zend_emtpy_array` will crash later when trying to dtor the zval.

I'm fixing this by returning `zend_new_array(0)` instead of `&zend_empty_array`.

An alternative was to make `ZVAL_ARR()` aware of immutable arrays, like `ZVAL_STR()` is with interned strings, but I found no other problematic cases.