### PR TITLE
Fix GH-16267 socket_strerror overflow on argument value.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1211,7 +1211,7 @@ PHP_FUNCTION(socket_strerror)
 		RETURN_THROWS();
 	}
 
-	if (arg1 < INT_MIN || arg1 > INT_MAX) {
+	if (ZEND_LONG_EXCEEDS_INT(arg1)) {
 		zend_argument_value_error(1, "must be between %d and %d", INT_MIN, INT_MAX);
 		RETURN_THROWS();
 	}

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1211,6 +1211,11 @@ PHP_FUNCTION(socket_strerror)
 		RETURN_THROWS();
 	}
 
+	if (arg1 < INT_MIN || arg1 > INT_MAX) {
+		zend_argument_value_error(1, "must be between %d and %d", INT_MIN, INT_MAX);
+		RETURN_THROWS();
+	}
+
 	RETURN_STRING(sockets_strerror(arg1));
 }
 /* }}} */

--- a/ext/sockets/tests/gh16267.phpt
+++ b/ext/sockets/tests/gh16267.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-16267 - overflow on socket_strerror argument
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die('skip 64-bit only'); ?>
+--FILE--
+<?php
+try {
+	socket_strerror(PHP_INT_MIN);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	socket_strerror(PHP_INT_MAX);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECTF--
+socket_strerror(): Argument #1 ($error_code) must be between %s and %s
+socket_strerror(): Argument #1 ($error_code) must be between %s and %s


### PR DESCRIPTION
only socket_strerror provides user-supplied value to sockets_strerror handler.