### PR TITLE
Fix property access of PHP objects wrapped in variant

### DIFF
--- a/ext/com_dotnet/tests/variant_variation2.phpt
+++ b/ext/com_dotnet/tests/variant_variation2.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Testing reading and writing of properties
+--EXTENSIONS--
+com_dotnet
+--FILE--
+<?php
+class MyClass {
+    public $foo = "foo";
+    public string $bar = "bar";
+}
+
+$o = new MyClass();
+$v = new variant($o);
+var_dump($v->foo);
+var_dump($v->bar);
+$v->foo = "new foo";
+var_dump($v->foo instanceof variant);
+var_dump((string) $v->foo);
+var_dump($o->foo instanceof variant);
+var_dump((string) $o->foo);
+$v->bar = "new bar";
+var_dump($v->bar);
+var_dump($o->bar);
+?>
+--EXPECT--
+string(3) "foo"
+string(3) "bar"
+bool(true)
+string(7) "new foo"
+bool(true)
+string(7) "new foo"
+string(7) "new bar"
+string(7) "new bar"


### PR DESCRIPTION
First, we fix the long standing issue that property access throws a `com_exception` ("0x80020003: member not found), because the `HRESULT` was not properly set after accessing the property.

Next, we fix an issue introduced as of PHP 7.0.0, where the string length for write access had been properly adapted, but the string length for read access had been overlooked.

Then we fix an issue introduced as of PHP 8.0.0, where new `HashTable`s no longer set `nNextFreeElement` to zero, but to `ZEND_LONG_MIN`.  This doesn't work well with the `DISPID` lookup, which is a `LONG`.

Finally we fix a potential double-free due to erroneously destroying the return value of `zend_read_property()`.

---

Given that this is completely broken as of PHP 8.0.0 at least, and apparently nobody has complained, I think we're good targeting master (we can backport later if necessary).

Note that this doesn't fix calling methods, which is broken since 2005, because `DISPATCH_METHOD|DISPATCH_PROPERTYGET` is passed as flag, and the latter is always prioritized in `disp_invokeex()` (what is likely good for regular COM objects).