### PR TITLE
ext/ldap: Various refactorings to `php_ldap_do_search()`

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1480,6 +1480,11 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 			ret = 0;
 			goto cleanup;
 		}
+		if (!zend_array_is_list(Z_ARRVAL_P(link))) {
+			zend_argument_value_error(1, "must be a list");
+			ret = 0;
+			goto cleanup;
+		}
 
 		if (base_dn_ht) {
 			nbases = zend_hash_num_elements(base_dn_ht);

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1650,13 +1650,13 @@ cleanup_parallel:
 		}
 
 		if (!base_dn_str) {
-			zend_argument_type_error(2, "must be of type string when argument #1 ($ldap) is an LDAP instance");
+			zend_argument_type_error(2, "must be of type string when argument #1 ($ldap) is an LDAP\\Connection instance");
 			ret = 0;
 			goto cleanup;
 		}
 
 		if (!filter_str) {
-			zend_argument_type_error(3, "must be of type string when argument #1 ($ldap) is an LDAP instance");
+			zend_argument_type_error(3, "must be of type string when argument #1 ($ldap) is an LDAP\\Connection instance");
 			ret = 0;
 			goto cleanup;
 		}
@@ -1704,7 +1704,7 @@ cleanup_parallel:
 			result->result = ldap_res;
 		}
 	} else {
-		zend_argument_type_error(1, "must be of type LDAP|array, %s given", zend_zval_value_name(link));
+		zend_argument_type_error(1, "must be of type LDAP\\Connection|array, %s given", zend_zval_value_name(link));
 	}
 
 cleanup:

