### PR TITLE
[skip ci] Re-enable nightly redis build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -871,8 +871,6 @@ jobs:
           repository: php-memcached-dev/php-memcached
           path: memcached
       - name: git checkout redis
-        # Currently fails to build
-        if: false
         uses: actions/checkout@v4
         with:
           repository: phpredis/phpredis
@@ -933,8 +931,6 @@ jobs:
           ./configure --prefix=/opt/php --with-php-config=/opt/php/bin/php-config
           make -j$(/usr/bin/nproc)
       - name: build redis
-        # Currently fails to build
-        if: false
         run: |
           cd redis
           /opt/php/bin/phpize

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -876,6 +876,7 @@ jobs:
           repository: phpredis/phpredis
           path: redis
       - name: git checkout xdebug
+        if: false
         uses: actions/checkout@v4
         with:
           repository: xdebug/xdebug
@@ -937,6 +938,7 @@ jobs:
           ./configure --prefix=/opt/php --with-php-config=/opt/php/bin/php-config
           make -j$(/usr/bin/nproc)
       - name: build xdebug
+        if: false
         run: |
           cd xdebug
           /opt/php/bin/phpize


### PR DESCRIPTION
Is there an easy way to test whether the build works again?

cc @iluuu1994 