### PR TITLE
ReflectionClass: show enums differently from classes, test output

### DIFF
--- a/ext/reflection/tests/ReflectionEnumUnitCase_getEnum.phpt
+++ b/ext/reflection/tests/ReflectionEnumUnitCase_getEnum.phpt
@@ -11,11 +11,14 @@ echo (new ReflectionEnumUnitCase(Foo::class, 'Bar'))->getEnum();
 
 ?>
 --EXPECTF--
-Class [ <user> final class Foo implements UnitEnum ] {
+Enum [ <user> enum Foo implements UnitEnum ] {
   @@ %sReflectionEnumUnitCase_getEnum.php 3-5
 
-  - Constants [1] {
-    Constant [ public Foo Bar ] { Object }
+  - Enum cases [1] {
+    Case Bar
+  }
+
+  - Constants [0] {
   }
 
   - Static properties [0] {

--- a/ext/reflection/tests/ReflectionEnum_toString.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString.phpt
@@ -11,11 +11,14 @@ echo new ReflectionEnum(Foo::class);
 
 ?>
 --EXPECTF--
-Class [ <user> final class Foo implements UnitEnum ] {
+Enum [ <user> enum Foo implements UnitEnum ] {
   @@ %sReflectionEnum_toString.php 3-5
 
-  - Constants [1] {
-    Constant [ public Foo Bar ] { Object }
+  - Enum cases [1] {
+    Case Bar
+  }
+
+  - Constants [0] {
   }
 
   - Static properties [0] {

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
@@ -1,0 +1,141 @@
+--TEST--
+ReflectionEnum::__toString() (larger case, int-backed)
+--FILE--
+<?php
+
+interface MyStringable {
+    public function toString(): string;
+}
+
+enum MyBool: int implements MyStringable {
+    case MyFalse = 0;
+    case MyTrue = 1;
+    
+    public const MyBool OtherTrue = MyBool::MyTrue;
+
+    public function toString(): string {
+        return $this->name . " = " . $this->value;
+    }
+}
+
+$r = new ReflectionClass( MyBool::class );
+echo $r;
+echo "\n";
+$r = new ReflectionEnum( MyBool::class );
+echo $r;
+
+var_export( MyBool::cases() );
+
+?>
+--EXPECTF--
+Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+  @@ %sReflectionEnum_toString_backed_int.php 7-16
+
+  - Constants [3] {
+    Constant [ public MyBool MyFalse ] { Object }
+    Constant [ public MyBool MyTrue ] { Object }
+    Constant [ public MyBool OtherTrue ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [3] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method from ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method tryFrom ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ ?static ]
+    }
+  }
+
+  - Properties [2] {
+    Property [ public protected(set) readonly string $name ]
+    Property [ public protected(set) readonly int $value ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_backed_int.php 13 - 15
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+
+Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+  @@ %sReflectionEnum_toString_backed_int.php 7-16
+
+  - Constants [3] {
+    Constant [ public MyBool MyFalse ] { Object }
+    Constant [ public MyBool MyTrue ] { Object }
+    Constant [ public MyBool OtherTrue ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [3] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method from ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method tryFrom ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ ?static ]
+    }
+  }
+
+  - Properties [2] {
+    Property [ public protected(set) readonly string $name ]
+    Property [ public protected(set) readonly int $value ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_backed_int.php 13 - 15
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+array (
+  0 => 
+  \MyBool::MyFalse,
+  1 => 
+  \MyBool::MyTrue,
+)

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_int.phpt
@@ -28,12 +28,15 @@ var_export( MyBool::cases() );
 
 ?>
 --EXPECTF--
-Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
   @@ %sReflectionEnum_toString_backed_int.php 7-16
 
-  - Constants [3] {
-    Constant [ public MyBool MyFalse ] { Object }
-    Constant [ public MyBool MyTrue ] { Object }
+  - Enum cases [2] {
+    Case MyFalse = 0
+    Case MyTrue = 1
+  }
+
+  - Constants [1] {
     Constant [ public MyBool OtherTrue ] { Object }
   }
 
@@ -81,12 +84,15 @@ Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum 
   }
 }
 
-Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+Enum [ <user> enum MyBool: int implements MyStringable, UnitEnum, BackedEnum ] {
   @@ %sReflectionEnum_toString_backed_int.php 7-16
 
-  - Constants [3] {
-    Constant [ public MyBool MyFalse ] { Object }
-    Constant [ public MyBool MyTrue ] { Object }
+  - Enum cases [2] {
+    Case MyFalse = 0
+    Case MyTrue = 1
+  }
+
+  - Constants [1] {
     Constant [ public MyBool OtherTrue ] { Object }
   }
 

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
@@ -1,0 +1,141 @@
+--TEST--
+ReflectionEnum::__toString() (larger case, string-backed)
+--FILE--
+<?php
+
+interface MyStringable {
+    public function toString(): string;
+}
+
+enum MyBool: string implements MyStringable {
+    case MyFalse = '~FALSE~';
+    case MyTrue = '~TRUE~';
+    
+    public const MyBool OtherTrue = MyBool::MyTrue;
+
+    public function toString(): string {
+        return $this->name . " = " . $this->value;
+    }
+}
+
+$r = new ReflectionClass( MyBool::class );
+echo $r;
+echo "\n";
+$r = new ReflectionEnum( MyBool::class );
+echo $r;
+
+var_export( MyBool::cases() );
+
+?>
+--EXPECTF--
+Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+  @@ %sReflectionEnum_toString_backed_string.php 7-16
+
+  - Constants [3] {
+    Constant [ public MyBool MyFalse ] { Object }
+    Constant [ public MyBool MyTrue ] { Object }
+    Constant [ public MyBool OtherTrue ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [3] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method from ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method tryFrom ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ ?static ]
+    }
+  }
+
+  - Properties [2] {
+    Property [ public protected(set) readonly string $name ]
+    Property [ public protected(set) readonly string $value ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_backed_string.php 13 - 15
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+
+Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+  @@ %sReflectionEnum_toString_backed_string.php 7-16
+
+  - Constants [3] {
+    Constant [ public MyBool MyFalse ] { Object }
+    Constant [ public MyBool MyTrue ] { Object }
+    Constant [ public MyBool OtherTrue ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [3] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method from ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ static ]
+    }
+
+    Method [ <internal, prototype BackedEnum> static public method tryFrom ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> string|int $value ]
+      }
+      - Return [ ?static ]
+    }
+  }
+
+  - Properties [2] {
+    Property [ public protected(set) readonly string $name ]
+    Property [ public protected(set) readonly string $value ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_backed_string.php 13 - 15
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+array (
+  0 => 
+  \MyBool::MyFalse,
+  1 => 
+  \MyBool::MyTrue,
+)

--- a/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_backed_string.phpt
@@ -28,12 +28,15 @@ var_export( MyBool::cases() );
 
 ?>
 --EXPECTF--
-Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum ] {
   @@ %sReflectionEnum_toString_backed_string.php 7-16
 
-  - Constants [3] {
-    Constant [ public MyBool MyFalse ] { Object }
-    Constant [ public MyBool MyTrue ] { Object }
+  - Enum cases [2] {
+    Case MyFalse = ~FALSE~
+    Case MyTrue = ~TRUE~
+  }
+
+  - Constants [1] {
     Constant [ public MyBool OtherTrue ] { Object }
   }
 
@@ -81,12 +84,15 @@ Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum 
   }
 }
 
-Class [ <user> final class MyBool implements MyStringable, UnitEnum, BackedEnum ] {
+Enum [ <user> enum MyBool: string implements MyStringable, UnitEnum, BackedEnum ] {
   @@ %sReflectionEnum_toString_backed_string.php 7-16
 
-  - Constants [3] {
-    Constant [ public MyBool MyFalse ] { Object }
-    Constant [ public MyBool MyTrue ] { Object }
+  - Enum cases [2] {
+    Case MyFalse = ~FALSE~
+    Case MyTrue = ~TRUE~
+  }
+
+  - Constants [1] {
     Constant [ public MyBool OtherTrue ] { Object }
   }
 

--- a/ext/reflection/tests/ReflectionEnum_toString_unbacked.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_unbacked.phpt
@@ -30,14 +30,17 @@ var_export( Suit::cases() );
 
 ?>
 --EXPECTF--
-Class [ <user> final class Suit implements MyStringable, UnitEnum ] {
+Enum [ <user> enum Suit implements MyStringable, UnitEnum ] {
   @@ %sReflectionEnum_toString_unbacked.php 7-18
 
-  - Constants [5] {
-    Constant [ public Suit Hearts ] { Object }
-    Constant [ public Suit Diamonds ] { Object }
-    Constant [ public Suit Clubs ] { Object }
-    Constant [ public Suit Spades ] { Object }
+  - Enum cases [4] {
+    Case Hearts
+    Case Diamonds
+    Case Clubs
+    Case Spades
+  }
+
+  - Constants [1] {
     Constant [ public Suit OtherHearts ] { Object }
   }
 
@@ -68,14 +71,17 @@ Class [ <user> final class Suit implements MyStringable, UnitEnum ] {
   }
 }
 
-Class [ <user> final class Suit implements MyStringable, UnitEnum ] {
+Enum [ <user> enum Suit implements MyStringable, UnitEnum ] {
   @@ %sReflectionEnum_toString_unbacked.php 7-18
 
-  - Constants [5] {
-    Constant [ public Suit Hearts ] { Object }
-    Constant [ public Suit Diamonds ] { Object }
-    Constant [ public Suit Clubs ] { Object }
-    Constant [ public Suit Spades ] { Object }
+  - Enum cases [4] {
+    Case Hearts
+    Case Diamonds
+    Case Clubs
+    Case Spades
+  }
+
+  - Constants [1] {
     Constant [ public Suit OtherHearts ] { Object }
   }
 

--- a/ext/reflection/tests/ReflectionEnum_toString_unbacked.phpt
+++ b/ext/reflection/tests/ReflectionEnum_toString_unbacked.phpt
@@ -1,0 +1,117 @@
+--TEST--
+ReflectionEnum::__toString() (larger case, unbacked)
+--FILE--
+<?php
+
+interface MyStringable {
+    public function toString(): string;
+}
+
+enum Suit implements MyStringable {
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+    
+    public const Suit OtherHearts = Suit::Hearts;
+
+    public function toString(): string {
+        return $this->name;
+    }
+}
+
+$r = new ReflectionClass( Suit::class );
+echo $r;
+echo "\n";
+$r = new ReflectionEnum( Suit::class );
+echo $r;
+
+var_export( Suit::cases() );
+
+?>
+--EXPECTF--
+Class [ <user> final class Suit implements MyStringable, UnitEnum ] {
+  @@ %sReflectionEnum_toString_unbacked.php 7-18
+
+  - Constants [5] {
+    Constant [ public Suit Hearts ] { Object }
+    Constant [ public Suit Diamonds ] { Object }
+    Constant [ public Suit Clubs ] { Object }
+    Constant [ public Suit Spades ] { Object }
+    Constant [ public Suit OtherHearts ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [1] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+  }
+
+  - Properties [1] {
+    Property [ public protected(set) readonly string $name ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_unbacked.php 15 - 17
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+
+Class [ <user> final class Suit implements MyStringable, UnitEnum ] {
+  @@ %sReflectionEnum_toString_unbacked.php 7-18
+
+  - Constants [5] {
+    Constant [ public Suit Hearts ] { Object }
+    Constant [ public Suit Diamonds ] { Object }
+    Constant [ public Suit Clubs ] { Object }
+    Constant [ public Suit Spades ] { Object }
+    Constant [ public Suit OtherHearts ] { Object }
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [1] {
+    Method [ <internal, prototype UnitEnum> static public method cases ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
+    }
+  }
+
+  - Properties [1] {
+    Property [ public protected(set) readonly string $name ]
+  }
+
+  - Methods [1] {
+    Method [ <user, prototype MyStringable> public method toString ] {
+      @@ %sReflectionEnum_toString_unbacked.php 15 - 17
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+  }
+}
+array (
+  0 => 
+  \Suit::Hearts,
+  1 => 
+  \Suit::Diamonds,
+  2 => 
+  \Suit::Clubs,
+  3 => 
+  \Suit::Spades,
+)


### PR DESCRIPTION
While internally enums are mostly the same as classes, their output in
`ReflectionClass::__toString()` should show the enum as the developer wrote it,
rather than as the engine stored it. Accordingly

- Say that the enum is an enum, not a final class

- Include the backing type, if any, in the declaration line

- List enum cases separately from constants, and show the underlying values, if
any

Also add tests for the output - the tests are added in the first commit, so
that the changes in the second commit can be more easily confirmed.

GH-15766