### PR TITLE
random: Do not use `ZVAL_DUP` in `Randomizer::shuffleArray()`

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -356,7 +356,7 @@ PHP_METHOD(Random_Randomizer, shuffleArray)
 		Z_PARAM_ARRAY(array)
 	ZEND_PARSE_PARAMETERS_END();
 
-	ZVAL_DUP(return_value, array);
+	RETVAL_ARR(zend_array_dup(Z_ARRVAL_P(array)));
 	if (!php_array_data_shuffle(randomizer->engine, return_value)) {
 		RETURN_THROWS();
 	}


### PR DESCRIPTION
PHP Internals Book says:

> The ZVAL_DUP macro is similar to ZVAL_COPY, but will duplicate arrays, rather
> than just incrementing their refcount. If you are using this macro, you are
> almost certainly doing something very wrong.

Replace this by an explicit call to `zend_array_dup()`, as done in `php_array_diff()`. Besides being more explicit in what is happening, this likely also results in better assembly.