### PR TITLE
Fix GH-16357: openssl may modify member types of certificate arrays

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1457,11 +1457,13 @@ static X509 *php_openssl_x509_from_zval(
 
 	*free_cert = 1;
 
-	if (!try_convert_to_string(val)) {
+	zend_string *str = zval_try_get_string(val);
+	if (str == NULL) {
 		return NULL;
 	}
-
-	return php_openssl_x509_from_str(Z_STR_P(val), arg_num, is_from_array, option_name);
+	X509 *cert = php_openssl_x509_from_str(str, arg_num, is_from_array, option_name);
+	zend_string_release(str);
+	return cert;
 }
 /* }}} */
 

--- a/ext/openssl/tests/gh16357.phpt
+++ b/ext/openssl/tests/gh16357.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-16357 (openssl may modify member types of certificate arrays)
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$infile = __DIR__ . "/cert.crt";
+$outfile = __DIR__ . "/gh16357.txt";
+$certs = [123];
+var_dump(openssl_pkcs7_encrypt($infile, $outfile, $certs, null));
+var_dump($certs);
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . "/gh16357.txt");
+?>
+--EXPECT--
+bool(false)
+array(1) {
+  [0]=>
+  int(123)
+}


### PR DESCRIPTION
We must not use `try_convert_to_string()` on members of unseparated array arguments; instead of separating, we use `zval_try_get_string()`.