### PR TITLE
Sync exif dependency on mbstring extension as optional

### DIFF
--- a/ext/exif/config.m4
+++ b/ext/exif/config.m4
@@ -10,4 +10,5 @@ if test "$PHP_EXIF" != "no"; then
     [exif.c],
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+  PHP_ADD_EXTENSION_DEP(exif, mbstring, true)
 fi

--- a/ext/exif/config.w32
+++ b/ext/exif/config.w32
@@ -2,12 +2,8 @@
 
 ARG_ENABLE('exif', 'Exchangeable image information (EXIF) Support', 'no');
 
-if(PHP_EXIF != 'no')
-{
-	if(ADD_EXTENSION_DEP('exif', 'mbstring'))
-	{
-		AC_DEFINE('HAVE_EXIF', 1, "Define to 1 if the PHP extension 'exif' is available.");
-
-		EXTENSION('exif', 'exif.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
-	}
+if(PHP_EXIF != 'no') {
+	AC_DEFINE('HAVE_EXIF', 1, "Define to 1 if the PHP extension 'exif' is available.");
+	EXTENSION('exif', 'exif.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	ADD_EXTENSION_DEP('exif', 'mbstring', true);
 }


### PR DESCRIPTION
When decoding multibyte data in EXIF tags, the mbstring extension needs to be enabled. In Autotools this is now synced with ZEND_MOD_OPTIONAL in the C code, and on Windows it is now also optional.

The required dependency on mbstring extension was removed via 755c2cd0d85b65f35abb2d54204fa7d38b820268 which made the mbstring extension optional dependency.

Documentation update: https://github.com/php/doc-en/pull/3793