### PR TITLE
Fix GH-16053: array_merge_recursive(): convert_to_array() may need separation

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3700,7 +3700,6 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 				}
 
 				ZEND_ASSERT(!Z_ISREF_P(dest_entry) || Z_REFCOUNT_P(dest_entry) > 1);
-				SEPARATE_ZVAL(dest_entry);
 				dest_zval = dest_entry;
 
 				if (Z_TYPE_P(dest_zval) == IS_NULL) {
@@ -3709,6 +3708,8 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 				} else {
 					convert_to_array(dest_zval);
 				}
+				SEPARATE_ZVAL(dest_zval);
+
 				ZVAL_UNDEF(&tmp);
 				if (Z_TYPE_P(src_zval) == IS_OBJECT) {
 					ZVAL_COPY(&tmp, src_zval);

--- a/ext/standard/tests/array/gh16053.phpt
+++ b/ext/standard/tests/array/gh16053.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-16053: Assertion failure in Zend/zend_hash.c
+--FILE--
+<?php
+
+class test
+{
+}
+$x = new test;
+$arr1 = array("string" => $x);
+$arr2 = array("string" => "hello");
+var_dump($arr1);
+var_dump(array_merge_recursive($arr1, $arr2));
+
+?>
+--EXPECTF--
+array(1) {
+  ["string"]=>
+  object(test)#%d (0) {
+  }
+}
+array(1) {
+  ["string"]=>
+  array(1) {
+    [0]=>
+    string(5) "hello"
+  }
+}


### PR DESCRIPTION
Fixes GH-16053