### PR TITLE
Allow to run push workflows manually

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,6 +33,7 @@ on:
       - .circleci/*
     branches:
       - '**'
+  workflow_dispatch: ~
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.url || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
As is, we're running the push workflow for all pushes and pull request, plus we run more comprehensive nightly workflow for all branches which had commits during the day.  That means that security branches may not run CI for weeks or even months.  In the meantime, dependencies might be updated, which can cause later workflow runs to fail.  For instance, a few openssl tests fail due to security fixes in OpenSSL[1], an update of Oracle Instant Client causes a couple of oci8 and pdo_oci tests to fail[2], and the macOS builds do no longer even built (investigation pending).

Therefore, we allow to run the pull workflow manually, so it is possible to check the CI condition of temporary inactive branches from time to time.

[1] <https://github.com/php/php-src/pull/16097>
[2] <https://github.com/php/php-src/pull/16107>