### PR TITLE
Fix use-after-free during lazy object initialization

### DIFF
--- a/Zend/tests/lazy_objects/gh15999.phpt
+++ b/Zend/tests/lazy_objects/gh15999.phpt
@@ -1,0 +1,107 @@
+--TEST--
+Lazy Objects: GH-15999: Object is released during initialization
+--FILE--
+<?php
+
+class C {
+    public $s;
+    public function __destruct() {
+        var_dump(__METHOD__);
+    }
+}
+
+print "# Ghost:\n";
+
+$r = new ReflectionClass(C::class);
+
+$o = $r->newLazyGhost(function ($obj) {
+    global $o;
+    $o = null;
+});
+
+try {
+    $o->s = $o;
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+print "# Proxy:\n";
+
+$o = $r->newLazyProxy(function ($obj) {
+    global $o;
+    $o = null;
+    return new C();
+});
+
+try {
+    $o->s = $o;
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+print "# GC cycle:\n";
+
+$o = $r->newLazyGhost(function ($obj) {
+    global $o;
+    $o->s = $o;
+    $o = null;
+    gc_collect_cycles();
+});
+
+$o->s = $o;
+gc_collect_cycles();
+
+print "# Nested error (ghost):\n";
+
+$r = new ReflectionClass(C::class);
+
+$o = $r->newLazyGhost(function ($obj) {
+    global $o;
+    $o = null;
+    return new stdClass;
+});
+
+try {
+    $o->s = $o;
+} catch (Error $e) {
+    do {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    } while ($e = $e->getPrevious());
+}
+
+print "# Nested error (proxy):\n";
+
+$r = new ReflectionClass(C::class);
+
+$o = $r->newLazyProxy(function ($obj) {
+    global $o;
+    $o = null;
+    return new stdClass;
+});
+
+try {
+    $o->s = $o;
+} catch (Error $e) {
+    do {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    } while ($e = $e->getPrevious());
+}
+
+?>
+==DONE==
+--EXPECT--
+# Ghost:
+string(13) "C::__destruct"
+Error: Lazy object was released during initialization
+# Proxy:
+string(13) "C::__destruct"
+Error: Lazy object was released during initialization
+# GC cycle:
+string(13) "C::__destruct"
+# Nested error (ghost):
+Error: Lazy object was released during initialization
+TypeError: Lazy object initializer must return NULL or no value
+# Nested error (proxy):
+Error: Lazy object was released during initialization
+TypeError: The real instance class stdClass is not compatible with the proxy class C. The proxy must be a instance of the same class as the real instance, or a sub-class with no additional properties, and no overrides of the __destructor or __clone methods.
+==DONE==

--- a/Zend/tests/lazy_objects/gh15999_001.phpt
+++ b/Zend/tests/lazy_objects/gh15999_001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Lazy Objects: GH-15999: Object is released during initialization
+Lazy Objects: GH-15999 001: Object is released during initialization
 --FILE--
 <?php
 
@@ -18,9 +18,10 @@ $o = $r->newLazyGhost(function ($obj) {
     global $o;
     $o = null;
 });
+$p = new stdClass;
 
 try {
-    $o->s = $o;
+    $o->s = $p;
 } catch (Error $e) {
     printf("%s: %s\n", $e::class, $e->getMessage());
 }
@@ -32,9 +33,10 @@ $o = $r->newLazyProxy(function ($obj) {
     $o = null;
     return new C();
 });
+$p = new stdClass;
 
 try {
-    $o->s = $o;
+    $o->s = $p;
 } catch (Error $e) {
     printf("%s: %s\n", $e::class, $e->getMessage());
 }
@@ -47,8 +49,9 @@ $o = $r->newLazyGhost(function ($obj) {
     $o = null;
     gc_collect_cycles();
 });
+$p = new stdClass;
 
-$o->s = $o;
+$o->s = $p;
 gc_collect_cycles();
 
 print "# Nested error (ghost):\n";
@@ -60,9 +63,10 @@ $o = $r->newLazyGhost(function ($obj) {
     $o = null;
     return new stdClass;
 });
+$p = new stdClass;
 
 try {
-    $o->s = $o;
+    $o->s = $p;
 } catch (Error $e) {
     do {
         printf("%s: %s\n", $e::class, $e->getMessage());
@@ -78,9 +82,10 @@ $o = $r->newLazyProxy(function ($obj) {
     $o = null;
     return new stdClass;
 });
+$p = new stdClass;
 
 try {
-    $o->s = $o;
+    $o->s = $p;
 } catch (Error $e) {
     do {
         printf("%s: %s\n", $e::class, $e->getMessage());

--- a/Zend/tests/lazy_objects/gh15999_002.phpt
+++ b/Zend/tests/lazy_objects/gh15999_002.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Lazy Objects: GH-15999 002: Assigned value is changed during lazy object initialization
+--FILE--
+<?php
+
+class C {
+    public $s;
+    public function __destruct() {
+        var_dump(__METHOD__);
+    }
+}
+
+print "# Ghost:\n";
+
+$r = new ReflectionClass(C::class);
+
+$o = $r->newLazyGhost(function ($obj) {
+    global $p;
+    $p = null;
+});
+
+$p = new stdClass;
+var_dump($o->s = $p);
+var_dump($o->s);
+
+print "# Proxy:\n";
+
+$r = new ReflectionClass(C::class);
+
+$o = $r->newLazyProxy(function ($obj) {
+    global $p;
+    $p = null;
+    return new C();
+});
+
+$p = new stdClass;
+var_dump($o->s = $p);
+var_dump($o->s);
+
+?>
+==DONE==
+--EXPECTF--
+# Ghost:
+object(stdClass)#%d (0) {
+}
+object(stdClass)#%d (0) {
+}
+# Proxy:
+string(13) "C::__destruct"
+object(stdClass)#%d (0) {
+}
+object(stdClass)#%d (0) {
+}
+==DONE==
+string(13) "C::__destruct"

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1183,17 +1183,21 @@ write_std_property:
 exit:
 	return variable_ptr;
 
-lazy_init:
+lazy_init:;
+	/* backup value as it may change during initialization */
+	zval backup;
+	ZVAL_COPY(&backup, value);
+
 	zobj = zend_lazy_object_init(zobj);
 	if (UNEXPECTED(!zobj)) {
 		variable_ptr = &EG(error_zval);
+		zval_ptr_dtor(&backup);
 		goto exit;
 	}
-	/* value may have changed during initialization */
-	if (UNEXPECTED(Z_ISREF_P(value))) {
-		value = Z_REFVAL_P(value);
-	}
-	return zend_std_write_property(zobj, name, value, cache_slot);
+
+	variable_ptr = zend_std_write_property(zobj, name, &backup, cache_slot);
+	zval_ptr_dtor(&backup);
+	return variable_ptr;
 }
 /* }}} */
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1189,6 +1189,10 @@ lazy_init:
 		variable_ptr = &EG(error_zval);
 		goto exit;
 	}
+	/* value may have changed during initialization */
+	if (UNEXPECTED(Z_ISREF_P(value))) {
+		value = Z_REFVAL_P(value);
+	}
 	return zend_std_write_property(zobj, name, value, cache_slot);
 }
 /* }}} */


### PR DESCRIPTION
Fixes two issues discovered by https://github.com/php/php-src/issues/15999:

 - Object may be released during initialization. Increase the object's refcount during initialization to prevent that. If the refcount is zero after restoring it, an exception is thrown (similarly to 47ed1904ef75).
 - The assigned value may be changed during initialization, so we may have to de-ref it again before forwarding the zend_std_write_property() call to the initialized object