### PR TITLE
[skip ci] Bump required C standard to C11

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -9,12 +9,10 @@ rewritten to comply with these rules.
 
 1. Document your code in source files and the manual. (tm)
 
-1. PHP is implemented in C99.
+1. PHP is implemented in C11.
     For instance, the optional fixed-width integers from
     stdint.h (int8_t, int16_t, int32_t, int64_t and their unsigned
     counterparts) are supposed to be available.
-    However, some features (most notably variable-length arrays) which are not
-    supported by all relevant compilers, must not be used.
 
 1. Functions that are given pointers to resources should not free them.
 


### PR DESCRIPTION
As we haven't merged GH-15397 in time, let's at least correctly specify the required version in the coding standards. I'll also update https://www.php.net/manual/it/install.unix.php accordingly.