### PR TITLE
Fix GH-16039: Segmentation fault (access null pointer) in ext/dom/parentnode/tree.c

### DIFF
--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -272,6 +272,11 @@ static zend_result dom_sanity_check_node_list_for_insertion(php_libxml_ref_obj *
 			if (instanceof_function(ce, dom_node_class_entry)) {
 				xmlNodePtr node = dom_object_get_node(Z_DOMOBJ_P(nodes + i));
 
+				if (!node) {
+					php_dom_throw_error(INVALID_STATE_ERR, /* strict */ true);
+					return FAILURE;
+				}
+
 				if (node->doc != documentNode) {
 					php_dom_throw_error(WRONG_DOCUMENT_ERR, dom_get_strict_error(document));
 					return FAILURE;

--- a/ext/dom/tests/gh16039.phpt
+++ b/ext/dom/tests/gh16039.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-16039 (Segmentation fault (access null pointer) in ext/dom/parentnode/tree.c)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$dom = new DOMDocument;
+$element = $dom->appendChild($dom->createElement('root'));
+try {
+    $element->prepend('x', new DOMEntity);
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+echo $dom->saveXML();
+$dom->strictErrorChecking = false; // Should not have influence
+try {
+    $element->prepend('x', new DOMEntity);
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+echo $dom->saveXML();
+
+?>
+--EXPECT--
+Invalid State Error
+<?xml version="1.0"?>
+<root/>
+Invalid State Error
+<?xml version="1.0"?>
+<root/>


### PR DESCRIPTION
dom_object_get_node() can fail if we don't have a user object associated.

This is gonna be a fun one to merge upwards...