### PR TITLE
Fix GH-15980: Signed integer overflow in main/streams/streams.c

### DIFF
--- a/ext/standard/tests/streams/gh15980.phpt
+++ b/ext/standard/tests/streams/gh15980.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-15980 (Signed integer overflow in main/streams/streams.c)
+--FILE--
+<?php
+$s = fopen(__FILE__, "r");
+fseek($s, 1);
+fseek($s, PHP_INT_MAX, SEEK_CUR);
+var_dump(ftell($s) > 1);
+?>
+--EXPECT--
+bool(true)

--- a/ext/standard/tests/streams/gh15980.phpt
+++ b/ext/standard/tests/streams/gh15980.phpt
@@ -4,7 +4,9 @@ GH-15980 (Signed integer overflow in main/streams/streams.c)
 <?php
 $s = fopen(__FILE__, "r");
 fseek($s, 1);
-var_dump(fseek($s, PHP_INT_MAX, SEEK_CUR));
-var_dump(ftell($s));
+$seekres = fseek($s, PHP_INT_MAX, SEEK_CUR);
+$tellres = ftell($s);
+var_dump($seekres === -1 || $tellres > 1);
 ?>
 --EXPECT--
+bool(true)

--- a/ext/standard/tests/streams/gh15980.phpt
+++ b/ext/standard/tests/streams/gh15980.phpt
@@ -4,8 +4,7 @@ GH-15980 (Signed integer overflow in main/streams/streams.c)
 <?php
 $s = fopen(__FILE__, "r");
 fseek($s, 1);
-fseek($s, PHP_INT_MAX, SEEK_CUR);
-var_dump(ftell($s) > 1);
+var_dump(fseek($s, PHP_INT_MAX, SEEK_CUR));
+var_dump(ftell($s));
 ?>
 --EXPECT--
-bool(true)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1354,8 +1354,13 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 
 		switch(whence) {
 			case SEEK_CUR:
-				offset = stream->position + offset;
-				whence = SEEK_SET;
+				ZEND_ASSERT(stream->position >= 0);
+				if (UNEXPECTED(offset > ZEND_LONG_MAX - stream->position)) {
+					offset = ZEND_LONG_MAX;
+				} else {
+					offset = stream->position + offset;
+				}
+ 				whence = SEEK_SET;
 				break;
 		}
 		ret = stream->ops->seek(stream, offset, whence, &stream->position);


### PR DESCRIPTION
We need to avoid signed integer overflows which are undefined behavior. We catch that, and set `offset` to `ZEND_LONG_MAX` (which is also the largest value of `zend_off_t` on all platforms).  Of course, after such a seek a stream is no longer readable, but that matches the current behavior for offsets near `ZEND_LONG_MAX`.