### PR TITLE
Fix some misleading comments about `__clone()` never being executed

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -295,7 +295,7 @@ static zend_object *zend_default_exception_new(zend_class_entry *class_type) /* 
 /* {{{ Clone the exception object */
 ZEND_COLD ZEND_METHOD(Exception, __clone)
 {
-	/* Should never be executable */
+	/* __clone() is private but this is reachable with reflection */
 	zend_throw_exception(NULL, "Cannot clone object using __clone()", 0);
 }
 /* }}} */

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1573,7 +1573,7 @@ static int get_parameter_default(zval *result, parameter_reference *param) {
 /* {{{ Preventing __clone from being called */
 ZEND_METHOD(ReflectionClass, __clone)
 {
-	/* Should never be executable */
+	/* __clone() is private but this is reachable with reflection */
 	_DO_THROW("Cannot clone object using __clone()");
 }
 /* }}} */
@@ -7178,7 +7178,7 @@ ZEND_METHOD(ReflectionAttribute, __construct)
 
 ZEND_METHOD(ReflectionAttribute, __clone)
 {
-	/* Should never be executable */
+	/* __clone() is private but this is reachable with reflection */
 	_DO_THROW("Cannot clone object using __clone()");
 }
 


### PR DESCRIPTION
For the `Exception`, `ReflectionClass`, and `ReflectionAttribute` classes, the `__clone()` method is declared to be private, and the implementation has a comment that it should never be executed. However, the implementation can be executed by using a `ReflectionMethod`. Fix the comments to instead explain why the implementation is needed.

[skip ci]