### PR TITLE
Fix pdoodbc_002.phpt to not try to load PDO_odbc

### DIFF
--- a/ext/pdo_odbc/tests/pdoodbc_002.phpt
+++ b/ext/pdo_odbc/tests/pdoodbc_002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 PDO_mysql connect through PDO::connect
 --EXTENSIONS--
-PDO_odbc
+pdo_odbc
 --SKIPIF--
 <?php
 require 'ext/pdo/tests/pdo_test.inc';


### PR DESCRIPTION
In the `--EXTENSIONS--` section, names of extension are handled case- sensitively.

---

I was pretty confused when I saw https://github.com/php/php-src/actions/runs/11082846756/job/30796380227?pr=16089#step:6:148; but it's pretty clear what's going: if the extension is already loaded, the test runner still tries to load `PDO_odbc` what even works with a case-insensitive file system. For case-sensitive file system, there likely would be an error about failing to load the extension.