### PR TITLE
Fix potential parallel test conflicts

### DIFF
--- a/ext/standard/tests/file/file_get_contents_basic.phpt
+++ b/ext/standard/tests/file/file_get_contents_basic.phpt
@@ -13,13 +13,13 @@ echo "*** Testing the basic functionality of the file_get_contents() function **
 echo "-- Testing with simple valid data file --\n";
 
 
-create_files($file_path, 1, "text", 0755, 100, "w", "file", 1, "byte");
+create_files($file_path, 1, "text", 0755, 100, "w", "file_get_contents_basic", 1, "byte");
 var_dump( file_get_contents($file_path."/file1.tmp") );
 delete_files($file_path, 1);
 
 echo "\n-- Testing with empty file --\n";
 
-create_files($file_path, 1, "empty", 0755, 100, "w", "file", 1, "byte");
+create_files($file_path, 1, "empty", 0755, 100, "w", "file_get_contents_basic", 1, "byte");
 var_dump( file_get_contents($file_path."/file1.tmp") );
 delete_files($file_path, 1);
 

--- a/ext/standard/tests/file/file_get_contents_basic.phpt
+++ b/ext/standard/tests/file/file_get_contents_basic.phpt
@@ -14,14 +14,14 @@ echo "-- Testing with simple valid data file --\n";
 
 
 create_files($file_path, 1, "text", 0755, 100, "w", "file_get_contents_basic", 1, "byte");
-var_dump( file_get_contents($file_path."/file1.tmp") );
-delete_files($file_path, 1);
+var_dump( file_get_contents($file_path."/file_get_contents_basic1.tmp") );
+delete_files($file_path, 1, "file_get_contents_basic", 1);
 
 echo "\n-- Testing with empty file --\n";
 
 create_files($file_path, 1, "empty", 0755, 100, "w", "file_get_contents_basic", 1, "byte");
-var_dump( file_get_contents($file_path."/file1.tmp") );
-delete_files($file_path, 1);
+var_dump( file_get_contents($file_path."/file_get_contents_basic1.tmp") );
+delete_files($file_path, 1, "file_get_contents_basic", 1);
 
 echo "\n*** Done ***";
 ?>

--- a/ext/standard/tests/file/file_get_contents_error.phpt
+++ b/ext/standard/tests/file/file_get_contents_error.phpt
@@ -13,7 +13,7 @@ include($file_path."/file.inc");
 echo "\n-- Testing with  Non-existing file --\n";
 print( file_get_contents("/no/such/file/or/dir") );
 
-create_files($file_path, 1, "text", 0755, 100, "w", "file", 1, "byte");
+create_files($file_path, 1, "text", 0755, 100, "w", "file_get_contents_error", 1, "byte");
 $file_handle = fopen($file_path."/file_put_contents_error.tmp", "w");
 
 echo "\n-- Testing for invalid negative maxlen values --\n";

--- a/ext/standard/tests/file/file_get_contents_error.phpt
+++ b/ext/standard/tests/file/file_get_contents_error.phpt
@@ -18,12 +18,12 @@ $file_handle = fopen($file_path."/file_put_contents_error.tmp", "w");
 
 echo "\n-- Testing for invalid negative maxlen values --\n";
 try {
-    file_get_contents($file_path."/file1.tmp", FALSE, $file_handle, 0, -5);
+    file_get_contents($file_path."/file_get_contents_error1.tmp", FALSE, $file_handle, 0, -5);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
-delete_files($file_path, 1);
+delete_files($file_path, 1, "file_get_contents_error", 1);
 fclose($file_handle);
 unlink($file_path."/file_put_contents_error.tmp");
 


### PR DESCRIPTION
Both tests call `create_files()` with the same `$name_prefix` what might clash.

---

Apparently, a [clash happened during our latest nightly build](https://github.com/php/php-src/actions/runs/11079926168/job/30789710237#step:12:128).