### PR TITLE
ext/[cd]*: fix a bunch of typos

### DIFF
--- a/ext/calendar/calendar.c
+++ b/ext/calendar/calendar.c
@@ -398,7 +398,7 @@ static char *heb_number_to_chars(int n, int fl, char **ret)
 		n -= 400;
 	}
 
-/* meot (hundreads) case */
+/* meot (hundreds) case */
 	if (n >= 100) {
 		*p = alef_bet[18 + n / 100];
 		p++;

--- a/ext/calendar/julian.c
+++ b/ext/calendar/julian.c
@@ -67,7 +67,7 @@
  *     the Julian calendar.
  *
  *     The details are unknown, but the lengths of the months were adjusted
- *     until they finally stablized in 8 A.D. with their current lengths:
+ *     until they finally stabilized in 8 A.D. with their current lengths:
  *
  *         January          31
  *         February         28/29

--- a/ext/com_dotnet/tests/gh8778.phpt
+++ b/ext/com_dotnet/tests/gh8778.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug GH-8778 (Integer arithmethic with large number variants fails)
+Bug GH-8778 (Integer arithmetic with large number variants fails)
 --EXTENSIONS--
 com_dotnet
 --SKIPIF--

--- a/ext/ctype/tests/ctype_xdigit_variation1.phpt
+++ b/ext/ctype/tests/ctype_xdigit_variation1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test ctype_xdigit() function : usage variations - different data typse as $c arg
+Test ctype_xdigit() function : usage variations - different data types as $c arg
 --EXTENSIONS--
 ctype
 --FILE--

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -61,7 +61,7 @@
 
 #ifdef __GNUC__
 /* don't complain about deprecated CURLOPT_* we're exposing to PHP; we
-   need to keep using those to avoid breaking PHP API compatibiltiy */
+   need to keep using those to avoid breaking PHP API compatibility */
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/ext/curl/tests/bug71144.phpt
+++ b/ext/curl/tests/bug71144.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #71144 (Sementation fault when using cURL with ZTS)
+Bug #71144 (Segmentation fault when using cURL with ZTS)
 --DESCRIPTION--
 Since Curl 7.62, CURLOPT_DNS_USE_GLOBAL_CACHE has no effect, and is
 silently ignored.

--- a/ext/curl/tests/curl_copy_handle_variation2.phpt
+++ b/ext/curl/tests/curl_copy_handle_variation2.phpt
@@ -6,7 +6,7 @@ Francesco Fullone ff@ideato.it
 --EXTENSIONS--
 curl
 --DESCRIPTION--
-the only way to test if a option is setten on a curl handle is using the curl_getinfo() function.
+the only way to test if a option is set on a curl handle is using the curl_getinfo() function.
 but this can only check on a limited amount of options...
 --FILE--
 <?php

--- a/ext/curl/tests/curl_multi_setopt_callables.phpt
+++ b/ext/curl/tests/curl_multi_setopt_callables.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test curl_multi_setopt() with options that take callabes
+Test curl_multi_setopt() with options that take callables
 --EXTENSIONS--
 curl
 --FILE--

--- a/ext/curl/tests/curl_setopt_callables.phpt
+++ b/ext/curl/tests/curl_setopt_callables.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test curl_setopt(_array)() with options that take callabes
+Test curl_setopt(_array)() with options that take callables
 --EXTENSIONS--
 curl
 --FILE--

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2699,7 +2699,7 @@ PHP_METHOD(DateTime, createFromInterface)
 }
 /* }}} */
 
-/* {{{ Creates new DateTime object from given unix timetamp */
+/* {{{ Creates new DateTime object from given unix timestamp */
 PHP_METHOD(DateTime, createFromTimestamp)
 {
 	zval         *value;

--- a/ext/date/tests/DateTimeZone_clone_basic1.phpt
+++ b/ext/date/tests/DateTimeZone_clone_basic1.phpt
@@ -22,7 +22,7 @@ if ($clone != $orig) {
 }else if ($clone === $orig) {
     echo "TEST FAILED : objects identical\n";
 } else {
-    echo "TEST PASSED : Objects equal but not indetical\n";
+    echo "TEST PASSED : Objects equal but not identical\n";
 }
 
 ?>
@@ -40,4 +40,4 @@ object(DateTimeZone)#%d (2) {
   ["timezone"]=>
   string(3) "GMT"
 }
