### PR TITLE
Fix oss-fuzz report triggered by GH-15712 commit.

### DIFF
--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3613,11 +3613,11 @@ rv_alloc(i) int i;
 rv_alloc(int i)
 #endif
 {
-	int k, *r;
+	int j, k, *r;
 
-	size_t j = sizeof(ULong);
+	j = sizeof(ULong);
 	for(k = 0;
-		sizeof(Bigint) - sizeof(ULong) - sizeof(int) + j <= (size_t)i;
+		j <= (INT_MAX >> 1) && sizeof(Bigint) - sizeof(ULong) - sizeof(int) + j <= (size_t)i;
 		j <<= 1)
 			k++;
 	r = (int*)Balloc(k);

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3613,13 +3613,22 @@ rv_alloc(i) int i;
 rv_alloc(int i)
 #endif
 {
-	int j, k, *r;
+
+	int k, *r;
+	size_t j, rem;
+
+	rem = sizeof(Bigint) - sizeof(ULong) - sizeof(int);
+
 
 	j = sizeof(ULong);
+	if (i > (INT_MAX - rem))
+		zend_error_noreturn(E_ERROR, "rv_alloc() allocation overflow %d", i);
 	for(k = 0;
-		j <= (INT_MAX >> 1) && sizeof(Bigint) - sizeof(ULong) - sizeof(int) + j <= (size_t)i;
-		j <<= 1)
+		j <= (INT_MAX >> 1) && rem + j <= (size_t)i; j <<= 1)
 			k++;
+	if (j > (INT_MAX >> 1))
+		zend_error_noreturn(E_ERROR, "rv_alloc() computation overflow " ZEND_LONG_FMT, j);
+
 	r = (int*)Balloc(k);
 	*r = k;
 	return

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3614,20 +3614,18 @@ rv_alloc(int i)
 #endif
 {
 
-	int k, *r;
-	size_t j, rem;
+	int j, k, *r;
+	size_t rem;
 
 	rem = sizeof(Bigint) - sizeof(ULong) - sizeof(int);
 
 
 	j = sizeof(ULong);
-	if (i > (INT_MAX - rem))
+	if (i > ((INT_MAX >> 2) + rem))
 		zend_error_noreturn(E_ERROR, "rv_alloc() allocation overflow %d", i);
 	for(k = 0;
-		j <= (INT_MAX >> 1) && rem + j <= (size_t)i; j <<= 1)
+		rem + j <= (size_t)i; j <<= 1)
 			k++;
-	if (j > (INT_MAX >> 1))
-		zend_error_noreturn(E_ERROR, "rv_alloc() computation overflow " ZEND_LONG_FMT, j);
 
 	r = (int*)Balloc(k);
 	*r = k;


### PR DESCRIPTION
It triggered allocation overflow which, even fixed, in turn gives memory leak on 32 bits but the allocator relies on signed integers so instead of changing `j` type we exit if an overflow during the buffer increase is going to happen.