### PR TITLE
Fix assertion failure in generator dtor

### DIFF
--- a/Zend/tests/gh15866.phpt
+++ b/Zend/tests/gh15866.phpt
@@ -1,0 +1,53 @@
+--TEST--
+GH-15866: Core dumped in Zend/zend_generators.c
+--FILE--
+<?php
+
+class Canary {
+    public function __construct(public mixed $value) {}
+    public function __destruct() {
+        printf("%s\n", __METHOD__);
+    }
+}
+
+function g() {
+    Fiber::suspend();
+}
+
+function f($canary) {
+    try {
+        var_dump(yield from g());
+    } finally {
+        print "Generator finally\n";
+    }
+}
+
+$canary = new Canary(null);
+$iterable = f($canary);
+$fiber = new Fiber(function () use ($iterable, $canary) {
+    try {
+        $iterable->next();
+    } finally {
+        print "Fiber finally\n";
+    }
+});
+$canary->value = $fiber;
+$fiber->start();
+
+// Reset roots
+gc_collect_cycles();
+
+// Add to roots, create garbage cycles
+$fiber = $iterable = $canary = null;
+
+print "Collect cycles\n";
+gc_collect_cycles();
+
+?>
+==DONE==
+--EXPECT--
+Collect cycles
+Canary::__destruct
+Generator finally
+Fiber finally
+==DONE==

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -93,7 +93,6 @@ static const zend_uchar ZEND_GENERATOR_FORCED_CLOSE      = 0x2;
 static const zend_uchar ZEND_GENERATOR_AT_FIRST_YIELD    = 0x4;
 static const zend_uchar ZEND_GENERATOR_DO_INIT           = 0x8;
 static const zend_uchar ZEND_GENERATOR_IN_FIBER          = 0x10;
-static const zend_uchar ZEND_GENERATOR_DTOR_VISITED      = 0x20;
 
 void zend_register_generator_ce(void);
 ZEND_API void zend_generator_close(zend_generator *generator, bool finished_execution);


### PR DESCRIPTION
Fixes GH-15866. Related: GH-15158, GH-10462.

I don't remember why I assumed that a generator with the ZEND_GENERATOR_IN_FIBER flag (implying the generator is running) could only be dtor during shutdown, but this assumption was wrong. It can happen during GC, of course.

Unfortunately it means that we can not cache the result of `check_node_running_in_fiber()` anymore, so we may traverse the tree more than once. However we only ever call this function when collecting a Fiber, which I expect to be rare.

This is already the 3rd follow up of GH-10462, so I considered [this idea](https://github.com/php/php-src/issues/9916#issuecomment-1309566763) again, but since we can start fibers in destructors now, this is not trivial.