-TEST PASSED : Objects equal but not indetical
+TEST PASSED : Objects equal but not identical

--- a/ext/date/tests/DateTimeZone_serialize_type_1.phpt
+++ b/ext/date/tests/DateTimeZone_serialize_type_1.phpt
@@ -12,7 +12,7 @@ var_dump($serialized);
 
 $tz2 = unserialize($serialized);
 var_dump($tz2);
-// Try to use unserialzied object
+// Try to use unserialized object
 var_dump( $tz2->getName() );
 
 ?>

--- a/ext/date/tests/DateTimeZone_serialize_type_2.phpt
+++ b/ext/date/tests/DateTimeZone_serialize_type_2.phpt
@@ -12,7 +12,7 @@ var_dump($serialized);
 
 $tz2 = unserialize($serialized);
 var_dump($tz2);
-// Try to use unserialzied object
+// Try to use unserialized object
 var_dump( $tz2->getName() );
 
 ?>

--- a/ext/date/tests/DateTimeZone_serialize_type_3.phpt
+++ b/ext/date/tests/DateTimeZone_serialize_type_3.phpt
@@ -12,7 +12,7 @@ var_dump($serialized);
 
 $tz2 = unserialize($serialized);
 var_dump($tz2);
-// Try to use unserialzied object
+// Try to use unserialized object
 var_dump( $tz2->getName() );
 
 ?>

--- a/ext/date/tests/DateTime_serialize.phpt
+++ b/ext/date/tests/DateTime_serialize.phpt
@@ -12,7 +12,7 @@ var_dump($serialized);
 
 $date2 = unserialize($serialized);
 var_dump($date2);
-// Try to use unserialzied object
+// Try to use unserialized object
 var_dump( $date2->format( "F j, Y, g:i a") );
 
 ?>

--- a/ext/date/tests/ExtendDateTime.phpt
+++ b/ext/date/tests/ExtendDateTime.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Extendig DatTime and calling __set_state without args
+Extending DateTime and calling __set_state without args
 --CREDITS--
 Gabriel Caruso (carusogabriel34@gmail.com)
 --FILE--

--- a/ext/date/tests/bug36224.phpt
+++ b/ext/date/tests/bug36224.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #36224 (date(DATE_ATOM) gives wrong resulsts)
+Bug #36224 (date(DATE_ATOM) gives wrong results)
 --FILE--
 <?php
 date_default_timezone_set("Europe/Oslo");

--- a/ext/date/tests/date_isodate_set_basic1.phpt
+++ b/ext/date/tests/date_isodate_set_basic1.phpt
@@ -7,7 +7,7 @@ echo "*** Testing date_isodate_set() : basic functionality ***\n";
 //Set the default time zone
 date_default_timezone_set("Europe/London");
 
-// Create a deate object
+// Create a date object
 $datetime = date_create("2009-01-30 17:57:32");
 
 // Which month is week 40 ?

--- a/ext/date/tests/getdate_variation4.phpt
+++ b/ext/date/tests/getdate_variation4.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test getdate() function : usage variation - Verifyig by supplying year-wise sample time stamps since Unix epoch time
+Test getdate() function : usage variation - Verifying by supplying year-wise sample time stamps since Unix epoch time
 --FILE--
 <?php
 echo "*** Testing getdate() : usage variation ***\n";

