### PR TITLE
test(pdo_firebird): Fix the dummy server running on localhost to IPv4

### DIFF
--- a/ext/pdo_firebird/tests/payload_server.php
+++ b/ext/pdo_firebird/tests/payload_server.php
@@ -1,6 +1,6 @@
 <?php
 
-$socket = stream_socket_server("tcp://localhost:0", $errno, $errstr);
+$socket = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
 if (!$socket) {
     echo "Can't start server: $errstr ($errno)\n";
     exit(1);


### PR DESCRIPTION
This is related to #16113.

In the pdo_firebird test, a dummy server was created on `localhost` using `stream_socket_server()` to test for error responses that do not normally occur.

`stream_socket_get_name()` was used to generate the name of the dummy server, but this function seems to return the IPv6 address `::1` even in host environments where IPv6 is not available. As a result, [in certain environments it was not possible to connect to the dummy server, and the test failed](https://github.com/php/php-src/pull/16113#discussion_r1779894775).

This problem is solved by creating a server on `127.0.0.1` and fixing it to IPv4, rather than creating it on `localhost` and leaving the choice of IPv6 or IPv4 to `stream_socket_get_name()`.