### PR TITLE
Fix zend_get_property_info_for_slot() for lazy objects

### DIFF
--- a/Zend/tests/lazy_objects/array_walk.phpt
+++ b/Zend/tests/lazy_objects/array_walk.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Lazy Objects: array_walk()
+--FILE--
+<?php
+
+class C {
+    public int $a = 1;
+}
+
+
+$reflector = new ReflectionClass(C::class);
+$obj = $reflector->newLazyProxy(function () {
+    return new C();
+});
+
+array_walk($obj, function (&$value, $key) {
+    try {
+        $value = 'string';
+    } catch (Error $e) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+    $value = 2;
+});
+
+var_dump($obj);
+
+?>
+--EXPECTF--
+TypeError: Cannot assign string to reference held by property C::$a of type int
+lazy proxy object(C)#%d (1) {
+  ["instance"]=>
+  object(C)#%d (1) {
+    ["a"]=>
+    int(2)
+  }
+}

--- a/Zend/tests/lazy_objects/oss_fuzz_71446.phpt
+++ b/Zend/tests/lazy_objects/oss_fuzz_71446.phpt
@@ -1,0 +1,22 @@
+--TEST--
+oss-fuzz #71446
+--FILE--
+<?php
+
+class C {
+    public mixed $a;
+    function __sleep() {
+        return['a'];
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+
+$obj = $reflector->newLazyProxy(function() {
+    $c = new C;
+    return $c;
+});
+
+serialize($obj);
+?>
+--EXPECTF--

--- a/Zend/tests/lazy_objects/serialize___sleep.phpt
+++ b/Zend/tests/lazy_objects/serialize___sleep.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Lazy Objects: serialize with __sleep fetches property info from the real instance
+--FILE--
+<?php
+
+class C {
+    public mixed $a;
+    private mixed $b = 1;
+    function __sleep() {
+        return['a', 'b'];
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+
+print "Init on serialize and successful initialization\n";
+
+$obj = $reflector->newLazyProxy(function() {
+    $c = new C;
+    return $c;
+});
+
+var_dump(serialize($obj));
+
+print "Init on serialize and failed initialization\n";
+
+$obj = $reflector->newLazyProxy(function() {
+    throw new \Exception('initializer');
+});
+
+try {
+    var_dump(serialize($obj));
+} catch (Exception $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+?>
+--EXPECTF--
+Init on serialize and successful initialization
+string(27) "O:1:"C":1:{s:4:"%0C%0b";i:1;}"
+Init on serialize and failed initialization
+Exception: initializer

--- a/Zend/tests/lazy_objects/typed_properties_001.phpt
+++ b/Zend/tests/lazy_objects/typed_properties_001.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Typed property assignment by ref with variable name on proxy
+--FILE--
+<?php
+
+class Test {
+    public int $prop;
+}
+
+$name = new class {
+    public function __toString() {
+        return 'prop';
+    }
+};
+
+$reflector = new ReflectionClass(Test::class);
+$test = $reflector->newLazyProxy(function () {
+    return new Test();
+});
+$ref = "foobar";
+try {
+    $test->$name =& $ref;
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($test);
+
+?>
+--EXPECTF--
+Cannot assign string to property Test::$prop of type int
+lazy proxy object(Test)#%d (1) {
+  ["instance"]=>
+  object(Test)#%d (0) {
+    ["prop"]=>
+    uninitialized(int)
+  }
+}

--- a/Zend/tests/lazy_objects/typed_properties_002.phpt
+++ b/Zend/tests/lazy_objects/typed_properties_002.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Typed property assignment by ref with variable name on proxy
+--FILE--
+<?php
+
+interface I {}
+interface J {}
+
+class A implements I {}
+class B implements J {}
+class C implements I, J {}
+
+class Test {
+    public function __construct(
+        public I $a,
+        public J $b,
+    ) {
+    }
+}
+
+function test($obj, $a, $b) {
+    $obj->$b =& $obj->$a;
+    try {
+        $obj->$a = new B;
+    } catch (Error $e) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+    try {
+        $obj->$b = new A;
+    } catch (Error $e) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+    $obj->$a = new C;
+    unset($obj->$a);
+    $obj->$b = new B;
+}
+
+$reflector = new ReflectionClass(Test::class);
+$obj = $reflector->newLazyProxy(function () {
+    return new Test(new C, new C);
+});
+
+test($obj, 'a', 'b');
+
+var_dump($obj);
+
+?>
+--EXPECTF--
+TypeError: Cannot assign B to property Test::$a of type I
+TypeError: Cannot assign A to property Test::$b of type J
+lazy proxy object(Test)#%d (1) {
+  ["instance"]=>
+  object(Test)#%d (1) {
+    ["a"]=>
+    uninitialized(I)
+    ["b"]=>
+    object(B)#%d (0) {
+    }
+  }
+}

--- a/Zend/tests/lazy_objects/typed_properties_003.phpt
+++ b/Zend/tests/lazy_objects/typed_properties_003.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Typed property assign op cached
+--FILE--
+<?php
+
+class Test {
+    public int $prop = 0;
+}
+
+function op($obj, $prop) {
+    $obj->$prop += 1;
+}
+function pre($obj, $prop) {
+    return ++$obj->$prop;
+}
+function post($obj, $prop) {
+    return $obj->$prop++;
+}
+
+$reflector = new ReflectionClass(Test::class);
+$obj = $reflector->newLazyProxy(function () {
+    return new Test();
+});
+
+op($obj, 'prop');
+op($obj, 'prop');
+
+pre($obj, 'prop');
+pre($obj, 'prop');
+
+post($obj, 'prop');
+post($obj, 'prop');
+
+var_dump($obj);
+
+?>
+--EXPECTF--
+lazy proxy object(Test)#%d (1) {
+  ["instance"]=>
+  object(Test)#%d (1) {
+    ["prop"]=>
+    int(6)
+  }
+}