--- a/ext/date/tests/getdate_variation5.phpt
+++ b/ext/date/tests/getdate_variation5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test getdate() function : usage variation - Verifyig with different timezones on Unix epoch timestamp
+Test getdate() function : usage variation - Verifying with different timezones on Unix epoch timestamp
 --FILE--
 <?php
 echo "*** Testing getdate() : usage variation ***\n";

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1191,7 +1191,7 @@ PHP_FUNCTION(dba_delete)
 /* }}} */
 
 /* {{{ If not inifile: Insert value as key, return false, if key exists already
-   If inifile: Add vakue as key (next instance of key) */
+   If inifile: Add value as key (next instance of key) */
 PHP_FUNCTION(dba_insert)
 {
 	php_dba_update(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -349,14 +349,14 @@ zend_result dom_document_recover_write(dom_object *obj, zval *newval)
 /* {{{ substituteEntities	boolean
 readonly=no
 */
-zend_result dom_document_substitue_entities_read(dom_object *obj, zval *retval)
+zend_result dom_document_substitute_entities_read(dom_object *obj, zval *retval)
 {
 	libxml_doc_props const* doc_prop = dom_get_doc_props_read_only(obj->document);
 	ZVAL_BOOL(retval, doc_prop->substituteentities);
 	return SUCCESS;
 }
 
-zend_result dom_document_substitue_entities_write(dom_object *obj, zval *newval)
+zend_result dom_document_substitute_entities_write(dom_object *obj, zval *newval)
 {
 	if (obj->document) {
 		dom_doc_propsptr doc_prop = dom_get_doc_props(obj->document);

--- a/ext/dom/dom_properties.h
+++ b/ext/dom/dom_properties.h
@@ -58,8 +58,8 @@ zend_result dom_document_preserve_whitespace_read(dom_object *obj, zval *retval)
 zend_result dom_document_preserve_whitespace_write(dom_object *obj, zval *newval);
 zend_result dom_document_recover_read(dom_object *obj, zval *retval);
 zend_result dom_document_recover_write(dom_object *obj, zval *newval);
-zend_result dom_document_substitue_entities_read(dom_object *obj, zval *retval);
-zend_result dom_document_substitue_entities_write(dom_object *obj, zval *newval);
+zend_result dom_document_substitute_entities_read(dom_object *obj, zval *retval);
+zend_result dom_document_substitute_entities_write(dom_object *obj, zval *newval);
 
 /* html5 document properties */
 zend_result dom_html_document_encoding_write(dom_object *obj, zval *retval);

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1747,7 +1747,7 @@ PHP_METHOD(DOMElement, toggleAttribute)
 			if (follow_spec) {
 				xmlSetNsProp(thisp, NULL, BAD_CAST qname, NULL);
 			} else {
-				/* The behaviour for namespaces isn't defined by spec, but this is based on observing browers behaviour.
+				/* The behaviour for namespaces isn't defined by spec, but this is based on observing browsers' behaviour.
 				* It follows the same rules when you'd manually add an attribute using the other APIs. */
 				int len;
 				const xmlChar *split = xmlSplitQName3((const xmlChar *) qname, &len);

--- a/ext/dom/infra.c
+++ b/ext/dom/infra.c
@@ -46,7 +46,7 @@ zend_string *dom_strip_and_collapse_ascii_whitespace(zend_string *input)
 	while (current < end) {
 		/* Copy non-whitespace */
 		size_t non_whitespace_len = strcspn(current, ascii_whitespace);
-		/* If the pointers are equal, we still haven't encountered collapsable or strippable whitespace. */
+		/* If the pointers are equal, we still haven't encountered collapsible or strippable whitespace. */
 		if (write_ptr != current) {
 			memmove(write_ptr, current, non_whitespace_len);
 		}

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -960,7 +960,7 @@ PHP_MINIT_FUNCTION(dom)
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "resolveExternals", dom_document_resolve_externals_read, dom_document_resolve_externals_write);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "preserveWhiteSpace", dom_document_preserve_whitespace_read, dom_document_preserve_whitespace_write);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "recover", dom_document_recover_read, dom_document_recover_write);
-	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "substituteEntities", dom_document_substitue_entities_read, dom_document_substitue_entities_write);
+	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "substituteEntities", dom_document_substitute_entities_read, dom_document_substitute_entities_write);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "firstElementChild", dom_parent_node_first_element_child_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "lastElementChild", dom_parent_node_last_element_child_read, NULL);
 	DOM_REGISTER_PROP_HANDLER(&dom_document_prop_handlers, "childElementCount", dom_parent_node_child_element_count, NULL);
