### PR TITLE
Push NDEBUG handling down to zend_portability.h

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -47,6 +47,11 @@
 #include "../TSRM/TSRM.h"
 
 #include <stdio.h>
+#if ZEND_DEBUG
+# undef NDEBUG
+#elif !defined(NDEBUG)
+# define NDEBUG
+#endif
 #include <assert.h>
 #include <math.h>
 

--- a/main/php.h
+++ b/main/php.h
@@ -109,13 +109,6 @@ typedef int pid_t;
 # endif
 #endif
 
-#if PHP_DEBUG
-#undef NDEBUG
-#else
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-#endif
 #include <assert.h>
 
 #ifdef HAVE_UNIX_H


### PR DESCRIPTION
As is, `NEDBUG` is set to match `PHP_DEBUG` (which matches `ZEND_DEBUG`) in php.h right before including assert.h; however, assert.h is already included at this point, so the `NDEBUG` handling is useless.  We push it down to zend_portability.h, where it has effect.

The alternative would be to drop that code in php.h altogether, but that would make some test assumptions invalid.   E.g. a build with `CFLAGS=-DNDEBUG ./configure --enable-debug-assertions` would fail internal_functions001.phpt, because the userland `PHP_DEBUG` is true, but assertions would not be evaluated.