### PR TITLE
ext/gmp: Fix some issues regarding operator overloading

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -619,6 +619,13 @@ static zend_result convert_to_gmp(mpz_t gmpnumber, zval *val, zend_long base, ui
 	case IS_STRING: {
 		return convert_zstr_to_gmp(gmpnumber, Z_STR_P(val), base, arg_pos);
 	}
+	case IS_NULL:
+		/* Just reject null for operator overloading */
+		if (arg_pos == 0) {
+			zend_type_error("Number must be of type GMP|string|int, %s given", zend_zval_type_name(val));
+			return FAILURE;
+		}
+		ZEND_FALLTHROUGH;
 	default: {
 		zend_long lval;
 		if (!zend_parse_arg_long_slow(val, &lval, arg_pos)) {

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -359,7 +359,8 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 		mpz_ptr gmpnum_op, gmpnum_result;
 		gmp_temp_t temp;
 
-		/* Inline FETCH_GMP_ZVAL(gmpnum_op, op1, temp, 1); as cannot use RETURN_THROWS() */
+		/* We do not use FETCH_GMP_ZVAL(...); here as we don't use convert_to_gmp()
+		 * as we want to handle the emitted exception ourself.  */
 		if (UNEXPECTED(!IS_GMP(op1))) {
 			if (UNEXPECTED(Z_TYPE_P(op1) != IS_LONG)) {
 				goto typeof_op_failure;
@@ -378,8 +379,7 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 		return SUCCESS;
 	}
 
-typeof_op_failure:
-	; /* Blank statement */
+typeof_op_failure: ;
 	/* Returning FAILURE without throwing an exception would emit the
 	 * Unsupported operand types: GMP OP TypeOfOp2
 	 * However, this leads to the engine trying to interpret the GMP object as an integer
@@ -388,13 +388,13 @@ typeof_op_failure:
 	switch (opcode) {
 		case ZEND_POW:
 			op_sigil = "**";
-		break;
+			break;
 		case ZEND_SL:
 			op_sigil = "<<";
-		break;
+			break;
 		case ZEND_SR:
 			op_sigil = ">>";
-		break;
+			break;
 		EMPTY_SWITCH_DEFAULT_CASE();
 	}
 	zend_type_error("Unsupported operand types: %s %s %s", zend_zval_type_name(op1), op_sigil, zend_zval_type_name(op2));

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -199,7 +199,7 @@ typedef void (*gmp_binary_ui_op_t)(mpz_ptr, mpz_srcptr, gmp_ulong);
 typedef void (*gmp_binary_op2_t)(mpz_ptr, mpz_ptr, mpz_srcptr, mpz_srcptr);
 typedef gmp_ulong (*gmp_binary_ui_op2_t)(mpz_ptr, mpz_ptr, mpz_srcptr, gmp_ulong);
 
-static inline zend_result gmp_zval_binary_ui_op(zval *return_value, zval *a_arg, zval *b_arg, gmp_binary_op_t gmp_op, gmp_binary_ui_op_t gmp_ui_op, bool check_b_zero, bool is_operator);
+static inline void gmp_zval_binary_ui_op(zval *return_value, zval *a_arg, zval *b_arg, gmp_binary_op_t gmp_op, gmp_binary_ui_op_t gmp_ui_op, bool check_b_zero, bool is_operator);
 static inline void gmp_zval_binary_ui_op2(zval *return_value, zval *a_arg, zval *b_arg, gmp_binary_op2_t gmp_op, gmp_binary_ui_op2_t gmp_ui_op, int check_b_zero);
 static inline void gmp_zval_unary_op(zval *return_value, zval *a_arg, gmp_unary_op_t gmp_op);
 
@@ -356,7 +356,10 @@ static void shift_operator_helper(gmp_binary_ui_op_t op, zval *return_value, zva
 }
 
 #define DO_BINARY_UI_OP_EX(op, uop, check_b_zero) \
-	return gmp_zval_binary_ui_op(result, op1, op2, op, uop, check_b_zero, /* is_operator */ true);
+	gmp_zval_binary_ui_op( \
+		result, op1, op2, op, uop, check_b_zero, /* is_operator */ true); \
+	if (UNEXPECTED(EG(exception))) { return FAILURE; } \
+	return SUCCESS;
 
 #define DO_BINARY_UI_OP(op) DO_BINARY_UI_OP_EX(op, op ## _ui, 0)
 #define DO_BINARY_OP(op) DO_BINARY_UI_OP_EX(op, NULL, 0)
@@ -434,7 +437,7 @@ static int gmp_compare(zval *op1, zval *op2) /* {{{ */
 	/* An error/exception occurs if one of the operands is not a numeric string
 	 * or an object which is different from GMP */
 	if (EG(exception)) {
-		return ZEND_UNCOMPARABLE;
+		return 1;
 	}
 	/* result can only be a zend_long if gmp_cmp hasn't thrown an Error */
 	ZEND_ASSERT(Z_TYPE(result) == IS_LONG);
@@ -616,16 +619,7 @@ static zend_result convert_to_gmp(mpz_t gmpnumber, zval *val, zend_long base, ui
 	case IS_STRING: {
 		return convert_zstr_to_gmp(gmpnumber, Z_STR_P(val), base, arg_pos);
 	}
-	case IS_NULL:
-		/* For operator overloading just reject null */
-		if (arg_pos == 0) {
-			return FAILURE;
-		}
-		ZEND_FALLTHROUGH;
-	case IS_DOUBLE:
-	case IS_FALSE:
-	case IS_TRUE:
-	{
+	default: {
 		zend_long lval;
 		if (!zend_parse_arg_long_slow(val, &lval, arg_pos)) {
 			if (arg_pos == 0) {
@@ -641,12 +635,6 @@ static zend_result convert_to_gmp(mpz_t gmpnumber, zval *val, zend_long base, ui
 		mpz_set_si(gmpnumber, lval);
 		return SUCCESS;
 	}
-	default:
-		if (arg_pos != 0) {
-			zend_argument_type_error(arg_pos,
-				"must be of type GMP|string|int, %s given", zend_zval_type_name(val));
-		}
-		return FAILURE;
 	}
 }
 /* }}} */
@@ -714,45 +702,18 @@ static void gmp_cmp(zval *return_value, zval *a_arg, zval *b_arg, bool is_operat
 /* {{{ gmp_zval_binary_ui_op
    Execute GMP binary operation.
 */
-static inline zend_result gmp_zval_binary_ui_op(zval *return_value, zval *a_arg, zval *b_arg, gmp_binary_op_t gmp_op, gmp_binary_ui_op_t gmp_ui_op, bool check_b_zero, bool is_operator)
+static inline void gmp_zval_binary_ui_op(zval *return_value, zval *a_arg, zval *b_arg, gmp_binary_op_t gmp_op, gmp_binary_ui_op_t gmp_ui_op, bool check_b_zero, bool is_operator)
 {
 	mpz_ptr gmpnum_a, gmpnum_b, gmpnum_result;
 	gmp_temp_t temp_a, temp_b;
 
-	/* Inline version of FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, is_operator ? 0 : 1);
-	 * because we cannot use RETURN_THROWS() here */
-	if (IS_GMP(a_arg)) {
-		gmpnum_a = GET_GMP_FROM_ZVAL(a_arg);
-		temp_a.is_used = 0;
-	} else {
-		mpz_init(temp_a.num);
-		if (convert_to_gmp(temp_a.num, a_arg, 0, is_operator ? 0 : 1) == FAILURE) {
-			mpz_clear(temp_a.num);
-			return FAILURE;
-		}
-		temp_a.is_used = 1;
-		gmpnum_a = temp_a.num;
-	}
+	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, is_operator ? 0 : 1);
 
 	if (gmp_ui_op && Z_TYPE_P(b_arg) == IS_LONG && Z_LVAL_P(b_arg) >= 0) {
 		gmpnum_b = NULL;
 		temp_b.is_used = 0;
 	} else {
-		/* Inline version of FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, is_operator ? 0 : 2);
-		 * because we cannot use RETURN_THROWS() here */
-		if (IS_GMP(b_arg)) {
-			gmpnum_b = GET_GMP_FROM_ZVAL(b_arg);
-			temp_b.is_used = 0;
-		} else {
-			mpz_init(temp_b.num);
-			if (convert_to_gmp(temp_b.num, b_arg, 0, is_operator ? 0 : 2) == FAILURE) {
-				mpz_clear(temp_b.num);
-				FREE_GMP_TEMP(temp_a);
-				return FAILURE;
-			}
-			temp_b.is_used = 1;
-			gmpnum_b = temp_b.num;
-		}
+		FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, is_operator ? 0 : 2);
 	}
 
 	if (check_b_zero) {
@@ -771,7 +732,7 @@ static inline zend_result gmp_zval_binary_ui_op(zval *return_value, zval *a_arg,
 			}
 			FREE_GMP_TEMP(temp_a);
 			FREE_GMP_TEMP(temp_b);
-			return FAILURE;
+			RETURN_THROWS();
 		}
 	}
 
@@ -785,7 +746,6 @@ static inline zend_result gmp_zval_binary_ui_op(zval *return_value, zval *a_arg,
 
 	FREE_GMP_TEMP(temp_a);
 	FREE_GMP_TEMP(temp_b);
-	return SUCCESS;
 }
 /* }}} */
 

--- a/ext/gmp/tests/overloading_cmp_op_with_null.phpt
+++ b/ext/gmp/tests/overloading_cmp_op_with_null.phpt
@@ -1,0 +1,53 @@
+--TEST--
+GMP comparison operator overloading supports null
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num < null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num > null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num <= null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num >= null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num == null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num <=> null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+int(1)

--- a/ext/gmp/tests/overloading_with_array.phpt
+++ b/ext/gmp/tests/overloading_with_array.phpt
@@ -1,0 +1,93 @@
+--TEST--
+GMP operator overloading does not support []
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> []);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}

--- a/ext/gmp/tests/overloading_with_array.phpt
+++ b/ext/gmp/tests/overloading_with_array.phpt
@@ -76,18 +76,9 @@ TypeError: Number must be of type GMP|string|int, array given
 TypeError: Number must be of type GMP|string|int, array given
 TypeError: Number must be of type GMP|string|int, array given
 TypeError: Number must be of type GMP|string|int, array given
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(1) "1"
-}
+TypeError: Unsupported operand types: GMP ** array
 TypeError: Number must be of type GMP|string|int, array given
 TypeError: Number must be of type GMP|string|int, array given
 TypeError: Number must be of type GMP|string|int, array given
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+TypeError: Unsupported operand types: GMP << array
+TypeError: Unsupported operand types: GMP >> array

--- a/ext/gmp/tests/overloading_with_array.phpt
+++ b/ext/gmp/tests/overloading_with_array.phpt
@@ -71,18 +71,18 @@ try {
 
 ?>
 --EXPECT--
-TypeError: Unsupported operand types: GMP + array
-TypeError: Unsupported operand types: GMP - array
-TypeError: Unsupported operand types: GMP * array
-TypeError: Unsupported operand types: GMP / array
-TypeError: Unsupported operand types: GMP % array
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
 object(GMP)#3 (1) {
   ["num"]=>
   string(1) "1"
 }
-TypeError: Unsupported operand types: GMP | array
-TypeError: Unsupported operand types: GMP & array
-TypeError: Unsupported operand types: GMP ^ array
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
+TypeError: Number must be of type GMP|string|int, array given
 object(GMP)#2 (1) {
   ["num"]=>
   string(2) "42"

--- a/ext/gmp/tests/overloading_with_array.phpt
+++ b/ext/gmp/tests/overloading_with_array.phpt
@@ -71,18 +71,18 @@ try {
 
 ?>
 --EXPECT--
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
+TypeError: Unsupported operand types: GMP + array
+TypeError: Unsupported operand types: GMP - array
+TypeError: Unsupported operand types: GMP * array
+TypeError: Unsupported operand types: GMP / array
+TypeError: Unsupported operand types: GMP % array
 object(GMP)#3 (1) {
   ["num"]=>
   string(1) "1"
 }
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
-TypeError: Number must be of type GMP|string|int, array given
+TypeError: Unsupported operand types: GMP | array
+TypeError: Unsupported operand types: GMP & array
+TypeError: Unsupported operand types: GMP ^ array
 object(GMP)#2 (1) {
   ["num"]=>
   string(2) "42"

--- a/ext/gmp/tests/overloading_with_float.phpt
+++ b/ext/gmp/tests/overloading_with_float.phpt
@@ -1,0 +1,117 @@
+--TEST--
+GMP operator overloading does support float with no fractional
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> 42.0);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "84"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(4) "1764"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(69) "150130937545296572356771972164254457814047970568738777235893533016064"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(15) "184717953466368"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}

