### PR TITLE
Remove redundant *spell* libraries on Alpine

### DIFF
--- a/.github/actions/apk/action.yml
+++ b/.github/actions/apk/action.yml
@@ -19,9 +19,6 @@ runs:
             re2c \
             pkgconf \
             mysql-client \
-            aspell-dev \
-            hunspell-dev \
-            hunspell-en \
             bzip2-dev \
             curl-dev \
             freetype-dev \
@@ -49,7 +46,6 @@ runs:
             lmdb-dev \
             argon2-dev \
             enchant2-dev \
-            enchant2-hunspell \
             freetds-dev \
             imap-dev \
             net-snmp-dev \


### PR DESCRIPTION
These were needed mostly for the PHP <= 8.3 pspell extension. The nchant2-hunspell gets installed automatically as a dependency with enchant2-dev if needed.