### PR TITLE
Fix GH-15986: Double-free due to Pdo\Pgsql::setNoticeCallback()

### DIFF
--- a/ext/pdo_pgsql/pdo_pgsql.c
+++ b/ext/pdo_pgsql/pdo_pgsql.c
@@ -169,9 +169,7 @@ PHP_METHOD(Pdo_Pgsql, setNoticeCallback)
 	return;
 
 cleanup:
-	if (ZEND_FCC_INITIALIZED(fcc)) {
-		zend_fcc_dtor(&fcc);
-	}
+	zend_release_fcall_info_cache(&fcc);
 	RETURN_THROWS();
 }
 


### PR DESCRIPTION
We need to release the fcall info cache instead of destroying it.