### PR TITLE
Cast big endian byte shuffling to uint

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -457,14 +457,14 @@ void phar_entry_remove(phar_entry_data *idata, char **error) /* {{{ */
 
 #ifdef WORDS_BIGENDIAN
 # define PHAR_GET_32(buffer, var) \
-	var = ((((unsigned char*)(buffer))[3]) << 24) \
-		| ((((unsigned char*)(buffer))[2]) << 16) \
-		| ((((unsigned char*)(buffer))[1]) <<  8) \
-		| (((unsigned char*)(buffer))[0]); \
+	var = ((uint32_t)(((unsigned char*)(buffer))[3]) << 24) \
+		| ((uint32_t)(((unsigned char*)(buffer))[2]) << 16) \
+		| ((uint32_t)(((unsigned char*)(buffer))[1]) <<  8) \
+		| ((uint32_t)((unsigned char*)(buffer))[0]); \
 	(buffer) += 4
 # define PHAR_GET_16(buffer, var) \
-	var = ((((unsigned char*)(buffer))[1]) <<  8) \
-		| (((unsigned char*)(buffer))[0]); \
+	var = ((uint16_t)(((unsigned char*)(buffer))[1]) <<  8) \
+		| ((uint16_t)((unsigned char*)(buffer))[0]); \
 	(buffer) += 2
 #else
 # define PHAR_GET_32(buffer, var) \


### PR DESCRIPTION
This works, but UBSan running on a big endian platform (in this, ppc64) will complain that the ((uchar*)buffer)[n] is int, and shifting that could be weird. Since the value of what PHAR_GET_32 et al usually set are almost always unsigned, it makes sense to cast these as unsigned.

Fixes phar tests on a big endian system with UBSan enabled.