### PR TITLE
Fix GH-15905: Assertion failure for TRACK_VARS_SERVER

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -897,6 +897,7 @@ static bool php_auto_globals_create_server(zend_string *name)
 	} else {
 		zval_ptr_dtor_nogc(&PG(http_globals)[TRACK_VARS_SERVER]);
 		array_init(&PG(http_globals)[TRACK_VARS_SERVER]);
+		zend_hash_real_init_mixed(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]));
 	}
 
 	check_http_proxy(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]));

--- a/tests/basic/gh15905.phpt
+++ b/tests/basic/gh15905.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-15905 (Assertion failure for TRACK_VARS_SERVER)
+--INI--
+variables_order=E
+auto_globals_jit=0
+register_argc_argv=1
+--FILE--
+<?php
+echo "okay\n";
+?>
+--EXPECT--
+okay


### PR DESCRIPTION
When the superglobals are eagerly initialized, but "S" is not contained in `variables_order`, `TRACK_VARS_SERVER` is created as empty array with refcount > 1.  Since this hash table may later be modified, a flag is set which allows such COW violations for assertions.  However, when `register_argc_argv` is on, the so far uninitialized hash table is updated with `argv`, what causes the hash table to be initialized, what drops the allow-COW-violations flag.  The following update with `argc` then triggers a refcount violation assertion.

Since we consider `HT_ALLOW_COW_VIOLATION` a hack, we do not want to keep the flag during hash table initialization, so we initialize the hash table right away after creation for this code path.