### PR TITLE
Avoid copying the local name in SOAP's parse_namespace()

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -538,7 +538,8 @@ static zval *master_to_zval_int(zval *ret, encodePtr encode, xmlNodePtr data)
 			if (type_attr != NULL) {
 				encodePtr new_enc;
 				xmlNsPtr nsptr;
-				char *ns, *cptype;
+				const char *cptype;
+				char *ns;
 				smart_str nscat = {0};
 
 				parse_namespace(type_attr->children->content, &cptype, &ns);
@@ -549,7 +550,6 @@ static zval *master_to_zval_int(zval *ret, encodePtr encode, xmlNodePtr data)
 				}
 				smart_str_appends(&nscat, cptype);
 				smart_str_0(&nscat);
-				efree(cptype);
 				if (ns) {efree(ns);}
 				if ((new_enc = zend_hash_find_ptr(SOAP_GLOBAL(typemap), nscat.s)) != NULL) {
 					encode = new_enc;
@@ -2466,7 +2466,8 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 	if (data &&
 	    (attr = get_attribute(data->properties,"arrayType")) &&
 	    attr->children && attr->children->content) {
-		char *type, *end, *ns;
+		const char *type;
+		char *end, *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(attr->children->content, &type, &ns);
@@ -2481,13 +2482,13 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr != NULL) {
 			enc = get_encoder(SOAP_GLOBAL(sdl), (char*)nsptr->href, type);
 		}
-		efree(type);
 		if (ns) {efree(ns);}
 
 	} else if ((attr = get_attribute(data->properties,"itemType")) &&
 	    attr->children &&
 	    attr->children->content) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(attr->children->content, &type, &ns);
@@ -2495,7 +2496,6 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr != NULL) {
 			enc = get_encoder(SOAP_GLOBAL(sdl), (char*)nsptr->href, type);
 		}
-		efree(type);
 		if (ns) {efree(ns);}
 
 		if ((attr = get_attribute(data->properties,"arraySize")) &&
@@ -2828,7 +2828,8 @@ static zval *guess_zval_convert(zval *ret, encodeTypePtr type, xmlNodePtr data)
 	master_to_zval_int(ret, enc, data);
 	if (SOAP_GLOBAL(sdl) && type_name && enc->details.sdl_type) {
 		zval soapvar;
-		char *ns, *cptype;
+		const char *cptype;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		object_init_ex(&soapvar, soap_var_class_entry);
@@ -2840,7 +2841,6 @@ static zval *guess_zval_convert(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr) {
 			ZVAL_STRING(Z_VAR_ENC_NS_P(&soapvar), (char*)nsptr->href);
 		}
-		efree(cptype);
 		if (ns) {efree(ns);}
 		ZVAL_COPY_VALUE(ret, &soapvar);
 	}

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -414,7 +414,8 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 
 	itemType = get_attribute(listType->properties, "itemType");
 	if (itemType != NULL) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(itemType->children->content, &type, &ns);
@@ -436,7 +437,6 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 			}
 			zend_hash_next_index_insert_ptr(cur_type->elements, newType);
 		}
-		if (type) {efree(type);}
 		if (ns) {efree(ns);}
 	}
 
@@ -498,7 +498,8 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 	memberTypes = get_attribute(unionType->properties, "memberTypes");
 	if (memberTypes != NULL) {
 		char *str, *start, *end, *next;
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		str = estrdup((char*)memberTypes->children->content);
@@ -532,7 +533,6 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 				}
 				zend_hash_next_index_insert_ptr(cur_type->elements, newType);
 			}
-			if (type) {efree(type);}
 			if (ns) {efree(ns);}
 
 			start = next;
@@ -641,7 +641,8 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 
 	base = get_attribute(restType->properties, "base");
 	if (base != NULL) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(base->children->content, &type, &ns);
