### PR TITLE
Build com_dotnet shared by default

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -36,7 +36,6 @@ set CFLAGS=/W1 /WX
 cmd /c configure.bat ^
 	--enable-snapshot-build ^
 	--disable-debug-pack ^
-	--enable-com-dotnet=shared ^
 	--without-analyzer ^
 	--enable-object-out-dir=%PHP_BUILD_OBJ_DIR% ^
 	--with-php-build=%DEPS_DIR% ^

--- a/ext/com_dotnet/config.w32
+++ b/ext/com_dotnet/config.w32
@@ -1,6 +1,6 @@
 // vim:ft=javascript
 
-ARG_ENABLE("com-dotnet", "COM and .Net support", "yes");
+ARG_ENABLE("com-dotnet", "COM and .Net support", "yes,shared");
 
 if (PHP_COM_DOTNET == "yes") {
 	CHECK_LIB('oleaut32.lib', 'com_dotnet');


### PR DESCRIPTION
The official Windows builds and CI are doing this for ages, so it appears to be overdue to finally switch the actual default.

---

Apparently, com_dotnet had been statically build for early PHP releases (makes some sense, because it could have been considered an integral part of PHP on Windows). However, as of PHP 5.5.0, com_dotnet had been built as shared extension, without changing the default in config.w32 (makes also sense to not break custom builds). That probably should have been changed in the next major PHP version, but obviously hasn't. Thus I'm suggesting to change it now (even if PHP next will be PHP 8.5), because I don't see any point in having a de-facto default which is different from the actual default. Custom builds with a static com_dotnet are still possible by passing `--enable-com-dotnet=yes`.
