### PR TITLE
[skip ci] Drop `ZIP_STATIC` hack

### DIFF
--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -10,12 +10,6 @@ if (PHP_ZIP != "no") {
 	) {
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
 		ADD_EXTENSION_DEP('zip', 'pcre');
-
-		if (get_define("LIBS_ZIP").match("libzip_a(?:_debug)?\.lib")) {
-			/* Using static dependency lib. */
-			AC_DEFINE("ZIP_STATIC", 1);
-		}
-
 		AC_DEFINE('HAVE_ZIP', 1, "Define to 1 if the PHP extension 'zip' is available.");
 		ADD_FLAG("CFLAGS_ZIP", "/D HAVE_SET_MTIME /D HAVE_ENCRYPTION /D HAVE_LIBZIP_VERSION /D HAVE_PROGRESS_CALLBACK /D HAVE_CANCEL_CALLBACK /D HAVE_METHOD_SUPPORTED /D LZMA_API_STATIC");
 	} else {


### PR DESCRIPTION
Old versions of libzip didn't export the `ZIP_STATIC` macro, even if they had been built as static libraries.  This hack in config.w32 is supposed to counteract that, since the macro is used in zip.h. However, PHP has no business in defining macros belonging to external libraries; instead the winlibs builds should have been fixed to set this macro in zip.h.  Furthermore, as of libzip there is zipconf.h, where this macro is defined as appropriate, if libzip was build with the proper configuration options.  Unfortunately, that has not been done so far, but assuming that new properly configured builds of libzip will be rolled out, we need to drop this hack to avoid conflicting macro definitions, since we define the macro to 1, but libzip only defines it (without further hackery).

---

This falls in the category "things that should not have happened, and either we apply the painful fix now, or never". The fix is painful, because with the currently shipped winlib libzip builds, ext/zip can no longer be built on Windows (thus `[skip ci]`), while properly configured static builds of libzip (`-DBUILD_SHARED_LIBS=OFF`) won't work without this fix (or additional hacks in zipconf.h). Now, the simple fix of using `#cmakedefine01` instead of `#cmakedefine` would work for static libzip builds (even with this patch), but not for shared builds of libzip.

Besides that ext/zip should never have used this hack in the first place, the problem appears to be that CMake either uses `#define`/`#undef`, or `#define 1`/`#define 0`, while our `AC_DEFINE` does not support `#define`/`#undef` at all.

And this is even more painful, because pecl/zip also defines `ZIP_STATIC` for static libzip builds, and does not even allow to build against shared libzip. Considering this, it might be best to stick with the hack forever, and patch libzip respectively to suit ext/zip; and to back away from dreaming that PHP on Windows can ever be built against unpatched dependency libraries.

Alternatives include to ignore the C4005 warning, not to build with `/WX`, to undefine the macro prior to the collsion, or to add support for `#define` to our `AC_DEFINE`.

cc @petk, @remicollet and @shivammathur 