### PR TITLE
Fix potentially erroneous php_win32_crt_compatible()

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3432,7 +3432,7 @@ function toolset_setup_common_libs()
 function toolset_setup_build_mode()
 {
 	if (PHP_DEBUG == "yes") {
-		ADD_FLAG("CFLAGS", "/LDd /MDd /Od /D _DEBUG /D ZEND_DEBUG=1 " +
+		ADD_FLAG("CFLAGS", "/LDd /MDd /Od /D ZEND_DEBUG=1 " +
 			(TARGET_ARCH == 'x86'?"/ZI":"/Zi"));
 		ADD_FLAG("LDFLAGS", "/debug");
 		// Avoid problems when linking to release libraries that use the release

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -486,7 +486,7 @@ PHP_WINUTIL_API BOOL php_win32_crt_compatible(char **err)
 {/*{{{*/
 #if PHP_LINKER_MAJOR == 14
 	/* Extend for other CRT if needed. */
-# if PHP_DEBUG
+# ifdef _DEBUG
 	const char *crt_name = "vcruntime140d.dll";
 # else
 	const char *crt_name = "vcruntime140.dll";


### PR DESCRIPTION
Whether we link with a debug runtime or a normal runtime is not really related to `PHP_DEBUG`, but rather to `_DEBUG`[1].

We also stop defining that flag, since the compiler already does that.

[1] <https://learn.microsoft.com/en-us/cpp/c-runtime-library/debug>