### PR TITLE
Use standard error message for stack limit in serialize()

### DIFF
--- a/ext/standard/tests/serialize/gh15169.phpt
+++ b/ext/standard/tests/serialize/gh15169.phpt
@@ -31,5 +31,5 @@ try {
     echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
-Maximum call stack size reached. Infinite recursion?
+--EXPECTF--
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1052,7 +1052,7 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 	}
 
 	if (UNEXPECTED(php_serialize_check_stack_limit())) {
-		zend_throw_error(NULL, "Maximum call stack size reached. Infinite recursion?");
+		zend_call_stack_size_error();
 		return;
 	}
 


### PR DESCRIPTION
With GH-16204 merged, we can use the standard error message for the recently-merged GH-16159.