### PR TITLE
Fix GH-15908 and GH-15026: leak / assertion failure in streams.c

### DIFF
--- a/ext/standard/tests/streams/gh15908.phpt
+++ b/ext/standard/tests/streams/gh15908.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-15908 (leak / assertion failure in streams.c)
+--CREDITS--
+YuanchengJiang
+LuMingYinDetect
+--FILE--
+<?php
+class TestStream {
+    public $context;
+    private $s = 0;
+    function stream_open($path, $mode, $options, &$opened_path) {
+        return true;
+    }
+    function stream_read($count) {
+        echo "Read done\n";
+        if ($this->s++ == 0)
+            return "a\nbb\ncc";
+        return "";
+    }
+    function stream_eof() {
+        return $this->s >= 2;
+    }
+}
+touch(__DIR__."/gh15908.tmp");
+stream_wrapper_register("test", "TestStream");
+$f = fopen("test://", "r");
+try {
+    file_put_contents(__DIR__."/gh15908.tmp", $f, FILE_USE_INCLUDE_PATH, $f);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__."/gh15908.tmp");
+?>
+--EXPECT--
+file_put_contents(): supplied resource is not a valid Stream-Context resource

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2175,6 +2175,9 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 			options &= ~USE_PATH;
 		}
 		if (EG(exception)) {
+			if (resolved_path) {
+				zend_string_release_ex(resolved_path, false);
+			}
 			return NULL;
 		}
 	}


### PR DESCRIPTION
This was first reported as a leak in GH-15026, but was mistakingly believed to be a false positive. Then an assertion was added and it got triggered in GH-15908. This fixes the leak. Upon merging into master the assertion should be removed as well.