### PR TITLE
reflection: Fix the return value of ReflectionFunction::{getNamespaceName,inNamespace}() for closures

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-16009 (Segmentation fault with frameless functions and
     undefined CVs). (nielsdos)
 
+- Reflection:
+  . Fixed bug GH-16122 (The return value of ReflectionFunction::getNamespaceName()
+    and ReflectionFunction::inNamespace() for closures is incorrect). (timwolla)
+
 - SAPI:
   . Fixed bug GHSA-9pqp-7h25-4f32 (Erroneous parsing of multipart form data).
     (CVE-2024-8925) (Arnaud)

--- a/Zend/tests/closure_067.phpt
+++ b/Zend/tests/closure_067.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionFunction::getShortName() returns the full name for closures defined in namespaces.
+ReflectionFunction::get{Short,Namespace}Name() and inNamespace() return the correct data for closures defined in namespaces.
 --FILE--
 <?php
 namespace Foo;
@@ -14,7 +14,17 @@ class Bar {
 
 $c = (new Bar())->baz();
 $r = new \ReflectionFunction($c);
+// Closures are not inside of a namespace, thus the short name is the full name.
 var_dump($r->getShortName());
+// The namespace is empty.
+var_dump($r->getNamespaceName());
+// The function is not inside of a namespace.
+var_dump($r->inNamespace());
+// And the namespace name + the short name together must be the full name.
+var_dump($r->getNamespaceName() . ($r->inNamespace() ? '\\' : '') . $r->getShortName() === $r->getName());
 ?>
 --EXPECT--
 string(26) "{closure:Foo\Bar::baz():6}"
+string(0) ""
+bool(false)
+bool(true)

--- a/Zend/tests/closure_068.phpt
+++ b/Zend/tests/closure_068.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionFunction::getShortName() returns the short name for first class callables defined in namespaces.
+ReflectionFunction::get{Short,Namespace}Name() and inNamespace() return the correct data for first class callables defined in namespaces.
 --FILE--
 <?php
 namespace Foo;
@@ -7,7 +7,21 @@ namespace Foo;
 function foo() {
 }
 $r = new \ReflectionFunction(foo(...));
+$r2 = new \ReflectionFunction('Foo\\foo');
 var_dump($r->getShortName());
+var_dump($r->getNamespaceName());
+var_dump($r->inNamespace());
+var_dump($r->getNamespaceName() . ($r->inNamespace() ? '\\' : '') . $r->getShortName() === $r->getName());
+
+var_dump($r->getShortName() === $r2->getShortName());
+var_dump($r->getNamespaceName() === $r2->getNamespaceName());
+var_dump($r->inNamespace() === $r2->inNamespace());
 ?>
 --EXPECT--
 string(3) "foo"
+string(3) "Foo"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3584,13 +3584,13 @@ ZEND_METHOD(ReflectionFunctionAbstract, inNamespace)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) != ZEND_ACC_CLOSURE) {
-		zend_string *name = fptr->common.function_name;
-		const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
-		RETURN_BOOL(backslash);
+	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) == ZEND_ACC_CLOSURE) {
+		RETURN_FALSE;
 	}
 
-	RETURN_FALSE;
+	zend_string *name = fptr->common.function_name;
+	const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
+	RETURN_BOOL(backslash);
 }
 /* }}} */
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3584,9 +3584,13 @@ ZEND_METHOD(ReflectionFunctionAbstract, inNamespace)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	zend_string *name = fptr->common.function_name;
-	const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
-	RETURN_BOOL(backslash);
+	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) != ZEND_ACC_CLOSURE) {
+		zend_string *name = fptr->common.function_name;
+		const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
+		RETURN_BOOL(backslash);
+	}
+
+	RETURN_FALSE;
 }
 /* }}} */
 
@@ -3602,11 +3606,14 @@ ZEND_METHOD(ReflectionFunctionAbstract, getNamespaceName)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	zend_string *name = fptr->common.function_name;
-	const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
-	if (backslash) {
-		RETURN_STRINGL(ZSTR_VAL(name), backslash - ZSTR_VAL(name));
+	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) != ZEND_ACC_CLOSURE) {
+		zend_string *name = fptr->common.function_name;
+		const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
+		if (backslash) {
+			RETURN_STRINGL(ZSTR_VAL(name), backslash - ZSTR_VAL(name));
+		}
 	}
+
 	RETURN_EMPTY_STRING();
 }
 /* }}} */

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3606,14 +3606,15 @@ ZEND_METHOD(ReflectionFunctionAbstract, getNamespaceName)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) != ZEND_ACC_CLOSURE) {
-		zend_string *name = fptr->common.function_name;
-		const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
-		if (backslash) {
-			RETURN_STRINGL(ZSTR_VAL(name), backslash - ZSTR_VAL(name));
-		}
+	if ((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) == ZEND_ACC_CLOSURE) {
+		RETURN_EMPTY_STRING();
 	}
 
+	zend_string *name = fptr->common.function_name;
+	const char *backslash = zend_memrchr(ZSTR_VAL(name), '\\', ZSTR_LEN(name));
+	if (backslash) {
+		RETURN_STRINGL(ZSTR_VAL(name), backslash - ZSTR_VAL(name));
+	}
 	RETURN_EMPTY_STRING();
 }
 /* }}} */


### PR DESCRIPTION
> The output is definitely bad, but closures don't have a namespace. Not sure what the correct output would be.

Given the (reasonable) assumption that namespacename + shortname = name, the only option is to return an empty namespace and return false when asking if the closure is inside of a namespace.

----------------

Fixes GH-16122