### PR TITLE
Fix OSS-Fuzz #371445205: Heap-use-after-free in attr_free

### DIFF
--- a/Zend/tests/attributes/ossfuzz371445205.phpt
+++ b/Zend/tests/attributes/ossfuzz371445205.phpt
@@ -1,0 +1,17 @@
+--TEST--
+OSS-Fuzz #371445205 (Heap-use-after-free in attr_free)
+--FILE--
+<?php
+#[Attribute]
+class MyAttrib{}
+#[MyAttrib(notinterned:'')]
+class Test1{}
+$attr=(new ReflectionClass(Test1::class))->getAttributes()[0];
+try {
+    $attr->newInstance();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Unknown named parameter $notinterned

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1879,7 +1879,6 @@ ZEND_API zend_result object_init_with_constructor(zval *arg, zend_class_entry *c
 			zend_hash_get_current_key(named_params, &arg_name, /* num_index */ NULL);
 			ZEND_ASSERT(arg_name != NULL);
 			zend_throw_error(NULL, "Unknown named parameter $%s", ZSTR_VAL(arg_name));
-			zend_string_release(arg_name);
 			/* Do not call destructor, free object, and set arg to IS_UNDEF */
 			zend_object_store_ctor_failed(obj);
 			zval_ptr_dtor(arg);


### PR DESCRIPTION
zend_hash_get_current_key() does not return a string with incremented refcount, so it shouldn't get released. This release caused a UAF later when the attribute was destroyed. This wasn't noticed earlier because object_init_with_constructor() was only ever tested with interned strings.

Link: https://issues.oss-fuzz.com/issues/371721670