### PR TITLE
Reflection: show the type of object constants used as default properties

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,6 +57,10 @@ PHP                                                                        NEWS
 - PHPDBG:
   . Fixed bug GH-16174 (Empty string is an invalid expression for ev). (cmb)
 
+- Reflection:
+  . Fixed bug GH-15902 (Core dumped in ext/reflection/php_reflection.c).
+    (DanielEScherzer)
+
 - Session:
   . Fixed bug GH-16385 (Unexpected null returned by session_set_cookie_params).
     (nielsdos)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -884,7 +884,10 @@ static zval *property_get_default(zend_property_info *prop_info) {
 		ZVAL_DEINDIRECT(prop);
 		return prop;
 	} else {
-		return &ce->default_properties_table[OBJ_PROP_TO_NUM(prop_info->offset)];
+		if (UNEXPECTED(zend_update_class_constants(ce) != SUCCESS)) {
+			return &EG(uninitialized_zval);
+		}
+		return &CE_DEFAULT_PROPERTIES_TABLE(ce)[OBJ_PROP_TO_NUM(prop_info->offset)];
 	}
 }
 

--- a/ext/reflection/tests/gh15902/ReflectionClass-callable.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionClass-callable.phpt
@@ -1,0 +1,36 @@
+--TEST--
+ReflectionClass object default property - used to say "callable"
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+define('FOO', new stdClass);
+
+new C;
+
+$reflector = new ReflectionClass(C::class);
+var_dump( (string)$reflector );
+?>
+--EXPECTF--
+string(%d) "Class [ <user> class C ] {
+  @@ %sReflectionClass-callable.php %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [1] {
+    Property [ public stdClass $a = object(stdClass) ]
+  }
+
+  - Methods [0] {
+  }
+}
+"

--- a/ext/reflection/tests/gh15902/ReflectionClass-class.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionClass-class.phpt
@@ -1,0 +1,37 @@
+--TEST--
+ReflectionClass object default property - used to say "__CLASS__"
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+$reflector = new ReflectionClass(C::class);
+
+define('FOO', new stdClass);
+new C;
+
+var_dump( (string)$reflector );
+
+?>
+--EXPECTF--
+string(%d) "Class [ <user> class C ] {
+  @@ %sReflectionClass-class.php %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [1] {
+    Property [ public stdClass $a = object(stdClass) ]
+  }
+
+  - Methods [0] {
+  }
+}
+"

--- a/ext/reflection/tests/gh15902/ReflectionProperty-callable.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionProperty-callable.phpt
@@ -1,0 +1,19 @@
+--TEST--
+ReflectionProperty object default - used to say "callable"
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+define('FOO', new stdClass);
+
+new C;
+
+$reflector = new ReflectionProperty(C::class, 'a');
+var_dump( (string)$reflector );
+
+?>
+--EXPECTF--
+string(%d) "Property [ public stdClass $a = object(stdClass) ]
+"

--- a/ext/reflection/tests/gh15902/ReflectionProperty-class.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionProperty-class.phpt
@@ -1,0 +1,19 @@
+--TEST--
+ReflectionProperty object default - used to say "__CLASS__"
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+$reflector = new ReflectionProperty(C::class, 'a');
+
+define('FOO', new stdClass);
+new C;
+
+var_dump( (string)$reflector );
+
+?>
+--EXPECTF--
+string(%d) "Property [ public stdClass $a = object(stdClass) ]
+"


### PR DESCRIPTION
When a property default is based on a global constant, show the type of the default. Previously, `format_default_value()` assumed that non-scalar and non-array defaults were always going to be `IS_CONSTANT_AST` pointers, and when the AST expression had been evaluated and produced an object, depending on when the `ReflectionClass` or `ReflectionProperty` instance had been created, the default was shown as one of `callable`, `__CLASS__`, or `...`.

Instead, if the default value is an object (`IS_OBJECT`), show the type of that object.

Add test cases for each of the `callable`, `__CLASS__`, and `...` cases to confirm that they all now properly show the name of the constant.

Closes gh-15902