### PR TITLE
Fix GH-16360 mb_substr overflow on start and length arguments.

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2172,6 +2172,16 @@ PHP_FUNCTION(mb_substr)
 		Z_PARAM_STR_OR_NULL(encoding)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (from == ZEND_LONG_MIN) {
+		zend_argument_value_error(2, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (ZEND_LONG_MIN + 1), ZEND_LONG_MAX);
+		RETURN_THROWS();
+	}
+
+	if (!len_is_null && len == ZEND_LONG_MIN) {
+		zend_argument_value_error(3, "must be between " ZEND_LONG_FMT " and " ZEND_LONG_FMT, (ZEND_LONG_MIN + 1), ZEND_LONG_MAX);
+		RETURN_THROWS();
+	}
+
 	string.encoding = php_mb_get_encoding(encoding, 4);
 	if (!string.encoding) {
 		RETURN_THROWS();

--- a/ext/mbstring/tests/gh16360.phpt
+++ b/ext/mbstring/tests/gh16360.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-16320 mb_substr overflow from negative length
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+try {
+	mb_substr("abcd", PHP_INT_MIN, 4, "UTF-8");
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	mb_substr("abcd", 0, PHP_INT_MIN, "UTF-8");
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+var_dump(mb_substr("abcd", PHP_INT_MAX, PHP_INT_MAX, "UTF-8"));
+?>
+--EXPECTF--
+mb_substr(): Argument #2 ($start) must be between %s and %s
+mb_substr(): Argument #3 ($length) must be between %s and %s
+string(0) ""
+


### PR DESCRIPTION
occurs when they are negated to start working from the end instead when set with ZEND_LONG_MIN.