--- a/ext/gmp/tests/overloading_with_float_fractional.phpt
+++ b/ext/gmp/tests/overloading_with_float_fractional.phpt
@@ -1,0 +1,132 @@
+--TEST--
+GMP operator overloading support for float with fractional is deprecated
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> 42.5);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECTF--
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "84"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(4) "1764"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(69) "150130937545296572356771972164254457814047970568738777235893533016064"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+
+Deprecated: Implicit conversion from float 42.5 to int loses precision in %s on line %d
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(15) "184717953466368"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}

--- a/ext/gmp/tests/overloading_with_float_string.phpt
+++ b/ext/gmp/tests/overloading_with_float_string.phpt
@@ -1,0 +1,93 @@
+--TEST--
+GMP operator overloading does not support float strings
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> "2.0");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(4) "1764"
+}
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(3) "168"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "10"
+}

--- a/ext/gmp/tests/overloading_with_float_string.phpt
+++ b/ext/gmp/tests/overloading_with_float_string.phpt
@@ -76,18 +76,9 @@ ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(4) "1764"
-}
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(3) "168"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "10"
-}
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string

--- a/ext/gmp/tests/overloading_with_int_string.phpt
+++ b/ext/gmp/tests/overloading_with_int_string.phpt
@@ -1,0 +1,117 @@
+--TEST--
+GMP operator overloading does support int strings
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> "2");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "44"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "40"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "84"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "21"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "0"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(4) "1764"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "2"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "40"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(3) "168"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "10"
+}

