### PR TITLE
Fix regression on systems built without JIT

### DIFF
--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -934,10 +934,12 @@ ZEND_FUNCTION(opcache_jit_blacklist)
 		RETURN_THROWS();
 	}
 
+#ifdef HAVE_JIT
 	const zend_function *func = zend_get_closure_method_def(Z_OBJ_P(closure));
 	if (ZEND_USER_CODE(func->type)) {
 		zend_jit_blacklist_function((zend_op_array *)&func->op_array);
 	}
+#endif
 }
 
 ZEND_FUNCTION(opcache_compile_file)


### PR DESCRIPTION
regressing commit: 654b787ee16ae6ebf9ee94507631da9251ff077b

This was called if JIT was enabled or not. If not enabled, it'll result in an undeclared function warning and maybe a bad time in the linker. Gate the meat of this PHP-side function on if JIT is enabled (but keep it existing so PHP userland code works with or without JIT, OFC).