### PR TITLE
Make ext/shmop/tests/gh14537.phpt more resilient

### DIFF
--- a/ext/shmop/tests/gh14537.phpt
+++ b/ext/shmop/tests/gh14537.phpt
@@ -23,5 +23,5 @@ var_dump($shm_id2);
 object(Shmop)#1 (0) {
 }
 
-Warning: shmop_open(): Unable to attach or create shared memory segment "No error" in %s on line %d
+Warning: shmop_open(): Unable to attach or create shared memory segment "%s" in %s on line %d
 bool(false)


### PR DESCRIPTION
The actual problem is our `shmget()` implementation which does not care to set `errno` appropriately; that should be fixed, although mapping the error conditions to those specified by POSIX might be hard.

For now, we only make the test case more resilient by ignoring the exact error; "No error" doesn't make sense anyway.