### PR TITLE
Generate and upload JUNIT test results on Windows CI

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -130,7 +130,7 @@ for %%i in (ldap) do (
 set TEST_PHPDBG_EXECUTABLE=%PHP_BUILD_DIR%\phpdbg.exe
 
 mkdir c:\tests_tmp
-
+set TEST_PHP_JUNIT=%GITHUB_WORKSPACE%\junit.out.xml
 nmake test TESTS="%OPCACHE_OPTS% -g FAIL,BORK,LEAK,XLEAK --no-progress -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp --bless %PARALLEL%"
 
 set EXIT_CODE=%errorlevel%

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -255,6 +255,10 @@ jobs:
         run: .github/scripts/windows/build.bat
       - name: Test
         run: .github/scripts/windows/test.bat
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            path: junit.out.xml
   BENCHMARKING:
     name: BENCHMARKING
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'


### PR DESCRIPTION
These are useful to get fine grained information about what was going on when the tests have been run, but won't clutter the build logs.

---

Now I see that these have been deliberately removed via #14555, stating as reasons:

> Nobody looks at those, and nightly regularly fails due to uploading them.

The former makes me sad. It's hard to notice that a complete test suite is skipped because a required server isn't properly set up (see e.g. #15896). I would be happy to have the JUNIT results available again, if only for Windows CI.