### PR TITLE
Unify types of PHP_VERSION and friends on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -108,9 +108,9 @@ function get_version_numbers()
 	var regex = /AC_INIT.+(\d+)\.(\d+)\.(\d+)([^\,^\]]*).+/g;
 
 	if (cin.match(new RegExp(regex))) {
-		PHP_VERSION = RegExp.$1;
-		PHP_MINOR_VERSION = RegExp.$2;
-		PHP_RELEASE_VERSION = RegExp.$3;
+		PHP_VERSION = +RegExp.$1;
+		PHP_MINOR_VERSION = +RegExp.$2;
+		PHP_RELEASE_VERSION = +RegExp.$3;
 		PHP_EXTRA_VERSION = RegExp.$4;
 	}
 


### PR DESCRIPTION
For `phpize` builds, all three version variables are numbers, but for `buildconf` builds, all are strings.  This can yield surprising results when extensions create their `PHP_VERSION_ID` like

10000 * PHP_VERSION + 100 * PHP_MINOR_VERSION + PHP_RELEASE_VERSION

Since `phpize` builds are way more common for external extensions nowadays, we change the types for `buildconf` builds.