### PR TITLE
x86 builds on Windows are warning level 1 clean

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -31,12 +31,7 @@ if %errorlevel% neq 0 exit /b 3
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 
-rem Some undefined behavior is reported on 32-bit, this should be fixed
-if "%PLATFORM%" == "x86" (
-	set CFLAGS=/W1
-) else (
-	set CFLAGS=/W1 /WX
-)
+set CFLAGS=/W1 /WX
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   WINDOWS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
-    name: WINDOWS_X64_ZTS
+    name: WINDOWS_X86_ZTS
     runs-on: windows-2022
     timeout-minutes: 50
     env:
@@ -235,7 +235,7 @@ jobs:
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs17
-      PLATFORM: x64
+      PLATFORM: x86
       THREAD_SAFE: "1"
       INTRINSICS: AVX2
       PARALLEL: -j2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   WINDOWS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
-    name: WINDOWS_X86_ZTS
+    name: WINDOWS_X64_ZTS
     runs-on: windows-2022
     timeout-minutes: 50
     env:
@@ -235,7 +235,7 @@ jobs:
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
       PHP_BUILD_CRT: vs17
-      PLATFORM: x86
+      PLATFORM: x64
       THREAD_SAFE: "1"
       INTRINSICS: AVX2
       PARALLEL: -j2


### PR DESCRIPTION
The only issue that was left was due to the old build of net-snmp 5.7.3; since updating to net-snmp 5.9.4, this is resolved.