@@ -649,7 +650,6 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (type) {efree(type);}
 		if (ns) {efree(ns);}
 	} else if (!simpleType) {
 		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
@@ -746,7 +746,8 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 
 	base = get_attribute(restType->properties, "base");
 	if (base != NULL) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(base->children->content, &type, &ns);
@@ -754,7 +755,6 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (type) {efree(type);}
 		if (ns) {efree(ns);}
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
@@ -871,7 +871,8 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 
 	base = get_attribute(extType->properties, "base");
 	if (base != NULL) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(base->children->content, &type, &ns);
@@ -879,7 +880,6 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (type) {efree(type);}
 		if (ns) {efree(ns);}
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
@@ -926,7 +926,8 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 
 	base = get_attribute(extType->properties, "base");
 	if (base != NULL) {
-		char *type, *ns;
+		const char *type;
+		char *ns;
 		xmlNsPtr nsptr;
 
 		parse_namespace(base->children->content, &type, &ns);
@@ -934,7 +935,6 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (type) {efree(type);}
 		if (ns) {efree(ns);}
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
@@ -1075,7 +1075,8 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 		smart_str key = {0};
 
 		if (ref) {
-			char *type, *ns;
+			const char *type;
+			char *ns;
 			xmlNsPtr nsptr;
 
 			parse_namespace(ref->children->content, &type, &ns);
@@ -1099,7 +1100,6 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			newModel->kind = XSD_CONTENT_GROUP_REF;
 			newModel->u.group_ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
 
-			if (type) {efree(type);}
 			if (ns) {efree(ns);}
 		} else {
 			newModel = emalloc(sizeof(sdlContentModel));
@@ -1513,7 +1513,8 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 
 		if (ref) {
 			smart_str nscat = {0};
-			char *type, *ns;
+			const char *type;
+			char *ns;
 			xmlNsPtr nsptr;
 
 			parse_namespace(ref->children->content, &type, &ns);
@@ -1534,7 +1535,6 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 			smart_str_appends(&nscat, type);
 			newType->name = estrdup(type);
 			smart_str_0(&nscat);
-			if (type) {efree(type);}
 			if (ns) {efree(ns);}
 			newType->ref = estrndup(ZSTR_VAL(nscat.s), ZSTR_LEN(nscat.s));
 			smart_str_free(&nscat);
@@ -1658,7 +1658,8 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 	/* type = QName */
 	type = get_attribute(attrs, "type");
 	if (type) {
-		char *cptype, *str_ns;
+		const char *cptype;
+		char *str_ns;
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
@@ -1670,7 +1671,6 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(cptype));
 		}
 		if (str_ns) {efree(str_ns);}
-		if (cptype) {efree(cptype);}
 	}
 
 	trav = element->children;
@@ -1745,7 +1745,8 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		memset(newAttr, 0, sizeof(sdlAttribute));
 
 		if (ref) {
-			char *attr_name, *ns;
+			const char *attr_name;
+			char *ns;
 			xmlNsPtr nsptr;
 
 			parse_namespace(ref->children->content, &attr_name, &ns);
@@ -1766,7 +1767,6 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			smart_str_appends(&key, attr_name);
 			smart_str_0(&key);
 			newAttr->ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
-			if (attr_name) {efree(attr_name);}
 			if (ns) {efree(ns);}
 		} else {
 			xmlAttrPtr ns;
@@ -1806,7 +1806,8 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 	/* type = QName */
 	type = get_attribute(attrType->properties, "type");
 	if (type) {
-		char *cptype, *str_ns;
+		const char *cptype;
+		char *str_ns;
 		xmlNsPtr nsptr;
 
 		if (ref != NULL) {
@@ -1818,7 +1819,6 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			newAttr->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(cptype));
 		}
 		if (str_ns) {efree(str_ns);}
-		if (cptype) {efree(cptype);}
 	}
 
 	attr = attrType->properties;
@@ -1860,7 +1860,8 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 				smart_str key2 = {0};
 				sdlExtraAttributePtr ext;
 				xmlNsPtr nsptr;
-				char *value, *ns;
+				const char *value;
+				char *ns;
 
 				ext = emalloc(sizeof(sdlExtraAttribute));
 				memset(ext, 0, sizeof(sdlExtraAttribute));
@@ -1873,7 +1874,6 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 					ext->val = estrdup((char*)attr->children->content);
 				}
 				if (ns) {efree(ns);}
-				efree(value);
 
 				if (!newAttr->extraAttributes) {
 					newAttr->extraAttributes = emalloc(sizeof(HashTable));
@@ -1986,7 +1986,8 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_free(&key);
 		} else if (ref) {
 			sdlAttributePtr newAttr;
-			char *group_name, *ns;
+			const char *group_name;
+			char *ns;
 			smart_str key = {0};
 			xmlNsPtr nsptr;
 
@@ -2006,7 +2007,6 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_appends(&key, group_name);
 			smart_str_0(&key);
 			newAttr->ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
-			if (group_name) {efree(group_name);}
 			if (ns) {efree(ns);}
 			smart_str_free(&key);
 

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -48,7 +48,8 @@ encodePtr get_encoder_from_prefix(sdlPtr sdl, xmlNodePtr node, const xmlChar *ty
 {
 	encodePtr enc = NULL;
 	xmlNsPtr nsptr;
-	char *ns, *cptype;
+	const char *cptype;
+	char *ns;
 
 	parse_namespace(type, &cptype, &ns);
 	nsptr = xmlSearchNs(node->doc, node, BAD_CAST(ns));
@@ -60,7 +61,6 @@ encodePtr get_encoder_from_prefix(sdlPtr sdl, xmlNodePtr node, const xmlChar *ty
 	} else {
 		enc = get_encoder_ex(sdl, (char*)type, xmlStrlen(type));
 	}
-	efree(cptype);
 	if (ns) {efree(ns);}
 	return enc;
 }
@@ -71,7 +71,8 @@ static sdlTypePtr get_element(sdlPtr sdl, xmlNodePtr node, const xmlChar *type)
 
 	if (sdl->elements) {
 		xmlNsPtr nsptr;
-		char *ns, *cptype;
+		const char *cptype;
+		char *ns;
 		sdlTypePtr sdl_type;
 
 		parse_namespace(type, &cptype, &ns);
@@ -99,7 +100,6 @@ static sdlTypePtr get_element(sdlPtr sdl, xmlNodePtr node, const xmlChar *type)
 			}
 		}
 
-		efree(cptype);
 		if (ns) {efree(ns);}
 	}
 	return ret;

--- a/ext/soap/php_xml.c
+++ b/ext/soap/php_xml.c
@@ -315,17 +315,16 @@ xmlNodePtr get_node_with_attribute_recursive_ex(xmlNodePtr node, char *name, cha
 	return NULL;
 }
 
-int parse_namespace(const xmlChar *inval, char **value, char **namespace)
+/* namespace is either a copy or NULL, value is never NULL and never a copy. */
+void parse_namespace(const xmlChar *inval, const char **value, char **namespace)
 {
-	char *found = strrchr((char*)inval, ':');
+	const char *found = strrchr((const char *) inval, ':');
 
-	if (found != NULL && found != (char*)inval) {
-		(*namespace) = estrndup((char*)inval, found - (char*)inval);
-		(*value) = estrdup(++found);
+	if (found != NULL && found != (const char *) inval) {
+		(*namespace) = estrndup((const char *) inval, found - (const char *) inval);
+		(*value) = ++found;
 	} else {
-		(*value) = estrdup((char*)inval);
+		(*value) = (const char *) inval;
 		(*namespace) = NULL;
 	}
-
-	return FALSE;
 }

--- a/ext/soap/php_xml.h
+++ b/ext/soap/php_xml.h
@@ -39,7 +39,7 @@ xmlNodePtr get_node_ex(xmlNodePtr node,char *name, char *ns);
 xmlNodePtr get_node_recursive_ex(xmlNodePtr node,char *name, char *ns);
 xmlNodePtr get_node_with_attribute_ex(xmlNodePtr node, char *name, char *name_ns, char *attribute, char *value, char *attr_ns);
 xmlNodePtr get_node_with_attribute_recursive_ex(xmlNodePtr node, char *name, char *name_ns, char *attribute, char *value, char *attr_ns);
-int parse_namespace(const xmlChar *inval,char **value,char **namespace);
+void parse_namespace(const xmlChar *inval, const char **value, char **namespace);
 
 #define FOREACHATTRNODE(n,c,i)      FOREACHATTRNODEEX(n,c,NULL,i)
 #define FOREACHATTRNODEEX(n,c,ns,i) \


### PR DESCRIPTION
The local name is either the entire input or is the last part, so we never need to make a copy.