### PR TITLE
Fix GH-16266: _ZendTestClass::test() segfaults on named parameter

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -647,6 +647,10 @@ static zend_object *zend_test_class_new(zend_class_entry *class_type)
 	return obj;
 }
 
+static zend_internal_arg_info arginfo_ZendTestClass___call[] = {
+	{"foo", {0}, NULL},
+};
+
 static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key)
 {
 	if (zend_string_equals_literal_ci(name, "test")) {
@@ -659,7 +663,8 @@ static zend_function *zend_test_class_method_get(zend_object **object, zend_stri
 	    }
 	    memset(fptr, 0, sizeof(zend_internal_function));
 	    fptr->type = ZEND_INTERNAL_FUNCTION;
-	    fptr->num_args = 1;
+		fptr->num_args = sizeof(arginfo_ZendTestClass___call) / sizeof(zend_internal_arg_info);
+		fptr->arg_info = arginfo_ZendTestClass___call;
 	    fptr->scope = (*object)->ce;
 	    fptr->fn_flags = ZEND_ACC_CALL_VIA_HANDLER;
 	    fptr->function_name = zend_string_copy(name);
@@ -682,7 +687,8 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 		}
 		memset(fptr, 0, sizeof(zend_internal_function));
 		fptr->type = ZEND_INTERNAL_FUNCTION;
-		fptr->num_args = 1;
+		fptr->num_args = sizeof(arginfo_ZendTestClass___call) / sizeof(zend_internal_arg_info);
+		fptr->arg_info = arginfo_ZendTestClass___call;
 		fptr->scope = ce;
 		fptr->fn_flags = ZEND_ACC_CALL_VIA_HANDLER|ZEND_ACC_STATIC;
 		fptr->function_name = zend_string_copy(name);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -647,10 +647,6 @@ static zend_object *zend_test_class_new(zend_class_entry *class_type)
 	return obj;
 }
 
-static zend_internal_arg_info arginfo_ZendTestClass___call[] = {
-	{"foo", {0}, NULL},
-};
-
 static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key)
 {
 	if (zend_string_equals_literal_ci(name, "test")) {
@@ -663,8 +659,7 @@ static zend_function *zend_test_class_method_get(zend_object **object, zend_stri
 	    }
 	    memset(fptr, 0, sizeof(zend_internal_function));
 	    fptr->type = ZEND_INTERNAL_FUNCTION;
-		fptr->num_args = sizeof(arginfo_ZendTestClass___call) / sizeof(zend_internal_arg_info);
-		fptr->arg_info = arginfo_ZendTestClass___call;
+	    fptr->num_args = 0;
 	    fptr->scope = (*object)->ce;
 	    fptr->fn_flags = ZEND_ACC_CALL_VIA_HANDLER;
 	    fptr->function_name = zend_string_copy(name);
@@ -687,8 +682,7 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 		}
 		memset(fptr, 0, sizeof(zend_internal_function));
 		fptr->type = ZEND_INTERNAL_FUNCTION;
-		fptr->num_args = sizeof(arginfo_ZendTestClass___call) / sizeof(zend_internal_arg_info);
-		fptr->arg_info = arginfo_ZendTestClass___call;
+		fptr->num_args = 0;
 		fptr->scope = ce;
 		fptr->fn_flags = ZEND_ACC_CALL_VIA_HANDLER|ZEND_ACC_STATIC;
 		fptr->function_name = zend_string_copy(name);

--- a/ext/zend_test/tests/gh16266.phpt
+++ b/ext/zend_test/tests/gh16266.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-16266 (_ZendTestClass::test() segfaults on named parameter)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+try {
+    $o = new _ZendTestClass();
+    $o->test('a', 'b', c: 'c');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    _ZendTestClass::test('a', 'b', c: 'c');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Unknown named parameter $c
+Unknown named parameter $c


### PR DESCRIPTION
We must not assume that an internal function has arg_info; that is at least not given for internal classes implementing the magic `__call()` method.  In such cases we cannot look up the parameter offset by name, and raise a fatal error.