### PR TITLE
Fix failing soap tests on Windows

### DIFF
--- a/ext/soap/tests/bugs/bug27722.phpt
+++ b/ext/soap/tests/bugs/bug27722.phpt
@@ -2,8 +2,7 @@
 Bug #27722 (Segfault on schema without targetNamespace)
 --EXTENSIONS--
 soap
---GET--
-wsdl
+--CGI--
 --INI--
 soap.wsdl_cache_enabled=0
 --FILE--

--- a/ext/soap/tests/bugs/bug27722.phpt
+++ b/ext/soap/tests/bugs/bug27722.phpt
@@ -2,7 +2,6 @@
 Bug #27722 (Segfault on schema without targetNamespace)
 --EXTENSIONS--
 soap
---CGI--
 --INI--
 soap.wsdl_cache_enabled=0
 --FILE--

--- a/ext/soap/tests/bugs/bug27742.phpt
+++ b/ext/soap/tests/bugs/bug27742.phpt
@@ -2,7 +2,6 @@
 Bug #27742 (WDSL SOAP Parsing Schema bug)
 --EXTENSIONS--
 soap
---CGI--
 --INI--
 soap.wsdl_cache_enabled=0
 --FILE--

--- a/ext/soap/tests/bugs/bug27742.phpt
+++ b/ext/soap/tests/bugs/bug27742.phpt
@@ -2,8 +2,7 @@
 Bug #27742 (WDSL SOAP Parsing Schema bug)
 --EXTENSIONS--
 soap
---GET--
-wsdl
+--CGI--
 --INI--
 soap.wsdl_cache_enabled=0
 --FILE--

--- a/ext/soap/tests/server011.phpt
+++ b/ext/soap/tests/server011.phpt
@@ -1,5 +1,11 @@
 --TEST--
 SOAP Server 11: bind
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === "Windows") {
+    die("skip current unsupported on Windows");
+}
+?>
 --EXTENSIONS--
 soap
 --GET--

--- a/ext/soap/tests/server011.phpt
+++ b/ext/soap/tests/server011.phpt
@@ -3,7 +3,7 @@ SOAP Server 11: bind
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY === "Windows") {
-    die("skip current unsupported on Windows");
+    die("skip currently unsupported on Windows");
 }
 ?>
 --EXTENSIONS--

--- a/ext/soap/tests/server012.phpt
+++ b/ext/soap/tests/server012.phpt
@@ -3,7 +3,7 @@ SOAP Server 12: WSDL generation
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY === "Windows") {
-    die("skip current unsupported on Windows");
+    die("skip currently unsupported on Windows");
 }
 ?>
 --EXTENSIONS--

--- a/ext/soap/tests/server012.phpt
+++ b/ext/soap/tests/server012.phpt
@@ -1,5 +1,11 @@
 --TEST--
 SOAP Server 12: WSDL generation
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === "Windows") {
+    die("skip current unsupported on Windows");
+}
+?>
 --EXTENSIONS--
 soap
 --GET--


### PR DESCRIPTION
These failures are caused by the fix for GHSA-p99j-rfp4-xqvq.  Since the two bug*.phpt tests don't need the "wsdl" query string, we use a `--CGI--` section instead.  The two server*.phpt tests are harder to fix, since during evaluation of the `--SKIPIF--` section, the soap extension can be loaded, but it may not during evaluation of the `--FILE--` section.  So for now, we skip these tests on Windows altogether.