### PR TITLE
Generated arginfo header files: replace `sizeof()` with `strlen()`

### DIFF
--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -85,59 +85,59 @@ static zend_class_entry *register_class_Attribute(void)
 
 	zval const_TARGET_CLASS_value;
 	ZVAL_LONG(&const_TARGET_CLASS_value, ZEND_ATTRIBUTE_TARGET_CLASS);
-	zend_string *const_TARGET_CLASS_name = zend_string_init_interned("TARGET_CLASS", sizeof("TARGET_CLASS") - 1, 1);
+	zend_string *const_TARGET_CLASS_name = zend_string_init_interned("TARGET_CLASS", strlen("TARGET_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_CLASS_name, &const_TARGET_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_CLASS_name);
 
 	zval const_TARGET_FUNCTION_value;
 	ZVAL_LONG(&const_TARGET_FUNCTION_value, ZEND_ATTRIBUTE_TARGET_FUNCTION);
-	zend_string *const_TARGET_FUNCTION_name = zend_string_init_interned("TARGET_FUNCTION", sizeof("TARGET_FUNCTION") - 1, 1);
+	zend_string *const_TARGET_FUNCTION_name = zend_string_init_interned("TARGET_FUNCTION", strlen("TARGET_FUNCTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_FUNCTION_name, &const_TARGET_FUNCTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_FUNCTION_name);
 
 	zval const_TARGET_METHOD_value;
 	ZVAL_LONG(&const_TARGET_METHOD_value, ZEND_ATTRIBUTE_TARGET_METHOD);
-	zend_string *const_TARGET_METHOD_name = zend_string_init_interned("TARGET_METHOD", sizeof("TARGET_METHOD") - 1, 1);
+	zend_string *const_TARGET_METHOD_name = zend_string_init_interned("TARGET_METHOD", strlen("TARGET_METHOD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_METHOD_name, &const_TARGET_METHOD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_METHOD_name);
 
 	zval const_TARGET_PROPERTY_value;
 	ZVAL_LONG(&const_TARGET_PROPERTY_value, ZEND_ATTRIBUTE_TARGET_PROPERTY);
-	zend_string *const_TARGET_PROPERTY_name = zend_string_init_interned("TARGET_PROPERTY", sizeof("TARGET_PROPERTY") - 1, 1);
+	zend_string *const_TARGET_PROPERTY_name = zend_string_init_interned("TARGET_PROPERTY", strlen("TARGET_PROPERTY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_PROPERTY_name, &const_TARGET_PROPERTY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_PROPERTY_name);
 
 	zval const_TARGET_CLASS_CONSTANT_value;
 	ZVAL_LONG(&const_TARGET_CLASS_CONSTANT_value, ZEND_ATTRIBUTE_TARGET_CLASS_CONST);
-	zend_string *const_TARGET_CLASS_CONSTANT_name = zend_string_init_interned("TARGET_CLASS_CONSTANT", sizeof("TARGET_CLASS_CONSTANT") - 1, 1);
+	zend_string *const_TARGET_CLASS_CONSTANT_name = zend_string_init_interned("TARGET_CLASS_CONSTANT", strlen("TARGET_CLASS_CONSTANT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_CLASS_CONSTANT_name, &const_TARGET_CLASS_CONSTANT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_CLASS_CONSTANT_name);
 
 	zval const_TARGET_PARAMETER_value;
 	ZVAL_LONG(&const_TARGET_PARAMETER_value, ZEND_ATTRIBUTE_TARGET_PARAMETER);
-	zend_string *const_TARGET_PARAMETER_name = zend_string_init_interned("TARGET_PARAMETER", sizeof("TARGET_PARAMETER") - 1, 1);
+	zend_string *const_TARGET_PARAMETER_name = zend_string_init_interned("TARGET_PARAMETER", strlen("TARGET_PARAMETER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_PARAMETER_name, &const_TARGET_PARAMETER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_PARAMETER_name);
 
 	zval const_TARGET_ALL_value;
 	ZVAL_LONG(&const_TARGET_ALL_value, ZEND_ATTRIBUTE_TARGET_ALL);
-	zend_string *const_TARGET_ALL_name = zend_string_init_interned("TARGET_ALL", sizeof("TARGET_ALL") - 1, 1);
+	zend_string *const_TARGET_ALL_name = zend_string_init_interned("TARGET_ALL", strlen("TARGET_ALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TARGET_ALL_name, &const_TARGET_ALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TARGET_ALL_name);
 
 	zval const_IS_REPEATABLE_value;
 	ZVAL_LONG(&const_IS_REPEATABLE_value, ZEND_ATTRIBUTE_IS_REPEATABLE);
-	zend_string *const_IS_REPEATABLE_name = zend_string_init_interned("IS_REPEATABLE", sizeof("IS_REPEATABLE") - 1, 1);
+	zend_string *const_IS_REPEATABLE_name = zend_string_init_interned("IS_REPEATABLE", strlen("IS_REPEATABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_REPEATABLE_name, &const_IS_REPEATABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_REPEATABLE_name);
 
 	zval property_flags_default_value;
 	ZVAL_UNDEF(&property_flags_default_value);
-	zend_string *property_flags_name = zend_string_init("flags", sizeof("flags") - 1, 1);
+	zend_string *property_flags_name = zend_string_init("flags", strlen("flags"), 1);
 	zend_declare_typed_property(class_entry, property_flags_name, &property_flags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_flags_name);
 
-	zend_string *attribute_name_Attribute_class_Attribute_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_Attribute_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_Attribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Attribute_0, 1);
 	zend_string_release(attribute_name_Attribute_class_Attribute_0);
 	zval attribute_Attribute_class_Attribute_0_arg0;
@@ -154,7 +154,7 @@ static zend_class_entry *register_class_ReturnTypeWillChange(void)
 	INIT_CLASS_ENTRY(ce, "ReturnTypeWillChange", class_ReturnTypeWillChange_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
-	zend_string *attribute_name_Attribute_class_ReturnTypeWillChange_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ReturnTypeWillChange_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ReturnTypeWillChange_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ReturnTypeWillChange_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ReturnTypeWillChange_0);
 	zval attribute_Attribute_class_ReturnTypeWillChange_0_arg0;
@@ -171,7 +171,7 @@ static zend_class_entry *register_class_AllowDynamicProperties(void)
 	INIT_CLASS_ENTRY(ce, "AllowDynamicProperties", class_AllowDynamicProperties_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
-	zend_string *attribute_name_Attribute_class_AllowDynamicProperties_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_AllowDynamicProperties_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_AllowDynamicProperties_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_AllowDynamicProperties_0, 1);
 	zend_string_release(attribute_name_Attribute_class_AllowDynamicProperties_0);
 	zval attribute_Attribute_class_AllowDynamicProperties_0_arg0;
@@ -188,7 +188,7 @@ static zend_class_entry *register_class_SensitiveParameter(void)
 	INIT_CLASS_ENTRY(ce, "SensitiveParameter", class_SensitiveParameter_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
-	zend_string *attribute_name_Attribute_class_SensitiveParameter_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_SensitiveParameter_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_SensitiveParameter_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_SensitiveParameter_0, 1);
 	zend_string_release(attribute_name_Attribute_class_SensitiveParameter_0);
 	zval attribute_Attribute_class_SensitiveParameter_0_arg0;
@@ -219,7 +219,7 @@ static zend_class_entry *register_class_Override(void)
 	INIT_CLASS_ENTRY(ce, "Override", class_Override_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
-	zend_string *attribute_name_Attribute_class_Override_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_Override_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_Override_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Override_0, 1);
 	zend_string_release(attribute_name_Attribute_class_Override_0);
 	zval attribute_Attribute_class_Override_0_arg0;
@@ -244,7 +244,7 @@ static zend_class_entry *register_class_Deprecated(void)
 	ZVAL_UNDEF(&property_since_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_SINCE), &property_since_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 
-	zend_string *attribute_name_Attribute_class_Deprecated_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_Deprecated_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_Deprecated_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Deprecated_0, 1);
 	zend_string_release(attribute_name_Attribute_class_Deprecated_0);
 	zval attribute_Attribute_class_Deprecated_0_arg0;

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -371,7 +371,7 @@ static zend_class_entry *register_class_stdClass(void)
 	INIT_CLASS_ENTRY(ce, "stdClass", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 
-	zend_string *attribute_name_AllowDynamicProperties_class_stdClass_0 = zend_string_init_interned("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
+	zend_string *attribute_name_AllowDynamicProperties_class_stdClass_0 = zend_string_init_interned("AllowDynamicProperties", strlen("AllowDynamicProperties"), 1);
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_stdClass_0, 0);
 	zend_string_release(attribute_name_AllowDynamicProperties_class_stdClass_0);
 

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -187,7 +187,7 @@ static zend_class_entry *register_class_Exception(zend_class_entry *class_entry_
 
 	zval property_previous_default_value;
 	ZVAL_NULL(&property_previous_default_value);
-	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
+	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", strlen("Throwable"), 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 
 	return class_entry;
@@ -241,7 +241,7 @@ static zend_class_entry *register_class_Error(zend_class_entry *class_entry_Thro
 
 	zval property_previous_default_value;
 	ZVAL_NULL(&property_previous_default_value);
-	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
+	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", strlen("Throwable"), 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 
 	return class_entry;

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -2445,7 +2445,7 @@ abstract class VariableLike
                     foreach ($arginfoType->classTypes as $classType) {
                         $escapedClassName = $classType->toEscapedName();
                         $varEscapedClassName = $classType->toVarEscapedName();
-                        $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\") - 1, 1);\n";
+                        $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", strlen(\"{$escapedClassName}\"), 1);\n";
                     }
 
                     $classTypeCount = count($arginfoType->classTypes);
@@ -2468,7 +2468,7 @@ abstract class VariableLike
                 } else {
                     $escapedClassName = $arginfoType->classTypes[0]->toEscapedName();
                     $varEscapedClassName = $arginfoType->classTypes[0]->toVarEscapedName();
-                    $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\")-1, 1);\n";
+                    $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", strlen(\"{$escapedClassName}\"), 1);\n";
 
                     $typeCode = "(zend_type) ZEND_TYPE_INIT_CLASS({$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName}, 0, " . $arginfoType->toTypeMask() . ")";
                 }
@@ -2772,7 +2772,7 @@ class ConstInfo extends VariableLike
 
         $code = "\n" . $zvalCode;
 
-        $code .= "\tzend_string *const_{$constName}_name = zend_string_init_interned(\"$constName\", sizeof(\"$constName\") - 1, 1);\n";
+        $code .= "\tzend_string *const_{$constName}_name = zend_string_init_interned(\"$constName\", strlen(\"$constName\"), 1);\n";
         $nameCode = "const_{$constName}_name";
 
         if ($this->exposedDocComment) {
@@ -3149,7 +3149,7 @@ class PropertyInfo extends VariableLike
         // Generally strings will not be known
         $nameCode = "property_{$propName}_name";
         $result = [
-            "\tzend_string *$nameCode = zend_string_init(\"$propName\", sizeof(\"$propName\") - 1, 1);\n",
+            "\tzend_string *$nameCode = zend_string_init(\"$propName\", strlen(\"$propName\"), 1);\n",
             $nameCode,
             "\tzend_string_release($nameCode);\n"
         ];
@@ -3297,7 +3297,7 @@ class AttributeInfo {
         if (isset($knowns[$escapedAttributeName])) {
             $code .= "\t" . ($this->args ? "zend_attribute *attribute_{$escapedAttributeName}_$nameSuffix = " : "") . "$invocation, ZSTR_KNOWN({$knowns[$escapedAttributeName]}), " . count($this->args) . ");\n";
         } else {
-            $code .= "\tzend_string *attribute_name_{$escapedAttributeName}_$nameSuffix = zend_string_init_interned(\"" . addcslashes($this->class, "\\") . "\", sizeof(\"" . addcslashes($this->class, "\\") . "\") - 1, 1);\n";
+            $code .= "\tzend_string *attribute_name_{$escapedAttributeName}_$nameSuffix = zend_string_init_interned(\"" . addcslashes($this->class, "\\") . "\", strlen(\"" . addcslashes($this->class, "\\") . "\"), 1);\n";
             $code .= "\t" . ($this->args ? "zend_attribute *attribute_{$escapedAttributeName}_$nameSuffix = " : "") . "$invocation, attribute_name_{$escapedAttributeName}_$nameSuffix, " . count($this->args) . ");\n";
             $code .= "\tzend_string_release(attribute_name_{$escapedAttributeName}_$nameSuffix);\n";
         }
@@ -3310,7 +3310,7 @@ class AttributeInfo {
                 if (isset($knowns[$arg->name->name])) {
                     $code .= "\tattribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].name = ZSTR_KNOWN({$knowns[$arg->name->name]});\n";
                 } else {
-                    $code .= "\tattribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].name = zend_string_init_interned(\"{$arg->name->name}\", sizeof(\"{$arg->name->name}\") - 1, 1);\n";
+                    $code .= "\tattribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].name = zend_string_init_interned(\"{$arg->name->name}\", strlen(\"{$arg->name->name}\"), 1);\n";
                 }
             }
         }
@@ -5382,7 +5382,7 @@ function generateFunctionAttributeInitialization(iterable $funcInfos, array $all
 
             foreach ($funcInfo->attributes as $key => $attribute) {
                 $code .= $attribute->generateCode(
-                    "zend_add_function_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", sizeof(\"" . $funcInfo->name->getNameForAttributes() . "\") - 1)",
+                    "zend_add_function_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", strlen(\"" . $funcInfo->name->getNameForAttributes() . "\"))",
                     "func_" . $funcInfo->name->getNameForAttributes() . "_$key",
                     $allConstInfos,
                     $phpVersionIdMinimumCompatibility
@@ -5392,7 +5392,7 @@ function generateFunctionAttributeInitialization(iterable $funcInfos, array $all
             foreach ($funcInfo->args as $index => $arg) {
                 foreach ($arg->attributes as $key => $attribute) {
                     $code .= $attribute->generateCode(
-                        "zend_add_parameter_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", sizeof(\"" . $funcInfo->name->getNameForAttributes() . "\") - 1), $index",
+                        "zend_add_parameter_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", strlen(\"" . $funcInfo->name->getNameForAttributes() . "\")), $index",
                         "func_{$funcInfo->name->getNameForAttributes()}_arg{$index}_$key",
                         $allConstInfos,
                         $phpVersionIdMinimumCompatibility

--- a/ext/bcmath/bcmath_arginfo.h
+++ b/ext/bcmath/bcmath_arginfo.h
@@ -208,7 +208,7 @@ static zend_class_entry *register_class_BcMath_Number(zend_class_entry *class_en
 
 	zval property_scale_default_value;
 	ZVAL_UNDEF(&property_scale_default_value);
-	zend_string *property_scale_name = zend_string_init("scale", sizeof("scale") - 1, 1);
+	zend_string *property_scale_name = zend_string_init("scale", strlen("scale"), 1);
 	zend_declare_typed_property(class_entry, property_scale_name, &property_scale_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_scale_name);
 

--- a/ext/curl/curl_file_arginfo.h
+++ b/ext/curl/curl_file_arginfo.h
@@ -64,13 +64,13 @@ static zend_class_entry *register_class_CURLFile(void)
 
 	zval property_mime_default_value;
 	ZVAL_EMPTY_STRING(&property_mime_default_value);
-	zend_string *property_mime_name = zend_string_init("mime", sizeof("mime") - 1, 1);
+	zend_string *property_mime_name = zend_string_init("mime", strlen("mime"), 1);
 	zend_declare_typed_property(class_entry, property_mime_name, &property_mime_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_mime_name);
 
 	zval property_postname_default_value;
 	ZVAL_EMPTY_STRING(&property_postname_default_value);
-	zend_string *property_postname_name = zend_string_init("postname", sizeof("postname") - 1, 1);
+	zend_string *property_postname_name = zend_string_init("postname", strlen("postname"), 1);
 	zend_declare_typed_property(class_entry, property_postname_name, &property_postname_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_postname_name);
 
@@ -86,19 +86,19 @@ static zend_class_entry *register_class_CURLStringFile(void)
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_postname_default_value;
 	ZVAL_UNDEF(&property_postname_default_value);
-	zend_string *property_postname_name = zend_string_init("postname", sizeof("postname") - 1, 1);
+	zend_string *property_postname_name = zend_string_init("postname", strlen("postname"), 1);
 	zend_declare_typed_property(class_entry, property_postname_name, &property_postname_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_postname_name);
 
 	zval property_mime_default_value;
 	ZVAL_UNDEF(&property_mime_default_value);
-	zend_string *property_mime_name = zend_string_init("mime", sizeof("mime") - 1, 1);
+	zend_string *property_mime_name = zend_string_init("mime", strlen("mime"), 1);
 	zend_declare_typed_property(class_entry, property_mime_name, &property_mime_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_mime_name);
 

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -813,7 +813,7 @@ static void register_php_date_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("SUNFUNCS_RET_DOUBLE", SUNFUNCS_RET_DOUBLE, CONST_PERSISTENT | CONST_DEPRECATED);
 
 
-	zend_attribute *attribute_Deprecated_func_strftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strftime", sizeof("strftime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_strftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strftime", strlen("strftime")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_strftime_0_arg0;
 	zend_string *attribute_Deprecated_func_strftime_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_strftime_0_arg0, attribute_Deprecated_func_strftime_0_arg0_str);
@@ -825,7 +825,7 @@ static void register_php_date_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_strftime_0->args[1].value, &attribute_Deprecated_func_strftime_0_arg1);
 	attribute_Deprecated_func_strftime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_gmstrftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "gmstrftime", sizeof("gmstrftime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_gmstrftime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "gmstrftime", strlen("gmstrftime")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_gmstrftime_0_arg0;
 	zend_string *attribute_Deprecated_func_gmstrftime_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_gmstrftime_0_arg0, attribute_Deprecated_func_gmstrftime_0_arg0_str);
@@ -837,7 +837,7 @@ static void register_php_date_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_gmstrftime_0->args[1].value, &attribute_Deprecated_func_gmstrftime_0_arg1);
 	attribute_Deprecated_func_gmstrftime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_date_sunrise_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunrise", sizeof("date_sunrise") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_date_sunrise_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunrise", strlen("date_sunrise")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_date_sunrise_0_arg0;
 	zend_string *attribute_Deprecated_func_date_sunrise_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_date_sunrise_0_arg0, attribute_Deprecated_func_date_sunrise_0_arg0_str);
@@ -849,7 +849,7 @@ static void register_php_date_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_date_sunrise_0->args[1].value, &attribute_Deprecated_func_date_sunrise_0_arg1);
 	attribute_Deprecated_func_date_sunrise_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_date_sunset_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunset", sizeof("date_sunset") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_date_sunset_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "date_sunset", strlen("date_sunset")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_date_sunset_0_arg0;
 	zend_string *attribute_Deprecated_func_date_sunset_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_date_sunset_0_arg0, attribute_Deprecated_func_date_sunset_0_arg0_str);
@@ -872,98 +872,98 @@ static zend_class_entry *register_class_DateTimeInterface(void)
 	zval const_ATOM_value;
 	zend_string *const_ATOM_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_ATOM_value, const_ATOM_value_str);
-	zend_string *const_ATOM_name = zend_string_init_interned("ATOM", sizeof("ATOM") - 1, 1);
+	zend_string *const_ATOM_name = zend_string_init_interned("ATOM", strlen("ATOM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATOM_name, &const_ATOM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_ATOM_name);
 
 	zval const_COOKIE_value;
 	zend_string *const_COOKIE_value_str = zend_string_init(DATE_FORMAT_COOKIE, strlen(DATE_FORMAT_COOKIE), 1);
 	ZVAL_STR(&const_COOKIE_value, const_COOKIE_value_str);
-	zend_string *const_COOKIE_name = zend_string_init_interned("COOKIE", sizeof("COOKIE") - 1, 1);
+	zend_string *const_COOKIE_name = zend_string_init_interned("COOKIE", strlen("COOKIE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_COOKIE_name, &const_COOKIE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_COOKIE_name);
 
 	zval const_ISO8601_value;
 	zend_string *const_ISO8601_value_str = zend_string_init(DATE_FORMAT_ISO8601, strlen(DATE_FORMAT_ISO8601), 1);
 	ZVAL_STR(&const_ISO8601_value, const_ISO8601_value_str);
-	zend_string *const_ISO8601_name = zend_string_init_interned("ISO8601", sizeof("ISO8601") - 1, 1);
+	zend_string *const_ISO8601_name = zend_string_init_interned("ISO8601", strlen("ISO8601"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ISO8601_name, &const_ISO8601_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_ISO8601_name);
 
 	zval const_ISO8601_EXPANDED_value;
 	zend_string *const_ISO8601_EXPANDED_value_str = zend_string_init(DATE_FORMAT_ISO8601_EXPANDED, strlen(DATE_FORMAT_ISO8601_EXPANDED), 1);
 	ZVAL_STR(&const_ISO8601_EXPANDED_value, const_ISO8601_EXPANDED_value_str);
-	zend_string *const_ISO8601_EXPANDED_name = zend_string_init_interned("ISO8601_EXPANDED", sizeof("ISO8601_EXPANDED") - 1, 1);
+	zend_string *const_ISO8601_EXPANDED_name = zend_string_init_interned("ISO8601_EXPANDED", strlen("ISO8601_EXPANDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ISO8601_EXPANDED_name, &const_ISO8601_EXPANDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_ISO8601_EXPANDED_name);
 
 	zval const_RFC822_value;
 	zend_string *const_RFC822_value_str = zend_string_init(DATE_FORMAT_RFC822, strlen(DATE_FORMAT_RFC822), 1);
 	ZVAL_STR(&const_RFC822_value, const_RFC822_value_str);
-	zend_string *const_RFC822_name = zend_string_init_interned("RFC822", sizeof("RFC822") - 1, 1);
+	zend_string *const_RFC822_name = zend_string_init_interned("RFC822", strlen("RFC822"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC822_name, &const_RFC822_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC822_name);
 
 	zval const_RFC850_value;
 	zend_string *const_RFC850_value_str = zend_string_init(DATE_FORMAT_RFC850, strlen(DATE_FORMAT_RFC850), 1);
 	ZVAL_STR(&const_RFC850_value, const_RFC850_value_str);
-	zend_string *const_RFC850_name = zend_string_init_interned("RFC850", sizeof("RFC850") - 1, 1);
+	zend_string *const_RFC850_name = zend_string_init_interned("RFC850", strlen("RFC850"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC850_name, &const_RFC850_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC850_name);
 
 	zval const_RFC1036_value;
 	zend_string *const_RFC1036_value_str = zend_string_init(DATE_FORMAT_RFC1036, strlen(DATE_FORMAT_RFC1036), 1);
 	ZVAL_STR(&const_RFC1036_value, const_RFC1036_value_str);
-	zend_string *const_RFC1036_name = zend_string_init_interned("RFC1036", sizeof("RFC1036") - 1, 1);
+	zend_string *const_RFC1036_name = zend_string_init_interned("RFC1036", strlen("RFC1036"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC1036_name, &const_RFC1036_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC1036_name);
 
 	zval const_RFC1123_value;
 	zend_string *const_RFC1123_value_str = zend_string_init(DATE_FORMAT_RFC1123, strlen(DATE_FORMAT_RFC1123), 1);
 	ZVAL_STR(&const_RFC1123_value, const_RFC1123_value_str);
-	zend_string *const_RFC1123_name = zend_string_init_interned("RFC1123", sizeof("RFC1123") - 1, 1);
+	zend_string *const_RFC1123_name = zend_string_init_interned("RFC1123", strlen("RFC1123"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC1123_name, &const_RFC1123_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC1123_name);
 
 	zval const_RFC7231_value;
 	zend_string *const_RFC7231_value_str = zend_string_init(DATE_FORMAT_RFC7231, strlen(DATE_FORMAT_RFC7231), 1);
 	ZVAL_STR(&const_RFC7231_value, const_RFC7231_value_str);
-	zend_string *const_RFC7231_name = zend_string_init_interned("RFC7231", sizeof("RFC7231") - 1, 1);
+	zend_string *const_RFC7231_name = zend_string_init_interned("RFC7231", strlen("RFC7231"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC7231_name, &const_RFC7231_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC7231_name);
 
 	zval const_RFC2822_value;
 	zend_string *const_RFC2822_value_str = zend_string_init(DATE_FORMAT_RFC2822, strlen(DATE_FORMAT_RFC2822), 1);
 	ZVAL_STR(&const_RFC2822_value, const_RFC2822_value_str);
-	zend_string *const_RFC2822_name = zend_string_init_interned("RFC2822", sizeof("RFC2822") - 1, 1);
+	zend_string *const_RFC2822_name = zend_string_init_interned("RFC2822", strlen("RFC2822"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC2822_name, &const_RFC2822_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC2822_name);
 
 	zval const_RFC3339_value;
 	zend_string *const_RFC3339_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_RFC3339_value, const_RFC3339_value_str);
-	zend_string *const_RFC3339_name = zend_string_init_interned("RFC3339", sizeof("RFC3339") - 1, 1);
+	zend_string *const_RFC3339_name = zend_string_init_interned("RFC3339", strlen("RFC3339"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC3339_name, &const_RFC3339_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC3339_name);
 
 	zval const_RFC3339_EXTENDED_value;
 	zend_string *const_RFC3339_EXTENDED_value_str = zend_string_init(DATE_FORMAT_RFC3339_EXTENDED, strlen(DATE_FORMAT_RFC3339_EXTENDED), 1);
 	ZVAL_STR(&const_RFC3339_EXTENDED_value, const_RFC3339_EXTENDED_value_str);
-	zend_string *const_RFC3339_EXTENDED_name = zend_string_init_interned("RFC3339_EXTENDED", sizeof("RFC3339_EXTENDED") - 1, 1);
+	zend_string *const_RFC3339_EXTENDED_name = zend_string_init_interned("RFC3339_EXTENDED", strlen("RFC3339_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RFC3339_EXTENDED_name, &const_RFC3339_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RFC3339_EXTENDED_name);
 
 	zval const_RSS_value;
 	zend_string *const_RSS_value_str = zend_string_init(DATE_FORMAT_RFC1123, strlen(DATE_FORMAT_RFC1123), 1);
 	ZVAL_STR(&const_RSS_value, const_RSS_value_str);
-	zend_string *const_RSS_name = zend_string_init_interned("RSS", sizeof("RSS") - 1, 1);
+	zend_string *const_RSS_name = zend_string_init_interned("RSS", strlen("RSS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RSS_name, &const_RSS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_RSS_name);
 
 	zval const_W3C_value;
 	zend_string *const_W3C_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_W3C_value, const_W3C_value_str);
-	zend_string *const_W3C_name = zend_string_init_interned("W3C", sizeof("W3C") - 1, 1);
+	zend_string *const_W3C_name = zend_string_init_interned("W3C", strlen("W3C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_W3C_name, &const_W3C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_W3C_name);
 
@@ -1001,85 +1001,85 @@ static zend_class_entry *register_class_DateTimeZone(void)
 
 	zval const_AFRICA_value;
 	ZVAL_LONG(&const_AFRICA_value, PHP_DATE_TIMEZONE_GROUP_AFRICA);
-	zend_string *const_AFRICA_name = zend_string_init_interned("AFRICA", sizeof("AFRICA") - 1, 1);
+	zend_string *const_AFRICA_name = zend_string_init_interned("AFRICA", strlen("AFRICA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AFRICA_name, &const_AFRICA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFRICA_name);
 
 	zval const_AMERICA_value;
 	ZVAL_LONG(&const_AMERICA_value, PHP_DATE_TIMEZONE_GROUP_AMERICA);
-	zend_string *const_AMERICA_name = zend_string_init_interned("AMERICA", sizeof("AMERICA") - 1, 1);
+	zend_string *const_AMERICA_name = zend_string_init_interned("AMERICA", strlen("AMERICA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AMERICA_name, &const_AMERICA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AMERICA_name);
 
 	zval const_ANTARCTICA_value;
 	ZVAL_LONG(&const_ANTARCTICA_value, PHP_DATE_TIMEZONE_GROUP_ANTARCTICA);
-	zend_string *const_ANTARCTICA_name = zend_string_init_interned("ANTARCTICA", sizeof("ANTARCTICA") - 1, 1);
+	zend_string *const_ANTARCTICA_name = zend_string_init_interned("ANTARCTICA", strlen("ANTARCTICA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ANTARCTICA_name, &const_ANTARCTICA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ANTARCTICA_name);
 
 	zval const_ARCTIC_value;
 	ZVAL_LONG(&const_ARCTIC_value, PHP_DATE_TIMEZONE_GROUP_ARCTIC);
-	zend_string *const_ARCTIC_name = zend_string_init_interned("ARCTIC", sizeof("ARCTIC") - 1, 1);
+	zend_string *const_ARCTIC_name = zend_string_init_interned("ARCTIC", strlen("ARCTIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ARCTIC_name, &const_ARCTIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ARCTIC_name);
 
 	zval const_ASIA_value;
 	ZVAL_LONG(&const_ASIA_value, PHP_DATE_TIMEZONE_GROUP_ASIA);
-	zend_string *const_ASIA_name = zend_string_init_interned("ASIA", sizeof("ASIA") - 1, 1);
+	zend_string *const_ASIA_name = zend_string_init_interned("ASIA", strlen("ASIA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ASIA_name, &const_ASIA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ASIA_name);
 
 	zval const_ATLANTIC_value;
 	ZVAL_LONG(&const_ATLANTIC_value, PHP_DATE_TIMEZONE_GROUP_ATLANTIC);
-	zend_string *const_ATLANTIC_name = zend_string_init_interned("ATLANTIC", sizeof("ATLANTIC") - 1, 1);
+	zend_string *const_ATLANTIC_name = zend_string_init_interned("ATLANTIC", strlen("ATLANTIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATLANTIC_name, &const_ATLANTIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATLANTIC_name);
 
 	zval const_AUSTRALIA_value;
 	ZVAL_LONG(&const_AUSTRALIA_value, PHP_DATE_TIMEZONE_GROUP_AUSTRALIA);
-	zend_string *const_AUSTRALIA_name = zend_string_init_interned("AUSTRALIA", sizeof("AUSTRALIA") - 1, 1);
+	zend_string *const_AUSTRALIA_name = zend_string_init_interned("AUSTRALIA", strlen("AUSTRALIA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AUSTRALIA_name, &const_AUSTRALIA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AUSTRALIA_name);
 
 	zval const_EUROPE_value;
 	ZVAL_LONG(&const_EUROPE_value, PHP_DATE_TIMEZONE_GROUP_EUROPE);
-	zend_string *const_EUROPE_name = zend_string_init_interned("EUROPE", sizeof("EUROPE") - 1, 1);
+	zend_string *const_EUROPE_name = zend_string_init_interned("EUROPE", strlen("EUROPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EUROPE_name, &const_EUROPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EUROPE_name);
 
 	zval const_INDIAN_value;
 	ZVAL_LONG(&const_INDIAN_value, PHP_DATE_TIMEZONE_GROUP_INDIAN);
-	zend_string *const_INDIAN_name = zend_string_init_interned("INDIAN", sizeof("INDIAN") - 1, 1);
+	zend_string *const_INDIAN_name = zend_string_init_interned("INDIAN", strlen("INDIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INDIAN_name, &const_INDIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INDIAN_name);
 
 	zval const_PACIFIC_value;
 	ZVAL_LONG(&const_PACIFIC_value, PHP_DATE_TIMEZONE_GROUP_PACIFIC);
-	zend_string *const_PACIFIC_name = zend_string_init_interned("PACIFIC", sizeof("PACIFIC") - 1, 1);
+	zend_string *const_PACIFIC_name = zend_string_init_interned("PACIFIC", strlen("PACIFIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PACIFIC_name, &const_PACIFIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PACIFIC_name);
 
 	zval const_UTC_value;
 	ZVAL_LONG(&const_UTC_value, PHP_DATE_TIMEZONE_GROUP_UTC);
-	zend_string *const_UTC_name = zend_string_init_interned("UTC", sizeof("UTC") - 1, 1);
+	zend_string *const_UTC_name = zend_string_init_interned("UTC", strlen("UTC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTC_name, &const_UTC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTC_name);
 
 	zval const_ALL_value;
 	ZVAL_LONG(&const_ALL_value, PHP_DATE_TIMEZONE_GROUP_ALL);
-	zend_string *const_ALL_name = zend_string_init_interned("ALL", sizeof("ALL") - 1, 1);
+	zend_string *const_ALL_name = zend_string_init_interned("ALL", strlen("ALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ALL_name, &const_ALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ALL_name);
 
 	zval const_ALL_WITH_BC_value;
 	ZVAL_LONG(&const_ALL_WITH_BC_value, PHP_DATE_TIMEZONE_GROUP_ALL_W_BC);
-	zend_string *const_ALL_WITH_BC_name = zend_string_init_interned("ALL_WITH_BC", sizeof("ALL_WITH_BC") - 1, 1);
+	zend_string *const_ALL_WITH_BC_name = zend_string_init_interned("ALL_WITH_BC", strlen("ALL_WITH_BC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ALL_WITH_BC_name, &const_ALL_WITH_BC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ALL_WITH_BC_name);
 
 	zval const_PER_COUNTRY_value;
 	ZVAL_LONG(&const_PER_COUNTRY_value, PHP_DATE_TIMEZONE_PER_COUNTRY);
-	zend_string *const_PER_COUNTRY_name = zend_string_init_interned("PER_COUNTRY", sizeof("PER_COUNTRY") - 1, 1);
+	zend_string *const_PER_COUNTRY_name = zend_string_init_interned("PER_COUNTRY", strlen("PER_COUNTRY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PER_COUNTRY_name, &const_PER_COUNTRY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PER_COUNTRY_name);
 
@@ -1106,59 +1106,59 @@ static zend_class_entry *register_class_DatePeriod(zend_class_entry *class_entry
 
 	zval const_EXCLUDE_START_DATE_value;
 	ZVAL_LONG(&const_EXCLUDE_START_DATE_value, PHP_DATE_PERIOD_EXCLUDE_START_DATE);
-	zend_string *const_EXCLUDE_START_DATE_name = zend_string_init_interned("EXCLUDE_START_DATE", sizeof("EXCLUDE_START_DATE") - 1, 1);
+	zend_string *const_EXCLUDE_START_DATE_name = zend_string_init_interned("EXCLUDE_START_DATE", strlen("EXCLUDE_START_DATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXCLUDE_START_DATE_name, &const_EXCLUDE_START_DATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXCLUDE_START_DATE_name);
 
 	zval const_INCLUDE_END_DATE_value;
 	ZVAL_LONG(&const_INCLUDE_END_DATE_value, PHP_DATE_PERIOD_INCLUDE_END_DATE);
-	zend_string *const_INCLUDE_END_DATE_name = zend_string_init_interned("INCLUDE_END_DATE", sizeof("INCLUDE_END_DATE") - 1, 1);
+	zend_string *const_INCLUDE_END_DATE_name = zend_string_init_interned("INCLUDE_END_DATE", strlen("INCLUDE_END_DATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INCLUDE_END_DATE_name, &const_INCLUDE_END_DATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INCLUDE_END_DATE_name);
 
 	zval property_start_default_value;
 	ZVAL_UNDEF(&property_start_default_value);
-	zend_string *property_start_name = zend_string_init("start", sizeof("start") - 1, 1);
-	zend_string *property_start_class_DateTimeInterface = zend_string_init("DateTimeInterface", sizeof("DateTimeInterface")-1, 1);
+	zend_string *property_start_name = zend_string_init("start", strlen("start"), 1);
+	zend_string *property_start_class_DateTimeInterface = zend_string_init("DateTimeInterface", strlen("DateTimeInterface"), 1);
 	zend_declare_typed_property(class_entry, property_start_name, &property_start_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_start_class_DateTimeInterface, 0, MAY_BE_NULL));
 	zend_string_release(property_start_name);
 
 	zval property_current_default_value;
 	ZVAL_UNDEF(&property_current_default_value);
-	zend_string *property_current_name = zend_string_init("current", sizeof("current") - 1, 1);
-	zend_string *property_current_class_DateTimeInterface = zend_string_init("DateTimeInterface", sizeof("DateTimeInterface")-1, 1);
+	zend_string *property_current_name = zend_string_init("current", strlen("current"), 1);
+	zend_string *property_current_class_DateTimeInterface = zend_string_init("DateTimeInterface", strlen("DateTimeInterface"), 1);
 	zend_declare_typed_property(class_entry, property_current_name, &property_current_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_current_class_DateTimeInterface, 0, MAY_BE_NULL));
 	zend_string_release(property_current_name);
 
 	zval property_end_default_value;
 	ZVAL_UNDEF(&property_end_default_value);
-	zend_string *property_end_name = zend_string_init("end", sizeof("end") - 1, 1);
-	zend_string *property_end_class_DateTimeInterface = zend_string_init("DateTimeInterface", sizeof("DateTimeInterface")-1, 1);
+	zend_string *property_end_name = zend_string_init("end", strlen("end"), 1);
+	zend_string *property_end_class_DateTimeInterface = zend_string_init("DateTimeInterface", strlen("DateTimeInterface"), 1);
 	zend_declare_typed_property(class_entry, property_end_name, &property_end_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_end_class_DateTimeInterface, 0, MAY_BE_NULL));
 	zend_string_release(property_end_name);
 
 	zval property_interval_default_value;
 	ZVAL_UNDEF(&property_interval_default_value);
-	zend_string *property_interval_name = zend_string_init("interval", sizeof("interval") - 1, 1);
-	zend_string *property_interval_class_DateInterval = zend_string_init("DateInterval", sizeof("DateInterval")-1, 1);
+	zend_string *property_interval_name = zend_string_init("interval", strlen("interval"), 1);
+	zend_string *property_interval_class_DateInterval = zend_string_init("DateInterval", strlen("DateInterval"), 1);
 	zend_declare_typed_property(class_entry, property_interval_name, &property_interval_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_interval_class_DateInterval, 0, MAY_BE_NULL));
 	zend_string_release(property_interval_name);
 
 	zval property_recurrences_default_value;
 	ZVAL_UNDEF(&property_recurrences_default_value);
-	zend_string *property_recurrences_name = zend_string_init("recurrences", sizeof("recurrences") - 1, 1);
+	zend_string *property_recurrences_name = zend_string_init("recurrences", strlen("recurrences"), 1);
 	zend_declare_typed_property(class_entry, property_recurrences_name, &property_recurrences_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_recurrences_name);
 
 	zval property_include_start_date_default_value;
 	ZVAL_UNDEF(&property_include_start_date_default_value);
-	zend_string *property_include_start_date_name = zend_string_init("include_start_date", sizeof("include_start_date") - 1, 1);
+	zend_string *property_include_start_date_name = zend_string_init("include_start_date", strlen("include_start_date"), 1);
 	zend_declare_typed_property(class_entry, property_include_start_date_name, &property_include_start_date_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_include_start_date_name);
 
 	zval property_include_end_date_default_value;
 	ZVAL_UNDEF(&property_include_end_date_default_value);
-	zend_string *property_include_end_date_name = zend_string_init("include_end_date", sizeof("include_end_date") - 1, 1);
+	zend_string *property_include_end_date_name = zend_string_init("include_end_date", strlen("include_end_date"), 1);
 	zend_declare_typed_property(class_entry, property_include_end_date_name, &property_include_end_date_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_include_end_date_name);
 

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1885,33 +1885,33 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 
 	zval property_entities_default_value;
 	ZVAL_UNDEF(&property_entities_default_value);
-	zend_string *property_entities_name = zend_string_init("entities", sizeof("entities") - 1, 1);
-	zend_string *property_entities_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_entities_name = zend_string_init("entities", strlen("entities"), 1);
+	zend_string *property_entities_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_entities_name, &property_entities_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_entities_class_DOMNamedNodeMap, 0, 0));
 	zend_string_release(property_entities_name);
 
 	zval property_notations_default_value;
 	ZVAL_UNDEF(&property_notations_default_value);
-	zend_string *property_notations_name = zend_string_init("notations", sizeof("notations") - 1, 1);
-	zend_string *property_notations_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_notations_name = zend_string_init("notations", strlen("notations"), 1);
+	zend_string *property_notations_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_notations_name, &property_notations_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_notations_class_DOMNamedNodeMap, 0, 0));
 	zend_string_release(property_notations_name);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
 	zval property_internalSubset_default_value;
 	ZVAL_UNDEF(&property_internalSubset_default_value);
-	zend_string *property_internalSubset_name = zend_string_init("internalSubset", sizeof("internalSubset") - 1, 1);
+	zend_string *property_internalSubset_name = zend_string_init("internalSubset", strlen("internalSubset"), 1);
 	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_internalSubset_name);
 
@@ -1967,154 +1967,154 @@ static zend_class_entry *register_class_DOMNode(void)
 
 	zval const_DOCUMENT_POSITION_DISCONNECTED_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_DISCONNECTED_value, 0x1);
-	zend_string *const_DOCUMENT_POSITION_DISCONNECTED_name = zend_string_init_interned("DOCUMENT_POSITION_DISCONNECTED", sizeof("DOCUMENT_POSITION_DISCONNECTED") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_DISCONNECTED_name = zend_string_init_interned("DOCUMENT_POSITION_DISCONNECTED", strlen("DOCUMENT_POSITION_DISCONNECTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_DISCONNECTED_name, &const_DOCUMENT_POSITION_DISCONNECTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_DISCONNECTED_name);
 
 	zval const_DOCUMENT_POSITION_PRECEDING_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_PRECEDING_value, 0x2);
-	zend_string *const_DOCUMENT_POSITION_PRECEDING_name = zend_string_init_interned("DOCUMENT_POSITION_PRECEDING", sizeof("DOCUMENT_POSITION_PRECEDING") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_PRECEDING_name = zend_string_init_interned("DOCUMENT_POSITION_PRECEDING", strlen("DOCUMENT_POSITION_PRECEDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_PRECEDING_name, &const_DOCUMENT_POSITION_PRECEDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_PRECEDING_name);
 
 	zval const_DOCUMENT_POSITION_FOLLOWING_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_FOLLOWING_value, 0x4);
-	zend_string *const_DOCUMENT_POSITION_FOLLOWING_name = zend_string_init_interned("DOCUMENT_POSITION_FOLLOWING", sizeof("DOCUMENT_POSITION_FOLLOWING") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_FOLLOWING_name = zend_string_init_interned("DOCUMENT_POSITION_FOLLOWING", strlen("DOCUMENT_POSITION_FOLLOWING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_FOLLOWING_name, &const_DOCUMENT_POSITION_FOLLOWING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_FOLLOWING_name);
 
 	zval const_DOCUMENT_POSITION_CONTAINS_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_CONTAINS_value, 0x8);
-	zend_string *const_DOCUMENT_POSITION_CONTAINS_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINS", sizeof("DOCUMENT_POSITION_CONTAINS") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_CONTAINS_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINS", strlen("DOCUMENT_POSITION_CONTAINS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_CONTAINS_name, &const_DOCUMENT_POSITION_CONTAINS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_CONTAINS_name);
 
 	zval const_DOCUMENT_POSITION_CONTAINED_BY_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_CONTAINED_BY_value, 0x10);
-	zend_string *const_DOCUMENT_POSITION_CONTAINED_BY_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINED_BY", sizeof("DOCUMENT_POSITION_CONTAINED_BY") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_CONTAINED_BY_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINED_BY", strlen("DOCUMENT_POSITION_CONTAINED_BY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_CONTAINED_BY_name, &const_DOCUMENT_POSITION_CONTAINED_BY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_CONTAINED_BY_name);
 
 	zval const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value, 0x20);
-	zend_string *const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name = zend_string_init_interned("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC", sizeof("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name = zend_string_init_interned("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC", strlen("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name, &const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name);
 
 	zval property_nodeName_default_value;
 	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", strlen("nodeName"), 1);
 	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_nodeName_name);
 
 	zval property_nodeValue_default_value;
 	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", strlen("nodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_nodeValue_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_parentNode_default_value;
 	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
-	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", strlen("parentNode"), 1);
+	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_parentNode_name);
 
 	zval property_parentElement_default_value;
 	ZVAL_UNDEF(&property_parentElement_default_value);
-	zend_string *property_parentElement_name = zend_string_init("parentElement", sizeof("parentElement") - 1, 1);
-	zend_string *property_parentElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_parentElement_name = zend_string_init("parentElement", strlen("parentElement"), 1);
+	zend_string *property_parentElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_parentElement_name, &property_parentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_parentElement_name);
 
 	zval property_childNodes_default_value;
 	ZVAL_UNDEF(&property_childNodes_default_value);
-	zend_string *property_childNodes_name = zend_string_init("childNodes", sizeof("childNodes") - 1, 1);
-	zend_string *property_childNodes_class_DOMNodeList = zend_string_init("DOMNodeList", sizeof("DOMNodeList")-1, 1);
+	zend_string *property_childNodes_name = zend_string_init("childNodes", strlen("childNodes"), 1);
+	zend_string *property_childNodes_class_DOMNodeList = zend_string_init("DOMNodeList", strlen("DOMNodeList"), 1);
 	zend_declare_typed_property(class_entry, property_childNodes_name, &property_childNodes_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_childNodes_class_DOMNodeList, 0, 0));
 	zend_string_release(property_childNodes_name);
 
 	zval property_firstChild_default_value;
 	ZVAL_UNDEF(&property_firstChild_default_value);
-	zend_string *property_firstChild_name = zend_string_init("firstChild", sizeof("firstChild") - 1, 1);
-	zend_string *property_firstChild_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_firstChild_name = zend_string_init("firstChild", strlen("firstChild"), 1);
+	zend_string *property_firstChild_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_firstChild_name, &property_firstChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstChild_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_firstChild_name);
 
 	zval property_lastChild_default_value;
 	ZVAL_UNDEF(&property_lastChild_default_value);
-	zend_string *property_lastChild_name = zend_string_init("lastChild", sizeof("lastChild") - 1, 1);
-	zend_string *property_lastChild_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_lastChild_name = zend_string_init("lastChild", strlen("lastChild"), 1);
+	zend_string *property_lastChild_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_lastChild_name, &property_lastChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastChild_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_lastChild_name);
 
 	zval property_previousSibling_default_value;
 	ZVAL_UNDEF(&property_previousSibling_default_value);
-	zend_string *property_previousSibling_name = zend_string_init("previousSibling", sizeof("previousSibling") - 1, 1);
-	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_previousSibling_name = zend_string_init("previousSibling", strlen("previousSibling"), 1);
+	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_previousSibling_name, &property_previousSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousSibling_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_previousSibling_name);
 
 	zval property_nextSibling_default_value;
 	ZVAL_UNDEF(&property_nextSibling_default_value);
-	zend_string *property_nextSibling_name = zend_string_init("nextSibling", sizeof("nextSibling") - 1, 1);
-	zend_string *property_nextSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_nextSibling_name = zend_string_init("nextSibling", strlen("nextSibling"), 1);
+	zend_string *property_nextSibling_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_nextSibling_name, &property_nextSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextSibling_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_nextSibling_name);
 
 	zval property_attributes_default_value;
 	ZVAL_UNDEF(&property_attributes_default_value);
-	zend_string *property_attributes_name = zend_string_init("attributes", sizeof("attributes") - 1, 1);
-	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_attributes_name = zend_string_init("attributes", strlen("attributes"), 1);
+	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_attributes_name, &property_attributes_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_attributes_class_DOMNamedNodeMap, 0, MAY_BE_NULL));
 	zend_string_release(property_attributes_name);
 
 	zval property_isConnected_default_value;
 	ZVAL_UNDEF(&property_isConnected_default_value);
-	zend_string *property_isConnected_name = zend_string_init("isConnected", sizeof("isConnected") - 1, 1);
+	zend_string *property_isConnected_name = zend_string_init("isConnected", strlen("isConnected"), 1);
 	zend_declare_typed_property(class_entry, property_isConnected_name, &property_isConnected_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isConnected_name);
 
 	zval property_ownerDocument_default_value;
 	ZVAL_UNDEF(&property_ownerDocument_default_value);
-	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", sizeof("ownerDocument") - 1, 1);
-	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", strlen("ownerDocument"), 1);
+	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_DOMDocument, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_localName_name);
 
 	zval property_baseURI_default_value;
 	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", strlen("baseURI"), 1);
 	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_baseURI_name);
 
 	zval property_textContent_default_value;
 	ZVAL_UNDEF(&property_textContent_default_value);
-	zend_string *property_textContent_name = zend_string_init("textContent", sizeof("textContent") - 1, 1);
+	zend_string *property_textContent_name = zend_string_init("textContent", strlen("textContent"), 1);
 	zend_declare_typed_property(class_entry, property_textContent_name, &property_textContent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_textContent_name);
 
@@ -2130,64 +2130,64 @@ static zend_class_entry *register_class_DOMNameSpaceNode(void)
 
 	zval property_nodeName_default_value;
 	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", strlen("nodeName"), 1);
 	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_nodeName_name);
 
 	zval property_nodeValue_default_value;
 	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", strlen("nodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_nodeValue_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_localName_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_isConnected_default_value;
 	ZVAL_UNDEF(&property_isConnected_default_value);
-	zend_string *property_isConnected_name = zend_string_init("isConnected", sizeof("isConnected") - 1, 1);
+	zend_string *property_isConnected_name = zend_string_init("isConnected", strlen("isConnected"), 1);
 	zend_declare_typed_property(class_entry, property_isConnected_name, &property_isConnected_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isConnected_name);
 
 	zval property_ownerDocument_default_value;
 	ZVAL_UNDEF(&property_ownerDocument_default_value);
-	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", sizeof("ownerDocument") - 1, 1);
-	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", strlen("ownerDocument"), 1);
+	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_DOMDocument, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
 	zval property_parentNode_default_value;
 	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
-	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", strlen("parentNode"), 1);
+	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_parentNode_name);
 
 	zval property_parentElement_default_value;
 	ZVAL_UNDEF(&property_parentElement_default_value);
-	zend_string *property_parentElement_name = zend_string_init("parentElement", sizeof("parentElement") - 1, 1);
-	zend_string *property_parentElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_parentElement_name = zend_string_init("parentElement", strlen("parentElement"), 1);
+	zend_string *property_parentElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_parentElement_name, &property_parentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_parentElement_name);
 
@@ -2214,21 +2214,21 @@ static zend_class_entry *register_class_DOMDocumentFragment(zend_class_entry *cl
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
@@ -2245,7 +2245,7 @@ static zend_class_entry *register_class_DOMNodeList(zend_class_entry *class_entr
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2262,27 +2262,27 @@ static zend_class_entry *register_class_DOMCharacterData(zend_class_entry *class
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
-	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
+	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
-	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
+	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
@@ -2302,7 +2302,7 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 
 	zval property_specified_default_value;
 	ZVAL_UNDEF(&property_specified_default_value);
-	zend_string *property_specified_name = zend_string_init("specified", sizeof("specified") - 1, 1);
+	zend_string *property_specified_name = zend_string_init("specified", strlen("specified"), 1);
 	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_specified_name);
 
@@ -2312,14 +2312,14 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 
 	zval property_ownerElement_default_value;
 	ZVAL_UNDEF(&property_ownerElement_default_value);
-	zend_string *property_ownerElement_name = zend_string_init("ownerElement", sizeof("ownerElement") - 1, 1);
-	zend_string *property_ownerElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_ownerElement_name = zend_string_init("ownerElement", strlen("ownerElement"), 1);
+	zend_string *property_ownerElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_ownerElement_name, &property_ownerElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerElement_name);
 
 	zval property_schemaTypeInfo_default_value;
 	ZVAL_UNDEF(&property_schemaTypeInfo_default_value);
-	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
+	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", strlen("schemaTypeInfo"), 1);
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_schemaTypeInfo_name);
 
@@ -2336,59 +2336,59 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 
 	zval property_tagName_default_value;
 	ZVAL_UNDEF(&property_tagName_default_value);
-	zend_string *property_tagName_name = zend_string_init("tagName", sizeof("tagName") - 1, 1);
+	zend_string *property_tagName_name = zend_string_init("tagName", strlen("tagName"), 1);
 	zend_declare_typed_property(class_entry, property_tagName_name, &property_tagName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_tagName_name);
 
 	zval property_className_default_value;
 	ZVAL_UNDEF(&property_className_default_value);
-	zend_string *property_className_name = zend_string_init("className", sizeof("className") - 1, 1);
+	zend_string *property_className_name = zend_string_init("className", strlen("className"), 1);
 	zend_declare_typed_property(class_entry, property_className_name, &property_className_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_className_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_id_name);
 
 	zval property_schemaTypeInfo_default_value;
 	ZVAL_UNDEF(&property_schemaTypeInfo_default_value);
-	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
+	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", strlen("schemaTypeInfo"), 1);
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_schemaTypeInfo_name);
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
-	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
+	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
-	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
+	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
@@ -2405,138 +2405,138 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 
 	zval property_doctype_default_value;
 	ZVAL_UNDEF(&property_doctype_default_value);
-	zend_string *property_doctype_name = zend_string_init("doctype", sizeof("doctype") - 1, 1);
-	zend_string *property_doctype_class_DOMDocumentType = zend_string_init("DOMDocumentType", sizeof("DOMDocumentType")-1, 1);
+	zend_string *property_doctype_name = zend_string_init("doctype", strlen("doctype"), 1);
+	zend_string *property_doctype_class_DOMDocumentType = zend_string_init("DOMDocumentType", strlen("DOMDocumentType"), 1);
 	zend_declare_typed_property(class_entry, property_doctype_name, &property_doctype_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_doctype_class_DOMDocumentType, 0, MAY_BE_NULL));
 	zend_string_release(property_doctype_name);
 
 	zval property_implementation_default_value;
 	ZVAL_UNDEF(&property_implementation_default_value);
-	zend_string *property_implementation_name = zend_string_init("implementation", sizeof("implementation") - 1, 1);
-	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", sizeof("DOMImplementation")-1, 1);
+	zend_string *property_implementation_name = zend_string_init("implementation", strlen("implementation"), 1);
+	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", strlen("DOMImplementation"), 1);
 	zend_declare_typed_property(class_entry, property_implementation_name, &property_implementation_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_implementation_class_DOMImplementation, 0, 0));
 	zend_string_release(property_implementation_name);
 
 	zval property_documentElement_default_value;
 	ZVAL_UNDEF(&property_documentElement_default_value);
-	zend_string *property_documentElement_name = zend_string_init("documentElement", sizeof("documentElement") - 1, 1);
-	zend_string *property_documentElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_documentElement_name = zend_string_init("documentElement", strlen("documentElement"), 1);
+	zend_string *property_documentElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_documentElement_name, &property_documentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_documentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_documentElement_name);
 
 	zval property_actualEncoding_default_value;
 	ZVAL_UNDEF(&property_actualEncoding_default_value);
-	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
+	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", strlen("actualEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_actualEncoding_name);
 
 	zval property_encoding_default_value;
 	ZVAL_UNDEF(&property_encoding_default_value);
-	zend_string *property_encoding_name = zend_string_init("encoding", sizeof("encoding") - 1, 1);
+	zend_string *property_encoding_name = zend_string_init("encoding", strlen("encoding"), 1);
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
 
 	zval property_xmlEncoding_default_value;
 	ZVAL_UNDEF(&property_xmlEncoding_default_value);
-	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", sizeof("xmlEncoding") - 1, 1);
+	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", strlen("xmlEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_xmlEncoding_name, &property_xmlEncoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_xmlEncoding_name);
 
 	zval property_standalone_default_value;
 	ZVAL_UNDEF(&property_standalone_default_value);
-	zend_string *property_standalone_name = zend_string_init("standalone", sizeof("standalone") - 1, 1);
+	zend_string *property_standalone_name = zend_string_init("standalone", strlen("standalone"), 1);
 	zend_declare_typed_property(class_entry, property_standalone_name, &property_standalone_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_standalone_name);
 
 	zval property_xmlStandalone_default_value;
 	ZVAL_UNDEF(&property_xmlStandalone_default_value);
-	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", sizeof("xmlStandalone") - 1, 1);
+	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", strlen("xmlStandalone"), 1);
 	zend_declare_typed_property(class_entry, property_xmlStandalone_name, &property_xmlStandalone_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_xmlStandalone_name);
 
 	zval property_version_default_value;
 	ZVAL_UNDEF(&property_version_default_value);
-	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_string *property_version_name = zend_string_init("version", strlen("version"), 1);
 	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_version_name);
 
 	zval property_xmlVersion_default_value;
 	ZVAL_UNDEF(&property_xmlVersion_default_value);
-	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", sizeof("xmlVersion") - 1, 1);
+	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", strlen("xmlVersion"), 1);
 	zend_declare_typed_property(class_entry, property_xmlVersion_name, &property_xmlVersion_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_xmlVersion_name);
 
 	zval property_strictErrorChecking_default_value;
 	ZVAL_UNDEF(&property_strictErrorChecking_default_value);
-	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", sizeof("strictErrorChecking") - 1, 1);
+	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", strlen("strictErrorChecking"), 1);
 	zend_declare_typed_property(class_entry, property_strictErrorChecking_name, &property_strictErrorChecking_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_strictErrorChecking_name);
 
 	zval property_documentURI_default_value;
 	ZVAL_UNDEF(&property_documentURI_default_value);
-	zend_string *property_documentURI_name = zend_string_init("documentURI", sizeof("documentURI") - 1, 1);
+	zend_string *property_documentURI_name = zend_string_init("documentURI", strlen("documentURI"), 1);
 	zend_declare_typed_property(class_entry, property_documentURI_name, &property_documentURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_documentURI_name);
 
 	zval property_config_default_value;
 	ZVAL_UNDEF(&property_config_default_value);
-	zend_string *property_config_name = zend_string_init("config", sizeof("config") - 1, 1);
+	zend_string *property_config_name = zend_string_init("config", strlen("config"), 1);
 	zend_declare_typed_property(class_entry, property_config_name, &property_config_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_config_name);
 
 	zval property_formatOutput_default_value;
 	ZVAL_UNDEF(&property_formatOutput_default_value);
-	zend_string *property_formatOutput_name = zend_string_init("formatOutput", sizeof("formatOutput") - 1, 1);
+	zend_string *property_formatOutput_name = zend_string_init("formatOutput", strlen("formatOutput"), 1);
 	zend_declare_typed_property(class_entry, property_formatOutput_name, &property_formatOutput_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_formatOutput_name);
 
 	zval property_validateOnParse_default_value;
 	ZVAL_UNDEF(&property_validateOnParse_default_value);
-	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", sizeof("validateOnParse") - 1, 1);
+	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", strlen("validateOnParse"), 1);
 	zend_declare_typed_property(class_entry, property_validateOnParse_name, &property_validateOnParse_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_validateOnParse_name);
 
 	zval property_resolveExternals_default_value;
 	ZVAL_UNDEF(&property_resolveExternals_default_value);
-	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", sizeof("resolveExternals") - 1, 1);
+	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", strlen("resolveExternals"), 1);
 	zend_declare_typed_property(class_entry, property_resolveExternals_name, &property_resolveExternals_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_resolveExternals_name);
 
 	zval property_preserveWhiteSpace_default_value;
 	ZVAL_UNDEF(&property_preserveWhiteSpace_default_value);
-	zend_string *property_preserveWhiteSpace_name = zend_string_init("preserveWhiteSpace", sizeof("preserveWhiteSpace") - 1, 1);
+	zend_string *property_preserveWhiteSpace_name = zend_string_init("preserveWhiteSpace", strlen("preserveWhiteSpace"), 1);
 	zend_declare_typed_property(class_entry, property_preserveWhiteSpace_name, &property_preserveWhiteSpace_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_preserveWhiteSpace_name);
 
 	zval property_recover_default_value;
 	ZVAL_UNDEF(&property_recover_default_value);
-	zend_string *property_recover_name = zend_string_init("recover", sizeof("recover") - 1, 1);
+	zend_string *property_recover_name = zend_string_init("recover", strlen("recover"), 1);
 	zend_declare_typed_property(class_entry, property_recover_name, &property_recover_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_recover_name);
 
 	zval property_substituteEntities_default_value;
 	ZVAL_UNDEF(&property_substituteEntities_default_value);
-	zend_string *property_substituteEntities_name = zend_string_init("substituteEntities", sizeof("substituteEntities") - 1, 1);
+	zend_string *property_substituteEntities_name = zend_string_init("substituteEntities", strlen("substituteEntities"), 1);
 	zend_declare_typed_property(class_entry, property_substituteEntities_name, &property_substituteEntities_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_substituteEntities_name);
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
@@ -2567,7 +2567,7 @@ static zend_class_entry *register_class_DOMText(zend_class_entry *class_entry_DO
 
 	zval property_wholeText_default_value;
 	ZVAL_UNDEF(&property_wholeText_default_value);
-	zend_string *property_wholeText_name = zend_string_init("wholeText", sizeof("wholeText") - 1, 1);
+	zend_string *property_wholeText_name = zend_string_init("wholeText", strlen("wholeText"), 1);
 	zend_declare_typed_property(class_entry, property_wholeText_name, &property_wholeText_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_wholeText_name);
 
@@ -2584,7 +2584,7 @@ static zend_class_entry *register_class_DOMNamedNodeMap(zend_class_entry *class_
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2600,37 +2600,37 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_systemId_name);
 
 	zval property_notationName_default_value;
 	ZVAL_UNDEF(&property_notationName_default_value);
-	zend_string *property_notationName_name = zend_string_init("notationName", sizeof("notationName") - 1, 1);
+	zend_string *property_notationName_name = zend_string_init("notationName", strlen("notationName"), 1);
 	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_notationName_name);
 
 	zval property_actualEncoding_default_value;
 	ZVAL_UNDEF(&property_actualEncoding_default_value);
-	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
+	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", strlen("actualEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_actualEncoding_name);
 
 	zval property_encoding_default_value;
 	ZVAL_UNDEF(&property_encoding_default_value);
-	zend_string *property_encoding_name = zend_string_init("encoding", sizeof("encoding") - 1, 1);
+	zend_string *property_encoding_name = zend_string_init("encoding", strlen("encoding"), 1);
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
 
 	zval property_version_default_value;
 	ZVAL_UNDEF(&property_version_default_value);
-	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_string *property_version_name = zend_string_init("version", strlen("version"), 1);
 	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_version_name);
 
@@ -2656,13 +2656,13 @@ static zend_class_entry *register_class_DOMNotation(zend_class_entry *class_entr
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
@@ -2678,13 +2678,13 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 
 	zval property_target_default_value;
 	ZVAL_UNDEF(&property_target_default_value);
-	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, 1);
+	zend_string *property_target_name = zend_string_init("target", strlen("target"), 1);
 	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_target_name);
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
@@ -2701,14 +2701,14 @@ static zend_class_entry *register_class_DOMXPath(void)
 
 	zval property_document_default_value;
 	ZVAL_UNDEF(&property_document_default_value);
-	zend_string *property_document_name = zend_string_init("document", sizeof("document") - 1, 1);
-	zend_string *property_document_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_document_name = zend_string_init("document", strlen("document"), 1);
+	zend_string *property_document_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zend_declare_typed_property(class_entry, property_document_name, &property_document_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_document_class_DOMDocument, 0, 0));
 	zend_string_release(property_document_name);
 
 	zval property_registerNodeNamespaces_default_value;
 	ZVAL_UNDEF(&property_registerNodeNamespaces_default_value);
-	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", sizeof("registerNodeNamespaces") - 1, 1);
+	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", strlen("registerNodeNamespaces"), 1);
 	zend_declare_typed_property(class_entry, property_registerNodeNamespaces_name, &property_registerNodeNamespaces_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_registerNodeNamespaces_name);
 
@@ -2755,129 +2755,129 @@ static zend_class_entry *register_class_Dom_Node(void)
 
 	zval const_DOCUMENT_POSITION_DISCONNECTED_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_DISCONNECTED_value, 0x1);
-	zend_string *const_DOCUMENT_POSITION_DISCONNECTED_name = zend_string_init_interned("DOCUMENT_POSITION_DISCONNECTED", sizeof("DOCUMENT_POSITION_DISCONNECTED") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_DISCONNECTED_name = zend_string_init_interned("DOCUMENT_POSITION_DISCONNECTED", strlen("DOCUMENT_POSITION_DISCONNECTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_DISCONNECTED_name, &const_DOCUMENT_POSITION_DISCONNECTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_DISCONNECTED_name);
 
 	zval const_DOCUMENT_POSITION_PRECEDING_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_PRECEDING_value, 0x2);
-	zend_string *const_DOCUMENT_POSITION_PRECEDING_name = zend_string_init_interned("DOCUMENT_POSITION_PRECEDING", sizeof("DOCUMENT_POSITION_PRECEDING") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_PRECEDING_name = zend_string_init_interned("DOCUMENT_POSITION_PRECEDING", strlen("DOCUMENT_POSITION_PRECEDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_PRECEDING_name, &const_DOCUMENT_POSITION_PRECEDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_PRECEDING_name);
 
 	zval const_DOCUMENT_POSITION_FOLLOWING_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_FOLLOWING_value, 0x4);
-	zend_string *const_DOCUMENT_POSITION_FOLLOWING_name = zend_string_init_interned("DOCUMENT_POSITION_FOLLOWING", sizeof("DOCUMENT_POSITION_FOLLOWING") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_FOLLOWING_name = zend_string_init_interned("DOCUMENT_POSITION_FOLLOWING", strlen("DOCUMENT_POSITION_FOLLOWING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_FOLLOWING_name, &const_DOCUMENT_POSITION_FOLLOWING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_FOLLOWING_name);
 
 	zval const_DOCUMENT_POSITION_CONTAINS_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_CONTAINS_value, 0x8);
-	zend_string *const_DOCUMENT_POSITION_CONTAINS_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINS", sizeof("DOCUMENT_POSITION_CONTAINS") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_CONTAINS_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINS", strlen("DOCUMENT_POSITION_CONTAINS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_CONTAINS_name, &const_DOCUMENT_POSITION_CONTAINS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_CONTAINS_name);
 
 	zval const_DOCUMENT_POSITION_CONTAINED_BY_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_CONTAINED_BY_value, 0x10);
-	zend_string *const_DOCUMENT_POSITION_CONTAINED_BY_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINED_BY", sizeof("DOCUMENT_POSITION_CONTAINED_BY") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_CONTAINED_BY_name = zend_string_init_interned("DOCUMENT_POSITION_CONTAINED_BY", strlen("DOCUMENT_POSITION_CONTAINED_BY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_CONTAINED_BY_name, &const_DOCUMENT_POSITION_CONTAINED_BY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_CONTAINED_BY_name);
 
 	zval const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value;
 	ZVAL_LONG(&const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value, 0x20);
-	zend_string *const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name = zend_string_init_interned("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC", sizeof("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC") - 1, 1);
+	zend_string *const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name = zend_string_init_interned("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC", strlen("DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name, &const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_nodeName_default_value;
 	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", strlen("nodeName"), 1);
 	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_nodeName_name);
 
 	zval property_baseURI_default_value;
 	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", strlen("baseURI"), 1);
 	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_baseURI_name);
 
 	zval property_isConnected_default_value;
 	ZVAL_UNDEF(&property_isConnected_default_value);
-	zend_string *property_isConnected_name = zend_string_init("isConnected", sizeof("isConnected") - 1, 1);
+	zend_string *property_isConnected_name = zend_string_init("isConnected", strlen("isConnected"), 1);
 	zend_declare_typed_property(class_entry, property_isConnected_name, &property_isConnected_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isConnected_name);
 
 	zval property_ownerDocument_default_value;
 	ZVAL_UNDEF(&property_ownerDocument_default_value);
-	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", sizeof("ownerDocument") - 1, 1);
-	zend_string *property_ownerDocument_class_Dom_Document = zend_string_init("Dom\\Document", sizeof("Dom\\Document")-1, 1);
+	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", strlen("ownerDocument"), 1);
+	zend_string *property_ownerDocument_class_Dom_Document = zend_string_init("Dom\\Document", strlen("Dom\\Document"), 1);
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_Dom_Document, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
 	zval property_parentNode_default_value;
 	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
-	zend_string *property_parentNode_class_Dom_Node = zend_string_init("Dom\\\116ode", sizeof("Dom\\\116ode")-1, 1);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", strlen("parentNode"), 1);
+	zend_string *property_parentNode_class_Dom_Node = zend_string_init("Dom\\\116ode", strlen("Dom\\\116ode"), 1);
 	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_Dom_Node, 0, MAY_BE_NULL));
 	zend_string_release(property_parentNode_name);
 
 	zval property_parentElement_default_value;
 	ZVAL_UNDEF(&property_parentElement_default_value);
-	zend_string *property_parentElement_name = zend_string_init("parentElement", sizeof("parentElement") - 1, 1);
-	zend_string *property_parentElement_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_parentElement_name = zend_string_init("parentElement", strlen("parentElement"), 1);
+	zend_string *property_parentElement_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_parentElement_name, &property_parentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentElement_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_parentElement_name);
 
 	zval property_childNodes_default_value;
 	ZVAL_UNDEF(&property_childNodes_default_value);
-	zend_string *property_childNodes_name = zend_string_init("childNodes", sizeof("childNodes") - 1, 1);
-	zend_string *property_childNodes_class_Dom_NodeList = zend_string_init("Dom\\\116odeList", sizeof("Dom\\\116odeList")-1, 1);
+	zend_string *property_childNodes_name = zend_string_init("childNodes", strlen("childNodes"), 1);
+	zend_string *property_childNodes_class_Dom_NodeList = zend_string_init("Dom\\\116odeList", strlen("Dom\\\116odeList"), 1);
 	zend_declare_typed_property(class_entry, property_childNodes_name, &property_childNodes_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_childNodes_class_Dom_NodeList, 0, 0));
 	zend_string_release(property_childNodes_name);
 
 	zval property_firstChild_default_value;
 	ZVAL_UNDEF(&property_firstChild_default_value);
-	zend_string *property_firstChild_name = zend_string_init("firstChild", sizeof("firstChild") - 1, 1);
-	zend_string *property_firstChild_class_Dom_Node = zend_string_init("Dom\\\116ode", sizeof("Dom\\\116ode")-1, 1);
+	zend_string *property_firstChild_name = zend_string_init("firstChild", strlen("firstChild"), 1);
+	zend_string *property_firstChild_class_Dom_Node = zend_string_init("Dom\\\116ode", strlen("Dom\\\116ode"), 1);
 	zend_declare_typed_property(class_entry, property_firstChild_name, &property_firstChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstChild_class_Dom_Node, 0, MAY_BE_NULL));
 	zend_string_release(property_firstChild_name);
 
 	zval property_lastChild_default_value;
 	ZVAL_UNDEF(&property_lastChild_default_value);
-	zend_string *property_lastChild_name = zend_string_init("lastChild", sizeof("lastChild") - 1, 1);
-	zend_string *property_lastChild_class_Dom_Node = zend_string_init("Dom\\\116ode", sizeof("Dom\\\116ode")-1, 1);
+	zend_string *property_lastChild_name = zend_string_init("lastChild", strlen("lastChild"), 1);
+	zend_string *property_lastChild_class_Dom_Node = zend_string_init("Dom\\\116ode", strlen("Dom\\\116ode"), 1);
 	zend_declare_typed_property(class_entry, property_lastChild_name, &property_lastChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastChild_class_Dom_Node, 0, MAY_BE_NULL));
 	zend_string_release(property_lastChild_name);
 
 	zval property_previousSibling_default_value;
 	ZVAL_UNDEF(&property_previousSibling_default_value);
-	zend_string *property_previousSibling_name = zend_string_init("previousSibling", sizeof("previousSibling") - 1, 1);
-	zend_string *property_previousSibling_class_Dom_Node = zend_string_init("Dom\\\116ode", sizeof("Dom\\\116ode")-1, 1);
+	zend_string *property_previousSibling_name = zend_string_init("previousSibling", strlen("previousSibling"), 1);
+	zend_string *property_previousSibling_class_Dom_Node = zend_string_init("Dom\\\116ode", strlen("Dom\\\116ode"), 1);
 	zend_declare_typed_property(class_entry, property_previousSibling_name, &property_previousSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousSibling_class_Dom_Node, 0, MAY_BE_NULL));
 	zend_string_release(property_previousSibling_name);
 
 	zval property_nextSibling_default_value;
 	ZVAL_UNDEF(&property_nextSibling_default_value);
-	zend_string *property_nextSibling_name = zend_string_init("nextSibling", sizeof("nextSibling") - 1, 1);
-	zend_string *property_nextSibling_class_Dom_Node = zend_string_init("Dom\\\116ode", sizeof("Dom\\\116ode")-1, 1);
+	zend_string *property_nextSibling_name = zend_string_init("nextSibling", strlen("nextSibling"), 1);
+	zend_string *property_nextSibling_class_Dom_Node = zend_string_init("Dom\\\116ode", strlen("Dom\\\116ode"), 1);
 	zend_declare_typed_property(class_entry, property_nextSibling_name, &property_nextSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextSibling_class_Dom_Node, 0, MAY_BE_NULL));
 	zend_string_release(property_nextSibling_name);
 
 	zval property_nodeValue_default_value;
 	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", strlen("nodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_nodeValue_name);
 
 	zval property_textContent_default_value;
 	ZVAL_UNDEF(&property_textContent_default_value);
-	zend_string *property_textContent_name = zend_string_init("textContent", sizeof("textContent") - 1, 1);
+	zend_string *property_textContent_name = zend_string_init("textContent", strlen("textContent"), 1);
 	zend_declare_typed_property(class_entry, property_textContent_name, &property_textContent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_textContent_name);
 
@@ -2894,7 +2894,7 @@ static zend_class_entry *register_class_Dom_NodeList(zend_class_entry *class_ent
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2911,7 +2911,7 @@ static zend_class_entry *register_class_Dom_NamedNodeMap(zend_class_entry *class
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2928,7 +2928,7 @@ static zend_class_entry *register_class_Dom_DtdNamedNodeMap(zend_class_entry *cl
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2945,7 +2945,7 @@ static zend_class_entry *register_class_Dom_HTMLCollection(zend_class_entry *cla
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -2989,91 +2989,91 @@ static zend_class_entry *register_class_Dom_Element(zend_class_entry *class_entr
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_localName_name);
 
 	zval property_tagName_default_value;
 	ZVAL_UNDEF(&property_tagName_default_value);
-	zend_string *property_tagName_name = zend_string_init("tagName", sizeof("tagName") - 1, 1);
+	zend_string *property_tagName_name = zend_string_init("tagName", strlen("tagName"), 1);
 	zend_declare_typed_property(class_entry, property_tagName_name, &property_tagName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_tagName_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_id_name);
 
 	zval property_className_default_value;
 	ZVAL_UNDEF(&property_className_default_value);
-	zend_string *property_className_name = zend_string_init("className", sizeof("className") - 1, 1);
+	zend_string *property_className_name = zend_string_init("className", strlen("className"), 1);
 	zend_declare_typed_property(class_entry, property_className_name, &property_className_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_className_name);
 
 	zval property_classList_default_value;
 	ZVAL_UNDEF(&property_classList_default_value);
-	zend_string *property_classList_name = zend_string_init("classList", sizeof("classList") - 1, 1);
-	zend_string *property_classList_class_Dom_TokenList = zend_string_init("Dom\\TokenList", sizeof("Dom\\TokenList")-1, 1);
+	zend_string *property_classList_name = zend_string_init("classList", strlen("classList"), 1);
+	zend_string *property_classList_class_Dom_TokenList = zend_string_init("Dom\\TokenList", strlen("Dom\\TokenList"), 1);
 	zend_declare_typed_property(class_entry, property_classList_name, &property_classList_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_classList_class_Dom_TokenList, 0, 0));
 	zend_string_release(property_classList_name);
 
 	zval property_attributes_default_value;
 	ZVAL_UNDEF(&property_attributes_default_value);
-	zend_string *property_attributes_name = zend_string_init("attributes", sizeof("attributes") - 1, 1);
-	zend_string *property_attributes_class_Dom_NamedNodeMap = zend_string_init("Dom\\\116amedNodeMap", sizeof("Dom\\\116amedNodeMap")-1, 1);
+	zend_string *property_attributes_name = zend_string_init("attributes", strlen("attributes"), 1);
+	zend_string *property_attributes_class_Dom_NamedNodeMap = zend_string_init("Dom\\\116amedNodeMap", strlen("Dom\\\116amedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_attributes_name, &property_attributes_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_attributes_class_Dom_NamedNodeMap, 0, 0));
 	zend_string_release(property_attributes_name);
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
-	zend_string *property_previousElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
+	zend_string *property_previousElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
-	zend_string *property_nextElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
+	zend_string *property_nextElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
 	zval property_innerHTML_default_value;
 	ZVAL_UNDEF(&property_innerHTML_default_value);
-	zend_string *property_innerHTML_name = zend_string_init("innerHTML", sizeof("innerHTML") - 1, 1);
+	zend_string *property_innerHTML_name = zend_string_init("innerHTML", strlen("innerHTML"), 1);
 	zend_declare_typed_property(class_entry, property_innerHTML_name, &property_innerHTML_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_innerHTML_name);
 
@@ -3085,7 +3085,7 @@ static zend_class_entry *register_class_Dom_Element(zend_class_entry *class_entr
 
 	zval property_substitutedNodeValue_default_value;
 	ZVAL_UNDEF(&property_substitutedNodeValue_default_value);
-	zend_string *property_substitutedNodeValue_name = zend_string_init("substitutedNodeValue", sizeof("substitutedNodeValue") - 1, 1);
+	zend_string *property_substitutedNodeValue_name = zend_string_init("substitutedNodeValue", strlen("substitutedNodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_substitutedNodeValue_name, &property_substitutedNodeValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_substitutedNodeValue_name);
 
@@ -3111,19 +3111,19 @@ static zend_class_entry *register_class_Dom_Attr(zend_class_entry *class_entry_D
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_localName_name);
 
@@ -3137,14 +3137,14 @@ static zend_class_entry *register_class_Dom_Attr(zend_class_entry *class_entry_D
 
 	zval property_ownerElement_default_value;
 	ZVAL_UNDEF(&property_ownerElement_default_value);
-	zend_string *property_ownerElement_name = zend_string_init("ownerElement", sizeof("ownerElement") - 1, 1);
-	zend_string *property_ownerElement_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_ownerElement_name = zend_string_init("ownerElement", strlen("ownerElement"), 1);
+	zend_string *property_ownerElement_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_ownerElement_name, &property_ownerElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerElement_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerElement_name);
 
 	zval property_specified_default_value;
 	ZVAL_UNDEF(&property_specified_default_value);
-	zend_string *property_specified_name = zend_string_init("specified", sizeof("specified") - 1, 1);
+	zend_string *property_specified_name = zend_string_init("specified", strlen("specified"), 1);
 	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_specified_name);
 
@@ -3161,27 +3161,27 @@ static zend_class_entry *register_class_Dom_CharacterData(zend_class_entry *clas
 
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
-	zend_string *property_previousElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
+	zend_string *property_previousElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
-	zend_string *property_nextElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
+	zend_string *property_nextElementSibling_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -3197,7 +3197,7 @@ static zend_class_entry *register_class_Dom_Text(zend_class_entry *class_entry_D
 
 	zval property_wholeText_default_value;
 	ZVAL_UNDEF(&property_wholeText_default_value);
-	zend_string *property_wholeText_name = zend_string_init("wholeText", sizeof("wholeText") - 1, 1);
+	zend_string *property_wholeText_name = zend_string_init("wholeText", strlen("wholeText"), 1);
 	zend_declare_typed_property(class_entry, property_wholeText_name, &property_wholeText_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_wholeText_name);
 
@@ -3223,7 +3223,7 @@ static zend_class_entry *register_class_Dom_ProcessingInstruction(zend_class_ent
 
 	zval property_target_default_value;
 	ZVAL_UNDEF(&property_target_default_value);
-	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, 1);
+	zend_string *property_target_name = zend_string_init("target", strlen("target"), 1);
 	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_target_name);
 
@@ -3254,33 +3254,33 @@ static zend_class_entry *register_class_Dom_DocumentType(zend_class_entry *class
 
 	zval property_entities_default_value;
 	ZVAL_UNDEF(&property_entities_default_value);
-	zend_string *property_entities_name = zend_string_init("entities", sizeof("entities") - 1, 1);
-	zend_string *property_entities_class_Dom_DtdNamedNodeMap = zend_string_init("Dom\\DtdNamedNodeMap", sizeof("Dom\\DtdNamedNodeMap")-1, 1);
+	zend_string *property_entities_name = zend_string_init("entities", strlen("entities"), 1);
+	zend_string *property_entities_class_Dom_DtdNamedNodeMap = zend_string_init("Dom\\DtdNamedNodeMap", strlen("Dom\\DtdNamedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_entities_name, &property_entities_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_entities_class_Dom_DtdNamedNodeMap, 0, 0));
 	zend_string_release(property_entities_name);
 
 	zval property_notations_default_value;
 	ZVAL_UNDEF(&property_notations_default_value);
-	zend_string *property_notations_name = zend_string_init("notations", sizeof("notations") - 1, 1);
-	zend_string *property_notations_class_Dom_DtdNamedNodeMap = zend_string_init("Dom\\DtdNamedNodeMap", sizeof("Dom\\DtdNamedNodeMap")-1, 1);
+	zend_string *property_notations_name = zend_string_init("notations", strlen("notations"), 1);
+	zend_string *property_notations_class_Dom_DtdNamedNodeMap = zend_string_init("Dom\\DtdNamedNodeMap", strlen("Dom\\DtdNamedNodeMap"), 1);
 	zend_declare_typed_property(class_entry, property_notations_name, &property_notations_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_notations_class_Dom_DtdNamedNodeMap, 0, 0));
 	zend_string_release(property_notations_name);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
 	zval property_internalSubset_default_value;
 	ZVAL_UNDEF(&property_internalSubset_default_value);
-	zend_string *property_internalSubset_name = zend_string_init("internalSubset", sizeof("internalSubset") - 1, 1);
+	zend_string *property_internalSubset_name = zend_string_init("internalSubset", strlen("internalSubset"), 1);
 	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_internalSubset_name);
 
@@ -3297,21 +3297,21 @@ static zend_class_entry *register_class_Dom_DocumentFragment(zend_class_entry *c
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
@@ -3327,19 +3327,19 @@ static zend_class_entry *register_class_Dom_Entity(zend_class_entry *class_entry
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_systemId_name);
 
 	zval property_notationName_default_value;
 	ZVAL_UNDEF(&property_notationName_default_value);
-	zend_string *property_notationName_name = zend_string_init("notationName", sizeof("notationName") - 1, 1);
+	zend_string *property_notationName_name = zend_string_init("notationName", strlen("notationName"), 1);
 	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_notationName_name);
 
@@ -3365,13 +3365,13 @@ static zend_class_entry *register_class_Dom_Notation(zend_class_entry *class_ent
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
@@ -3388,92 +3388,92 @@ static zend_class_entry *register_class_Dom_Document(zend_class_entry *class_ent
 
 	zval property_implementation_default_value;
 	ZVAL_UNDEF(&property_implementation_default_value);
-	zend_string *property_implementation_name = zend_string_init("implementation", sizeof("implementation") - 1, 1);
-	zend_string *property_implementation_class_Dom_Implementation = zend_string_init("Dom\\Implementation", sizeof("Dom\\Implementation")-1, 1);
+	zend_string *property_implementation_name = zend_string_init("implementation", strlen("implementation"), 1);
+	zend_string *property_implementation_class_Dom_Implementation = zend_string_init("Dom\\Implementation", strlen("Dom\\Implementation"), 1);
 	zend_declare_typed_property(class_entry, property_implementation_name, &property_implementation_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_implementation_class_Dom_Implementation, 0, 0));
 	zend_string_release(property_implementation_name);
 
 	zval property_URL_default_value;
 	ZVAL_UNDEF(&property_URL_default_value);
-	zend_string *property_URL_name = zend_string_init("URL", sizeof("URL") - 1, 1);
+	zend_string *property_URL_name = zend_string_init("URL", strlen("URL"), 1);
 	zend_declare_typed_property(class_entry, property_URL_name, &property_URL_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_URL_name);
 
 	zval property_documentURI_default_value;
 	ZVAL_UNDEF(&property_documentURI_default_value);
-	zend_string *property_documentURI_name = zend_string_init("documentURI", sizeof("documentURI") - 1, 1);
+	zend_string *property_documentURI_name = zend_string_init("documentURI", strlen("documentURI"), 1);
 	zend_declare_typed_property(class_entry, property_documentURI_name, &property_documentURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_documentURI_name);
 
 	zval property_characterSet_default_value;
 	ZVAL_UNDEF(&property_characterSet_default_value);
-	zend_string *property_characterSet_name = zend_string_init("characterSet", sizeof("characterSet") - 1, 1);
+	zend_string *property_characterSet_name = zend_string_init("characterSet", strlen("characterSet"), 1);
 	zend_declare_typed_property(class_entry, property_characterSet_name, &property_characterSet_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_characterSet_name);
 
 	zval property_charset_default_value;
 	ZVAL_UNDEF(&property_charset_default_value);
-	zend_string *property_charset_name = zend_string_init("charset", sizeof("charset") - 1, 1);
+	zend_string *property_charset_name = zend_string_init("charset", strlen("charset"), 1);
 	zend_declare_typed_property(class_entry, property_charset_name, &property_charset_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_charset_name);
 
 	zval property_inputEncoding_default_value;
 	ZVAL_UNDEF(&property_inputEncoding_default_value);
-	zend_string *property_inputEncoding_name = zend_string_init("inputEncoding", sizeof("inputEncoding") - 1, 1);
+	zend_string *property_inputEncoding_name = zend_string_init("inputEncoding", strlen("inputEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_inputEncoding_name, &property_inputEncoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_inputEncoding_name);
 
 	zval property_doctype_default_value;
 	ZVAL_UNDEF(&property_doctype_default_value);
-	zend_string *property_doctype_name = zend_string_init("doctype", sizeof("doctype") - 1, 1);
-	zend_string *property_doctype_class_Dom_DocumentType = zend_string_init("Dom\\DocumentType", sizeof("Dom\\DocumentType")-1, 1);
+	zend_string *property_doctype_name = zend_string_init("doctype", strlen("doctype"), 1);
+	zend_string *property_doctype_class_Dom_DocumentType = zend_string_init("Dom\\DocumentType", strlen("Dom\\DocumentType"), 1);
 	zend_declare_typed_property(class_entry, property_doctype_name, &property_doctype_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_doctype_class_Dom_DocumentType, 0, MAY_BE_NULL));
 	zend_string_release(property_doctype_name);
 
 	zval property_documentElement_default_value;
 	ZVAL_UNDEF(&property_documentElement_default_value);
-	zend_string *property_documentElement_name = zend_string_init("documentElement", sizeof("documentElement") - 1, 1);
-	zend_string *property_documentElement_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_documentElement_name = zend_string_init("documentElement", strlen("documentElement"), 1);
+	zend_string *property_documentElement_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_documentElement_name, &property_documentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_documentElement_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_documentElement_name);
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
-	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
+	zend_string *property_firstElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
-	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
+	zend_string *property_lastElementChild_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_Dom_Element, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
 	zval property_body_default_value;
 	ZVAL_UNDEF(&property_body_default_value);
-	zend_string *property_body_name = zend_string_init("body", sizeof("body") - 1, 1);
-	zend_string *property_body_class_Dom_HTMLElement = zend_string_init("Dom\\HTMLElement", sizeof("Dom\\HTMLElement")-1, 1);
+	zend_string *property_body_name = zend_string_init("body", strlen("body"), 1);
+	zend_string *property_body_class_Dom_HTMLElement = zend_string_init("Dom\\HTMLElement", strlen("Dom\\HTMLElement"), 1);
 	zend_declare_typed_property(class_entry, property_body_name, &property_body_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_body_class_Dom_HTMLElement, 0, MAY_BE_NULL));
 	zend_string_release(property_body_name);
 
 	zval property_head_default_value;
 	ZVAL_UNDEF(&property_head_default_value);
-	zend_string *property_head_name = zend_string_init("head", sizeof("head") - 1, 1);
-	zend_string *property_head_class_Dom_HTMLElement = zend_string_init("Dom\\HTMLElement", sizeof("Dom\\HTMLElement")-1, 1);
+	zend_string *property_head_name = zend_string_init("head", strlen("head"), 1);
+	zend_string *property_head_class_Dom_HTMLElement = zend_string_init("Dom\\HTMLElement", strlen("Dom\\HTMLElement"), 1);
 	zend_declare_typed_property(class_entry, property_head_name, &property_head_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_head_class_Dom_HTMLElement, 0, MAY_BE_NULL));
 	zend_string_release(property_head_name);
 
 	zval property_title_default_value;
 	ZVAL_UNDEF(&property_title_default_value);
-	zend_string *property_title_name = zend_string_init("title", sizeof("title") - 1, 1);
+	zend_string *property_title_name = zend_string_init("title", strlen("title"), 1);
 	zend_declare_typed_property(class_entry, property_title_name, &property_title_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_title_name);
 
@@ -3499,25 +3499,25 @@ static zend_class_entry *register_class_Dom_XMLDocument(zend_class_entry *class_
 
 	zval property_xmlEncoding_default_value;
 	ZVAL_UNDEF(&property_xmlEncoding_default_value);
-	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", sizeof("xmlEncoding") - 1, 1);
+	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", strlen("xmlEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_xmlEncoding_name, &property_xmlEncoding_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_xmlEncoding_name);
 
 	zval property_xmlStandalone_default_value;
 	ZVAL_UNDEF(&property_xmlStandalone_default_value);
-	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", sizeof("xmlStandalone") - 1, 1);
+	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", strlen("xmlStandalone"), 1);
 	zend_declare_typed_property(class_entry, property_xmlStandalone_name, &property_xmlStandalone_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_xmlStandalone_name);
 
 	zval property_xmlVersion_default_value;
 	ZVAL_UNDEF(&property_xmlVersion_default_value);
-	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", sizeof("xmlVersion") - 1, 1);
+	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", strlen("xmlVersion"), 1);
 	zend_declare_typed_property(class_entry, property_xmlVersion_name, &property_xmlVersion_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_xmlVersion_name);
 
 	zval property_formatOutput_default_value;
 	ZVAL_UNDEF(&property_formatOutput_default_value);
-	zend_string *property_formatOutput_name = zend_string_init("formatOutput", sizeof("formatOutput") - 1, 1);
+	zend_string *property_formatOutput_name = zend_string_init("formatOutput", strlen("formatOutput"), 1);
 	zend_declare_typed_property(class_entry, property_formatOutput_name, &property_formatOutput_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_formatOutput_name);
 
@@ -3534,7 +3534,7 @@ static zend_class_entry *register_class_Dom_TokenList(zend_class_entry *class_en
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -3554,20 +3554,20 @@ static zend_class_entry *register_class_Dom_NamespaceInfo(void)
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_prefix_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_element_default_value;
 	ZVAL_UNDEF(&property_element_default_value);
-	zend_string *property_element_name = zend_string_init("element", sizeof("element") - 1, 1);
-	zend_string *property_element_class_Dom_Element = zend_string_init("Dom\\Element", sizeof("Dom\\Element")-1, 1);
+	zend_string *property_element_name = zend_string_init("element", strlen("element"), 1);
+	zend_string *property_element_class_Dom_Element = zend_string_init("Dom\\Element", strlen("Dom\\Element"), 1);
 	zend_declare_typed_property(class_entry, property_element_name, &property_element_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_element_class_Dom_Element, 0, 0));
 	zend_string_release(property_element_name);
 
@@ -3584,14 +3584,14 @@ static zend_class_entry *register_class_Dom_XPath(void)
 
 	zval property_document_default_value;
 	ZVAL_UNDEF(&property_document_default_value);
-	zend_string *property_document_name = zend_string_init("document", sizeof("document") - 1, 1);
-	zend_string *property_document_class_Dom_Document = zend_string_init("Dom\\Document", sizeof("Dom\\Document")-1, 1);
+	zend_string *property_document_name = zend_string_init("document", strlen("document"), 1);
+	zend_string *property_document_class_Dom_Document = zend_string_init("Dom\\Document", strlen("Dom\\Document"), 1);
 	zend_declare_typed_property(class_entry, property_document_name, &property_document_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_document_class_Dom_Document, 0, 0));
 	zend_string_release(property_document_name);
 
 	zval property_registerNodeNamespaces_default_value;
 	ZVAL_UNDEF(&property_registerNodeNamespaces_default_value);
-	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", sizeof("registerNodeNamespaces") - 1, 1);
+	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", strlen("registerNodeNamespaces"), 1);
 	zend_declare_typed_property(class_entry, property_registerNodeNamespaces_name, &property_registerNodeNamespaces_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_registerNodeNamespaces_name);
 

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -155,7 +155,7 @@ static void register_enchant_symbols(int module_number)
 #endif
 
 
-	zend_attribute *attribute_Deprecated_func_enchant_broker_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free", sizeof("enchant_broker_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_enchant_broker_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free", strlen("enchant_broker_free")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_enchant_broker_free_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_broker_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_0_arg0, attribute_Deprecated_func_enchant_broker_free_0_arg0_str);
@@ -167,21 +167,21 @@ static void register_enchant_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_0->args[1].value, &attribute_Deprecated_func_enchant_broker_free_0_arg1);
 	attribute_Deprecated_func_enchant_broker_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_enchant_broker_set_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_set_dict_path", sizeof("enchant_broker_set_dict_path") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_enchant_broker_set_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_set_dict_path", strlen("enchant_broker_set_dict_path")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0, attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_set_dict_path_0->args[0].value, &attribute_Deprecated_func_enchant_broker_set_dict_path_0_arg0);
 	attribute_Deprecated_func_enchant_broker_set_dict_path_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_enchant_broker_get_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_get_dict_path", sizeof("enchant_broker_get_dict_path") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_enchant_broker_get_dict_path_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_get_dict_path", strlen("enchant_broker_get_dict_path")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0, attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_get_dict_path_0->args[0].value, &attribute_Deprecated_func_enchant_broker_get_dict_path_0_arg0);
 	attribute_Deprecated_func_enchant_broker_get_dict_path_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_enchant_broker_free_dict_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free_dict", sizeof("enchant_broker_free_dict") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_enchant_broker_free_dict_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_broker_free_dict", strlen("enchant_broker_free_dict")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_enchant_broker_free_dict_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_broker_free_dict_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_broker_free_dict_0_arg0, attribute_Deprecated_func_enchant_broker_free_dict_0_arg0_str);
@@ -193,7 +193,7 @@ static void register_enchant_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_broker_free_dict_0->args[1].value, &attribute_Deprecated_func_enchant_broker_free_dict_0_arg1);
 	attribute_Deprecated_func_enchant_broker_free_dict_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_enchant_dict_add_to_personal_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_add_to_personal", sizeof("enchant_dict_add_to_personal") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_enchant_dict_add_to_personal_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_add_to_personal", strlen("enchant_dict_add_to_personal")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0, attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg0_str);
@@ -205,7 +205,7 @@ static void register_enchant_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[1].value, &attribute_Deprecated_func_enchant_dict_add_to_personal_0_arg1);
 	attribute_Deprecated_func_enchant_dict_add_to_personal_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_enchant_dict_is_in_session_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_is_in_session", sizeof("enchant_dict_is_in_session") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_enchant_dict_is_in_session_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "enchant_dict_is_in_session", strlen("enchant_dict_is_in_session")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0;
 	zend_string *attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0, attribute_Deprecated_func_enchant_dict_is_in_session_0_arg0_str);

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -205,7 +205,7 @@ static zend_class_entry *register_class_FFI(void)
 
 	zval const___BIGGEST_ALIGNMENT___value;
 	ZVAL_LONG(&const___BIGGEST_ALIGNMENT___value, __BIGGEST_ALIGNMENT__);
-	zend_string *const___BIGGEST_ALIGNMENT___name = zend_string_init_interned("__BIGGEST_ALIGNMENT__", sizeof("__BIGGEST_ALIGNMENT__") - 1, 1);
+	zend_string *const___BIGGEST_ALIGNMENT___name = zend_string_init_interned("__BIGGEST_ALIGNMENT__", strlen("__BIGGEST_ALIGNMENT__"), 1);
 	zend_declare_typed_class_constant(class_entry, const___BIGGEST_ALIGNMENT___name, &const___BIGGEST_ALIGNMENT___value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const___BIGGEST_ALIGNMENT___name);
 
@@ -231,231 +231,231 @@ static zend_class_entry *register_class_FFI_CType(void)
 
 	zval const_TYPE_VOID_value;
 	ZVAL_LONG(&const_TYPE_VOID_value, ZEND_FFI_TYPE_VOID);
-	zend_string *const_TYPE_VOID_name = zend_string_init_interned("TYPE_VOID", sizeof("TYPE_VOID") - 1, 1);
+	zend_string *const_TYPE_VOID_name = zend_string_init_interned("TYPE_VOID", strlen("TYPE_VOID"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_VOID_name, &const_TYPE_VOID_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_VOID_name);
 
 	zval const_TYPE_FLOAT_value;
 	ZVAL_LONG(&const_TYPE_FLOAT_value, ZEND_FFI_TYPE_FLOAT);
-	zend_string *const_TYPE_FLOAT_name = zend_string_init_interned("TYPE_FLOAT", sizeof("TYPE_FLOAT") - 1, 1);
+	zend_string *const_TYPE_FLOAT_name = zend_string_init_interned("TYPE_FLOAT", strlen("TYPE_FLOAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_FLOAT_name, &const_TYPE_FLOAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_FLOAT_name);
 
 	zval const_TYPE_DOUBLE_value;
 	ZVAL_LONG(&const_TYPE_DOUBLE_value, ZEND_FFI_TYPE_DOUBLE);
-	zend_string *const_TYPE_DOUBLE_name = zend_string_init_interned("TYPE_DOUBLE", sizeof("TYPE_DOUBLE") - 1, 1);
+	zend_string *const_TYPE_DOUBLE_name = zend_string_init_interned("TYPE_DOUBLE", strlen("TYPE_DOUBLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_DOUBLE_name, &const_TYPE_DOUBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_DOUBLE_name);
 #if defined(HAVE_LONG_DOUBLE)
 
 	zval const_TYPE_LONGDOUBLE_value;
 	ZVAL_LONG(&const_TYPE_LONGDOUBLE_value, ZEND_FFI_TYPE_LONGDOUBLE);
-	zend_string *const_TYPE_LONGDOUBLE_name = zend_string_init_interned("TYPE_LONGDOUBLE", sizeof("TYPE_LONGDOUBLE") - 1, 1);
+	zend_string *const_TYPE_LONGDOUBLE_name = zend_string_init_interned("TYPE_LONGDOUBLE", strlen("TYPE_LONGDOUBLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_LONGDOUBLE_name, &const_TYPE_LONGDOUBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_LONGDOUBLE_name);
 #endif
 
 	zval const_TYPE_UINT8_value;
 	ZVAL_LONG(&const_TYPE_UINT8_value, ZEND_FFI_TYPE_UINT8);
-	zend_string *const_TYPE_UINT8_name = zend_string_init_interned("TYPE_UINT8", sizeof("TYPE_UINT8") - 1, 1);
+	zend_string *const_TYPE_UINT8_name = zend_string_init_interned("TYPE_UINT8", strlen("TYPE_UINT8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT8_name, &const_TYPE_UINT8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT8_name);
 
 	zval const_TYPE_SINT8_value;
 	ZVAL_LONG(&const_TYPE_SINT8_value, ZEND_FFI_TYPE_SINT8);
-	zend_string *const_TYPE_SINT8_name = zend_string_init_interned("TYPE_SINT8", sizeof("TYPE_SINT8") - 1, 1);
+	zend_string *const_TYPE_SINT8_name = zend_string_init_interned("TYPE_SINT8", strlen("TYPE_SINT8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT8_name, &const_TYPE_SINT8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT8_name);
 
 	zval const_TYPE_UINT16_value;
 	ZVAL_LONG(&const_TYPE_UINT16_value, ZEND_FFI_TYPE_UINT16);
-	zend_string *const_TYPE_UINT16_name = zend_string_init_interned("TYPE_UINT16", sizeof("TYPE_UINT16") - 1, 1);
+	zend_string *const_TYPE_UINT16_name = zend_string_init_interned("TYPE_UINT16", strlen("TYPE_UINT16"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT16_name, &const_TYPE_UINT16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT16_name);
 
 	zval const_TYPE_SINT16_value;
 	ZVAL_LONG(&const_TYPE_SINT16_value, ZEND_FFI_TYPE_SINT16);
-	zend_string *const_TYPE_SINT16_name = zend_string_init_interned("TYPE_SINT16", sizeof("TYPE_SINT16") - 1, 1);
+	zend_string *const_TYPE_SINT16_name = zend_string_init_interned("TYPE_SINT16", strlen("TYPE_SINT16"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT16_name, &const_TYPE_SINT16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT16_name);
 
 	zval const_TYPE_UINT32_value;
 	ZVAL_LONG(&const_TYPE_UINT32_value, ZEND_FFI_TYPE_UINT32);
-	zend_string *const_TYPE_UINT32_name = zend_string_init_interned("TYPE_UINT32", sizeof("TYPE_UINT32") - 1, 1);
+	zend_string *const_TYPE_UINT32_name = zend_string_init_interned("TYPE_UINT32", strlen("TYPE_UINT32"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT32_name, &const_TYPE_UINT32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT32_name);
 
 	zval const_TYPE_SINT32_value;
 	ZVAL_LONG(&const_TYPE_SINT32_value, ZEND_FFI_TYPE_SINT32);
-	zend_string *const_TYPE_SINT32_name = zend_string_init_interned("TYPE_SINT32", sizeof("TYPE_SINT32") - 1, 1);
+	zend_string *const_TYPE_SINT32_name = zend_string_init_interned("TYPE_SINT32", strlen("TYPE_SINT32"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT32_name, &const_TYPE_SINT32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT32_name);
 
 	zval const_TYPE_UINT64_value;
 	ZVAL_LONG(&const_TYPE_UINT64_value, ZEND_FFI_TYPE_UINT64);
-	zend_string *const_TYPE_UINT64_name = zend_string_init_interned("TYPE_UINT64", sizeof("TYPE_UINT64") - 1, 1);
+	zend_string *const_TYPE_UINT64_name = zend_string_init_interned("TYPE_UINT64", strlen("TYPE_UINT64"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT64_name, &const_TYPE_UINT64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT64_name);
 
 	zval const_TYPE_SINT64_value;
 	ZVAL_LONG(&const_TYPE_SINT64_value, ZEND_FFI_TYPE_SINT64);
-	zend_string *const_TYPE_SINT64_name = zend_string_init_interned("TYPE_SINT64", sizeof("TYPE_SINT64") - 1, 1);
+	zend_string *const_TYPE_SINT64_name = zend_string_init_interned("TYPE_SINT64", strlen("TYPE_SINT64"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT64_name, &const_TYPE_SINT64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT64_name);
 
 	zval const_TYPE_ENUM_value;
 	ZVAL_LONG(&const_TYPE_ENUM_value, ZEND_FFI_TYPE_ENUM);
-	zend_string *const_TYPE_ENUM_name = zend_string_init_interned("TYPE_ENUM", sizeof("TYPE_ENUM") - 1, 1);
+	zend_string *const_TYPE_ENUM_name = zend_string_init_interned("TYPE_ENUM", strlen("TYPE_ENUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_ENUM_name, &const_TYPE_ENUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_ENUM_name);
 
 	zval const_TYPE_BOOL_value;
 	ZVAL_LONG(&const_TYPE_BOOL_value, ZEND_FFI_TYPE_BOOL);
-	zend_string *const_TYPE_BOOL_name = zend_string_init_interned("TYPE_BOOL", sizeof("TYPE_BOOL") - 1, 1);
+	zend_string *const_TYPE_BOOL_name = zend_string_init_interned("TYPE_BOOL", strlen("TYPE_BOOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_BOOL_name, &const_TYPE_BOOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_BOOL_name);
 
 	zval const_TYPE_CHAR_value;
 	ZVAL_LONG(&const_TYPE_CHAR_value, ZEND_FFI_TYPE_CHAR);
-	zend_string *const_TYPE_CHAR_name = zend_string_init_interned("TYPE_CHAR", sizeof("TYPE_CHAR") - 1, 1);
+	zend_string *const_TYPE_CHAR_name = zend_string_init_interned("TYPE_CHAR", strlen("TYPE_CHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_CHAR_name, &const_TYPE_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CHAR_name);
 
 	zval const_TYPE_POINTER_value;
 	ZVAL_LONG(&const_TYPE_POINTER_value, ZEND_FFI_TYPE_POINTER);
-	zend_string *const_TYPE_POINTER_name = zend_string_init_interned("TYPE_POINTER", sizeof("TYPE_POINTER") - 1, 1);
+	zend_string *const_TYPE_POINTER_name = zend_string_init_interned("TYPE_POINTER", strlen("TYPE_POINTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_POINTER_name, &const_TYPE_POINTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_POINTER_name);
 
 	zval const_TYPE_FUNC_value;
 	ZVAL_LONG(&const_TYPE_FUNC_value, ZEND_FFI_TYPE_FUNC);
-	zend_string *const_TYPE_FUNC_name = zend_string_init_interned("TYPE_FUNC", sizeof("TYPE_FUNC") - 1, 1);
+	zend_string *const_TYPE_FUNC_name = zend_string_init_interned("TYPE_FUNC", strlen("TYPE_FUNC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_FUNC_name, &const_TYPE_FUNC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_FUNC_name);
 
 	zval const_TYPE_ARRAY_value;
 	ZVAL_LONG(&const_TYPE_ARRAY_value, ZEND_FFI_TYPE_ARRAY);
-	zend_string *const_TYPE_ARRAY_name = zend_string_init_interned("TYPE_ARRAY", sizeof("TYPE_ARRAY") - 1, 1);
+	zend_string *const_TYPE_ARRAY_name = zend_string_init_interned("TYPE_ARRAY", strlen("TYPE_ARRAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_ARRAY_name, &const_TYPE_ARRAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_ARRAY_name);
 
 	zval const_TYPE_STRUCT_value;
 	ZVAL_LONG(&const_TYPE_STRUCT_value, ZEND_FFI_TYPE_STRUCT);
-	zend_string *const_TYPE_STRUCT_name = zend_string_init_interned("TYPE_STRUCT", sizeof("TYPE_STRUCT") - 1, 1);
+	zend_string *const_TYPE_STRUCT_name = zend_string_init_interned("TYPE_STRUCT", strlen("TYPE_STRUCT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_STRUCT_name, &const_TYPE_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_STRUCT_name);
 
 	zval const_ATTR_CONST_value;
 	ZVAL_LONG(&const_ATTR_CONST_value, ZEND_FFI_ATTR_CONST);
-	zend_string *const_ATTR_CONST_name = zend_string_init_interned("ATTR_CONST", sizeof("ATTR_CONST") - 1, 1);
+	zend_string *const_ATTR_CONST_name = zend_string_init_interned("ATTR_CONST", strlen("ATTR_CONST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CONST_name, &const_ATTR_CONST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CONST_name);
 
 	zval const_ATTR_INCOMPLETE_TAG_value;
 	ZVAL_LONG(&const_ATTR_INCOMPLETE_TAG_value, ZEND_FFI_ATTR_INCOMPLETE_TAG);
-	zend_string *const_ATTR_INCOMPLETE_TAG_name = zend_string_init_interned("ATTR_INCOMPLETE_TAG", sizeof("ATTR_INCOMPLETE_TAG") - 1, 1);
+	zend_string *const_ATTR_INCOMPLETE_TAG_name = zend_string_init_interned("ATTR_INCOMPLETE_TAG", strlen("ATTR_INCOMPLETE_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_INCOMPLETE_TAG_name, &const_ATTR_INCOMPLETE_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_INCOMPLETE_TAG_name);
 
 	zval const_ATTR_VARIADIC_value;
 	ZVAL_LONG(&const_ATTR_VARIADIC_value, ZEND_FFI_ATTR_VARIADIC);
-	zend_string *const_ATTR_VARIADIC_name = zend_string_init_interned("ATTR_VARIADIC", sizeof("ATTR_VARIADIC") - 1, 1);
+	zend_string *const_ATTR_VARIADIC_name = zend_string_init_interned("ATTR_VARIADIC", strlen("ATTR_VARIADIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_VARIADIC_name, &const_ATTR_VARIADIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_VARIADIC_name);
 
 	zval const_ATTR_INCOMPLETE_ARRAY_value;
 	ZVAL_LONG(&const_ATTR_INCOMPLETE_ARRAY_value, ZEND_FFI_ATTR_INCOMPLETE_ARRAY);
-	zend_string *const_ATTR_INCOMPLETE_ARRAY_name = zend_string_init_interned("ATTR_INCOMPLETE_ARRAY", sizeof("ATTR_INCOMPLETE_ARRAY") - 1, 1);
+	zend_string *const_ATTR_INCOMPLETE_ARRAY_name = zend_string_init_interned("ATTR_INCOMPLETE_ARRAY", strlen("ATTR_INCOMPLETE_ARRAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_INCOMPLETE_ARRAY_name, &const_ATTR_INCOMPLETE_ARRAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_INCOMPLETE_ARRAY_name);
 
 	zval const_ATTR_VLA_value;
 	ZVAL_LONG(&const_ATTR_VLA_value, ZEND_FFI_ATTR_VLA);
-	zend_string *const_ATTR_VLA_name = zend_string_init_interned("ATTR_VLA", sizeof("ATTR_VLA") - 1, 1);
+	zend_string *const_ATTR_VLA_name = zend_string_init_interned("ATTR_VLA", strlen("ATTR_VLA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_VLA_name, &const_ATTR_VLA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_VLA_name);
 
 	zval const_ATTR_UNION_value;
 	ZVAL_LONG(&const_ATTR_UNION_value, ZEND_FFI_ATTR_UNION);
-	zend_string *const_ATTR_UNION_name = zend_string_init_interned("ATTR_UNION", sizeof("ATTR_UNION") - 1, 1);
+	zend_string *const_ATTR_UNION_name = zend_string_init_interned("ATTR_UNION", strlen("ATTR_UNION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_UNION_name, &const_ATTR_UNION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_UNION_name);
 
 	zval const_ATTR_PACKED_value;
 	ZVAL_LONG(&const_ATTR_PACKED_value, ZEND_FFI_ATTR_PACKED);
-	zend_string *const_ATTR_PACKED_name = zend_string_init_interned("ATTR_PACKED", sizeof("ATTR_PACKED") - 1, 1);
+	zend_string *const_ATTR_PACKED_name = zend_string_init_interned("ATTR_PACKED", strlen("ATTR_PACKED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_PACKED_name, &const_ATTR_PACKED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_PACKED_name);
 
 	zval const_ATTR_MS_STRUCT_value;
 	ZVAL_LONG(&const_ATTR_MS_STRUCT_value, ZEND_FFI_ATTR_MS_STRUCT);
-	zend_string *const_ATTR_MS_STRUCT_name = zend_string_init_interned("ATTR_MS_STRUCT", sizeof("ATTR_MS_STRUCT") - 1, 1);
+	zend_string *const_ATTR_MS_STRUCT_name = zend_string_init_interned("ATTR_MS_STRUCT", strlen("ATTR_MS_STRUCT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_MS_STRUCT_name, &const_ATTR_MS_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_MS_STRUCT_name);
 
 	zval const_ATTR_GCC_STRUCT_value;
 	ZVAL_LONG(&const_ATTR_GCC_STRUCT_value, ZEND_FFI_ATTR_GCC_STRUCT);
-	zend_string *const_ATTR_GCC_STRUCT_name = zend_string_init_interned("ATTR_GCC_STRUCT", sizeof("ATTR_GCC_STRUCT") - 1, 1);
+	zend_string *const_ATTR_GCC_STRUCT_name = zend_string_init_interned("ATTR_GCC_STRUCT", strlen("ATTR_GCC_STRUCT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_GCC_STRUCT_name, &const_ATTR_GCC_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_GCC_STRUCT_name);
 
 	zval const_ABI_DEFAULT_value;
 	ZVAL_LONG(&const_ABI_DEFAULT_value, ZEND_FFI_ABI_DEFAULT);
-	zend_string *const_ABI_DEFAULT_name = zend_string_init_interned("ABI_DEFAULT", sizeof("ABI_DEFAULT") - 1, 1);
+	zend_string *const_ABI_DEFAULT_name = zend_string_init_interned("ABI_DEFAULT", strlen("ABI_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_DEFAULT_name, &const_ABI_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_DEFAULT_name);
 
 	zval const_ABI_CDECL_value;
 	ZVAL_LONG(&const_ABI_CDECL_value, ZEND_FFI_ABI_CDECL);
-	zend_string *const_ABI_CDECL_name = zend_string_init_interned("ABI_CDECL", sizeof("ABI_CDECL") - 1, 1);
+	zend_string *const_ABI_CDECL_name = zend_string_init_interned("ABI_CDECL", strlen("ABI_CDECL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_CDECL_name, &const_ABI_CDECL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_CDECL_name);
 
 	zval const_ABI_FASTCALL_value;
 	ZVAL_LONG(&const_ABI_FASTCALL_value, ZEND_FFI_ABI_FASTCALL);
-	zend_string *const_ABI_FASTCALL_name = zend_string_init_interned("ABI_FASTCALL", sizeof("ABI_FASTCALL") - 1, 1);
+	zend_string *const_ABI_FASTCALL_name = zend_string_init_interned("ABI_FASTCALL", strlen("ABI_FASTCALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_FASTCALL_name, &const_ABI_FASTCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_FASTCALL_name);
 
 	zval const_ABI_THISCALL_value;
 	ZVAL_LONG(&const_ABI_THISCALL_value, ZEND_FFI_ABI_THISCALL);
-	zend_string *const_ABI_THISCALL_name = zend_string_init_interned("ABI_THISCALL", sizeof("ABI_THISCALL") - 1, 1);
+	zend_string *const_ABI_THISCALL_name = zend_string_init_interned("ABI_THISCALL", strlen("ABI_THISCALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_THISCALL_name, &const_ABI_THISCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_THISCALL_name);
 
 	zval const_ABI_STDCALL_value;
 	ZVAL_LONG(&const_ABI_STDCALL_value, ZEND_FFI_ABI_STDCALL);
-	zend_string *const_ABI_STDCALL_name = zend_string_init_interned("ABI_STDCALL", sizeof("ABI_STDCALL") - 1, 1);
+	zend_string *const_ABI_STDCALL_name = zend_string_init_interned("ABI_STDCALL", strlen("ABI_STDCALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_STDCALL_name, &const_ABI_STDCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_STDCALL_name);
 
 	zval const_ABI_PASCAL_value;
 	ZVAL_LONG(&const_ABI_PASCAL_value, ZEND_FFI_ABI_PASCAL);
-	zend_string *const_ABI_PASCAL_name = zend_string_init_interned("ABI_PASCAL", sizeof("ABI_PASCAL") - 1, 1);
+	zend_string *const_ABI_PASCAL_name = zend_string_init_interned("ABI_PASCAL", strlen("ABI_PASCAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_PASCAL_name, &const_ABI_PASCAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_PASCAL_name);
 
 	zval const_ABI_REGISTER_value;
 	ZVAL_LONG(&const_ABI_REGISTER_value, ZEND_FFI_ABI_REGISTER);
-	zend_string *const_ABI_REGISTER_name = zend_string_init_interned("ABI_REGISTER", sizeof("ABI_REGISTER") - 1, 1);
+	zend_string *const_ABI_REGISTER_name = zend_string_init_interned("ABI_REGISTER", strlen("ABI_REGISTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_REGISTER_name, &const_ABI_REGISTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_REGISTER_name);
 
 	zval const_ABI_MS_value;
 	ZVAL_LONG(&const_ABI_MS_value, ZEND_FFI_ABI_MS);
-	zend_string *const_ABI_MS_name = zend_string_init_interned("ABI_MS", sizeof("ABI_MS") - 1, 1);
+	zend_string *const_ABI_MS_name = zend_string_init_interned("ABI_MS", strlen("ABI_MS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_MS_name, &const_ABI_MS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_MS_name);
 
 	zval const_ABI_SYSV_value;
 	ZVAL_LONG(&const_ABI_SYSV_value, ZEND_FFI_ABI_SYSV);
-	zend_string *const_ABI_SYSV_name = zend_string_init_interned("ABI_SYSV", sizeof("ABI_SYSV") - 1, 1);
+	zend_string *const_ABI_SYSV_name = zend_string_init_interned("ABI_SYSV", strlen("ABI_SYSV"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_SYSV_name, &const_ABI_SYSV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_SYSV_name);
 
 	zval const_ABI_VECTORCALL_value;
 	ZVAL_LONG(&const_ABI_VECTORCALL_value, ZEND_FFI_ABI_VECTORCALL);
-	zend_string *const_ABI_VECTORCALL_name = zend_string_init_interned("ABI_VECTORCALL", sizeof("ABI_VECTORCALL") - 1, 1);
+	zend_string *const_ABI_VECTORCALL_name = zend_string_init_interned("ABI_VECTORCALL", strlen("ABI_VECTORCALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ABI_VECTORCALL_name, &const_ABI_VECTORCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_VECTORCALL_name);
 

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -288,7 +288,7 @@ static void register_ftp_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("FTP_MOREDATA", PHP_FTP_MOREDATA, CONST_PERSISTENT);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ftp_login", sizeof("ftp_login") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ftp_login", strlen("ftp_login")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_FTP_Connection(void)

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -193,50 +193,50 @@ static void register_hash_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("HASH_HMAC", PHP_HASH_HMAC, CONST_PERSISTENT);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac", sizeof("hash_hmac") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac", strlen("hash_hmac")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac_file", sizeof("hash_hmac_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac_file", strlen("hash_hmac_file")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_init", sizeof("hash_init") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_init", strlen("hash_init")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_pbkdf2", sizeof("hash_pbkdf2") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_pbkdf2", strlen("hash_pbkdf2")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", strlen("hash_equals")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", strlen("hash_equals")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hkdf", sizeof("hash_hkdf") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hkdf", strlen("hash_hkdf")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(PHP_MHASH_BC)
 
-	zend_attribute *attribute_Deprecated_func_mhash_get_block_size_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_block_size", sizeof("mhash_get_block_size") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_mhash_get_block_size_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_block_size", strlen("mhash_get_block_size")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_mhash_get_block_size_0_arg0;
 	zend_string *attribute_Deprecated_func_mhash_get_block_size_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mhash_get_block_size_0_arg0, attribute_Deprecated_func_mhash_get_block_size_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_block_size_0->args[0].value, &attribute_Deprecated_func_mhash_get_block_size_0_arg0);
 	attribute_Deprecated_func_mhash_get_block_size_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_mhash_get_hash_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_hash_name", sizeof("mhash_get_hash_name") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_mhash_get_hash_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_get_hash_name", strlen("mhash_get_hash_name")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_mhash_get_hash_name_0_arg0;
 	zend_string *attribute_Deprecated_func_mhash_get_hash_name_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mhash_get_hash_name_0_arg0, attribute_Deprecated_func_mhash_get_hash_name_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_get_hash_name_0->args[0].value, &attribute_Deprecated_func_mhash_get_hash_name_0_arg0);
 	attribute_Deprecated_func_mhash_get_hash_name_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_mhash_keygen_s2k_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_keygen_s2k", sizeof("mhash_keygen_s2k") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_mhash_keygen_s2k_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_keygen_s2k", strlen("mhash_keygen_s2k")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_mhash_keygen_s2k_0_arg0;
 	zend_string *attribute_Deprecated_func_mhash_keygen_s2k_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mhash_keygen_s2k_0_arg0, attribute_Deprecated_func_mhash_keygen_s2k_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].value, &attribute_Deprecated_func_mhash_keygen_s2k_0_arg0);
 	attribute_Deprecated_func_mhash_keygen_s2k_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_mhash_count_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_count", sizeof("mhash_count") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_mhash_count_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash_count", strlen("mhash_count")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_mhash_count_0_arg0;
 	zend_string *attribute_Deprecated_func_mhash_count_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mhash_count_0_arg0, attribute_Deprecated_func_mhash_count_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mhash_count_0->args[0].value, &attribute_Deprecated_func_mhash_count_0_arg0);
 	attribute_Deprecated_func_mhash_count_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_mhash_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash", sizeof("mhash") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_mhash_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mhash", strlen("mhash")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_mhash_0_arg0;
 	zend_string *attribute_Deprecated_func_mhash_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mhash_0_arg0, attribute_Deprecated_func_mhash_0_arg0_str);

--- a/ext/intl/breakiterator/breakiterator_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_arginfo.h
@@ -161,115 +161,115 @@ static zend_class_entry *register_class_IntlBreakIterator(zend_class_entry *clas
 
 	zval const_DONE_value;
 	ZVAL_LONG(&const_DONE_value, BreakIterator::DONE);
-	zend_string *const_DONE_name = zend_string_init_interned("DONE", sizeof("DONE") - 1, 1);
+	zend_string *const_DONE_name = zend_string_init_interned("DONE", strlen("DONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DONE_name, &const_DONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DONE_name);
 
 	zval const_WORD_NONE_value;
 	ZVAL_LONG(&const_WORD_NONE_value, UBRK_WORD_NONE);
-	zend_string *const_WORD_NONE_name = zend_string_init_interned("WORD_NONE", sizeof("WORD_NONE") - 1, 1);
+	zend_string *const_WORD_NONE_name = zend_string_init_interned("WORD_NONE", strlen("WORD_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_NONE_name, &const_WORD_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_NONE_name);
 
 	zval const_WORD_NONE_LIMIT_value;
 	ZVAL_LONG(&const_WORD_NONE_LIMIT_value, UBRK_WORD_NONE_LIMIT);
-	zend_string *const_WORD_NONE_LIMIT_name = zend_string_init_interned("WORD_NONE_LIMIT", sizeof("WORD_NONE_LIMIT") - 1, 1);
+	zend_string *const_WORD_NONE_LIMIT_name = zend_string_init_interned("WORD_NONE_LIMIT", strlen("WORD_NONE_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_NONE_LIMIT_name, &const_WORD_NONE_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_NONE_LIMIT_name);
 
 	zval const_WORD_NUMBER_value;
 	ZVAL_LONG(&const_WORD_NUMBER_value, UBRK_WORD_NUMBER);
-	zend_string *const_WORD_NUMBER_name = zend_string_init_interned("WORD_NUMBER", sizeof("WORD_NUMBER") - 1, 1);
+	zend_string *const_WORD_NUMBER_name = zend_string_init_interned("WORD_NUMBER", strlen("WORD_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_NUMBER_name, &const_WORD_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_NUMBER_name);
 
 	zval const_WORD_NUMBER_LIMIT_value;
 	ZVAL_LONG(&const_WORD_NUMBER_LIMIT_value, UBRK_WORD_NUMBER_LIMIT);
-	zend_string *const_WORD_NUMBER_LIMIT_name = zend_string_init_interned("WORD_NUMBER_LIMIT", sizeof("WORD_NUMBER_LIMIT") - 1, 1);
+	zend_string *const_WORD_NUMBER_LIMIT_name = zend_string_init_interned("WORD_NUMBER_LIMIT", strlen("WORD_NUMBER_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_NUMBER_LIMIT_name, &const_WORD_NUMBER_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_NUMBER_LIMIT_name);
 
 	zval const_WORD_LETTER_value;
 	ZVAL_LONG(&const_WORD_LETTER_value, UBRK_WORD_LETTER);
-	zend_string *const_WORD_LETTER_name = zend_string_init_interned("WORD_LETTER", sizeof("WORD_LETTER") - 1, 1);
+	zend_string *const_WORD_LETTER_name = zend_string_init_interned("WORD_LETTER", strlen("WORD_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_LETTER_name, &const_WORD_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_LETTER_name);
 
 	zval const_WORD_LETTER_LIMIT_value;
 	ZVAL_LONG(&const_WORD_LETTER_LIMIT_value, UBRK_WORD_LETTER_LIMIT);
-	zend_string *const_WORD_LETTER_LIMIT_name = zend_string_init_interned("WORD_LETTER_LIMIT", sizeof("WORD_LETTER_LIMIT") - 1, 1);
+	zend_string *const_WORD_LETTER_LIMIT_name = zend_string_init_interned("WORD_LETTER_LIMIT", strlen("WORD_LETTER_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_LETTER_LIMIT_name, &const_WORD_LETTER_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_LETTER_LIMIT_name);
 
 	zval const_WORD_KANA_value;
 	ZVAL_LONG(&const_WORD_KANA_value, UBRK_WORD_KANA);
-	zend_string *const_WORD_KANA_name = zend_string_init_interned("WORD_KANA", sizeof("WORD_KANA") - 1, 1);
+	zend_string *const_WORD_KANA_name = zend_string_init_interned("WORD_KANA", strlen("WORD_KANA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_KANA_name, &const_WORD_KANA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_KANA_name);
 
 	zval const_WORD_KANA_LIMIT_value;
 	ZVAL_LONG(&const_WORD_KANA_LIMIT_value, UBRK_WORD_KANA_LIMIT);
-	zend_string *const_WORD_KANA_LIMIT_name = zend_string_init_interned("WORD_KANA_LIMIT", sizeof("WORD_KANA_LIMIT") - 1, 1);
+	zend_string *const_WORD_KANA_LIMIT_name = zend_string_init_interned("WORD_KANA_LIMIT", strlen("WORD_KANA_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_KANA_LIMIT_name, &const_WORD_KANA_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_KANA_LIMIT_name);
 
 	zval const_WORD_IDEO_value;
 	ZVAL_LONG(&const_WORD_IDEO_value, UBRK_WORD_IDEO);
-	zend_string *const_WORD_IDEO_name = zend_string_init_interned("WORD_IDEO", sizeof("WORD_IDEO") - 1, 1);
+	zend_string *const_WORD_IDEO_name = zend_string_init_interned("WORD_IDEO", strlen("WORD_IDEO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_IDEO_name, &const_WORD_IDEO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_IDEO_name);
 
 	zval const_WORD_IDEO_LIMIT_value;
 	ZVAL_LONG(&const_WORD_IDEO_LIMIT_value, UBRK_WORD_IDEO_LIMIT);
-	zend_string *const_WORD_IDEO_LIMIT_name = zend_string_init_interned("WORD_IDEO_LIMIT", sizeof("WORD_IDEO_LIMIT") - 1, 1);
+	zend_string *const_WORD_IDEO_LIMIT_name = zend_string_init_interned("WORD_IDEO_LIMIT", strlen("WORD_IDEO_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WORD_IDEO_LIMIT_name, &const_WORD_IDEO_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WORD_IDEO_LIMIT_name);
 
 	zval const_LINE_SOFT_value;
 	ZVAL_LONG(&const_LINE_SOFT_value, UBRK_LINE_SOFT);
-	zend_string *const_LINE_SOFT_name = zend_string_init_interned("LINE_SOFT", sizeof("LINE_SOFT") - 1, 1);
+	zend_string *const_LINE_SOFT_name = zend_string_init_interned("LINE_SOFT", strlen("LINE_SOFT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LINE_SOFT_name, &const_LINE_SOFT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LINE_SOFT_name);
 
 	zval const_LINE_SOFT_LIMIT_value;
 	ZVAL_LONG(&const_LINE_SOFT_LIMIT_value, UBRK_LINE_SOFT_LIMIT);
-	zend_string *const_LINE_SOFT_LIMIT_name = zend_string_init_interned("LINE_SOFT_LIMIT", sizeof("LINE_SOFT_LIMIT") - 1, 1);
+	zend_string *const_LINE_SOFT_LIMIT_name = zend_string_init_interned("LINE_SOFT_LIMIT", strlen("LINE_SOFT_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LINE_SOFT_LIMIT_name, &const_LINE_SOFT_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LINE_SOFT_LIMIT_name);
 
 	zval const_LINE_HARD_value;
 	ZVAL_LONG(&const_LINE_HARD_value, UBRK_LINE_HARD);
-	zend_string *const_LINE_HARD_name = zend_string_init_interned("LINE_HARD", sizeof("LINE_HARD") - 1, 1);
+	zend_string *const_LINE_HARD_name = zend_string_init_interned("LINE_HARD", strlen("LINE_HARD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LINE_HARD_name, &const_LINE_HARD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LINE_HARD_name);
 
 	zval const_LINE_HARD_LIMIT_value;
 	ZVAL_LONG(&const_LINE_HARD_LIMIT_value, UBRK_LINE_HARD_LIMIT);
-	zend_string *const_LINE_HARD_LIMIT_name = zend_string_init_interned("LINE_HARD_LIMIT", sizeof("LINE_HARD_LIMIT") - 1, 1);
+	zend_string *const_LINE_HARD_LIMIT_name = zend_string_init_interned("LINE_HARD_LIMIT", strlen("LINE_HARD_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LINE_HARD_LIMIT_name, &const_LINE_HARD_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LINE_HARD_LIMIT_name);
 
 	zval const_SENTENCE_TERM_value;
 	ZVAL_LONG(&const_SENTENCE_TERM_value, UBRK_SENTENCE_TERM);
-	zend_string *const_SENTENCE_TERM_name = zend_string_init_interned("SENTENCE_TERM", sizeof("SENTENCE_TERM") - 1, 1);
+	zend_string *const_SENTENCE_TERM_name = zend_string_init_interned("SENTENCE_TERM", strlen("SENTENCE_TERM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SENTENCE_TERM_name, &const_SENTENCE_TERM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SENTENCE_TERM_name);
 
 	zval const_SENTENCE_TERM_LIMIT_value;
 	ZVAL_LONG(&const_SENTENCE_TERM_LIMIT_value, UBRK_SENTENCE_TERM_LIMIT);
-	zend_string *const_SENTENCE_TERM_LIMIT_name = zend_string_init_interned("SENTENCE_TERM_LIMIT", sizeof("SENTENCE_TERM_LIMIT") - 1, 1);
+	zend_string *const_SENTENCE_TERM_LIMIT_name = zend_string_init_interned("SENTENCE_TERM_LIMIT", strlen("SENTENCE_TERM_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SENTENCE_TERM_LIMIT_name, &const_SENTENCE_TERM_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SENTENCE_TERM_LIMIT_name);
 
 	zval const_SENTENCE_SEP_value;
 	ZVAL_LONG(&const_SENTENCE_SEP_value, UBRK_SENTENCE_SEP);
-	zend_string *const_SENTENCE_SEP_name = zend_string_init_interned("SENTENCE_SEP", sizeof("SENTENCE_SEP") - 1, 1);
+	zend_string *const_SENTENCE_SEP_name = zend_string_init_interned("SENTENCE_SEP", strlen("SENTENCE_SEP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SENTENCE_SEP_name, &const_SENTENCE_SEP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SENTENCE_SEP_name);
 
 	zval const_SENTENCE_SEP_LIMIT_value;
 	ZVAL_LONG(&const_SENTENCE_SEP_LIMIT_value, UBRK_SENTENCE_SEP_LIMIT);
-	zend_string *const_SENTENCE_SEP_LIMIT_name = zend_string_init_interned("SENTENCE_SEP_LIMIT", sizeof("SENTENCE_SEP_LIMIT") - 1, 1);
+	zend_string *const_SENTENCE_SEP_LIMIT_name = zend_string_init_interned("SENTENCE_SEP_LIMIT", strlen("SENTENCE_SEP_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SENTENCE_SEP_LIMIT_name, &const_SENTENCE_SEP_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SENTENCE_SEP_LIMIT_name);
 

--- a/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
@@ -25,19 +25,19 @@ static zend_class_entry *register_class_IntlPartsIterator(zend_class_entry *clas
 
 	zval const_KEY_SEQUENTIAL_value;
 	ZVAL_LONG(&const_KEY_SEQUENTIAL_value, PARTS_ITERATOR_KEY_SEQUENTIAL);
-	zend_string *const_KEY_SEQUENTIAL_name = zend_string_init_interned("KEY_SEQUENTIAL", sizeof("KEY_SEQUENTIAL") - 1, 1);
+	zend_string *const_KEY_SEQUENTIAL_name = zend_string_init_interned("KEY_SEQUENTIAL", strlen("KEY_SEQUENTIAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_SEQUENTIAL_name, &const_KEY_SEQUENTIAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_SEQUENTIAL_name);
 
 	zval const_KEY_LEFT_value;
 	ZVAL_LONG(&const_KEY_LEFT_value, PARTS_ITERATOR_KEY_LEFT);
-	zend_string *const_KEY_LEFT_name = zend_string_init_interned("KEY_LEFT", sizeof("KEY_LEFT") - 1, 1);
+	zend_string *const_KEY_LEFT_name = zend_string_init_interned("KEY_LEFT", strlen("KEY_LEFT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_LEFT_name, &const_KEY_LEFT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_LEFT_name);
 
 	zval const_KEY_RIGHT_value;
 	ZVAL_LONG(&const_KEY_RIGHT_value, PARTS_ITERATOR_KEY_RIGHT);
-	zend_string *const_KEY_RIGHT_name = zend_string_init_interned("KEY_RIGHT", sizeof("KEY_RIGHT") - 1, 1);
+	zend_string *const_KEY_RIGHT_name = zend_string_init_interned("KEY_RIGHT", strlen("KEY_RIGHT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_RIGHT_name, &const_KEY_RIGHT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_RIGHT_name);
 

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -329,235 +329,235 @@ static zend_class_entry *register_class_IntlCalendar(void)
 
 	zval const_FIELD_ERA_value;
 	ZVAL_LONG(&const_FIELD_ERA_value, UCAL_ERA);
-	zend_string *const_FIELD_ERA_name = zend_string_init_interned("FIELD_ERA", sizeof("FIELD_ERA") - 1, 1);
+	zend_string *const_FIELD_ERA_name = zend_string_init_interned("FIELD_ERA", strlen("FIELD_ERA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_ERA_name, &const_FIELD_ERA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_ERA_name);
 
 	zval const_FIELD_YEAR_value;
 	ZVAL_LONG(&const_FIELD_YEAR_value, UCAL_YEAR);
-	zend_string *const_FIELD_YEAR_name = zend_string_init_interned("FIELD_YEAR", sizeof("FIELD_YEAR") - 1, 1);
+	zend_string *const_FIELD_YEAR_name = zend_string_init_interned("FIELD_YEAR", strlen("FIELD_YEAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_YEAR_name, &const_FIELD_YEAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_YEAR_name);
 
 	zval const_FIELD_MONTH_value;
 	ZVAL_LONG(&const_FIELD_MONTH_value, UCAL_MONTH);
-	zend_string *const_FIELD_MONTH_name = zend_string_init_interned("FIELD_MONTH", sizeof("FIELD_MONTH") - 1, 1);
+	zend_string *const_FIELD_MONTH_name = zend_string_init_interned("FIELD_MONTH", strlen("FIELD_MONTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_MONTH_name, &const_FIELD_MONTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_MONTH_name);
 
 	zval const_FIELD_WEEK_OF_YEAR_value;
 	ZVAL_LONG(&const_FIELD_WEEK_OF_YEAR_value, UCAL_WEEK_OF_YEAR);
-	zend_string *const_FIELD_WEEK_OF_YEAR_name = zend_string_init_interned("FIELD_WEEK_OF_YEAR", sizeof("FIELD_WEEK_OF_YEAR") - 1, 1);
+	zend_string *const_FIELD_WEEK_OF_YEAR_name = zend_string_init_interned("FIELD_WEEK_OF_YEAR", strlen("FIELD_WEEK_OF_YEAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_WEEK_OF_YEAR_name, &const_FIELD_WEEK_OF_YEAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_WEEK_OF_YEAR_name);
 
 	zval const_FIELD_WEEK_OF_MONTH_value;
 	ZVAL_LONG(&const_FIELD_WEEK_OF_MONTH_value, UCAL_WEEK_OF_MONTH);
-	zend_string *const_FIELD_WEEK_OF_MONTH_name = zend_string_init_interned("FIELD_WEEK_OF_MONTH", sizeof("FIELD_WEEK_OF_MONTH") - 1, 1);
+	zend_string *const_FIELD_WEEK_OF_MONTH_name = zend_string_init_interned("FIELD_WEEK_OF_MONTH", strlen("FIELD_WEEK_OF_MONTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_WEEK_OF_MONTH_name, &const_FIELD_WEEK_OF_MONTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_WEEK_OF_MONTH_name);
 
 	zval const_FIELD_DATE_value;
 	ZVAL_LONG(&const_FIELD_DATE_value, UCAL_DATE);
-	zend_string *const_FIELD_DATE_name = zend_string_init_interned("FIELD_DATE", sizeof("FIELD_DATE") - 1, 1);
+	zend_string *const_FIELD_DATE_name = zend_string_init_interned("FIELD_DATE", strlen("FIELD_DATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DATE_name, &const_FIELD_DATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DATE_name);
 
 	zval const_FIELD_DAY_OF_YEAR_value;
 	ZVAL_LONG(&const_FIELD_DAY_OF_YEAR_value, UCAL_DAY_OF_YEAR);
-	zend_string *const_FIELD_DAY_OF_YEAR_name = zend_string_init_interned("FIELD_DAY_OF_YEAR", sizeof("FIELD_DAY_OF_YEAR") - 1, 1);
+	zend_string *const_FIELD_DAY_OF_YEAR_name = zend_string_init_interned("FIELD_DAY_OF_YEAR", strlen("FIELD_DAY_OF_YEAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DAY_OF_YEAR_name, &const_FIELD_DAY_OF_YEAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DAY_OF_YEAR_name);
 
 	zval const_FIELD_DAY_OF_WEEK_value;
 	ZVAL_LONG(&const_FIELD_DAY_OF_WEEK_value, UCAL_DAY_OF_WEEK);
-	zend_string *const_FIELD_DAY_OF_WEEK_name = zend_string_init_interned("FIELD_DAY_OF_WEEK", sizeof("FIELD_DAY_OF_WEEK") - 1, 1);
+	zend_string *const_FIELD_DAY_OF_WEEK_name = zend_string_init_interned("FIELD_DAY_OF_WEEK", strlen("FIELD_DAY_OF_WEEK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DAY_OF_WEEK_name, &const_FIELD_DAY_OF_WEEK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DAY_OF_WEEK_name);
 
 	zval const_FIELD_DAY_OF_WEEK_IN_MONTH_value;
 	ZVAL_LONG(&const_FIELD_DAY_OF_WEEK_IN_MONTH_value, UCAL_DAY_OF_WEEK_IN_MONTH);
-	zend_string *const_FIELD_DAY_OF_WEEK_IN_MONTH_name = zend_string_init_interned("FIELD_DAY_OF_WEEK_IN_MONTH", sizeof("FIELD_DAY_OF_WEEK_IN_MONTH") - 1, 1);
+	zend_string *const_FIELD_DAY_OF_WEEK_IN_MONTH_name = zend_string_init_interned("FIELD_DAY_OF_WEEK_IN_MONTH", strlen("FIELD_DAY_OF_WEEK_IN_MONTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DAY_OF_WEEK_IN_MONTH_name, &const_FIELD_DAY_OF_WEEK_IN_MONTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DAY_OF_WEEK_IN_MONTH_name);
 
 	zval const_FIELD_AM_PM_value;
 	ZVAL_LONG(&const_FIELD_AM_PM_value, UCAL_AM_PM);
-	zend_string *const_FIELD_AM_PM_name = zend_string_init_interned("FIELD_AM_PM", sizeof("FIELD_AM_PM") - 1, 1);
+	zend_string *const_FIELD_AM_PM_name = zend_string_init_interned("FIELD_AM_PM", strlen("FIELD_AM_PM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_AM_PM_name, &const_FIELD_AM_PM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_AM_PM_name);
 
 	zval const_FIELD_HOUR_value;
 	ZVAL_LONG(&const_FIELD_HOUR_value, UCAL_HOUR);
-	zend_string *const_FIELD_HOUR_name = zend_string_init_interned("FIELD_HOUR", sizeof("FIELD_HOUR") - 1, 1);
+	zend_string *const_FIELD_HOUR_name = zend_string_init_interned("FIELD_HOUR", strlen("FIELD_HOUR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_HOUR_name, &const_FIELD_HOUR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_HOUR_name);
 
 	zval const_FIELD_HOUR_OF_DAY_value;
 	ZVAL_LONG(&const_FIELD_HOUR_OF_DAY_value, UCAL_HOUR_OF_DAY);
-	zend_string *const_FIELD_HOUR_OF_DAY_name = zend_string_init_interned("FIELD_HOUR_OF_DAY", sizeof("FIELD_HOUR_OF_DAY") - 1, 1);
+	zend_string *const_FIELD_HOUR_OF_DAY_name = zend_string_init_interned("FIELD_HOUR_OF_DAY", strlen("FIELD_HOUR_OF_DAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_HOUR_OF_DAY_name, &const_FIELD_HOUR_OF_DAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_HOUR_OF_DAY_name);
 
 	zval const_FIELD_MINUTE_value;
 	ZVAL_LONG(&const_FIELD_MINUTE_value, UCAL_MINUTE);
-	zend_string *const_FIELD_MINUTE_name = zend_string_init_interned("FIELD_MINUTE", sizeof("FIELD_MINUTE") - 1, 1);
+	zend_string *const_FIELD_MINUTE_name = zend_string_init_interned("FIELD_MINUTE", strlen("FIELD_MINUTE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_MINUTE_name, &const_FIELD_MINUTE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_MINUTE_name);
 
 	zval const_FIELD_SECOND_value;
 	ZVAL_LONG(&const_FIELD_SECOND_value, UCAL_SECOND);
-	zend_string *const_FIELD_SECOND_name = zend_string_init_interned("FIELD_SECOND", sizeof("FIELD_SECOND") - 1, 1);
+	zend_string *const_FIELD_SECOND_name = zend_string_init_interned("FIELD_SECOND", strlen("FIELD_SECOND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_SECOND_name, &const_FIELD_SECOND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_SECOND_name);
 
 	zval const_FIELD_MILLISECOND_value;
 	ZVAL_LONG(&const_FIELD_MILLISECOND_value, UCAL_MILLISECOND);
-	zend_string *const_FIELD_MILLISECOND_name = zend_string_init_interned("FIELD_MILLISECOND", sizeof("FIELD_MILLISECOND") - 1, 1);
+	zend_string *const_FIELD_MILLISECOND_name = zend_string_init_interned("FIELD_MILLISECOND", strlen("FIELD_MILLISECOND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_MILLISECOND_name, &const_FIELD_MILLISECOND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_MILLISECOND_name);
 
 	zval const_FIELD_ZONE_OFFSET_value;
 	ZVAL_LONG(&const_FIELD_ZONE_OFFSET_value, UCAL_ZONE_OFFSET);
-	zend_string *const_FIELD_ZONE_OFFSET_name = zend_string_init_interned("FIELD_ZONE_OFFSET", sizeof("FIELD_ZONE_OFFSET") - 1, 1);
+	zend_string *const_FIELD_ZONE_OFFSET_name = zend_string_init_interned("FIELD_ZONE_OFFSET", strlen("FIELD_ZONE_OFFSET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_ZONE_OFFSET_name, &const_FIELD_ZONE_OFFSET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_ZONE_OFFSET_name);
 
 	zval const_FIELD_DST_OFFSET_value;
 	ZVAL_LONG(&const_FIELD_DST_OFFSET_value, UCAL_DST_OFFSET);
-	zend_string *const_FIELD_DST_OFFSET_name = zend_string_init_interned("FIELD_DST_OFFSET", sizeof("FIELD_DST_OFFSET") - 1, 1);
+	zend_string *const_FIELD_DST_OFFSET_name = zend_string_init_interned("FIELD_DST_OFFSET", strlen("FIELD_DST_OFFSET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DST_OFFSET_name, &const_FIELD_DST_OFFSET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DST_OFFSET_name);
 
 	zval const_FIELD_YEAR_WOY_value;
 	ZVAL_LONG(&const_FIELD_YEAR_WOY_value, UCAL_YEAR_WOY);
-	zend_string *const_FIELD_YEAR_WOY_name = zend_string_init_interned("FIELD_YEAR_WOY", sizeof("FIELD_YEAR_WOY") - 1, 1);
+	zend_string *const_FIELD_YEAR_WOY_name = zend_string_init_interned("FIELD_YEAR_WOY", strlen("FIELD_YEAR_WOY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_YEAR_WOY_name, &const_FIELD_YEAR_WOY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_YEAR_WOY_name);
 
 	zval const_FIELD_DOW_LOCAL_value;
 	ZVAL_LONG(&const_FIELD_DOW_LOCAL_value, UCAL_DOW_LOCAL);
-	zend_string *const_FIELD_DOW_LOCAL_name = zend_string_init_interned("FIELD_DOW_LOCAL", sizeof("FIELD_DOW_LOCAL") - 1, 1);
+	zend_string *const_FIELD_DOW_LOCAL_name = zend_string_init_interned("FIELD_DOW_LOCAL", strlen("FIELD_DOW_LOCAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DOW_LOCAL_name, &const_FIELD_DOW_LOCAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DOW_LOCAL_name);
 
 	zval const_FIELD_EXTENDED_YEAR_value;
 	ZVAL_LONG(&const_FIELD_EXTENDED_YEAR_value, UCAL_EXTENDED_YEAR);
-	zend_string *const_FIELD_EXTENDED_YEAR_name = zend_string_init_interned("FIELD_EXTENDED_YEAR", sizeof("FIELD_EXTENDED_YEAR") - 1, 1);
+	zend_string *const_FIELD_EXTENDED_YEAR_name = zend_string_init_interned("FIELD_EXTENDED_YEAR", strlen("FIELD_EXTENDED_YEAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_EXTENDED_YEAR_name, &const_FIELD_EXTENDED_YEAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_EXTENDED_YEAR_name);
 
 	zval const_FIELD_JULIAN_DAY_value;
 	ZVAL_LONG(&const_FIELD_JULIAN_DAY_value, UCAL_JULIAN_DAY);
-	zend_string *const_FIELD_JULIAN_DAY_name = zend_string_init_interned("FIELD_JULIAN_DAY", sizeof("FIELD_JULIAN_DAY") - 1, 1);
+	zend_string *const_FIELD_JULIAN_DAY_name = zend_string_init_interned("FIELD_JULIAN_DAY", strlen("FIELD_JULIAN_DAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_JULIAN_DAY_name, &const_FIELD_JULIAN_DAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_JULIAN_DAY_name);
 
 	zval const_FIELD_MILLISECONDS_IN_DAY_value;
 	ZVAL_LONG(&const_FIELD_MILLISECONDS_IN_DAY_value, UCAL_MILLISECONDS_IN_DAY);
-	zend_string *const_FIELD_MILLISECONDS_IN_DAY_name = zend_string_init_interned("FIELD_MILLISECONDS_IN_DAY", sizeof("FIELD_MILLISECONDS_IN_DAY") - 1, 1);
+	zend_string *const_FIELD_MILLISECONDS_IN_DAY_name = zend_string_init_interned("FIELD_MILLISECONDS_IN_DAY", strlen("FIELD_MILLISECONDS_IN_DAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_MILLISECONDS_IN_DAY_name, &const_FIELD_MILLISECONDS_IN_DAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_MILLISECONDS_IN_DAY_name);
 
 	zval const_FIELD_IS_LEAP_MONTH_value;
 	ZVAL_LONG(&const_FIELD_IS_LEAP_MONTH_value, UCAL_IS_LEAP_MONTH);
-	zend_string *const_FIELD_IS_LEAP_MONTH_name = zend_string_init_interned("FIELD_IS_LEAP_MONTH", sizeof("FIELD_IS_LEAP_MONTH") - 1, 1);
+	zend_string *const_FIELD_IS_LEAP_MONTH_name = zend_string_init_interned("FIELD_IS_LEAP_MONTH", strlen("FIELD_IS_LEAP_MONTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_IS_LEAP_MONTH_name, &const_FIELD_IS_LEAP_MONTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_IS_LEAP_MONTH_name);
 
 	zval const_FIELD_FIELD_COUNT_value;
 	ZVAL_LONG(&const_FIELD_FIELD_COUNT_value, UCAL_FIELD_COUNT);
-	zend_string *const_FIELD_FIELD_COUNT_name = zend_string_init_interned("FIELD_FIELD_COUNT", sizeof("FIELD_FIELD_COUNT") - 1, 1);
+	zend_string *const_FIELD_FIELD_COUNT_name = zend_string_init_interned("FIELD_FIELD_COUNT", strlen("FIELD_FIELD_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_FIELD_COUNT_name, &const_FIELD_FIELD_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_FIELD_COUNT_name);
 
 	zval const_FIELD_DAY_OF_MONTH_value;
 	ZVAL_LONG(&const_FIELD_DAY_OF_MONTH_value, UCAL_DAY_OF_MONTH);
-	zend_string *const_FIELD_DAY_OF_MONTH_name = zend_string_init_interned("FIELD_DAY_OF_MONTH", sizeof("FIELD_DAY_OF_MONTH") - 1, 1);
+	zend_string *const_FIELD_DAY_OF_MONTH_name = zend_string_init_interned("FIELD_DAY_OF_MONTH", strlen("FIELD_DAY_OF_MONTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FIELD_DAY_OF_MONTH_name, &const_FIELD_DAY_OF_MONTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FIELD_DAY_OF_MONTH_name);
 
 	zval const_DOW_SUNDAY_value;
 	ZVAL_LONG(&const_DOW_SUNDAY_value, UCAL_SUNDAY);
-	zend_string *const_DOW_SUNDAY_name = zend_string_init_interned("DOW_SUNDAY", sizeof("DOW_SUNDAY") - 1, 1);
+	zend_string *const_DOW_SUNDAY_name = zend_string_init_interned("DOW_SUNDAY", strlen("DOW_SUNDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_SUNDAY_name, &const_DOW_SUNDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_SUNDAY_name);
 
 	zval const_DOW_MONDAY_value;
 	ZVAL_LONG(&const_DOW_MONDAY_value, UCAL_MONDAY);
-	zend_string *const_DOW_MONDAY_name = zend_string_init_interned("DOW_MONDAY", sizeof("DOW_MONDAY") - 1, 1);
+	zend_string *const_DOW_MONDAY_name = zend_string_init_interned("DOW_MONDAY", strlen("DOW_MONDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_MONDAY_name, &const_DOW_MONDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_MONDAY_name);
 
 	zval const_DOW_TUESDAY_value;
 	ZVAL_LONG(&const_DOW_TUESDAY_value, UCAL_TUESDAY);
-	zend_string *const_DOW_TUESDAY_name = zend_string_init_interned("DOW_TUESDAY", sizeof("DOW_TUESDAY") - 1, 1);
+	zend_string *const_DOW_TUESDAY_name = zend_string_init_interned("DOW_TUESDAY", strlen("DOW_TUESDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_TUESDAY_name, &const_DOW_TUESDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_TUESDAY_name);
 
 	zval const_DOW_WEDNESDAY_value;
 	ZVAL_LONG(&const_DOW_WEDNESDAY_value, UCAL_WEDNESDAY);
-	zend_string *const_DOW_WEDNESDAY_name = zend_string_init_interned("DOW_WEDNESDAY", sizeof("DOW_WEDNESDAY") - 1, 1);
+	zend_string *const_DOW_WEDNESDAY_name = zend_string_init_interned("DOW_WEDNESDAY", strlen("DOW_WEDNESDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_WEDNESDAY_name, &const_DOW_WEDNESDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_WEDNESDAY_name);
 
 	zval const_DOW_THURSDAY_value;
 	ZVAL_LONG(&const_DOW_THURSDAY_value, UCAL_THURSDAY);
-	zend_string *const_DOW_THURSDAY_name = zend_string_init_interned("DOW_THURSDAY", sizeof("DOW_THURSDAY") - 1, 1);
+	zend_string *const_DOW_THURSDAY_name = zend_string_init_interned("DOW_THURSDAY", strlen("DOW_THURSDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_THURSDAY_name, &const_DOW_THURSDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_THURSDAY_name);
 
 	zval const_DOW_FRIDAY_value;
 	ZVAL_LONG(&const_DOW_FRIDAY_value, UCAL_FRIDAY);
-	zend_string *const_DOW_FRIDAY_name = zend_string_init_interned("DOW_FRIDAY", sizeof("DOW_FRIDAY") - 1, 1);
+	zend_string *const_DOW_FRIDAY_name = zend_string_init_interned("DOW_FRIDAY", strlen("DOW_FRIDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_FRIDAY_name, &const_DOW_FRIDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_FRIDAY_name);
 
 	zval const_DOW_SATURDAY_value;
 	ZVAL_LONG(&const_DOW_SATURDAY_value, UCAL_SATURDAY);
-	zend_string *const_DOW_SATURDAY_name = zend_string_init_interned("DOW_SATURDAY", sizeof("DOW_SATURDAY") - 1, 1);
+	zend_string *const_DOW_SATURDAY_name = zend_string_init_interned("DOW_SATURDAY", strlen("DOW_SATURDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_SATURDAY_name, &const_DOW_SATURDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_SATURDAY_name);
 
 	zval const_DOW_TYPE_WEEKDAY_value;
 	ZVAL_LONG(&const_DOW_TYPE_WEEKDAY_value, UCAL_WEEKDAY);
-	zend_string *const_DOW_TYPE_WEEKDAY_name = zend_string_init_interned("DOW_TYPE_WEEKDAY", sizeof("DOW_TYPE_WEEKDAY") - 1, 1);
+	zend_string *const_DOW_TYPE_WEEKDAY_name = zend_string_init_interned("DOW_TYPE_WEEKDAY", strlen("DOW_TYPE_WEEKDAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_TYPE_WEEKDAY_name, &const_DOW_TYPE_WEEKDAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_TYPE_WEEKDAY_name);
 
 	zval const_DOW_TYPE_WEEKEND_value;
 	ZVAL_LONG(&const_DOW_TYPE_WEEKEND_value, UCAL_WEEKEND);
-	zend_string *const_DOW_TYPE_WEEKEND_name = zend_string_init_interned("DOW_TYPE_WEEKEND", sizeof("DOW_TYPE_WEEKEND") - 1, 1);
+	zend_string *const_DOW_TYPE_WEEKEND_name = zend_string_init_interned("DOW_TYPE_WEEKEND", strlen("DOW_TYPE_WEEKEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_TYPE_WEEKEND_name, &const_DOW_TYPE_WEEKEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_TYPE_WEEKEND_name);
 
 	zval const_DOW_TYPE_WEEKEND_OFFSET_value;
 	ZVAL_LONG(&const_DOW_TYPE_WEEKEND_OFFSET_value, UCAL_WEEKEND_ONSET);
-	zend_string *const_DOW_TYPE_WEEKEND_OFFSET_name = zend_string_init_interned("DOW_TYPE_WEEKEND_OFFSET", sizeof("DOW_TYPE_WEEKEND_OFFSET") - 1, 1);
+	zend_string *const_DOW_TYPE_WEEKEND_OFFSET_name = zend_string_init_interned("DOW_TYPE_WEEKEND_OFFSET", strlen("DOW_TYPE_WEEKEND_OFFSET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_TYPE_WEEKEND_OFFSET_name, &const_DOW_TYPE_WEEKEND_OFFSET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_TYPE_WEEKEND_OFFSET_name);
 
 	zval const_DOW_TYPE_WEEKEND_CEASE_value;
 	ZVAL_LONG(&const_DOW_TYPE_WEEKEND_CEASE_value, UCAL_WEEKEND_CEASE);
-	zend_string *const_DOW_TYPE_WEEKEND_CEASE_name = zend_string_init_interned("DOW_TYPE_WEEKEND_CEASE", sizeof("DOW_TYPE_WEEKEND_CEASE") - 1, 1);
+	zend_string *const_DOW_TYPE_WEEKEND_CEASE_name = zend_string_init_interned("DOW_TYPE_WEEKEND_CEASE", strlen("DOW_TYPE_WEEKEND_CEASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOW_TYPE_WEEKEND_CEASE_name, &const_DOW_TYPE_WEEKEND_CEASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOW_TYPE_WEEKEND_CEASE_name);
 
 	zval const_WALLTIME_FIRST_value;
 	ZVAL_LONG(&const_WALLTIME_FIRST_value, UCAL_WALLTIME_FIRST);
-	zend_string *const_WALLTIME_FIRST_name = zend_string_init_interned("WALLTIME_FIRST", sizeof("WALLTIME_FIRST") - 1, 1);
+	zend_string *const_WALLTIME_FIRST_name = zend_string_init_interned("WALLTIME_FIRST", strlen("WALLTIME_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WALLTIME_FIRST_name, &const_WALLTIME_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WALLTIME_FIRST_name);
 
 	zval const_WALLTIME_LAST_value;
 	ZVAL_LONG(&const_WALLTIME_LAST_value, UCAL_WALLTIME_LAST);
-	zend_string *const_WALLTIME_LAST_name = zend_string_init_interned("WALLTIME_LAST", sizeof("WALLTIME_LAST") - 1, 1);
+	zend_string *const_WALLTIME_LAST_name = zend_string_init_interned("WALLTIME_LAST", strlen("WALLTIME_LAST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WALLTIME_LAST_name, &const_WALLTIME_LAST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WALLTIME_LAST_name);
 
 	zval const_WALLTIME_NEXT_VALID_value;
 	ZVAL_LONG(&const_WALLTIME_NEXT_VALID_value, UCAL_WALLTIME_NEXT_VALID);
-	zend_string *const_WALLTIME_NEXT_VALID_name = zend_string_init_interned("WALLTIME_NEXT_VALID", sizeof("WALLTIME_NEXT_VALID") - 1, 1);
+	zend_string *const_WALLTIME_NEXT_VALID_name = zend_string_init_interned("WALLTIME_NEXT_VALID", strlen("WALLTIME_NEXT_VALID"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WALLTIME_NEXT_VALID_name, &const_WALLTIME_NEXT_VALID_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WALLTIME_NEXT_VALID_name);
 

--- a/ext/intl/collator/collator_arginfo.h
+++ b/ext/intl/collator/collator_arginfo.h
@@ -103,145 +103,145 @@ static zend_class_entry *register_class_Collator(void)
 
 	zval const_DEFAULT_VALUE_value;
 	ZVAL_LONG(&const_DEFAULT_VALUE_value, UCOL_DEFAULT);
-	zend_string *const_DEFAULT_VALUE_name = zend_string_init_interned("DEFAULT_VALUE", sizeof("DEFAULT_VALUE") - 1, 1);
+	zend_string *const_DEFAULT_VALUE_name = zend_string_init_interned("DEFAULT_VALUE", strlen("DEFAULT_VALUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULT_VALUE_name, &const_DEFAULT_VALUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULT_VALUE_name);
 
 	zval const_PRIMARY_value;
 	ZVAL_LONG(&const_PRIMARY_value, UCOL_PRIMARY);
-	zend_string *const_PRIMARY_name = zend_string_init_interned("PRIMARY", sizeof("PRIMARY") - 1, 1);
+	zend_string *const_PRIMARY_name = zend_string_init_interned("PRIMARY", strlen("PRIMARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PRIMARY_name, &const_PRIMARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PRIMARY_name);
 
 	zval const_SECONDARY_value;
 	ZVAL_LONG(&const_SECONDARY_value, UCOL_SECONDARY);
-	zend_string *const_SECONDARY_name = zend_string_init_interned("SECONDARY", sizeof("SECONDARY") - 1, 1);
+	zend_string *const_SECONDARY_name = zend_string_init_interned("SECONDARY", strlen("SECONDARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SECONDARY_name, &const_SECONDARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SECONDARY_name);
 
 	zval const_TERTIARY_value;
 	ZVAL_LONG(&const_TERTIARY_value, UCOL_TERTIARY);
-	zend_string *const_TERTIARY_name = zend_string_init_interned("TERTIARY", sizeof("TERTIARY") - 1, 1);
+	zend_string *const_TERTIARY_name = zend_string_init_interned("TERTIARY", strlen("TERTIARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TERTIARY_name, &const_TERTIARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TERTIARY_name);
 
 	zval const_DEFAULT_STRENGTH_value;
 	ZVAL_LONG(&const_DEFAULT_STRENGTH_value, UCOL_DEFAULT_STRENGTH);
-	zend_string *const_DEFAULT_STRENGTH_name = zend_string_init_interned("DEFAULT_STRENGTH", sizeof("DEFAULT_STRENGTH") - 1, 1);
+	zend_string *const_DEFAULT_STRENGTH_name = zend_string_init_interned("DEFAULT_STRENGTH", strlen("DEFAULT_STRENGTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULT_STRENGTH_name, &const_DEFAULT_STRENGTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULT_STRENGTH_name);
 
 	zval const_QUATERNARY_value;
 	ZVAL_LONG(&const_QUATERNARY_value, UCOL_QUATERNARY);
-	zend_string *const_QUATERNARY_name = zend_string_init_interned("QUATERNARY", sizeof("QUATERNARY") - 1, 1);
+	zend_string *const_QUATERNARY_name = zend_string_init_interned("QUATERNARY", strlen("QUATERNARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_QUATERNARY_name, &const_QUATERNARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_QUATERNARY_name);
 
 	zval const_IDENTICAL_value;
 	ZVAL_LONG(&const_IDENTICAL_value, UCOL_IDENTICAL);
-	zend_string *const_IDENTICAL_name = zend_string_init_interned("IDENTICAL", sizeof("IDENTICAL") - 1, 1);
+	zend_string *const_IDENTICAL_name = zend_string_init_interned("IDENTICAL", strlen("IDENTICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IDENTICAL_name, &const_IDENTICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IDENTICAL_name);
 
 	zval const_OFF_value;
 	ZVAL_LONG(&const_OFF_value, UCOL_OFF);
-	zend_string *const_OFF_name = zend_string_init_interned("OFF", sizeof("OFF") - 1, 1);
+	zend_string *const_OFF_name = zend_string_init_interned("OFF", strlen("OFF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OFF_name, &const_OFF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OFF_name);
 
 	zval const_ON_value;
 	ZVAL_LONG(&const_ON_value, UCOL_ON);
-	zend_string *const_ON_name = zend_string_init_interned("ON", sizeof("ON") - 1, 1);
+	zend_string *const_ON_name = zend_string_init_interned("ON", strlen("ON"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ON_name, &const_ON_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ON_name);
 
 	zval const_SHIFTED_value;
 	ZVAL_LONG(&const_SHIFTED_value, UCOL_SHIFTED);
-	zend_string *const_SHIFTED_name = zend_string_init_interned("SHIFTED", sizeof("SHIFTED") - 1, 1);
+	zend_string *const_SHIFTED_name = zend_string_init_interned("SHIFTED", strlen("SHIFTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHIFTED_name, &const_SHIFTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHIFTED_name);
 
 	zval const_NON_IGNORABLE_value;
 	ZVAL_LONG(&const_NON_IGNORABLE_value, UCOL_NON_IGNORABLE);
-	zend_string *const_NON_IGNORABLE_name = zend_string_init_interned("NON_IGNORABLE", sizeof("NON_IGNORABLE") - 1, 1);
+	zend_string *const_NON_IGNORABLE_name = zend_string_init_interned("NON_IGNORABLE", strlen("NON_IGNORABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NON_IGNORABLE_name, &const_NON_IGNORABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NON_IGNORABLE_name);
 
 	zval const_LOWER_FIRST_value;
 	ZVAL_LONG(&const_LOWER_FIRST_value, UCOL_LOWER_FIRST);
-	zend_string *const_LOWER_FIRST_name = zend_string_init_interned("LOWER_FIRST", sizeof("LOWER_FIRST") - 1, 1);
+	zend_string *const_LOWER_FIRST_name = zend_string_init_interned("LOWER_FIRST", strlen("LOWER_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LOWER_FIRST_name, &const_LOWER_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LOWER_FIRST_name);
 
 	zval const_UPPER_FIRST_value;
 	ZVAL_LONG(&const_UPPER_FIRST_value, UCOL_UPPER_FIRST);
-	zend_string *const_UPPER_FIRST_name = zend_string_init_interned("UPPER_FIRST", sizeof("UPPER_FIRST") - 1, 1);
+	zend_string *const_UPPER_FIRST_name = zend_string_init_interned("UPPER_FIRST", strlen("UPPER_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UPPER_FIRST_name, &const_UPPER_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UPPER_FIRST_name);
 
 	zval const_FRENCH_COLLATION_value;
 	ZVAL_LONG(&const_FRENCH_COLLATION_value, UCOL_FRENCH_COLLATION);
-	zend_string *const_FRENCH_COLLATION_name = zend_string_init_interned("FRENCH_COLLATION", sizeof("FRENCH_COLLATION") - 1, 1);
+	zend_string *const_FRENCH_COLLATION_name = zend_string_init_interned("FRENCH_COLLATION", strlen("FRENCH_COLLATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FRENCH_COLLATION_name, &const_FRENCH_COLLATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FRENCH_COLLATION_name);
 
 	zval const_ALTERNATE_HANDLING_value;
 	ZVAL_LONG(&const_ALTERNATE_HANDLING_value, UCOL_ALTERNATE_HANDLING);
-	zend_string *const_ALTERNATE_HANDLING_name = zend_string_init_interned("ALTERNATE_HANDLING", sizeof("ALTERNATE_HANDLING") - 1, 1);
+	zend_string *const_ALTERNATE_HANDLING_name = zend_string_init_interned("ALTERNATE_HANDLING", strlen("ALTERNATE_HANDLING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ALTERNATE_HANDLING_name, &const_ALTERNATE_HANDLING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ALTERNATE_HANDLING_name);
 
 	zval const_CASE_FIRST_value;
 	ZVAL_LONG(&const_CASE_FIRST_value, UCOL_CASE_FIRST);
-	zend_string *const_CASE_FIRST_name = zend_string_init_interned("CASE_FIRST", sizeof("CASE_FIRST") - 1, 1);
+	zend_string *const_CASE_FIRST_name = zend_string_init_interned("CASE_FIRST", strlen("CASE_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_FIRST_name, &const_CASE_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_FIRST_name);
 
 	zval const_CASE_LEVEL_value;
 	ZVAL_LONG(&const_CASE_LEVEL_value, UCOL_CASE_LEVEL);
-	zend_string *const_CASE_LEVEL_name = zend_string_init_interned("CASE_LEVEL", sizeof("CASE_LEVEL") - 1, 1);
+	zend_string *const_CASE_LEVEL_name = zend_string_init_interned("CASE_LEVEL", strlen("CASE_LEVEL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_LEVEL_name, &const_CASE_LEVEL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_LEVEL_name);
 
 	zval const_NORMALIZATION_MODE_value;
 	ZVAL_LONG(&const_NORMALIZATION_MODE_value, UCOL_NORMALIZATION_MODE);
-	zend_string *const_NORMALIZATION_MODE_name = zend_string_init_interned("NORMALIZATION_MODE", sizeof("NORMALIZATION_MODE") - 1, 1);
+	zend_string *const_NORMALIZATION_MODE_name = zend_string_init_interned("NORMALIZATION_MODE", strlen("NORMALIZATION_MODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NORMALIZATION_MODE_name, &const_NORMALIZATION_MODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NORMALIZATION_MODE_name);
 
 	zval const_STRENGTH_value;
 	ZVAL_LONG(&const_STRENGTH_value, UCOL_STRENGTH);
-	zend_string *const_STRENGTH_name = zend_string_init_interned("STRENGTH", sizeof("STRENGTH") - 1, 1);
+	zend_string *const_STRENGTH_name = zend_string_init_interned("STRENGTH", strlen("STRENGTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_STRENGTH_name, &const_STRENGTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_STRENGTH_name);
 
 	zval const_HIRAGANA_QUATERNARY_MODE_value;
 	ZVAL_LONG(&const_HIRAGANA_QUATERNARY_MODE_value, UCOL_HIRAGANA_QUATERNARY_MODE);
-	zend_string *const_HIRAGANA_QUATERNARY_MODE_name = zend_string_init_interned("HIRAGANA_QUATERNARY_MODE", sizeof("HIRAGANA_QUATERNARY_MODE") - 1, 1);
+	zend_string *const_HIRAGANA_QUATERNARY_MODE_name = zend_string_init_interned("HIRAGANA_QUATERNARY_MODE", strlen("HIRAGANA_QUATERNARY_MODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HIRAGANA_QUATERNARY_MODE_name, &const_HIRAGANA_QUATERNARY_MODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HIRAGANA_QUATERNARY_MODE_name);
 
 	zval const_NUMERIC_COLLATION_value;
 	ZVAL_LONG(&const_NUMERIC_COLLATION_value, UCOL_NUMERIC_COLLATION);
-	zend_string *const_NUMERIC_COLLATION_name = zend_string_init_interned("NUMERIC_COLLATION", sizeof("NUMERIC_COLLATION") - 1, 1);
+	zend_string *const_NUMERIC_COLLATION_name = zend_string_init_interned("NUMERIC_COLLATION", strlen("NUMERIC_COLLATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NUMERIC_COLLATION_name, &const_NUMERIC_COLLATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NUMERIC_COLLATION_name);
 
 	zval const_SORT_REGULAR_value;
 	ZVAL_LONG(&const_SORT_REGULAR_value, COLLATOR_SORT_REGULAR);
-	zend_string *const_SORT_REGULAR_name = zend_string_init_interned("SORT_REGULAR", sizeof("SORT_REGULAR") - 1, 1);
+	zend_string *const_SORT_REGULAR_name = zend_string_init_interned("SORT_REGULAR", strlen("SORT_REGULAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SORT_REGULAR_name, &const_SORT_REGULAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SORT_REGULAR_name);
 
 	zval const_SORT_STRING_value;
 	ZVAL_LONG(&const_SORT_STRING_value, COLLATOR_SORT_STRING);
-	zend_string *const_SORT_STRING_name = zend_string_init_interned("SORT_STRING", sizeof("SORT_STRING") - 1, 1);
+	zend_string *const_SORT_STRING_name = zend_string_init_interned("SORT_STRING", strlen("SORT_STRING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SORT_STRING_name, &const_SORT_STRING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SORT_STRING_name);
 
 	zval const_SORT_NUMERIC_value;
 	ZVAL_LONG(&const_SORT_NUMERIC_value, COLLATOR_SORT_NUMERIC);
-	zend_string *const_SORT_NUMERIC_name = zend_string_init_interned("SORT_NUMERIC", sizeof("SORT_NUMERIC") - 1, 1);
+	zend_string *const_SORT_NUMERIC_name = zend_string_init_interned("SORT_NUMERIC", strlen("SORT_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SORT_NUMERIC_name, &const_SORT_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SORT_NUMERIC_name);
 

--- a/ext/intl/converter/converter_arginfo.h
+++ b/ext/intl/converter/converter_arginfo.h
@@ -126,247 +126,247 @@ static zend_class_entry *register_class_UConverter(void)
 
 	zval const_REASON_UNASSIGNED_value;
 	ZVAL_LONG(&const_REASON_UNASSIGNED_value, UCNV_UNASSIGNED);
-	zend_string *const_REASON_UNASSIGNED_name = zend_string_init_interned("REASON_UNASSIGNED", sizeof("REASON_UNASSIGNED") - 1, 1);
+	zend_string *const_REASON_UNASSIGNED_name = zend_string_init_interned("REASON_UNASSIGNED", strlen("REASON_UNASSIGNED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_UNASSIGNED_name, &const_REASON_UNASSIGNED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_UNASSIGNED_name);
 
 	zval const_REASON_ILLEGAL_value;
 	ZVAL_LONG(&const_REASON_ILLEGAL_value, UCNV_ILLEGAL);
-	zend_string *const_REASON_ILLEGAL_name = zend_string_init_interned("REASON_ILLEGAL", sizeof("REASON_ILLEGAL") - 1, 1);
+	zend_string *const_REASON_ILLEGAL_name = zend_string_init_interned("REASON_ILLEGAL", strlen("REASON_ILLEGAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_ILLEGAL_name, &const_REASON_ILLEGAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_ILLEGAL_name);
 
 	zval const_REASON_IRREGULAR_value;
 	ZVAL_LONG(&const_REASON_IRREGULAR_value, UCNV_IRREGULAR);
-	zend_string *const_REASON_IRREGULAR_name = zend_string_init_interned("REASON_IRREGULAR", sizeof("REASON_IRREGULAR") - 1, 1);
+	zend_string *const_REASON_IRREGULAR_name = zend_string_init_interned("REASON_IRREGULAR", strlen("REASON_IRREGULAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_IRREGULAR_name, &const_REASON_IRREGULAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_IRREGULAR_name);
 
 	zval const_REASON_RESET_value;
 	ZVAL_LONG(&const_REASON_RESET_value, UCNV_RESET);
-	zend_string *const_REASON_RESET_name = zend_string_init_interned("REASON_RESET", sizeof("REASON_RESET") - 1, 1);
+	zend_string *const_REASON_RESET_name = zend_string_init_interned("REASON_RESET", strlen("REASON_RESET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_RESET_name, &const_REASON_RESET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_RESET_name);
 
 	zval const_REASON_CLOSE_value;
 	ZVAL_LONG(&const_REASON_CLOSE_value, UCNV_CLOSE);
-	zend_string *const_REASON_CLOSE_name = zend_string_init_interned("REASON_CLOSE", sizeof("REASON_CLOSE") - 1, 1);
+	zend_string *const_REASON_CLOSE_name = zend_string_init_interned("REASON_CLOSE", strlen("REASON_CLOSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_CLOSE_name, &const_REASON_CLOSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_CLOSE_name);
 
 	zval const_REASON_CLONE_value;
 	ZVAL_LONG(&const_REASON_CLONE_value, UCNV_CLONE);
-	zend_string *const_REASON_CLONE_name = zend_string_init_interned("REASON_CLONE", sizeof("REASON_CLONE") - 1, 1);
+	zend_string *const_REASON_CLONE_name = zend_string_init_interned("REASON_CLONE", strlen("REASON_CLONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REASON_CLONE_name, &const_REASON_CLONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REASON_CLONE_name);
 
 	zval const_UNSUPPORTED_CONVERTER_value;
 	ZVAL_LONG(&const_UNSUPPORTED_CONVERTER_value, UCNV_UNSUPPORTED_CONVERTER);
-	zend_string *const_UNSUPPORTED_CONVERTER_name = zend_string_init_interned("UNSUPPORTED_CONVERTER", sizeof("UNSUPPORTED_CONVERTER") - 1, 1);
+	zend_string *const_UNSUPPORTED_CONVERTER_name = zend_string_init_interned("UNSUPPORTED_CONVERTER", strlen("UNSUPPORTED_CONVERTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNSUPPORTED_CONVERTER_name, &const_UNSUPPORTED_CONVERTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNSUPPORTED_CONVERTER_name);
 
 	zval const_SBCS_value;
 	ZVAL_LONG(&const_SBCS_value, UCNV_SBCS);
-	zend_string *const_SBCS_name = zend_string_init_interned("SBCS", sizeof("SBCS") - 1, 1);
+	zend_string *const_SBCS_name = zend_string_init_interned("SBCS", strlen("SBCS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SBCS_name, &const_SBCS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SBCS_name);
 
 	zval const_DBCS_value;
 	ZVAL_LONG(&const_DBCS_value, UCNV_DBCS);
-	zend_string *const_DBCS_name = zend_string_init_interned("DBCS", sizeof("DBCS") - 1, 1);
+	zend_string *const_DBCS_name = zend_string_init_interned("DBCS", strlen("DBCS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DBCS_name, &const_DBCS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DBCS_name);
 
 	zval const_MBCS_value;
 	ZVAL_LONG(&const_MBCS_value, UCNV_MBCS);
-	zend_string *const_MBCS_name = zend_string_init_interned("MBCS", sizeof("MBCS") - 1, 1);
+	zend_string *const_MBCS_name = zend_string_init_interned("MBCS", strlen("MBCS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MBCS_name, &const_MBCS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MBCS_name);
 
 	zval const_LATIN_1_value;
 	ZVAL_LONG(&const_LATIN_1_value, UCNV_LATIN_1);
-	zend_string *const_LATIN_1_name = zend_string_init_interned("LATIN_1", sizeof("LATIN_1") - 1, 1);
+	zend_string *const_LATIN_1_name = zend_string_init_interned("LATIN_1", strlen("LATIN_1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LATIN_1_name, &const_LATIN_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LATIN_1_name);
 
 	zval const_UTF8_value;
 	ZVAL_LONG(&const_UTF8_value, UCNV_UTF8);
-	zend_string *const_UTF8_name = zend_string_init_interned("UTF8", sizeof("UTF8") - 1, 1);
+	zend_string *const_UTF8_name = zend_string_init_interned("UTF8", strlen("UTF8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF8_name, &const_UTF8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF8_name);
 
 	zval const_UTF16_BigEndian_value;
 	ZVAL_LONG(&const_UTF16_BigEndian_value, UCNV_UTF16_BigEndian);
-	zend_string *const_UTF16_BigEndian_name = zend_string_init_interned("UTF16_BigEndian", sizeof("UTF16_BigEndian") - 1, 1);
+	zend_string *const_UTF16_BigEndian_name = zend_string_init_interned("UTF16_BigEndian", strlen("UTF16_BigEndian"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF16_BigEndian_name, &const_UTF16_BigEndian_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF16_BigEndian_name);
 
 	zval const_UTF16_LittleEndian_value;
 	ZVAL_LONG(&const_UTF16_LittleEndian_value, UCNV_UTF16_LittleEndian);
-	zend_string *const_UTF16_LittleEndian_name = zend_string_init_interned("UTF16_LittleEndian", sizeof("UTF16_LittleEndian") - 1, 1);
+	zend_string *const_UTF16_LittleEndian_name = zend_string_init_interned("UTF16_LittleEndian", strlen("UTF16_LittleEndian"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF16_LittleEndian_name, &const_UTF16_LittleEndian_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF16_LittleEndian_name);
 
 	zval const_UTF32_BigEndian_value;
 	ZVAL_LONG(&const_UTF32_BigEndian_value, UCNV_UTF32_BigEndian);
-	zend_string *const_UTF32_BigEndian_name = zend_string_init_interned("UTF32_BigEndian", sizeof("UTF32_BigEndian") - 1, 1);
+	zend_string *const_UTF32_BigEndian_name = zend_string_init_interned("UTF32_BigEndian", strlen("UTF32_BigEndian"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF32_BigEndian_name, &const_UTF32_BigEndian_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF32_BigEndian_name);
 
 	zval const_UTF32_LittleEndian_value;
 	ZVAL_LONG(&const_UTF32_LittleEndian_value, UCNV_UTF32_LittleEndian);
-	zend_string *const_UTF32_LittleEndian_name = zend_string_init_interned("UTF32_LittleEndian", sizeof("UTF32_LittleEndian") - 1, 1);
+	zend_string *const_UTF32_LittleEndian_name = zend_string_init_interned("UTF32_LittleEndian", strlen("UTF32_LittleEndian"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF32_LittleEndian_name, &const_UTF32_LittleEndian_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF32_LittleEndian_name);
 
 	zval const_EBCDIC_STATEFUL_value;
 	ZVAL_LONG(&const_EBCDIC_STATEFUL_value, UCNV_EBCDIC_STATEFUL);
-	zend_string *const_EBCDIC_STATEFUL_name = zend_string_init_interned("EBCDIC_STATEFUL", sizeof("EBCDIC_STATEFUL") - 1, 1);
+	zend_string *const_EBCDIC_STATEFUL_name = zend_string_init_interned("EBCDIC_STATEFUL", strlen("EBCDIC_STATEFUL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EBCDIC_STATEFUL_name, &const_EBCDIC_STATEFUL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EBCDIC_STATEFUL_name);
 
 	zval const_ISO_2022_value;
 	ZVAL_LONG(&const_ISO_2022_value, UCNV_ISO_2022);
-	zend_string *const_ISO_2022_name = zend_string_init_interned("ISO_2022", sizeof("ISO_2022") - 1, 1);
+	zend_string *const_ISO_2022_name = zend_string_init_interned("ISO_2022", strlen("ISO_2022"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ISO_2022_name, &const_ISO_2022_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ISO_2022_name);
 
 	zval const_LMBCS_1_value;
 	ZVAL_LONG(&const_LMBCS_1_value, UCNV_LMBCS_1);
-	zend_string *const_LMBCS_1_name = zend_string_init_interned("LMBCS_1", sizeof("LMBCS_1") - 1, 1);
+	zend_string *const_LMBCS_1_name = zend_string_init_interned("LMBCS_1", strlen("LMBCS_1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_1_name, &const_LMBCS_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_1_name);
 
 	zval const_LMBCS_2_value;
 	ZVAL_LONG(&const_LMBCS_2_value, UCNV_LMBCS_2);
-	zend_string *const_LMBCS_2_name = zend_string_init_interned("LMBCS_2", sizeof("LMBCS_2") - 1, 1);
+	zend_string *const_LMBCS_2_name = zend_string_init_interned("LMBCS_2", strlen("LMBCS_2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_2_name, &const_LMBCS_2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_2_name);
 
 	zval const_LMBCS_3_value;
 	ZVAL_LONG(&const_LMBCS_3_value, UCNV_LMBCS_3);
-	zend_string *const_LMBCS_3_name = zend_string_init_interned("LMBCS_3", sizeof("LMBCS_3") - 1, 1);
+	zend_string *const_LMBCS_3_name = zend_string_init_interned("LMBCS_3", strlen("LMBCS_3"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_3_name, &const_LMBCS_3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_3_name);
 
 	zval const_LMBCS_4_value;
 	ZVAL_LONG(&const_LMBCS_4_value, UCNV_LMBCS_4);
-	zend_string *const_LMBCS_4_name = zend_string_init_interned("LMBCS_4", sizeof("LMBCS_4") - 1, 1);
+	zend_string *const_LMBCS_4_name = zend_string_init_interned("LMBCS_4", strlen("LMBCS_4"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_4_name, &const_LMBCS_4_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_4_name);
 
 	zval const_LMBCS_5_value;
 	ZVAL_LONG(&const_LMBCS_5_value, UCNV_LMBCS_5);
-	zend_string *const_LMBCS_5_name = zend_string_init_interned("LMBCS_5", sizeof("LMBCS_5") - 1, 1);
+	zend_string *const_LMBCS_5_name = zend_string_init_interned("LMBCS_5", strlen("LMBCS_5"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_5_name, &const_LMBCS_5_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_5_name);
 
 	zval const_LMBCS_6_value;
 	ZVAL_LONG(&const_LMBCS_6_value, UCNV_LMBCS_6);
-	zend_string *const_LMBCS_6_name = zend_string_init_interned("LMBCS_6", sizeof("LMBCS_6") - 1, 1);
+	zend_string *const_LMBCS_6_name = zend_string_init_interned("LMBCS_6", strlen("LMBCS_6"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_6_name, &const_LMBCS_6_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_6_name);
 
 	zval const_LMBCS_8_value;
 	ZVAL_LONG(&const_LMBCS_8_value, UCNV_LMBCS_8);
-	zend_string *const_LMBCS_8_name = zend_string_init_interned("LMBCS_8", sizeof("LMBCS_8") - 1, 1);
+	zend_string *const_LMBCS_8_name = zend_string_init_interned("LMBCS_8", strlen("LMBCS_8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_8_name, &const_LMBCS_8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_8_name);
 
 	zval const_LMBCS_11_value;
 	ZVAL_LONG(&const_LMBCS_11_value, UCNV_LMBCS_11);
-	zend_string *const_LMBCS_11_name = zend_string_init_interned("LMBCS_11", sizeof("LMBCS_11") - 1, 1);
+	zend_string *const_LMBCS_11_name = zend_string_init_interned("LMBCS_11", strlen("LMBCS_11"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_11_name, &const_LMBCS_11_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_11_name);
 
 	zval const_LMBCS_16_value;
 	ZVAL_LONG(&const_LMBCS_16_value, UCNV_LMBCS_16);
-	zend_string *const_LMBCS_16_name = zend_string_init_interned("LMBCS_16", sizeof("LMBCS_16") - 1, 1);
+	zend_string *const_LMBCS_16_name = zend_string_init_interned("LMBCS_16", strlen("LMBCS_16"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_16_name, &const_LMBCS_16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_16_name);
 
 	zval const_LMBCS_17_value;
 	ZVAL_LONG(&const_LMBCS_17_value, UCNV_LMBCS_17);
-	zend_string *const_LMBCS_17_name = zend_string_init_interned("LMBCS_17", sizeof("LMBCS_17") - 1, 1);
+	zend_string *const_LMBCS_17_name = zend_string_init_interned("LMBCS_17", strlen("LMBCS_17"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_17_name, &const_LMBCS_17_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_17_name);
 
 	zval const_LMBCS_18_value;
 	ZVAL_LONG(&const_LMBCS_18_value, UCNV_LMBCS_18);
-	zend_string *const_LMBCS_18_name = zend_string_init_interned("LMBCS_18", sizeof("LMBCS_18") - 1, 1);
+	zend_string *const_LMBCS_18_name = zend_string_init_interned("LMBCS_18", strlen("LMBCS_18"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_18_name, &const_LMBCS_18_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_18_name);
 
 	zval const_LMBCS_19_value;
 	ZVAL_LONG(&const_LMBCS_19_value, UCNV_LMBCS_19);
-	zend_string *const_LMBCS_19_name = zend_string_init_interned("LMBCS_19", sizeof("LMBCS_19") - 1, 1);
+	zend_string *const_LMBCS_19_name = zend_string_init_interned("LMBCS_19", strlen("LMBCS_19"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_19_name, &const_LMBCS_19_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_19_name);
 
 	zval const_LMBCS_LAST_value;
 	ZVAL_LONG(&const_LMBCS_LAST_value, UCNV_LMBCS_LAST);
-	zend_string *const_LMBCS_LAST_name = zend_string_init_interned("LMBCS_LAST", sizeof("LMBCS_LAST") - 1, 1);
+	zend_string *const_LMBCS_LAST_name = zend_string_init_interned("LMBCS_LAST", strlen("LMBCS_LAST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LMBCS_LAST_name, &const_LMBCS_LAST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LMBCS_LAST_name);
 
 	zval const_HZ_value;
 	ZVAL_LONG(&const_HZ_value, UCNV_HZ);
-	zend_string *const_HZ_name = zend_string_init_interned("HZ", sizeof("HZ") - 1, 1);
+	zend_string *const_HZ_name = zend_string_init_interned("HZ", strlen("HZ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HZ_name, &const_HZ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HZ_name);
 
 	zval const_SCSU_value;
 	ZVAL_LONG(&const_SCSU_value, UCNV_SCSU);
-	zend_string *const_SCSU_name = zend_string_init_interned("SCSU", sizeof("SCSU") - 1, 1);
+	zend_string *const_SCSU_name = zend_string_init_interned("SCSU", strlen("SCSU"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SCSU_name, &const_SCSU_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SCSU_name);
 
 	zval const_ISCII_value;
 	ZVAL_LONG(&const_ISCII_value, UCNV_ISCII);
-	zend_string *const_ISCII_name = zend_string_init_interned("ISCII", sizeof("ISCII") - 1, 1);
+	zend_string *const_ISCII_name = zend_string_init_interned("ISCII", strlen("ISCII"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ISCII_name, &const_ISCII_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ISCII_name);
 
 	zval const_US_ASCII_value;
 	ZVAL_LONG(&const_US_ASCII_value, UCNV_US_ASCII);
-	zend_string *const_US_ASCII_name = zend_string_init_interned("US_ASCII", sizeof("US_ASCII") - 1, 1);
+	zend_string *const_US_ASCII_name = zend_string_init_interned("US_ASCII", strlen("US_ASCII"), 1);
 	zend_declare_typed_class_constant(class_entry, const_US_ASCII_name, &const_US_ASCII_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_US_ASCII_name);
 
 	zval const_UTF7_value;
 	ZVAL_LONG(&const_UTF7_value, UCNV_UTF7);
-	zend_string *const_UTF7_name = zend_string_init_interned("UTF7", sizeof("UTF7") - 1, 1);
+	zend_string *const_UTF7_name = zend_string_init_interned("UTF7", strlen("UTF7"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF7_name, &const_UTF7_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF7_name);
 
 	zval const_BOCU1_value;
 	ZVAL_LONG(&const_BOCU1_value, UCNV_BOCU1);
-	zend_string *const_BOCU1_name = zend_string_init_interned("BOCU1", sizeof("BOCU1") - 1, 1);
+	zend_string *const_BOCU1_name = zend_string_init_interned("BOCU1", strlen("BOCU1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BOCU1_name, &const_BOCU1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BOCU1_name);
 
 	zval const_UTF16_value;
 	ZVAL_LONG(&const_UTF16_value, UCNV_UTF16);
-	zend_string *const_UTF16_name = zend_string_init_interned("UTF16", sizeof("UTF16") - 1, 1);
+	zend_string *const_UTF16_name = zend_string_init_interned("UTF16", strlen("UTF16"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF16_name, &const_UTF16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF16_name);
 
 	zval const_UTF32_value;
 	ZVAL_LONG(&const_UTF32_value, UCNV_UTF32);
-	zend_string *const_UTF32_name = zend_string_init_interned("UTF32", sizeof("UTF32") - 1, 1);
+	zend_string *const_UTF32_name = zend_string_init_interned("UTF32", strlen("UTF32"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UTF32_name, &const_UTF32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UTF32_name);
 
 	zval const_CESU8_value;
 	ZVAL_LONG(&const_CESU8_value, UCNV_CESU8);
-	zend_string *const_CESU8_name = zend_string_init_interned("CESU8", sizeof("CESU8") - 1, 1);
+	zend_string *const_CESU8_name = zend_string_init_interned("CESU8", strlen("CESU8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CESU8_name, &const_CESU8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CESU8_name);
 
 	zval const_IMAP_MAILBOX_value;
 	ZVAL_LONG(&const_IMAP_MAILBOX_value, UCNV_IMAP_MAILBOX);
-	zend_string *const_IMAP_MAILBOX_name = zend_string_init_interned("IMAP_MAILBOX", sizeof("IMAP_MAILBOX") - 1, 1);
+	zend_string *const_IMAP_MAILBOX_name = zend_string_init_interned("IMAP_MAILBOX", strlen("IMAP_MAILBOX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IMAP_MAILBOX_name, &const_IMAP_MAILBOX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IMAP_MAILBOX_name);
 

--- a/ext/intl/dateformat/dateformat_arginfo.h
+++ b/ext/intl/dateformat/dateformat_arginfo.h
@@ -149,73 +149,73 @@ static zend_class_entry *register_class_IntlDateFormatter(void)
 
 	zval const_FULL_value;
 	ZVAL_LONG(&const_FULL_value, UDAT_FULL);
-	zend_string *const_FULL_name = zend_string_init_interned("FULL", sizeof("FULL") - 1, 1);
+	zend_string *const_FULL_name = zend_string_init_interned("FULL", strlen("FULL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FULL_name, &const_FULL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FULL_name);
 
 	zval const_LONG_value;
 	ZVAL_LONG(&const_LONG_value, UDAT_LONG);
-	zend_string *const_LONG_name = zend_string_init_interned("LONG", sizeof("LONG") - 1, 1);
+	zend_string *const_LONG_name = zend_string_init_interned("LONG", strlen("LONG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LONG_name, &const_LONG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LONG_name);
 
 	zval const_MEDIUM_value;
 	ZVAL_LONG(&const_MEDIUM_value, UDAT_MEDIUM);
-	zend_string *const_MEDIUM_name = zend_string_init_interned("MEDIUM", sizeof("MEDIUM") - 1, 1);
+	zend_string *const_MEDIUM_name = zend_string_init_interned("MEDIUM", strlen("MEDIUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MEDIUM_name, &const_MEDIUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MEDIUM_name);
 
 	zval const_SHORT_value;
 	ZVAL_LONG(&const_SHORT_value, UDAT_SHORT);
-	zend_string *const_SHORT_name = zend_string_init_interned("SHORT", sizeof("SHORT") - 1, 1);
+	zend_string *const_SHORT_name = zend_string_init_interned("SHORT", strlen("SHORT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHORT_name, &const_SHORT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHORT_name);
 
 	zval const_NONE_value;
 	ZVAL_LONG(&const_NONE_value, UDAT_NONE);
-	zend_string *const_NONE_name = zend_string_init_interned("NONE", sizeof("NONE") - 1, 1);
+	zend_string *const_NONE_name = zend_string_init_interned("NONE", strlen("NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NONE_name, &const_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NONE_name);
 
 	zval const_RELATIVE_FULL_value;
 	ZVAL_LONG(&const_RELATIVE_FULL_value, UDAT_FULL_RELATIVE);
-	zend_string *const_RELATIVE_FULL_name = zend_string_init_interned("RELATIVE_FULL", sizeof("RELATIVE_FULL") - 1, 1);
+	zend_string *const_RELATIVE_FULL_name = zend_string_init_interned("RELATIVE_FULL", strlen("RELATIVE_FULL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RELATIVE_FULL_name, &const_RELATIVE_FULL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RELATIVE_FULL_name);
 
 	zval const_RELATIVE_LONG_value;
 	ZVAL_LONG(&const_RELATIVE_LONG_value, UDAT_LONG_RELATIVE);
-	zend_string *const_RELATIVE_LONG_name = zend_string_init_interned("RELATIVE_LONG", sizeof("RELATIVE_LONG") - 1, 1);
+	zend_string *const_RELATIVE_LONG_name = zend_string_init_interned("RELATIVE_LONG", strlen("RELATIVE_LONG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RELATIVE_LONG_name, &const_RELATIVE_LONG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RELATIVE_LONG_name);
 
 	zval const_RELATIVE_MEDIUM_value;
 	ZVAL_LONG(&const_RELATIVE_MEDIUM_value, UDAT_MEDIUM_RELATIVE);
-	zend_string *const_RELATIVE_MEDIUM_name = zend_string_init_interned("RELATIVE_MEDIUM", sizeof("RELATIVE_MEDIUM") - 1, 1);
+	zend_string *const_RELATIVE_MEDIUM_name = zend_string_init_interned("RELATIVE_MEDIUM", strlen("RELATIVE_MEDIUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RELATIVE_MEDIUM_name, &const_RELATIVE_MEDIUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RELATIVE_MEDIUM_name);
 
 	zval const_RELATIVE_SHORT_value;
 	ZVAL_LONG(&const_RELATIVE_SHORT_value, UDAT_SHORT_RELATIVE);
-	zend_string *const_RELATIVE_SHORT_name = zend_string_init_interned("RELATIVE_SHORT", sizeof("RELATIVE_SHORT") - 1, 1);
+	zend_string *const_RELATIVE_SHORT_name = zend_string_init_interned("RELATIVE_SHORT", strlen("RELATIVE_SHORT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RELATIVE_SHORT_name, &const_RELATIVE_SHORT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RELATIVE_SHORT_name);
 
 	zval const_PATTERN_value;
 	ZVAL_LONG(&const_PATTERN_value, UDAT_PATTERN);
-	zend_string *const_PATTERN_name = zend_string_init_interned("PATTERN", sizeof("PATTERN") - 1, 1);
+	zend_string *const_PATTERN_name = zend_string_init_interned("PATTERN", strlen("PATTERN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PATTERN_name, &const_PATTERN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PATTERN_name);
 
 	zval const_GREGORIAN_value;
 	ZVAL_LONG(&const_GREGORIAN_value, UCAL_GREGORIAN);
-	zend_string *const_GREGORIAN_name = zend_string_init_interned("GREGORIAN", sizeof("GREGORIAN") - 1, 1);
+	zend_string *const_GREGORIAN_name = zend_string_init_interned("GREGORIAN", strlen("GREGORIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GREGORIAN_name, &const_GREGORIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GREGORIAN_name);
 
 	zval const_TRADITIONAL_value;
 	ZVAL_LONG(&const_TRADITIONAL_value, UCAL_TRADITIONAL);
-	zend_string *const_TRADITIONAL_name = zend_string_init_interned("TRADITIONAL", sizeof("TRADITIONAL") - 1, 1);
+	zend_string *const_TRADITIONAL_name = zend_string_init_interned("TRADITIONAL", strlen("TRADITIONAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRADITIONAL_name, &const_TRADITIONAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRADITIONAL_name);
 

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -127,465 +127,465 @@ static zend_class_entry *register_class_NumberFormatter(void)
 
 	zval const_PATTERN_DECIMAL_value;
 	ZVAL_LONG(&const_PATTERN_DECIMAL_value, UNUM_PATTERN_DECIMAL);
-	zend_string *const_PATTERN_DECIMAL_name = zend_string_init_interned("PATTERN_DECIMAL", sizeof("PATTERN_DECIMAL") - 1, 1);
+	zend_string *const_PATTERN_DECIMAL_name = zend_string_init_interned("PATTERN_DECIMAL", strlen("PATTERN_DECIMAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PATTERN_DECIMAL_name, &const_PATTERN_DECIMAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PATTERN_DECIMAL_name);
 
 	zval const_DECIMAL_value;
 	ZVAL_LONG(&const_DECIMAL_value, UNUM_DECIMAL);
-	zend_string *const_DECIMAL_name = zend_string_init_interned("DECIMAL", sizeof("DECIMAL") - 1, 1);
+	zend_string *const_DECIMAL_name = zend_string_init_interned("DECIMAL", strlen("DECIMAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DECIMAL_name, &const_DECIMAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DECIMAL_name);
 
 	zval const_CURRENCY_value;
 	ZVAL_LONG(&const_CURRENCY_value, UNUM_CURRENCY);
-	zend_string *const_CURRENCY_name = zend_string_init_interned("CURRENCY", sizeof("CURRENCY") - 1, 1);
+	zend_string *const_CURRENCY_name = zend_string_init_interned("CURRENCY", strlen("CURRENCY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENCY_name, &const_CURRENCY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENCY_name);
 
 	zval const_PERCENT_value;
 	ZVAL_LONG(&const_PERCENT_value, UNUM_PERCENT);
-	zend_string *const_PERCENT_name = zend_string_init_interned("PERCENT", sizeof("PERCENT") - 1, 1);
+	zend_string *const_PERCENT_name = zend_string_init_interned("PERCENT", strlen("PERCENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PERCENT_name, &const_PERCENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PERCENT_name);
 
 	zval const_SCIENTIFIC_value;
 	ZVAL_LONG(&const_SCIENTIFIC_value, UNUM_SCIENTIFIC);
-	zend_string *const_SCIENTIFIC_name = zend_string_init_interned("SCIENTIFIC", sizeof("SCIENTIFIC") - 1, 1);
+	zend_string *const_SCIENTIFIC_name = zend_string_init_interned("SCIENTIFIC", strlen("SCIENTIFIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SCIENTIFIC_name, &const_SCIENTIFIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SCIENTIFIC_name);
 
 	zval const_SPELLOUT_value;
 	ZVAL_LONG(&const_SPELLOUT_value, UNUM_SPELLOUT);
-	zend_string *const_SPELLOUT_name = zend_string_init_interned("SPELLOUT", sizeof("SPELLOUT") - 1, 1);
+	zend_string *const_SPELLOUT_name = zend_string_init_interned("SPELLOUT", strlen("SPELLOUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SPELLOUT_name, &const_SPELLOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SPELLOUT_name);
 
 	zval const_ORDINAL_value;
 	ZVAL_LONG(&const_ORDINAL_value, UNUM_ORDINAL);
-	zend_string *const_ORDINAL_name = zend_string_init_interned("ORDINAL", sizeof("ORDINAL") - 1, 1);
+	zend_string *const_ORDINAL_name = zend_string_init_interned("ORDINAL", strlen("ORDINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ORDINAL_name, &const_ORDINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ORDINAL_name);
 
 	zval const_DURATION_value;
 	ZVAL_LONG(&const_DURATION_value, UNUM_DURATION);
-	zend_string *const_DURATION_name = zend_string_init_interned("DURATION", sizeof("DURATION") - 1, 1);
+	zend_string *const_DURATION_name = zend_string_init_interned("DURATION", strlen("DURATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DURATION_name, &const_DURATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DURATION_name);
 
 	zval const_PATTERN_RULEBASED_value;
 	ZVAL_LONG(&const_PATTERN_RULEBASED_value, UNUM_PATTERN_RULEBASED);
-	zend_string *const_PATTERN_RULEBASED_name = zend_string_init_interned("PATTERN_RULEBASED", sizeof("PATTERN_RULEBASED") - 1, 1);
+	zend_string *const_PATTERN_RULEBASED_name = zend_string_init_interned("PATTERN_RULEBASED", strlen("PATTERN_RULEBASED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PATTERN_RULEBASED_name, &const_PATTERN_RULEBASED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PATTERN_RULEBASED_name);
 
 	zval const_IGNORE_value;
 	ZVAL_LONG(&const_IGNORE_value, UNUM_IGNORE);
-	zend_string *const_IGNORE_name = zend_string_init_interned("IGNORE", sizeof("IGNORE") - 1, 1);
+	zend_string *const_IGNORE_name = zend_string_init_interned("IGNORE", strlen("IGNORE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IGNORE_name, &const_IGNORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IGNORE_name);
 
 	zval const_CURRENCY_ACCOUNTING_value;
 	ZVAL_LONG(&const_CURRENCY_ACCOUNTING_value, UNUM_CURRENCY_ACCOUNTING);
-	zend_string *const_CURRENCY_ACCOUNTING_name = zend_string_init_interned("CURRENCY_ACCOUNTING", sizeof("CURRENCY_ACCOUNTING") - 1, 1);
+	zend_string *const_CURRENCY_ACCOUNTING_name = zend_string_init_interned("CURRENCY_ACCOUNTING", strlen("CURRENCY_ACCOUNTING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENCY_ACCOUNTING_name, &const_CURRENCY_ACCOUNTING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENCY_ACCOUNTING_name);
 
 	zval const_DEFAULT_STYLE_value;
 	ZVAL_LONG(&const_DEFAULT_STYLE_value, UNUM_DEFAULT);
-	zend_string *const_DEFAULT_STYLE_name = zend_string_init_interned("DEFAULT_STYLE", sizeof("DEFAULT_STYLE") - 1, 1);
+	zend_string *const_DEFAULT_STYLE_name = zend_string_init_interned("DEFAULT_STYLE", strlen("DEFAULT_STYLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULT_STYLE_name, &const_DEFAULT_STYLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULT_STYLE_name);
 
 	zval const_ROUND_CEILING_value;
 	ZVAL_LONG(&const_ROUND_CEILING_value, UNUM_ROUND_CEILING);
-	zend_string *const_ROUND_CEILING_name = zend_string_init_interned("ROUND_CEILING", sizeof("ROUND_CEILING") - 1, 1);
+	zend_string *const_ROUND_CEILING_name = zend_string_init_interned("ROUND_CEILING", strlen("ROUND_CEILING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_CEILING_name, &const_ROUND_CEILING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_CEILING_name);
 
 	zval const_ROUND_FLOOR_value;
 	ZVAL_LONG(&const_ROUND_FLOOR_value, UNUM_ROUND_FLOOR);
-	zend_string *const_ROUND_FLOOR_name = zend_string_init_interned("ROUND_FLOOR", sizeof("ROUND_FLOOR") - 1, 1);
+	zend_string *const_ROUND_FLOOR_name = zend_string_init_interned("ROUND_FLOOR", strlen("ROUND_FLOOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_FLOOR_name, &const_ROUND_FLOOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_FLOOR_name);
 
 	zval const_ROUND_DOWN_value;
 	ZVAL_LONG(&const_ROUND_DOWN_value, UNUM_ROUND_DOWN);
-	zend_string *const_ROUND_DOWN_name = zend_string_init_interned("ROUND_DOWN", sizeof("ROUND_DOWN") - 1, 1);
+	zend_string *const_ROUND_DOWN_name = zend_string_init_interned("ROUND_DOWN", strlen("ROUND_DOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_DOWN_name, &const_ROUND_DOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_DOWN_name);
 
 	zval const_ROUND_UP_value;
 	ZVAL_LONG(&const_ROUND_UP_value, UNUM_ROUND_UP);
-	zend_string *const_ROUND_UP_name = zend_string_init_interned("ROUND_UP", sizeof("ROUND_UP") - 1, 1);
+	zend_string *const_ROUND_UP_name = zend_string_init_interned("ROUND_UP", strlen("ROUND_UP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_UP_name, &const_ROUND_UP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_UP_name);
 
 	zval const_ROUND_TOWARD_ZERO_value;
 	ZVAL_LONG(&const_ROUND_TOWARD_ZERO_value, UNUM_ROUND_DOWN);
-	zend_string *const_ROUND_TOWARD_ZERO_name = zend_string_init_interned("ROUND_TOWARD_ZERO", sizeof("ROUND_TOWARD_ZERO") - 1, 1);
+	zend_string *const_ROUND_TOWARD_ZERO_name = zend_string_init_interned("ROUND_TOWARD_ZERO", strlen("ROUND_TOWARD_ZERO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_TOWARD_ZERO_name, &const_ROUND_TOWARD_ZERO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_TOWARD_ZERO_name);
 
 	zval const_ROUND_AWAY_FROM_ZERO_value;
 	ZVAL_LONG(&const_ROUND_AWAY_FROM_ZERO_value, UNUM_ROUND_UP);
-	zend_string *const_ROUND_AWAY_FROM_ZERO_name = zend_string_init_interned("ROUND_AWAY_FROM_ZERO", sizeof("ROUND_AWAY_FROM_ZERO") - 1, 1);
+	zend_string *const_ROUND_AWAY_FROM_ZERO_name = zend_string_init_interned("ROUND_AWAY_FROM_ZERO", strlen("ROUND_AWAY_FROM_ZERO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_AWAY_FROM_ZERO_name, &const_ROUND_AWAY_FROM_ZERO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_AWAY_FROM_ZERO_name);
 
 	zval const_ROUND_HALFEVEN_value;
 	ZVAL_LONG(&const_ROUND_HALFEVEN_value, UNUM_ROUND_HALFEVEN);
-	zend_string *const_ROUND_HALFEVEN_name = zend_string_init_interned("ROUND_HALFEVEN", sizeof("ROUND_HALFEVEN") - 1, 1);
+	zend_string *const_ROUND_HALFEVEN_name = zend_string_init_interned("ROUND_HALFEVEN", strlen("ROUND_HALFEVEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFEVEN_name, &const_ROUND_HALFEVEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_HALFEVEN_name);
 #if U_ICU_VERSION_MAJOR_NUM >= 69
 
 	zval const_ROUND_HALFODD_value;
 	ZVAL_LONG(&const_ROUND_HALFODD_value, UNUM_ROUND_HALF_ODD);
-	zend_string *const_ROUND_HALFODD_name = zend_string_init_interned("ROUND_HALFODD", sizeof("ROUND_HALFODD") - 1, 1);
+	zend_string *const_ROUND_HALFODD_name = zend_string_init_interned("ROUND_HALFODD", strlen("ROUND_HALFODD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFODD_name, &const_ROUND_HALFODD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_HALFODD_name);
 #endif
 
 	zval const_ROUND_HALFDOWN_value;
 	ZVAL_LONG(&const_ROUND_HALFDOWN_value, UNUM_ROUND_HALFDOWN);
-	zend_string *const_ROUND_HALFDOWN_name = zend_string_init_interned("ROUND_HALFDOWN", sizeof("ROUND_HALFDOWN") - 1, 1);
+	zend_string *const_ROUND_HALFDOWN_name = zend_string_init_interned("ROUND_HALFDOWN", strlen("ROUND_HALFDOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFDOWN_name, &const_ROUND_HALFDOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_HALFDOWN_name);
 
 	zval const_ROUND_HALFUP_value;
 	ZVAL_LONG(&const_ROUND_HALFUP_value, UNUM_ROUND_HALFUP);
-	zend_string *const_ROUND_HALFUP_name = zend_string_init_interned("ROUND_HALFUP", sizeof("ROUND_HALFUP") - 1, 1);
+	zend_string *const_ROUND_HALFUP_name = zend_string_init_interned("ROUND_HALFUP", strlen("ROUND_HALFUP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUND_HALFUP_name, &const_ROUND_HALFUP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUND_HALFUP_name);
 
 	zval const_PAD_BEFORE_PREFIX_value;
 	ZVAL_LONG(&const_PAD_BEFORE_PREFIX_value, UNUM_PAD_BEFORE_PREFIX);
-	zend_string *const_PAD_BEFORE_PREFIX_name = zend_string_init_interned("PAD_BEFORE_PREFIX", sizeof("PAD_BEFORE_PREFIX") - 1, 1);
+	zend_string *const_PAD_BEFORE_PREFIX_name = zend_string_init_interned("PAD_BEFORE_PREFIX", strlen("PAD_BEFORE_PREFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PAD_BEFORE_PREFIX_name, &const_PAD_BEFORE_PREFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PAD_BEFORE_PREFIX_name);
 
 	zval const_PAD_AFTER_PREFIX_value;
 	ZVAL_LONG(&const_PAD_AFTER_PREFIX_value, UNUM_PAD_AFTER_PREFIX);
-	zend_string *const_PAD_AFTER_PREFIX_name = zend_string_init_interned("PAD_AFTER_PREFIX", sizeof("PAD_AFTER_PREFIX") - 1, 1);
+	zend_string *const_PAD_AFTER_PREFIX_name = zend_string_init_interned("PAD_AFTER_PREFIX", strlen("PAD_AFTER_PREFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PAD_AFTER_PREFIX_name, &const_PAD_AFTER_PREFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PAD_AFTER_PREFIX_name);
 
 	zval const_PAD_BEFORE_SUFFIX_value;
 	ZVAL_LONG(&const_PAD_BEFORE_SUFFIX_value, UNUM_PAD_BEFORE_SUFFIX);
-	zend_string *const_PAD_BEFORE_SUFFIX_name = zend_string_init_interned("PAD_BEFORE_SUFFIX", sizeof("PAD_BEFORE_SUFFIX") - 1, 1);
+	zend_string *const_PAD_BEFORE_SUFFIX_name = zend_string_init_interned("PAD_BEFORE_SUFFIX", strlen("PAD_BEFORE_SUFFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PAD_BEFORE_SUFFIX_name, &const_PAD_BEFORE_SUFFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PAD_BEFORE_SUFFIX_name);
 
 	zval const_PAD_AFTER_SUFFIX_value;
 	ZVAL_LONG(&const_PAD_AFTER_SUFFIX_value, UNUM_PAD_AFTER_SUFFIX);
-	zend_string *const_PAD_AFTER_SUFFIX_name = zend_string_init_interned("PAD_AFTER_SUFFIX", sizeof("PAD_AFTER_SUFFIX") - 1, 1);
+	zend_string *const_PAD_AFTER_SUFFIX_name = zend_string_init_interned("PAD_AFTER_SUFFIX", strlen("PAD_AFTER_SUFFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PAD_AFTER_SUFFIX_name, &const_PAD_AFTER_SUFFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PAD_AFTER_SUFFIX_name);
 
 	zval const_PARSE_INT_ONLY_value;
 	ZVAL_LONG(&const_PARSE_INT_ONLY_value, UNUM_PARSE_INT_ONLY);
-	zend_string *const_PARSE_INT_ONLY_name = zend_string_init_interned("PARSE_INT_ONLY", sizeof("PARSE_INT_ONLY") - 1, 1);
+	zend_string *const_PARSE_INT_ONLY_name = zend_string_init_interned("PARSE_INT_ONLY", strlen("PARSE_INT_ONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARSE_INT_ONLY_name, &const_PARSE_INT_ONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARSE_INT_ONLY_name);
 
 	zval const_GROUPING_USED_value;
 	ZVAL_LONG(&const_GROUPING_USED_value, UNUM_GROUPING_USED);
-	zend_string *const_GROUPING_USED_name = zend_string_init_interned("GROUPING_USED", sizeof("GROUPING_USED") - 1, 1);
+	zend_string *const_GROUPING_USED_name = zend_string_init_interned("GROUPING_USED", strlen("GROUPING_USED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GROUPING_USED_name, &const_GROUPING_USED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GROUPING_USED_name);
 
 	zval const_DECIMAL_ALWAYS_SHOWN_value;
 	ZVAL_LONG(&const_DECIMAL_ALWAYS_SHOWN_value, UNUM_DECIMAL_ALWAYS_SHOWN);
-	zend_string *const_DECIMAL_ALWAYS_SHOWN_name = zend_string_init_interned("DECIMAL_ALWAYS_SHOWN", sizeof("DECIMAL_ALWAYS_SHOWN") - 1, 1);
+	zend_string *const_DECIMAL_ALWAYS_SHOWN_name = zend_string_init_interned("DECIMAL_ALWAYS_SHOWN", strlen("DECIMAL_ALWAYS_SHOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DECIMAL_ALWAYS_SHOWN_name, &const_DECIMAL_ALWAYS_SHOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DECIMAL_ALWAYS_SHOWN_name);
 
 	zval const_MAX_INTEGER_DIGITS_value;
 	ZVAL_LONG(&const_MAX_INTEGER_DIGITS_value, UNUM_MAX_INTEGER_DIGITS);
-	zend_string *const_MAX_INTEGER_DIGITS_name = zend_string_init_interned("MAX_INTEGER_DIGITS", sizeof("MAX_INTEGER_DIGITS") - 1, 1);
+	zend_string *const_MAX_INTEGER_DIGITS_name = zend_string_init_interned("MAX_INTEGER_DIGITS", strlen("MAX_INTEGER_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MAX_INTEGER_DIGITS_name, &const_MAX_INTEGER_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MAX_INTEGER_DIGITS_name);
 
 	zval const_MIN_INTEGER_DIGITS_value;
 	ZVAL_LONG(&const_MIN_INTEGER_DIGITS_value, UNUM_MIN_INTEGER_DIGITS);
-	zend_string *const_MIN_INTEGER_DIGITS_name = zend_string_init_interned("MIN_INTEGER_DIGITS", sizeof("MIN_INTEGER_DIGITS") - 1, 1);
+	zend_string *const_MIN_INTEGER_DIGITS_name = zend_string_init_interned("MIN_INTEGER_DIGITS", strlen("MIN_INTEGER_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIN_INTEGER_DIGITS_name, &const_MIN_INTEGER_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIN_INTEGER_DIGITS_name);
 
 	zval const_INTEGER_DIGITS_value;
 	ZVAL_LONG(&const_INTEGER_DIGITS_value, UNUM_INTEGER_DIGITS);
-	zend_string *const_INTEGER_DIGITS_name = zend_string_init_interned("INTEGER_DIGITS", sizeof("INTEGER_DIGITS") - 1, 1);
+	zend_string *const_INTEGER_DIGITS_name = zend_string_init_interned("INTEGER_DIGITS", strlen("INTEGER_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INTEGER_DIGITS_name, &const_INTEGER_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INTEGER_DIGITS_name);
 
 	zval const_MAX_FRACTION_DIGITS_value;
 	ZVAL_LONG(&const_MAX_FRACTION_DIGITS_value, UNUM_MAX_FRACTION_DIGITS);
-	zend_string *const_MAX_FRACTION_DIGITS_name = zend_string_init_interned("MAX_FRACTION_DIGITS", sizeof("MAX_FRACTION_DIGITS") - 1, 1);
+	zend_string *const_MAX_FRACTION_DIGITS_name = zend_string_init_interned("MAX_FRACTION_DIGITS", strlen("MAX_FRACTION_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MAX_FRACTION_DIGITS_name, &const_MAX_FRACTION_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MAX_FRACTION_DIGITS_name);
 
 	zval const_MIN_FRACTION_DIGITS_value;
 	ZVAL_LONG(&const_MIN_FRACTION_DIGITS_value, UNUM_MIN_FRACTION_DIGITS);
-	zend_string *const_MIN_FRACTION_DIGITS_name = zend_string_init_interned("MIN_FRACTION_DIGITS", sizeof("MIN_FRACTION_DIGITS") - 1, 1);
+	zend_string *const_MIN_FRACTION_DIGITS_name = zend_string_init_interned("MIN_FRACTION_DIGITS", strlen("MIN_FRACTION_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIN_FRACTION_DIGITS_name, &const_MIN_FRACTION_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIN_FRACTION_DIGITS_name);
 
 	zval const_FRACTION_DIGITS_value;
 	ZVAL_LONG(&const_FRACTION_DIGITS_value, UNUM_FRACTION_DIGITS);
-	zend_string *const_FRACTION_DIGITS_name = zend_string_init_interned("FRACTION_DIGITS", sizeof("FRACTION_DIGITS") - 1, 1);
+	zend_string *const_FRACTION_DIGITS_name = zend_string_init_interned("FRACTION_DIGITS", strlen("FRACTION_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FRACTION_DIGITS_name, &const_FRACTION_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FRACTION_DIGITS_name);
 
 	zval const_MULTIPLIER_value;
 	ZVAL_LONG(&const_MULTIPLIER_value, UNUM_MULTIPLIER);
-	zend_string *const_MULTIPLIER_name = zend_string_init_interned("MULTIPLIER", sizeof("MULTIPLIER") - 1, 1);
+	zend_string *const_MULTIPLIER_name = zend_string_init_interned("MULTIPLIER", strlen("MULTIPLIER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MULTIPLIER_name, &const_MULTIPLIER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MULTIPLIER_name);
 
 	zval const_GROUPING_SIZE_value;
 	ZVAL_LONG(&const_GROUPING_SIZE_value, UNUM_GROUPING_SIZE);
-	zend_string *const_GROUPING_SIZE_name = zend_string_init_interned("GROUPING_SIZE", sizeof("GROUPING_SIZE") - 1, 1);
+	zend_string *const_GROUPING_SIZE_name = zend_string_init_interned("GROUPING_SIZE", strlen("GROUPING_SIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GROUPING_SIZE_name, &const_GROUPING_SIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GROUPING_SIZE_name);
 
 	zval const_ROUNDING_MODE_value;
 	ZVAL_LONG(&const_ROUNDING_MODE_value, UNUM_ROUNDING_MODE);
-	zend_string *const_ROUNDING_MODE_name = zend_string_init_interned("ROUNDING_MODE", sizeof("ROUNDING_MODE") - 1, 1);
+	zend_string *const_ROUNDING_MODE_name = zend_string_init_interned("ROUNDING_MODE", strlen("ROUNDING_MODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUNDING_MODE_name, &const_ROUNDING_MODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUNDING_MODE_name);
 
 	zval const_ROUNDING_INCREMENT_value;
 	ZVAL_LONG(&const_ROUNDING_INCREMENT_value, UNUM_ROUNDING_INCREMENT);
-	zend_string *const_ROUNDING_INCREMENT_name = zend_string_init_interned("ROUNDING_INCREMENT", sizeof("ROUNDING_INCREMENT") - 1, 1);
+	zend_string *const_ROUNDING_INCREMENT_name = zend_string_init_interned("ROUNDING_INCREMENT", strlen("ROUNDING_INCREMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ROUNDING_INCREMENT_name, &const_ROUNDING_INCREMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ROUNDING_INCREMENT_name);
 
 	zval const_FORMAT_WIDTH_value;
 	ZVAL_LONG(&const_FORMAT_WIDTH_value, UNUM_FORMAT_WIDTH);
-	zend_string *const_FORMAT_WIDTH_name = zend_string_init_interned("FORMAT_WIDTH", sizeof("FORMAT_WIDTH") - 1, 1);
+	zend_string *const_FORMAT_WIDTH_name = zend_string_init_interned("FORMAT_WIDTH", strlen("FORMAT_WIDTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORMAT_WIDTH_name, &const_FORMAT_WIDTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORMAT_WIDTH_name);
 
 	zval const_PADDING_POSITION_value;
 	ZVAL_LONG(&const_PADDING_POSITION_value, UNUM_PADDING_POSITION);
-	zend_string *const_PADDING_POSITION_name = zend_string_init_interned("PADDING_POSITION", sizeof("PADDING_POSITION") - 1, 1);
+	zend_string *const_PADDING_POSITION_name = zend_string_init_interned("PADDING_POSITION", strlen("PADDING_POSITION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PADDING_POSITION_name, &const_PADDING_POSITION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PADDING_POSITION_name);
 
 	zval const_SECONDARY_GROUPING_SIZE_value;
 	ZVAL_LONG(&const_SECONDARY_GROUPING_SIZE_value, UNUM_SECONDARY_GROUPING_SIZE);
-	zend_string *const_SECONDARY_GROUPING_SIZE_name = zend_string_init_interned("SECONDARY_GROUPING_SIZE", sizeof("SECONDARY_GROUPING_SIZE") - 1, 1);
+	zend_string *const_SECONDARY_GROUPING_SIZE_name = zend_string_init_interned("SECONDARY_GROUPING_SIZE", strlen("SECONDARY_GROUPING_SIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SECONDARY_GROUPING_SIZE_name, &const_SECONDARY_GROUPING_SIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SECONDARY_GROUPING_SIZE_name);
 
 	zval const_SIGNIFICANT_DIGITS_USED_value;
 	ZVAL_LONG(&const_SIGNIFICANT_DIGITS_USED_value, UNUM_SIGNIFICANT_DIGITS_USED);
-	zend_string *const_SIGNIFICANT_DIGITS_USED_name = zend_string_init_interned("SIGNIFICANT_DIGITS_USED", sizeof("SIGNIFICANT_DIGITS_USED") - 1, 1);
+	zend_string *const_SIGNIFICANT_DIGITS_USED_name = zend_string_init_interned("SIGNIFICANT_DIGITS_USED", strlen("SIGNIFICANT_DIGITS_USED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SIGNIFICANT_DIGITS_USED_name, &const_SIGNIFICANT_DIGITS_USED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SIGNIFICANT_DIGITS_USED_name);
 
 	zval const_MIN_SIGNIFICANT_DIGITS_value;
 	ZVAL_LONG(&const_MIN_SIGNIFICANT_DIGITS_value, UNUM_MIN_SIGNIFICANT_DIGITS);
-	zend_string *const_MIN_SIGNIFICANT_DIGITS_name = zend_string_init_interned("MIN_SIGNIFICANT_DIGITS", sizeof("MIN_SIGNIFICANT_DIGITS") - 1, 1);
+	zend_string *const_MIN_SIGNIFICANT_DIGITS_name = zend_string_init_interned("MIN_SIGNIFICANT_DIGITS", strlen("MIN_SIGNIFICANT_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIN_SIGNIFICANT_DIGITS_name, &const_MIN_SIGNIFICANT_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIN_SIGNIFICANT_DIGITS_name);
 
 	zval const_MAX_SIGNIFICANT_DIGITS_value;
 	ZVAL_LONG(&const_MAX_SIGNIFICANT_DIGITS_value, UNUM_MAX_SIGNIFICANT_DIGITS);
-	zend_string *const_MAX_SIGNIFICANT_DIGITS_name = zend_string_init_interned("MAX_SIGNIFICANT_DIGITS", sizeof("MAX_SIGNIFICANT_DIGITS") - 1, 1);
+	zend_string *const_MAX_SIGNIFICANT_DIGITS_name = zend_string_init_interned("MAX_SIGNIFICANT_DIGITS", strlen("MAX_SIGNIFICANT_DIGITS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MAX_SIGNIFICANT_DIGITS_name, &const_MAX_SIGNIFICANT_DIGITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MAX_SIGNIFICANT_DIGITS_name);
 
 	zval const_LENIENT_PARSE_value;
 	ZVAL_LONG(&const_LENIENT_PARSE_value, UNUM_LENIENT_PARSE);
-	zend_string *const_LENIENT_PARSE_name = zend_string_init_interned("LENIENT_PARSE", sizeof("LENIENT_PARSE") - 1, 1);
+	zend_string *const_LENIENT_PARSE_name = zend_string_init_interned("LENIENT_PARSE", strlen("LENIENT_PARSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LENIENT_PARSE_name, &const_LENIENT_PARSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LENIENT_PARSE_name);
 
 	zval const_POSITIVE_PREFIX_value;
 	ZVAL_LONG(&const_POSITIVE_PREFIX_value, UNUM_POSITIVE_PREFIX);
-	zend_string *const_POSITIVE_PREFIX_name = zend_string_init_interned("POSITIVE_PREFIX", sizeof("POSITIVE_PREFIX") - 1, 1);
+	zend_string *const_POSITIVE_PREFIX_name = zend_string_init_interned("POSITIVE_PREFIX", strlen("POSITIVE_PREFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_POSITIVE_PREFIX_name, &const_POSITIVE_PREFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_POSITIVE_PREFIX_name);
 
 	zval const_POSITIVE_SUFFIX_value;
 	ZVAL_LONG(&const_POSITIVE_SUFFIX_value, UNUM_POSITIVE_SUFFIX);
-	zend_string *const_POSITIVE_SUFFIX_name = zend_string_init_interned("POSITIVE_SUFFIX", sizeof("POSITIVE_SUFFIX") - 1, 1);
+	zend_string *const_POSITIVE_SUFFIX_name = zend_string_init_interned("POSITIVE_SUFFIX", strlen("POSITIVE_SUFFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_POSITIVE_SUFFIX_name, &const_POSITIVE_SUFFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_POSITIVE_SUFFIX_name);
 
 	zval const_NEGATIVE_PREFIX_value;
 	ZVAL_LONG(&const_NEGATIVE_PREFIX_value, UNUM_NEGATIVE_PREFIX);
-	zend_string *const_NEGATIVE_PREFIX_name = zend_string_init_interned("NEGATIVE_PREFIX", sizeof("NEGATIVE_PREFIX") - 1, 1);
+	zend_string *const_NEGATIVE_PREFIX_name = zend_string_init_interned("NEGATIVE_PREFIX", strlen("NEGATIVE_PREFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NEGATIVE_PREFIX_name, &const_NEGATIVE_PREFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NEGATIVE_PREFIX_name);
 
 	zval const_NEGATIVE_SUFFIX_value;
 	ZVAL_LONG(&const_NEGATIVE_SUFFIX_value, UNUM_NEGATIVE_SUFFIX);
-	zend_string *const_NEGATIVE_SUFFIX_name = zend_string_init_interned("NEGATIVE_SUFFIX", sizeof("NEGATIVE_SUFFIX") - 1, 1);
+	zend_string *const_NEGATIVE_SUFFIX_name = zend_string_init_interned("NEGATIVE_SUFFIX", strlen("NEGATIVE_SUFFIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NEGATIVE_SUFFIX_name, &const_NEGATIVE_SUFFIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NEGATIVE_SUFFIX_name);
 
 	zval const_PADDING_CHARACTER_value;
 	ZVAL_LONG(&const_PADDING_CHARACTER_value, UNUM_PADDING_CHARACTER);
-	zend_string *const_PADDING_CHARACTER_name = zend_string_init_interned("PADDING_CHARACTER", sizeof("PADDING_CHARACTER") - 1, 1);
+	zend_string *const_PADDING_CHARACTER_name = zend_string_init_interned("PADDING_CHARACTER", strlen("PADDING_CHARACTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PADDING_CHARACTER_name, &const_PADDING_CHARACTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PADDING_CHARACTER_name);
 
 	zval const_CURRENCY_CODE_value;
 	ZVAL_LONG(&const_CURRENCY_CODE_value, UNUM_CURRENCY_CODE);
-	zend_string *const_CURRENCY_CODE_name = zend_string_init_interned("CURRENCY_CODE", sizeof("CURRENCY_CODE") - 1, 1);
+	zend_string *const_CURRENCY_CODE_name = zend_string_init_interned("CURRENCY_CODE", strlen("CURRENCY_CODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENCY_CODE_name, &const_CURRENCY_CODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENCY_CODE_name);
 
 	zval const_DEFAULT_RULESET_value;
 	ZVAL_LONG(&const_DEFAULT_RULESET_value, UNUM_DEFAULT_RULESET);
-	zend_string *const_DEFAULT_RULESET_name = zend_string_init_interned("DEFAULT_RULESET", sizeof("DEFAULT_RULESET") - 1, 1);
+	zend_string *const_DEFAULT_RULESET_name = zend_string_init_interned("DEFAULT_RULESET", strlen("DEFAULT_RULESET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULT_RULESET_name, &const_DEFAULT_RULESET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULT_RULESET_name);
 
 	zval const_PUBLIC_RULESETS_value;
 	ZVAL_LONG(&const_PUBLIC_RULESETS_value, UNUM_PUBLIC_RULESETS);
-	zend_string *const_PUBLIC_RULESETS_name = zend_string_init_interned("PUBLIC_RULESETS", sizeof("PUBLIC_RULESETS") - 1, 1);
+	zend_string *const_PUBLIC_RULESETS_name = zend_string_init_interned("PUBLIC_RULESETS", strlen("PUBLIC_RULESETS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PUBLIC_RULESETS_name, &const_PUBLIC_RULESETS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PUBLIC_RULESETS_name);
 
 	zval const_DECIMAL_SEPARATOR_SYMBOL_value;
 	ZVAL_LONG(&const_DECIMAL_SEPARATOR_SYMBOL_value, UNUM_DECIMAL_SEPARATOR_SYMBOL);
-	zend_string *const_DECIMAL_SEPARATOR_SYMBOL_name = zend_string_init_interned("DECIMAL_SEPARATOR_SYMBOL", sizeof("DECIMAL_SEPARATOR_SYMBOL") - 1, 1);
+	zend_string *const_DECIMAL_SEPARATOR_SYMBOL_name = zend_string_init_interned("DECIMAL_SEPARATOR_SYMBOL", strlen("DECIMAL_SEPARATOR_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DECIMAL_SEPARATOR_SYMBOL_name, &const_DECIMAL_SEPARATOR_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DECIMAL_SEPARATOR_SYMBOL_name);
 
 	zval const_GROUPING_SEPARATOR_SYMBOL_value;
 	ZVAL_LONG(&const_GROUPING_SEPARATOR_SYMBOL_value, UNUM_GROUPING_SEPARATOR_SYMBOL);
-	zend_string *const_GROUPING_SEPARATOR_SYMBOL_name = zend_string_init_interned("GROUPING_SEPARATOR_SYMBOL", sizeof("GROUPING_SEPARATOR_SYMBOL") - 1, 1);
+	zend_string *const_GROUPING_SEPARATOR_SYMBOL_name = zend_string_init_interned("GROUPING_SEPARATOR_SYMBOL", strlen("GROUPING_SEPARATOR_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GROUPING_SEPARATOR_SYMBOL_name, &const_GROUPING_SEPARATOR_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GROUPING_SEPARATOR_SYMBOL_name);
 
 	zval const_PATTERN_SEPARATOR_SYMBOL_value;
 	ZVAL_LONG(&const_PATTERN_SEPARATOR_SYMBOL_value, UNUM_PATTERN_SEPARATOR_SYMBOL);
-	zend_string *const_PATTERN_SEPARATOR_SYMBOL_name = zend_string_init_interned("PATTERN_SEPARATOR_SYMBOL", sizeof("PATTERN_SEPARATOR_SYMBOL") - 1, 1);
+	zend_string *const_PATTERN_SEPARATOR_SYMBOL_name = zend_string_init_interned("PATTERN_SEPARATOR_SYMBOL", strlen("PATTERN_SEPARATOR_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PATTERN_SEPARATOR_SYMBOL_name, &const_PATTERN_SEPARATOR_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PATTERN_SEPARATOR_SYMBOL_name);
 
 	zval const_PERCENT_SYMBOL_value;
 	ZVAL_LONG(&const_PERCENT_SYMBOL_value, UNUM_PERCENT_SYMBOL);
-	zend_string *const_PERCENT_SYMBOL_name = zend_string_init_interned("PERCENT_SYMBOL", sizeof("PERCENT_SYMBOL") - 1, 1);
+	zend_string *const_PERCENT_SYMBOL_name = zend_string_init_interned("PERCENT_SYMBOL", strlen("PERCENT_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PERCENT_SYMBOL_name, &const_PERCENT_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PERCENT_SYMBOL_name);
 
 	zval const_ZERO_DIGIT_SYMBOL_value;
 	ZVAL_LONG(&const_ZERO_DIGIT_SYMBOL_value, UNUM_ZERO_DIGIT_SYMBOL);
-	zend_string *const_ZERO_DIGIT_SYMBOL_name = zend_string_init_interned("ZERO_DIGIT_SYMBOL", sizeof("ZERO_DIGIT_SYMBOL") - 1, 1);
+	zend_string *const_ZERO_DIGIT_SYMBOL_name = zend_string_init_interned("ZERO_DIGIT_SYMBOL", strlen("ZERO_DIGIT_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ZERO_DIGIT_SYMBOL_name, &const_ZERO_DIGIT_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ZERO_DIGIT_SYMBOL_name);
 
 	zval const_DIGIT_SYMBOL_value;
 	ZVAL_LONG(&const_DIGIT_SYMBOL_value, UNUM_DIGIT_SYMBOL);
-	zend_string *const_DIGIT_SYMBOL_name = zend_string_init_interned("DIGIT_SYMBOL", sizeof("DIGIT_SYMBOL") - 1, 1);
+	zend_string *const_DIGIT_SYMBOL_name = zend_string_init_interned("DIGIT_SYMBOL", strlen("DIGIT_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DIGIT_SYMBOL_name, &const_DIGIT_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DIGIT_SYMBOL_name);
 
 	zval const_MINUS_SIGN_SYMBOL_value;
 	ZVAL_LONG(&const_MINUS_SIGN_SYMBOL_value, UNUM_MINUS_SIGN_SYMBOL);
-	zend_string *const_MINUS_SIGN_SYMBOL_name = zend_string_init_interned("MINUS_SIGN_SYMBOL", sizeof("MINUS_SIGN_SYMBOL") - 1, 1);
+	zend_string *const_MINUS_SIGN_SYMBOL_name = zend_string_init_interned("MINUS_SIGN_SYMBOL", strlen("MINUS_SIGN_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MINUS_SIGN_SYMBOL_name, &const_MINUS_SIGN_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MINUS_SIGN_SYMBOL_name);
 
 	zval const_PLUS_SIGN_SYMBOL_value;
 	ZVAL_LONG(&const_PLUS_SIGN_SYMBOL_value, UNUM_PLUS_SIGN_SYMBOL);
-	zend_string *const_PLUS_SIGN_SYMBOL_name = zend_string_init_interned("PLUS_SIGN_SYMBOL", sizeof("PLUS_SIGN_SYMBOL") - 1, 1);
+	zend_string *const_PLUS_SIGN_SYMBOL_name = zend_string_init_interned("PLUS_SIGN_SYMBOL", strlen("PLUS_SIGN_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PLUS_SIGN_SYMBOL_name, &const_PLUS_SIGN_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PLUS_SIGN_SYMBOL_name);
 
 	zval const_CURRENCY_SYMBOL_value;
 	ZVAL_LONG(&const_CURRENCY_SYMBOL_value, UNUM_CURRENCY_SYMBOL);
-	zend_string *const_CURRENCY_SYMBOL_name = zend_string_init_interned("CURRENCY_SYMBOL", sizeof("CURRENCY_SYMBOL") - 1, 1);
+	zend_string *const_CURRENCY_SYMBOL_name = zend_string_init_interned("CURRENCY_SYMBOL", strlen("CURRENCY_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENCY_SYMBOL_name, &const_CURRENCY_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENCY_SYMBOL_name);
 
 	zval const_INTL_CURRENCY_SYMBOL_value;
 	ZVAL_LONG(&const_INTL_CURRENCY_SYMBOL_value, UNUM_INTL_CURRENCY_SYMBOL);
-	zend_string *const_INTL_CURRENCY_SYMBOL_name = zend_string_init_interned("INTL_CURRENCY_SYMBOL", sizeof("INTL_CURRENCY_SYMBOL") - 1, 1);
+	zend_string *const_INTL_CURRENCY_SYMBOL_name = zend_string_init_interned("INTL_CURRENCY_SYMBOL", strlen("INTL_CURRENCY_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INTL_CURRENCY_SYMBOL_name, &const_INTL_CURRENCY_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INTL_CURRENCY_SYMBOL_name);
 
 	zval const_MONETARY_SEPARATOR_SYMBOL_value;
 	ZVAL_LONG(&const_MONETARY_SEPARATOR_SYMBOL_value, UNUM_MONETARY_SEPARATOR_SYMBOL);
-	zend_string *const_MONETARY_SEPARATOR_SYMBOL_name = zend_string_init_interned("MONETARY_SEPARATOR_SYMBOL", sizeof("MONETARY_SEPARATOR_SYMBOL") - 1, 1);
+	zend_string *const_MONETARY_SEPARATOR_SYMBOL_name = zend_string_init_interned("MONETARY_SEPARATOR_SYMBOL", strlen("MONETARY_SEPARATOR_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MONETARY_SEPARATOR_SYMBOL_name, &const_MONETARY_SEPARATOR_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MONETARY_SEPARATOR_SYMBOL_name);
 
 	zval const_EXPONENTIAL_SYMBOL_value;
 	ZVAL_LONG(&const_EXPONENTIAL_SYMBOL_value, UNUM_EXPONENTIAL_SYMBOL);
-	zend_string *const_EXPONENTIAL_SYMBOL_name = zend_string_init_interned("EXPONENTIAL_SYMBOL", sizeof("EXPONENTIAL_SYMBOL") - 1, 1);
+	zend_string *const_EXPONENTIAL_SYMBOL_name = zend_string_init_interned("EXPONENTIAL_SYMBOL", strlen("EXPONENTIAL_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXPONENTIAL_SYMBOL_name, &const_EXPONENTIAL_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXPONENTIAL_SYMBOL_name);
 
 	zval const_PERMILL_SYMBOL_value;
 	ZVAL_LONG(&const_PERMILL_SYMBOL_value, UNUM_PERMILL_SYMBOL);
-	zend_string *const_PERMILL_SYMBOL_name = zend_string_init_interned("PERMILL_SYMBOL", sizeof("PERMILL_SYMBOL") - 1, 1);
+	zend_string *const_PERMILL_SYMBOL_name = zend_string_init_interned("PERMILL_SYMBOL", strlen("PERMILL_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PERMILL_SYMBOL_name, &const_PERMILL_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PERMILL_SYMBOL_name);
 
 	zval const_PAD_ESCAPE_SYMBOL_value;
 	ZVAL_LONG(&const_PAD_ESCAPE_SYMBOL_value, UNUM_PAD_ESCAPE_SYMBOL);
-	zend_string *const_PAD_ESCAPE_SYMBOL_name = zend_string_init_interned("PAD_ESCAPE_SYMBOL", sizeof("PAD_ESCAPE_SYMBOL") - 1, 1);
+	zend_string *const_PAD_ESCAPE_SYMBOL_name = zend_string_init_interned("PAD_ESCAPE_SYMBOL", strlen("PAD_ESCAPE_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PAD_ESCAPE_SYMBOL_name, &const_PAD_ESCAPE_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PAD_ESCAPE_SYMBOL_name);
 
 	zval const_INFINITY_SYMBOL_value;
 	ZVAL_LONG(&const_INFINITY_SYMBOL_value, UNUM_INFINITY_SYMBOL);
-	zend_string *const_INFINITY_SYMBOL_name = zend_string_init_interned("INFINITY_SYMBOL", sizeof("INFINITY_SYMBOL") - 1, 1);
+	zend_string *const_INFINITY_SYMBOL_name = zend_string_init_interned("INFINITY_SYMBOL", strlen("INFINITY_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INFINITY_SYMBOL_name, &const_INFINITY_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INFINITY_SYMBOL_name);
 
 	zval const_NAN_SYMBOL_value;
 	ZVAL_LONG(&const_NAN_SYMBOL_value, UNUM_NAN_SYMBOL);
-	zend_string *const_NAN_SYMBOL_name = zend_string_init_interned("NAN_SYMBOL", sizeof("NAN_SYMBOL") - 1, 1);
+	zend_string *const_NAN_SYMBOL_name = zend_string_init_interned("NAN_SYMBOL", strlen("NAN_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NAN_SYMBOL_name, &const_NAN_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NAN_SYMBOL_name);
 
 	zval const_SIGNIFICANT_DIGIT_SYMBOL_value;
 	ZVAL_LONG(&const_SIGNIFICANT_DIGIT_SYMBOL_value, UNUM_SIGNIFICANT_DIGIT_SYMBOL);
-	zend_string *const_SIGNIFICANT_DIGIT_SYMBOL_name = zend_string_init_interned("SIGNIFICANT_DIGIT_SYMBOL", sizeof("SIGNIFICANT_DIGIT_SYMBOL") - 1, 1);
+	zend_string *const_SIGNIFICANT_DIGIT_SYMBOL_name = zend_string_init_interned("SIGNIFICANT_DIGIT_SYMBOL", strlen("SIGNIFICANT_DIGIT_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SIGNIFICANT_DIGIT_SYMBOL_name, &const_SIGNIFICANT_DIGIT_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SIGNIFICANT_DIGIT_SYMBOL_name);
 
 	zval const_MONETARY_GROUPING_SEPARATOR_SYMBOL_value;
 	ZVAL_LONG(&const_MONETARY_GROUPING_SEPARATOR_SYMBOL_value, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL);
-	zend_string *const_MONETARY_GROUPING_SEPARATOR_SYMBOL_name = zend_string_init_interned("MONETARY_GROUPING_SEPARATOR_SYMBOL", sizeof("MONETARY_GROUPING_SEPARATOR_SYMBOL") - 1, 1);
+	zend_string *const_MONETARY_GROUPING_SEPARATOR_SYMBOL_name = zend_string_init_interned("MONETARY_GROUPING_SEPARATOR_SYMBOL", strlen("MONETARY_GROUPING_SEPARATOR_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MONETARY_GROUPING_SEPARATOR_SYMBOL_name, &const_MONETARY_GROUPING_SEPARATOR_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MONETARY_GROUPING_SEPARATOR_SYMBOL_name);
 
 	zval const_TYPE_DEFAULT_value;
 	ZVAL_LONG(&const_TYPE_DEFAULT_value, FORMAT_TYPE_DEFAULT);
-	zend_string *const_TYPE_DEFAULT_name = zend_string_init_interned("TYPE_DEFAULT", sizeof("TYPE_DEFAULT") - 1, 1);
+	zend_string *const_TYPE_DEFAULT_name = zend_string_init_interned("TYPE_DEFAULT", strlen("TYPE_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_DEFAULT_name, &const_TYPE_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_DEFAULT_name);
 
 	zval const_TYPE_INT32_value;
 	ZVAL_LONG(&const_TYPE_INT32_value, FORMAT_TYPE_INT32);
-	zend_string *const_TYPE_INT32_name = zend_string_init_interned("TYPE_INT32", sizeof("TYPE_INT32") - 1, 1);
+	zend_string *const_TYPE_INT32_name = zend_string_init_interned("TYPE_INT32", strlen("TYPE_INT32"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_INT32_name, &const_TYPE_INT32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_INT32_name);
 
 	zval const_TYPE_INT64_value;
 	ZVAL_LONG(&const_TYPE_INT64_value, FORMAT_TYPE_INT64);
-	zend_string *const_TYPE_INT64_name = zend_string_init_interned("TYPE_INT64", sizeof("TYPE_INT64") - 1, 1);
+	zend_string *const_TYPE_INT64_name = zend_string_init_interned("TYPE_INT64", strlen("TYPE_INT64"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_INT64_name, &const_TYPE_INT64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_INT64_name);
 
 	zval const_TYPE_DOUBLE_value;
 	ZVAL_LONG(&const_TYPE_DOUBLE_value, FORMAT_TYPE_DOUBLE);
-	zend_string *const_TYPE_DOUBLE_name = zend_string_init_interned("TYPE_DOUBLE", sizeof("TYPE_DOUBLE") - 1, 1);
+	zend_string *const_TYPE_DOUBLE_name = zend_string_init_interned("TYPE_DOUBLE", strlen("TYPE_DOUBLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_DOUBLE_name, &const_TYPE_DOUBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_DOUBLE_name);
 
 	zval const_TYPE_CURRENCY_value;
 	ZVAL_LONG(&const_TYPE_CURRENCY_value, FORMAT_TYPE_CURRENCY);
-	zend_string *const_TYPE_CURRENCY_name = zend_string_init_interned("TYPE_CURRENCY", sizeof("TYPE_CURRENCY") - 1, 1);
+	zend_string *const_TYPE_CURRENCY_name = zend_string_init_interned("TYPE_CURRENCY", strlen("TYPE_CURRENCY"), 1);
 	zend_class_constant *const_TYPE_CURRENCY = zend_declare_typed_class_constant(class_entry, const_TYPE_CURRENCY_name, &const_TYPE_CURRENCY_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CURRENCY_name);
 

--- a/ext/intl/locale/locale_arginfo.h
+++ b/ext/intl/locale/locale_arginfo.h
@@ -112,68 +112,68 @@ static zend_class_entry *register_class_Locale(void)
 
 	zval const_ACTUAL_LOCALE_value;
 	ZVAL_LONG(&const_ACTUAL_LOCALE_value, ULOC_ACTUAL_LOCALE);
-	zend_string *const_ACTUAL_LOCALE_name = zend_string_init_interned("ACTUAL_LOCALE", sizeof("ACTUAL_LOCALE") - 1, 1);
+	zend_string *const_ACTUAL_LOCALE_name = zend_string_init_interned("ACTUAL_LOCALE", strlen("ACTUAL_LOCALE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ACTUAL_LOCALE_name, &const_ACTUAL_LOCALE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ACTUAL_LOCALE_name);
 
 	zval const_VALID_LOCALE_value;
 	ZVAL_LONG(&const_VALID_LOCALE_value, ULOC_VALID_LOCALE);
-	zend_string *const_VALID_LOCALE_name = zend_string_init_interned("VALID_LOCALE", sizeof("VALID_LOCALE") - 1, 1);
+	zend_string *const_VALID_LOCALE_name = zend_string_init_interned("VALID_LOCALE", strlen("VALID_LOCALE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VALID_LOCALE_name, &const_VALID_LOCALE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VALID_LOCALE_name);
 
 	zval const_DEFAULT_LOCALE_value;
 	ZVAL_NULL(&const_DEFAULT_LOCALE_value);
-	zend_string *const_DEFAULT_LOCALE_name = zend_string_init_interned("DEFAULT_LOCALE", sizeof("DEFAULT_LOCALE") - 1, 1);
+	zend_string *const_DEFAULT_LOCALE_name = zend_string_init_interned("DEFAULT_LOCALE", strlen("DEFAULT_LOCALE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULT_LOCALE_name, &const_DEFAULT_LOCALE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_NULL));
 	zend_string_release(const_DEFAULT_LOCALE_name);
 
 	zval const_LANG_TAG_value;
 	zend_string *const_LANG_TAG_value_str = zend_string_init(LOC_LANG_TAG, strlen(LOC_LANG_TAG), 1);
 	ZVAL_STR(&const_LANG_TAG_value, const_LANG_TAG_value_str);
-	zend_string *const_LANG_TAG_name = zend_string_init_interned("LANG_TAG", sizeof("LANG_TAG") - 1, 1);
+	zend_string *const_LANG_TAG_name = zend_string_init_interned("LANG_TAG", strlen("LANG_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LANG_TAG_name, &const_LANG_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_LANG_TAG_name);
 
 	zval const_EXTLANG_TAG_value;
 	zend_string *const_EXTLANG_TAG_value_str = zend_string_init(LOC_EXTLANG_TAG, strlen(LOC_EXTLANG_TAG), 1);
 	ZVAL_STR(&const_EXTLANG_TAG_value, const_EXTLANG_TAG_value_str);
-	zend_string *const_EXTLANG_TAG_name = zend_string_init_interned("EXTLANG_TAG", sizeof("EXTLANG_TAG") - 1, 1);
+	zend_string *const_EXTLANG_TAG_name = zend_string_init_interned("EXTLANG_TAG", strlen("EXTLANG_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXTLANG_TAG_name, &const_EXTLANG_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_EXTLANG_TAG_name);
 
 	zval const_SCRIPT_TAG_value;
 	zend_string *const_SCRIPT_TAG_value_str = zend_string_init(LOC_SCRIPT_TAG, strlen(LOC_SCRIPT_TAG), 1);
 	ZVAL_STR(&const_SCRIPT_TAG_value, const_SCRIPT_TAG_value_str);
-	zend_string *const_SCRIPT_TAG_name = zend_string_init_interned("SCRIPT_TAG", sizeof("SCRIPT_TAG") - 1, 1);
+	zend_string *const_SCRIPT_TAG_name = zend_string_init_interned("SCRIPT_TAG", strlen("SCRIPT_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SCRIPT_TAG_name, &const_SCRIPT_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_SCRIPT_TAG_name);
 
 	zval const_REGION_TAG_value;
 	zend_string *const_REGION_TAG_value_str = zend_string_init(LOC_REGION_TAG, strlen(LOC_REGION_TAG), 1);
 	ZVAL_STR(&const_REGION_TAG_value, const_REGION_TAG_value_str);
-	zend_string *const_REGION_TAG_name = zend_string_init_interned("REGION_TAG", sizeof("REGION_TAG") - 1, 1);
+	zend_string *const_REGION_TAG_name = zend_string_init_interned("REGION_TAG", strlen("REGION_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REGION_TAG_name, &const_REGION_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_REGION_TAG_name);
 
 	zval const_VARIANT_TAG_value;
 	zend_string *const_VARIANT_TAG_value_str = zend_string_init(LOC_VARIANT_TAG, strlen(LOC_VARIANT_TAG), 1);
 	ZVAL_STR(&const_VARIANT_TAG_value, const_VARIANT_TAG_value_str);
-	zend_string *const_VARIANT_TAG_name = zend_string_init_interned("VARIANT_TAG", sizeof("VARIANT_TAG") - 1, 1);
+	zend_string *const_VARIANT_TAG_name = zend_string_init_interned("VARIANT_TAG", strlen("VARIANT_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VARIANT_TAG_name, &const_VARIANT_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_VARIANT_TAG_name);
 
 	zval const_GRANDFATHERED_LANG_TAG_value;
 	zend_string *const_GRANDFATHERED_LANG_TAG_value_str = zend_string_init(LOC_GRANDFATHERED_LANG_TAG, strlen(LOC_GRANDFATHERED_LANG_TAG), 1);
 	ZVAL_STR(&const_GRANDFATHERED_LANG_TAG_value, const_GRANDFATHERED_LANG_TAG_value_str);
-	zend_string *const_GRANDFATHERED_LANG_TAG_name = zend_string_init_interned("GRANDFATHERED_LANG_TAG", sizeof("GRANDFATHERED_LANG_TAG") - 1, 1);
+	zend_string *const_GRANDFATHERED_LANG_TAG_name = zend_string_init_interned("GRANDFATHERED_LANG_TAG", strlen("GRANDFATHERED_LANG_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GRANDFATHERED_LANG_TAG_name, &const_GRANDFATHERED_LANG_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_GRANDFATHERED_LANG_TAG_name);
 
 	zval const_PRIVATE_TAG_value;
 	zend_string *const_PRIVATE_TAG_value_str = zend_string_init(LOC_PRIVATE_TAG, strlen(LOC_PRIVATE_TAG), 1);
 	ZVAL_STR(&const_PRIVATE_TAG_value, const_PRIVATE_TAG_value_str);
-	zend_string *const_PRIVATE_TAG_name = zend_string_init_interned("PRIVATE_TAG", sizeof("PRIVATE_TAG") - 1, 1);
+	zend_string *const_PRIVATE_TAG_name = zend_string_init_interned("PRIVATE_TAG", strlen("PRIVATE_TAG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PRIVATE_TAG_name, &const_PRIVATE_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_PRIVATE_TAG_name);
 

--- a/ext/intl/normalizer/normalizer_arginfo.h
+++ b/ext/intl/normalizer/normalizer_arginfo.h
@@ -36,61 +36,61 @@ static zend_class_entry *register_class_Normalizer(void)
 
 	zval const_FORM_D_value;
 	ZVAL_LONG(&const_FORM_D_value, NORMALIZER_FORM_D);
-	zend_string *const_FORM_D_name = zend_string_init_interned("FORM_D", sizeof("FORM_D") - 1, 1);
+	zend_string *const_FORM_D_name = zend_string_init_interned("FORM_D", strlen("FORM_D"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORM_D_name, &const_FORM_D_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORM_D_name);
 
 	zval const_NFD_value;
 	ZVAL_LONG(&const_NFD_value, NORMALIZER_NFD);
-	zend_string *const_NFD_name = zend_string_init_interned("NFD", sizeof("NFD") - 1, 1);
+	zend_string *const_NFD_name = zend_string_init_interned("NFD", strlen("NFD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NFD_name, &const_NFD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NFD_name);
 
 	zval const_FORM_KD_value;
 	ZVAL_LONG(&const_FORM_KD_value, NORMALIZER_FORM_KD);
-	zend_string *const_FORM_KD_name = zend_string_init_interned("FORM_KD", sizeof("FORM_KD") - 1, 1);
+	zend_string *const_FORM_KD_name = zend_string_init_interned("FORM_KD", strlen("FORM_KD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORM_KD_name, &const_FORM_KD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORM_KD_name);
 
 	zval const_NFKD_value;
 	ZVAL_LONG(&const_NFKD_value, NORMALIZER_NFKD);
-	zend_string *const_NFKD_name = zend_string_init_interned("NFKD", sizeof("NFKD") - 1, 1);
+	zend_string *const_NFKD_name = zend_string_init_interned("NFKD", strlen("NFKD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NFKD_name, &const_NFKD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NFKD_name);
 
 	zval const_FORM_C_value;
 	ZVAL_LONG(&const_FORM_C_value, NORMALIZER_FORM_C);
-	zend_string *const_FORM_C_name = zend_string_init_interned("FORM_C", sizeof("FORM_C") - 1, 1);
+	zend_string *const_FORM_C_name = zend_string_init_interned("FORM_C", strlen("FORM_C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORM_C_name, &const_FORM_C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORM_C_name);
 
 	zval const_NFC_value;
 	ZVAL_LONG(&const_NFC_value, NORMALIZER_NFC);
-	zend_string *const_NFC_name = zend_string_init_interned("NFC", sizeof("NFC") - 1, 1);
+	zend_string *const_NFC_name = zend_string_init_interned("NFC", strlen("NFC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NFC_name, &const_NFC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NFC_name);
 
 	zval const_FORM_KC_value;
 	ZVAL_LONG(&const_FORM_KC_value, NORMALIZER_FORM_KC);
-	zend_string *const_FORM_KC_name = zend_string_init_interned("FORM_KC", sizeof("FORM_KC") - 1, 1);
+	zend_string *const_FORM_KC_name = zend_string_init_interned("FORM_KC", strlen("FORM_KC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORM_KC_name, &const_FORM_KC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORM_KC_name);
 
 	zval const_NFKC_value;
 	ZVAL_LONG(&const_NFKC_value, NORMALIZER_NFKC);
-	zend_string *const_NFKC_name = zend_string_init_interned("NFKC", sizeof("NFKC") - 1, 1);
+	zend_string *const_NFKC_name = zend_string_init_interned("NFKC", strlen("NFKC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NFKC_name, &const_NFKC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NFKC_name);
 
 	zval const_FORM_KC_CF_value;
 	ZVAL_LONG(&const_FORM_KC_CF_value, NORMALIZER_FORM_KC_CF);
-	zend_string *const_FORM_KC_CF_name = zend_string_init_interned("FORM_KC_CF", sizeof("FORM_KC_CF") - 1, 1);
+	zend_string *const_FORM_KC_CF_name = zend_string_init_interned("FORM_KC_CF", strlen("FORM_KC_CF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORM_KC_CF_name, &const_FORM_KC_CF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORM_KC_CF_name);
 
 	zval const_NFKC_CF_value;
 	ZVAL_LONG(&const_NFKC_CF_value, NORMALIZER_NFKC_CF);
-	zend_string *const_NFKC_CF_name = zend_string_init_interned("NFKC_CF", sizeof("NFKC_CF") - 1, 1);
+	zend_string *const_NFKC_CF_name = zend_string_init_interned("NFKC_CF", strlen("NFKC_CF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NFKC_CF_name, &const_NFKC_CF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NFKC_CF_name);
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1196,7 +1196,7 @@ static void register_php_intl_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("IDNA_ERROR_CONTEXTJ", UIDNA_ERROR_CONTEXTJ, CONST_PERSISTENT);
 
 
-	zend_attribute *attribute_Deprecated_func_intlcal_set_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlcal_set", sizeof("intlcal_set") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_intlcal_set_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlcal_set", strlen("intlcal_set")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_intlcal_set_0_arg0;
 	zend_string *attribute_Deprecated_func_intlcal_set_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_intlcal_set_0_arg0, attribute_Deprecated_func_intlcal_set_0_arg0_str);
@@ -1208,7 +1208,7 @@ static void register_php_intl_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_intlcal_set_0->args[1].value, &attribute_Deprecated_func_intlcal_set_0_arg1);
 	attribute_Deprecated_func_intlcal_set_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_intlgregcal_create_instance_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlgregcal_create_instance", sizeof("intlgregcal_create_instance") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_intlgregcal_create_instance_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "intlgregcal_create_instance", strlen("intlgregcal_create_instance")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_intlgregcal_create_instance_0_arg0;
 	zend_string *attribute_Deprecated_func_intlgregcal_create_instance_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_intlgregcal_create_instance_0_arg0, attribute_Deprecated_func_intlgregcal_create_instance_0_arg0_str);

--- a/ext/intl/spoofchecker/spoofchecker_arginfo.h
+++ b/ext/intl/spoofchecker/spoofchecker_arginfo.h
@@ -66,50 +66,50 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_SINGLE_SCRIPT_CONFUSABLE_value;
 	ZVAL_LONG(&const_SINGLE_SCRIPT_CONFUSABLE_value, USPOOF_SINGLE_SCRIPT_CONFUSABLE);
-	zend_string *const_SINGLE_SCRIPT_CONFUSABLE_name = zend_string_init_interned("SINGLE_SCRIPT_CONFUSABLE", sizeof("SINGLE_SCRIPT_CONFUSABLE") - 1, 1);
+	zend_string *const_SINGLE_SCRIPT_CONFUSABLE_name = zend_string_init_interned("SINGLE_SCRIPT_CONFUSABLE", strlen("SINGLE_SCRIPT_CONFUSABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SINGLE_SCRIPT_CONFUSABLE_name, &const_SINGLE_SCRIPT_CONFUSABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SINGLE_SCRIPT_CONFUSABLE_name);
 
 	zval const_MIXED_SCRIPT_CONFUSABLE_value;
 	ZVAL_LONG(&const_MIXED_SCRIPT_CONFUSABLE_value, USPOOF_MIXED_SCRIPT_CONFUSABLE);
-	zend_string *const_MIXED_SCRIPT_CONFUSABLE_name = zend_string_init_interned("MIXED_SCRIPT_CONFUSABLE", sizeof("MIXED_SCRIPT_CONFUSABLE") - 1, 1);
+	zend_string *const_MIXED_SCRIPT_CONFUSABLE_name = zend_string_init_interned("MIXED_SCRIPT_CONFUSABLE", strlen("MIXED_SCRIPT_CONFUSABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIXED_SCRIPT_CONFUSABLE_name, &const_MIXED_SCRIPT_CONFUSABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIXED_SCRIPT_CONFUSABLE_name);
 
 	zval const_WHOLE_SCRIPT_CONFUSABLE_value;
 	ZVAL_LONG(&const_WHOLE_SCRIPT_CONFUSABLE_value, USPOOF_WHOLE_SCRIPT_CONFUSABLE);
-	zend_string *const_WHOLE_SCRIPT_CONFUSABLE_name = zend_string_init_interned("WHOLE_SCRIPT_CONFUSABLE", sizeof("WHOLE_SCRIPT_CONFUSABLE") - 1, 1);
+	zend_string *const_WHOLE_SCRIPT_CONFUSABLE_name = zend_string_init_interned("WHOLE_SCRIPT_CONFUSABLE", strlen("WHOLE_SCRIPT_CONFUSABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WHOLE_SCRIPT_CONFUSABLE_name, &const_WHOLE_SCRIPT_CONFUSABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WHOLE_SCRIPT_CONFUSABLE_name);
 
 	zval const_ANY_CASE_value;
 	ZVAL_LONG(&const_ANY_CASE_value, USPOOF_ANY_CASE);
-	zend_string *const_ANY_CASE_name = zend_string_init_interned("ANY_CASE", sizeof("ANY_CASE") - 1, 1);
+	zend_string *const_ANY_CASE_name = zend_string_init_interned("ANY_CASE", strlen("ANY_CASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ANY_CASE_name, &const_ANY_CASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ANY_CASE_name);
 
 	zval const_SINGLE_SCRIPT_value;
 	ZVAL_LONG(&const_SINGLE_SCRIPT_value, USPOOF_SINGLE_SCRIPT);
-	zend_string *const_SINGLE_SCRIPT_name = zend_string_init_interned("SINGLE_SCRIPT", sizeof("SINGLE_SCRIPT") - 1, 1);
+	zend_string *const_SINGLE_SCRIPT_name = zend_string_init_interned("SINGLE_SCRIPT", strlen("SINGLE_SCRIPT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SINGLE_SCRIPT_name, &const_SINGLE_SCRIPT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SINGLE_SCRIPT_name);
 
 	zval const_INVISIBLE_value;
 	ZVAL_LONG(&const_INVISIBLE_value, USPOOF_INVISIBLE);
-	zend_string *const_INVISIBLE_name = zend_string_init_interned("INVISIBLE", sizeof("INVISIBLE") - 1, 1);
+	zend_string *const_INVISIBLE_name = zend_string_init_interned("INVISIBLE", strlen("INVISIBLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INVISIBLE_name, &const_INVISIBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INVISIBLE_name);
 
 	zval const_CHAR_LIMIT_value;
 	ZVAL_LONG(&const_CHAR_LIMIT_value, USPOOF_CHAR_LIMIT);
-	zend_string *const_CHAR_LIMIT_name = zend_string_init_interned("CHAR_LIMIT", sizeof("CHAR_LIMIT") - 1, 1);
+	zend_string *const_CHAR_LIMIT_name = zend_string_init_interned("CHAR_LIMIT", strlen("CHAR_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_LIMIT_name, &const_CHAR_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_LIMIT_name);
 #if U_ICU_VERSION_MAJOR_NUM >= 58
 
 	zval const_ASCII_value;
 	ZVAL_LONG(&const_ASCII_value, USPOOF_ASCII);
-	zend_string *const_ASCII_name = zend_string_init_interned("ASCII", sizeof("ASCII") - 1, 1);
+	zend_string *const_ASCII_name = zend_string_init_interned("ASCII", strlen("ASCII"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ASCII_name, &const_ASCII_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ASCII_name);
 #endif
@@ -117,7 +117,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_HIGHLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_HIGHLY_RESTRICTIVE_value, USPOOF_HIGHLY_RESTRICTIVE);
-	zend_string *const_HIGHLY_RESTRICTIVE_name = zend_string_init_interned("HIGHLY_RESTRICTIVE", sizeof("HIGHLY_RESTRICTIVE") - 1, 1);
+	zend_string *const_HIGHLY_RESTRICTIVE_name = zend_string_init_interned("HIGHLY_RESTRICTIVE", strlen("HIGHLY_RESTRICTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HIGHLY_RESTRICTIVE_name, &const_HIGHLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HIGHLY_RESTRICTIVE_name);
 #endif
@@ -125,7 +125,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_MODERATELY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MODERATELY_RESTRICTIVE_value, USPOOF_MODERATELY_RESTRICTIVE);
-	zend_string *const_MODERATELY_RESTRICTIVE_name = zend_string_init_interned("MODERATELY_RESTRICTIVE", sizeof("MODERATELY_RESTRICTIVE") - 1, 1);
+	zend_string *const_MODERATELY_RESTRICTIVE_name = zend_string_init_interned("MODERATELY_RESTRICTIVE", strlen("MODERATELY_RESTRICTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MODERATELY_RESTRICTIVE_name, &const_MODERATELY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MODERATELY_RESTRICTIVE_name);
 #endif
@@ -133,7 +133,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_MINIMALLY_RESTRICTIVE_value;
 	ZVAL_LONG(&const_MINIMALLY_RESTRICTIVE_value, USPOOF_MINIMALLY_RESTRICTIVE);
-	zend_string *const_MINIMALLY_RESTRICTIVE_name = zend_string_init_interned("MINIMALLY_RESTRICTIVE", sizeof("MINIMALLY_RESTRICTIVE") - 1, 1);
+	zend_string *const_MINIMALLY_RESTRICTIVE_name = zend_string_init_interned("MINIMALLY_RESTRICTIVE", strlen("MINIMALLY_RESTRICTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MINIMALLY_RESTRICTIVE_name, &const_MINIMALLY_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MINIMALLY_RESTRICTIVE_name);
 #endif
@@ -141,7 +141,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_UNRESTRICTIVE_value;
 	ZVAL_LONG(&const_UNRESTRICTIVE_value, USPOOF_UNRESTRICTIVE);
-	zend_string *const_UNRESTRICTIVE_name = zend_string_init_interned("UNRESTRICTIVE", sizeof("UNRESTRICTIVE") - 1, 1);
+	zend_string *const_UNRESTRICTIVE_name = zend_string_init_interned("UNRESTRICTIVE", strlen("UNRESTRICTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNRESTRICTIVE_name, &const_UNRESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNRESTRICTIVE_name);
 #endif
@@ -149,7 +149,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_SINGLE_SCRIPT_RESTRICTIVE_value;
 	ZVAL_LONG(&const_SINGLE_SCRIPT_RESTRICTIVE_value, USPOOF_SINGLE_SCRIPT_RESTRICTIVE);
-	zend_string *const_SINGLE_SCRIPT_RESTRICTIVE_name = zend_string_init_interned("SINGLE_SCRIPT_RESTRICTIVE", sizeof("SINGLE_SCRIPT_RESTRICTIVE") - 1, 1);
+	zend_string *const_SINGLE_SCRIPT_RESTRICTIVE_name = zend_string_init_interned("SINGLE_SCRIPT_RESTRICTIVE", strlen("SINGLE_SCRIPT_RESTRICTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SINGLE_SCRIPT_RESTRICTIVE_name, &const_SINGLE_SCRIPT_RESTRICTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SINGLE_SCRIPT_RESTRICTIVE_name);
 #endif
@@ -157,7 +157,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_MIXED_NUMBERS_value;
 	ZVAL_LONG(&const_MIXED_NUMBERS_value, USPOOF_MIXED_NUMBERS);
-	zend_string *const_MIXED_NUMBERS_name = zend_string_init_interned("MIXED_NUMBERS", sizeof("MIXED_NUMBERS") - 1, 1);
+	zend_string *const_MIXED_NUMBERS_name = zend_string_init_interned("MIXED_NUMBERS", strlen("MIXED_NUMBERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIXED_NUMBERS_name, &const_MIXED_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIXED_NUMBERS_name);
 #endif
@@ -165,33 +165,33 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	zval const_HIDDEN_OVERLAY_value;
 	ZVAL_LONG(&const_HIDDEN_OVERLAY_value, USPOOF_HIDDEN_OVERLAY);
-	zend_string *const_HIDDEN_OVERLAY_name = zend_string_init_interned("HIDDEN_OVERLAY", sizeof("HIDDEN_OVERLAY") - 1, 1);
+	zend_string *const_HIDDEN_OVERLAY_name = zend_string_init_interned("HIDDEN_OVERLAY", strlen("HIDDEN_OVERLAY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HIDDEN_OVERLAY_name, &const_HIDDEN_OVERLAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HIDDEN_OVERLAY_name);
 #endif
 
 	zval const_IGNORE_SPACE_value;
 	ZVAL_LONG(&const_IGNORE_SPACE_value, USET_IGNORE_SPACE);
-	zend_string *const_IGNORE_SPACE_name = zend_string_init_interned("IGNORE_SPACE", sizeof("IGNORE_SPACE") - 1, 1);
+	zend_string *const_IGNORE_SPACE_name = zend_string_init_interned("IGNORE_SPACE", strlen("IGNORE_SPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IGNORE_SPACE_name, &const_IGNORE_SPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IGNORE_SPACE_name);
 
 	zval const_CASE_INSENSITIVE_value;
 	ZVAL_LONG(&const_CASE_INSENSITIVE_value, USET_CASE_INSENSITIVE);
-	zend_string *const_CASE_INSENSITIVE_name = zend_string_init_interned("CASE_INSENSITIVE", sizeof("CASE_INSENSITIVE") - 1, 1);
+	zend_string *const_CASE_INSENSITIVE_name = zend_string_init_interned("CASE_INSENSITIVE", strlen("CASE_INSENSITIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_INSENSITIVE_name, &const_CASE_INSENSITIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_INSENSITIVE_name);
 
 	zval const_ADD_CASE_MAPPINGS_value;
 	ZVAL_LONG(&const_ADD_CASE_MAPPINGS_value, USET_ADD_CASE_MAPPINGS);
-	zend_string *const_ADD_CASE_MAPPINGS_name = zend_string_init_interned("ADD_CASE_MAPPINGS", sizeof("ADD_CASE_MAPPINGS") - 1, 1);
+	zend_string *const_ADD_CASE_MAPPINGS_name = zend_string_init_interned("ADD_CASE_MAPPINGS", strlen("ADD_CASE_MAPPINGS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ADD_CASE_MAPPINGS_name, &const_ADD_CASE_MAPPINGS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ADD_CASE_MAPPINGS_name);
 #if U_ICU_VERSION_MAJOR_NUM >= 73
 
 	zval const_SIMPLE_CASE_INSENSITIVE_value;
 	ZVAL_LONG(&const_SIMPLE_CASE_INSENSITIVE_value, USET_SIMPLE_CASE_INSENSITIVE);
-	zend_string *const_SIMPLE_CASE_INSENSITIVE_name = zend_string_init_interned("SIMPLE_CASE_INSENSITIVE", sizeof("SIMPLE_CASE_INSENSITIVE") - 1, 1);
+	zend_string *const_SIMPLE_CASE_INSENSITIVE_name = zend_string_init_interned("SIMPLE_CASE_INSENSITIVE", strlen("SIMPLE_CASE_INSENSITIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SIMPLE_CASE_INSENSITIVE_name, &const_SIMPLE_CASE_INSENSITIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SIMPLE_CASE_INSENSITIVE_name);
 #endif

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -168,67 +168,67 @@ static zend_class_entry *register_class_IntlTimeZone(void)
 
 	zval const_DISPLAY_SHORT_value;
 	ZVAL_LONG(&const_DISPLAY_SHORT_value, TimeZone::SHORT);
-	zend_string *const_DISPLAY_SHORT_name = zend_string_init_interned("DISPLAY_SHORT", sizeof("DISPLAY_SHORT") - 1, 1);
+	zend_string *const_DISPLAY_SHORT_name = zend_string_init_interned("DISPLAY_SHORT", strlen("DISPLAY_SHORT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_SHORT_name, &const_DISPLAY_SHORT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_SHORT_name);
 
 	zval const_DISPLAY_LONG_value;
 	ZVAL_LONG(&const_DISPLAY_LONG_value, TimeZone::LONG);
-	zend_string *const_DISPLAY_LONG_name = zend_string_init_interned("DISPLAY_LONG", sizeof("DISPLAY_LONG") - 1, 1);
+	zend_string *const_DISPLAY_LONG_name = zend_string_init_interned("DISPLAY_LONG", strlen("DISPLAY_LONG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_LONG_name, &const_DISPLAY_LONG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_LONG_name);
 
 	zval const_DISPLAY_SHORT_GENERIC_value;
 	ZVAL_LONG(&const_DISPLAY_SHORT_GENERIC_value, TimeZone::SHORT_GENERIC);
-	zend_string *const_DISPLAY_SHORT_GENERIC_name = zend_string_init_interned("DISPLAY_SHORT_GENERIC", sizeof("DISPLAY_SHORT_GENERIC") - 1, 1);
+	zend_string *const_DISPLAY_SHORT_GENERIC_name = zend_string_init_interned("DISPLAY_SHORT_GENERIC", strlen("DISPLAY_SHORT_GENERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_SHORT_GENERIC_name, &const_DISPLAY_SHORT_GENERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_SHORT_GENERIC_name);
 
 	zval const_DISPLAY_LONG_GENERIC_value;
 	ZVAL_LONG(&const_DISPLAY_LONG_GENERIC_value, TimeZone::LONG_GENERIC);
-	zend_string *const_DISPLAY_LONG_GENERIC_name = zend_string_init_interned("DISPLAY_LONG_GENERIC", sizeof("DISPLAY_LONG_GENERIC") - 1, 1);
+	zend_string *const_DISPLAY_LONG_GENERIC_name = zend_string_init_interned("DISPLAY_LONG_GENERIC", strlen("DISPLAY_LONG_GENERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_LONG_GENERIC_name, &const_DISPLAY_LONG_GENERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_LONG_GENERIC_name);
 
 	zval const_DISPLAY_SHORT_GMT_value;
 	ZVAL_LONG(&const_DISPLAY_SHORT_GMT_value, TimeZone::SHORT_GMT);
-	zend_string *const_DISPLAY_SHORT_GMT_name = zend_string_init_interned("DISPLAY_SHORT_GMT", sizeof("DISPLAY_SHORT_GMT") - 1, 1);
+	zend_string *const_DISPLAY_SHORT_GMT_name = zend_string_init_interned("DISPLAY_SHORT_GMT", strlen("DISPLAY_SHORT_GMT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_SHORT_GMT_name, &const_DISPLAY_SHORT_GMT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_SHORT_GMT_name);
 
 	zval const_DISPLAY_LONG_GMT_value;
 	ZVAL_LONG(&const_DISPLAY_LONG_GMT_value, TimeZone::LONG_GMT);
-	zend_string *const_DISPLAY_LONG_GMT_name = zend_string_init_interned("DISPLAY_LONG_GMT", sizeof("DISPLAY_LONG_GMT") - 1, 1);
+	zend_string *const_DISPLAY_LONG_GMT_name = zend_string_init_interned("DISPLAY_LONG_GMT", strlen("DISPLAY_LONG_GMT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_LONG_GMT_name, &const_DISPLAY_LONG_GMT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_LONG_GMT_name);
 
 	zval const_DISPLAY_SHORT_COMMONLY_USED_value;
 	ZVAL_LONG(&const_DISPLAY_SHORT_COMMONLY_USED_value, TimeZone::SHORT_COMMONLY_USED);
-	zend_string *const_DISPLAY_SHORT_COMMONLY_USED_name = zend_string_init_interned("DISPLAY_SHORT_COMMONLY_USED", sizeof("DISPLAY_SHORT_COMMONLY_USED") - 1, 1);
+	zend_string *const_DISPLAY_SHORT_COMMONLY_USED_name = zend_string_init_interned("DISPLAY_SHORT_COMMONLY_USED", strlen("DISPLAY_SHORT_COMMONLY_USED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_SHORT_COMMONLY_USED_name, &const_DISPLAY_SHORT_COMMONLY_USED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_SHORT_COMMONLY_USED_name);
 
 	zval const_DISPLAY_GENERIC_LOCATION_value;
 	ZVAL_LONG(&const_DISPLAY_GENERIC_LOCATION_value, TimeZone::GENERIC_LOCATION);
-	zend_string *const_DISPLAY_GENERIC_LOCATION_name = zend_string_init_interned("DISPLAY_GENERIC_LOCATION", sizeof("DISPLAY_GENERIC_LOCATION") - 1, 1);
+	zend_string *const_DISPLAY_GENERIC_LOCATION_name = zend_string_init_interned("DISPLAY_GENERIC_LOCATION", strlen("DISPLAY_GENERIC_LOCATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DISPLAY_GENERIC_LOCATION_name, &const_DISPLAY_GENERIC_LOCATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DISPLAY_GENERIC_LOCATION_name);
 
 	zval const_TYPE_ANY_value;
 	ZVAL_LONG(&const_TYPE_ANY_value, UCAL_ZONE_TYPE_ANY);
-	zend_string *const_TYPE_ANY_name = zend_string_init_interned("TYPE_ANY", sizeof("TYPE_ANY") - 1, 1);
+	zend_string *const_TYPE_ANY_name = zend_string_init_interned("TYPE_ANY", strlen("TYPE_ANY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_ANY_name, &const_TYPE_ANY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_ANY_name);
 
 	zval const_TYPE_CANONICAL_value;
 	ZVAL_LONG(&const_TYPE_CANONICAL_value, UCAL_ZONE_TYPE_CANONICAL);
-	zend_string *const_TYPE_CANONICAL_name = zend_string_init_interned("TYPE_CANONICAL", sizeof("TYPE_CANONICAL") - 1, 1);
+	zend_string *const_TYPE_CANONICAL_name = zend_string_init_interned("TYPE_CANONICAL", strlen("TYPE_CANONICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_CANONICAL_name, &const_TYPE_CANONICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CANONICAL_name);
 
 	zval const_TYPE_CANONICAL_LOCATION_value;
 	ZVAL_LONG(&const_TYPE_CANONICAL_LOCATION_value, UCAL_ZONE_TYPE_CANONICAL_LOCATION);
-	zend_string *const_TYPE_CANONICAL_LOCATION_name = zend_string_init_interned("TYPE_CANONICAL_LOCATION", sizeof("TYPE_CANONICAL_LOCATION") - 1, 1);
+	zend_string *const_TYPE_CANONICAL_LOCATION_name = zend_string_init_interned("TYPE_CANONICAL_LOCATION", strlen("TYPE_CANONICAL_LOCATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_CANONICAL_LOCATION_name, &const_TYPE_CANONICAL_LOCATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CANONICAL_LOCATION_name);
 

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -62,19 +62,19 @@ static zend_class_entry *register_class_Transliterator(void)
 
 	zval const_FORWARD_value;
 	ZVAL_LONG(&const_FORWARD_value, TRANSLITERATOR_FORWARD);
-	zend_string *const_FORWARD_name = zend_string_init_interned("FORWARD", sizeof("FORWARD") - 1, 1);
+	zend_string *const_FORWARD_name = zend_string_init_interned("FORWARD", strlen("FORWARD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FORWARD_name, &const_FORWARD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FORWARD_name);
 
 	zval const_REVERSE_value;
 	ZVAL_LONG(&const_REVERSE_value, TRANSLITERATOR_REVERSE);
-	zend_string *const_REVERSE_name = zend_string_init_interned("REVERSE", sizeof("REVERSE") - 1, 1);
+	zend_string *const_REVERSE_name = zend_string_init_interned("REVERSE", strlen("REVERSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REVERSE_name, &const_REVERSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REVERSE_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_id_name);
 

--- a/ext/intl/uchar/uchar_arginfo.h
+++ b/ext/intl/uchar/uchar_arginfo.h
@@ -311,158 +311,158 @@ static zend_class_entry *register_class_IntlChar(void)
 	zval const_UNICODE_VERSION_value;
 	zend_string *const_UNICODE_VERSION_value_str = zend_string_init(U_UNICODE_VERSION, strlen(U_UNICODE_VERSION), 1);
 	ZVAL_STR(&const_UNICODE_VERSION_value, const_UNICODE_VERSION_value_str);
-	zend_string *const_UNICODE_VERSION_name = zend_string_init_interned("UNICODE_VERSION", sizeof("UNICODE_VERSION") - 1, 1);
+	zend_string *const_UNICODE_VERSION_name = zend_string_init_interned("UNICODE_VERSION", strlen("UNICODE_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNICODE_VERSION_name, &const_UNICODE_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_UNICODE_VERSION_name);
 
 	zval const_CODEPOINT_MIN_value;
 	ZVAL_LONG(&const_CODEPOINT_MIN_value, UCHAR_MIN_VALUE);
-	zend_string *const_CODEPOINT_MIN_name = zend_string_init_interned("CODEPOINT_MIN", sizeof("CODEPOINT_MIN") - 1, 1);
+	zend_string *const_CODEPOINT_MIN_name = zend_string_init_interned("CODEPOINT_MIN", strlen("CODEPOINT_MIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CODEPOINT_MIN_name, &const_CODEPOINT_MIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CODEPOINT_MIN_name);
 
 	zval const_CODEPOINT_MAX_value;
 	ZVAL_LONG(&const_CODEPOINT_MAX_value, UCHAR_MAX_VALUE);
-	zend_string *const_CODEPOINT_MAX_name = zend_string_init_interned("CODEPOINT_MAX", sizeof("CODEPOINT_MAX") - 1, 1);
+	zend_string *const_CODEPOINT_MAX_name = zend_string_init_interned("CODEPOINT_MAX", strlen("CODEPOINT_MAX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CODEPOINT_MAX_name, &const_CODEPOINT_MAX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CODEPOINT_MAX_name);
 
 	zval const_NO_NUMERIC_VALUE_value;
 	ZVAL_DOUBLE(&const_NO_NUMERIC_VALUE_value, U_NO_NUMERIC_VALUE);
-	zend_string *const_NO_NUMERIC_VALUE_name = zend_string_init_interned("NO_NUMERIC_VALUE", sizeof("NO_NUMERIC_VALUE") - 1, 1);
+	zend_string *const_NO_NUMERIC_VALUE_name = zend_string_init_interned("NO_NUMERIC_VALUE", strlen("NO_NUMERIC_VALUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NO_NUMERIC_VALUE_name, &const_NO_NUMERIC_VALUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(const_NO_NUMERIC_VALUE_name);
 
 	zval const_PROPERTY_ALPHABETIC_value;
 	ZVAL_LONG(&const_PROPERTY_ALPHABETIC_value, UCHAR_ALPHABETIC);
-	zend_string *const_PROPERTY_ALPHABETIC_name = zend_string_init_interned("PROPERTY_ALPHABETIC", sizeof("PROPERTY_ALPHABETIC") - 1, 1);
+	zend_string *const_PROPERTY_ALPHABETIC_name = zend_string_init_interned("PROPERTY_ALPHABETIC", strlen("PROPERTY_ALPHABETIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ALPHABETIC_name, &const_PROPERTY_ALPHABETIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ALPHABETIC_name);
 
 	zval const_PROPERTY_BINARY_START_value;
 	ZVAL_LONG(&const_PROPERTY_BINARY_START_value, UCHAR_BINARY_START);
-	zend_string *const_PROPERTY_BINARY_START_name = zend_string_init_interned("PROPERTY_BINARY_START", sizeof("PROPERTY_BINARY_START") - 1, 1);
+	zend_string *const_PROPERTY_BINARY_START_name = zend_string_init_interned("PROPERTY_BINARY_START", strlen("PROPERTY_BINARY_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BINARY_START_name, &const_PROPERTY_BINARY_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BINARY_START_name);
 
 	zval const_PROPERTY_ASCII_HEX_DIGIT_value;
 	ZVAL_LONG(&const_PROPERTY_ASCII_HEX_DIGIT_value, UCHAR_ASCII_HEX_DIGIT);
-	zend_string *const_PROPERTY_ASCII_HEX_DIGIT_name = zend_string_init_interned("PROPERTY_ASCII_HEX_DIGIT", sizeof("PROPERTY_ASCII_HEX_DIGIT") - 1, 1);
+	zend_string *const_PROPERTY_ASCII_HEX_DIGIT_name = zend_string_init_interned("PROPERTY_ASCII_HEX_DIGIT", strlen("PROPERTY_ASCII_HEX_DIGIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ASCII_HEX_DIGIT_name, &const_PROPERTY_ASCII_HEX_DIGIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ASCII_HEX_DIGIT_name);
 
 	zval const_PROPERTY_BIDI_CONTROL_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_CONTROL_value, UCHAR_BIDI_CONTROL);
-	zend_string *const_PROPERTY_BIDI_CONTROL_name = zend_string_init_interned("PROPERTY_BIDI_CONTROL", sizeof("PROPERTY_BIDI_CONTROL") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_CONTROL_name = zend_string_init_interned("PROPERTY_BIDI_CONTROL", strlen("PROPERTY_BIDI_CONTROL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_CONTROL_name, &const_PROPERTY_BIDI_CONTROL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_CONTROL_name);
 
 	zval const_PROPERTY_BIDI_MIRRORED_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_MIRRORED_value, UCHAR_BIDI_MIRRORED);
-	zend_string *const_PROPERTY_BIDI_MIRRORED_name = zend_string_init_interned("PROPERTY_BIDI_MIRRORED", sizeof("PROPERTY_BIDI_MIRRORED") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_MIRRORED_name = zend_string_init_interned("PROPERTY_BIDI_MIRRORED", strlen("PROPERTY_BIDI_MIRRORED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_MIRRORED_name, &const_PROPERTY_BIDI_MIRRORED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_MIRRORED_name);
 
 	zval const_PROPERTY_DASH_value;
 	ZVAL_LONG(&const_PROPERTY_DASH_value, UCHAR_DASH);
-	zend_string *const_PROPERTY_DASH_name = zend_string_init_interned("PROPERTY_DASH", sizeof("PROPERTY_DASH") - 1, 1);
+	zend_string *const_PROPERTY_DASH_name = zend_string_init_interned("PROPERTY_DASH", strlen("PROPERTY_DASH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DASH_name, &const_PROPERTY_DASH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DASH_name);
 
 	zval const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_value;
 	ZVAL_LONG(&const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_value, UCHAR_DEFAULT_IGNORABLE_CODE_POINT);
-	zend_string *const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_name = zend_string_init_interned("PROPERTY_DEFAULT_IGNORABLE_CODE_POINT", sizeof("PROPERTY_DEFAULT_IGNORABLE_CODE_POINT") - 1, 1);
+	zend_string *const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_name = zend_string_init_interned("PROPERTY_DEFAULT_IGNORABLE_CODE_POINT", strlen("PROPERTY_DEFAULT_IGNORABLE_CODE_POINT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_name, &const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DEFAULT_IGNORABLE_CODE_POINT_name);
 
 	zval const_PROPERTY_DEPRECATED_value;
 	ZVAL_LONG(&const_PROPERTY_DEPRECATED_value, UCHAR_DEPRECATED);
-	zend_string *const_PROPERTY_DEPRECATED_name = zend_string_init_interned("PROPERTY_DEPRECATED", sizeof("PROPERTY_DEPRECATED") - 1, 1);
+	zend_string *const_PROPERTY_DEPRECATED_name = zend_string_init_interned("PROPERTY_DEPRECATED", strlen("PROPERTY_DEPRECATED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DEPRECATED_name, &const_PROPERTY_DEPRECATED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DEPRECATED_name);
 
 	zval const_PROPERTY_DIACRITIC_value;
 	ZVAL_LONG(&const_PROPERTY_DIACRITIC_value, UCHAR_DIACRITIC);
-	zend_string *const_PROPERTY_DIACRITIC_name = zend_string_init_interned("PROPERTY_DIACRITIC", sizeof("PROPERTY_DIACRITIC") - 1, 1);
+	zend_string *const_PROPERTY_DIACRITIC_name = zend_string_init_interned("PROPERTY_DIACRITIC", strlen("PROPERTY_DIACRITIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DIACRITIC_name, &const_PROPERTY_DIACRITIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DIACRITIC_name);
 
 	zval const_PROPERTY_EXTENDER_value;
 	ZVAL_LONG(&const_PROPERTY_EXTENDER_value, UCHAR_EXTENDER);
-	zend_string *const_PROPERTY_EXTENDER_name = zend_string_init_interned("PROPERTY_EXTENDER", sizeof("PROPERTY_EXTENDER") - 1, 1);
+	zend_string *const_PROPERTY_EXTENDER_name = zend_string_init_interned("PROPERTY_EXTENDER", strlen("PROPERTY_EXTENDER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_EXTENDER_name, &const_PROPERTY_EXTENDER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_EXTENDER_name);
 
 	zval const_PROPERTY_FULL_COMPOSITION_EXCLUSION_value;
 	ZVAL_LONG(&const_PROPERTY_FULL_COMPOSITION_EXCLUSION_value, UCHAR_FULL_COMPOSITION_EXCLUSION);
-	zend_string *const_PROPERTY_FULL_COMPOSITION_EXCLUSION_name = zend_string_init_interned("PROPERTY_FULL_COMPOSITION_EXCLUSION", sizeof("PROPERTY_FULL_COMPOSITION_EXCLUSION") - 1, 1);
+	zend_string *const_PROPERTY_FULL_COMPOSITION_EXCLUSION_name = zend_string_init_interned("PROPERTY_FULL_COMPOSITION_EXCLUSION", strlen("PROPERTY_FULL_COMPOSITION_EXCLUSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_FULL_COMPOSITION_EXCLUSION_name, &const_PROPERTY_FULL_COMPOSITION_EXCLUSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_FULL_COMPOSITION_EXCLUSION_name);
 
 	zval const_PROPERTY_GRAPHEME_BASE_value;
 	ZVAL_LONG(&const_PROPERTY_GRAPHEME_BASE_value, UCHAR_GRAPHEME_BASE);
-	zend_string *const_PROPERTY_GRAPHEME_BASE_name = zend_string_init_interned("PROPERTY_GRAPHEME_BASE", sizeof("PROPERTY_GRAPHEME_BASE") - 1, 1);
+	zend_string *const_PROPERTY_GRAPHEME_BASE_name = zend_string_init_interned("PROPERTY_GRAPHEME_BASE", strlen("PROPERTY_GRAPHEME_BASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GRAPHEME_BASE_name, &const_PROPERTY_GRAPHEME_BASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GRAPHEME_BASE_name);
 
 	zval const_PROPERTY_GRAPHEME_EXTEND_value;
 	ZVAL_LONG(&const_PROPERTY_GRAPHEME_EXTEND_value, UCHAR_GRAPHEME_EXTEND);
-	zend_string *const_PROPERTY_GRAPHEME_EXTEND_name = zend_string_init_interned("PROPERTY_GRAPHEME_EXTEND", sizeof("PROPERTY_GRAPHEME_EXTEND") - 1, 1);
+	zend_string *const_PROPERTY_GRAPHEME_EXTEND_name = zend_string_init_interned("PROPERTY_GRAPHEME_EXTEND", strlen("PROPERTY_GRAPHEME_EXTEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GRAPHEME_EXTEND_name, &const_PROPERTY_GRAPHEME_EXTEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GRAPHEME_EXTEND_name);
 
 	zval const_PROPERTY_GRAPHEME_LINK_value;
 	ZVAL_LONG(&const_PROPERTY_GRAPHEME_LINK_value, UCHAR_GRAPHEME_LINK);
-	zend_string *const_PROPERTY_GRAPHEME_LINK_name = zend_string_init_interned("PROPERTY_GRAPHEME_LINK", sizeof("PROPERTY_GRAPHEME_LINK") - 1, 1);
+	zend_string *const_PROPERTY_GRAPHEME_LINK_name = zend_string_init_interned("PROPERTY_GRAPHEME_LINK", strlen("PROPERTY_GRAPHEME_LINK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GRAPHEME_LINK_name, &const_PROPERTY_GRAPHEME_LINK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GRAPHEME_LINK_name);
 
 	zval const_PROPERTY_HEX_DIGIT_value;
 	ZVAL_LONG(&const_PROPERTY_HEX_DIGIT_value, UCHAR_HEX_DIGIT);
-	zend_string *const_PROPERTY_HEX_DIGIT_name = zend_string_init_interned("PROPERTY_HEX_DIGIT", sizeof("PROPERTY_HEX_DIGIT") - 1, 1);
+	zend_string *const_PROPERTY_HEX_DIGIT_name = zend_string_init_interned("PROPERTY_HEX_DIGIT", strlen("PROPERTY_HEX_DIGIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_HEX_DIGIT_name, &const_PROPERTY_HEX_DIGIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_HEX_DIGIT_name);
 
 	zval const_PROPERTY_HYPHEN_value;
 	ZVAL_LONG(&const_PROPERTY_HYPHEN_value, UCHAR_HYPHEN);
-	zend_string *const_PROPERTY_HYPHEN_name = zend_string_init_interned("PROPERTY_HYPHEN", sizeof("PROPERTY_HYPHEN") - 1, 1);
+	zend_string *const_PROPERTY_HYPHEN_name = zend_string_init_interned("PROPERTY_HYPHEN", strlen("PROPERTY_HYPHEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_HYPHEN_name, &const_PROPERTY_HYPHEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_HYPHEN_name);
 
 	zval const_PROPERTY_ID_CONTINUE_value;
 	ZVAL_LONG(&const_PROPERTY_ID_CONTINUE_value, UCHAR_ID_CONTINUE);
-	zend_string *const_PROPERTY_ID_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_CONTINUE", sizeof("PROPERTY_ID_CONTINUE") - 1, 1);
+	zend_string *const_PROPERTY_ID_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_CONTINUE", strlen("PROPERTY_ID_CONTINUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_CONTINUE_name, &const_PROPERTY_ID_CONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ID_CONTINUE_name);
 
 	zval const_PROPERTY_ID_START_value;
 	ZVAL_LONG(&const_PROPERTY_ID_START_value, UCHAR_ID_START);
-	zend_string *const_PROPERTY_ID_START_name = zend_string_init_interned("PROPERTY_ID_START", sizeof("PROPERTY_ID_START") - 1, 1);
+	zend_string *const_PROPERTY_ID_START_name = zend_string_init_interned("PROPERTY_ID_START", strlen("PROPERTY_ID_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_START_name, &const_PROPERTY_ID_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ID_START_name);
 
 	zval const_PROPERTY_IDEOGRAPHIC_value;
 	ZVAL_LONG(&const_PROPERTY_IDEOGRAPHIC_value, UCHAR_IDEOGRAPHIC);
-	zend_string *const_PROPERTY_IDEOGRAPHIC_name = zend_string_init_interned("PROPERTY_IDEOGRAPHIC", sizeof("PROPERTY_IDEOGRAPHIC") - 1, 1);
+	zend_string *const_PROPERTY_IDEOGRAPHIC_name = zend_string_init_interned("PROPERTY_IDEOGRAPHIC", strlen("PROPERTY_IDEOGRAPHIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_IDEOGRAPHIC_name, &const_PROPERTY_IDEOGRAPHIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_IDEOGRAPHIC_name);
 
 	zval const_PROPERTY_IDS_BINARY_OPERATOR_value;
 	ZVAL_LONG(&const_PROPERTY_IDS_BINARY_OPERATOR_value, UCHAR_IDS_BINARY_OPERATOR);
-	zend_string *const_PROPERTY_IDS_BINARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_BINARY_OPERATOR", sizeof("PROPERTY_IDS_BINARY_OPERATOR") - 1, 1);
+	zend_string *const_PROPERTY_IDS_BINARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_BINARY_OPERATOR", strlen("PROPERTY_IDS_BINARY_OPERATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_IDS_BINARY_OPERATOR_name, &const_PROPERTY_IDS_BINARY_OPERATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_IDS_BINARY_OPERATOR_name);
 
 	zval const_PROPERTY_IDS_TRINARY_OPERATOR_value;
 	ZVAL_LONG(&const_PROPERTY_IDS_TRINARY_OPERATOR_value, UCHAR_IDS_TRINARY_OPERATOR);
-	zend_string *const_PROPERTY_IDS_TRINARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_TRINARY_OPERATOR", sizeof("PROPERTY_IDS_TRINARY_OPERATOR") - 1, 1);
+	zend_string *const_PROPERTY_IDS_TRINARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_TRINARY_OPERATOR", strlen("PROPERTY_IDS_TRINARY_OPERATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_IDS_TRINARY_OPERATOR_name, &const_PROPERTY_IDS_TRINARY_OPERATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_IDS_TRINARY_OPERATOR_name);
 #if U_ICU_VERSION_MAJOR_NUM >= 74
 
 	zval const_PROPERTY_IDS_UNARY_OPERATOR_value;
 	ZVAL_LONG(&const_PROPERTY_IDS_UNARY_OPERATOR_value, UCHAR_IDS_UNARY_OPERATOR);
-	zend_string *const_PROPERTY_IDS_UNARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_UNARY_OPERATOR", sizeof("PROPERTY_IDS_UNARY_OPERATOR") - 1, 1);
+	zend_string *const_PROPERTY_IDS_UNARY_OPERATOR_name = zend_string_init_interned("PROPERTY_IDS_UNARY_OPERATOR", strlen("PROPERTY_IDS_UNARY_OPERATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_IDS_UNARY_OPERATOR_name, &const_PROPERTY_IDS_UNARY_OPERATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_IDS_UNARY_OPERATOR_name);
 #endif
@@ -470,7 +470,7 @@ static zend_class_entry *register_class_IntlChar(void)
 
 	zval const_PROPERTY_ID_COMPAT_MATH_START_value;
 	ZVAL_LONG(&const_PROPERTY_ID_COMPAT_MATH_START_value, UCHAR_ID_COMPAT_MATH_START);
-	zend_string *const_PROPERTY_ID_COMPAT_MATH_START_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_START", sizeof("PROPERTY_ID_COMPAT_MATH_START") - 1, 1);
+	zend_string *const_PROPERTY_ID_COMPAT_MATH_START_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_START", strlen("PROPERTY_ID_COMPAT_MATH_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPAT_MATH_START_name, &const_PROPERTY_ID_COMPAT_MATH_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ID_COMPAT_MATH_START_name);
 #endif
@@ -478,3836 +478,3836 @@ static zend_class_entry *register_class_IntlChar(void)
 
 	zval const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value;
 	ZVAL_LONG(&const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value, UCHAR_ID_COMPAT_MATH_CONTINUE);
-	zend_string *const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_CONTINUE", sizeof("PROPERTY_ID_COMPAT_MATH_CONTINUE") - 1, 1);
+	zend_string *const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name = zend_string_init_interned("PROPERTY_ID_COMPAT_MATH_CONTINUE", strlen("PROPERTY_ID_COMPAT_MATH_CONTINUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name, &const_PROPERTY_ID_COMPAT_MATH_CONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ID_COMPAT_MATH_CONTINUE_name);
 #endif
 
 	zval const_PROPERTY_JOIN_CONTROL_value;
 	ZVAL_LONG(&const_PROPERTY_JOIN_CONTROL_value, UCHAR_JOIN_CONTROL);
-	zend_string *const_PROPERTY_JOIN_CONTROL_name = zend_string_init_interned("PROPERTY_JOIN_CONTROL", sizeof("PROPERTY_JOIN_CONTROL") - 1, 1);
+	zend_string *const_PROPERTY_JOIN_CONTROL_name = zend_string_init_interned("PROPERTY_JOIN_CONTROL", strlen("PROPERTY_JOIN_CONTROL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_JOIN_CONTROL_name, &const_PROPERTY_JOIN_CONTROL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_JOIN_CONTROL_name);
 
 	zval const_PROPERTY_LOGICAL_ORDER_EXCEPTION_value;
 	ZVAL_LONG(&const_PROPERTY_LOGICAL_ORDER_EXCEPTION_value, UCHAR_LOGICAL_ORDER_EXCEPTION);
-	zend_string *const_PROPERTY_LOGICAL_ORDER_EXCEPTION_name = zend_string_init_interned("PROPERTY_LOGICAL_ORDER_EXCEPTION", sizeof("PROPERTY_LOGICAL_ORDER_EXCEPTION") - 1, 1);
+	zend_string *const_PROPERTY_LOGICAL_ORDER_EXCEPTION_name = zend_string_init_interned("PROPERTY_LOGICAL_ORDER_EXCEPTION", strlen("PROPERTY_LOGICAL_ORDER_EXCEPTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_LOGICAL_ORDER_EXCEPTION_name, &const_PROPERTY_LOGICAL_ORDER_EXCEPTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_LOGICAL_ORDER_EXCEPTION_name);
 
 	zval const_PROPERTY_LOWERCASE_value;
 	ZVAL_LONG(&const_PROPERTY_LOWERCASE_value, UCHAR_LOWERCASE);
-	zend_string *const_PROPERTY_LOWERCASE_name = zend_string_init_interned("PROPERTY_LOWERCASE", sizeof("PROPERTY_LOWERCASE") - 1, 1);
+	zend_string *const_PROPERTY_LOWERCASE_name = zend_string_init_interned("PROPERTY_LOWERCASE", strlen("PROPERTY_LOWERCASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_LOWERCASE_name, &const_PROPERTY_LOWERCASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_LOWERCASE_name);
 
 	zval const_PROPERTY_MATH_value;
 	ZVAL_LONG(&const_PROPERTY_MATH_value, UCHAR_MATH);
-	zend_string *const_PROPERTY_MATH_name = zend_string_init_interned("PROPERTY_MATH", sizeof("PROPERTY_MATH") - 1, 1);
+	zend_string *const_PROPERTY_MATH_name = zend_string_init_interned("PROPERTY_MATH", strlen("PROPERTY_MATH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_MATH_name, &const_PROPERTY_MATH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_MATH_name);
 
 	zval const_PROPERTY_NONCHARACTER_CODE_POINT_value;
 	ZVAL_LONG(&const_PROPERTY_NONCHARACTER_CODE_POINT_value, UCHAR_NONCHARACTER_CODE_POINT);
-	zend_string *const_PROPERTY_NONCHARACTER_CODE_POINT_name = zend_string_init_interned("PROPERTY_NONCHARACTER_CODE_POINT", sizeof("PROPERTY_NONCHARACTER_CODE_POINT") - 1, 1);
+	zend_string *const_PROPERTY_NONCHARACTER_CODE_POINT_name = zend_string_init_interned("PROPERTY_NONCHARACTER_CODE_POINT", strlen("PROPERTY_NONCHARACTER_CODE_POINT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NONCHARACTER_CODE_POINT_name, &const_PROPERTY_NONCHARACTER_CODE_POINT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NONCHARACTER_CODE_POINT_name);
 
 	zval const_PROPERTY_QUOTATION_MARK_value;
 	ZVAL_LONG(&const_PROPERTY_QUOTATION_MARK_value, UCHAR_QUOTATION_MARK);
-	zend_string *const_PROPERTY_QUOTATION_MARK_name = zend_string_init_interned("PROPERTY_QUOTATION_MARK", sizeof("PROPERTY_QUOTATION_MARK") - 1, 1);
+	zend_string *const_PROPERTY_QUOTATION_MARK_name = zend_string_init_interned("PROPERTY_QUOTATION_MARK", strlen("PROPERTY_QUOTATION_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_QUOTATION_MARK_name, &const_PROPERTY_QUOTATION_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_QUOTATION_MARK_name);
 
 	zval const_PROPERTY_RADICAL_value;
 	ZVAL_LONG(&const_PROPERTY_RADICAL_value, UCHAR_RADICAL);
-	zend_string *const_PROPERTY_RADICAL_name = zend_string_init_interned("PROPERTY_RADICAL", sizeof("PROPERTY_RADICAL") - 1, 1);
+	zend_string *const_PROPERTY_RADICAL_name = zend_string_init_interned("PROPERTY_RADICAL", strlen("PROPERTY_RADICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_RADICAL_name, &const_PROPERTY_RADICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_RADICAL_name);
 
 	zval const_PROPERTY_SOFT_DOTTED_value;
 	ZVAL_LONG(&const_PROPERTY_SOFT_DOTTED_value, UCHAR_SOFT_DOTTED);
-	zend_string *const_PROPERTY_SOFT_DOTTED_name = zend_string_init_interned("PROPERTY_SOFT_DOTTED", sizeof("PROPERTY_SOFT_DOTTED") - 1, 1);
+	zend_string *const_PROPERTY_SOFT_DOTTED_name = zend_string_init_interned("PROPERTY_SOFT_DOTTED", strlen("PROPERTY_SOFT_DOTTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SOFT_DOTTED_name, &const_PROPERTY_SOFT_DOTTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SOFT_DOTTED_name);
 
 	zval const_PROPERTY_TERMINAL_PUNCTUATION_value;
 	ZVAL_LONG(&const_PROPERTY_TERMINAL_PUNCTUATION_value, UCHAR_TERMINAL_PUNCTUATION);
-	zend_string *const_PROPERTY_TERMINAL_PUNCTUATION_name = zend_string_init_interned("PROPERTY_TERMINAL_PUNCTUATION", sizeof("PROPERTY_TERMINAL_PUNCTUATION") - 1, 1);
+	zend_string *const_PROPERTY_TERMINAL_PUNCTUATION_name = zend_string_init_interned("PROPERTY_TERMINAL_PUNCTUATION", strlen("PROPERTY_TERMINAL_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_TERMINAL_PUNCTUATION_name, &const_PROPERTY_TERMINAL_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_TERMINAL_PUNCTUATION_name);
 
 	zval const_PROPERTY_UNIFIED_IDEOGRAPH_value;
 	ZVAL_LONG(&const_PROPERTY_UNIFIED_IDEOGRAPH_value, UCHAR_UNIFIED_IDEOGRAPH);
-	zend_string *const_PROPERTY_UNIFIED_IDEOGRAPH_name = zend_string_init_interned("PROPERTY_UNIFIED_IDEOGRAPH", sizeof("PROPERTY_UNIFIED_IDEOGRAPH") - 1, 1);
+	zend_string *const_PROPERTY_UNIFIED_IDEOGRAPH_name = zend_string_init_interned("PROPERTY_UNIFIED_IDEOGRAPH", strlen("PROPERTY_UNIFIED_IDEOGRAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_UNIFIED_IDEOGRAPH_name, &const_PROPERTY_UNIFIED_IDEOGRAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_UNIFIED_IDEOGRAPH_name);
 
 	zval const_PROPERTY_UPPERCASE_value;
 	ZVAL_LONG(&const_PROPERTY_UPPERCASE_value, UCHAR_UPPERCASE);
-	zend_string *const_PROPERTY_UPPERCASE_name = zend_string_init_interned("PROPERTY_UPPERCASE", sizeof("PROPERTY_UPPERCASE") - 1, 1);
+	zend_string *const_PROPERTY_UPPERCASE_name = zend_string_init_interned("PROPERTY_UPPERCASE", strlen("PROPERTY_UPPERCASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_UPPERCASE_name, &const_PROPERTY_UPPERCASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_UPPERCASE_name);
 
 	zval const_PROPERTY_WHITE_SPACE_value;
 	ZVAL_LONG(&const_PROPERTY_WHITE_SPACE_value, UCHAR_WHITE_SPACE);
-	zend_string *const_PROPERTY_WHITE_SPACE_name = zend_string_init_interned("PROPERTY_WHITE_SPACE", sizeof("PROPERTY_WHITE_SPACE") - 1, 1);
+	zend_string *const_PROPERTY_WHITE_SPACE_name = zend_string_init_interned("PROPERTY_WHITE_SPACE", strlen("PROPERTY_WHITE_SPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_WHITE_SPACE_name, &const_PROPERTY_WHITE_SPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_WHITE_SPACE_name);
 
 	zval const_PROPERTY_XID_CONTINUE_value;
 	ZVAL_LONG(&const_PROPERTY_XID_CONTINUE_value, UCHAR_XID_CONTINUE);
-	zend_string *const_PROPERTY_XID_CONTINUE_name = zend_string_init_interned("PROPERTY_XID_CONTINUE", sizeof("PROPERTY_XID_CONTINUE") - 1, 1);
+	zend_string *const_PROPERTY_XID_CONTINUE_name = zend_string_init_interned("PROPERTY_XID_CONTINUE", strlen("PROPERTY_XID_CONTINUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_XID_CONTINUE_name, &const_PROPERTY_XID_CONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_XID_CONTINUE_name);
 
 	zval const_PROPERTY_XID_START_value;
 	ZVAL_LONG(&const_PROPERTY_XID_START_value, UCHAR_XID_START);
-	zend_string *const_PROPERTY_XID_START_name = zend_string_init_interned("PROPERTY_XID_START", sizeof("PROPERTY_XID_START") - 1, 1);
+	zend_string *const_PROPERTY_XID_START_name = zend_string_init_interned("PROPERTY_XID_START", strlen("PROPERTY_XID_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_XID_START_name, &const_PROPERTY_XID_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_XID_START_name);
 
 	zval const_PROPERTY_CASE_SENSITIVE_value;
 	ZVAL_LONG(&const_PROPERTY_CASE_SENSITIVE_value, UCHAR_CASE_SENSITIVE);
-	zend_string *const_PROPERTY_CASE_SENSITIVE_name = zend_string_init_interned("PROPERTY_CASE_SENSITIVE", sizeof("PROPERTY_CASE_SENSITIVE") - 1, 1);
+	zend_string *const_PROPERTY_CASE_SENSITIVE_name = zend_string_init_interned("PROPERTY_CASE_SENSITIVE", strlen("PROPERTY_CASE_SENSITIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CASE_SENSITIVE_name, &const_PROPERTY_CASE_SENSITIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CASE_SENSITIVE_name);
 
 	zval const_PROPERTY_S_TERM_value;
 	ZVAL_LONG(&const_PROPERTY_S_TERM_value, UCHAR_S_TERM);
-	zend_string *const_PROPERTY_S_TERM_name = zend_string_init_interned("PROPERTY_S_TERM", sizeof("PROPERTY_S_TERM") - 1, 1);
+	zend_string *const_PROPERTY_S_TERM_name = zend_string_init_interned("PROPERTY_S_TERM", strlen("PROPERTY_S_TERM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_S_TERM_name, &const_PROPERTY_S_TERM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_S_TERM_name);
 
 	zval const_PROPERTY_VARIATION_SELECTOR_value;
 	ZVAL_LONG(&const_PROPERTY_VARIATION_SELECTOR_value, UCHAR_VARIATION_SELECTOR);
-	zend_string *const_PROPERTY_VARIATION_SELECTOR_name = zend_string_init_interned("PROPERTY_VARIATION_SELECTOR", sizeof("PROPERTY_VARIATION_SELECTOR") - 1, 1);
+	zend_string *const_PROPERTY_VARIATION_SELECTOR_name = zend_string_init_interned("PROPERTY_VARIATION_SELECTOR", strlen("PROPERTY_VARIATION_SELECTOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_VARIATION_SELECTOR_name, &const_PROPERTY_VARIATION_SELECTOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_VARIATION_SELECTOR_name);
 
 	zval const_PROPERTY_NFD_INERT_value;
 	ZVAL_LONG(&const_PROPERTY_NFD_INERT_value, UCHAR_NFD_INERT);
-	zend_string *const_PROPERTY_NFD_INERT_name = zend_string_init_interned("PROPERTY_NFD_INERT", sizeof("PROPERTY_NFD_INERT") - 1, 1);
+	zend_string *const_PROPERTY_NFD_INERT_name = zend_string_init_interned("PROPERTY_NFD_INERT", strlen("PROPERTY_NFD_INERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFD_INERT_name, &const_PROPERTY_NFD_INERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFD_INERT_name);
 
 	zval const_PROPERTY_NFKD_INERT_value;
 	ZVAL_LONG(&const_PROPERTY_NFKD_INERT_value, UCHAR_NFKD_INERT);
-	zend_string *const_PROPERTY_NFKD_INERT_name = zend_string_init_interned("PROPERTY_NFKD_INERT", sizeof("PROPERTY_NFKD_INERT") - 1, 1);
+	zend_string *const_PROPERTY_NFKD_INERT_name = zend_string_init_interned("PROPERTY_NFKD_INERT", strlen("PROPERTY_NFKD_INERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFKD_INERT_name, &const_PROPERTY_NFKD_INERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFKD_INERT_name);
 
 	zval const_PROPERTY_NFC_INERT_value;
 	ZVAL_LONG(&const_PROPERTY_NFC_INERT_value, UCHAR_NFC_INERT);
-	zend_string *const_PROPERTY_NFC_INERT_name = zend_string_init_interned("PROPERTY_NFC_INERT", sizeof("PROPERTY_NFC_INERT") - 1, 1);
+	zend_string *const_PROPERTY_NFC_INERT_name = zend_string_init_interned("PROPERTY_NFC_INERT", strlen("PROPERTY_NFC_INERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFC_INERT_name, &const_PROPERTY_NFC_INERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFC_INERT_name);
 
 	zval const_PROPERTY_NFKC_INERT_value;
 	ZVAL_LONG(&const_PROPERTY_NFKC_INERT_value, UCHAR_NFKC_INERT);
-	zend_string *const_PROPERTY_NFKC_INERT_name = zend_string_init_interned("PROPERTY_NFKC_INERT", sizeof("PROPERTY_NFKC_INERT") - 1, 1);
+	zend_string *const_PROPERTY_NFKC_INERT_name = zend_string_init_interned("PROPERTY_NFKC_INERT", strlen("PROPERTY_NFKC_INERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFKC_INERT_name, &const_PROPERTY_NFKC_INERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFKC_INERT_name);
 
 	zval const_PROPERTY_SEGMENT_STARTER_value;
 	ZVAL_LONG(&const_PROPERTY_SEGMENT_STARTER_value, UCHAR_SEGMENT_STARTER);
-	zend_string *const_PROPERTY_SEGMENT_STARTER_name = zend_string_init_interned("PROPERTY_SEGMENT_STARTER", sizeof("PROPERTY_SEGMENT_STARTER") - 1, 1);
+	zend_string *const_PROPERTY_SEGMENT_STARTER_name = zend_string_init_interned("PROPERTY_SEGMENT_STARTER", strlen("PROPERTY_SEGMENT_STARTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SEGMENT_STARTER_name, &const_PROPERTY_SEGMENT_STARTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SEGMENT_STARTER_name);
 
 	zval const_PROPERTY_PATTERN_SYNTAX_value;
 	ZVAL_LONG(&const_PROPERTY_PATTERN_SYNTAX_value, UCHAR_PATTERN_SYNTAX);
-	zend_string *const_PROPERTY_PATTERN_SYNTAX_name = zend_string_init_interned("PROPERTY_PATTERN_SYNTAX", sizeof("PROPERTY_PATTERN_SYNTAX") - 1, 1);
+	zend_string *const_PROPERTY_PATTERN_SYNTAX_name = zend_string_init_interned("PROPERTY_PATTERN_SYNTAX", strlen("PROPERTY_PATTERN_SYNTAX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_PATTERN_SYNTAX_name, &const_PROPERTY_PATTERN_SYNTAX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_PATTERN_SYNTAX_name);
 
 	zval const_PROPERTY_PATTERN_WHITE_SPACE_value;
 	ZVAL_LONG(&const_PROPERTY_PATTERN_WHITE_SPACE_value, UCHAR_PATTERN_WHITE_SPACE);
-	zend_string *const_PROPERTY_PATTERN_WHITE_SPACE_name = zend_string_init_interned("PROPERTY_PATTERN_WHITE_SPACE", sizeof("PROPERTY_PATTERN_WHITE_SPACE") - 1, 1);
+	zend_string *const_PROPERTY_PATTERN_WHITE_SPACE_name = zend_string_init_interned("PROPERTY_PATTERN_WHITE_SPACE", strlen("PROPERTY_PATTERN_WHITE_SPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_PATTERN_WHITE_SPACE_name, &const_PROPERTY_PATTERN_WHITE_SPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_PATTERN_WHITE_SPACE_name);
 
 	zval const_PROPERTY_POSIX_ALNUM_value;
 	ZVAL_LONG(&const_PROPERTY_POSIX_ALNUM_value, UCHAR_POSIX_ALNUM);
-	zend_string *const_PROPERTY_POSIX_ALNUM_name = zend_string_init_interned("PROPERTY_POSIX_ALNUM", sizeof("PROPERTY_POSIX_ALNUM") - 1, 1);
+	zend_string *const_PROPERTY_POSIX_ALNUM_name = zend_string_init_interned("PROPERTY_POSIX_ALNUM", strlen("PROPERTY_POSIX_ALNUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_POSIX_ALNUM_name, &const_PROPERTY_POSIX_ALNUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_POSIX_ALNUM_name);
 
 	zval const_PROPERTY_POSIX_BLANK_value;
 	ZVAL_LONG(&const_PROPERTY_POSIX_BLANK_value, UCHAR_POSIX_BLANK);
-	zend_string *const_PROPERTY_POSIX_BLANK_name = zend_string_init_interned("PROPERTY_POSIX_BLANK", sizeof("PROPERTY_POSIX_BLANK") - 1, 1);
+	zend_string *const_PROPERTY_POSIX_BLANK_name = zend_string_init_interned("PROPERTY_POSIX_BLANK", strlen("PROPERTY_POSIX_BLANK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_POSIX_BLANK_name, &const_PROPERTY_POSIX_BLANK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_POSIX_BLANK_name);
 
 	zval const_PROPERTY_POSIX_GRAPH_value;
 	ZVAL_LONG(&const_PROPERTY_POSIX_GRAPH_value, UCHAR_POSIX_GRAPH);
-	zend_string *const_PROPERTY_POSIX_GRAPH_name = zend_string_init_interned("PROPERTY_POSIX_GRAPH", sizeof("PROPERTY_POSIX_GRAPH") - 1, 1);
+	zend_string *const_PROPERTY_POSIX_GRAPH_name = zend_string_init_interned("PROPERTY_POSIX_GRAPH", strlen("PROPERTY_POSIX_GRAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_POSIX_GRAPH_name, &const_PROPERTY_POSIX_GRAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_POSIX_GRAPH_name);
 
 	zval const_PROPERTY_POSIX_PRINT_value;
 	ZVAL_LONG(&const_PROPERTY_POSIX_PRINT_value, UCHAR_POSIX_PRINT);
-	zend_string *const_PROPERTY_POSIX_PRINT_name = zend_string_init_interned("PROPERTY_POSIX_PRINT", sizeof("PROPERTY_POSIX_PRINT") - 1, 1);
+	zend_string *const_PROPERTY_POSIX_PRINT_name = zend_string_init_interned("PROPERTY_POSIX_PRINT", strlen("PROPERTY_POSIX_PRINT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_POSIX_PRINT_name, &const_PROPERTY_POSIX_PRINT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_POSIX_PRINT_name);
 
 	zval const_PROPERTY_POSIX_XDIGIT_value;
 	ZVAL_LONG(&const_PROPERTY_POSIX_XDIGIT_value, UCHAR_POSIX_XDIGIT);
-	zend_string *const_PROPERTY_POSIX_XDIGIT_name = zend_string_init_interned("PROPERTY_POSIX_XDIGIT", sizeof("PROPERTY_POSIX_XDIGIT") - 1, 1);
+	zend_string *const_PROPERTY_POSIX_XDIGIT_name = zend_string_init_interned("PROPERTY_POSIX_XDIGIT", strlen("PROPERTY_POSIX_XDIGIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_POSIX_XDIGIT_name, &const_PROPERTY_POSIX_XDIGIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_POSIX_XDIGIT_name);
 
 	zval const_PROPERTY_CASED_value;
 	ZVAL_LONG(&const_PROPERTY_CASED_value, UCHAR_CASED);
-	zend_string *const_PROPERTY_CASED_name = zend_string_init_interned("PROPERTY_CASED", sizeof("PROPERTY_CASED") - 1, 1);
+	zend_string *const_PROPERTY_CASED_name = zend_string_init_interned("PROPERTY_CASED", strlen("PROPERTY_CASED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CASED_name, &const_PROPERTY_CASED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CASED_name);
 
 	zval const_PROPERTY_CASE_IGNORABLE_value;
 	ZVAL_LONG(&const_PROPERTY_CASE_IGNORABLE_value, UCHAR_CASE_IGNORABLE);
-	zend_string *const_PROPERTY_CASE_IGNORABLE_name = zend_string_init_interned("PROPERTY_CASE_IGNORABLE", sizeof("PROPERTY_CASE_IGNORABLE") - 1, 1);
+	zend_string *const_PROPERTY_CASE_IGNORABLE_name = zend_string_init_interned("PROPERTY_CASE_IGNORABLE", strlen("PROPERTY_CASE_IGNORABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CASE_IGNORABLE_name, &const_PROPERTY_CASE_IGNORABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CASE_IGNORABLE_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_LOWERCASED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_LOWERCASED_value, UCHAR_CHANGES_WHEN_LOWERCASED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_LOWERCASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_LOWERCASED", sizeof("PROPERTY_CHANGES_WHEN_LOWERCASED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_LOWERCASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_LOWERCASED", strlen("PROPERTY_CHANGES_WHEN_LOWERCASED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_LOWERCASED_name, &const_PROPERTY_CHANGES_WHEN_LOWERCASED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_LOWERCASED_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_UPPERCASED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_UPPERCASED_value, UCHAR_CHANGES_WHEN_UPPERCASED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_UPPERCASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_UPPERCASED", sizeof("PROPERTY_CHANGES_WHEN_UPPERCASED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_UPPERCASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_UPPERCASED", strlen("PROPERTY_CHANGES_WHEN_UPPERCASED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_UPPERCASED_name, &const_PROPERTY_CHANGES_WHEN_UPPERCASED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_UPPERCASED_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_TITLECASED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_TITLECASED_value, UCHAR_CHANGES_WHEN_TITLECASED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_TITLECASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_TITLECASED", sizeof("PROPERTY_CHANGES_WHEN_TITLECASED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_TITLECASED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_TITLECASED", strlen("PROPERTY_CHANGES_WHEN_TITLECASED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_TITLECASED_name, &const_PROPERTY_CHANGES_WHEN_TITLECASED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_TITLECASED_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_CASEFOLDED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_CASEFOLDED_value, UCHAR_CHANGES_WHEN_CASEFOLDED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_CASEFOLDED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_CASEFOLDED", sizeof("PROPERTY_CHANGES_WHEN_CASEFOLDED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_CASEFOLDED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_CASEFOLDED", strlen("PROPERTY_CHANGES_WHEN_CASEFOLDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_CASEFOLDED_name, &const_PROPERTY_CHANGES_WHEN_CASEFOLDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_CASEFOLDED_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_CASEMAPPED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_CASEMAPPED_value, UCHAR_CHANGES_WHEN_CASEMAPPED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_CASEMAPPED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_CASEMAPPED", sizeof("PROPERTY_CHANGES_WHEN_CASEMAPPED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_CASEMAPPED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_CASEMAPPED", strlen("PROPERTY_CHANGES_WHEN_CASEMAPPED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_CASEMAPPED_name, &const_PROPERTY_CHANGES_WHEN_CASEMAPPED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_CASEMAPPED_name);
 
 	zval const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_value;
 	ZVAL_LONG(&const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_value, UCHAR_CHANGES_WHEN_NFKC_CASEFOLDED);
-	zend_string *const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED", sizeof("PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED") - 1, 1);
+	zend_string *const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_name = zend_string_init_interned("PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED", strlen("PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_name, &const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED_name);
 
 	zval const_PROPERTY_BINARY_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_BINARY_LIMIT_value, UCHAR_BINARY_LIMIT);
-	zend_string *const_PROPERTY_BINARY_LIMIT_name = zend_string_init_interned("PROPERTY_BINARY_LIMIT", sizeof("PROPERTY_BINARY_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_BINARY_LIMIT_name = zend_string_init_interned("PROPERTY_BINARY_LIMIT", strlen("PROPERTY_BINARY_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BINARY_LIMIT_name, &const_PROPERTY_BINARY_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BINARY_LIMIT_name);
 
 	zval const_PROPERTY_BIDI_CLASS_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_CLASS_value, UCHAR_BIDI_CLASS);
-	zend_string *const_PROPERTY_BIDI_CLASS_name = zend_string_init_interned("PROPERTY_BIDI_CLASS", sizeof("PROPERTY_BIDI_CLASS") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_CLASS_name = zend_string_init_interned("PROPERTY_BIDI_CLASS", strlen("PROPERTY_BIDI_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_CLASS_name, &const_PROPERTY_BIDI_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_CLASS_name);
 
 	zval const_PROPERTY_INT_START_value;
 	ZVAL_LONG(&const_PROPERTY_INT_START_value, UCHAR_INT_START);
-	zend_string *const_PROPERTY_INT_START_name = zend_string_init_interned("PROPERTY_INT_START", sizeof("PROPERTY_INT_START") - 1, 1);
+	zend_string *const_PROPERTY_INT_START_name = zend_string_init_interned("PROPERTY_INT_START", strlen("PROPERTY_INT_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_INT_START_name, &const_PROPERTY_INT_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_INT_START_name);
 
 	zval const_PROPERTY_BLOCK_value;
 	ZVAL_LONG(&const_PROPERTY_BLOCK_value, UCHAR_BLOCK);
-	zend_string *const_PROPERTY_BLOCK_name = zend_string_init_interned("PROPERTY_BLOCK", sizeof("PROPERTY_BLOCK") - 1, 1);
+	zend_string *const_PROPERTY_BLOCK_name = zend_string_init_interned("PROPERTY_BLOCK", strlen("PROPERTY_BLOCK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BLOCK_name, &const_PROPERTY_BLOCK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BLOCK_name);
 
 	zval const_PROPERTY_CANONICAL_COMBINING_CLASS_value;
 	ZVAL_LONG(&const_PROPERTY_CANONICAL_COMBINING_CLASS_value, UCHAR_CANONICAL_COMBINING_CLASS);
-	zend_string *const_PROPERTY_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_CANONICAL_COMBINING_CLASS", sizeof("PROPERTY_CANONICAL_COMBINING_CLASS") - 1, 1);
+	zend_string *const_PROPERTY_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_CANONICAL_COMBINING_CLASS", strlen("PROPERTY_CANONICAL_COMBINING_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CANONICAL_COMBINING_CLASS_name, &const_PROPERTY_CANONICAL_COMBINING_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CANONICAL_COMBINING_CLASS_name);
 
 	zval const_PROPERTY_DECOMPOSITION_TYPE_value;
 	ZVAL_LONG(&const_PROPERTY_DECOMPOSITION_TYPE_value, UCHAR_DECOMPOSITION_TYPE);
-	zend_string *const_PROPERTY_DECOMPOSITION_TYPE_name = zend_string_init_interned("PROPERTY_DECOMPOSITION_TYPE", sizeof("PROPERTY_DECOMPOSITION_TYPE") - 1, 1);
+	zend_string *const_PROPERTY_DECOMPOSITION_TYPE_name = zend_string_init_interned("PROPERTY_DECOMPOSITION_TYPE", strlen("PROPERTY_DECOMPOSITION_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DECOMPOSITION_TYPE_name, &const_PROPERTY_DECOMPOSITION_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DECOMPOSITION_TYPE_name);
 
 	zval const_PROPERTY_EAST_ASIAN_WIDTH_value;
 	ZVAL_LONG(&const_PROPERTY_EAST_ASIAN_WIDTH_value, UCHAR_EAST_ASIAN_WIDTH);
-	zend_string *const_PROPERTY_EAST_ASIAN_WIDTH_name = zend_string_init_interned("PROPERTY_EAST_ASIAN_WIDTH", sizeof("PROPERTY_EAST_ASIAN_WIDTH") - 1, 1);
+	zend_string *const_PROPERTY_EAST_ASIAN_WIDTH_name = zend_string_init_interned("PROPERTY_EAST_ASIAN_WIDTH", strlen("PROPERTY_EAST_ASIAN_WIDTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_EAST_ASIAN_WIDTH_name, &const_PROPERTY_EAST_ASIAN_WIDTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_EAST_ASIAN_WIDTH_name);
 
 	zval const_PROPERTY_GENERAL_CATEGORY_value;
 	ZVAL_LONG(&const_PROPERTY_GENERAL_CATEGORY_value, UCHAR_GENERAL_CATEGORY);
-	zend_string *const_PROPERTY_GENERAL_CATEGORY_name = zend_string_init_interned("PROPERTY_GENERAL_CATEGORY", sizeof("PROPERTY_GENERAL_CATEGORY") - 1, 1);
+	zend_string *const_PROPERTY_GENERAL_CATEGORY_name = zend_string_init_interned("PROPERTY_GENERAL_CATEGORY", strlen("PROPERTY_GENERAL_CATEGORY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GENERAL_CATEGORY_name, &const_PROPERTY_GENERAL_CATEGORY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GENERAL_CATEGORY_name);
 
 	zval const_PROPERTY_JOINING_GROUP_value;
 	ZVAL_LONG(&const_PROPERTY_JOINING_GROUP_value, UCHAR_JOINING_GROUP);
-	zend_string *const_PROPERTY_JOINING_GROUP_name = zend_string_init_interned("PROPERTY_JOINING_GROUP", sizeof("PROPERTY_JOINING_GROUP") - 1, 1);
+	zend_string *const_PROPERTY_JOINING_GROUP_name = zend_string_init_interned("PROPERTY_JOINING_GROUP", strlen("PROPERTY_JOINING_GROUP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_JOINING_GROUP_name, &const_PROPERTY_JOINING_GROUP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_JOINING_GROUP_name);
 
 	zval const_PROPERTY_JOINING_TYPE_value;
 	ZVAL_LONG(&const_PROPERTY_JOINING_TYPE_value, UCHAR_JOINING_TYPE);
-	zend_string *const_PROPERTY_JOINING_TYPE_name = zend_string_init_interned("PROPERTY_JOINING_TYPE", sizeof("PROPERTY_JOINING_TYPE") - 1, 1);
+	zend_string *const_PROPERTY_JOINING_TYPE_name = zend_string_init_interned("PROPERTY_JOINING_TYPE", strlen("PROPERTY_JOINING_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_JOINING_TYPE_name, &const_PROPERTY_JOINING_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_JOINING_TYPE_name);
 
 	zval const_PROPERTY_LINE_BREAK_value;
 	ZVAL_LONG(&const_PROPERTY_LINE_BREAK_value, UCHAR_LINE_BREAK);
-	zend_string *const_PROPERTY_LINE_BREAK_name = zend_string_init_interned("PROPERTY_LINE_BREAK", sizeof("PROPERTY_LINE_BREAK") - 1, 1);
+	zend_string *const_PROPERTY_LINE_BREAK_name = zend_string_init_interned("PROPERTY_LINE_BREAK", strlen("PROPERTY_LINE_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_LINE_BREAK_name, &const_PROPERTY_LINE_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_LINE_BREAK_name);
 
 	zval const_PROPERTY_NUMERIC_TYPE_value;
 	ZVAL_LONG(&const_PROPERTY_NUMERIC_TYPE_value, UCHAR_NUMERIC_TYPE);
-	zend_string *const_PROPERTY_NUMERIC_TYPE_name = zend_string_init_interned("PROPERTY_NUMERIC_TYPE", sizeof("PROPERTY_NUMERIC_TYPE") - 1, 1);
+	zend_string *const_PROPERTY_NUMERIC_TYPE_name = zend_string_init_interned("PROPERTY_NUMERIC_TYPE", strlen("PROPERTY_NUMERIC_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NUMERIC_TYPE_name, &const_PROPERTY_NUMERIC_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NUMERIC_TYPE_name);
 
 	zval const_PROPERTY_SCRIPT_value;
 	ZVAL_LONG(&const_PROPERTY_SCRIPT_value, UCHAR_SCRIPT);
-	zend_string *const_PROPERTY_SCRIPT_name = zend_string_init_interned("PROPERTY_SCRIPT", sizeof("PROPERTY_SCRIPT") - 1, 1);
+	zend_string *const_PROPERTY_SCRIPT_name = zend_string_init_interned("PROPERTY_SCRIPT", strlen("PROPERTY_SCRIPT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SCRIPT_name, &const_PROPERTY_SCRIPT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SCRIPT_name);
 
 	zval const_PROPERTY_HANGUL_SYLLABLE_TYPE_value;
 	ZVAL_LONG(&const_PROPERTY_HANGUL_SYLLABLE_TYPE_value, UCHAR_HANGUL_SYLLABLE_TYPE);
-	zend_string *const_PROPERTY_HANGUL_SYLLABLE_TYPE_name = zend_string_init_interned("PROPERTY_HANGUL_SYLLABLE_TYPE", sizeof("PROPERTY_HANGUL_SYLLABLE_TYPE") - 1, 1);
+	zend_string *const_PROPERTY_HANGUL_SYLLABLE_TYPE_name = zend_string_init_interned("PROPERTY_HANGUL_SYLLABLE_TYPE", strlen("PROPERTY_HANGUL_SYLLABLE_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_HANGUL_SYLLABLE_TYPE_name, &const_PROPERTY_HANGUL_SYLLABLE_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_HANGUL_SYLLABLE_TYPE_name);
 
 	zval const_PROPERTY_NFD_QUICK_CHECK_value;
 	ZVAL_LONG(&const_PROPERTY_NFD_QUICK_CHECK_value, UCHAR_NFD_QUICK_CHECK);
-	zend_string *const_PROPERTY_NFD_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFD_QUICK_CHECK", sizeof("PROPERTY_NFD_QUICK_CHECK") - 1, 1);
+	zend_string *const_PROPERTY_NFD_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFD_QUICK_CHECK", strlen("PROPERTY_NFD_QUICK_CHECK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFD_QUICK_CHECK_name, &const_PROPERTY_NFD_QUICK_CHECK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFD_QUICK_CHECK_name);
 
 	zval const_PROPERTY_NFKD_QUICK_CHECK_value;
 	ZVAL_LONG(&const_PROPERTY_NFKD_QUICK_CHECK_value, UCHAR_NFKD_QUICK_CHECK);
-	zend_string *const_PROPERTY_NFKD_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFKD_QUICK_CHECK", sizeof("PROPERTY_NFKD_QUICK_CHECK") - 1, 1);
+	zend_string *const_PROPERTY_NFKD_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFKD_QUICK_CHECK", strlen("PROPERTY_NFKD_QUICK_CHECK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFKD_QUICK_CHECK_name, &const_PROPERTY_NFKD_QUICK_CHECK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFKD_QUICK_CHECK_name);
 
 	zval const_PROPERTY_NFC_QUICK_CHECK_value;
 	ZVAL_LONG(&const_PROPERTY_NFC_QUICK_CHECK_value, UCHAR_NFC_QUICK_CHECK);
-	zend_string *const_PROPERTY_NFC_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFC_QUICK_CHECK", sizeof("PROPERTY_NFC_QUICK_CHECK") - 1, 1);
+	zend_string *const_PROPERTY_NFC_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFC_QUICK_CHECK", strlen("PROPERTY_NFC_QUICK_CHECK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFC_QUICK_CHECK_name, &const_PROPERTY_NFC_QUICK_CHECK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFC_QUICK_CHECK_name);
 
 	zval const_PROPERTY_NFKC_QUICK_CHECK_value;
 	ZVAL_LONG(&const_PROPERTY_NFKC_QUICK_CHECK_value, UCHAR_NFKC_QUICK_CHECK);
-	zend_string *const_PROPERTY_NFKC_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFKC_QUICK_CHECK", sizeof("PROPERTY_NFKC_QUICK_CHECK") - 1, 1);
+	zend_string *const_PROPERTY_NFKC_QUICK_CHECK_name = zend_string_init_interned("PROPERTY_NFKC_QUICK_CHECK", strlen("PROPERTY_NFKC_QUICK_CHECK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NFKC_QUICK_CHECK_name, &const_PROPERTY_NFKC_QUICK_CHECK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NFKC_QUICK_CHECK_name);
 
 	zval const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_value;
 	ZVAL_LONG(&const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_value, UCHAR_LEAD_CANONICAL_COMBINING_CLASS);
-	zend_string *const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_LEAD_CANONICAL_COMBINING_CLASS", sizeof("PROPERTY_LEAD_CANONICAL_COMBINING_CLASS") - 1, 1);
+	zend_string *const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_LEAD_CANONICAL_COMBINING_CLASS", strlen("PROPERTY_LEAD_CANONICAL_COMBINING_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_name, &const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_LEAD_CANONICAL_COMBINING_CLASS_name);
 
 	zval const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_value;
 	ZVAL_LONG(&const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_value, UCHAR_TRAIL_CANONICAL_COMBINING_CLASS);
-	zend_string *const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS", sizeof("PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS") - 1, 1);
+	zend_string *const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_name = zend_string_init_interned("PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS", strlen("PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_name, &const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS_name);
 
 	zval const_PROPERTY_GRAPHEME_CLUSTER_BREAK_value;
 	ZVAL_LONG(&const_PROPERTY_GRAPHEME_CLUSTER_BREAK_value, UCHAR_GRAPHEME_CLUSTER_BREAK);
-	zend_string *const_PROPERTY_GRAPHEME_CLUSTER_BREAK_name = zend_string_init_interned("PROPERTY_GRAPHEME_CLUSTER_BREAK", sizeof("PROPERTY_GRAPHEME_CLUSTER_BREAK") - 1, 1);
+	zend_string *const_PROPERTY_GRAPHEME_CLUSTER_BREAK_name = zend_string_init_interned("PROPERTY_GRAPHEME_CLUSTER_BREAK", strlen("PROPERTY_GRAPHEME_CLUSTER_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GRAPHEME_CLUSTER_BREAK_name, &const_PROPERTY_GRAPHEME_CLUSTER_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GRAPHEME_CLUSTER_BREAK_name);
 
 	zval const_PROPERTY_SENTENCE_BREAK_value;
 	ZVAL_LONG(&const_PROPERTY_SENTENCE_BREAK_value, UCHAR_SENTENCE_BREAK);
-	zend_string *const_PROPERTY_SENTENCE_BREAK_name = zend_string_init_interned("PROPERTY_SENTENCE_BREAK", sizeof("PROPERTY_SENTENCE_BREAK") - 1, 1);
+	zend_string *const_PROPERTY_SENTENCE_BREAK_name = zend_string_init_interned("PROPERTY_SENTENCE_BREAK", strlen("PROPERTY_SENTENCE_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SENTENCE_BREAK_name, &const_PROPERTY_SENTENCE_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SENTENCE_BREAK_name);
 
 	zval const_PROPERTY_WORD_BREAK_value;
 	ZVAL_LONG(&const_PROPERTY_WORD_BREAK_value, UCHAR_WORD_BREAK);
-	zend_string *const_PROPERTY_WORD_BREAK_name = zend_string_init_interned("PROPERTY_WORD_BREAK", sizeof("PROPERTY_WORD_BREAK") - 1, 1);
+	zend_string *const_PROPERTY_WORD_BREAK_name = zend_string_init_interned("PROPERTY_WORD_BREAK", strlen("PROPERTY_WORD_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_WORD_BREAK_name, &const_PROPERTY_WORD_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_WORD_BREAK_name);
 
 	zval const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_value, UCHAR_BIDI_PAIRED_BRACKET_TYPE);
-	zend_string *const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_name = zend_string_init_interned("PROPERTY_BIDI_PAIRED_BRACKET_TYPE", sizeof("PROPERTY_BIDI_PAIRED_BRACKET_TYPE") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_name = zend_string_init_interned("PROPERTY_BIDI_PAIRED_BRACKET_TYPE", strlen("PROPERTY_BIDI_PAIRED_BRACKET_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_name, &const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_PAIRED_BRACKET_TYPE_name);
 
 	zval const_PROPERTY_INT_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_INT_LIMIT_value, UCHAR_INT_LIMIT);
-	zend_string *const_PROPERTY_INT_LIMIT_name = zend_string_init_interned("PROPERTY_INT_LIMIT", sizeof("PROPERTY_INT_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_INT_LIMIT_name = zend_string_init_interned("PROPERTY_INT_LIMIT", strlen("PROPERTY_INT_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_INT_LIMIT_name, &const_PROPERTY_INT_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_INT_LIMIT_name);
 
 	zval const_PROPERTY_GENERAL_CATEGORY_MASK_value;
 	ZVAL_LONG(&const_PROPERTY_GENERAL_CATEGORY_MASK_value, UCHAR_GENERAL_CATEGORY_MASK);
-	zend_string *const_PROPERTY_GENERAL_CATEGORY_MASK_name = zend_string_init_interned("PROPERTY_GENERAL_CATEGORY_MASK", sizeof("PROPERTY_GENERAL_CATEGORY_MASK") - 1, 1);
+	zend_string *const_PROPERTY_GENERAL_CATEGORY_MASK_name = zend_string_init_interned("PROPERTY_GENERAL_CATEGORY_MASK", strlen("PROPERTY_GENERAL_CATEGORY_MASK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_GENERAL_CATEGORY_MASK_name, &const_PROPERTY_GENERAL_CATEGORY_MASK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_GENERAL_CATEGORY_MASK_name);
 
 	zval const_PROPERTY_MASK_START_value;
 	ZVAL_LONG(&const_PROPERTY_MASK_START_value, UCHAR_MASK_START);
-	zend_string *const_PROPERTY_MASK_START_name = zend_string_init_interned("PROPERTY_MASK_START", sizeof("PROPERTY_MASK_START") - 1, 1);
+	zend_string *const_PROPERTY_MASK_START_name = zend_string_init_interned("PROPERTY_MASK_START", strlen("PROPERTY_MASK_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_MASK_START_name, &const_PROPERTY_MASK_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_MASK_START_name);
 
 	zval const_PROPERTY_MASK_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_MASK_LIMIT_value, UCHAR_MASK_LIMIT);
-	zend_string *const_PROPERTY_MASK_LIMIT_name = zend_string_init_interned("PROPERTY_MASK_LIMIT", sizeof("PROPERTY_MASK_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_MASK_LIMIT_name = zend_string_init_interned("PROPERTY_MASK_LIMIT", strlen("PROPERTY_MASK_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_MASK_LIMIT_name, &const_PROPERTY_MASK_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_MASK_LIMIT_name);
 
 	zval const_PROPERTY_NUMERIC_VALUE_value;
 	ZVAL_LONG(&const_PROPERTY_NUMERIC_VALUE_value, UCHAR_NUMERIC_VALUE);
-	zend_string *const_PROPERTY_NUMERIC_VALUE_name = zend_string_init_interned("PROPERTY_NUMERIC_VALUE", sizeof("PROPERTY_NUMERIC_VALUE") - 1, 1);
+	zend_string *const_PROPERTY_NUMERIC_VALUE_name = zend_string_init_interned("PROPERTY_NUMERIC_VALUE", strlen("PROPERTY_NUMERIC_VALUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NUMERIC_VALUE_name, &const_PROPERTY_NUMERIC_VALUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NUMERIC_VALUE_name);
 
 	zval const_PROPERTY_DOUBLE_START_value;
 	ZVAL_LONG(&const_PROPERTY_DOUBLE_START_value, UCHAR_DOUBLE_START);
-	zend_string *const_PROPERTY_DOUBLE_START_name = zend_string_init_interned("PROPERTY_DOUBLE_START", sizeof("PROPERTY_DOUBLE_START") - 1, 1);
+	zend_string *const_PROPERTY_DOUBLE_START_name = zend_string_init_interned("PROPERTY_DOUBLE_START", strlen("PROPERTY_DOUBLE_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DOUBLE_START_name, &const_PROPERTY_DOUBLE_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DOUBLE_START_name);
 
 	zval const_PROPERTY_DOUBLE_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_DOUBLE_LIMIT_value, UCHAR_DOUBLE_LIMIT);
-	zend_string *const_PROPERTY_DOUBLE_LIMIT_name = zend_string_init_interned("PROPERTY_DOUBLE_LIMIT", sizeof("PROPERTY_DOUBLE_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_DOUBLE_LIMIT_name = zend_string_init_interned("PROPERTY_DOUBLE_LIMIT", strlen("PROPERTY_DOUBLE_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_DOUBLE_LIMIT_name, &const_PROPERTY_DOUBLE_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_DOUBLE_LIMIT_name);
 
 	zval const_PROPERTY_AGE_value;
 	ZVAL_LONG(&const_PROPERTY_AGE_value, UCHAR_AGE);
-	zend_string *const_PROPERTY_AGE_name = zend_string_init_interned("PROPERTY_AGE", sizeof("PROPERTY_AGE") - 1, 1);
+	zend_string *const_PROPERTY_AGE_name = zend_string_init_interned("PROPERTY_AGE", strlen("PROPERTY_AGE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_AGE_name, &const_PROPERTY_AGE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_AGE_name);
 
 	zval const_PROPERTY_STRING_START_value;
 	ZVAL_LONG(&const_PROPERTY_STRING_START_value, UCHAR_STRING_START);
-	zend_string *const_PROPERTY_STRING_START_name = zend_string_init_interned("PROPERTY_STRING_START", sizeof("PROPERTY_STRING_START") - 1, 1);
+	zend_string *const_PROPERTY_STRING_START_name = zend_string_init_interned("PROPERTY_STRING_START", strlen("PROPERTY_STRING_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_STRING_START_name, &const_PROPERTY_STRING_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_STRING_START_name);
 
 	zval const_PROPERTY_BIDI_MIRRORING_GLYPH_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_MIRRORING_GLYPH_value, UCHAR_BIDI_MIRRORING_GLYPH);
-	zend_string *const_PROPERTY_BIDI_MIRRORING_GLYPH_name = zend_string_init_interned("PROPERTY_BIDI_MIRRORING_GLYPH", sizeof("PROPERTY_BIDI_MIRRORING_GLYPH") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_MIRRORING_GLYPH_name = zend_string_init_interned("PROPERTY_BIDI_MIRRORING_GLYPH", strlen("PROPERTY_BIDI_MIRRORING_GLYPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_MIRRORING_GLYPH_name, &const_PROPERTY_BIDI_MIRRORING_GLYPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_MIRRORING_GLYPH_name);
 
 	zval const_PROPERTY_CASE_FOLDING_value;
 	ZVAL_LONG(&const_PROPERTY_CASE_FOLDING_value, UCHAR_CASE_FOLDING);
-	zend_string *const_PROPERTY_CASE_FOLDING_name = zend_string_init_interned("PROPERTY_CASE_FOLDING", sizeof("PROPERTY_CASE_FOLDING") - 1, 1);
+	zend_string *const_PROPERTY_CASE_FOLDING_name = zend_string_init_interned("PROPERTY_CASE_FOLDING", strlen("PROPERTY_CASE_FOLDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_CASE_FOLDING_name, &const_PROPERTY_CASE_FOLDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_CASE_FOLDING_name);
 
 	zval const_PROPERTY_ISO_COMMENT_value;
 	ZVAL_LONG(&const_PROPERTY_ISO_COMMENT_value, UCHAR_ISO_COMMENT);
-	zend_string *const_PROPERTY_ISO_COMMENT_name = zend_string_init_interned("PROPERTY_ISO_COMMENT", sizeof("PROPERTY_ISO_COMMENT") - 1, 1);
+	zend_string *const_PROPERTY_ISO_COMMENT_name = zend_string_init_interned("PROPERTY_ISO_COMMENT", strlen("PROPERTY_ISO_COMMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_ISO_COMMENT_name, &const_PROPERTY_ISO_COMMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_ISO_COMMENT_name);
 
 	zval const_PROPERTY_LOWERCASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_LOWERCASE_MAPPING_value, UCHAR_LOWERCASE_MAPPING);
-	zend_string *const_PROPERTY_LOWERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_LOWERCASE_MAPPING", sizeof("PROPERTY_LOWERCASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_LOWERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_LOWERCASE_MAPPING", strlen("PROPERTY_LOWERCASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_LOWERCASE_MAPPING_name, &const_PROPERTY_LOWERCASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_LOWERCASE_MAPPING_name);
 
 	zval const_PROPERTY_NAME_value;
 	ZVAL_LONG(&const_PROPERTY_NAME_value, UCHAR_NAME);
-	zend_string *const_PROPERTY_NAME_name = zend_string_init_interned("PROPERTY_NAME", sizeof("PROPERTY_NAME") - 1, 1);
+	zend_string *const_PROPERTY_NAME_name = zend_string_init_interned("PROPERTY_NAME", strlen("PROPERTY_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NAME_name, &const_PROPERTY_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NAME_name);
 
 	zval const_PROPERTY_SIMPLE_CASE_FOLDING_value;
 	ZVAL_LONG(&const_PROPERTY_SIMPLE_CASE_FOLDING_value, UCHAR_SIMPLE_CASE_FOLDING);
-	zend_string *const_PROPERTY_SIMPLE_CASE_FOLDING_name = zend_string_init_interned("PROPERTY_SIMPLE_CASE_FOLDING", sizeof("PROPERTY_SIMPLE_CASE_FOLDING") - 1, 1);
+	zend_string *const_PROPERTY_SIMPLE_CASE_FOLDING_name = zend_string_init_interned("PROPERTY_SIMPLE_CASE_FOLDING", strlen("PROPERTY_SIMPLE_CASE_FOLDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SIMPLE_CASE_FOLDING_name, &const_PROPERTY_SIMPLE_CASE_FOLDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SIMPLE_CASE_FOLDING_name);
 
 	zval const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_value, UCHAR_SIMPLE_LOWERCASE_MAPPING);
-	zend_string *const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_LOWERCASE_MAPPING", sizeof("PROPERTY_SIMPLE_LOWERCASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_LOWERCASE_MAPPING", strlen("PROPERTY_SIMPLE_LOWERCASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_name, &const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SIMPLE_LOWERCASE_MAPPING_name);
 
 	zval const_PROPERTY_SIMPLE_TITLECASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_SIMPLE_TITLECASE_MAPPING_value, UCHAR_SIMPLE_TITLECASE_MAPPING);
-	zend_string *const_PROPERTY_SIMPLE_TITLECASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_TITLECASE_MAPPING", sizeof("PROPERTY_SIMPLE_TITLECASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_SIMPLE_TITLECASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_TITLECASE_MAPPING", strlen("PROPERTY_SIMPLE_TITLECASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SIMPLE_TITLECASE_MAPPING_name, &const_PROPERTY_SIMPLE_TITLECASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SIMPLE_TITLECASE_MAPPING_name);
 
 	zval const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_value, UCHAR_SIMPLE_UPPERCASE_MAPPING);
-	zend_string *const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_UPPERCASE_MAPPING", sizeof("PROPERTY_SIMPLE_UPPERCASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_SIMPLE_UPPERCASE_MAPPING", strlen("PROPERTY_SIMPLE_UPPERCASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_name, &const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SIMPLE_UPPERCASE_MAPPING_name);
 
 	zval const_PROPERTY_TITLECASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_TITLECASE_MAPPING_value, UCHAR_TITLECASE_MAPPING);
-	zend_string *const_PROPERTY_TITLECASE_MAPPING_name = zend_string_init_interned("PROPERTY_TITLECASE_MAPPING", sizeof("PROPERTY_TITLECASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_TITLECASE_MAPPING_name = zend_string_init_interned("PROPERTY_TITLECASE_MAPPING", strlen("PROPERTY_TITLECASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_TITLECASE_MAPPING_name, &const_PROPERTY_TITLECASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_TITLECASE_MAPPING_name);
 
 	zval const_PROPERTY_UNICODE_1_NAME_value;
 	ZVAL_LONG(&const_PROPERTY_UNICODE_1_NAME_value, UCHAR_UNICODE_1_NAME);
-	zend_string *const_PROPERTY_UNICODE_1_NAME_name = zend_string_init_interned("PROPERTY_UNICODE_1_NAME", sizeof("PROPERTY_UNICODE_1_NAME") - 1, 1);
+	zend_string *const_PROPERTY_UNICODE_1_NAME_name = zend_string_init_interned("PROPERTY_UNICODE_1_NAME", strlen("PROPERTY_UNICODE_1_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_UNICODE_1_NAME_name, &const_PROPERTY_UNICODE_1_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_UNICODE_1_NAME_name);
 
 	zval const_PROPERTY_UPPERCASE_MAPPING_value;
 	ZVAL_LONG(&const_PROPERTY_UPPERCASE_MAPPING_value, UCHAR_UPPERCASE_MAPPING);
-	zend_string *const_PROPERTY_UPPERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_UPPERCASE_MAPPING", sizeof("PROPERTY_UPPERCASE_MAPPING") - 1, 1);
+	zend_string *const_PROPERTY_UPPERCASE_MAPPING_name = zend_string_init_interned("PROPERTY_UPPERCASE_MAPPING", strlen("PROPERTY_UPPERCASE_MAPPING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_UPPERCASE_MAPPING_name, &const_PROPERTY_UPPERCASE_MAPPING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_UPPERCASE_MAPPING_name);
 
 	zval const_PROPERTY_BIDI_PAIRED_BRACKET_value;
 	ZVAL_LONG(&const_PROPERTY_BIDI_PAIRED_BRACKET_value, UCHAR_BIDI_PAIRED_BRACKET);
-	zend_string *const_PROPERTY_BIDI_PAIRED_BRACKET_name = zend_string_init_interned("PROPERTY_BIDI_PAIRED_BRACKET", sizeof("PROPERTY_BIDI_PAIRED_BRACKET") - 1, 1);
+	zend_string *const_PROPERTY_BIDI_PAIRED_BRACKET_name = zend_string_init_interned("PROPERTY_BIDI_PAIRED_BRACKET", strlen("PROPERTY_BIDI_PAIRED_BRACKET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_BIDI_PAIRED_BRACKET_name, &const_PROPERTY_BIDI_PAIRED_BRACKET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_BIDI_PAIRED_BRACKET_name);
 
 	zval const_PROPERTY_STRING_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_STRING_LIMIT_value, UCHAR_STRING_LIMIT);
-	zend_string *const_PROPERTY_STRING_LIMIT_name = zend_string_init_interned("PROPERTY_STRING_LIMIT", sizeof("PROPERTY_STRING_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_STRING_LIMIT_name = zend_string_init_interned("PROPERTY_STRING_LIMIT", strlen("PROPERTY_STRING_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_STRING_LIMIT_name, &const_PROPERTY_STRING_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_STRING_LIMIT_name);
 
 	zval const_PROPERTY_SCRIPT_EXTENSIONS_value;
 	ZVAL_LONG(&const_PROPERTY_SCRIPT_EXTENSIONS_value, UCHAR_SCRIPT_EXTENSIONS);
-	zend_string *const_PROPERTY_SCRIPT_EXTENSIONS_name = zend_string_init_interned("PROPERTY_SCRIPT_EXTENSIONS", sizeof("PROPERTY_SCRIPT_EXTENSIONS") - 1, 1);
+	zend_string *const_PROPERTY_SCRIPT_EXTENSIONS_name = zend_string_init_interned("PROPERTY_SCRIPT_EXTENSIONS", strlen("PROPERTY_SCRIPT_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_SCRIPT_EXTENSIONS_name, &const_PROPERTY_SCRIPT_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_SCRIPT_EXTENSIONS_name);
 
 	zval const_PROPERTY_OTHER_PROPERTY_START_value;
 	ZVAL_LONG(&const_PROPERTY_OTHER_PROPERTY_START_value, UCHAR_OTHER_PROPERTY_START);
-	zend_string *const_PROPERTY_OTHER_PROPERTY_START_name = zend_string_init_interned("PROPERTY_OTHER_PROPERTY_START", sizeof("PROPERTY_OTHER_PROPERTY_START") - 1, 1);
+	zend_string *const_PROPERTY_OTHER_PROPERTY_START_name = zend_string_init_interned("PROPERTY_OTHER_PROPERTY_START", strlen("PROPERTY_OTHER_PROPERTY_START"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_OTHER_PROPERTY_START_name, &const_PROPERTY_OTHER_PROPERTY_START_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_OTHER_PROPERTY_START_name);
 
 	zval const_PROPERTY_OTHER_PROPERTY_LIMIT_value;
 	ZVAL_LONG(&const_PROPERTY_OTHER_PROPERTY_LIMIT_value, UCHAR_OTHER_PROPERTY_LIMIT);
-	zend_string *const_PROPERTY_OTHER_PROPERTY_LIMIT_name = zend_string_init_interned("PROPERTY_OTHER_PROPERTY_LIMIT", sizeof("PROPERTY_OTHER_PROPERTY_LIMIT") - 1, 1);
+	zend_string *const_PROPERTY_OTHER_PROPERTY_LIMIT_name = zend_string_init_interned("PROPERTY_OTHER_PROPERTY_LIMIT", strlen("PROPERTY_OTHER_PROPERTY_LIMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_OTHER_PROPERTY_LIMIT_name, &const_PROPERTY_OTHER_PROPERTY_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_OTHER_PROPERTY_LIMIT_name);
 
 	zval const_PROPERTY_INVALID_CODE_value;
 	ZVAL_LONG(&const_PROPERTY_INVALID_CODE_value, UCHAR_INVALID_CODE);
-	zend_string *const_PROPERTY_INVALID_CODE_name = zend_string_init_interned("PROPERTY_INVALID_CODE", sizeof("PROPERTY_INVALID_CODE") - 1, 1);
+	zend_string *const_PROPERTY_INVALID_CODE_name = zend_string_init_interned("PROPERTY_INVALID_CODE", strlen("PROPERTY_INVALID_CODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_INVALID_CODE_name, &const_PROPERTY_INVALID_CODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_INVALID_CODE_name);
 
 	zval const_CHAR_CATEGORY_UNASSIGNED_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_UNASSIGNED_value, U_UNASSIGNED);
-	zend_string *const_CHAR_CATEGORY_UNASSIGNED_name = zend_string_init_interned("CHAR_CATEGORY_UNASSIGNED", sizeof("CHAR_CATEGORY_UNASSIGNED") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_UNASSIGNED_name = zend_string_init_interned("CHAR_CATEGORY_UNASSIGNED", strlen("CHAR_CATEGORY_UNASSIGNED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_UNASSIGNED_name, &const_CHAR_CATEGORY_UNASSIGNED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_UNASSIGNED_name);
 
 	zval const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_value, U_GENERAL_OTHER_TYPES);
-	zend_string *const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_name = zend_string_init_interned("CHAR_CATEGORY_GENERAL_OTHER_TYPES", sizeof("CHAR_CATEGORY_GENERAL_OTHER_TYPES") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_name = zend_string_init_interned("CHAR_CATEGORY_GENERAL_OTHER_TYPES", strlen("CHAR_CATEGORY_GENERAL_OTHER_TYPES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_name, &const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_GENERAL_OTHER_TYPES_name);
 
 	zval const_CHAR_CATEGORY_UPPERCASE_LETTER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_UPPERCASE_LETTER_value, U_UPPERCASE_LETTER);
-	zend_string *const_CHAR_CATEGORY_UPPERCASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_UPPERCASE_LETTER", sizeof("CHAR_CATEGORY_UPPERCASE_LETTER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_UPPERCASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_UPPERCASE_LETTER", strlen("CHAR_CATEGORY_UPPERCASE_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_UPPERCASE_LETTER_name, &const_CHAR_CATEGORY_UPPERCASE_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_UPPERCASE_LETTER_name);
 
 	zval const_CHAR_CATEGORY_LOWERCASE_LETTER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_LOWERCASE_LETTER_value, U_LOWERCASE_LETTER);
-	zend_string *const_CHAR_CATEGORY_LOWERCASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_LOWERCASE_LETTER", sizeof("CHAR_CATEGORY_LOWERCASE_LETTER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_LOWERCASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_LOWERCASE_LETTER", strlen("CHAR_CATEGORY_LOWERCASE_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_LOWERCASE_LETTER_name, &const_CHAR_CATEGORY_LOWERCASE_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_LOWERCASE_LETTER_name);
 
 	zval const_CHAR_CATEGORY_TITLECASE_LETTER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_TITLECASE_LETTER_value, U_TITLECASE_LETTER);
-	zend_string *const_CHAR_CATEGORY_TITLECASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_TITLECASE_LETTER", sizeof("CHAR_CATEGORY_TITLECASE_LETTER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_TITLECASE_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_TITLECASE_LETTER", strlen("CHAR_CATEGORY_TITLECASE_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_TITLECASE_LETTER_name, &const_CHAR_CATEGORY_TITLECASE_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_TITLECASE_LETTER_name);
 
 	zval const_CHAR_CATEGORY_MODIFIER_LETTER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_MODIFIER_LETTER_value, U_MODIFIER_LETTER);
-	zend_string *const_CHAR_CATEGORY_MODIFIER_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_MODIFIER_LETTER", sizeof("CHAR_CATEGORY_MODIFIER_LETTER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_MODIFIER_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_MODIFIER_LETTER", strlen("CHAR_CATEGORY_MODIFIER_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_MODIFIER_LETTER_name, &const_CHAR_CATEGORY_MODIFIER_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_MODIFIER_LETTER_name);
 
 	zval const_CHAR_CATEGORY_OTHER_LETTER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_OTHER_LETTER_value, U_OTHER_LETTER);
-	zend_string *const_CHAR_CATEGORY_OTHER_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_LETTER", sizeof("CHAR_CATEGORY_OTHER_LETTER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_OTHER_LETTER_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_LETTER", strlen("CHAR_CATEGORY_OTHER_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_OTHER_LETTER_name, &const_CHAR_CATEGORY_OTHER_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_OTHER_LETTER_name);
 
 	zval const_CHAR_CATEGORY_NON_SPACING_MARK_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_NON_SPACING_MARK_value, U_NON_SPACING_MARK);
-	zend_string *const_CHAR_CATEGORY_NON_SPACING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_NON_SPACING_MARK", sizeof("CHAR_CATEGORY_NON_SPACING_MARK") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_NON_SPACING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_NON_SPACING_MARK", strlen("CHAR_CATEGORY_NON_SPACING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_NON_SPACING_MARK_name, &const_CHAR_CATEGORY_NON_SPACING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_NON_SPACING_MARK_name);
 
 	zval const_CHAR_CATEGORY_ENCLOSING_MARK_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_ENCLOSING_MARK_value, U_ENCLOSING_MARK);
-	zend_string *const_CHAR_CATEGORY_ENCLOSING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_ENCLOSING_MARK", sizeof("CHAR_CATEGORY_ENCLOSING_MARK") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_ENCLOSING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_ENCLOSING_MARK", strlen("CHAR_CATEGORY_ENCLOSING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_ENCLOSING_MARK_name, &const_CHAR_CATEGORY_ENCLOSING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_ENCLOSING_MARK_name);
 
 	zval const_CHAR_CATEGORY_COMBINING_SPACING_MARK_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_COMBINING_SPACING_MARK_value, U_COMBINING_SPACING_MARK);
-	zend_string *const_CHAR_CATEGORY_COMBINING_SPACING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_COMBINING_SPACING_MARK", sizeof("CHAR_CATEGORY_COMBINING_SPACING_MARK") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_COMBINING_SPACING_MARK_name = zend_string_init_interned("CHAR_CATEGORY_COMBINING_SPACING_MARK", strlen("CHAR_CATEGORY_COMBINING_SPACING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_COMBINING_SPACING_MARK_name, &const_CHAR_CATEGORY_COMBINING_SPACING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_COMBINING_SPACING_MARK_name);
 
 	zval const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_value, U_DECIMAL_DIGIT_NUMBER);
-	zend_string *const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER", sizeof("CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER", strlen("CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_name, &const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER_name);
 
 	zval const_CHAR_CATEGORY_LETTER_NUMBER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_LETTER_NUMBER_value, U_LETTER_NUMBER);
-	zend_string *const_CHAR_CATEGORY_LETTER_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_LETTER_NUMBER", sizeof("CHAR_CATEGORY_LETTER_NUMBER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_LETTER_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_LETTER_NUMBER", strlen("CHAR_CATEGORY_LETTER_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_LETTER_NUMBER_name, &const_CHAR_CATEGORY_LETTER_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_LETTER_NUMBER_name);
 
 	zval const_CHAR_CATEGORY_OTHER_NUMBER_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_OTHER_NUMBER_value, U_OTHER_NUMBER);
-	zend_string *const_CHAR_CATEGORY_OTHER_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_NUMBER", sizeof("CHAR_CATEGORY_OTHER_NUMBER") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_OTHER_NUMBER_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_NUMBER", strlen("CHAR_CATEGORY_OTHER_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_OTHER_NUMBER_name, &const_CHAR_CATEGORY_OTHER_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_OTHER_NUMBER_name);
 
 	zval const_CHAR_CATEGORY_SPACE_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_SPACE_SEPARATOR_value, U_SPACE_SEPARATOR);
-	zend_string *const_CHAR_CATEGORY_SPACE_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_SPACE_SEPARATOR", sizeof("CHAR_CATEGORY_SPACE_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_SPACE_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_SPACE_SEPARATOR", strlen("CHAR_CATEGORY_SPACE_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_SPACE_SEPARATOR_name, &const_CHAR_CATEGORY_SPACE_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_SPACE_SEPARATOR_name);
 
 	zval const_CHAR_CATEGORY_LINE_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_LINE_SEPARATOR_value, U_LINE_SEPARATOR);
-	zend_string *const_CHAR_CATEGORY_LINE_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_LINE_SEPARATOR", sizeof("CHAR_CATEGORY_LINE_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_LINE_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_LINE_SEPARATOR", strlen("CHAR_CATEGORY_LINE_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_LINE_SEPARATOR_name, &const_CHAR_CATEGORY_LINE_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_LINE_SEPARATOR_name);
 
 	zval const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_value, U_PARAGRAPH_SEPARATOR);
-	zend_string *const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_PARAGRAPH_SEPARATOR", sizeof("CHAR_CATEGORY_PARAGRAPH_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_name = zend_string_init_interned("CHAR_CATEGORY_PARAGRAPH_SEPARATOR", strlen("CHAR_CATEGORY_PARAGRAPH_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_name, &const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_PARAGRAPH_SEPARATOR_name);
 
 	zval const_CHAR_CATEGORY_CONTROL_CHAR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_CONTROL_CHAR_value, U_CONTROL_CHAR);
-	zend_string *const_CHAR_CATEGORY_CONTROL_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_CONTROL_CHAR", sizeof("CHAR_CATEGORY_CONTROL_CHAR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_CONTROL_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_CONTROL_CHAR", strlen("CHAR_CATEGORY_CONTROL_CHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_CONTROL_CHAR_name, &const_CHAR_CATEGORY_CONTROL_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_CONTROL_CHAR_name);
 
 	zval const_CHAR_CATEGORY_FORMAT_CHAR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_FORMAT_CHAR_value, U_FORMAT_CHAR);
-	zend_string *const_CHAR_CATEGORY_FORMAT_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_FORMAT_CHAR", sizeof("CHAR_CATEGORY_FORMAT_CHAR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_FORMAT_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_FORMAT_CHAR", strlen("CHAR_CATEGORY_FORMAT_CHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_FORMAT_CHAR_name, &const_CHAR_CATEGORY_FORMAT_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_FORMAT_CHAR_name);
 
 	zval const_CHAR_CATEGORY_PRIVATE_USE_CHAR_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_PRIVATE_USE_CHAR_value, U_PRIVATE_USE_CHAR);
-	zend_string *const_CHAR_CATEGORY_PRIVATE_USE_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_PRIVATE_USE_CHAR", sizeof("CHAR_CATEGORY_PRIVATE_USE_CHAR") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_PRIVATE_USE_CHAR_name = zend_string_init_interned("CHAR_CATEGORY_PRIVATE_USE_CHAR", strlen("CHAR_CATEGORY_PRIVATE_USE_CHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_PRIVATE_USE_CHAR_name, &const_CHAR_CATEGORY_PRIVATE_USE_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_PRIVATE_USE_CHAR_name);
 
 	zval const_CHAR_CATEGORY_SURROGATE_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_SURROGATE_value, U_SURROGATE);
-	zend_string *const_CHAR_CATEGORY_SURROGATE_name = zend_string_init_interned("CHAR_CATEGORY_SURROGATE", sizeof("CHAR_CATEGORY_SURROGATE") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_SURROGATE_name = zend_string_init_interned("CHAR_CATEGORY_SURROGATE", strlen("CHAR_CATEGORY_SURROGATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_SURROGATE_name, &const_CHAR_CATEGORY_SURROGATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_SURROGATE_name);
 
 	zval const_CHAR_CATEGORY_DASH_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_DASH_PUNCTUATION_value, U_DASH_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_DASH_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_DASH_PUNCTUATION", sizeof("CHAR_CATEGORY_DASH_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_DASH_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_DASH_PUNCTUATION", strlen("CHAR_CATEGORY_DASH_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_DASH_PUNCTUATION_name, &const_CHAR_CATEGORY_DASH_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_DASH_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_START_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_START_PUNCTUATION_value, U_START_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_START_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_START_PUNCTUATION", sizeof("CHAR_CATEGORY_START_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_START_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_START_PUNCTUATION", strlen("CHAR_CATEGORY_START_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_START_PUNCTUATION_name, &const_CHAR_CATEGORY_START_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_START_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_END_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_END_PUNCTUATION_value, U_END_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_END_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_END_PUNCTUATION", sizeof("CHAR_CATEGORY_END_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_END_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_END_PUNCTUATION", strlen("CHAR_CATEGORY_END_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_END_PUNCTUATION_name, &const_CHAR_CATEGORY_END_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_END_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_value, U_CONNECTOR_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_CONNECTOR_PUNCTUATION", sizeof("CHAR_CATEGORY_CONNECTOR_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_CONNECTOR_PUNCTUATION", strlen("CHAR_CATEGORY_CONNECTOR_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_name, &const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_CONNECTOR_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_OTHER_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_OTHER_PUNCTUATION_value, U_OTHER_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_OTHER_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_PUNCTUATION", sizeof("CHAR_CATEGORY_OTHER_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_OTHER_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_PUNCTUATION", strlen("CHAR_CATEGORY_OTHER_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_OTHER_PUNCTUATION_name, &const_CHAR_CATEGORY_OTHER_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_OTHER_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_MATH_SYMBOL_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_MATH_SYMBOL_value, U_MATH_SYMBOL);
-	zend_string *const_CHAR_CATEGORY_MATH_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_MATH_SYMBOL", sizeof("CHAR_CATEGORY_MATH_SYMBOL") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_MATH_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_MATH_SYMBOL", strlen("CHAR_CATEGORY_MATH_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_MATH_SYMBOL_name, &const_CHAR_CATEGORY_MATH_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_MATH_SYMBOL_name);
 
 	zval const_CHAR_CATEGORY_CURRENCY_SYMBOL_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_CURRENCY_SYMBOL_value, U_CURRENCY_SYMBOL);
-	zend_string *const_CHAR_CATEGORY_CURRENCY_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_CURRENCY_SYMBOL", sizeof("CHAR_CATEGORY_CURRENCY_SYMBOL") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_CURRENCY_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_CURRENCY_SYMBOL", strlen("CHAR_CATEGORY_CURRENCY_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_CURRENCY_SYMBOL_name, &const_CHAR_CATEGORY_CURRENCY_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_CURRENCY_SYMBOL_name);
 
 	zval const_CHAR_CATEGORY_MODIFIER_SYMBOL_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_MODIFIER_SYMBOL_value, U_MODIFIER_SYMBOL);
-	zend_string *const_CHAR_CATEGORY_MODIFIER_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_MODIFIER_SYMBOL", sizeof("CHAR_CATEGORY_MODIFIER_SYMBOL") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_MODIFIER_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_MODIFIER_SYMBOL", strlen("CHAR_CATEGORY_MODIFIER_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_MODIFIER_SYMBOL_name, &const_CHAR_CATEGORY_MODIFIER_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_MODIFIER_SYMBOL_name);
 
 	zval const_CHAR_CATEGORY_OTHER_SYMBOL_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_OTHER_SYMBOL_value, U_OTHER_SYMBOL);
-	zend_string *const_CHAR_CATEGORY_OTHER_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_SYMBOL", sizeof("CHAR_CATEGORY_OTHER_SYMBOL") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_OTHER_SYMBOL_name = zend_string_init_interned("CHAR_CATEGORY_OTHER_SYMBOL", strlen("CHAR_CATEGORY_OTHER_SYMBOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_OTHER_SYMBOL_name, &const_CHAR_CATEGORY_OTHER_SYMBOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_OTHER_SYMBOL_name);
 
 	zval const_CHAR_CATEGORY_INITIAL_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_INITIAL_PUNCTUATION_value, U_INITIAL_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_INITIAL_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_INITIAL_PUNCTUATION", sizeof("CHAR_CATEGORY_INITIAL_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_INITIAL_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_INITIAL_PUNCTUATION", strlen("CHAR_CATEGORY_INITIAL_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_INITIAL_PUNCTUATION_name, &const_CHAR_CATEGORY_INITIAL_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_INITIAL_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_FINAL_PUNCTUATION_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_FINAL_PUNCTUATION_value, U_FINAL_PUNCTUATION);
-	zend_string *const_CHAR_CATEGORY_FINAL_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_FINAL_PUNCTUATION", sizeof("CHAR_CATEGORY_FINAL_PUNCTUATION") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_FINAL_PUNCTUATION_name = zend_string_init_interned("CHAR_CATEGORY_FINAL_PUNCTUATION", strlen("CHAR_CATEGORY_FINAL_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_FINAL_PUNCTUATION_name, &const_CHAR_CATEGORY_FINAL_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_FINAL_PUNCTUATION_name);
 
 	zval const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_value;
 	ZVAL_LONG(&const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_value, U_CHAR_CATEGORY_COUNT);
-	zend_string *const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_name = zend_string_init_interned("CHAR_CATEGORY_CHAR_CATEGORY_COUNT", sizeof("CHAR_CATEGORY_CHAR_CATEGORY_COUNT") - 1, 1);
+	zend_string *const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_name = zend_string_init_interned("CHAR_CATEGORY_CHAR_CATEGORY_COUNT", strlen("CHAR_CATEGORY_CHAR_CATEGORY_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_name, &const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_CATEGORY_CHAR_CATEGORY_COUNT_name);
 
 	zval const_CHAR_DIRECTION_LEFT_TO_RIGHT_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_LEFT_TO_RIGHT_value, U_LEFT_TO_RIGHT);
-	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT", sizeof("CHAR_DIRECTION_LEFT_TO_RIGHT") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT", strlen("CHAR_DIRECTION_LEFT_TO_RIGHT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_LEFT_TO_RIGHT_name, &const_CHAR_DIRECTION_LEFT_TO_RIGHT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_LEFT_TO_RIGHT_name);
 
 	zval const_CHAR_DIRECTION_RIGHT_TO_LEFT_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_RIGHT_TO_LEFT_value, U_RIGHT_TO_LEFT);
-	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT", sizeof("CHAR_DIRECTION_RIGHT_TO_LEFT") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT", strlen("CHAR_DIRECTION_RIGHT_TO_LEFT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_RIGHT_TO_LEFT_name, &const_CHAR_DIRECTION_RIGHT_TO_LEFT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_RIGHT_TO_LEFT_name);
 
 	zval const_CHAR_DIRECTION_EUROPEAN_NUMBER_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_EUROPEAN_NUMBER_value, U_EUROPEAN_NUMBER);
-	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER", sizeof("CHAR_DIRECTION_EUROPEAN_NUMBER") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER", strlen("CHAR_DIRECTION_EUROPEAN_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_EUROPEAN_NUMBER_name, &const_CHAR_DIRECTION_EUROPEAN_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_EUROPEAN_NUMBER_name);
 
 	zval const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_value, U_EUROPEAN_NUMBER_SEPARATOR);
-	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR", sizeof("CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR", strlen("CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_name, &const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR_name);
 
 	zval const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_value, U_EUROPEAN_NUMBER_TERMINATOR);
-	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR", sizeof("CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_name = zend_string_init_interned("CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR", strlen("CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_name, &const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR_name);
 
 	zval const_CHAR_DIRECTION_ARABIC_NUMBER_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_ARABIC_NUMBER_value, U_ARABIC_NUMBER);
-	zend_string *const_CHAR_DIRECTION_ARABIC_NUMBER_name = zend_string_init_interned("CHAR_DIRECTION_ARABIC_NUMBER", sizeof("CHAR_DIRECTION_ARABIC_NUMBER") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_ARABIC_NUMBER_name = zend_string_init_interned("CHAR_DIRECTION_ARABIC_NUMBER", strlen("CHAR_DIRECTION_ARABIC_NUMBER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_ARABIC_NUMBER_name, &const_CHAR_DIRECTION_ARABIC_NUMBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_ARABIC_NUMBER_name);
 
 	zval const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_value, U_COMMON_NUMBER_SEPARATOR);
-	zend_string *const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR", sizeof("CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR", strlen("CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_name, &const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR_name);
 
 	zval const_CHAR_DIRECTION_BLOCK_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_BLOCK_SEPARATOR_value, U_BLOCK_SEPARATOR);
-	zend_string *const_CHAR_DIRECTION_BLOCK_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_BLOCK_SEPARATOR", sizeof("CHAR_DIRECTION_BLOCK_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_BLOCK_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_BLOCK_SEPARATOR", strlen("CHAR_DIRECTION_BLOCK_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_BLOCK_SEPARATOR_name, &const_CHAR_DIRECTION_BLOCK_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_BLOCK_SEPARATOR_name);
 
 	zval const_CHAR_DIRECTION_SEGMENT_SEPARATOR_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_SEGMENT_SEPARATOR_value, U_SEGMENT_SEPARATOR);
-	zend_string *const_CHAR_DIRECTION_SEGMENT_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_SEGMENT_SEPARATOR", sizeof("CHAR_DIRECTION_SEGMENT_SEPARATOR") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_SEGMENT_SEPARATOR_name = zend_string_init_interned("CHAR_DIRECTION_SEGMENT_SEPARATOR", strlen("CHAR_DIRECTION_SEGMENT_SEPARATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_SEGMENT_SEPARATOR_name, &const_CHAR_DIRECTION_SEGMENT_SEPARATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_SEGMENT_SEPARATOR_name);
 
 	zval const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_value, U_WHITE_SPACE_NEUTRAL);
-	zend_string *const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_WHITE_SPACE_NEUTRAL", sizeof("CHAR_DIRECTION_WHITE_SPACE_NEUTRAL") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_WHITE_SPACE_NEUTRAL", strlen("CHAR_DIRECTION_WHITE_SPACE_NEUTRAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_name, &const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_WHITE_SPACE_NEUTRAL_name);
 
 	zval const_CHAR_DIRECTION_OTHER_NEUTRAL_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_OTHER_NEUTRAL_value, U_OTHER_NEUTRAL);
-	zend_string *const_CHAR_DIRECTION_OTHER_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_OTHER_NEUTRAL", sizeof("CHAR_DIRECTION_OTHER_NEUTRAL") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_OTHER_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_OTHER_NEUTRAL", strlen("CHAR_DIRECTION_OTHER_NEUTRAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_OTHER_NEUTRAL_name, &const_CHAR_DIRECTION_OTHER_NEUTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_OTHER_NEUTRAL_name);
 
 	zval const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_value, U_LEFT_TO_RIGHT_EMBEDDING);
-	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING", sizeof("CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING", strlen("CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_name, &const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING_name);
 
 	zval const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_value, U_LEFT_TO_RIGHT_OVERRIDE);
-	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE", sizeof("CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE", strlen("CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_name, &const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE_name);
 
 	zval const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_value, U_RIGHT_TO_LEFT_ARABIC);
-	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC", sizeof("CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC", strlen("CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_name, &const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC_name);
 
 	zval const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_value, U_RIGHT_TO_LEFT_EMBEDDING);
-	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING", sizeof("CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING", strlen("CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_name, &const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING_name);
 
 	zval const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_value, U_RIGHT_TO_LEFT_OVERRIDE);
-	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE", sizeof("CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE", strlen("CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_name, &const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE_name);
 
 	zval const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_value, U_POP_DIRECTIONAL_FORMAT);
-	zend_string *const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_name = zend_string_init_interned("CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT", sizeof("CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_name = zend_string_init_interned("CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT", strlen("CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_name, &const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT_name);
 
 	zval const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_value, U_DIR_NON_SPACING_MARK);
-	zend_string *const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_name = zend_string_init_interned("CHAR_DIRECTION_DIR_NON_SPACING_MARK", sizeof("CHAR_DIRECTION_DIR_NON_SPACING_MARK") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_name = zend_string_init_interned("CHAR_DIRECTION_DIR_NON_SPACING_MARK", strlen("CHAR_DIRECTION_DIR_NON_SPACING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_name, &const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_DIR_NON_SPACING_MARK_name);
 
 	zval const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_value, U_BOUNDARY_NEUTRAL);
-	zend_string *const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_BOUNDARY_NEUTRAL", sizeof("CHAR_DIRECTION_BOUNDARY_NEUTRAL") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_name = zend_string_init_interned("CHAR_DIRECTION_BOUNDARY_NEUTRAL", strlen("CHAR_DIRECTION_BOUNDARY_NEUTRAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_name, &const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_BOUNDARY_NEUTRAL_name);
 
 	zval const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_value, U_FIRST_STRONG_ISOLATE);
-	zend_string *const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_FIRST_STRONG_ISOLATE", sizeof("CHAR_DIRECTION_FIRST_STRONG_ISOLATE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_FIRST_STRONG_ISOLATE", strlen("CHAR_DIRECTION_FIRST_STRONG_ISOLATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_name, &const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_FIRST_STRONG_ISOLATE_name);
 
 	zval const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_value, U_LEFT_TO_RIGHT_ISOLATE);
-	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE", sizeof("CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE", strlen("CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_name, &const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE_name);
 
 	zval const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_value, U_RIGHT_TO_LEFT_ISOLATE);
-	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE", sizeof("CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE", strlen("CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_name, &const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE_name);
 
 	zval const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_value, U_POP_DIRECTIONAL_ISOLATE);
-	zend_string *const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE", sizeof("CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_name = zend_string_init_interned("CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE", strlen("CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_name, &const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE_name);
 
 	zval const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_value;
 	ZVAL_LONG(&const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_value, U_CHAR_DIRECTION_COUNT);
-	zend_string *const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_name = zend_string_init_interned("CHAR_DIRECTION_CHAR_DIRECTION_COUNT", sizeof("CHAR_DIRECTION_CHAR_DIRECTION_COUNT") - 1, 1);
+	zend_string *const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_name = zend_string_init_interned("CHAR_DIRECTION_CHAR_DIRECTION_COUNT", strlen("CHAR_DIRECTION_CHAR_DIRECTION_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_name, &const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_DIRECTION_CHAR_DIRECTION_COUNT_name);
 
 	zval const_BLOCK_CODE_NO_BLOCK_value;
 	ZVAL_LONG(&const_BLOCK_CODE_NO_BLOCK_value, UBLOCK_NO_BLOCK);
-	zend_string *const_BLOCK_CODE_NO_BLOCK_name = zend_string_init_interned("BLOCK_CODE_NO_BLOCK", sizeof("BLOCK_CODE_NO_BLOCK") - 1, 1);
+	zend_string *const_BLOCK_CODE_NO_BLOCK_name = zend_string_init_interned("BLOCK_CODE_NO_BLOCK", strlen("BLOCK_CODE_NO_BLOCK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_NO_BLOCK_name, &const_BLOCK_CODE_NO_BLOCK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_NO_BLOCK_name);
 
 	zval const_BLOCK_CODE_BASIC_LATIN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BASIC_LATIN_value, UBLOCK_BASIC_LATIN);
-	zend_string *const_BLOCK_CODE_BASIC_LATIN_name = zend_string_init_interned("BLOCK_CODE_BASIC_LATIN", sizeof("BLOCK_CODE_BASIC_LATIN") - 1, 1);
+	zend_string *const_BLOCK_CODE_BASIC_LATIN_name = zend_string_init_interned("BLOCK_CODE_BASIC_LATIN", strlen("BLOCK_CODE_BASIC_LATIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BASIC_LATIN_name, &const_BLOCK_CODE_BASIC_LATIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BASIC_LATIN_name);
 
 	zval const_BLOCK_CODE_LATIN_1_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_1_SUPPLEMENT_value, UBLOCK_LATIN_1_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_LATIN_1_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_LATIN_1_SUPPLEMENT", sizeof("BLOCK_CODE_LATIN_1_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_1_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_LATIN_1_SUPPLEMENT", strlen("BLOCK_CODE_LATIN_1_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_1_SUPPLEMENT_name, &const_BLOCK_CODE_LATIN_1_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_1_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_A_value, UBLOCK_LATIN_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_A", sizeof("BLOCK_CODE_LATIN_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_A", strlen("BLOCK_CODE_LATIN_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_A_name, &const_BLOCK_CODE_LATIN_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_B_value, UBLOCK_LATIN_EXTENDED_B);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_B", sizeof("BLOCK_CODE_LATIN_EXTENDED_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_B", strlen("BLOCK_CODE_LATIN_EXTENDED_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_B_name, &const_BLOCK_CODE_LATIN_EXTENDED_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_B_name);
 
 	zval const_BLOCK_CODE_IPA_EXTENSIONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_IPA_EXTENSIONS_value, UBLOCK_IPA_EXTENSIONS);
-	zend_string *const_BLOCK_CODE_IPA_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_IPA_EXTENSIONS", sizeof("BLOCK_CODE_IPA_EXTENSIONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_IPA_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_IPA_EXTENSIONS", strlen("BLOCK_CODE_IPA_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_IPA_EXTENSIONS_name, &const_BLOCK_CODE_IPA_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_IPA_EXTENSIONS_name);
 
 	zval const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_value, UBLOCK_SPACING_MODIFIER_LETTERS);
-	zend_string *const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_name = zend_string_init_interned("BLOCK_CODE_SPACING_MODIFIER_LETTERS", sizeof("BLOCK_CODE_SPACING_MODIFIER_LETTERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_name = zend_string_init_interned("BLOCK_CODE_SPACING_MODIFIER_LETTERS", strlen("BLOCK_CODE_SPACING_MODIFIER_LETTERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_name, &const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SPACING_MODIFIER_LETTERS_name);
 
 	zval const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_value, UBLOCK_COMBINING_DIACRITICAL_MARKS);
-	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS", sizeof("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS", strlen("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_name, &const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_name);
 
 	zval const_BLOCK_CODE_GREEK_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GREEK_value, UBLOCK_GREEK);
-	zend_string *const_BLOCK_CODE_GREEK_name = zend_string_init_interned("BLOCK_CODE_GREEK", sizeof("BLOCK_CODE_GREEK") - 1, 1);
+	zend_string *const_BLOCK_CODE_GREEK_name = zend_string_init_interned("BLOCK_CODE_GREEK", strlen("BLOCK_CODE_GREEK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GREEK_name, &const_BLOCK_CODE_GREEK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GREEK_name);
 
 	zval const_BLOCK_CODE_CYRILLIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYRILLIC_value, UBLOCK_CYRILLIC);
-	zend_string *const_BLOCK_CODE_CYRILLIC_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC", sizeof("BLOCK_CODE_CYRILLIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYRILLIC_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC", strlen("BLOCK_CODE_CYRILLIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYRILLIC_name, &const_BLOCK_CODE_CYRILLIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYRILLIC_name);
 
 	zval const_BLOCK_CODE_ARMENIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARMENIAN_value, UBLOCK_ARMENIAN);
-	zend_string *const_BLOCK_CODE_ARMENIAN_name = zend_string_init_interned("BLOCK_CODE_ARMENIAN", sizeof("BLOCK_CODE_ARMENIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARMENIAN_name = zend_string_init_interned("BLOCK_CODE_ARMENIAN", strlen("BLOCK_CODE_ARMENIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARMENIAN_name, &const_BLOCK_CODE_ARMENIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARMENIAN_name);
 
 	zval const_BLOCK_CODE_HEBREW_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HEBREW_value, UBLOCK_HEBREW);
-	zend_string *const_BLOCK_CODE_HEBREW_name = zend_string_init_interned("BLOCK_CODE_HEBREW", sizeof("BLOCK_CODE_HEBREW") - 1, 1);
+	zend_string *const_BLOCK_CODE_HEBREW_name = zend_string_init_interned("BLOCK_CODE_HEBREW", strlen("BLOCK_CODE_HEBREW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HEBREW_name, &const_BLOCK_CODE_HEBREW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HEBREW_name);
 
 	zval const_BLOCK_CODE_ARABIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_value, UBLOCK_ARABIC);
-	zend_string *const_BLOCK_CODE_ARABIC_name = zend_string_init_interned("BLOCK_CODE_ARABIC", sizeof("BLOCK_CODE_ARABIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_name = zend_string_init_interned("BLOCK_CODE_ARABIC", strlen("BLOCK_CODE_ARABIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_name, &const_BLOCK_CODE_ARABIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_name);
 
 	zval const_BLOCK_CODE_SYRIAC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SYRIAC_value, UBLOCK_SYRIAC);
-	zend_string *const_BLOCK_CODE_SYRIAC_name = zend_string_init_interned("BLOCK_CODE_SYRIAC", sizeof("BLOCK_CODE_SYRIAC") - 1, 1);
+	zend_string *const_BLOCK_CODE_SYRIAC_name = zend_string_init_interned("BLOCK_CODE_SYRIAC", strlen("BLOCK_CODE_SYRIAC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SYRIAC_name, &const_BLOCK_CODE_SYRIAC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SYRIAC_name);
 
 	zval const_BLOCK_CODE_THAANA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_THAANA_value, UBLOCK_THAANA);
-	zend_string *const_BLOCK_CODE_THAANA_name = zend_string_init_interned("BLOCK_CODE_THAANA", sizeof("BLOCK_CODE_THAANA") - 1, 1);
+	zend_string *const_BLOCK_CODE_THAANA_name = zend_string_init_interned("BLOCK_CODE_THAANA", strlen("BLOCK_CODE_THAANA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_THAANA_name, &const_BLOCK_CODE_THAANA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_THAANA_name);
 
 	zval const_BLOCK_CODE_DEVANAGARI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DEVANAGARI_value, UBLOCK_DEVANAGARI);
-	zend_string *const_BLOCK_CODE_DEVANAGARI_name = zend_string_init_interned("BLOCK_CODE_DEVANAGARI", sizeof("BLOCK_CODE_DEVANAGARI") - 1, 1);
+	zend_string *const_BLOCK_CODE_DEVANAGARI_name = zend_string_init_interned("BLOCK_CODE_DEVANAGARI", strlen("BLOCK_CODE_DEVANAGARI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DEVANAGARI_name, &const_BLOCK_CODE_DEVANAGARI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DEVANAGARI_name);
 
 	zval const_BLOCK_CODE_BENGALI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BENGALI_value, UBLOCK_BENGALI);
-	zend_string *const_BLOCK_CODE_BENGALI_name = zend_string_init_interned("BLOCK_CODE_BENGALI", sizeof("BLOCK_CODE_BENGALI") - 1, 1);
+	zend_string *const_BLOCK_CODE_BENGALI_name = zend_string_init_interned("BLOCK_CODE_BENGALI", strlen("BLOCK_CODE_BENGALI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BENGALI_name, &const_BLOCK_CODE_BENGALI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BENGALI_name);
 
 	zval const_BLOCK_CODE_GURMUKHI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GURMUKHI_value, UBLOCK_GURMUKHI);
-	zend_string *const_BLOCK_CODE_GURMUKHI_name = zend_string_init_interned("BLOCK_CODE_GURMUKHI", sizeof("BLOCK_CODE_GURMUKHI") - 1, 1);
+	zend_string *const_BLOCK_CODE_GURMUKHI_name = zend_string_init_interned("BLOCK_CODE_GURMUKHI", strlen("BLOCK_CODE_GURMUKHI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GURMUKHI_name, &const_BLOCK_CODE_GURMUKHI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GURMUKHI_name);
 
 	zval const_BLOCK_CODE_GUJARATI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GUJARATI_value, UBLOCK_GUJARATI);
-	zend_string *const_BLOCK_CODE_GUJARATI_name = zend_string_init_interned("BLOCK_CODE_GUJARATI", sizeof("BLOCK_CODE_GUJARATI") - 1, 1);
+	zend_string *const_BLOCK_CODE_GUJARATI_name = zend_string_init_interned("BLOCK_CODE_GUJARATI", strlen("BLOCK_CODE_GUJARATI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GUJARATI_name, &const_BLOCK_CODE_GUJARATI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GUJARATI_name);
 
 	zval const_BLOCK_CODE_ORIYA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ORIYA_value, UBLOCK_ORIYA);
-	zend_string *const_BLOCK_CODE_ORIYA_name = zend_string_init_interned("BLOCK_CODE_ORIYA", sizeof("BLOCK_CODE_ORIYA") - 1, 1);
+	zend_string *const_BLOCK_CODE_ORIYA_name = zend_string_init_interned("BLOCK_CODE_ORIYA", strlen("BLOCK_CODE_ORIYA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ORIYA_name, &const_BLOCK_CODE_ORIYA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ORIYA_name);
 
 	zval const_BLOCK_CODE_TAMIL_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAMIL_value, UBLOCK_TAMIL);
-	zend_string *const_BLOCK_CODE_TAMIL_name = zend_string_init_interned("BLOCK_CODE_TAMIL", sizeof("BLOCK_CODE_TAMIL") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAMIL_name = zend_string_init_interned("BLOCK_CODE_TAMIL", strlen("BLOCK_CODE_TAMIL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAMIL_name, &const_BLOCK_CODE_TAMIL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAMIL_name);
 
 	zval const_BLOCK_CODE_TELUGU_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TELUGU_value, UBLOCK_TELUGU);
-	zend_string *const_BLOCK_CODE_TELUGU_name = zend_string_init_interned("BLOCK_CODE_TELUGU", sizeof("BLOCK_CODE_TELUGU") - 1, 1);
+	zend_string *const_BLOCK_CODE_TELUGU_name = zend_string_init_interned("BLOCK_CODE_TELUGU", strlen("BLOCK_CODE_TELUGU"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TELUGU_name, &const_BLOCK_CODE_TELUGU_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TELUGU_name);
 
 	zval const_BLOCK_CODE_KANNADA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KANNADA_value, UBLOCK_KANNADA);
-	zend_string *const_BLOCK_CODE_KANNADA_name = zend_string_init_interned("BLOCK_CODE_KANNADA", sizeof("BLOCK_CODE_KANNADA") - 1, 1);
+	zend_string *const_BLOCK_CODE_KANNADA_name = zend_string_init_interned("BLOCK_CODE_KANNADA", strlen("BLOCK_CODE_KANNADA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KANNADA_name, &const_BLOCK_CODE_KANNADA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KANNADA_name);
 
 	zval const_BLOCK_CODE_MALAYALAM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MALAYALAM_value, UBLOCK_MALAYALAM);
-	zend_string *const_BLOCK_CODE_MALAYALAM_name = zend_string_init_interned("BLOCK_CODE_MALAYALAM", sizeof("BLOCK_CODE_MALAYALAM") - 1, 1);
+	zend_string *const_BLOCK_CODE_MALAYALAM_name = zend_string_init_interned("BLOCK_CODE_MALAYALAM", strlen("BLOCK_CODE_MALAYALAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MALAYALAM_name, &const_BLOCK_CODE_MALAYALAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MALAYALAM_name);
 
 	zval const_BLOCK_CODE_SINHALA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SINHALA_value, UBLOCK_SINHALA);
-	zend_string *const_BLOCK_CODE_SINHALA_name = zend_string_init_interned("BLOCK_CODE_SINHALA", sizeof("BLOCK_CODE_SINHALA") - 1, 1);
+	zend_string *const_BLOCK_CODE_SINHALA_name = zend_string_init_interned("BLOCK_CODE_SINHALA", strlen("BLOCK_CODE_SINHALA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SINHALA_name, &const_BLOCK_CODE_SINHALA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SINHALA_name);
 
 	zval const_BLOCK_CODE_THAI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_THAI_value, UBLOCK_THAI);
-	zend_string *const_BLOCK_CODE_THAI_name = zend_string_init_interned("BLOCK_CODE_THAI", sizeof("BLOCK_CODE_THAI") - 1, 1);
+	zend_string *const_BLOCK_CODE_THAI_name = zend_string_init_interned("BLOCK_CODE_THAI", strlen("BLOCK_CODE_THAI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_THAI_name, &const_BLOCK_CODE_THAI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_THAI_name);
 
 	zval const_BLOCK_CODE_LAO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LAO_value, UBLOCK_LAO);
-	zend_string *const_BLOCK_CODE_LAO_name = zend_string_init_interned("BLOCK_CODE_LAO", sizeof("BLOCK_CODE_LAO") - 1, 1);
+	zend_string *const_BLOCK_CODE_LAO_name = zend_string_init_interned("BLOCK_CODE_LAO", strlen("BLOCK_CODE_LAO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LAO_name, &const_BLOCK_CODE_LAO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LAO_name);
 
 	zval const_BLOCK_CODE_TIBETAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TIBETAN_value, UBLOCK_TIBETAN);
-	zend_string *const_BLOCK_CODE_TIBETAN_name = zend_string_init_interned("BLOCK_CODE_TIBETAN", sizeof("BLOCK_CODE_TIBETAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_TIBETAN_name = zend_string_init_interned("BLOCK_CODE_TIBETAN", strlen("BLOCK_CODE_TIBETAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TIBETAN_name, &const_BLOCK_CODE_TIBETAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TIBETAN_name);
 
 	zval const_BLOCK_CODE_MYANMAR_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MYANMAR_value, UBLOCK_MYANMAR);
-	zend_string *const_BLOCK_CODE_MYANMAR_name = zend_string_init_interned("BLOCK_CODE_MYANMAR", sizeof("BLOCK_CODE_MYANMAR") - 1, 1);
+	zend_string *const_BLOCK_CODE_MYANMAR_name = zend_string_init_interned("BLOCK_CODE_MYANMAR", strlen("BLOCK_CODE_MYANMAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MYANMAR_name, &const_BLOCK_CODE_MYANMAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MYANMAR_name);
 
 	zval const_BLOCK_CODE_GEORGIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GEORGIAN_value, UBLOCK_GEORGIAN);
-	zend_string *const_BLOCK_CODE_GEORGIAN_name = zend_string_init_interned("BLOCK_CODE_GEORGIAN", sizeof("BLOCK_CODE_GEORGIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_GEORGIAN_name = zend_string_init_interned("BLOCK_CODE_GEORGIAN", strlen("BLOCK_CODE_GEORGIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GEORGIAN_name, &const_BLOCK_CODE_GEORGIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GEORGIAN_name);
 
 	zval const_BLOCK_CODE_HANGUL_JAMO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANGUL_JAMO_value, UBLOCK_HANGUL_JAMO);
-	zend_string *const_BLOCK_CODE_HANGUL_JAMO_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO", sizeof("BLOCK_CODE_HANGUL_JAMO") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANGUL_JAMO_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO", strlen("BLOCK_CODE_HANGUL_JAMO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANGUL_JAMO_name, &const_BLOCK_CODE_HANGUL_JAMO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANGUL_JAMO_name);
 
 	zval const_BLOCK_CODE_ETHIOPIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ETHIOPIC_value, UBLOCK_ETHIOPIC);
-	zend_string *const_BLOCK_CODE_ETHIOPIC_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC", sizeof("BLOCK_CODE_ETHIOPIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_ETHIOPIC_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC", strlen("BLOCK_CODE_ETHIOPIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ETHIOPIC_name, &const_BLOCK_CODE_ETHIOPIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ETHIOPIC_name);
 
 	zval const_BLOCK_CODE_CHEROKEE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CHEROKEE_value, UBLOCK_CHEROKEE);
-	zend_string *const_BLOCK_CODE_CHEROKEE_name = zend_string_init_interned("BLOCK_CODE_CHEROKEE", sizeof("BLOCK_CODE_CHEROKEE") - 1, 1);
+	zend_string *const_BLOCK_CODE_CHEROKEE_name = zend_string_init_interned("BLOCK_CODE_CHEROKEE", strlen("BLOCK_CODE_CHEROKEE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CHEROKEE_name, &const_BLOCK_CODE_CHEROKEE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CHEROKEE_name);
 
 	zval const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_value, UBLOCK_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS);
-	zend_string *const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_name = zend_string_init_interned("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS", sizeof("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS") - 1, 1);
+	zend_string *const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_name = zend_string_init_interned("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS", strlen("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_name, &const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_name);
 
 	zval const_BLOCK_CODE_OGHAM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OGHAM_value, UBLOCK_OGHAM);
-	zend_string *const_BLOCK_CODE_OGHAM_name = zend_string_init_interned("BLOCK_CODE_OGHAM", sizeof("BLOCK_CODE_OGHAM") - 1, 1);
+	zend_string *const_BLOCK_CODE_OGHAM_name = zend_string_init_interned("BLOCK_CODE_OGHAM", strlen("BLOCK_CODE_OGHAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OGHAM_name, &const_BLOCK_CODE_OGHAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OGHAM_name);
 
 	zval const_BLOCK_CODE_RUNIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_RUNIC_value, UBLOCK_RUNIC);
-	zend_string *const_BLOCK_CODE_RUNIC_name = zend_string_init_interned("BLOCK_CODE_RUNIC", sizeof("BLOCK_CODE_RUNIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_RUNIC_name = zend_string_init_interned("BLOCK_CODE_RUNIC", strlen("BLOCK_CODE_RUNIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_RUNIC_name, &const_BLOCK_CODE_RUNIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_RUNIC_name);
 
 	zval const_BLOCK_CODE_KHMER_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KHMER_value, UBLOCK_KHMER);
-	zend_string *const_BLOCK_CODE_KHMER_name = zend_string_init_interned("BLOCK_CODE_KHMER", sizeof("BLOCK_CODE_KHMER") - 1, 1);
+	zend_string *const_BLOCK_CODE_KHMER_name = zend_string_init_interned("BLOCK_CODE_KHMER", strlen("BLOCK_CODE_KHMER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KHMER_name, &const_BLOCK_CODE_KHMER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KHMER_name);
 
 	zval const_BLOCK_CODE_MONGOLIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MONGOLIAN_value, UBLOCK_MONGOLIAN);
-	zend_string *const_BLOCK_CODE_MONGOLIAN_name = zend_string_init_interned("BLOCK_CODE_MONGOLIAN", sizeof("BLOCK_CODE_MONGOLIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_MONGOLIAN_name = zend_string_init_interned("BLOCK_CODE_MONGOLIAN", strlen("BLOCK_CODE_MONGOLIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MONGOLIAN_name, &const_BLOCK_CODE_MONGOLIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MONGOLIAN_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_value, UBLOCK_LATIN_EXTENDED_ADDITIONAL);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL", sizeof("BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL", strlen("BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_name, &const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL_name);
 
 	zval const_BLOCK_CODE_GREEK_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GREEK_EXTENDED_value, UBLOCK_GREEK_EXTENDED);
-	zend_string *const_BLOCK_CODE_GREEK_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_GREEK_EXTENDED", sizeof("BLOCK_CODE_GREEK_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_GREEK_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_GREEK_EXTENDED", strlen("BLOCK_CODE_GREEK_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GREEK_EXTENDED_name, &const_BLOCK_CODE_GREEK_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GREEK_EXTENDED_name);
 
 	zval const_BLOCK_CODE_GENERAL_PUNCTUATION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GENERAL_PUNCTUATION_value, UBLOCK_GENERAL_PUNCTUATION);
-	zend_string *const_BLOCK_CODE_GENERAL_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_GENERAL_PUNCTUATION", sizeof("BLOCK_CODE_GENERAL_PUNCTUATION") - 1, 1);
+	zend_string *const_BLOCK_CODE_GENERAL_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_GENERAL_PUNCTUATION", strlen("BLOCK_CODE_GENERAL_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GENERAL_PUNCTUATION_name, &const_BLOCK_CODE_GENERAL_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GENERAL_PUNCTUATION_name);
 
 	zval const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_value, UBLOCK_SUPERSCRIPTS_AND_SUBSCRIPTS);
-	zend_string *const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_name = zend_string_init_interned("BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS", sizeof("BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_name = zend_string_init_interned("BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS", strlen("BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_name, &const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS_name);
 
 	zval const_BLOCK_CODE_CURRENCY_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CURRENCY_SYMBOLS_value, UBLOCK_CURRENCY_SYMBOLS);
-	zend_string *const_BLOCK_CODE_CURRENCY_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_CURRENCY_SYMBOLS", sizeof("BLOCK_CODE_CURRENCY_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_CURRENCY_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_CURRENCY_SYMBOLS", strlen("BLOCK_CODE_CURRENCY_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CURRENCY_SYMBOLS_name, &const_BLOCK_CODE_CURRENCY_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CURRENCY_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_value, UBLOCK_COMBINING_MARKS_FOR_SYMBOLS);
-	zend_string *const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS", sizeof("BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS", strlen("BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_name, &const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_LETTERLIKE_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LETTERLIKE_SYMBOLS_value, UBLOCK_LETTERLIKE_SYMBOLS);
-	zend_string *const_BLOCK_CODE_LETTERLIKE_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_LETTERLIKE_SYMBOLS", sizeof("BLOCK_CODE_LETTERLIKE_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_LETTERLIKE_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_LETTERLIKE_SYMBOLS", strlen("BLOCK_CODE_LETTERLIKE_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LETTERLIKE_SYMBOLS_name, &const_BLOCK_CODE_LETTERLIKE_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LETTERLIKE_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_NUMBER_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_NUMBER_FORMS_value, UBLOCK_NUMBER_FORMS);
-	zend_string *const_BLOCK_CODE_NUMBER_FORMS_name = zend_string_init_interned("BLOCK_CODE_NUMBER_FORMS", sizeof("BLOCK_CODE_NUMBER_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_NUMBER_FORMS_name = zend_string_init_interned("BLOCK_CODE_NUMBER_FORMS", strlen("BLOCK_CODE_NUMBER_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_NUMBER_FORMS_name, &const_BLOCK_CODE_NUMBER_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_NUMBER_FORMS_name);
 
 	zval const_BLOCK_CODE_ARROWS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARROWS_value, UBLOCK_ARROWS);
-	zend_string *const_BLOCK_CODE_ARROWS_name = zend_string_init_interned("BLOCK_CODE_ARROWS", sizeof("BLOCK_CODE_ARROWS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARROWS_name = zend_string_init_interned("BLOCK_CODE_ARROWS", strlen("BLOCK_CODE_ARROWS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARROWS_name, &const_BLOCK_CODE_ARROWS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARROWS_name);
 
 	zval const_BLOCK_CODE_MATHEMATICAL_OPERATORS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MATHEMATICAL_OPERATORS_value, UBLOCK_MATHEMATICAL_OPERATORS);
-	zend_string *const_BLOCK_CODE_MATHEMATICAL_OPERATORS_name = zend_string_init_interned("BLOCK_CODE_MATHEMATICAL_OPERATORS", sizeof("BLOCK_CODE_MATHEMATICAL_OPERATORS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MATHEMATICAL_OPERATORS_name = zend_string_init_interned("BLOCK_CODE_MATHEMATICAL_OPERATORS", strlen("BLOCK_CODE_MATHEMATICAL_OPERATORS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MATHEMATICAL_OPERATORS_name, &const_BLOCK_CODE_MATHEMATICAL_OPERATORS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MATHEMATICAL_OPERATORS_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_value, UBLOCK_MISCELLANEOUS_TECHNICAL);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_TECHNICAL", sizeof("BLOCK_CODE_MISCELLANEOUS_TECHNICAL") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_TECHNICAL", strlen("BLOCK_CODE_MISCELLANEOUS_TECHNICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_name, &const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_TECHNICAL_name);
 
 	zval const_BLOCK_CODE_CONTROL_PICTURES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CONTROL_PICTURES_value, UBLOCK_CONTROL_PICTURES);
-	zend_string *const_BLOCK_CODE_CONTROL_PICTURES_name = zend_string_init_interned("BLOCK_CODE_CONTROL_PICTURES", sizeof("BLOCK_CODE_CONTROL_PICTURES") - 1, 1);
+	zend_string *const_BLOCK_CODE_CONTROL_PICTURES_name = zend_string_init_interned("BLOCK_CODE_CONTROL_PICTURES", strlen("BLOCK_CODE_CONTROL_PICTURES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CONTROL_PICTURES_name, &const_BLOCK_CODE_CONTROL_PICTURES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CONTROL_PICTURES_name);
 
 	zval const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_value, UBLOCK_OPTICAL_CHARACTER_RECOGNITION);
-	zend_string *const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_name = zend_string_init_interned("BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION", sizeof("BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION") - 1, 1);
+	zend_string *const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_name = zend_string_init_interned("BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION", strlen("BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_name, &const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION_name);
 
 	zval const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_value, UBLOCK_ENCLOSED_ALPHANUMERICS);
-	zend_string *const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_ALPHANUMERICS", sizeof("BLOCK_CODE_ENCLOSED_ALPHANUMERICS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_ALPHANUMERICS", strlen("BLOCK_CODE_ENCLOSED_ALPHANUMERICS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_name, &const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ENCLOSED_ALPHANUMERICS_name);
 
 	zval const_BLOCK_CODE_BOX_DRAWING_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BOX_DRAWING_value, UBLOCK_BOX_DRAWING);
-	zend_string *const_BLOCK_CODE_BOX_DRAWING_name = zend_string_init_interned("BLOCK_CODE_BOX_DRAWING", sizeof("BLOCK_CODE_BOX_DRAWING") - 1, 1);
+	zend_string *const_BLOCK_CODE_BOX_DRAWING_name = zend_string_init_interned("BLOCK_CODE_BOX_DRAWING", strlen("BLOCK_CODE_BOX_DRAWING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BOX_DRAWING_name, &const_BLOCK_CODE_BOX_DRAWING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BOX_DRAWING_name);
 
 	zval const_BLOCK_CODE_BLOCK_ELEMENTS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BLOCK_ELEMENTS_value, UBLOCK_BLOCK_ELEMENTS);
-	zend_string *const_BLOCK_CODE_BLOCK_ELEMENTS_name = zend_string_init_interned("BLOCK_CODE_BLOCK_ELEMENTS", sizeof("BLOCK_CODE_BLOCK_ELEMENTS") - 1, 1);
+	zend_string *const_BLOCK_CODE_BLOCK_ELEMENTS_name = zend_string_init_interned("BLOCK_CODE_BLOCK_ELEMENTS", strlen("BLOCK_CODE_BLOCK_ELEMENTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BLOCK_ELEMENTS_name, &const_BLOCK_CODE_BLOCK_ELEMENTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BLOCK_ELEMENTS_name);
 
 	zval const_BLOCK_CODE_GEOMETRIC_SHAPES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GEOMETRIC_SHAPES_value, UBLOCK_GEOMETRIC_SHAPES);
-	zend_string *const_BLOCK_CODE_GEOMETRIC_SHAPES_name = zend_string_init_interned("BLOCK_CODE_GEOMETRIC_SHAPES", sizeof("BLOCK_CODE_GEOMETRIC_SHAPES") - 1, 1);
+	zend_string *const_BLOCK_CODE_GEOMETRIC_SHAPES_name = zend_string_init_interned("BLOCK_CODE_GEOMETRIC_SHAPES", strlen("BLOCK_CODE_GEOMETRIC_SHAPES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GEOMETRIC_SHAPES_name, &const_BLOCK_CODE_GEOMETRIC_SHAPES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GEOMETRIC_SHAPES_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_value, UBLOCK_MISCELLANEOUS_SYMBOLS);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS", sizeof("BLOCK_CODE_MISCELLANEOUS_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS", strlen("BLOCK_CODE_MISCELLANEOUS_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_name, &const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_DINGBATS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DINGBATS_value, UBLOCK_DINGBATS);
-	zend_string *const_BLOCK_CODE_DINGBATS_name = zend_string_init_interned("BLOCK_CODE_DINGBATS", sizeof("BLOCK_CODE_DINGBATS") - 1, 1);
+	zend_string *const_BLOCK_CODE_DINGBATS_name = zend_string_init_interned("BLOCK_CODE_DINGBATS", strlen("BLOCK_CODE_DINGBATS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DINGBATS_name, &const_BLOCK_CODE_DINGBATS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DINGBATS_name);
 
 	zval const_BLOCK_CODE_BRAILLE_PATTERNS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BRAILLE_PATTERNS_value, UBLOCK_BRAILLE_PATTERNS);
-	zend_string *const_BLOCK_CODE_BRAILLE_PATTERNS_name = zend_string_init_interned("BLOCK_CODE_BRAILLE_PATTERNS", sizeof("BLOCK_CODE_BRAILLE_PATTERNS") - 1, 1);
+	zend_string *const_BLOCK_CODE_BRAILLE_PATTERNS_name = zend_string_init_interned("BLOCK_CODE_BRAILLE_PATTERNS", strlen("BLOCK_CODE_BRAILLE_PATTERNS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BRAILLE_PATTERNS_name, &const_BLOCK_CODE_BRAILLE_PATTERNS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BRAILLE_PATTERNS_name);
 
 	zval const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_value, UBLOCK_CJK_RADICALS_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CJK_RADICALS_SUPPLEMENT", sizeof("BLOCK_CODE_CJK_RADICALS_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CJK_RADICALS_SUPPLEMENT", strlen("BLOCK_CODE_CJK_RADICALS_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_name, &const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_RADICALS_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_KANGXI_RADICALS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KANGXI_RADICALS_value, UBLOCK_KANGXI_RADICALS);
-	zend_string *const_BLOCK_CODE_KANGXI_RADICALS_name = zend_string_init_interned("BLOCK_CODE_KANGXI_RADICALS", sizeof("BLOCK_CODE_KANGXI_RADICALS") - 1, 1);
+	zend_string *const_BLOCK_CODE_KANGXI_RADICALS_name = zend_string_init_interned("BLOCK_CODE_KANGXI_RADICALS", strlen("BLOCK_CODE_KANGXI_RADICALS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KANGXI_RADICALS_name, &const_BLOCK_CODE_KANGXI_RADICALS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KANGXI_RADICALS_name);
 
 	zval const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_value, UBLOCK_IDEOGRAPHIC_DESCRIPTION_CHARACTERS);
-	zend_string *const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_name = zend_string_init_interned("BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS", sizeof("BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_name = zend_string_init_interned("BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS", strlen("BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_name, &const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS_name);
 
 	zval const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_value, UBLOCK_CJK_SYMBOLS_AND_PUNCTUATION);
-	zend_string *const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION", sizeof("BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION", strlen("BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_name, &const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION_name);
 
 	zval const_BLOCK_CODE_HIRAGANA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HIRAGANA_value, UBLOCK_HIRAGANA);
-	zend_string *const_BLOCK_CODE_HIRAGANA_name = zend_string_init_interned("BLOCK_CODE_HIRAGANA", sizeof("BLOCK_CODE_HIRAGANA") - 1, 1);
+	zend_string *const_BLOCK_CODE_HIRAGANA_name = zend_string_init_interned("BLOCK_CODE_HIRAGANA", strlen("BLOCK_CODE_HIRAGANA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HIRAGANA_name, &const_BLOCK_CODE_HIRAGANA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HIRAGANA_name);
 
 	zval const_BLOCK_CODE_KATAKANA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KATAKANA_value, UBLOCK_KATAKANA);
-	zend_string *const_BLOCK_CODE_KATAKANA_name = zend_string_init_interned("BLOCK_CODE_KATAKANA", sizeof("BLOCK_CODE_KATAKANA") - 1, 1);
+	zend_string *const_BLOCK_CODE_KATAKANA_name = zend_string_init_interned("BLOCK_CODE_KATAKANA", strlen("BLOCK_CODE_KATAKANA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KATAKANA_name, &const_BLOCK_CODE_KATAKANA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KATAKANA_name);
 
 	zval const_BLOCK_CODE_BOPOMOFO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BOPOMOFO_value, UBLOCK_BOPOMOFO);
-	zend_string *const_BLOCK_CODE_BOPOMOFO_name = zend_string_init_interned("BLOCK_CODE_BOPOMOFO", sizeof("BLOCK_CODE_BOPOMOFO") - 1, 1);
+	zend_string *const_BLOCK_CODE_BOPOMOFO_name = zend_string_init_interned("BLOCK_CODE_BOPOMOFO", strlen("BLOCK_CODE_BOPOMOFO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BOPOMOFO_name, &const_BLOCK_CODE_BOPOMOFO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BOPOMOFO_name);
 
 	zval const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_value, UBLOCK_HANGUL_COMPATIBILITY_JAMO);
-	zend_string *const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_name = zend_string_init_interned("BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO", sizeof("BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_name = zend_string_init_interned("BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO", strlen("BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_name, &const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO_name);
 
 	zval const_BLOCK_CODE_KANBUN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KANBUN_value, UBLOCK_KANBUN);
-	zend_string *const_BLOCK_CODE_KANBUN_name = zend_string_init_interned("BLOCK_CODE_KANBUN", sizeof("BLOCK_CODE_KANBUN") - 1, 1);
+	zend_string *const_BLOCK_CODE_KANBUN_name = zend_string_init_interned("BLOCK_CODE_KANBUN", strlen("BLOCK_CODE_KANBUN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KANBUN_name, &const_BLOCK_CODE_KANBUN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KANBUN_name);
 
 	zval const_BLOCK_CODE_BOPOMOFO_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BOPOMOFO_EXTENDED_value, UBLOCK_BOPOMOFO_EXTENDED);
-	zend_string *const_BLOCK_CODE_BOPOMOFO_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_BOPOMOFO_EXTENDED", sizeof("BLOCK_CODE_BOPOMOFO_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_BOPOMOFO_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_BOPOMOFO_EXTENDED", strlen("BLOCK_CODE_BOPOMOFO_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BOPOMOFO_EXTENDED_name, &const_BLOCK_CODE_BOPOMOFO_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BOPOMOFO_EXTENDED_name);
 
 	zval const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_value, UBLOCK_ENCLOSED_CJK_LETTERS_AND_MONTHS);
-	zend_string *const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS", sizeof("BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS", strlen("BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_name, &const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS_name);
 
 	zval const_BLOCK_CODE_CJK_COMPATIBILITY_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_COMPATIBILITY_value, UBLOCK_CJK_COMPATIBILITY);
-	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY", sizeof("BLOCK_CODE_CJK_COMPATIBILITY") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY", strlen("BLOCK_CODE_CJK_COMPATIBILITY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_COMPATIBILITY_name, &const_BLOCK_CODE_CJK_COMPATIBILITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_COMPATIBILITY_name);
 
 	zval const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_value, UBLOCK_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A);
-	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A", sizeof("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A", strlen("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_name, &const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A_name);
 
 	zval const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_value, UBLOCK_CJK_UNIFIED_IDEOGRAPHS);
-	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS", sizeof("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS", strlen("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_name, &const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_name);
 
 	zval const_BLOCK_CODE_YI_SYLLABLES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_YI_SYLLABLES_value, UBLOCK_YI_SYLLABLES);
-	zend_string *const_BLOCK_CODE_YI_SYLLABLES_name = zend_string_init_interned("BLOCK_CODE_YI_SYLLABLES", sizeof("BLOCK_CODE_YI_SYLLABLES") - 1, 1);
+	zend_string *const_BLOCK_CODE_YI_SYLLABLES_name = zend_string_init_interned("BLOCK_CODE_YI_SYLLABLES", strlen("BLOCK_CODE_YI_SYLLABLES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_YI_SYLLABLES_name, &const_BLOCK_CODE_YI_SYLLABLES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_YI_SYLLABLES_name);
 
 	zval const_BLOCK_CODE_YI_RADICALS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_YI_RADICALS_value, UBLOCK_YI_RADICALS);
-	zend_string *const_BLOCK_CODE_YI_RADICALS_name = zend_string_init_interned("BLOCK_CODE_YI_RADICALS", sizeof("BLOCK_CODE_YI_RADICALS") - 1, 1);
+	zend_string *const_BLOCK_CODE_YI_RADICALS_name = zend_string_init_interned("BLOCK_CODE_YI_RADICALS", strlen("BLOCK_CODE_YI_RADICALS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_YI_RADICALS_name, &const_BLOCK_CODE_YI_RADICALS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_YI_RADICALS_name);
 
 	zval const_BLOCK_CODE_HANGUL_SYLLABLES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANGUL_SYLLABLES_value, UBLOCK_HANGUL_SYLLABLES);
-	zend_string *const_BLOCK_CODE_HANGUL_SYLLABLES_name = zend_string_init_interned("BLOCK_CODE_HANGUL_SYLLABLES", sizeof("BLOCK_CODE_HANGUL_SYLLABLES") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANGUL_SYLLABLES_name = zend_string_init_interned("BLOCK_CODE_HANGUL_SYLLABLES", strlen("BLOCK_CODE_HANGUL_SYLLABLES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANGUL_SYLLABLES_name, &const_BLOCK_CODE_HANGUL_SYLLABLES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANGUL_SYLLABLES_name);
 
 	zval const_BLOCK_CODE_HIGH_SURROGATES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HIGH_SURROGATES_value, UBLOCK_HIGH_SURROGATES);
-	zend_string *const_BLOCK_CODE_HIGH_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_HIGH_SURROGATES", sizeof("BLOCK_CODE_HIGH_SURROGATES") - 1, 1);
+	zend_string *const_BLOCK_CODE_HIGH_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_HIGH_SURROGATES", strlen("BLOCK_CODE_HIGH_SURROGATES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HIGH_SURROGATES_name, &const_BLOCK_CODE_HIGH_SURROGATES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HIGH_SURROGATES_name);
 
 	zval const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_value, UBLOCK_HIGH_PRIVATE_USE_SURROGATES);
-	zend_string *const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES", sizeof("BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES") - 1, 1);
+	zend_string *const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES", strlen("BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_name, &const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES_name);
 
 	zval const_BLOCK_CODE_LOW_SURROGATES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LOW_SURROGATES_value, UBLOCK_LOW_SURROGATES);
-	zend_string *const_BLOCK_CODE_LOW_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_LOW_SURROGATES", sizeof("BLOCK_CODE_LOW_SURROGATES") - 1, 1);
+	zend_string *const_BLOCK_CODE_LOW_SURROGATES_name = zend_string_init_interned("BLOCK_CODE_LOW_SURROGATES", strlen("BLOCK_CODE_LOW_SURROGATES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LOW_SURROGATES_name, &const_BLOCK_CODE_LOW_SURROGATES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LOW_SURROGATES_name);
 
 	zval const_BLOCK_CODE_PRIVATE_USE_AREA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PRIVATE_USE_AREA_value, UBLOCK_PRIVATE_USE_AREA);
-	zend_string *const_BLOCK_CODE_PRIVATE_USE_AREA_name = zend_string_init_interned("BLOCK_CODE_PRIVATE_USE_AREA", sizeof("BLOCK_CODE_PRIVATE_USE_AREA") - 1, 1);
+	zend_string *const_BLOCK_CODE_PRIVATE_USE_AREA_name = zend_string_init_interned("BLOCK_CODE_PRIVATE_USE_AREA", strlen("BLOCK_CODE_PRIVATE_USE_AREA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PRIVATE_USE_AREA_name, &const_BLOCK_CODE_PRIVATE_USE_AREA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PRIVATE_USE_AREA_name);
 
 	zval const_BLOCK_CODE_PRIVATE_USE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PRIVATE_USE_value, UBLOCK_PRIVATE_USE);
-	zend_string *const_BLOCK_CODE_PRIVATE_USE_name = zend_string_init_interned("BLOCK_CODE_PRIVATE_USE", sizeof("BLOCK_CODE_PRIVATE_USE") - 1, 1);
+	zend_string *const_BLOCK_CODE_PRIVATE_USE_name = zend_string_init_interned("BLOCK_CODE_PRIVATE_USE", strlen("BLOCK_CODE_PRIVATE_USE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PRIVATE_USE_name, &const_BLOCK_CODE_PRIVATE_USE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PRIVATE_USE_name);
 
 	zval const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_value, UBLOCK_CJK_COMPATIBILITY_IDEOGRAPHS);
-	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS", sizeof("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS", strlen("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_name, &const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_name);
 
 	zval const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_value, UBLOCK_ALPHABETIC_PRESENTATION_FORMS);
-	zend_string *const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_name = zend_string_init_interned("BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS", sizeof("BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_name = zend_string_init_interned("BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS", strlen("BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_name, &const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS_name);
 
 	zval const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_value, UBLOCK_ARABIC_PRESENTATION_FORMS_A);
-	zend_string *const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_name = zend_string_init_interned("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A", sizeof("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_name = zend_string_init_interned("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A", strlen("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_name, &const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A_name);
 
 	zval const_BLOCK_CODE_COMBINING_HALF_MARKS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMBINING_HALF_MARKS_value, UBLOCK_COMBINING_HALF_MARKS);
-	zend_string *const_BLOCK_CODE_COMBINING_HALF_MARKS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_HALF_MARKS", sizeof("BLOCK_CODE_COMBINING_HALF_MARKS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMBINING_HALF_MARKS_name = zend_string_init_interned("BLOCK_CODE_COMBINING_HALF_MARKS", strlen("BLOCK_CODE_COMBINING_HALF_MARKS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMBINING_HALF_MARKS_name, &const_BLOCK_CODE_COMBINING_HALF_MARKS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMBINING_HALF_MARKS_name);
 
 	zval const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_value, UBLOCK_CJK_COMPATIBILITY_FORMS);
-	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_FORMS", sizeof("BLOCK_CODE_CJK_COMPATIBILITY_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_FORMS", strlen("BLOCK_CODE_CJK_COMPATIBILITY_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_name, &const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_COMPATIBILITY_FORMS_name);
 
 	zval const_BLOCK_CODE_SMALL_FORM_VARIANTS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SMALL_FORM_VARIANTS_value, UBLOCK_SMALL_FORM_VARIANTS);
-	zend_string *const_BLOCK_CODE_SMALL_FORM_VARIANTS_name = zend_string_init_interned("BLOCK_CODE_SMALL_FORM_VARIANTS", sizeof("BLOCK_CODE_SMALL_FORM_VARIANTS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SMALL_FORM_VARIANTS_name = zend_string_init_interned("BLOCK_CODE_SMALL_FORM_VARIANTS", strlen("BLOCK_CODE_SMALL_FORM_VARIANTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SMALL_FORM_VARIANTS_name, &const_BLOCK_CODE_SMALL_FORM_VARIANTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SMALL_FORM_VARIANTS_name);
 
 	zval const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_value, UBLOCK_ARABIC_PRESENTATION_FORMS_B);
-	zend_string *const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_name = zend_string_init_interned("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B", sizeof("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_name = zend_string_init_interned("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B", strlen("BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_name, &const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B_name);
 
 	zval const_BLOCK_CODE_SPECIALS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SPECIALS_value, UBLOCK_SPECIALS);
-	zend_string *const_BLOCK_CODE_SPECIALS_name = zend_string_init_interned("BLOCK_CODE_SPECIALS", sizeof("BLOCK_CODE_SPECIALS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SPECIALS_name = zend_string_init_interned("BLOCK_CODE_SPECIALS", strlen("BLOCK_CODE_SPECIALS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SPECIALS_name, &const_BLOCK_CODE_SPECIALS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SPECIALS_name);
 
 	zval const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_value, UBLOCK_HALFWIDTH_AND_FULLWIDTH_FORMS);
-	zend_string *const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_name = zend_string_init_interned("BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS", sizeof("BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_name = zend_string_init_interned("BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS", strlen("BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_name, &const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS_name);
 
 	zval const_BLOCK_CODE_OLD_ITALIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_ITALIC_value, UBLOCK_OLD_ITALIC);
-	zend_string *const_BLOCK_CODE_OLD_ITALIC_name = zend_string_init_interned("BLOCK_CODE_OLD_ITALIC", sizeof("BLOCK_CODE_OLD_ITALIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_ITALIC_name = zend_string_init_interned("BLOCK_CODE_OLD_ITALIC", strlen("BLOCK_CODE_OLD_ITALIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_ITALIC_name, &const_BLOCK_CODE_OLD_ITALIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_ITALIC_name);
 
 	zval const_BLOCK_CODE_GOTHIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GOTHIC_value, UBLOCK_GOTHIC);
-	zend_string *const_BLOCK_CODE_GOTHIC_name = zend_string_init_interned("BLOCK_CODE_GOTHIC", sizeof("BLOCK_CODE_GOTHIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_GOTHIC_name = zend_string_init_interned("BLOCK_CODE_GOTHIC", strlen("BLOCK_CODE_GOTHIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GOTHIC_name, &const_BLOCK_CODE_GOTHIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GOTHIC_name);
 
 	zval const_BLOCK_CODE_DESERET_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DESERET_value, UBLOCK_DESERET);
-	zend_string *const_BLOCK_CODE_DESERET_name = zend_string_init_interned("BLOCK_CODE_DESERET", sizeof("BLOCK_CODE_DESERET") - 1, 1);
+	zend_string *const_BLOCK_CODE_DESERET_name = zend_string_init_interned("BLOCK_CODE_DESERET", strlen("BLOCK_CODE_DESERET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DESERET_name, &const_BLOCK_CODE_DESERET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DESERET_name);
 
 	zval const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_value, UBLOCK_BYZANTINE_MUSICAL_SYMBOLS);
-	zend_string *const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS", sizeof("BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS", strlen("BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_name, &const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_MUSICAL_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MUSICAL_SYMBOLS_value, UBLOCK_MUSICAL_SYMBOLS);
-	zend_string *const_BLOCK_CODE_MUSICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MUSICAL_SYMBOLS", sizeof("BLOCK_CODE_MUSICAL_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MUSICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MUSICAL_SYMBOLS", strlen("BLOCK_CODE_MUSICAL_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MUSICAL_SYMBOLS_name, &const_BLOCK_CODE_MUSICAL_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MUSICAL_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_value, UBLOCK_MATHEMATICAL_ALPHANUMERIC_SYMBOLS);
-	zend_string *const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS", sizeof("BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS", strlen("BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_name, &const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_value, UBLOCK_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B);
-	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B", sizeof("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B", strlen("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_name, &const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B_name);
 
 	zval const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_value, UBLOCK_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT", sizeof("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT", strlen("BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_name, &const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_TAGS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAGS_value, UBLOCK_TAGS);
-	zend_string *const_BLOCK_CODE_TAGS_name = zend_string_init_interned("BLOCK_CODE_TAGS", sizeof("BLOCK_CODE_TAGS") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAGS_name = zend_string_init_interned("BLOCK_CODE_TAGS", strlen("BLOCK_CODE_TAGS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAGS_name, &const_BLOCK_CODE_TAGS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAGS_name);
 
 	zval const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_value, UBLOCK_CYRILLIC_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_SUPPLEMENT", sizeof("BLOCK_CODE_CYRILLIC_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_SUPPLEMENT", strlen("BLOCK_CODE_CYRILLIC_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_name, &const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYRILLIC_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_value, UBLOCK_CYRILLIC_SUPPLEMENTARY);
-	zend_string *const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_SUPPLEMENTARY", sizeof("BLOCK_CODE_CYRILLIC_SUPPLEMENTARY") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_SUPPLEMENTARY", strlen("BLOCK_CODE_CYRILLIC_SUPPLEMENTARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_name, &const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYRILLIC_SUPPLEMENTARY_name);
 
 	zval const_BLOCK_CODE_TAGALOG_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAGALOG_value, UBLOCK_TAGALOG);
-	zend_string *const_BLOCK_CODE_TAGALOG_name = zend_string_init_interned("BLOCK_CODE_TAGALOG", sizeof("BLOCK_CODE_TAGALOG") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAGALOG_name = zend_string_init_interned("BLOCK_CODE_TAGALOG", strlen("BLOCK_CODE_TAGALOG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAGALOG_name, &const_BLOCK_CODE_TAGALOG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAGALOG_name);
 
 	zval const_BLOCK_CODE_HANUNOO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANUNOO_value, UBLOCK_HANUNOO);
-	zend_string *const_BLOCK_CODE_HANUNOO_name = zend_string_init_interned("BLOCK_CODE_HANUNOO", sizeof("BLOCK_CODE_HANUNOO") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANUNOO_name = zend_string_init_interned("BLOCK_CODE_HANUNOO", strlen("BLOCK_CODE_HANUNOO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANUNOO_name, &const_BLOCK_CODE_HANUNOO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANUNOO_name);
 
 	zval const_BLOCK_CODE_BUHID_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BUHID_value, UBLOCK_BUHID);
-	zend_string *const_BLOCK_CODE_BUHID_name = zend_string_init_interned("BLOCK_CODE_BUHID", sizeof("BLOCK_CODE_BUHID") - 1, 1);
+	zend_string *const_BLOCK_CODE_BUHID_name = zend_string_init_interned("BLOCK_CODE_BUHID", strlen("BLOCK_CODE_BUHID"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BUHID_name, &const_BLOCK_CODE_BUHID_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BUHID_name);
 
 	zval const_BLOCK_CODE_TAGBANWA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAGBANWA_value, UBLOCK_TAGBANWA);
-	zend_string *const_BLOCK_CODE_TAGBANWA_name = zend_string_init_interned("BLOCK_CODE_TAGBANWA", sizeof("BLOCK_CODE_TAGBANWA") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAGBANWA_name = zend_string_init_interned("BLOCK_CODE_TAGBANWA", strlen("BLOCK_CODE_TAGBANWA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAGBANWA_name, &const_BLOCK_CODE_TAGBANWA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAGBANWA_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_value, UBLOCK_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A", sizeof("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A", strlen("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_name, &const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_value, UBLOCK_SUPPLEMENTAL_ARROWS_A);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_A", sizeof("BLOCK_CODE_SUPPLEMENTAL_ARROWS_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_A", strlen("BLOCK_CODE_SUPPLEMENTAL_ARROWS_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_name, &const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_A_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_value, UBLOCK_SUPPLEMENTAL_ARROWS_B);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_B", sizeof("BLOCK_CODE_SUPPLEMENTAL_ARROWS_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_B", strlen("BLOCK_CODE_SUPPLEMENTAL_ARROWS_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_name, &const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_B_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_value, UBLOCK_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B", sizeof("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B", strlen("BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_name, &const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_value, UBLOCK_SUPPLEMENTAL_MATHEMATICAL_OPERATORS);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS", sizeof("BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS", strlen("BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_name, &const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS_name);
 
 	zval const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_value, UBLOCK_KATAKANA_PHONETIC_EXTENSIONS);
-	zend_string *const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS", sizeof("BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS", strlen("BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_name, &const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS_name);
 
 	zval const_BLOCK_CODE_VARIATION_SELECTORS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_VARIATION_SELECTORS_value, UBLOCK_VARIATION_SELECTORS);
-	zend_string *const_BLOCK_CODE_VARIATION_SELECTORS_name = zend_string_init_interned("BLOCK_CODE_VARIATION_SELECTORS", sizeof("BLOCK_CODE_VARIATION_SELECTORS") - 1, 1);
+	zend_string *const_BLOCK_CODE_VARIATION_SELECTORS_name = zend_string_init_interned("BLOCK_CODE_VARIATION_SELECTORS", strlen("BLOCK_CODE_VARIATION_SELECTORS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_VARIATION_SELECTORS_name, &const_BLOCK_CODE_VARIATION_SELECTORS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_VARIATION_SELECTORS_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_value, UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_A);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A", sizeof("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A", strlen("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_name, &const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_value, UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_B);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B", sizeof("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B", strlen("BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_name, &const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B_name);
 
 	zval const_BLOCK_CODE_LIMBU_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LIMBU_value, UBLOCK_LIMBU);
-	zend_string *const_BLOCK_CODE_LIMBU_name = zend_string_init_interned("BLOCK_CODE_LIMBU", sizeof("BLOCK_CODE_LIMBU") - 1, 1);
+	zend_string *const_BLOCK_CODE_LIMBU_name = zend_string_init_interned("BLOCK_CODE_LIMBU", strlen("BLOCK_CODE_LIMBU"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LIMBU_name, &const_BLOCK_CODE_LIMBU_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LIMBU_name);
 
 	zval const_BLOCK_CODE_TAI_LE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAI_LE_value, UBLOCK_TAI_LE);
-	zend_string *const_BLOCK_CODE_TAI_LE_name = zend_string_init_interned("BLOCK_CODE_TAI_LE", sizeof("BLOCK_CODE_TAI_LE") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAI_LE_name = zend_string_init_interned("BLOCK_CODE_TAI_LE", strlen("BLOCK_CODE_TAI_LE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAI_LE_name, &const_BLOCK_CODE_TAI_LE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAI_LE_name);
 
 	zval const_BLOCK_CODE_KHMER_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KHMER_SYMBOLS_value, UBLOCK_KHMER_SYMBOLS);
-	zend_string *const_BLOCK_CODE_KHMER_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_KHMER_SYMBOLS", sizeof("BLOCK_CODE_KHMER_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_KHMER_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_KHMER_SYMBOLS", strlen("BLOCK_CODE_KHMER_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KHMER_SYMBOLS_name, &const_BLOCK_CODE_KHMER_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KHMER_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_PHONETIC_EXTENSIONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PHONETIC_EXTENSIONS_value, UBLOCK_PHONETIC_EXTENSIONS);
-	zend_string *const_BLOCK_CODE_PHONETIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_PHONETIC_EXTENSIONS", sizeof("BLOCK_CODE_PHONETIC_EXTENSIONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_PHONETIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_PHONETIC_EXTENSIONS", strlen("BLOCK_CODE_PHONETIC_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PHONETIC_EXTENSIONS_name, &const_BLOCK_CODE_PHONETIC_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PHONETIC_EXTENSIONS_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_value, UBLOCK_MISCELLANEOUS_SYMBOLS_AND_ARROWS);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS", sizeof("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS", strlen("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_name, &const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS_name);
 
 	zval const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_value, UBLOCK_YIJING_HEXAGRAM_SYMBOLS);
-	zend_string *const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS", sizeof("BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS", strlen("BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_name, &const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_LINEAR_B_SYLLABARY_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LINEAR_B_SYLLABARY_value, UBLOCK_LINEAR_B_SYLLABARY);
-	zend_string *const_BLOCK_CODE_LINEAR_B_SYLLABARY_name = zend_string_init_interned("BLOCK_CODE_LINEAR_B_SYLLABARY", sizeof("BLOCK_CODE_LINEAR_B_SYLLABARY") - 1, 1);
+	zend_string *const_BLOCK_CODE_LINEAR_B_SYLLABARY_name = zend_string_init_interned("BLOCK_CODE_LINEAR_B_SYLLABARY", strlen("BLOCK_CODE_LINEAR_B_SYLLABARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LINEAR_B_SYLLABARY_name, &const_BLOCK_CODE_LINEAR_B_SYLLABARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LINEAR_B_SYLLABARY_name);
 
 	zval const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_value, UBLOCK_LINEAR_B_IDEOGRAMS);
-	zend_string *const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_name = zend_string_init_interned("BLOCK_CODE_LINEAR_B_IDEOGRAMS", sizeof("BLOCK_CODE_LINEAR_B_IDEOGRAMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_name = zend_string_init_interned("BLOCK_CODE_LINEAR_B_IDEOGRAMS", strlen("BLOCK_CODE_LINEAR_B_IDEOGRAMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_name, &const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LINEAR_B_IDEOGRAMS_name);
 
 	zval const_BLOCK_CODE_AEGEAN_NUMBERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_AEGEAN_NUMBERS_value, UBLOCK_AEGEAN_NUMBERS);
-	zend_string *const_BLOCK_CODE_AEGEAN_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_AEGEAN_NUMBERS", sizeof("BLOCK_CODE_AEGEAN_NUMBERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_AEGEAN_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_AEGEAN_NUMBERS", strlen("BLOCK_CODE_AEGEAN_NUMBERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_AEGEAN_NUMBERS_name, &const_BLOCK_CODE_AEGEAN_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_AEGEAN_NUMBERS_name);
 
 	zval const_BLOCK_CODE_UGARITIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_UGARITIC_value, UBLOCK_UGARITIC);
-	zend_string *const_BLOCK_CODE_UGARITIC_name = zend_string_init_interned("BLOCK_CODE_UGARITIC", sizeof("BLOCK_CODE_UGARITIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_UGARITIC_name = zend_string_init_interned("BLOCK_CODE_UGARITIC", strlen("BLOCK_CODE_UGARITIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_UGARITIC_name, &const_BLOCK_CODE_UGARITIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_UGARITIC_name);
 
 	zval const_BLOCK_CODE_SHAVIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SHAVIAN_value, UBLOCK_SHAVIAN);
-	zend_string *const_BLOCK_CODE_SHAVIAN_name = zend_string_init_interned("BLOCK_CODE_SHAVIAN", sizeof("BLOCK_CODE_SHAVIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_SHAVIAN_name = zend_string_init_interned("BLOCK_CODE_SHAVIAN", strlen("BLOCK_CODE_SHAVIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SHAVIAN_name, &const_BLOCK_CODE_SHAVIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SHAVIAN_name);
 
 	zval const_BLOCK_CODE_OSMANYA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OSMANYA_value, UBLOCK_OSMANYA);
-	zend_string *const_BLOCK_CODE_OSMANYA_name = zend_string_init_interned("BLOCK_CODE_OSMANYA", sizeof("BLOCK_CODE_OSMANYA") - 1, 1);
+	zend_string *const_BLOCK_CODE_OSMANYA_name = zend_string_init_interned("BLOCK_CODE_OSMANYA", strlen("BLOCK_CODE_OSMANYA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OSMANYA_name, &const_BLOCK_CODE_OSMANYA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OSMANYA_name);
 
 	zval const_BLOCK_CODE_CYPRIOT_SYLLABARY_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYPRIOT_SYLLABARY_value, UBLOCK_CYPRIOT_SYLLABARY);
-	zend_string *const_BLOCK_CODE_CYPRIOT_SYLLABARY_name = zend_string_init_interned("BLOCK_CODE_CYPRIOT_SYLLABARY", sizeof("BLOCK_CODE_CYPRIOT_SYLLABARY") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYPRIOT_SYLLABARY_name = zend_string_init_interned("BLOCK_CODE_CYPRIOT_SYLLABARY", strlen("BLOCK_CODE_CYPRIOT_SYLLABARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYPRIOT_SYLLABARY_name, &const_BLOCK_CODE_CYPRIOT_SYLLABARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYPRIOT_SYLLABARY_name);
 
 	zval const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_value, UBLOCK_TAI_XUAN_JING_SYMBOLS);
-	zend_string *const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_TAI_XUAN_JING_SYMBOLS", sizeof("BLOCK_CODE_TAI_XUAN_JING_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_TAI_XUAN_JING_SYMBOLS", strlen("BLOCK_CODE_TAI_XUAN_JING_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_name, &const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAI_XUAN_JING_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_value, UBLOCK_VARIATION_SELECTORS_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT", sizeof("BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT", strlen("BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_name, &const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_value, UBLOCK_ANCIENT_GREEK_MUSICAL_NOTATION);
-	zend_string *const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION", sizeof("BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION") - 1, 1);
+	zend_string *const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION", strlen("BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_name, &const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION_name);
 
 	zval const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_value, UBLOCK_ANCIENT_GREEK_NUMBERS);
-	zend_string *const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_GREEK_NUMBERS", sizeof("BLOCK_CODE_ANCIENT_GREEK_NUMBERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_GREEK_NUMBERS", strlen("BLOCK_CODE_ANCIENT_GREEK_NUMBERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_name, &const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ANCIENT_GREEK_NUMBERS_name);
 
 	zval const_BLOCK_CODE_ARABIC_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_SUPPLEMENT_value, UBLOCK_ARABIC_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_ARABIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ARABIC_SUPPLEMENT", sizeof("BLOCK_CODE_ARABIC_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ARABIC_SUPPLEMENT", strlen("BLOCK_CODE_ARABIC_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_SUPPLEMENT_name, &const_BLOCK_CODE_ARABIC_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_BUGINESE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BUGINESE_value, UBLOCK_BUGINESE);
-	zend_string *const_BLOCK_CODE_BUGINESE_name = zend_string_init_interned("BLOCK_CODE_BUGINESE", sizeof("BLOCK_CODE_BUGINESE") - 1, 1);
+	zend_string *const_BLOCK_CODE_BUGINESE_name = zend_string_init_interned("BLOCK_CODE_BUGINESE", strlen("BLOCK_CODE_BUGINESE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BUGINESE_name, &const_BLOCK_CODE_BUGINESE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BUGINESE_name);
 
 	zval const_BLOCK_CODE_CJK_STROKES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_STROKES_value, UBLOCK_CJK_STROKES);
-	zend_string *const_BLOCK_CODE_CJK_STROKES_name = zend_string_init_interned("BLOCK_CODE_CJK_STROKES", sizeof("BLOCK_CODE_CJK_STROKES") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_STROKES_name = zend_string_init_interned("BLOCK_CODE_CJK_STROKES", strlen("BLOCK_CODE_CJK_STROKES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_STROKES_name, &const_BLOCK_CODE_CJK_STROKES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_STROKES_name);
 
 	zval const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_value, UBLOCK_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT", sizeof("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT", strlen("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_name, &const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_COPTIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COPTIC_value, UBLOCK_COPTIC);
-	zend_string *const_BLOCK_CODE_COPTIC_name = zend_string_init_interned("BLOCK_CODE_COPTIC", sizeof("BLOCK_CODE_COPTIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_COPTIC_name = zend_string_init_interned("BLOCK_CODE_COPTIC", strlen("BLOCK_CODE_COPTIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COPTIC_name, &const_BLOCK_CODE_COPTIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COPTIC_name);
 
 	zval const_BLOCK_CODE_ETHIOPIC_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ETHIOPIC_EXTENDED_value, UBLOCK_ETHIOPIC_EXTENDED);
-	zend_string *const_BLOCK_CODE_ETHIOPIC_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_EXTENDED", sizeof("BLOCK_CODE_ETHIOPIC_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_ETHIOPIC_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_EXTENDED", strlen("BLOCK_CODE_ETHIOPIC_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ETHIOPIC_EXTENDED_name, &const_BLOCK_CODE_ETHIOPIC_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ETHIOPIC_EXTENDED_name);
 
 	zval const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_value, UBLOCK_ETHIOPIC_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_SUPPLEMENT", sizeof("BLOCK_CODE_ETHIOPIC_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_SUPPLEMENT", strlen("BLOCK_CODE_ETHIOPIC_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_name, &const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ETHIOPIC_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_value, UBLOCK_GEORGIAN_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_GEORGIAN_SUPPLEMENT", sizeof("BLOCK_CODE_GEORGIAN_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_GEORGIAN_SUPPLEMENT", strlen("BLOCK_CODE_GEORGIAN_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_name, &const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GEORGIAN_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_GLAGOLITIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GLAGOLITIC_value, UBLOCK_GLAGOLITIC);
-	zend_string *const_BLOCK_CODE_GLAGOLITIC_name = zend_string_init_interned("BLOCK_CODE_GLAGOLITIC", sizeof("BLOCK_CODE_GLAGOLITIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_GLAGOLITIC_name = zend_string_init_interned("BLOCK_CODE_GLAGOLITIC", strlen("BLOCK_CODE_GLAGOLITIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GLAGOLITIC_name, &const_BLOCK_CODE_GLAGOLITIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GLAGOLITIC_name);
 
 	zval const_BLOCK_CODE_KHAROSHTHI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KHAROSHTHI_value, UBLOCK_KHAROSHTHI);
-	zend_string *const_BLOCK_CODE_KHAROSHTHI_name = zend_string_init_interned("BLOCK_CODE_KHAROSHTHI", sizeof("BLOCK_CODE_KHAROSHTHI") - 1, 1);
+	zend_string *const_BLOCK_CODE_KHAROSHTHI_name = zend_string_init_interned("BLOCK_CODE_KHAROSHTHI", strlen("BLOCK_CODE_KHAROSHTHI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KHAROSHTHI_name, &const_BLOCK_CODE_KHAROSHTHI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KHAROSHTHI_name);
 
 	zval const_BLOCK_CODE_MODIFIER_TONE_LETTERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MODIFIER_TONE_LETTERS_value, UBLOCK_MODIFIER_TONE_LETTERS);
-	zend_string *const_BLOCK_CODE_MODIFIER_TONE_LETTERS_name = zend_string_init_interned("BLOCK_CODE_MODIFIER_TONE_LETTERS", sizeof("BLOCK_CODE_MODIFIER_TONE_LETTERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MODIFIER_TONE_LETTERS_name = zend_string_init_interned("BLOCK_CODE_MODIFIER_TONE_LETTERS", strlen("BLOCK_CODE_MODIFIER_TONE_LETTERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MODIFIER_TONE_LETTERS_name, &const_BLOCK_CODE_MODIFIER_TONE_LETTERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MODIFIER_TONE_LETTERS_name);
 
 	zval const_BLOCK_CODE_NEW_TAI_LUE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_NEW_TAI_LUE_value, UBLOCK_NEW_TAI_LUE);
-	zend_string *const_BLOCK_CODE_NEW_TAI_LUE_name = zend_string_init_interned("BLOCK_CODE_NEW_TAI_LUE", sizeof("BLOCK_CODE_NEW_TAI_LUE") - 1, 1);
+	zend_string *const_BLOCK_CODE_NEW_TAI_LUE_name = zend_string_init_interned("BLOCK_CODE_NEW_TAI_LUE", strlen("BLOCK_CODE_NEW_TAI_LUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_NEW_TAI_LUE_name, &const_BLOCK_CODE_NEW_TAI_LUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_NEW_TAI_LUE_name);
 
 	zval const_BLOCK_CODE_OLD_PERSIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_PERSIAN_value, UBLOCK_OLD_PERSIAN);
-	zend_string *const_BLOCK_CODE_OLD_PERSIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_PERSIAN", sizeof("BLOCK_CODE_OLD_PERSIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_PERSIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_PERSIAN", strlen("BLOCK_CODE_OLD_PERSIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_PERSIAN_name, &const_BLOCK_CODE_OLD_PERSIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_PERSIAN_name);
 
 	zval const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_value, UBLOCK_PHONETIC_EXTENSIONS_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT", sizeof("BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT", strlen("BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_name, &const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_value, UBLOCK_SUPPLEMENTAL_PUNCTUATION);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION", sizeof("BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION", strlen("BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_name, &const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION_name);
 
 	zval const_BLOCK_CODE_SYLOTI_NAGRI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SYLOTI_NAGRI_value, UBLOCK_SYLOTI_NAGRI);
-	zend_string *const_BLOCK_CODE_SYLOTI_NAGRI_name = zend_string_init_interned("BLOCK_CODE_SYLOTI_NAGRI", sizeof("BLOCK_CODE_SYLOTI_NAGRI") - 1, 1);
+	zend_string *const_BLOCK_CODE_SYLOTI_NAGRI_name = zend_string_init_interned("BLOCK_CODE_SYLOTI_NAGRI", strlen("BLOCK_CODE_SYLOTI_NAGRI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SYLOTI_NAGRI_name, &const_BLOCK_CODE_SYLOTI_NAGRI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SYLOTI_NAGRI_name);
 
 	zval const_BLOCK_CODE_TIFINAGH_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TIFINAGH_value, UBLOCK_TIFINAGH);
-	zend_string *const_BLOCK_CODE_TIFINAGH_name = zend_string_init_interned("BLOCK_CODE_TIFINAGH", sizeof("BLOCK_CODE_TIFINAGH") - 1, 1);
+	zend_string *const_BLOCK_CODE_TIFINAGH_name = zend_string_init_interned("BLOCK_CODE_TIFINAGH", strlen("BLOCK_CODE_TIFINAGH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TIFINAGH_name, &const_BLOCK_CODE_TIFINAGH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TIFINAGH_name);
 
 	zval const_BLOCK_CODE_VERTICAL_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_VERTICAL_FORMS_value, UBLOCK_VERTICAL_FORMS);
-	zend_string *const_BLOCK_CODE_VERTICAL_FORMS_name = zend_string_init_interned("BLOCK_CODE_VERTICAL_FORMS", sizeof("BLOCK_CODE_VERTICAL_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_VERTICAL_FORMS_name = zend_string_init_interned("BLOCK_CODE_VERTICAL_FORMS", strlen("BLOCK_CODE_VERTICAL_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_VERTICAL_FORMS_name, &const_BLOCK_CODE_VERTICAL_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_VERTICAL_FORMS_name);
 
 	zval const_BLOCK_CODE_NKO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_NKO_value, UBLOCK_NKO);
-	zend_string *const_BLOCK_CODE_NKO_name = zend_string_init_interned("BLOCK_CODE_NKO", sizeof("BLOCK_CODE_NKO") - 1, 1);
+	zend_string *const_BLOCK_CODE_NKO_name = zend_string_init_interned("BLOCK_CODE_NKO", strlen("BLOCK_CODE_NKO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_NKO_name, &const_BLOCK_CODE_NKO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_NKO_name);
 
 	zval const_BLOCK_CODE_BALINESE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BALINESE_value, UBLOCK_BALINESE);
-	zend_string *const_BLOCK_CODE_BALINESE_name = zend_string_init_interned("BLOCK_CODE_BALINESE", sizeof("BLOCK_CODE_BALINESE") - 1, 1);
+	zend_string *const_BLOCK_CODE_BALINESE_name = zend_string_init_interned("BLOCK_CODE_BALINESE", strlen("BLOCK_CODE_BALINESE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BALINESE_name, &const_BLOCK_CODE_BALINESE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BALINESE_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_C_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_C_value, UBLOCK_LATIN_EXTENDED_C);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_C_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_C", sizeof("BLOCK_CODE_LATIN_EXTENDED_C") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_C_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_C", strlen("BLOCK_CODE_LATIN_EXTENDED_C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_C_name, &const_BLOCK_CODE_LATIN_EXTENDED_C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_C_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_D_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_D_value, UBLOCK_LATIN_EXTENDED_D);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_D_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_D", sizeof("BLOCK_CODE_LATIN_EXTENDED_D") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_D_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_D", strlen("BLOCK_CODE_LATIN_EXTENDED_D"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_D_name, &const_BLOCK_CODE_LATIN_EXTENDED_D_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_D_name);
 
 	zval const_BLOCK_CODE_PHAGS_PA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PHAGS_PA_value, UBLOCK_PHAGS_PA);
-	zend_string *const_BLOCK_CODE_PHAGS_PA_name = zend_string_init_interned("BLOCK_CODE_PHAGS_PA", sizeof("BLOCK_CODE_PHAGS_PA") - 1, 1);
+	zend_string *const_BLOCK_CODE_PHAGS_PA_name = zend_string_init_interned("BLOCK_CODE_PHAGS_PA", strlen("BLOCK_CODE_PHAGS_PA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PHAGS_PA_name, &const_BLOCK_CODE_PHAGS_PA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PHAGS_PA_name);
 
 	zval const_BLOCK_CODE_PHOENICIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PHOENICIAN_value, UBLOCK_PHOENICIAN);
-	zend_string *const_BLOCK_CODE_PHOENICIAN_name = zend_string_init_interned("BLOCK_CODE_PHOENICIAN", sizeof("BLOCK_CODE_PHOENICIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_PHOENICIAN_name = zend_string_init_interned("BLOCK_CODE_PHOENICIAN", strlen("BLOCK_CODE_PHOENICIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PHOENICIAN_name, &const_BLOCK_CODE_PHOENICIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PHOENICIAN_name);
 
 	zval const_BLOCK_CODE_CUNEIFORM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CUNEIFORM_value, UBLOCK_CUNEIFORM);
-	zend_string *const_BLOCK_CODE_CUNEIFORM_name = zend_string_init_interned("BLOCK_CODE_CUNEIFORM", sizeof("BLOCK_CODE_CUNEIFORM") - 1, 1);
+	zend_string *const_BLOCK_CODE_CUNEIFORM_name = zend_string_init_interned("BLOCK_CODE_CUNEIFORM", strlen("BLOCK_CODE_CUNEIFORM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CUNEIFORM_name, &const_BLOCK_CODE_CUNEIFORM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CUNEIFORM_name);
 
 	zval const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_value, UBLOCK_CUNEIFORM_NUMBERS_AND_PUNCTUATION);
-	zend_string *const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION", sizeof("BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION") - 1, 1);
+	zend_string *const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_name = zend_string_init_interned("BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION", strlen("BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_name, &const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION_name);
 
 	zval const_BLOCK_CODE_COUNTING_ROD_NUMERALS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COUNTING_ROD_NUMERALS_value, UBLOCK_COUNTING_ROD_NUMERALS);
-	zend_string *const_BLOCK_CODE_COUNTING_ROD_NUMERALS_name = zend_string_init_interned("BLOCK_CODE_COUNTING_ROD_NUMERALS", sizeof("BLOCK_CODE_COUNTING_ROD_NUMERALS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COUNTING_ROD_NUMERALS_name = zend_string_init_interned("BLOCK_CODE_COUNTING_ROD_NUMERALS", strlen("BLOCK_CODE_COUNTING_ROD_NUMERALS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COUNTING_ROD_NUMERALS_name, &const_BLOCK_CODE_COUNTING_ROD_NUMERALS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COUNTING_ROD_NUMERALS_name);
 
 	zval const_BLOCK_CODE_SUNDANESE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUNDANESE_value, UBLOCK_SUNDANESE);
-	zend_string *const_BLOCK_CODE_SUNDANESE_name = zend_string_init_interned("BLOCK_CODE_SUNDANESE", sizeof("BLOCK_CODE_SUNDANESE") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUNDANESE_name = zend_string_init_interned("BLOCK_CODE_SUNDANESE", strlen("BLOCK_CODE_SUNDANESE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUNDANESE_name, &const_BLOCK_CODE_SUNDANESE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUNDANESE_name);
 
 	zval const_BLOCK_CODE_LEPCHA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LEPCHA_value, UBLOCK_LEPCHA);
-	zend_string *const_BLOCK_CODE_LEPCHA_name = zend_string_init_interned("BLOCK_CODE_LEPCHA", sizeof("BLOCK_CODE_LEPCHA") - 1, 1);
+	zend_string *const_BLOCK_CODE_LEPCHA_name = zend_string_init_interned("BLOCK_CODE_LEPCHA", strlen("BLOCK_CODE_LEPCHA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LEPCHA_name, &const_BLOCK_CODE_LEPCHA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LEPCHA_name);
 
 	zval const_BLOCK_CODE_OL_CHIKI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OL_CHIKI_value, UBLOCK_OL_CHIKI);
-	zend_string *const_BLOCK_CODE_OL_CHIKI_name = zend_string_init_interned("BLOCK_CODE_OL_CHIKI", sizeof("BLOCK_CODE_OL_CHIKI") - 1, 1);
+	zend_string *const_BLOCK_CODE_OL_CHIKI_name = zend_string_init_interned("BLOCK_CODE_OL_CHIKI", strlen("BLOCK_CODE_OL_CHIKI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OL_CHIKI_name, &const_BLOCK_CODE_OL_CHIKI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OL_CHIKI_name);
 
 	zval const_BLOCK_CODE_CYRILLIC_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYRILLIC_EXTENDED_A_value, UBLOCK_CYRILLIC_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_CYRILLIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_EXTENDED_A", sizeof("BLOCK_CODE_CYRILLIC_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYRILLIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_EXTENDED_A", strlen("BLOCK_CODE_CYRILLIC_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYRILLIC_EXTENDED_A_name, &const_BLOCK_CODE_CYRILLIC_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYRILLIC_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_VAI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_VAI_value, UBLOCK_VAI);
-	zend_string *const_BLOCK_CODE_VAI_name = zend_string_init_interned("BLOCK_CODE_VAI", sizeof("BLOCK_CODE_VAI") - 1, 1);
+	zend_string *const_BLOCK_CODE_VAI_name = zend_string_init_interned("BLOCK_CODE_VAI", strlen("BLOCK_CODE_VAI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_VAI_name, &const_BLOCK_CODE_VAI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_VAI_name);
 
 	zval const_BLOCK_CODE_CYRILLIC_EXTENDED_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CYRILLIC_EXTENDED_B_value, UBLOCK_CYRILLIC_EXTENDED_B);
-	zend_string *const_BLOCK_CODE_CYRILLIC_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_EXTENDED_B", sizeof("BLOCK_CODE_CYRILLIC_EXTENDED_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_CYRILLIC_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_CYRILLIC_EXTENDED_B", strlen("BLOCK_CODE_CYRILLIC_EXTENDED_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CYRILLIC_EXTENDED_B_name, &const_BLOCK_CODE_CYRILLIC_EXTENDED_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CYRILLIC_EXTENDED_B_name);
 
 	zval const_BLOCK_CODE_SAURASHTRA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SAURASHTRA_value, UBLOCK_SAURASHTRA);
-	zend_string *const_BLOCK_CODE_SAURASHTRA_name = zend_string_init_interned("BLOCK_CODE_SAURASHTRA", sizeof("BLOCK_CODE_SAURASHTRA") - 1, 1);
+	zend_string *const_BLOCK_CODE_SAURASHTRA_name = zend_string_init_interned("BLOCK_CODE_SAURASHTRA", strlen("BLOCK_CODE_SAURASHTRA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SAURASHTRA_name, &const_BLOCK_CODE_SAURASHTRA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SAURASHTRA_name);
 
 	zval const_BLOCK_CODE_KAYAH_LI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KAYAH_LI_value, UBLOCK_KAYAH_LI);
-	zend_string *const_BLOCK_CODE_KAYAH_LI_name = zend_string_init_interned("BLOCK_CODE_KAYAH_LI", sizeof("BLOCK_CODE_KAYAH_LI") - 1, 1);
+	zend_string *const_BLOCK_CODE_KAYAH_LI_name = zend_string_init_interned("BLOCK_CODE_KAYAH_LI", strlen("BLOCK_CODE_KAYAH_LI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KAYAH_LI_name, &const_BLOCK_CODE_KAYAH_LI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KAYAH_LI_name);
 
 	zval const_BLOCK_CODE_REJANG_value;
 	ZVAL_LONG(&const_BLOCK_CODE_REJANG_value, UBLOCK_REJANG);
-	zend_string *const_BLOCK_CODE_REJANG_name = zend_string_init_interned("BLOCK_CODE_REJANG", sizeof("BLOCK_CODE_REJANG") - 1, 1);
+	zend_string *const_BLOCK_CODE_REJANG_name = zend_string_init_interned("BLOCK_CODE_REJANG", strlen("BLOCK_CODE_REJANG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_REJANG_name, &const_BLOCK_CODE_REJANG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_REJANG_name);
 
 	zval const_BLOCK_CODE_CHAM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CHAM_value, UBLOCK_CHAM);
-	zend_string *const_BLOCK_CODE_CHAM_name = zend_string_init_interned("BLOCK_CODE_CHAM", sizeof("BLOCK_CODE_CHAM") - 1, 1);
+	zend_string *const_BLOCK_CODE_CHAM_name = zend_string_init_interned("BLOCK_CODE_CHAM", strlen("BLOCK_CODE_CHAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CHAM_name, &const_BLOCK_CODE_CHAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CHAM_name);
 
 	zval const_BLOCK_CODE_ANCIENT_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ANCIENT_SYMBOLS_value, UBLOCK_ANCIENT_SYMBOLS);
-	zend_string *const_BLOCK_CODE_ANCIENT_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_SYMBOLS", sizeof("BLOCK_CODE_ANCIENT_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ANCIENT_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ANCIENT_SYMBOLS", strlen("BLOCK_CODE_ANCIENT_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ANCIENT_SYMBOLS_name, &const_BLOCK_CODE_ANCIENT_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ANCIENT_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_PHAISTOS_DISC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PHAISTOS_DISC_value, UBLOCK_PHAISTOS_DISC);
-	zend_string *const_BLOCK_CODE_PHAISTOS_DISC_name = zend_string_init_interned("BLOCK_CODE_PHAISTOS_DISC", sizeof("BLOCK_CODE_PHAISTOS_DISC") - 1, 1);
+	zend_string *const_BLOCK_CODE_PHAISTOS_DISC_name = zend_string_init_interned("BLOCK_CODE_PHAISTOS_DISC", strlen("BLOCK_CODE_PHAISTOS_DISC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PHAISTOS_DISC_name, &const_BLOCK_CODE_PHAISTOS_DISC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PHAISTOS_DISC_name);
 
 	zval const_BLOCK_CODE_LYCIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LYCIAN_value, UBLOCK_LYCIAN);
-	zend_string *const_BLOCK_CODE_LYCIAN_name = zend_string_init_interned("BLOCK_CODE_LYCIAN", sizeof("BLOCK_CODE_LYCIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_LYCIAN_name = zend_string_init_interned("BLOCK_CODE_LYCIAN", strlen("BLOCK_CODE_LYCIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LYCIAN_name, &const_BLOCK_CODE_LYCIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LYCIAN_name);
 
 	zval const_BLOCK_CODE_CARIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CARIAN_value, UBLOCK_CARIAN);
-	zend_string *const_BLOCK_CODE_CARIAN_name = zend_string_init_interned("BLOCK_CODE_CARIAN", sizeof("BLOCK_CODE_CARIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_CARIAN_name = zend_string_init_interned("BLOCK_CODE_CARIAN", strlen("BLOCK_CODE_CARIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CARIAN_name, &const_BLOCK_CODE_CARIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CARIAN_name);
 
 	zval const_BLOCK_CODE_LYDIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LYDIAN_value, UBLOCK_LYDIAN);
-	zend_string *const_BLOCK_CODE_LYDIAN_name = zend_string_init_interned("BLOCK_CODE_LYDIAN", sizeof("BLOCK_CODE_LYDIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_LYDIAN_name = zend_string_init_interned("BLOCK_CODE_LYDIAN", strlen("BLOCK_CODE_LYDIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LYDIAN_name, &const_BLOCK_CODE_LYDIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LYDIAN_name);
 
 	zval const_BLOCK_CODE_MAHJONG_TILES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MAHJONG_TILES_value, UBLOCK_MAHJONG_TILES);
-	zend_string *const_BLOCK_CODE_MAHJONG_TILES_name = zend_string_init_interned("BLOCK_CODE_MAHJONG_TILES", sizeof("BLOCK_CODE_MAHJONG_TILES") - 1, 1);
+	zend_string *const_BLOCK_CODE_MAHJONG_TILES_name = zend_string_init_interned("BLOCK_CODE_MAHJONG_TILES", strlen("BLOCK_CODE_MAHJONG_TILES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MAHJONG_TILES_name, &const_BLOCK_CODE_MAHJONG_TILES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MAHJONG_TILES_name);
 
 	zval const_BLOCK_CODE_DOMINO_TILES_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DOMINO_TILES_value, UBLOCK_DOMINO_TILES);
-	zend_string *const_BLOCK_CODE_DOMINO_TILES_name = zend_string_init_interned("BLOCK_CODE_DOMINO_TILES", sizeof("BLOCK_CODE_DOMINO_TILES") - 1, 1);
+	zend_string *const_BLOCK_CODE_DOMINO_TILES_name = zend_string_init_interned("BLOCK_CODE_DOMINO_TILES", strlen("BLOCK_CODE_DOMINO_TILES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DOMINO_TILES_name, &const_BLOCK_CODE_DOMINO_TILES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DOMINO_TILES_name);
 
 	zval const_BLOCK_CODE_SAMARITAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SAMARITAN_value, UBLOCK_SAMARITAN);
-	zend_string *const_BLOCK_CODE_SAMARITAN_name = zend_string_init_interned("BLOCK_CODE_SAMARITAN", sizeof("BLOCK_CODE_SAMARITAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_SAMARITAN_name = zend_string_init_interned("BLOCK_CODE_SAMARITAN", strlen("BLOCK_CODE_SAMARITAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SAMARITAN_name, &const_BLOCK_CODE_SAMARITAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SAMARITAN_name);
 
 	zval const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_value, UBLOCK_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED);
-	zend_string *const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED", sizeof("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED", strlen("BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_name, &const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED_name);
 
 	zval const_BLOCK_CODE_TAI_THAM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAI_THAM_value, UBLOCK_TAI_THAM);
-	zend_string *const_BLOCK_CODE_TAI_THAM_name = zend_string_init_interned("BLOCK_CODE_TAI_THAM", sizeof("BLOCK_CODE_TAI_THAM") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAI_THAM_name = zend_string_init_interned("BLOCK_CODE_TAI_THAM", strlen("BLOCK_CODE_TAI_THAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAI_THAM_name, &const_BLOCK_CODE_TAI_THAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAI_THAM_name);
 
 	zval const_BLOCK_CODE_VEDIC_EXTENSIONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_VEDIC_EXTENSIONS_value, UBLOCK_VEDIC_EXTENSIONS);
-	zend_string *const_BLOCK_CODE_VEDIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_VEDIC_EXTENSIONS", sizeof("BLOCK_CODE_VEDIC_EXTENSIONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_VEDIC_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_VEDIC_EXTENSIONS", strlen("BLOCK_CODE_VEDIC_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_VEDIC_EXTENSIONS_name, &const_BLOCK_CODE_VEDIC_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_VEDIC_EXTENSIONS_name);
 
 	zval const_BLOCK_CODE_LISU_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LISU_value, UBLOCK_LISU);
-	zend_string *const_BLOCK_CODE_LISU_name = zend_string_init_interned("BLOCK_CODE_LISU", sizeof("BLOCK_CODE_LISU") - 1, 1);
+	zend_string *const_BLOCK_CODE_LISU_name = zend_string_init_interned("BLOCK_CODE_LISU", strlen("BLOCK_CODE_LISU"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LISU_name, &const_BLOCK_CODE_LISU_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LISU_name);
 
 	zval const_BLOCK_CODE_BAMUM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BAMUM_value, UBLOCK_BAMUM);
-	zend_string *const_BLOCK_CODE_BAMUM_name = zend_string_init_interned("BLOCK_CODE_BAMUM", sizeof("BLOCK_CODE_BAMUM") - 1, 1);
+	zend_string *const_BLOCK_CODE_BAMUM_name = zend_string_init_interned("BLOCK_CODE_BAMUM", strlen("BLOCK_CODE_BAMUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BAMUM_name, &const_BLOCK_CODE_BAMUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BAMUM_name);
 
 	zval const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_value, UBLOCK_COMMON_INDIC_NUMBER_FORMS);
-	zend_string *const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_name = zend_string_init_interned("BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS", sizeof("BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_name = zend_string_init_interned("BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS", strlen("BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_name, &const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS_name);
 
 	zval const_BLOCK_CODE_DEVANAGARI_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DEVANAGARI_EXTENDED_value, UBLOCK_DEVANAGARI_EXTENDED);
-	zend_string *const_BLOCK_CODE_DEVANAGARI_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_DEVANAGARI_EXTENDED", sizeof("BLOCK_CODE_DEVANAGARI_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_DEVANAGARI_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_DEVANAGARI_EXTENDED", strlen("BLOCK_CODE_DEVANAGARI_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DEVANAGARI_EXTENDED_name, &const_BLOCK_CODE_DEVANAGARI_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DEVANAGARI_EXTENDED_name);
 
 	zval const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_value, UBLOCK_HANGUL_JAMO_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO_EXTENDED_A", sizeof("BLOCK_CODE_HANGUL_JAMO_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO_EXTENDED_A", strlen("BLOCK_CODE_HANGUL_JAMO_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_name, &const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_JAVANESE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_JAVANESE_value, UBLOCK_JAVANESE);
-	zend_string *const_BLOCK_CODE_JAVANESE_name = zend_string_init_interned("BLOCK_CODE_JAVANESE", sizeof("BLOCK_CODE_JAVANESE") - 1, 1);
+	zend_string *const_BLOCK_CODE_JAVANESE_name = zend_string_init_interned("BLOCK_CODE_JAVANESE", strlen("BLOCK_CODE_JAVANESE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_JAVANESE_name, &const_BLOCK_CODE_JAVANESE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_JAVANESE_name);
 
 	zval const_BLOCK_CODE_MYANMAR_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MYANMAR_EXTENDED_A_value, UBLOCK_MYANMAR_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_MYANMAR_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_MYANMAR_EXTENDED_A", sizeof("BLOCK_CODE_MYANMAR_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_MYANMAR_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_MYANMAR_EXTENDED_A", strlen("BLOCK_CODE_MYANMAR_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MYANMAR_EXTENDED_A_name, &const_BLOCK_CODE_MYANMAR_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MYANMAR_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_TAI_VIET_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAI_VIET_value, UBLOCK_TAI_VIET);
-	zend_string *const_BLOCK_CODE_TAI_VIET_name = zend_string_init_interned("BLOCK_CODE_TAI_VIET", sizeof("BLOCK_CODE_TAI_VIET") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAI_VIET_name = zend_string_init_interned("BLOCK_CODE_TAI_VIET", strlen("BLOCK_CODE_TAI_VIET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAI_VIET_name, &const_BLOCK_CODE_TAI_VIET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAI_VIET_name);
 
 	zval const_BLOCK_CODE_MEETEI_MAYEK_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MEETEI_MAYEK_value, UBLOCK_MEETEI_MAYEK);
-	zend_string *const_BLOCK_CODE_MEETEI_MAYEK_name = zend_string_init_interned("BLOCK_CODE_MEETEI_MAYEK", sizeof("BLOCK_CODE_MEETEI_MAYEK") - 1, 1);
+	zend_string *const_BLOCK_CODE_MEETEI_MAYEK_name = zend_string_init_interned("BLOCK_CODE_MEETEI_MAYEK", strlen("BLOCK_CODE_MEETEI_MAYEK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MEETEI_MAYEK_name, &const_BLOCK_CODE_MEETEI_MAYEK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MEETEI_MAYEK_name);
 
 	zval const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_value, UBLOCK_HANGUL_JAMO_EXTENDED_B);
-	zend_string *const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO_EXTENDED_B", sizeof("BLOCK_CODE_HANGUL_JAMO_EXTENDED_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_HANGUL_JAMO_EXTENDED_B", strlen("BLOCK_CODE_HANGUL_JAMO_EXTENDED_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_name, &const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_HANGUL_JAMO_EXTENDED_B_name);
 
 	zval const_BLOCK_CODE_IMPERIAL_ARAMAIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_IMPERIAL_ARAMAIC_value, UBLOCK_IMPERIAL_ARAMAIC);
-	zend_string *const_BLOCK_CODE_IMPERIAL_ARAMAIC_name = zend_string_init_interned("BLOCK_CODE_IMPERIAL_ARAMAIC", sizeof("BLOCK_CODE_IMPERIAL_ARAMAIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_IMPERIAL_ARAMAIC_name = zend_string_init_interned("BLOCK_CODE_IMPERIAL_ARAMAIC", strlen("BLOCK_CODE_IMPERIAL_ARAMAIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_IMPERIAL_ARAMAIC_name, &const_BLOCK_CODE_IMPERIAL_ARAMAIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_IMPERIAL_ARAMAIC_name);
 
 	zval const_BLOCK_CODE_OLD_SOUTH_ARABIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_SOUTH_ARABIAN_value, UBLOCK_OLD_SOUTH_ARABIAN);
-	zend_string *const_BLOCK_CODE_OLD_SOUTH_ARABIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_SOUTH_ARABIAN", sizeof("BLOCK_CODE_OLD_SOUTH_ARABIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_SOUTH_ARABIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_SOUTH_ARABIAN", strlen("BLOCK_CODE_OLD_SOUTH_ARABIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_SOUTH_ARABIAN_name, &const_BLOCK_CODE_OLD_SOUTH_ARABIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_SOUTH_ARABIAN_name);
 
 	zval const_BLOCK_CODE_AVESTAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_AVESTAN_value, UBLOCK_AVESTAN);
-	zend_string *const_BLOCK_CODE_AVESTAN_name = zend_string_init_interned("BLOCK_CODE_AVESTAN", sizeof("BLOCK_CODE_AVESTAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_AVESTAN_name = zend_string_init_interned("BLOCK_CODE_AVESTAN", strlen("BLOCK_CODE_AVESTAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_AVESTAN_name, &const_BLOCK_CODE_AVESTAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_AVESTAN_name);
 
 	zval const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_value, UBLOCK_INSCRIPTIONAL_PARTHIAN);
-	zend_string *const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_name = zend_string_init_interned("BLOCK_CODE_INSCRIPTIONAL_PARTHIAN", sizeof("BLOCK_CODE_INSCRIPTIONAL_PARTHIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_name = zend_string_init_interned("BLOCK_CODE_INSCRIPTIONAL_PARTHIAN", strlen("BLOCK_CODE_INSCRIPTIONAL_PARTHIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_name, &const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_INSCRIPTIONAL_PARTHIAN_name);
 
 	zval const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_value, UBLOCK_INSCRIPTIONAL_PAHLAVI);
-	zend_string *const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_name = zend_string_init_interned("BLOCK_CODE_INSCRIPTIONAL_PAHLAVI", sizeof("BLOCK_CODE_INSCRIPTIONAL_PAHLAVI") - 1, 1);
+	zend_string *const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_name = zend_string_init_interned("BLOCK_CODE_INSCRIPTIONAL_PAHLAVI", strlen("BLOCK_CODE_INSCRIPTIONAL_PAHLAVI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_name, &const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_INSCRIPTIONAL_PAHLAVI_name);
 
 	zval const_BLOCK_CODE_OLD_TURKIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_TURKIC_value, UBLOCK_OLD_TURKIC);
-	zend_string *const_BLOCK_CODE_OLD_TURKIC_name = zend_string_init_interned("BLOCK_CODE_OLD_TURKIC", sizeof("BLOCK_CODE_OLD_TURKIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_TURKIC_name = zend_string_init_interned("BLOCK_CODE_OLD_TURKIC", strlen("BLOCK_CODE_OLD_TURKIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_TURKIC_name, &const_BLOCK_CODE_OLD_TURKIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_TURKIC_name);
 
 	zval const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_value, UBLOCK_RUMI_NUMERAL_SYMBOLS);
-	zend_string *const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_RUMI_NUMERAL_SYMBOLS", sizeof("BLOCK_CODE_RUMI_NUMERAL_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_RUMI_NUMERAL_SYMBOLS", strlen("BLOCK_CODE_RUMI_NUMERAL_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_name, &const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_RUMI_NUMERAL_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_KAITHI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KAITHI_value, UBLOCK_KAITHI);
-	zend_string *const_BLOCK_CODE_KAITHI_name = zend_string_init_interned("BLOCK_CODE_KAITHI", sizeof("BLOCK_CODE_KAITHI") - 1, 1);
+	zend_string *const_BLOCK_CODE_KAITHI_name = zend_string_init_interned("BLOCK_CODE_KAITHI", strlen("BLOCK_CODE_KAITHI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KAITHI_name, &const_BLOCK_CODE_KAITHI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KAITHI_name);
 
 	zval const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_value, UBLOCK_EGYPTIAN_HIEROGLYPHS);
-	zend_string *const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_name = zend_string_init_interned("BLOCK_CODE_EGYPTIAN_HIEROGLYPHS", sizeof("BLOCK_CODE_EGYPTIAN_HIEROGLYPHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_name = zend_string_init_interned("BLOCK_CODE_EGYPTIAN_HIEROGLYPHS", strlen("BLOCK_CODE_EGYPTIAN_HIEROGLYPHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_name, &const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_EGYPTIAN_HIEROGLYPHS_name);
 
 	zval const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_value, UBLOCK_ENCLOSED_ALPHANUMERIC_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT", sizeof("BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT", strlen("BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_name, &const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_value, UBLOCK_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT", sizeof("BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT", strlen("BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_name, &const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_value, UBLOCK_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C);
-	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C", sizeof("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C", strlen("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_name, &const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C_name);
 
 	zval const_BLOCK_CODE_MANDAIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MANDAIC_value, UBLOCK_MANDAIC);
-	zend_string *const_BLOCK_CODE_MANDAIC_name = zend_string_init_interned("BLOCK_CODE_MANDAIC", sizeof("BLOCK_CODE_MANDAIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_MANDAIC_name = zend_string_init_interned("BLOCK_CODE_MANDAIC", strlen("BLOCK_CODE_MANDAIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MANDAIC_name, &const_BLOCK_CODE_MANDAIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MANDAIC_name);
 
 	zval const_BLOCK_CODE_BATAK_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BATAK_value, UBLOCK_BATAK);
-	zend_string *const_BLOCK_CODE_BATAK_name = zend_string_init_interned("BLOCK_CODE_BATAK", sizeof("BLOCK_CODE_BATAK") - 1, 1);
+	zend_string *const_BLOCK_CODE_BATAK_name = zend_string_init_interned("BLOCK_CODE_BATAK", strlen("BLOCK_CODE_BATAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BATAK_name, &const_BLOCK_CODE_BATAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BATAK_name);
 
 	zval const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_value, UBLOCK_ETHIOPIC_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_EXTENDED_A", sizeof("BLOCK_CODE_ETHIOPIC_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_ETHIOPIC_EXTENDED_A", strlen("BLOCK_CODE_ETHIOPIC_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_name, &const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ETHIOPIC_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_BRAHMI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BRAHMI_value, UBLOCK_BRAHMI);
-	zend_string *const_BLOCK_CODE_BRAHMI_name = zend_string_init_interned("BLOCK_CODE_BRAHMI", sizeof("BLOCK_CODE_BRAHMI") - 1, 1);
+	zend_string *const_BLOCK_CODE_BRAHMI_name = zend_string_init_interned("BLOCK_CODE_BRAHMI", strlen("BLOCK_CODE_BRAHMI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BRAHMI_name, &const_BLOCK_CODE_BRAHMI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BRAHMI_name);
 
 	zval const_BLOCK_CODE_BAMUM_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BAMUM_SUPPLEMENT_value, UBLOCK_BAMUM_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_BAMUM_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_BAMUM_SUPPLEMENT", sizeof("BLOCK_CODE_BAMUM_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_BAMUM_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_BAMUM_SUPPLEMENT", strlen("BLOCK_CODE_BAMUM_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BAMUM_SUPPLEMENT_name, &const_BLOCK_CODE_BAMUM_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BAMUM_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_KANA_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KANA_SUPPLEMENT_value, UBLOCK_KANA_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_KANA_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_KANA_SUPPLEMENT", sizeof("BLOCK_CODE_KANA_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_KANA_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_KANA_SUPPLEMENT", strlen("BLOCK_CODE_KANA_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KANA_SUPPLEMENT_name, &const_BLOCK_CODE_KANA_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KANA_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_PLAYING_CARDS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PLAYING_CARDS_value, UBLOCK_PLAYING_CARDS);
-	zend_string *const_BLOCK_CODE_PLAYING_CARDS_name = zend_string_init_interned("BLOCK_CODE_PLAYING_CARDS", sizeof("BLOCK_CODE_PLAYING_CARDS") - 1, 1);
+	zend_string *const_BLOCK_CODE_PLAYING_CARDS_name = zend_string_init_interned("BLOCK_CODE_PLAYING_CARDS", strlen("BLOCK_CODE_PLAYING_CARDS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PLAYING_CARDS_name, &const_BLOCK_CODE_PLAYING_CARDS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PLAYING_CARDS_name);
 
 	zval const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_value, UBLOCK_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS);
-	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS", sizeof("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_name = zend_string_init_interned("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS", strlen("BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_name, &const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS_name);
 
 	zval const_BLOCK_CODE_EMOTICONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_EMOTICONS_value, UBLOCK_EMOTICONS);
-	zend_string *const_BLOCK_CODE_EMOTICONS_name = zend_string_init_interned("BLOCK_CODE_EMOTICONS", sizeof("BLOCK_CODE_EMOTICONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_EMOTICONS_name = zend_string_init_interned("BLOCK_CODE_EMOTICONS", strlen("BLOCK_CODE_EMOTICONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_EMOTICONS_name, &const_BLOCK_CODE_EMOTICONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_EMOTICONS_name);
 
 	zval const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_value, UBLOCK_TRANSPORT_AND_MAP_SYMBOLS);
-	zend_string *const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS", sizeof("BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS", strlen("BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_name, &const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_value, UBLOCK_ALCHEMICAL_SYMBOLS);
-	zend_string *const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ALCHEMICAL_SYMBOLS", sizeof("BLOCK_CODE_ALCHEMICAL_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ALCHEMICAL_SYMBOLS", strlen("BLOCK_CODE_ALCHEMICAL_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_name, &const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ALCHEMICAL_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_value, UBLOCK_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D);
-	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D", sizeof("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D") - 1, 1);
+	zend_string *const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_name = zend_string_init_interned("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D", strlen("BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_name, &const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D_name);
 
 	zval const_BLOCK_CODE_ARABIC_EXTENDED_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_EXTENDED_A_value, UBLOCK_ARABIC_EXTENDED_A);
-	zend_string *const_BLOCK_CODE_ARABIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_ARABIC_EXTENDED_A", sizeof("BLOCK_CODE_ARABIC_EXTENDED_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_EXTENDED_A_name = zend_string_init_interned("BLOCK_CODE_ARABIC_EXTENDED_A", strlen("BLOCK_CODE_ARABIC_EXTENDED_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_EXTENDED_A_name, &const_BLOCK_CODE_ARABIC_EXTENDED_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_EXTENDED_A_name);
 
 	zval const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_value, UBLOCK_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS);
-	zend_string *const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS", sizeof("BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_name = zend_string_init_interned("BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS", strlen("BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_name, &const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS_name);
 
 	zval const_BLOCK_CODE_CHAKMA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CHAKMA_value, UBLOCK_CHAKMA);
-	zend_string *const_BLOCK_CODE_CHAKMA_name = zend_string_init_interned("BLOCK_CODE_CHAKMA", sizeof("BLOCK_CODE_CHAKMA") - 1, 1);
+	zend_string *const_BLOCK_CODE_CHAKMA_name = zend_string_init_interned("BLOCK_CODE_CHAKMA", strlen("BLOCK_CODE_CHAKMA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CHAKMA_name, &const_BLOCK_CODE_CHAKMA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CHAKMA_name);
 
 	zval const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_value, UBLOCK_MEETEI_MAYEK_EXTENSIONS);
-	zend_string *const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS", sizeof("BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_name = zend_string_init_interned("BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS", strlen("BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_name, &const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS_name);
 
 	zval const_BLOCK_CODE_MEROITIC_CURSIVE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MEROITIC_CURSIVE_value, UBLOCK_MEROITIC_CURSIVE);
-	zend_string *const_BLOCK_CODE_MEROITIC_CURSIVE_name = zend_string_init_interned("BLOCK_CODE_MEROITIC_CURSIVE", sizeof("BLOCK_CODE_MEROITIC_CURSIVE") - 1, 1);
+	zend_string *const_BLOCK_CODE_MEROITIC_CURSIVE_name = zend_string_init_interned("BLOCK_CODE_MEROITIC_CURSIVE", strlen("BLOCK_CODE_MEROITIC_CURSIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MEROITIC_CURSIVE_name, &const_BLOCK_CODE_MEROITIC_CURSIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MEROITIC_CURSIVE_name);
 
 	zval const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_value, UBLOCK_MEROITIC_HIEROGLYPHS);
-	zend_string *const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_name = zend_string_init_interned("BLOCK_CODE_MEROITIC_HIEROGLYPHS", sizeof("BLOCK_CODE_MEROITIC_HIEROGLYPHS") - 1, 1);
+	zend_string *const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_name = zend_string_init_interned("BLOCK_CODE_MEROITIC_HIEROGLYPHS", strlen("BLOCK_CODE_MEROITIC_HIEROGLYPHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_name, &const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MEROITIC_HIEROGLYPHS_name);
 
 	zval const_BLOCK_CODE_MIAO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MIAO_value, UBLOCK_MIAO);
-	zend_string *const_BLOCK_CODE_MIAO_name = zend_string_init_interned("BLOCK_CODE_MIAO", sizeof("BLOCK_CODE_MIAO") - 1, 1);
+	zend_string *const_BLOCK_CODE_MIAO_name = zend_string_init_interned("BLOCK_CODE_MIAO", strlen("BLOCK_CODE_MIAO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MIAO_name, &const_BLOCK_CODE_MIAO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MIAO_name);
 
 	zval const_BLOCK_CODE_SHARADA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SHARADA_value, UBLOCK_SHARADA);
-	zend_string *const_BLOCK_CODE_SHARADA_name = zend_string_init_interned("BLOCK_CODE_SHARADA", sizeof("BLOCK_CODE_SHARADA") - 1, 1);
+	zend_string *const_BLOCK_CODE_SHARADA_name = zend_string_init_interned("BLOCK_CODE_SHARADA", strlen("BLOCK_CODE_SHARADA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SHARADA_name, &const_BLOCK_CODE_SHARADA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SHARADA_name);
 
 	zval const_BLOCK_CODE_SORA_SOMPENG_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SORA_SOMPENG_value, UBLOCK_SORA_SOMPENG);
-	zend_string *const_BLOCK_CODE_SORA_SOMPENG_name = zend_string_init_interned("BLOCK_CODE_SORA_SOMPENG", sizeof("BLOCK_CODE_SORA_SOMPENG") - 1, 1);
+	zend_string *const_BLOCK_CODE_SORA_SOMPENG_name = zend_string_init_interned("BLOCK_CODE_SORA_SOMPENG", strlen("BLOCK_CODE_SORA_SOMPENG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SORA_SOMPENG_name, &const_BLOCK_CODE_SORA_SOMPENG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SORA_SOMPENG_name);
 
 	zval const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_value, UBLOCK_SUNDANESE_SUPPLEMENT);
-	zend_string *const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_SUNDANESE_SUPPLEMENT", sizeof("BLOCK_CODE_SUNDANESE_SUPPLEMENT") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_name = zend_string_init_interned("BLOCK_CODE_SUNDANESE_SUPPLEMENT", strlen("BLOCK_CODE_SUNDANESE_SUPPLEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_name, &const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUNDANESE_SUPPLEMENT_name);
 
 	zval const_BLOCK_CODE_TAKRI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TAKRI_value, UBLOCK_TAKRI);
-	zend_string *const_BLOCK_CODE_TAKRI_name = zend_string_init_interned("BLOCK_CODE_TAKRI", sizeof("BLOCK_CODE_TAKRI") - 1, 1);
+	zend_string *const_BLOCK_CODE_TAKRI_name = zend_string_init_interned("BLOCK_CODE_TAKRI", strlen("BLOCK_CODE_TAKRI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TAKRI_name, &const_BLOCK_CODE_TAKRI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TAKRI_name);
 
 	zval const_BLOCK_CODE_BASSA_VAH_value;
 	ZVAL_LONG(&const_BLOCK_CODE_BASSA_VAH_value, UBLOCK_BASSA_VAH);
-	zend_string *const_BLOCK_CODE_BASSA_VAH_name = zend_string_init_interned("BLOCK_CODE_BASSA_VAH", sizeof("BLOCK_CODE_BASSA_VAH") - 1, 1);
+	zend_string *const_BLOCK_CODE_BASSA_VAH_name = zend_string_init_interned("BLOCK_CODE_BASSA_VAH", strlen("BLOCK_CODE_BASSA_VAH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_BASSA_VAH_name, &const_BLOCK_CODE_BASSA_VAH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_BASSA_VAH_name);
 
 	zval const_BLOCK_CODE_CAUCASIAN_ALBANIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_CAUCASIAN_ALBANIAN_value, UBLOCK_CAUCASIAN_ALBANIAN);
-	zend_string *const_BLOCK_CODE_CAUCASIAN_ALBANIAN_name = zend_string_init_interned("BLOCK_CODE_CAUCASIAN_ALBANIAN", sizeof("BLOCK_CODE_CAUCASIAN_ALBANIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_CAUCASIAN_ALBANIAN_name = zend_string_init_interned("BLOCK_CODE_CAUCASIAN_ALBANIAN", strlen("BLOCK_CODE_CAUCASIAN_ALBANIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_CAUCASIAN_ALBANIAN_name, &const_BLOCK_CODE_CAUCASIAN_ALBANIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_CAUCASIAN_ALBANIAN_name);
 
 	zval const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_value, UBLOCK_COPTIC_EPACT_NUMBERS);
-	zend_string *const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_COPTIC_EPACT_NUMBERS", sizeof("BLOCK_CODE_COPTIC_EPACT_NUMBERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_COPTIC_EPACT_NUMBERS", strlen("BLOCK_CODE_COPTIC_EPACT_NUMBERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_name, &const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COPTIC_EPACT_NUMBERS_name);
 
 	zval const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_value, UBLOCK_COMBINING_DIACRITICAL_MARKS_EXTENDED);
-	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED", sizeof("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED", strlen("BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_name, &const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED_name);
 
 	zval const_BLOCK_CODE_DUPLOYAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_DUPLOYAN_value, UBLOCK_DUPLOYAN);
-	zend_string *const_BLOCK_CODE_DUPLOYAN_name = zend_string_init_interned("BLOCK_CODE_DUPLOYAN", sizeof("BLOCK_CODE_DUPLOYAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_DUPLOYAN_name = zend_string_init_interned("BLOCK_CODE_DUPLOYAN", strlen("BLOCK_CODE_DUPLOYAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_DUPLOYAN_name, &const_BLOCK_CODE_DUPLOYAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_DUPLOYAN_name);
 
 	zval const_BLOCK_CODE_ELBASAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ELBASAN_value, UBLOCK_ELBASAN);
-	zend_string *const_BLOCK_CODE_ELBASAN_name = zend_string_init_interned("BLOCK_CODE_ELBASAN", sizeof("BLOCK_CODE_ELBASAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_ELBASAN_name = zend_string_init_interned("BLOCK_CODE_ELBASAN", strlen("BLOCK_CODE_ELBASAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ELBASAN_name, &const_BLOCK_CODE_ELBASAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ELBASAN_name);
 
 	zval const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_value, UBLOCK_GEOMETRIC_SHAPES_EXTENDED);
-	zend_string *const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED", sizeof("BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED") - 1, 1);
+	zend_string *const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_name = zend_string_init_interned("BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED", strlen("BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_name, &const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED_name);
 
 	zval const_BLOCK_CODE_GRANTHA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_GRANTHA_value, UBLOCK_GRANTHA);
-	zend_string *const_BLOCK_CODE_GRANTHA_name = zend_string_init_interned("BLOCK_CODE_GRANTHA", sizeof("BLOCK_CODE_GRANTHA") - 1, 1);
+	zend_string *const_BLOCK_CODE_GRANTHA_name = zend_string_init_interned("BLOCK_CODE_GRANTHA", strlen("BLOCK_CODE_GRANTHA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_GRANTHA_name, &const_BLOCK_CODE_GRANTHA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_GRANTHA_name);
 
 	zval const_BLOCK_CODE_KHOJKI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KHOJKI_value, UBLOCK_KHOJKI);
-	zend_string *const_BLOCK_CODE_KHOJKI_name = zend_string_init_interned("BLOCK_CODE_KHOJKI", sizeof("BLOCK_CODE_KHOJKI") - 1, 1);
+	zend_string *const_BLOCK_CODE_KHOJKI_name = zend_string_init_interned("BLOCK_CODE_KHOJKI", strlen("BLOCK_CODE_KHOJKI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KHOJKI_name, &const_BLOCK_CODE_KHOJKI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KHOJKI_name);
 
 	zval const_BLOCK_CODE_KHUDAWADI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_KHUDAWADI_value, UBLOCK_KHUDAWADI);
-	zend_string *const_BLOCK_CODE_KHUDAWADI_name = zend_string_init_interned("BLOCK_CODE_KHUDAWADI", sizeof("BLOCK_CODE_KHUDAWADI") - 1, 1);
+	zend_string *const_BLOCK_CODE_KHUDAWADI_name = zend_string_init_interned("BLOCK_CODE_KHUDAWADI", strlen("BLOCK_CODE_KHUDAWADI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_KHUDAWADI_name, &const_BLOCK_CODE_KHUDAWADI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_KHUDAWADI_name);
 
 	zval const_BLOCK_CODE_LATIN_EXTENDED_E_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LATIN_EXTENDED_E_value, UBLOCK_LATIN_EXTENDED_E);
-	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_E_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_E", sizeof("BLOCK_CODE_LATIN_EXTENDED_E") - 1, 1);
+	zend_string *const_BLOCK_CODE_LATIN_EXTENDED_E_name = zend_string_init_interned("BLOCK_CODE_LATIN_EXTENDED_E", strlen("BLOCK_CODE_LATIN_EXTENDED_E"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LATIN_EXTENDED_E_name, &const_BLOCK_CODE_LATIN_EXTENDED_E_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LATIN_EXTENDED_E_name);
 
 	zval const_BLOCK_CODE_LINEAR_A_value;
 	ZVAL_LONG(&const_BLOCK_CODE_LINEAR_A_value, UBLOCK_LINEAR_A);
-	zend_string *const_BLOCK_CODE_LINEAR_A_name = zend_string_init_interned("BLOCK_CODE_LINEAR_A", sizeof("BLOCK_CODE_LINEAR_A") - 1, 1);
+	zend_string *const_BLOCK_CODE_LINEAR_A_name = zend_string_init_interned("BLOCK_CODE_LINEAR_A", strlen("BLOCK_CODE_LINEAR_A"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_LINEAR_A_name, &const_BLOCK_CODE_LINEAR_A_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_LINEAR_A_name);
 
 	zval const_BLOCK_CODE_MAHAJANI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MAHAJANI_value, UBLOCK_MAHAJANI);
-	zend_string *const_BLOCK_CODE_MAHAJANI_name = zend_string_init_interned("BLOCK_CODE_MAHAJANI", sizeof("BLOCK_CODE_MAHAJANI") - 1, 1);
+	zend_string *const_BLOCK_CODE_MAHAJANI_name = zend_string_init_interned("BLOCK_CODE_MAHAJANI", strlen("BLOCK_CODE_MAHAJANI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MAHAJANI_name, &const_BLOCK_CODE_MAHAJANI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MAHAJANI_name);
 
 	zval const_BLOCK_CODE_MANICHAEAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MANICHAEAN_value, UBLOCK_MANICHAEAN);
-	zend_string *const_BLOCK_CODE_MANICHAEAN_name = zend_string_init_interned("BLOCK_CODE_MANICHAEAN", sizeof("BLOCK_CODE_MANICHAEAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_MANICHAEAN_name = zend_string_init_interned("BLOCK_CODE_MANICHAEAN", strlen("BLOCK_CODE_MANICHAEAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MANICHAEAN_name, &const_BLOCK_CODE_MANICHAEAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MANICHAEAN_name);
 
 	zval const_BLOCK_CODE_MENDE_KIKAKUI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MENDE_KIKAKUI_value, UBLOCK_MENDE_KIKAKUI);
-	zend_string *const_BLOCK_CODE_MENDE_KIKAKUI_name = zend_string_init_interned("BLOCK_CODE_MENDE_KIKAKUI", sizeof("BLOCK_CODE_MENDE_KIKAKUI") - 1, 1);
+	zend_string *const_BLOCK_CODE_MENDE_KIKAKUI_name = zend_string_init_interned("BLOCK_CODE_MENDE_KIKAKUI", strlen("BLOCK_CODE_MENDE_KIKAKUI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MENDE_KIKAKUI_name, &const_BLOCK_CODE_MENDE_KIKAKUI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MENDE_KIKAKUI_name);
 
 	zval const_BLOCK_CODE_MODI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MODI_value, UBLOCK_MODI);
-	zend_string *const_BLOCK_CODE_MODI_name = zend_string_init_interned("BLOCK_CODE_MODI", sizeof("BLOCK_CODE_MODI") - 1, 1);
+	zend_string *const_BLOCK_CODE_MODI_name = zend_string_init_interned("BLOCK_CODE_MODI", strlen("BLOCK_CODE_MODI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MODI_name, &const_BLOCK_CODE_MODI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MODI_name);
 
 	zval const_BLOCK_CODE_MRO_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MRO_value, UBLOCK_MRO);
-	zend_string *const_BLOCK_CODE_MRO_name = zend_string_init_interned("BLOCK_CODE_MRO", sizeof("BLOCK_CODE_MRO") - 1, 1);
+	zend_string *const_BLOCK_CODE_MRO_name = zend_string_init_interned("BLOCK_CODE_MRO", strlen("BLOCK_CODE_MRO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MRO_name, &const_BLOCK_CODE_MRO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MRO_name);
 
 	zval const_BLOCK_CODE_MYANMAR_EXTENDED_B_value;
 	ZVAL_LONG(&const_BLOCK_CODE_MYANMAR_EXTENDED_B_value, UBLOCK_MYANMAR_EXTENDED_B);
-	zend_string *const_BLOCK_CODE_MYANMAR_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_MYANMAR_EXTENDED_B", sizeof("BLOCK_CODE_MYANMAR_EXTENDED_B") - 1, 1);
+	zend_string *const_BLOCK_CODE_MYANMAR_EXTENDED_B_name = zend_string_init_interned("BLOCK_CODE_MYANMAR_EXTENDED_B", strlen("BLOCK_CODE_MYANMAR_EXTENDED_B"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_MYANMAR_EXTENDED_B_name, &const_BLOCK_CODE_MYANMAR_EXTENDED_B_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_MYANMAR_EXTENDED_B_name);
 
 	zval const_BLOCK_CODE_NABATAEAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_NABATAEAN_value, UBLOCK_NABATAEAN);
-	zend_string *const_BLOCK_CODE_NABATAEAN_name = zend_string_init_interned("BLOCK_CODE_NABATAEAN", sizeof("BLOCK_CODE_NABATAEAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_NABATAEAN_name = zend_string_init_interned("BLOCK_CODE_NABATAEAN", strlen("BLOCK_CODE_NABATAEAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_NABATAEAN_name, &const_BLOCK_CODE_NABATAEAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_NABATAEAN_name);
 
 	zval const_BLOCK_CODE_OLD_NORTH_ARABIAN_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_NORTH_ARABIAN_value, UBLOCK_OLD_NORTH_ARABIAN);
-	zend_string *const_BLOCK_CODE_OLD_NORTH_ARABIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_NORTH_ARABIAN", sizeof("BLOCK_CODE_OLD_NORTH_ARABIAN") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_NORTH_ARABIAN_name = zend_string_init_interned("BLOCK_CODE_OLD_NORTH_ARABIAN", strlen("BLOCK_CODE_OLD_NORTH_ARABIAN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_NORTH_ARABIAN_name, &const_BLOCK_CODE_OLD_NORTH_ARABIAN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_NORTH_ARABIAN_name);
 
 	zval const_BLOCK_CODE_OLD_PERMIC_value;
 	ZVAL_LONG(&const_BLOCK_CODE_OLD_PERMIC_value, UBLOCK_OLD_PERMIC);
-	zend_string *const_BLOCK_CODE_OLD_PERMIC_name = zend_string_init_interned("BLOCK_CODE_OLD_PERMIC", sizeof("BLOCK_CODE_OLD_PERMIC") - 1, 1);
+	zend_string *const_BLOCK_CODE_OLD_PERMIC_name = zend_string_init_interned("BLOCK_CODE_OLD_PERMIC", strlen("BLOCK_CODE_OLD_PERMIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_OLD_PERMIC_name, &const_BLOCK_CODE_OLD_PERMIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_OLD_PERMIC_name);
 
 	zval const_BLOCK_CODE_ORNAMENTAL_DINGBATS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_ORNAMENTAL_DINGBATS_value, UBLOCK_ORNAMENTAL_DINGBATS);
-	zend_string *const_BLOCK_CODE_ORNAMENTAL_DINGBATS_name = zend_string_init_interned("BLOCK_CODE_ORNAMENTAL_DINGBATS", sizeof("BLOCK_CODE_ORNAMENTAL_DINGBATS") - 1, 1);
+	zend_string *const_BLOCK_CODE_ORNAMENTAL_DINGBATS_name = zend_string_init_interned("BLOCK_CODE_ORNAMENTAL_DINGBATS", strlen("BLOCK_CODE_ORNAMENTAL_DINGBATS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_ORNAMENTAL_DINGBATS_name, &const_BLOCK_CODE_ORNAMENTAL_DINGBATS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_ORNAMENTAL_DINGBATS_name);
 
 	zval const_BLOCK_CODE_PAHAWH_HMONG_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PAHAWH_HMONG_value, UBLOCK_PAHAWH_HMONG);
-	zend_string *const_BLOCK_CODE_PAHAWH_HMONG_name = zend_string_init_interned("BLOCK_CODE_PAHAWH_HMONG", sizeof("BLOCK_CODE_PAHAWH_HMONG") - 1, 1);
+	zend_string *const_BLOCK_CODE_PAHAWH_HMONG_name = zend_string_init_interned("BLOCK_CODE_PAHAWH_HMONG", strlen("BLOCK_CODE_PAHAWH_HMONG"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PAHAWH_HMONG_name, &const_BLOCK_CODE_PAHAWH_HMONG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PAHAWH_HMONG_name);
 
 	zval const_BLOCK_CODE_PALMYRENE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PALMYRENE_value, UBLOCK_PALMYRENE);
-	zend_string *const_BLOCK_CODE_PALMYRENE_name = zend_string_init_interned("BLOCK_CODE_PALMYRENE", sizeof("BLOCK_CODE_PALMYRENE") - 1, 1);
+	zend_string *const_BLOCK_CODE_PALMYRENE_name = zend_string_init_interned("BLOCK_CODE_PALMYRENE", strlen("BLOCK_CODE_PALMYRENE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PALMYRENE_name, &const_BLOCK_CODE_PALMYRENE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PALMYRENE_name);
 
 	zval const_BLOCK_CODE_PAU_CIN_HAU_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PAU_CIN_HAU_value, UBLOCK_PAU_CIN_HAU);
-	zend_string *const_BLOCK_CODE_PAU_CIN_HAU_name = zend_string_init_interned("BLOCK_CODE_PAU_CIN_HAU", sizeof("BLOCK_CODE_PAU_CIN_HAU") - 1, 1);
+	zend_string *const_BLOCK_CODE_PAU_CIN_HAU_name = zend_string_init_interned("BLOCK_CODE_PAU_CIN_HAU", strlen("BLOCK_CODE_PAU_CIN_HAU"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PAU_CIN_HAU_name, &const_BLOCK_CODE_PAU_CIN_HAU_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PAU_CIN_HAU_name);
 
 	zval const_BLOCK_CODE_PSALTER_PAHLAVI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_PSALTER_PAHLAVI_value, UBLOCK_PSALTER_PAHLAVI);
-	zend_string *const_BLOCK_CODE_PSALTER_PAHLAVI_name = zend_string_init_interned("BLOCK_CODE_PSALTER_PAHLAVI", sizeof("BLOCK_CODE_PSALTER_PAHLAVI") - 1, 1);
+	zend_string *const_BLOCK_CODE_PSALTER_PAHLAVI_name = zend_string_init_interned("BLOCK_CODE_PSALTER_PAHLAVI", strlen("BLOCK_CODE_PSALTER_PAHLAVI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_PSALTER_PAHLAVI_name, &const_BLOCK_CODE_PSALTER_PAHLAVI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_PSALTER_PAHLAVI_name);
 
 	zval const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_value, UBLOCK_SHORTHAND_FORMAT_CONTROLS);
-	zend_string *const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_name = zend_string_init_interned("BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS", sizeof("BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_name = zend_string_init_interned("BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS", strlen("BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_name, &const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS_name);
 
 	zval const_BLOCK_CODE_SIDDHAM_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SIDDHAM_value, UBLOCK_SIDDHAM);
-	zend_string *const_BLOCK_CODE_SIDDHAM_name = zend_string_init_interned("BLOCK_CODE_SIDDHAM", sizeof("BLOCK_CODE_SIDDHAM") - 1, 1);
+	zend_string *const_BLOCK_CODE_SIDDHAM_name = zend_string_init_interned("BLOCK_CODE_SIDDHAM", strlen("BLOCK_CODE_SIDDHAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SIDDHAM_name, &const_BLOCK_CODE_SIDDHAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SIDDHAM_name);
 
 	zval const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_value, UBLOCK_SINHALA_ARCHAIC_NUMBERS);
-	zend_string *const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS", sizeof("BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS") - 1, 1);
+	zend_string *const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_name = zend_string_init_interned("BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS", strlen("BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_name, &const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS_name);
 
 	zval const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_value;
 	ZVAL_LONG(&const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_value, UBLOCK_SUPPLEMENTAL_ARROWS_C);
-	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_C", sizeof("BLOCK_CODE_SUPPLEMENTAL_ARROWS_C") - 1, 1);
+	zend_string *const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_name = zend_string_init_interned("BLOCK_CODE_SUPPLEMENTAL_ARROWS_C", strlen("BLOCK_CODE_SUPPLEMENTAL_ARROWS_C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_name, &const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_SUPPLEMENTAL_ARROWS_C_name);
 
 	zval const_BLOCK_CODE_TIRHUTA_value;
 	ZVAL_LONG(&const_BLOCK_CODE_TIRHUTA_value, UBLOCK_TIRHUTA);
-	zend_string *const_BLOCK_CODE_TIRHUTA_name = zend_string_init_interned("BLOCK_CODE_TIRHUTA", sizeof("BLOCK_CODE_TIRHUTA") - 1, 1);
+	zend_string *const_BLOCK_CODE_TIRHUTA_name = zend_string_init_interned("BLOCK_CODE_TIRHUTA", strlen("BLOCK_CODE_TIRHUTA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_TIRHUTA_name, &const_BLOCK_CODE_TIRHUTA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_TIRHUTA_name);
 
 	zval const_BLOCK_CODE_WARANG_CITI_value;
 	ZVAL_LONG(&const_BLOCK_CODE_WARANG_CITI_value, UBLOCK_WARANG_CITI);
-	zend_string *const_BLOCK_CODE_WARANG_CITI_name = zend_string_init_interned("BLOCK_CODE_WARANG_CITI", sizeof("BLOCK_CODE_WARANG_CITI") - 1, 1);
+	zend_string *const_BLOCK_CODE_WARANG_CITI_name = zend_string_init_interned("BLOCK_CODE_WARANG_CITI", strlen("BLOCK_CODE_WARANG_CITI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_WARANG_CITI_name, &const_BLOCK_CODE_WARANG_CITI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_WARANG_CITI_name);
 
 	zval const_BLOCK_CODE_COUNT_value;
 	ZVAL_LONG(&const_BLOCK_CODE_COUNT_value, UBLOCK_COUNT);
-	zend_string *const_BLOCK_CODE_COUNT_name = zend_string_init_interned("BLOCK_CODE_COUNT", sizeof("BLOCK_CODE_COUNT") - 1, 1);
+	zend_string *const_BLOCK_CODE_COUNT_name = zend_string_init_interned("BLOCK_CODE_COUNT", strlen("BLOCK_CODE_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_COUNT_name, &const_BLOCK_CODE_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_COUNT_name);
 
 	zval const_BLOCK_CODE_INVALID_CODE_value;
 	ZVAL_LONG(&const_BLOCK_CODE_INVALID_CODE_value, UBLOCK_INVALID_CODE);
-	zend_string *const_BLOCK_CODE_INVALID_CODE_name = zend_string_init_interned("BLOCK_CODE_INVALID_CODE", sizeof("BLOCK_CODE_INVALID_CODE") - 1, 1);
+	zend_string *const_BLOCK_CODE_INVALID_CODE_name = zend_string_init_interned("BLOCK_CODE_INVALID_CODE", strlen("BLOCK_CODE_INVALID_CODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BLOCK_CODE_INVALID_CODE_name, &const_BLOCK_CODE_INVALID_CODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BLOCK_CODE_INVALID_CODE_name);
 
 	zval const_BPT_NONE_value;
 	ZVAL_LONG(&const_BPT_NONE_value, U_BPT_NONE);
-	zend_string *const_BPT_NONE_name = zend_string_init_interned("BPT_NONE", sizeof("BPT_NONE") - 1, 1);
+	zend_string *const_BPT_NONE_name = zend_string_init_interned("BPT_NONE", strlen("BPT_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BPT_NONE_name, &const_BPT_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BPT_NONE_name);
 
 	zval const_BPT_OPEN_value;
 	ZVAL_LONG(&const_BPT_OPEN_value, U_BPT_OPEN);
-	zend_string *const_BPT_OPEN_name = zend_string_init_interned("BPT_OPEN", sizeof("BPT_OPEN") - 1, 1);
+	zend_string *const_BPT_OPEN_name = zend_string_init_interned("BPT_OPEN", strlen("BPT_OPEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BPT_OPEN_name, &const_BPT_OPEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BPT_OPEN_name);
 
 	zval const_BPT_CLOSE_value;
 	ZVAL_LONG(&const_BPT_CLOSE_value, U_BPT_CLOSE);
-	zend_string *const_BPT_CLOSE_name = zend_string_init_interned("BPT_CLOSE", sizeof("BPT_CLOSE") - 1, 1);
+	zend_string *const_BPT_CLOSE_name = zend_string_init_interned("BPT_CLOSE", strlen("BPT_CLOSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BPT_CLOSE_name, &const_BPT_CLOSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BPT_CLOSE_name);
 
 	zval const_BPT_COUNT_value;
 	ZVAL_LONG(&const_BPT_COUNT_value, U_BPT_COUNT);
-	zend_string *const_BPT_COUNT_name = zend_string_init_interned("BPT_COUNT", sizeof("BPT_COUNT") - 1, 1);
+	zend_string *const_BPT_COUNT_name = zend_string_init_interned("BPT_COUNT", strlen("BPT_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BPT_COUNT_name, &const_BPT_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BPT_COUNT_name);
 
 	zval const_EA_NEUTRAL_value;
 	ZVAL_LONG(&const_EA_NEUTRAL_value, U_EA_NEUTRAL);
-	zend_string *const_EA_NEUTRAL_name = zend_string_init_interned("EA_NEUTRAL", sizeof("EA_NEUTRAL") - 1, 1);
+	zend_string *const_EA_NEUTRAL_name = zend_string_init_interned("EA_NEUTRAL", strlen("EA_NEUTRAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_NEUTRAL_name, &const_EA_NEUTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_NEUTRAL_name);
 
 	zval const_EA_AMBIGUOUS_value;
 	ZVAL_LONG(&const_EA_AMBIGUOUS_value, U_EA_AMBIGUOUS);
-	zend_string *const_EA_AMBIGUOUS_name = zend_string_init_interned("EA_AMBIGUOUS", sizeof("EA_AMBIGUOUS") - 1, 1);
+	zend_string *const_EA_AMBIGUOUS_name = zend_string_init_interned("EA_AMBIGUOUS", strlen("EA_AMBIGUOUS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_AMBIGUOUS_name, &const_EA_AMBIGUOUS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_AMBIGUOUS_name);
 
 	zval const_EA_HALFWIDTH_value;
 	ZVAL_LONG(&const_EA_HALFWIDTH_value, U_EA_HALFWIDTH);
-	zend_string *const_EA_HALFWIDTH_name = zend_string_init_interned("EA_HALFWIDTH", sizeof("EA_HALFWIDTH") - 1, 1);
+	zend_string *const_EA_HALFWIDTH_name = zend_string_init_interned("EA_HALFWIDTH", strlen("EA_HALFWIDTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_HALFWIDTH_name, &const_EA_HALFWIDTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_HALFWIDTH_name);
 
 	zval const_EA_FULLWIDTH_value;
 	ZVAL_LONG(&const_EA_FULLWIDTH_value, U_EA_FULLWIDTH);
-	zend_string *const_EA_FULLWIDTH_name = zend_string_init_interned("EA_FULLWIDTH", sizeof("EA_FULLWIDTH") - 1, 1);
+	zend_string *const_EA_FULLWIDTH_name = zend_string_init_interned("EA_FULLWIDTH", strlen("EA_FULLWIDTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_FULLWIDTH_name, &const_EA_FULLWIDTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_FULLWIDTH_name);
 
 	zval const_EA_NARROW_value;
 	ZVAL_LONG(&const_EA_NARROW_value, U_EA_NARROW);
-	zend_string *const_EA_NARROW_name = zend_string_init_interned("EA_NARROW", sizeof("EA_NARROW") - 1, 1);
+	zend_string *const_EA_NARROW_name = zend_string_init_interned("EA_NARROW", strlen("EA_NARROW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_NARROW_name, &const_EA_NARROW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_NARROW_name);
 
 	zval const_EA_WIDE_value;
 	ZVAL_LONG(&const_EA_WIDE_value, U_EA_WIDE);
-	zend_string *const_EA_WIDE_name = zend_string_init_interned("EA_WIDE", sizeof("EA_WIDE") - 1, 1);
+	zend_string *const_EA_WIDE_name = zend_string_init_interned("EA_WIDE", strlen("EA_WIDE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_WIDE_name, &const_EA_WIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_WIDE_name);
 
 	zval const_EA_COUNT_value;
 	ZVAL_LONG(&const_EA_COUNT_value, U_EA_COUNT);
-	zend_string *const_EA_COUNT_name = zend_string_init_interned("EA_COUNT", sizeof("EA_COUNT") - 1, 1);
+	zend_string *const_EA_COUNT_name = zend_string_init_interned("EA_COUNT", strlen("EA_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EA_COUNT_name, &const_EA_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EA_COUNT_name);
 
 	zval const_UNICODE_CHAR_NAME_value;
 	ZVAL_LONG(&const_UNICODE_CHAR_NAME_value, U_UNICODE_CHAR_NAME);
-	zend_string *const_UNICODE_CHAR_NAME_name = zend_string_init_interned("UNICODE_CHAR_NAME", sizeof("UNICODE_CHAR_NAME") - 1, 1);
+	zend_string *const_UNICODE_CHAR_NAME_name = zend_string_init_interned("UNICODE_CHAR_NAME", strlen("UNICODE_CHAR_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNICODE_CHAR_NAME_name, &const_UNICODE_CHAR_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNICODE_CHAR_NAME_name);
 
 	zval const_UNICODE_10_CHAR_NAME_value;
 	ZVAL_LONG(&const_UNICODE_10_CHAR_NAME_value, U_UNICODE_10_CHAR_NAME);
-	zend_string *const_UNICODE_10_CHAR_NAME_name = zend_string_init_interned("UNICODE_10_CHAR_NAME", sizeof("UNICODE_10_CHAR_NAME") - 1, 1);
+	zend_string *const_UNICODE_10_CHAR_NAME_name = zend_string_init_interned("UNICODE_10_CHAR_NAME", strlen("UNICODE_10_CHAR_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNICODE_10_CHAR_NAME_name, &const_UNICODE_10_CHAR_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNICODE_10_CHAR_NAME_name);
 
 	zval const_EXTENDED_CHAR_NAME_value;
 	ZVAL_LONG(&const_EXTENDED_CHAR_NAME_value, U_EXTENDED_CHAR_NAME);
-	zend_string *const_EXTENDED_CHAR_NAME_name = zend_string_init_interned("EXTENDED_CHAR_NAME", sizeof("EXTENDED_CHAR_NAME") - 1, 1);
+	zend_string *const_EXTENDED_CHAR_NAME_name = zend_string_init_interned("EXTENDED_CHAR_NAME", strlen("EXTENDED_CHAR_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXTENDED_CHAR_NAME_name, &const_EXTENDED_CHAR_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXTENDED_CHAR_NAME_name);
 
 	zval const_CHAR_NAME_ALIAS_value;
 	ZVAL_LONG(&const_CHAR_NAME_ALIAS_value, U_CHAR_NAME_ALIAS);
-	zend_string *const_CHAR_NAME_ALIAS_name = zend_string_init_interned("CHAR_NAME_ALIAS", sizeof("CHAR_NAME_ALIAS") - 1, 1);
+	zend_string *const_CHAR_NAME_ALIAS_name = zend_string_init_interned("CHAR_NAME_ALIAS", strlen("CHAR_NAME_ALIAS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_NAME_ALIAS_name, &const_CHAR_NAME_ALIAS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_NAME_ALIAS_name);
 
 	zval const_CHAR_NAME_CHOICE_COUNT_value;
 	ZVAL_LONG(&const_CHAR_NAME_CHOICE_COUNT_value, U_CHAR_NAME_CHOICE_COUNT);
-	zend_string *const_CHAR_NAME_CHOICE_COUNT_name = zend_string_init_interned("CHAR_NAME_CHOICE_COUNT", sizeof("CHAR_NAME_CHOICE_COUNT") - 1, 1);
+	zend_string *const_CHAR_NAME_CHOICE_COUNT_name = zend_string_init_interned("CHAR_NAME_CHOICE_COUNT", strlen("CHAR_NAME_CHOICE_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHAR_NAME_CHOICE_COUNT_name, &const_CHAR_NAME_CHOICE_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHAR_NAME_CHOICE_COUNT_name);
 
 	zval const_SHORT_PROPERTY_NAME_value;
 	ZVAL_LONG(&const_SHORT_PROPERTY_NAME_value, U_SHORT_PROPERTY_NAME);
-	zend_string *const_SHORT_PROPERTY_NAME_name = zend_string_init_interned("SHORT_PROPERTY_NAME", sizeof("SHORT_PROPERTY_NAME") - 1, 1);
+	zend_string *const_SHORT_PROPERTY_NAME_name = zend_string_init_interned("SHORT_PROPERTY_NAME", strlen("SHORT_PROPERTY_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHORT_PROPERTY_NAME_name, &const_SHORT_PROPERTY_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHORT_PROPERTY_NAME_name);
 
 	zval const_LONG_PROPERTY_NAME_value;
 	ZVAL_LONG(&const_LONG_PROPERTY_NAME_value, U_LONG_PROPERTY_NAME);
-	zend_string *const_LONG_PROPERTY_NAME_name = zend_string_init_interned("LONG_PROPERTY_NAME", sizeof("LONG_PROPERTY_NAME") - 1, 1);
+	zend_string *const_LONG_PROPERTY_NAME_name = zend_string_init_interned("LONG_PROPERTY_NAME", strlen("LONG_PROPERTY_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LONG_PROPERTY_NAME_name, &const_LONG_PROPERTY_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LONG_PROPERTY_NAME_name);
 
 	zval const_PROPERTY_NAME_CHOICE_COUNT_value;
 	ZVAL_LONG(&const_PROPERTY_NAME_CHOICE_COUNT_value, U_PROPERTY_NAME_CHOICE_COUNT);
-	zend_string *const_PROPERTY_NAME_CHOICE_COUNT_name = zend_string_init_interned("PROPERTY_NAME_CHOICE_COUNT", sizeof("PROPERTY_NAME_CHOICE_COUNT") - 1, 1);
+	zend_string *const_PROPERTY_NAME_CHOICE_COUNT_name = zend_string_init_interned("PROPERTY_NAME_CHOICE_COUNT", strlen("PROPERTY_NAME_CHOICE_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PROPERTY_NAME_CHOICE_COUNT_name, &const_PROPERTY_NAME_CHOICE_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PROPERTY_NAME_CHOICE_COUNT_name);
 
 	zval const_DT_NONE_value;
 	ZVAL_LONG(&const_DT_NONE_value, U_DT_NONE);
-	zend_string *const_DT_NONE_name = zend_string_init_interned("DT_NONE", sizeof("DT_NONE") - 1, 1);
+	zend_string *const_DT_NONE_name = zend_string_init_interned("DT_NONE", strlen("DT_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_NONE_name, &const_DT_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_NONE_name);
 
 	zval const_DT_CANONICAL_value;
 	ZVAL_LONG(&const_DT_CANONICAL_value, U_DT_CANONICAL);
-	zend_string *const_DT_CANONICAL_name = zend_string_init_interned("DT_CANONICAL", sizeof("DT_CANONICAL") - 1, 1);
+	zend_string *const_DT_CANONICAL_name = zend_string_init_interned("DT_CANONICAL", strlen("DT_CANONICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_CANONICAL_name, &const_DT_CANONICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_CANONICAL_name);
 
 	zval const_DT_COMPAT_value;
 	ZVAL_LONG(&const_DT_COMPAT_value, U_DT_COMPAT);
-	zend_string *const_DT_COMPAT_name = zend_string_init_interned("DT_COMPAT", sizeof("DT_COMPAT") - 1, 1);
+	zend_string *const_DT_COMPAT_name = zend_string_init_interned("DT_COMPAT", strlen("DT_COMPAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_COMPAT_name, &const_DT_COMPAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_COMPAT_name);
 
 	zval const_DT_CIRCLE_value;
 	ZVAL_LONG(&const_DT_CIRCLE_value, U_DT_CIRCLE);
-	zend_string *const_DT_CIRCLE_name = zend_string_init_interned("DT_CIRCLE", sizeof("DT_CIRCLE") - 1, 1);
+	zend_string *const_DT_CIRCLE_name = zend_string_init_interned("DT_CIRCLE", strlen("DT_CIRCLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_CIRCLE_name, &const_DT_CIRCLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_CIRCLE_name);
 
 	zval const_DT_FINAL_value;
 	ZVAL_LONG(&const_DT_FINAL_value, U_DT_FINAL);
-	zend_string *const_DT_FINAL_name = zend_string_init_interned("DT_FINAL", sizeof("DT_FINAL") - 1, 1);
+	zend_string *const_DT_FINAL_name = zend_string_init_interned("DT_FINAL", strlen("DT_FINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_FINAL_name, &const_DT_FINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_FINAL_name);
 
 	zval const_DT_FONT_value;
 	ZVAL_LONG(&const_DT_FONT_value, U_DT_FONT);
-	zend_string *const_DT_FONT_name = zend_string_init_interned("DT_FONT", sizeof("DT_FONT") - 1, 1);
+	zend_string *const_DT_FONT_name = zend_string_init_interned("DT_FONT", strlen("DT_FONT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_FONT_name, &const_DT_FONT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_FONT_name);
 
 	zval const_DT_FRACTION_value;
 	ZVAL_LONG(&const_DT_FRACTION_value, U_DT_FRACTION);
-	zend_string *const_DT_FRACTION_name = zend_string_init_interned("DT_FRACTION", sizeof("DT_FRACTION") - 1, 1);
+	zend_string *const_DT_FRACTION_name = zend_string_init_interned("DT_FRACTION", strlen("DT_FRACTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_FRACTION_name, &const_DT_FRACTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_FRACTION_name);
 
 	zval const_DT_INITIAL_value;
 	ZVAL_LONG(&const_DT_INITIAL_value, U_DT_INITIAL);
-	zend_string *const_DT_INITIAL_name = zend_string_init_interned("DT_INITIAL", sizeof("DT_INITIAL") - 1, 1);
+	zend_string *const_DT_INITIAL_name = zend_string_init_interned("DT_INITIAL", strlen("DT_INITIAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_INITIAL_name, &const_DT_INITIAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_INITIAL_name);
 
 	zval const_DT_ISOLATED_value;
 	ZVAL_LONG(&const_DT_ISOLATED_value, U_DT_ISOLATED);
-	zend_string *const_DT_ISOLATED_name = zend_string_init_interned("DT_ISOLATED", sizeof("DT_ISOLATED") - 1, 1);
+	zend_string *const_DT_ISOLATED_name = zend_string_init_interned("DT_ISOLATED", strlen("DT_ISOLATED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_ISOLATED_name, &const_DT_ISOLATED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_ISOLATED_name);
 
 	zval const_DT_MEDIAL_value;
 	ZVAL_LONG(&const_DT_MEDIAL_value, U_DT_MEDIAL);
-	zend_string *const_DT_MEDIAL_name = zend_string_init_interned("DT_MEDIAL", sizeof("DT_MEDIAL") - 1, 1);
+	zend_string *const_DT_MEDIAL_name = zend_string_init_interned("DT_MEDIAL", strlen("DT_MEDIAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_MEDIAL_name, &const_DT_MEDIAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_MEDIAL_name);
 
 	zval const_DT_NARROW_value;
 	ZVAL_LONG(&const_DT_NARROW_value, U_DT_NARROW);
-	zend_string *const_DT_NARROW_name = zend_string_init_interned("DT_NARROW", sizeof("DT_NARROW") - 1, 1);
+	zend_string *const_DT_NARROW_name = zend_string_init_interned("DT_NARROW", strlen("DT_NARROW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_NARROW_name, &const_DT_NARROW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_NARROW_name);
 
 	zval const_DT_NOBREAK_value;
 	ZVAL_LONG(&const_DT_NOBREAK_value, U_DT_NOBREAK);
-	zend_string *const_DT_NOBREAK_name = zend_string_init_interned("DT_NOBREAK", sizeof("DT_NOBREAK") - 1, 1);
+	zend_string *const_DT_NOBREAK_name = zend_string_init_interned("DT_NOBREAK", strlen("DT_NOBREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_NOBREAK_name, &const_DT_NOBREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_NOBREAK_name);
 
 	zval const_DT_SMALL_value;
 	ZVAL_LONG(&const_DT_SMALL_value, U_DT_SMALL);
-	zend_string *const_DT_SMALL_name = zend_string_init_interned("DT_SMALL", sizeof("DT_SMALL") - 1, 1);
+	zend_string *const_DT_SMALL_name = zend_string_init_interned("DT_SMALL", strlen("DT_SMALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_SMALL_name, &const_DT_SMALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_SMALL_name);
 
 	zval const_DT_SQUARE_value;
 	ZVAL_LONG(&const_DT_SQUARE_value, U_DT_SQUARE);
-	zend_string *const_DT_SQUARE_name = zend_string_init_interned("DT_SQUARE", sizeof("DT_SQUARE") - 1, 1);
+	zend_string *const_DT_SQUARE_name = zend_string_init_interned("DT_SQUARE", strlen("DT_SQUARE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_SQUARE_name, &const_DT_SQUARE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_SQUARE_name);
 
 	zval const_DT_SUB_value;
 	ZVAL_LONG(&const_DT_SUB_value, U_DT_SUB);
-	zend_string *const_DT_SUB_name = zend_string_init_interned("DT_SUB", sizeof("DT_SUB") - 1, 1);
+	zend_string *const_DT_SUB_name = zend_string_init_interned("DT_SUB", strlen("DT_SUB"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_SUB_name, &const_DT_SUB_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_SUB_name);
 
 	zval const_DT_SUPER_value;
 	ZVAL_LONG(&const_DT_SUPER_value, U_DT_SUPER);
-	zend_string *const_DT_SUPER_name = zend_string_init_interned("DT_SUPER", sizeof("DT_SUPER") - 1, 1);
+	zend_string *const_DT_SUPER_name = zend_string_init_interned("DT_SUPER", strlen("DT_SUPER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_SUPER_name, &const_DT_SUPER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_SUPER_name);
 
 	zval const_DT_VERTICAL_value;
 	ZVAL_LONG(&const_DT_VERTICAL_value, U_DT_VERTICAL);
-	zend_string *const_DT_VERTICAL_name = zend_string_init_interned("DT_VERTICAL", sizeof("DT_VERTICAL") - 1, 1);
+	zend_string *const_DT_VERTICAL_name = zend_string_init_interned("DT_VERTICAL", strlen("DT_VERTICAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_VERTICAL_name, &const_DT_VERTICAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_VERTICAL_name);
 
 	zval const_DT_WIDE_value;
 	ZVAL_LONG(&const_DT_WIDE_value, U_DT_WIDE);
-	zend_string *const_DT_WIDE_name = zend_string_init_interned("DT_WIDE", sizeof("DT_WIDE") - 1, 1);
+	zend_string *const_DT_WIDE_name = zend_string_init_interned("DT_WIDE", strlen("DT_WIDE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_WIDE_name, &const_DT_WIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_WIDE_name);
 
 	zval const_DT_COUNT_value;
 	ZVAL_LONG(&const_DT_COUNT_value, U_DT_COUNT);
-	zend_string *const_DT_COUNT_name = zend_string_init_interned("DT_COUNT", sizeof("DT_COUNT") - 1, 1);
+	zend_string *const_DT_COUNT_name = zend_string_init_interned("DT_COUNT", strlen("DT_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DT_COUNT_name, &const_DT_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DT_COUNT_name);
 
 	zval const_JT_NON_JOINING_value;
 	ZVAL_LONG(&const_JT_NON_JOINING_value, U_JT_NON_JOINING);
-	zend_string *const_JT_NON_JOINING_name = zend_string_init_interned("JT_NON_JOINING", sizeof("JT_NON_JOINING") - 1, 1);
+	zend_string *const_JT_NON_JOINING_name = zend_string_init_interned("JT_NON_JOINING", strlen("JT_NON_JOINING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_NON_JOINING_name, &const_JT_NON_JOINING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_NON_JOINING_name);
 
 	zval const_JT_JOIN_CAUSING_value;
 	ZVAL_LONG(&const_JT_JOIN_CAUSING_value, U_JT_JOIN_CAUSING);
-	zend_string *const_JT_JOIN_CAUSING_name = zend_string_init_interned("JT_JOIN_CAUSING", sizeof("JT_JOIN_CAUSING") - 1, 1);
+	zend_string *const_JT_JOIN_CAUSING_name = zend_string_init_interned("JT_JOIN_CAUSING", strlen("JT_JOIN_CAUSING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_JOIN_CAUSING_name, &const_JT_JOIN_CAUSING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_JOIN_CAUSING_name);
 
 	zval const_JT_DUAL_JOINING_value;
 	ZVAL_LONG(&const_JT_DUAL_JOINING_value, U_JT_DUAL_JOINING);
-	zend_string *const_JT_DUAL_JOINING_name = zend_string_init_interned("JT_DUAL_JOINING", sizeof("JT_DUAL_JOINING") - 1, 1);
+	zend_string *const_JT_DUAL_JOINING_name = zend_string_init_interned("JT_DUAL_JOINING", strlen("JT_DUAL_JOINING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_DUAL_JOINING_name, &const_JT_DUAL_JOINING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_DUAL_JOINING_name);
 
 	zval const_JT_LEFT_JOINING_value;
 	ZVAL_LONG(&const_JT_LEFT_JOINING_value, U_JT_LEFT_JOINING);
-	zend_string *const_JT_LEFT_JOINING_name = zend_string_init_interned("JT_LEFT_JOINING", sizeof("JT_LEFT_JOINING") - 1, 1);
+	zend_string *const_JT_LEFT_JOINING_name = zend_string_init_interned("JT_LEFT_JOINING", strlen("JT_LEFT_JOINING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_LEFT_JOINING_name, &const_JT_LEFT_JOINING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_LEFT_JOINING_name);
 
 	zval const_JT_RIGHT_JOINING_value;
 	ZVAL_LONG(&const_JT_RIGHT_JOINING_value, U_JT_RIGHT_JOINING);
-	zend_string *const_JT_RIGHT_JOINING_name = zend_string_init_interned("JT_RIGHT_JOINING", sizeof("JT_RIGHT_JOINING") - 1, 1);
+	zend_string *const_JT_RIGHT_JOINING_name = zend_string_init_interned("JT_RIGHT_JOINING", strlen("JT_RIGHT_JOINING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_RIGHT_JOINING_name, &const_JT_RIGHT_JOINING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_RIGHT_JOINING_name);
 
 	zval const_JT_TRANSPARENT_value;
 	ZVAL_LONG(&const_JT_TRANSPARENT_value, U_JT_TRANSPARENT);
-	zend_string *const_JT_TRANSPARENT_name = zend_string_init_interned("JT_TRANSPARENT", sizeof("JT_TRANSPARENT") - 1, 1);
+	zend_string *const_JT_TRANSPARENT_name = zend_string_init_interned("JT_TRANSPARENT", strlen("JT_TRANSPARENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_TRANSPARENT_name, &const_JT_TRANSPARENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_TRANSPARENT_name);
 
 	zval const_JT_COUNT_value;
 	ZVAL_LONG(&const_JT_COUNT_value, U_JT_COUNT);
-	zend_string *const_JT_COUNT_name = zend_string_init_interned("JT_COUNT", sizeof("JT_COUNT") - 1, 1);
+	zend_string *const_JT_COUNT_name = zend_string_init_interned("JT_COUNT", strlen("JT_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JT_COUNT_name, &const_JT_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JT_COUNT_name);
 
 	zval const_JG_NO_JOINING_GROUP_value;
 	ZVAL_LONG(&const_JG_NO_JOINING_GROUP_value, U_JG_NO_JOINING_GROUP);
-	zend_string *const_JG_NO_JOINING_GROUP_name = zend_string_init_interned("JG_NO_JOINING_GROUP", sizeof("JG_NO_JOINING_GROUP") - 1, 1);
+	zend_string *const_JG_NO_JOINING_GROUP_name = zend_string_init_interned("JG_NO_JOINING_GROUP", strlen("JG_NO_JOINING_GROUP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_NO_JOINING_GROUP_name, &const_JG_NO_JOINING_GROUP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_NO_JOINING_GROUP_name);
 
 	zval const_JG_AIN_value;
 	ZVAL_LONG(&const_JG_AIN_value, U_JG_AIN);
-	zend_string *const_JG_AIN_name = zend_string_init_interned("JG_AIN", sizeof("JG_AIN") - 1, 1);
+	zend_string *const_JG_AIN_name = zend_string_init_interned("JG_AIN", strlen("JG_AIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_AIN_name, &const_JG_AIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_AIN_name);
 
 	zval const_JG_ALAPH_value;
 	ZVAL_LONG(&const_JG_ALAPH_value, U_JG_ALAPH);
-	zend_string *const_JG_ALAPH_name = zend_string_init_interned("JG_ALAPH", sizeof("JG_ALAPH") - 1, 1);
+	zend_string *const_JG_ALAPH_name = zend_string_init_interned("JG_ALAPH", strlen("JG_ALAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_ALAPH_name, &const_JG_ALAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_ALAPH_name);
 
 	zval const_JG_ALEF_value;
 	ZVAL_LONG(&const_JG_ALEF_value, U_JG_ALEF);
-	zend_string *const_JG_ALEF_name = zend_string_init_interned("JG_ALEF", sizeof("JG_ALEF") - 1, 1);
+	zend_string *const_JG_ALEF_name = zend_string_init_interned("JG_ALEF", strlen("JG_ALEF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_ALEF_name, &const_JG_ALEF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_ALEF_name);
 
 	zval const_JG_BEH_value;
 	ZVAL_LONG(&const_JG_BEH_value, U_JG_BEH);
-	zend_string *const_JG_BEH_name = zend_string_init_interned("JG_BEH", sizeof("JG_BEH") - 1, 1);
+	zend_string *const_JG_BEH_name = zend_string_init_interned("JG_BEH", strlen("JG_BEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_BEH_name, &const_JG_BEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_BEH_name);
 
 	zval const_JG_BETH_value;
 	ZVAL_LONG(&const_JG_BETH_value, U_JG_BETH);
-	zend_string *const_JG_BETH_name = zend_string_init_interned("JG_BETH", sizeof("JG_BETH") - 1, 1);
+	zend_string *const_JG_BETH_name = zend_string_init_interned("JG_BETH", strlen("JG_BETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_BETH_name, &const_JG_BETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_BETH_name);
 
 	zval const_JG_DAL_value;
 	ZVAL_LONG(&const_JG_DAL_value, U_JG_DAL);
-	zend_string *const_JG_DAL_name = zend_string_init_interned("JG_DAL", sizeof("JG_DAL") - 1, 1);
+	zend_string *const_JG_DAL_name = zend_string_init_interned("JG_DAL", strlen("JG_DAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_DAL_name, &const_JG_DAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_DAL_name);
 
 	zval const_JG_DALATH_RISH_value;
 	ZVAL_LONG(&const_JG_DALATH_RISH_value, U_JG_DALATH_RISH);
-	zend_string *const_JG_DALATH_RISH_name = zend_string_init_interned("JG_DALATH_RISH", sizeof("JG_DALATH_RISH") - 1, 1);
+	zend_string *const_JG_DALATH_RISH_name = zend_string_init_interned("JG_DALATH_RISH", strlen("JG_DALATH_RISH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_DALATH_RISH_name, &const_JG_DALATH_RISH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_DALATH_RISH_name);
 
 	zval const_JG_E_value;
 	ZVAL_LONG(&const_JG_E_value, U_JG_E);
-	zend_string *const_JG_E_name = zend_string_init_interned("JG_E", sizeof("JG_E") - 1, 1);
+	zend_string *const_JG_E_name = zend_string_init_interned("JG_E", strlen("JG_E"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_E_name, &const_JG_E_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_E_name);
 
 	zval const_JG_FEH_value;
 	ZVAL_LONG(&const_JG_FEH_value, U_JG_FEH);
-	zend_string *const_JG_FEH_name = zend_string_init_interned("JG_FEH", sizeof("JG_FEH") - 1, 1);
+	zend_string *const_JG_FEH_name = zend_string_init_interned("JG_FEH", strlen("JG_FEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_FEH_name, &const_JG_FEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_FEH_name);
 
 	zval const_JG_FINAL_SEMKATH_value;
 	ZVAL_LONG(&const_JG_FINAL_SEMKATH_value, U_JG_FINAL_SEMKATH);
-	zend_string *const_JG_FINAL_SEMKATH_name = zend_string_init_interned("JG_FINAL_SEMKATH", sizeof("JG_FINAL_SEMKATH") - 1, 1);
+	zend_string *const_JG_FINAL_SEMKATH_name = zend_string_init_interned("JG_FINAL_SEMKATH", strlen("JG_FINAL_SEMKATH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_FINAL_SEMKATH_name, &const_JG_FINAL_SEMKATH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_FINAL_SEMKATH_name);
 
 	zval const_JG_GAF_value;
 	ZVAL_LONG(&const_JG_GAF_value, U_JG_GAF);
-	zend_string *const_JG_GAF_name = zend_string_init_interned("JG_GAF", sizeof("JG_GAF") - 1, 1);
+	zend_string *const_JG_GAF_name = zend_string_init_interned("JG_GAF", strlen("JG_GAF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_GAF_name, &const_JG_GAF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_GAF_name);
 
 	zval const_JG_GAMAL_value;
 	ZVAL_LONG(&const_JG_GAMAL_value, U_JG_GAMAL);
-	zend_string *const_JG_GAMAL_name = zend_string_init_interned("JG_GAMAL", sizeof("JG_GAMAL") - 1, 1);
+	zend_string *const_JG_GAMAL_name = zend_string_init_interned("JG_GAMAL", strlen("JG_GAMAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_GAMAL_name, &const_JG_GAMAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_GAMAL_name);
 
 	zval const_JG_HAH_value;
 	ZVAL_LONG(&const_JG_HAH_value, U_JG_HAH);
-	zend_string *const_JG_HAH_name = zend_string_init_interned("JG_HAH", sizeof("JG_HAH") - 1, 1);
+	zend_string *const_JG_HAH_name = zend_string_init_interned("JG_HAH", strlen("JG_HAH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HAH_name, &const_JG_HAH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HAH_name);
 
 	zval const_JG_TEH_MARBUTA_GOAL_value;
 	ZVAL_LONG(&const_JG_TEH_MARBUTA_GOAL_value, U_JG_TEH_MARBUTA_GOAL);
-	zend_string *const_JG_TEH_MARBUTA_GOAL_name = zend_string_init_interned("JG_TEH_MARBUTA_GOAL", sizeof("JG_TEH_MARBUTA_GOAL") - 1, 1);
+	zend_string *const_JG_TEH_MARBUTA_GOAL_name = zend_string_init_interned("JG_TEH_MARBUTA_GOAL", strlen("JG_TEH_MARBUTA_GOAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_TEH_MARBUTA_GOAL_name, &const_JG_TEH_MARBUTA_GOAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_TEH_MARBUTA_GOAL_name);
 
 	zval const_JG_HAMZA_ON_HEH_GOAL_value;
 	ZVAL_LONG(&const_JG_HAMZA_ON_HEH_GOAL_value, U_JG_HAMZA_ON_HEH_GOAL);
-	zend_string *const_JG_HAMZA_ON_HEH_GOAL_name = zend_string_init_interned("JG_HAMZA_ON_HEH_GOAL", sizeof("JG_HAMZA_ON_HEH_GOAL") - 1, 1);
+	zend_string *const_JG_HAMZA_ON_HEH_GOAL_name = zend_string_init_interned("JG_HAMZA_ON_HEH_GOAL", strlen("JG_HAMZA_ON_HEH_GOAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HAMZA_ON_HEH_GOAL_name, &const_JG_HAMZA_ON_HEH_GOAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HAMZA_ON_HEH_GOAL_name);
 
 	zval const_JG_HE_value;
 	ZVAL_LONG(&const_JG_HE_value, U_JG_HE);
-	zend_string *const_JG_HE_name = zend_string_init_interned("JG_HE", sizeof("JG_HE") - 1, 1);
+	zend_string *const_JG_HE_name = zend_string_init_interned("JG_HE", strlen("JG_HE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HE_name, &const_JG_HE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HE_name);
 
 	zval const_JG_HEH_value;
 	ZVAL_LONG(&const_JG_HEH_value, U_JG_HEH);
-	zend_string *const_JG_HEH_name = zend_string_init_interned("JG_HEH", sizeof("JG_HEH") - 1, 1);
+	zend_string *const_JG_HEH_name = zend_string_init_interned("JG_HEH", strlen("JG_HEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HEH_name, &const_JG_HEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HEH_name);
 
 	zval const_JG_HEH_GOAL_value;
 	ZVAL_LONG(&const_JG_HEH_GOAL_value, U_JG_HEH_GOAL);
-	zend_string *const_JG_HEH_GOAL_name = zend_string_init_interned("JG_HEH_GOAL", sizeof("JG_HEH_GOAL") - 1, 1);
+	zend_string *const_JG_HEH_GOAL_name = zend_string_init_interned("JG_HEH_GOAL", strlen("JG_HEH_GOAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HEH_GOAL_name, &const_JG_HEH_GOAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HEH_GOAL_name);
 
 	zval const_JG_HETH_value;
 	ZVAL_LONG(&const_JG_HETH_value, U_JG_HETH);
-	zend_string *const_JG_HETH_name = zend_string_init_interned("JG_HETH", sizeof("JG_HETH") - 1, 1);
+	zend_string *const_JG_HETH_name = zend_string_init_interned("JG_HETH", strlen("JG_HETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_HETH_name, &const_JG_HETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_HETH_name);
 
 	zval const_JG_KAF_value;
 	ZVAL_LONG(&const_JG_KAF_value, U_JG_KAF);
-	zend_string *const_JG_KAF_name = zend_string_init_interned("JG_KAF", sizeof("JG_KAF") - 1, 1);
+	zend_string *const_JG_KAF_name = zend_string_init_interned("JG_KAF", strlen("JG_KAF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_KAF_name, &const_JG_KAF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_KAF_name);
 
 	zval const_JG_KAPH_value;
 	ZVAL_LONG(&const_JG_KAPH_value, U_JG_KAPH);
-	zend_string *const_JG_KAPH_name = zend_string_init_interned("JG_KAPH", sizeof("JG_KAPH") - 1, 1);
+	zend_string *const_JG_KAPH_name = zend_string_init_interned("JG_KAPH", strlen("JG_KAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_KAPH_name, &const_JG_KAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_KAPH_name);
 
 	zval const_JG_KNOTTED_HEH_value;
 	ZVAL_LONG(&const_JG_KNOTTED_HEH_value, U_JG_KNOTTED_HEH);
-	zend_string *const_JG_KNOTTED_HEH_name = zend_string_init_interned("JG_KNOTTED_HEH", sizeof("JG_KNOTTED_HEH") - 1, 1);
+	zend_string *const_JG_KNOTTED_HEH_name = zend_string_init_interned("JG_KNOTTED_HEH", strlen("JG_KNOTTED_HEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_KNOTTED_HEH_name, &const_JG_KNOTTED_HEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_KNOTTED_HEH_name);
 
 	zval const_JG_LAM_value;
 	ZVAL_LONG(&const_JG_LAM_value, U_JG_LAM);
-	zend_string *const_JG_LAM_name = zend_string_init_interned("JG_LAM", sizeof("JG_LAM") - 1, 1);
+	zend_string *const_JG_LAM_name = zend_string_init_interned("JG_LAM", strlen("JG_LAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_LAM_name, &const_JG_LAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_LAM_name);
 
 	zval const_JG_LAMADH_value;
 	ZVAL_LONG(&const_JG_LAMADH_value, U_JG_LAMADH);
-	zend_string *const_JG_LAMADH_name = zend_string_init_interned("JG_LAMADH", sizeof("JG_LAMADH") - 1, 1);
+	zend_string *const_JG_LAMADH_name = zend_string_init_interned("JG_LAMADH", strlen("JG_LAMADH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_LAMADH_name, &const_JG_LAMADH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_LAMADH_name);
 
 	zval const_JG_MEEM_value;
 	ZVAL_LONG(&const_JG_MEEM_value, U_JG_MEEM);
-	zend_string *const_JG_MEEM_name = zend_string_init_interned("JG_MEEM", sizeof("JG_MEEM") - 1, 1);
+	zend_string *const_JG_MEEM_name = zend_string_init_interned("JG_MEEM", strlen("JG_MEEM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MEEM_name, &const_JG_MEEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MEEM_name);
 
 	zval const_JG_MIM_value;
 	ZVAL_LONG(&const_JG_MIM_value, U_JG_MIM);
-	zend_string *const_JG_MIM_name = zend_string_init_interned("JG_MIM", sizeof("JG_MIM") - 1, 1);
+	zend_string *const_JG_MIM_name = zend_string_init_interned("JG_MIM", strlen("JG_MIM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MIM_name, &const_JG_MIM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MIM_name);
 
 	zval const_JG_NOON_value;
 	ZVAL_LONG(&const_JG_NOON_value, U_JG_NOON);
-	zend_string *const_JG_NOON_name = zend_string_init_interned("JG_NOON", sizeof("JG_NOON") - 1, 1);
+	zend_string *const_JG_NOON_name = zend_string_init_interned("JG_NOON", strlen("JG_NOON"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_NOON_name, &const_JG_NOON_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_NOON_name);
 
 	zval const_JG_NUN_value;
 	ZVAL_LONG(&const_JG_NUN_value, U_JG_NUN);
-	zend_string *const_JG_NUN_name = zend_string_init_interned("JG_NUN", sizeof("JG_NUN") - 1, 1);
+	zend_string *const_JG_NUN_name = zend_string_init_interned("JG_NUN", strlen("JG_NUN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_NUN_name, &const_JG_NUN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_NUN_name);
 
 	zval const_JG_PE_value;
 	ZVAL_LONG(&const_JG_PE_value, U_JG_PE);
-	zend_string *const_JG_PE_name = zend_string_init_interned("JG_PE", sizeof("JG_PE") - 1, 1);
+	zend_string *const_JG_PE_name = zend_string_init_interned("JG_PE", strlen("JG_PE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_PE_name, &const_JG_PE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_PE_name);
 
 	zval const_JG_QAF_value;
 	ZVAL_LONG(&const_JG_QAF_value, U_JG_QAF);
-	zend_string *const_JG_QAF_name = zend_string_init_interned("JG_QAF", sizeof("JG_QAF") - 1, 1);
+	zend_string *const_JG_QAF_name = zend_string_init_interned("JG_QAF", strlen("JG_QAF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_QAF_name, &const_JG_QAF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_QAF_name);
 
 	zval const_JG_QAPH_value;
 	ZVAL_LONG(&const_JG_QAPH_value, U_JG_QAPH);
-	zend_string *const_JG_QAPH_name = zend_string_init_interned("JG_QAPH", sizeof("JG_QAPH") - 1, 1);
+	zend_string *const_JG_QAPH_name = zend_string_init_interned("JG_QAPH", strlen("JG_QAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_QAPH_name, &const_JG_QAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_QAPH_name);
 
 	zval const_JG_REH_value;
 	ZVAL_LONG(&const_JG_REH_value, U_JG_REH);
-	zend_string *const_JG_REH_name = zend_string_init_interned("JG_REH", sizeof("JG_REH") - 1, 1);
+	zend_string *const_JG_REH_name = zend_string_init_interned("JG_REH", strlen("JG_REH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_REH_name, &const_JG_REH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_REH_name);
 
 	zval const_JG_REVERSED_PE_value;
 	ZVAL_LONG(&const_JG_REVERSED_PE_value, U_JG_REVERSED_PE);
-	zend_string *const_JG_REVERSED_PE_name = zend_string_init_interned("JG_REVERSED_PE", sizeof("JG_REVERSED_PE") - 1, 1);
+	zend_string *const_JG_REVERSED_PE_name = zend_string_init_interned("JG_REVERSED_PE", strlen("JG_REVERSED_PE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_REVERSED_PE_name, &const_JG_REVERSED_PE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_REVERSED_PE_name);
 
 	zval const_JG_SAD_value;
 	ZVAL_LONG(&const_JG_SAD_value, U_JG_SAD);
-	zend_string *const_JG_SAD_name = zend_string_init_interned("JG_SAD", sizeof("JG_SAD") - 1, 1);
+	zend_string *const_JG_SAD_name = zend_string_init_interned("JG_SAD", strlen("JG_SAD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SAD_name, &const_JG_SAD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SAD_name);
 
 	zval const_JG_SADHE_value;
 	ZVAL_LONG(&const_JG_SADHE_value, U_JG_SADHE);
-	zend_string *const_JG_SADHE_name = zend_string_init_interned("JG_SADHE", sizeof("JG_SADHE") - 1, 1);
+	zend_string *const_JG_SADHE_name = zend_string_init_interned("JG_SADHE", strlen("JG_SADHE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SADHE_name, &const_JG_SADHE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SADHE_name);
 
 	zval const_JG_SEEN_value;
 	ZVAL_LONG(&const_JG_SEEN_value, U_JG_SEEN);
-	zend_string *const_JG_SEEN_name = zend_string_init_interned("JG_SEEN", sizeof("JG_SEEN") - 1, 1);
+	zend_string *const_JG_SEEN_name = zend_string_init_interned("JG_SEEN", strlen("JG_SEEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SEEN_name, &const_JG_SEEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SEEN_name);
 
 	zval const_JG_SEMKATH_value;
 	ZVAL_LONG(&const_JG_SEMKATH_value, U_JG_SEMKATH);
-	zend_string *const_JG_SEMKATH_name = zend_string_init_interned("JG_SEMKATH", sizeof("JG_SEMKATH") - 1, 1);
+	zend_string *const_JG_SEMKATH_name = zend_string_init_interned("JG_SEMKATH", strlen("JG_SEMKATH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SEMKATH_name, &const_JG_SEMKATH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SEMKATH_name);
 
 	zval const_JG_SHIN_value;
 	ZVAL_LONG(&const_JG_SHIN_value, U_JG_SHIN);
-	zend_string *const_JG_SHIN_name = zend_string_init_interned("JG_SHIN", sizeof("JG_SHIN") - 1, 1);
+	zend_string *const_JG_SHIN_name = zend_string_init_interned("JG_SHIN", strlen("JG_SHIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SHIN_name, &const_JG_SHIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SHIN_name);
 
 	zval const_JG_SWASH_KAF_value;
 	ZVAL_LONG(&const_JG_SWASH_KAF_value, U_JG_SWASH_KAF);
-	zend_string *const_JG_SWASH_KAF_name = zend_string_init_interned("JG_SWASH_KAF", sizeof("JG_SWASH_KAF") - 1, 1);
+	zend_string *const_JG_SWASH_KAF_name = zend_string_init_interned("JG_SWASH_KAF", strlen("JG_SWASH_KAF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SWASH_KAF_name, &const_JG_SWASH_KAF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SWASH_KAF_name);
 
 	zval const_JG_SYRIAC_WAW_value;
 	ZVAL_LONG(&const_JG_SYRIAC_WAW_value, U_JG_SYRIAC_WAW);
-	zend_string *const_JG_SYRIAC_WAW_name = zend_string_init_interned("JG_SYRIAC_WAW", sizeof("JG_SYRIAC_WAW") - 1, 1);
+	zend_string *const_JG_SYRIAC_WAW_name = zend_string_init_interned("JG_SYRIAC_WAW", strlen("JG_SYRIAC_WAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_SYRIAC_WAW_name, &const_JG_SYRIAC_WAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_SYRIAC_WAW_name);
 
 	zval const_JG_TAH_value;
 	ZVAL_LONG(&const_JG_TAH_value, U_JG_TAH);
-	zend_string *const_JG_TAH_name = zend_string_init_interned("JG_TAH", sizeof("JG_TAH") - 1, 1);
+	zend_string *const_JG_TAH_name = zend_string_init_interned("JG_TAH", strlen("JG_TAH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_TAH_name, &const_JG_TAH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_TAH_name);
 
 	zval const_JG_TAW_value;
 	ZVAL_LONG(&const_JG_TAW_value, U_JG_TAW);
-	zend_string *const_JG_TAW_name = zend_string_init_interned("JG_TAW", sizeof("JG_TAW") - 1, 1);
+	zend_string *const_JG_TAW_name = zend_string_init_interned("JG_TAW", strlen("JG_TAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_TAW_name, &const_JG_TAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_TAW_name);
 
 	zval const_JG_TEH_MARBUTA_value;
 	ZVAL_LONG(&const_JG_TEH_MARBUTA_value, U_JG_TEH_MARBUTA);
-	zend_string *const_JG_TEH_MARBUTA_name = zend_string_init_interned("JG_TEH_MARBUTA", sizeof("JG_TEH_MARBUTA") - 1, 1);
+	zend_string *const_JG_TEH_MARBUTA_name = zend_string_init_interned("JG_TEH_MARBUTA", strlen("JG_TEH_MARBUTA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_TEH_MARBUTA_name, &const_JG_TEH_MARBUTA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_TEH_MARBUTA_name);
 
 	zval const_JG_TETH_value;
 	ZVAL_LONG(&const_JG_TETH_value, U_JG_TETH);
-	zend_string *const_JG_TETH_name = zend_string_init_interned("JG_TETH", sizeof("JG_TETH") - 1, 1);
+	zend_string *const_JG_TETH_name = zend_string_init_interned("JG_TETH", strlen("JG_TETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_TETH_name, &const_JG_TETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_TETH_name);
 
 	zval const_JG_WAW_value;
 	ZVAL_LONG(&const_JG_WAW_value, U_JG_WAW);
-	zend_string *const_JG_WAW_name = zend_string_init_interned("JG_WAW", sizeof("JG_WAW") - 1, 1);
+	zend_string *const_JG_WAW_name = zend_string_init_interned("JG_WAW", strlen("JG_WAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_WAW_name, &const_JG_WAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_WAW_name);
 
 	zval const_JG_YEH_value;
 	ZVAL_LONG(&const_JG_YEH_value, U_JG_YEH);
-	zend_string *const_JG_YEH_name = zend_string_init_interned("JG_YEH", sizeof("JG_YEH") - 1, 1);
+	zend_string *const_JG_YEH_name = zend_string_init_interned("JG_YEH", strlen("JG_YEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_YEH_name, &const_JG_YEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_YEH_name);
 
 	zval const_JG_YEH_BARREE_value;
 	ZVAL_LONG(&const_JG_YEH_BARREE_value, U_JG_YEH_BARREE);
-	zend_string *const_JG_YEH_BARREE_name = zend_string_init_interned("JG_YEH_BARREE", sizeof("JG_YEH_BARREE") - 1, 1);
+	zend_string *const_JG_YEH_BARREE_name = zend_string_init_interned("JG_YEH_BARREE", strlen("JG_YEH_BARREE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_YEH_BARREE_name, &const_JG_YEH_BARREE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_YEH_BARREE_name);
 
 	zval const_JG_YEH_WITH_TAIL_value;
 	ZVAL_LONG(&const_JG_YEH_WITH_TAIL_value, U_JG_YEH_WITH_TAIL);
-	zend_string *const_JG_YEH_WITH_TAIL_name = zend_string_init_interned("JG_YEH_WITH_TAIL", sizeof("JG_YEH_WITH_TAIL") - 1, 1);
+	zend_string *const_JG_YEH_WITH_TAIL_name = zend_string_init_interned("JG_YEH_WITH_TAIL", strlen("JG_YEH_WITH_TAIL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_YEH_WITH_TAIL_name, &const_JG_YEH_WITH_TAIL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_YEH_WITH_TAIL_name);
 
 	zval const_JG_YUDH_value;
 	ZVAL_LONG(&const_JG_YUDH_value, U_JG_YUDH);
-	zend_string *const_JG_YUDH_name = zend_string_init_interned("JG_YUDH", sizeof("JG_YUDH") - 1, 1);
+	zend_string *const_JG_YUDH_name = zend_string_init_interned("JG_YUDH", strlen("JG_YUDH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_YUDH_name, &const_JG_YUDH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_YUDH_name);
 
 	zval const_JG_YUDH_HE_value;
 	ZVAL_LONG(&const_JG_YUDH_HE_value, U_JG_YUDH_HE);
-	zend_string *const_JG_YUDH_HE_name = zend_string_init_interned("JG_YUDH_HE", sizeof("JG_YUDH_HE") - 1, 1);
+	zend_string *const_JG_YUDH_HE_name = zend_string_init_interned("JG_YUDH_HE", strlen("JG_YUDH_HE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_YUDH_HE_name, &const_JG_YUDH_HE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_YUDH_HE_name);
 
 	zval const_JG_ZAIN_value;
 	ZVAL_LONG(&const_JG_ZAIN_value, U_JG_ZAIN);
-	zend_string *const_JG_ZAIN_name = zend_string_init_interned("JG_ZAIN", sizeof("JG_ZAIN") - 1, 1);
+	zend_string *const_JG_ZAIN_name = zend_string_init_interned("JG_ZAIN", strlen("JG_ZAIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_ZAIN_name, &const_JG_ZAIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_ZAIN_name);
 
 	zval const_JG_FE_value;
 	ZVAL_LONG(&const_JG_FE_value, U_JG_FE);
-	zend_string *const_JG_FE_name = zend_string_init_interned("JG_FE", sizeof("JG_FE") - 1, 1);
+	zend_string *const_JG_FE_name = zend_string_init_interned("JG_FE", strlen("JG_FE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_FE_name, &const_JG_FE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_FE_name);
 
 	zval const_JG_KHAPH_value;
 	ZVAL_LONG(&const_JG_KHAPH_value, U_JG_KHAPH);
-	zend_string *const_JG_KHAPH_name = zend_string_init_interned("JG_KHAPH", sizeof("JG_KHAPH") - 1, 1);
+	zend_string *const_JG_KHAPH_name = zend_string_init_interned("JG_KHAPH", strlen("JG_KHAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_KHAPH_name, &const_JG_KHAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_KHAPH_name);
 
 	zval const_JG_ZHAIN_value;
 	ZVAL_LONG(&const_JG_ZHAIN_value, U_JG_ZHAIN);
-	zend_string *const_JG_ZHAIN_name = zend_string_init_interned("JG_ZHAIN", sizeof("JG_ZHAIN") - 1, 1);
+	zend_string *const_JG_ZHAIN_name = zend_string_init_interned("JG_ZHAIN", strlen("JG_ZHAIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_ZHAIN_name, &const_JG_ZHAIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_ZHAIN_name);
 
 	zval const_JG_BURUSHASKI_YEH_BARREE_value;
 	ZVAL_LONG(&const_JG_BURUSHASKI_YEH_BARREE_value, U_JG_BURUSHASKI_YEH_BARREE);
-	zend_string *const_JG_BURUSHASKI_YEH_BARREE_name = zend_string_init_interned("JG_BURUSHASKI_YEH_BARREE", sizeof("JG_BURUSHASKI_YEH_BARREE") - 1, 1);
+	zend_string *const_JG_BURUSHASKI_YEH_BARREE_name = zend_string_init_interned("JG_BURUSHASKI_YEH_BARREE", strlen("JG_BURUSHASKI_YEH_BARREE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_BURUSHASKI_YEH_BARREE_name, &const_JG_BURUSHASKI_YEH_BARREE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_BURUSHASKI_YEH_BARREE_name);
 
 	zval const_JG_FARSI_YEH_value;
 	ZVAL_LONG(&const_JG_FARSI_YEH_value, U_JG_FARSI_YEH);
-	zend_string *const_JG_FARSI_YEH_name = zend_string_init_interned("JG_FARSI_YEH", sizeof("JG_FARSI_YEH") - 1, 1);
+	zend_string *const_JG_FARSI_YEH_name = zend_string_init_interned("JG_FARSI_YEH", strlen("JG_FARSI_YEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_FARSI_YEH_name, &const_JG_FARSI_YEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_FARSI_YEH_name);
 
 	zval const_JG_NYA_value;
 	ZVAL_LONG(&const_JG_NYA_value, U_JG_NYA);
-	zend_string *const_JG_NYA_name = zend_string_init_interned("JG_NYA", sizeof("JG_NYA") - 1, 1);
+	zend_string *const_JG_NYA_name = zend_string_init_interned("JG_NYA", strlen("JG_NYA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_NYA_name, &const_JG_NYA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_NYA_name);
 
 	zval const_JG_ROHINGYA_YEH_value;
 	ZVAL_LONG(&const_JG_ROHINGYA_YEH_value, U_JG_ROHINGYA_YEH);
-	zend_string *const_JG_ROHINGYA_YEH_name = zend_string_init_interned("JG_ROHINGYA_YEH", sizeof("JG_ROHINGYA_YEH") - 1, 1);
+	zend_string *const_JG_ROHINGYA_YEH_name = zend_string_init_interned("JG_ROHINGYA_YEH", strlen("JG_ROHINGYA_YEH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_ROHINGYA_YEH_name, &const_JG_ROHINGYA_YEH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_ROHINGYA_YEH_name);
 
 	zval const_JG_MANICHAEAN_ALEPH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_ALEPH_value, U_JG_MANICHAEAN_ALEPH);
-	zend_string *const_JG_MANICHAEAN_ALEPH_name = zend_string_init_interned("JG_MANICHAEAN_ALEPH", sizeof("JG_MANICHAEAN_ALEPH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_ALEPH_name = zend_string_init_interned("JG_MANICHAEAN_ALEPH", strlen("JG_MANICHAEAN_ALEPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_ALEPH_name, &const_JG_MANICHAEAN_ALEPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_ALEPH_name);
 
 	zval const_JG_MANICHAEAN_AYIN_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_AYIN_value, U_JG_MANICHAEAN_AYIN);
-	zend_string *const_JG_MANICHAEAN_AYIN_name = zend_string_init_interned("JG_MANICHAEAN_AYIN", sizeof("JG_MANICHAEAN_AYIN") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_AYIN_name = zend_string_init_interned("JG_MANICHAEAN_AYIN", strlen("JG_MANICHAEAN_AYIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_AYIN_name, &const_JG_MANICHAEAN_AYIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_AYIN_name);
 
 	zval const_JG_MANICHAEAN_BETH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_BETH_value, U_JG_MANICHAEAN_BETH);
-	zend_string *const_JG_MANICHAEAN_BETH_name = zend_string_init_interned("JG_MANICHAEAN_BETH", sizeof("JG_MANICHAEAN_BETH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_BETH_name = zend_string_init_interned("JG_MANICHAEAN_BETH", strlen("JG_MANICHAEAN_BETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_BETH_name, &const_JG_MANICHAEAN_BETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_BETH_name);
 
 	zval const_JG_MANICHAEAN_DALETH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_DALETH_value, U_JG_MANICHAEAN_DALETH);
-	zend_string *const_JG_MANICHAEAN_DALETH_name = zend_string_init_interned("JG_MANICHAEAN_DALETH", sizeof("JG_MANICHAEAN_DALETH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_DALETH_name = zend_string_init_interned("JG_MANICHAEAN_DALETH", strlen("JG_MANICHAEAN_DALETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_DALETH_name, &const_JG_MANICHAEAN_DALETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_DALETH_name);
 
 	zval const_JG_MANICHAEAN_DHAMEDH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_DHAMEDH_value, U_JG_MANICHAEAN_DHAMEDH);
-	zend_string *const_JG_MANICHAEAN_DHAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_DHAMEDH", sizeof("JG_MANICHAEAN_DHAMEDH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_DHAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_DHAMEDH", strlen("JG_MANICHAEAN_DHAMEDH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_DHAMEDH_name, &const_JG_MANICHAEAN_DHAMEDH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_DHAMEDH_name);
 
 	zval const_JG_MANICHAEAN_FIVE_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_FIVE_value, U_JG_MANICHAEAN_FIVE);
-	zend_string *const_JG_MANICHAEAN_FIVE_name = zend_string_init_interned("JG_MANICHAEAN_FIVE", sizeof("JG_MANICHAEAN_FIVE") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_FIVE_name = zend_string_init_interned("JG_MANICHAEAN_FIVE", strlen("JG_MANICHAEAN_FIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_FIVE_name, &const_JG_MANICHAEAN_FIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_FIVE_name);
 
 	zval const_JG_MANICHAEAN_GIMEL_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_GIMEL_value, U_JG_MANICHAEAN_GIMEL);
-	zend_string *const_JG_MANICHAEAN_GIMEL_name = zend_string_init_interned("JG_MANICHAEAN_GIMEL", sizeof("JG_MANICHAEAN_GIMEL") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_GIMEL_name = zend_string_init_interned("JG_MANICHAEAN_GIMEL", strlen("JG_MANICHAEAN_GIMEL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_GIMEL_name, &const_JG_MANICHAEAN_GIMEL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_GIMEL_name);
 
 	zval const_JG_MANICHAEAN_HETH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_HETH_value, U_JG_MANICHAEAN_HETH);
-	zend_string *const_JG_MANICHAEAN_HETH_name = zend_string_init_interned("JG_MANICHAEAN_HETH", sizeof("JG_MANICHAEAN_HETH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_HETH_name = zend_string_init_interned("JG_MANICHAEAN_HETH", strlen("JG_MANICHAEAN_HETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_HETH_name, &const_JG_MANICHAEAN_HETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_HETH_name);
 
 	zval const_JG_MANICHAEAN_HUNDRED_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_HUNDRED_value, U_JG_MANICHAEAN_HUNDRED);
-	zend_string *const_JG_MANICHAEAN_HUNDRED_name = zend_string_init_interned("JG_MANICHAEAN_HUNDRED", sizeof("JG_MANICHAEAN_HUNDRED") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_HUNDRED_name = zend_string_init_interned("JG_MANICHAEAN_HUNDRED", strlen("JG_MANICHAEAN_HUNDRED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_HUNDRED_name, &const_JG_MANICHAEAN_HUNDRED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_HUNDRED_name);
 
 	zval const_JG_MANICHAEAN_KAPH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_KAPH_value, U_JG_MANICHAEAN_KAPH);
-	zend_string *const_JG_MANICHAEAN_KAPH_name = zend_string_init_interned("JG_MANICHAEAN_KAPH", sizeof("JG_MANICHAEAN_KAPH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_KAPH_name = zend_string_init_interned("JG_MANICHAEAN_KAPH", strlen("JG_MANICHAEAN_KAPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_KAPH_name, &const_JG_MANICHAEAN_KAPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_KAPH_name);
 
 	zval const_JG_MANICHAEAN_LAMEDH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_LAMEDH_value, U_JG_MANICHAEAN_LAMEDH);
-	zend_string *const_JG_MANICHAEAN_LAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_LAMEDH", sizeof("JG_MANICHAEAN_LAMEDH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_LAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_LAMEDH", strlen("JG_MANICHAEAN_LAMEDH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_LAMEDH_name, &const_JG_MANICHAEAN_LAMEDH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_LAMEDH_name);
 
 	zval const_JG_MANICHAEAN_MEM_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_MEM_value, U_JG_MANICHAEAN_MEM);
-	zend_string *const_JG_MANICHAEAN_MEM_name = zend_string_init_interned("JG_MANICHAEAN_MEM", sizeof("JG_MANICHAEAN_MEM") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_MEM_name = zend_string_init_interned("JG_MANICHAEAN_MEM", strlen("JG_MANICHAEAN_MEM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_MEM_name, &const_JG_MANICHAEAN_MEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_MEM_name);
 
 	zval const_JG_MANICHAEAN_NUN_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_NUN_value, U_JG_MANICHAEAN_NUN);
-	zend_string *const_JG_MANICHAEAN_NUN_name = zend_string_init_interned("JG_MANICHAEAN_NUN", sizeof("JG_MANICHAEAN_NUN") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_NUN_name = zend_string_init_interned("JG_MANICHAEAN_NUN", strlen("JG_MANICHAEAN_NUN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_NUN_name, &const_JG_MANICHAEAN_NUN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_NUN_name);
 
 	zval const_JG_MANICHAEAN_ONE_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_ONE_value, U_JG_MANICHAEAN_ONE);
-	zend_string *const_JG_MANICHAEAN_ONE_name = zend_string_init_interned("JG_MANICHAEAN_ONE", sizeof("JG_MANICHAEAN_ONE") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_ONE_name = zend_string_init_interned("JG_MANICHAEAN_ONE", strlen("JG_MANICHAEAN_ONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_ONE_name, &const_JG_MANICHAEAN_ONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_ONE_name);
 
 	zval const_JG_MANICHAEAN_PE_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_PE_value, U_JG_MANICHAEAN_PE);
-	zend_string *const_JG_MANICHAEAN_PE_name = zend_string_init_interned("JG_MANICHAEAN_PE", sizeof("JG_MANICHAEAN_PE") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_PE_name = zend_string_init_interned("JG_MANICHAEAN_PE", strlen("JG_MANICHAEAN_PE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_PE_name, &const_JG_MANICHAEAN_PE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_PE_name);
 
 	zval const_JG_MANICHAEAN_QOPH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_QOPH_value, U_JG_MANICHAEAN_QOPH);
-	zend_string *const_JG_MANICHAEAN_QOPH_name = zend_string_init_interned("JG_MANICHAEAN_QOPH", sizeof("JG_MANICHAEAN_QOPH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_QOPH_name = zend_string_init_interned("JG_MANICHAEAN_QOPH", strlen("JG_MANICHAEAN_QOPH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_QOPH_name, &const_JG_MANICHAEAN_QOPH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_QOPH_name);
 
 	zval const_JG_MANICHAEAN_RESH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_RESH_value, U_JG_MANICHAEAN_RESH);
-	zend_string *const_JG_MANICHAEAN_RESH_name = zend_string_init_interned("JG_MANICHAEAN_RESH", sizeof("JG_MANICHAEAN_RESH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_RESH_name = zend_string_init_interned("JG_MANICHAEAN_RESH", strlen("JG_MANICHAEAN_RESH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_RESH_name, &const_JG_MANICHAEAN_RESH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_RESH_name);
 
 	zval const_JG_MANICHAEAN_SADHE_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_SADHE_value, U_JG_MANICHAEAN_SADHE);
-	zend_string *const_JG_MANICHAEAN_SADHE_name = zend_string_init_interned("JG_MANICHAEAN_SADHE", sizeof("JG_MANICHAEAN_SADHE") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_SADHE_name = zend_string_init_interned("JG_MANICHAEAN_SADHE", strlen("JG_MANICHAEAN_SADHE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_SADHE_name, &const_JG_MANICHAEAN_SADHE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_SADHE_name);
 
 	zval const_JG_MANICHAEAN_SAMEKH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_SAMEKH_value, U_JG_MANICHAEAN_SAMEKH);
-	zend_string *const_JG_MANICHAEAN_SAMEKH_name = zend_string_init_interned("JG_MANICHAEAN_SAMEKH", sizeof("JG_MANICHAEAN_SAMEKH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_SAMEKH_name = zend_string_init_interned("JG_MANICHAEAN_SAMEKH", strlen("JG_MANICHAEAN_SAMEKH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_SAMEKH_name, &const_JG_MANICHAEAN_SAMEKH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_SAMEKH_name);
 
 	zval const_JG_MANICHAEAN_TAW_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_TAW_value, U_JG_MANICHAEAN_TAW);
-	zend_string *const_JG_MANICHAEAN_TAW_name = zend_string_init_interned("JG_MANICHAEAN_TAW", sizeof("JG_MANICHAEAN_TAW") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_TAW_name = zend_string_init_interned("JG_MANICHAEAN_TAW", strlen("JG_MANICHAEAN_TAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_TAW_name, &const_JG_MANICHAEAN_TAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_TAW_name);
 
 	zval const_JG_MANICHAEAN_TEN_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_TEN_value, U_JG_MANICHAEAN_TEN);
-	zend_string *const_JG_MANICHAEAN_TEN_name = zend_string_init_interned("JG_MANICHAEAN_TEN", sizeof("JG_MANICHAEAN_TEN") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_TEN_name = zend_string_init_interned("JG_MANICHAEAN_TEN", strlen("JG_MANICHAEAN_TEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_TEN_name, &const_JG_MANICHAEAN_TEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_TEN_name);
 
 	zval const_JG_MANICHAEAN_TETH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_TETH_value, U_JG_MANICHAEAN_TETH);
-	zend_string *const_JG_MANICHAEAN_TETH_name = zend_string_init_interned("JG_MANICHAEAN_TETH", sizeof("JG_MANICHAEAN_TETH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_TETH_name = zend_string_init_interned("JG_MANICHAEAN_TETH", strlen("JG_MANICHAEAN_TETH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_TETH_name, &const_JG_MANICHAEAN_TETH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_TETH_name);
 
 	zval const_JG_MANICHAEAN_THAMEDH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_THAMEDH_value, U_JG_MANICHAEAN_THAMEDH);
-	zend_string *const_JG_MANICHAEAN_THAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_THAMEDH", sizeof("JG_MANICHAEAN_THAMEDH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_THAMEDH_name = zend_string_init_interned("JG_MANICHAEAN_THAMEDH", strlen("JG_MANICHAEAN_THAMEDH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_THAMEDH_name, &const_JG_MANICHAEAN_THAMEDH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_THAMEDH_name);
 
 	zval const_JG_MANICHAEAN_TWENTY_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_TWENTY_value, U_JG_MANICHAEAN_TWENTY);
-	zend_string *const_JG_MANICHAEAN_TWENTY_name = zend_string_init_interned("JG_MANICHAEAN_TWENTY", sizeof("JG_MANICHAEAN_TWENTY") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_TWENTY_name = zend_string_init_interned("JG_MANICHAEAN_TWENTY", strlen("JG_MANICHAEAN_TWENTY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_TWENTY_name, &const_JG_MANICHAEAN_TWENTY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_TWENTY_name);
 
 	zval const_JG_MANICHAEAN_WAW_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_WAW_value, U_JG_MANICHAEAN_WAW);
-	zend_string *const_JG_MANICHAEAN_WAW_name = zend_string_init_interned("JG_MANICHAEAN_WAW", sizeof("JG_MANICHAEAN_WAW") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_WAW_name = zend_string_init_interned("JG_MANICHAEAN_WAW", strlen("JG_MANICHAEAN_WAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_WAW_name, &const_JG_MANICHAEAN_WAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_WAW_name);
 
 	zval const_JG_MANICHAEAN_YODH_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_YODH_value, U_JG_MANICHAEAN_YODH);
-	zend_string *const_JG_MANICHAEAN_YODH_name = zend_string_init_interned("JG_MANICHAEAN_YODH", sizeof("JG_MANICHAEAN_YODH") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_YODH_name = zend_string_init_interned("JG_MANICHAEAN_YODH", strlen("JG_MANICHAEAN_YODH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_YODH_name, &const_JG_MANICHAEAN_YODH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_YODH_name);
 
 	zval const_JG_MANICHAEAN_ZAYIN_value;
 	ZVAL_LONG(&const_JG_MANICHAEAN_ZAYIN_value, U_JG_MANICHAEAN_ZAYIN);
-	zend_string *const_JG_MANICHAEAN_ZAYIN_name = zend_string_init_interned("JG_MANICHAEAN_ZAYIN", sizeof("JG_MANICHAEAN_ZAYIN") - 1, 1);
+	zend_string *const_JG_MANICHAEAN_ZAYIN_name = zend_string_init_interned("JG_MANICHAEAN_ZAYIN", strlen("JG_MANICHAEAN_ZAYIN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_MANICHAEAN_ZAYIN_name, &const_JG_MANICHAEAN_ZAYIN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_MANICHAEAN_ZAYIN_name);
 
 	zval const_JG_STRAIGHT_WAW_value;
 	ZVAL_LONG(&const_JG_STRAIGHT_WAW_value, U_JG_STRAIGHT_WAW);
-	zend_string *const_JG_STRAIGHT_WAW_name = zend_string_init_interned("JG_STRAIGHT_WAW", sizeof("JG_STRAIGHT_WAW") - 1, 1);
+	zend_string *const_JG_STRAIGHT_WAW_name = zend_string_init_interned("JG_STRAIGHT_WAW", strlen("JG_STRAIGHT_WAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_STRAIGHT_WAW_name, &const_JG_STRAIGHT_WAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_STRAIGHT_WAW_name);
 
 	zval const_JG_COUNT_value;
 	ZVAL_LONG(&const_JG_COUNT_value, U_JG_COUNT);
-	zend_string *const_JG_COUNT_name = zend_string_init_interned("JG_COUNT", sizeof("JG_COUNT") - 1, 1);
+	zend_string *const_JG_COUNT_name = zend_string_init_interned("JG_COUNT", strlen("JG_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_JG_COUNT_name, &const_JG_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_JG_COUNT_name);
 
 	zval const_GCB_OTHER_value;
 	ZVAL_LONG(&const_GCB_OTHER_value, U_GCB_OTHER);
-	zend_string *const_GCB_OTHER_name = zend_string_init_interned("GCB_OTHER", sizeof("GCB_OTHER") - 1, 1);
+	zend_string *const_GCB_OTHER_name = zend_string_init_interned("GCB_OTHER", strlen("GCB_OTHER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_OTHER_name, &const_GCB_OTHER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_OTHER_name);
 
 	zval const_GCB_CONTROL_value;
 	ZVAL_LONG(&const_GCB_CONTROL_value, U_GCB_CONTROL);
-	zend_string *const_GCB_CONTROL_name = zend_string_init_interned("GCB_CONTROL", sizeof("GCB_CONTROL") - 1, 1);
+	zend_string *const_GCB_CONTROL_name = zend_string_init_interned("GCB_CONTROL", strlen("GCB_CONTROL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_CONTROL_name, &const_GCB_CONTROL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_CONTROL_name);
 
 	zval const_GCB_CR_value;
 	ZVAL_LONG(&const_GCB_CR_value, U_GCB_CR);
-	zend_string *const_GCB_CR_name = zend_string_init_interned("GCB_CR", sizeof("GCB_CR") - 1, 1);
+	zend_string *const_GCB_CR_name = zend_string_init_interned("GCB_CR", strlen("GCB_CR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_CR_name, &const_GCB_CR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_CR_name);
 
 	zval const_GCB_EXTEND_value;
 	ZVAL_LONG(&const_GCB_EXTEND_value, U_GCB_EXTEND);
-	zend_string *const_GCB_EXTEND_name = zend_string_init_interned("GCB_EXTEND", sizeof("GCB_EXTEND") - 1, 1);
+	zend_string *const_GCB_EXTEND_name = zend_string_init_interned("GCB_EXTEND", strlen("GCB_EXTEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_EXTEND_name, &const_GCB_EXTEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_EXTEND_name);
 
 	zval const_GCB_L_value;
 	ZVAL_LONG(&const_GCB_L_value, U_GCB_L);
-	zend_string *const_GCB_L_name = zend_string_init_interned("GCB_L", sizeof("GCB_L") - 1, 1);
+	zend_string *const_GCB_L_name = zend_string_init_interned("GCB_L", strlen("GCB_L"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_L_name, &const_GCB_L_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_L_name);
 
 	zval const_GCB_LF_value;
 	ZVAL_LONG(&const_GCB_LF_value, U_GCB_LF);
-	zend_string *const_GCB_LF_name = zend_string_init_interned("GCB_LF", sizeof("GCB_LF") - 1, 1);
+	zend_string *const_GCB_LF_name = zend_string_init_interned("GCB_LF", strlen("GCB_LF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_LF_name, &const_GCB_LF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_LF_name);
 
 	zval const_GCB_LV_value;
 	ZVAL_LONG(&const_GCB_LV_value, U_GCB_LV);
-	zend_string *const_GCB_LV_name = zend_string_init_interned("GCB_LV", sizeof("GCB_LV") - 1, 1);
+	zend_string *const_GCB_LV_name = zend_string_init_interned("GCB_LV", strlen("GCB_LV"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_LV_name, &const_GCB_LV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_LV_name);
 
 	zval const_GCB_LVT_value;
 	ZVAL_LONG(&const_GCB_LVT_value, U_GCB_LVT);
-	zend_string *const_GCB_LVT_name = zend_string_init_interned("GCB_LVT", sizeof("GCB_LVT") - 1, 1);
+	zend_string *const_GCB_LVT_name = zend_string_init_interned("GCB_LVT", strlen("GCB_LVT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_LVT_name, &const_GCB_LVT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_LVT_name);
 
 	zval const_GCB_T_value;
 	ZVAL_LONG(&const_GCB_T_value, U_GCB_T);
-	zend_string *const_GCB_T_name = zend_string_init_interned("GCB_T", sizeof("GCB_T") - 1, 1);
+	zend_string *const_GCB_T_name = zend_string_init_interned("GCB_T", strlen("GCB_T"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_T_name, &const_GCB_T_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_T_name);
 
 	zval const_GCB_V_value;
 	ZVAL_LONG(&const_GCB_V_value, U_GCB_V);
-	zend_string *const_GCB_V_name = zend_string_init_interned("GCB_V", sizeof("GCB_V") - 1, 1);
+	zend_string *const_GCB_V_name = zend_string_init_interned("GCB_V", strlen("GCB_V"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_V_name, &const_GCB_V_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_V_name);
 
 	zval const_GCB_SPACING_MARK_value;
 	ZVAL_LONG(&const_GCB_SPACING_MARK_value, U_GCB_SPACING_MARK);
-	zend_string *const_GCB_SPACING_MARK_name = zend_string_init_interned("GCB_SPACING_MARK", sizeof("GCB_SPACING_MARK") - 1, 1);
+	zend_string *const_GCB_SPACING_MARK_name = zend_string_init_interned("GCB_SPACING_MARK", strlen("GCB_SPACING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_SPACING_MARK_name, &const_GCB_SPACING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_SPACING_MARK_name);
 
 	zval const_GCB_PREPEND_value;
 	ZVAL_LONG(&const_GCB_PREPEND_value, U_GCB_PREPEND);
-	zend_string *const_GCB_PREPEND_name = zend_string_init_interned("GCB_PREPEND", sizeof("GCB_PREPEND") - 1, 1);
+	zend_string *const_GCB_PREPEND_name = zend_string_init_interned("GCB_PREPEND", strlen("GCB_PREPEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_PREPEND_name, &const_GCB_PREPEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_PREPEND_name);
 
 	zval const_GCB_REGIONAL_INDICATOR_value;
 	ZVAL_LONG(&const_GCB_REGIONAL_INDICATOR_value, U_GCB_REGIONAL_INDICATOR);
-	zend_string *const_GCB_REGIONAL_INDICATOR_name = zend_string_init_interned("GCB_REGIONAL_INDICATOR", sizeof("GCB_REGIONAL_INDICATOR") - 1, 1);
+	zend_string *const_GCB_REGIONAL_INDICATOR_name = zend_string_init_interned("GCB_REGIONAL_INDICATOR", strlen("GCB_REGIONAL_INDICATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_REGIONAL_INDICATOR_name, &const_GCB_REGIONAL_INDICATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_REGIONAL_INDICATOR_name);
 
 	zval const_GCB_COUNT_value;
 	ZVAL_LONG(&const_GCB_COUNT_value, U_GCB_COUNT);
-	zend_string *const_GCB_COUNT_name = zend_string_init_interned("GCB_COUNT", sizeof("GCB_COUNT") - 1, 1);
+	zend_string *const_GCB_COUNT_name = zend_string_init_interned("GCB_COUNT", strlen("GCB_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GCB_COUNT_name, &const_GCB_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GCB_COUNT_name);
 
 	zval const_WB_OTHER_value;
 	ZVAL_LONG(&const_WB_OTHER_value, U_WB_OTHER);
-	zend_string *const_WB_OTHER_name = zend_string_init_interned("WB_OTHER", sizeof("WB_OTHER") - 1, 1);
+	zend_string *const_WB_OTHER_name = zend_string_init_interned("WB_OTHER", strlen("WB_OTHER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_OTHER_name, &const_WB_OTHER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_OTHER_name);
 
 	zval const_WB_ALETTER_value;
 	ZVAL_LONG(&const_WB_ALETTER_value, U_WB_ALETTER);
-	zend_string *const_WB_ALETTER_name = zend_string_init_interned("WB_ALETTER", sizeof("WB_ALETTER") - 1, 1);
+	zend_string *const_WB_ALETTER_name = zend_string_init_interned("WB_ALETTER", strlen("WB_ALETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_ALETTER_name, &const_WB_ALETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_ALETTER_name);
 
 	zval const_WB_FORMAT_value;
 	ZVAL_LONG(&const_WB_FORMAT_value, U_WB_FORMAT);
-	zend_string *const_WB_FORMAT_name = zend_string_init_interned("WB_FORMAT", sizeof("WB_FORMAT") - 1, 1);
+	zend_string *const_WB_FORMAT_name = zend_string_init_interned("WB_FORMAT", strlen("WB_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_FORMAT_name, &const_WB_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_FORMAT_name);
 
 	zval const_WB_KATAKANA_value;
 	ZVAL_LONG(&const_WB_KATAKANA_value, U_WB_KATAKANA);
-	zend_string *const_WB_KATAKANA_name = zend_string_init_interned("WB_KATAKANA", sizeof("WB_KATAKANA") - 1, 1);
+	zend_string *const_WB_KATAKANA_name = zend_string_init_interned("WB_KATAKANA", strlen("WB_KATAKANA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_KATAKANA_name, &const_WB_KATAKANA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_KATAKANA_name);
 
 	zval const_WB_MIDLETTER_value;
 	ZVAL_LONG(&const_WB_MIDLETTER_value, U_WB_MIDLETTER);
-	zend_string *const_WB_MIDLETTER_name = zend_string_init_interned("WB_MIDLETTER", sizeof("WB_MIDLETTER") - 1, 1);
+	zend_string *const_WB_MIDLETTER_name = zend_string_init_interned("WB_MIDLETTER", strlen("WB_MIDLETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_MIDLETTER_name, &const_WB_MIDLETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_MIDLETTER_name);
 
 	zval const_WB_MIDNUM_value;
 	ZVAL_LONG(&const_WB_MIDNUM_value, U_WB_MIDNUM);
-	zend_string *const_WB_MIDNUM_name = zend_string_init_interned("WB_MIDNUM", sizeof("WB_MIDNUM") - 1, 1);
+	zend_string *const_WB_MIDNUM_name = zend_string_init_interned("WB_MIDNUM", strlen("WB_MIDNUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_MIDNUM_name, &const_WB_MIDNUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_MIDNUM_name);
 
 	zval const_WB_NUMERIC_value;
 	ZVAL_LONG(&const_WB_NUMERIC_value, U_WB_NUMERIC);
-	zend_string *const_WB_NUMERIC_name = zend_string_init_interned("WB_NUMERIC", sizeof("WB_NUMERIC") - 1, 1);
+	zend_string *const_WB_NUMERIC_name = zend_string_init_interned("WB_NUMERIC", strlen("WB_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_NUMERIC_name, &const_WB_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_NUMERIC_name);
 
 	zval const_WB_EXTENDNUMLET_value;
 	ZVAL_LONG(&const_WB_EXTENDNUMLET_value, U_WB_EXTENDNUMLET);
-	zend_string *const_WB_EXTENDNUMLET_name = zend_string_init_interned("WB_EXTENDNUMLET", sizeof("WB_EXTENDNUMLET") - 1, 1);
+	zend_string *const_WB_EXTENDNUMLET_name = zend_string_init_interned("WB_EXTENDNUMLET", strlen("WB_EXTENDNUMLET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_EXTENDNUMLET_name, &const_WB_EXTENDNUMLET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_EXTENDNUMLET_name);
 
 	zval const_WB_CR_value;
 	ZVAL_LONG(&const_WB_CR_value, U_WB_CR);
-	zend_string *const_WB_CR_name = zend_string_init_interned("WB_CR", sizeof("WB_CR") - 1, 1);
+	zend_string *const_WB_CR_name = zend_string_init_interned("WB_CR", strlen("WB_CR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_CR_name, &const_WB_CR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_CR_name);
 
 	zval const_WB_EXTEND_value;
 	ZVAL_LONG(&const_WB_EXTEND_value, U_WB_EXTEND);
-	zend_string *const_WB_EXTEND_name = zend_string_init_interned("WB_EXTEND", sizeof("WB_EXTEND") - 1, 1);
+	zend_string *const_WB_EXTEND_name = zend_string_init_interned("WB_EXTEND", strlen("WB_EXTEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_EXTEND_name, &const_WB_EXTEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_EXTEND_name);
 
 	zval const_WB_LF_value;
 	ZVAL_LONG(&const_WB_LF_value, U_WB_LF);
-	zend_string *const_WB_LF_name = zend_string_init_interned("WB_LF", sizeof("WB_LF") - 1, 1);
+	zend_string *const_WB_LF_name = zend_string_init_interned("WB_LF", strlen("WB_LF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_LF_name, &const_WB_LF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_LF_name);
 
 	zval const_WB_MIDNUMLET_value;
 	ZVAL_LONG(&const_WB_MIDNUMLET_value, U_WB_MIDNUMLET);
-	zend_string *const_WB_MIDNUMLET_name = zend_string_init_interned("WB_MIDNUMLET", sizeof("WB_MIDNUMLET") - 1, 1);
+	zend_string *const_WB_MIDNUMLET_name = zend_string_init_interned("WB_MIDNUMLET", strlen("WB_MIDNUMLET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_MIDNUMLET_name, &const_WB_MIDNUMLET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_MIDNUMLET_name);
 
 	zval const_WB_NEWLINE_value;
 	ZVAL_LONG(&const_WB_NEWLINE_value, U_WB_NEWLINE);
-	zend_string *const_WB_NEWLINE_name = zend_string_init_interned("WB_NEWLINE", sizeof("WB_NEWLINE") - 1, 1);
+	zend_string *const_WB_NEWLINE_name = zend_string_init_interned("WB_NEWLINE", strlen("WB_NEWLINE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_NEWLINE_name, &const_WB_NEWLINE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_NEWLINE_name);
 
 	zval const_WB_REGIONAL_INDICATOR_value;
 	ZVAL_LONG(&const_WB_REGIONAL_INDICATOR_value, U_WB_REGIONAL_INDICATOR);
-	zend_string *const_WB_REGIONAL_INDICATOR_name = zend_string_init_interned("WB_REGIONAL_INDICATOR", sizeof("WB_REGIONAL_INDICATOR") - 1, 1);
+	zend_string *const_WB_REGIONAL_INDICATOR_name = zend_string_init_interned("WB_REGIONAL_INDICATOR", strlen("WB_REGIONAL_INDICATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_REGIONAL_INDICATOR_name, &const_WB_REGIONAL_INDICATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_REGIONAL_INDICATOR_name);
 
 	zval const_WB_HEBREW_LETTER_value;
 	ZVAL_LONG(&const_WB_HEBREW_LETTER_value, U_WB_HEBREW_LETTER);
-	zend_string *const_WB_HEBREW_LETTER_name = zend_string_init_interned("WB_HEBREW_LETTER", sizeof("WB_HEBREW_LETTER") - 1, 1);
+	zend_string *const_WB_HEBREW_LETTER_name = zend_string_init_interned("WB_HEBREW_LETTER", strlen("WB_HEBREW_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_HEBREW_LETTER_name, &const_WB_HEBREW_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_HEBREW_LETTER_name);
 
 	zval const_WB_SINGLE_QUOTE_value;
 	ZVAL_LONG(&const_WB_SINGLE_QUOTE_value, U_WB_SINGLE_QUOTE);
-	zend_string *const_WB_SINGLE_QUOTE_name = zend_string_init_interned("WB_SINGLE_QUOTE", sizeof("WB_SINGLE_QUOTE") - 1, 1);
+	zend_string *const_WB_SINGLE_QUOTE_name = zend_string_init_interned("WB_SINGLE_QUOTE", strlen("WB_SINGLE_QUOTE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_SINGLE_QUOTE_name, &const_WB_SINGLE_QUOTE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_SINGLE_QUOTE_name);
 
 	zval const_WB_DOUBLE_QUOTE_value;
 	ZVAL_LONG(&const_WB_DOUBLE_QUOTE_value, U_WB_DOUBLE_QUOTE);
-	zend_string *const_WB_DOUBLE_QUOTE_name = zend_string_init_interned("WB_DOUBLE_QUOTE", sizeof("WB_DOUBLE_QUOTE") - 1, 1);
+	zend_string *const_WB_DOUBLE_QUOTE_name = zend_string_init_interned("WB_DOUBLE_QUOTE", strlen("WB_DOUBLE_QUOTE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_DOUBLE_QUOTE_name, &const_WB_DOUBLE_QUOTE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_DOUBLE_QUOTE_name);
 
 	zval const_WB_COUNT_value;
 	ZVAL_LONG(&const_WB_COUNT_value, U_WB_COUNT);
-	zend_string *const_WB_COUNT_name = zend_string_init_interned("WB_COUNT", sizeof("WB_COUNT") - 1, 1);
+	zend_string *const_WB_COUNT_name = zend_string_init_interned("WB_COUNT", strlen("WB_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WB_COUNT_name, &const_WB_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WB_COUNT_name);
 
 	zval const_SB_OTHER_value;
 	ZVAL_LONG(&const_SB_OTHER_value, U_SB_OTHER);
-	zend_string *const_SB_OTHER_name = zend_string_init_interned("SB_OTHER", sizeof("SB_OTHER") - 1, 1);
+	zend_string *const_SB_OTHER_name = zend_string_init_interned("SB_OTHER", strlen("SB_OTHER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_OTHER_name, &const_SB_OTHER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_OTHER_name);
 
 	zval const_SB_ATERM_value;
 	ZVAL_LONG(&const_SB_ATERM_value, U_SB_ATERM);
-	zend_string *const_SB_ATERM_name = zend_string_init_interned("SB_ATERM", sizeof("SB_ATERM") - 1, 1);
+	zend_string *const_SB_ATERM_name = zend_string_init_interned("SB_ATERM", strlen("SB_ATERM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_ATERM_name, &const_SB_ATERM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_ATERM_name);
 
 	zval const_SB_CLOSE_value;
 	ZVAL_LONG(&const_SB_CLOSE_value, U_SB_CLOSE);
-	zend_string *const_SB_CLOSE_name = zend_string_init_interned("SB_CLOSE", sizeof("SB_CLOSE") - 1, 1);
+	zend_string *const_SB_CLOSE_name = zend_string_init_interned("SB_CLOSE", strlen("SB_CLOSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_CLOSE_name, &const_SB_CLOSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_CLOSE_name);
 
 	zval const_SB_FORMAT_value;
 	ZVAL_LONG(&const_SB_FORMAT_value, U_SB_FORMAT);
-	zend_string *const_SB_FORMAT_name = zend_string_init_interned("SB_FORMAT", sizeof("SB_FORMAT") - 1, 1);
+	zend_string *const_SB_FORMAT_name = zend_string_init_interned("SB_FORMAT", strlen("SB_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_FORMAT_name, &const_SB_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_FORMAT_name);
 
 	zval const_SB_LOWER_value;
 	ZVAL_LONG(&const_SB_LOWER_value, U_SB_LOWER);
-	zend_string *const_SB_LOWER_name = zend_string_init_interned("SB_LOWER", sizeof("SB_LOWER") - 1, 1);
+	zend_string *const_SB_LOWER_name = zend_string_init_interned("SB_LOWER", strlen("SB_LOWER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_LOWER_name, &const_SB_LOWER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_LOWER_name);
 
 	zval const_SB_NUMERIC_value;
 	ZVAL_LONG(&const_SB_NUMERIC_value, U_SB_NUMERIC);
-	zend_string *const_SB_NUMERIC_name = zend_string_init_interned("SB_NUMERIC", sizeof("SB_NUMERIC") - 1, 1);
+	zend_string *const_SB_NUMERIC_name = zend_string_init_interned("SB_NUMERIC", strlen("SB_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_NUMERIC_name, &const_SB_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_NUMERIC_name);
 
 	zval const_SB_OLETTER_value;
 	ZVAL_LONG(&const_SB_OLETTER_value, U_SB_OLETTER);
-	zend_string *const_SB_OLETTER_name = zend_string_init_interned("SB_OLETTER", sizeof("SB_OLETTER") - 1, 1);
+	zend_string *const_SB_OLETTER_name = zend_string_init_interned("SB_OLETTER", strlen("SB_OLETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_OLETTER_name, &const_SB_OLETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_OLETTER_name);
 
 	zval const_SB_SEP_value;
 	ZVAL_LONG(&const_SB_SEP_value, U_SB_SEP);
-	zend_string *const_SB_SEP_name = zend_string_init_interned("SB_SEP", sizeof("SB_SEP") - 1, 1);
+	zend_string *const_SB_SEP_name = zend_string_init_interned("SB_SEP", strlen("SB_SEP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_SEP_name, &const_SB_SEP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_SEP_name);
 
 	zval const_SB_SP_value;
 	ZVAL_LONG(&const_SB_SP_value, U_SB_SP);
-	zend_string *const_SB_SP_name = zend_string_init_interned("SB_SP", sizeof("SB_SP") - 1, 1);
+	zend_string *const_SB_SP_name = zend_string_init_interned("SB_SP", strlen("SB_SP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_SP_name, &const_SB_SP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_SP_name);
 
 	zval const_SB_STERM_value;
 	ZVAL_LONG(&const_SB_STERM_value, U_SB_STERM);
-	zend_string *const_SB_STERM_name = zend_string_init_interned("SB_STERM", sizeof("SB_STERM") - 1, 1);
+	zend_string *const_SB_STERM_name = zend_string_init_interned("SB_STERM", strlen("SB_STERM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_STERM_name, &const_SB_STERM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_STERM_name);
 
 	zval const_SB_UPPER_value;
 	ZVAL_LONG(&const_SB_UPPER_value, U_SB_UPPER);
-	zend_string *const_SB_UPPER_name = zend_string_init_interned("SB_UPPER", sizeof("SB_UPPER") - 1, 1);
+	zend_string *const_SB_UPPER_name = zend_string_init_interned("SB_UPPER", strlen("SB_UPPER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_UPPER_name, &const_SB_UPPER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_UPPER_name);
 
 	zval const_SB_CR_value;
 	ZVAL_LONG(&const_SB_CR_value, U_SB_CR);
-	zend_string *const_SB_CR_name = zend_string_init_interned("SB_CR", sizeof("SB_CR") - 1, 1);
+	zend_string *const_SB_CR_name = zend_string_init_interned("SB_CR", strlen("SB_CR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_CR_name, &const_SB_CR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_CR_name);
 
 	zval const_SB_EXTEND_value;
 	ZVAL_LONG(&const_SB_EXTEND_value, U_SB_EXTEND);
-	zend_string *const_SB_EXTEND_name = zend_string_init_interned("SB_EXTEND", sizeof("SB_EXTEND") - 1, 1);
+	zend_string *const_SB_EXTEND_name = zend_string_init_interned("SB_EXTEND", strlen("SB_EXTEND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_EXTEND_name, &const_SB_EXTEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_EXTEND_name);
 
 	zval const_SB_LF_value;
 	ZVAL_LONG(&const_SB_LF_value, U_SB_LF);
-	zend_string *const_SB_LF_name = zend_string_init_interned("SB_LF", sizeof("SB_LF") - 1, 1);
+	zend_string *const_SB_LF_name = zend_string_init_interned("SB_LF", strlen("SB_LF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_LF_name, &const_SB_LF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_LF_name);
 
 	zval const_SB_SCONTINUE_value;
 	ZVAL_LONG(&const_SB_SCONTINUE_value, U_SB_SCONTINUE);
-	zend_string *const_SB_SCONTINUE_name = zend_string_init_interned("SB_SCONTINUE", sizeof("SB_SCONTINUE") - 1, 1);
+	zend_string *const_SB_SCONTINUE_name = zend_string_init_interned("SB_SCONTINUE", strlen("SB_SCONTINUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_SCONTINUE_name, &const_SB_SCONTINUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_SCONTINUE_name);
 
 	zval const_SB_COUNT_value;
 	ZVAL_LONG(&const_SB_COUNT_value, U_SB_COUNT);
-	zend_string *const_SB_COUNT_name = zend_string_init_interned("SB_COUNT", sizeof("SB_COUNT") - 1, 1);
+	zend_string *const_SB_COUNT_name = zend_string_init_interned("SB_COUNT", strlen("SB_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SB_COUNT_name, &const_SB_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SB_COUNT_name);
 
 	zval const_LB_UNKNOWN_value;
 	ZVAL_LONG(&const_LB_UNKNOWN_value, U_LB_UNKNOWN);
-	zend_string *const_LB_UNKNOWN_name = zend_string_init_interned("LB_UNKNOWN", sizeof("LB_UNKNOWN") - 1, 1);
+	zend_string *const_LB_UNKNOWN_name = zend_string_init_interned("LB_UNKNOWN", strlen("LB_UNKNOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_UNKNOWN_name, &const_LB_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_UNKNOWN_name);
 
 	zval const_LB_AMBIGUOUS_value;
 	ZVAL_LONG(&const_LB_AMBIGUOUS_value, U_LB_AMBIGUOUS);
-	zend_string *const_LB_AMBIGUOUS_name = zend_string_init_interned("LB_AMBIGUOUS", sizeof("LB_AMBIGUOUS") - 1, 1);
+	zend_string *const_LB_AMBIGUOUS_name = zend_string_init_interned("LB_AMBIGUOUS", strlen("LB_AMBIGUOUS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_AMBIGUOUS_name, &const_LB_AMBIGUOUS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_AMBIGUOUS_name);
 
 	zval const_LB_ALPHABETIC_value;
 	ZVAL_LONG(&const_LB_ALPHABETIC_value, U_LB_ALPHABETIC);
-	zend_string *const_LB_ALPHABETIC_name = zend_string_init_interned("LB_ALPHABETIC", sizeof("LB_ALPHABETIC") - 1, 1);
+	zend_string *const_LB_ALPHABETIC_name = zend_string_init_interned("LB_ALPHABETIC", strlen("LB_ALPHABETIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_ALPHABETIC_name, &const_LB_ALPHABETIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_ALPHABETIC_name);
 
 	zval const_LB_BREAK_BOTH_value;
 	ZVAL_LONG(&const_LB_BREAK_BOTH_value, U_LB_BREAK_BOTH);
-	zend_string *const_LB_BREAK_BOTH_name = zend_string_init_interned("LB_BREAK_BOTH", sizeof("LB_BREAK_BOTH") - 1, 1);
+	zend_string *const_LB_BREAK_BOTH_name = zend_string_init_interned("LB_BREAK_BOTH", strlen("LB_BREAK_BOTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_BREAK_BOTH_name, &const_LB_BREAK_BOTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_BREAK_BOTH_name);
 
 	zval const_LB_BREAK_AFTER_value;
 	ZVAL_LONG(&const_LB_BREAK_AFTER_value, U_LB_BREAK_AFTER);
-	zend_string *const_LB_BREAK_AFTER_name = zend_string_init_interned("LB_BREAK_AFTER", sizeof("LB_BREAK_AFTER") - 1, 1);
+	zend_string *const_LB_BREAK_AFTER_name = zend_string_init_interned("LB_BREAK_AFTER", strlen("LB_BREAK_AFTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_BREAK_AFTER_name, &const_LB_BREAK_AFTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_BREAK_AFTER_name);
 
 	zval const_LB_BREAK_BEFORE_value;
 	ZVAL_LONG(&const_LB_BREAK_BEFORE_value, U_LB_BREAK_BEFORE);
-	zend_string *const_LB_BREAK_BEFORE_name = zend_string_init_interned("LB_BREAK_BEFORE", sizeof("LB_BREAK_BEFORE") - 1, 1);
+	zend_string *const_LB_BREAK_BEFORE_name = zend_string_init_interned("LB_BREAK_BEFORE", strlen("LB_BREAK_BEFORE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_BREAK_BEFORE_name, &const_LB_BREAK_BEFORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_BREAK_BEFORE_name);
 
 	zval const_LB_MANDATORY_BREAK_value;
 	ZVAL_LONG(&const_LB_MANDATORY_BREAK_value, U_LB_MANDATORY_BREAK);
-	zend_string *const_LB_MANDATORY_BREAK_name = zend_string_init_interned("LB_MANDATORY_BREAK", sizeof("LB_MANDATORY_BREAK") - 1, 1);
+	zend_string *const_LB_MANDATORY_BREAK_name = zend_string_init_interned("LB_MANDATORY_BREAK", strlen("LB_MANDATORY_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_MANDATORY_BREAK_name, &const_LB_MANDATORY_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_MANDATORY_BREAK_name);
 
 	zval const_LB_CONTINGENT_BREAK_value;
 	ZVAL_LONG(&const_LB_CONTINGENT_BREAK_value, U_LB_CONTINGENT_BREAK);
-	zend_string *const_LB_CONTINGENT_BREAK_name = zend_string_init_interned("LB_CONTINGENT_BREAK", sizeof("LB_CONTINGENT_BREAK") - 1, 1);
+	zend_string *const_LB_CONTINGENT_BREAK_name = zend_string_init_interned("LB_CONTINGENT_BREAK", strlen("LB_CONTINGENT_BREAK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_CONTINGENT_BREAK_name, &const_LB_CONTINGENT_BREAK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_CONTINGENT_BREAK_name);
 
 	zval const_LB_CLOSE_PUNCTUATION_value;
 	ZVAL_LONG(&const_LB_CLOSE_PUNCTUATION_value, U_LB_CLOSE_PUNCTUATION);
-	zend_string *const_LB_CLOSE_PUNCTUATION_name = zend_string_init_interned("LB_CLOSE_PUNCTUATION", sizeof("LB_CLOSE_PUNCTUATION") - 1, 1);
+	zend_string *const_LB_CLOSE_PUNCTUATION_name = zend_string_init_interned("LB_CLOSE_PUNCTUATION", strlen("LB_CLOSE_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_CLOSE_PUNCTUATION_name, &const_LB_CLOSE_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_CLOSE_PUNCTUATION_name);
 
 	zval const_LB_COMBINING_MARK_value;
 	ZVAL_LONG(&const_LB_COMBINING_MARK_value, U_LB_COMBINING_MARK);
-	zend_string *const_LB_COMBINING_MARK_name = zend_string_init_interned("LB_COMBINING_MARK", sizeof("LB_COMBINING_MARK") - 1, 1);
+	zend_string *const_LB_COMBINING_MARK_name = zend_string_init_interned("LB_COMBINING_MARK", strlen("LB_COMBINING_MARK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_COMBINING_MARK_name, &const_LB_COMBINING_MARK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_COMBINING_MARK_name);
 
 	zval const_LB_CARRIAGE_RETURN_value;
 	ZVAL_LONG(&const_LB_CARRIAGE_RETURN_value, U_LB_CARRIAGE_RETURN);
-	zend_string *const_LB_CARRIAGE_RETURN_name = zend_string_init_interned("LB_CARRIAGE_RETURN", sizeof("LB_CARRIAGE_RETURN") - 1, 1);
+	zend_string *const_LB_CARRIAGE_RETURN_name = zend_string_init_interned("LB_CARRIAGE_RETURN", strlen("LB_CARRIAGE_RETURN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_CARRIAGE_RETURN_name, &const_LB_CARRIAGE_RETURN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_CARRIAGE_RETURN_name);
 
 	zval const_LB_EXCLAMATION_value;
 	ZVAL_LONG(&const_LB_EXCLAMATION_value, U_LB_EXCLAMATION);
-	zend_string *const_LB_EXCLAMATION_name = zend_string_init_interned("LB_EXCLAMATION", sizeof("LB_EXCLAMATION") - 1, 1);
+	zend_string *const_LB_EXCLAMATION_name = zend_string_init_interned("LB_EXCLAMATION", strlen("LB_EXCLAMATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_EXCLAMATION_name, &const_LB_EXCLAMATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_EXCLAMATION_name);
 
 	zval const_LB_GLUE_value;
 	ZVAL_LONG(&const_LB_GLUE_value, U_LB_GLUE);
-	zend_string *const_LB_GLUE_name = zend_string_init_interned("LB_GLUE", sizeof("LB_GLUE") - 1, 1);
+	zend_string *const_LB_GLUE_name = zend_string_init_interned("LB_GLUE", strlen("LB_GLUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_GLUE_name, &const_LB_GLUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_GLUE_name);
 
 	zval const_LB_HYPHEN_value;
 	ZVAL_LONG(&const_LB_HYPHEN_value, U_LB_HYPHEN);
-	zend_string *const_LB_HYPHEN_name = zend_string_init_interned("LB_HYPHEN", sizeof("LB_HYPHEN") - 1, 1);
+	zend_string *const_LB_HYPHEN_name = zend_string_init_interned("LB_HYPHEN", strlen("LB_HYPHEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_HYPHEN_name, &const_LB_HYPHEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_HYPHEN_name);
 
 	zval const_LB_IDEOGRAPHIC_value;
 	ZVAL_LONG(&const_LB_IDEOGRAPHIC_value, U_LB_IDEOGRAPHIC);
-	zend_string *const_LB_IDEOGRAPHIC_name = zend_string_init_interned("LB_IDEOGRAPHIC", sizeof("LB_IDEOGRAPHIC") - 1, 1);
+	zend_string *const_LB_IDEOGRAPHIC_name = zend_string_init_interned("LB_IDEOGRAPHIC", strlen("LB_IDEOGRAPHIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_IDEOGRAPHIC_name, &const_LB_IDEOGRAPHIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_IDEOGRAPHIC_name);
 
 	zval const_LB_INSEPARABLE_value;
 	ZVAL_LONG(&const_LB_INSEPARABLE_value, U_LB_INSEPARABLE);
-	zend_string *const_LB_INSEPARABLE_name = zend_string_init_interned("LB_INSEPARABLE", sizeof("LB_INSEPARABLE") - 1, 1);
+	zend_string *const_LB_INSEPARABLE_name = zend_string_init_interned("LB_INSEPARABLE", strlen("LB_INSEPARABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_INSEPARABLE_name, &const_LB_INSEPARABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_INSEPARABLE_name);
 
 	zval const_LB_INSEPERABLE_value;
 	ZVAL_LONG(&const_LB_INSEPERABLE_value, U_LB_INSEPERABLE);
-	zend_string *const_LB_INSEPERABLE_name = zend_string_init_interned("LB_INSEPERABLE", sizeof("LB_INSEPERABLE") - 1, 1);
+	zend_string *const_LB_INSEPERABLE_name = zend_string_init_interned("LB_INSEPERABLE", strlen("LB_INSEPERABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_INSEPERABLE_name, &const_LB_INSEPERABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_INSEPERABLE_name);
 
 	zval const_LB_INFIX_NUMERIC_value;
 	ZVAL_LONG(&const_LB_INFIX_NUMERIC_value, U_LB_INFIX_NUMERIC);
-	zend_string *const_LB_INFIX_NUMERIC_name = zend_string_init_interned("LB_INFIX_NUMERIC", sizeof("LB_INFIX_NUMERIC") - 1, 1);
+	zend_string *const_LB_INFIX_NUMERIC_name = zend_string_init_interned("LB_INFIX_NUMERIC", strlen("LB_INFIX_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_INFIX_NUMERIC_name, &const_LB_INFIX_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_INFIX_NUMERIC_name);
 
 	zval const_LB_LINE_FEED_value;
 	ZVAL_LONG(&const_LB_LINE_FEED_value, U_LB_LINE_FEED);
-	zend_string *const_LB_LINE_FEED_name = zend_string_init_interned("LB_LINE_FEED", sizeof("LB_LINE_FEED") - 1, 1);
+	zend_string *const_LB_LINE_FEED_name = zend_string_init_interned("LB_LINE_FEED", strlen("LB_LINE_FEED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_LINE_FEED_name, &const_LB_LINE_FEED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_LINE_FEED_name);
 
 	zval const_LB_NONSTARTER_value;
 	ZVAL_LONG(&const_LB_NONSTARTER_value, U_LB_NONSTARTER);
-	zend_string *const_LB_NONSTARTER_name = zend_string_init_interned("LB_NONSTARTER", sizeof("LB_NONSTARTER") - 1, 1);
+	zend_string *const_LB_NONSTARTER_name = zend_string_init_interned("LB_NONSTARTER", strlen("LB_NONSTARTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_NONSTARTER_name, &const_LB_NONSTARTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_NONSTARTER_name);
 
 	zval const_LB_NUMERIC_value;
 	ZVAL_LONG(&const_LB_NUMERIC_value, U_LB_NUMERIC);
-	zend_string *const_LB_NUMERIC_name = zend_string_init_interned("LB_NUMERIC", sizeof("LB_NUMERIC") - 1, 1);
+	zend_string *const_LB_NUMERIC_name = zend_string_init_interned("LB_NUMERIC", strlen("LB_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_NUMERIC_name, &const_LB_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_NUMERIC_name);
 
 	zval const_LB_OPEN_PUNCTUATION_value;
 	ZVAL_LONG(&const_LB_OPEN_PUNCTUATION_value, U_LB_OPEN_PUNCTUATION);
-	zend_string *const_LB_OPEN_PUNCTUATION_name = zend_string_init_interned("LB_OPEN_PUNCTUATION", sizeof("LB_OPEN_PUNCTUATION") - 1, 1);
+	zend_string *const_LB_OPEN_PUNCTUATION_name = zend_string_init_interned("LB_OPEN_PUNCTUATION", strlen("LB_OPEN_PUNCTUATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_OPEN_PUNCTUATION_name, &const_LB_OPEN_PUNCTUATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_OPEN_PUNCTUATION_name);
 
 	zval const_LB_POSTFIX_NUMERIC_value;
 	ZVAL_LONG(&const_LB_POSTFIX_NUMERIC_value, U_LB_POSTFIX_NUMERIC);
-	zend_string *const_LB_POSTFIX_NUMERIC_name = zend_string_init_interned("LB_POSTFIX_NUMERIC", sizeof("LB_POSTFIX_NUMERIC") - 1, 1);
+	zend_string *const_LB_POSTFIX_NUMERIC_name = zend_string_init_interned("LB_POSTFIX_NUMERIC", strlen("LB_POSTFIX_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_POSTFIX_NUMERIC_name, &const_LB_POSTFIX_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_POSTFIX_NUMERIC_name);
 
 	zval const_LB_PREFIX_NUMERIC_value;
 	ZVAL_LONG(&const_LB_PREFIX_NUMERIC_value, U_LB_PREFIX_NUMERIC);
-	zend_string *const_LB_PREFIX_NUMERIC_name = zend_string_init_interned("LB_PREFIX_NUMERIC", sizeof("LB_PREFIX_NUMERIC") - 1, 1);
+	zend_string *const_LB_PREFIX_NUMERIC_name = zend_string_init_interned("LB_PREFIX_NUMERIC", strlen("LB_PREFIX_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_PREFIX_NUMERIC_name, &const_LB_PREFIX_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_PREFIX_NUMERIC_name);
 
 	zval const_LB_QUOTATION_value;
 	ZVAL_LONG(&const_LB_QUOTATION_value, U_LB_QUOTATION);
-	zend_string *const_LB_QUOTATION_name = zend_string_init_interned("LB_QUOTATION", sizeof("LB_QUOTATION") - 1, 1);
+	zend_string *const_LB_QUOTATION_name = zend_string_init_interned("LB_QUOTATION", strlen("LB_QUOTATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_QUOTATION_name, &const_LB_QUOTATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_QUOTATION_name);
 
 	zval const_LB_COMPLEX_CONTEXT_value;
 	ZVAL_LONG(&const_LB_COMPLEX_CONTEXT_value, U_LB_COMPLEX_CONTEXT);
-	zend_string *const_LB_COMPLEX_CONTEXT_name = zend_string_init_interned("LB_COMPLEX_CONTEXT", sizeof("LB_COMPLEX_CONTEXT") - 1, 1);
+	zend_string *const_LB_COMPLEX_CONTEXT_name = zend_string_init_interned("LB_COMPLEX_CONTEXT", strlen("LB_COMPLEX_CONTEXT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_COMPLEX_CONTEXT_name, &const_LB_COMPLEX_CONTEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_COMPLEX_CONTEXT_name);
 
 	zval const_LB_SURROGATE_value;
 	ZVAL_LONG(&const_LB_SURROGATE_value, U_LB_SURROGATE);
-	zend_string *const_LB_SURROGATE_name = zend_string_init_interned("LB_SURROGATE", sizeof("LB_SURROGATE") - 1, 1);
+	zend_string *const_LB_SURROGATE_name = zend_string_init_interned("LB_SURROGATE", strlen("LB_SURROGATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_SURROGATE_name, &const_LB_SURROGATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_SURROGATE_name);
 
 	zval const_LB_SPACE_value;
 	ZVAL_LONG(&const_LB_SPACE_value, U_LB_SPACE);
-	zend_string *const_LB_SPACE_name = zend_string_init_interned("LB_SPACE", sizeof("LB_SPACE") - 1, 1);
+	zend_string *const_LB_SPACE_name = zend_string_init_interned("LB_SPACE", strlen("LB_SPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_SPACE_name, &const_LB_SPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_SPACE_name);
 
 	zval const_LB_BREAK_SYMBOLS_value;
 	ZVAL_LONG(&const_LB_BREAK_SYMBOLS_value, U_LB_BREAK_SYMBOLS);
-	zend_string *const_LB_BREAK_SYMBOLS_name = zend_string_init_interned("LB_BREAK_SYMBOLS", sizeof("LB_BREAK_SYMBOLS") - 1, 1);
+	zend_string *const_LB_BREAK_SYMBOLS_name = zend_string_init_interned("LB_BREAK_SYMBOLS", strlen("LB_BREAK_SYMBOLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_BREAK_SYMBOLS_name, &const_LB_BREAK_SYMBOLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_BREAK_SYMBOLS_name);
 
 	zval const_LB_ZWSPACE_value;
 	ZVAL_LONG(&const_LB_ZWSPACE_value, U_LB_ZWSPACE);
-	zend_string *const_LB_ZWSPACE_name = zend_string_init_interned("LB_ZWSPACE", sizeof("LB_ZWSPACE") - 1, 1);
+	zend_string *const_LB_ZWSPACE_name = zend_string_init_interned("LB_ZWSPACE", strlen("LB_ZWSPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_ZWSPACE_name, &const_LB_ZWSPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_ZWSPACE_name);
 
 	zval const_LB_NEXT_LINE_value;
 	ZVAL_LONG(&const_LB_NEXT_LINE_value, U_LB_NEXT_LINE);
-	zend_string *const_LB_NEXT_LINE_name = zend_string_init_interned("LB_NEXT_LINE", sizeof("LB_NEXT_LINE") - 1, 1);
+	zend_string *const_LB_NEXT_LINE_name = zend_string_init_interned("LB_NEXT_LINE", strlen("LB_NEXT_LINE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_NEXT_LINE_name, &const_LB_NEXT_LINE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_NEXT_LINE_name);
 
 	zval const_LB_WORD_JOINER_value;
 	ZVAL_LONG(&const_LB_WORD_JOINER_value, U_LB_WORD_JOINER);
-	zend_string *const_LB_WORD_JOINER_name = zend_string_init_interned("LB_WORD_JOINER", sizeof("LB_WORD_JOINER") - 1, 1);
+	zend_string *const_LB_WORD_JOINER_name = zend_string_init_interned("LB_WORD_JOINER", strlen("LB_WORD_JOINER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_WORD_JOINER_name, &const_LB_WORD_JOINER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_WORD_JOINER_name);
 
 	zval const_LB_H2_value;
 	ZVAL_LONG(&const_LB_H2_value, U_LB_H2);
-	zend_string *const_LB_H2_name = zend_string_init_interned("LB_H2", sizeof("LB_H2") - 1, 1);
+	zend_string *const_LB_H2_name = zend_string_init_interned("LB_H2", strlen("LB_H2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_H2_name, &const_LB_H2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_H2_name);
 
 	zval const_LB_H3_value;
 	ZVAL_LONG(&const_LB_H3_value, U_LB_H3);
-	zend_string *const_LB_H3_name = zend_string_init_interned("LB_H3", sizeof("LB_H3") - 1, 1);
+	zend_string *const_LB_H3_name = zend_string_init_interned("LB_H3", strlen("LB_H3"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_H3_name, &const_LB_H3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_H3_name);
 
 	zval const_LB_JL_value;
 	ZVAL_LONG(&const_LB_JL_value, U_LB_JL);
-	zend_string *const_LB_JL_name = zend_string_init_interned("LB_JL", sizeof("LB_JL") - 1, 1);
+	zend_string *const_LB_JL_name = zend_string_init_interned("LB_JL", strlen("LB_JL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_JL_name, &const_LB_JL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_JL_name);
 
 	zval const_LB_JT_value;
 	ZVAL_LONG(&const_LB_JT_value, U_LB_JT);
-	zend_string *const_LB_JT_name = zend_string_init_interned("LB_JT", sizeof("LB_JT") - 1, 1);
+	zend_string *const_LB_JT_name = zend_string_init_interned("LB_JT", strlen("LB_JT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_JT_name, &const_LB_JT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_JT_name);
 
 	zval const_LB_JV_value;
 	ZVAL_LONG(&const_LB_JV_value, U_LB_JV);
-	zend_string *const_LB_JV_name = zend_string_init_interned("LB_JV", sizeof("LB_JV") - 1, 1);
+	zend_string *const_LB_JV_name = zend_string_init_interned("LB_JV", strlen("LB_JV"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_JV_name, &const_LB_JV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_JV_name);
 
 	zval const_LB_CLOSE_PARENTHESIS_value;
 	ZVAL_LONG(&const_LB_CLOSE_PARENTHESIS_value, U_LB_CLOSE_PARENTHESIS);
-	zend_string *const_LB_CLOSE_PARENTHESIS_name = zend_string_init_interned("LB_CLOSE_PARENTHESIS", sizeof("LB_CLOSE_PARENTHESIS") - 1, 1);
+	zend_string *const_LB_CLOSE_PARENTHESIS_name = zend_string_init_interned("LB_CLOSE_PARENTHESIS", strlen("LB_CLOSE_PARENTHESIS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_CLOSE_PARENTHESIS_name, &const_LB_CLOSE_PARENTHESIS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_CLOSE_PARENTHESIS_name);
 
 	zval const_LB_CONDITIONAL_JAPANESE_STARTER_value;
 	ZVAL_LONG(&const_LB_CONDITIONAL_JAPANESE_STARTER_value, U_LB_CONDITIONAL_JAPANESE_STARTER);
-	zend_string *const_LB_CONDITIONAL_JAPANESE_STARTER_name = zend_string_init_interned("LB_CONDITIONAL_JAPANESE_STARTER", sizeof("LB_CONDITIONAL_JAPANESE_STARTER") - 1, 1);
+	zend_string *const_LB_CONDITIONAL_JAPANESE_STARTER_name = zend_string_init_interned("LB_CONDITIONAL_JAPANESE_STARTER", strlen("LB_CONDITIONAL_JAPANESE_STARTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_CONDITIONAL_JAPANESE_STARTER_name, &const_LB_CONDITIONAL_JAPANESE_STARTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_CONDITIONAL_JAPANESE_STARTER_name);
 
 	zval const_LB_HEBREW_LETTER_value;
 	ZVAL_LONG(&const_LB_HEBREW_LETTER_value, U_LB_HEBREW_LETTER);
-	zend_string *const_LB_HEBREW_LETTER_name = zend_string_init_interned("LB_HEBREW_LETTER", sizeof("LB_HEBREW_LETTER") - 1, 1);
+	zend_string *const_LB_HEBREW_LETTER_name = zend_string_init_interned("LB_HEBREW_LETTER", strlen("LB_HEBREW_LETTER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_HEBREW_LETTER_name, &const_LB_HEBREW_LETTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_HEBREW_LETTER_name);
 
 	zval const_LB_REGIONAL_INDICATOR_value;
 	ZVAL_LONG(&const_LB_REGIONAL_INDICATOR_value, U_LB_REGIONAL_INDICATOR);
-	zend_string *const_LB_REGIONAL_INDICATOR_name = zend_string_init_interned("LB_REGIONAL_INDICATOR", sizeof("LB_REGIONAL_INDICATOR") - 1, 1);
+	zend_string *const_LB_REGIONAL_INDICATOR_name = zend_string_init_interned("LB_REGIONAL_INDICATOR", strlen("LB_REGIONAL_INDICATOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_REGIONAL_INDICATOR_name, &const_LB_REGIONAL_INDICATOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_REGIONAL_INDICATOR_name);
 
 	zval const_LB_COUNT_value;
 	ZVAL_LONG(&const_LB_COUNT_value, U_LB_COUNT);
-	zend_string *const_LB_COUNT_name = zend_string_init_interned("LB_COUNT", sizeof("LB_COUNT") - 1, 1);
+	zend_string *const_LB_COUNT_name = zend_string_init_interned("LB_COUNT", strlen("LB_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LB_COUNT_name, &const_LB_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LB_COUNT_name);
 
 	zval const_NT_NONE_value;
 	ZVAL_LONG(&const_NT_NONE_value, U_NT_NONE);
-	zend_string *const_NT_NONE_name = zend_string_init_interned("NT_NONE", sizeof("NT_NONE") - 1, 1);
+	zend_string *const_NT_NONE_name = zend_string_init_interned("NT_NONE", strlen("NT_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NT_NONE_name, &const_NT_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NT_NONE_name);
 
 	zval const_NT_DECIMAL_value;
 	ZVAL_LONG(&const_NT_DECIMAL_value, U_NT_DECIMAL);
-	zend_string *const_NT_DECIMAL_name = zend_string_init_interned("NT_DECIMAL", sizeof("NT_DECIMAL") - 1, 1);
+	zend_string *const_NT_DECIMAL_name = zend_string_init_interned("NT_DECIMAL", strlen("NT_DECIMAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NT_DECIMAL_name, &const_NT_DECIMAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NT_DECIMAL_name);
 
 	zval const_NT_DIGIT_value;
 	ZVAL_LONG(&const_NT_DIGIT_value, U_NT_DIGIT);
-	zend_string *const_NT_DIGIT_name = zend_string_init_interned("NT_DIGIT", sizeof("NT_DIGIT") - 1, 1);
+	zend_string *const_NT_DIGIT_name = zend_string_init_interned("NT_DIGIT", strlen("NT_DIGIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NT_DIGIT_name, &const_NT_DIGIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NT_DIGIT_name);
 
 	zval const_NT_NUMERIC_value;
 	ZVAL_LONG(&const_NT_NUMERIC_value, U_NT_NUMERIC);
-	zend_string *const_NT_NUMERIC_name = zend_string_init_interned("NT_NUMERIC", sizeof("NT_NUMERIC") - 1, 1);
+	zend_string *const_NT_NUMERIC_name = zend_string_init_interned("NT_NUMERIC", strlen("NT_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NT_NUMERIC_name, &const_NT_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NT_NUMERIC_name);
 
 	zval const_NT_COUNT_value;
 	ZVAL_LONG(&const_NT_COUNT_value, U_NT_COUNT);
-	zend_string *const_NT_COUNT_name = zend_string_init_interned("NT_COUNT", sizeof("NT_COUNT") - 1, 1);
+	zend_string *const_NT_COUNT_name = zend_string_init_interned("NT_COUNT", strlen("NT_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NT_COUNT_name, &const_NT_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NT_COUNT_name);
 
 	zval const_HST_NOT_APPLICABLE_value;
 	ZVAL_LONG(&const_HST_NOT_APPLICABLE_value, U_HST_NOT_APPLICABLE);
-	zend_string *const_HST_NOT_APPLICABLE_name = zend_string_init_interned("HST_NOT_APPLICABLE", sizeof("HST_NOT_APPLICABLE") - 1, 1);
+	zend_string *const_HST_NOT_APPLICABLE_name = zend_string_init_interned("HST_NOT_APPLICABLE", strlen("HST_NOT_APPLICABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_NOT_APPLICABLE_name, &const_HST_NOT_APPLICABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_NOT_APPLICABLE_name);
 
 	zval const_HST_LEADING_JAMO_value;
 	ZVAL_LONG(&const_HST_LEADING_JAMO_value, U_HST_LEADING_JAMO);
-	zend_string *const_HST_LEADING_JAMO_name = zend_string_init_interned("HST_LEADING_JAMO", sizeof("HST_LEADING_JAMO") - 1, 1);
+	zend_string *const_HST_LEADING_JAMO_name = zend_string_init_interned("HST_LEADING_JAMO", strlen("HST_LEADING_JAMO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_LEADING_JAMO_name, &const_HST_LEADING_JAMO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_LEADING_JAMO_name);
 
 	zval const_HST_VOWEL_JAMO_value;
 	ZVAL_LONG(&const_HST_VOWEL_JAMO_value, U_HST_VOWEL_JAMO);
-	zend_string *const_HST_VOWEL_JAMO_name = zend_string_init_interned("HST_VOWEL_JAMO", sizeof("HST_VOWEL_JAMO") - 1, 1);
+	zend_string *const_HST_VOWEL_JAMO_name = zend_string_init_interned("HST_VOWEL_JAMO", strlen("HST_VOWEL_JAMO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_VOWEL_JAMO_name, &const_HST_VOWEL_JAMO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_VOWEL_JAMO_name);
 
 	zval const_HST_TRAILING_JAMO_value;
 	ZVAL_LONG(&const_HST_TRAILING_JAMO_value, U_HST_TRAILING_JAMO);
-	zend_string *const_HST_TRAILING_JAMO_name = zend_string_init_interned("HST_TRAILING_JAMO", sizeof("HST_TRAILING_JAMO") - 1, 1);
+	zend_string *const_HST_TRAILING_JAMO_name = zend_string_init_interned("HST_TRAILING_JAMO", strlen("HST_TRAILING_JAMO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_TRAILING_JAMO_name, &const_HST_TRAILING_JAMO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_TRAILING_JAMO_name);
 
 	zval const_HST_LV_SYLLABLE_value;
 	ZVAL_LONG(&const_HST_LV_SYLLABLE_value, U_HST_LV_SYLLABLE);
-	zend_string *const_HST_LV_SYLLABLE_name = zend_string_init_interned("HST_LV_SYLLABLE", sizeof("HST_LV_SYLLABLE") - 1, 1);
+	zend_string *const_HST_LV_SYLLABLE_name = zend_string_init_interned("HST_LV_SYLLABLE", strlen("HST_LV_SYLLABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_LV_SYLLABLE_name, &const_HST_LV_SYLLABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_LV_SYLLABLE_name);
 
 	zval const_HST_LVT_SYLLABLE_value;
 	ZVAL_LONG(&const_HST_LVT_SYLLABLE_value, U_HST_LVT_SYLLABLE);
-	zend_string *const_HST_LVT_SYLLABLE_name = zend_string_init_interned("HST_LVT_SYLLABLE", sizeof("HST_LVT_SYLLABLE") - 1, 1);
+	zend_string *const_HST_LVT_SYLLABLE_name = zend_string_init_interned("HST_LVT_SYLLABLE", strlen("HST_LVT_SYLLABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_LVT_SYLLABLE_name, &const_HST_LVT_SYLLABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_LVT_SYLLABLE_name);
 
 	zval const_HST_COUNT_value;
 	ZVAL_LONG(&const_HST_COUNT_value, U_HST_COUNT);
-	zend_string *const_HST_COUNT_name = zend_string_init_interned("HST_COUNT", sizeof("HST_COUNT") - 1, 1);
+	zend_string *const_HST_COUNT_name = zend_string_init_interned("HST_COUNT", strlen("HST_COUNT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_HST_COUNT_name, &const_HST_COUNT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_HST_COUNT_name);
 
 	zval const_FOLD_CASE_DEFAULT_value;
 	ZVAL_LONG(&const_FOLD_CASE_DEFAULT_value, U_FOLD_CASE_DEFAULT);
-	zend_string *const_FOLD_CASE_DEFAULT_name = zend_string_init_interned("FOLD_CASE_DEFAULT", sizeof("FOLD_CASE_DEFAULT") - 1, 1);
+	zend_string *const_FOLD_CASE_DEFAULT_name = zend_string_init_interned("FOLD_CASE_DEFAULT", strlen("FOLD_CASE_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FOLD_CASE_DEFAULT_name, &const_FOLD_CASE_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FOLD_CASE_DEFAULT_name);
 
 	zval const_FOLD_CASE_EXCLUDE_SPECIAL_I_value;
 	ZVAL_LONG(&const_FOLD_CASE_EXCLUDE_SPECIAL_I_value, U_FOLD_CASE_EXCLUDE_SPECIAL_I);
-	zend_string *const_FOLD_CASE_EXCLUDE_SPECIAL_I_name = zend_string_init_interned("FOLD_CASE_EXCLUDE_SPECIAL_I", sizeof("FOLD_CASE_EXCLUDE_SPECIAL_I") - 1, 1);
+	zend_string *const_FOLD_CASE_EXCLUDE_SPECIAL_I_name = zend_string_init_interned("FOLD_CASE_EXCLUDE_SPECIAL_I", strlen("FOLD_CASE_EXCLUDE_SPECIAL_I"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FOLD_CASE_EXCLUDE_SPECIAL_I_name, &const_FOLD_CASE_EXCLUDE_SPECIAL_I_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FOLD_CASE_EXCLUDE_SPECIAL_I_name);
 

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -805,25 +805,25 @@ static void register_ldap_symbols(int module_number)
 
 #if defined(HAVE_ORALDAP)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect", sizeof("ldap_connect") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect", strlen("ldap_connect")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(HAVE_ORALDAP) && defined(LDAP_API_FEATURE_X_OPENLDAP)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect_wallet", sizeof("ldap_connect_wallet") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect_wallet", strlen("ldap_connect_wallet")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind", sizeof("ldap_bind") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind", strlen("ldap_bind")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind_ext", sizeof("ldap_bind_ext") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind_ext", strlen("ldap_bind_ext")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_LDAP_SASL)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_sasl_bind", sizeof("ldap_sasl_bind") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_sasl_bind", strlen("ldap_sasl_bind")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(HAVE_LDAP_PASSWD)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", strlen("ldap_exop_passwd")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", strlen("ldap_exop_passwd")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 }
 

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -87,7 +87,7 @@ static void register_libxml_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("LIBXML_ERR_FATAL", XML_ERR_FATAL, CONST_PERSISTENT);
 
 
-	zend_attribute *attribute_Deprecated_func_libxml_disable_entity_loader_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "libxml_disable_entity_loader", sizeof("libxml_disable_entity_loader") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_libxml_disable_entity_loader_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "libxml_disable_entity_loader", strlen("libxml_disable_entity_loader")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0;
 	zend_string *attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0, attribute_Deprecated_func_libxml_disable_entity_loader_0_arg0_str);
@@ -109,7 +109,7 @@ static zend_class_entry *register_class_LibXMLError(void)
 
 	zval property_level_default_value;
 	ZVAL_UNDEF(&property_level_default_value);
-	zend_string *property_level_name = zend_string_init("level", sizeof("level") - 1, 1);
+	zend_string *property_level_name = zend_string_init("level", strlen("level"), 1);
 	zend_declare_typed_property(class_entry, property_level_name, &property_level_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_level_name);
 
@@ -119,7 +119,7 @@ static zend_class_entry *register_class_LibXMLError(void)
 
 	zval property_column_default_value;
 	ZVAL_UNDEF(&property_column_default_value);
-	zend_string *property_column_name = zend_string_init("column", sizeof("column") - 1, 1);
+	zend_string *property_column_name = zend_string_init("column", strlen("column"), 1);
 	zend_declare_typed_property(class_entry, property_column_name, &property_column_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_column_name);
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1146,11 +1146,11 @@ static void register_mysqli_symbols(int module_number)
 	REGISTER_BOOL_CONSTANT("MYSQLI_IS_MARIADB", false, CONST_PERSISTENT | CONST_DEPRECATED);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_change_user", sizeof("mysqli_change_user") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_change_user", strlen("mysqli_change_user")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_connect", sizeof("mysqli_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_connect", strlen("mysqli_connect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_mysqli_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_kill", sizeof("mysqli_kill") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_mysqli_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_kill", strlen("mysqli_kill")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_mysqli_kill_0_arg0;
 	zend_string *attribute_Deprecated_func_mysqli_kill_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mysqli_kill_0_arg0, attribute_Deprecated_func_mysqli_kill_0_arg0_str);
@@ -1162,7 +1162,7 @@ static void register_mysqli_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mysqli_kill_0->args[1].value, &attribute_Deprecated_func_mysqli_kill_0_arg1);
 	attribute_Deprecated_func_mysqli_kill_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_mysqli_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_ping", sizeof("mysqli_ping") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_mysqli_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_ping", strlen("mysqli_ping")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_mysqli_ping_0_arg0;
 	zend_string *attribute_Deprecated_func_mysqli_ping_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mysqli_ping_0_arg0, attribute_Deprecated_func_mysqli_ping_0_arg0_str);
@@ -1174,9 +1174,9 @@ static void register_mysqli_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mysqli_ping_0->args[1].value, &attribute_Deprecated_func_mysqli_ping_0_arg1);
 	attribute_Deprecated_func_mysqli_ping_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_real_connect", sizeof("mysqli_real_connect") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_real_connect", strlen("mysqli_real_connect")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_mysqli_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_refresh", sizeof("mysqli_refresh") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_mysqli_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_refresh", strlen("mysqli_refresh")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_mysqli_refresh_0_arg0;
 	zend_string *attribute_Deprecated_func_mysqli_refresh_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_mysqli_refresh_0_arg0, attribute_Deprecated_func_mysqli_refresh_0_arg0_str);
@@ -1198,25 +1198,25 @@ static zend_class_entry *register_class_mysqli_driver(void)
 
 	zval property_client_info_default_value;
 	ZVAL_UNDEF(&property_client_info_default_value);
-	zend_string *property_client_info_name = zend_string_init("client_info", sizeof("client_info") - 1, 1);
+	zend_string *property_client_info_name = zend_string_init("client_info", strlen("client_info"), 1);
 	zend_declare_typed_property(class_entry, property_client_info_name, &property_client_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_client_info_name);
 
 	zval property_client_version_default_value;
 	ZVAL_UNDEF(&property_client_version_default_value);
-	zend_string *property_client_version_name = zend_string_init("client_version", sizeof("client_version") - 1, 1);
+	zend_string *property_client_version_name = zend_string_init("client_version", strlen("client_version"), 1);
 	zend_declare_typed_property(class_entry, property_client_version_name, &property_client_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_client_version_name);
 
 	zval property_driver_version_default_value;
 	ZVAL_UNDEF(&property_driver_version_default_value);
-	zend_string *property_driver_version_name = zend_string_init("driver_version", sizeof("driver_version") - 1, 1);
+	zend_string *property_driver_version_name = zend_string_init("driver_version", strlen("driver_version"), 1);
 	zend_declare_typed_property(class_entry, property_driver_version_name, &property_driver_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_driver_version_name);
 
 	zval property_report_mode_default_value;
 	ZVAL_LONG(&property_report_mode_default_value, 0);
-	zend_string *property_report_mode_name = zend_string_init("report_mode", sizeof("report_mode") - 1, 1);
+	zend_string *property_report_mode_name = zend_string_init("report_mode", strlen("report_mode"), 1);
 	zend_declare_typed_property(class_entry, property_report_mode_name, &property_report_mode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_report_mode_name);
 
@@ -1232,120 +1232,120 @@ static zend_class_entry *register_class_mysqli(void)
 
 	zval property_affected_rows_default_value;
 	ZVAL_UNDEF(&property_affected_rows_default_value);
-	zend_string *property_affected_rows_name = zend_string_init("affected_rows", sizeof("affected_rows") - 1, 1);
+	zend_string *property_affected_rows_name = zend_string_init("affected_rows", strlen("affected_rows"), 1);
 	zend_declare_typed_property(class_entry, property_affected_rows_name, &property_affected_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_affected_rows_name);
 
 	zval property_client_info_default_value;
 	ZVAL_UNDEF(&property_client_info_default_value);
-	zend_string *property_client_info_name = zend_string_init("client_info", sizeof("client_info") - 1, 1);
+	zend_string *property_client_info_name = zend_string_init("client_info", strlen("client_info"), 1);
 	zend_declare_typed_property(class_entry, property_client_info_name, &property_client_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_client_info_name);
 
 	zval property_client_version_default_value;
 	ZVAL_UNDEF(&property_client_version_default_value);
-	zend_string *property_client_version_name = zend_string_init("client_version", sizeof("client_version") - 1, 1);
+	zend_string *property_client_version_name = zend_string_init("client_version", strlen("client_version"), 1);
 	zend_declare_typed_property(class_entry, property_client_version_name, &property_client_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_client_version_name);
 
 	zval property_connect_errno_default_value;
 	ZVAL_UNDEF(&property_connect_errno_default_value);
-	zend_string *property_connect_errno_name = zend_string_init("connect_errno", sizeof("connect_errno") - 1, 1);
+	zend_string *property_connect_errno_name = zend_string_init("connect_errno", strlen("connect_errno"), 1);
 	zend_declare_typed_property(class_entry, property_connect_errno_name, &property_connect_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_connect_errno_name);
 
 	zval property_connect_error_default_value;
 	ZVAL_UNDEF(&property_connect_error_default_value);
-	zend_string *property_connect_error_name = zend_string_init("connect_error", sizeof("connect_error") - 1, 1);
+	zend_string *property_connect_error_name = zend_string_init("connect_error", strlen("connect_error"), 1);
 	zend_declare_typed_property(class_entry, property_connect_error_name, &property_connect_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_connect_error_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_name = zend_string_init("error", strlen("error"), 1);
 	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_error_name);
 
 	zval property_error_list_default_value;
 	ZVAL_UNDEF(&property_error_list_default_value);
-	zend_string *property_error_list_name = zend_string_init("error_list", sizeof("error_list") - 1, 1);
+	zend_string *property_error_list_name = zend_string_init("error_list", strlen("error_list"), 1);
 	zend_declare_typed_property(class_entry, property_error_list_name, &property_error_list_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_error_list_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_host_info_default_value;
 	ZVAL_UNDEF(&property_host_info_default_value);
-	zend_string *property_host_info_name = zend_string_init("host_info", sizeof("host_info") - 1, 1);
+	zend_string *property_host_info_name = zend_string_init("host_info", strlen("host_info"), 1);
 	zend_declare_typed_property(class_entry, property_host_info_name, &property_host_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_host_info_name);
 
 	zval property_info_default_value;
 	ZVAL_UNDEF(&property_info_default_value);
-	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_string *property_info_name = zend_string_init("info", strlen("info"), 1);
 	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_info_name);
 
 	zval property_insert_id_default_value;
 	ZVAL_UNDEF(&property_insert_id_default_value);
-	zend_string *property_insert_id_name = zend_string_init("insert_id", sizeof("insert_id") - 1, 1);
+	zend_string *property_insert_id_name = zend_string_init("insert_id", strlen("insert_id"), 1);
 	zend_declare_typed_property(class_entry, property_insert_id_name, &property_insert_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_insert_id_name);
 
 	zval property_server_info_default_value;
 	ZVAL_UNDEF(&property_server_info_default_value);
-	zend_string *property_server_info_name = zend_string_init("server_info", sizeof("server_info") - 1, 1);
+	zend_string *property_server_info_name = zend_string_init("server_info", strlen("server_info"), 1);
 	zend_declare_typed_property(class_entry, property_server_info_name, &property_server_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_server_info_name);
 
 	zval property_server_version_default_value;
 	ZVAL_UNDEF(&property_server_version_default_value);
-	zend_string *property_server_version_name = zend_string_init("server_version", sizeof("server_version") - 1, 1);
+	zend_string *property_server_version_name = zend_string_init("server_version", strlen("server_version"), 1);
 	zend_declare_typed_property(class_entry, property_server_version_name, &property_server_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_server_version_name);
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_protocol_version_default_value;
 	ZVAL_UNDEF(&property_protocol_version_default_value);
-	zend_string *property_protocol_version_name = zend_string_init("protocol_version", sizeof("protocol_version") - 1, 1);
+	zend_string *property_protocol_version_name = zend_string_init("protocol_version", strlen("protocol_version"), 1);
 	zend_declare_typed_property(class_entry, property_protocol_version_name, &property_protocol_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_protocol_version_name);
 
 	zval property_thread_id_default_value;
 	ZVAL_UNDEF(&property_thread_id_default_value);
-	zend_string *property_thread_id_name = zend_string_init("thread_id", sizeof("thread_id") - 1, 1);
+	zend_string *property_thread_id_name = zend_string_init("thread_id", strlen("thread_id"), 1);
 	zend_declare_typed_property(class_entry, property_thread_id_name, &property_thread_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_thread_id_name);
 
 	zval property_warning_count_default_value;
 	ZVAL_UNDEF(&property_warning_count_default_value);
-	zend_string *property_warning_count_name = zend_string_init("warning_count", sizeof("warning_count") - 1, 1);
+	zend_string *property_warning_count_name = zend_string_init("warning_count", strlen("warning_count"), 1);
 	zend_declare_typed_property(class_entry, property_warning_count_name, &property_warning_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_warning_count_name);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", strlen("__construct")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "change_user", sizeof("change_user") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "change_user", strlen("change_user")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", strlen("connect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_get_client_info_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "get_client_info", sizeof("get_client_info") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_get_client_info_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "get_client_info", strlen("get_client_info")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_get_client_info_0_arg0;
 	zend_string *attribute_Deprecated_func_get_client_info_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_get_client_info_0_arg0, attribute_Deprecated_func_get_client_info_0_arg0_str);
@@ -1357,7 +1357,7 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_get_client_info_0->args[1].value, &attribute_Deprecated_func_get_client_info_0_arg1);
 	attribute_Deprecated_func_get_client_info_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_init_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "init", sizeof("init") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_init_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "init", strlen("init")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_init_0_arg0;
 	zend_string *attribute_Deprecated_func_init_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_init_0_arg0, attribute_Deprecated_func_init_0_arg0_str);
@@ -1369,7 +1369,7 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_init_0->args[1].value, &attribute_Deprecated_func_init_0_arg1);
 	attribute_Deprecated_func_init_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "kill", sizeof("kill") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "kill", strlen("kill")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_kill_0_arg0;
 	zend_string *attribute_Deprecated_func_kill_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_kill_0_arg0, attribute_Deprecated_func_kill_0_arg0_str);
@@ -1381,7 +1381,7 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_kill_0->args[1].value, &attribute_Deprecated_func_kill_0_arg1);
 	attribute_Deprecated_func_kill_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "ping", sizeof("ping") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "ping", strlen("ping")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_ping_0_arg0;
 	zend_string *attribute_Deprecated_func_ping_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_ping_0_arg0, attribute_Deprecated_func_ping_0_arg0_str);
@@ -1393,9 +1393,9 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_ping_0->args[1].value, &attribute_Deprecated_func_ping_0_arg1);
 	attribute_Deprecated_func_ping_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", sizeof("real_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", strlen("real_connect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "refresh", sizeof("refresh") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_refresh_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "refresh", strlen("refresh")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_refresh_0_arg0;
 	zend_string *attribute_Deprecated_func_refresh_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_refresh_0_arg0, attribute_Deprecated_func_refresh_0_arg0_str);
@@ -1420,25 +1420,25 @@ static zend_class_entry *register_class_mysqli_result(zend_class_entry *class_en
 
 	zval property_current_field_default_value;
 	ZVAL_UNDEF(&property_current_field_default_value);
-	zend_string *property_current_field_name = zend_string_init("current_field", sizeof("current_field") - 1, 1);
+	zend_string *property_current_field_name = zend_string_init("current_field", strlen("current_field"), 1);
 	zend_declare_typed_property(class_entry, property_current_field_name, &property_current_field_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_current_field_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_lengths_default_value;
 	ZVAL_UNDEF(&property_lengths_default_value);
-	zend_string *property_lengths_name = zend_string_init("lengths", sizeof("lengths") - 1, 1);
+	zend_string *property_lengths_name = zend_string_init("lengths", strlen("lengths"), 1);
 	zend_declare_typed_property(class_entry, property_lengths_name, &property_lengths_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_lengths_name);
 
 	zval property_num_rows_default_value;
 	ZVAL_UNDEF(&property_num_rows_default_value);
-	zend_string *property_num_rows_name = zend_string_init("num_rows", sizeof("num_rows") - 1, 1);
+	zend_string *property_num_rows_name = zend_string_init("num_rows", strlen("num_rows"), 1);
 	zend_declare_typed_property(class_entry, property_num_rows_name, &property_num_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_num_rows_name);
 
@@ -1458,61 +1458,61 @@ static zend_class_entry *register_class_mysqli_stmt(void)
 
 	zval property_affected_rows_default_value;
 	ZVAL_UNDEF(&property_affected_rows_default_value);
-	zend_string *property_affected_rows_name = zend_string_init("affected_rows", sizeof("affected_rows") - 1, 1);
+	zend_string *property_affected_rows_name = zend_string_init("affected_rows", strlen("affected_rows"), 1);
 	zend_declare_typed_property(class_entry, property_affected_rows_name, &property_affected_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_affected_rows_name);
 
 	zval property_insert_id_default_value;
 	ZVAL_UNDEF(&property_insert_id_default_value);
-	zend_string *property_insert_id_name = zend_string_init("insert_id", sizeof("insert_id") - 1, 1);
+	zend_string *property_insert_id_name = zend_string_init("insert_id", strlen("insert_id"), 1);
 	zend_declare_typed_property(class_entry, property_insert_id_name, &property_insert_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_insert_id_name);
 
 	zval property_num_rows_default_value;
 	ZVAL_UNDEF(&property_num_rows_default_value);
-	zend_string *property_num_rows_name = zend_string_init("num_rows", sizeof("num_rows") - 1, 1);
+	zend_string *property_num_rows_name = zend_string_init("num_rows", strlen("num_rows"), 1);
 	zend_declare_typed_property(class_entry, property_num_rows_name, &property_num_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_num_rows_name);
 
 	zval property_param_count_default_value;
 	ZVAL_UNDEF(&property_param_count_default_value);
-	zend_string *property_param_count_name = zend_string_init("param_count", sizeof("param_count") - 1, 1);
+	zend_string *property_param_count_name = zend_string_init("param_count", strlen("param_count"), 1);
 	zend_declare_typed_property(class_entry, property_param_count_name, &property_param_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_param_count_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_name = zend_string_init("error", strlen("error"), 1);
 	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_error_name);
 
 	zval property_error_list_default_value;
 	ZVAL_UNDEF(&property_error_list_default_value);
-	zend_string *property_error_list_name = zend_string_init("error_list", sizeof("error_list") - 1, 1);
+	zend_string *property_error_list_name = zend_string_init("error_list", strlen("error_list"), 1);
 	zend_declare_typed_property(class_entry, property_error_list_name, &property_error_list_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_error_list_name);
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_id_name);
 
@@ -1532,13 +1532,13 @@ static zend_class_entry *register_class_mysqli_warning(void)
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
@@ -1555,7 +1555,7 @@ static zend_class_entry *register_class_mysqli_sql_exception(zend_class_entry *c
 	zval property_sqlstate_default_value;
 	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", strlen("00000"), 1);
 	ZVAL_STR(&property_sqlstate_default_value, property_sqlstate_default_value_str);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -461,16 +461,16 @@ static void register_odbc_symbols(int module_number)
 #endif
 
 
-	zend_attribute *attribute_Deprecated_func_odbc_result_all_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_result_all", sizeof("odbc_result_all") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_odbc_result_all_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_result_all", strlen("odbc_result_all")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_odbc_result_all_0_arg0;
 	zend_string *attribute_Deprecated_func_odbc_result_all_0_arg0_str = zend_string_init("8.1", strlen("8.1"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_odbc_result_all_0_arg0, attribute_Deprecated_func_odbc_result_all_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_odbc_result_all_0->args[0].value, &attribute_Deprecated_func_odbc_result_all_0_arg0);
 	attribute_Deprecated_func_odbc_result_all_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_connect", sizeof("odbc_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_connect", strlen("odbc_connect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_pconnect", sizeof("odbc_pconnect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_pconnect", strlen("odbc_pconnect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_Odbc_Connection(void)

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -656,9 +656,9 @@ static void register_openssl_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("OPENSSL_ENCODING_PEM", ENCODING_PEM, CONST_PERSISTENT);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_check_private_key", sizeof("openssl_x509_check_private_key") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_check_private_key", strlen("openssl_x509_check_private_key")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_openssl_x509_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_free", sizeof("openssl_x509_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_openssl_x509_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_free", strlen("openssl_x509_free")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_openssl_x509_free_0_arg0;
 	zend_string *attribute_Deprecated_func_openssl_x509_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_openssl_x509_free_0_arg0, attribute_Deprecated_func_openssl_x509_free_0_arg0_str);
@@ -670,29 +670,29 @@ static void register_openssl_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_x509_free_0->args[1].value, &attribute_Deprecated_func_openssl_x509_free_0_arg1);
 	attribute_Deprecated_func_openssl_x509_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", strlen("openssl_pkcs12_export_to_file")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", strlen("openssl_pkcs12_export_to_file")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", strlen("openssl_pkcs12_export")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", strlen("openssl_pkcs12_export")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_read", sizeof("openssl_pkcs12_read") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_read", strlen("openssl_pkcs12_read")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_sign", sizeof("openssl_csr_sign") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_sign", strlen("openssl_csr_sign")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_new", sizeof("openssl_csr_new") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_new", strlen("openssl_csr_new")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", strlen("openssl_pkey_export_to_file")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", strlen("openssl_pkey_export_to_file")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", strlen("openssl_pkey_export")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", strlen("openssl_pkey_export")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_attribute *attribute_Deprecated_func_openssl_pkey_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_free", sizeof("openssl_pkey_free") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_openssl_pkey_free_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_free", strlen("openssl_pkey_free")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_openssl_pkey_free_0_arg0;
 	zend_string *attribute_Deprecated_func_openssl_pkey_free_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_openssl_pkey_free_0_arg0, attribute_Deprecated_func_openssl_pkey_free_0_arg0_str);
@@ -704,7 +704,7 @@ static void register_openssl_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_pkey_free_0->args[1].value, &attribute_Deprecated_func_openssl_pkey_free_0_arg1);
 	attribute_Deprecated_func_openssl_pkey_free_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_openssl_free_key_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_free_key", sizeof("openssl_free_key") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_openssl_free_key_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_free_key", strlen("openssl_free_key")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_openssl_free_key_0_arg0;
 	zend_string *attribute_Deprecated_func_openssl_free_key_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_openssl_free_key_0_arg0, attribute_Deprecated_func_openssl_free_key_0_arg0_str);
@@ -716,64 +716,64 @@ static void register_openssl_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_openssl_free_key_0->args[1].value, &attribute_Deprecated_func_openssl_free_key_0_arg1);
 	attribute_Deprecated_func_openssl_free_key_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", strlen("openssl_pkey_get_private")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", strlen("openssl_pkey_get_private")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", strlen("openssl_get_privatekey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", strlen("openssl_get_privatekey")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pbkdf2", sizeof("openssl_pbkdf2") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pbkdf2", strlen("openssl_pbkdf2")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_sign", sizeof("openssl_pkcs7_sign") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_sign", strlen("openssl_pkcs7_sign")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", strlen("openssl_pkcs7_decrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", strlen("openssl_pkcs7_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_sign", sizeof("openssl_cms_sign") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_sign", strlen("openssl_cms_sign")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", strlen("openssl_cms_decrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", strlen("openssl_cms_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", strlen("openssl_private_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", strlen("openssl_private_encrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", strlen("openssl_private_decrypt")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", strlen("openssl_private_decrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_encrypt", sizeof("openssl_public_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_encrypt", strlen("openssl_public_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_decrypt", sizeof("openssl_public_decrypt") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_decrypt", strlen("openssl_public_decrypt")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_sign", sizeof("openssl_sign") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_sign", strlen("openssl_sign")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_seal", sizeof("openssl_seal") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_seal", strlen("openssl_seal")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", strlen("openssl_open")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", strlen("openssl_open")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", strlen("openssl_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", strlen("openssl_encrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_decrypt", sizeof("openssl_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_decrypt", strlen("openssl_decrypt")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_dh_compute_key", sizeof("openssl_dh_compute_key") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_dh_compute_key", strlen("openssl_dh_compute_key")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_derive", sizeof("openssl_pkey_derive") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_derive", strlen("openssl_pkey_derive")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_spki_new", sizeof("openssl_spki_new") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_spki_new", strlen("openssl_spki_new")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_OPENSSL_ARGON2)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_hash", sizeof("openssl_password_hash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_hash", strlen("openssl_password_hash")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_verify", sizeof("openssl_password_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_password_verify", strlen("openssl_password_verify")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 }
 

--- a/ext/pdo/pdo_arginfo.h
+++ b/ext/pdo/pdo_arginfo.h
@@ -24,7 +24,7 @@ static zend_class_entry *register_class_PDOException(zend_class_entry *class_ent
 
 	zval property_errorInfo_default_value;
 	ZVAL_NULL(&property_errorInfo_default_value);
-	zend_string *property_errorInfo_name = zend_string_init("errorInfo", sizeof("errorInfo") - 1, 1);
+	zend_string *property_errorInfo_name = zend_string_init("errorInfo", strlen("errorInfo"), 1);
 	zend_declare_typed_property(class_entry, property_errorInfo_name, &property_errorInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_errorInfo_name);
 

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -111,459 +111,459 @@ static zend_class_entry *register_class_PDO(void)
 
 	zval const_PARAM_NULL_value;
 	ZVAL_LONG(&const_PARAM_NULL_value, LONG_CONST(PDO_PARAM_NULL));
-	zend_string *const_PARAM_NULL_name = zend_string_init_interned("PARAM_NULL", sizeof("PARAM_NULL") - 1, 1);
+	zend_string *const_PARAM_NULL_name = zend_string_init_interned("PARAM_NULL", strlen("PARAM_NULL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_NULL_name, &const_PARAM_NULL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_NULL_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_NULL) == 0);
 
 	zval const_PARAM_BOOL_value;
 	ZVAL_LONG(&const_PARAM_BOOL_value, LONG_CONST(PDO_PARAM_BOOL));
-	zend_string *const_PARAM_BOOL_name = zend_string_init_interned("PARAM_BOOL", sizeof("PARAM_BOOL") - 1, 1);
+	zend_string *const_PARAM_BOOL_name = zend_string_init_interned("PARAM_BOOL", strlen("PARAM_BOOL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_BOOL_name, &const_PARAM_BOOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_BOOL_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_BOOL) == 5);
 
 	zval const_PARAM_INT_value;
 	ZVAL_LONG(&const_PARAM_INT_value, LONG_CONST(PDO_PARAM_INT));
-	zend_string *const_PARAM_INT_name = zend_string_init_interned("PARAM_INT", sizeof("PARAM_INT") - 1, 1);
+	zend_string *const_PARAM_INT_name = zend_string_init_interned("PARAM_INT", strlen("PARAM_INT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_INT_name, &const_PARAM_INT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_INT_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_INT) == 1);
 
 	zval const_PARAM_STR_value;
 	ZVAL_LONG(&const_PARAM_STR_value, LONG_CONST(PDO_PARAM_STR));
-	zend_string *const_PARAM_STR_name = zend_string_init_interned("PARAM_STR", sizeof("PARAM_STR") - 1, 1);
+	zend_string *const_PARAM_STR_name = zend_string_init_interned("PARAM_STR", strlen("PARAM_STR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_STR_name, &const_PARAM_STR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_STR_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_STR) == 2);
 
 	zval const_PARAM_LOB_value;
 	ZVAL_LONG(&const_PARAM_LOB_value, LONG_CONST(PDO_PARAM_LOB));
-	zend_string *const_PARAM_LOB_name = zend_string_init_interned("PARAM_LOB", sizeof("PARAM_LOB") - 1, 1);
+	zend_string *const_PARAM_LOB_name = zend_string_init_interned("PARAM_LOB", strlen("PARAM_LOB"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_LOB_name, &const_PARAM_LOB_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_LOB_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_LOB) == 3);
 
 	zval const_PARAM_STMT_value;
 	ZVAL_LONG(&const_PARAM_STMT_value, LONG_CONST(PDO_PARAM_STMT));
-	zend_string *const_PARAM_STMT_name = zend_string_init_interned("PARAM_STMT", sizeof("PARAM_STMT") - 1, 1);
+	zend_string *const_PARAM_STMT_name = zend_string_init_interned("PARAM_STMT", strlen("PARAM_STMT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_STMT_name, &const_PARAM_STMT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_STMT_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_STMT) == 4);
 
 	zval const_PARAM_INPUT_OUTPUT_value;
 	ZVAL_LONG(&const_PARAM_INPUT_OUTPUT_value, LONG_CONST(PDO_PARAM_INPUT_OUTPUT));
-	zend_string *const_PARAM_INPUT_OUTPUT_name = zend_string_init_interned("PARAM_INPUT_OUTPUT", sizeof("PARAM_INPUT_OUTPUT") - 1, 1);
+	zend_string *const_PARAM_INPUT_OUTPUT_name = zend_string_init_interned("PARAM_INPUT_OUTPUT", strlen("PARAM_INPUT_OUTPUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_INPUT_OUTPUT_name, &const_PARAM_INPUT_OUTPUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_INPUT_OUTPUT_name);
 
 	zval const_PARAM_STR_NATL_value;
 	ZVAL_LONG(&const_PARAM_STR_NATL_value, LONG_CONST(PDO_PARAM_STR_NATL));
-	zend_string *const_PARAM_STR_NATL_name = zend_string_init_interned("PARAM_STR_NATL", sizeof("PARAM_STR_NATL") - 1, 1);
+	zend_string *const_PARAM_STR_NATL_name = zend_string_init_interned("PARAM_STR_NATL", strlen("PARAM_STR_NATL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_STR_NATL_name, &const_PARAM_STR_NATL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_STR_NATL_name);
 
 	zval const_PARAM_STR_CHAR_value;
 	ZVAL_LONG(&const_PARAM_STR_CHAR_value, LONG_CONST(PDO_PARAM_STR_CHAR));
-	zend_string *const_PARAM_STR_CHAR_name = zend_string_init_interned("PARAM_STR_CHAR", sizeof("PARAM_STR_CHAR") - 1, 1);
+	zend_string *const_PARAM_STR_CHAR_name = zend_string_init_interned("PARAM_STR_CHAR", strlen("PARAM_STR_CHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_STR_CHAR_name, &const_PARAM_STR_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_STR_CHAR_name);
 
 	zval const_PARAM_EVT_ALLOC_value;
 	ZVAL_LONG(&const_PARAM_EVT_ALLOC_value, LONG_CONST(PDO_PARAM_EVT_ALLOC));
-	zend_string *const_PARAM_EVT_ALLOC_name = zend_string_init_interned("PARAM_EVT_ALLOC", sizeof("PARAM_EVT_ALLOC") - 1, 1);
+	zend_string *const_PARAM_EVT_ALLOC_name = zend_string_init_interned("PARAM_EVT_ALLOC", strlen("PARAM_EVT_ALLOC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_ALLOC_name, &const_PARAM_EVT_ALLOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_ALLOC_name);
 
 	zval const_PARAM_EVT_FREE_value;
 	ZVAL_LONG(&const_PARAM_EVT_FREE_value, LONG_CONST(PDO_PARAM_EVT_FREE));
-	zend_string *const_PARAM_EVT_FREE_name = zend_string_init_interned("PARAM_EVT_FREE", sizeof("PARAM_EVT_FREE") - 1, 1);
+	zend_string *const_PARAM_EVT_FREE_name = zend_string_init_interned("PARAM_EVT_FREE", strlen("PARAM_EVT_FREE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_FREE_name, &const_PARAM_EVT_FREE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_FREE_name);
 
 	zval const_PARAM_EVT_EXEC_PRE_value;
 	ZVAL_LONG(&const_PARAM_EVT_EXEC_PRE_value, LONG_CONST(PDO_PARAM_EVT_EXEC_PRE));
-	zend_string *const_PARAM_EVT_EXEC_PRE_name = zend_string_init_interned("PARAM_EVT_EXEC_PRE", sizeof("PARAM_EVT_EXEC_PRE") - 1, 1);
+	zend_string *const_PARAM_EVT_EXEC_PRE_name = zend_string_init_interned("PARAM_EVT_EXEC_PRE", strlen("PARAM_EVT_EXEC_PRE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_EXEC_PRE_name, &const_PARAM_EVT_EXEC_PRE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_EXEC_PRE_name);
 
 	zval const_PARAM_EVT_EXEC_POST_value;
 	ZVAL_LONG(&const_PARAM_EVT_EXEC_POST_value, LONG_CONST(PDO_PARAM_EVT_EXEC_POST));
-	zend_string *const_PARAM_EVT_EXEC_POST_name = zend_string_init_interned("PARAM_EVT_EXEC_POST", sizeof("PARAM_EVT_EXEC_POST") - 1, 1);
+	zend_string *const_PARAM_EVT_EXEC_POST_name = zend_string_init_interned("PARAM_EVT_EXEC_POST", strlen("PARAM_EVT_EXEC_POST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_EXEC_POST_name, &const_PARAM_EVT_EXEC_POST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_EXEC_POST_name);
 
 	zval const_PARAM_EVT_FETCH_PRE_value;
 	ZVAL_LONG(&const_PARAM_EVT_FETCH_PRE_value, LONG_CONST(PDO_PARAM_EVT_FETCH_PRE));
-	zend_string *const_PARAM_EVT_FETCH_PRE_name = zend_string_init_interned("PARAM_EVT_FETCH_PRE", sizeof("PARAM_EVT_FETCH_PRE") - 1, 1);
+	zend_string *const_PARAM_EVT_FETCH_PRE_name = zend_string_init_interned("PARAM_EVT_FETCH_PRE", strlen("PARAM_EVT_FETCH_PRE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_FETCH_PRE_name, &const_PARAM_EVT_FETCH_PRE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_FETCH_PRE_name);
 
 	zval const_PARAM_EVT_FETCH_POST_value;
 	ZVAL_LONG(&const_PARAM_EVT_FETCH_POST_value, LONG_CONST(PDO_PARAM_EVT_FETCH_POST));
-	zend_string *const_PARAM_EVT_FETCH_POST_name = zend_string_init_interned("PARAM_EVT_FETCH_POST", sizeof("PARAM_EVT_FETCH_POST") - 1, 1);
+	zend_string *const_PARAM_EVT_FETCH_POST_name = zend_string_init_interned("PARAM_EVT_FETCH_POST", strlen("PARAM_EVT_FETCH_POST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_FETCH_POST_name, &const_PARAM_EVT_FETCH_POST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_FETCH_POST_name);
 
 	zval const_PARAM_EVT_NORMALIZE_value;
 	ZVAL_LONG(&const_PARAM_EVT_NORMALIZE_value, LONG_CONST(PDO_PARAM_EVT_NORMALIZE));
-	zend_string *const_PARAM_EVT_NORMALIZE_name = zend_string_init_interned("PARAM_EVT_NORMALIZE", sizeof("PARAM_EVT_NORMALIZE") - 1, 1);
+	zend_string *const_PARAM_EVT_NORMALIZE_name = zend_string_init_interned("PARAM_EVT_NORMALIZE", strlen("PARAM_EVT_NORMALIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PARAM_EVT_NORMALIZE_name, &const_PARAM_EVT_NORMALIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PARAM_EVT_NORMALIZE_name);
 
 	zval const_FETCH_DEFAULT_value;
 	ZVAL_LONG(&const_FETCH_DEFAULT_value, LONG_CONST(PDO_FETCH_USE_DEFAULT));
-	zend_string *const_FETCH_DEFAULT_name = zend_string_init_interned("FETCH_DEFAULT", sizeof("FETCH_DEFAULT") - 1, 1);
+	zend_string *const_FETCH_DEFAULT_name = zend_string_init_interned("FETCH_DEFAULT", strlen("FETCH_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_DEFAULT_name, &const_FETCH_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_DEFAULT_name);
 
 	zval const_FETCH_LAZY_value;
 	ZVAL_LONG(&const_FETCH_LAZY_value, LONG_CONST(PDO_FETCH_LAZY));
-	zend_string *const_FETCH_LAZY_name = zend_string_init_interned("FETCH_LAZY", sizeof("FETCH_LAZY") - 1, 1);
+	zend_string *const_FETCH_LAZY_name = zend_string_init_interned("FETCH_LAZY", strlen("FETCH_LAZY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_LAZY_name, &const_FETCH_LAZY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_LAZY_name);
 
 	zval const_FETCH_ASSOC_value;
 	ZVAL_LONG(&const_FETCH_ASSOC_value, LONG_CONST(PDO_FETCH_ASSOC));
-	zend_string *const_FETCH_ASSOC_name = zend_string_init_interned("FETCH_ASSOC", sizeof("FETCH_ASSOC") - 1, 1);
+	zend_string *const_FETCH_ASSOC_name = zend_string_init_interned("FETCH_ASSOC", strlen("FETCH_ASSOC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ASSOC_name, &const_FETCH_ASSOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ASSOC_name);
 
 	zval const_FETCH_NUM_value;
 	ZVAL_LONG(&const_FETCH_NUM_value, LONG_CONST(PDO_FETCH_NUM));
-	zend_string *const_FETCH_NUM_name = zend_string_init_interned("FETCH_NUM", sizeof("FETCH_NUM") - 1, 1);
+	zend_string *const_FETCH_NUM_name = zend_string_init_interned("FETCH_NUM", strlen("FETCH_NUM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_NUM_name, &const_FETCH_NUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_NUM_name);
 
 	zval const_FETCH_BOTH_value;
 	ZVAL_LONG(&const_FETCH_BOTH_value, LONG_CONST(PDO_FETCH_BOTH));
-	zend_string *const_FETCH_BOTH_name = zend_string_init_interned("FETCH_BOTH", sizeof("FETCH_BOTH") - 1, 1);
+	zend_string *const_FETCH_BOTH_name = zend_string_init_interned("FETCH_BOTH", strlen("FETCH_BOTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_BOTH_name, &const_FETCH_BOTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_BOTH_name);
 
 	zval const_FETCH_OBJ_value;
 	ZVAL_LONG(&const_FETCH_OBJ_value, LONG_CONST(PDO_FETCH_OBJ));
-	zend_string *const_FETCH_OBJ_name = zend_string_init_interned("FETCH_OBJ", sizeof("FETCH_OBJ") - 1, 1);
+	zend_string *const_FETCH_OBJ_name = zend_string_init_interned("FETCH_OBJ", strlen("FETCH_OBJ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_OBJ_name, &const_FETCH_OBJ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_OBJ_name);
 
 	zval const_FETCH_BOUND_value;
 	ZVAL_LONG(&const_FETCH_BOUND_value, LONG_CONST(PDO_FETCH_BOUND));
-	zend_string *const_FETCH_BOUND_name = zend_string_init_interned("FETCH_BOUND", sizeof("FETCH_BOUND") - 1, 1);
+	zend_string *const_FETCH_BOUND_name = zend_string_init_interned("FETCH_BOUND", strlen("FETCH_BOUND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_BOUND_name, &const_FETCH_BOUND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_BOUND_name);
 
 	zval const_FETCH_COLUMN_value;
 	ZVAL_LONG(&const_FETCH_COLUMN_value, LONG_CONST(PDO_FETCH_COLUMN));
-	zend_string *const_FETCH_COLUMN_name = zend_string_init_interned("FETCH_COLUMN", sizeof("FETCH_COLUMN") - 1, 1);
+	zend_string *const_FETCH_COLUMN_name = zend_string_init_interned("FETCH_COLUMN", strlen("FETCH_COLUMN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_COLUMN_name, &const_FETCH_COLUMN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_COLUMN_name);
 
 	zval const_FETCH_CLASS_value;
 	ZVAL_LONG(&const_FETCH_CLASS_value, LONG_CONST(PDO_FETCH_CLASS));
-	zend_string *const_FETCH_CLASS_name = zend_string_init_interned("FETCH_CLASS", sizeof("FETCH_CLASS") - 1, 1);
+	zend_string *const_FETCH_CLASS_name = zend_string_init_interned("FETCH_CLASS", strlen("FETCH_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_CLASS_name, &const_FETCH_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_CLASS_name);
 
 	zval const_FETCH_INTO_value;
 	ZVAL_LONG(&const_FETCH_INTO_value, LONG_CONST(PDO_FETCH_INTO));
-	zend_string *const_FETCH_INTO_name = zend_string_init_interned("FETCH_INTO", sizeof("FETCH_INTO") - 1, 1);
+	zend_string *const_FETCH_INTO_name = zend_string_init_interned("FETCH_INTO", strlen("FETCH_INTO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_INTO_name, &const_FETCH_INTO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_INTO_name);
 
 	zval const_FETCH_FUNC_value;
 	ZVAL_LONG(&const_FETCH_FUNC_value, LONG_CONST(PDO_FETCH_FUNC));
-	zend_string *const_FETCH_FUNC_name = zend_string_init_interned("FETCH_FUNC", sizeof("FETCH_FUNC") - 1, 1);
+	zend_string *const_FETCH_FUNC_name = zend_string_init_interned("FETCH_FUNC", strlen("FETCH_FUNC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_FUNC_name, &const_FETCH_FUNC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_FUNC_name);
 
 	zval const_FETCH_GROUP_value;
 	ZVAL_LONG(&const_FETCH_GROUP_value, LONG_CONST(PDO_FETCH_GROUP));
-	zend_string *const_FETCH_GROUP_name = zend_string_init_interned("FETCH_GROUP", sizeof("FETCH_GROUP") - 1, 1);
+	zend_string *const_FETCH_GROUP_name = zend_string_init_interned("FETCH_GROUP", strlen("FETCH_GROUP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_GROUP_name, &const_FETCH_GROUP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_GROUP_name);
 
 	zval const_FETCH_UNIQUE_value;
 	ZVAL_LONG(&const_FETCH_UNIQUE_value, LONG_CONST(PDO_FETCH_UNIQUE));
-	zend_string *const_FETCH_UNIQUE_name = zend_string_init_interned("FETCH_UNIQUE", sizeof("FETCH_UNIQUE") - 1, 1);
+	zend_string *const_FETCH_UNIQUE_name = zend_string_init_interned("FETCH_UNIQUE", strlen("FETCH_UNIQUE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_UNIQUE_name, &const_FETCH_UNIQUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_UNIQUE_name);
 
 	zval const_FETCH_KEY_PAIR_value;
 	ZVAL_LONG(&const_FETCH_KEY_PAIR_value, LONG_CONST(PDO_FETCH_KEY_PAIR));
-	zend_string *const_FETCH_KEY_PAIR_name = zend_string_init_interned("FETCH_KEY_PAIR", sizeof("FETCH_KEY_PAIR") - 1, 1);
+	zend_string *const_FETCH_KEY_PAIR_name = zend_string_init_interned("FETCH_KEY_PAIR", strlen("FETCH_KEY_PAIR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_KEY_PAIR_name, &const_FETCH_KEY_PAIR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_KEY_PAIR_name);
 
 	zval const_FETCH_CLASSTYPE_value;
 	ZVAL_LONG(&const_FETCH_CLASSTYPE_value, LONG_CONST(PDO_FETCH_CLASSTYPE));
-	zend_string *const_FETCH_CLASSTYPE_name = zend_string_init_interned("FETCH_CLASSTYPE", sizeof("FETCH_CLASSTYPE") - 1, 1);
+	zend_string *const_FETCH_CLASSTYPE_name = zend_string_init_interned("FETCH_CLASSTYPE", strlen("FETCH_CLASSTYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_CLASSTYPE_name, &const_FETCH_CLASSTYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_CLASSTYPE_name);
 
 	zval const_FETCH_SERIALIZE_value;
 	ZVAL_LONG(&const_FETCH_SERIALIZE_value, LONG_CONST(PDO_FETCH_SERIALIZE));
-	zend_string *const_FETCH_SERIALIZE_name = zend_string_init_interned("FETCH_SERIALIZE", sizeof("FETCH_SERIALIZE") - 1, 1);
+	zend_string *const_FETCH_SERIALIZE_name = zend_string_init_interned("FETCH_SERIALIZE", strlen("FETCH_SERIALIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_SERIALIZE_name, &const_FETCH_SERIALIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_SERIALIZE_name);
 
 	zval const_FETCH_PROPS_LATE_value;
 	ZVAL_LONG(&const_FETCH_PROPS_LATE_value, LONG_CONST(PDO_FETCH_PROPS_LATE));
-	zend_string *const_FETCH_PROPS_LATE_name = zend_string_init_interned("FETCH_PROPS_LATE", sizeof("FETCH_PROPS_LATE") - 1, 1);
+	zend_string *const_FETCH_PROPS_LATE_name = zend_string_init_interned("FETCH_PROPS_LATE", strlen("FETCH_PROPS_LATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_PROPS_LATE_name, &const_FETCH_PROPS_LATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_PROPS_LATE_name);
 
 	zval const_FETCH_NAMED_value;
 	ZVAL_LONG(&const_FETCH_NAMED_value, LONG_CONST(PDO_FETCH_NAMED));
-	zend_string *const_FETCH_NAMED_name = zend_string_init_interned("FETCH_NAMED", sizeof("FETCH_NAMED") - 1, 1);
+	zend_string *const_FETCH_NAMED_name = zend_string_init_interned("FETCH_NAMED", strlen("FETCH_NAMED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_NAMED_name, &const_FETCH_NAMED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_NAMED_name);
 
 	zval const_ATTR_AUTOCOMMIT_value;
 	ZVAL_LONG(&const_ATTR_AUTOCOMMIT_value, LONG_CONST(PDO_ATTR_AUTOCOMMIT));
-	zend_string *const_ATTR_AUTOCOMMIT_name = zend_string_init_interned("ATTR_AUTOCOMMIT", sizeof("ATTR_AUTOCOMMIT") - 1, 1);
+	zend_string *const_ATTR_AUTOCOMMIT_name = zend_string_init_interned("ATTR_AUTOCOMMIT", strlen("ATTR_AUTOCOMMIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_AUTOCOMMIT_name, &const_ATTR_AUTOCOMMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_AUTOCOMMIT_name);
 
 	zval const_ATTR_PREFETCH_value;
 	ZVAL_LONG(&const_ATTR_PREFETCH_value, LONG_CONST(PDO_ATTR_PREFETCH));
-	zend_string *const_ATTR_PREFETCH_name = zend_string_init_interned("ATTR_PREFETCH", sizeof("ATTR_PREFETCH") - 1, 1);
+	zend_string *const_ATTR_PREFETCH_name = zend_string_init_interned("ATTR_PREFETCH", strlen("ATTR_PREFETCH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_PREFETCH_name, &const_ATTR_PREFETCH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_PREFETCH_name);
 
 	zval const_ATTR_TIMEOUT_value;
 	ZVAL_LONG(&const_ATTR_TIMEOUT_value, LONG_CONST(PDO_ATTR_TIMEOUT));
-	zend_string *const_ATTR_TIMEOUT_name = zend_string_init_interned("ATTR_TIMEOUT", sizeof("ATTR_TIMEOUT") - 1, 1);
+	zend_string *const_ATTR_TIMEOUT_name = zend_string_init_interned("ATTR_TIMEOUT", strlen("ATTR_TIMEOUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_TIMEOUT_name, &const_ATTR_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_TIMEOUT_name);
 
 	zval const_ATTR_ERRMODE_value;
 	ZVAL_LONG(&const_ATTR_ERRMODE_value, LONG_CONST(PDO_ATTR_ERRMODE));
-	zend_string *const_ATTR_ERRMODE_name = zend_string_init_interned("ATTR_ERRMODE", sizeof("ATTR_ERRMODE") - 1, 1);
+	zend_string *const_ATTR_ERRMODE_name = zend_string_init_interned("ATTR_ERRMODE", strlen("ATTR_ERRMODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_ERRMODE_name, &const_ATTR_ERRMODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_ERRMODE_name);
 
 	zval const_ATTR_SERVER_VERSION_value;
 	ZVAL_LONG(&const_ATTR_SERVER_VERSION_value, LONG_CONST(PDO_ATTR_SERVER_VERSION));
-	zend_string *const_ATTR_SERVER_VERSION_name = zend_string_init_interned("ATTR_SERVER_VERSION", sizeof("ATTR_SERVER_VERSION") - 1, 1);
+	zend_string *const_ATTR_SERVER_VERSION_name = zend_string_init_interned("ATTR_SERVER_VERSION", strlen("ATTR_SERVER_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SERVER_VERSION_name, &const_ATTR_SERVER_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SERVER_VERSION_name);
 
 	zval const_ATTR_CLIENT_VERSION_value;
 	ZVAL_LONG(&const_ATTR_CLIENT_VERSION_value, LONG_CONST(PDO_ATTR_CLIENT_VERSION));
-	zend_string *const_ATTR_CLIENT_VERSION_name = zend_string_init_interned("ATTR_CLIENT_VERSION", sizeof("ATTR_CLIENT_VERSION") - 1, 1);
+	zend_string *const_ATTR_CLIENT_VERSION_name = zend_string_init_interned("ATTR_CLIENT_VERSION", strlen("ATTR_CLIENT_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CLIENT_VERSION_name, &const_ATTR_CLIENT_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CLIENT_VERSION_name);
 
 	zval const_ATTR_SERVER_INFO_value;
 	ZVAL_LONG(&const_ATTR_SERVER_INFO_value, LONG_CONST(PDO_ATTR_SERVER_INFO));
-	zend_string *const_ATTR_SERVER_INFO_name = zend_string_init_interned("ATTR_SERVER_INFO", sizeof("ATTR_SERVER_INFO") - 1, 1);
+	zend_string *const_ATTR_SERVER_INFO_name = zend_string_init_interned("ATTR_SERVER_INFO", strlen("ATTR_SERVER_INFO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SERVER_INFO_name, &const_ATTR_SERVER_INFO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SERVER_INFO_name);
 
 	zval const_ATTR_CONNECTION_STATUS_value;
 	ZVAL_LONG(&const_ATTR_CONNECTION_STATUS_value, LONG_CONST(PDO_ATTR_CONNECTION_STATUS));
-	zend_string *const_ATTR_CONNECTION_STATUS_name = zend_string_init_interned("ATTR_CONNECTION_STATUS", sizeof("ATTR_CONNECTION_STATUS") - 1, 1);
+	zend_string *const_ATTR_CONNECTION_STATUS_name = zend_string_init_interned("ATTR_CONNECTION_STATUS", strlen("ATTR_CONNECTION_STATUS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CONNECTION_STATUS_name, &const_ATTR_CONNECTION_STATUS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CONNECTION_STATUS_name);
 
 	zval const_ATTR_CASE_value;
 	ZVAL_LONG(&const_ATTR_CASE_value, LONG_CONST(PDO_ATTR_CASE));
-	zend_string *const_ATTR_CASE_name = zend_string_init_interned("ATTR_CASE", sizeof("ATTR_CASE") - 1, 1);
+	zend_string *const_ATTR_CASE_name = zend_string_init_interned("ATTR_CASE", strlen("ATTR_CASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CASE_name, &const_ATTR_CASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CASE_name);
 
 	zval const_ATTR_CURSOR_NAME_value;
 	ZVAL_LONG(&const_ATTR_CURSOR_NAME_value, LONG_CONST(PDO_ATTR_CURSOR_NAME));
-	zend_string *const_ATTR_CURSOR_NAME_name = zend_string_init_interned("ATTR_CURSOR_NAME", sizeof("ATTR_CURSOR_NAME") - 1, 1);
+	zend_string *const_ATTR_CURSOR_NAME_name = zend_string_init_interned("ATTR_CURSOR_NAME", strlen("ATTR_CURSOR_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CURSOR_NAME_name, &const_ATTR_CURSOR_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CURSOR_NAME_name);
 
 	zval const_ATTR_CURSOR_value;
 	ZVAL_LONG(&const_ATTR_CURSOR_value, LONG_CONST(PDO_ATTR_CURSOR));
-	zend_string *const_ATTR_CURSOR_name = zend_string_init_interned("ATTR_CURSOR", sizeof("ATTR_CURSOR") - 1, 1);
+	zend_string *const_ATTR_CURSOR_name = zend_string_init_interned("ATTR_CURSOR", strlen("ATTR_CURSOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CURSOR_name, &const_ATTR_CURSOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CURSOR_name);
 
 	zval const_ATTR_ORACLE_NULLS_value;
 	ZVAL_LONG(&const_ATTR_ORACLE_NULLS_value, LONG_CONST(PDO_ATTR_ORACLE_NULLS));
-	zend_string *const_ATTR_ORACLE_NULLS_name = zend_string_init_interned("ATTR_ORACLE_NULLS", sizeof("ATTR_ORACLE_NULLS") - 1, 1);
+	zend_string *const_ATTR_ORACLE_NULLS_name = zend_string_init_interned("ATTR_ORACLE_NULLS", strlen("ATTR_ORACLE_NULLS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_ORACLE_NULLS_name, &const_ATTR_ORACLE_NULLS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_ORACLE_NULLS_name);
 
 	zval const_ATTR_PERSISTENT_value;
 	ZVAL_LONG(&const_ATTR_PERSISTENT_value, LONG_CONST(PDO_ATTR_PERSISTENT));
-	zend_string *const_ATTR_PERSISTENT_name = zend_string_init_interned("ATTR_PERSISTENT", sizeof("ATTR_PERSISTENT") - 1, 1);
+	zend_string *const_ATTR_PERSISTENT_name = zend_string_init_interned("ATTR_PERSISTENT", strlen("ATTR_PERSISTENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_PERSISTENT_name, &const_ATTR_PERSISTENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_PERSISTENT_name);
 
 	zval const_ATTR_STATEMENT_CLASS_value;
 	ZVAL_LONG(&const_ATTR_STATEMENT_CLASS_value, LONG_CONST(PDO_ATTR_STATEMENT_CLASS));
-	zend_string *const_ATTR_STATEMENT_CLASS_name = zend_string_init_interned("ATTR_STATEMENT_CLASS", sizeof("ATTR_STATEMENT_CLASS") - 1, 1);
+	zend_string *const_ATTR_STATEMENT_CLASS_name = zend_string_init_interned("ATTR_STATEMENT_CLASS", strlen("ATTR_STATEMENT_CLASS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_STATEMENT_CLASS_name, &const_ATTR_STATEMENT_CLASS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_STATEMENT_CLASS_name);
 
 	zval const_ATTR_FETCH_TABLE_NAMES_value;
 	ZVAL_LONG(&const_ATTR_FETCH_TABLE_NAMES_value, LONG_CONST(PDO_ATTR_FETCH_TABLE_NAMES));
-	zend_string *const_ATTR_FETCH_TABLE_NAMES_name = zend_string_init_interned("ATTR_FETCH_TABLE_NAMES", sizeof("ATTR_FETCH_TABLE_NAMES") - 1, 1);
+	zend_string *const_ATTR_FETCH_TABLE_NAMES_name = zend_string_init_interned("ATTR_FETCH_TABLE_NAMES", strlen("ATTR_FETCH_TABLE_NAMES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_FETCH_TABLE_NAMES_name, &const_ATTR_FETCH_TABLE_NAMES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_FETCH_TABLE_NAMES_name);
 
 	zval const_ATTR_FETCH_CATALOG_NAMES_value;
 	ZVAL_LONG(&const_ATTR_FETCH_CATALOG_NAMES_value, LONG_CONST(PDO_ATTR_FETCH_CATALOG_NAMES));
-	zend_string *const_ATTR_FETCH_CATALOG_NAMES_name = zend_string_init_interned("ATTR_FETCH_CATALOG_NAMES", sizeof("ATTR_FETCH_CATALOG_NAMES") - 1, 1);
+	zend_string *const_ATTR_FETCH_CATALOG_NAMES_name = zend_string_init_interned("ATTR_FETCH_CATALOG_NAMES", strlen("ATTR_FETCH_CATALOG_NAMES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_FETCH_CATALOG_NAMES_name, &const_ATTR_FETCH_CATALOG_NAMES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_FETCH_CATALOG_NAMES_name);
 
 	zval const_ATTR_DRIVER_NAME_value;
 	ZVAL_LONG(&const_ATTR_DRIVER_NAME_value, LONG_CONST(PDO_ATTR_DRIVER_NAME));
-	zend_string *const_ATTR_DRIVER_NAME_name = zend_string_init_interned("ATTR_DRIVER_NAME", sizeof("ATTR_DRIVER_NAME") - 1, 1);
+	zend_string *const_ATTR_DRIVER_NAME_name = zend_string_init_interned("ATTR_DRIVER_NAME", strlen("ATTR_DRIVER_NAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DRIVER_NAME_name, &const_ATTR_DRIVER_NAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DRIVER_NAME_name);
 
 	zval const_ATTR_STRINGIFY_FETCHES_value;
 	ZVAL_LONG(&const_ATTR_STRINGIFY_FETCHES_value, LONG_CONST(PDO_ATTR_STRINGIFY_FETCHES));
-	zend_string *const_ATTR_STRINGIFY_FETCHES_name = zend_string_init_interned("ATTR_STRINGIFY_FETCHES", sizeof("ATTR_STRINGIFY_FETCHES") - 1, 1);
+	zend_string *const_ATTR_STRINGIFY_FETCHES_name = zend_string_init_interned("ATTR_STRINGIFY_FETCHES", strlen("ATTR_STRINGIFY_FETCHES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_STRINGIFY_FETCHES_name, &const_ATTR_STRINGIFY_FETCHES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_STRINGIFY_FETCHES_name);
 
 	zval const_ATTR_MAX_COLUMN_LEN_value;
 	ZVAL_LONG(&const_ATTR_MAX_COLUMN_LEN_value, LONG_CONST(PDO_ATTR_MAX_COLUMN_LEN));
-	zend_string *const_ATTR_MAX_COLUMN_LEN_name = zend_string_init_interned("ATTR_MAX_COLUMN_LEN", sizeof("ATTR_MAX_COLUMN_LEN") - 1, 1);
+	zend_string *const_ATTR_MAX_COLUMN_LEN_name = zend_string_init_interned("ATTR_MAX_COLUMN_LEN", strlen("ATTR_MAX_COLUMN_LEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_MAX_COLUMN_LEN_name, &const_ATTR_MAX_COLUMN_LEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_MAX_COLUMN_LEN_name);
 
 	zval const_ATTR_EMULATE_PREPARES_value;
 	ZVAL_LONG(&const_ATTR_EMULATE_PREPARES_value, LONG_CONST(PDO_ATTR_EMULATE_PREPARES));
-	zend_string *const_ATTR_EMULATE_PREPARES_name = zend_string_init_interned("ATTR_EMULATE_PREPARES", sizeof("ATTR_EMULATE_PREPARES") - 1, 1);
+	zend_string *const_ATTR_EMULATE_PREPARES_name = zend_string_init_interned("ATTR_EMULATE_PREPARES", strlen("ATTR_EMULATE_PREPARES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_EMULATE_PREPARES_name, &const_ATTR_EMULATE_PREPARES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_EMULATE_PREPARES_name);
 
 	zval const_ATTR_DEFAULT_FETCH_MODE_value;
 	ZVAL_LONG(&const_ATTR_DEFAULT_FETCH_MODE_value, LONG_CONST(PDO_ATTR_DEFAULT_FETCH_MODE));
-	zend_string *const_ATTR_DEFAULT_FETCH_MODE_name = zend_string_init_interned("ATTR_DEFAULT_FETCH_MODE", sizeof("ATTR_DEFAULT_FETCH_MODE") - 1, 1);
+	zend_string *const_ATTR_DEFAULT_FETCH_MODE_name = zend_string_init_interned("ATTR_DEFAULT_FETCH_MODE", strlen("ATTR_DEFAULT_FETCH_MODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DEFAULT_FETCH_MODE_name, &const_ATTR_DEFAULT_FETCH_MODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DEFAULT_FETCH_MODE_name);
 
 	zval const_ATTR_DEFAULT_STR_PARAM_value;
 	ZVAL_LONG(&const_ATTR_DEFAULT_STR_PARAM_value, LONG_CONST(PDO_ATTR_DEFAULT_STR_PARAM));
-	zend_string *const_ATTR_DEFAULT_STR_PARAM_name = zend_string_init_interned("ATTR_DEFAULT_STR_PARAM", sizeof("ATTR_DEFAULT_STR_PARAM") - 1, 1);
+	zend_string *const_ATTR_DEFAULT_STR_PARAM_name = zend_string_init_interned("ATTR_DEFAULT_STR_PARAM", strlen("ATTR_DEFAULT_STR_PARAM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DEFAULT_STR_PARAM_name, &const_ATTR_DEFAULT_STR_PARAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DEFAULT_STR_PARAM_name);
 
 	zval const_ERRMODE_SILENT_value;
 	ZVAL_LONG(&const_ERRMODE_SILENT_value, LONG_CONST(PDO_ERRMODE_SILENT));
-	zend_string *const_ERRMODE_SILENT_name = zend_string_init_interned("ERRMODE_SILENT", sizeof("ERRMODE_SILENT") - 1, 1);
+	zend_string *const_ERRMODE_SILENT_name = zend_string_init_interned("ERRMODE_SILENT", strlen("ERRMODE_SILENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRMODE_SILENT_name, &const_ERRMODE_SILENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRMODE_SILENT_name);
 
 	zval const_ERRMODE_WARNING_value;
 	ZVAL_LONG(&const_ERRMODE_WARNING_value, LONG_CONST(PDO_ERRMODE_WARNING));
-	zend_string *const_ERRMODE_WARNING_name = zend_string_init_interned("ERRMODE_WARNING", sizeof("ERRMODE_WARNING") - 1, 1);
+	zend_string *const_ERRMODE_WARNING_name = zend_string_init_interned("ERRMODE_WARNING", strlen("ERRMODE_WARNING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRMODE_WARNING_name, &const_ERRMODE_WARNING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRMODE_WARNING_name);
 
 	zval const_ERRMODE_EXCEPTION_value;
 	ZVAL_LONG(&const_ERRMODE_EXCEPTION_value, LONG_CONST(PDO_ERRMODE_EXCEPTION));
-	zend_string *const_ERRMODE_EXCEPTION_name = zend_string_init_interned("ERRMODE_EXCEPTION", sizeof("ERRMODE_EXCEPTION") - 1, 1);
+	zend_string *const_ERRMODE_EXCEPTION_name = zend_string_init_interned("ERRMODE_EXCEPTION", strlen("ERRMODE_EXCEPTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRMODE_EXCEPTION_name, &const_ERRMODE_EXCEPTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRMODE_EXCEPTION_name);
 
 	zval const_CASE_NATURAL_value;
 	ZVAL_LONG(&const_CASE_NATURAL_value, LONG_CONST(PDO_CASE_NATURAL));
-	zend_string *const_CASE_NATURAL_name = zend_string_init_interned("CASE_NATURAL", sizeof("CASE_NATURAL") - 1, 1);
+	zend_string *const_CASE_NATURAL_name = zend_string_init_interned("CASE_NATURAL", strlen("CASE_NATURAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_NATURAL_name, &const_CASE_NATURAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_NATURAL_name);
 
 	zval const_CASE_LOWER_value;
 	ZVAL_LONG(&const_CASE_LOWER_value, LONG_CONST(PDO_CASE_LOWER));
-	zend_string *const_CASE_LOWER_name = zend_string_init_interned("CASE_LOWER", sizeof("CASE_LOWER") - 1, 1);
+	zend_string *const_CASE_LOWER_name = zend_string_init_interned("CASE_LOWER", strlen("CASE_LOWER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_LOWER_name, &const_CASE_LOWER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_LOWER_name);
 
 	zval const_CASE_UPPER_value;
 	ZVAL_LONG(&const_CASE_UPPER_value, LONG_CONST(PDO_CASE_UPPER));
-	zend_string *const_CASE_UPPER_name = zend_string_init_interned("CASE_UPPER", sizeof("CASE_UPPER") - 1, 1);
+	zend_string *const_CASE_UPPER_name = zend_string_init_interned("CASE_UPPER", strlen("CASE_UPPER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CASE_UPPER_name, &const_CASE_UPPER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CASE_UPPER_name);
 
 	zval const_NULL_NATURAL_value;
 	ZVAL_LONG(&const_NULL_NATURAL_value, LONG_CONST(PDO_NULL_NATURAL));
-	zend_string *const_NULL_NATURAL_name = zend_string_init_interned("NULL_NATURAL", sizeof("NULL_NATURAL") - 1, 1);
+	zend_string *const_NULL_NATURAL_name = zend_string_init_interned("NULL_NATURAL", strlen("NULL_NATURAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NULL_NATURAL_name, &const_NULL_NATURAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NULL_NATURAL_name);
 
 	zval const_NULL_EMPTY_STRING_value;
 	ZVAL_LONG(&const_NULL_EMPTY_STRING_value, LONG_CONST(PDO_NULL_EMPTY_STRING));
-	zend_string *const_NULL_EMPTY_STRING_name = zend_string_init_interned("NULL_EMPTY_STRING", sizeof("NULL_EMPTY_STRING") - 1, 1);
+	zend_string *const_NULL_EMPTY_STRING_name = zend_string_init_interned("NULL_EMPTY_STRING", strlen("NULL_EMPTY_STRING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NULL_EMPTY_STRING_name, &const_NULL_EMPTY_STRING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NULL_EMPTY_STRING_name);
 
 	zval const_NULL_TO_STRING_value;
 	ZVAL_LONG(&const_NULL_TO_STRING_value, LONG_CONST(PDO_NULL_TO_STRING));
-	zend_string *const_NULL_TO_STRING_name = zend_string_init_interned("NULL_TO_STRING", sizeof("NULL_TO_STRING") - 1, 1);
+	zend_string *const_NULL_TO_STRING_name = zend_string_init_interned("NULL_TO_STRING", strlen("NULL_TO_STRING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NULL_TO_STRING_name, &const_NULL_TO_STRING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NULL_TO_STRING_name);
 
 	zval const_ERR_NONE_value;
 	zend_string *const_ERR_NONE_value_str = zend_string_init(PDO_ERR_NONE, strlen(PDO_ERR_NONE), 1);
 	ZVAL_STR(&const_ERR_NONE_value, const_ERR_NONE_value_str);
-	zend_string *const_ERR_NONE_name = zend_string_init_interned("ERR_NONE", sizeof("ERR_NONE") - 1, 1);
+	zend_string *const_ERR_NONE_name = zend_string_init_interned("ERR_NONE", strlen("ERR_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERR_NONE_name, &const_ERR_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_ERR_NONE_name);
 
 	zval const_FETCH_ORI_NEXT_value;
 	ZVAL_LONG(&const_FETCH_ORI_NEXT_value, LONG_CONST(PDO_FETCH_ORI_NEXT));
-	zend_string *const_FETCH_ORI_NEXT_name = zend_string_init_interned("FETCH_ORI_NEXT", sizeof("FETCH_ORI_NEXT") - 1, 1);
+	zend_string *const_FETCH_ORI_NEXT_name = zend_string_init_interned("FETCH_ORI_NEXT", strlen("FETCH_ORI_NEXT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_NEXT_name, &const_FETCH_ORI_NEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_NEXT_name);
 
 	zval const_FETCH_ORI_PRIOR_value;
 	ZVAL_LONG(&const_FETCH_ORI_PRIOR_value, LONG_CONST(PDO_FETCH_ORI_PRIOR));
-	zend_string *const_FETCH_ORI_PRIOR_name = zend_string_init_interned("FETCH_ORI_PRIOR", sizeof("FETCH_ORI_PRIOR") - 1, 1);
+	zend_string *const_FETCH_ORI_PRIOR_name = zend_string_init_interned("FETCH_ORI_PRIOR", strlen("FETCH_ORI_PRIOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_PRIOR_name, &const_FETCH_ORI_PRIOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_PRIOR_name);
 
 	zval const_FETCH_ORI_FIRST_value;
 	ZVAL_LONG(&const_FETCH_ORI_FIRST_value, LONG_CONST(PDO_FETCH_ORI_FIRST));
-	zend_string *const_FETCH_ORI_FIRST_name = zend_string_init_interned("FETCH_ORI_FIRST", sizeof("FETCH_ORI_FIRST") - 1, 1);
+	zend_string *const_FETCH_ORI_FIRST_name = zend_string_init_interned("FETCH_ORI_FIRST", strlen("FETCH_ORI_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_FIRST_name, &const_FETCH_ORI_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_FIRST_name);
 
 	zval const_FETCH_ORI_LAST_value;
 	ZVAL_LONG(&const_FETCH_ORI_LAST_value, LONG_CONST(PDO_FETCH_ORI_LAST));
-	zend_string *const_FETCH_ORI_LAST_name = zend_string_init_interned("FETCH_ORI_LAST", sizeof("FETCH_ORI_LAST") - 1, 1);
+	zend_string *const_FETCH_ORI_LAST_name = zend_string_init_interned("FETCH_ORI_LAST", strlen("FETCH_ORI_LAST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_LAST_name, &const_FETCH_ORI_LAST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_LAST_name);
 
 	zval const_FETCH_ORI_ABS_value;
 	ZVAL_LONG(&const_FETCH_ORI_ABS_value, LONG_CONST(PDO_FETCH_ORI_ABS));
-	zend_string *const_FETCH_ORI_ABS_name = zend_string_init_interned("FETCH_ORI_ABS", sizeof("FETCH_ORI_ABS") - 1, 1);
+	zend_string *const_FETCH_ORI_ABS_name = zend_string_init_interned("FETCH_ORI_ABS", strlen("FETCH_ORI_ABS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_ABS_name, &const_FETCH_ORI_ABS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_ABS_name);
 
 	zval const_FETCH_ORI_REL_value;
 	ZVAL_LONG(&const_FETCH_ORI_REL_value, LONG_CONST(PDO_FETCH_ORI_REL));
-	zend_string *const_FETCH_ORI_REL_name = zend_string_init_interned("FETCH_ORI_REL", sizeof("FETCH_ORI_REL") - 1, 1);
+	zend_string *const_FETCH_ORI_REL_name = zend_string_init_interned("FETCH_ORI_REL", strlen("FETCH_ORI_REL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FETCH_ORI_REL_name, &const_FETCH_ORI_REL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FETCH_ORI_REL_name);
 
 	zval const_CURSOR_FWDONLY_value;
 	ZVAL_LONG(&const_CURSOR_FWDONLY_value, LONG_CONST(PDO_CURSOR_FWDONLY));
-	zend_string *const_CURSOR_FWDONLY_name = zend_string_init_interned("CURSOR_FWDONLY", sizeof("CURSOR_FWDONLY") - 1, 1);
+	zend_string *const_CURSOR_FWDONLY_name = zend_string_init_interned("CURSOR_FWDONLY", strlen("CURSOR_FWDONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURSOR_FWDONLY_name, &const_CURSOR_FWDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURSOR_FWDONLY_name);
 
 	zval const_CURSOR_SCROLL_value;
 	ZVAL_LONG(&const_CURSOR_SCROLL_value, LONG_CONST(PDO_CURSOR_SCROLL));
-	zend_string *const_CURSOR_SCROLL_name = zend_string_init_interned("CURSOR_SCROLL", sizeof("CURSOR_SCROLL") - 1, 1);
+	zend_string *const_CURSOR_SCROLL_name = zend_string_init_interned("CURSOR_SCROLL", strlen("CURSOR_SCROLL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURSOR_SCROLL_name, &const_CURSOR_SCROLL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURSOR_SCROLL_name);
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", strlen("__construct")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", strlen("connect")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	return class_entry;
 }

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -142,7 +142,7 @@ static zend_class_entry *register_class_PDOStatement(zend_class_entry *class_ent
 
 	zval property_queryString_default_value;
 	ZVAL_UNDEF(&property_queryString_default_value);
-	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, 1);
+	zend_string *property_queryString_name = zend_string_init("queryString", strlen("queryString"), 1);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_queryString_name);
 
@@ -158,7 +158,7 @@ static zend_class_entry *register_class_PDORow(void)
 
 	zval property_queryString_default_value;
 	ZVAL_UNDEF(&property_queryString_default_value);
-	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, 1);
+	zend_string *property_queryString_name = zend_string_init("queryString", strlen("queryString"), 1);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_queryString_name);
 

--- a/ext/pdo_dblib/pdo_dblib_arginfo.h
+++ b/ext/pdo_dblib/pdo_dblib_arginfo.h
@@ -10,43 +10,43 @@ static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_
 
 	zval const_ATTR_CONNECTION_TIMEOUT_value;
 	ZVAL_LONG(&const_ATTR_CONNECTION_TIMEOUT_value, PDO_DBLIB_ATTR_CONNECTION_TIMEOUT);
-	zend_string *const_ATTR_CONNECTION_TIMEOUT_name = zend_string_init_interned("ATTR_CONNECTION_TIMEOUT", sizeof("ATTR_CONNECTION_TIMEOUT") - 1, 1);
+	zend_string *const_ATTR_CONNECTION_TIMEOUT_name = zend_string_init_interned("ATTR_CONNECTION_TIMEOUT", strlen("ATTR_CONNECTION_TIMEOUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_CONNECTION_TIMEOUT_name, &const_ATTR_CONNECTION_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CONNECTION_TIMEOUT_name);
 
 	zval const_ATTR_QUERY_TIMEOUT_value;
 	ZVAL_LONG(&const_ATTR_QUERY_TIMEOUT_value, PDO_DBLIB_ATTR_QUERY_TIMEOUT);
-	zend_string *const_ATTR_QUERY_TIMEOUT_name = zend_string_init_interned("ATTR_QUERY_TIMEOUT", sizeof("ATTR_QUERY_TIMEOUT") - 1, 1);
+	zend_string *const_ATTR_QUERY_TIMEOUT_name = zend_string_init_interned("ATTR_QUERY_TIMEOUT", strlen("ATTR_QUERY_TIMEOUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_QUERY_TIMEOUT_name, &const_ATTR_QUERY_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_QUERY_TIMEOUT_name);
 
 	zval const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_value;
 	ZVAL_LONG(&const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_value, PDO_DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER);
-	zend_string *const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_name = zend_string_init_interned("ATTR_STRINGIFY_UNIQUEIDENTIFIER", sizeof("ATTR_STRINGIFY_UNIQUEIDENTIFIER") - 1, 1);
+	zend_string *const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_name = zend_string_init_interned("ATTR_STRINGIFY_UNIQUEIDENTIFIER", strlen("ATTR_STRINGIFY_UNIQUEIDENTIFIER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_name, &const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_STRINGIFY_UNIQUEIDENTIFIER_name);
 
 	zval const_ATTR_VERSION_value;
 	ZVAL_LONG(&const_ATTR_VERSION_value, PDO_DBLIB_ATTR_VERSION);
-	zend_string *const_ATTR_VERSION_name = zend_string_init_interned("ATTR_VERSION", sizeof("ATTR_VERSION") - 1, 1);
+	zend_string *const_ATTR_VERSION_name = zend_string_init_interned("ATTR_VERSION", strlen("ATTR_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_VERSION_name, &const_ATTR_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_VERSION_name);
 
 	zval const_ATTR_TDS_VERSION_value;
 	ZVAL_LONG(&const_ATTR_TDS_VERSION_value, PDO_DBLIB_ATTR_TDS_VERSION);
-	zend_string *const_ATTR_TDS_VERSION_name = zend_string_init_interned("ATTR_TDS_VERSION", sizeof("ATTR_TDS_VERSION") - 1, 1);
+	zend_string *const_ATTR_TDS_VERSION_name = zend_string_init_interned("ATTR_TDS_VERSION", strlen("ATTR_TDS_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_TDS_VERSION_name, &const_ATTR_TDS_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_TDS_VERSION_name);
 
 	zval const_ATTR_SKIP_EMPTY_ROWSETS_value;
 	ZVAL_LONG(&const_ATTR_SKIP_EMPTY_ROWSETS_value, PDO_DBLIB_ATTR_SKIP_EMPTY_ROWSETS);
-	zend_string *const_ATTR_SKIP_EMPTY_ROWSETS_name = zend_string_init_interned("ATTR_SKIP_EMPTY_ROWSETS", sizeof("ATTR_SKIP_EMPTY_ROWSETS") - 1, 1);
+	zend_string *const_ATTR_SKIP_EMPTY_ROWSETS_name = zend_string_init_interned("ATTR_SKIP_EMPTY_ROWSETS", strlen("ATTR_SKIP_EMPTY_ROWSETS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SKIP_EMPTY_ROWSETS_name, &const_ATTR_SKIP_EMPTY_ROWSETS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SKIP_EMPTY_ROWSETS_name);
 
 	zval const_ATTR_DATETIME_CONVERT_value;
 	ZVAL_LONG(&const_ATTR_DATETIME_CONVERT_value, PDO_DBLIB_ATTR_DATETIME_CONVERT);
-	zend_string *const_ATTR_DATETIME_CONVERT_name = zend_string_init_interned("ATTR_DATETIME_CONVERT", sizeof("ATTR_DATETIME_CONVERT") - 1, 1);
+	zend_string *const_ATTR_DATETIME_CONVERT_name = zend_string_init_interned("ATTR_DATETIME_CONVERT", strlen("ATTR_DATETIME_CONVERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DATETIME_CONVERT_name, &const_ATTR_DATETIME_CONVERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DATETIME_CONVERT_name);
 

--- a/ext/pdo_firebird/pdo_firebird_arginfo.h
+++ b/ext/pdo_firebird/pdo_firebird_arginfo.h
@@ -20,49 +20,49 @@ static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_ent
 
 	zval const_ATTR_DATE_FORMAT_value;
 	ZVAL_LONG(&const_ATTR_DATE_FORMAT_value, PDO_FB_ATTR_DATE_FORMAT);
-	zend_string *const_ATTR_DATE_FORMAT_name = zend_string_init_interned("ATTR_DATE_FORMAT", sizeof("ATTR_DATE_FORMAT") - 1, 1);
+	zend_string *const_ATTR_DATE_FORMAT_name = zend_string_init_interned("ATTR_DATE_FORMAT", strlen("ATTR_DATE_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DATE_FORMAT_name, &const_ATTR_DATE_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DATE_FORMAT_name);
 
 	zval const_ATTR_TIME_FORMAT_value;
 	ZVAL_LONG(&const_ATTR_TIME_FORMAT_value, PDO_FB_ATTR_TIME_FORMAT);
-	zend_string *const_ATTR_TIME_FORMAT_name = zend_string_init_interned("ATTR_TIME_FORMAT", sizeof("ATTR_TIME_FORMAT") - 1, 1);
+	zend_string *const_ATTR_TIME_FORMAT_name = zend_string_init_interned("ATTR_TIME_FORMAT", strlen("ATTR_TIME_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_TIME_FORMAT_name, &const_ATTR_TIME_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_TIME_FORMAT_name);
 
 	zval const_ATTR_TIMESTAMP_FORMAT_value;
 	ZVAL_LONG(&const_ATTR_TIMESTAMP_FORMAT_value, PDO_FB_ATTR_TIMESTAMP_FORMAT);
-	zend_string *const_ATTR_TIMESTAMP_FORMAT_name = zend_string_init_interned("ATTR_TIMESTAMP_FORMAT", sizeof("ATTR_TIMESTAMP_FORMAT") - 1, 1);
+	zend_string *const_ATTR_TIMESTAMP_FORMAT_name = zend_string_init_interned("ATTR_TIMESTAMP_FORMAT", strlen("ATTR_TIMESTAMP_FORMAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_TIMESTAMP_FORMAT_name, &const_ATTR_TIMESTAMP_FORMAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_TIMESTAMP_FORMAT_name);
 
 	zval const_TRANSACTION_ISOLATION_LEVEL_value;
 	ZVAL_LONG(&const_TRANSACTION_ISOLATION_LEVEL_value, PDO_FB_TRANSACTION_ISOLATION_LEVEL);
-	zend_string *const_TRANSACTION_ISOLATION_LEVEL_name = zend_string_init_interned("TRANSACTION_ISOLATION_LEVEL", sizeof("TRANSACTION_ISOLATION_LEVEL") - 1, 1);
+	zend_string *const_TRANSACTION_ISOLATION_LEVEL_name = zend_string_init_interned("TRANSACTION_ISOLATION_LEVEL", strlen("TRANSACTION_ISOLATION_LEVEL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_ISOLATION_LEVEL_name, &const_TRANSACTION_ISOLATION_LEVEL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_ISOLATION_LEVEL_name);
 
 	zval const_READ_COMMITTED_value;
 	ZVAL_LONG(&const_READ_COMMITTED_value, PDO_FB_READ_COMMITTED);
-	zend_string *const_READ_COMMITTED_name = zend_string_init_interned("READ_COMMITTED", sizeof("READ_COMMITTED") - 1, 1);
+	zend_string *const_READ_COMMITTED_name = zend_string_init_interned("READ_COMMITTED", strlen("READ_COMMITTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_READ_COMMITTED_name, &const_READ_COMMITTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_READ_COMMITTED_name);
 
 	zval const_REPEATABLE_READ_value;
 	ZVAL_LONG(&const_REPEATABLE_READ_value, PDO_FB_REPEATABLE_READ);
-	zend_string *const_REPEATABLE_READ_name = zend_string_init_interned("REPEATABLE_READ", sizeof("REPEATABLE_READ") - 1, 1);
+	zend_string *const_REPEATABLE_READ_name = zend_string_init_interned("REPEATABLE_READ", strlen("REPEATABLE_READ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REPEATABLE_READ_name, &const_REPEATABLE_READ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REPEATABLE_READ_name);
 
 	zval const_SERIALIZABLE_value;
 	ZVAL_LONG(&const_SERIALIZABLE_value, PDO_FB_SERIALIZABLE);
-	zend_string *const_SERIALIZABLE_name = zend_string_init_interned("SERIALIZABLE", sizeof("SERIALIZABLE") - 1, 1);
+	zend_string *const_SERIALIZABLE_name = zend_string_init_interned("SERIALIZABLE", strlen("SERIALIZABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SERIALIZABLE_name, &const_SERIALIZABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SERIALIZABLE_name);
 
 	zval const_WRITABLE_TRANSACTION_value;
 	ZVAL_LONG(&const_WRITABLE_TRANSACTION_value, PDO_FB_WRITABLE_TRANSACTION);
-	zend_string *const_WRITABLE_TRANSACTION_name = zend_string_init_interned("WRITABLE_TRANSACTION", sizeof("WRITABLE_TRANSACTION") - 1, 1);
+	zend_string *const_WRITABLE_TRANSACTION_name = zend_string_init_interned("WRITABLE_TRANSACTION", strlen("WRITABLE_TRANSACTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WRITABLE_TRANSACTION_name, &const_WRITABLE_TRANSACTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WRITABLE_TRANSACTION_name);
 

--- a/ext/pdo_mysql/pdo_mysql_arginfo.h
+++ b/ext/pdo_mysql/pdo_mysql_arginfo.h
@@ -20,26 +20,26 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 
 	zval const_ATTR_USE_BUFFERED_QUERY_value;
 	ZVAL_LONG(&const_ATTR_USE_BUFFERED_QUERY_value, PDO_MYSQL_ATTR_USE_BUFFERED_QUERY);
-	zend_string *const_ATTR_USE_BUFFERED_QUERY_name = zend_string_init_interned("ATTR_USE_BUFFERED_QUERY", sizeof("ATTR_USE_BUFFERED_QUERY") - 1, 1);
+	zend_string *const_ATTR_USE_BUFFERED_QUERY_name = zend_string_init_interned("ATTR_USE_BUFFERED_QUERY", strlen("ATTR_USE_BUFFERED_QUERY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_USE_BUFFERED_QUERY_name, &const_ATTR_USE_BUFFERED_QUERY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_USE_BUFFERED_QUERY_name);
 
 	zval const_ATTR_LOCAL_INFILE_value;
 	ZVAL_LONG(&const_ATTR_LOCAL_INFILE_value, PDO_MYSQL_ATTR_LOCAL_INFILE);
-	zend_string *const_ATTR_LOCAL_INFILE_name = zend_string_init_interned("ATTR_LOCAL_INFILE", sizeof("ATTR_LOCAL_INFILE") - 1, 1);
+	zend_string *const_ATTR_LOCAL_INFILE_name = zend_string_init_interned("ATTR_LOCAL_INFILE", strlen("ATTR_LOCAL_INFILE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_LOCAL_INFILE_name, &const_ATTR_LOCAL_INFILE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_LOCAL_INFILE_name);
 
 	zval const_ATTR_INIT_COMMAND_value;
 	ZVAL_LONG(&const_ATTR_INIT_COMMAND_value, PDO_MYSQL_ATTR_INIT_COMMAND);
-	zend_string *const_ATTR_INIT_COMMAND_name = zend_string_init_interned("ATTR_INIT_COMMAND", sizeof("ATTR_INIT_COMMAND") - 1, 1);
+	zend_string *const_ATTR_INIT_COMMAND_name = zend_string_init_interned("ATTR_INIT_COMMAND", strlen("ATTR_INIT_COMMAND"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_INIT_COMMAND_name, &const_ATTR_INIT_COMMAND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_INIT_COMMAND_name);
 #if !defined(PDO_USE_MYSQLND)
 
 	zval const_ATTR_MAX_BUFFER_SIZE_value;
 	ZVAL_LONG(&const_ATTR_MAX_BUFFER_SIZE_value, PDO_MYSQL_ATTR_MAX_BUFFER_SIZE);
-	zend_string *const_ATTR_MAX_BUFFER_SIZE_name = zend_string_init_interned("ATTR_MAX_BUFFER_SIZE", sizeof("ATTR_MAX_BUFFER_SIZE") - 1, 1);
+	zend_string *const_ATTR_MAX_BUFFER_SIZE_name = zend_string_init_interned("ATTR_MAX_BUFFER_SIZE", strlen("ATTR_MAX_BUFFER_SIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_MAX_BUFFER_SIZE_name, &const_ATTR_MAX_BUFFER_SIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_MAX_BUFFER_SIZE_name);
 #endif
@@ -47,7 +47,7 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 
 	zval const_ATTR_READ_DEFAULT_FILE_value;
 	ZVAL_LONG(&const_ATTR_READ_DEFAULT_FILE_value, PDO_MYSQL_ATTR_READ_DEFAULT_FILE);
-	zend_string *const_ATTR_READ_DEFAULT_FILE_name = zend_string_init_interned("ATTR_READ_DEFAULT_FILE", sizeof("ATTR_READ_DEFAULT_FILE") - 1, 1);
+	zend_string *const_ATTR_READ_DEFAULT_FILE_name = zend_string_init_interned("ATTR_READ_DEFAULT_FILE", strlen("ATTR_READ_DEFAULT_FILE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_READ_DEFAULT_FILE_name, &const_ATTR_READ_DEFAULT_FILE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_READ_DEFAULT_FILE_name);
 #endif
@@ -55,83 +55,83 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 
 	zval const_ATTR_READ_DEFAULT_GROUP_value;
 	ZVAL_LONG(&const_ATTR_READ_DEFAULT_GROUP_value, PDO_MYSQL_ATTR_READ_DEFAULT_GROUP);
-	zend_string *const_ATTR_READ_DEFAULT_GROUP_name = zend_string_init_interned("ATTR_READ_DEFAULT_GROUP", sizeof("ATTR_READ_DEFAULT_GROUP") - 1, 1);
+	zend_string *const_ATTR_READ_DEFAULT_GROUP_name = zend_string_init_interned("ATTR_READ_DEFAULT_GROUP", strlen("ATTR_READ_DEFAULT_GROUP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_READ_DEFAULT_GROUP_name, &const_ATTR_READ_DEFAULT_GROUP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_READ_DEFAULT_GROUP_name);
 #endif
 
 	zval const_ATTR_COMPRESS_value;
 	ZVAL_LONG(&const_ATTR_COMPRESS_value, PDO_MYSQL_ATTR_COMPRESS);
-	zend_string *const_ATTR_COMPRESS_name = zend_string_init_interned("ATTR_COMPRESS", sizeof("ATTR_COMPRESS") - 1, 1);
+	zend_string *const_ATTR_COMPRESS_name = zend_string_init_interned("ATTR_COMPRESS", strlen("ATTR_COMPRESS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_COMPRESS_name, &const_ATTR_COMPRESS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_COMPRESS_name);
 
 	zval const_ATTR_DIRECT_QUERY_value;
 	ZVAL_LONG(&const_ATTR_DIRECT_QUERY_value, PDO_MYSQL_ATTR_DIRECT_QUERY);
-	zend_string *const_ATTR_DIRECT_QUERY_name = zend_string_init_interned("ATTR_DIRECT_QUERY", sizeof("ATTR_DIRECT_QUERY") - 1, 1);
+	zend_string *const_ATTR_DIRECT_QUERY_name = zend_string_init_interned("ATTR_DIRECT_QUERY", strlen("ATTR_DIRECT_QUERY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DIRECT_QUERY_name, &const_ATTR_DIRECT_QUERY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DIRECT_QUERY_name);
 
 	zval const_ATTR_FOUND_ROWS_value;
 	ZVAL_LONG(&const_ATTR_FOUND_ROWS_value, PDO_MYSQL_ATTR_FOUND_ROWS);
-	zend_string *const_ATTR_FOUND_ROWS_name = zend_string_init_interned("ATTR_FOUND_ROWS", sizeof("ATTR_FOUND_ROWS") - 1, 1);
+	zend_string *const_ATTR_FOUND_ROWS_name = zend_string_init_interned("ATTR_FOUND_ROWS", strlen("ATTR_FOUND_ROWS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_FOUND_ROWS_name, &const_ATTR_FOUND_ROWS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_FOUND_ROWS_name);
 
 	zval const_ATTR_IGNORE_SPACE_value;
 	ZVAL_LONG(&const_ATTR_IGNORE_SPACE_value, PDO_MYSQL_ATTR_IGNORE_SPACE);
-	zend_string *const_ATTR_IGNORE_SPACE_name = zend_string_init_interned("ATTR_IGNORE_SPACE", sizeof("ATTR_IGNORE_SPACE") - 1, 1);
+	zend_string *const_ATTR_IGNORE_SPACE_name = zend_string_init_interned("ATTR_IGNORE_SPACE", strlen("ATTR_IGNORE_SPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_IGNORE_SPACE_name, &const_ATTR_IGNORE_SPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_IGNORE_SPACE_name);
 
 	zval const_ATTR_SSL_KEY_value;
 	ZVAL_LONG(&const_ATTR_SSL_KEY_value, PDO_MYSQL_ATTR_SSL_KEY);
-	zend_string *const_ATTR_SSL_KEY_name = zend_string_init_interned("ATTR_SSL_KEY", sizeof("ATTR_SSL_KEY") - 1, 1);
+	zend_string *const_ATTR_SSL_KEY_name = zend_string_init_interned("ATTR_SSL_KEY", strlen("ATTR_SSL_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_KEY_name, &const_ATTR_SSL_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_KEY_name);
 
 	zval const_ATTR_SSL_CERT_value;
 	ZVAL_LONG(&const_ATTR_SSL_CERT_value, PDO_MYSQL_ATTR_SSL_CERT);
-	zend_string *const_ATTR_SSL_CERT_name = zend_string_init_interned("ATTR_SSL_CERT", sizeof("ATTR_SSL_CERT") - 1, 1);
+	zend_string *const_ATTR_SSL_CERT_name = zend_string_init_interned("ATTR_SSL_CERT", strlen("ATTR_SSL_CERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_CERT_name, &const_ATTR_SSL_CERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_CERT_name);
 
 	zval const_ATTR_SSL_CA_value;
 	ZVAL_LONG(&const_ATTR_SSL_CA_value, PDO_MYSQL_ATTR_SSL_CA);
-	zend_string *const_ATTR_SSL_CA_name = zend_string_init_interned("ATTR_SSL_CA", sizeof("ATTR_SSL_CA") - 1, 1);
+	zend_string *const_ATTR_SSL_CA_name = zend_string_init_interned("ATTR_SSL_CA", strlen("ATTR_SSL_CA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_CA_name, &const_ATTR_SSL_CA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_CA_name);
 
 	zval const_ATTR_SSL_CAPATH_value;
 	ZVAL_LONG(&const_ATTR_SSL_CAPATH_value, PDO_MYSQL_ATTR_SSL_CAPATH);
-	zend_string *const_ATTR_SSL_CAPATH_name = zend_string_init_interned("ATTR_SSL_CAPATH", sizeof("ATTR_SSL_CAPATH") - 1, 1);
+	zend_string *const_ATTR_SSL_CAPATH_name = zend_string_init_interned("ATTR_SSL_CAPATH", strlen("ATTR_SSL_CAPATH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_CAPATH_name, &const_ATTR_SSL_CAPATH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_CAPATH_name);
 
 	zval const_ATTR_SSL_CIPHER_value;
 	ZVAL_LONG(&const_ATTR_SSL_CIPHER_value, PDO_MYSQL_ATTR_SSL_CIPHER);
-	zend_string *const_ATTR_SSL_CIPHER_name = zend_string_init_interned("ATTR_SSL_CIPHER", sizeof("ATTR_SSL_CIPHER") - 1, 1);
+	zend_string *const_ATTR_SSL_CIPHER_name = zend_string_init_interned("ATTR_SSL_CIPHER", strlen("ATTR_SSL_CIPHER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_CIPHER_name, &const_ATTR_SSL_CIPHER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_CIPHER_name);
 #if MYSQL_VERSION_ID > 50605 || defined(PDO_USE_MYSQLND)
 
 	zval const_ATTR_SERVER_PUBLIC_KEY_value;
 	ZVAL_LONG(&const_ATTR_SERVER_PUBLIC_KEY_value, PDO_MYSQL_ATTR_SERVER_PUBLIC_KEY);
-	zend_string *const_ATTR_SERVER_PUBLIC_KEY_name = zend_string_init_interned("ATTR_SERVER_PUBLIC_KEY", sizeof("ATTR_SERVER_PUBLIC_KEY") - 1, 1);
+	zend_string *const_ATTR_SERVER_PUBLIC_KEY_name = zend_string_init_interned("ATTR_SERVER_PUBLIC_KEY", strlen("ATTR_SERVER_PUBLIC_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SERVER_PUBLIC_KEY_name, &const_ATTR_SERVER_PUBLIC_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SERVER_PUBLIC_KEY_name);
 #endif
 
 	zval const_ATTR_MULTI_STATEMENTS_value;
 	ZVAL_LONG(&const_ATTR_MULTI_STATEMENTS_value, PDO_MYSQL_ATTR_MULTI_STATEMENTS);
-	zend_string *const_ATTR_MULTI_STATEMENTS_name = zend_string_init_interned("ATTR_MULTI_STATEMENTS", sizeof("ATTR_MULTI_STATEMENTS") - 1, 1);
+	zend_string *const_ATTR_MULTI_STATEMENTS_name = zend_string_init_interned("ATTR_MULTI_STATEMENTS", strlen("ATTR_MULTI_STATEMENTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_MULTI_STATEMENTS_name, &const_ATTR_MULTI_STATEMENTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_MULTI_STATEMENTS_name);
 #if defined(PDO_USE_MYSQLND)
 
 	zval const_ATTR_SSL_VERIFY_SERVER_CERT_value;
 	ZVAL_LONG(&const_ATTR_SSL_VERIFY_SERVER_CERT_value, PDO_MYSQL_ATTR_SSL_VERIFY_SERVER_CERT);
-	zend_string *const_ATTR_SSL_VERIFY_SERVER_CERT_name = zend_string_init_interned("ATTR_SSL_VERIFY_SERVER_CERT", sizeof("ATTR_SSL_VERIFY_SERVER_CERT") - 1, 1);
+	zend_string *const_ATTR_SSL_VERIFY_SERVER_CERT_name = zend_string_init_interned("ATTR_SSL_VERIFY_SERVER_CERT", strlen("ATTR_SSL_VERIFY_SERVER_CERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_SSL_VERIFY_SERVER_CERT_name, &const_ATTR_SSL_VERIFY_SERVER_CERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_SSL_VERIFY_SERVER_CERT_name);
 #endif
@@ -139,7 +139,7 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 
 	zval const_ATTR_LOCAL_INFILE_DIRECTORY_value;
 	ZVAL_LONG(&const_ATTR_LOCAL_INFILE_DIRECTORY_value, PDO_MYSQL_ATTR_LOCAL_INFILE_DIRECTORY);
-	zend_string *const_ATTR_LOCAL_INFILE_DIRECTORY_name = zend_string_init_interned("ATTR_LOCAL_INFILE_DIRECTORY", sizeof("ATTR_LOCAL_INFILE_DIRECTORY") - 1, 1);
+	zend_string *const_ATTR_LOCAL_INFILE_DIRECTORY_name = zend_string_init_interned("ATTR_LOCAL_INFILE_DIRECTORY", strlen("ATTR_LOCAL_INFILE_DIRECTORY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_LOCAL_INFILE_DIRECTORY_name, &const_ATTR_LOCAL_INFILE_DIRECTORY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_LOCAL_INFILE_DIRECTORY_name);
 #endif

--- a/ext/pdo_odbc/pdo_odbc_arginfo.h
+++ b/ext/pdo_odbc/pdo_odbc_arginfo.h
@@ -15,31 +15,31 @@ static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_P
 
 	zval const_ATTR_USE_CURSOR_LIBRARY_value;
 	ZVAL_LONG(&const_ATTR_USE_CURSOR_LIBRARY_value, PDO_ODBC_ATTR_USE_CURSOR_LIBRARY);
-	zend_string *const_ATTR_USE_CURSOR_LIBRARY_name = zend_string_init_interned("ATTR_USE_CURSOR_LIBRARY", sizeof("ATTR_USE_CURSOR_LIBRARY") - 1, 1);
+	zend_string *const_ATTR_USE_CURSOR_LIBRARY_name = zend_string_init_interned("ATTR_USE_CURSOR_LIBRARY", strlen("ATTR_USE_CURSOR_LIBRARY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_USE_CURSOR_LIBRARY_name, &const_ATTR_USE_CURSOR_LIBRARY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_USE_CURSOR_LIBRARY_name);
 
 	zval const_ATTR_ASSUME_UTF8_value;
 	ZVAL_LONG(&const_ATTR_ASSUME_UTF8_value, PDO_ODBC_ATTR_ASSUME_UTF8);
-	zend_string *const_ATTR_ASSUME_UTF8_name = zend_string_init_interned("ATTR_ASSUME_UTF8", sizeof("ATTR_ASSUME_UTF8") - 1, 1);
+	zend_string *const_ATTR_ASSUME_UTF8_name = zend_string_init_interned("ATTR_ASSUME_UTF8", strlen("ATTR_ASSUME_UTF8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_ASSUME_UTF8_name, &const_ATTR_ASSUME_UTF8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_ASSUME_UTF8_name);
 
 	zval const_SQL_USE_IF_NEEDED_value;
 	ZVAL_LONG(&const_SQL_USE_IF_NEEDED_value, SQL_CUR_USE_IF_NEEDED);
-	zend_string *const_SQL_USE_IF_NEEDED_name = zend_string_init_interned("SQL_USE_IF_NEEDED", sizeof("SQL_USE_IF_NEEDED") - 1, 1);
+	zend_string *const_SQL_USE_IF_NEEDED_name = zend_string_init_interned("SQL_USE_IF_NEEDED", strlen("SQL_USE_IF_NEEDED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SQL_USE_IF_NEEDED_name, &const_SQL_USE_IF_NEEDED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SQL_USE_IF_NEEDED_name);
 
 	zval const_SQL_USE_DRIVER_value;
 	ZVAL_LONG(&const_SQL_USE_DRIVER_value, SQL_CUR_USE_DRIVER);
-	zend_string *const_SQL_USE_DRIVER_name = zend_string_init_interned("SQL_USE_DRIVER", sizeof("SQL_USE_DRIVER") - 1, 1);
+	zend_string *const_SQL_USE_DRIVER_name = zend_string_init_interned("SQL_USE_DRIVER", strlen("SQL_USE_DRIVER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SQL_USE_DRIVER_name, &const_SQL_USE_DRIVER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SQL_USE_DRIVER_name);
 
 	zval const_SQL_USE_ODBC_value;
 	ZVAL_LONG(&const_SQL_USE_ODBC_value, SQL_CUR_USE_ODBC);
-	zend_string *const_SQL_USE_ODBC_name = zend_string_init_interned("SQL_USE_ODBC", sizeof("SQL_USE_ODBC") - 1, 1);
+	zend_string *const_SQL_USE_ODBC_name = zend_string_init_interned("SQL_USE_ODBC", strlen("SQL_USE_ODBC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SQL_USE_ODBC_name, &const_SQL_USE_ODBC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SQL_USE_ODBC_name);
 

--- a/ext/pdo_pgsql/pdo_pgsql_arginfo.h
+++ b/ext/pdo_pgsql/pdo_pgsql_arginfo.h
@@ -90,45 +90,45 @@ static zend_class_entry *register_class_Pdo_Pgsql(zend_class_entry *class_entry_
 
 	zval const_ATTR_DISABLE_PREPARES_value;
 	ZVAL_LONG(&const_ATTR_DISABLE_PREPARES_value, PDO_PGSQL_ATTR_DISABLE_PREPARES);
-	zend_string *const_ATTR_DISABLE_PREPARES_name = zend_string_init_interned("ATTR_DISABLE_PREPARES", sizeof("ATTR_DISABLE_PREPARES") - 1, 1);
+	zend_string *const_ATTR_DISABLE_PREPARES_name = zend_string_init_interned("ATTR_DISABLE_PREPARES", strlen("ATTR_DISABLE_PREPARES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DISABLE_PREPARES_name, &const_ATTR_DISABLE_PREPARES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_DISABLE_PREPARES_name);
 #if defined(HAVE_PG_RESULT_MEMORY_SIZE)
 
 	zval const_ATTR_RESULT_MEMORY_SIZE_value;
 	ZVAL_LONG(&const_ATTR_RESULT_MEMORY_SIZE_value, PDO_PGSQL_ATTR_RESULT_MEMORY_SIZE);
-	zend_string *const_ATTR_RESULT_MEMORY_SIZE_name = zend_string_init_interned("ATTR_RESULT_MEMORY_SIZE", sizeof("ATTR_RESULT_MEMORY_SIZE") - 1, 1);
+	zend_string *const_ATTR_RESULT_MEMORY_SIZE_name = zend_string_init_interned("ATTR_RESULT_MEMORY_SIZE", strlen("ATTR_RESULT_MEMORY_SIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_RESULT_MEMORY_SIZE_name, &const_ATTR_RESULT_MEMORY_SIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_RESULT_MEMORY_SIZE_name);
 #endif
 
 	zval const_TRANSACTION_IDLE_value;
 	ZVAL_LONG(&const_TRANSACTION_IDLE_value, PGSQL_TRANSACTION_IDLE);
-	zend_string *const_TRANSACTION_IDLE_name = zend_string_init_interned("TRANSACTION_IDLE", sizeof("TRANSACTION_IDLE") - 1, 1);
+	zend_string *const_TRANSACTION_IDLE_name = zend_string_init_interned("TRANSACTION_IDLE", strlen("TRANSACTION_IDLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_IDLE_name, &const_TRANSACTION_IDLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_IDLE_name);
 
 	zval const_TRANSACTION_ACTIVE_value;
 	ZVAL_LONG(&const_TRANSACTION_ACTIVE_value, PGSQL_TRANSACTION_ACTIVE);
-	zend_string *const_TRANSACTION_ACTIVE_name = zend_string_init_interned("TRANSACTION_ACTIVE", sizeof("TRANSACTION_ACTIVE") - 1, 1);
+	zend_string *const_TRANSACTION_ACTIVE_name = zend_string_init_interned("TRANSACTION_ACTIVE", strlen("TRANSACTION_ACTIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_ACTIVE_name, &const_TRANSACTION_ACTIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_ACTIVE_name);
 
 	zval const_TRANSACTION_INTRANS_value;
 	ZVAL_LONG(&const_TRANSACTION_INTRANS_value, PGSQL_TRANSACTION_INTRANS);
-	zend_string *const_TRANSACTION_INTRANS_name = zend_string_init_interned("TRANSACTION_INTRANS", sizeof("TRANSACTION_INTRANS") - 1, 1);
+	zend_string *const_TRANSACTION_INTRANS_name = zend_string_init_interned("TRANSACTION_INTRANS", strlen("TRANSACTION_INTRANS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_INTRANS_name, &const_TRANSACTION_INTRANS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_INTRANS_name);
 
 	zval const_TRANSACTION_INERROR_value;
 	ZVAL_LONG(&const_TRANSACTION_INERROR_value, PGSQL_TRANSACTION_INERROR);
-	zend_string *const_TRANSACTION_INERROR_name = zend_string_init_interned("TRANSACTION_INERROR", sizeof("TRANSACTION_INERROR") - 1, 1);
+	zend_string *const_TRANSACTION_INERROR_name = zend_string_init_interned("TRANSACTION_INERROR", strlen("TRANSACTION_INERROR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_INERROR_name, &const_TRANSACTION_INERROR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_INERROR_name);
 
 	zval const_TRANSACTION_UNKNOWN_value;
 	ZVAL_LONG(&const_TRANSACTION_UNKNOWN_value, PGSQL_TRANSACTION_UNKNOWN);
-	zend_string *const_TRANSACTION_UNKNOWN_name = zend_string_init_interned("TRANSACTION_UNKNOWN", sizeof("TRANSACTION_UNKNOWN") - 1, 1);
+	zend_string *const_TRANSACTION_UNKNOWN_name = zend_string_init_interned("TRANSACTION_UNKNOWN", strlen("TRANSACTION_UNKNOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_UNKNOWN_name, &const_TRANSACTION_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_UNKNOWN_name);
 

--- a/ext/pdo_sqlite/pdo_sqlite_arginfo.h
+++ b/ext/pdo_sqlite/pdo_sqlite_arginfo.h
@@ -63,44 +63,44 @@ static zend_class_entry *register_class_Pdo_Sqlite(zend_class_entry *class_entry
 
 	zval const_DETERMINISTIC_value;
 	ZVAL_LONG(&const_DETERMINISTIC_value, SQLITE_DETERMINISTIC);
-	zend_string *const_DETERMINISTIC_name = zend_string_init_interned("DETERMINISTIC", sizeof("DETERMINISTIC") - 1, 1);
+	zend_string *const_DETERMINISTIC_name = zend_string_init_interned("DETERMINISTIC", strlen("DETERMINISTIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DETERMINISTIC_name, &const_DETERMINISTIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DETERMINISTIC_name);
 #endif
 
 	zval const_OPEN_READONLY_value;
 	ZVAL_LONG(&const_OPEN_READONLY_value, SQLITE_OPEN_READONLY);
-	zend_string *const_OPEN_READONLY_name = zend_string_init_interned("OPEN_READONLY", sizeof("OPEN_READONLY") - 1, 1);
+	zend_string *const_OPEN_READONLY_name = zend_string_init_interned("OPEN_READONLY", strlen("OPEN_READONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPEN_READONLY_name, &const_OPEN_READONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPEN_READONLY_name);
 
 	zval const_OPEN_READWRITE_value;
 	ZVAL_LONG(&const_OPEN_READWRITE_value, SQLITE_OPEN_READWRITE);
-	zend_string *const_OPEN_READWRITE_name = zend_string_init_interned("OPEN_READWRITE", sizeof("OPEN_READWRITE") - 1, 1);
+	zend_string *const_OPEN_READWRITE_name = zend_string_init_interned("OPEN_READWRITE", strlen("OPEN_READWRITE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPEN_READWRITE_name, &const_OPEN_READWRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPEN_READWRITE_name);
 
 	zval const_OPEN_CREATE_value;
 	ZVAL_LONG(&const_OPEN_CREATE_value, SQLITE_OPEN_CREATE);
-	zend_string *const_OPEN_CREATE_name = zend_string_init_interned("OPEN_CREATE", sizeof("OPEN_CREATE") - 1, 1);
+	zend_string *const_OPEN_CREATE_name = zend_string_init_interned("OPEN_CREATE", strlen("OPEN_CREATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPEN_CREATE_name, &const_OPEN_CREATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPEN_CREATE_name);
 
 	zval const_ATTR_OPEN_FLAGS_value;
 	ZVAL_LONG(&const_ATTR_OPEN_FLAGS_value, PDO_SQLITE_ATTR_OPEN_FLAGS);
-	zend_string *const_ATTR_OPEN_FLAGS_name = zend_string_init_interned("ATTR_OPEN_FLAGS", sizeof("ATTR_OPEN_FLAGS") - 1, 1);
+	zend_string *const_ATTR_OPEN_FLAGS_name = zend_string_init_interned("ATTR_OPEN_FLAGS", strlen("ATTR_OPEN_FLAGS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_OPEN_FLAGS_name, &const_ATTR_OPEN_FLAGS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_OPEN_FLAGS_name);
 
 	zval const_ATTR_READONLY_STATEMENT_value;
 	ZVAL_LONG(&const_ATTR_READONLY_STATEMENT_value, PDO_SQLITE_ATTR_READONLY_STATEMENT);
-	zend_string *const_ATTR_READONLY_STATEMENT_name = zend_string_init_interned("ATTR_READONLY_STATEMENT", sizeof("ATTR_READONLY_STATEMENT") - 1, 1);
+	zend_string *const_ATTR_READONLY_STATEMENT_name = zend_string_init_interned("ATTR_READONLY_STATEMENT", strlen("ATTR_READONLY_STATEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_READONLY_STATEMENT_name, &const_ATTR_READONLY_STATEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_READONLY_STATEMENT_name);
 
 	zval const_ATTR_EXTENDED_RESULT_CODES_value;
 	ZVAL_LONG(&const_ATTR_EXTENDED_RESULT_CODES_value, PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES);
-	zend_string *const_ATTR_EXTENDED_RESULT_CODES_name = zend_string_init_interned("ATTR_EXTENDED_RESULT_CODES", sizeof("ATTR_EXTENDED_RESULT_CODES") - 1, 1);
+	zend_string *const_ATTR_EXTENDED_RESULT_CODES_name = zend_string_init_interned("ATTR_EXTENDED_RESULT_CODES", strlen("ATTR_EXTENDED_RESULT_CODES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_EXTENDED_RESULT_CODES_name, &const_ATTR_EXTENDED_RESULT_CODES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_EXTENDED_RESULT_CODES_name);
 

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -852,7 +852,7 @@ static void register_pgsql_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
 
 
-	zend_attribute *attribute_Deprecated_func_pg_errormessage_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_errormessage", sizeof("pg_errormessage") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_errormessage_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_errormessage", strlen("pg_errormessage")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_errormessage_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_errormessage_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_errormessage_0_arg0, attribute_Deprecated_func_pg_errormessage_0_arg0_str);
@@ -864,7 +864,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_errormessage_0->args[1].value, &attribute_Deprecated_func_pg_errormessage_0_arg1);
 	attribute_Deprecated_func_pg_errormessage_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_numrows_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numrows", sizeof("pg_numrows") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_numrows_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numrows", strlen("pg_numrows")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_numrows_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_numrows_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_numrows_0_arg0, attribute_Deprecated_func_pg_numrows_0_arg0_str);
@@ -876,7 +876,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numrows_0->args[1].value, &attribute_Deprecated_func_pg_numrows_0_arg1);
 	attribute_Deprecated_func_pg_numrows_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_numfields_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numfields", sizeof("pg_numfields") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_numfields_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_numfields", strlen("pg_numfields")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_numfields_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_numfields_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_numfields_0_arg0, attribute_Deprecated_func_pg_numfields_0_arg0_str);
@@ -888,7 +888,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_numfields_0->args[1].value, &attribute_Deprecated_func_pg_numfields_0_arg1);
 	attribute_Deprecated_func_pg_numfields_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_cmdtuples_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_cmdtuples", sizeof("pg_cmdtuples") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_cmdtuples_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_cmdtuples", strlen("pg_cmdtuples")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_cmdtuples_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_cmdtuples_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_cmdtuples_0_arg0, attribute_Deprecated_func_pg_cmdtuples_0_arg0_str);
@@ -900,7 +900,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_cmdtuples_0->args[1].value, &attribute_Deprecated_func_pg_cmdtuples_0_arg1);
 	attribute_Deprecated_func_pg_cmdtuples_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldname_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldname", sizeof("pg_fieldname") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldname_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldname", strlen("pg_fieldname")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldname_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldname_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldname_0_arg0, attribute_Deprecated_func_pg_fieldname_0_arg0_str);
@@ -912,7 +912,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldname_0->args[1].value, &attribute_Deprecated_func_pg_fieldname_0_arg1);
 	attribute_Deprecated_func_pg_fieldname_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldsize", sizeof("pg_fieldsize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldsize", strlen("pg_fieldsize")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldsize_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldsize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldsize_0_arg0, attribute_Deprecated_func_pg_fieldsize_0_arg0_str);
@@ -924,7 +924,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldsize_0->args[1].value, &attribute_Deprecated_func_pg_fieldsize_0_arg1);
 	attribute_Deprecated_func_pg_fieldsize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldtype_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldtype", sizeof("pg_fieldtype") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldtype_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldtype", strlen("pg_fieldtype")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldtype_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldtype_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldtype_0_arg0, attribute_Deprecated_func_pg_fieldtype_0_arg0_str);
@@ -936,7 +936,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldtype_0->args[1].value, &attribute_Deprecated_func_pg_fieldtype_0_arg1);
 	attribute_Deprecated_func_pg_fieldtype_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldnum_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldnum", sizeof("pg_fieldnum") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldnum_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldnum", strlen("pg_fieldnum")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldnum_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldnum_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldnum_0_arg0, attribute_Deprecated_func_pg_fieldnum_0_arg0_str);
@@ -948,7 +948,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldnum_0->args[1].value, &attribute_Deprecated_func_pg_fieldnum_0_arg1);
 	attribute_Deprecated_func_pg_fieldnum_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_result_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_result", sizeof("pg_result") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_result_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_result", strlen("pg_result")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_result_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_result_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_result_0_arg0, attribute_Deprecated_func_pg_result_0_arg0_str);
@@ -960,7 +960,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_result_0->args[1].value, &attribute_Deprecated_func_pg_result_0_arg1);
 	attribute_Deprecated_func_pg_result_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldprtlen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldprtlen", sizeof("pg_fieldprtlen") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldprtlen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldprtlen", strlen("pg_fieldprtlen")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldprtlen_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldprtlen_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldprtlen_0_arg0, attribute_Deprecated_func_pg_fieldprtlen_0_arg0_str);
@@ -972,7 +972,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldprtlen_0->args[1].value, &attribute_Deprecated_func_pg_fieldprtlen_0_arg1);
 	attribute_Deprecated_func_pg_fieldprtlen_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_fieldisnull_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldisnull", sizeof("pg_fieldisnull") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_fieldisnull_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_fieldisnull", strlen("pg_fieldisnull")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_fieldisnull_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_fieldisnull_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_fieldisnull_0_arg0, attribute_Deprecated_func_pg_fieldisnull_0_arg0_str);
@@ -984,7 +984,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_fieldisnull_0->args[1].value, &attribute_Deprecated_func_pg_fieldisnull_0_arg1);
 	attribute_Deprecated_func_pg_fieldisnull_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_freeresult_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_freeresult", sizeof("pg_freeresult") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_freeresult_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_freeresult", strlen("pg_freeresult")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_freeresult_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_freeresult_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_freeresult_0_arg0, attribute_Deprecated_func_pg_freeresult_0_arg0_str);
@@ -996,7 +996,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_freeresult_0->args[1].value, &attribute_Deprecated_func_pg_freeresult_0_arg1);
 	attribute_Deprecated_func_pg_freeresult_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_getlastoid_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_getlastoid", sizeof("pg_getlastoid") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_getlastoid_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_getlastoid", strlen("pg_getlastoid")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_getlastoid_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_getlastoid_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_getlastoid_0_arg0, attribute_Deprecated_func_pg_getlastoid_0_arg0_str);
@@ -1008,7 +1008,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_getlastoid_0->args[1].value, &attribute_Deprecated_func_pg_getlastoid_0_arg1);
 	attribute_Deprecated_func_pg_getlastoid_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_locreate_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_locreate", sizeof("pg_locreate") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_locreate_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_locreate", strlen("pg_locreate")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_locreate_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_locreate_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_locreate_0_arg0, attribute_Deprecated_func_pg_locreate_0_arg0_str);
@@ -1020,7 +1020,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_locreate_0->args[1].value, &attribute_Deprecated_func_pg_locreate_0_arg1);
 	attribute_Deprecated_func_pg_locreate_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_lounlink_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lounlink", sizeof("pg_lounlink") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_lounlink_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lounlink", strlen("pg_lounlink")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_lounlink_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_lounlink_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_lounlink_0_arg0, attribute_Deprecated_func_pg_lounlink_0_arg0_str);
@@ -1032,7 +1032,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lounlink_0->args[1].value, &attribute_Deprecated_func_pg_lounlink_0_arg1);
 	attribute_Deprecated_func_pg_lounlink_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loopen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loopen", sizeof("pg_loopen") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loopen_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loopen", strlen("pg_loopen")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loopen_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loopen_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loopen_0_arg0, attribute_Deprecated_func_pg_loopen_0_arg0_str);
@@ -1044,7 +1044,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loopen_0->args[1].value, &attribute_Deprecated_func_pg_loopen_0_arg1);
 	attribute_Deprecated_func_pg_loopen_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loclose_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loclose", sizeof("pg_loclose") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loclose_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loclose", strlen("pg_loclose")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loclose_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loclose_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loclose_0_arg0, attribute_Deprecated_func_pg_loclose_0_arg0_str);
@@ -1056,7 +1056,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loclose_0->args[1].value, &attribute_Deprecated_func_pg_loclose_0_arg1);
 	attribute_Deprecated_func_pg_loclose_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loread_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loread", sizeof("pg_loread") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loread_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loread", strlen("pg_loread")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loread_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loread_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loread_0_arg0, attribute_Deprecated_func_pg_loread_0_arg0_str);
@@ -1068,7 +1068,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loread_0->args[1].value, &attribute_Deprecated_func_pg_loread_0_arg1);
 	attribute_Deprecated_func_pg_loread_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_lowrite_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lowrite", sizeof("pg_lowrite") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_lowrite_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_lowrite", strlen("pg_lowrite")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_lowrite_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_lowrite_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_lowrite_0_arg0, attribute_Deprecated_func_pg_lowrite_0_arg0_str);
@@ -1080,7 +1080,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_lowrite_0->args[1].value, &attribute_Deprecated_func_pg_lowrite_0_arg1);
 	attribute_Deprecated_func_pg_lowrite_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loreadall_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loreadall", sizeof("pg_loreadall") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loreadall_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loreadall", strlen("pg_loreadall")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loreadall_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loreadall_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loreadall_0_arg0, attribute_Deprecated_func_pg_loreadall_0_arg0_str);
@@ -1092,7 +1092,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loreadall_0->args[1].value, &attribute_Deprecated_func_pg_loreadall_0_arg1);
 	attribute_Deprecated_func_pg_loreadall_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loimport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loimport", sizeof("pg_loimport") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loimport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loimport", strlen("pg_loimport")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loimport_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loimport_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loimport_0_arg0, attribute_Deprecated_func_pg_loimport_0_arg0_str);
@@ -1104,7 +1104,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loimport_0->args[1].value, &attribute_Deprecated_func_pg_loimport_0_arg1);
 	attribute_Deprecated_func_pg_loimport_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_loexport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loexport", sizeof("pg_loexport") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_loexport_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_loexport", strlen("pg_loexport")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_loexport_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_loexport_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_loexport_0_arg0, attribute_Deprecated_func_pg_loexport_0_arg0_str);
@@ -1116,7 +1116,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_loexport_0->args[1].value, &attribute_Deprecated_func_pg_loexport_0_arg1);
 	attribute_Deprecated_func_pg_loexport_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_setclientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_setclientencoding", sizeof("pg_setclientencoding") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_setclientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_setclientencoding", strlen("pg_setclientencoding")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_setclientencoding_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_setclientencoding_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_setclientencoding_0_arg0, attribute_Deprecated_func_pg_setclientencoding_0_arg0_str);
@@ -1128,7 +1128,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_setclientencoding_0->args[1].value, &attribute_Deprecated_func_pg_setclientencoding_0_arg1);
 	attribute_Deprecated_func_pg_setclientencoding_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_pg_clientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_clientencoding", sizeof("pg_clientencoding") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_pg_clientencoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_clientencoding", strlen("pg_clientencoding")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_pg_clientencoding_0_arg0;
 	zend_string *attribute_Deprecated_func_pg_clientencoding_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_pg_clientencoding_0_arg0, attribute_Deprecated_func_pg_clientencoding_0_arg0_str);
@@ -1140,7 +1140,7 @@ static void register_pgsql_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_pg_clientencoding_0->args[1].value, &attribute_Deprecated_func_pg_clientencoding_0_arg1);
 	attribute_Deprecated_func_pg_clientencoding_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_change_password", sizeof("pg_change_password") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "pg_change_password", strlen("pg_change_password")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_PgSql_Connection(void)

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -624,97 +624,97 @@ static zend_class_entry *register_class_Phar(zend_class_entry *class_entry_Recur
 
 	zval const_BZ2_value;
 	ZVAL_LONG(&const_BZ2_value, PHAR_ENT_COMPRESSED_BZ2);
-	zend_string *const_BZ2_name = zend_string_init_interned("BZ2", sizeof("BZ2") - 1, 1);
+	zend_string *const_BZ2_name = zend_string_init_interned("BZ2", strlen("BZ2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BZ2_name, &const_BZ2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BZ2_name);
 
 	zval const_GZ_value;
 	ZVAL_LONG(&const_GZ_value, PHAR_ENT_COMPRESSED_GZ);
-	zend_string *const_GZ_name = zend_string_init_interned("GZ", sizeof("GZ") - 1, 1);
+	zend_string *const_GZ_name = zend_string_init_interned("GZ", strlen("GZ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GZ_name, &const_GZ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GZ_name);
 
 	zval const_NONE_value;
 	ZVAL_LONG(&const_NONE_value, PHAR_ENT_COMPRESSED_NONE);
-	zend_string *const_NONE_name = zend_string_init_interned("NONE", sizeof("NONE") - 1, 1);
+	zend_string *const_NONE_name = zend_string_init_interned("NONE", strlen("NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NONE_name, &const_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NONE_name);
 
 	zval const_PHAR_value;
 	ZVAL_LONG(&const_PHAR_value, PHAR_FORMAT_PHAR);
-	zend_string *const_PHAR_name = zend_string_init_interned("PHAR", sizeof("PHAR") - 1, 1);
+	zend_string *const_PHAR_name = zend_string_init_interned("PHAR", strlen("PHAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PHAR_name, &const_PHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PHAR_name);
 
 	zval const_TAR_value;
 	ZVAL_LONG(&const_TAR_value, PHAR_FORMAT_TAR);
-	zend_string *const_TAR_name = zend_string_init_interned("TAR", sizeof("TAR") - 1, 1);
+	zend_string *const_TAR_name = zend_string_init_interned("TAR", strlen("TAR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TAR_name, &const_TAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TAR_name);
 
 	zval const_ZIP_value;
 	ZVAL_LONG(&const_ZIP_value, PHAR_FORMAT_ZIP);
-	zend_string *const_ZIP_name = zend_string_init_interned("ZIP", sizeof("ZIP") - 1, 1);
+	zend_string *const_ZIP_name = zend_string_init_interned("ZIP", strlen("ZIP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ZIP_name, &const_ZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ZIP_name);
 
 	zval const_COMPRESSED_value;
 	ZVAL_LONG(&const_COMPRESSED_value, PHAR_ENT_COMPRESSION_MASK);
-	zend_string *const_COMPRESSED_name = zend_string_init_interned("COMPRESSED", sizeof("COMPRESSED") - 1, 1);
+	zend_string *const_COMPRESSED_name = zend_string_init_interned("COMPRESSED", strlen("COMPRESSED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_COMPRESSED_name, &const_COMPRESSED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_COMPRESSED_name);
 
 	zval const_PHP_value;
 	ZVAL_LONG(&const_PHP_value, PHAR_MIME_PHP);
-	zend_string *const_PHP_name = zend_string_init_interned("PHP", sizeof("PHP") - 1, 1);
+	zend_string *const_PHP_name = zend_string_init_interned("PHP", strlen("PHP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PHP_name, &const_PHP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PHP_name);
 
 	zval const_PHPS_value;
 	ZVAL_LONG(&const_PHPS_value, PHAR_MIME_PHPS);
-	zend_string *const_PHPS_name = zend_string_init_interned("PHPS", sizeof("PHPS") - 1, 1);
+	zend_string *const_PHPS_name = zend_string_init_interned("PHPS", strlen("PHPS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PHPS_name, &const_PHPS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PHPS_name);
 
 	zval const_MD5_value;
 	ZVAL_LONG(&const_MD5_value, PHAR_SIG_MD5);
-	zend_string *const_MD5_name = zend_string_init_interned("MD5", sizeof("MD5") - 1, 1);
+	zend_string *const_MD5_name = zend_string_init_interned("MD5", strlen("MD5"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MD5_name, &const_MD5_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MD5_name);
 
 	zval const_OPENSSL_value;
 	ZVAL_LONG(&const_OPENSSL_value, PHAR_SIG_OPENSSL);
-	zend_string *const_OPENSSL_name = zend_string_init_interned("OPENSSL", sizeof("OPENSSL") - 1, 1);
+	zend_string *const_OPENSSL_name = zend_string_init_interned("OPENSSL", strlen("OPENSSL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPENSSL_name, &const_OPENSSL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPENSSL_name);
 
 	zval const_OPENSSL_SHA256_value;
 	ZVAL_LONG(&const_OPENSSL_SHA256_value, PHAR_SIG_OPENSSL_SHA256);
-	zend_string *const_OPENSSL_SHA256_name = zend_string_init_interned("OPENSSL_SHA256", sizeof("OPENSSL_SHA256") - 1, 1);
+	zend_string *const_OPENSSL_SHA256_name = zend_string_init_interned("OPENSSL_SHA256", strlen("OPENSSL_SHA256"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPENSSL_SHA256_name, &const_OPENSSL_SHA256_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPENSSL_SHA256_name);
 
 	zval const_OPENSSL_SHA512_value;
 	ZVAL_LONG(&const_OPENSSL_SHA512_value, PHAR_SIG_OPENSSL_SHA512);
-	zend_string *const_OPENSSL_SHA512_name = zend_string_init_interned("OPENSSL_SHA512", sizeof("OPENSSL_SHA512") - 1, 1);
+	zend_string *const_OPENSSL_SHA512_name = zend_string_init_interned("OPENSSL_SHA512", strlen("OPENSSL_SHA512"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPENSSL_SHA512_name, &const_OPENSSL_SHA512_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPENSSL_SHA512_name);
 
 	zval const_SHA1_value;
 	ZVAL_LONG(&const_SHA1_value, PHAR_SIG_SHA1);
-	zend_string *const_SHA1_name = zend_string_init_interned("SHA1", sizeof("SHA1") - 1, 1);
+	zend_string *const_SHA1_name = zend_string_init_interned("SHA1", strlen("SHA1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHA1_name, &const_SHA1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHA1_name);
 
 	zval const_SHA256_value;
 	ZVAL_LONG(&const_SHA256_value, PHAR_SIG_SHA256);
-	zend_string *const_SHA256_name = zend_string_init_interned("SHA256", sizeof("SHA256") - 1, 1);
+	zend_string *const_SHA256_name = zend_string_init_interned("SHA256", strlen("SHA256"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHA256_name, &const_SHA256_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHA256_name);
 
 	zval const_SHA512_value;
 	ZVAL_LONG(&const_SHA512_value, PHAR_SIG_SHA512);
-	zend_string *const_SHA512_name = zend_string_init_interned("SHA512", sizeof("SHA512") - 1, 1);
+	zend_string *const_SHA512_name = zend_string_init_interned("SHA512", strlen("SHA512"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SHA512_name, &const_SHA512_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SHA512_name);
 

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -229,7 +229,7 @@ static void register_random_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("MT_RAND_PHP", MT_RAND_PHP, CONST_PERSISTENT | CONST_DEPRECATED);
 
 
-	zend_attribute *attribute_Deprecated_func_lcg_value_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "lcg_value", sizeof("lcg_value") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_lcg_value_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "lcg_value", strlen("lcg_value")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_lcg_value_0_arg0;
 	zend_string *attribute_Deprecated_func_lcg_value_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_lcg_value_0_arg0, attribute_Deprecated_func_lcg_value_0_arg0_str);
@@ -316,8 +316,8 @@ static zend_class_entry *register_class_Random_Randomizer(void)
 
 	zval property_engine_default_value;
 	ZVAL_UNDEF(&property_engine_default_value);
-	zend_string *property_engine_name = zend_string_init("engine", sizeof("engine") - 1, 1);
-	zend_string *property_engine_class_Random_Engine = zend_string_init("Random\\Engine", sizeof("Random\\Engine")-1, 1);
+	zend_string *property_engine_name = zend_string_init("engine", strlen("engine"), 1);
+	zend_string *property_engine_class_Random_Engine = zend_string_init("Random\\Engine", strlen("Random\\Engine"), 1);
 	zend_declare_typed_property(class_entry, property_engine_name, &property_engine_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_engine_class_Random_Engine, 0, 0));
 	zend_string_release(property_engine_name);
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1413,12 +1413,12 @@ static zend_class_entry *register_class_ReflectionFunction(zend_class_entry *cla
 
 	zval const_IS_DEPRECATED_value;
 	ZVAL_LONG(&const_IS_DEPRECATED_value, ZEND_ACC_DEPRECATED);
-	zend_string *const_IS_DEPRECATED_name = zend_string_init_interned("IS_DEPRECATED", sizeof("IS_DEPRECATED") - 1, 1);
+	zend_string *const_IS_DEPRECATED_name = zend_string_init_interned("IS_DEPRECATED", strlen("IS_DEPRECATED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_DEPRECATED_name, &const_IS_DEPRECATED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_DEPRECATED_name);
 
 
-	zend_attribute *attribute_Deprecated_func_isdisabled_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isdisabled", sizeof("isdisabled") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_isdisabled_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isdisabled", strlen("isdisabled")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_isdisabled_0_arg0;
 	zend_string *attribute_Deprecated_func_isdisabled_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_isdisabled_0_arg0, attribute_Deprecated_func_isdisabled_0_arg0_str);
@@ -1452,37 +1452,37 @@ static zend_class_entry *register_class_ReflectionMethod(zend_class_entry *class
 
 	zval const_IS_STATIC_value;
 	ZVAL_LONG(&const_IS_STATIC_value, ZEND_ACC_STATIC);
-	zend_string *const_IS_STATIC_name = zend_string_init_interned("IS_STATIC", sizeof("IS_STATIC") - 1, 1);
+	zend_string *const_IS_STATIC_name = zend_string_init_interned("IS_STATIC", strlen("IS_STATIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_STATIC_name, &const_IS_STATIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_STATIC_name);
 
 	zval const_IS_PUBLIC_value;
 	ZVAL_LONG(&const_IS_PUBLIC_value, ZEND_ACC_PUBLIC);
-	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", sizeof("IS_PUBLIC") - 1, 1);
+	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", strlen("IS_PUBLIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PUBLIC_name, &const_IS_PUBLIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PUBLIC_name);
 
 	zval const_IS_PROTECTED_value;
 	ZVAL_LONG(&const_IS_PROTECTED_value, ZEND_ACC_PROTECTED);
-	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", sizeof("IS_PROTECTED") - 1, 1);
+	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", strlen("IS_PROTECTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PROTECTED_name, &const_IS_PROTECTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PROTECTED_name);
 
 	zval const_IS_PRIVATE_value;
 	ZVAL_LONG(&const_IS_PRIVATE_value, ZEND_ACC_PRIVATE);
-	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", sizeof("IS_PRIVATE") - 1, 1);
+	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", strlen("IS_PRIVATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PRIVATE_name, &const_IS_PRIVATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PRIVATE_name);
 
 	zval const_IS_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_ABSTRACT_value, ZEND_ACC_ABSTRACT);
-	zend_string *const_IS_ABSTRACT_name = zend_string_init_interned("IS_ABSTRACT", sizeof("IS_ABSTRACT") - 1, 1);
+	zend_string *const_IS_ABSTRACT_name = zend_string_init_interned("IS_ABSTRACT", strlen("IS_ABSTRACT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_ABSTRACT_name, &const_IS_ABSTRACT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_ABSTRACT_name);
 
 	zval const_IS_FINAL_value;
 	ZVAL_LONG(&const_IS_FINAL_value, ZEND_ACC_FINAL);
-	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", sizeof("IS_FINAL") - 1, 1);
+	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", strlen("IS_FINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_FINAL_name, &const_IS_FINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_FINAL_name);
 
@@ -1503,37 +1503,37 @@ static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_
 
 	zval const_IS_IMPLICIT_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_IMPLICIT_ABSTRACT_value, ZEND_ACC_IMPLICIT_ABSTRACT_CLASS);
-	zend_string *const_IS_IMPLICIT_ABSTRACT_name = zend_string_init_interned("IS_IMPLICIT_ABSTRACT", sizeof("IS_IMPLICIT_ABSTRACT") - 1, 1);
+	zend_string *const_IS_IMPLICIT_ABSTRACT_name = zend_string_init_interned("IS_IMPLICIT_ABSTRACT", strlen("IS_IMPLICIT_ABSTRACT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_IMPLICIT_ABSTRACT_name, &const_IS_IMPLICIT_ABSTRACT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_IMPLICIT_ABSTRACT_name);
 
 	zval const_IS_EXPLICIT_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_EXPLICIT_ABSTRACT_value, ZEND_ACC_EXPLICIT_ABSTRACT_CLASS);
-	zend_string *const_IS_EXPLICIT_ABSTRACT_name = zend_string_init_interned("IS_EXPLICIT_ABSTRACT", sizeof("IS_EXPLICIT_ABSTRACT") - 1, 1);
+	zend_string *const_IS_EXPLICIT_ABSTRACT_name = zend_string_init_interned("IS_EXPLICIT_ABSTRACT", strlen("IS_EXPLICIT_ABSTRACT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_EXPLICIT_ABSTRACT_name, &const_IS_EXPLICIT_ABSTRACT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_EXPLICIT_ABSTRACT_name);
 
 	zval const_IS_FINAL_value;
 	ZVAL_LONG(&const_IS_FINAL_value, ZEND_ACC_FINAL);
-	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", sizeof("IS_FINAL") - 1, 1);
+	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", strlen("IS_FINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_FINAL_name, &const_IS_FINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_FINAL_name);
 
 	zval const_IS_READONLY_value;
 	ZVAL_LONG(&const_IS_READONLY_value, ZEND_ACC_READONLY_CLASS);
-	zend_string *const_IS_READONLY_name = zend_string_init_interned("IS_READONLY", sizeof("IS_READONLY") - 1, 1);
+	zend_string *const_IS_READONLY_name = zend_string_init_interned("IS_READONLY", strlen("IS_READONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_READONLY_name, &const_IS_READONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_READONLY_name);
 
 	zval const_SKIP_INITIALIZATION_ON_SERIALIZE_value;
 	ZVAL_LONG(&const_SKIP_INITIALIZATION_ON_SERIALIZE_value, ZEND_LAZY_OBJECT_SKIP_INITIALIZATION_ON_SERIALIZE);
-	zend_string *const_SKIP_INITIALIZATION_ON_SERIALIZE_name = zend_string_init_interned("SKIP_INITIALIZATION_ON_SERIALIZE", sizeof("SKIP_INITIALIZATION_ON_SERIALIZE") - 1, 1);
+	zend_string *const_SKIP_INITIALIZATION_ON_SERIALIZE_name = zend_string_init_interned("SKIP_INITIALIZATION_ON_SERIALIZE", strlen("SKIP_INITIALIZATION_ON_SERIALIZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SKIP_INITIALIZATION_ON_SERIALIZE_name, &const_SKIP_INITIALIZATION_ON_SERIALIZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SKIP_INITIALIZATION_ON_SERIALIZE_name);
 
 	zval const_SKIP_DESTRUCTOR_value;
 	ZVAL_LONG(&const_SKIP_DESTRUCTOR_value, ZEND_LAZY_OBJECT_SKIP_DESTRUCTOR);
-	zend_string *const_SKIP_DESTRUCTOR_name = zend_string_init_interned("SKIP_DESTRUCTOR", sizeof("SKIP_DESTRUCTOR") - 1, 1);
+	zend_string *const_SKIP_DESTRUCTOR_name = zend_string_init_interned("SKIP_DESTRUCTOR", strlen("SKIP_DESTRUCTOR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SKIP_DESTRUCTOR_name, &const_SKIP_DESTRUCTOR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SKIP_DESTRUCTOR_name);
 
@@ -1581,49 +1581,49 @@ static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *cla
 
 	zval const_IS_STATIC_value;
 	ZVAL_LONG(&const_IS_STATIC_value, ZEND_ACC_STATIC);
-	zend_string *const_IS_STATIC_name = zend_string_init_interned("IS_STATIC", sizeof("IS_STATIC") - 1, 1);
+	zend_string *const_IS_STATIC_name = zend_string_init_interned("IS_STATIC", strlen("IS_STATIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_STATIC_name, &const_IS_STATIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_STATIC_name);
 
 	zval const_IS_READONLY_value;
 	ZVAL_LONG(&const_IS_READONLY_value, ZEND_ACC_READONLY);
-	zend_string *const_IS_READONLY_name = zend_string_init_interned("IS_READONLY", sizeof("IS_READONLY") - 1, 1);
+	zend_string *const_IS_READONLY_name = zend_string_init_interned("IS_READONLY", strlen("IS_READONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_READONLY_name, &const_IS_READONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_READONLY_name);
 
 	zval const_IS_PUBLIC_value;
 	ZVAL_LONG(&const_IS_PUBLIC_value, ZEND_ACC_PUBLIC);
-	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", sizeof("IS_PUBLIC") - 1, 1);
+	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", strlen("IS_PUBLIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PUBLIC_name, &const_IS_PUBLIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PUBLIC_name);
 
 	zval const_IS_PROTECTED_value;
 	ZVAL_LONG(&const_IS_PROTECTED_value, ZEND_ACC_PROTECTED);
-	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", sizeof("IS_PROTECTED") - 1, 1);
+	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", strlen("IS_PROTECTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PROTECTED_name, &const_IS_PROTECTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PROTECTED_name);
 
 	zval const_IS_PRIVATE_value;
 	ZVAL_LONG(&const_IS_PRIVATE_value, ZEND_ACC_PRIVATE);
-	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", sizeof("IS_PRIVATE") - 1, 1);
+	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", strlen("IS_PRIVATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PRIVATE_name, &const_IS_PRIVATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PRIVATE_name);
 
 	zval const_IS_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_ABSTRACT_value, ZEND_ACC_ABSTRACT);
-	zend_string *const_IS_ABSTRACT_name = zend_string_init_interned("IS_ABSTRACT", sizeof("IS_ABSTRACT") - 1, 1);
+	zend_string *const_IS_ABSTRACT_name = zend_string_init_interned("IS_ABSTRACT", strlen("IS_ABSTRACT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_ABSTRACT_name, &const_IS_ABSTRACT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_ABSTRACT_name);
 
 	zval const_IS_PROTECTED_SET_value;
 	ZVAL_LONG(&const_IS_PROTECTED_SET_value, ZEND_ACC_PROTECTED_SET);
-	zend_string *const_IS_PROTECTED_SET_name = zend_string_init_interned("IS_PROTECTED_SET", sizeof("IS_PROTECTED_SET") - 1, 1);
+	zend_string *const_IS_PROTECTED_SET_name = zend_string_init_interned("IS_PROTECTED_SET", strlen("IS_PROTECTED_SET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PROTECTED_SET_name, &const_IS_PROTECTED_SET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PROTECTED_SET_name);
 
 	zval const_IS_PRIVATE_SET_value;
 	ZVAL_LONG(&const_IS_PRIVATE_SET_value, ZEND_ACC_PRIVATE_SET);
-	zend_string *const_IS_PRIVATE_SET_name = zend_string_init_interned("IS_PRIVATE_SET", sizeof("IS_PRIVATE_SET") - 1, 1);
+	zend_string *const_IS_PRIVATE_SET_name = zend_string_init_interned("IS_PRIVATE_SET", strlen("IS_PRIVATE_SET"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PRIVATE_SET_name, &const_IS_PRIVATE_SET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PRIVATE_SET_name);
 
@@ -1635,7 +1635,7 @@ static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *cla
 
 	zval const_IS_FINAL_value;
 	ZVAL_LONG(&const_IS_FINAL_value, ZEND_ACC_FINAL);
-	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", sizeof("IS_FINAL") - 1, 1);
+	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", strlen("IS_FINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_FINAL_name, &const_IS_FINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_FINAL_name);
 
@@ -1660,25 +1660,25 @@ static zend_class_entry *register_class_ReflectionClassConstant(zend_class_entry
 
 	zval const_IS_PUBLIC_value;
 	ZVAL_LONG(&const_IS_PUBLIC_value, ZEND_ACC_PUBLIC);
-	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", sizeof("IS_PUBLIC") - 1, 1);
+	zend_string *const_IS_PUBLIC_name = zend_string_init_interned("IS_PUBLIC", strlen("IS_PUBLIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PUBLIC_name, &const_IS_PUBLIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PUBLIC_name);
 
 	zval const_IS_PROTECTED_value;
 	ZVAL_LONG(&const_IS_PROTECTED_value, ZEND_ACC_PROTECTED);
-	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", sizeof("IS_PROTECTED") - 1, 1);
+	zend_string *const_IS_PROTECTED_name = zend_string_init_interned("IS_PROTECTED", strlen("IS_PROTECTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PROTECTED_name, &const_IS_PROTECTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PROTECTED_name);
 
 	zval const_IS_PRIVATE_value;
 	ZVAL_LONG(&const_IS_PRIVATE_value, ZEND_ACC_PRIVATE);
-	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", sizeof("IS_PRIVATE") - 1, 1);
+	zend_string *const_IS_PRIVATE_name = zend_string_init_interned("IS_PRIVATE", strlen("IS_PRIVATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_PRIVATE_name, &const_IS_PRIVATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_PRIVATE_name);
 
 	zval const_IS_FINAL_value;
 	ZVAL_LONG(&const_IS_FINAL_value, ZEND_ACC_FINAL);
-	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", sizeof("IS_FINAL") - 1, 1);
+	zend_string *const_IS_FINAL_name = zend_string_init_interned("IS_FINAL", strlen("IS_FINAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_FINAL_name, &const_IS_FINAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_FINAL_name);
 
@@ -1706,7 +1706,7 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
 
-	zend_attribute *attribute_Deprecated_func_getclass_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "getclass", sizeof("getclass") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_getclass_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "getclass", strlen("getclass")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_getclass_0_arg0;
 	zend_string *attribute_Deprecated_func_getclass_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_getclass_0_arg0, attribute_Deprecated_func_getclass_0_arg0_str);
@@ -1718,7 +1718,7 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_getclass_0->args[1].value, &attribute_Deprecated_func_getclass_0_arg1);
 	attribute_Deprecated_func_getclass_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_isarray_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isarray", sizeof("isarray") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_isarray_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "isarray", strlen("isarray")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_isarray_0_arg0;
 	zend_string *attribute_Deprecated_func_isarray_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_isarray_0_arg0, attribute_Deprecated_func_isarray_0_arg0_str);
@@ -1730,7 +1730,7 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_isarray_0->args[1].value, &attribute_Deprecated_func_isarray_0_arg1);
 	attribute_Deprecated_func_isarray_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_iscallable_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "iscallable", sizeof("iscallable") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_iscallable_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "iscallable", strlen("iscallable")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_iscallable_0_arg0;
 	zend_string *attribute_Deprecated_func_iscallable_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_iscallable_0_arg0, attribute_Deprecated_func_iscallable_0_arg0_str);
@@ -1836,7 +1836,7 @@ static zend_class_entry *register_class_ReflectionAttribute(zend_class_entry *cl
 
 	zval const_IS_INSTANCEOF_value;
 	ZVAL_LONG(&const_IS_INSTANCEOF_value, REFLECTION_ATTRIBUTE_IS_INSTANCEOF);
-	zend_string *const_IS_INSTANCEOF_name = zend_string_init_interned("IS_INSTANCEOF", sizeof("IS_INSTANCEOF") - 1, 1);
+	zend_string *const_IS_INSTANCEOF_name = zend_string_init_interned("IS_INSTANCEOF", strlen("IS_INSTANCEOF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IS_INSTANCEOF_name, &const_IS_INSTANCEOF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IS_INSTANCEOF_name);
 

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -52,7 +52,7 @@ static const zend_function_entry ext_functions[] = {
 static void register_shmop_symbols(int module_number)
 {
 
-	zend_attribute *attribute_Deprecated_func_shmop_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "shmop_close", sizeof("shmop_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_shmop_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "shmop_close", strlen("shmop_close")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_shmop_close_0_arg0;
 	zend_string *attribute_Deprecated_func_shmop_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_shmop_close_0_arg0, attribute_Deprecated_func_shmop_close_0_arg0_str);

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -270,121 +270,121 @@ static zend_class_entry *register_class_SNMP(void)
 
 	zval const_VERSION_1_value;
 	ZVAL_LONG(&const_VERSION_1_value, SNMP_VERSION_1);
-	zend_string *const_VERSION_1_name = zend_string_init_interned("VERSION_1", sizeof("VERSION_1") - 1, 1);
+	zend_string *const_VERSION_1_name = zend_string_init_interned("VERSION_1", strlen("VERSION_1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VERSION_1_name, &const_VERSION_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_1_name);
 
 	zval const_VERSION_2c_value;
 	ZVAL_LONG(&const_VERSION_2c_value, SNMP_VERSION_2c);
-	zend_string *const_VERSION_2c_name = zend_string_init_interned("VERSION_2c", sizeof("VERSION_2c") - 1, 1);
+	zend_string *const_VERSION_2c_name = zend_string_init_interned("VERSION_2c", strlen("VERSION_2c"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VERSION_2c_name, &const_VERSION_2c_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_2c_name);
 
 	zval const_VERSION_2C_value;
 	ZVAL_LONG(&const_VERSION_2C_value, SNMP_VERSION_2c);
-	zend_string *const_VERSION_2C_name = zend_string_init_interned("VERSION_2C", sizeof("VERSION_2C") - 1, 1);
+	zend_string *const_VERSION_2C_name = zend_string_init_interned("VERSION_2C", strlen("VERSION_2C"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VERSION_2C_name, &const_VERSION_2C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_2C_name);
 
 	zval const_VERSION_3_value;
 	ZVAL_LONG(&const_VERSION_3_value, SNMP_VERSION_3);
-	zend_string *const_VERSION_3_name = zend_string_init_interned("VERSION_3", sizeof("VERSION_3") - 1, 1);
+	zend_string *const_VERSION_3_name = zend_string_init_interned("VERSION_3", strlen("VERSION_3"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VERSION_3_name, &const_VERSION_3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_3_name);
 
 	zval const_ERRNO_NOERROR_value;
 	ZVAL_LONG(&const_ERRNO_NOERROR_value, PHP_SNMP_ERRNO_NOERROR);
-	zend_string *const_ERRNO_NOERROR_name = zend_string_init_interned("ERRNO_NOERROR", sizeof("ERRNO_NOERROR") - 1, 1);
+	zend_string *const_ERRNO_NOERROR_name = zend_string_init_interned("ERRNO_NOERROR", strlen("ERRNO_NOERROR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_NOERROR_name, &const_ERRNO_NOERROR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_NOERROR_name);
 
 	zval const_ERRNO_ANY_value;
 	ZVAL_LONG(&const_ERRNO_ANY_value, PHP_SNMP_ERRNO_ANY);
-	zend_string *const_ERRNO_ANY_name = zend_string_init_interned("ERRNO_ANY", sizeof("ERRNO_ANY") - 1, 1);
+	zend_string *const_ERRNO_ANY_name = zend_string_init_interned("ERRNO_ANY", strlen("ERRNO_ANY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_ANY_name, &const_ERRNO_ANY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_ANY_name);
 
 	zval const_ERRNO_GENERIC_value;
 	ZVAL_LONG(&const_ERRNO_GENERIC_value, PHP_SNMP_ERRNO_GENERIC);
-	zend_string *const_ERRNO_GENERIC_name = zend_string_init_interned("ERRNO_GENERIC", sizeof("ERRNO_GENERIC") - 1, 1);
+	zend_string *const_ERRNO_GENERIC_name = zend_string_init_interned("ERRNO_GENERIC", strlen("ERRNO_GENERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_GENERIC_name, &const_ERRNO_GENERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_GENERIC_name);
 
 	zval const_ERRNO_TIMEOUT_value;
 	ZVAL_LONG(&const_ERRNO_TIMEOUT_value, PHP_SNMP_ERRNO_TIMEOUT);
-	zend_string *const_ERRNO_TIMEOUT_name = zend_string_init_interned("ERRNO_TIMEOUT", sizeof("ERRNO_TIMEOUT") - 1, 1);
+	zend_string *const_ERRNO_TIMEOUT_name = zend_string_init_interned("ERRNO_TIMEOUT", strlen("ERRNO_TIMEOUT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_TIMEOUT_name, &const_ERRNO_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_TIMEOUT_name);
 
 	zval const_ERRNO_ERROR_IN_REPLY_value;
 	ZVAL_LONG(&const_ERRNO_ERROR_IN_REPLY_value, PHP_SNMP_ERRNO_ERROR_IN_REPLY);
-	zend_string *const_ERRNO_ERROR_IN_REPLY_name = zend_string_init_interned("ERRNO_ERROR_IN_REPLY", sizeof("ERRNO_ERROR_IN_REPLY") - 1, 1);
+	zend_string *const_ERRNO_ERROR_IN_REPLY_name = zend_string_init_interned("ERRNO_ERROR_IN_REPLY", strlen("ERRNO_ERROR_IN_REPLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_ERROR_IN_REPLY_name, &const_ERRNO_ERROR_IN_REPLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_ERROR_IN_REPLY_name);
 
 	zval const_ERRNO_OID_NOT_INCREASING_value;
 	ZVAL_LONG(&const_ERRNO_OID_NOT_INCREASING_value, PHP_SNMP_ERRNO_OID_NOT_INCREASING);
-	zend_string *const_ERRNO_OID_NOT_INCREASING_name = zend_string_init_interned("ERRNO_OID_NOT_INCREASING", sizeof("ERRNO_OID_NOT_INCREASING") - 1, 1);
+	zend_string *const_ERRNO_OID_NOT_INCREASING_name = zend_string_init_interned("ERRNO_OID_NOT_INCREASING", strlen("ERRNO_OID_NOT_INCREASING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_OID_NOT_INCREASING_name, &const_ERRNO_OID_NOT_INCREASING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_OID_NOT_INCREASING_name);
 
 	zval const_ERRNO_OID_PARSING_ERROR_value;
 	ZVAL_LONG(&const_ERRNO_OID_PARSING_ERROR_value, PHP_SNMP_ERRNO_OID_PARSING_ERROR);
-	zend_string *const_ERRNO_OID_PARSING_ERROR_name = zend_string_init_interned("ERRNO_OID_PARSING_ERROR", sizeof("ERRNO_OID_PARSING_ERROR") - 1, 1);
+	zend_string *const_ERRNO_OID_PARSING_ERROR_name = zend_string_init_interned("ERRNO_OID_PARSING_ERROR", strlen("ERRNO_OID_PARSING_ERROR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_OID_PARSING_ERROR_name, &const_ERRNO_OID_PARSING_ERROR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_OID_PARSING_ERROR_name);
 
 	zval const_ERRNO_MULTIPLE_SET_QUERIES_value;
 	ZVAL_LONG(&const_ERRNO_MULTIPLE_SET_QUERIES_value, PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES);
-	zend_string *const_ERRNO_MULTIPLE_SET_QUERIES_name = zend_string_init_interned("ERRNO_MULTIPLE_SET_QUERIES", sizeof("ERRNO_MULTIPLE_SET_QUERIES") - 1, 1);
+	zend_string *const_ERRNO_MULTIPLE_SET_QUERIES_name = zend_string_init_interned("ERRNO_MULTIPLE_SET_QUERIES", strlen("ERRNO_MULTIPLE_SET_QUERIES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ERRNO_MULTIPLE_SET_QUERIES_name, &const_ERRNO_MULTIPLE_SET_QUERIES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_MULTIPLE_SET_QUERIES_name);
 
 	zval property_info_default_value;
 	ZVAL_UNDEF(&property_info_default_value);
-	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_string *property_info_name = zend_string_init("info", strlen("info"), 1);
 	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_info_name);
 
 	zval property_max_oids_default_value;
 	ZVAL_UNDEF(&property_max_oids_default_value);
-	zend_string *property_max_oids_name = zend_string_init("max_oids", sizeof("max_oids") - 1, 1);
+	zend_string *property_max_oids_name = zend_string_init("max_oids", strlen("max_oids"), 1);
 	zend_declare_typed_property(class_entry, property_max_oids_name, &property_max_oids_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_max_oids_name);
 
 	zval property_valueretrieval_default_value;
 	ZVAL_UNDEF(&property_valueretrieval_default_value);
-	zend_string *property_valueretrieval_name = zend_string_init("valueretrieval", sizeof("valueretrieval") - 1, 1);
+	zend_string *property_valueretrieval_name = zend_string_init("valueretrieval", strlen("valueretrieval"), 1);
 	zend_declare_typed_property(class_entry, property_valueretrieval_name, &property_valueretrieval_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_valueretrieval_name);
 
 	zval property_quick_print_default_value;
 	ZVAL_UNDEF(&property_quick_print_default_value);
-	zend_string *property_quick_print_name = zend_string_init("quick_print", sizeof("quick_print") - 1, 1);
+	zend_string *property_quick_print_name = zend_string_init("quick_print", strlen("quick_print"), 1);
 	zend_declare_typed_property(class_entry, property_quick_print_name, &property_quick_print_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_quick_print_name);
 
 	zval property_enum_print_default_value;
 	ZVAL_UNDEF(&property_enum_print_default_value);
-	zend_string *property_enum_print_name = zend_string_init("enum_print", sizeof("enum_print") - 1, 1);
+	zend_string *property_enum_print_name = zend_string_init("enum_print", strlen("enum_print"), 1);
 	zend_declare_typed_property(class_entry, property_enum_print_name, &property_enum_print_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_enum_print_name);
 
 	zval property_oid_output_format_default_value;
 	ZVAL_UNDEF(&property_oid_output_format_default_value);
-	zend_string *property_oid_output_format_name = zend_string_init("oid_output_format", sizeof("oid_output_format") - 1, 1);
+	zend_string *property_oid_output_format_name = zend_string_init("oid_output_format", strlen("oid_output_format"), 1);
 	zend_declare_typed_property(class_entry, property_oid_output_format_name, &property_oid_output_format_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_oid_output_format_name);
 
 	zval property_oid_increasing_check_default_value;
 	ZVAL_UNDEF(&property_oid_increasing_check_default_value);
-	zend_string *property_oid_increasing_check_name = zend_string_init("oid_increasing_check", sizeof("oid_increasing_check") - 1, 1);
+	zend_string *property_oid_increasing_check_name = zend_string_init("oid_increasing_check", strlen("oid_increasing_check"), 1);
 	zend_declare_typed_property(class_entry, property_oid_increasing_check_name, &property_oid_increasing_check_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_oid_increasing_check_name);
 
 	zval property_exceptions_enabled_default_value;
 	ZVAL_UNDEF(&property_exceptions_enabled_default_value);
-	zend_string *property_exceptions_enabled_name = zend_string_init("exceptions_enabled", sizeof("exceptions_enabled") - 1, 1);
+	zend_string *property_exceptions_enabled_name = zend_string_init("exceptions_enabled", strlen("exceptions_enabled"), 1);
 	zend_declare_typed_property(class_entry, property_exceptions_enabled_name, &property_exceptions_enabled_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_exceptions_enabled_name);
 

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -344,13 +344,13 @@ static zend_class_entry *register_class_SoapParam(void)
 
 	zval property_param_name_default_value;
 	ZVAL_UNDEF(&property_param_name_default_value);
-	zend_string *property_param_name_name = zend_string_init("param_name", sizeof("param_name") - 1, 1);
+	zend_string *property_param_name_name = zend_string_init("param_name", strlen("param_name"), 1);
 	zend_declare_typed_property(class_entry, property_param_name_name, &property_param_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_param_name_name);
 
 	zval property_param_data_default_value;
 	ZVAL_UNDEF(&property_param_data_default_value);
-	zend_string *property_param_data_name = zend_string_init("param_data", sizeof("param_data") - 1, 1);
+	zend_string *property_param_data_name = zend_string_init("param_data", strlen("param_data"), 1);
 	zend_declare_typed_property(class_entry, property_param_data_name, &property_param_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_param_data_name);
 
@@ -366,7 +366,7 @@ static zend_class_entry *register_class_SoapHeader(void)
 
 	zval property_namespace_default_value;
 	ZVAL_UNDEF(&property_namespace_default_value);
-	zend_string *property_namespace_name = zend_string_init("namespace", sizeof("namespace") - 1, 1);
+	zend_string *property_namespace_name = zend_string_init("namespace", strlen("namespace"), 1);
 	zend_declare_typed_property(class_entry, property_namespace_name, &property_namespace_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_namespace_name);
 
@@ -376,19 +376,19 @@ static zend_class_entry *register_class_SoapHeader(void)
 
 	zval property_data_default_value;
 	ZVAL_NULL(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_data_name);
 
 	zval property_mustUnderstand_default_value;
 	ZVAL_UNDEF(&property_mustUnderstand_default_value);
-	zend_string *property_mustUnderstand_name = zend_string_init("mustUnderstand", sizeof("mustUnderstand") - 1, 1);
+	zend_string *property_mustUnderstand_name = zend_string_init("mustUnderstand", strlen("mustUnderstand"), 1);
 	zend_declare_typed_property(class_entry, property_mustUnderstand_name, &property_mustUnderstand_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_mustUnderstand_name);
 
 	zval property_actor_default_value;
 	ZVAL_UNDEF(&property_actor_default_value);
-	zend_string *property_actor_name = zend_string_init("actor", sizeof("actor") - 1, 1);
+	zend_string *property_actor_name = zend_string_init("actor", strlen("actor"), 1);
 	zend_declare_typed_property(class_entry, property_actor_name, &property_actor_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_actor_name);
 
@@ -404,43 +404,43 @@ static zend_class_entry *register_class_SoapFault(zend_class_entry *class_entry_
 
 	zval property_faultstring_default_value;
 	ZVAL_UNDEF(&property_faultstring_default_value);
-	zend_string *property_faultstring_name = zend_string_init("faultstring", sizeof("faultstring") - 1, 1);
+	zend_string *property_faultstring_name = zend_string_init("faultstring", strlen("faultstring"), 1);
 	zend_declare_typed_property(class_entry, property_faultstring_name, &property_faultstring_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_faultstring_name);
 
 	zval property_faultcode_default_value;
 	ZVAL_NULL(&property_faultcode_default_value);
-	zend_string *property_faultcode_name = zend_string_init("faultcode", sizeof("faultcode") - 1, 1);
+	zend_string *property_faultcode_name = zend_string_init("faultcode", strlen("faultcode"), 1);
 	zend_declare_typed_property(class_entry, property_faultcode_name, &property_faultcode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultcode_name);
 
 	zval property_faultcodens_default_value;
 	ZVAL_NULL(&property_faultcodens_default_value);
-	zend_string *property_faultcodens_name = zend_string_init("faultcodens", sizeof("faultcodens") - 1, 1);
+	zend_string *property_faultcodens_name = zend_string_init("faultcodens", strlen("faultcodens"), 1);
 	zend_declare_typed_property(class_entry, property_faultcodens_name, &property_faultcodens_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultcodens_name);
 
 	zval property_faultactor_default_value;
 	ZVAL_NULL(&property_faultactor_default_value);
-	zend_string *property_faultactor_name = zend_string_init("faultactor", sizeof("faultactor") - 1, 1);
+	zend_string *property_faultactor_name = zend_string_init("faultactor", strlen("faultactor"), 1);
 	zend_declare_typed_property(class_entry, property_faultactor_name, &property_faultactor_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultactor_name);
 
 	zval property_detail_default_value;
 	ZVAL_NULL(&property_detail_default_value);
-	zend_string *property_detail_name = zend_string_init("detail", sizeof("detail") - 1, 1);
+	zend_string *property_detail_name = zend_string_init("detail", strlen("detail"), 1);
 	zend_declare_typed_property(class_entry, property_detail_name, &property_detail_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_detail_name);
 
 	zval property__name_default_value;
 	ZVAL_NULL(&property__name_default_value);
-	zend_string *property__name_name = zend_string_init("_name", sizeof("_name") - 1, 1);
+	zend_string *property__name_name = zend_string_init("_name", strlen("_name"), 1);
 	zend_declare_typed_property(class_entry, property__name_name, &property__name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__name_name);
 
 	zval property_headerfault_default_value;
 	ZVAL_NULL(&property_headerfault_default_value);
-	zend_string *property_headerfault_name = zend_string_init("headerfault", sizeof("headerfault") - 1, 1);
+	zend_string *property_headerfault_name = zend_string_init("headerfault", strlen("headerfault"), 1);
 	zend_declare_typed_property(class_entry, property_headerfault_name, &property_headerfault_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_headerfault_name);
 
@@ -456,37 +456,37 @@ static zend_class_entry *register_class_SoapVar(void)
 
 	zval property_enc_type_default_value;
 	ZVAL_UNDEF(&property_enc_type_default_value);
-	zend_string *property_enc_type_name = zend_string_init("enc_type", sizeof("enc_type") - 1, 1);
+	zend_string *property_enc_type_name = zend_string_init("enc_type", strlen("enc_type"), 1);
 	zend_declare_typed_property(class_entry, property_enc_type_name, &property_enc_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_enc_type_name);
 
 	zval property_enc_value_default_value;
 	ZVAL_NULL(&property_enc_value_default_value);
-	zend_string *property_enc_value_name = zend_string_init("enc_value", sizeof("enc_value") - 1, 1);
+	zend_string *property_enc_value_name = zend_string_init("enc_value", strlen("enc_value"), 1);
 	zend_declare_typed_property(class_entry, property_enc_value_name, &property_enc_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_enc_value_name);
 
 	zval property_enc_stype_default_value;
 	ZVAL_NULL(&property_enc_stype_default_value);
-	zend_string *property_enc_stype_name = zend_string_init("enc_stype", sizeof("enc_stype") - 1, 1);
+	zend_string *property_enc_stype_name = zend_string_init("enc_stype", strlen("enc_stype"), 1);
 	zend_declare_typed_property(class_entry, property_enc_stype_name, &property_enc_stype_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_stype_name);
 
 	zval property_enc_ns_default_value;
 	ZVAL_NULL(&property_enc_ns_default_value);
-	zend_string *property_enc_ns_name = zend_string_init("enc_ns", sizeof("enc_ns") - 1, 1);
+	zend_string *property_enc_ns_name = zend_string_init("enc_ns", strlen("enc_ns"), 1);
 	zend_declare_typed_property(class_entry, property_enc_ns_name, &property_enc_ns_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_ns_name);
 
 	zval property_enc_name_default_value;
 	ZVAL_NULL(&property_enc_name_default_value);
-	zend_string *property_enc_name_name = zend_string_init("enc_name", sizeof("enc_name") - 1, 1);
+	zend_string *property_enc_name_name = zend_string_init("enc_name", strlen("enc_name"), 1);
 	zend_declare_typed_property(class_entry, property_enc_name_name, &property_enc_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_name_name);
 
 	zval property_enc_namens_default_value;
 	ZVAL_NULL(&property_enc_namens_default_value);
-	zend_string *property_enc_namens_name = zend_string_init("enc_namens", sizeof("enc_namens") - 1, 1);
+	zend_string *property_enc_namens_name = zend_string_init("enc_namens", strlen("enc_namens"), 1);
 	zend_declare_typed_property(class_entry, property_enc_namens_name, &property_enc_namens_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_namens_name);
 
@@ -502,8 +502,8 @@ static zend_class_entry *register_class_SoapServer(void)
 
 	zval property___soap_fault_default_value;
 	ZVAL_NULL(&property___soap_fault_default_value);
-	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", sizeof("__soap_fault") - 1, 1);
-	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", sizeof("SoapFault")-1, 1);
+	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", strlen("__soap_fault"), 1);
+	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", strlen("SoapFault"), 1);
 	zend_declare_typed_property(class_entry, property___soap_fault_name, &property___soap_fault_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property___soap_fault_class_SoapFault, 0, MAY_BE_NULL));
 	zend_string_release(property___soap_fault_name);
 
@@ -519,25 +519,25 @@ static zend_class_entry *register_class_SoapClient(void)
 
 	zval property_uri_default_value;
 	ZVAL_NULL(&property_uri_default_value);
-	zend_string *property_uri_name = zend_string_init("uri", sizeof("uri") - 1, 1);
+	zend_string *property_uri_name = zend_string_init("uri", strlen("uri"), 1);
 	zend_declare_typed_property(class_entry, property_uri_name, &property_uri_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_uri_name);
 
 	zval property_style_default_value;
 	ZVAL_NULL(&property_style_default_value);
-	zend_string *property_style_name = zend_string_init("style", sizeof("style") - 1, 1);
+	zend_string *property_style_name = zend_string_init("style", strlen("style"), 1);
 	zend_declare_typed_property(class_entry, property_style_name, &property_style_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_style_name);
 
 	zval property_use_default_value;
 	ZVAL_NULL(&property_use_default_value);
-	zend_string *property_use_name = zend_string_init("use", sizeof("use") - 1, 1);
+	zend_string *property_use_name = zend_string_init("use", strlen("use"), 1);
 	zend_declare_typed_property(class_entry, property_use_name, &property_use_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_use_name);
 
 	zval property_location_default_value;
 	ZVAL_NULL(&property_location_default_value);
-	zend_string *property_location_name = zend_string_init("location", sizeof("location") - 1, 1);
+	zend_string *property_location_name = zend_string_init("location", strlen("location"), 1);
 	zend_declare_typed_property(class_entry, property_location_name, &property_location_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_location_name);
 
@@ -547,190 +547,190 @@ static zend_class_entry *register_class_SoapClient(void)
 
 	zval property_compression_default_value;
 	ZVAL_NULL(&property_compression_default_value);
-	zend_string *property_compression_name = zend_string_init("compression", sizeof("compression") - 1, 1);
+	zend_string *property_compression_name = zend_string_init("compression", strlen("compression"), 1);
 	zend_declare_typed_property(class_entry, property_compression_name, &property_compression_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_compression_name);
 
 	zval property_sdl_default_value;
 	ZVAL_NULL(&property_sdl_default_value);
-	zend_string *property_sdl_name = zend_string_init("sdl", sizeof("sdl") - 1, 1);
-	zend_string *property_sdl_class_Soap_Sdl = zend_string_init("Soap\\Sdl", sizeof("Soap\\Sdl")-1, 1);
+	zend_string *property_sdl_name = zend_string_init("sdl", strlen("sdl"), 1);
+	zend_string *property_sdl_class_Soap_Sdl = zend_string_init("Soap\\Sdl", strlen("Soap\\Sdl"), 1);
 	zend_declare_typed_property(class_entry, property_sdl_name, &property_sdl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_sdl_class_Soap_Sdl, 0, MAY_BE_NULL));
 	zend_string_release(property_sdl_name);
 
 	zval property_typemap_default_value;
 	ZVAL_NULL(&property_typemap_default_value);
-	zend_string *property_typemap_name = zend_string_init("typemap", sizeof("typemap") - 1, 1);
+	zend_string *property_typemap_name = zend_string_init("typemap", strlen("typemap"), 1);
 	zend_declare_typed_property(class_entry, property_typemap_name, &property_typemap_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_typemap_name);
 
 	zval property_httpsocket_default_value;
 	ZVAL_NULL(&property_httpsocket_default_value);
-	zend_string *property_httpsocket_name = zend_string_init("httpsocket", sizeof("httpsocket") - 1, 1);
+	zend_string *property_httpsocket_name = zend_string_init("httpsocket", strlen("httpsocket"), 1);
 	zend_declare_typed_property(class_entry, property_httpsocket_name, &property_httpsocket_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_httpsocket_name);
 
 	zval property_httpurl_default_value;
 	ZVAL_NULL(&property_httpurl_default_value);
-	zend_string *property_httpurl_name = zend_string_init("httpurl", sizeof("httpurl") - 1, 1);
-	zend_string *property_httpurl_class_Soap_Url = zend_string_init("Soap\\\125rl", sizeof("Soap\\\125rl")-1, 1);
+	zend_string *property_httpurl_name = zend_string_init("httpurl", strlen("httpurl"), 1);
+	zend_string *property_httpurl_class_Soap_Url = zend_string_init("Soap\\\125rl", strlen("Soap\\\125rl"), 1);
 	zend_declare_typed_property(class_entry, property_httpurl_name, &property_httpurl_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_httpurl_class_Soap_Url, 0, MAY_BE_NULL));
 	zend_string_release(property_httpurl_name);
 
 	zval property__login_default_value;
 	ZVAL_NULL(&property__login_default_value);
-	zend_string *property__login_name = zend_string_init("_login", sizeof("_login") - 1, 1);
+	zend_string *property__login_name = zend_string_init("_login", strlen("_login"), 1);
 	zend_declare_typed_property(class_entry, property__login_name, &property__login_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__login_name);
 
 	zval property__password_default_value;
 	ZVAL_NULL(&property__password_default_value);
-	zend_string *property__password_name = zend_string_init("_password", sizeof("_password") - 1, 1);
+	zend_string *property__password_name = zend_string_init("_password", strlen("_password"), 1);
 	zend_declare_typed_property(class_entry, property__password_name, &property__password_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__password_name);
 
 	zval property__use_digest_default_value;
 	ZVAL_FALSE(&property__use_digest_default_value);
-	zend_string *property__use_digest_name = zend_string_init("_use_digest", sizeof("_use_digest") - 1, 1);
+	zend_string *property__use_digest_name = zend_string_init("_use_digest", strlen("_use_digest"), 1);
 	zend_declare_typed_property(class_entry, property__use_digest_name, &property__use_digest_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__use_digest_name);
 
 	zval property__digest_default_value;
 	ZVAL_NULL(&property__digest_default_value);
-	zend_string *property__digest_name = zend_string_init("_digest", sizeof("_digest") - 1, 1);
+	zend_string *property__digest_name = zend_string_init("_digest", strlen("_digest"), 1);
 	zend_declare_typed_property(class_entry, property__digest_name, &property__digest_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__digest_name);
 
 	zval property__proxy_host_default_value;
 	ZVAL_NULL(&property__proxy_host_default_value);
-	zend_string *property__proxy_host_name = zend_string_init("_proxy_host", sizeof("_proxy_host") - 1, 1);
+	zend_string *property__proxy_host_name = zend_string_init("_proxy_host", strlen("_proxy_host"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_host_name, &property__proxy_host_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_host_name);
 
 	zval property__proxy_port_default_value;
 	ZVAL_NULL(&property__proxy_port_default_value);
-	zend_string *property__proxy_port_name = zend_string_init("_proxy_port", sizeof("_proxy_port") - 1, 1);
+	zend_string *property__proxy_port_name = zend_string_init("_proxy_port", strlen("_proxy_port"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_port_name, &property__proxy_port_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__proxy_port_name);
 
 	zval property__proxy_login_default_value;
 	ZVAL_NULL(&property__proxy_login_default_value);
-	zend_string *property__proxy_login_name = zend_string_init("_proxy_login", sizeof("_proxy_login") - 1, 1);
+	zend_string *property__proxy_login_name = zend_string_init("_proxy_login", strlen("_proxy_login"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_login_name, &property__proxy_login_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_login_name);
 
 	zval property__proxy_password_default_value;
 	ZVAL_NULL(&property__proxy_password_default_value);
-	zend_string *property__proxy_password_name = zend_string_init("_proxy_password", sizeof("_proxy_password") - 1, 1);
+	zend_string *property__proxy_password_name = zend_string_init("_proxy_password", strlen("_proxy_password"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_password_name, &property__proxy_password_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_password_name);
 
 	zval property__exceptions_default_value;
 	ZVAL_TRUE(&property__exceptions_default_value);
-	zend_string *property__exceptions_name = zend_string_init("_exceptions", sizeof("_exceptions") - 1, 1);
+	zend_string *property__exceptions_name = zend_string_init("_exceptions", strlen("_exceptions"), 1);
 	zend_declare_typed_property(class_entry, property__exceptions_name, &property__exceptions_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__exceptions_name);
 
 	zval property__encoding_default_value;
 	ZVAL_NULL(&property__encoding_default_value);
-	zend_string *property__encoding_name = zend_string_init("_encoding", sizeof("_encoding") - 1, 1);
+	zend_string *property__encoding_name = zend_string_init("_encoding", strlen("_encoding"), 1);
 	zend_declare_typed_property(class_entry, property__encoding_name, &property__encoding_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__encoding_name);
 
 	zval property__classmap_default_value;
 	ZVAL_NULL(&property__classmap_default_value);
-	zend_string *property__classmap_name = zend_string_init("_classmap", sizeof("_classmap") - 1, 1);
+	zend_string *property__classmap_name = zend_string_init("_classmap", strlen("_classmap"), 1);
 	zend_declare_typed_property(class_entry, property__classmap_name, &property__classmap_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property__classmap_name);
 
 	zval property__features_default_value;
 	ZVAL_NULL(&property__features_default_value);
-	zend_string *property__features_name = zend_string_init("_features", sizeof("_features") - 1, 1);
+	zend_string *property__features_name = zend_string_init("_features", strlen("_features"), 1);
 	zend_declare_typed_property(class_entry, property__features_name, &property__features_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__features_name);
 
 	zval property__connection_timeout_default_value;
 	ZVAL_LONG(&property__connection_timeout_default_value, 0);
-	zend_string *property__connection_timeout_name = zend_string_init("_connection_timeout", sizeof("_connection_timeout") - 1, 1);
+	zend_string *property__connection_timeout_name = zend_string_init("_connection_timeout", strlen("_connection_timeout"), 1);
 	zend_declare_typed_property(class_entry, property__connection_timeout_name, &property__connection_timeout_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property__connection_timeout_name);
 
 	zval property__stream_context_default_value;
 	ZVAL_NULL(&property__stream_context_default_value);
-	zend_string *property__stream_context_name = zend_string_init("_stream_context", sizeof("_stream_context") - 1, 1);
+	zend_string *property__stream_context_name = zend_string_init("_stream_context", strlen("_stream_context"), 1);
 	zend_declare_typed_property(class_entry, property__stream_context_name, &property__stream_context_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property__stream_context_name);
 
 	zval property__user_agent_default_value;
 	ZVAL_NULL(&property__user_agent_default_value);
-	zend_string *property__user_agent_name = zend_string_init("_user_agent", sizeof("_user_agent") - 1, 1);
+	zend_string *property__user_agent_name = zend_string_init("_user_agent", strlen("_user_agent"), 1);
 	zend_declare_typed_property(class_entry, property__user_agent_name, &property__user_agent_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__user_agent_name);
 
 	zval property__keep_alive_default_value;
 	ZVAL_TRUE(&property__keep_alive_default_value);
-	zend_string *property__keep_alive_name = zend_string_init("_keep_alive", sizeof("_keep_alive") - 1, 1);
+	zend_string *property__keep_alive_name = zend_string_init("_keep_alive", strlen("_keep_alive"), 1);
 	zend_declare_typed_property(class_entry, property__keep_alive_name, &property__keep_alive_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__keep_alive_name);
 
 	zval property__ssl_method_default_value;
 	ZVAL_NULL(&property__ssl_method_default_value);
-	zend_string *property__ssl_method_name = zend_string_init("_ssl_method", sizeof("_ssl_method") - 1, 1);
+	zend_string *property__ssl_method_name = zend_string_init("_ssl_method", strlen("_ssl_method"), 1);
 	zend_declare_typed_property(class_entry, property__ssl_method_name, &property__ssl_method_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__ssl_method_name);
 
 	zval property__soap_version_default_value;
 	ZVAL_UNDEF(&property__soap_version_default_value);
-	zend_string *property__soap_version_name = zend_string_init("_soap_version", sizeof("_soap_version") - 1, 1);
+	zend_string *property__soap_version_name = zend_string_init("_soap_version", strlen("_soap_version"), 1);
 	zend_declare_typed_property(class_entry, property__soap_version_name, &property__soap_version_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property__soap_version_name);
 
 	zval property__use_proxy_default_value;
 	ZVAL_NULL(&property__use_proxy_default_value);
-	zend_string *property__use_proxy_name = zend_string_init("_use_proxy", sizeof("_use_proxy") - 1, 1);
+	zend_string *property__use_proxy_name = zend_string_init("_use_proxy", strlen("_use_proxy"), 1);
 	zend_declare_typed_property(class_entry, property__use_proxy_name, &property__use_proxy_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__use_proxy_name);
 
 	zval property__cookies_default_value;
 	ZVAL_EMPTY_ARRAY(&property__cookies_default_value);
-	zend_string *property__cookies_name = zend_string_init("_cookies", sizeof("_cookies") - 1, 1);
+	zend_string *property__cookies_name = zend_string_init("_cookies", strlen("_cookies"), 1);
 	zend_declare_typed_property(class_entry, property__cookies_name, &property__cookies_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property__cookies_name);
 
 	zval property___default_headers_default_value;
 	ZVAL_NULL(&property___default_headers_default_value);
-	zend_string *property___default_headers_name = zend_string_init("__default_headers", sizeof("__default_headers") - 1, 1);
+	zend_string *property___default_headers_name = zend_string_init("__default_headers", strlen("__default_headers"), 1);
 	zend_declare_typed_property(class_entry, property___default_headers_name, &property___default_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property___default_headers_name);
 
 	zval property___soap_fault_default_value;
 	ZVAL_NULL(&property___soap_fault_default_value);
-	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", sizeof("__soap_fault") - 1, 1);
-	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", sizeof("SoapFault")-1, 1);
+	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", strlen("__soap_fault"), 1);
+	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", strlen("SoapFault"), 1);
 	zend_declare_typed_property(class_entry, property___soap_fault_name, &property___soap_fault_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property___soap_fault_class_SoapFault, 0, MAY_BE_NULL));
 	zend_string_release(property___soap_fault_name);
 
 	zval property___last_request_default_value;
 	ZVAL_NULL(&property___last_request_default_value);
-	zend_string *property___last_request_name = zend_string_init("__last_request", sizeof("__last_request") - 1, 1);
+	zend_string *property___last_request_name = zend_string_init("__last_request", strlen("__last_request"), 1);
 	zend_declare_typed_property(class_entry, property___last_request_name, &property___last_request_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_request_name);
 
 	zval property___last_response_default_value;
 	ZVAL_NULL(&property___last_response_default_value);
-	zend_string *property___last_response_name = zend_string_init("__last_response", sizeof("__last_response") - 1, 1);
+	zend_string *property___last_response_name = zend_string_init("__last_response", strlen("__last_response"), 1);
 	zend_declare_typed_property(class_entry, property___last_response_name, &property___last_response_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_response_name);
 
 	zval property___last_request_headers_default_value;
 	ZVAL_NULL(&property___last_request_headers_default_value);
-	zend_string *property___last_request_headers_name = zend_string_init("__last_request_headers", sizeof("__last_request_headers") - 1, 1);
+	zend_string *property___last_request_headers_name = zend_string_init("__last_request_headers", strlen("__last_request_headers"), 1);
 	zend_declare_typed_property(class_entry, property___last_request_headers_name, &property___last_request_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_request_headers_name);
 
 	zval property___last_response_headers_default_value;
 	ZVAL_NULL(&property___last_response_headers_default_value);
-	zend_string *property___last_response_headers_name = zend_string_init("__last_response_headers", sizeof("__last_response_headers") - 1, 1);
+	zend_string *property___last_response_headers_name = zend_string_init("__last_response_headers", strlen("__last_response_headers"), 1);
 	zend_declare_typed_property(class_entry, property___last_response_headers_name, &property___last_response_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_response_headers_name);
 

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -968,180 +968,180 @@ static void register_libsodium_symbols(int module_number)
 
 #if defined(HAVE_AESGCM)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_decrypt", sizeof("sodium_crypto_aead_aes256gcm_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_decrypt", strlen("sodium_crypto_aead_aes256gcm_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", strlen("sodium_crypto_aead_aes256gcm_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", strlen("sodium_crypto_aead_aes256gcm_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_aead_aegis128l_KEYBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_decrypt", sizeof("sodium_crypto_aead_aegis128l_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_decrypt", strlen("sodium_crypto_aead_aegis128l_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", sizeof("sodium_crypto_aead_aegis128l_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", strlen("sodium_crypto_aead_aegis128l_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", sizeof("sodium_crypto_aead_aegis128l_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", strlen("sodium_crypto_aead_aegis128l_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_aead_aegis256_KEYBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_decrypt", sizeof("sodium_crypto_aead_aegis256_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_decrypt", strlen("sodium_crypto_aead_aegis256_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", sizeof("sodium_crypto_aead_aegis256_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", strlen("sodium_crypto_aead_aegis256_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", sizeof("sodium_crypto_aead_aegis256_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", strlen("sodium_crypto_aead_aegis256_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_decrypt", strlen("sodium_crypto_aead_chacha20poly1305_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", strlen("sodium_crypto_aead_chacha20poly1305_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", strlen("sodium_crypto_aead_chacha20poly1305_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_decrypt", strlen("sodium_crypto_aead_chacha20poly1305_ietf_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", strlen("sodium_crypto_aead_chacha20poly1305_ietf_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", strlen("sodium_crypto_aead_chacha20poly1305_ietf_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_decrypt", strlen("sodium_crypto_aead_xchacha20poly1305_ietf_decrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", strlen("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", strlen("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth", sizeof("sodium_crypto_auth") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth", strlen("sodium_crypto_auth")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth_verify", sizeof("sodium_crypto_auth_verify") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth_verify", strlen("sodium_crypto_auth_verify")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", strlen("sodium_crypto_box")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", strlen("sodium_crypto_box")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seed_keypair", sizeof("sodium_crypto_box_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seed_keypair", strlen("sodium_crypto_box_seed_keypair")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_box_keypair_from_secretkey_and_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_keypair_from_secretkey_and_publickey", strlen("sodium_crypto_box_keypair_from_secretkey_and_publickey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_open", sizeof("sodium_crypto_box_open") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_open", strlen("sodium_crypto_box_open")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey", sizeof("sodium_crypto_box_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey", strlen("sodium_crypto_box_publickey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey_from_secretkey", sizeof("sodium_crypto_box_publickey_from_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey_from_secretkey", strlen("sodium_crypto_box_publickey_from_secretkey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal", sizeof("sodium_crypto_box_seal") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal", strlen("sodium_crypto_box_seal")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal_open", sizeof("sodium_crypto_box_seal_open") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal_open", strlen("sodium_crypto_box_seal_open")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_secretkey", sizeof("sodium_crypto_box_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_secretkey", strlen("sodium_crypto_box_secretkey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_publickey", sizeof("sodium_crypto_kx_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_publickey", strlen("sodium_crypto_kx_publickey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_secretkey", sizeof("sodium_crypto_kx_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_secretkey", strlen("sodium_crypto_kx_secretkey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_seed_keypair", sizeof("sodium_crypto_kx_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_seed_keypair", strlen("sodium_crypto_kx_seed_keypair")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_client_session_keys", sizeof("sodium_crypto_kx_client_session_keys") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_client_session_keys", strlen("sodium_crypto_kx_client_session_keys")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_server_session_keys", sizeof("sodium_crypto_kx_server_session_keys") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_server_session_keys", strlen("sodium_crypto_kx_server_session_keys")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash", sizeof("sodium_crypto_generichash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash", strlen("sodium_crypto_generichash")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash_init", sizeof("sodium_crypto_generichash_init") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash_init", strlen("sodium_crypto_generichash_init")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kdf_derive_from_key", sizeof("sodium_crypto_kdf_derive_from_key") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kdf_derive_from_key", strlen("sodium_crypto_kdf_derive_from_key")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_pwhash_SALTBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash", sizeof("sodium_crypto_pwhash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash", strlen("sodium_crypto_pwhash")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str", sizeof("sodium_crypto_pwhash_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str", strlen("sodium_crypto_pwhash_str")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str_verify", sizeof("sodium_crypto_pwhash_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str_verify", strlen("sodium_crypto_pwhash_str_verify")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256", strlen("sodium_crypto_pwhash_scryptsalsa208sha256")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str", strlen("sodium_crypto_pwhash_scryptsalsa208sha256_str")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str_verify", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str_verify", strlen("sodium_crypto_pwhash_scryptsalsa208sha256_str_verify")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", strlen("sodium_crypto_secretbox")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", strlen("sodium_crypto_secretbox")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox_open", sizeof("sodium_crypto_secretbox_open") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox_open", strlen("sodium_crypto_secretbox_open")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_push") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_push", strlen("sodium_crypto_secretstream_xchacha20poly1305_init_push")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_push") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_push", strlen("sodium_crypto_secretstream_xchacha20poly1305_push")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_pull", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_pull") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_pull", strlen("sodium_crypto_secretstream_xchacha20poly1305_init_pull")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_shorthash", sizeof("sodium_crypto_shorthash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_shorthash", strlen("sodium_crypto_shorthash")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign", sizeof("sodium_crypto_sign") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign", strlen("sodium_crypto_sign")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_detached", sizeof("sodium_crypto_sign_detached") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_detached", strlen("sodium_crypto_sign_detached")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_ed25519_sk_to_curve25519", sizeof("sodium_crypto_sign_ed25519_sk_to_curve25519") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_ed25519_sk_to_curve25519", strlen("sodium_crypto_sign_ed25519_sk_to_curve25519")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_sign_keypair_from_secretkey_and_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_keypair_from_secretkey_and_publickey", strlen("sodium_crypto_sign_keypair_from_secretkey_and_publickey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey", sizeof("sodium_crypto_sign_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey", strlen("sodium_crypto_sign_publickey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_secretkey", sizeof("sodium_crypto_sign_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_secretkey", strlen("sodium_crypto_sign_secretkey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey_from_secretkey", sizeof("sodium_crypto_sign_publickey_from_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey_from_secretkey", strlen("sodium_crypto_sign_publickey_from_secretkey")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_seed_keypair", sizeof("sodium_crypto_sign_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_seed_keypair", strlen("sodium_crypto_sign_seed_keypair")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream", sizeof("sodium_crypto_stream") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream", strlen("sodium_crypto_stream")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", strlen("sodium_crypto_stream_xor")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", strlen("sodium_crypto_stream_xor")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20", sizeof("sodium_crypto_stream_xchacha20") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20", strlen("sodium_crypto_stream_xchacha20")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", strlen("sodium_crypto_stream_xchacha20_xor")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", strlen("sodium_crypto_stream_xchacha20_xor")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", strlen("sodium_crypto_stream_xchacha20_xor_ic")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", strlen("sodium_crypto_stream_xchacha20_xor_ic")), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", strlen("sodium_compare")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", strlen("sodium_compare")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", strlen("sodium_memcmp")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", strlen("sodium_memcmp")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memzero", sizeof("sodium_memzero") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memzero", strlen("sodium_memzero")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_pad", sizeof("sodium_pad") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_pad", strlen("sodium_pad")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_unpad", sizeof("sodium_unpad") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_unpad", strlen("sodium_unpad")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2hex", sizeof("sodium_bin2hex") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2hex", strlen("sodium_bin2hex")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_hex2bin", sizeof("sodium_hex2bin") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_hex2bin", strlen("sodium_hex2bin")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2base64", sizeof("sodium_bin2base64") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2base64", strlen("sodium_bin2base64")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_base642bin", sizeof("sodium_base642bin") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_base642bin", strlen("sodium_base642bin")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_scalarmult_base", sizeof("sodium_crypto_scalarmult_base") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_scalarmult_base", strlen("sodium_crypto_scalarmult_base")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_SodiumException(zend_class_entry *class_entry_Exception)

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -264,13 +264,13 @@ static zend_class_entry *register_class_ArrayObject(zend_class_entry *class_entr
 
 	zval const_STD_PROP_LIST_value;
 	ZVAL_LONG(&const_STD_PROP_LIST_value, SPL_ARRAY_STD_PROP_LIST);
-	zend_string *const_STD_PROP_LIST_name = zend_string_init_interned("STD_PROP_LIST", sizeof("STD_PROP_LIST") - 1, 1);
+	zend_string *const_STD_PROP_LIST_name = zend_string_init_interned("STD_PROP_LIST", strlen("STD_PROP_LIST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_STD_PROP_LIST_name, &const_STD_PROP_LIST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_STD_PROP_LIST_name);
 
 	zval const_ARRAY_AS_PROPS_value;
 	ZVAL_LONG(&const_ARRAY_AS_PROPS_value, SPL_ARRAY_ARRAY_AS_PROPS);
-	zend_string *const_ARRAY_AS_PROPS_name = zend_string_init_interned("ARRAY_AS_PROPS", sizeof("ARRAY_AS_PROPS") - 1, 1);
+	zend_string *const_ARRAY_AS_PROPS_name = zend_string_init_interned("ARRAY_AS_PROPS", strlen("ARRAY_AS_PROPS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ARRAY_AS_PROPS_name, &const_ARRAY_AS_PROPS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ARRAY_AS_PROPS_name);
 
@@ -287,13 +287,13 @@ static zend_class_entry *register_class_ArrayIterator(zend_class_entry *class_en
 
 	zval const_STD_PROP_LIST_value;
 	ZVAL_LONG(&const_STD_PROP_LIST_value, SPL_ARRAY_STD_PROP_LIST);
-	zend_string *const_STD_PROP_LIST_name = zend_string_init_interned("STD_PROP_LIST", sizeof("STD_PROP_LIST") - 1, 1);
+	zend_string *const_STD_PROP_LIST_name = zend_string_init_interned("STD_PROP_LIST", strlen("STD_PROP_LIST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_STD_PROP_LIST_name, &const_STD_PROP_LIST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_STD_PROP_LIST_name);
 
 	zval const_ARRAY_AS_PROPS_value;
 	ZVAL_LONG(&const_ARRAY_AS_PROPS_value, SPL_ARRAY_ARRAY_AS_PROPS);
-	zend_string *const_ARRAY_AS_PROPS_name = zend_string_init_interned("ARRAY_AS_PROPS", sizeof("ARRAY_AS_PROPS") - 1, 1);
+	zend_string *const_ARRAY_AS_PROPS_name = zend_string_init_interned("ARRAY_AS_PROPS", strlen("ARRAY_AS_PROPS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ARRAY_AS_PROPS_name, &const_ARRAY_AS_PROPS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ARRAY_AS_PROPS_name);
 
@@ -310,7 +310,7 @@ static zend_class_entry *register_class_RecursiveArrayIterator(zend_class_entry 
 
 	zval const_CHILD_ARRAYS_ONLY_value;
 	ZVAL_LONG(&const_CHILD_ARRAYS_ONLY_value, SPL_ARRAY_CHILD_ARRAYS_ONLY);
-	zend_string *const_CHILD_ARRAYS_ONLY_name = zend_string_init_interned("CHILD_ARRAYS_ONLY", sizeof("CHILD_ARRAYS_ONLY") - 1, 1);
+	zend_string *const_CHILD_ARRAYS_ONLY_name = zend_string_init_interned("CHILD_ARRAYS_ONLY", strlen("CHILD_ARRAYS_ONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHILD_ARRAYS_ONLY_name, &const_CHILD_ARRAYS_ONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHILD_ARRAYS_ONLY_name);
 

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -488,7 +488,7 @@ static zend_class_entry *register_class_SplFileInfo(zend_class_entry *class_entr
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 
-	zend_attribute *attribute_Deprecated_func__bad_state_ex_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "_bad_state_ex", sizeof("_bad_state_ex") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func__bad_state_ex_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "_bad_state_ex", strlen("_bad_state_ex")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func__bad_state_ex_0_arg0;
 	zend_string *attribute_Deprecated_func__bad_state_ex_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
 	ZVAL_STR(&attribute_Deprecated_func__bad_state_ex_0_arg0, attribute_Deprecated_func__bad_state_ex_0_arg0_str);
@@ -518,73 +518,73 @@ static zend_class_entry *register_class_FilesystemIterator(zend_class_entry *cla
 
 	zval const_CURRENT_MODE_MASK_value;
 	ZVAL_LONG(&const_CURRENT_MODE_MASK_value, SPL_FILE_DIR_CURRENT_MODE_MASK);
-	zend_string *const_CURRENT_MODE_MASK_name = zend_string_init_interned("CURRENT_MODE_MASK", sizeof("CURRENT_MODE_MASK") - 1, 1);
+	zend_string *const_CURRENT_MODE_MASK_name = zend_string_init_interned("CURRENT_MODE_MASK", strlen("CURRENT_MODE_MASK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENT_MODE_MASK_name, &const_CURRENT_MODE_MASK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENT_MODE_MASK_name);
 
 	zval const_CURRENT_AS_PATHNAME_value;
 	ZVAL_LONG(&const_CURRENT_AS_PATHNAME_value, SPL_FILE_DIR_CURRENT_AS_PATHNAME);
-	zend_string *const_CURRENT_AS_PATHNAME_name = zend_string_init_interned("CURRENT_AS_PATHNAME", sizeof("CURRENT_AS_PATHNAME") - 1, 1);
+	zend_string *const_CURRENT_AS_PATHNAME_name = zend_string_init_interned("CURRENT_AS_PATHNAME", strlen("CURRENT_AS_PATHNAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENT_AS_PATHNAME_name, &const_CURRENT_AS_PATHNAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENT_AS_PATHNAME_name);
 
 	zval const_CURRENT_AS_FILEINFO_value;
 	ZVAL_LONG(&const_CURRENT_AS_FILEINFO_value, SPL_FILE_DIR_CURRENT_AS_FILEINFO);
-	zend_string *const_CURRENT_AS_FILEINFO_name = zend_string_init_interned("CURRENT_AS_FILEINFO", sizeof("CURRENT_AS_FILEINFO") - 1, 1);
+	zend_string *const_CURRENT_AS_FILEINFO_name = zend_string_init_interned("CURRENT_AS_FILEINFO", strlen("CURRENT_AS_FILEINFO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENT_AS_FILEINFO_name, &const_CURRENT_AS_FILEINFO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENT_AS_FILEINFO_name);
 
 	zval const_CURRENT_AS_SELF_value;
 	ZVAL_LONG(&const_CURRENT_AS_SELF_value, SPL_FILE_DIR_CURRENT_AS_SELF);
-	zend_string *const_CURRENT_AS_SELF_name = zend_string_init_interned("CURRENT_AS_SELF", sizeof("CURRENT_AS_SELF") - 1, 1);
+	zend_string *const_CURRENT_AS_SELF_name = zend_string_init_interned("CURRENT_AS_SELF", strlen("CURRENT_AS_SELF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CURRENT_AS_SELF_name, &const_CURRENT_AS_SELF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CURRENT_AS_SELF_name);
 
 	zval const_KEY_MODE_MASK_value;
 	ZVAL_LONG(&const_KEY_MODE_MASK_value, SPL_FILE_DIR_KEY_MODE_MASK);
-	zend_string *const_KEY_MODE_MASK_name = zend_string_init_interned("KEY_MODE_MASK", sizeof("KEY_MODE_MASK") - 1, 1);
+	zend_string *const_KEY_MODE_MASK_name = zend_string_init_interned("KEY_MODE_MASK", strlen("KEY_MODE_MASK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_MODE_MASK_name, &const_KEY_MODE_MASK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_MODE_MASK_name);
 
 	zval const_KEY_AS_PATHNAME_value;
 	ZVAL_LONG(&const_KEY_AS_PATHNAME_value, SPL_FILE_DIR_KEY_AS_PATHNAME);
-	zend_string *const_KEY_AS_PATHNAME_name = zend_string_init_interned("KEY_AS_PATHNAME", sizeof("KEY_AS_PATHNAME") - 1, 1);
+	zend_string *const_KEY_AS_PATHNAME_name = zend_string_init_interned("KEY_AS_PATHNAME", strlen("KEY_AS_PATHNAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_AS_PATHNAME_name, &const_KEY_AS_PATHNAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_AS_PATHNAME_name);
 
 	zval const_FOLLOW_SYMLINKS_value;
 	ZVAL_LONG(&const_FOLLOW_SYMLINKS_value, SPL_FILE_DIR_FOLLOW_SYMLINKS);
-	zend_string *const_FOLLOW_SYMLINKS_name = zend_string_init_interned("FOLLOW_SYMLINKS", sizeof("FOLLOW_SYMLINKS") - 1, 1);
+	zend_string *const_FOLLOW_SYMLINKS_name = zend_string_init_interned("FOLLOW_SYMLINKS", strlen("FOLLOW_SYMLINKS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FOLLOW_SYMLINKS_name, &const_FOLLOW_SYMLINKS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FOLLOW_SYMLINKS_name);
 
 	zval const_KEY_AS_FILENAME_value;
 	ZVAL_LONG(&const_KEY_AS_FILENAME_value, SPL_FILE_DIR_KEY_AS_FILENAME);
-	zend_string *const_KEY_AS_FILENAME_name = zend_string_init_interned("KEY_AS_FILENAME", sizeof("KEY_AS_FILENAME") - 1, 1);
+	zend_string *const_KEY_AS_FILENAME_name = zend_string_init_interned("KEY_AS_FILENAME", strlen("KEY_AS_FILENAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_KEY_AS_FILENAME_name, &const_KEY_AS_FILENAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_KEY_AS_FILENAME_name);
 
 	zval const_NEW_CURRENT_AND_KEY_value;
 	ZVAL_LONG(&const_NEW_CURRENT_AND_KEY_value, SPL_FILE_NEW_CURRENT_AND_KEY);
-	zend_string *const_NEW_CURRENT_AND_KEY_name = zend_string_init_interned("NEW_CURRENT_AND_KEY", sizeof("NEW_CURRENT_AND_KEY") - 1, 1);
+	zend_string *const_NEW_CURRENT_AND_KEY_name = zend_string_init_interned("NEW_CURRENT_AND_KEY", strlen("NEW_CURRENT_AND_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NEW_CURRENT_AND_KEY_name, &const_NEW_CURRENT_AND_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NEW_CURRENT_AND_KEY_name);
 
 	zval const_OTHER_MODE_MASK_value;
 	ZVAL_LONG(&const_OTHER_MODE_MASK_value, SPL_FILE_DIR_OTHERS_MASK);
-	zend_string *const_OTHER_MODE_MASK_name = zend_string_init_interned("OTHER_MODE_MASK", sizeof("OTHER_MODE_MASK") - 1, 1);
+	zend_string *const_OTHER_MODE_MASK_name = zend_string_init_interned("OTHER_MODE_MASK", strlen("OTHER_MODE_MASK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OTHER_MODE_MASK_name, &const_OTHER_MODE_MASK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OTHER_MODE_MASK_name);
 
 	zval const_SKIP_DOTS_value;
 	ZVAL_LONG(&const_SKIP_DOTS_value, SPL_FILE_DIR_SKIPDOTS);
-	zend_string *const_SKIP_DOTS_name = zend_string_init_interned("SKIP_DOTS", sizeof("SKIP_DOTS") - 1, 1);
+	zend_string *const_SKIP_DOTS_name = zend_string_init_interned("SKIP_DOTS", strlen("SKIP_DOTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SKIP_DOTS_name, &const_SKIP_DOTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SKIP_DOTS_name);
 
 	zval const_UNIX_PATHS_value;
 	ZVAL_LONG(&const_UNIX_PATHS_value, SPL_FILE_DIR_UNIXPATHS);
-	zend_string *const_UNIX_PATHS_name = zend_string_init_interned("UNIX_PATHS", sizeof("UNIX_PATHS") - 1, 1);
+	zend_string *const_UNIX_PATHS_name = zend_string_init_interned("UNIX_PATHS", strlen("UNIX_PATHS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UNIX_PATHS_name, &const_UNIX_PATHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UNIX_PATHS_name);
 
@@ -625,25 +625,25 @@ static zend_class_entry *register_class_SplFileObject(zend_class_entry *class_en
 
 	zval const_DROP_NEW_LINE_value;
 	ZVAL_LONG(&const_DROP_NEW_LINE_value, SPL_FILE_OBJECT_DROP_NEW_LINE);
-	zend_string *const_DROP_NEW_LINE_name = zend_string_init_interned("DROP_NEW_LINE", sizeof("DROP_NEW_LINE") - 1, 1);
+	zend_string *const_DROP_NEW_LINE_name = zend_string_init_interned("DROP_NEW_LINE", strlen("DROP_NEW_LINE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_NEW_LINE_name, &const_DROP_NEW_LINE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_NEW_LINE_name);
 
 	zval const_READ_AHEAD_value;
 	ZVAL_LONG(&const_READ_AHEAD_value, SPL_FILE_OBJECT_READ_AHEAD);
-	zend_string *const_READ_AHEAD_name = zend_string_init_interned("READ_AHEAD", sizeof("READ_AHEAD") - 1, 1);
+	zend_string *const_READ_AHEAD_name = zend_string_init_interned("READ_AHEAD", strlen("READ_AHEAD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_READ_AHEAD_name, &const_READ_AHEAD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_READ_AHEAD_name);
 
 	zval const_SKIP_EMPTY_value;
 	ZVAL_LONG(&const_SKIP_EMPTY_value, SPL_FILE_OBJECT_SKIP_EMPTY);
-	zend_string *const_SKIP_EMPTY_name = zend_string_init_interned("SKIP_EMPTY", sizeof("SKIP_EMPTY") - 1, 1);
+	zend_string *const_SKIP_EMPTY_name = zend_string_init_interned("SKIP_EMPTY", strlen("SKIP_EMPTY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SKIP_EMPTY_name, &const_SKIP_EMPTY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SKIP_EMPTY_name);
 
 	zval const_READ_CSV_value;
 	ZVAL_LONG(&const_READ_CSV_value, SPL_FILE_OBJECT_READ_CSV);
-	zend_string *const_READ_CSV_name = zend_string_init_interned("READ_CSV", sizeof("READ_CSV") - 1, 1);
+	zend_string *const_READ_CSV_name = zend_string_init_interned("READ_CSV", strlen("READ_CSV"), 1);
 	zend_declare_typed_class_constant(class_entry, const_READ_CSV_name, &const_READ_CSV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_READ_CSV_name);
 

--- a/ext/spl/spl_dllist_arginfo.h
+++ b/ext/spl/spl_dllist_arginfo.h
@@ -156,25 +156,25 @@ static zend_class_entry *register_class_SplDoublyLinkedList(zend_class_entry *cl
 
 	zval const_IT_MODE_LIFO_value;
 	ZVAL_LONG(&const_IT_MODE_LIFO_value, SPL_DLLIST_IT_LIFO);
-	zend_string *const_IT_MODE_LIFO_name = zend_string_init_interned("IT_MODE_LIFO", sizeof("IT_MODE_LIFO") - 1, 1);
+	zend_string *const_IT_MODE_LIFO_name = zend_string_init_interned("IT_MODE_LIFO", strlen("IT_MODE_LIFO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IT_MODE_LIFO_name, &const_IT_MODE_LIFO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IT_MODE_LIFO_name);
 
 	zval const_IT_MODE_FIFO_value;
 	ZVAL_LONG(&const_IT_MODE_FIFO_value, SPL_DLLIST_IT_FIFO);
-	zend_string *const_IT_MODE_FIFO_name = zend_string_init_interned("IT_MODE_FIFO", sizeof("IT_MODE_FIFO") - 1, 1);
+	zend_string *const_IT_MODE_FIFO_name = zend_string_init_interned("IT_MODE_FIFO", strlen("IT_MODE_FIFO"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IT_MODE_FIFO_name, &const_IT_MODE_FIFO_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IT_MODE_FIFO_name);
 
 	zval const_IT_MODE_DELETE_value;
 	ZVAL_LONG(&const_IT_MODE_DELETE_value, SPL_DLLIST_IT_DELETE);
-	zend_string *const_IT_MODE_DELETE_name = zend_string_init_interned("IT_MODE_DELETE", sizeof("IT_MODE_DELETE") - 1, 1);
+	zend_string *const_IT_MODE_DELETE_name = zend_string_init_interned("IT_MODE_DELETE", strlen("IT_MODE_DELETE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IT_MODE_DELETE_name, &const_IT_MODE_DELETE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IT_MODE_DELETE_name);
 
 	zval const_IT_MODE_KEEP_value;
 	ZVAL_LONG(&const_IT_MODE_KEEP_value, SPL_DLLIST_IT_KEEP);
-	zend_string *const_IT_MODE_KEEP_name = zend_string_init_interned("IT_MODE_KEEP", sizeof("IT_MODE_KEEP") - 1, 1);
+	zend_string *const_IT_MODE_KEEP_name = zend_string_init_interned("IT_MODE_KEEP", strlen("IT_MODE_KEEP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IT_MODE_KEEP_name, &const_IT_MODE_KEEP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IT_MODE_KEEP_name);
 

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -98,7 +98,7 @@ static zend_class_entry *register_class_SplFixedArray(zend_class_entry *class_en
 	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Countable, class_entry_JsonSerializable);
 
 
-	zend_attribute *attribute_Deprecated_func___wakeup_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__wakeup", sizeof("__wakeup") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func___wakeup_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__wakeup", strlen("__wakeup")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func___wakeup_0_arg0;
 	zend_string *attribute_Deprecated_func___wakeup_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0_arg0, attribute_Deprecated_func___wakeup_0_arg0_str);

--- a/ext/spl/spl_heap_arginfo.h
+++ b/ext/spl/spl_heap_arginfo.h
@@ -166,19 +166,19 @@ static zend_class_entry *register_class_SplPriorityQueue(zend_class_entry *class
 
 	zval const_EXTR_BOTH_value;
 	ZVAL_LONG(&const_EXTR_BOTH_value, SPL_PQUEUE_EXTR_BOTH);
-	zend_string *const_EXTR_BOTH_name = zend_string_init_interned("EXTR_BOTH", sizeof("EXTR_BOTH") - 1, 1);
+	zend_string *const_EXTR_BOTH_name = zend_string_init_interned("EXTR_BOTH", strlen("EXTR_BOTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXTR_BOTH_name, &const_EXTR_BOTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXTR_BOTH_name);
 
 	zval const_EXTR_PRIORITY_value;
 	ZVAL_LONG(&const_EXTR_PRIORITY_value, SPL_PQUEUE_EXTR_PRIORITY);
-	zend_string *const_EXTR_PRIORITY_name = zend_string_init_interned("EXTR_PRIORITY", sizeof("EXTR_PRIORITY") - 1, 1);
+	zend_string *const_EXTR_PRIORITY_name = zend_string_init_interned("EXTR_PRIORITY", strlen("EXTR_PRIORITY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXTR_PRIORITY_name, &const_EXTR_PRIORITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXTR_PRIORITY_name);
 
 	zval const_EXTR_DATA_value;
 	ZVAL_LONG(&const_EXTR_DATA_value, SPL_PQUEUE_EXTR_DATA);
-	zend_string *const_EXTR_DATA_name = zend_string_init_interned("EXTR_DATA", sizeof("EXTR_DATA") - 1, 1);
+	zend_string *const_EXTR_DATA_name = zend_string_init_interned("EXTR_DATA", strlen("EXTR_DATA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXTR_DATA_name, &const_EXTR_DATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXTR_DATA_name);
 

--- a/ext/spl/spl_iterators_arginfo.h
+++ b/ext/spl/spl_iterators_arginfo.h
@@ -653,25 +653,25 @@ static zend_class_entry *register_class_RecursiveIteratorIterator(zend_class_ent
 
 	zval const_LEAVES_ONLY_value;
 	ZVAL_LONG(&const_LEAVES_ONLY_value, RIT_LEAVES_ONLY);
-	zend_string *const_LEAVES_ONLY_name = zend_string_init_interned("LEAVES_ONLY", sizeof("LEAVES_ONLY") - 1, 1);
+	zend_string *const_LEAVES_ONLY_name = zend_string_init_interned("LEAVES_ONLY", strlen("LEAVES_ONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LEAVES_ONLY_name, &const_LEAVES_ONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LEAVES_ONLY_name);
 
 	zval const_SELF_FIRST_value;
 	ZVAL_LONG(&const_SELF_FIRST_value, RIT_SELF_FIRST);
-	zend_string *const_SELF_FIRST_name = zend_string_init_interned("SELF_FIRST", sizeof("SELF_FIRST") - 1, 1);
+	zend_string *const_SELF_FIRST_name = zend_string_init_interned("SELF_FIRST", strlen("SELF_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SELF_FIRST_name, &const_SELF_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SELF_FIRST_name);
 
 	zval const_CHILD_FIRST_value;
 	ZVAL_LONG(&const_CHILD_FIRST_value, RIT_CHILD_FIRST);
-	zend_string *const_CHILD_FIRST_name = zend_string_init_interned("CHILD_FIRST", sizeof("CHILD_FIRST") - 1, 1);
+	zend_string *const_CHILD_FIRST_name = zend_string_init_interned("CHILD_FIRST", strlen("CHILD_FIRST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHILD_FIRST_name, &const_CHILD_FIRST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHILD_FIRST_name);
 
 	zval const_CATCH_GET_CHILD_value;
 	ZVAL_LONG(&const_CATCH_GET_CHILD_value, RIT_CATCH_GET_CHILD);
-	zend_string *const_CATCH_GET_CHILD_name = zend_string_init_interned("CATCH_GET_CHILD", sizeof("CATCH_GET_CHILD") - 1, 1);
+	zend_string *const_CATCH_GET_CHILD_name = zend_string_init_interned("CATCH_GET_CHILD", strlen("CATCH_GET_CHILD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CATCH_GET_CHILD_name, &const_CATCH_GET_CHILD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CATCH_GET_CHILD_name);
 
@@ -762,37 +762,37 @@ static zend_class_entry *register_class_CachingIterator(zend_class_entry *class_
 
 	zval const_CALL_TOSTRING_value;
 	ZVAL_LONG(&const_CALL_TOSTRING_value, CIT_CALL_TOSTRING);
-	zend_string *const_CALL_TOSTRING_name = zend_string_init_interned("CALL_TOSTRING", sizeof("CALL_TOSTRING") - 1, 1);
+	zend_string *const_CALL_TOSTRING_name = zend_string_init_interned("CALL_TOSTRING", strlen("CALL_TOSTRING"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CALL_TOSTRING_name, &const_CALL_TOSTRING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CALL_TOSTRING_name);
 
 	zval const_CATCH_GET_CHILD_value;
 	ZVAL_LONG(&const_CATCH_GET_CHILD_value, CIT_CATCH_GET_CHILD);
-	zend_string *const_CATCH_GET_CHILD_name = zend_string_init_interned("CATCH_GET_CHILD", sizeof("CATCH_GET_CHILD") - 1, 1);
+	zend_string *const_CATCH_GET_CHILD_name = zend_string_init_interned("CATCH_GET_CHILD", strlen("CATCH_GET_CHILD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CATCH_GET_CHILD_name, &const_CATCH_GET_CHILD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CATCH_GET_CHILD_name);
 
 	zval const_TOSTRING_USE_KEY_value;
 	ZVAL_LONG(&const_TOSTRING_USE_KEY_value, CIT_TOSTRING_USE_KEY);
-	zend_string *const_TOSTRING_USE_KEY_name = zend_string_init_interned("TOSTRING_USE_KEY", sizeof("TOSTRING_USE_KEY") - 1, 1);
+	zend_string *const_TOSTRING_USE_KEY_name = zend_string_init_interned("TOSTRING_USE_KEY", strlen("TOSTRING_USE_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TOSTRING_USE_KEY_name, &const_TOSTRING_USE_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TOSTRING_USE_KEY_name);
 
 	zval const_TOSTRING_USE_CURRENT_value;
 	ZVAL_LONG(&const_TOSTRING_USE_CURRENT_value, CIT_TOSTRING_USE_CURRENT);
-	zend_string *const_TOSTRING_USE_CURRENT_name = zend_string_init_interned("TOSTRING_USE_CURRENT", sizeof("TOSTRING_USE_CURRENT") - 1, 1);
+	zend_string *const_TOSTRING_USE_CURRENT_name = zend_string_init_interned("TOSTRING_USE_CURRENT", strlen("TOSTRING_USE_CURRENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TOSTRING_USE_CURRENT_name, &const_TOSTRING_USE_CURRENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TOSTRING_USE_CURRENT_name);
 
 	zval const_TOSTRING_USE_INNER_value;
 	ZVAL_LONG(&const_TOSTRING_USE_INNER_value, CIT_TOSTRING_USE_INNER);
-	zend_string *const_TOSTRING_USE_INNER_name = zend_string_init_interned("TOSTRING_USE_INNER", sizeof("TOSTRING_USE_INNER") - 1, 1);
+	zend_string *const_TOSTRING_USE_INNER_name = zend_string_init_interned("TOSTRING_USE_INNER", strlen("TOSTRING_USE_INNER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TOSTRING_USE_INNER_name, &const_TOSTRING_USE_INNER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TOSTRING_USE_INNER_name);
 
 	zval const_FULL_CACHE_value;
 	ZVAL_LONG(&const_FULL_CACHE_value, CIT_FULL_CACHE);
-	zend_string *const_FULL_CACHE_name = zend_string_init_interned("FULL_CACHE", sizeof("FULL_CACHE") - 1, 1);
+	zend_string *const_FULL_CACHE_name = zend_string_init_interned("FULL_CACHE", strlen("FULL_CACHE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FULL_CACHE_name, &const_FULL_CACHE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FULL_CACHE_name);
 
@@ -849,49 +849,49 @@ static zend_class_entry *register_class_RegexIterator(zend_class_entry *class_en
 
 	zval const_USE_KEY_value;
 	ZVAL_LONG(&const_USE_KEY_value, REGIT_USE_KEY);
-	zend_string *const_USE_KEY_name = zend_string_init_interned("USE_KEY", sizeof("USE_KEY") - 1, 1);
+	zend_string *const_USE_KEY_name = zend_string_init_interned("USE_KEY", strlen("USE_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_USE_KEY_name, &const_USE_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_USE_KEY_name);
 
 	zval const_INVERT_MATCH_value;
 	ZVAL_LONG(&const_INVERT_MATCH_value, REGIT_INVERTED);
-	zend_string *const_INVERT_MATCH_name = zend_string_init_interned("INVERT_MATCH", sizeof("INVERT_MATCH") - 1, 1);
+	zend_string *const_INVERT_MATCH_name = zend_string_init_interned("INVERT_MATCH", strlen("INVERT_MATCH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INVERT_MATCH_name, &const_INVERT_MATCH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INVERT_MATCH_name);
 
 	zval const_MATCH_value;
 	ZVAL_LONG(&const_MATCH_value, REGIT_MODE_MATCH);
-	zend_string *const_MATCH_name = zend_string_init_interned("MATCH", sizeof("MATCH") - 1, 1);
+	zend_string *const_MATCH_name = zend_string_init_interned("MATCH", strlen("MATCH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MATCH_name, &const_MATCH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MATCH_name);
 
 	zval const_GET_MATCH_value;
 	ZVAL_LONG(&const_GET_MATCH_value, REGIT_MODE_GET_MATCH);
-	zend_string *const_GET_MATCH_name = zend_string_init_interned("GET_MATCH", sizeof("GET_MATCH") - 1, 1);
+	zend_string *const_GET_MATCH_name = zend_string_init_interned("GET_MATCH", strlen("GET_MATCH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_GET_MATCH_name, &const_GET_MATCH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_GET_MATCH_name);
 
 	zval const_ALL_MATCHES_value;
 	ZVAL_LONG(&const_ALL_MATCHES_value, REGIT_MODE_ALL_MATCHES);
-	zend_string *const_ALL_MATCHES_name = zend_string_init_interned("ALL_MATCHES", sizeof("ALL_MATCHES") - 1, 1);
+	zend_string *const_ALL_MATCHES_name = zend_string_init_interned("ALL_MATCHES", strlen("ALL_MATCHES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ALL_MATCHES_name, &const_ALL_MATCHES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ALL_MATCHES_name);
 
 	zval const_SPLIT_value;
 	ZVAL_LONG(&const_SPLIT_value, REGIT_MODE_SPLIT);
-	zend_string *const_SPLIT_name = zend_string_init_interned("SPLIT", sizeof("SPLIT") - 1, 1);
+	zend_string *const_SPLIT_name = zend_string_init_interned("SPLIT", strlen("SPLIT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SPLIT_name, &const_SPLIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SPLIT_name);
 
 	zval const_REPLACE_value;
 	ZVAL_LONG(&const_REPLACE_value, REGIT_MODE_REPLACE);
-	zend_string *const_REPLACE_name = zend_string_init_interned("REPLACE", sizeof("REPLACE") - 1, 1);
+	zend_string *const_REPLACE_name = zend_string_init_interned("REPLACE", strlen("REPLACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REPLACE_name, &const_REPLACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REPLACE_name);
 
 	zval property_replacement_default_value;
 	ZVAL_NULL(&property_replacement_default_value);
-	zend_string *property_replacement_name = zend_string_init("replacement", sizeof("replacement") - 1, 1);
+	zend_string *property_replacement_name = zend_string_init("replacement", strlen("replacement"), 1);
 	zend_declare_typed_property(class_entry, property_replacement_name, &property_replacement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_replacement_name);
 
@@ -918,49 +918,49 @@ static zend_class_entry *register_class_RecursiveTreeIterator(zend_class_entry *
 
 	zval const_BYPASS_CURRENT_value;
 	ZVAL_LONG(&const_BYPASS_CURRENT_value, RTIT_BYPASS_CURRENT);
-	zend_string *const_BYPASS_CURRENT_name = zend_string_init_interned("BYPASS_CURRENT", sizeof("BYPASS_CURRENT") - 1, 1);
+	zend_string *const_BYPASS_CURRENT_name = zend_string_init_interned("BYPASS_CURRENT", strlen("BYPASS_CURRENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BYPASS_CURRENT_name, &const_BYPASS_CURRENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BYPASS_CURRENT_name);
 
 	zval const_BYPASS_KEY_value;
 	ZVAL_LONG(&const_BYPASS_KEY_value, RTIT_BYPASS_KEY);
-	zend_string *const_BYPASS_KEY_name = zend_string_init_interned("BYPASS_KEY", sizeof("BYPASS_KEY") - 1, 1);
+	zend_string *const_BYPASS_KEY_name = zend_string_init_interned("BYPASS_KEY", strlen("BYPASS_KEY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_BYPASS_KEY_name, &const_BYPASS_KEY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_BYPASS_KEY_name);
 
 	zval const_PREFIX_LEFT_value;
 	ZVAL_LONG(&const_PREFIX_LEFT_value, 0);
-	zend_string *const_PREFIX_LEFT_name = zend_string_init_interned("PREFIX_LEFT", sizeof("PREFIX_LEFT") - 1, 1);
+	zend_string *const_PREFIX_LEFT_name = zend_string_init_interned("PREFIX_LEFT", strlen("PREFIX_LEFT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_LEFT_name, &const_PREFIX_LEFT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_LEFT_name);
 
 	zval const_PREFIX_MID_HAS_NEXT_value;
 	ZVAL_LONG(&const_PREFIX_MID_HAS_NEXT_value, 1);
-	zend_string *const_PREFIX_MID_HAS_NEXT_name = zend_string_init_interned("PREFIX_MID_HAS_NEXT", sizeof("PREFIX_MID_HAS_NEXT") - 1, 1);
+	zend_string *const_PREFIX_MID_HAS_NEXT_name = zend_string_init_interned("PREFIX_MID_HAS_NEXT", strlen("PREFIX_MID_HAS_NEXT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_MID_HAS_NEXT_name, &const_PREFIX_MID_HAS_NEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_MID_HAS_NEXT_name);
 
 	zval const_PREFIX_MID_LAST_value;
 	ZVAL_LONG(&const_PREFIX_MID_LAST_value, 2);
-	zend_string *const_PREFIX_MID_LAST_name = zend_string_init_interned("PREFIX_MID_LAST", sizeof("PREFIX_MID_LAST") - 1, 1);
+	zend_string *const_PREFIX_MID_LAST_name = zend_string_init_interned("PREFIX_MID_LAST", strlen("PREFIX_MID_LAST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_MID_LAST_name, &const_PREFIX_MID_LAST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_MID_LAST_name);
 
 	zval const_PREFIX_END_HAS_NEXT_value;
 	ZVAL_LONG(&const_PREFIX_END_HAS_NEXT_value, 3);
-	zend_string *const_PREFIX_END_HAS_NEXT_name = zend_string_init_interned("PREFIX_END_HAS_NEXT", sizeof("PREFIX_END_HAS_NEXT") - 1, 1);
+	zend_string *const_PREFIX_END_HAS_NEXT_name = zend_string_init_interned("PREFIX_END_HAS_NEXT", strlen("PREFIX_END_HAS_NEXT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_END_HAS_NEXT_name, &const_PREFIX_END_HAS_NEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_END_HAS_NEXT_name);
 
 	zval const_PREFIX_END_LAST_value;
 	ZVAL_LONG(&const_PREFIX_END_LAST_value, 4);
-	zend_string *const_PREFIX_END_LAST_name = zend_string_init_interned("PREFIX_END_LAST", sizeof("PREFIX_END_LAST") - 1, 1);
+	zend_string *const_PREFIX_END_LAST_name = zend_string_init_interned("PREFIX_END_LAST", strlen("PREFIX_END_LAST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_END_LAST_name, &const_PREFIX_END_LAST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_END_LAST_name);
 
 	zval const_PREFIX_RIGHT_value;
 	ZVAL_LONG(&const_PREFIX_RIGHT_value, 5);
-	zend_string *const_PREFIX_RIGHT_name = zend_string_init_interned("PREFIX_RIGHT", sizeof("PREFIX_RIGHT") - 1, 1);
+	zend_string *const_PREFIX_RIGHT_name = zend_string_init_interned("PREFIX_RIGHT", strlen("PREFIX_RIGHT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_RIGHT_name, &const_PREFIX_RIGHT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PREFIX_RIGHT_name);
 

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -271,25 +271,25 @@ static zend_class_entry *register_class_MultipleIterator(zend_class_entry *class
 
 	zval const_MIT_NEED_ANY_value;
 	ZVAL_LONG(&const_MIT_NEED_ANY_value, MIT_NEED_ANY);
-	zend_string *const_MIT_NEED_ANY_name = zend_string_init_interned("MIT_NEED_ANY", sizeof("MIT_NEED_ANY") - 1, 1);
+	zend_string *const_MIT_NEED_ANY_name = zend_string_init_interned("MIT_NEED_ANY", strlen("MIT_NEED_ANY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIT_NEED_ANY_name, &const_MIT_NEED_ANY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIT_NEED_ANY_name);
 
 	zval const_MIT_NEED_ALL_value;
 	ZVAL_LONG(&const_MIT_NEED_ALL_value, MIT_NEED_ALL);
-	zend_string *const_MIT_NEED_ALL_name = zend_string_init_interned("MIT_NEED_ALL", sizeof("MIT_NEED_ALL") - 1, 1);
+	zend_string *const_MIT_NEED_ALL_name = zend_string_init_interned("MIT_NEED_ALL", strlen("MIT_NEED_ALL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIT_NEED_ALL_name, &const_MIT_NEED_ALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIT_NEED_ALL_name);
 
 	zval const_MIT_KEYS_NUMERIC_value;
 	ZVAL_LONG(&const_MIT_KEYS_NUMERIC_value, MIT_KEYS_NUMERIC);
-	zend_string *const_MIT_KEYS_NUMERIC_name = zend_string_init_interned("MIT_KEYS_NUMERIC", sizeof("MIT_KEYS_NUMERIC") - 1, 1);
+	zend_string *const_MIT_KEYS_NUMERIC_name = zend_string_init_interned("MIT_KEYS_NUMERIC", strlen("MIT_KEYS_NUMERIC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIT_KEYS_NUMERIC_name, &const_MIT_KEYS_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIT_KEYS_NUMERIC_name);
 
 	zval const_MIT_KEYS_ASSOC_value;
 	ZVAL_LONG(&const_MIT_KEYS_ASSOC_value, MIT_KEYS_ASSOC);
-	zend_string *const_MIT_KEYS_ASSOC_name = zend_string_init_interned("MIT_KEYS_ASSOC", sizeof("MIT_KEYS_ASSOC") - 1, 1);
+	zend_string *const_MIT_KEYS_ASSOC_name = zend_string_init_interned("MIT_KEYS_ASSOC", strlen("MIT_KEYS_ASSOC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_MIT_KEYS_ASSOC_name, &const_MIT_KEYS_ASSOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_MIT_KEYS_ASSOC_name);
 

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -304,224 +304,224 @@ static zend_class_entry *register_class_SQLite3(void)
 
 	zval const_OK_value;
 	ZVAL_LONG(&const_OK_value, SQLITE_OK);
-	zend_string *const_OK_name = zend_string_init_interned("OK", sizeof("OK") - 1, 1);
+	zend_string *const_OK_name = zend_string_init_interned("OK", strlen("OK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OK_name, &const_OK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OK_name);
 
 	zval const_DENY_value;
 	ZVAL_LONG(&const_DENY_value, SQLITE_DENY);
-	zend_string *const_DENY_name = zend_string_init_interned("DENY", sizeof("DENY") - 1, 1);
+	zend_string *const_DENY_name = zend_string_init_interned("DENY", strlen("DENY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DENY_name, &const_DENY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DENY_name);
 
 	zval const_IGNORE_value;
 	ZVAL_LONG(&const_IGNORE_value, SQLITE_IGNORE);
-	zend_string *const_IGNORE_name = zend_string_init_interned("IGNORE", sizeof("IGNORE") - 1, 1);
+	zend_string *const_IGNORE_name = zend_string_init_interned("IGNORE", strlen("IGNORE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_IGNORE_name, &const_IGNORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_IGNORE_name);
 
 	zval const_CREATE_INDEX_value;
 	ZVAL_LONG(&const_CREATE_INDEX_value, SQLITE_CREATE_INDEX);
-	zend_string *const_CREATE_INDEX_name = zend_string_init_interned("CREATE_INDEX", sizeof("CREATE_INDEX") - 1, 1);
+	zend_string *const_CREATE_INDEX_name = zend_string_init_interned("CREATE_INDEX", strlen("CREATE_INDEX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_INDEX_name, &const_CREATE_INDEX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_INDEX_name);
 
 	zval const_CREATE_TABLE_value;
 	ZVAL_LONG(&const_CREATE_TABLE_value, SQLITE_CREATE_TABLE);
-	zend_string *const_CREATE_TABLE_name = zend_string_init_interned("CREATE_TABLE", sizeof("CREATE_TABLE") - 1, 1);
+	zend_string *const_CREATE_TABLE_name = zend_string_init_interned("CREATE_TABLE", strlen("CREATE_TABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TABLE_name, &const_CREATE_TABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TABLE_name);
 
 	zval const_CREATE_TEMP_INDEX_value;
 	ZVAL_LONG(&const_CREATE_TEMP_INDEX_value, SQLITE_CREATE_TEMP_INDEX);
-	zend_string *const_CREATE_TEMP_INDEX_name = zend_string_init_interned("CREATE_TEMP_INDEX", sizeof("CREATE_TEMP_INDEX") - 1, 1);
+	zend_string *const_CREATE_TEMP_INDEX_name = zend_string_init_interned("CREATE_TEMP_INDEX", strlen("CREATE_TEMP_INDEX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TEMP_INDEX_name, &const_CREATE_TEMP_INDEX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TEMP_INDEX_name);
 
 	zval const_CREATE_TEMP_TABLE_value;
 	ZVAL_LONG(&const_CREATE_TEMP_TABLE_value, SQLITE_CREATE_TEMP_TABLE);
-	zend_string *const_CREATE_TEMP_TABLE_name = zend_string_init_interned("CREATE_TEMP_TABLE", sizeof("CREATE_TEMP_TABLE") - 1, 1);
+	zend_string *const_CREATE_TEMP_TABLE_name = zend_string_init_interned("CREATE_TEMP_TABLE", strlen("CREATE_TEMP_TABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TEMP_TABLE_name, &const_CREATE_TEMP_TABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TEMP_TABLE_name);
 
 	zval const_CREATE_TEMP_TRIGGER_value;
 	ZVAL_LONG(&const_CREATE_TEMP_TRIGGER_value, SQLITE_CREATE_TEMP_TRIGGER);
-	zend_string *const_CREATE_TEMP_TRIGGER_name = zend_string_init_interned("CREATE_TEMP_TRIGGER", sizeof("CREATE_TEMP_TRIGGER") - 1, 1);
+	zend_string *const_CREATE_TEMP_TRIGGER_name = zend_string_init_interned("CREATE_TEMP_TRIGGER", strlen("CREATE_TEMP_TRIGGER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TEMP_TRIGGER_name, &const_CREATE_TEMP_TRIGGER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TEMP_TRIGGER_name);
 
 	zval const_CREATE_TEMP_VIEW_value;
 	ZVAL_LONG(&const_CREATE_TEMP_VIEW_value, SQLITE_CREATE_TEMP_VIEW);
-	zend_string *const_CREATE_TEMP_VIEW_name = zend_string_init_interned("CREATE_TEMP_VIEW", sizeof("CREATE_TEMP_VIEW") - 1, 1);
+	zend_string *const_CREATE_TEMP_VIEW_name = zend_string_init_interned("CREATE_TEMP_VIEW", strlen("CREATE_TEMP_VIEW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TEMP_VIEW_name, &const_CREATE_TEMP_VIEW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TEMP_VIEW_name);
 
 	zval const_CREATE_TRIGGER_value;
 	ZVAL_LONG(&const_CREATE_TRIGGER_value, SQLITE_CREATE_TRIGGER);
-	zend_string *const_CREATE_TRIGGER_name = zend_string_init_interned("CREATE_TRIGGER", sizeof("CREATE_TRIGGER") - 1, 1);
+	zend_string *const_CREATE_TRIGGER_name = zend_string_init_interned("CREATE_TRIGGER", strlen("CREATE_TRIGGER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_TRIGGER_name, &const_CREATE_TRIGGER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_TRIGGER_name);
 
 	zval const_CREATE_VIEW_value;
 	ZVAL_LONG(&const_CREATE_VIEW_value, SQLITE_CREATE_VIEW);
-	zend_string *const_CREATE_VIEW_name = zend_string_init_interned("CREATE_VIEW", sizeof("CREATE_VIEW") - 1, 1);
+	zend_string *const_CREATE_VIEW_name = zend_string_init_interned("CREATE_VIEW", strlen("CREATE_VIEW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_VIEW_name, &const_CREATE_VIEW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_VIEW_name);
 
 	zval const_DELETE_value;
 	ZVAL_LONG(&const_DELETE_value, SQLITE_DELETE);
-	zend_string *const_DELETE_name = zend_string_init_interned("DELETE", sizeof("DELETE") - 1, 1);
+	zend_string *const_DELETE_name = zend_string_init_interned("DELETE", strlen("DELETE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DELETE_name, &const_DELETE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DELETE_name);
 
 	zval const_DROP_INDEX_value;
 	ZVAL_LONG(&const_DROP_INDEX_value, SQLITE_DROP_INDEX);
-	zend_string *const_DROP_INDEX_name = zend_string_init_interned("DROP_INDEX", sizeof("DROP_INDEX") - 1, 1);
+	zend_string *const_DROP_INDEX_name = zend_string_init_interned("DROP_INDEX", strlen("DROP_INDEX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_INDEX_name, &const_DROP_INDEX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_INDEX_name);
 
 	zval const_DROP_TABLE_value;
 	ZVAL_LONG(&const_DROP_TABLE_value, SQLITE_DROP_TABLE);
-	zend_string *const_DROP_TABLE_name = zend_string_init_interned("DROP_TABLE", sizeof("DROP_TABLE") - 1, 1);
+	zend_string *const_DROP_TABLE_name = zend_string_init_interned("DROP_TABLE", strlen("DROP_TABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TABLE_name, &const_DROP_TABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TABLE_name);
 
 	zval const_DROP_TEMP_INDEX_value;
 	ZVAL_LONG(&const_DROP_TEMP_INDEX_value, SQLITE_DROP_TEMP_INDEX);
-	zend_string *const_DROP_TEMP_INDEX_name = zend_string_init_interned("DROP_TEMP_INDEX", sizeof("DROP_TEMP_INDEX") - 1, 1);
+	zend_string *const_DROP_TEMP_INDEX_name = zend_string_init_interned("DROP_TEMP_INDEX", strlen("DROP_TEMP_INDEX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TEMP_INDEX_name, &const_DROP_TEMP_INDEX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TEMP_INDEX_name);
 
 	zval const_DROP_TEMP_TABLE_value;
 	ZVAL_LONG(&const_DROP_TEMP_TABLE_value, SQLITE_DROP_TEMP_TABLE);
-	zend_string *const_DROP_TEMP_TABLE_name = zend_string_init_interned("DROP_TEMP_TABLE", sizeof("DROP_TEMP_TABLE") - 1, 1);
+	zend_string *const_DROP_TEMP_TABLE_name = zend_string_init_interned("DROP_TEMP_TABLE", strlen("DROP_TEMP_TABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TEMP_TABLE_name, &const_DROP_TEMP_TABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TEMP_TABLE_name);
 
 	zval const_DROP_TEMP_TRIGGER_value;
 	ZVAL_LONG(&const_DROP_TEMP_TRIGGER_value, SQLITE_DROP_TEMP_TRIGGER);
-	zend_string *const_DROP_TEMP_TRIGGER_name = zend_string_init_interned("DROP_TEMP_TRIGGER", sizeof("DROP_TEMP_TRIGGER") - 1, 1);
+	zend_string *const_DROP_TEMP_TRIGGER_name = zend_string_init_interned("DROP_TEMP_TRIGGER", strlen("DROP_TEMP_TRIGGER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TEMP_TRIGGER_name, &const_DROP_TEMP_TRIGGER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TEMP_TRIGGER_name);
 
 	zval const_DROP_TEMP_VIEW_value;
 	ZVAL_LONG(&const_DROP_TEMP_VIEW_value, SQLITE_DROP_TEMP_VIEW);
-	zend_string *const_DROP_TEMP_VIEW_name = zend_string_init_interned("DROP_TEMP_VIEW", sizeof("DROP_TEMP_VIEW") - 1, 1);
+	zend_string *const_DROP_TEMP_VIEW_name = zend_string_init_interned("DROP_TEMP_VIEW", strlen("DROP_TEMP_VIEW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TEMP_VIEW_name, &const_DROP_TEMP_VIEW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TEMP_VIEW_name);
 
 	zval const_DROP_TRIGGER_value;
 	ZVAL_LONG(&const_DROP_TRIGGER_value, SQLITE_DROP_TRIGGER);
-	zend_string *const_DROP_TRIGGER_name = zend_string_init_interned("DROP_TRIGGER", sizeof("DROP_TRIGGER") - 1, 1);
+	zend_string *const_DROP_TRIGGER_name = zend_string_init_interned("DROP_TRIGGER", strlen("DROP_TRIGGER"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_TRIGGER_name, &const_DROP_TRIGGER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_TRIGGER_name);
 
 	zval const_DROP_VIEW_value;
 	ZVAL_LONG(&const_DROP_VIEW_value, SQLITE_DROP_VIEW);
-	zend_string *const_DROP_VIEW_name = zend_string_init_interned("DROP_VIEW", sizeof("DROP_VIEW") - 1, 1);
+	zend_string *const_DROP_VIEW_name = zend_string_init_interned("DROP_VIEW", strlen("DROP_VIEW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_VIEW_name, &const_DROP_VIEW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_VIEW_name);
 
 	zval const_INSERT_value;
 	ZVAL_LONG(&const_INSERT_value, SQLITE_INSERT);
-	zend_string *const_INSERT_name = zend_string_init_interned("INSERT", sizeof("INSERT") - 1, 1);
+	zend_string *const_INSERT_name = zend_string_init_interned("INSERT", strlen("INSERT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_INSERT_name, &const_INSERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_INSERT_name);
 
 	zval const_PRAGMA_value;
 	ZVAL_LONG(&const_PRAGMA_value, SQLITE_PRAGMA);
-	zend_string *const_PRAGMA_name = zend_string_init_interned("PRAGMA", sizeof("PRAGMA") - 1, 1);
+	zend_string *const_PRAGMA_name = zend_string_init_interned("PRAGMA", strlen("PRAGMA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PRAGMA_name, &const_PRAGMA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PRAGMA_name);
 
 	zval const_READ_value;
 	ZVAL_LONG(&const_READ_value, SQLITE_READ);
-	zend_string *const_READ_name = zend_string_init_interned("READ", sizeof("READ") - 1, 1);
+	zend_string *const_READ_name = zend_string_init_interned("READ", strlen("READ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_READ_name, &const_READ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_READ_name);
 
 	zval const_SELECT_value;
 	ZVAL_LONG(&const_SELECT_value, SQLITE_SELECT);
-	zend_string *const_SELECT_name = zend_string_init_interned("SELECT", sizeof("SELECT") - 1, 1);
+	zend_string *const_SELECT_name = zend_string_init_interned("SELECT", strlen("SELECT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SELECT_name, &const_SELECT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SELECT_name);
 
 	zval const_TRANSACTION_value;
 	ZVAL_LONG(&const_TRANSACTION_value, SQLITE_TRANSACTION);
-	zend_string *const_TRANSACTION_name = zend_string_init_interned("TRANSACTION", sizeof("TRANSACTION") - 1, 1);
+	zend_string *const_TRANSACTION_name = zend_string_init_interned("TRANSACTION", strlen("TRANSACTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TRANSACTION_name, &const_TRANSACTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TRANSACTION_name);
 
 	zval const_UPDATE_value;
 	ZVAL_LONG(&const_UPDATE_value, SQLITE_UPDATE);
-	zend_string *const_UPDATE_name = zend_string_init_interned("UPDATE", sizeof("UPDATE") - 1, 1);
+	zend_string *const_UPDATE_name = zend_string_init_interned("UPDATE", strlen("UPDATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_UPDATE_name, &const_UPDATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_UPDATE_name);
 
 	zval const_ATTACH_value;
 	ZVAL_LONG(&const_ATTACH_value, SQLITE_ATTACH);
-	zend_string *const_ATTACH_name = zend_string_init_interned("ATTACH", sizeof("ATTACH") - 1, 1);
+	zend_string *const_ATTACH_name = zend_string_init_interned("ATTACH", strlen("ATTACH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTACH_name, &const_ATTACH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTACH_name);
 
 	zval const_DETACH_value;
 	ZVAL_LONG(&const_DETACH_value, SQLITE_DETACH);
-	zend_string *const_DETACH_name = zend_string_init_interned("DETACH", sizeof("DETACH") - 1, 1);
+	zend_string *const_DETACH_name = zend_string_init_interned("DETACH", strlen("DETACH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DETACH_name, &const_DETACH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DETACH_name);
 
 	zval const_ALTER_TABLE_value;
 	ZVAL_LONG(&const_ALTER_TABLE_value, SQLITE_ALTER_TABLE);
-	zend_string *const_ALTER_TABLE_name = zend_string_init_interned("ALTER_TABLE", sizeof("ALTER_TABLE") - 1, 1);
+	zend_string *const_ALTER_TABLE_name = zend_string_init_interned("ALTER_TABLE", strlen("ALTER_TABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ALTER_TABLE_name, &const_ALTER_TABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ALTER_TABLE_name);
 
 	zval const_REINDEX_value;
 	ZVAL_LONG(&const_REINDEX_value, SQLITE_REINDEX);
-	zend_string *const_REINDEX_name = zend_string_init_interned("REINDEX", sizeof("REINDEX") - 1, 1);
+	zend_string *const_REINDEX_name = zend_string_init_interned("REINDEX", strlen("REINDEX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_REINDEX_name, &const_REINDEX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_REINDEX_name);
 
 	zval const_ANALYZE_value;
 	ZVAL_LONG(&const_ANALYZE_value, SQLITE_ANALYZE);
-	zend_string *const_ANALYZE_name = zend_string_init_interned("ANALYZE", sizeof("ANALYZE") - 1, 1);
+	zend_string *const_ANALYZE_name = zend_string_init_interned("ANALYZE", strlen("ANALYZE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ANALYZE_name, &const_ANALYZE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ANALYZE_name);
 
 	zval const_CREATE_VTABLE_value;
 	ZVAL_LONG(&const_CREATE_VTABLE_value, SQLITE_CREATE_VTABLE);
-	zend_string *const_CREATE_VTABLE_name = zend_string_init_interned("CREATE_VTABLE", sizeof("CREATE_VTABLE") - 1, 1);
+	zend_string *const_CREATE_VTABLE_name = zend_string_init_interned("CREATE_VTABLE", strlen("CREATE_VTABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_VTABLE_name, &const_CREATE_VTABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_VTABLE_name);
 
 	zval const_DROP_VTABLE_value;
 	ZVAL_LONG(&const_DROP_VTABLE_value, SQLITE_DROP_VTABLE);
-	zend_string *const_DROP_VTABLE_name = zend_string_init_interned("DROP_VTABLE", sizeof("DROP_VTABLE") - 1, 1);
+	zend_string *const_DROP_VTABLE_name = zend_string_init_interned("DROP_VTABLE", strlen("DROP_VTABLE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DROP_VTABLE_name, &const_DROP_VTABLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DROP_VTABLE_name);
 
 	zval const_FUNCTION_value;
 	ZVAL_LONG(&const_FUNCTION_value, SQLITE_FUNCTION);
-	zend_string *const_FUNCTION_name = zend_string_init_interned("FUNCTION", sizeof("FUNCTION") - 1, 1);
+	zend_string *const_FUNCTION_name = zend_string_init_interned("FUNCTION", strlen("FUNCTION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FUNCTION_name, &const_FUNCTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FUNCTION_name);
 
 	zval const_SAVEPOINT_value;
 	ZVAL_LONG(&const_SAVEPOINT_value, SQLITE_SAVEPOINT);
-	zend_string *const_SAVEPOINT_name = zend_string_init_interned("SAVEPOINT", sizeof("SAVEPOINT") - 1, 1);
+	zend_string *const_SAVEPOINT_name = zend_string_init_interned("SAVEPOINT", strlen("SAVEPOINT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SAVEPOINT_name, &const_SAVEPOINT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SAVEPOINT_name);
 
 	zval const_COPY_value;
 	ZVAL_LONG(&const_COPY_value, SQLITE_COPY);
-	zend_string *const_COPY_name = zend_string_init_interned("COPY", sizeof("COPY") - 1, 1);
+	zend_string *const_COPY_name = zend_string_init_interned("COPY", strlen("COPY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_COPY_name, &const_COPY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_COPY_name);
 #if defined(SQLITE_RECURSIVE)
 
 	zval const_RECURSIVE_value;
 	ZVAL_LONG(&const_RECURSIVE_value, SQLITE_RECURSIVE);
-	zend_string *const_RECURSIVE_name = zend_string_init_interned("RECURSIVE", sizeof("RECURSIVE") - 1, 1);
+	zend_string *const_RECURSIVE_name = zend_string_init_interned("RECURSIVE", strlen("RECURSIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RECURSIVE_name, &const_RECURSIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RECURSIVE_name);
 #endif

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -3992,10 +3992,10 @@ static void register_basic_functions_symbols(int module_number)
 #endif
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "crypt", sizeof("crypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "crypt", strlen("crypt")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_STRPTIME)
 
-	zend_attribute *attribute_Deprecated_func_strptime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strptime", sizeof("strptime") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_strptime_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "strptime", strlen("strptime")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_strptime_0_arg0;
 	zend_string *attribute_Deprecated_func_strptime_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_strptime_0_arg0, attribute_Deprecated_func_strptime_0_arg0_str);
@@ -4008,14 +4008,14 @@ static void register_basic_functions_symbols(int module_number)
 	attribute_Deprecated_func_strptime_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 #endif
 
-	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", sizeof("assert_options") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_assert_options_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "assert_options", strlen("assert_options")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_assert_options_0_arg0;
 	zend_string *attribute_Deprecated_func_assert_options_0_arg0_str = zend_string_init("8.3", strlen("8.3"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_assert_options_0_arg0, attribute_Deprecated_func_assert_options_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_assert_options_0->args[0].value, &attribute_Deprecated_func_assert_options_0_arg0);
 	attribute_Deprecated_func_assert_options_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_utf8_encode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_encode", sizeof("utf8_encode") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_utf8_encode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_encode", strlen("utf8_encode")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_utf8_encode_0_arg0;
 	zend_string *attribute_Deprecated_func_utf8_encode_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_utf8_encode_0_arg0, attribute_Deprecated_func_utf8_encode_0_arg0_str);
@@ -4027,7 +4027,7 @@ static void register_basic_functions_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_encode_0->args[1].value, &attribute_Deprecated_func_utf8_encode_0_arg1);
 	attribute_Deprecated_func_utf8_encode_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_utf8_decode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_decode", sizeof("utf8_decode") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_utf8_decode_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "utf8_decode", strlen("utf8_decode")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_utf8_decode_0_arg0;
 	zend_string *attribute_Deprecated_func_utf8_decode_0_arg0_str = zend_string_init("8.2", strlen("8.2"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_utf8_decode_0_arg0, attribute_Deprecated_func_utf8_decode_0_arg0_str);
@@ -4039,9 +4039,9 @@ static void register_basic_functions_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_decode_0->args[1].value, &attribute_Deprecated_func_utf8_decode_0_arg1);
 	attribute_Deprecated_func_utf8_decode_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", strlen("password_hash")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_verify", sizeof("password_verify") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_verify", strlen("password_verify")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class___PHP_Incomplete_Class(void)
@@ -4051,7 +4051,7 @@ static zend_class_entry *register_class___PHP_Incomplete_Class(void)
 	INIT_CLASS_ENTRY(ce, "__PHP_Incomplete_Class", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 
-	zend_string *attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0 = zend_string_init_interned("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
+	zend_string *attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0 = zend_string_init_interned("AllowDynamicProperties", strlen("AllowDynamicProperties"), 1);
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0, 0);
 	zend_string_release(attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0);
 

--- a/ext/standard/dir_arginfo.h
+++ b/ext/standard/dir_arginfo.h
@@ -66,7 +66,7 @@ static zend_class_entry *register_class_Directory(void)
 
 	zval property_handle_default_value;
 	ZVAL_UNDEF(&property_handle_default_value);
-	zend_string *property_handle_name = zend_string_init("handle", sizeof("handle") - 1, 1);
+	zend_string *property_handle_name = zend_string_init("handle", strlen("handle"), 1);
 	zend_declare_typed_property(class_entry, property_handle_name, &property_handle_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_handle_name);
 

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -44,19 +44,19 @@ static zend_class_entry *register_class_php_user_filter(void)
 
 	zval property_filtername_default_value;
 	ZVAL_EMPTY_STRING(&property_filtername_default_value);
-	zend_string *property_filtername_name = zend_string_init("filtername", sizeof("filtername") - 1, 1);
+	zend_string *property_filtername_name = zend_string_init("filtername", strlen("filtername"), 1);
 	zend_declare_typed_property(class_entry, property_filtername_name, &property_filtername_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_filtername_name);
 
 	zval property_params_default_value;
 	ZVAL_EMPTY_STRING(&property_params_default_value);
-	zend_string *property_params_name = zend_string_init("params", sizeof("params") - 1, 1);
+	zend_string *property_params_name = zend_string_init("params", strlen("params"), 1);
 	zend_declare_typed_property(class_entry, property_params_name, &property_params_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_params_name);
 
 	zval property_stream_default_value;
 	ZVAL_NULL(&property_stream_default_value);
-	zend_string *property_stream_name = zend_string_init("stream", sizeof("stream") - 1, 1);
+	zend_string *property_stream_name = zend_string_init("stream", strlen("stream"), 1);
 	zend_declare_typed_property(class_entry, property_stream_name, &property_stream_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_stream_name);
 
@@ -72,25 +72,25 @@ static zend_class_entry *register_class_StreamBucket(void)
 
 	zval property_bucket_default_value;
 	ZVAL_NULL(&property_bucket_default_value);
-	zend_string *property_bucket_name = zend_string_init("bucket", sizeof("bucket") - 1, 1);
+	zend_string *property_bucket_name = zend_string_init("bucket", strlen("bucket"), 1);
 	zend_declare_typed_property(class_entry, property_bucket_name, &property_bucket_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_bucket_name);
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_datalen_default_value;
 	ZVAL_UNDEF(&property_datalen_default_value);
-	zend_string *property_datalen_name = zend_string_init("datalen", sizeof("datalen") - 1, 1);
+	zend_string *property_datalen_name = zend_string_init("datalen", strlen("datalen"), 1);
 	zend_declare_typed_property(class_entry, property_datalen_name, &property_datalen_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_datalen_name);
 
 	zval property_dataLength_default_value;
 	ZVAL_UNDEF(&property_dataLength_default_value);
-	zend_string *property_dataLength_name = zend_string_init("dataLength", sizeof("dataLength") - 1, 1);
+	zend_string *property_dataLength_name = zend_string_init("dataLength", strlen("dataLength"), 1);
 	zend_declare_typed_property(class_entry, property_dataLength_name, &property_dataLength_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_dataLength_name);
 

--- a/ext/tidy/tidy_arginfo.h
+++ b/ext/tidy/tidy_arginfo.h
@@ -530,7 +530,7 @@ static zend_class_entry *register_class_tidy(void)
 
 	zval property_errorBuffer_default_value;
 	ZVAL_NULL(&property_errorBuffer_default_value);
-	zend_string *property_errorBuffer_name = zend_string_init("errorBuffer", sizeof("errorBuffer") - 1, 1);
+	zend_string *property_errorBuffer_name = zend_string_init("errorBuffer", strlen("errorBuffer"), 1);
 	zend_declare_typed_property(class_entry, property_errorBuffer_name, &property_errorBuffer_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_errorBuffer_name);
 
@@ -566,31 +566,31 @@ static zend_class_entry *register_class_tidyNode(void)
 
 	zval property_column_default_value;
 	ZVAL_UNDEF(&property_column_default_value);
-	zend_string *property_column_name = zend_string_init("column", sizeof("column") - 1, 1);
+	zend_string *property_column_name = zend_string_init("column", strlen("column"), 1);
 	zend_declare_typed_property(class_entry, property_column_name, &property_column_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_column_name);
 
 	zval property_proprietary_default_value;
 	ZVAL_UNDEF(&property_proprietary_default_value);
-	zend_string *property_proprietary_name = zend_string_init("proprietary", sizeof("proprietary") - 1, 1);
+	zend_string *property_proprietary_name = zend_string_init("proprietary", strlen("proprietary"), 1);
 	zend_declare_typed_property(class_entry, property_proprietary_name, &property_proprietary_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_proprietary_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_id_name);
 
 	zval property_attribute_default_value;
 	ZVAL_UNDEF(&property_attribute_default_value);
-	zend_string *property_attribute_name = zend_string_init("attribute", sizeof("attribute") - 1, 1);
+	zend_string *property_attribute_name = zend_string_init("attribute", strlen("attribute"), 1);
 	zend_declare_typed_property(class_entry, property_attribute_name, &property_attribute_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_attribute_name);
 
 	zval property_child_default_value;
 	ZVAL_UNDEF(&property_child_default_value);
-	zend_string *property_child_name = zend_string_init("child", sizeof("child") - 1, 1);
+	zend_string *property_child_name = zend_string_init("child", strlen("child"), 1);
 	zend_declare_typed_property(class_entry, property_child_name, &property_child_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_child_name);
 

--- a/ext/tokenizer/tokenizer_arginfo.h
+++ b/ext/tokenizer/tokenizer_arginfo.h
@@ -72,13 +72,13 @@ static zend_class_entry *register_class_PhpToken(zend_class_entry *class_entry_S
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_id_name);
 
 	zval property_text_default_value;
 	ZVAL_UNDEF(&property_text_default_value);
-	zend_string *property_text_name = zend_string_init("text", sizeof("text") - 1, 1);
+	zend_string *property_text_name = zend_string_init("text", strlen("text"), 1);
 	zend_declare_typed_property(class_entry, property_text_name, &property_text_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_text_name);
 
@@ -88,7 +88,7 @@ static zend_class_entry *register_class_PhpToken(zend_class_entry *class_entry_S
 
 	zval property_pos_default_value;
 	ZVAL_UNDEF(&property_pos_default_value);
-	zend_string *property_pos_name = zend_string_init("pos", sizeof("pos") - 1, 1);
+	zend_string *property_pos_name = zend_string_init("pos", strlen("pos"), 1);
 	zend_declare_typed_property(class_entry, property_pos_name, &property_pos_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_pos_name);
 

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -163,7 +163,7 @@ static void register_xml_symbols(int module_number)
 	REGISTER_STRING_CONSTANT("XML_SAX_IMPL", PHP_XML_SAX_IMPL, CONST_PERSISTENT);
 
 
-	zend_attribute *attribute_Deprecated_func_xml_set_object_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "xml_set_object", sizeof("xml_set_object") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_xml_set_object_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "xml_set_object", strlen("xml_set_object")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_xml_set_object_0_arg0;
 	zend_string *attribute_Deprecated_func_xml_set_object_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_xml_set_object_0_arg0, attribute_Deprecated_func_xml_set_object_0_arg0_str);

--- a/ext/xmlreader/php_xmlreader_arginfo.h
+++ b/ext/xmlreader/php_xmlreader_arginfo.h
@@ -180,181 +180,181 @@ static zend_class_entry *register_class_XMLReader(void)
 
 	zval const_NONE_value;
 	ZVAL_LONG(&const_NONE_value, XML_READER_TYPE_NONE);
-	zend_string *const_NONE_name = zend_string_init_interned("NONE", sizeof("NONE") - 1, 1);
+	zend_string *const_NONE_name = zend_string_init_interned("NONE", strlen("NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NONE_name, &const_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NONE_name);
 
 	zval const_ELEMENT_value;
 	ZVAL_LONG(&const_ELEMENT_value, XML_READER_TYPE_ELEMENT);
-	zend_string *const_ELEMENT_name = zend_string_init_interned("ELEMENT", sizeof("ELEMENT") - 1, 1);
+	zend_string *const_ELEMENT_name = zend_string_init_interned("ELEMENT", strlen("ELEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ELEMENT_name, &const_ELEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ELEMENT_name);
 
 	zval const_ATTRIBUTE_value;
 	ZVAL_LONG(&const_ATTRIBUTE_value, XML_READER_TYPE_ATTRIBUTE);
-	zend_string *const_ATTRIBUTE_name = zend_string_init_interned("ATTRIBUTE", sizeof("ATTRIBUTE") - 1, 1);
+	zend_string *const_ATTRIBUTE_name = zend_string_init_interned("ATTRIBUTE", strlen("ATTRIBUTE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ATTRIBUTE_name, &const_ATTRIBUTE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTRIBUTE_name);
 
 	zval const_TEXT_value;
 	ZVAL_LONG(&const_TEXT_value, XML_READER_TYPE_TEXT);
-	zend_string *const_TEXT_name = zend_string_init_interned("TEXT", sizeof("TEXT") - 1, 1);
+	zend_string *const_TEXT_name = zend_string_init_interned("TEXT", strlen("TEXT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_TEXT_name, &const_TEXT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TEXT_name);
 
 	zval const_CDATA_value;
 	ZVAL_LONG(&const_CDATA_value, XML_READER_TYPE_CDATA);
-	zend_string *const_CDATA_name = zend_string_init_interned("CDATA", sizeof("CDATA") - 1, 1);
+	zend_string *const_CDATA_name = zend_string_init_interned("CDATA", strlen("CDATA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CDATA_name, &const_CDATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CDATA_name);
 
 	zval const_ENTITY_REF_value;
 	ZVAL_LONG(&const_ENTITY_REF_value, XML_READER_TYPE_ENTITY_REFERENCE);
-	zend_string *const_ENTITY_REF_name = zend_string_init_interned("ENTITY_REF", sizeof("ENTITY_REF") - 1, 1);
+	zend_string *const_ENTITY_REF_name = zend_string_init_interned("ENTITY_REF", strlen("ENTITY_REF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ENTITY_REF_name, &const_ENTITY_REF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ENTITY_REF_name);
 
 	zval const_ENTITY_value;
 	ZVAL_LONG(&const_ENTITY_value, XML_READER_TYPE_ENTITY);
-	zend_string *const_ENTITY_name = zend_string_init_interned("ENTITY", sizeof("ENTITY") - 1, 1);
+	zend_string *const_ENTITY_name = zend_string_init_interned("ENTITY", strlen("ENTITY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ENTITY_name, &const_ENTITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ENTITY_name);
 
 	zval const_PI_value;
 	ZVAL_LONG(&const_PI_value, XML_READER_TYPE_PROCESSING_INSTRUCTION);
-	zend_string *const_PI_name = zend_string_init_interned("PI", sizeof("PI") - 1, 1);
+	zend_string *const_PI_name = zend_string_init_interned("PI", strlen("PI"), 1);
 	zend_declare_typed_class_constant(class_entry, const_PI_name, &const_PI_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_PI_name);
 
 	zval const_COMMENT_value;
 	ZVAL_LONG(&const_COMMENT_value, XML_READER_TYPE_COMMENT);
-	zend_string *const_COMMENT_name = zend_string_init_interned("COMMENT", sizeof("COMMENT") - 1, 1);
+	zend_string *const_COMMENT_name = zend_string_init_interned("COMMENT", strlen("COMMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_COMMENT_name, &const_COMMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_COMMENT_name);
 
 	zval const_DOC_value;
 	ZVAL_LONG(&const_DOC_value, XML_READER_TYPE_DOCUMENT);
-	zend_string *const_DOC_name = zend_string_init_interned("DOC", sizeof("DOC") - 1, 1);
+	zend_string *const_DOC_name = zend_string_init_interned("DOC", strlen("DOC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOC_name, &const_DOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_name);
 
 	zval const_DOC_TYPE_value;
 	ZVAL_LONG(&const_DOC_TYPE_value, XML_READER_TYPE_DOCUMENT_TYPE);
-	zend_string *const_DOC_TYPE_name = zend_string_init_interned("DOC_TYPE", sizeof("DOC_TYPE") - 1, 1);
+	zend_string *const_DOC_TYPE_name = zend_string_init_interned("DOC_TYPE", strlen("DOC_TYPE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOC_TYPE_name, &const_DOC_TYPE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_TYPE_name);
 
 	zval const_DOC_FRAGMENT_value;
 	ZVAL_LONG(&const_DOC_FRAGMENT_value, XML_READER_TYPE_DOCUMENT_FRAGMENT);
-	zend_string *const_DOC_FRAGMENT_name = zend_string_init_interned("DOC_FRAGMENT", sizeof("DOC_FRAGMENT") - 1, 1);
+	zend_string *const_DOC_FRAGMENT_name = zend_string_init_interned("DOC_FRAGMENT", strlen("DOC_FRAGMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DOC_FRAGMENT_name, &const_DOC_FRAGMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DOC_FRAGMENT_name);
 
 	zval const_NOTATION_value;
 	ZVAL_LONG(&const_NOTATION_value, XML_READER_TYPE_NOTATION);
-	zend_string *const_NOTATION_name = zend_string_init_interned("NOTATION", sizeof("NOTATION") - 1, 1);
+	zend_string *const_NOTATION_name = zend_string_init_interned("NOTATION", strlen("NOTATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_NOTATION_name, &const_NOTATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_NOTATION_name);
 
 	zval const_WHITESPACE_value;
 	ZVAL_LONG(&const_WHITESPACE_value, XML_READER_TYPE_WHITESPACE);
-	zend_string *const_WHITESPACE_name = zend_string_init_interned("WHITESPACE", sizeof("WHITESPACE") - 1, 1);
+	zend_string *const_WHITESPACE_name = zend_string_init_interned("WHITESPACE", strlen("WHITESPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_WHITESPACE_name, &const_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WHITESPACE_name);
 
 	zval const_SIGNIFICANT_WHITESPACE_value;
 	ZVAL_LONG(&const_SIGNIFICANT_WHITESPACE_value, XML_READER_TYPE_SIGNIFICANT_WHITESPACE);
-	zend_string *const_SIGNIFICANT_WHITESPACE_name = zend_string_init_interned("SIGNIFICANT_WHITESPACE", sizeof("SIGNIFICANT_WHITESPACE") - 1, 1);
+	zend_string *const_SIGNIFICANT_WHITESPACE_name = zend_string_init_interned("SIGNIFICANT_WHITESPACE", strlen("SIGNIFICANT_WHITESPACE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SIGNIFICANT_WHITESPACE_name, &const_SIGNIFICANT_WHITESPACE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SIGNIFICANT_WHITESPACE_name);
 
 	zval const_END_ELEMENT_value;
 	ZVAL_LONG(&const_END_ELEMENT_value, XML_READER_TYPE_END_ELEMENT);
-	zend_string *const_END_ELEMENT_name = zend_string_init_interned("END_ELEMENT", sizeof("END_ELEMENT") - 1, 1);
+	zend_string *const_END_ELEMENT_name = zend_string_init_interned("END_ELEMENT", strlen("END_ELEMENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_END_ELEMENT_name, &const_END_ELEMENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_END_ELEMENT_name);
 
 	zval const_END_ENTITY_value;
 	ZVAL_LONG(&const_END_ENTITY_value, XML_READER_TYPE_END_ENTITY);
-	zend_string *const_END_ENTITY_name = zend_string_init_interned("END_ENTITY", sizeof("END_ENTITY") - 1, 1);
+	zend_string *const_END_ENTITY_name = zend_string_init_interned("END_ENTITY", strlen("END_ENTITY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_END_ENTITY_name, &const_END_ENTITY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_END_ENTITY_name);
 
 	zval const_XML_DECLARATION_value;
 	ZVAL_LONG(&const_XML_DECLARATION_value, XML_READER_TYPE_XML_DECLARATION);
-	zend_string *const_XML_DECLARATION_name = zend_string_init_interned("XML_DECLARATION", sizeof("XML_DECLARATION") - 1, 1);
+	zend_string *const_XML_DECLARATION_name = zend_string_init_interned("XML_DECLARATION", strlen("XML_DECLARATION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_XML_DECLARATION_name, &const_XML_DECLARATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_XML_DECLARATION_name);
 
 	zval const_LOADDTD_value;
 	ZVAL_LONG(&const_LOADDTD_value, XML_PARSER_LOADDTD);
-	zend_string *const_LOADDTD_name = zend_string_init_interned("LOADDTD", sizeof("LOADDTD") - 1, 1);
+	zend_string *const_LOADDTD_name = zend_string_init_interned("LOADDTD", strlen("LOADDTD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LOADDTD_name, &const_LOADDTD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LOADDTD_name);
 
 	zval const_DEFAULTATTRS_value;
 	ZVAL_LONG(&const_DEFAULTATTRS_value, XML_PARSER_DEFAULTATTRS);
-	zend_string *const_DEFAULTATTRS_name = zend_string_init_interned("DEFAULTATTRS", sizeof("DEFAULTATTRS") - 1, 1);
+	zend_string *const_DEFAULTATTRS_name = zend_string_init_interned("DEFAULTATTRS", strlen("DEFAULTATTRS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_DEFAULTATTRS_name, &const_DEFAULTATTRS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DEFAULTATTRS_name);
 
 	zval const_VALIDATE_value;
 	ZVAL_LONG(&const_VALIDATE_value, XML_PARSER_VALIDATE);
-	zend_string *const_VALIDATE_name = zend_string_init_interned("VALIDATE", sizeof("VALIDATE") - 1, 1);
+	zend_string *const_VALIDATE_name = zend_string_init_interned("VALIDATE", strlen("VALIDATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_VALIDATE_name, &const_VALIDATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VALIDATE_name);
 
 	zval const_SUBST_ENTITIES_value;
 	ZVAL_LONG(&const_SUBST_ENTITIES_value, XML_PARSER_SUBST_ENTITIES);
-	zend_string *const_SUBST_ENTITIES_name = zend_string_init_interned("SUBST_ENTITIES", sizeof("SUBST_ENTITIES") - 1, 1);
+	zend_string *const_SUBST_ENTITIES_name = zend_string_init_interned("SUBST_ENTITIES", strlen("SUBST_ENTITIES"), 1);
 	zend_declare_typed_class_constant(class_entry, const_SUBST_ENTITIES_name, &const_SUBST_ENTITIES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_SUBST_ENTITIES_name);
 
 	zval property_attributeCount_default_value;
 	ZVAL_UNDEF(&property_attributeCount_default_value);
-	zend_string *property_attributeCount_name = zend_string_init("attributeCount", sizeof("attributeCount") - 1, 1);
+	zend_string *property_attributeCount_name = zend_string_init("attributeCount", strlen("attributeCount"), 1);
 	zend_declare_typed_property(class_entry, property_attributeCount_name, &property_attributeCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_attributeCount_name);
 
 	zval property_baseURI_default_value;
 	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", strlen("baseURI"), 1);
 	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_baseURI_name);
 
 	zval property_depth_default_value;
 	ZVAL_UNDEF(&property_depth_default_value);
-	zend_string *property_depth_name = zend_string_init("depth", sizeof("depth") - 1, 1);
+	zend_string *property_depth_name = zend_string_init("depth", strlen("depth"), 1);
 	zend_declare_typed_property(class_entry, property_depth_name, &property_depth_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_depth_name);
 
 	zval property_hasAttributes_default_value;
 	ZVAL_UNDEF(&property_hasAttributes_default_value);
-	zend_string *property_hasAttributes_name = zend_string_init("hasAttributes", sizeof("hasAttributes") - 1, 1);
+	zend_string *property_hasAttributes_name = zend_string_init("hasAttributes", strlen("hasAttributes"), 1);
 	zend_declare_typed_property(class_entry, property_hasAttributes_name, &property_hasAttributes_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_hasAttributes_name);
 
 	zval property_hasValue_default_value;
 	ZVAL_UNDEF(&property_hasValue_default_value);
-	zend_string *property_hasValue_name = zend_string_init("hasValue", sizeof("hasValue") - 1, 1);
+	zend_string *property_hasValue_name = zend_string_init("hasValue", strlen("hasValue"), 1);
 	zend_declare_typed_property(class_entry, property_hasValue_name, &property_hasValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_hasValue_name);
 
 	zval property_isDefault_default_value;
 	ZVAL_UNDEF(&property_isDefault_default_value);
-	zend_string *property_isDefault_name = zend_string_init("isDefault", sizeof("isDefault") - 1, 1);
+	zend_string *property_isDefault_name = zend_string_init("isDefault", strlen("isDefault"), 1);
 	zend_declare_typed_property(class_entry, property_isDefault_name, &property_isDefault_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isDefault_name);
 
 	zval property_isEmptyElement_default_value;
 	ZVAL_UNDEF(&property_isEmptyElement_default_value);
-	zend_string *property_isEmptyElement_name = zend_string_init("isEmptyElement", sizeof("isEmptyElement") - 1, 1);
+	zend_string *property_isEmptyElement_name = zend_string_init("isEmptyElement", strlen("isEmptyElement"), 1);
 	zend_declare_typed_property(class_entry, property_isEmptyElement_name, &property_isEmptyElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isEmptyElement_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_localName_name);
 
@@ -364,19 +364,19 @@ static zend_class_entry *register_class_XMLReader(void)
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
@@ -386,7 +386,7 @@ static zend_class_entry *register_class_XMLReader(void)
 
 	zval property_xmlLang_default_value;
 	ZVAL_UNDEF(&property_xmlLang_default_value);
-	zend_string *property_xmlLang_name = zend_string_init("xmlLang", sizeof("xmlLang") - 1, 1);
+	zend_string *property_xmlLang_name = zend_string_init("xmlLang", strlen("xmlLang"), 1);
 	zend_declare_typed_property(class_entry, property_xmlLang_name, &property_xmlLang_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_xmlLang_name);
 

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -121,25 +121,25 @@ static zend_class_entry *register_class_XSLTProcessor(void)
 
 	zval property_doXInclude_default_value;
 	ZVAL_FALSE(&property_doXInclude_default_value);
-	zend_string *property_doXInclude_name = zend_string_init("doXInclude", sizeof("doXInclude") - 1, 1);
+	zend_string *property_doXInclude_name = zend_string_init("doXInclude", strlen("doXInclude"), 1);
 	zend_declare_typed_property(class_entry, property_doXInclude_name, &property_doXInclude_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_doXInclude_name);
 
 	zval property_cloneDocument_default_value;
 	ZVAL_FALSE(&property_cloneDocument_default_value);
-	zend_string *property_cloneDocument_name = zend_string_init("cloneDocument", sizeof("cloneDocument") - 1, 1);
+	zend_string *property_cloneDocument_name = zend_string_init("cloneDocument", strlen("cloneDocument"), 1);
 	zend_declare_typed_property(class_entry, property_cloneDocument_name, &property_cloneDocument_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_cloneDocument_name);
 
 	zval property_maxTemplateDepth_default_value;
 	ZVAL_UNDEF(&property_maxTemplateDepth_default_value);
-	zend_string *property_maxTemplateDepth_name = zend_string_init("maxTemplateDepth", sizeof("maxTemplateDepth") - 1, 1);
+	zend_string *property_maxTemplateDepth_name = zend_string_init("maxTemplateDepth", strlen("maxTemplateDepth"), 1);
 	zend_declare_typed_property(class_entry, property_maxTemplateDepth_name, &property_maxTemplateDepth_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_maxTemplateDepth_name);
 
 	zval property_maxTemplateVars_default_value;
 	ZVAL_UNDEF(&property_maxTemplateVars_default_value);
-	zend_string *property_maxTemplateVars_name = zend_string_init("maxTemplateVars", sizeof("maxTemplateVars") - 1, 1);
+	zend_string *property_maxTemplateVars_name = zend_string_init("maxTemplateVars", strlen("maxTemplateVars"), 1);
 	zend_declare_typed_property(class_entry, property_maxTemplateVars_name, &property_maxTemplateVars_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_maxTemplateVars_name);
 

--- a/ext/zend_test/object_handlers_arginfo.h
+++ b/ext/zend_test/object_handlers_arginfo.h
@@ -49,7 +49,7 @@ static zend_class_entry *register_class_DoOperationNoCast(void)
 
 	zval property_val_default_value;
 	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_string *property_val_name = zend_string_init("val", strlen("val"), 1);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_val_name);
 
@@ -65,7 +65,7 @@ static zend_class_entry *register_class_LongCastableNoOperations(void)
 
 	zval property_val_default_value;
 	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_string *property_val_name = zend_string_init("val", strlen("val"), 1);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_val_name);
 
@@ -81,7 +81,7 @@ static zend_class_entry *register_class_FloatCastableNoOperations(void)
 
 	zval property_val_default_value;
 	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_string *property_val_name = zend_string_init("val", strlen("val"), 1);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(property_val_name);
 
@@ -97,7 +97,7 @@ static zend_class_entry *register_class_NumericCastableNoOperations(void)
 
 	zval property_val_default_value;
 	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_string *property_val_name = zend_string_init("val", strlen("val"), 1);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_DOUBLE));
 	zend_string_release(property_val_name);
 
@@ -113,49 +113,49 @@ static zend_class_entry *register_class_DimensionHandlersNoArrayAccess(void)
 
 	zval property_read_default_value;
 	ZVAL_FALSE(&property_read_default_value);
-	zend_string *property_read_name = zend_string_init("read", sizeof("read") - 1, 1);
+	zend_string *property_read_name = zend_string_init("read", strlen("read"), 1);
 	zend_declare_typed_property(class_entry, property_read_name, &property_read_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_read_name);
 
 	zval property_write_default_value;
 	ZVAL_FALSE(&property_write_default_value);
-	zend_string *property_write_name = zend_string_init("write", sizeof("write") - 1, 1);
+	zend_string *property_write_name = zend_string_init("write", strlen("write"), 1);
 	zend_declare_typed_property(class_entry, property_write_name, &property_write_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_write_name);
 
 	zval property_has_default_value;
 	ZVAL_FALSE(&property_has_default_value);
-	zend_string *property_has_name = zend_string_init("has", sizeof("has") - 1, 1);
+	zend_string *property_has_name = zend_string_init("has", strlen("has"), 1);
 	zend_declare_typed_property(class_entry, property_has_name, &property_has_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_has_name);
 
 	zval property_unset_default_value;
 	ZVAL_FALSE(&property_unset_default_value);
-	zend_string *property_unset_name = zend_string_init("unset", sizeof("unset") - 1, 1);
+	zend_string *property_unset_name = zend_string_init("unset", strlen("unset"), 1);
 	zend_declare_typed_property(class_entry, property_unset_name, &property_unset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_unset_name);
 
 	zval property_readType_default_value;
 	ZVAL_UNDEF(&property_readType_default_value);
-	zend_string *property_readType_name = zend_string_init("readType", sizeof("readType") - 1, 1);
+	zend_string *property_readType_name = zend_string_init("readType", strlen("readType"), 1);
 	zend_declare_typed_property(class_entry, property_readType_name, &property_readType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_readType_name);
 
 	zval property_hasOffset_default_value;
 	ZVAL_FALSE(&property_hasOffset_default_value);
-	zend_string *property_hasOffset_name = zend_string_init("hasOffset", sizeof("hasOffset") - 1, 1);
+	zend_string *property_hasOffset_name = zend_string_init("hasOffset", strlen("hasOffset"), 1);
 	zend_declare_typed_property(class_entry, property_hasOffset_name, &property_hasOffset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_hasOffset_name);
 
 	zval property_checkEmpty_default_value;
 	ZVAL_UNDEF(&property_checkEmpty_default_value);
-	zend_string *property_checkEmpty_name = zend_string_init("checkEmpty", sizeof("checkEmpty") - 1, 1);
+	zend_string *property_checkEmpty_name = zend_string_init("checkEmpty", strlen("checkEmpty"), 1);
 	zend_declare_typed_property(class_entry, property_checkEmpty_name, &property_checkEmpty_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_checkEmpty_name);
 
 	zval property_offset_default_value;
 	ZVAL_UNDEF(&property_offset_default_value);
-	zend_string *property_offset_name = zend_string_init("offset", sizeof("offset") - 1, 1);
+	zend_string *property_offset_name = zend_string_init("offset", strlen("offset"), 1);
 	zend_declare_typed_property(class_entry, property_offset_name, &property_offset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_offset_name);
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -551,8 +551,8 @@ static void register_test_symbols(int module_number)
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZendSubNS\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT);
 
 
-	zend_string *attribute_name_Deprecated_func_zend_test_deprecated_attr_0 = zend_string_init_interned("Deprecated", sizeof("Deprecated") - 1, 1);
-	zend_attribute *attribute_Deprecated_func_zend_test_deprecated_attr_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_deprecated_attr", sizeof("zend_test_deprecated_attr") - 1), attribute_name_Deprecated_func_zend_test_deprecated_attr_0, 1);
+	zend_string *attribute_name_Deprecated_func_zend_test_deprecated_attr_0 = zend_string_init_interned("Deprecated", strlen("Deprecated"), 1);
+	zend_attribute *attribute_Deprecated_func_zend_test_deprecated_attr_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_deprecated_attr", strlen("zend_test_deprecated_attr")), attribute_name_Deprecated_func_zend_test_deprecated_attr_0, 1);
 	zend_string_release(attribute_name_Deprecated_func_zend_test_deprecated_attr_0);
 	zval attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0;
 	zend_string *attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0_str = zend_string_init("custom message", strlen("custom message"), 1);
@@ -560,22 +560,22 @@ static void register_test_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zend_test_deprecated_attr_0->args[0].value, &attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0);
 	attribute_Deprecated_func_zend_test_deprecated_attr_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_string *attribute_name_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", sizeof("ZendTestParameterAttribute") - 1, 1);
-	zend_attribute *attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_parameter_with_attribute", sizeof("zend_test_parameter_with_attribute") - 1), 0, attribute_name_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0, 1);
+	zend_string *attribute_name_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", strlen("ZendTestParameterAttribute"), 1);
+	zend_attribute *attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_parameter_with_attribute", strlen("zend_test_parameter_with_attribute")), 0, attribute_name_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0, 1);
 	zend_string_release(attribute_name_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0);
 	zval attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0_arg0;
 	zend_string *attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0_arg0_str = zend_string_init("value1", strlen("value1"), 1);
 	ZVAL_STR(&attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0_arg0, attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0->args[0].value, &attribute_ZendTestParameterAttribute_func_zend_test_parameter_with_attribute_arg0_0_arg0);
 
-	zend_string *attribute_name_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0 = zend_string_init_interned("ZendTestAttributeWithArguments", sizeof("ZendTestAttributeWithArguments") - 1, 1);
-	zend_attribute *attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_attribute_with_named_argument", sizeof("zend_test_attribute_with_named_argument") - 1), attribute_name_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0, 1);
+	zend_string *attribute_name_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0 = zend_string_init_interned("ZendTestAttributeWithArguments", strlen("ZendTestAttributeWithArguments"), 1);
+	zend_attribute *attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_attribute_with_named_argument", strlen("zend_test_attribute_with_named_argument")), attribute_name_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0, 1);
 	zend_string_release(attribute_name_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0);
 	zval attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0;
 	zend_string *attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0_str = zend_string_init("foo", strlen("foo"), 1);
 	ZVAL_STR(&attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0, attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0->args[0].value, &attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0);
-	attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0->args[0].name = zend_string_init_interned("arg", sizeof("arg") - 1, 1);
+	attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0->args[0].name = zend_string_init_interned("arg", strlen("arg"), 1);
 }
 
 static zend_class_entry *register_class__ZendTestInterface(void)
@@ -587,7 +587,7 @@ static zend_class_entry *register_class__ZendTestInterface(void)
 
 	zval const_DUMMY_value;
 	ZVAL_LONG(&const_DUMMY_value, 0);
-	zend_string *const_DUMMY_name = zend_string_init_interned("DUMMY", sizeof("DUMMY") - 1, 1);
+	zend_string *const_DUMMY_name = zend_string_init_interned("DUMMY", strlen("DUMMY"), 1);
 	zend_string *const_DUMMY_comment = zend_string_init_interned("/**\n         * \"Lorem ipsum\"\n         * @see https://www.php.net\n         * @since 8.2\n         */", 98, 1);
 	zend_declare_class_constant_ex(class_entry, const_DUMMY_name, &const_DUMMY_value, ZEND_ACC_PUBLIC, const_DUMMY_comment);
 	zend_string_release(const_DUMMY_name);
@@ -610,7 +610,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval const_TYPED_CLASS_CONST1_value;
 	ZVAL_EMPTY_ARRAY(&const_TYPED_CLASS_CONST1_value);
-	zend_string *const_TYPED_CLASS_CONST1_name = zend_string_init_interned("TYPED_CLASS_CONST1", sizeof("TYPED_CLASS_CONST1") - 1, 1);
+	zend_string *const_TYPED_CLASS_CONST1_name = zend_string_init_interned("TYPED_CLASS_CONST1", strlen("TYPED_CLASS_CONST1"), 1);
 #if (PHP_VERSION_ID >= 80300)
 	zend_declare_typed_class_constant(class_entry, const_TYPED_CLASS_CONST1_name, &const_TYPED_CLASS_CONST1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 #else
@@ -620,7 +620,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval const_TYPED_CLASS_CONST2_value;
 	ZVAL_LONG(&const_TYPED_CLASS_CONST2_value, 42);
-	zend_string *const_TYPED_CLASS_CONST2_name = zend_string_init_interned("TYPED_CLASS_CONST2", sizeof("TYPED_CLASS_CONST2") - 1, 1);
+	zend_string *const_TYPED_CLASS_CONST2_name = zend_string_init_interned("TYPED_CLASS_CONST2", strlen("TYPED_CLASS_CONST2"), 1);
 #if (PHP_VERSION_ID >= 80300)
 	zend_declare_typed_class_constant(class_entry, const_TYPED_CLASS_CONST2_name, &const_TYPED_CLASS_CONST2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_ARRAY));
 #else
@@ -630,7 +630,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval const_TYPED_CLASS_CONST3_value;
 	ZVAL_LONG(&const_TYPED_CLASS_CONST3_value, 1);
-	zend_string *const_TYPED_CLASS_CONST3_name = zend_string_init_interned("TYPED_CLASS_CONST3", sizeof("TYPED_CLASS_CONST3") - 1, 1);
+	zend_string *const_TYPED_CLASS_CONST3_name = zend_string_init_interned("TYPED_CLASS_CONST3", strlen("TYPED_CLASS_CONST3"), 1);
 #if (PHP_VERSION_ID >= 80300)
 	zend_declare_typed_class_constant(class_entry, const_TYPED_CLASS_CONST3_name, &const_TYPED_CLASS_CONST3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 #else
@@ -640,7 +640,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval const_ZEND_TEST_DEPRECATED_value;
 	ZVAL_LONG(&const_ZEND_TEST_DEPRECATED_value, 42);
-	zend_string *const_ZEND_TEST_DEPRECATED_name = zend_string_init_interned("ZEND_TEST_DEPRECATED", sizeof("ZEND_TEST_DEPRECATED") - 1, 1);
+	zend_string *const_ZEND_TEST_DEPRECATED_name = zend_string_init_interned("ZEND_TEST_DEPRECATED", strlen("ZEND_TEST_DEPRECATED"), 1);
 #if (PHP_VERSION_ID >= 80300)
 	zend_declare_typed_class_constant(class_entry, const_ZEND_TEST_DEPRECATED_name, &const_ZEND_TEST_DEPRECATED_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 #else
@@ -650,7 +650,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval const_ZEND_TEST_DEPRECATED_ATTR_value;
 	ZVAL_LONG(&const_ZEND_TEST_DEPRECATED_ATTR_value, 42);
-	zend_string *const_ZEND_TEST_DEPRECATED_ATTR_name = zend_string_init_interned("ZEND_TEST_DEPRECATED_ATTR", sizeof("ZEND_TEST_DEPRECATED_ATTR") - 1, 1);
+	zend_string *const_ZEND_TEST_DEPRECATED_ATTR_name = zend_string_init_interned("ZEND_TEST_DEPRECATED_ATTR", strlen("ZEND_TEST_DEPRECATED_ATTR"), 1);
 #if (PHP_VERSION_ID >= 80300)
 	zend_class_constant *const_ZEND_TEST_DEPRECATED_ATTR = zend_declare_typed_class_constant(class_entry, const_ZEND_TEST_DEPRECATED_ATTR_name, &const_ZEND_TEST_DEPRECATED_ATTR_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 #else
@@ -660,34 +660,34 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval property__StaticProp_default_value;
 	ZVAL_NULL(&property__StaticProp_default_value);
-	zend_string *property__StaticProp_name = zend_string_init("_StaticProp", sizeof("_StaticProp") - 1, 1);
+	zend_string *property__StaticProp_name = zend_string_init("_StaticProp", strlen("_StaticProp"), 1);
 	zend_declare_typed_property(class_entry, property__StaticProp_name, &property__StaticProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property__StaticProp_name);
 
 	zval property_staticIntProp_default_value;
 	ZVAL_LONG(&property_staticIntProp_default_value, 123);
-	zend_string *property_staticIntProp_name = zend_string_init("staticIntProp", sizeof("staticIntProp") - 1, 1);
+	zend_string *property_staticIntProp_name = zend_string_init("staticIntProp", strlen("staticIntProp"), 1);
 	zend_declare_typed_property(class_entry, property_staticIntProp_name, &property_staticIntProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_staticIntProp_name);
 
 	zval property_intProp_default_value;
 	ZVAL_LONG(&property_intProp_default_value, 123);
-	zend_string *property_intProp_name = zend_string_init("intProp", sizeof("intProp") - 1, 1);
+	zend_string *property_intProp_name = zend_string_init("intProp", strlen("intProp"), 1);
 	zend_declare_typed_property(class_entry, property_intProp_name, &property_intProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_intProp_name);
 
 	zval property_classProp_default_value;
 	ZVAL_NULL(&property_classProp_default_value);
-	zend_string *property_classProp_name = zend_string_init("classProp", sizeof("classProp") - 1, 1);
-	zend_string *property_classProp_class_stdClass = zend_string_init("stdClass", sizeof("stdClass")-1, 1);
+	zend_string *property_classProp_name = zend_string_init("classProp", strlen("classProp"), 1);
+	zend_string *property_classProp_class_stdClass = zend_string_init("stdClass", strlen("stdClass"), 1);
 	zend_declare_typed_property(class_entry, property_classProp_name, &property_classProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_classProp_class_stdClass, 0, MAY_BE_NULL));
 	zend_string_release(property_classProp_name);
 
 	zval property_classUnionProp_default_value;
 	ZVAL_NULL(&property_classUnionProp_default_value);
-	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", sizeof("classUnionProp") - 1, 1);
-	zend_string *property_classUnionProp_class_stdClass = zend_string_init("stdClass", sizeof("stdClass") - 1, 1);
-	zend_string *property_classUnionProp_class_Iterator = zend_string_init("Iterator", sizeof("Iterator") - 1, 1);
+	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", strlen("classUnionProp"), 1);
+	zend_string *property_classUnionProp_class_stdClass = zend_string_init("stdClass", strlen("stdClass"), 1);
+	zend_string *property_classUnionProp_class_Iterator = zend_string_init("Iterator", strlen("Iterator"), 1);
 	zend_type_list *property_classUnionProp_type_list = malloc(ZEND_TYPE_LIST_SIZE(2));
 	property_classUnionProp_type_list->num_types = 2;
 	property_classUnionProp_type_list->types[0] = (zend_type) ZEND_TYPE_INIT_CLASS(property_classUnionProp_class_stdClass, 0, 0);
@@ -698,9 +698,9 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval property_classIntersectionProp_default_value;
 	ZVAL_UNDEF(&property_classIntersectionProp_default_value);
-	zend_string *property_classIntersectionProp_name = zend_string_init("classIntersectionProp", sizeof("classIntersectionProp") - 1, 1);
-	zend_string *property_classIntersectionProp_class_Traversable = zend_string_init("Traversable", sizeof("Traversable") - 1, 1);
-	zend_string *property_classIntersectionProp_class_Countable = zend_string_init("Countable", sizeof("Countable") - 1, 1);
+	zend_string *property_classIntersectionProp_name = zend_string_init("classIntersectionProp", strlen("classIntersectionProp"), 1);
+	zend_string *property_classIntersectionProp_class_Traversable = zend_string_init("Traversable", strlen("Traversable"), 1);
+	zend_string *property_classIntersectionProp_class_Countable = zend_string_init("Countable", strlen("Countable"), 1);
 	zend_type_list *property_classIntersectionProp_type_list = malloc(ZEND_TYPE_LIST_SIZE(2));
 	property_classIntersectionProp_type_list->num_types = 2;
 	property_classIntersectionProp_type_list->types[0] = (zend_type) ZEND_TYPE_INIT_CLASS(property_classIntersectionProp_class_Traversable, 0, 0);
@@ -711,7 +711,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval property_readonlyProp_default_value;
 	ZVAL_UNDEF(&property_readonlyProp_default_value);
-	zend_string *property_readonlyProp_name = zend_string_init("readonlyProp", sizeof("readonlyProp") - 1, 1);
+	zend_string *property_readonlyProp_name = zend_string_init("readonlyProp", strlen("readonlyProp"), 1);
 #if (PHP_VERSION_ID >= 80100)
 	zend_declare_typed_property(class_entry, property_readonlyProp_name, &property_readonlyProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 #elif (PHP_VERSION_ID >= 80000)
@@ -720,7 +720,7 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 	zend_string_release(property_readonlyProp_name);
 
 
-	zend_string *attribute_name_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0 = zend_string_init_interned("Deprecated", sizeof("Deprecated") - 1, 1);
+	zend_string *attribute_name_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0 = zend_string_init_interned("Deprecated", strlen("Deprecated"), 1);
 	zend_attribute *attribute_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0 = zend_add_class_constant_attribute(class_entry, const_ZEND_TEST_DEPRECATED_ATTR, attribute_name_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0, 1);
 	zend_string_release(attribute_name_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0);
 	zval attribute_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0_arg0;
@@ -787,31 +787,31 @@ static zend_class_entry *register_class_ZendAttributeTest(void)
 
 	zval const_TEST_CONST_value;
 	ZVAL_LONG(&const_TEST_CONST_value, 1);
-	zend_string *const_TEST_CONST_name = zend_string_init_interned("TEST_CONST", sizeof("TEST_CONST") - 1, 1);
+	zend_string *const_TEST_CONST_name = zend_string_init_interned("TEST_CONST", strlen("TEST_CONST"), 1);
 	zend_class_constant *const_TEST_CONST = zend_declare_class_constant_ex(class_entry, const_TEST_CONST_name, &const_TEST_CONST_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_TEST_CONST_name);
 
 	zval property_testProp_default_value;
 	ZVAL_NULL(&property_testProp_default_value);
-	zend_string *property_testProp_name = zend_string_init("testProp", sizeof("testProp") - 1, 1);
+	zend_string *property_testProp_name = zend_string_init("testProp", strlen("testProp"), 1);
 	zend_property_info *property_testProp = zend_declare_typed_property(class_entry, property_testProp_name, &property_testProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_testProp_name);
 
 
-	zend_string *attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_0 = zend_string_init_interned("ZendTestRepeatableAttribute", sizeof("ZendTestRepeatableAttribute") - 1, 1);
+	zend_string *attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_0 = zend_string_init_interned("ZendTestRepeatableAttribute", strlen("ZendTestRepeatableAttribute"), 1);
 	zend_add_class_constant_attribute(class_entry, const_TEST_CONST, attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_0, 0);
 	zend_string_release(attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_0);
 
-	zend_string *attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_1 = zend_string_init_interned("ZendTestRepeatableAttribute", sizeof("ZendTestRepeatableAttribute") - 1, 1);
+	zend_string *attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_1 = zend_string_init_interned("ZendTestRepeatableAttribute", strlen("ZendTestRepeatableAttribute"), 1);
 	zend_add_class_constant_attribute(class_entry, const_TEST_CONST, attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_1, 0);
 	zend_string_release(attribute_name_ZendTestRepeatableAttribute_const_TEST_CONST_1);
 
 
-	zend_string *attribute_name_ZendTestRepeatableAttribute_property_testProp_0 = zend_string_init_interned("ZendTestRepeatableAttribute", sizeof("ZendTestRepeatableAttribute") - 1, 1);
+	zend_string *attribute_name_ZendTestRepeatableAttribute_property_testProp_0 = zend_string_init_interned("ZendTestRepeatableAttribute", strlen("ZendTestRepeatableAttribute"), 1);
 	zend_add_property_attribute(class_entry, property_testProp, attribute_name_ZendTestRepeatableAttribute_property_testProp_0, 0);
 	zend_string_release(attribute_name_ZendTestRepeatableAttribute_property_testProp_0);
 
-	zend_string *attribute_name_ZendTestPropertyAttribute_property_testProp_1 = zend_string_init_interned("ZendTestPropertyAttribute", sizeof("ZendTestPropertyAttribute") - 1, 1);
+	zend_string *attribute_name_ZendTestPropertyAttribute_property_testProp_1 = zend_string_init_interned("ZendTestPropertyAttribute", strlen("ZendTestPropertyAttribute"), 1);
 	zend_attribute *attribute_ZendTestPropertyAttribute_property_testProp_1 = zend_add_property_attribute(class_entry, property_testProp, attribute_name_ZendTestPropertyAttribute_property_testProp_1, 1);
 	zend_string_release(attribute_name_ZendTestPropertyAttribute_property_testProp_1);
 	zval attribute_ZendTestPropertyAttribute_property_testProp_1_arg0;
@@ -820,8 +820,8 @@ static zend_class_entry *register_class_ZendAttributeTest(void)
 	ZVAL_COPY_VALUE(&attribute_ZendTestPropertyAttribute_property_testProp_1->args[0].value, &attribute_ZendTestPropertyAttribute_property_testProp_1_arg0);
 
 
-	zend_string *attribute_name_ZendTestAttribute_func_testmethod_0 = zend_string_init_interned("ZendTestAttribute", sizeof("ZendTestAttribute") - 1, 1);
-	zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "testmethod", sizeof("testmethod") - 1), attribute_name_ZendTestAttribute_func_testmethod_0, 0);
+	zend_string *attribute_name_ZendTestAttribute_func_testmethod_0 = zend_string_init_interned("ZendTestAttribute", strlen("ZendTestAttribute"), 1);
+	zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "testmethod", strlen("testmethod")), attribute_name_ZendTestAttribute_func_testmethod_0, 0);
 	zend_string_release(attribute_name_ZendTestAttribute_func_testmethod_0);
 
 	return class_entry;
@@ -841,15 +841,15 @@ static zend_class_entry *register_class__ZendTestTrait(void)
 
 	zval property_testProp_default_value;
 	ZVAL_NULL(&property_testProp_default_value);
-	zend_string *property_testProp_name = zend_string_init("testProp", sizeof("testProp") - 1, 1);
+	zend_string *property_testProp_name = zend_string_init("testProp", strlen("testProp"), 1);
 	zend_declare_typed_property(class_entry, property_testProp_name, &property_testProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_testProp_name);
 
 	zval property_classUnionProp_default_value;
 	ZVAL_UNDEF(&property_classUnionProp_default_value);
-	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", sizeof("classUnionProp") - 1, 1);
-	zend_string *property_classUnionProp_class_Traversable = zend_string_init("Traversable", sizeof("Traversable") - 1, 1);
-	zend_string *property_classUnionProp_class_Countable = zend_string_init("Countable", sizeof("Countable") - 1, 1);
+	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", strlen("classUnionProp"), 1);
+	zend_string *property_classUnionProp_class_Traversable = zend_string_init("Traversable", strlen("Traversable"), 1);
+	zend_string *property_classUnionProp_class_Countable = zend_string_init("Countable", strlen("Countable"), 1);
 	zend_type_list *property_classUnionProp_type_list = malloc(ZEND_TYPE_LIST_SIZE(2));
 	property_classUnionProp_type_list->num_types = 2;
 	property_classUnionProp_type_list->types[0] = (zend_type) ZEND_TYPE_INIT_CLASS(property_classUnionProp_class_Traversable, 0, 0);
@@ -873,7 +873,7 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 #endif
 
-	zend_string *attribute_name_Attribute_class_ZendTestAttribute_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ZendTestAttribute_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ZendTestAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestAttribute_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestAttribute_0);
 	zval attribute_Attribute_class_ZendTestAttribute_0_arg0;
@@ -897,7 +897,7 @@ static zend_class_entry *register_class_ZendTestAttributeWithArguments(void)
 
 	zval property_arg_default_value;
 	ZVAL_UNDEF(&property_arg_default_value);
-	zend_string *property_arg_name = zend_string_init("arg", sizeof("arg") - 1, 1);
+	zend_string *property_arg_name = zend_string_init("arg", strlen("arg"), 1);
 #if (PHP_VERSION_ID >= 80100)
 	zend_declare_typed_property(class_entry, property_arg_name, &property_arg_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 #elif (PHP_VERSION_ID >= 80000)
@@ -905,7 +905,7 @@ static zend_class_entry *register_class_ZendTestAttributeWithArguments(void)
 #endif
 	zend_string_release(property_arg_name);
 
-	zend_string *attribute_name_Attribute_class_ZendTestAttributeWithArguments_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ZendTestAttributeWithArguments_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ZendTestAttributeWithArguments_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestAttributeWithArguments_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestAttributeWithArguments_0);
 	zval attribute_Attribute_class_ZendTestAttributeWithArguments_0_arg0;
@@ -927,7 +927,7 @@ static zend_class_entry *register_class_ZendTestRepeatableAttribute(void)
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 #endif
 
-	zend_string *attribute_name_Attribute_class_ZendTestRepeatableAttribute_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ZendTestRepeatableAttribute_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ZendTestRepeatableAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestRepeatableAttribute_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestRepeatableAttribute_0);
 	zval attribute_Attribute_class_ZendTestRepeatableAttribute_0_arg0;
@@ -951,11 +951,11 @@ static zend_class_entry *register_class_ZendTestParameterAttribute(void)
 
 	zval property_parameter_default_value;
 	ZVAL_UNDEF(&property_parameter_default_value);
-	zend_string *property_parameter_name = zend_string_init("parameter", sizeof("parameter") - 1, 1);
+	zend_string *property_parameter_name = zend_string_init("parameter", strlen("parameter"), 1);
 	zend_declare_typed_property(class_entry, property_parameter_name, &property_parameter_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_parameter_name);
 
-	zend_string *attribute_name_Attribute_class_ZendTestParameterAttribute_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ZendTestParameterAttribute_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ZendTestParameterAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestParameterAttribute_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestParameterAttribute_0);
 	zval attribute_Attribute_class_ZendTestParameterAttribute_0_arg0;
@@ -982,12 +982,12 @@ static zend_class_entry *register_class_ZendTestPropertyAttribute(void)
 
 	zval property_parameter_default_value;
 	ZVAL_UNDEF(&property_parameter_default_value);
-	zend_string *property_parameter_name = zend_string_init("parameter", sizeof("parameter") - 1, 1);
+	zend_string *property_parameter_name = zend_string_init("parameter", strlen("parameter"), 1);
 	zend_string *property_parameter_comment = zend_string_init_interned("/**\n         * \"Lorem ipsum\"\n         * @see https://www.php.net\n         * @since 8.4\n         */", 98, 1);
 	zend_declare_typed_property(class_entry, property_parameter_name, &property_parameter_default_value, ZEND_ACC_PUBLIC, property_parameter_comment, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_parameter_name);
 
-	zend_string *attribute_name_Attribute_class_ZendTestPropertyAttribute_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_string *attribute_name_Attribute_class_ZendTestPropertyAttribute_0 = zend_string_init_interned("Attribute", strlen("Attribute"), 1);
 	zend_attribute *attribute_Attribute_class_ZendTestPropertyAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestPropertyAttribute_0, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestPropertyAttribute_0);
 	zval attribute_Attribute_class_ZendTestPropertyAttribute_0_arg0;
@@ -1009,16 +1009,16 @@ static zend_class_entry *register_class_ZendTestClassWithMethodWithParameterAttr
 #endif
 
 
-	zend_string *attribute_name_ZendTestParameterAttribute_func_no_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", sizeof("ZendTestParameterAttribute") - 1, 1);
-	zend_attribute *attribute_ZendTestParameterAttribute_func_no_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "no_override", sizeof("no_override") - 1), 0, attribute_name_ZendTestParameterAttribute_func_no_override_arg0_0, 1);
+	zend_string *attribute_name_ZendTestParameterAttribute_func_no_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", strlen("ZendTestParameterAttribute"), 1);
+	zend_attribute *attribute_ZendTestParameterAttribute_func_no_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "no_override", strlen("no_override")), 0, attribute_name_ZendTestParameterAttribute_func_no_override_arg0_0, 1);
 	zend_string_release(attribute_name_ZendTestParameterAttribute_func_no_override_arg0_0);
 	zval attribute_ZendTestParameterAttribute_func_no_override_arg0_0_arg0;
 	zend_string *attribute_ZendTestParameterAttribute_func_no_override_arg0_0_arg0_str = zend_string_init("value2", strlen("value2"), 1);
 	ZVAL_STR(&attribute_ZendTestParameterAttribute_func_no_override_arg0_0_arg0, attribute_ZendTestParameterAttribute_func_no_override_arg0_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_ZendTestParameterAttribute_func_no_override_arg0_0->args[0].value, &attribute_ZendTestParameterAttribute_func_no_override_arg0_0_arg0);
 
-	zend_string *attribute_name_ZendTestParameterAttribute_func_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", sizeof("ZendTestParameterAttribute") - 1, 1);
-	zend_attribute *attribute_ZendTestParameterAttribute_func_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "override", sizeof("override") - 1), 0, attribute_name_ZendTestParameterAttribute_func_override_arg0_0, 1);
+	zend_string *attribute_name_ZendTestParameterAttribute_func_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", strlen("ZendTestParameterAttribute"), 1);
+	zend_attribute *attribute_ZendTestParameterAttribute_func_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "override", strlen("override")), 0, attribute_name_ZendTestParameterAttribute_func_override_arg0_0, 1);
 	zend_string_release(attribute_name_ZendTestParameterAttribute_func_override_arg0_0);
 	zval attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0;
 	zend_string *attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str = zend_string_init("value3", strlen("value3"), 1);
@@ -1040,8 +1040,8 @@ static zend_class_entry *register_class_ZendTestChildClassWithMethodWithParamete
 #endif
 
 
-	zend_string *attribute_name_ZendTestParameterAttribute_func_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", sizeof("ZendTestParameterAttribute") - 1, 1);
-	zend_attribute *attribute_ZendTestParameterAttribute_func_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "override", sizeof("override") - 1), 0, attribute_name_ZendTestParameterAttribute_func_override_arg0_0, 1);
+	zend_string *attribute_name_ZendTestParameterAttribute_func_override_arg0_0 = zend_string_init_interned("ZendTestParameterAttribute", strlen("ZendTestParameterAttribute"), 1);
+	zend_attribute *attribute_ZendTestParameterAttribute_func_override_arg0_0 = zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "override", strlen("override")), 0, attribute_name_ZendTestParameterAttribute_func_override_arg0_0, 1);
 	zend_string_release(attribute_name_ZendTestParameterAttribute_func_override_arg0_0);
 	zval attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0;
 	zend_string *attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str = zend_string_init("value4", strlen("value4"), 1);
@@ -1064,12 +1064,12 @@ static zend_class_entry *register_class_ZendTestClassWithPropertyAttribute(void)
 
 	zval property_attributed_default_value;
 	ZVAL_UNDEF(&property_attributed_default_value);
-	zend_string *property_attributed_name = zend_string_init("attributed", sizeof("attributed") - 1, 1);
+	zend_string *property_attributed_name = zend_string_init("attributed", strlen("attributed"), 1);
 	zend_property_info *property_attributed = zend_declare_typed_property(class_entry, property_attributed_name, &property_attributed_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_attributed_name);
 
 
-	zend_string *attribute_name_ZendTestAttribute_property_attributed_0 = zend_string_init_interned("ZendTestAttribute", sizeof("ZendTestAttribute") - 1, 1);
+	zend_string *attribute_name_ZendTestAttribute_property_attributed_0 = zend_string_init_interned("ZendTestAttribute", strlen("ZendTestAttribute"), 1);
 	zend_add_property_attribute(class_entry, property_attributed, attribute_name_ZendTestAttribute_property_attributed_0, 0);
 	zend_string_release(attribute_name_ZendTestAttribute_property_attributed_0);
 
@@ -1209,8 +1209,8 @@ static zend_class_entry *register_class_ZendTestNS2_Foo(void)
 
 	zval property_foo_default_value;
 	ZVAL_UNDEF(&property_foo_default_value);
-	zend_string *property_foo_name = zend_string_init("foo", sizeof("foo") - 1, 1);
-	zend_string *property_foo_class_ZendTestNS2_ZendSubNS_Foo = zend_string_init("ZendTestNS2\\ZendSubNS\\Foo", sizeof("ZendTestNS2\\ZendSubNS\\Foo")-1, 1);
+	zend_string *property_foo_name = zend_string_init("foo", strlen("foo"), 1);
+	zend_string *property_foo_class_ZendTestNS2_ZendSubNS_Foo = zend_string_init("ZendTestNS2\\ZendSubNS\\Foo", strlen("ZendTestNS2\\ZendSubNS\\Foo"), 1);
 	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS2_ZendSubNS_Foo, 0, 0));
 	zend_string_release(property_foo_name);
 

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -464,7 +464,7 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 static void register_php_zip_symbols(int module_number)
 {
 
-	zend_attribute *attribute_Deprecated_func_zip_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_open", sizeof("zip_open") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_open", strlen("zip_open")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_open_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_open_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_open_0_arg0, attribute_Deprecated_func_zip_open_0_arg0_str);
@@ -476,7 +476,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_open_0->args[1].value, &attribute_Deprecated_func_zip_open_0_arg1);
 	attribute_Deprecated_func_zip_open_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_close", sizeof("zip_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_close", strlen("zip_close")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_close_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_close_0_arg0, attribute_Deprecated_func_zip_close_0_arg0_str);
@@ -488,7 +488,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_close_0->args[1].value, &attribute_Deprecated_func_zip_close_0_arg1);
 	attribute_Deprecated_func_zip_close_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_read", sizeof("zip_read") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_read", strlen("zip_read")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_read_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_read_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_read_0_arg0, attribute_Deprecated_func_zip_read_0_arg0_str);
@@ -500,21 +500,21 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_read_0->args[1].value, &attribute_Deprecated_func_zip_read_0_arg1);
 	attribute_Deprecated_func_zip_read_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_open", sizeof("zip_entry_open") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_zip_entry_open_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_open", strlen("zip_entry_open")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_zip_entry_open_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_open_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_open_0_arg0, attribute_Deprecated_func_zip_entry_open_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_open_0->args[0].value, &attribute_Deprecated_func_zip_entry_open_0_arg0);
 	attribute_Deprecated_func_zip_entry_open_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_close", sizeof("zip_entry_close") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
+	zend_attribute *attribute_Deprecated_func_zip_entry_close_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_close", strlen("zip_entry_close")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	zval attribute_Deprecated_func_zip_entry_close_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_close_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_close_0_arg0, attribute_Deprecated_func_zip_entry_close_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_close_0->args[0].value, &attribute_Deprecated_func_zip_entry_close_0_arg0);
 	attribute_Deprecated_func_zip_entry_close_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_read", sizeof("zip_entry_read") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_entry_read_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_read", strlen("zip_entry_read")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_entry_read_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_read_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_read_0_arg0, attribute_Deprecated_func_zip_entry_read_0_arg0_str);
@@ -526,7 +526,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_read_0->args[1].value, &attribute_Deprecated_func_zip_entry_read_0_arg1);
 	attribute_Deprecated_func_zip_entry_read_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_name", sizeof("zip_entry_name") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_entry_name_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_name", strlen("zip_entry_name")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_entry_name_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_name_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_name_0_arg0, attribute_Deprecated_func_zip_entry_name_0_arg0_str);
@@ -538,7 +538,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_name_0->args[1].value, &attribute_Deprecated_func_zip_entry_name_0_arg1);
 	attribute_Deprecated_func_zip_entry_name_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_compressedsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressedsize", sizeof("zip_entry_compressedsize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_entry_compressedsize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressedsize", strlen("zip_entry_compressedsize")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_entry_compressedsize_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_compressedsize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressedsize_0_arg0, attribute_Deprecated_func_zip_entry_compressedsize_0_arg0_str);
@@ -550,7 +550,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_compressedsize_0->args[1].value, &attribute_Deprecated_func_zip_entry_compressedsize_0_arg1);
 	attribute_Deprecated_func_zip_entry_compressedsize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_filesize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_filesize", sizeof("zip_entry_filesize") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_entry_filesize_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_filesize", strlen("zip_entry_filesize")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_entry_filesize_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_filesize_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_filesize_0_arg0, attribute_Deprecated_func_zip_entry_filesize_0_arg0_str);
@@ -562,7 +562,7 @@ static void register_php_zip_symbols(int module_number)
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zip_entry_filesize_0->args[1].value, &attribute_Deprecated_func_zip_entry_filesize_0_arg1);
 	attribute_Deprecated_func_zip_entry_filesize_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
-	zend_attribute *attribute_Deprecated_func_zip_entry_compressionmethod_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressionmethod", sizeof("zip_entry_compressionmethod") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zend_attribute *attribute_Deprecated_func_zip_entry_compressionmethod_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zip_entry_compressionmethod", strlen("zip_entry_compressionmethod")), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	zval attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0;
 	zend_string *attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0_str = zend_string_init("8.0", strlen("8.0"), 1);
 	ZVAL_STR(&attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0, attribute_Deprecated_func_zip_entry_compressionmethod_0_arg0_str);
@@ -585,210 +585,210 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_CREATE_value;
 	ZVAL_LONG(&const_CREATE_value, ZIP_CREATE);
-	zend_string *const_CREATE_name = zend_string_init_interned("CREATE", sizeof("CREATE") - 1, 1);
+	zend_string *const_CREATE_name = zend_string_init_interned("CREATE", strlen("CREATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CREATE_name, &const_CREATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_name);
 
 	zval const_EXCL_value;
 	ZVAL_LONG(&const_EXCL_value, ZIP_EXCL);
-	zend_string *const_EXCL_name = zend_string_init_interned("EXCL", sizeof("EXCL") - 1, 1);
+	zend_string *const_EXCL_name = zend_string_init_interned("EXCL", strlen("EXCL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EXCL_name, &const_EXCL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXCL_name);
 
 	zval const_CHECKCONS_value;
 	ZVAL_LONG(&const_CHECKCONS_value, ZIP_CHECKCONS);
-	zend_string *const_CHECKCONS_name = zend_string_init_interned("CHECKCONS", sizeof("CHECKCONS") - 1, 1);
+	zend_string *const_CHECKCONS_name = zend_string_init_interned("CHECKCONS", strlen("CHECKCONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CHECKCONS_name, &const_CHECKCONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHECKCONS_name);
 
 	zval const_OVERWRITE_value;
 	ZVAL_LONG(&const_OVERWRITE_value, ZIP_OVERWRITE);
-	zend_string *const_OVERWRITE_name = zend_string_init_interned("OVERWRITE", sizeof("OVERWRITE") - 1, 1);
+	zend_string *const_OVERWRITE_name = zend_string_init_interned("OVERWRITE", strlen("OVERWRITE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OVERWRITE_name, &const_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OVERWRITE_name);
 #if defined(ZIP_RDONLY)
 
 	zval const_RDONLY_value;
 	ZVAL_LONG(&const_RDONLY_value, ZIP_RDONLY);
-	zend_string *const_RDONLY_name = zend_string_init_interned("RDONLY", sizeof("RDONLY") - 1, 1);
+	zend_string *const_RDONLY_name = zend_string_init_interned("RDONLY", strlen("RDONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_RDONLY_name, &const_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RDONLY_name);
 #endif
 
 	zval const_FL_NOCASE_value;
 	ZVAL_LONG(&const_FL_NOCASE_value, ZIP_FL_NOCASE);
-	zend_string *const_FL_NOCASE_name = zend_string_init_interned("FL_NOCASE", sizeof("FL_NOCASE") - 1, 1);
+	zend_string *const_FL_NOCASE_name = zend_string_init_interned("FL_NOCASE", strlen("FL_NOCASE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_NOCASE_name, &const_FL_NOCASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_NOCASE_name);
 
 	zval const_FL_NODIR_value;
 	ZVAL_LONG(&const_FL_NODIR_value, ZIP_FL_NODIR);
-	zend_string *const_FL_NODIR_name = zend_string_init_interned("FL_NODIR", sizeof("FL_NODIR") - 1, 1);
+	zend_string *const_FL_NODIR_name = zend_string_init_interned("FL_NODIR", strlen("FL_NODIR"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_NODIR_name, &const_FL_NODIR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_NODIR_name);
 
 	zval const_FL_COMPRESSED_value;
 	ZVAL_LONG(&const_FL_COMPRESSED_value, ZIP_FL_COMPRESSED);
-	zend_string *const_FL_COMPRESSED_name = zend_string_init_interned("FL_COMPRESSED", sizeof("FL_COMPRESSED") - 1, 1);
+	zend_string *const_FL_COMPRESSED_name = zend_string_init_interned("FL_COMPRESSED", strlen("FL_COMPRESSED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_COMPRESSED_name, &const_FL_COMPRESSED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_COMPRESSED_name);
 
 	zval const_FL_UNCHANGED_value;
 	ZVAL_LONG(&const_FL_UNCHANGED_value, ZIP_FL_UNCHANGED);
-	zend_string *const_FL_UNCHANGED_name = zend_string_init_interned("FL_UNCHANGED", sizeof("FL_UNCHANGED") - 1, 1);
+	zend_string *const_FL_UNCHANGED_name = zend_string_init_interned("FL_UNCHANGED", strlen("FL_UNCHANGED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_UNCHANGED_name, &const_FL_UNCHANGED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_UNCHANGED_name);
 #if defined(ZIP_FL_RECOMPRESS)
 
 	zval const_FL_RECOMPRESS_value;
 	ZVAL_LONG(&const_FL_RECOMPRESS_value, ZIP_FL_RECOMPRESS);
-	zend_string *const_FL_RECOMPRESS_name = zend_string_init_interned("FL_RECOMPRESS", sizeof("FL_RECOMPRESS") - 1, 1);
+	zend_string *const_FL_RECOMPRESS_name = zend_string_init_interned("FL_RECOMPRESS", strlen("FL_RECOMPRESS"), 1);
 	zend_class_constant *const_FL_RECOMPRESS = zend_declare_typed_class_constant(class_entry, const_FL_RECOMPRESS_name, &const_FL_RECOMPRESS_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_RECOMPRESS_name);
 #endif
 
 	zval const_FL_ENCRYPTED_value;
 	ZVAL_LONG(&const_FL_ENCRYPTED_value, ZIP_FL_ENCRYPTED);
-	zend_string *const_FL_ENCRYPTED_name = zend_string_init_interned("FL_ENCRYPTED", sizeof("FL_ENCRYPTED") - 1, 1);
+	zend_string *const_FL_ENCRYPTED_name = zend_string_init_interned("FL_ENCRYPTED", strlen("FL_ENCRYPTED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENCRYPTED_name, &const_FL_ENCRYPTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENCRYPTED_name);
 
 	zval const_FL_OVERWRITE_value;
 	ZVAL_LONG(&const_FL_OVERWRITE_value, ZIP_FL_OVERWRITE);
-	zend_string *const_FL_OVERWRITE_name = zend_string_init_interned("FL_OVERWRITE", sizeof("FL_OVERWRITE") - 1, 1);
+	zend_string *const_FL_OVERWRITE_name = zend_string_init_interned("FL_OVERWRITE", strlen("FL_OVERWRITE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_OVERWRITE_name, &const_FL_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_OVERWRITE_name);
 
 	zval const_FL_LOCAL_value;
 	ZVAL_LONG(&const_FL_LOCAL_value, ZIP_FL_LOCAL);
-	zend_string *const_FL_LOCAL_name = zend_string_init_interned("FL_LOCAL", sizeof("FL_LOCAL") - 1, 1);
+	zend_string *const_FL_LOCAL_name = zend_string_init_interned("FL_LOCAL", strlen("FL_LOCAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_LOCAL_name, &const_FL_LOCAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_LOCAL_name);
 
 	zval const_FL_CENTRAL_value;
 	ZVAL_LONG(&const_FL_CENTRAL_value, ZIP_FL_CENTRAL);
-	zend_string *const_FL_CENTRAL_name = zend_string_init_interned("FL_CENTRAL", sizeof("FL_CENTRAL") - 1, 1);
+	zend_string *const_FL_CENTRAL_name = zend_string_init_interned("FL_CENTRAL", strlen("FL_CENTRAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_CENTRAL_name, &const_FL_CENTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_CENTRAL_name);
 
 	zval const_FL_ENC_GUESS_value;
 	ZVAL_LONG(&const_FL_ENC_GUESS_value, ZIP_FL_ENC_GUESS);
-	zend_string *const_FL_ENC_GUESS_name = zend_string_init_interned("FL_ENC_GUESS", sizeof("FL_ENC_GUESS") - 1, 1);
+	zend_string *const_FL_ENC_GUESS_name = zend_string_init_interned("FL_ENC_GUESS", strlen("FL_ENC_GUESS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENC_GUESS_name, &const_FL_ENC_GUESS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_GUESS_name);
 
 	zval const_FL_ENC_RAW_value;
 	ZVAL_LONG(&const_FL_ENC_RAW_value, ZIP_FL_ENC_RAW);
-	zend_string *const_FL_ENC_RAW_name = zend_string_init_interned("FL_ENC_RAW", sizeof("FL_ENC_RAW") - 1, 1);
+	zend_string *const_FL_ENC_RAW_name = zend_string_init_interned("FL_ENC_RAW", strlen("FL_ENC_RAW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENC_RAW_name, &const_FL_ENC_RAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_RAW_name);
 
 	zval const_FL_ENC_STRICT_value;
 	ZVAL_LONG(&const_FL_ENC_STRICT_value, ZIP_FL_ENC_STRICT);
-	zend_string *const_FL_ENC_STRICT_name = zend_string_init_interned("FL_ENC_STRICT", sizeof("FL_ENC_STRICT") - 1, 1);
+	zend_string *const_FL_ENC_STRICT_name = zend_string_init_interned("FL_ENC_STRICT", strlen("FL_ENC_STRICT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENC_STRICT_name, &const_FL_ENC_STRICT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_STRICT_name);
 
 	zval const_FL_ENC_UTF_8_value;
 	ZVAL_LONG(&const_FL_ENC_UTF_8_value, ZIP_FL_ENC_UTF_8);
-	zend_string *const_FL_ENC_UTF_8_name = zend_string_init_interned("FL_ENC_UTF_8", sizeof("FL_ENC_UTF_8") - 1, 1);
+	zend_string *const_FL_ENC_UTF_8_name = zend_string_init_interned("FL_ENC_UTF_8", strlen("FL_ENC_UTF_8"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENC_UTF_8_name, &const_FL_ENC_UTF_8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_UTF_8_name);
 
 	zval const_FL_ENC_CP437_value;
 	ZVAL_LONG(&const_FL_ENC_CP437_value, ZIP_FL_ENC_CP437);
-	zend_string *const_FL_ENC_CP437_name = zend_string_init_interned("FL_ENC_CP437", sizeof("FL_ENC_CP437") - 1, 1);
+	zend_string *const_FL_ENC_CP437_name = zend_string_init_interned("FL_ENC_CP437", strlen("FL_ENC_CP437"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_ENC_CP437_name, &const_FL_ENC_CP437_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_CP437_name);
 
 	zval const_FL_OPEN_FILE_NOW_value;
 	ZVAL_LONG(&const_FL_OPEN_FILE_NOW_value, ZIP_FL_OPEN_FILE_NOW);
-	zend_string *const_FL_OPEN_FILE_NOW_name = zend_string_init_interned("FL_OPEN_FILE_NOW", sizeof("FL_OPEN_FILE_NOW") - 1, 1);
+	zend_string *const_FL_OPEN_FILE_NOW_name = zend_string_init_interned("FL_OPEN_FILE_NOW", strlen("FL_OPEN_FILE_NOW"), 1);
 	zend_declare_typed_class_constant(class_entry, const_FL_OPEN_FILE_NOW_name, &const_FL_OPEN_FILE_NOW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_OPEN_FILE_NOW_name);
 
 	zval const_CM_DEFAULT_value;
 	ZVAL_LONG(&const_CM_DEFAULT_value, ZIP_CM_DEFAULT);
-	zend_string *const_CM_DEFAULT_name = zend_string_init_interned("CM_DEFAULT", sizeof("CM_DEFAULT") - 1, 1);
+	zend_string *const_CM_DEFAULT_name = zend_string_init_interned("CM_DEFAULT", strlen("CM_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_DEFAULT_name, &const_CM_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFAULT_name);
 
 	zval const_CM_STORE_value;
 	ZVAL_LONG(&const_CM_STORE_value, ZIP_CM_STORE);
-	zend_string *const_CM_STORE_name = zend_string_init_interned("CM_STORE", sizeof("CM_STORE") - 1, 1);
+	zend_string *const_CM_STORE_name = zend_string_init_interned("CM_STORE", strlen("CM_STORE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_STORE_name, &const_CM_STORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_STORE_name);
 
 	zval const_CM_SHRINK_value;
 	ZVAL_LONG(&const_CM_SHRINK_value, ZIP_CM_SHRINK);
-	zend_string *const_CM_SHRINK_name = zend_string_init_interned("CM_SHRINK", sizeof("CM_SHRINK") - 1, 1);
+	zend_string *const_CM_SHRINK_name = zend_string_init_interned("CM_SHRINK", strlen("CM_SHRINK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_SHRINK_name, &const_CM_SHRINK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_SHRINK_name);
 
 	zval const_CM_REDUCE_1_value;
 	ZVAL_LONG(&const_CM_REDUCE_1_value, ZIP_CM_REDUCE_1);
-	zend_string *const_CM_REDUCE_1_name = zend_string_init_interned("CM_REDUCE_1", sizeof("CM_REDUCE_1") - 1, 1);
+	zend_string *const_CM_REDUCE_1_name = zend_string_init_interned("CM_REDUCE_1", strlen("CM_REDUCE_1"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_1_name, &const_CM_REDUCE_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_1_name);
 
 	zval const_CM_REDUCE_2_value;
 	ZVAL_LONG(&const_CM_REDUCE_2_value, ZIP_CM_REDUCE_2);
-	zend_string *const_CM_REDUCE_2_name = zend_string_init_interned("CM_REDUCE_2", sizeof("CM_REDUCE_2") - 1, 1);
+	zend_string *const_CM_REDUCE_2_name = zend_string_init_interned("CM_REDUCE_2", strlen("CM_REDUCE_2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_2_name, &const_CM_REDUCE_2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_2_name);
 
 	zval const_CM_REDUCE_3_value;
 	ZVAL_LONG(&const_CM_REDUCE_3_value, ZIP_CM_REDUCE_3);
-	zend_string *const_CM_REDUCE_3_name = zend_string_init_interned("CM_REDUCE_3", sizeof("CM_REDUCE_3") - 1, 1);
+	zend_string *const_CM_REDUCE_3_name = zend_string_init_interned("CM_REDUCE_3", strlen("CM_REDUCE_3"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_3_name, &const_CM_REDUCE_3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_3_name);
 
 	zval const_CM_REDUCE_4_value;
 	ZVAL_LONG(&const_CM_REDUCE_4_value, ZIP_CM_REDUCE_4);
-	zend_string *const_CM_REDUCE_4_name = zend_string_init_interned("CM_REDUCE_4", sizeof("CM_REDUCE_4") - 1, 1);
+	zend_string *const_CM_REDUCE_4_name = zend_string_init_interned("CM_REDUCE_4", strlen("CM_REDUCE_4"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_4_name, &const_CM_REDUCE_4_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_4_name);
 
 	zval const_CM_IMPLODE_value;
 	ZVAL_LONG(&const_CM_IMPLODE_value, ZIP_CM_IMPLODE);
-	zend_string *const_CM_IMPLODE_name = zend_string_init_interned("CM_IMPLODE", sizeof("CM_IMPLODE") - 1, 1);
+	zend_string *const_CM_IMPLODE_name = zend_string_init_interned("CM_IMPLODE", strlen("CM_IMPLODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_IMPLODE_name, &const_CM_IMPLODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_IMPLODE_name);
 
 	zval const_CM_DEFLATE_value;
 	ZVAL_LONG(&const_CM_DEFLATE_value, ZIP_CM_DEFLATE);
-	zend_string *const_CM_DEFLATE_name = zend_string_init_interned("CM_DEFLATE", sizeof("CM_DEFLATE") - 1, 1);
+	zend_string *const_CM_DEFLATE_name = zend_string_init_interned("CM_DEFLATE", strlen("CM_DEFLATE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_DEFLATE_name, &const_CM_DEFLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFLATE_name);
 
 	zval const_CM_DEFLATE64_value;
 	ZVAL_LONG(&const_CM_DEFLATE64_value, ZIP_CM_DEFLATE64);
-	zend_string *const_CM_DEFLATE64_name = zend_string_init_interned("CM_DEFLATE64", sizeof("CM_DEFLATE64") - 1, 1);
+	zend_string *const_CM_DEFLATE64_name = zend_string_init_interned("CM_DEFLATE64", strlen("CM_DEFLATE64"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_DEFLATE64_name, &const_CM_DEFLATE64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFLATE64_name);
 
 	zval const_CM_PKWARE_IMPLODE_value;
 	ZVAL_LONG(&const_CM_PKWARE_IMPLODE_value, ZIP_CM_PKWARE_IMPLODE);
-	zend_string *const_CM_PKWARE_IMPLODE_name = zend_string_init_interned("CM_PKWARE_IMPLODE", sizeof("CM_PKWARE_IMPLODE") - 1, 1);
+	zend_string *const_CM_PKWARE_IMPLODE_name = zend_string_init_interned("CM_PKWARE_IMPLODE", strlen("CM_PKWARE_IMPLODE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_PKWARE_IMPLODE_name, &const_CM_PKWARE_IMPLODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_PKWARE_IMPLODE_name);
 
 	zval const_CM_BZIP2_value;
 	ZVAL_LONG(&const_CM_BZIP2_value, ZIP_CM_BZIP2);
-	zend_string *const_CM_BZIP2_name = zend_string_init_interned("CM_BZIP2", sizeof("CM_BZIP2") - 1, 1);
+	zend_string *const_CM_BZIP2_name = zend_string_init_interned("CM_BZIP2", strlen("CM_BZIP2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_BZIP2_name, &const_CM_BZIP2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_BZIP2_name);
 
 	zval const_CM_LZMA_value;
 	ZVAL_LONG(&const_CM_LZMA_value, ZIP_CM_LZMA);
-	zend_string *const_CM_LZMA_name = zend_string_init_interned("CM_LZMA", sizeof("CM_LZMA") - 1, 1);
+	zend_string *const_CM_LZMA_name = zend_string_init_interned("CM_LZMA", strlen("CM_LZMA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_LZMA_name, &const_CM_LZMA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZMA_name);
 #if defined(ZIP_CM_LZMA2)
 
 	zval const_CM_LZMA2_value;
 	ZVAL_LONG(&const_CM_LZMA2_value, ZIP_CM_LZMA2);
-	zend_string *const_CM_LZMA2_name = zend_string_init_interned("CM_LZMA2", sizeof("CM_LZMA2") - 1, 1);
+	zend_string *const_CM_LZMA2_name = zend_string_init_interned("CM_LZMA2", strlen("CM_LZMA2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_LZMA2_name, &const_CM_LZMA2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZMA2_name);
 #endif
@@ -796,7 +796,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_CM_ZSTD_value;
 	ZVAL_LONG(&const_CM_ZSTD_value, ZIP_CM_ZSTD);
-	zend_string *const_CM_ZSTD_name = zend_string_init_interned("CM_ZSTD", sizeof("CM_ZSTD") - 1, 1);
+	zend_string *const_CM_ZSTD_name = zend_string_init_interned("CM_ZSTD", strlen("CM_ZSTD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_ZSTD_name, &const_CM_ZSTD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_ZSTD_name);
 #endif
@@ -804,207 +804,207 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_CM_XZ_value;
 	ZVAL_LONG(&const_CM_XZ_value, ZIP_CM_XZ);
-	zend_string *const_CM_XZ_name = zend_string_init_interned("CM_XZ", sizeof("CM_XZ") - 1, 1);
+	zend_string *const_CM_XZ_name = zend_string_init_interned("CM_XZ", strlen("CM_XZ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_XZ_name, &const_CM_XZ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_XZ_name);
 #endif
 
 	zval const_CM_TERSE_value;
 	ZVAL_LONG(&const_CM_TERSE_value, ZIP_CM_TERSE);
-	zend_string *const_CM_TERSE_name = zend_string_init_interned("CM_TERSE", sizeof("CM_TERSE") - 1, 1);
+	zend_string *const_CM_TERSE_name = zend_string_init_interned("CM_TERSE", strlen("CM_TERSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_TERSE_name, &const_CM_TERSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_TERSE_name);
 
 	zval const_CM_LZ77_value;
 	ZVAL_LONG(&const_CM_LZ77_value, ZIP_CM_LZ77);
-	zend_string *const_CM_LZ77_name = zend_string_init_interned("CM_LZ77", sizeof("CM_LZ77") - 1, 1);
+	zend_string *const_CM_LZ77_name = zend_string_init_interned("CM_LZ77", strlen("CM_LZ77"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_LZ77_name, &const_CM_LZ77_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZ77_name);
 
 	zval const_CM_WAVPACK_value;
 	ZVAL_LONG(&const_CM_WAVPACK_value, ZIP_CM_WAVPACK);
-	zend_string *const_CM_WAVPACK_name = zend_string_init_interned("CM_WAVPACK", sizeof("CM_WAVPACK") - 1, 1);
+	zend_string *const_CM_WAVPACK_name = zend_string_init_interned("CM_WAVPACK", strlen("CM_WAVPACK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_WAVPACK_name, &const_CM_WAVPACK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_WAVPACK_name);
 
 	zval const_CM_PPMD_value;
 	ZVAL_LONG(&const_CM_PPMD_value, ZIP_CM_PPMD);
-	zend_string *const_CM_PPMD_name = zend_string_init_interned("CM_PPMD", sizeof("CM_PPMD") - 1, 1);
+	zend_string *const_CM_PPMD_name = zend_string_init_interned("CM_PPMD", strlen("CM_PPMD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_CM_PPMD_name, &const_CM_PPMD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_PPMD_name);
 
 	zval const_ER_OK_value;
 	ZVAL_LONG(&const_ER_OK_value, ZIP_ER_OK);
-	zend_string *const_ER_OK_name = zend_string_init_interned("ER_OK", sizeof("ER_OK") - 1, 1);
+	zend_string *const_ER_OK_name = zend_string_init_interned("ER_OK", strlen("ER_OK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_OK_name, &const_ER_OK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OK_name);
 
 	zval const_ER_MULTIDISK_value;
 	ZVAL_LONG(&const_ER_MULTIDISK_value, ZIP_ER_MULTIDISK);
-	zend_string *const_ER_MULTIDISK_name = zend_string_init_interned("ER_MULTIDISK", sizeof("ER_MULTIDISK") - 1, 1);
+	zend_string *const_ER_MULTIDISK_name = zend_string_init_interned("ER_MULTIDISK", strlen("ER_MULTIDISK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_MULTIDISK_name, &const_ER_MULTIDISK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_MULTIDISK_name);
 
 	zval const_ER_RENAME_value;
 	ZVAL_LONG(&const_ER_RENAME_value, ZIP_ER_RENAME);
-	zend_string *const_ER_RENAME_name = zend_string_init_interned("ER_RENAME", sizeof("ER_RENAME") - 1, 1);
+	zend_string *const_ER_RENAME_name = zend_string_init_interned("ER_RENAME", strlen("ER_RENAME"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_RENAME_name, &const_ER_RENAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_RENAME_name);
 
 	zval const_ER_CLOSE_value;
 	ZVAL_LONG(&const_ER_CLOSE_value, ZIP_ER_CLOSE);
-	zend_string *const_ER_CLOSE_name = zend_string_init_interned("ER_CLOSE", sizeof("ER_CLOSE") - 1, 1);
+	zend_string *const_ER_CLOSE_name = zend_string_init_interned("ER_CLOSE", strlen("ER_CLOSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_CLOSE_name, &const_ER_CLOSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CLOSE_name);
 
 	zval const_ER_SEEK_value;
 	ZVAL_LONG(&const_ER_SEEK_value, ZIP_ER_SEEK);
-	zend_string *const_ER_SEEK_name = zend_string_init_interned("ER_SEEK", sizeof("ER_SEEK") - 1, 1);
+	zend_string *const_ER_SEEK_name = zend_string_init_interned("ER_SEEK", strlen("ER_SEEK"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_SEEK_name, &const_ER_SEEK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_SEEK_name);
 
 	zval const_ER_READ_value;
 	ZVAL_LONG(&const_ER_READ_value, ZIP_ER_READ);
-	zend_string *const_ER_READ_name = zend_string_init_interned("ER_READ", sizeof("ER_READ") - 1, 1);
+	zend_string *const_ER_READ_name = zend_string_init_interned("ER_READ", strlen("ER_READ"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_READ_name, &const_ER_READ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_READ_name);
 
 	zval const_ER_WRITE_value;
 	ZVAL_LONG(&const_ER_WRITE_value, ZIP_ER_WRITE);
-	zend_string *const_ER_WRITE_name = zend_string_init_interned("ER_WRITE", sizeof("ER_WRITE") - 1, 1);
+	zend_string *const_ER_WRITE_name = zend_string_init_interned("ER_WRITE", strlen("ER_WRITE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_WRITE_name, &const_ER_WRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_WRITE_name);
 
 	zval const_ER_CRC_value;
 	ZVAL_LONG(&const_ER_CRC_value, ZIP_ER_CRC);
-	zend_string *const_ER_CRC_name = zend_string_init_interned("ER_CRC", sizeof("ER_CRC") - 1, 1);
+	zend_string *const_ER_CRC_name = zend_string_init_interned("ER_CRC", strlen("ER_CRC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_CRC_name, &const_ER_CRC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CRC_name);
 
 	zval const_ER_ZIPCLOSED_value;
 	ZVAL_LONG(&const_ER_ZIPCLOSED_value, ZIP_ER_ZIPCLOSED);
-	zend_string *const_ER_ZIPCLOSED_name = zend_string_init_interned("ER_ZIPCLOSED", sizeof("ER_ZIPCLOSED") - 1, 1);
+	zend_string *const_ER_ZIPCLOSED_name = zend_string_init_interned("ER_ZIPCLOSED", strlen("ER_ZIPCLOSED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_ZIPCLOSED_name, &const_ER_ZIPCLOSED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ZIPCLOSED_name);
 
 	zval const_ER_NOENT_value;
 	ZVAL_LONG(&const_ER_NOENT_value, ZIP_ER_NOENT);
-	zend_string *const_ER_NOENT_name = zend_string_init_interned("ER_NOENT", sizeof("ER_NOENT") - 1, 1);
+	zend_string *const_ER_NOENT_name = zend_string_init_interned("ER_NOENT", strlen("ER_NOENT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_NOENT_name, &const_ER_NOENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOENT_name);
 
 	zval const_ER_EXISTS_value;
 	ZVAL_LONG(&const_ER_EXISTS_value, ZIP_ER_EXISTS);
-	zend_string *const_ER_EXISTS_name = zend_string_init_interned("ER_EXISTS", sizeof("ER_EXISTS") - 1, 1);
+	zend_string *const_ER_EXISTS_name = zend_string_init_interned("ER_EXISTS", strlen("ER_EXISTS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_EXISTS_name, &const_ER_EXISTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_EXISTS_name);
 
 	zval const_ER_OPEN_value;
 	ZVAL_LONG(&const_ER_OPEN_value, ZIP_ER_OPEN);
-	zend_string *const_ER_OPEN_name = zend_string_init_interned("ER_OPEN", sizeof("ER_OPEN") - 1, 1);
+	zend_string *const_ER_OPEN_name = zend_string_init_interned("ER_OPEN", strlen("ER_OPEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_OPEN_name, &const_ER_OPEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OPEN_name);
 
 	zval const_ER_TMPOPEN_value;
 	ZVAL_LONG(&const_ER_TMPOPEN_value, ZIP_ER_TMPOPEN);
-	zend_string *const_ER_TMPOPEN_name = zend_string_init_interned("ER_TMPOPEN", sizeof("ER_TMPOPEN") - 1, 1);
+	zend_string *const_ER_TMPOPEN_name = zend_string_init_interned("ER_TMPOPEN", strlen("ER_TMPOPEN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_TMPOPEN_name, &const_ER_TMPOPEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_TMPOPEN_name);
 
 	zval const_ER_ZLIB_value;
 	ZVAL_LONG(&const_ER_ZLIB_value, ZIP_ER_ZLIB);
-	zend_string *const_ER_ZLIB_name = zend_string_init_interned("ER_ZLIB", sizeof("ER_ZLIB") - 1, 1);
+	zend_string *const_ER_ZLIB_name = zend_string_init_interned("ER_ZLIB", strlen("ER_ZLIB"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_ZLIB_name, &const_ER_ZLIB_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ZLIB_name);
 
 	zval const_ER_MEMORY_value;
 	ZVAL_LONG(&const_ER_MEMORY_value, ZIP_ER_MEMORY);
-	zend_string *const_ER_MEMORY_name = zend_string_init_interned("ER_MEMORY", sizeof("ER_MEMORY") - 1, 1);
+	zend_string *const_ER_MEMORY_name = zend_string_init_interned("ER_MEMORY", strlen("ER_MEMORY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_MEMORY_name, &const_ER_MEMORY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_MEMORY_name);
 
 	zval const_ER_CHANGED_value;
 	ZVAL_LONG(&const_ER_CHANGED_value, ZIP_ER_CHANGED);
-	zend_string *const_ER_CHANGED_name = zend_string_init_interned("ER_CHANGED", sizeof("ER_CHANGED") - 1, 1);
+	zend_string *const_ER_CHANGED_name = zend_string_init_interned("ER_CHANGED", strlen("ER_CHANGED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_CHANGED_name, &const_ER_CHANGED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CHANGED_name);
 
 	zval const_ER_COMPNOTSUPP_value;
 	ZVAL_LONG(&const_ER_COMPNOTSUPP_value, ZIP_ER_COMPNOTSUPP);
-	zend_string *const_ER_COMPNOTSUPP_name = zend_string_init_interned("ER_COMPNOTSUPP", sizeof("ER_COMPNOTSUPP") - 1, 1);
+	zend_string *const_ER_COMPNOTSUPP_name = zend_string_init_interned("ER_COMPNOTSUPP", strlen("ER_COMPNOTSUPP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_COMPNOTSUPP_name, &const_ER_COMPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_COMPNOTSUPP_name);
 
 	zval const_ER_EOF_value;
 	ZVAL_LONG(&const_ER_EOF_value, ZIP_ER_EOF);
-	zend_string *const_ER_EOF_name = zend_string_init_interned("ER_EOF", sizeof("ER_EOF") - 1, 1);
+	zend_string *const_ER_EOF_name = zend_string_init_interned("ER_EOF", strlen("ER_EOF"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_EOF_name, &const_ER_EOF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_EOF_name);
 
 	zval const_ER_INVAL_value;
 	ZVAL_LONG(&const_ER_INVAL_value, ZIP_ER_INVAL);
-	zend_string *const_ER_INVAL_name = zend_string_init_interned("ER_INVAL", sizeof("ER_INVAL") - 1, 1);
+	zend_string *const_ER_INVAL_name = zend_string_init_interned("ER_INVAL", strlen("ER_INVAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_INVAL_name, &const_ER_INVAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INVAL_name);
 
 	zval const_ER_NOZIP_value;
 	ZVAL_LONG(&const_ER_NOZIP_value, ZIP_ER_NOZIP);
-	zend_string *const_ER_NOZIP_name = zend_string_init_interned("ER_NOZIP", sizeof("ER_NOZIP") - 1, 1);
+	zend_string *const_ER_NOZIP_name = zend_string_init_interned("ER_NOZIP", strlen("ER_NOZIP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_NOZIP_name, &const_ER_NOZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOZIP_name);
 
 	zval const_ER_INTERNAL_value;
 	ZVAL_LONG(&const_ER_INTERNAL_value, ZIP_ER_INTERNAL);
-	zend_string *const_ER_INTERNAL_name = zend_string_init_interned("ER_INTERNAL", sizeof("ER_INTERNAL") - 1, 1);
+	zend_string *const_ER_INTERNAL_name = zend_string_init_interned("ER_INTERNAL", strlen("ER_INTERNAL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_INTERNAL_name, &const_ER_INTERNAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INTERNAL_name);
 
 	zval const_ER_INCONS_value;
 	ZVAL_LONG(&const_ER_INCONS_value, ZIP_ER_INCONS);
-	zend_string *const_ER_INCONS_name = zend_string_init_interned("ER_INCONS", sizeof("ER_INCONS") - 1, 1);
+	zend_string *const_ER_INCONS_name = zend_string_init_interned("ER_INCONS", strlen("ER_INCONS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_INCONS_name, &const_ER_INCONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INCONS_name);
 
 	zval const_ER_REMOVE_value;
 	ZVAL_LONG(&const_ER_REMOVE_value, ZIP_ER_REMOVE);
-	zend_string *const_ER_REMOVE_name = zend_string_init_interned("ER_REMOVE", sizeof("ER_REMOVE") - 1, 1);
+	zend_string *const_ER_REMOVE_name = zend_string_init_interned("ER_REMOVE", strlen("ER_REMOVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_REMOVE_name, &const_ER_REMOVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_REMOVE_name);
 
 	zval const_ER_DELETED_value;
 	ZVAL_LONG(&const_ER_DELETED_value, ZIP_ER_DELETED);
-	zend_string *const_ER_DELETED_name = zend_string_init_interned("ER_DELETED", sizeof("ER_DELETED") - 1, 1);
+	zend_string *const_ER_DELETED_name = zend_string_init_interned("ER_DELETED", strlen("ER_DELETED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_DELETED_name, &const_ER_DELETED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_DELETED_name);
 
 	zval const_ER_ENCRNOTSUPP_value;
 	ZVAL_LONG(&const_ER_ENCRNOTSUPP_value, ZIP_ER_ENCRNOTSUPP);
-	zend_string *const_ER_ENCRNOTSUPP_name = zend_string_init_interned("ER_ENCRNOTSUPP", sizeof("ER_ENCRNOTSUPP") - 1, 1);
+	zend_string *const_ER_ENCRNOTSUPP_name = zend_string_init_interned("ER_ENCRNOTSUPP", strlen("ER_ENCRNOTSUPP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_ENCRNOTSUPP_name, &const_ER_ENCRNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ENCRNOTSUPP_name);
 
 	zval const_ER_RDONLY_value;
 	ZVAL_LONG(&const_ER_RDONLY_value, ZIP_ER_RDONLY);
-	zend_string *const_ER_RDONLY_name = zend_string_init_interned("ER_RDONLY", sizeof("ER_RDONLY") - 1, 1);
+	zend_string *const_ER_RDONLY_name = zend_string_init_interned("ER_RDONLY", strlen("ER_RDONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_RDONLY_name, &const_ER_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_RDONLY_name);
 
 	zval const_ER_NOPASSWD_value;
 	ZVAL_LONG(&const_ER_NOPASSWD_value, ZIP_ER_NOPASSWD);
-	zend_string *const_ER_NOPASSWD_name = zend_string_init_interned("ER_NOPASSWD", sizeof("ER_NOPASSWD") - 1, 1);
+	zend_string *const_ER_NOPASSWD_name = zend_string_init_interned("ER_NOPASSWD", strlen("ER_NOPASSWD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_NOPASSWD_name, &const_ER_NOPASSWD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOPASSWD_name);
 
 	zval const_ER_WRONGPASSWD_value;
 	ZVAL_LONG(&const_ER_WRONGPASSWD_value, ZIP_ER_WRONGPASSWD);
-	zend_string *const_ER_WRONGPASSWD_name = zend_string_init_interned("ER_WRONGPASSWD", sizeof("ER_WRONGPASSWD") - 1, 1);
+	zend_string *const_ER_WRONGPASSWD_name = zend_string_init_interned("ER_WRONGPASSWD", strlen("ER_WRONGPASSWD"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_WRONGPASSWD_name, &const_ER_WRONGPASSWD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_WRONGPASSWD_name);
 #if defined(ZIP_ER_OPNOTSUPP)
 
 	zval const_ER_OPNOTSUPP_value;
 	ZVAL_LONG(&const_ER_OPNOTSUPP_value, ZIP_ER_OPNOTSUPP);
-	zend_string *const_ER_OPNOTSUPP_name = zend_string_init_interned("ER_OPNOTSUPP", sizeof("ER_OPNOTSUPP") - 1, 1);
+	zend_string *const_ER_OPNOTSUPP_name = zend_string_init_interned("ER_OPNOTSUPP", strlen("ER_OPNOTSUPP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_OPNOTSUPP_name, &const_ER_OPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OPNOTSUPP_name);
 #endif
@@ -1012,7 +1012,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_INUSE_value;
 	ZVAL_LONG(&const_ER_INUSE_value, ZIP_ER_INUSE);
-	zend_string *const_ER_INUSE_name = zend_string_init_interned("ER_INUSE", sizeof("ER_INUSE") - 1, 1);
+	zend_string *const_ER_INUSE_name = zend_string_init_interned("ER_INUSE", strlen("ER_INUSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_INUSE_name, &const_ER_INUSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INUSE_name);
 #endif
@@ -1020,7 +1020,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_TELL_value;
 	ZVAL_LONG(&const_ER_TELL_value, ZIP_ER_TELL);
-	zend_string *const_ER_TELL_name = zend_string_init_interned("ER_TELL", sizeof("ER_TELL") - 1, 1);
+	zend_string *const_ER_TELL_name = zend_string_init_interned("ER_TELL", strlen("ER_TELL"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_TELL_name, &const_ER_TELL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_TELL_name);
 #endif
@@ -1028,7 +1028,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_COMPRESSED_DATA_value;
 	ZVAL_LONG(&const_ER_COMPRESSED_DATA_value, ZIP_ER_COMPRESSED_DATA);
-	zend_string *const_ER_COMPRESSED_DATA_name = zend_string_init_interned("ER_COMPRESSED_DATA", sizeof("ER_COMPRESSED_DATA") - 1, 1);
+	zend_string *const_ER_COMPRESSED_DATA_name = zend_string_init_interned("ER_COMPRESSED_DATA", strlen("ER_COMPRESSED_DATA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_COMPRESSED_DATA_name, &const_ER_COMPRESSED_DATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_COMPRESSED_DATA_name);
 #endif
@@ -1036,7 +1036,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_CANCELLED_value;
 	ZVAL_LONG(&const_ER_CANCELLED_value, ZIP_ER_CANCELLED);
-	zend_string *const_ER_CANCELLED_name = zend_string_init_interned("ER_CANCELLED", sizeof("ER_CANCELLED") - 1, 1);
+	zend_string *const_ER_CANCELLED_name = zend_string_init_interned("ER_CANCELLED", strlen("ER_CANCELLED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_CANCELLED_name, &const_ER_CANCELLED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CANCELLED_name);
 #endif
@@ -1044,7 +1044,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_DATA_LENGTH_value;
 	ZVAL_LONG(&const_ER_DATA_LENGTH_value, ZIP_ER_DATA_LENGTH);
-	zend_string *const_ER_DATA_LENGTH_name = zend_string_init_interned("ER_DATA_LENGTH", sizeof("ER_DATA_LENGTH") - 1, 1);
+	zend_string *const_ER_DATA_LENGTH_name = zend_string_init_interned("ER_DATA_LENGTH", strlen("ER_DATA_LENGTH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_DATA_LENGTH_name, &const_ER_DATA_LENGTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_DATA_LENGTH_name);
 #endif
@@ -1052,7 +1052,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_NOT_ALLOWED_value;
 	ZVAL_LONG(&const_ER_NOT_ALLOWED_value, ZIP_ER_NOT_ALLOWED);
-	zend_string *const_ER_NOT_ALLOWED_name = zend_string_init_interned("ER_NOT_ALLOWED", sizeof("ER_NOT_ALLOWED") - 1, 1);
+	zend_string *const_ER_NOT_ALLOWED_name = zend_string_init_interned("ER_NOT_ALLOWED", strlen("ER_NOT_ALLOWED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_NOT_ALLOWED_name, &const_ER_NOT_ALLOWED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOT_ALLOWED_name);
 #endif
@@ -1060,7 +1060,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_ER_TRUNCATED_ZIP_value;
 	ZVAL_LONG(&const_ER_TRUNCATED_ZIP_value, ZIP_ER_TRUNCATED_ZIP);
-	zend_string *const_ER_TRUNCATED_ZIP_name = zend_string_init_interned("ER_TRUNCATED_ZIP", sizeof("ER_TRUNCATED_ZIP") - 1, 1);
+	zend_string *const_ER_TRUNCATED_ZIP_name = zend_string_init_interned("ER_TRUNCATED_ZIP", strlen("ER_TRUNCATED_ZIP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_ER_TRUNCATED_ZIP_name, &const_ER_TRUNCATED_ZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_TRUNCATED_ZIP_name);
 #endif
@@ -1068,7 +1068,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_AFL_RDONLY_value;
 	ZVAL_LONG(&const_AFL_RDONLY_value, ZIP_AFL_RDONLY);
-	zend_string *const_AFL_RDONLY_name = zend_string_init_interned("AFL_RDONLY", sizeof("AFL_RDONLY") - 1, 1);
+	zend_string *const_AFL_RDONLY_name = zend_string_init_interned("AFL_RDONLY", strlen("AFL_RDONLY"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AFL_RDONLY_name, &const_AFL_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_RDONLY_name);
 #endif
@@ -1076,7 +1076,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_AFL_IS_TORRENTZIP_value;
 	ZVAL_LONG(&const_AFL_IS_TORRENTZIP_value, ZIP_AFL_IS_TORRENTZIP);
-	zend_string *const_AFL_IS_TORRENTZIP_name = zend_string_init_interned("AFL_IS_TORRENTZIP", sizeof("AFL_IS_TORRENTZIP") - 1, 1);
+	zend_string *const_AFL_IS_TORRENTZIP_name = zend_string_init_interned("AFL_IS_TORRENTZIP", strlen("AFL_IS_TORRENTZIP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AFL_IS_TORRENTZIP_name, &const_AFL_IS_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_IS_TORRENTZIP_name);
 #endif
@@ -1084,7 +1084,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_AFL_WANT_TORRENTZIP_value;
 	ZVAL_LONG(&const_AFL_WANT_TORRENTZIP_value, ZIP_AFL_WANT_TORRENTZIP);
-	zend_string *const_AFL_WANT_TORRENTZIP_name = zend_string_init_interned("AFL_WANT_TORRENTZIP", sizeof("AFL_WANT_TORRENTZIP") - 1, 1);
+	zend_string *const_AFL_WANT_TORRENTZIP_name = zend_string_init_interned("AFL_WANT_TORRENTZIP", strlen("AFL_WANT_TORRENTZIP"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AFL_WANT_TORRENTZIP_name, &const_AFL_WANT_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_WANT_TORRENTZIP_name);
 #endif
@@ -1092,7 +1092,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value;
 	ZVAL_LONG(&const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value, ZIP_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE);
-	zend_string *const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name = zend_string_init_interned("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE", sizeof("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE") - 1, 1);
+	zend_string *const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name = zend_string_init_interned("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE", strlen("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name, &const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name);
 #endif
@@ -1100,7 +1100,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_DOS_value;
 	ZVAL_LONG(&const_OPSYS_DOS_value, ZIP_OPSYS_DOS);
-	zend_string *const_OPSYS_DOS_name = zend_string_init_interned("OPSYS_DOS", sizeof("OPSYS_DOS") - 1, 1);
+	zend_string *const_OPSYS_DOS_name = zend_string_init_interned("OPSYS_DOS", strlen("OPSYS_DOS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_DOS_name, &const_OPSYS_DOS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_DOS_name);
 #endif
@@ -1108,7 +1108,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_AMIGA_value;
 	ZVAL_LONG(&const_OPSYS_AMIGA_value, ZIP_OPSYS_AMIGA);
-	zend_string *const_OPSYS_AMIGA_name = zend_string_init_interned("OPSYS_AMIGA", sizeof("OPSYS_AMIGA") - 1, 1);
+	zend_string *const_OPSYS_AMIGA_name = zend_string_init_interned("OPSYS_AMIGA", strlen("OPSYS_AMIGA"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_AMIGA_name, &const_OPSYS_AMIGA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_AMIGA_name);
 #endif
@@ -1116,7 +1116,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_OPENVMS_value;
 	ZVAL_LONG(&const_OPSYS_OPENVMS_value, ZIP_OPSYS_OPENVMS);
-	zend_string *const_OPSYS_OPENVMS_name = zend_string_init_interned("OPSYS_OPENVMS", sizeof("OPSYS_OPENVMS") - 1, 1);
+	zend_string *const_OPSYS_OPENVMS_name = zend_string_init_interned("OPSYS_OPENVMS", strlen("OPSYS_OPENVMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_OPENVMS_name, &const_OPSYS_OPENVMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OPENVMS_name);
 #endif
@@ -1124,7 +1124,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_UNIX_value;
 	ZVAL_LONG(&const_OPSYS_UNIX_value, ZIP_OPSYS_UNIX);
-	zend_string *const_OPSYS_UNIX_name = zend_string_init_interned("OPSYS_UNIX", sizeof("OPSYS_UNIX") - 1, 1);
+	zend_string *const_OPSYS_UNIX_name = zend_string_init_interned("OPSYS_UNIX", strlen("OPSYS_UNIX"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_UNIX_name, &const_OPSYS_UNIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_UNIX_name);
 #endif
@@ -1132,7 +1132,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_VM_CMS_value;
 	ZVAL_LONG(&const_OPSYS_VM_CMS_value, ZIP_OPSYS_VM_CMS);
-	zend_string *const_OPSYS_VM_CMS_name = zend_string_init_interned("OPSYS_VM_CMS", sizeof("OPSYS_VM_CMS") - 1, 1);
+	zend_string *const_OPSYS_VM_CMS_name = zend_string_init_interned("OPSYS_VM_CMS", strlen("OPSYS_VM_CMS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_VM_CMS_name, &const_OPSYS_VM_CMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VM_CMS_name);
 #endif
@@ -1140,7 +1140,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_ATARI_ST_value;
 	ZVAL_LONG(&const_OPSYS_ATARI_ST_value, ZIP_OPSYS_ATARI_ST);
-	zend_string *const_OPSYS_ATARI_ST_name = zend_string_init_interned("OPSYS_ATARI_ST", sizeof("OPSYS_ATARI_ST") - 1, 1);
+	zend_string *const_OPSYS_ATARI_ST_name = zend_string_init_interned("OPSYS_ATARI_ST", strlen("OPSYS_ATARI_ST"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_ATARI_ST_name, &const_OPSYS_ATARI_ST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ATARI_ST_name);
 #endif
@@ -1148,7 +1148,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_OS_2_value;
 	ZVAL_LONG(&const_OPSYS_OS_2_value, ZIP_OPSYS_OS_2);
-	zend_string *const_OPSYS_OS_2_name = zend_string_init_interned("OPSYS_OS_2", sizeof("OPSYS_OS_2") - 1, 1);
+	zend_string *const_OPSYS_OS_2_name = zend_string_init_interned("OPSYS_OS_2", strlen("OPSYS_OS_2"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_2_name, &const_OPSYS_OS_2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_2_name);
 #endif
@@ -1156,7 +1156,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_MACINTOSH_value;
 	ZVAL_LONG(&const_OPSYS_MACINTOSH_value, ZIP_OPSYS_MACINTOSH);
-	zend_string *const_OPSYS_MACINTOSH_name = zend_string_init_interned("OPSYS_MACINTOSH", sizeof("OPSYS_MACINTOSH") - 1, 1);
+	zend_string *const_OPSYS_MACINTOSH_name = zend_string_init_interned("OPSYS_MACINTOSH", strlen("OPSYS_MACINTOSH"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_MACINTOSH_name, &const_OPSYS_MACINTOSH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_MACINTOSH_name);
 #endif
@@ -1164,7 +1164,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_Z_SYSTEM_value;
 	ZVAL_LONG(&const_OPSYS_Z_SYSTEM_value, ZIP_OPSYS_Z_SYSTEM);
-	zend_string *const_OPSYS_Z_SYSTEM_name = zend_string_init_interned("OPSYS_Z_SYSTEM", sizeof("OPSYS_Z_SYSTEM") - 1, 1);
+	zend_string *const_OPSYS_Z_SYSTEM_name = zend_string_init_interned("OPSYS_Z_SYSTEM", strlen("OPSYS_Z_SYSTEM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_Z_SYSTEM_name, &const_OPSYS_Z_SYSTEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_Z_SYSTEM_name);
 #endif
@@ -1172,7 +1172,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_CPM_value;
 	ZVAL_LONG(&const_OPSYS_CPM_value, ZIP_OPSYS_CPM);
-	zend_string *const_OPSYS_CPM_name = zend_string_init_interned("OPSYS_CPM", sizeof("OPSYS_CPM") - 1, 1);
+	zend_string *const_OPSYS_CPM_name = zend_string_init_interned("OPSYS_CPM", strlen("OPSYS_CPM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_CPM_name, &const_OPSYS_CPM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_CPM_name);
 #endif
@@ -1180,7 +1180,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_WINDOWS_NTFS_value;
 	ZVAL_LONG(&const_OPSYS_WINDOWS_NTFS_value, ZIP_OPSYS_WINDOWS_NTFS);
-	zend_string *const_OPSYS_WINDOWS_NTFS_name = zend_string_init_interned("OPSYS_WINDOWS_NTFS", sizeof("OPSYS_WINDOWS_NTFS") - 1, 1);
+	zend_string *const_OPSYS_WINDOWS_NTFS_name = zend_string_init_interned("OPSYS_WINDOWS_NTFS", strlen("OPSYS_WINDOWS_NTFS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_WINDOWS_NTFS_name, &const_OPSYS_WINDOWS_NTFS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_WINDOWS_NTFS_name);
 #endif
@@ -1188,7 +1188,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_MVS_value;
 	ZVAL_LONG(&const_OPSYS_MVS_value, ZIP_OPSYS_MVS);
-	zend_string *const_OPSYS_MVS_name = zend_string_init_interned("OPSYS_MVS", sizeof("OPSYS_MVS") - 1, 1);
+	zend_string *const_OPSYS_MVS_name = zend_string_init_interned("OPSYS_MVS", strlen("OPSYS_MVS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_MVS_name, &const_OPSYS_MVS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_MVS_name);
 #endif
@@ -1196,7 +1196,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_VSE_value;
 	ZVAL_LONG(&const_OPSYS_VSE_value, ZIP_OPSYS_VSE);
-	zend_string *const_OPSYS_VSE_name = zend_string_init_interned("OPSYS_VSE", sizeof("OPSYS_VSE") - 1, 1);
+	zend_string *const_OPSYS_VSE_name = zend_string_init_interned("OPSYS_VSE", strlen("OPSYS_VSE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_VSE_name, &const_OPSYS_VSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VSE_name);
 #endif
@@ -1204,7 +1204,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_ACORN_RISC_value;
 	ZVAL_LONG(&const_OPSYS_ACORN_RISC_value, ZIP_OPSYS_ACORN_RISC);
-	zend_string *const_OPSYS_ACORN_RISC_name = zend_string_init_interned("OPSYS_ACORN_RISC", sizeof("OPSYS_ACORN_RISC") - 1, 1);
+	zend_string *const_OPSYS_ACORN_RISC_name = zend_string_init_interned("OPSYS_ACORN_RISC", strlen("OPSYS_ACORN_RISC"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_ACORN_RISC_name, &const_OPSYS_ACORN_RISC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ACORN_RISC_name);
 #endif
@@ -1212,7 +1212,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_VFAT_value;
 	ZVAL_LONG(&const_OPSYS_VFAT_value, ZIP_OPSYS_VFAT);
-	zend_string *const_OPSYS_VFAT_name = zend_string_init_interned("OPSYS_VFAT", sizeof("OPSYS_VFAT") - 1, 1);
+	zend_string *const_OPSYS_VFAT_name = zend_string_init_interned("OPSYS_VFAT", strlen("OPSYS_VFAT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_VFAT_name, &const_OPSYS_VFAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VFAT_name);
 #endif
@@ -1220,7 +1220,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_ALTERNATE_MVS_value;
 	ZVAL_LONG(&const_OPSYS_ALTERNATE_MVS_value, ZIP_OPSYS_ALTERNATE_MVS);
-	zend_string *const_OPSYS_ALTERNATE_MVS_name = zend_string_init_interned("OPSYS_ALTERNATE_MVS", sizeof("OPSYS_ALTERNATE_MVS") - 1, 1);
+	zend_string *const_OPSYS_ALTERNATE_MVS_name = zend_string_init_interned("OPSYS_ALTERNATE_MVS", strlen("OPSYS_ALTERNATE_MVS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_ALTERNATE_MVS_name, &const_OPSYS_ALTERNATE_MVS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ALTERNATE_MVS_name);
 #endif
@@ -1228,7 +1228,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_BEOS_value;
 	ZVAL_LONG(&const_OPSYS_BEOS_value, ZIP_OPSYS_BEOS);
-	zend_string *const_OPSYS_BEOS_name = zend_string_init_interned("OPSYS_BEOS", sizeof("OPSYS_BEOS") - 1, 1);
+	zend_string *const_OPSYS_BEOS_name = zend_string_init_interned("OPSYS_BEOS", strlen("OPSYS_BEOS"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_BEOS_name, &const_OPSYS_BEOS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_BEOS_name);
 #endif
@@ -1236,7 +1236,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_TANDEM_value;
 	ZVAL_LONG(&const_OPSYS_TANDEM_value, ZIP_OPSYS_TANDEM);
-	zend_string *const_OPSYS_TANDEM_name = zend_string_init_interned("OPSYS_TANDEM", sizeof("OPSYS_TANDEM") - 1, 1);
+	zend_string *const_OPSYS_TANDEM_name = zend_string_init_interned("OPSYS_TANDEM", strlen("OPSYS_TANDEM"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_TANDEM_name, &const_OPSYS_TANDEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_TANDEM_name);
 #endif
@@ -1244,7 +1244,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_OS_400_value;
 	ZVAL_LONG(&const_OPSYS_OS_400_value, ZIP_OPSYS_OS_400);
-	zend_string *const_OPSYS_OS_400_name = zend_string_init_interned("OPSYS_OS_400", sizeof("OPSYS_OS_400") - 1, 1);
+	zend_string *const_OPSYS_OS_400_name = zend_string_init_interned("OPSYS_OS_400", strlen("OPSYS_OS_400"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_400_name, &const_OPSYS_OS_400_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_400_name);
 #endif
@@ -1252,7 +1252,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_OS_X_value;
 	ZVAL_LONG(&const_OPSYS_OS_X_value, ZIP_OPSYS_OS_X);
-	zend_string *const_OPSYS_OS_X_name = zend_string_init_interned("OPSYS_OS_X", sizeof("OPSYS_OS_X") - 1, 1);
+	zend_string *const_OPSYS_OS_X_name = zend_string_init_interned("OPSYS_OS_X", strlen("OPSYS_OS_X"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_X_name, &const_OPSYS_OS_X_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_X_name);
 #endif
@@ -1260,27 +1260,27 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_OPSYS_DEFAULT_value;
 	ZVAL_LONG(&const_OPSYS_DEFAULT_value, ZIP_OPSYS_DEFAULT);
-	zend_string *const_OPSYS_DEFAULT_name = zend_string_init_interned("OPSYS_DEFAULT", sizeof("OPSYS_DEFAULT") - 1, 1);
+	zend_string *const_OPSYS_DEFAULT_name = zend_string_init_interned("OPSYS_DEFAULT", strlen("OPSYS_DEFAULT"), 1);
 	zend_declare_typed_class_constant(class_entry, const_OPSYS_DEFAULT_name, &const_OPSYS_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_DEFAULT_name);
 #endif
 
 	zval const_EM_NONE_value;
 	ZVAL_LONG(&const_EM_NONE_value, ZIP_EM_NONE);
-	zend_string *const_EM_NONE_name = zend_string_init_interned("EM_NONE", sizeof("EM_NONE") - 1, 1);
+	zend_string *const_EM_NONE_name = zend_string_init_interned("EM_NONE", strlen("EM_NONE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_NONE_name, &const_EM_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_NONE_name);
 
 	zval const_EM_TRAD_PKWARE_value;
 	ZVAL_LONG(&const_EM_TRAD_PKWARE_value, ZIP_EM_TRAD_PKWARE);
-	zend_string *const_EM_TRAD_PKWARE_name = zend_string_init_interned("EM_TRAD_PKWARE", sizeof("EM_TRAD_PKWARE") - 1, 1);
+	zend_string *const_EM_TRAD_PKWARE_name = zend_string_init_interned("EM_TRAD_PKWARE", strlen("EM_TRAD_PKWARE"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_TRAD_PKWARE_name, &const_EM_TRAD_PKWARE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_TRAD_PKWARE_name);
 #if defined(HAVE_ENCRYPTION)
 
 	zval const_EM_AES_128_value;
 	ZVAL_LONG(&const_EM_AES_128_value, ZIP_EM_AES_128);
-	zend_string *const_EM_AES_128_name = zend_string_init_interned("EM_AES_128", sizeof("EM_AES_128") - 1, 1);
+	zend_string *const_EM_AES_128_name = zend_string_init_interned("EM_AES_128", strlen("EM_AES_128"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_AES_128_name, &const_EM_AES_128_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_128_name);
 #endif
@@ -1288,7 +1288,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_EM_AES_192_value;
 	ZVAL_LONG(&const_EM_AES_192_value, ZIP_EM_AES_192);
-	zend_string *const_EM_AES_192_name = zend_string_init_interned("EM_AES_192", sizeof("EM_AES_192") - 1, 1);
+	zend_string *const_EM_AES_192_name = zend_string_init_interned("EM_AES_192", strlen("EM_AES_192"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_AES_192_name, &const_EM_AES_192_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_192_name);
 #endif
@@ -1296,71 +1296,71 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval const_EM_AES_256_value;
 	ZVAL_LONG(&const_EM_AES_256_value, ZIP_EM_AES_256);
-	zend_string *const_EM_AES_256_name = zend_string_init_interned("EM_AES_256", sizeof("EM_AES_256") - 1, 1);
+	zend_string *const_EM_AES_256_name = zend_string_init_interned("EM_AES_256", strlen("EM_AES_256"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_AES_256_name, &const_EM_AES_256_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_256_name);
 #endif
 
 	zval const_EM_UNKNOWN_value;
 	ZVAL_LONG(&const_EM_UNKNOWN_value, ZIP_EM_UNKNOWN);
-	zend_string *const_EM_UNKNOWN_name = zend_string_init_interned("EM_UNKNOWN", sizeof("EM_UNKNOWN") - 1, 1);
+	zend_string *const_EM_UNKNOWN_name = zend_string_init_interned("EM_UNKNOWN", strlen("EM_UNKNOWN"), 1);
 	zend_declare_typed_class_constant(class_entry, const_EM_UNKNOWN_name, &const_EM_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_UNKNOWN_name);
 
 	zval const_LIBZIP_VERSION_value;
 	zend_string *const_LIBZIP_VERSION_value_str = zend_string_init(LIBZIP_VERSION_STR, strlen(LIBZIP_VERSION_STR), 1);
 	ZVAL_STR(&const_LIBZIP_VERSION_value, const_LIBZIP_VERSION_value_str);
-	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
+	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", strlen("LIBZIP_VERSION"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_LIBZIP_VERSION_name);
 
 	zval const_LENGTH_TO_END_value;
 	ZVAL_LONG(&const_LENGTH_TO_END_value, ZIP_LENGTH_TO_END);
-	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
+	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", strlen("LENGTH_TO_END"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LENGTH_TO_END_name);
 #if defined(ZIP_LENGTH_UNCHECKED)
 
 	zval const_LENGTH_UNCHECKED_value;
 	ZVAL_LONG(&const_LENGTH_UNCHECKED_value, ZIP_LENGTH_UNCHECKED);
-	zend_string *const_LENGTH_UNCHECKED_name = zend_string_init_interned("LENGTH_UNCHECKED", sizeof("LENGTH_UNCHECKED") - 1, 1);
+	zend_string *const_LENGTH_UNCHECKED_name = zend_string_init_interned("LENGTH_UNCHECKED", strlen("LENGTH_UNCHECKED"), 1);
 	zend_declare_typed_class_constant(class_entry, const_LENGTH_UNCHECKED_name, &const_LENGTH_UNCHECKED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LENGTH_UNCHECKED_name);
 #endif
 
 	zval property_lastId_default_value;
 	ZVAL_UNDEF(&property_lastId_default_value);
-	zend_string *property_lastId_name = zend_string_init("lastId", sizeof("lastId") - 1, 1);
+	zend_string *property_lastId_name = zend_string_init("lastId", strlen("lastId"), 1);
 	zend_declare_typed_property(class_entry, property_lastId_name, &property_lastId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_lastId_name);
 
 	zval property_status_default_value;
 	ZVAL_UNDEF(&property_status_default_value);
-	zend_string *property_status_name = zend_string_init("status", sizeof("status") - 1, 1);
+	zend_string *property_status_name = zend_string_init("status", strlen("status"), 1);
 	zend_declare_typed_property(class_entry, property_status_name, &property_status_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_status_name);
 
 	zval property_statusSys_default_value;
 	ZVAL_UNDEF(&property_statusSys_default_value);
-	zend_string *property_statusSys_name = zend_string_init("statusSys", sizeof("statusSys") - 1, 1);
+	zend_string *property_statusSys_name = zend_string_init("statusSys", strlen("statusSys"), 1);
 	zend_declare_typed_property(class_entry, property_statusSys_name, &property_statusSys_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_statusSys_name);
 
 	zval property_numFiles_default_value;
 	ZVAL_UNDEF(&property_numFiles_default_value);
-	zend_string *property_numFiles_name = zend_string_init("numFiles", sizeof("numFiles") - 1, 1);
+	zend_string *property_numFiles_name = zend_string_init("numFiles", strlen("numFiles"), 1);
 	zend_declare_typed_property(class_entry, property_numFiles_name, &property_numFiles_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_numFiles_name);
 
 	zval property_filename_default_value;
 	ZVAL_UNDEF(&property_filename_default_value);
-	zend_string *property_filename_name = zend_string_init("filename", sizeof("filename") - 1, 1);
+	zend_string *property_filename_name = zend_string_init("filename", strlen("filename"), 1);
 	zend_declare_typed_property(class_entry, property_filename_name, &property_filename_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_filename_name);
 
 	zval property_comment_default_value;
 	ZVAL_UNDEF(&property_comment_default_value);
-	zend_string *property_comment_name = zend_string_init("comment", sizeof("comment") - 1, 1);
+	zend_string *property_comment_name = zend_string_init("comment", strlen("comment"), 1);
 	zend_declare_typed_property(class_entry, property_comment_name, &property_comment_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_comment_name);
 
@@ -1375,12 +1375,12 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 #endif
 
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setpassword", sizeof("setpassword") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setpassword", strlen("setpassword")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_ENCRYPTION)
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionname", sizeof("setencryptionname") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionname", strlen("setencryptionname")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", sizeof("setencryptionindex") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", strlen("setencryptionindex")), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
 	return class_entry;


### PR DESCRIPTION
The coding conventions call for using `strlen()` on constant strings, but not refactoring existing uses of `sizeof()` unless there is existing refactoring taking place. I have recently sent a few patches that refactored/simplified some of the arginfo headers, but this patch touches more of them.

The generated headers present a special case - until they are updated to use `strlen()`, new additions will be forced to use `sizeof()`, since that is what the generator script produces. Let's just make the change now.