### PR TITLE
Fix minimal Windows version

### DIFF
--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -6,7 +6,7 @@
 #undef _WIN32_WINNT
 #undef NTDDI_VERSION
 #define _WIN32_WINNT 0x0602
-#define NTDDI_VERSION 0x06010000
+#define NTDDI_VERSION 0x06020000
 
 /* Default PHP / PEAR directories */
 #define PHP_CONFIG_FILE_PATH ""

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -50,7 +50,7 @@ var PHP_MAKEFILE_FRAGMENTS = PHP_SRC_DIR + "\\Makefile.fragments.w32";
 
 /* Care also about NTDDI_VERSION and _WIN32_WINNT in config.w32.h.in
    and manifest. */
-var WINVER = "0x0601"; /* 7/2008r2 */
+var WINVER = "0x0602"; /* 8/2012 */
 
 // There's a minimum requirement for bison.
 var MINBISON = "3.0.0";

--- a/win32/build/default.manifest
+++ b/win32/build/default.manifest
@@ -9,8 +9,6 @@
     </trustInfo>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
        <application>
-           <!-- Windows 7 -->
-           <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
            <!-- Windows 8 -->
            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
            <!-- Windows 8.1 -->


### PR DESCRIPTION
As of PHP 8.3.0, Windows 8/Server 2012 are the minimum requirement. However, PR #9104 only updated `_WIN32_WINNT`, but not `WINVER`[1], `NTDDI_VERSION`[2] nor the manifest[3].

[1] <https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers>
[2] <https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers>
[3] <https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests>