### PR TITLE
Fix getColumnMeta() for GH-15287 Pdo\Pgsql::setAttribute(PDO::ATTR_PREFETCH, 0)

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -258,6 +258,10 @@ static void pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 			PQfinish(H->server);
 			H->server = NULL;
 		}
+		if (H->cached_table_name) {
+			efree(H->cached_table_name);
+			H->cached_table_name = NULL;
+		}
 		if (H->einfo.errmsg) {
 			pefree(H->einfo.errmsg, dbh->is_persistent);
 			H->einfo.errmsg = NULL;
@@ -1461,6 +1465,7 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{
 
 	H->attached = 1;
 	H->pgoid = -1;
+	H->cached_table_oid = InvalidOid;
 
 	dbh->methods = &pgsql_methods;
 	dbh->alloc_own_columns = 1;

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -36,6 +36,7 @@
 #include "pgsql_driver_arginfo.h"
 
 static bool pgsql_handle_in_transaction(pdo_dbh_t *dbh);
+void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode);
 
 static char * _pdo_pgsql_trim_message(const char *message, int persistent)
 {
@@ -108,6 +109,37 @@ int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const char *
 	return errcode;
 }
 /* }}} */
+
+static zend_always_inline void pgsql_finish_running_stmt(pdo_pgsql_db_handle *H)
+{
+	if (H->running_stmt) {
+		pgsql_stmt_finish(H->running_stmt, 0);
+	}
+}
+
+static zend_always_inline void pgsql_discard_running_stmt(pdo_pgsql_db_handle *H)
+{
+	if (H->running_stmt) {
+		pgsql_stmt_finish(H->running_stmt, FIN_DISCARD);
+	}
+
+	PGresult *pgsql_result;
+	bool first = true;
+	while ((pgsql_result = PQgetResult(H->server))) {
+		/* We should not arrive here, where libpq has a result to deliver without us
+		 * having registered a running statement:
+		 * every result discarding should go through the unified pgsql_stmt_finish,
+		 * but maybe there still is an internal query that we omitted to adapt.
+		 * So instead of asserting let's just emit an informational notice,
+		 * and consume anyway (results consumption is handle-wise, so we have no formal
+		 * need for the statement). */
+		if (first) {
+			php_error_docref(NULL, E_NOTICE, "Internal error: unable to link a libpq result to consume, to its origin statement");
+			first = false;
+		}
+		PQclear(pgsql_result);
+	}
+}
 
 static void _pdo_pgsql_notice(void *context, const char *message) /* {{{ */
 {
@@ -355,6 +387,7 @@ static zend_long pgsql_handle_doer(pdo_dbh_t *dbh, const zend_string *sql)
 
 	bool in_trans = pgsql_handle_in_transaction(dbh);
 
+	pgsql_finish_running_stmt(H);
 	if (!(res = PQexec(H->server, ZSTR_VAL(sql)))) {
 		/* fatal error */
 		pdo_pgsql_error(dbh, PGRES_FATAL_ERROR, NULL);
@@ -430,6 +463,7 @@ static zend_string *pdo_pgsql_last_insert_id(pdo_dbh_t *dbh, const zend_string *
 	PGresult *res;
 	ExecStatusType status;
 
+	pgsql_finish_running_stmt(H);
 	if (name == NULL) {
 		res = PQexec(H->server, "SELECT LASTVAL()");
 	} else {
@@ -593,6 +627,7 @@ static bool pdo_pgsql_transaction_cmd(const char *cmd, pdo_dbh_t *dbh)
 	PGresult *res;
 	bool ret = true;
 
+	pgsql_finish_running_stmt(H);
 	res = PQexec(H->server, cmd);
 
 	if (PQresultStatus(res) != PGRES_COMMAND_OK) {
@@ -700,9 +735,8 @@ void pgsqlCopyFromArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 	/* Obtain db Handle */
 	H = (pdo_pgsql_db_handle *)dbh->driver_data;
 
-	while ((pgsql_result = PQgetResult(H->server))) {
-		PQclear(pgsql_result);
-	}
+	pgsql_discard_running_stmt(H);
+
 	pgsql_result = PQexec(H->server, query);
 
 	efree(query);
@@ -824,9 +858,8 @@ void pgsqlCopyFromFile_internal(INTERNAL_FUNCTION_PARAMETERS)
 
 	H = (pdo_pgsql_db_handle *)dbh->driver_data;
 
-	while ((pgsql_result = PQgetResult(H->server))) {
-		PQclear(pgsql_result);
-	}
+	pgsql_discard_running_stmt(H);
+
 	pgsql_result = PQexec(H->server, query);
 
 	efree(query);
@@ -920,9 +953,7 @@ void pgsqlCopyToFile_internal(INTERNAL_FUNCTION_PARAMETERS)
 		RETURN_FALSE;
 	}
 
-	while ((pgsql_result = PQgetResult(H->server))) {
-		PQclear(pgsql_result);
-	}
+	pgsql_discard_running_stmt(H);
 
 	/* using pre-9.0 syntax as PDO_pgsql is 7.4+ compatible */
 	if (pg_fields) {
@@ -1011,9 +1042,7 @@ void pgsqlCopyToArray_internal(INTERNAL_FUNCTION_PARAMETERS)
 
 	H = (pdo_pgsql_db_handle *)dbh->driver_data;
 
-	while ((pgsql_result = PQgetResult(H->server))) {
-		PQclear(pgsql_result);
-	}
+	pgsql_discard_running_stmt(H);
 
 	/* using pre-9.0 syntax as PDO_pgsql is 7.4+ compatible */
 	if (pg_fields) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -56,14 +56,14 @@
 #define FLOAT8LABEL "float8"
 #define FLOAT8OID 701
 
-#define FIN_DISCARD 0x1
-#define FIN_CLOSE   0x2
-#define FIN_ABORT   0x4
 
 
-
-static void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode)
+void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode)
 {
+	if (!S) {
+		return;
+	}
+
 	pdo_pgsql_db_handle *H = S->H;
 
 	if (S->is_running_unbuffered && S->result && (fin_mode & FIN_ABORT)) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -113,9 +113,10 @@ void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode)
 		}
 
 		S->is_prepared = false;
-		if (H->running_stmt == S) {
-			H->running_stmt = NULL;
-		}
+	}
+
+	if (H->running_stmt == S && (fin_mode & (FIN_CLOSE|FIN_ABORT))) {
+		H->running_stmt = NULL;
 	}
 }
 
@@ -190,7 +191,6 @@ static int pgsql_stmt_execute(pdo_stmt_t *stmt)
 	 * (maybe it will change with pipeline mode in libpq 14?) */
 	if (H->running_stmt && H->running_stmt->is_unbuffered) {
 		pgsql_stmt_finish(H->running_stmt, FIN_CLOSE);
-		H->running_stmt = NULL;
 	}
 	/* ensure that we free any previous unfetched results */
 	pgsql_stmt_finish(S, 0);

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -43,6 +43,8 @@ typedef struct {
 	unsigned 	_reserved:31;
 	pdo_pgsql_error_info	einfo;
 	Oid 		pgoid;
+	Oid cached_table_oid;
+	char *cached_table_name;
 	unsigned int	stmt_counter;
 	bool		emulate_prepares;
 	bool		disable_prepares;

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -92,6 +92,12 @@ extern int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const
 
 extern const struct pdo_stmt_methods pgsql_stmt_methods;
 
+#define FIN_DISCARD 0x1
+#define FIN_CLOSE   0x2
+#define FIN_ABORT   0x4
+
+extern void pgsql_stmt_finish(pdo_pgsql_stmt *S, int fin_mode);
+
 #define pdo_pgsql_sqlstate(r) PQresultErrorField(r, PG_DIAG_SQLSTATE)
 
 enum {

--- a/ext/pdo_pgsql/tests/gh15287.phpt
+++ b/ext/pdo_pgsql/tests/gh15287.phpt
@@ -132,6 +132,17 @@ $res = []; while (($re = $stmt->fetch())) $res[] = $re; display($res);
 $stmt->execute([ 0 ]);
 $res = []; for ($i = -1; ++$i < 2;) $res[] = $stmt->fetch(); display($res);
 display($pdo->query("select * from t2")->fetchAll());
+
+// Metadata calls the server for some operations (notably table oid-to-name conversion).
+// This will break libpq (that forbids a second PQexec before we consumed the first one).
+// Instead of either letting libpq return an error, or blindly forbid this call, we expect
+// being transparently provided at least attributes which do not require a server roundtrip.
+// And good news: column name is one of those "local" attributes.
+echo "=== meta ===\n";
+$stmt = $pdo->query("select * from t limit 2");
+echo "Starting with column " . $stmt->getColumnMeta(0)['name'] . ":\n";
+display($stmt->fetchAll());
+
 ?>
 --EXPECTF--
 === non regression ===
@@ -181,3 +192,7 @@ multiple calls to the same prepared statement, some interrupted before having re
 0
 1
 678	ok
+=== meta ===
+Starting with column n:
+0	original
+1	non original


### PR DESCRIPTION
As stated in the UPGRADING, using the passthrough ("single-row") mode of libpq (introduced in #15287) forbids passing a new query while the current one's results have not been entirely consumed.
… But I didn't notice that ext/pdo_pgsql _internally_ used new queries to fetch metadata (example use case: a call to `getColumnMeta()` while `fetch()`ing row by row will interleave the `getColumnMeta()`-triggered internal query to the database, with the results fetching for the user-called query).

This PR **makes those internal calls return NULL for non-essential metadata**, instead of letting libpq abort the user-called query.

It moreover includes a small tweak to table oid-to-name translation, with a 1-slot cache.
This may by chance allow the internal call to return something instead of NULL,
but it will nonetheless avoid 30 server calls to get the table name of 30 columns of the same table.