### PR TITLE
Remove redundant Kerberos library installation

### DIFF
--- a/.github/actions/apk/action.yml
+++ b/.github/actions/apk/action.yml
@@ -44,7 +44,6 @@ runs:
             readline-dev \
             sqlite-dev \
             tidyhtml-dev \
-            krb5-dev \
             gdbm-dev \
             lmdb-dev \
             argon2-dev \


### PR DESCRIPTION
This was once needed for the --with-kerberos configure options by openssl or imap extensions.