--- a/Zend/tests/lazy_objects/typed_properties_004.phpt
+++ b/Zend/tests/lazy_objects/typed_properties_004.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Lazy Objects: Foreach by ref over typed properties
+--FILE--
+<?php
+
+class C {
+    public int $a = 1;
+    private int $_b = 1;
+    public int $b {
+        &get { $value = &$this->_b; return $value; }
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+$obj = $reflector->newLazyProxy(function () {
+    return new C();
+});
+
+foreach ($obj as $key => &$value) {
+    var_dump($key);
+    try {
+        $value = 'string';
+    } catch (Error $e) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+    $value = 2;
+}
+
+var_dump($obj);
+
+?>
+--EXPECTF--
+string(1) "a"
+TypeError: Cannot assign string to reference held by property C::$a of type int
+string(1) "b"
+TypeError: Cannot assign string to reference held by property C::$_b of type int
+lazy proxy object(C)#%d (1) {
+  ["instance"]=>
+  object(C)#%d (2) {
+    ["a"]=>
+    int(2)
+    ["_b":"C":private]=>
+    &int(2)
+  }
+}

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -734,3 +734,21 @@ HashTable *zend_lazy_object_get_gc(zend_object *zobj, zval **table, int *n)
 	zend_get_gc_buffer_use(gc_buffer, table, n);
 	return NULL;
 }
+
+zend_property_info *zend_lazy_object_get_property_info_for_slot(zend_object *obj, zval *slot)
+{
+	ZEND_ASSERT(zend_object_is_lazy_proxy(obj));
+
+	zend_property_info **table = obj->ce->properties_info_table;
+	intptr_t prop_num = slot - obj->properties_table;
+	if (prop_num >= 0 && prop_num < obj->ce->default_properties_count) {
+		return table[prop_num];
+	}
+
+	if (!zend_lazy_object_initialized(obj)) {
+		return NULL;
+	}
+
+	obj = zend_lazy_object_get_instance(obj);
+	return zend_get_property_info_for_slot(obj, slot);
+}

