### PR TITLE
Fix GH-16326: Memory management is broken for bad dictionaries

### DIFF
--- a/ext/zlib/tests/gh16326.phpt
+++ b/ext/zlib/tests/gh16326.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16326 (Memory management is broken for bad dictionaries)
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ["dictionary" => [" ", ""]]);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ["dictionary" => ["hello", "wor\0ld"]]);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+?>
+--EXPECT--
+deflate_init(): Argument #2 ($options) must not contain empty strings
+deflate_init(): Argument #2 ($options) must not contain strings with null bytes

--- a/ext/zlib/tests/gh16326.phpt
+++ b/ext/zlib/tests/gh16326.phpt
@@ -14,7 +14,13 @@ try {
 } catch (ValueError $ex) {
     echo $ex->getMessage(), "\n";
 }
+try {
+    deflate_init(ZLIB_ENCODING_DEFLATE, ["dictionary" => [" ", new stdClass]]);
+} catch (Error $ex) {
+    echo $ex->getMessage(), "\n";
+}
 ?>
 --EXPECT--
 deflate_init(): Argument #2 ($options) must not contain empty strings
 deflate_init(): Argument #2 ($options) must not contain strings with null bytes
+Object of class stdClass could not be converted to string

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -807,7 +807,7 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 				if (zend_hash_num_elements(dictionary) > 0) {
 					char *dictptr;
 					zval *cur;
-					zend_string **strings = emalloc(sizeof(zend_string *) * zend_hash_num_elements(dictionary));
+					zend_string **strings = safe_emalloc(zend_hash_num_elements(dictionary), sizeof(zend_string *), 0);
 					zend_string **end, **ptr = strings - 1;
 
 					ZEND_HASH_FOREACH_VAL(dictionary, cur) {
@@ -816,10 +816,10 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 						*++ptr = zval_get_string(cur);
 						if (!*ptr || ZSTR_LEN(*ptr) == 0 || EG(exception)) {
 							if (*ptr) {
-								efree(*ptr);
+								zend_string_release(*ptr);
 							}
 							while (--ptr >= strings) {
-								efree(ptr);
+								zend_string_release(*ptr);
 							}
 							efree(strings);
 							if (!EG(exception)) {
@@ -830,7 +830,7 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 						for (i = 0; i < ZSTR_LEN(*ptr); i++) {
 							if (ZSTR_VAL(*ptr)[i] == 0) {
 								do {
-									efree(ptr);
+									zend_string_release(*ptr);
 								} while (--ptr >= strings);
 								efree(strings);
 								zend_argument_value_error(2, "must not contain strings with null bytes");

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -811,8 +811,6 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 					zend_string **end, **ptr = strings - 1;
 
 					ZEND_HASH_FOREACH_VAL(dictionary, cur) {
-						size_t i;
-
 						*++ptr = zval_get_string(cur);
 						ZEND_ASSERT(*ptr);
 						if (ZSTR_LEN(*ptr) == 0 || EG(exception)) {


### PR DESCRIPTION
We must not `efree()` `zend_string`s, since they may have a refcount greater than one, and may even be interned.

We also must not confuse `zend_string *` with `zend_string **`.

And we should play it safe by using `safe_emalloc()` to avoid theoretical integer overflows.