### PR TITLE
Fix Soap leaking http_msg on error

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -461,6 +461,7 @@ try_again:
 		}
 		add_soap_fault(this_ptr, "HTTP", "Unable to parse URL", NULL, NULL);
 		smart_str_free(&soap_headers_z);
+		efree(http_msg);
 		return FALSE;
 	}
 
@@ -474,6 +475,7 @@ try_again:
 		}
 		add_soap_fault(this_ptr, "HTTP", "Unknown protocol. Only http and https are allowed.", NULL, NULL);
 		smart_str_free(&soap_headers_z);
+		efree(http_msg);
 		return FALSE;
 	}
 
@@ -487,6 +489,7 @@ try_again:
 		add_soap_fault(this_ptr, "HTTP", "SSL support is not available in this build", NULL, NULL);
 		PG(allow_url_fopen) = old_allow_url_fopen;
 		smart_str_free(&soap_headers_z);
+		efree(http_msg);
 		return FALSE;
 	}
 
@@ -541,6 +544,7 @@ try_again:
 			add_soap_fault(this_ptr, "HTTP", "Could not connect to host", NULL, NULL);
 			PG(allow_url_fopen) = old_allow_url_fopen;
 			smart_str_free(&soap_headers_z);
+			efree(http_msg);
 			return FALSE;
 		}
 	}
@@ -684,6 +688,7 @@ try_again:
 					convert_to_null(Z_CLIENT_USE_PROXY_P(this_ptr));
 					smart_str_free(&soap_headers_z);
 					smart_str_free(&soap_headers);
+					efree(http_msg);
 					return FALSE;
 				}
 
@@ -901,12 +906,14 @@ try_again:
 			convert_to_null(Z_CLIENT_USE_PROXY_P(this_ptr));
 			add_soap_fault(this_ptr, "HTTP", "Failed Sending HTTP SOAP request", NULL, NULL);
 			smart_str_free(&soap_headers_z);
+			efree(http_msg);
 			return FALSE;
 		}
 		smart_str_free(&soap_headers);
 	} else {
 		add_soap_fault(this_ptr, "HTTP", "Failed to create stream??", NULL, NULL);
 		smart_str_free(&soap_headers_z);
+		efree(http_msg);
 		return FALSE;
 	}
 
@@ -915,6 +922,7 @@ try_again:
 		convert_to_null(Z_CLIENT_HTTPSOCKET_P(this_ptr));
 		convert_to_null(Z_CLIENT_USE_PROXY_P(this_ptr));
 		smart_str_free(&soap_headers_z);
+		efree(http_msg);
 		return TRUE;
 	}
 
@@ -929,6 +937,7 @@ try_again:
 			convert_to_null(Z_CLIENT_USE_PROXY_P(this_ptr));
 			add_soap_fault(this_ptr, "HTTP", "Error Fetching http headers", NULL, NULL);
 			smart_str_free(&soap_headers_z);
+			efree(http_msg);
 			return FALSE;
 		}
 
@@ -1157,6 +1166,7 @@ try_again:
 				if (--redirect_max < 1) {
 					add_soap_fault(this_ptr, "HTTP", "Redirection limit reached, aborting", NULL, NULL);
 					smart_str_free(&soap_headers_z);
+					efree(http_msg);
 					return FALSE;
 				}
 


### PR DESCRIPTION
Testing all cases is not so easy to do as we would need a server that redirects from e.g. http to https while SSL is not available.

Found with help of an experimental static analyser I'm working on.