--- a/Zend/zend_lazy_objects.h
+++ b/Zend/zend_lazy_objects.h
@@ -53,6 +53,7 @@ typedef struct _zend_lazy_objects_store {
 	HashTable infos;
 } zend_lazy_objects_store;
 
+typedef struct _zend_property_info zend_property_info;
 typedef struct _zend_fcall_info zend_fcall_info;
 typedef struct _zend_fcall_info_cache zend_fcall_info_cache;
 
@@ -75,6 +76,7 @@ HashTable *zend_lazy_object_debug_info(zend_object *object, int *is_temp);
 HashTable *zend_lazy_object_get_gc(zend_object *zobj, zval **table, int *n);
 bool zend_lazy_object_decr_lazy_props(zend_object *obj);
 void zend_lazy_object_realize(zend_object *obj);
+ZEND_API zend_property_info *zend_lazy_object_get_property_info_for_slot(zend_object *obj, zval *slot);
 
 static zend_always_inline bool zend_object_is_lazy(zend_object *obj)
 {

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -65,7 +65,7 @@ void zend_object_dtor_property(zend_object *object, zval *p)
 	if (Z_REFCOUNTED_P(p)) {
 		if (UNEXPECTED(Z_ISREF_P(p)) &&
 				(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(p)))) {
-			zend_property_info *prop_info = zend_get_property_info_for_slot(object, p);
+			zend_property_info *prop_info = zend_get_property_info_for_slot_self(object, p);
 			if (ZEND_TYPE_IS_SET(prop_info->type)) {
 				ZEND_REF_DEL_TYPE_SOURCE(Z_REF_P(p), prop_info);
 			}
@@ -233,7 +233,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 
 			if (UNEXPECTED(Z_ISREF_P(dst)) &&
 					(ZEND_DEBUG || ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(dst)))) {
-				zend_property_info *prop_info = zend_get_property_info_for_slot(new_object, dst);
+				zend_property_info *prop_info = zend_get_property_info_for_slot_self(new_object, dst);
 				if (ZEND_TYPE_IS_SET(prop_info->type)) {
 					ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(dst), prop_info);
 				}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1012,6 +1012,7 @@ ZEND_VM_HANDLER(28, ZEND_ASSIGN_OBJ_OP, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, OP)
 	zval *property;
 	zval *value;
 	zval *zptr;
+	void *_cache_slot[3] = {0};
 	void **cache_slot;
 	zend_property_info *prop_info;
 	zend_object *zobj;
@@ -1049,14 +1050,13 @@ ZEND_VM_C_LABEL(assign_op_object):
 				break;
 			}
 		}
-		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR((opline+1)->extended_value) : NULL;
+		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR((opline+1)->extended_value) : _cache_slot;
 		if (EXPECTED((zptr = zobj->handlers->get_property_ptr_ptr(zobj, name, BP_VAR_RW, cache_slot)) != NULL)) {
 			if (UNEXPECTED(Z_ISERROR_P(zptr))) {
 				if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 					ZVAL_NULL(EX_VAR(opline->result.var));
 				}
 			} else {
-				zval *orig_zptr = zptr;
 				zend_reference *ref;
 
 				do {
@@ -1069,11 +1069,7 @@ ZEND_VM_C_LABEL(assign_op_object):
 						}
 					}
 
-					if (OP2_TYPE == IS_CONST) {
-						prop_info = (zend_property_info*)CACHED_PTR_EX(cache_slot + 2);
-					} else {
-						prop_info = zend_object_fetch_property_type_info(Z_OBJ_P(object), orig_zptr);
-					}
+					prop_info = (zend_property_info*)CACHED_PTR_EX(cache_slot + 2);
 					if (prop_info) {
 						/* special case for typed properties */
 						zend_binary_assign_op_typed_prop(prop_info, zptr, value OPLINE_CC EXECUTE_DATA_CC);
@@ -1286,6 +1282,7 @@ ZEND_VM_HANDLER(132, ZEND_PRE_INC_OBJ, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, CACH
 	zval *object;
 	zval *property;
 	zval *zptr;
+	void *_cache_slot[3] = {0};
 	void **cache_slot;
 	zend_property_info *prop_info;
 	zend_object *zobj;
@@ -1321,18 +1318,14 @@ ZEND_VM_C_LABEL(pre_incdec_object):
 				break;
 			}
 		}
