### PR TITLE
GH-16067: prevent invalid `abstract` during compilation of methods

### DIFF
--- a/Zend/tests/abstract_implicit.phpt
+++ b/Zend/tests/abstract_implicit.phpt
@@ -16,4 +16,4 @@ class NotAbstract {
 }
 ?>
 --EXPECTF--
-Fatal error: Class NotAbstract contains abstract method NotAbstract::bar and must therefore be declared abstract in %s on line %d
+Fatal error: Class NotAbstract declares abstract method bar() and must therefore be declared abstract in %s on line %d

--- a/Zend/tests/abstract_implicit.phpt
+++ b/Zend/tests/abstract_implicit.phpt
@@ -16,4 +16,4 @@ class NotAbstract {
 }
 ?>
 --EXPECTF--
-Fatal error: Class NotAbstract contains 1 abstract method and must therefore be declared abstract or implement the remaining method (NotAbstract::bar) in %s on line %d
+Fatal error: Class NotAbstract contains abstract method NotAbstract::bar and must therefore be declared abstract in %s on line %d

--- a/Zend/tests/abstract_implicit.phpt
+++ b/Zend/tests/abstract_implicit.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Abstract methods not allowed in classes that are not abstract (GH-16067)
+--FILE--
+<?php
+
+// Still allowed via trait
+trait TraitWithAbstract {
+    abstract public function foo();
+}
+class TraitWorks {
+    use TraitWithAbstract;
+}
+
+class NotAbstract {
+    abstract public function bar();
+}
+?>
+--EXPECTF--
+Fatal error: Class NotAbstract contains 1 abstract method and must therefore be declared abstract or implement the remaining method (NotAbstract::bar) in %s on line %d

--- a/Zend/tests/anon/gh16067.phpt
+++ b/Zend/tests/anon/gh16067.phpt
@@ -8,4 +8,4 @@ $c = new class {
 }
 ?>
 --EXPECTF--
-Fatal error: Anonymous class class@anonymous cannot contain abstract method class@anonymous::f in %s on line 4
+Fatal error: Anonymous class method f() must not be abstract in %s on line 4

--- a/Zend/tests/anon/gh16067.phpt
+++ b/Zend/tests/anon/gh16067.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Compiler prevents explicit `abstract` methods on anonymous classes
+--FILE--
+<?php
+
+$c = new class {
+    abstract public function f();
+}
+?>
+--EXPECTF--
+Fatal error: Class class@anonymous must implement 1 abstract method (class@anonymous::f) in %s on line 3

--- a/Zend/tests/anon/gh16067.phpt
+++ b/Zend/tests/anon/gh16067.phpt
@@ -8,4 +8,4 @@ $c = new class {
 }
 ?>
 --EXPECTF--
-Fatal error: Class class@anonymous must implement 1 abstract method (class@anonymous::f) in %s on line 3
+Fatal error: Anonymous class class@anonymous cannot contain abstract method class@anonymous::f in %s on line 4

