### PR TITLE
Fix GH-16354 convert GMP to number failure.

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -619,6 +619,15 @@ static zend_result convert_to_gmp(mpz_t gmpnumber, zval *val, zend_long base, ui
 	case IS_STRING: {
 		return convert_zstr_to_gmp(gmpnumber, Z_STR_P(val), base, arg_pos);
 	}
+	case IS_NULL: {
+		/**
+		 * zend_parse_arg_long_slow support nullable argument but expects it
+		 * to be the 2nd, and onward, argument or non null but at any place.
+		 **/
+		zend_type_error(
+			"Number must be of type GMP|string|int, null given");
+		return FAILURE;
+	}
 	default: {
 		zend_long lval;
 		if (!zend_parse_arg_long_slow(val, &lval, arg_pos)) {

--- a/ext/gmp/tests/gh16368.phpt
+++ b/ext/gmp/tests/gh16368.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug GH-16368: gmp_init on first argument as null.
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+gmp_init($inexistent);
+?>
+--EXPECTF--
+Warning: Undefined variable $inexistent in %s on line %d
+
+Deprecated: gmp_init(): Passing null to parameter #1 ($num) of type string|int is deprecated in %s on line %d

--- a/ext/gmp/tests/gmp_strict_types.phpt
+++ b/ext/gmp/tests/gmp_strict_types.phpt
@@ -53,5 +53,5 @@ object(GMP)#2 (1) {
 gmp_abs(): Argument #1 ($num) must be of type GMP|string|int, float given
 gmp_abs(): Argument #1 ($num) must be of type GMP|string|int, bool given
 gmp_abs(): Argument #1 ($num) must be of type GMP|string|int, bool given
-gmp_abs(): Argument #1 ($num) must be of type GMP|string|int, null given
+Number must be of type GMP|string|int, null given
 gmp_abs(): Argument #1 ($num) must be of type GMP|string|int, array given


### PR DESCRIPTION
zend_parse_arg_long_slow/zend_null_arg_deprecated handle nullable as 2nd (or +) argument so here we trigger a TypeError exception in case we deal with null at 1st argument.