-		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL;
+		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : _cache_slot;
 		if (EXPECTED((zptr = zobj->handlers->get_property_ptr_ptr(zobj, name, BP_VAR_RW, cache_slot)) != NULL)) {
 			if (UNEXPECTED(Z_ISERROR_P(zptr))) {
 				if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 					ZVAL_NULL(EX_VAR(opline->result.var));
 				}
 			} else {
-				if (OP2_TYPE == IS_CONST) {
-					prop_info = (zend_property_info *) CACHED_PTR_EX(cache_slot + 2);
-				} else {
-					prop_info = zend_object_fetch_property_type_info(Z_OBJ_P(object), zptr);
-				}
+				prop_info = (zend_property_info *) CACHED_PTR_EX(cache_slot + 2);
 				zend_pre_incdec_property_zval(zptr, prop_info OPLINE_CC EXECUTE_DATA_CC);
 			}
 		} else {
@@ -1359,6 +1352,7 @@ ZEND_VM_HANDLER(134, ZEND_POST_INC_OBJ, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, CAC
 	zval *object;
 	zval *property;
 	zval *zptr;
+	void *_cache_slot[3] = {0};
 	void **cache_slot;
 	zend_property_info *prop_info;
 	zend_object *zobj;
@@ -1394,17 +1388,12 @@ ZEND_VM_C_LABEL(post_incdec_object):
 				break;
 			}
 		}
