### PR TITLE
Fix ext/snmp for newer net-snmp versions on Windows

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -26,6 +26,11 @@
 #include "php.h"
 #include "main/php_network.h"
 #include "ext/standard/info.h"
+
+#ifdef PHP_WIN32
+// avoid conflicting declarations of (v)asprintf()
+# define HAVE_ASPRINTF
+#endif
 #include "php_snmp.h"
 
 #include "zend_exceptions.h"


### PR DESCRIPTION
As of net-snmp 5.8.0, the library defines their own `(v)asprintf()` if not available on the system.  However, PHP also does this, so when building ext/snmp there would be conflicting declarations on Windows. To avoid this, we explictly define `HAVE_ASPRINTF`, so net-snmp does not redeclare when its headers are included.