### PR TITLE
[skip ci] Mention AVX(2) detection fix for MSVC in UPGRADING

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1171,6 +1171,8 @@ PHP 8.4 UPGRADE NOTES
 * Building with Visual Studio now requires at least Visual Studio 2019 (Visual
   Studio 2022 is recommended, though).
 
+* AVX(2) CPU support is now properly detected for MSVC builds.
+
 * Native AVX-512 builds are now supported (--enable-native-intrinsics=avx512).
 
 ========================================


### PR DESCRIPTION
This is likely more important than the possibility to build for AVX-512 since our official binaries have build time support for SSE2 only.  So proper detection of AVX may make a huge performance difference for `base64_*()` and some MBString functionality.

---

For reference: https://github.com/php/php-src/pull/15301