### PR TITLE
Fix regression on platforms without `ZEND_CHECK_STACK_LIMIT` set

### DIFF
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1052,7 +1052,9 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 	}
 
 	if (UNEXPECTED(php_serialize_check_stack_limit())) {
+#ifdef ZEND_CHECK_STACK_LIMIT
 		zend_call_stack_size_error();
+#endif
 		return;
 	}
 


### PR DESCRIPTION
There was a guard on one instance of this, but not the other. Unsure if this is the best place for this; the functions are `#ifdef` gated in `zend_execute.c`, but not the associated header; perhaps it should be `#else` with a nop version of the function in that case? I added a guard at this call site to be consistent with other places.

Fixes build on ppc64 CI. I couldn't seem to reproduce it with a default build on ppc64, but CI has sanitizers and such on.

```
/usr/bin/powerpc64-unknown-linux-gnu-ld.bfd: ext/standard/var.o: in function `php_var_serialize_intern':
/srv/actions/.cache/act/2afa8512bdf5ceb6/hostexecutor/ext/standard/var.c:1055:(.text+0x18f64): undefined reference to `zend_call_stack_size_error'
/usr/bin/powerpc64-unknown-linux-gnu-ld.bfd: ext/standard/var.o: in function `php_var_serialize_intern':
/srv/actions/.cache/act/2afa8512bdf5ceb6/hostexecutor/ext/standard/var.c:1055:(.text+0x18f64): undefined reference to `zend_call_stack_size_error'
/usr/bin/powerpc64-unknown-linux-gnu-ld.bfd: ext/standard/var.o: in function `php_var_serialize_intern':
/srv/actions/.cache/act/2afa8512bdf5ceb6/hostexecutor/ext/standard/var.c:1055:(.text+0x18f64): undefined reference to `zend_call_stack_size_error'
/usr/bin/powerpc64-unknown-linux-gnu-ld.bfd: ext/standard/var.o: in function `php_var_serialize_intern':
/srv/actions/.cache/act/2afa8512bdf5ceb6/hostexecutor/ext/standard/var.c:1055:(.text+0x18f64): undefined reference to `zend_call_stack_size_error'
clang-17: error: linker command failed with exit code 1 (use -v to see invocation)
```