### PR TITLE
Fix segfault on debug_backtrace() in _ZendTestFiber

### DIFF
--- a/ext/zend_test/fiber.c
+++ b/ext/zend_test/fiber.c
@@ -91,6 +91,7 @@ static ZEND_STACK_ALIGNED void zend_test_fiber_execute(zend_fiber_transfer *tran
 		execute_data = (zend_execute_data *) stack->top;
 
 		memset(execute_data, 0, sizeof(zend_execute_data));
+		execute_data->func = (zend_function *) &zend_pass_function;
 
 		EG(current_execute_data) = execute_data;
 		EG(jit_trace_num) = 0;

--- a/ext/zend_test/tests/gh16230.phpt
+++ b/ext/zend_test/tests/gh16230.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-16230: Segfault on debug_backtrace() inside _ZendTestFiber
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$test = new _ZendTestFiber(function (): void {
+    var_dump(debug_backtrace());
+});
+$test->start();
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(2) {
+    ["function"]=>
+    string(9) "{closure}"
+    ["args"]=>
+    array(0) {
+    }
+  }
+}


### PR DESCRIPTION
Fixes GH-16230