### PR TITLE
ext/standard/exec.c: combine conditions, update docs

### DIFF
--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -119,9 +119,6 @@ PHPAPI int php_exec(int type, const char *cmd, zval *array, zval *return_value)
 	size_t buflen, bufl = 0;
 #if PHP_SIGCHILD
 	void (*sig_handler)() = NULL;
-#endif
-
-#if PHP_SIGCHILD
 	sig_handler = signal (SIGCHLD, SIG_DFL);
 #endif
 
@@ -272,8 +269,7 @@ PHP_FUNCTION(passthru)
    Escape all chars that could possibly be used to
    break out of a shell command
 
-   This function emalloc's a string and returns the pointer.
-   Remember to efree it when done with it.
+   This function allocates a new zend_string, remember to free it when done.
 
    *NOT* safe for binary strings
 */

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -269,7 +269,7 @@ PHP_FUNCTION(passthru)
    Escape all chars that could possibly be used to
    break out of a shell command
 
-   This function allocates a new zend_string, remember to free it when done.
+   This function returns a zend_string, remember to release it when done.
 
    *NOT* safe for binary strings
 */

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -269,7 +269,7 @@ PHP_FUNCTION(passthru)
    Escape all chars that could possibly be used to
    break out of a shell command
 
-   This function returns a zend_string, remember to release it when done.
+   This function returns an owned zend_string, remember to release it when done.
 
    *NOT* safe for binary strings
 */


### PR DESCRIPTION
While `php_escape_shell_cmd()` did indeed `emalloc` a string that needed to be freed by the caller in the original implementation that was put in GitHub (see commit 257de2baded9330ff392f33fd5a7cc0ba271e18d) a few months ago the return type was changed to use `zend_string`, see #14353.