### PR TITLE
Fix MySQL and MSSQL test failures

### DIFF
--- a/.github/actions/setup-mssql/action.yml
+++ b/.github/actions/setup-mssql/action.yml
@@ -11,4 +11,4 @@ runs:
           -p 1433:1433 \
           --name sql1 \
           -h sql1 \
-          -d mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04
+          -d mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04

--- a/.github/actions/setup-x64/action.yml
+++ b/.github/actions/setup-x64/action.yml
@@ -6,11 +6,7 @@ runs:
       run: |
         set -x
 
-        sudo service mysql start
         sudo service slapd start
-        mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
-        # Ensure local_infile tests can run.
-        mysql -uroot -proot -e "SET GLOBAL local_infile = true"
         docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "create login pdo_test with password='password', check_policy=off; create user pdo_test for login pdo_test; grant alter, control to pdo_test;"
         docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "create login odbc_test with password='password', check_policy=off; create user odbc_test for login odbc_test; grant alter, control, delete to odbc_test;"
         docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "ALTER SERVER ROLE sysadmin ADD MEMBER odbc_test;"

--- a/.github/actions/setup-x64/action.yml
+++ b/.github/actions/setup-x64/action.yml
@@ -11,11 +11,11 @@ runs:
         mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
         # Ensure local_infile tests can run.
         mysql -uroot -proot -e "SET GLOBAL local_infile = true"
-        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "create login pdo_test with password='password', check_policy=off; create user pdo_test for login pdo_test; grant alter, control to pdo_test;"
-        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "create login odbc_test with password='password', check_policy=off; create user odbc_test for login odbc_test; grant alter, control, delete to odbc_test;"
-        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "ALTER SERVER ROLE sysadmin ADD MEMBER odbc_test;"
-        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "CREATE DATABASE odbc;"
-        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "CREATE DATABASE pdo_odbc;"
+        docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "create login pdo_test with password='password', check_policy=off; create user pdo_test for login pdo_test; grant alter, control to pdo_test;"
+        docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "create login odbc_test with password='password', check_policy=off; create user odbc_test for login odbc_test; grant alter, control, delete to odbc_test;"
+        docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "ALTER SERVER ROLE sysadmin ADD MEMBER odbc_test;"
+        docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "CREATE DATABASE odbc;"
+        docker exec sql1 /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U SA -C -P "<YourStrong@Passw0rd>" -Q "CREATE DATABASE pdo_odbc;"
         sudo locale-gen de_DE
 
         ./.github/scripts/setup-slapd.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,13 @@ jobs:
     needs: GENERATE_MATRIX
     if: ${{ needs.GENERATE_MATRIX.outputs.branches != '[]' }}
     services:
+      mysql:
+        image: mysql:8.3
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
       postgres:
         image: postgres
         env:
@@ -286,6 +293,13 @@ jobs:
   COVERAGE_DEBUG_NTS:
     if: github.repository_owner == 'php' || github.event_name == 'workflow_dispatch'
     services:
+      mysql:
+        image: mysql:8.3
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
       postgres:
         image: postgres
         env:
@@ -501,6 +515,13 @@ jobs:
     needs: GENERATE_MATRIX
     if: ${{ needs.GENERATE_MATRIX.outputs.branches != '[]' }}
     services:
+      mysql:
+        image: mysql:8.3
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
       postgres:
         image: postgres
         env:


### PR DESCRIPTION
This is a related fix to #15997.

* MySQL: Many tests were randomly failing because they were also trying to start locally, even though they were using a service container. I removed those unnecessary local starts.
  * *UPDATE: 2024-09-24 01:25 JST* Since the nightly test was run locally, I unified it to use the service container.
* MSSQL: The container image used for MSSQL tests was very old. It appears that this broke upstream recently. I updated to a more recent container image and fixed the setup command accordingly.