### PR TITLE
fix printf negative infinity

### DIFF
--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -247,8 +247,16 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 
 	if (zend_isinf(number)) {
 		is_negative = (number<0);
-		php_sprintf_appendstring(buffer, pos, "INF", 3, 0, padding,
-								 alignment, 3, is_negative, 0, always_sign);
+		if (is_negative) {
+			// ideally negative should have been handled inside php_sprintf_appendstring ,
+			// but the code is difficult to debug, and it's easy to break stuff inside there (I tried, I broke stuff),
+			// handling it here is much easier..
+			php_sprintf_appendstring(buffer, pos, "-INF", 4, 0, padding,
+									 alignment, 4, is_negative, 0, always_sign);
+		} else {
+			php_sprintf_appendstring(buffer, pos, "INF", 3, 0, padding,
+									 alignment, 3, is_negative, 0, always_sign);
+		}
 		return;
 	}
 

--- a/tests/strings/002.phpt
+++ b/tests/strings/002.phpt
@@ -44,6 +44,8 @@ try {
 } catch(\ValueError $e) {
     print('Error found: '.$e->getMessage()."\n");
 }
+printf("printf test 31:%.17g\n", INF);
+printf("printf test 32:%.17g\n", -INF);
 vprintf("vprintf test 1:%2\$-2d %1\$2d\n", array(1, 2));
 
 
@@ -83,4 +85,6 @@ printf test 27:3 1 2
 printf test 28:02  1
 printf test 29:2   1
 printf test 30:Error found: Argument number specifier must be greater than zero and less than 2147483647
+printf test 31:INF
+printf test 32:-INF
 vprintf test 1:2   1


### PR DESCRIPTION
`sprintf("%.17g", -INF);`  should return `-INF` not `INF`

resolves https://github.com/php/php-src/issues/15964

I tried fixing it inside php_sprintf_appendstring as it seems the original author intended, but.. that was difficult, and I broke other stuff.

(I think php_sprintf_appendstring would benefit from using smart_str https://www.phpinternalsbook.com/php7/internal_types/strings/smart_str.html  , but idk if the effort would be worth it)