### PR TITLE
Add headers handler in CLI SAPI

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -373,12 +373,6 @@ static char* sapi_cli_read_cookies(void) /* {{{ */
 }
 /* }}} */
 
-static int sapi_cli_header_handler(sapi_header_struct *h, sapi_header_op_enum op, sapi_headers_struct *s) /* {{{ */
-{
-	return 0;
-}
-/* }}} */
-
 static int sapi_cli_send_headers(sapi_headers_struct *sapi_headers) /* {{{ */
 {
 	/* We do nothing here, this function is needed to prevent that the fallback
@@ -430,7 +424,7 @@ static sapi_module_struct cli_sapi_module = {
 
 	php_error,						/* error handler */
 
-	sapi_cli_header_handler,		/* header handler */
+	NULL,							/* header handler */
 	sapi_cli_send_headers,			/* send headers handler */
 	sapi_cli_send_header,			/* send header handler */
 

--- a/sapi/cli/tests/cli_header_handler.phpt
+++ b/sapi/cli/tests/cli_header_handler.phpt
@@ -1,0 +1,35 @@
+--TEST--
+CLI header(), header_remove() and headers_list()
+--SKIPIF--
+<?php include "skipif.inc" ?>
+--INI--
+expose_php=On
+--FILE--
+<?php
+header("A: first");
+header("A: second", TRUE);
+$headers1 = headers_list();
+header("A: third", FALSE);
+$headers2 = headers_list();
+header_remove("A");
+$headers3 = headers_list();
+print_r($headers1);
+print_r($headers2);
+print_r($headers3);
+?>
+--EXPECTF--
+Array
+(
+    [0] => X-Powered-By: %s
+    [1] => A: second
+)
+Array
+(
+    [0] => X-Powered-By: %s
+    [1] => A: second
+    [2] => A: third
+)
+Array
+(
+    [0] => X-Powered-By: %s
+)

--- a/sapi/cli/tests/cli_header_session.phpt
+++ b/sapi/cli/tests/cli_header_session.phpt
@@ -1,0 +1,24 @@
+--TEST--
+CLI setcookie() create header
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--INI--
+expose_php=On
+--FILE--
+<?php
+session_name("foo");
+session_id('bar');
+session_start();
+
+$headers = headers_list();
+print_r($headers);
+?>
+--EXPECTF--
+Array
+(
+    [0] => X-Powered-By: %s
+    [1] => Set-Cookie: foo=bar; path=/
+    [2] => Expires: %s
+    [3] => Cache-Control: no-store, no-cache, must-revalidate
+    [4] => Pragma: no-cache
+)

--- a/sapi/cli/tests/cli_header_setcookie.phpt
+++ b/sapi/cli/tests/cli_header_setcookie.phpt
@@ -1,0 +1,22 @@
+--TEST--
+CLI setcookie() create header
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--INI--
+expose_php=On
+--FILE--
+<?php
+setcookie('hi', time()+3600);
+
+setcookie('hi');
+
+$headers = headers_list();
+print_r($headers);
+?>
+--EXPECTF--
+Array
+(
+    [0] => X-Powered-By: %s
+    [1] => Set-Cookie: hi=%s
+    [2] => Set-Cookie: hi=deleted;%s
+)

--- a/sapi/cli/tests/cli_headers_sent.phpt
+++ b/sapi/cli/tests/cli_headers_sent.phpt
@@ -2,8 +2,6 @@
 CLI headers_sent()
 --SKIPIF--
 <?php include "skipif.inc" ?>
---INI--
-expose_php=On
 --FILE--
 <?php
 $sent1 = headers_sent();

--- a/sapi/cli/tests/cli_headers_sent.phpt
+++ b/sapi/cli/tests/cli_headers_sent.phpt
@@ -1,0 +1,37 @@
+--TEST--
+CLI headers_sent()
+--SKIPIF--
+<?php include "skipif.inc" ?>
+--INI--
+expose_php=On
+--FILE--
+<?php
+$sent1 = headers_sent();
+
+fwrite(STDOUT, "Hi !!");
+$sent2 = headers_sent();
+
+ob_start();
+echo "Bye !!\n";
+$sent3 = headers_sent();
+
+$out = ob_get_clean();
+$sent4 = headers_sent();
+
+echo $out;
+
+var_dump(
+    $sent1,
+    $sent2,
+    $sent3,
+    $sent4,
+    headers_sent()
+);
+?>
+--EXPECT--
+Hi !!Bye !!
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(true)


### PR DESCRIPTION
Check issue #12304

With this change, we can use the headers from CLI SAPI. But the most important think is that we can also use setcookie() and sessions.

All the included tests pass.

Only fail the actual `header() and friends [ext/standard/tests/general_functions/head.phpt]` that test the old behavior.
I can change this test if this PR will be accepted.
https://github.com/joanhey/php-src/blob/cli-header-handler/ext/standard/tests/general_functions/head.phpt

I don't think that this feature need an RFC, but you'll say it.

Thank you 