### PR TITLE
Fix bugs GH-16150 and GH-16152: intern document mismanagement

### DIFF
--- a/ext/dom/tests/gh16150.phpt
+++ b/ext/dom/tests/gh16150.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-16150 (Use after free in php_dom.c)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+function test($fname) {
+    $e1 = new DOMElement("E1");
+    $e2 = new DOMElement("E2");
+    $e3 = new DOMElement("E3");
+    $doc = new DOMDocument(); // Must be placed here so it is destroyed first
+    $doc->{$fname}($e3);
+    $e2->append($e1);
+    $e3->{$fname}($e2);
+    echo $doc->saveXML();
+}
+
+test('appendChild');
+test('insertBefore');
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<E3><E2><E1/></E2></E3>
+<?xml version="1.0"?>
+<E3><E2><E1/></E2></E3>

--- a/ext/dom/tests/gh16152.phpt
+++ b/ext/dom/tests/gh16152.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-16152 (Memory leak in DOMProcessingInstruction/DOMDocument)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+function test($fname) {
+    $doc = new DOMDocument();
+    $instr = new DOMProcessingInstruction("tr", "r");
+    $frag = new DOMDocumentFragment();
+    $frag2 = new DOMDocumentFragment();
+    $frag2->append($instr);
+    $frag->append($frag2);
+    $doc->{$fname}($frag);
+    echo $doc->saveXML();
+}
+
+test('insertBefore');
+test('appendChild');
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<?tr r?>
+<?xml version="1.0"?>
+<?tr r?>


### PR DESCRIPTION
The reference counts of the internal document pointer are mismanaged. In the case of fragments the refcount may be increased too much, while for other cases the document reference may not be applied to all children.

This bug existed for a long time and this doesn't reproduce (easily) on 8.2 due to other bugs. Furthermore 8.2 will enter security mode soon, and this change may be too risky.