--- a/ext/gmp/tests/overloading_with_non_numeric_string.phpt
+++ b/ext/gmp/tests/overloading_with_non_numeric_string.phpt
@@ -76,18 +76,9 @@ ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(1) "1"
-}
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
 ValueError: Number is not an integer string
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string

--- a/ext/gmp/tests/overloading_with_non_numeric_string.phpt
+++ b/ext/gmp/tests/overloading_with_non_numeric_string.phpt
@@ -1,0 +1,93 @@
+--TEST--
+GMP operator overloading does not support non-numeric strings
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> "string");
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+ValueError: Number is not an integer string
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}

--- a/ext/gmp/tests/overloading_with_null.phpt
+++ b/ext/gmp/tests/overloading_with_null.phpt
@@ -76,18 +76,9 @@ TypeError: Number must be of type GMP|string|int, null given
 TypeError: Number must be of type GMP|string|int, null given
 TypeError: Number must be of type GMP|string|int, null given
 TypeError: Number must be of type GMP|string|int, null given
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(1) "1"
-}
+TypeError: Unsupported operand types: GMP ** null
 TypeError: Number must be of type GMP|string|int, null given
 TypeError: Number must be of type GMP|string|int, null given
 TypeError: Number must be of type GMP|string|int, null given
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+TypeError: Unsupported operand types: GMP << null
+TypeError: Unsupported operand types: GMP >> null

