### PR TITLE
Fix #49169: SoapServer calls wrong function, although "SOAP action" header is correct

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -3058,6 +3058,8 @@ static void deserialize_parameters(xmlNodePtr params, sdlFunctionPtr function, u
 }
 /* }}} */
 
+/* This function attempts to find the right function name based on the first node's name in the soap body.
+ * If that doesn't work it falls back to get_doc_function(). */
 static sdlFunctionPtr find_function(sdlPtr sdl, xmlNodePtr func, zval* function_name) /* {{{ */
 {
 	sdlFunctionPtr function;
@@ -4185,6 +4187,10 @@ static sdlFunctionPtr get_function(sdlPtr sdl, const char *function_name, size_t
 }
 /* }}} */
 
+/* This function tries to find the function that matches the given parameters.
+ * If params is NULL, it will return the first function that has no parameters.
+ * If params is not NULL, it will return the first function that has the same
+ * parameters as the given XML node. */
 static sdlFunctionPtr get_doc_function(sdlPtr sdl, xmlNodePtr params) /* {{{ */
 {
 	if (sdl) {

--- a/ext/soap/tests/bugs/bug49169.phpt
+++ b/ext/soap/tests/bugs/bug49169.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Bug #49169 (SoapServer calls wrong function, although "SOAP action" header is correct)
+--EXTENSIONS--
+soap
+--INI--
+soap.wsdl_cache_enabled=0
+--SKIPIF--
+<?php
+    if (php_sapi_name()=='cli') echo 'skip';
+?>
+--POST--
+<SOAP-ENV:Envelope
+    xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+    SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+>
+    <SOAP-ENV:Body>
+        <testParam xsi:type="xsd:string">hello</testParam>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+--FILE--
+<?php
+function test($input) {
+  return strrev($input);
+}
+function test2($input) {
+  return strlen($input);
+}
+
+$server = new soapserver(__DIR__.'/bug49169.wsdl', []);
+$server->addfunction("test");
+$server->addfunction("test2");
+$_SERVER["HTTP_SOAPACTION"] = "#test";
+$server->handle();
+$_SERVER["HTTP_SOAPACTION"] = "#test2";
+$server->handle();
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><testParam xsi:type="xsd:string">olleh</testParam></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><testParam xsi:type="xsd:string">5</testParam></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/bugs/bug49169.wsdl
+++ b/ext/soap/tests/bugs/bug49169.wsdl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<definitions name="InteropTest"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+             xmlns:tns="http://test-uri/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/"
+             targetNamespace="http://test-uri/">
+    <message name="testMessage">
+        <part name="testParam" type="xsd:string"/>
+    </message>
+    <portType name="testPortType">
+        <operation name="test">
+            <input message="testMessage"/>
+            <output message="testMessage"/>
+        </operation>
+        <operation name="test2">
+            <input message="testMessage"/>
+            <output message="testMessage"/>
+        </operation>
+    </portType>
+    <binding name="testBinding" type="testPortType">
+        <soap:binding style="rcp" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="test">
+            <soap:operation soapAction="#test" style="rcp"/>
+            <input>
+                <soap:body use="encoded" namespace="http://test-uri/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+            </input>
+            <output>
+                <soap:body use="encoded" namespace="http://test-uri/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+            </output>
+        </operation>
+        <operation name="test2">
+            <soap:operation soapAction="#test2" style="rcp"/>
+            <input>
+                <soap:body use="encoded" namespace="http://test-uri/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+            </input>
+            <output>
+                <soap:body use="encoded" namespace="http://test-uri/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="testService">
+        <port name="testPort" binding="tns:testBinding">
+            <soap:address location="http://localhost:8080/server.php" />
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
See individual commits and their descriptions.
Sending to master because the fix is fairly non-trivial.