### PR TITLE
Fix GH-15918: Assertion failure in ext/spl/spl_fixedarray.c

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1084,7 +1084,7 @@ static void spl_array_set_array(zval *object, spl_array_object *intern, zval *ar
 			}
 		} else {
 			zend_object_get_properties_t handler = Z_OBJ_HANDLER_P(array, get_properties);
-			if (handler != zend_std_get_properties) {
+			if (handler != zend_std_get_properties || Z_OBJ_HANDLER_P(array, get_properties_for)) {
 				zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
 					"Overloaded object of type %s is not compatible with %s",
 					ZSTR_VAL(Z_OBJCE_P(array)->name), ZSTR_VAL(intern->std.ce->name));

--- a/ext/spl/tests/ArrayObject_overloaded_SplFixedArray.phpt
+++ b/ext/spl/tests/ArrayObject_overloaded_SplFixedArray.phpt
@@ -1,28 +1,16 @@
 --TEST--
-SplFixedArray properties is compatible with ArrayObject
+SplFixedArray properties is incompatible with ArrayObject
 --FILE--
 <?php
 $ao = new ArrayObject([1, 2, 3]);
 $fixedArray = new SplFixedArray(1);
 $fixedArray[0] = new SplDoublyLinkedList();
-$ao->exchangeArray($fixedArray);
-$ao[0] = new stdClass();
-var_dump($ao);
+try {
+  // See GH-15918: this *should* fail to not break invariants
+  $ao->exchangeArray($fixedArray);
+} catch (InvalidArgumentException $e) {
+  echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-object(ArrayObject)#1 (1) {
-  ["storage":"ArrayObject":private]=>
-  object(SplFixedArray)#2 (2) {
-    [0]=>
-    object(SplDoublyLinkedList)#3 (2) {
-      ["flags":"SplDoublyLinkedList":private]=>
-      int(0)
-      ["dllist":"SplDoublyLinkedList":private]=>
-      array(0) {
-      }
-    }
-    ["0"]=>
-    object(stdClass)#4 (0) {
-    }
-  }
-}
+Overloaded object of type SplFixedArray is not compatible with ArrayObject

--- a/ext/spl/tests/gh15918.phpt
+++ b/ext/spl/tests/gh15918.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15918 (Assertion failure in ext/spl/spl_fixedarray.c)
+--FILE--
+<?php
+$foo = new SplFixedArray(5);
+try {
+    $arrayObject = new ArrayObject($foo);
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Overloaded object of type SplFixedArray is not compatible with ArrayObject


### PR DESCRIPTION
SplFixedArray should've never get supported in ArrayObject because it's overloaded, and so that breaks assumptions. This regressed in c4ecd82f.