--- a/ext/gmp/tests/overloading_with_null.phpt
+++ b/ext/gmp/tests/overloading_with_null.phpt
@@ -2,8 +2,6 @@
 GMP operator overloading does not support null
 --EXTENSIONS--
 gmp
---XFAIL--
-Test showcasing segfaulting behaviour
 --FILE--
 <?php
 
@@ -73,4 +71,23 @@ try {
 
 ?>
 --EXPECT--
-SEGFAULT
+int(42)
+int(42)
+int(0)
+DivisionByZeroError: Division by zero
+DivisionByZeroError: Modulo by zero
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+int(42)
+int(0)
+int(42)
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}

--- a/ext/gmp/tests/overloading_with_null.phpt
+++ b/ext/gmp/tests/overloading_with_null.phpt
@@ -2,8 +2,6 @@
 GMP operator overloading does not support null
 --EXTENSIONS--
 gmp
---XFAIL--
-Test showcasing segfaulting behaviour
 --FILE--
 <?php
 
@@ -73,4 +71,23 @@ try {
 
 ?>
 --EXPECT--
-SEGFAULT
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(1) "1"
+}
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+TypeError: Number must be of type GMP|string|int, null given
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(2) "42"
+}

--- a/ext/gmp/tests/overloading_with_null.phpt
+++ b/ext/gmp/tests/overloading_with_null.phpt
@@ -2,6 +2,8 @@
 GMP operator overloading does not support null
 --EXTENSIONS--
 gmp