--- a/ext/ldap/tests/gh16101.phpt
+++ b/ext/ldap/tests/gh16101.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug GH-16101: Segfault in ldap_list(), ldap_read(), and ldap_search() when LDAPs array is not a list
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+/* We are assuming 3333 is not connectable */
+$ldap = ldap_connect('ldap://127.0.0.1:3333');
+$valid_dn = "cn=userA,something";
+$valid_filter = "";
+
+$ldaps_dict = [
+    "hello"  => $ldap,
+    "world"  => $ldap,
+];
+try {
+    var_dump(ldap_list($ldaps_dict, $valid_dn, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: ldap_list(): Argument #1 ($ldap) must be a list

--- a/ext/ldap/tests/ldap_list_read_search_parallel_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_parallel_programming_errors.phpt
@@ -13,6 +13,16 @@ $valid_filter = "";
 
 $ldaps = [$ldap, $ldap];
 
+$not_list_ldaps = [
+    "string1",
+    $ldap,
+];
+try {
+    var_dump(ldap_list($not_list_ldaps, $valid_dn, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
 $dn = "dn_with\0nul_byte";
 try {
     var_dump(ldap_list($ldaps, $dn, $valid_filter));
@@ -58,11 +68,46 @@ try {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
+$list_not_all_strings = [
+    42,
+    "string2",
+];
+try {
+    var_dump(ldap_list($ldaps, $list_not_all_strings, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $list_not_all_strings));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$list_strings_with_nul_bytes = [
+    "string\0nul_byte",
+    "string2",
+];
+try {
+    var_dump(ldap_list($ldaps, $list_strings_with_nul_bytes, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $list_strings_with_nul_bytes));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
 ?>
 --EXPECT--
+ValueError: ldap_list(): Argument #1 ($ldap) must be a list of LDAP\Connection
 ValueError: ldap_list(): Argument #2 ($base) must not contain null bytes
 ValueError: ldap_list(): Argument #3 ($filter) must not contain null bytes
 ValueError: ldap_list(): Argument #2 ($base) must be a list
 ValueError: ldap_list(): Argument #3 ($filter) must be a list
 ValueError: ldap_list(): Argument #2 ($base) must be the same size as argument #1
 ValueError: ldap_list(): Argument #3 ($filter) must be the same size as argument #1
+TypeError: ldap_list(): Argument #2 ($base) must be a list of strings, int given
+TypeError: ldap_list(): Argument #3 ($filter) must be a list of strings, int given
+ValueError: ldap_list(): Argument #2 ($base) must not contain null bytes
+ValueError: ldap_list(): Argument #3 ($filter) must not contain null bytes

--- a/ext/ldap/tests/ldap_list_read_search_parallel_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_parallel_programming_errors.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Programming errors (Value/Type errors) for parallel usage of ldap_list(), ldap_read(), and ldap_search()
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+/* ldap_list(), ldap_read(), and ldap_search() share an underlying C function */
+/* We are assuming 3333 is not connectable */
+$ldap = ldap_connect('ldap://127.0.0.1:3333');
+$valid_dn = "cn=userA,something";
+$valid_filter = "";
+
+$ldaps = [$ldap, $ldap];
+
+$dn = "dn_with\0nul_byte";
+try {
+    var_dump(ldap_list($ldaps, $dn, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$filter = "filter_with\0nul_byte";
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$not_list = [
+    "attrib1",
+    "wat" => "attrib2",
+];
+try {
+    var_dump(ldap_list($ldaps, $not_list, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $not_list));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$list_not_same_length = [
+    "string1",
+    "string2",
+    "string3",
+];
+try {
+    var_dump(ldap_list($ldaps, $list_not_same_length, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $list_not_same_length));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: ldap_list(): Argument #2 ($base) must not contain null bytes
+ValueError: ldap_list(): Argument #3 ($filter) must not contain null bytes
+ValueError: ldap_list(): Argument #2 ($base) must be a list
+ValueError: ldap_list(): Argument #3 ($filter) must be a list
+ValueError: ldap_list(): Argument #2 ($base) must be the same size as argument #1
+ValueError: ldap_list(): Argument #3 ($filter) must be the same size as argument #1

--- a/ext/ldap/tests/ldap_list_read_search_parallel_references.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_parallel_references.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Programming errors (Value/Type errors) for parallel usage of ldap_list(), ldap_read(), and ldap_search() with references
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+/* ldap_list(), ldap_read(), and ldap_search() share an underlying C function */
+/* We are assuming 3333 is not connectable */
+$ldap = ldap_connect('ldap://127.0.0.1:3333');
+$valid_dn = "cn=userA,something";
+$valid_filter = "";
+
+$ldaps = [&$ldap, $ldap];
+
+$str = "string\0with_nul_byte";
+
+$list_with_ref_nul_byte = [
+    &$str,
+    "string2",
+];
+
+try {
+    var_dump(ldap_list($ldaps, $list_with_ref_nul_byte, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+    var_dump(ldap_list($ldaps, $valid_dn, $list_with_ref_nul_byte));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: ldap_list(): Argument #2 ($base) must not contain null bytes
+ValueError: ldap_list(): Argument #3 ($filter) must not contain null bytes

--- a/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Programming errors (Value/Type errors) for ldap_list(), ldap_read(), and ldap_search()
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+/* ldap_list(), ldap_read(), and ldap_search() share an underlying C function */
+/* We are assuming 3333 is not connectable */
+$ldap = ldap_connect('ldap://127.0.0.1:3333');
+$valid_dn = "cn=userA,something";
+$valid_filter = "";
+
+$not_list = [
+    "attrib1",
+    "wat" => "attrib2",
+    "attrib3",
+];
+try {
+    var_dump(ldap_list($ldap, $valid_dn, $valid_filter, $not_list));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$not_list_of_strings = [
+    "attrib1",
+    42,
+    "attrib3",
+];
+try {
+    var_dump(ldap_list($ldap, $valid_dn, $valid_filter, $not_list_of_strings));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$list_of_strings_with_null_byte = [
+    "attrib1",
+    "attrib_with\0nul_byte",
+    "attrib3",
+];
+try {
+    var_dump(ldap_list($ldap, $valid_dn, $valid_filter, $list_of_strings_with_null_byte));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+$str = "attrib_with\0nul_byte";
+
+$list_with_ref_nul_byte = [
+    "attrib1",
+    &$str,
+    "attrib3",
+];
+try {
+    var_dump(ldap_list($ldap, $valid_dn, $valid_filter, $list_with_ref_nul_byte));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ValueError: ldap_list(): Argument #4 ($attributes) must be a list
+TypeError: ldap_list(): Argument #4 ($attributes) must be a list of strings, int given
+ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes
+ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes

--- a/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
@@ -11,6 +11,24 @@ $ldap = ldap_connect('ldap://127.0.0.1:3333');
 $valid_dn = "cn=userA,something";
 $valid_filter = "";
 
+try {
+    var_dump(ldap_list(42, $valid_dn, $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump(ldap_list($ldap, [$valid_dn], $valid_filter));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump(ldap_list($ldap, $valid_dn, [$valid_filter]));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
 $not_list = [
     "attrib1",
     "wat" => "attrib2",
@@ -59,6 +77,9 @@ try {
 
 ?>
 --EXPECT--
+TypeError: ldap_list(): Argument #1 ($ldap) must be of type LDAP\Connection|array, int given
+TypeError: ldap_list(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
+TypeError: ldap_list(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
 ValueError: ldap_list(): Argument #4 ($attributes) must be a list
 TypeError: ldap_list(): Argument #4 ($attributes) must be a list of strings, int given
 ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes

--- a/ext/ldap/tests/ldap_search_error.phpt
+++ b/ext/ldap/tests/ldap_search_error.phpt
@@ -64,5 +64,5 @@ ldap_search(): Argument #4 ($attributes) must be a list
 ldap_search(): Argument #1 ($ldap) must not be empty
 ldap_search(): Argument #2 ($base) must be the same size as argument #1
 ldap_search(): Argument #3 ($filter) must be the same size as argument #1
-ldap_search(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP instance
-ldap_search(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP instance
+ldap_search(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
+ldap_search(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance

--- a/ext/ldap/tests/ldap_search_error.phpt
+++ b/ext/ldap/tests/ldap_search_error.phpt
@@ -62,7 +62,7 @@ Warning: ldap_search(): Search: No such object in %s on line %d
 bool(false)
 ldap_search(): Argument #4 ($attributes) must be a list
 ldap_search(): Argument #1 ($ldap) must not be empty
-ldap_search(): Argument #2 ($base) must have the same number of elements as the links array
-ldap_search(): Argument #3 ($filter) must have the same number of elements as the links array
+ldap_search(): Argument #2 ($base) must be the same size as argument #1
+ldap_search(): Argument #3 ($filter) must be the same size as argument #1
 ldap_search(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP instance
 ldap_search(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP instance

--- a/ext/ldap/tests/ldap_search_error.phpt
+++ b/ext/ldap/tests/ldap_search_error.phpt
@@ -19,8 +19,12 @@ $filter = "(dc=*)";
 $result = ldap_search($link, $dn, $filter);
 var_dump($result);
 
-$result = ldap_search($link, $dn, $filter, array(1 => 'top'));
-var_dump($result);
+try {
+    $result = ldap_search($link, $dn, $filter, array(1 => 'top'));
+    var_dump($result);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 try {
     ldap_search(array(), $dn, $filter, array('top'));
@@ -56,9 +60,7 @@ try {
 --EXPECTF--
 Warning: ldap_search(): Search: No such object in %s on line %d
 bool(false)
-
-Warning: ldap_search(): Array initialization wrong in %s on line %d
-bool(false)
+ldap_search(): Argument #4 ($attributes) must be a list
 ldap_search(): Argument #1 ($ldap) must not be empty
 ldap_search(): Argument #2 ($base) must have the same number of elements as the links array
 ldap_search(): Argument #3 ($filter) must have the same number of elements as the links array


### PR DESCRIPTION
There is much more to be done here, such as checking the PHP `int` inputs fit into a C `int` (and possibly are >= 0, but that would require changing the default value from `-1` to `0`), turning the `$attributes_only` parameter into a `bool`, and possibly just split the batch processing functionality into new functions.

However, this should already address some issues and improve code readability.

Depends partially on: #16102