### PR TITLE
Fix GH-16186: Ignore scope when compiling closure in non-tracing jit

### DIFF
--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -123,6 +123,7 @@ static zend_always_inline bool zend_jit_same_addr(zend_jit_addr addr1, zend_jit_
 
 typedef struct _zend_jit_op_array_extension {
 	zend_func_info func_info;
+	const zend_op_array *op_array;
 	const void *orig_handler;
 } zend_jit_op_array_extension;
 
@@ -160,6 +161,7 @@ void ZEND_FASTCALL zend_jit_hot_func(zend_execute_data *execute_data, const zend
 
 typedef struct _zend_jit_op_array_hot_extension {
 	zend_func_info func_info;
+	const zend_op_array *op_array;
 	int16_t    *counter;
 	const void *orig_handlers[1];
 } zend_jit_op_array_hot_extension;

--- a/ext/opcache/tests/gh16186_001.phpt
+++ b/ext/opcache/tests/gh16186_001.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-16186 001 (Non-tracing JIT uses Closure scope)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=0234
+opcache.file_update_protection=0
+opcache.revalidate_freq=0
+opcache.protect_memory=1
+--FILE--
+<?php
+
+class A {
+    private $x;
+    public function getIncrementor() {
+        return function() { $this->x++; };
+    }
+}
+$a = new A();
+$f = $a->getIncrementor();
+$c = new stdClass();
+$f();
+$f2 = Closure::bind($f, $c);
+$f2();
+$f2();
+
+var_dump($c);
+
+?>
+--EXPECTF--
+Warning: Undefined property: stdClass::$x in %s on line %d
+object(stdClass)#%d (1) {
+  ["x"]=>
+  int(2)
+}

--- a/ext/opcache/tests/gh16186_002.phpt
+++ b/ext/opcache/tests/gh16186_002.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-16186 002 (Non-tracing JIT uses Closure scope)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=64M
+opcache.jit=0214
+opcache.file_update_protection=0
+opcache.revalidate_freq=0
+opcache.protect_memory=1
+--FILE--
+<?php
+
+class A {
+    private $x;
+    public function getIncrementor() {
+        return function() { $this->x++; };
+    }
+}
+$a = new A();
+$f = $a->getIncrementor();
+$c = new stdClass();
+$f();
+$f2 = Closure::bind($f, $c);
+$f2();
+$f2();
+
+var_dump($c);
+
+?>
+--EXPECTF--
+Warning: Undefined property: stdClass::$x in %s on line %d
+object(stdClass)#%d (1) {
+  ["x"]=>
+  int(2)
+}


### PR DESCRIPTION
Fixes GH-16186.

`zend_jit()` assumes that Closure op_arrays have no scope, but this is not true for all triggers. E.g. with the hot counter trigger, the op_array is a copy with a scope.

As a result, we assume the class of `$this` [here](https://github.com/php/php-src/blob/2d8a93cbb66585cedfe27b828b2839f0aea9a691/ext/opcache/jit/zend_jit.c#L1749), but it is later changed in `::bind()`, which causes the issue.

Here I copy what is done for the tracing JIT: Use the original op_array, which has no scope.