### PR TITLE
Fix nightly builds regarding libavif

### DIFF
--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -6,6 +6,9 @@ inputs:
   skipSlow:
     default: false
     required: false
+  asan:
+    default: false
+    required: false
 runs:
   using: composite
   steps:
@@ -28,7 +31,7 @@ runs:
           --enable-gd \
           --with-jpeg \
           --with-webp \
-          ${{ inputs.skipSlow == 'false' && '--with-avif' || '' }} \
+          ${{ inputs.asan == 'false' && '--with-avif' || '' }} \
           --with-freetype \
           --with-xpm \
           --enable-exif \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,6 +147,8 @@ jobs:
         uses: ./.github/actions/setup-mssql
       - name: apt
         uses: ./.github/actions/apt-x64
+        with:
+          asan: ${{ matrix.asan && 'true' || 'false' }}
       - name: System info
         run: |
           echo "::group::Show host CPU info"


### PR DESCRIPTION
Currently, we're running LINUX_X64 Asan builds on ubuntu-20.04, where libavif-dev is not available, so apt-x64 fails.  This PR is a follow up to PR #16049 to pass the respective parameter to apt-x64, and to fix the conditional check in configure-x64.

It might be clearer to just have an `avif` parameter or to pass the runner version to these actions, but this should do for now.

---

@iluuu1994, what do you think? Does this needs to be applied to lower branches, too?