### PR TITLE
pdo: Use `zend_string_toupper` in  pdo_stmt_describe_columns

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -144,15 +144,10 @@ bool pdo_stmt_describe_columns(pdo_stmt_t *stmt) /* {{{ */
 					stmt->columns[col].name = zend_string_tolower(orig_name);
 					zend_string_release(orig_name);
 					break;
-				case PDO_CASE_UPPER: {
-					stmt->columns[col].name = zend_string_separate(orig_name, 0);
-					char *s = ZSTR_VAL(stmt->columns[col].name);
-					while (*s != '\0') {
-						*s = toupper(*s);
-						s++;
-					}
+				case PDO_CASE_UPPER:
+					stmt->columns[col].name = zend_string_toupper(orig_name);
+					zend_string_release(orig_name);
 					break;
-				}
 				EMPTY_SWITCH_DEFAULT_CASE()
 			}
 		}


### PR DESCRIPTION
zend_string_toupper was only introduced in PHP 8.2 and thus it likely was not used here, since this code was last touched for PHP 8.0.