### PR TITLE
Fix bug71610.phpt

### DIFF
--- a/ext/soap/tests/bug71610.phpt
+++ b/ext/soap/tests/bug71610.phpt
@@ -4,11 +4,20 @@ SOAP Bug #71610 - Type Confusion Vulnerability - SOAP / make_http_soap_request()
 soap
 --SKIPIF--
 <?php
-if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
+if (!file_exists(__DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc")) {
+    echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+}
 ?>
 --FILE--
 <?php
-$exploit = unserialize('O:10:"SoapClient":3:{s:3:"uri";s:1:"a";s:8:"location";s:19:"http://example.org/";s:8:"_cookies";a:1:{s:8:"manhluat";a:3:{i:0;s:0:"";i:1;N;i:2;N;}}}');
+include __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
+php_cli_server_start();
+
+$url = "http://" . PHP_CLI_SERVER_ADDRESS;
+$ser = 'O:10:"SoapClient":3:{s:3:"uri";s:1:"a";s:8:"location";s:' . strlen($url) . ':"'
+    . $url . '";s:8:"_cookies";a:1:{s:8:"manhluat";a:3:{i:0;s:0:"";i:1;N;i:2;N;}}}';
+
+$exploit = unserialize($ser);
 try {
 $exploit->blahblah();
 } catch(SoapFault $e) {


### PR DESCRIPTION
Apparently example.org now rejects POST requests, so we would need to adjust the test expectation ("Method not allowed").  However, there is no need for an online test; instead we're just using the CLI test server.  The serialization is a bit fiddly, but as long as there are no quotes in `PHP_CLI_SERVER_ADDRESS` we're fine.

---

I've noticed this when testing the new releases (https://github.com/cmb69/php-ftw/actions/runs/11030040982/job/30633774744#step:5:98), while the test ran fine two weeks ago.

While fixing the test I've noticed that the soap test suite could need some TLC.

PS: note to merged: the test has been moved to the bugs/ subdirectory in PHP-8.4, so the paths to server.inc need to be adjusted when merging upwards.