### PR TITLE
Fix GH-16256: Assertion failure in ext/soap/php_encoding.c:460

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -837,6 +837,9 @@ PHP_METHOD(SoapServer, __construct)
 
 		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
+			if (HT_IS_PACKED(Z_ARRVAL_P(tmp))) {
+				php_error_docref(NULL, E_ERROR, "'classmap' option must be an associative array");
+			}
 			service->class_map = zend_array_dup(Z_ARRVAL_P(tmp));
 		}
 
@@ -2003,6 +2006,9 @@ PHP_METHOD(SoapClient, __construct)
 		}
 		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
+			if (HT_IS_PACKED(Z_ARRVAL_P(tmp))) {
+				php_error_docref(NULL, E_ERROR, "'classmap' option must be an associative array");
+			}
 			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
 		}
 

--- a/ext/soap/tests/bugs/gh16256.phpt
+++ b/ext/soap/tests/bugs/gh16256.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-16256 (Assertion failure in ext/soap/php_encoding.c:460)
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+$classmap = [
+    "bogus",
+];
+$wsdl = __DIR__."/ext/soap/tests/bug41004.wsdl";
+try {
+    new SoapClient($wsdl, ["classmap" => $classmap]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    new SoapServer($wsdl, ["classmap" => $classmap]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+SoapClient::__construct(): 'classmap' option must be an associative array
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>SoapServer::__construct(): 'classmap' option must be an associative array</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>


### PR DESCRIPTION
The class map must be an associative array, not a packed array.