### PR TITLE
Fix GH-16367: macOS CI fails to configure ext/intl on master

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -13,7 +13,7 @@ runs:
 
         # Some packages exist on x86 but not arm, or vice versa.
         # Install them with reinstall to avoid warnings.
-        brew reinstall autoconf webp tidy-html5 libzip libsodium
+        brew reinstall autoconf webp tidy-html5 libzip libsodium icu4c
         brew install \
           bison \
           re2c


### PR DESCRIPTION
Well, an attempt.