### PR TITLE
Fix GH-16054: Segmentation fault when resizing hash table iterator list while adding

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2346,22 +2346,20 @@ static zend_always_inline bool zend_array_dup_element(HashTable *source, HashTab
 
 // We need to duplicate iterators to be able to search through all copy-on-write copies to find the actually iterated HashTable and position back
 static void zend_array_dup_ht_iterators(HashTable *source, HashTable *target) {
-	HashTableIterator *iter = EG(ht_iterators);
-	uint32_t nr_iterators_used = EG(ht_iterators_used);
-	HashTableIterator *end = iter + nr_iterators_used;
+	uint32_t iter_index = 0;
+	uint32_t end_index = EG(ht_iterators_used);
 
-	while (iter != end) {
+	while (iter_index != end_index) {
+		HashTableIterator *iter = &EG(ht_iterators)[iter_index];
 		if (iter->ht == source) {
-			size_t iter_index = iter - EG(ht_iterators);
 			uint32_t copy_idx = zend_hash_iterator_add(target, iter->pos);
-			/* Refetch iter and recompute end because the memory may be reallocated. */
-			end = EG(ht_iterators) + nr_iterators_used;
+			/* Refetch iter because the memory may be reallocated. */
 			iter = &EG(ht_iterators)[iter_index];
 			HashTableIterator *copy_iter = EG(ht_iterators) + copy_idx;
 			copy_iter->next_copy = iter->next_copy;
 			iter->next_copy = copy_idx;
 		}
-		iter++;
+		iter_index++;
 	}
 }
 

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2347,11 +2347,16 @@ static zend_always_inline bool zend_array_dup_element(HashTable *source, HashTab
 // We need to duplicate iterators to be able to search through all copy-on-write copies to find the actually iterated HashTable and position back
 static void zend_array_dup_ht_iterators(HashTable *source, HashTable *target) {
 	HashTableIterator *iter = EG(ht_iterators);
-	HashTableIterator *end  = iter + EG(ht_iterators_used);
+	uint32_t nr_iterators_used = EG(ht_iterators_used);
+	HashTableIterator *end = iter + nr_iterators_used;
 
 	while (iter != end) {
 		if (iter->ht == source) {
+			size_t iter_index = iter - EG(ht_iterators);
 			uint32_t copy_idx = zend_hash_iterator_add(target, iter->pos);
+			/* Refetch iter and recompute end because the memory may be reallocated. */
+			end = EG(ht_iterators) + nr_iterators_used;
+			iter = &EG(ht_iterators)[iter_index];
 			HashTableIterator *copy_iter = EG(ht_iterators) + copy_idx;
 			copy_iter->next_copy = iter->next_copy;
 			iter->next_copy = copy_idx;

--- a/ext/spl/tests/gh16054.phpt
+++ b/ext/spl/tests/gh16054.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-16054 (Segmentation fault when resizing hash table iterator list while adding)
+--FILE--
+<?php
+$multi_array = ['zero'];
+$multi_array[] =& $multi_array;
+$it = new RecursiveTreeIterator(new RecursiveArrayIterator($multi_array), 0);
+$counter = 0;
+foreach ($it as $k => $v) {
+    if (++$counter > 200) break;
+}
+echo "ok\n";
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
zend_array_dup_ht_iterators() loops over the hash table iterators and can call zend_hash_iterator_add(). zend_hash_iterator_add() can resize the array causing a crash in zend_array_dup_ht_iterators().

We solve this by refetching the iter pointer after an add happened.