### PR TITLE
Fix GH-16261: Reference invariant broken in mb_convert_variables()

### DIFF
--- a/ext/mbstring/tests/gh16261.phpt
+++ b/ext/mbstring/tests/gh16261.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-16261 (Reference invariant broken in mb_convert_variables())
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+class Test {
+    public string $x;
+    public string $y;
+    public array $z;
+}
+$test = new Test;
+$ref = "hello";
+$ref2 = "world";
+$ref3 = [&$ref2];
+$test->x =& $ref;
+$test->z =& $ref3;
+mb_convert_variables("EUC-JP", "Shift_JIS", $test);
+
+class Test2 {
+    public function __construct(public string $x) {}
+}
+$test2 = new Test2("foo");
+
+mb_convert_variables("EUC-JP", "Shift_JIS", $test->x);
+
+var_dump($test, $test2);
+?>
+--EXPECT--
+object(Test)#1 (2) {
+  ["x"]=>
+  string(5) "hello"
+  ["y"]=>
+  uninitialized(string)
+  ["z"]=>
+  &array(1) {
+    [0]=>
+    string(5) "world"
+  }
+}
+object(Test2)#2 (1) {
+  ["x"]=>
+  string(3) "foo"
+}


### PR DESCRIPTION
The behaviour is weird in the sense that the reference must get unwrapped. What ended up happening is that when destroying the old reference the sources list was not cleaned properly. We add handling for that. Normally we would use use ZEND_TRY_ASSIGN_STRINGL but that doesn't work here as it would keep the reference and change values through references (see bug #26639).