### PR TITLE
Skip tests requiring to load dl_test dynamically

### DIFF
--- a/ext/opcache/tests/gh8466.phpt
+++ b/ext/opcache/tests/gh8466.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Bug GH-8466: ini_get() is optimized out when the option does not exist during compilation
 --SKIPIF--
-<?php include dirname(__DIR__, 2) . "/dl_test/tests/skip.inc"; ?>
+<?php
+include dirname(__DIR__, 2) . "/dl_test/tests/skip.inc";
+if (extension_loaded('dl_test')) {
+    die('skip dl_test is already loaded');
+}
+?>
 --FILE--
 <?php
-
-if (extension_loaded('dl_test')) {
-    exit('Error: dl_test is already loaded');
-}
-
 if (PHP_OS_FAMILY === 'Windows') {
     $loaded = dl('php_dl_test.dll');
 } else {

--- a/ext/standard/tests/general_functions/dl-001.phpt
+++ b/ext/standard/tests/general_functions/dl-001.phpt
@@ -3,15 +3,13 @@ dl(): Loaded extensions properly unregister their ini settings
 --SKIPIF--
 <?php
 include dirname(__DIR__, 3) . "/dl_test/tests/skip.inc";
+if (extension_loaded('dl_test')) {
+    die('skip dl_test is already loaded');
+}
 if (getenv('SKIP_ASAN')) die('skip fails intermittently on ASAN');
 ?>
 --FILE--
 <?php
-
-if (extension_loaded('dl_test')) {
-    exit('Error: dl_test is already loaded');
-}
-
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     $loaded = dl('php_dl_test.dll');
 } else {

--- a/ext/standard/tests/general_functions/dl-002.phpt
+++ b/ext/standard/tests/general_functions/dl-002.phpt
@@ -5,14 +5,13 @@ PHP_DL_TEST_USE_OLD_REGISTER_INI_ENTRIES=1
 --SKIPIF--
 <?php
 include dirname(__DIR__, 3) . "/dl_test/tests/skip.inc";
+if (extension_loaded('dl_test')) {
+    die('skip dl_test is already loaded');
+}
 if (getenv('SKIP_ASAN')) die('skip fails intermittently on ASAN');
 ?>
 --FILE--
 <?php
-
-if (extension_loaded('dl_test')) {
-    exit('Error: dl_test is already loaded');
-}
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     $loaded = dl('php_dl_test.dll');
 } else {

--- a/ext/standard/tests/general_functions/dl-003.phpt
+++ b/ext/standard/tests/general_functions/dl-003.phpt
@@ -3,14 +3,13 @@ dl(): Loaded extensions support ini_set()
 --SKIPIF--
 <?php
 include dirname(__DIR__, 3) . "/dl_test/tests/skip.inc";
+if (extension_loaded('dl_test')) {
+    die('skip dl_test is already loaded');
+}
 if (getenv('SKIP_ASAN')) die('skip fails intermittently on ASAN');
 ?>
 --FILE--
 <?php
-
-if (extension_loaded('dl_test')) {
-    exit('Error: dl_test is already loaded');
-}
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     $loaded = dl('php_dl_test.dll');
 } else {

--- a/ext/standard/tests/general_functions/dl-use_register_functions_directly.phpt
+++ b/ext/standard/tests/general_functions/dl-use_register_functions_directly.phpt
@@ -3,14 +3,14 @@ dl(): use zend_register_functions() directly
 --ENV--
 PHP_DL_TEST_USE_REGISTER_FUNCTIONS_DIRECTLY=1
 --SKIPIF--
-<?php require dirname(__DIR__, 3) . "/dl_test/tests/skip.inc"; ?>
+<?php
+require dirname(__DIR__, 3) . "/dl_test/tests/skip.inc";
+if (extension_loaded('dl_test')) {
+    die('skip dl_test is already loaded');
+}
+?>
 --FILE--
 <?php
-
-if (extension_loaded('dl_test')) {
-    exit('Error: dl_test is already loaded');
-}
-
 if (PHP_OS_FAMILY === 'Windows') {
     $loaded = dl('php_dl_test.dll');
 } else {


### PR DESCRIPTION
We have a couple of test cases which are useless, if the dl_test extension is already loaded, since they test the behavior of `dl()`. However, they are currently failing if dl_test is already loaded; we skip these tests now instead.

---

If we want to ensure that these tests are exercised, we should make sure that the extension cannot be built statically (currently at least configure would be fine with this on Windows), and we should ensure that the extension cannot be loaded via php.ini and friends. And for Windows, we should probably adapt `--enable-test-ini` accordingly.

@arnaud-lb, thoughts?