### PR TITLE
Fix GH-16237: Segmentation fault when cloning SoapServer

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -412,6 +412,7 @@ PHP_MINIT_FUNCTION(soap)
 	memcpy(&soap_server_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	soap_server_object_handlers.offset = XtOffsetOf(soap_server_object, std);
 	soap_server_object_handlers.free_obj = soap_server_object_free;
+	soap_server_object_handlers.clone_obj = NULL;
 
 	/* Register SoapFault class */
 	soap_fault_class_entry = register_class_SoapFault(zend_ce_exception);

--- a/ext/soap/tests/bugs/gh16237.phpt
+++ b/ext/soap/tests/bugs/gh16237.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-16237 (Segmentation fault when cloning SoapServer)
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+
+$server = new SoapServer(null, ['uri'=>"http://testuri.org"]);
+try {
+    clone $server;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Trying to clone an uncloneable object of class SoapServer


### PR DESCRIPTION
Bisect points to 94ee4f9, however this only reveals the problem. Cloning an object on a lower branch and trying to call its methods crashes as well. Cloning the object shouldn't be possible in the first place because there's an engine constraint that when we have a new object handler we should also have a clone handler. This constraint is not fulfilled here.