### PR TITLE
ReflectionParameter::__construct(): switch `@param` to typehint

### DIFF
--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -638,8 +638,7 @@ class ReflectionParameter implements Reflector
     /** @implementation-alias ReflectionClass::__clone */
     private function __clone(): void {}
 
-    /** @param string|array|object $function */
-    public function __construct($function, int|string $param) {}
+    public function __construct(string|array|object $function, int|string $param) {}
 
     public function __toString(): string {}
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 261798b92d4eac170538185ced1068bc72705385 */
+ * Stub hash: a7f13bddd4915c489acbfaf05045973b8a65de72 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -502,7 +502,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionParameter___clone arginfo_class_ReflectionFunctionAbstract___clone
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionParameter___construct, 0, 0, 2)
-	ZEND_ARG_INFO(0, function)
+	ZEND_ARG_TYPE_MASK(0, function, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
 	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_LONG|MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
The type is checked (though for values of the wrong type a `ReflectionException` is thrown rather than a `TypeError`), but the information about the required type is not provided to Reflection. Replace the `@param` comment with a real typehint so that the information is also available via Reflection.