### PR TITLE
Fix GH-15395: php-fpm: zend_mm_heap corrupted with cgi-fcgi request

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -507,12 +507,15 @@ SAPI_API void sapi_deactivate_module(void)
 	}
 	if (SG(request_info).auth_user) {
 		efree(SG(request_info).auth_user);
+		SG(request_info).auth_user = NULL;
 	}
 	if (SG(request_info).auth_password) {
 		efree(SG(request_info).auth_password);
+		SG(request_info).auth_password = NULL;
 	}
 	if (SG(request_info).auth_digest) {
 		efree(SG(request_info).auth_digest);
+		SG(request_info).auth_digest = NULL;
 	}
 	if (SG(request_info).content_type_dup) {
 		efree(SG(request_info).content_type_dup);

--- a/main/main.c
+++ b/main/main.c
@@ -2672,7 +2672,9 @@ PHPAPI int php_handle_auth_data(const char *auth)
 			if (pass) {
 				*pass++ = '\0';
 				SG(request_info).auth_user = estrndup(ZSTR_VAL(user), ZSTR_LEN(user));
-				SG(request_info).auth_password = estrdup(pass);
+				if (strlen(pass) > 0) {
+					SG(request_info).auth_password = estrdup(pass);
+				}
 				ret = 0;
 			}
 			zend_string_free(user);

--- a/sapi/fpm/tests/gh15395-php-auth-shutdown.phpt
+++ b/sapi/fpm/tests/gh15395-php-auth-shutdown.phpt
@@ -1,0 +1,61 @@
+--TEST--
+FPM: GH-15335 - PHP_AUTH shutdown  use after free
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+log_level = notice
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+catch_workers_output = yes
+php_admin_value[cgi.fix_pathinfo] = no
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$_SERVER["SCRIPT_NAME"] . "\n";
+echo \$_SERVER["SCRIPT_FILENAME"] . "\n";
+echo \$_SERVER["PHP_SELF"];
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName();
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(
+        headers: [ "HTTP_AUTHORIZATION" => "Basic Zm9vOg==", "REQUEST_METHOD" => "GET"],
+        uri: $scriptName,
+        address: '{{ADDR}}',
+        scriptFilename: __DIR__ . "/__unknown.php",
+        scriptName: "/",
+    )
+    ->expectStatus('404 Not Found');
+$tester
+    ->request(
+        uri: $scriptName,
+        address: '{{ADDR}}',
+        params: [],
+    );
+$tester->expectNoLogPattern("/zend_mm_heap corrupted/");
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -762,6 +762,7 @@ class Tester
         string|array $stdin = null,
         bool $expectError = false,
         int $readLimit = -1,
+        array $params = null,
     ): Response {
         if ($this->hasError()) {
             return $this->createResponse(expectInvalid: true);
@@ -771,7 +772,7 @@ class Tester
             $stdin = $this->parseStdin($stdin, $headers);
         }
 
-        $params = $this->getRequestParams($query, $headers, $uri, $scriptFilename, $scriptName, $stdin);
+        $params = $params ?? $this->getRequestParams($query, $headers, $uri, $scriptFilename, $scriptName, $stdin);
         $this->trace('Request params', $params);
 
         try {


### PR DESCRIPTION
This is an update of GH-15416 with a proper test that fails when there is an issue.