### PR TITLE
Fix GH-15169: stack overflow when var serialization in ext/standard/var

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_001.phpt
+++ b/Zend/tests/stack_limit/stack_limit_001.phpt
@@ -27,13 +27,6 @@ class Test2 {
     }
 }
 
-class Test3 {
-    public function __sleep()
-    {
-        serialize($this);
-    }
-}
-
 function replace() {
     return preg_replace_callback('#.#', function () {
         return replace();
@@ -48,12 +41,6 @@ try {
 
 try {
     clone new Test2;
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
-
-try {
-    serialize(new Test3);
 } catch (Error $e) {
     echo $e->getMessage(), "\n";
 }
@@ -76,7 +63,6 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_002.phpt
+++ b/Zend/tests/stack_limit/stack_limit_002.phpt
@@ -26,13 +26,6 @@ class Test2 {
     }
 }
 
-class Test3 {
-    public function __sleep()
-    {
-        serialize($this);
-    }
-}
-
 function replace() {
     return preg_replace_callback('#.#', function () {
         return replace();
@@ -48,12 +41,6 @@ $fiber = new Fiber(function (): void {
 
     try {
         clone new Test2;
-    } catch (Error $e) {
-        echo $e->getMessage(), "\n";
-    }
-
-    try {
-        serialize(new Test3);
     } catch (Error $e) {
         echo $e->getMessage(), "\n";
     }
@@ -79,7 +66,6 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/ext/standard/tests/serialize/gh15169.phpt
+++ b/ext/standard/tests/serialize/gh15169.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-15169 (stack overflow when var serialization in ext/standard/var)
+--SKIPIF--
+<?php
+if (ini_get('zend.max_allowed_stack_size') === false) {
+    die('skip No stack limit support');
+}
+if (getenv('SKIP_ASAN')) {
+    die('skip ASAN needs different stack limit setting due to more stack space usage');
+}
+?>
+--INI--
+zend.max_allowed_stack_size=512K
+--FILE--
+<?php
+class Node
+{
+    public $next;
+}
+$firstNode = new Node();
+$node = $firstNode;
+for ($i = 0; $i < 30000; $i++) {
+    $newNode = new Node();
+    $node->next = $newNode;
+    $node = $newNode;
+}
+
+try {
+    serialize($firstNode);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Maximum call stack size reached. Infinite recursion?

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -986,12 +986,26 @@ static void php_var_serialize_class(smart_str *buf, zval *struc, HashTable *ht, 
 }
 /* }}} */
 
+static zend_always_inline bool php_serialize_check_stack_limit(void)
+{
+#ifdef ZEND_CHECK_STACK_LIMIT
+	return zend_call_stack_overflowed(EG(stack_limit));
+#else
+	return false;
+#endif
+}
+
 static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool in_rcn_array, bool is_root) /* {{{ */
 {
 	zend_long var_already;
 	HashTable *myht;
 
 	if (EG(exception)) {
+		return;
+	}
+
+	if (UNEXPECTED(php_serialize_check_stack_limit())) {
+		zend_throw_error(NULL, "Maximum call stack size reached. Infinite recursion?");
 		return;
 	}
 


### PR DESCRIPTION
Adding a stack check here as I consider serialization to be a more sensitive place where erroring out with an exception seems appropriate.