### PR TITLE
Remove special handling of exit/die in stubs

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -83,14 +83,9 @@ function processStubFile(string $stubFile, Context $context, bool $includeOnly =
             }
         }
 
-        /* Because exit() and die() are proper token/keywords we need to hack-around */
-        $hasSpecialExitAsFunctionHandling = str_ends_with($stubFile, 'zend_builtin_functions.stub.php');
         if (!$fileInfo = $context->parsedFiles[$stubFile] ?? null) {
             initPhpParser();
             $stubContent = $stubCode ?? file_get_contents($stubFile);
-            if ($hasSpecialExitAsFunctionHandling) {
-                $stubContent = str_replace(['exit', 'die'], ['exit_dummy', 'die_dummy'], $stubContent);
-            }
             $fileInfo = parseStubFile($stubContent);
             $context->parsedFiles[$stubFile] = $fileInfo;
 
@@ -124,9 +119,6 @@ function processStubFile(string $stubFile, Context $context, bool $includeOnly =
             $context->allConstInfos,
             $stubHash
         );
-        if ($hasSpecialExitAsFunctionHandling) {
-            $arginfoCode = str_replace(['exit_dummy', 'die_dummy'], ['exit', 'die'], $arginfoCode);
-        }
         if (($context->forceRegeneration || $stubHash !== $oldStubHash) && file_put_contents($arginfoFile, $arginfoCode)) {
             echo "Saved $arginfoFile\n";
         }
@@ -6152,7 +6144,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "5.0.0";
+    $version = "5.3.1";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);


### PR DESCRIPTION
PHP-Parser 5.3.1 allows these as function names to allow direct use in stubs.