### PR TITLE
Fix segfault in zend_test_execute_internal()

### DIFF
--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -288,7 +288,7 @@ static void zend_test_execute_internal(zend_execute_data *execute_data, zval *re
 		} else {
 			php_printf("%*s<!-- internal enter %s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.function_name));
 		}
-	} else {
+	} else if (ZEND_USER_CODE(fbc->type)) {
 		php_printf("%*s<!-- internal enter '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->op_array.filename));
 	}
 

--- a/ext/zend_test/tests/gh16294.phpt
+++ b/ext/zend_test/tests/gh16294.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-16294: Segfault in test observer on zend_pass_function
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.execute_internal=1
+--FILE--
+<?php
+
+class Foo {};
+new Foo([]);
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
zend_pass_function also has no name, so we might also be referring to an internal function here. In this case, ZEND_NEW uses the zend_pass_function when there is no constructor.

Fixes GH-16294