### PR TITLE
Fix GH-16292: Segmentation fault in ext/xmlreader/php_xmlreader.c:1282

### DIFF
--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -60,21 +60,23 @@ PHP_DOM_EXPORT xmlNodePtr dom_object_get_node(dom_object *obj);
     (const xmlChar *) "http://www.w3.org/2000/xmlns/"
 
 #define NODE_GET_OBJ(__ptr, __id, __prtype, __intern) { \
-	__intern = Z_LIBXML_NODE_P(__id); \
+	zval *__zv = (__id); \
+	__intern = Z_LIBXML_NODE_P(__zv); \
 	if (__intern->node == NULL || !(__ptr = (__prtype)__intern->node->node)) { \
-  		php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", \
-			ZSTR_VAL(__intern->std.ce->name));\
-  		RETURN_NULL();\
+		php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", \
+			ZSTR_VAL(Z_OBJCE_P(__zv)->name));\
+		RETURN_NULL();\
   	} \
 }
 
 #define DOC_GET_OBJ(__ptr, __id, __prtype, __intern) { \
-	__intern = Z_LIBXML_NODE_P(__id); \
+	zval *__zv = (__id); \
+	__intern = Z_LIBXML_NODE_P(__zv); \
 	if (__intern->document != NULL) { \
 		if (!(__ptr = (__prtype)__intern->document->ptr)) { \
-  			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", __intern->std.ce->name);\
-  			RETURN_NULL();\
-  		} \
+			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(Z_OBJCE_P(__zv)->name));\
+			RETURN_NULL();\
+		} \
 	} \
 }
 

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -1122,7 +1122,13 @@ PHP_METHOD(XMLReader, expand)
 	}
 
 	if (basenode != NULL) {
-		NODE_GET_OBJ(node, basenode, xmlNodePtr, domobj);
+		/* Note: cannot use NODE_GET_OBJ here because of the wrong return type */
+		domobj = Z_LIBXML_NODE_P(basenode);
+		if (UNEXPECTED(domobj->node == NULL || domobj->node->node == NULL)) {
+			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", ZSTR_VAL(Z_OBJCE_P(basenode)->name));
+			RETURN_FALSE;
+		}
+		node = domobj->node->node;
 		docp = node->doc;
 	}
 

--- a/ext/xmlreader/tests/gh16292.phpt
+++ b/ext/xmlreader/tests/gh16292.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-16292 (Segmentation fault in ext/xmlreader/php_xmlreader.c:1282)
+--EXTENSIONS--
+dom
+xmlreader
+--FILE--
+<?php
+
+$character_data = new DOMCharacterData();
+$xmlstring = '<?xml version="1.0" encoding="UTF-8"?>
+<books><book>new book</book></books>';
+$reader = new XMLReader();
+$reader->XML($xmlstring);
+while ($reader->read()) {
+    if ($reader->localName == "book") {
+        var_dump($reader->expand($character_data));
+    }
+}
+
+?>
+--EXPECTF--
+Warning: XMLReader::expand(): Couldn't fetch DOMCharacterData in %s on line %d
+bool(false)
+
+Warning: XMLReader::expand(): Couldn't fetch DOMCharacterData in %s on line %d
+bool(false)


### PR DESCRIPTION
3 issues:
1) RETURN_NULL() was used via the macro NODE_GET_OBJ(), but the function
   returns false on failure and cannot return null according to its
   stub.
2) The struct layout of the different implementors of libxml only
   guarantees overlap between the node pointer and the document
   reference, so accessing the std zend_object may not work.
3) DOC_GET_OBJ() wasn't using ZSTR_VAL().

Note to self: update the condition in php_xmlreader.c upon merging up.