@@ -2095,7 +2095,7 @@ int dom_validate_and_extract(const zend_string *namespace, const zend_string *qn
 	*localName = xmlSplitQName2(BAD_CAST ZSTR_VAL(qname), prefix);
 
 	/* 6. If prefix is non-null and namespace is null, then throw a "NamespaceError" DOMException.
-	 *    Note that null namespace means empty string here becaue of step 1. */
+	 *    Note that null namespace means empty string here because of step 1. */
 	if (*prefix != NULL && ZSTR_VAL(namespace)[0] == '\0') {
 		return NAMESPACE_ERR;
 	}

--- a/ext/dom/tests/DOMDocument_saveHTML_variant2.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTML_variant2.phpt
@@ -1,5 +1,5 @@
 --TEST--
-DOMDocument::saveHTML() vs DOMDocumet::saveXML()
+DOMDocument::saveHTML() vs DOMDocument::saveXML()
 --EXTENSIONS--
 dom
 --FILE--

--- a/ext/dom/tests/bug69846.phpt
+++ b/ext/dom/tests/bug69846.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #69846 Segmenation fault (access violation) when iterating over DOMNodeList
+Bug #69846 Segmentation fault (access violation) when iterating over DOMNodeList
 --EXTENSIONS--
 dom
 --FILE--

--- a/ext/dom/tests/bug79968.phpt
+++ b/ext/dom/tests/bug79968.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dom: Bug #79968 - Crash when calling before without valid hierachy
+dom: Bug #79968 - Crash when calling before without valid hierarchy
 --EXTENSIONS--
 dom
 --FILE--

--- a/ext/dom/tests/modern/spec/gh11404_1.phpt
+++ b/ext/dom/tests/modern/spec/gh11404_1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-11404 (DOMDocument::savexml and friends ommit xmlns="" declaration for null namespace, creating incorrect xml representation of the DOM)
+GH-11404 (DOMDocument::savexml and friends omit xmlns="" declaration for null namespace, creating incorrect xml representation of the DOM)
 --EXTENSIONS--
 dom
 --FILE--

--- a/ext/dom/tests/modern/spec/gh11404_2.phpt
+++ b/ext/dom/tests/modern/spec/gh11404_2.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-11404 (DOMDocument::savexml and friends ommit xmlns="" declaration for null namespace, creating incorrect xml representation of the DOM)
+GH-11404 (DOMDocument::savexml and friends omit xmlns="" declaration for null namespace, creating incorrect xml representation of the DOM)
 --EXTENSIONS--
 dom
 --FILE--

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -353,7 +353,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type, bool modern) 
 						xmlNsPtr original = (xmlNsPtr) node;
 
 						/* Make sure parent dom object exists, so we can take an extra reference. */
-						zval parent_zval; /* don't destroy me, my lifetime is transfered to the fake namespace decl */
+						zval parent_zval; /* don't destroy me, my lifetime is transferred to the fake namespace decl */
 						php_dom_create_object(nsparent, &parent_zval, &intern->dom);
 						dom_object *parent_intern = Z_DOMOBJ_P(&parent_zval);
 

--- a/ext/dom/xpath_callbacks.c
+++ b/ext/dom/xpath_callbacks.c
@@ -350,7 +350,7 @@ static zval *php_dom_xpath_callback_fetch_args(xmlXPathParserContextPtr ctxt, ui
 								xmlNsPtr original = (xmlNsPtr) node;
 
 								/* Make sure parent dom object exists, so we can take an extra reference. */
-								zval parent_zval; /* don't destroy me, my lifetime is transfered to the fake namespace decl */
+								zval parent_zval; /* don't destroy me, my lifetime is transferred to the fake namespace decl */
 								php_dom_create_object(nsparent, &parent_zval, intern);
 								dom_object *parent_intern = Z_DOMOBJ_P(&parent_zval);
 


### PR DESCRIPTION
Only functional change is the renaming of the functions `dom_document_substitue_entities_(read|write)` to replace `substitue` with `substitute`.