### PR TITLE
Fix GH-16149: Null pointer dereference in DOMElement->getAttributeNames()

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -339,7 +339,11 @@ PHP_METHOD(DOMElement, getAttributeNames)
 
 	for (xmlNsPtr nsptr = nodep->nsDef; nsptr; nsptr = nsptr->next) {
 		const char *prefix = (const char *) nsptr->prefix;
-		ZVAL_STR(&tmp, dom_node_concatenated_name_helper(strlen(prefix), prefix, strlen("xmlns"), (const char *) "xmlns"));
+		if (prefix == NULL) {
+			ZVAL_STRING(&tmp, "xmlns");
+		} else {
+			ZVAL_STR(&tmp, dom_node_concatenated_name_helper(strlen(prefix), prefix, strlen("xmlns"), (const char *) "xmlns"));
+		}
 		zend_hash_next_index_insert(ht, &tmp);
 	}
 

--- a/ext/dom/tests/gh16149.phpt
+++ b/ext/dom/tests/gh16149.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-16149 (Null pointer dereference in DOMElement->getAttributeNames())
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$element = new DOMElement("b", null, "a");
+var_dump($element->getAttributeNames());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(5) "xmlns"
+}


### PR DESCRIPTION
A namespace without a prefix is by definition always the "xmlns" namespace.