### PR TITLE
ext/pdo_pgsql: Expanding COPY input from an array to an iterable

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -696,7 +696,6 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 		if (Z_TYPE_P(pg_rows) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pg_rows), tmp) {
 				if (!_pdo_pgsql_send_copy_data(H, tmp)) {
-					efree(query);
 					RETURN_THROWS();
 				}
 			} ZEND_HASH_FOREACH_END();
@@ -709,16 +708,11 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 			for (; iter->funcs->valid(iter) == SUCCESS && EG(exception) == NULL; iter->funcs->move_forward(iter)) {
 				tmp = iter->funcs->get_current_data(iter);
 				if (!_pdo_pgsql_send_copy_data(H, tmp)) {
-					efree(query);
 					zend_iterator_dtor(iter);
 					RETURN_THROWS();
 				}
 			}
 			zend_iterator_dtor(iter);
-		}
-
-		if (query) {
-			efree(query);
 		}
 
 		if (PQputCopyEnd(H->server, NULL) != 1) {

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -696,7 +696,9 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 		if (Z_TYPE_P(pg_rows) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pg_rows), tmp) {
 				if (!_pdo_pgsql_send_copy_data(H, tmp)) {
-					RETURN_THROWS();
+					pdo_pgsql_error(dbh, PGRES_FATAL_ERROR, NULL);
+					PDO_HANDLE_DBH_ERR();
+					RETURN_FALSE;
 				}
 			} ZEND_HASH_FOREACH_END();
 		} else {
@@ -709,7 +711,9 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 				tmp = iter->funcs->get_current_data(iter);
 				if (!_pdo_pgsql_send_copy_data(H, tmp)) {
 					zend_iterator_dtor(iter);
-					RETURN_THROWS();
+					pdo_pgsql_error(dbh, PGRES_FATAL_ERROR, NULL);
+					PDO_HANDLE_DBH_ERR();
+					RETURN_FALSE;
 				}
 			}
 			zend_iterator_dtor(iter);

--- a/ext/pdo_pgsql/pgsql_driver.stub.php
+++ b/ext/pdo_pgsql/pgsql_driver.stub.php
@@ -8,7 +8,7 @@
  */
 class PDO_PGSql_Ext {
     /** @tentative-return-type */
-    public function pgsqlCopyFromArray(string $tableName, array $rows, string $separator = "\t", string $nullAs = "\\\\N", ?string $fields = null): bool {}
+    public function pgsqlCopyFromArray(string $tableName, array | Traversable $rows, string $separator = "\t", string $nullAs = "\\\\N", ?string $fields = null): bool {}
 
     /** @tentative-return-type */
     public function pgsqlCopyFromFile(string $tableName, string $filename, string $separator = "\t", string $nullAs = "\\\\N", ?string $fields = null): bool {}

--- a/ext/pdo_pgsql/pgsql_driver_arginfo.h
+++ b/ext/pdo_pgsql/pgsql_driver_arginfo.h
@@ -1,9 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dd20abc5d8580d72b25bfb3c598b1ca54a501fcc */
+ * Stub hash: 30c01b4d2e7f836b81a31dc0c1a115883eb41568 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlCopyFromArray, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_ARRAY, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, rows, Traversable, MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, separator, IS_STRING, 0, "\"\\t\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nullAs, IS_STRING, 0, "\"\\\\\\\\N\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fields, IS_STRING, 1, "null")

--- a/ext/pdo_pgsql/tests/copy_from_generator.phpt
+++ b/ext/pdo_pgsql/tests/copy_from_generator.phpt
@@ -1,0 +1,51 @@
+--TEST--
+PDO PgSQL pgsqlCopyFromArray using Generator
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+$db->exec('CREATE TABLE test_copy_from_generator (v int)');
+
+$generator = (function(){
+    $position = 0;
+    $values = [1, 1, 2, 3, 5];
+
+    while(isset($values[$position])){
+        yield $values[$position];
+        ++$position;
+    }
+})();
+
+
+$db->pgsqlCopyFromArray('test_copy_from_generator',$generator);
+
+$stmt = $db->query("select * from test_copy_from_generator order by 1");
+$result = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+var_export($result);
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_copy_from_generator CASCADE');
+?>
+--EXPECT--
+array (
+  0 => 1,
+  1 => 1,
+  2 => 2,
+  3 => 3,
+  4 => 5,
+)

--- a/ext/pdo_pgsql/tests/copy_from_iterator.phpt
+++ b/ext/pdo_pgsql/tests/copy_from_iterator.phpt
@@ -1,0 +1,65 @@
+--TEST--
+PDO PgSQL pgsqlCopyFromArray using Iterator
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+$db->exec('CREATE TABLE test_copy_from_traversable (v int)');
+
+$iterator = new class implements Iterator{
+    private $position = 0;
+    private $values = [1, 1, 2, 3, 5];
+
+    public function rewind(): void {
+        $this->position = 0;
+    }
+
+    public function current(): int {
+        return $this->values[$this->position];
+    }
+
+    public function key(): int {
+        return $this->position;
+    }
+
+    public function next(): void {
+        ++$this->position;
+    }
+
+    public function valid(): bool {
+        return isset($this->values[$this->position]);
+    }
+};
+
+$db->pgsqlCopyFromArray('test_copy_from_traversable',$iterator);
+
+$stmt = $db->query("select * from test_copy_from_traversable order by 1");
+$result = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+var_export($result);
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_copy_from_traversable CASCADE');
+?>
+--EXPECT--
+array (
+  0 => 1,
+  1 => 1,
+  2 => 2,
+  3 => 3,
+  4 => 5,
+)


### PR DESCRIPTION
This pull request allows `PDO::pgsqlCopyFromArray` to accept `Iterable` instead of just `array`. This is not a breaking change since it still accepts `array`.

The PostgreSQL `COPY` statement is a great interface. We can bulk insert a set of records by inputting them as CSV or TSV. PostgreSQL also supports processing them as a stream.

However, the current `pgsqlCopyFromArray` does not take full advantage of this capability. It requires that the records to be inserted be input as a single array, so it cannot be processed by piping external input to PostgreSQL's `COPY`.

This weakness will be overcome by supporting not only simple arrays but also `Traversable` and `Generator`.