### PR TITLE
Fix op2 caching for static properties

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3617,8 +3617,8 @@ static zend_always_inline zval* zend_fetch_static_property_address(zend_property
 	if (opline->op1_type == IS_CONST
 	 && (opline->op2_type == IS_CONST
 	  || (opline->op2_type == IS_UNUSED
-	   && (opline->op2.num == ZEND_FETCH_CLASS_SELF
-	    || opline->op2.num == ZEND_FETCH_CLASS_PARENT)))
+	   && ((opline->op2.num & ZEND_FETCH_CLASS_MASK) == ZEND_FETCH_CLASS_SELF
+	    || (opline->op2.num & ZEND_FETCH_CLASS_MASK) == ZEND_FETCH_CLASS_PARENT)))
 	 && EXPECTED(CACHED_PTR(cache_slot + sizeof(void *)) != NULL)) {
 		result = CACHED_PTR(cache_slot + sizeof(void *));
 		property_info = CACHED_PTR(cache_slot + sizeof(void *) * 2);


### PR DESCRIPTION
op2.num may contain other flags, like ZEND_FETCH_CLASS_EXCEPTION. These currently circumvent caching. Once the property is cached, these flags have no influence on the result, so it doesn't seem like this was done on purpose.

@dstogov Please let me know if you think this should be backported.