### PR TITLE
Bind traits before parent class

### DIFF
--- a/Zend/tests/traits/constant_015.phpt
+++ b/Zend/tests/traits/constant_015.phpt
@@ -15,18 +15,6 @@ class DerivedClass1 extends BaseClass1 {
     use TestTrait1;
 }
 
-trait TestTrait2 {
-    public final const Constant = 123;
-}
-
-class BaseClass2 {
-    public final const Constant = 456;
-}
-
-class DerivedClass2 extends BaseClass2 {
-    use TestTrait2;
-}
-
 ?>
 --EXPECTF--
-Fatal error: BaseClass2 and TestTrait2 define the same constant (Constant) in the composition of DerivedClass2. However, the definition differs and is considered incompatible. Class was composed in %s on line %d
+Fatal error: DerivedClass1::Constant cannot override final constant BaseClass1::Constant in %s on line %d

--- a/Zend/tests/traits/error_001.phpt
+++ b/Zend/tests/traits/error_001.phpt
@@ -16,7 +16,7 @@ trait foo2 {
 }
 
 
-class A extends foo {
+class A {
     use foo {
         foo2::foo insteadof foo;
         foo2::foo insteadof foo;
@@ -25,4 +25,4 @@ class A extends foo {
 
 ?>
 --EXPECTF--
-Fatal error: Class A cannot extend trait foo in %s on line %d
+Fatal error: Required Trait foo2 wasn't added to A in %s on line %d

--- a/Zend/tests/traits/gh16198.phpt
+++ b/Zend/tests/traits/gh16198.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-16198: Incorrect trait constant conflict when declared via trait
+--FILE--
+<?php
+
+trait T1 {
+    final public const string C1 = 'T1';
+}
+
+interface I1 {
+    public const ?string C1 = null;
+    public const ?string C2 = null;
+}
+
+final class O1 implements I1 {
+    final public const string C2 = 'O1';
+}
+
+final class O2 implements I1 {
+    use T1;
+}
+
+abstract class A1 implements I1 {}
+
+final class O3 extends A1 {
+    final public const string C2 = 'O3';
+}
+
+final class O4 extends A1 {
+    use T1;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/traits/gh16198_2.phpt
+++ b/Zend/tests/traits/gh16198_2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-16198: Usage of super in cloned trait method
+--FILE--
+<?php
+
+trait T {
+    public function __destruct() {
+        parent::__destruct();
+    }
+}
+
+class P {
+    public function __destruct() {
+        var_dump(__METHOD__);
+    }
+}
+
+class C extends P {
+    use T;
+}
+
+$c = new C();
+unset($c);
+
+?>
+--EXPECT--
+string(13) "P::__destruct"

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2355,7 +2355,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 {
 	zend_function *existing_fn = NULL;
 	zend_function *new_fn;
-	bool check_inheritance = false;
 
 	if ((existing_fn = zend_hash_find_ptr(&ce->function_table, key)) != NULL) {
 		/* if it is the same function with the same visibility and has not been assigned a class scope yet, regardless
@@ -2389,8 +2388,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 				ZSTR_VAL(fn->common.scope->name), ZSTR_VAL(fn->common.function_name),
 				ZSTR_VAL(ce->name), ZSTR_VAL(name),
 				ZSTR_VAL(existing_fn->common.scope->name), ZSTR_VAL(existing_fn->common.function_name));
-		} else {
-			check_inheritance = true;
 		}
 	}
 
@@ -2410,19 +2407,6 @@ static void zend_add_trait_method(zend_class_entry *ce, zend_string *name, zend_
 	function_add_ref(new_fn);
 	fn = zend_hash_update_ptr(&ce->function_table, key, new_fn);
 	zend_add_magic_method(ce, fn, key);
-
-	if (check_inheritance) {
-		/* Inherited members are overridden by members inserted by traits.
-		 * Check whether the trait method fulfills the inheritance requirements. */
-		uint32_t flags = ZEND_INHERITANCE_CHECK_PROTO | ZEND_INHERITANCE_CHECK_VISIBILITY;
-		if (!(existing_fn->common.scope->ce_flags & ZEND_ACC_TRAIT)) {
-			flags |= ZEND_INHERITANCE_SET_CHILD_CHANGED |ZEND_INHERITANCE_SET_CHILD_PROTO |
-				ZEND_INHERITANCE_RESET_CHILD_OVERRIDE;
-		}
-		do_inheritance_check_on_method(
-			fn, fixup_trait_scope(fn, ce), existing_fn, fixup_trait_scope(existing_fn, ce),
-			ce, NULL, flags);
-	}
 }
 /* }}} */
 

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1136,7 +1136,9 @@ static inheritance_status do_inheritance_check_on_method(
 #define SEPARATE_METHOD() do { \
 			if ((flags & ZEND_INHERITANCE_LAZY_CHILD_CLONE) \
 			 && child_scope != ce \
-			 /* Trait scopes are fixed after inheritance. However, they are always duplicated. */ \
+			 /* Trait methods have already been separated at this point. However, their */ \
+			 /* scope isn't fixed until after inheritance checks to preserve the scope */ \
+			 /* in error messages. Skip them here explicitly. */ \
 			 && !(child_scope->ce_flags & ZEND_ACC_TRAIT) \
 			 && child->type == ZEND_USER_FUNCTION) { \
 				/* op_array wasn't duplicated yet */ \


### PR DESCRIPTION
This more accurately matches the "copy & paste" semantics described in
the documentation. Abstract trait methods diverge from this behavior,
given that a parent method can satisfy trait methods used in the child.
In that case, the method is not copied, but the check is performed after
the parent has been bound.

Fixes GH-15753
Fixes GH-16198