### PR TITLE
Mention where headers were already sent if session_start fails

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2644,7 +2644,14 @@ PHP_FUNCTION(session_start)
 	 * module is unable to rewrite output.
 	 */
 	if (PS(use_cookies) && SG(headers_sent)) {
-		php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent");
+		/* It's the header sent to blame, not the session in this case */
+		const char *output_start_filename = php_output_get_start_filename();
+		int output_start_lineno = php_output_get_start_lineno();
+		if (output_start_filename != NULL) {
+			php_error_docref(NULL, E_NOTICE, "Session cannot be started after headers have already been sent (started from %s on line %d)", output_start_filename, output_start_lineno);
+		} else {
+			php_error_docref(NULL, E_NOTICE, "Session cannot be started after headers have already been sent");
+		}
 		RETURN_FALSE;
 	}
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2648,7 +2648,7 @@ PHP_FUNCTION(session_start)
 		const char *output_start_filename = php_output_get_start_filename();
 		int output_start_lineno = php_output_get_start_lineno();
 		if (output_start_filename != NULL) {
-			php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent (started from %s on line %d)", output_start_filename, output_start_lineno);
+			php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent (sent from %s on line %d)", output_start_filename, output_start_lineno);
 		} else {
 			php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent");
 		}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2648,9 +2648,9 @@ PHP_FUNCTION(session_start)
 		const char *output_start_filename = php_output_get_start_filename();
 		int output_start_lineno = php_output_get_start_lineno();
 		if (output_start_filename != NULL) {
-			php_error_docref(NULL, E_NOTICE, "Session cannot be started after headers have already been sent (started from %s on line %d)", output_start_filename, output_start_lineno);
+			php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent (started from %s on line %d)", output_start_filename, output_start_lineno);
 		} else {
-			php_error_docref(NULL, E_NOTICE, "Session cannot be started after headers have already been sent");
+			php_error_docref(NULL, E_WARNING, "Session cannot be started after headers have already been sent");
 		}
 		RETURN_FALSE;
 	}

--- a/ext/session/tests/gh-16372.phpt
+++ b/ext/session/tests/gh-16372.phpt
@@ -16,4 +16,4 @@ session_start();
 --EXPECTF--
 Sent headers
 
-Warning: session_start(): Session cannot be started after headers have already been sent (started from %s on line %d) in %s on line %d
+Warning: session_start(): Session cannot be started after headers have already been sent (sent from %s on line %d) in %s on line %d

--- a/ext/session/tests/gh-16372.phpt
+++ b/ext/session/tests/gh-16372.phpt
@@ -16,4 +16,4 @@ session_start();
 --EXPECTF--
 Sent headers
 
-Notice: session_start(): Session cannot be started after headers have already been sent (started from %s on line %d) in %s on line %d
+Warning: session_start(): Session cannot be started after headers have already been sent (started from %s on line %d) in %s on line %d

--- a/ext/session/tests/gh-16372.phpt
+++ b/ext/session/tests/gh-16372.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-16372: Mention where headers were already sent if session_start fails
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+header("X-PHP-Test: test");
+
+echo "Sent headers\n";
+
+session_start();
+?>
+--EXPECTF--
+Sent headers
+
+Notice: session_start(): Session cannot be started after headers have already been sent (started from %s on line %d) in %s on line %d


### PR DESCRIPTION
We had previously improved where sessions were already started, and where headers were already sent when setting headers, but not where a header has been sent if we try to set the header cookie.

Fixes GH-16372