### PR TITLE
Avoid dl() in run-tests.php

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -84,8 +84,6 @@ rem set SSLEAY_CONF=
 
 rem prepare for OPcache
 if "%OPCACHE%" equ "1" set OPCACHE_OPTS=-d opcache.enable=1 -d opcache.enable_cli=1 -d opcache.protect_memory=1 -d opcache.jit_buffer_size=64M -d opcache.jit=tracing
-rem work-around for failing to dl(mysqli) with OPcache (https://github.com/php/php-src/issues/8508)
-if "%OPCACHE%" equ "1" set OPCACHE_OPTS=%OPCACHE_OPTS% -d extension=mysqli
 
 rem prepare for enchant
 mkdir %~d0\usr\local\lib\enchant-2

--- a/run-tests.php
+++ b/run-tests.php
@@ -867,7 +867,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
-                if (!extension_loaded($matches[1]) && @dl($matches[1])) {
+                if (!extension_loaded($matches[1])) {
                     $exts[] = $matches[1];
                 }
             }


### PR DESCRIPTION
Prior to running the tests, the test runner checks for all generally available extensions; it does this by scanning the `extension_dir` for files matching the typical extension pattern, but verifies that the file is actually a PHP extension by calling `dl()`.  However, `dl()` has known issues[1].  On Windows CI we always get an ugly "zend_mm_heap corrupted" message, and we even can't `dl()` ext/mysql when OPcache is enabled[2].  So we better avoid the double-check with `dl()`, which is unlikely to be necessary anyway.

[1] <https://github.com/php/php-src/issues/9196>
[2] <https://github.com/php/php-src/issues/8508>