### PR TITLE
Fix GH-15901: phpdbg: Assertion failure on `i funcs`

### DIFF
--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -399,27 +399,29 @@ PHPDBG_INFO(classes) /* {{{ */
 	phpdbg_notice("User Classes (%d)", zend_hash_num_elements(&classes));
 
 	/* once added, assume that classes are stable... until shutdown. */
-	ZEND_HASH_PACKED_FOREACH_PTR(&classes, ce) {
-		phpdbg_print_class_name(ce);
+	if (HT_IS_PACKED(&classes)) {
+		ZEND_HASH_PACKED_FOREACH_PTR(&classes, ce) {
+			phpdbg_print_class_name(ce);
 
-		if (ce->parent) {
-			if (ce->ce_flags & ZEND_ACC_LINKED) {
-				zend_class_entry *pce = ce->parent;
-				do {
-					phpdbg_out("|-------- ");
-					phpdbg_print_class_name(pce);
-				} while ((pce = pce->parent));
-			} else {
-				phpdbg_writeln("|-------- User Class %s (not yet linked because declaration for parent was not encountered when declaring the class)", ZSTR_VAL(ce->parent_name));
+			if (ce->parent) {
+				if (ce->ce_flags & ZEND_ACC_LINKED) {
+					zend_class_entry *pce = ce->parent;
+					do {
+						phpdbg_out("|-------- ");
+						phpdbg_print_class_name(pce);
+					} while ((pce = pce->parent));
+				} else {
+					phpdbg_writeln("|-------- User Class %s (not yet linked because declaration for parent was not encountered when declaring the class)", ZSTR_VAL(ce->parent_name));
+				}
 			}
-		}
 
-		if (ce->info.user.filename) {
-			phpdbg_writeln("|---- in %s on line %u", ZSTR_VAL(ce->info.user.filename), ce->info.user.line_start);
-		} else {
-			phpdbg_writeln("|---- no source code");
-		}
-	} ZEND_HASH_FOREACH_END();
+			if (ce->info.user.filename) {
+				phpdbg_writeln("|---- in %s on line %u", ZSTR_VAL(ce->info.user.filename), ce->info.user.line_start);
+			} else {
+				phpdbg_writeln("|---- no source code");
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
 
 	zend_hash_destroy(&classes);
 
@@ -445,17 +447,19 @@ PHPDBG_INFO(funcs) /* {{{ */
 
 	phpdbg_notice("User Functions (%d)", zend_hash_num_elements(&functions));
 
-	ZEND_HASH_PACKED_FOREACH_PTR(&functions, zf) {
-		zend_op_array *op_array = &zf->op_array;
+	if (HT_IS_PACKED(&functions)) {
+		ZEND_HASH_PACKED_FOREACH_PTR(&functions, zf) {
+			zend_op_array *op_array = &zf->op_array;
 
-		phpdbg_write("|-------- %s", op_array->function_name ? ZSTR_VAL(op_array->function_name) : "{main}");
+			phpdbg_write("|-------- %s", op_array->function_name ? ZSTR_VAL(op_array->function_name) : "{main}");
 
-		if (op_array->filename) {
-			phpdbg_writeln(" in %s on line %d", ZSTR_VAL(op_array->filename), op_array->line_start);
-		} else {
-			phpdbg_writeln(" (no source code)");
-		}
-	} ZEND_HASH_FOREACH_END();
+			if (op_array->filename) {
+				phpdbg_writeln(" in %s on line %d", ZSTR_VAL(op_array->filename), op_array->line_start);
+			} else {
+				phpdbg_writeln(" (no source code)");
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
 
 	zend_hash_destroy(&functions);
 

--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -399,7 +399,7 @@ PHPDBG_INFO(classes) /* {{{ */
 	phpdbg_notice("User Classes (%d)", zend_hash_num_elements(&classes));
 
 	/* once added, assume that classes are stable... until shutdown. */
-	if (HT_IS_PACKED(&classes)) {
+	if (HT_IS_INITIALIZED(&classes)) {
 		ZEND_HASH_PACKED_FOREACH_PTR(&classes, ce) {
 			phpdbg_print_class_name(ce);
 
@@ -447,7 +447,7 @@ PHPDBG_INFO(funcs) /* {{{ */
 
 	phpdbg_notice("User Functions (%d)", zend_hash_num_elements(&functions));
 
-	if (HT_IS_PACKED(&functions)) {
+	if (HT_IS_INITIALIZED(&functions)) {
 		ZEND_HASH_PACKED_FOREACH_PTR(&functions, zf) {
 			zend_op_array *op_array = &zf->op_array;
 

--- a/sapi/phpdbg/tests/gh15901.phpt
+++ b/sapi/phpdbg/tests/gh15901.phpt
@@ -1,0 +1,10 @@
+--TEST--
+GH-15901 (phpdbg: Assertion failure on `i funcs`)
+--PHPDBG--
+i funcs
+i classes
+--EXPECT--
+prompt> [User Functions (0)]
+prompt> [User Classes (0)]
+prompt> [User Classes (0)]
+prompt>


### PR DESCRIPTION
New hash tables are not automatically packed, so we must not treat them as such.  Therefore we guard the foreach appropriately.