### PR TITLE
Declare zend_call_stack_size_error() as ZEND_API

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2500,7 +2500,7 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_new_element_for_s
 }
 
 #ifdef ZEND_CHECK_STACK_LIMIT
-zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void)
+ZEND_API zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void)
 {
 	size_t max_stack_size = 0;
 	if ((uintptr_t) EG(stack_base) > (uintptr_t) EG(stack_limit)) {

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -66,7 +66,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_deprecated_class_constant(const zend_
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_false_to_array_deprecated(void);
 ZEND_COLD void ZEND_FASTCALL zend_param_must_be_ref(const zend_function *func, uint32_t arg_num);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_use_resource_as_offset(const zval *dim);
-zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void);
+ZEND_API zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void);
 
 ZEND_API bool ZEND_FASTCALL zend_verify_ref_assignable_zval(zend_reference *ref, zval *zv, bool strict);
 


### PR DESCRIPTION
This is necessary at least on Windows to be able to actually call the function from a different module (in this case php8phpdbg.dll could not be build).

---

The `zend_never_inline` may no longer be necessary (or have any effect).

cc @arnaud-lb 