### PR TITLE
Fix regression on platforms without `ZEND_CHECK_STACK_LIMIT` set (8.4)

### DIFF
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1052,7 +1052,9 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 	}
 
 	if (UNEXPECTED(php_serialize_check_stack_limit())) {
+#ifdef ZEND_CHECK_STACK_LIMIT
 		zend_call_stack_size_error();
+#endif
 		return;
 	}
 

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1040,9 +1040,8 @@ static zend_always_inline bool php_serialize_check_stack_limit(void)
 		zend_call_stack_size_error();
 		return true;
 	}
-#else
-	return false;
 #endif
+	return false;
 }
 
 static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool in_rcn_array, bool is_root) /* {{{ */

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1036,7 +1036,10 @@ static void php_var_serialize_class(smart_str *buf, zval *struc, HashTable *ht, 
 static zend_always_inline bool php_serialize_check_stack_limit(void)
 {
 #ifdef ZEND_CHECK_STACK_LIMIT
-	return zend_call_stack_overflowed(EG(stack_limit));
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_call_stack_size_error();
+		return true;
+	}
 #else
 	return false;
 #endif
@@ -1052,9 +1055,6 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 	}
 
 	if (UNEXPECTED(php_serialize_check_stack_limit())) {
-#ifdef ZEND_CHECK_STACK_LIMIT
-		zend_call_stack_size_error();
-#endif
 		return;
 	}
 


### PR DESCRIPTION
There was a guard on one instance of this, but not the other. Unsure if this is the best place for this; the functions are `#ifdef` gated in `zend_execute.c`, but not the associated header; perhaps it should be `#else` with a nop version of the function in that case? I added a guard at this call site to be consistent with other places.

8.4 targeting version of GH-16284, obsoletes that.