### PR TITLE
GH-15976: clarify error messages for enum/trait/interface/alias names

### DIFF
--- a/Zend/tests/enum/enum_underscore_as_name.phpt
+++ b/Zend/tests/enum/enum_underscore_as_name.phpt
@@ -13,6 +13,6 @@ namespace {
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as an enum name is deprecated since 8.4 in %s on line %d
 
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as an enum name is deprecated since 8.4 in %s on line %d

--- a/Zend/tests/errmsg_028.phpt
+++ b/Zend/tests/errmsg_028.phpt
@@ -9,4 +9,4 @@ class self {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'self' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/errmsg_029.phpt
+++ b/Zend/tests/errmsg_029.phpt
@@ -9,4 +9,4 @@ class parent {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'parent' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'parent' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/gh15976/alias-names.phpt
+++ b/Zend/tests/gh15976/alias-names.phpt
@@ -8,6 +8,6 @@ class_alias( 'stdClass', 'bool' );
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %salias-names.php on line 3
+Deprecated: Using "_" as a type alias is deprecated since 8.4 in %salias-names.php on line 3
 
-Fatal error: Cannot use 'bool' as class name as it is reserved in %salias-names.php on line 4
+Fatal error: Cannot use 'bool' as a type alias as it is reserved in %salias-names.php on line 4

--- a/Zend/tests/gh15976/alias-names.phpt
+++ b/Zend/tests/gh15976/alias-names.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15976: Bad class alias names
+--FILE--
+<?php
+
+class_alias( 'stdClass', '_' );
+class_alias( 'stdClass', 'bool' );
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %salias-names.php on line 3
+
+Fatal error: Cannot use 'bool' as class name as it is reserved in %salias-names.php on line 4

--- a/Zend/tests/gh15976/class-names.phpt
+++ b/Zend/tests/gh15976/class-names.phpt
@@ -10,4 +10,4 @@ class bool {}
 --EXPECTF--
 Deprecated: Using "_" as a class name is deprecated since 8.4 in %sclass-names.php on line 3
 
-Fatal error: Cannot use 'bool' as class name as it is reserved in %sclass-names.php on line 4
+Fatal error: Cannot use 'bool' as a class name as it is reserved in %sclass-names.php on line 4

--- a/Zend/tests/gh15976/class-names.phpt
+++ b/Zend/tests/gh15976/class-names.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15976: Bad class names
+--FILE--
+<?php
+
+class _ {}
+class bool {}
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %sclass-names.php on line 3
+
+Fatal error: Cannot use 'bool' as class name as it is reserved in %sclass-names.php on line 4

--- a/Zend/tests/gh15976/enum-names.phpt
+++ b/Zend/tests/gh15976/enum-names.phpt
@@ -8,6 +8,6 @@ enum bool {}
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %senum-names.php on line 3
+Deprecated: Using "_" as an enum name is deprecated since 8.4 in %senum-names.php on line 3
 
-Fatal error: Cannot use 'bool' as class name as it is reserved in %senum-names.php on line 4
+Fatal error: Cannot use 'bool' as an enum name as it is reserved in %senum-names.php on line 4

--- a/Zend/tests/gh15976/enum-names.phpt
+++ b/Zend/tests/gh15976/enum-names.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15976: Bad enum names
+--FILE--
+<?php
+
+enum _ {}
+enum bool {}
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %senum-names.php on line 3
+
+Fatal error: Cannot use 'bool' as class name as it is reserved in %senum-names.php on line 4

--- a/Zend/tests/gh15976/interface-names.phpt
+++ b/Zend/tests/gh15976/interface-names.phpt
@@ -8,6 +8,6 @@ interface bool {}
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %sinterface-names.php on line 3
+Deprecated: Using "_" as an interface name is deprecated since 8.4 in %sinterface-names.php on line 3
 
-Fatal error: Cannot use 'bool' as class name as it is reserved in %sinterface-names.php on line 4
+Fatal error: Cannot use 'bool' as an interface name as it is reserved in %sinterface-names.php on line 4

--- a/Zend/tests/gh15976/interface-names.phpt
+++ b/Zend/tests/gh15976/interface-names.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15976: Bad interface names
+--FILE--
+<?php
+
+interface _ {}
+interface bool {}
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %sinterface-names.php on line 3
+
+Fatal error: Cannot use 'bool' as class name as it is reserved in %sinterface-names.php on line 4

--- a/Zend/tests/gh15976/trait-names.phpt
+++ b/Zend/tests/gh15976/trait-names.phpt
@@ -8,6 +8,6 @@ trait bool {}
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %strait-names.php on line 3
+Deprecated: Using "_" as a trait name is deprecated since 8.4 in %strait-names.php on line 3
 
-Fatal error: Cannot use 'bool' as class name as it is reserved in %strait-names.php on line 4
+Fatal error: Cannot use 'bool' as a trait name as it is reserved in %strait-names.php on line 4

--- a/Zend/tests/gh15976/trait-names.phpt
+++ b/Zend/tests/gh15976/trait-names.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-15976: Bad trait names
+--FILE--
+<?php
+
+trait _ {}
+trait bool {}
+
+?>
+--EXPECTF--
+Deprecated: Using "_" as a class name is deprecated since 8.4 in %strait-names.php on line 3
+
+Fatal error: Cannot use 'bool' as class name as it is reserved in %strait-names.php on line 4

--- a/Zend/tests/interface_underscore_as_name.phpt
+++ b/Zend/tests/interface_underscore_as_name.phpt
@@ -13,6 +13,6 @@ namespace {
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as an interface name is deprecated since 8.4 in %s on line %d
 
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as an interface name is deprecated since 8.4 in %s on line %d

--- a/Zend/tests/lazy_objects/unclean_shutdown.phpt
+++ b/Zend/tests/lazy_objects/unclean_shutdown.phpt
@@ -16,4 +16,4 @@ $obj = $reflector->newLazyGhost(function ($obj) {
 
 var_dump($obj->a);
 --EXPECTF--
-Fatal error: Cannot use 'bool' as class name%s on line %d
+Fatal error: Cannot use 'bool' as a class name%s on line %d

--- a/Zend/tests/restore_error_reporting.phpt
+++ b/Zend/tests/restore_error_reporting.phpt
@@ -11,4 +11,4 @@ var_dump($undef_var);
 Warning: Undefined variable $undef_var in %s on line %d
 NULL
 
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'self' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/special_name_error3.phpt
+++ b/Zend/tests/special_name_error3.phpt
@@ -7,4 +7,4 @@ trait self {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'self' as a trait name as it is reserved in %s on line %d

--- a/Zend/tests/traits/enum_underscore_as_name.phpt
+++ b/Zend/tests/traits/enum_underscore_as_name.phpt
@@ -13,6 +13,6 @@ namespace {
 
 ?>
 --EXPECTF--
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as a trait name is deprecated since 8.4 in %s on line %d
 
-Deprecated: Using "_" as a class name is deprecated since 8.4 in %s on line %d
+Deprecated: Using "_" as a trait name is deprecated since 8.4 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/syntax/mixed_class_error.phpt
+++ b/Zend/tests/type_declarations/mixed/syntax/mixed_class_error.phpt
@@ -9,4 +9,4 @@ class mixed
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'mixed' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'mixed' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_relative_typehint_disallowed.phpt
+++ b/Zend/tests/type_declarations/scalar_relative_typehint_disallowed.phpt
@@ -11,4 +11,4 @@ foo(10);
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'bar\int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'bar\int' as a type name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved2.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved2.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (2)
 class int {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'int' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved2_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved2_class_alias.phpt
@@ -7,4 +7,4 @@ class foobar {}
 class_alias("foobar", "int");
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'int' as a type alias as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved3.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved3.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (3)
 class float {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'float' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'float' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved3_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved3_class_alias.phpt
@@ -7,4 +7,4 @@ class foobar {}
 class_alias("foobar", "float");
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'float' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'float' as a type alias as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved4.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved4.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (4)
 class string {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'string' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'string' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved4_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved4_class_alias.phpt
@@ -7,4 +7,4 @@ class foobar {}
 class_alias("foobar", "string");
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'string' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'string' as a type alias as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved6.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved6.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (6)
 class bool {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'bool' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'bool' as a class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved6_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved6_class_alias.phpt
@@ -7,4 +7,4 @@ class foobar {}
 class_alias("foobar", "bool");
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'bool' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'bool' as a type alias as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved7.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved7.phpt
@@ -7,4 +7,4 @@ namespace foo;
 class int {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'int' as a class name as it is reserved in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3571,7 +3571,7 @@ ZEND_API zend_result zend_register_class_alias_ex(const char *name, size_t name_
 		zend_str_tolower_copy(ZSTR_VAL(lcname), name, name_len);
 	}
 
-	zend_assert_valid_class_name(lcname);
+	zend_assert_valid_class_name(lcname, "a type alias");
 
 	lcname = zend_new_interned_string(lcname);
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -237,14 +237,14 @@ static bool zend_is_reserved_class_name(const zend_string *name) /* {{{ */
 }
 /* }}} */
 
-void zend_assert_valid_class_name(const zend_string *name) /* {{{ */
+void zend_assert_valid_class_name(const zend_string *name, const char *type) /* {{{ */
 {
 	if (zend_is_reserved_class_name(name)) {
 		zend_error_noreturn(E_COMPILE_ERROR,
-			"Cannot use '%s' as class name as it is reserved", ZSTR_VAL(name));
+			"Cannot use '%s' as %s as it is reserved", ZSTR_VAL(name), type);
 	}
 	if (zend_string_equals_literal(name, "_")) {
-		zend_error(E_DEPRECATED, "Using \"_\" as a class name is deprecated since 8.4");
+		zend_error(E_DEPRECATED, "Using \"_\" as %s is deprecated since 8.4", type);
 	}
 }
 /* }}} */
@@ -6985,7 +6985,7 @@ static zend_type zend_compile_single_typename(zend_ast *ast)
 			uint32_t fetch_type = zend_get_class_fetch_type_ast(ast);
 			if (fetch_type == ZEND_FETCH_CLASS_DEFAULT) {
 				class_name = zend_resolve_class_name_ast(ast);
-				zend_assert_valid_class_name(class_name);
+				zend_assert_valid_class_name(class_name, "a type name");
 			} else {
 				zend_ensure_valid_class_fetch_type(fetch_type);
 				zend_string_addref(class_name);
@@ -8996,7 +8996,15 @@ static void zend_compile_class_decl(znode *result, zend_ast *ast, bool toplevel)
 			zend_error_noreturn(E_COMPILE_ERROR, "Class declarations may not be nested");
 		}
 
-		zend_assert_valid_class_name(unqualified_name);
+		const char *type = "a class name";
+		if (decl->flags & ZEND_ACC_ENUM) {
+			type = "an enum name";
+		} else if (decl->flags & ZEND_ACC_INTERFACE) {
+			type = "an interface name";
+		} else if (decl->flags & ZEND_ACC_TRAIT) {
+			type = "a trait name";
+		}
+		zend_assert_valid_class_name(unqualified_name, type);
 		name = zend_prefix_with_ns(unqualified_name);
 		name = zend_new_interned_string(name);
 		lcname = zend_string_tolower(name);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1001,7 +1001,7 @@ ZEND_API void zend_set_function_arg_flags(zend_function *func);
 
 int ZEND_FASTCALL zendlex(zend_parser_stack_elem *elem);
 
-void zend_assert_valid_class_name(const zend_string *const_name);
+void zend_assert_valid_class_name(const zend_string *const_name, const char *type);
 
 zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scope);
 ZEND_API zend_string *zend_type_to_string(zend_type type);

--- a/ext/spl/tests/RecursiveIteratorIterator_dtor_order.phpt
+++ b/ext/spl/tests/RecursiveIteratorIterator_dtor_order.phpt
@@ -11,4 +11,4 @@ foreach ($it as $v) {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use 'self' as a class name as it is reserved in %s on line %d


### PR DESCRIPTION
Instead of always saying that a name is reserved or deprecated and
cannot/should not be used as a class name, take the usage into account and say
the name cannot be used as an enum name, trait name, etc. In the process, for
class names add a missing "a".

Add tests for the new messages.