### PR TITLE
Fix GH-15868: Assertion failure in xml_parse_into_struct after exception

### DIFF
--- a/ext/xml/tests/gh15868.phpt
+++ b/ext/xml/tests/gh15868.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-15868 (Assertion failure in xml_parse_into_struct after exception)
+--EXTENSIONS--
+xml
+--FILE--
+<?php
+$parser = xml_parser_create();
+xml_set_element_handler($parser,
+    function ($parser, $name, $attrs) {
+        throw new Error('stop 1');
+    }, function ($parser, $name) {
+    }
+);
+try {
+    xml_parse_into_struct($parser, "<container/>", $values, $tags);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$parser = xml_parser_create();
+xml_set_element_handler($parser,
+    function ($parser, $name, $attrs) {
+    }, function ($parser, $name) {
+        throw new Error('stop 2');
+    }
+);
+try {
+    xml_parse_into_struct($parser, "<container/>", $values, $tags);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$parser = xml_parser_create();
+xml_set_character_data_handler($parser, function() {
+    throw new Error('stop 3');
+});
+try {
+    xml_parse_into_struct($parser, "<root><![CDATA[x]]></root>", $values, $tags);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+stop 1
+stop 2
+stop 3

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -628,7 +628,7 @@ void _xml_startElementHandler(void *userData, const XML_Char *name, const XML_Ch
 		zval_ptr_dtor(&retval);
 	}
 
-	if (!Z_ISUNDEF(parser->data)) {
+	if (!Z_ISUNDEF(parser->data) && !EG(exception)) {
 		if (parser->level <= XML_MAXLEVEL)  {
 			zval tag, atr;
 			int atcnt = 0;
@@ -699,7 +699,7 @@ void _xml_endElementHandler(void *userData, const XML_Char *name)
 		zval_ptr_dtor(&retval);
 	}
 
-	if (!Z_ISUNDEF(parser->data)) {
+	if (!Z_ISUNDEF(parser->data) && !EG(exception)) {
 		zval tag;
 
 		if (parser->lastwasopen) {
@@ -747,7 +747,7 @@ void _xml_characterDataHandler(void *userData, const XML_Char *s, int len)
 		zval_ptr_dtor(&retval);
 	}
 
-	if (Z_ISUNDEF(parser->data)) {
+	if (Z_ISUNDEF(parser->data) || EG(exception)) {
 		return;
 	}
 


### PR DESCRIPTION
Upon unwinding from an exception, the parser state is not stable, we should not continue updating the values if an exception was thrown.