--- a/Zend/tests/enum/no-abstract.phpt
+++ b/Zend/tests/enum/no-abstract.phpt
@@ -9,4 +9,4 @@ enum Example {
 
 ?>
 --EXPECTF--
-Fatal error: Enum Example cannot contain abstract method Example::foo in %s on line 4
+Fatal error: Enum method Example::foo() must not be abstract in %s on line 4

--- a/Zend/tests/enum/no-abstract.phpt
+++ b/Zend/tests/enum/no-abstract.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Compiler prevents `abstract` methods on enums classes (GH-16067)
+--FILE--
+<?php
+
+enum Example {
+    abstract public function foo();
+}
+
+?>
+--EXPECTF--
+Fatal error: Enum Example cannot contain abstract method Example::foo in %s on line 4

--- a/Zend/tests/errmsg/errmsg_018.phpt
+++ b/Zend/tests/errmsg/errmsg_018.phpt
@@ -10,4 +10,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Class test contains abstract method test::foo and must therefore be declared abstract in %s on line %d
+Fatal error: Class test declares abstract method foo() and must therefore be declared abstract in %s on line %d

--- a/Zend/tests/errmsg/errmsg_018.phpt
+++ b/Zend/tests/errmsg/errmsg_018.phpt
@@ -10,4 +10,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Class test contains 1 abstract method and must therefore be declared abstract or implement the remaining method (test::foo) in %s on line %d
+Fatal error: Class test contains abstract method test::foo and must therefore be declared abstract in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8068,14 +8068,15 @@ static zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string 
 	}
 
 	if ((fn_flags & ZEND_ACC_ABSTRACT) &&
-		!(ce->ce_flags & (ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_TRAIT)) &&
-		!in_interface
+		!(ce->ce_flags & (ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_TRAIT|ZEND_ACC_INTERFACE))
 	) {
 		// Don't say that the class should be declared abstract if it is
-		// anonymous and can't be abstract
+		// anonymous or an enum and can't be abstract
 		const char *msg;
 		if (ce->ce_flags & ZEND_ACC_ANON_CLASS) {
 			msg = "Anonymous class %s cannot contain abstract method %s::%s";
+		} else if (ce->ce_flags & ZEND_ACC_ENUM) {
+			msg = "Enum %s cannot contain abstract method %s::%s";
 		} else {
 			msg = "Class %s contains abstract method %s::%s and must therefore be declared abstract";
 		}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8067,6 +8067,27 @@ static zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string 
 		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");
 	}
 
+	if ((fn_flags & ZEND_ACC_ABSTRACT) &&
+		!(ce->ce_flags & (ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_TRAIT)) &&
+		!in_interface
+	) {
+		// Don't say that the class should be declared abstract if it is
+		// anonymous and can't be abstract
+		const char *msg;
+		if (ce->ce_flags & ZEND_ACC_ANON_CLASS) {
+			msg = "Anonymous class %s cannot contain abstract method %s::%s";
+		} else {
+			msg = "Class %s contains abstract method %s::%s and must therefore be declared abstract";
+		}
+		zend_error_noreturn(
+			E_COMPILE_ERROR,
+			msg,
+			ZSTR_VAL(ce->name),
+			ZSTR_VAL(ce->name),
+			ZSTR_VAL(name)
+		);
+	}
+
 	if (in_interface) {
 		if (!(fn_flags & ZEND_ACC_PUBLIC)) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface method "

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8067,26 +8067,20 @@ static zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string 
 		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");
 	}
 