-		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL;
+		cache_slot = (OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : _cache_slot;
 		if (EXPECTED((zptr = zobj->handlers->get_property_ptr_ptr(zobj, name, BP_VAR_RW, cache_slot)) != NULL)) {
 			if (UNEXPECTED(Z_ISERROR_P(zptr))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			} else {
-				if (OP2_TYPE == IS_CONST) {
-					prop_info = (zend_property_info*)CACHED_PTR_EX(cache_slot + 2);
-				} else {
-					prop_info = zend_object_fetch_property_type_info(Z_OBJ_P(object), zptr);
-				}
-
+				prop_info = (zend_property_info*)CACHED_PTR_EX(cache_slot + 2);
 				zend_post_incdec_property_zval(zptr, prop_info OPLINE_CC EXECUTE_DATA_CC);
 			}
 		} else {
@@ -2217,7 +2206,7 @@ ZEND_VM_HANDLER(85, ZEND_FETCH_OBJ_W, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, FETCH
 	zend_fetch_property_address(
 		result, container, OP1_TYPE, property, OP2_TYPE,
 		((OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
-		BP_VAR_W, opline->extended_value OPLINE_CC EXECUTE_DATA_CC);
+		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -2234,7 +2223,7 @@ ZEND_VM_HANDLER(88, ZEND_FETCH_OBJ_RW, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, CACH
 	container = GET_OP1_OBJ_ZVAL_PTR_PTR_UNDEF(BP_VAR_RW);
 	property = GET_OP2_ZVAL_PTR(BP_VAR_R);
 	result = EX_VAR(opline->result.var);
-	zend_fetch_property_address(result, container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0 OPLINE_CC EXECUTE_DATA_CC);
+	zend_fetch_property_address(result, container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -2389,7 +2378,7 @@ ZEND_VM_HANDLER(97, ZEND_FETCH_OBJ_UNSET, VAR|UNUSED|THIS|CV, CONST|TMPVAR|CV, C
 	container = GET_OP1_OBJ_ZVAL_PTR_PTR_UNDEF(BP_VAR_UNSET);
 	property = GET_OP2_ZVAL_PTR(BP_VAR_R);
 	result = EX_VAR(opline->result.var);
-	zend_fetch_property_address(result, container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0 OPLINE_CC EXECUTE_DATA_CC);
+	zend_fetch_property_address(result, container, OP1_TYPE, property, OP2_TYPE, ((OP2_TYPE == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 	FREE_OP2();
 	if (OP1_TYPE == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -2065,22 +2065,6 @@ static zend_always_inline bool check_type_array_assignable(zend_type type) {
 	return (ZEND_TYPE_FULL_MASK(type) & MAY_BE_ARRAY) != 0;
 }
 
-static zend_property_info *zend_object_fetch_property_type_info(
-		zend_object *obj, zval *slot)
-{
-	if (EXPECTED(!ZEND_CLASS_HAS_TYPE_HINTS(obj->ce))) {
-		return NULL;
-	}
-
-	/* Not a declared property */
-	if (UNEXPECTED(slot < obj->properties_table ||
-			slot >= obj->properties_table + obj->ce->default_properties_count)) {
-		return NULL;
-	}
-
-	return zend_get_typed_property_info_for_slot(obj, slot);
-}
-
 static zend_never_inline ZEND_COLD void zend_throw_auto_init_in_prop_error(zend_property_info *prop, const char *type) {
 	zend_string *type_str = zend_type_to_string(prop->type);
 	zend_type_error(
@@ -2107,10 +2091,7 @@ static zend_never_inline bool zend_handle_fetch_obj_flags(
 		case ZEND_FETCH_DIM_WRITE:
 			if (promotes_to_array(ptr)) {
 				if (!prop_info) {
-					prop_info = zend_object_fetch_property_type_info(obj, ptr);
-					if (!prop_info) {
-						break;
-					}
+					break;
 				}
 				if (!check_type_array_assignable(prop_info->type)) {
 					zend_throw_auto_init_in_prop_error(prop_info, "array");
@@ -2122,10 +2103,7 @@ static zend_never_inline bool zend_handle_fetch_obj_flags(
 		case ZEND_FETCH_REF:
 			if (Z_TYPE_P(ptr) != IS_REFERENCE) {
 				if (!prop_info) {
-					prop_info = zend_object_fetch_property_type_info(obj, ptr);
-					if (!prop_info) {
-						break;
-					}
+					break;
 				}
 				if (Z_TYPE_P(ptr) == IS_UNDEF) {
 					if (!ZEND_TYPE_ALLOW_NULL(prop_info->type)) {
@@ -2154,6 +2132,7 @@ static void ZEND_FASTCALL zend_jit_fetch_obj_w_slow(zend_object *zobj)
 	zend_string *name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 	zval *result = EX_VAR(opline->result.var);
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
+	ZEND_ASSERT(cache_slot);
 
 	retval = zobj->handlers->get_property_ptr_ptr(zobj, name, BP_VAR_W, cache_slot);
 	if (NULL == retval) {
@@ -2180,13 +2159,10 @@ static void ZEND_FASTCALL zend_jit_fetch_obj_w_slow(zend_object *zobj)
 		uint32_t flags = opline->extended_value & ZEND_FETCH_OBJ_FLAGS;
 
 		if (flags) {
-			zend_property_info *prop_info = NULL;
+			zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 
-			if (opline->op2_type == IS_CONST) {
-				prop_info = CACHED_PTR_EX(cache_slot + 2);
-				if (!prop_info) {
-					break;
-				}
+			if (!prop_info) {
+				break;
 			}
 			if (UNEXPECTED(!zend_handle_fetch_obj_flags(result, retval, zobj, prop_info, flags))) {
 				return;


### PR DESCRIPTION
zend_get_property_info_for_slot(obj, slot) assumes that 'slot' belongs to 'obj', but that may not be the case for lazy proxies.

Fortunatley, the property info is often already available in path when it is nedded.

For other cases, I make zend_get_property_info_for_slot() aware of lazy objects, and add zend_get_property_info_for_slot_self() for cases where the 'slot' is known to belong to the object itself.

Fixes oss-fuzz #71446

VM uses zend_get_property_info_for_slot() for variable property accesses such as `$obj->$prop`. I retrieve the property info by inspecting the cache_slot, as it's set by the read_property or get_property_ptr_ptr handlers. An alternative would be to add a `zend_property_info **` parameter to these handlers.