### PR TITLE
test(pdo_pgsql): Exclude `pdo` implicitly required by `pdo_pgsql` from `EXTENSIONS`

### DIFF
--- a/ext/pdo_pgsql/tests/bug36727.phpt
+++ b/ext/pdo_pgsql/tests/bug36727.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #36727 (segfault in bindValue() when no parameters are defined)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug43925.phpt
+++ b/ext/pdo_pgsql/tests/bug43925.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #43925 (Incorrect argument counter in prepared statements with pgsql)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug46274.phpt
+++ b/ext/pdo_pgsql/tests/bug46274.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #46274 (pdo_pgsql - Segfault when using PDO::ATTR_STRINGIFY_FETCHES and blob)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug46274_2.phpt
+++ b/ext/pdo_pgsql/tests/bug46274_2.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #46274 (pdo_pgsql - Segfault when using PDO::ATTR_STRINGIFY_FETCHES and blob)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug48764.phpt
+++ b/ext/pdo_pgsql/tests/bug48764.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #48764 (PDO_pgsql::query always uses implicit prepared statements if v3 proto available)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug61267.phpt
+++ b/ext/pdo_pgsql/tests/bug61267.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO::exec() returns 0 when the statement is a SELECT.
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug62479.phpt
+++ b/ext/pdo_pgsql/tests/bug62479.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #62479 (PDO-psql cannot connect if password contains spaces)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug62498-32bit.phpt
+++ b/ext/pdo_pgsql/tests/bug62498-32bit.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #62498 (pdo_pgsql inefficient when getColumnMeta() is used), 32-bit
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug62498.phpt
+++ b/ext/pdo_pgsql/tests/bug62498.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #62498 (pdo_pgsql inefficient when getColumnMeta() is used), 64-bit
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug62593.phpt
+++ b/ext/pdo_pgsql/tests/bug62593.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #62593 (Emulate prepares behave strangely with PARAM_BOOL)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug64953.phpt
+++ b/ext/pdo_pgsql/tests/bug64953.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #64953 (Postgres prepared statement positional parameter casting)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug66584.phpt
+++ b/ext/pdo_pgsql/tests/bug66584.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #66584 (Segmentation fault on statement deallocation)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug67462.phpt
+++ b/ext/pdo_pgsql/tests/bug67462.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #67462 (PDO_PGSQL::beginTransaction() wrongly throws exception when not in transaction)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug68199.phpt
+++ b/ext/pdo_pgsql/tests/bug68199.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #68199 (PDO::pgsqlGetNotify doesn't support NOTIFY payloads)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug68371.phpt
+++ b/ext/pdo_pgsql/tests/bug68371.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #38671 (PDO#getAttribute() cannot be called with platform-specific attribute names)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug69344.phpt
+++ b/ext/pdo_pgsql/tests/bug69344.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #69344 (PDO PgSQL Incorrect binding numeric array with gaps)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug69362.phpt
+++ b/ext/pdo_pgsql/tests/bug69362.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #69362 (PDO-pgsql fails to connect if password contains a leading single quote)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug69752.phpt
+++ b/ext/pdo_pgsql/tests/bug69752.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #69752 (memory leak with closeCursor)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug70313.phpt
+++ b/ext/pdo_pgsql/tests/bug70313.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #70313 (PDO statement fails to throw exception)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug70861.phpt
+++ b/ext/pdo_pgsql/tests/bug70861.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #70861 Segmentation fault in pdo_parse_params() during Drupal 8 test suite
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug71573.phpt
+++ b/ext/pdo_pgsql/tests/bug71573.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #71573 (Segfault (core dumped) if paramno beyond bound)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug71885.phpt
+++ b/ext/pdo_pgsql/tests/bug71885.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Request #71855 (PDO placeholder escaping)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug71885_2.phpt
+++ b/ext/pdo_pgsql/tests/bug71885_2.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Request #71855 (PDO placeholder escaping, part 2)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug72294.phpt
+++ b/ext/pdo_pgsql/tests/bug72294.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #72294 Segmentation fault/invalid pointer in connection with pgsql_stmt_dtor
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug72570.phpt
+++ b/ext/pdo_pgsql/tests/bug72570.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #72570 (Segmentation fault when binding parameters on a query without placeholders)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug72633.phpt
+++ b/ext/pdo_pgsql/tests/bug72633.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #72633 (Postgres PDO lastInsertId() should work without specifying a sequence)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug73959.phpt
+++ b/ext/pdo_pgsql/tests/bug73959.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #73959 (lastInsertId fails to throw an exception)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug75402.phpt
+++ b/ext/pdo_pgsql/tests/bug75402.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #75402 Possible Memory Leak using PDO::CURSOR_SCROLL option
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug81343.phpt
+++ b/ext/pdo_pgsql/tests/bug81343.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #81343 pdo_pgsql: Inconsitent boolean conversion after calling closeCursor()
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug_14244.phpt
+++ b/ext/pdo_pgsql/tests/bug_14244.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #14244 (Postgres sees parameters in a dollar-delimited string)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug_33876.phpt
+++ b/ext/pdo_pgsql/tests/bug_33876.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Bug #33876 (PDO misquotes/miscasts bool(false))
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/bug_49985.phpt
+++ b/ext/pdo_pgsql/tests/bug_49985.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug #49985 (pdo_pgsql prepare() re-use previous aborted transaction)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/copy_from.phpt
+++ b/ext/pdo_pgsql/tests/copy_from.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL pgsqlCopyFromArray and pgsqlCopyFromFile
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/copy_to.phpt
+++ b/ext/pdo_pgsql/tests/copy_to.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL pgsqlCopyToArray and pgsqlCopyToFile
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/disable_prepares.phpt
+++ b/ext/pdo_pgsql/tests/disable_prepares.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL PGSQL_ATTR_DISABLE_PREPARES
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/float.phpt
+++ b/ext/pdo_pgsql/tests/float.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL float value
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/getnotify.phpt
+++ b/ext/pdo_pgsql/tests/getnotify.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL LISTEN/NOTIFY support
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/gh12423.phpt
+++ b/ext/pdo_pgsql/tests/gh12423.phpt
@@ -1,7 +1,6 @@
 --TEST--
 GitHub #12424 (Fix GH-12423: [pdo_pgsql] Changed to prioritize DSN authentication information over arguments.)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/gh7723.phpt
