### PR TITLE
GH-15994: fix suggestion that anonymous classes be made abstract

### DIFF
--- a/Zend/tests/anon/gh15994.phpt
+++ b/Zend/tests/anon/gh15994.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Abstract function must be implemented
+--FILE--
+<?php
+
+$c = new class {
+    abstract public function f();
+};
+?>
+--EXPECTF--
+Fatal error: Class class@anonymous must implement 1 abstract method (class@anonymous::f) in %sgh15994.php on line 3

--- a/Zend/tests/anon/gh15994.phpt
+++ b/Zend/tests/anon/gh15994.phpt
@@ -3,9 +3,11 @@ Abstract function must be implemented
 --FILE--
 <?php
 
-$c = new class {
+abstract class ParentClass {
     abstract public function f();
-};
+}
+
+$o = new class extends ParentClass {};
 ?>
 --EXPECTF--
-Fatal error: Class class@anonymous must implement 1 abstract method (class@anonymous::f) in %sgh15994.php on line 3
+Fatal error: Class ParentClass@anonymous must implement 1 abstract method (ParentClass::f) in %sgh15994.php on line 7

--- a/Zend/tests/gh7792_1.phpt
+++ b/Zend/tests/gh7792_1.phpt
@@ -11,4 +11,4 @@ enum B implements A {}
 
 ?>
 --EXPECTF--
-Fatal error: Enum B must implement 1 abstract private method (A::a) in %s on line %d
+Fatal error: Enum B must implement 1 abstract method (A::a) in %s on line %d

--- a/Zend/tests/traits/abstract_method_6.phpt
+++ b/Zend/tests/traits/abstract_method_6.phpt
@@ -17,4 +17,4 @@ class D extends C {
 
 ?>
 --EXPECTF--
-Fatal error: Class C must implement 1 abstract private method (C::method) in %s on line %d
+Fatal error: Class C must implement 1 abstract method (C::method) in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2981,7 +2981,7 @@ void zend_verify_abstract_class(zend_class_entry *ce) /* {{{ */
 	const zend_function *func;
 	zend_abstract_info ai;
 	bool is_explicit_abstract = (ce->ce_flags & ZEND_ACC_EXPLICIT_ABSTRACT_CLASS) != 0;
-	bool can_be_abstract = (ce->ce_flags & ZEND_ACC_ENUM) == 0;
+	bool can_be_abstract = (ce->ce_flags & (ZEND_ACC_ENUM|ZEND_ACC_ANON_CLASS)) == 0;
 	memset(&ai, 0, sizeof(ai));
 
 	ZEND_HASH_MAP_FOREACH_PTR(&ce->function_table, func) {
@@ -3022,7 +3022,7 @@ void zend_verify_abstract_class(zend_class_entry *ce) /* {{{ */
 			);
 		} else {
 			zend_error_noreturn(E_ERROR,
-				"%s %s must implement %d abstract private method%s (" MAX_ABSTRACT_INFO_FMT MAX_ABSTRACT_INFO_FMT MAX_ABSTRACT_INFO_FMT ")",
+				"%s %s must implement %d abstract method%s (" MAX_ABSTRACT_INFO_FMT MAX_ABSTRACT_INFO_FMT MAX_ABSTRACT_INFO_FMT ")",
 				zend_get_object_type_uc(ce),
 				ZSTR_VAL(ce->name), ai.cnt,
 				ai.cnt > 1 ? "s" : "",


### PR DESCRIPTION
In the process, remove the (incorrect) assumption that any abstract method that
needs to be implemented by a class that cannot itself be made abstract must be
a private method - the existing test for an enum already showed that this was
not the case.