### PR TITLE
Drop legacy fallback for `isc_get_client_version()`

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1219,27 +1219,9 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			ZVAL_BOOL(val, !isc_version(&H->db, php_firebird_info_cb, NULL));
 			return 1;
 
-		case PDO_ATTR_CLIENT_VERSION: {
-#if defined(__GNUC__) || defined(PHP_WIN32)
-			info_func_t info_func = NULL;
-#ifdef __GNUC__
-			info_func = (info_func_t)dlsym(RTLD_DEFAULT, "isc_get_client_version");
-#else
-			HMODULE l = GetModuleHandle("fbclient");
-
-			if (!l) {
-				break;
-			}
-			info_func = (info_func_t)GetProcAddress(l, "isc_get_client_version");
-#endif
-			if (info_func) {
-				info_func(tmp);
-				ZVAL_STRING(val, tmp);
-			}
-#else
-			ZVAL_NULL(val);
-#endif
-			}
+		case PDO_ATTR_CLIENT_VERSION:
+			isc_get_client_version(tmp);
+			ZVAL_STRING(val, tmp);
 			return 1;
 
 		case PDO_ATTR_SERVER_VERSION:

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -45,12 +45,6 @@
 /* Firebird API has a couple of missing const decls in its API */
 #define const_cast(s) ((char*)(s))
 
-#ifdef PHP_WIN32
-typedef void (__stdcall *info_func_t)(char*);
-#else
-typedef void (*info_func_t)(char*);
-#endif
-
 #ifndef min
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif


### PR DESCRIPTION
The respective code had been introduced 20 years ago, and we can assume that the function is available at least of Firebird 3.0, what we require anyway.