### PR TITLE
Fix GH-16181: phpdbg: exit in exception handler reports fatal error

### DIFF
--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -907,7 +907,7 @@ free_cmd:
 				}
 			} zend_end_try();
 
-			if (EG(exception)) {
+			if (EG(exception) && !zend_is_unwind_exit(EG(exception))) {
 				phpdbg_handle_exception();
 			}
 		}

--- a/sapi/phpdbg/tests/gh16181.phpt
+++ b/sapi/phpdbg/tests/gh16181.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-16181 (phpdbg: exit in exception handler reports fatal error)
+--PHPDBG--
+r
+c
+q
+--FILE--
+<?php
+set_exception_handler(function() {
+	echo "exception caught\n";
+	die;
+});
+
+echo "throwing exception\n";
+throw new \Exception("oh noes");
+?>
+--EXPECTF--
+[Successful compilation of %s]
+prompt> throwing exception
+[Uncaught Exception in %s on line %d: oh noes]
+>00008: throw new \Exception("oh noes");
+ 00009: ?>
+ 00010: 
+prompt> exception caught
+[Script ended normally]
+prompt>


### PR DESCRIPTION
When running PHP code, we must not handle `UnwindExit` exceptions, but rather have to ignore them.