### PR TITLE
Use Zend's GDB JIT definitions in IR

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -100,7 +100,7 @@ if test "$PHP_OPCACHE" != "no"; then
     PHP_SUBST([DASM_FLAGS])
     PHP_SUBST([DASM_ARCH])
 
-    JIT_CFLAGS="-I@ext_builddir@/jit/ir -D$IR_TARGET -DIR_PHP"
+    JIT_CFLAGS="-I@ext_builddir@/jit/ir -D$IR_TARGET -DIR_PHP -DIR_EXTERNAL_GDB_ENTRY"
     AS_VAR_IF([ZEND_DEBUG], [yes], [JIT_CFLAGS="$JIT_CFLAGS -DIR_DEBUG"])
   ])
 


### PR DESCRIPTION
Define `IR_EXTERNAL_GDB_ENTRY` so that IR will not define its own `__jit_debug_descriptor` and `__jit_debug_register_code` symbols. When these symbols are defined multiple times, GDB and the program may not use the same ones, which breaks the GDB integration.

Related: https://github.com/dstogov/ir/pull/93