### PR TITLE
Download enchant dict from downloads.php.net

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -103,7 +103,7 @@ mkdir %~d0\usr\local\share\enchant\hunspell
 if %errorlevel% neq 0 exit /b 3
 echo Fetching enchant dicts
 pushd %~d0\usr\local\share\enchant\hunspell
-powershell -Command wget http://windows.php.net/downloads/qa/appveyor/ext/enchant/dict.zip -OutFile dict.zip
+powershell -Command wget https://downloads.php.net/~windows/qa/appveyor/ext/enchant/dict.zip -OutFile dict.zip
 unzip dict.zip
 del /q dict.zip
 popd


### PR DESCRIPTION
Since windows.php.net is in the progress to be migrated to downloads.php.net anyway, we may as well fetch the dictionary from the new site right away.

---

Triggered by https://github.com/php/php-src/actions/runs/11244415090/job/31262430749#step:6:42.