### PR TITLE
[skip ci] PHP 8.4 NEWS: fix typos in parameter names

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -269,7 +269,7 @@ PHP                                                                        NEWS
   . The SplFixedArray::__wakeup() method has been deprecated as it implements
     __serialize() and __unserialize() which need to be overwritten instead.
     (TysonAndre)
-  . Passing a non-empty string for the $enclosure parameter of:
+  . Passing a non-empty string for the $escape parameter of:
     - SplFileObject::setCsvControl()
     - SplFileObject::fputcsv()
     - SplFileObject::fgetcsv()
@@ -278,7 +278,7 @@ PHP                                                                        NEWS
 - Standard:
   . Unserializing the uppercase 'S' tag is now deprecated. (timwolla)
   . Enables crc32 auxiliary detection on OpenBSD. (David Carlier)
-  . Passing a non-empty string for the $enclosure parameter of:
+  . Passing a non-empty string for the $escape parameter of:
     - fputcsv()
     - fgetcsv()
     - str_getcsv()


### PR DESCRIPTION
Ref: PR #15362 / https://github.com/php/php-src/commit/c818d944cf998b3151e4b312d655c51223612c4e / https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism