### PR TITLE
ext/phar: Remove phar_resolve_alias()

### DIFF
--- a/ext/phar/config.m4
+++ b/ext/phar/config.m4
@@ -32,8 +32,6 @@ if test "$PHP_PHAR" != "no"; then
   PHP_ADD_EXTENSION_DEP(phar, spl)
   PHP_ADD_MAKEFILE_FRAGMENT
 
-  PHP_INSTALL_HEADERS([ext/phar], [php_phar.h])
-
   AC_CONFIG_FILES([
     $ext_dir/phar.1
     $ext_dir/phar.phar.1

--- a/ext/phar/config.w32
+++ b/ext/phar/config.w32
@@ -36,7 +36,6 @@ if (PHP_PHAR != "no") {
 	}
 	ADD_EXTENSION_DEP('phar', 'hash');
 	ADD_EXTENSION_DEP('phar', 'spl');
-	PHP_INSTALL_HEADERS("ext/phar", "php_phar.h");
 
 	ADD_MAKEFILE_FRAGMENT();
 }

--- a/ext/phar/php_phar.h
+++ b/ext/phar/php_phar.h
@@ -22,16 +22,7 @@
 
 #define PHP_PHAR_VERSION PHP_VERSION
 
-#include "ext/standard/basic_functions.h"
 extern zend_module_entry phar_module_entry;
 #define phpext_phar_ptr &phar_module_entry
-
-#ifdef PHP_WIN32
-#define PHP_PHAR_API __declspec(dllexport)
-#else
-#define PHP_PHAR_API PHPAPI
-#endif
-
-PHP_PHAR_API zend_result phar_resolve_alias(char *alias, size_t alias_len, char **filename, size_t *filename_len);
 
 #endif /* PHP_PHAR_H */

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -19,7 +19,6 @@
 */
 
 #include "phar_internal.h"
-#include "php_phar.h"
 #include "ext/hash/php_hash.h" /* Needed for PHP_HASH_API in ext/hash/php_hash_sha.h */
 #include "ext/hash/php_hash_sha.h"
 #include "ext/standard/md5.h"
@@ -972,18 +971,6 @@ phar_entry_info * phar_open_jit(phar_archive_data *phar, phar_entry_info *entry,
 		return NULL;
 	}
 	return entry;
-}
-/* }}} */
-
-PHP_PHAR_API zend_result phar_resolve_alias(char *alias, size_t alias_len, char **filename, size_t *filename_len) /* {{{ */ {
-	phar_archive_data *fd_ptr;
-	if (HT_IS_INITIALIZED(&PHAR_G(phar_alias_map))
-			&& NULL != (fd_ptr = zend_hash_str_find_ptr(&(PHAR_G(phar_alias_map)), alias, alias_len))) {
-		*filename = fd_ptr->fname;
-		*filename_len = fd_ptr->fname_len;
-		return SUCCESS;
-	}
-	return FAILURE;
 }
 /* }}} */
 


### PR DESCRIPTION
As this is unused and a SourceGraph search returns 0 result.

I'm not sure if we can just delete the header in the future?