### PR TITLE
Fix GH-15923: GDB: Python Exception <class 'TypeError'>: exceptions must derive from BaseException

### DIFF
--- a/main/debug_gdb_scripts.c
+++ b/main/debug_gdb_scripts.c
@@ -971,7 +971,7 @@ asm(
     ".ascii \"\\n\"\n"
     ".ascii \"    (symbol,_) = gdb.lookup_symbol(\\\"zend_gc_refcount\\\")\\n\"\n"
     ".ascii \"    if symbol == None:\\n\"\n"
-    ".ascii \"        raise \\\"Could not find zend_types.h: symbol zend_gc_refcount not found\\\"\\n\"\n"
+    ".ascii \"        raise Exception(\\\"Could not find zend_types.h: symbol zend_gc_refcount not found\\\")\\n\"\n"
     ".ascii \"    filename = symbol.symtab.fullname()\\n\"\n"
     ".ascii \"\\n\"\n"
     ".ascii \"    bits = {}\\n\"\n"

--- a/scripts/gdb/php_gdb.py
+++ b/scripts/gdb/php_gdb.py
@@ -301,7 +301,7 @@ def load_type_bits():
 
     (symbol,_) = gdb.lookup_symbol("zend_gc_refcount")
     if symbol == None:
-        raise "Could not find zend_types.h: symbol zend_gc_refcount not found"
+        raise Exception("Could not find zend_types.h: symbol zend_gc_refcount not found")
     filename = symbol.symtab.fullname()
 
     bits = {}


### PR DESCRIPTION
Triggers on release builds when printing data structures. You can't raise a string, you must raise exceptions.