### PR TITLE
Fix missing libavif-dev in asan nightly

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -1,4 +1,8 @@
 name: apt
+inputs:
+  asan:
+    default: false
+    required: false
 runs:
   using: composite
   steps:
@@ -39,7 +43,7 @@ runs:
           libsqlite3-dev \
           libsqlite3-mod-spatialite \
           libwebp-dev \
-          libavif-dev \
+          ${{ inputs.asan == 'false' && 'libavif-dev' || '' }} \
           libonig-dev \
           libcurl4-openssl-dev \
           libxml2-dev \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -28,7 +28,7 @@ runs:
           --enable-gd \
           --with-jpeg \
           --with-webp \
-          --with-avif \
+          ${{ inputs.skipSlow == 'false' && '--with-avif' || '' }} \
           --with-freetype \
           --with-xpm \
           --enable-exif \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -162,6 +162,7 @@ jobs:
             ${{ matrix.configuration_parameters }}
             --${{ matrix.debug && 'enable' || 'disable' }}-debug
             --${{ matrix.zts && 'enable' || 'disable' }}-zts
+          asan: ${{ matrix.asan && 'true' || 'false' }}
       - name: make
         run: make -j$(/usr/bin/nproc) >/dev/null
       - name: make install


### PR DESCRIPTION
Asan still runs on Ubuntu 20.04, which doesn't contain the libavif-dev package.

Note: This will cause warnings because of undefined `asan` input on older branches. The input would need to be backported to avoid this warning, but `--with-avif` is currently only set for `master`.