+--XFAIL--
+Test showcasing segfaulting behaviour
 --FILE--
 <?php
 
@@ -71,23 +73,4 @@ try {
 
 ?>
 --EXPECT--
-int(42)
-int(42)
-int(0)
-DivisionByZeroError: Division by zero
-DivisionByZeroError: Modulo by zero
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(1) "1"
-}
-int(42)
-int(0)
-int(42)
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+SEGFAULT

--- a/ext/gmp/tests/overloading_with_null.phpt
+++ b/ext/gmp/tests/overloading_with_null.phpt
@@ -1,0 +1,76 @@
+--TEST--
+GMP operator overloading does not support null
+--EXTENSIONS--
+gmp
+--XFAIL--
+Test showcasing segfaulting behaviour
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> null);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+SEGFAULT

--- a/ext/gmp/tests/overloading_with_object_not_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_not_stringable.phpt
@@ -72,20 +72,20 @@ try {
 
 ?>
 --EXPECTF--
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Unsupported operand types: GMP + stdClass
+TypeError: Unsupported operand types: GMP - stdClass
+TypeError: Unsupported operand types: GMP * stdClass
+TypeError: Unsupported operand types: GMP / stdClass
+TypeError: Unsupported operand types: GMP % stdClass
 
 Warning: Object of class stdClass could not be converted to int in %s on line %d
 object(GMP)#4 (1) {
   ["num"]=>
   string(2) "42"
 }
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
-TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Unsupported operand types: GMP | stdClass
+TypeError: Unsupported operand types: GMP & stdClass
+TypeError: Unsupported operand types: GMP ^ stdClass
 
 Warning: Object of class stdClass could not be converted to int in %s on line %d
 object(GMP)#3 (1) {

--- a/ext/gmp/tests/overloading_with_object_not_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_not_stringable.phpt
@@ -1,0 +1,100 @@
+--TEST--
+GMP operator overloading does not support non-stringable objects
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+$o = new stdClass();
+
+try {
+    var_dump($num + $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECTF--
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+
+Warning: Object of class stdClass could not be converted to int in %s on line %d
+object(GMP)#4 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+
+Warning: Object of class stdClass could not be converted to int in %s on line %d
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(2) "84"
+}
+
+Warning: Object of class stdClass could not be converted to int in %s on line %d
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(2) "21"
+}

--- a/ext/gmp/tests/overloading_with_object_not_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_not_stringable.phpt
@@ -72,20 +72,20 @@ try {
 
 ?>
 --EXPECTF--
-TypeError: Unsupported operand types: GMP + stdClass
-TypeError: Unsupported operand types: GMP - stdClass
-TypeError: Unsupported operand types: GMP * stdClass
-TypeError: Unsupported operand types: GMP / stdClass
-TypeError: Unsupported operand types: GMP % stdClass
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
 
 Warning: Object of class stdClass could not be converted to int in %s on line %d
 object(GMP)#4 (1) {
   ["num"]=>
   string(2) "42"
 }
-TypeError: Unsupported operand types: GMP | stdClass
-TypeError: Unsupported operand types: GMP & stdClass
-TypeError: Unsupported operand types: GMP ^ stdClass
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
+TypeError: Number must be of type GMP|string|int, stdClass given
 
 Warning: Object of class stdClass could not be converted to int in %s on line %d
 object(GMP)#3 (1) {

