### PR TITLE
Remove phpdbg binary during make clean

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -117,7 +117,7 @@ clean:
 	find . -name \*.la -o -name \*.a | xargs rm -f
 	find . -name \*.so | xargs rm -f
 	find . -name .libs -a -type d|xargs rm -rf
-	rm -f libphp.la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
+	rm -f libphp.la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(SAPI_PHPDBG_PATH) $(SAPI_PHPDBG_SHARED_PATH) $(OVERALL_TARGET) modules/* libs/*
 	rm -f ext/opcache/jit/ir/gen_ir_fold_hash
 	rm -f ext/opcache/jit/ir/minilua
 	rm -f ext/opcache/jit/ir/ir_fold_hash.h
@@ -143,7 +143,7 @@ prof-clean:
 	find . -name \*.lo -o -name \*.o | xargs rm -f
 	find . -name \*.la -o -name \*.a | xargs rm -f
 	find . -name \*.so | xargs rm -f
-	rm -f libphp.la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
+	rm -f libphp.la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(SAPI_PHPDBG_PATH) $(SAPI_PHPDBG_SHARED_PATH) $(OVERALL_TARGET) modules/* libs/*
 
 prof-use:
 	CCACHE_DISABLE=1 $(MAKE) PROF_FLAGS=-fprofile-use all

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -1,11 +1,11 @@
-phpdbg: $(BUILD_BINARY)
+phpdbg: $(SAPI_PHPDBG_PATH)
 
-phpdbg-shared: $(BUILD_SHARED)
+phpdbg-shared: $(SAPI_PHPDBG_SHARED_PATH)
 
-$(BUILD_SHARED): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
+$(SAPI_PHPDBG_SHARED_PATH): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
 	$(BUILD_PHPDBG_SHARED)
 
-$(BUILD_BINARY): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
+$(SAPI_PHPDBG_PATH): $(PHP_GLOBAL_OBJS) $(PHP_BINARY_OBJS) $(PHP_PHPDBG_OBJS)
 	$(BUILD_PHPDBG)
 
 %.c: %.y
@@ -20,12 +20,12 @@ $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y
 	@$(YACC) $(YFLAGS) -v -d $(srcdir)/phpdbg_parser.y -o $@
 
-install-phpdbg: $(BUILD_BINARY)
+install-phpdbg: $(SAPI_PHPDBG_PATH)
 	@echo "Installing phpdbg binary:         $(INSTALL_ROOT)$(bindir)/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/log
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/run
-	@$(INSTALL) -m 0755 $(BUILD_BINARY) $(INSTALL_ROOT)$(bindir)/$(program_prefix)phpdbg$(program_suffix)$(EXEEXT)
+	@$(INSTALL) -m 0755 $(SAPI_PHPDBG_PATH) $(INSTALL_ROOT)$(bindir)/$(program_prefix)phpdbg$(program_suffix)$(EXEEXT)
 	@echo "Installing phpdbg man page:       $(INSTALL_ROOT)$(mandir)/man1/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
 	@$(INSTALL_DATA) sapi/phpdbg/phpdbg.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phpdbg$(program_suffix).1

--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -90,8 +90,8 @@ if test "$PHP_PHPDBG" != "no"; then
     ]),
     [$PHP_PHPDBG_CFLAGS])
 
-  BUILD_BINARY="sapi/phpdbg/phpdbg"
-  BUILD_SHARED="sapi/phpdbg/libphpdbg.la"
+  SAPI_PHPDBG_PATH="sapi/phpdbg/phpdbg"
+  SAPI_PHPDBG_SHARED_PATH="sapi/phpdbg/libphpdbg.la"
 
   BUILD_PHPDBG="\$(LIBTOOL) --tag=CC --mode=link \
         \$(CC) -export-dynamic \$(CFLAGS_CLEAN) \$(EXTRA_CFLAGS) \$(EXTRA_LDFLAGS_PROGRAM) \$(LDFLAGS) \$(PHP_RPATHS) \
@@ -102,7 +102,7 @@ if test "$PHP_PHPDBG" != "no"; then
                 \$(PHPDBG_EXTRA_LIBS) \
                 \$(ZEND_EXTRA_LIBS) \
                 \$(PHP_FRAMEWORKS) \
-         -o \$(BUILD_BINARY)"
+         -o \$(SAPI_PHPDBG_PATH)"
 
   BUILD_PHPDBG_SHARED="\$(LIBTOOL) --tag=CC --mode=link \
         \$(CC) -shared -Wl,-soname,libphpdbg.so -export-dynamic \$(CFLAGS_CLEAN) \$(EXTRA_CFLAGS) \$(EXTRA_LDFLAGS_PROGRAM) \$(LDFLAGS) \$(PHP_RPATHS) \
@@ -112,11 +112,11 @@ if test "$PHP_PHPDBG" != "no"; then
                 \$(EXTRA_LIBS) \
                 \$(PHPDBG_EXTRA_LIBS) \
                 \$(ZEND_EXTRA_LIBS) \
-         -o \$(BUILD_SHARED)"
+         -o \$(SAPI_PHPDBG_SHARED_PATH)"
 
   PHP_SUBST([PHPDBG_EXTRA_LIBS])
-  PHP_SUBST([BUILD_BINARY])
-  PHP_SUBST([BUILD_SHARED])
+  PHP_SUBST([SAPI_PHPDBG_PATH])
+  PHP_SUBST([SAPI_PHPDBG_SHARED_PATH])
   PHP_SUBST([BUILD_PHPDBG])
   PHP_SUBST([BUILD_PHPDBG_SHARED])
 


### PR DESCRIPTION
`make clean` does not remove the `phpdbg` binary. This is annoying because after rebuilding without phpdbg, `make test` will attempt to run phpdbg tests, which will fail of the binary is not compatible with extensions. E.g.:

```
./configure && make
make clean

./configure --disable-phpdbg --enable-zts && make

# phpdbg tests are not skipped because the binary exists
# but they fail because extensions can not be loaded
make test
```
