### PR TITLE
Don't attempt to close a handle twice

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -708,6 +708,7 @@ TSRM_API int shmget(key_t key, size_t size, int flags)
 	if (NULL != shm->descriptor && (shm->descriptor->shm_perm.key != key || size > shm->descriptor->shm_segsz)) {
 		if (NULL != shm->segment) {
 			CloseHandle(shm->segment);
+			shm->segment = INVALID_HANDLE_VALUE;
 		}
 		UnmapViewOfFile(shm->descriptor);
 		shm->descriptor = NULL;


### PR DESCRIPTION
This is pretty harmless, but still, when running e.g. gh14537.phpt with a debugger attached we get a `C0000028` ("an invalid handle was specified") error at

https://github.com/php/php-src/blob/27b3131422b53f9b37bba5235bc20610687fad2e/TSRM/tsrm_win32.c#L74