### PR TITLE
Fix setRawValueWithoutLazyInitialization() / skipLazyInitialization() on initialized proxy

### DIFF
--- a/Zend/tests/lazy_objects/skipLazyInitialization_initialized_object.phpt
+++ b/Zend/tests/lazy_objects/skipLazyInitialization_initialized_object.phpt
@@ -36,6 +36,19 @@ $obj = $reflector->newLazyProxy(function () {
 
 test('Proxy', $obj);
 
+$real = new C('foo');
+$obj = $reflector->newLazyProxy(function () use ($real) {
+    return $real;
+});
+$reflector->initializeLazyObject($obj);
+$reflector->resetAsLazyProxy($real, function () {
+    var_dump("initializer");
+    return new C('bar');
+});
+$reflector->initializeLazyObject($real);
+
+test('Nested Proxy', $obj);
+
 ?>
 --EXPECTF--
 # Ghost
@@ -48,7 +61,7 @@ object(C)#%d (2) {
   NULL
 }
 # Proxy
-int(1)
+int(2)
 bool(true)
 lazy proxy object(C)#%d (1) {
   ["instance"]=>
@@ -57,5 +70,21 @@ lazy proxy object(C)#%d (1) {
     int(2)
     ["b"]=>
     NULL
+  }
+}
+string(11) "initializer"
+# Nested Proxy
+int(2)
+bool(true)
+lazy proxy object(C)#%d (1) {
+  ["instance"]=>
+  lazy proxy object(C)#%d (1) {
+    ["instance"]=>
+    object(C)#%d (2) {
+      ["a"]=>
+      int(2)
+      ["b"]=>
+      NULL
+    }
   }
 }


### PR DESCRIPTION
`skipLazyInitialization()` removes the lazy flag of a property and initializes it to its default value. If the property was already initialized, it has no effect.

However, initialized proxies have all their properties marked as lazy, but `skipLazyInitialization()` should not initialize them.

Similarly, `setRawValueWithoutLazyInitialization()` should not set the value on initialized proxies.

Here I make sure to produce the effect on the real instance rather than the proxy.

NB: It's possible that the real instance is also a proxy. In this case I fetch its real instance again, and the affected object is the deepest instance.