### PR TITLE
Optimize in-memory XMLWriter

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.h
+++ b/ext/xmlwriter/php_xmlwriter.h
@@ -35,7 +35,7 @@ extern zend_module_entry xmlwriter_module_entry;
 /* Extends zend object */
 typedef struct _ze_xmlwriter_object {
 	xmlTextWriterPtr ptr;
-	xmlBufferPtr output;
+	smart_str *output;
 	zend_object std;
 } ze_xmlwriter_object;
 

--- a/ext/xmlwriter/tests/xmlwriter_toMemory_flush_combinations.phpt
+++ b/ext/xmlwriter/tests/xmlwriter_toMemory_flush_combinations.phpt
@@ -1,0 +1,23 @@
+--TEST--
+XMLWriter::toMemory() with combinations of empty flush and non-empty flush
+--EXTENSIONS--
+xmlwriter
+--FILE--
+<?php
+
+$writer = XMLWriter::toMemory();
+var_dump($writer->flush(empty: false));
+$writer->startElement('foo');
+var_dump($writer->flush(empty: false));
+$writer->endElement();
+var_dump($writer->flush(empty: false));
+var_dump($writer->flush());
+var_dump($writer->flush());
+
+?>
+--EXPECT--
+string(0) ""
+string(4) "<foo"
+string(6) "<foo/>"
+string(6) "<foo/>"
+string(0) ""


### PR DESCRIPTION
We're currently using a libxml buffer, which requires copying the buffer to zend_strings every time we want to output the string. Furthermore, its use of the system allocator instead of ZendMM makes it not count towards the memory_limit and hinders performance.

This patch adds a custom writer such that the strings are written to a smart_str instance, using ZendMM for improved performance, and giving the ability to not copy the string in the common case where flush has empty set to true.