-	if ((fn_flags & ZEND_ACC_ABSTRACT) &&
-		!(ce->ce_flags & (ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_TRAIT|ZEND_ACC_INTERFACE))
-	) {
+	if ((fn_flags & ZEND_ACC_ABSTRACT)
+	 && !(ce->ce_flags & (ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_TRAIT))) {
 		// Don't say that the class should be declared abstract if it is
 		// anonymous or an enum and can't be abstract
-		const char *msg;
 		if (ce->ce_flags & ZEND_ACC_ANON_CLASS) {
-			msg = "Anonymous class %s cannot contain abstract method %s::%s";
-		} else if (ce->ce_flags & ZEND_ACC_ENUM) {
-			msg = "Enum %s cannot contain abstract method %s::%s";
+			zend_error_noreturn(E_COMPILE_ERROR, "Anonymous class method %s() must not be abstract",
+				ZSTR_VAL(name));
+		} else if (ce->ce_flags & (ZEND_ACC_ENUM|ZEND_ACC_INTERFACE)) {
+			zend_error_noreturn(E_COMPILE_ERROR, "%s method %s::%s() must not be abstract",
+				zend_get_object_type_case(ce, true), ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		} else {
-			msg = "Class %s contains abstract method %s::%s and must therefore be declared abstract";
+			zend_error_noreturn(E_COMPILE_ERROR, "Class %s declares abstract method %s() and must therefore be declared abstract",
+				ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
-		zend_error_noreturn(
-			E_COMPILE_ERROR,
-			msg,
-			ZSTR_VAL(ce->name),
-			ZSTR_VAL(ce->name),
-			ZSTR_VAL(name)
-		);
 	}
 
 	if (in_interface) {
@@ -8097,10 +8091,6 @@ static zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string 
 		if (fn_flags & ZEND_ACC_FINAL) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Interface method "
 				"%s::%s() must not be final", ZSTR_VAL(ce->name), ZSTR_VAL(name));
-		}
-		if (fn_flags & ZEND_ACC_ABSTRACT) {
-			zend_error_noreturn(E_COMPILE_ERROR, "Interface method "
-				"%s::%s() must not be abstract", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
 		op_array->fn_flags |= ZEND_ACC_ABSTRACT;
 	}

--- a/tests/classes/abstract_derived.phpt
+++ b/tests/classes/abstract_derived.phpt
@@ -13,4 +13,4 @@ class derived extends base {
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Class derived contains abstract method derived::show and must therefore be declared abstract in %sabstract_derived.php on line %d
+Fatal error: Class derived declares abstract method show() and must therefore be declared abstract in %sabstract_derived.php on line %d

--- a/tests/classes/abstract_derived.phpt
+++ b/tests/classes/abstract_derived.phpt
@@ -13,4 +13,4 @@ class derived extends base {
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Class derived contains 1 abstract method and must therefore be declared abstract or implement the remaining method (derived::show) in %sabstract_derived.php on line %d
+Fatal error: Class derived contains abstract method derived::show and must therefore be declared abstract in %sabstract_derived.php on line %d

--- a/tests/classes/abstract_not_declared.phpt
+++ b/tests/classes/abstract_not_declared.phpt
@@ -10,4 +10,4 @@ class fail {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Class fail contains 1 abstract method and must therefore be declared abstract or implement the remaining method (fail::show) in %s on line %d
+Fatal error: Class fail contains abstract method fail::show and must therefore be declared abstract in %s on line %d

--- a/tests/classes/abstract_not_declared.phpt
+++ b/tests/classes/abstract_not_declared.phpt
@@ -10,4 +10,4 @@ class fail {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Class fail contains abstract method fail::show and must therefore be declared abstract in %s on line %d
+Fatal error: Class fail declares abstract method show() and must therefore be declared abstract in %s on line %d

--- a/tests/classes/abstract_redeclare.phpt
+++ b/tests/classes/abstract_redeclare.phpt
@@ -16,4 +16,4 @@ class fail extends pass {
 echo "Done\n"; // Shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Class fail contains 1 abstract method and must therefore be declared abstract or implement the remaining method (fail::show) in %sabstract_redeclare.php on line %d
+Fatal error: Class fail contains abstract method fail::show and must therefore be declared abstract in %sabstract_redeclare.php on line %d

--- a/tests/classes/abstract_redeclare.phpt
+++ b/tests/classes/abstract_redeclare.phpt
@@ -16,4 +16,4 @@ class fail extends pass {
 echo "Done\n"; // Shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Class fail contains abstract method fail::show and must therefore be declared abstract in %sabstract_redeclare.php on line %d
+Fatal error: Class fail declares abstract method show() and must therefore be declared abstract in %sabstract_redeclare.php on line %d

--- a/tests/classes/abstract_static.phpt
+++ b/tests/classes/abstract_static.phpt
@@ -31,4 +31,4 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Class fail contains 1 abstract method and must therefore be declared abstract or implement the remaining method (fail::func) in %sabstract_static.php(%d) : eval()'d code on line %d
+Fatal error: Class fail contains abstract method fail::func and must therefore be declared abstract in %sabstract_static.php(%d) : eval()'d code on line %d

--- a/tests/classes/abstract_static.phpt
+++ b/tests/classes/abstract_static.phpt
@@ -31,4 +31,4 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Class fail contains abstract method fail::func and must therefore be declared abstract in %sabstract_static.php(%d) : eval()'d code on line %d
+Fatal error: Class fail declares abstract method func() and must therefore be declared abstract in %sabstract_static.php(%d) : eval()'d code on line %d

--- a/tests/classes/interface_method_private.phpt
+++ b/tests/classes/interface_method_private.phpt
@@ -4,7 +4,7 @@ ZE2 An interface method cannot be private
 <?php
 
 interface if_a {
-    abstract private function err();
+    private function err();
 }
 
 ?>


### PR DESCRIPTION
For classes that are not declared `abstract`, produce a compiler error for any `abstract` methods. For anonymous classes and enums, since they cannot be made abstract, the error messages are slightly different.