### PR TITLE
PDO_MySQL not properly quoting PDO_PARAM_LOB binary data

### DIFF
--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_binary.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_binary.phpt
@@ -13,6 +13,10 @@ MySQLPDOTest::skip();
     $db = MySQLPDOTest::factory();
     $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
+    // Force the connection to utf8, which is enough to make the test fail
+    // MySQL 5.6+ would be required for utf8mb4
+    $db->exec("SET NAMES 'utf8'");
+
     $content = '0191D886E6DC73E7AF1FEE7F99EC6235';
 
     $statement = $db->prepare('SELECT HEX(?) as test');

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_binary.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_binary.phpt
@@ -1,0 +1,44 @@
+--TEST--
+MySQL PDO->prepare(), no warnings should be raised for binary values using emulated PS
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+require_once __DIR__ . '/inc/mysql_pdo_test.inc';
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+    require_once __DIR__ . '/inc/mysql_pdo_test.inc';
+    $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+    $content = '0191D886E6DC73E7AF1FEE7F99EC6235';
+
+    $statement = $db->prepare('SELECT HEX(?) as test');
+    $statement->bindValue(1, hex2bin($content), PDO::PARAM_LOB);
+    $statement->execute();
+
+    var_dump($statement->fetchAll(PDO::FETCH_ASSOC)[0]['test'] === $content);
+    var_dump($db->query('SHOW WARNINGS')->fetchAll(PDO::FETCH_ASSOC));
+
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+    $statement2 = $db->prepare('SELECT HEX(?) as test');
+    $statement2->bindValue(1, hex2bin($content), PDO::PARAM_LOB);
+    $statement2->execute();
+
+    var_dump($statement2->fetchAll(PDO::FETCH_ASSOC)[0]['test'] === $content);
+
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true); // SHOW WARNINGS can only be used when PDO::ATTR_EMULATE_PREPARES=true
+    var_dump($db->query('SHOW WARNINGS')->fetchAll(PDO::FETCH_ASSOC));
+    print "done!";
+?>
+--EXPECTF--
+bool(true)
+array(0) {
+}
+bool(true)
+array(0) {
+}
+done!

--- a/ext/pdo_mysql/tests/pdo_mysql_quote_binary.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_quote_binary.phpt
@@ -1,0 +1,28 @@
+--TEST--
+MySQL PDO->quote(), properly handle binary data
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+require_once __DIR__ . '/inc/mysql_pdo_test.inc';
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+    require_once __DIR__ . '/inc/mysql_pdo_test.inc';
+    $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+    // Force the connection to utf8, which is enough to make the test fail
+    // MySQL 5.6+ would be required for utf8mb4
+    $db->exec("SET NAMES 'utf8'");
+
+    $content = "\xC3\xA1\xC3";
+    $quoted = $db->quote($content, PDO::PARAM_LOB);
+
+    var_dump($quoted);
+    var_dump($db->query("SELECT HEX({$quoted})")->fetch(PDO::FETCH_NUM)[0]);
+?>
+--EXPECTF--
+string(%d) "_binary'%s'"
+string(6) "C3A1C3"


### PR DESCRIPTION
The prepared statement emulation layer is handling binary content in a way that creates warnings in MySQL.

When analysing the query logs, we saw that the content sent to the server is missing `0x5C` characters when the using emulated prepares.

This introduces a minimal test case that reproduces the issue to aid the solution.

More info: https://github.com/doctrine/dbal/pull/6522#issuecomment-2340939347