--- a/ext/gmp/tests/overloading_with_object_not_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_not_stringable.phpt
@@ -71,30 +71,15 @@ try {
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
-
-Warning: Object of class stdClass could not be converted to int in %s on line %d
-object(GMP)#4 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+TypeError: Unsupported operand types: GMP ** stdClass
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
 TypeError: Number must be of type GMP|string|int, stdClass given
-
-Warning: Object of class stdClass could not be converted to int in %s on line %d
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(2) "84"
-}
-
-Warning: Object of class stdClass could not be converted to int in %s on line %d
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(2) "21"
-}
+TypeError: Unsupported operand types: GMP << stdClass
+TypeError: Unsupported operand types: GMP >> stdClass

--- a/ext/gmp/tests/overloading_with_object_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_stringable.phpt
@@ -83,24 +83,9 @@ TypeError: Number must be of type GMP|string|int, T given
 TypeError: Number must be of type GMP|string|int, T given
 TypeError: Number must be of type GMP|string|int, T given
 TypeError: Number must be of type GMP|string|int, T given
-
-Warning: Object of class T could not be converted to int in %s on line %d
-object(GMP)#4 (1) {
-  ["num"]=>
-  string(2) "42"
-}
+TypeError: Unsupported operand types: GMP ** T
 TypeError: Number must be of type GMP|string|int, T given
 TypeError: Number must be of type GMP|string|int, T given
 TypeError: Number must be of type GMP|string|int, T given
-
-Warning: Object of class T could not be converted to int in %s on line %d
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(2) "84"
-}
-
-Warning: Object of class T could not be converted to int in %s on line %d
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(2) "21"
-}
+TypeError: Unsupported operand types: GMP << T
+TypeError: Unsupported operand types: GMP >> T

--- a/ext/gmp/tests/overloading_with_object_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_stringable.phpt
@@ -78,20 +78,20 @@ try {
 
 ?>
 --EXPECTF--
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
+TypeError: Unsupported operand types: GMP + T
+TypeError: Unsupported operand types: GMP - T
+TypeError: Unsupported operand types: GMP * T
+TypeError: Unsupported operand types: GMP / T
+TypeError: Unsupported operand types: GMP % T
 
 Warning: Object of class T could not be converted to int in %s on line %d
 object(GMP)#4 (1) {
   ["num"]=>
   string(2) "42"
 }
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
-TypeError: Number must be of type GMP|string|int, T given
+TypeError: Unsupported operand types: GMP | T
+TypeError: Unsupported operand types: GMP & T
+TypeError: Unsupported operand types: GMP ^ T
 
 Warning: Object of class T could not be converted to int in %s on line %d
 object(GMP)#3 (1) {

--- a/ext/gmp/tests/overloading_with_object_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_stringable.phpt
@@ -78,20 +78,20 @@ try {
 
 ?>
 --EXPECTF--
-TypeError: Unsupported operand types: GMP + T
-TypeError: Unsupported operand types: GMP - T
-TypeError: Unsupported operand types: GMP * T
-TypeError: Unsupported operand types: GMP / T
-TypeError: Unsupported operand types: GMP % T
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
 
 Warning: Object of class T could not be converted to int in %s on line %d
 object(GMP)#4 (1) {
   ["num"]=>
   string(2) "42"
 }
-TypeError: Unsupported operand types: GMP | T
-TypeError: Unsupported operand types: GMP & T
-TypeError: Unsupported operand types: GMP ^ T
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
 
 Warning: Object of class T could not be converted to int in %s on line %d
 object(GMP)#3 (1) {

--- a/ext/gmp/tests/overloading_with_object_stringable.phpt
+++ b/ext/gmp/tests/overloading_with_object_stringable.phpt
@@ -1,0 +1,106 @@
+--TEST--
+GMP operator overloading does not support stringable objects
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+class T {
+    public function __toString() {
+        return "42";
+    }
+}
+
+$num = gmp_init(42);
+$o = new T();
+
+try {
+    var_dump($num + $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> $o);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECTF--
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+
+Warning: Object of class T could not be converted to int in %s on line %d
+object(GMP)#4 (1) {
+  ["num"]=>
+  string(2) "42"
+}
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+TypeError: Number must be of type GMP|string|int, T given
+
+Warning: Object of class T could not be converted to int in %s on line %d
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(2) "84"
+}
+
+Warning: Object of class T could not be converted to int in %s on line %d
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(2) "21"
+}

