### PR TITLE
Fix socket_recvfrom overflow on buffer size.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1402,7 +1402,8 @@ PHP_FUNCTION(socket_recvfrom)
 
 	/* overflow check */
 	/* Shouldthrow ? */
-	if ((arg3 + 2) < 3) {
+
+	if (arg3 <= 0 || arg3 > ZEND_LONG_MAX - 1) {
 		RETURN_FALSE;
 	}
 

--- a/ext/sockets/tests/socket_recv_overflow.phpt
+++ b/ext/sockets/tests/socket_recv_overflow.phpt
@@ -1,0 +1,19 @@
+--TEST--
+socket_recvfrom overflow on length argument
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
+    die('skip not valid for Windows.');
+}
+--FILE--
+<?php
+$s = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+$buf = $end = "";
+var_dump(socket_recvfrom($s, $buf, PHP_INT_MAX, 0, $end));
+var_dump(socket_recvfrom($s, $buf, -1, 0, $end));
+?>
+--EXPECT--
+bool(false)
+bool(false)


### PR DESCRIPTION
when passing PHP_INT_MAX for the $length param we get this (with ubsan)

`ext/sockets/sockets.c:1409:36: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'`