### PR TITLE
Fix GH-16229: Address overflowed in mb_send_mail when empty string

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4346,7 +4346,7 @@ PHP_FUNCTION(mb_send_mail)
 	smart_str str = {0};
 	bool empty = true;
 
-	if (str_headers != NULL) {
+	if (str_headers != NULL && ZSTR_LEN(str_headers) > 0) {
 		/* Strip trailing CRLF from `str_headers`; we will add CRLF back if necessary */
 		size_t len = ZSTR_LEN(str_headers);
 		if (ZSTR_VAL(str_headers)[len-1] == '\n') {

--- a/ext/mbstring/tests/gh16229.phpt
+++ b/ext/mbstring/tests/gh16229.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-16229 (Address overflowed in ext/mbstring/mbstring.c:4613 #16229)
+--EXTENSIONS--
+mbstring
+--INI--
+sendmail_path={MAIL:{PWD}/mb_send_mail_gh16229.eml}
+mail.add_x_header=off
+--SKIPIF--
+<?php
+if (!function_exists("mb_send_mail") || !mb_language("japanese")) {
+    die("skip mb_send_mail() not available");
+}
+?>
+--FILE--
+<?php
+try {
+	$a = false;
+	mb_send_mail($a,$a,$a,$a,$a);
+} catch (Exception $e) {
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail_gh16229.eml");
+?>
+--EXPECTF--


### PR DESCRIPTION
Closes: GH-16229
cc @alexdowad 