### PR TITLE
Fix GH-15968: Avoid converting objects to strings in operator calculations.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . bcpow() performance improvement. (Jorg Sowa)
   . ext/bcmath: Check for scale overflow. (SakiTakamachi)
   . [RFC] ext/bcmath: Added bcdivmod. (SakiTakamachi)
+  . Fix GH-15968 (Avoid converting objects to strings in operator calculations).
+    (SakiTakamachi)
 
 - Curl:
   . Added CURLOPT_DEBUGFUNCTION as a Curl option. (Ayesh Karunaratne)

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -1178,7 +1178,7 @@ static zend_result bcmath_number_parse_num(zval *zv, zend_object **obj, zend_str
 				return FAILURE;
 
 			default:
-				return zend_parse_arg_str_or_long_slow(zv, str, lval, 1 /* dummy */) ? SUCCESS : FAILURE;
+				return zend_parse_arg_long_slow(zv, lval, 1 /* dummy */) ? SUCCESS : FAILURE;
 		}
 	}
 }

--- a/ext/bcmath/tests/gh15968.phpt
+++ b/ext/bcmath/tests/gh15968.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-15968 BCMath\Number operators may typecast operand
+--EXTENSIONS--
+bcmath
+--FILE--
+<?php
+class MyString {
+    function __toString() {
+        return "2";
+    }
+}
+
+$a = new BCMath\Number("1");
+$b = new MyString();
+try {
+    var_dump($a + $b);
+} catch (Error $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+Unsupported operand types: BcMath\Number + MyString


### PR DESCRIPTION
fixes #15968

As Gina commented, there was a problem with the function I was using.
https://github.com/php/php-src/issues/15968#issuecomment-2367738164

There are almost no cases where want to treat a stringable class other than the Number class as a string in operator calculations, so modify it so that the object is not converted to a string.