+++ b/ext/pdo_pgsql/tests/gh7723.phpt
@@ -1,7 +1,6 @@
 --TEST--
 GitHub #7723 (Fix error message allocation of PDO PgSQL)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/gh9411.phpt
+++ b/ext/pdo_pgsql/tests/gh9411.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Bug GH-9411 (PgSQL large object resource is incorrectly closed)
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/is_in_transaction.phpt
+++ b/ext/pdo_pgsql/tests/is_in_transaction.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL isInTransaction
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/large_objects.phpt
+++ b/ext/pdo_pgsql/tests/large_objects.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL Large Objects
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdo_pgsql_parser.phpt
+++ b/ext/pdo_pgsql/tests/pdo_pgsql_parser.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PgSQL PDO Parser custom syntax
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdopgsql_001.phpt
+++ b/ext/pdo_pgsql/tests/pdopgsql_001.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Pdo\Pgsql subclass basic
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdopgsql_002.phpt
+++ b/ext/pdo_pgsql/tests/pdopgsql_002.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Pdo\Pgsql connect through PDO::connect
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdopgsql_003.phpt
+++ b/ext/pdo_pgsql/tests/pdopgsql_003.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Pdo\Pgsql getWarningCount
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdopgsql_setNoticeCallback.phpt
+++ b/ext/pdo_pgsql/tests/pdopgsql_setNoticeCallback.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Pdo\Pgsql::setNoticeCallback()
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pdopgsql_setNoticeCallback_trampoline_no_leak.phpt
+++ b/ext/pdo_pgsql/tests/pdopgsql_setNoticeCallback_trampoline_no_leak.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Pdo\Pgsql::setNoticeCallback() use F ZPP for trampoline callback and does not leak
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php

--- a/ext/pdo_pgsql/tests/pg_debug_emulated_prepares.phpt
+++ b/ext/pdo_pgsql/tests/pg_debug_emulated_prepares.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PDO PgSQL PDOStatement::debugDumpParams() with emulated prepares
 --EXTENSIONS--
-pdo
 pdo_pgsql
 --SKIPIF--
 <?php


### PR DESCRIPTION
The `EXTENSIONS` written in `pdo_pgsql` tests are:

* Both `pdo` and `pdo_pgsql` are declared
* Only `pdo_pgsql` is declared

Both were mixed. However, if `pdo_pgsql` is installed, `pdo` will be present, so there is no need to specify both.

Therefore, I unified all tests to declare only `pdo_pgsql`.