### PR TITLE
Do load default ini files in tests

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -89,23 +89,11 @@ PHP_DEPRECATED_DIRECTIVES_REGEX = '^(magic_quotes_(gpc|runtime|sybase)?|(zend_)?
 
 test: all
 	@if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \
-		INI_FILE=`$(PHP_EXECUTABLE) -d 'display_errors=stderr' -r 'echo php_ini_loaded_file();' 2> /dev/null`; \
-		if test "$$INI_FILE"; then \
-			$(EGREP) -h -v $(PHP_DEPRECATED_DIRECTIVES_REGEX) "$$INI_FILE" > $(top_builddir)/tmp-php.ini; \
-		else \
-			echo > $(top_builddir)/tmp-php.ini; \
-		fi; \
-		INI_SCANNED_PATH=`$(PHP_EXECUTABLE) -d 'display_errors=stderr' -r '$$a = explode(",\n", trim(php_ini_scanned_files())); echo $$a[0];' 2> /dev/null`; \
-		if test "$$INI_SCANNED_PATH"; then \
-			INI_SCANNED_PATH=`$(top_srcdir)/build/shtool path -d $$INI_SCANNED_PATH`; \
-			$(EGREP) -h -v $(PHP_DEPRECATED_DIRECTIVES_REGEX) "$$INI_SCANNED_PATH"/*.ini >> $(top_builddir)/tmp-php.ini; \
-		fi; \
 		TEST_PHP_EXECUTABLE=$(PHP_EXECUTABLE) \
 		TEST_PHP_SRCDIR=$(top_srcdir) \
 		CC="$(CC)" \
-			$(PHP_EXECUTABLE) -n -c $(top_builddir)/tmp-php.ini $(PHP_TEST_SETTINGS) $(top_srcdir)/run-tests.php -n -c $(top_builddir)/tmp-php.ini -d extension_dir=$(top_builddir)/modules/ $(PHP_TEST_SHARED_EXTENSIONS) $(TESTS); \
+			$(PHP_EXECUTABLE) -n $(PHP_TEST_SETTINGS) $(top_srcdir)/run-tests.php -n -d extension_dir=$(top_builddir)/modules/ $(PHP_TEST_SHARED_EXTENSIONS) $(TESTS); \
 		TEST_RESULT_EXIT_CODE=$$?; \
-		rm $(top_builddir)/tmp-php.ini; \
 		exit $$TEST_RESULT_EXIT_CODE; \
 	else \
 		echo "ERROR: Cannot run tests without CLI sapi."; \


### PR DESCRIPTION
`make test` concatenates the default ini files (from `config-file-path` and `config-file-scan-dir`) into a temporary `tmp-php.ini`, which is loaded in tests.

This leads to unexpected results, and sometimes to difficulties when trying to debug failing tests (mostly because generated `.sh` scripts for failing tests try to load the `tmp-php.ini` file, which is removed by `make test`).

I think that we should not load any ini file by default in tests, to reduce the impact of the environment on the test suite. It is always possible to specify an ini file explicitly (`make test TESTS="-c file.ini"`) or ini settings (`make test TESTS="-d ..."`).
