### PR TITLE
Drop fallback for `PathCchCanonicalizeEx()`

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3426,7 +3426,7 @@ function toolset_setup_common_ldlags()
 function toolset_setup_common_libs()
 {
 	// urlmon.lib ole32.lib oleaut32.lib uuid.lib gdi32.lib winspool.lib comdlg32.lib
-	DEFINE("LIBS", "kernel32.lib ole32.lib user32.lib advapi32.lib shell32.lib ws2_32.lib Dnsapi.lib psapi.lib bcrypt.lib");
+	DEFINE("LIBS", "kernel32.lib ole32.lib user32.lib advapi32.lib shell32.lib ws2_32.lib Dnsapi.lib psapi.lib bcrypt.lib Pathcch.lib");
 }
 
 function toolset_setup_build_mode()

--- a/win32/dllmain.c
+++ b/win32/dllmain.c
@@ -17,7 +17,6 @@
 #include <config.w32.h>
 
 #include <php.h>
-#include <win32/ioutil.h>
 
 #ifdef HAVE_LIBXML
 #include <libxml/threads.h>
@@ -34,16 +33,11 @@ BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID dummy)
 {
 	BOOL ret = TRUE;
 
+#if 0 /* prepared */
 	switch (reason)
 	{
 		case DLL_PROCESS_ATTACH:
-			ret = ret && php_win32_ioutil_init();
-			if (!ret) {
-				fprintf(stderr, "ioutil initialization failed");
-				return ret;
-			}
 			break;
-#if 0 /* prepared */
 		case DLL_PROCESS_DETACH:
 			/* pass */
 			break;
@@ -55,8 +49,8 @@ BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID dummy)
 		case DLL_THREAD_DETACH:
 			/* pass */
 			break;
-#endif
 	}
+#endif
 
 #ifdef HAVE_LIBXML
 	/* This imply that only LIBXML_STATIC_FOR_DLL is supported ATM.

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -169,11 +169,6 @@ typedef enum {
 } while (0);
 
 PW32IO php_win32_ioutil_normalization_result php_win32_ioutil_normalize_path_w(wchar_t **buf, size_t len, size_t *new_len);
-#ifdef PHP_EXPORTS
-/* This symbols are needed only for the DllMain, but should not be exported
-	or be available when used with PHP binaries. */
-BOOL php_win32_ioutil_init(void);
-#endif
 
 /* Keep these functions aliased for case some additional handling
    is needed later. */


### PR DESCRIPTION
This function is only available as of Windows 8 and Windows Server 2012, respectively, and thus needed a fallback (albeit a non working one). However, as of PHP 8.3.0 Windows 8/Server 2012 is required anyway, so we can drop the fallback as well as the dynamic loading in favor of linking to the import library.