### PR TITLE
ext/bcmath: `null` should not be supported for operator overloading + comparison issues

### DIFF
--- a/ext/bcmath/tests/number/operators/calc_non_numeric_string.phpt
+++ b/ext/bcmath/tests/number/operators/calc_non_numeric_string.phpt
@@ -43,9 +43,9 @@ try {
 }
 ?>
 --EXPECT--
-Number is not well-formed
-Number is not well-formed
-Number is not well-formed
-Number is not well-formed
-Number is not well-formed
-Number is not well-formed
+Right string operand cannot be converted to BcMath\Number
+Right string operand cannot be converted to BcMath\Number
+Right string operand cannot be converted to BcMath\Number
+Right string operand cannot be converted to BcMath\Number
+Right string operand cannot be converted to BcMath\Number
+Right string operand cannot be converted to BcMath\Number

--- a/ext/bcmath/tests/number/operators/calc_null.phpt
+++ b/ext/bcmath/tests/number/operators/calc_null.phpt
@@ -7,56 +7,45 @@ bcmath
 $num = new BcMath\Number(100);
 
 try {
-    $num + $undef;
+    $num + null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 
 try {
-    $num - $undef;
+    $num - null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 
 try {
-    $num * $undef;
+    $num * null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 
 try {
-    $num / $undef;
+    $num / null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 
 try {
-    $num % $undef;
+    $num % null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 
 try {
-    $num ** $undef;
+    $num ** null;
 } catch (Error $e) {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-Warning: Undefined variable $undef in %s
+--EXPECT--
 Unsupported operand types: BcMath\Number + null
-
-Warning: Undefined variable $undef in %s
 Unsupported operand types: BcMath\Number - null
-
-Warning: Undefined variable $undef in %s
 Unsupported operand types: BcMath\Number * null
-
-Warning: Undefined variable $undef in %s
 Unsupported operand types: BcMath\Number / null
-
-Warning: Undefined variable $undef in %s
 Unsupported operand types: BcMath\Number % null
-
-Warning: Undefined variable $undef in %s
 Unsupported operand types: BcMath\Number ** null

--- a/ext/bcmath/tests/number/operators/compare_with_invalid_types.phpt
+++ b/ext/bcmath/tests/number/operators/compare_with_invalid_types.phpt
@@ -1,0 +1,105 @@
+--TEST--
+BcMath\Number compare by operator with non-sense
+--EXTENSIONS--
+bcmath
+--FILE--
+<?php
+
+$values2 = [
+    [null, 'null'],
+    ['string', 'string'],
+    [new stdClass(), 'object'],
+    [[], 'array'],
+    [STDERR, 'resource'],
+];
+
+$value1 = new BcMath\Number('100.0000');
+
+foreach ($values2 as [$value2, $type2]) {
+    echo "========== with {$type2} ==========\n";
+    echo "{$value1} >  {$type2}: " . ($value1 > $value2 ? 'true' : 'false') . "\n";
+    echo "{$value1} >= {$type2}: " . ($value1 >= $value2 ? 'true' : 'false') . "\n";
+    echo "{$value1} == {$type2}: " . ($value1 == $value2 ? 'true' : 'false') . "\n";
+    echo "{$value1} <= {$type2}: " . ($value1 <= $value2 ? 'true' : 'false') . "\n";
+    echo "{$value1} <  {$type2}: " . ($value1 < $value2 ? 'true' : 'false') . "\n";
+
+    echo "\ninversion\n";
+    echo "{$type2} >  {$value1}: " . ($value2 > $value1 ? 'true' : 'false') . "\n";
+    echo "{$type2} >= {$value1}: " . ($value2 >= $value1 ? 'true' : 'false') . "\n";
+    echo "{$type2} == {$value1}: " . ($value2 == $value1 ? 'true' : 'false') . "\n";
+    echo "{$type2} <= {$value1}: " . ($value2 <= $value1 ? 'true' : 'false') . "\n";
+    echo "{$type2} <  {$value1}: " . ($value2 < $value1 ? 'true' : 'false') . "\n";
+
+    echo "\n";
+}
+?>
+--EXPECT--
+========== with null ==========
+100.0000 >  null: true
+100.0000 >= null: true
+100.0000 == null: false
+100.0000 <= null: false
+100.0000 <  null: false
+
+inversion
+null >  100.0000: false
+null >= 100.0000: false
+null == 100.0000: false
+null <= 100.0000: true
+null <  100.0000: true
+
+========== with string ==========
+100.0000 >  string: false
+100.0000 >= string: false
+100.0000 == string: false
+100.0000 <= string: false
+100.0000 <  string: false
+
+inversion
+string >  100.0000: false
+string >= 100.0000: false
+string == 100.0000: false
+string <= 100.0000: false
+string <  100.0000: false
+
+========== with object ==========
+100.0000 >  object: false
+100.0000 >= object: false
+100.0000 == object: false
+100.0000 <= object: false
+100.0000 <  object: false
+
+inversion
+object >  100.0000: false
+object >= 100.0000: false
+object == 100.0000: false
+object <= 100.0000: false
+object <  100.0000: false
+
+========== with array ==========
+100.0000 >  array: false
+100.0000 >= array: false
+100.0000 == array: false
+100.0000 <= array: false
+100.0000 <  array: false
+
+inversion
+array >  100.0000: false
+array >= 100.0000: false
+array == 100.0000: false
+array <= 100.0000: false
+array <  100.0000: false
+
+========== with resource ==========
+100.0000 >  resource: false
+100.0000 >= resource: false
+100.0000 == resource: false
+100.0000 <= resource: false
+100.0000 <  resource: false
+
+inversion
+resource >  100.0000: false
+resource >= 100.0000: false
+resource == 100.0000: false
+resource <= 100.0000: false
+resource <  100.0000: false


### PR DESCRIPTION
@SakiTakamachi you have memory leaks with the handling of the comparison operators and some conversions to string which don't make much sense to me (namely `array` to string).