### PR TITLE
CI: Update `actions/cache` in nightly run to v4

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           # the correct commit hashes.
           fetch-depth: 0
       - name: Grab the commit mapping
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: branch-commit-cache.json
           # The cache key needs to change every time for the


### PR DESCRIPTION
Fixes a deprecation notice in GH-Actions that complain about node-16 deprecation caused by `actions/cache@v3`.