### PR TITLE
Fix GH-16184: UBSan address overflowed in ext/pcre/php_pcre.c

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1747,9 +1747,11 @@ matched:
 						}
 						if (preg_get_backref(&walk, &backref)) {
 							if (backref < count) {
-								match_len = offsets[(backref<<1)+1] - offsets[backref<<1];
-								memcpy(walkbuf, subject + offsets[backref<<1], match_len);
-								walkbuf += match_len;
+								if (offsets[backref<<1] < SIZE_MAX) {
+									match_len = offsets[(backref<<1)+1] - offsets[backref<<1];
+									memcpy(walkbuf, subject + offsets[backref<<1], match_len);
+									walkbuf += match_len;
+								}
 							}
 							continue;
 						}

--- a/ext/pcre/tests/gh16184.phpt
+++ b/ext/pcre/tests/gh16184.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-16184 (UBSan address overflowed in ext/pcre/php_pcre.c)
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+
+$string = 'This is a string. It contains numbers (0*9) as well as parentheses and some other things!';
+echo preg_replace(array('/\b\w{1}s/', '/(\d{1})*(\d{1})/', '/[\(!\)]/'), array('test', '$1 to $2', '*'), $string), "\n";
+
+?>
+--EXPECT--
+This test a string. It contains numbers * to 0* to 9* test well test parentheses and some other things*


### PR DESCRIPTION
libpcre2 can return the special value -1 for a non-match. In this case we get pointer overflow, although it doesn't matter in practice because the pointer will be in bounds and the copy length will be 0. Still, we should fix the UBSAN warning.