### PR TITLE
Improve JIT TRACE coverage

### DIFF
--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -647,7 +647,12 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_ret_trace_helper(ZEND_OPCODE_HAND
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_trace_helper(ZEND_OPCODE_HANDLER_ARGS);
 
 int ZEND_FASTCALL zend_jit_trace_hot_root(zend_execute_data *execute_data, const zend_op *opline);
-zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *execute_data, const zend_op *opline, zend_jit_trace_rec *trace_buffer, uint8_t start, uint32_t is_megamorphc);
+zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *execute_data,
+                                                         const zend_op      *opline,
+                                                         zend_jit_trace_rec *trace_buffer,
+                                                         uint8_t             start,
+                                                         uint32_t            is_megamorphc,
+                                                         int                 ret_depth);
 
 static zend_always_inline const zend_op* zend_jit_trace_get_exit_opline(zend_jit_trace_rec *trace, const zend_op *opline, bool *exit_if_true)
 {


### PR DESCRIPTION
Now PHP tracing JIT may lose some parts of the "hot" code.

In case we have a root LOOP trace with an inlined call of some function, and we get a SIDE exit inside that function - we start recording a side trace, but we finish recording at the RETURN of the inlined function. As result the opcodes between RETURN from SIDE trace and root trace LOOP exit might be never traced and were always executed in interpreter.

This patch introduces a "ret_depth" argument that prevents stopping tracing on RETURN of such SIDE trace.

This is targeted to PHP-8.4, because this may disclose unrelated JIT problems and I don't like to do this in old stable releases. 