--- a/ext/gmp/tests/overloading_with_resource.phpt
+++ b/ext/gmp/tests/overloading_with_resource.phpt
@@ -1,0 +1,93 @@
+--TEST--
+GMP operator overloading does not support resources
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+
+$num = gmp_init(42);
+
+try {
+    var_dump($num + STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num - STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num * STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num / STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num % STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num ** STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump($num | STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num & STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num ^ STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num << STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump($num >> STDERR);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+object(GMP)#3 (1) {
+  ["num"]=>
+  string(5) "74088"
+}
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(3) "336"
+}
+object(GMP)#2 (1) {
+  ["num"]=>
+  string(1) "5"
+}

--- a/ext/gmp/tests/overloading_with_resource.phpt
+++ b/ext/gmp/tests/overloading_with_resource.phpt
@@ -71,18 +71,18 @@ try {
 
 ?>
 --EXPECT--
-TypeError: Unsupported operand types: GMP + resource
-TypeError: Unsupported operand types: GMP - resource
-TypeError: Unsupported operand types: GMP * resource
-TypeError: Unsupported operand types: GMP / resource
-TypeError: Unsupported operand types: GMP % resource
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
 object(GMP)#3 (1) {
   ["num"]=>
   string(5) "74088"
 }
-TypeError: Unsupported operand types: GMP | resource
-TypeError: Unsupported operand types: GMP & resource
-TypeError: Unsupported operand types: GMP ^ resource
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Number must be of type GMP|string|int, resource given
 object(GMP)#2 (1) {
   ["num"]=>
   string(3) "336"

--- a/ext/gmp/tests/overloading_with_resource.phpt
+++ b/ext/gmp/tests/overloading_with_resource.phpt
@@ -71,18 +71,18 @@ try {
 
 ?>
 --EXPECT--
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Unsupported operand types: GMP + resource
+TypeError: Unsupported operand types: GMP - resource
+TypeError: Unsupported operand types: GMP * resource
+TypeError: Unsupported operand types: GMP / resource
+TypeError: Unsupported operand types: GMP % resource
 object(GMP)#3 (1) {
   ["num"]=>
   string(5) "74088"
 }
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
-TypeError: Number must be of type GMP|string|int, resource given
+TypeError: Unsupported operand types: GMP | resource
+TypeError: Unsupported operand types: GMP & resource
+TypeError: Unsupported operand types: GMP ^ resource
 object(GMP)#2 (1) {
   ["num"]=>
   string(3) "336"

--- a/ext/gmp/tests/overloading_with_resource.phpt
+++ b/ext/gmp/tests/overloading_with_resource.phpt
@@ -76,18 +76,9 @@ TypeError: Number must be of type GMP|string|int, resource given
 TypeError: Number must be of type GMP|string|int, resource given
 TypeError: Number must be of type GMP|string|int, resource given
 TypeError: Number must be of type GMP|string|int, resource given
-object(GMP)#3 (1) {
-  ["num"]=>
-  string(5) "74088"
-}
+TypeError: Unsupported operand types: GMP ** resource
 TypeError: Number must be of type GMP|string|int, resource given
 TypeError: Number must be of type GMP|string|int, resource given
 TypeError: Number must be of type GMP|string|int, resource given
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(3) "336"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(1) "5"
-}
+TypeError: Unsupported operand types: GMP << resource
+TypeError: Unsupported operand types: GMP >> resource


### PR DESCRIPTION
Related to #15660 

The behaviour of the engine in regards to operator overloading atm is kinda bonkers and needs some deeper fixes.

The implementation of operator overloading in GMP also needs an overhaul as it should return `FAILURE` instead of throwing exceptions if it cannot handle the operands.