### PR TITLE
Stubs and generated arginfo: remove tentative returns from final methods

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1291,6 +1291,9 @@ class FuncInfo {
         $this->attributes = $attributes;
         $this->framelessFunctionInfos = $framelessFunctionInfos;
         $this->exposedDocComment = $exposedDocComment;
+        if ($return->tentativeReturnType && $this->isFinalMethod()) {
+            throw new Exception("Tentative return inapplicable for final method");
+        }
     }
 
     public function isMethod(): bool

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -146,22 +146,16 @@ final class ReflectionGenerator
 {
     public function __construct(Generator $generator) {}
 
-    /** @tentative-return-type */
     public function getExecutingLine(): int {}
 
-    /** @tentative-return-type */
     public function getExecutingFile(): string {}
 
-    /** @tentative-return-type */
     public function getTrace(int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT): array {}
 
-    /** @tentative-return-type */
     public function getFunction(): ReflectionFunctionAbstract {}
 
-    /** @tentative-return-type */
     public function getThis(): ?object {}
 
-    /** @tentative-return-type */
     public function getExecutingGenerator(): Generator {}
 
     public function isClosed(): bool {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 261798b92d4eac170538185ced1068bc72705385 */
+ * Stub hash: ad354b7dc9caadc2bb5ed810964ebf83acd27f1d */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -112,20 +112,22 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionGenerator___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, generator, Generator, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_ReflectionGenerator_getExecutingLine arginfo_class_ReflectionFunctionAbstract_getNumberOfParameters
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionGenerator_getExecutingLine, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_class_ReflectionGenerator_getExecutingFile arginfo_class_ReflectionFunctionAbstract_getName
+#define arginfo_class_ReflectionGenerator_getExecutingFile arginfo_class_ReflectionFunction___toString
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionGenerator_getTrace, 0, 0, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionGenerator_getTrace, 0, 0, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "DEBUG_BACKTRACE_PROVIDE_OBJECT")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionGenerator_getFunction, 0, 0, ReflectionFunctionAbstract, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionGenerator_getFunction, 0, 0, ReflectionFunctionAbstract, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_ReflectionGenerator_getThis arginfo_class_ReflectionFunctionAbstract_getClosureThis
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionGenerator_getThis, 0, 0, IS_OBJECT, 1)
+ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionGenerator_getExecutingGenerator, 0, 0, Generator, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionGenerator_getExecutingGenerator, 0, 0, Generator, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionGenerator_isClosed arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
@@ -514,7 +516,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionParameter_canBePassedByValue arginfo_class_ReflectionFunctionAbstract_inNamespace
 
-#define arginfo_class_ReflectionParameter_getDeclaringFunction arginfo_class_ReflectionGenerator_getFunction
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionParameter_getDeclaringFunction, 0, 0, ReflectionFunctionAbstract, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionParameter_getDeclaringClass arginfo_class_ReflectionFunctionAbstract_getClosureScopeClass
 
@@ -624,8 +627,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionAttribute_getName arginfo_class_ReflectionFunction___toString
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_getTarget, 0, 0, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_ReflectionAttribute_getTarget arginfo_class_ReflectionGenerator_getExecutingLine
 
 #define arginfo_class_ReflectionAttribute_isRepeated arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
@@ -686,9 +688,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFiber_getCallable, 0, 0, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFiber_getTrace, 0, 0, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "DEBUG_BACKTRACE_PROVIDE_OBJECT")
-ZEND_END_ARG_INFO()
+#define arginfo_class_ReflectionFiber_getTrace arginfo_class_ReflectionGenerator_getTrace
 
 #define arginfo_class_ReflectionConstant___construct arginfo_class_ReflectionExtension___construct
 

--- a/ext/spl/spl_directory.stub.php
+++ b/ext/spl/spl_directory.stub.php
@@ -97,9 +97,6 @@ class SplFileInfo implements Stringable
     /** @tentative-return-type */
     public function __debugInfo(): array {}
 
-    /**
-     * @tentative-return-type
-     */
     #[\Deprecated(since: '8.2')]
     final public function _bad_state_ex(): void {}
 }

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3ed3a9f6609e1b8fa642f1e4cfaa1de40e3cc11e */
+ * Stub hash: c8c3c642d6f8c19a83f6a94ede5b6138a969bc12 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileInfo___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -83,7 +83,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileInfo___debugInfo, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileInfo__bad_state_ex, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_SplFileInfo__bad_state_ex, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DirectoryIterator___construct, 0, 0, 1)
@@ -98,7 +98,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DirectoryIterator_isDot arginfo_class_SplFileInfo_isWritable
 
-#define arginfo_class_DirectoryIterator_rewind arginfo_class_SplFileInfo__bad_state_ex
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DirectoryIterator_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_DirectoryIterator_valid arginfo_class_SplFileInfo_isWritable
 
@@ -107,7 +108,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DirectoryIterator_current arginfo_class_DirectoryIterator_key
 
-#define arginfo_class_DirectoryIterator_next arginfo_class_SplFileInfo__bad_state_ex
+#define arginfo_class_DirectoryIterator_next arginfo_class_DirectoryIterator_rewind
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DirectoryIterator_seek, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
@@ -120,7 +121,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_FilesystemIterator___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_FilesystemIterator_rewind arginfo_class_SplFileInfo__bad_state_ex
+#define arginfo_class_FilesystemIterator_rewind arginfo_class_DirectoryIterator_rewind
 
 #define arginfo_class_FilesystemIterator_key arginfo_class_SplFileInfo_getPath
 
@@ -167,7 +168,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileObject___construct, 0, 0, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_SplFileObject_rewind arginfo_class_SplFileInfo__bad_state_ex
+#define arginfo_class_SplFileObject_rewind arginfo_class_DirectoryIterator_rewind
 
 #define arginfo_class_SplFileObject_eof arginfo_class_SplFileInfo_isWritable
 
@@ -240,7 +241,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_SplFileObject_key arginfo_class_FilesystemIterator_getFlags
 
-#define arginfo_class_SplFileObject_next arginfo_class_SplFileInfo__bad_state_ex
+#define arginfo_class_SplFileObject_next arginfo_class_DirectoryIterator_rewind
 
 #define arginfo_class_SplFileObject_setFlags arginfo_class_FilesystemIterator_setFlags
 


### PR DESCRIPTION
A tentative return type is used to allow userland code that overrides a method to not include a typehint without a fatal error; this is inapplicable to final methods (including all methods of final classes), which cannot be overridden. Remove the tentative return declarations, and update the build script to complain about future additions.