### PR TITLE
Run snmp tests in Windows CI, again

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -103,7 +103,7 @@ popd
 
 rem prepare for snmp
 set MIBDIRS=%DEPS_DIR%\share\mibs
-start %DEPS_DIR%\bin\snmpd.exe -C -c %APPVEYOR_BUILD_FOLDER%\ext\snmp\tests\snmpd.conf -Ln
+start %DEPS_DIR%\bin\snmpd.exe -C -c %GITHUB_WORKSPACE%\ext\snmp\tests\snmpd.conf -Ln
 
 set PHP_BUILD_DIR=%PHP_BUILD_OBJ_DIR%\Release
 if "%THREAD_SAFE%" equ "1" set PHP_BUILD_DIR=%PHP_BUILD_DIR%_TS


### PR DESCRIPTION
That was broken when CI was moved to GH, since `APPVEYOR_BUILD_FOLDER` is no longer set; instead we use `GITHUB_WORKSPACE` which has the same meaning.