### PR TITLE
ext/gmp: gmp_pow fix FPE with large values.

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1293,7 +1293,7 @@ ZEND_FUNCTION(gmp_pow)
 		mpz_ui_pow_ui(gmpnum_result, Z_LVAL_P(base_arg), exp);
 	} else {
 		mpz_ptr gmpnum_base;
-		unsigned long int gmpnum;
+		zend_ulong gmpnum;
 		FETCH_GMP_ZVAL(gmpnum_base, base_arg, temp_base, 1);
 		INIT_GMP_RETVAL(gmpnum_result);
 		gmpnum = mpz_get_ui(gmpnum_base);

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1282,20 +1282,22 @@ ZEND_FUNCTION(gmp_pow)
 		RETURN_THROWS();
 	}
 
+    double powmax = log((double)ZEND_LONG_MAX);
+
 	if (Z_TYPE_P(base_arg) == IS_LONG && Z_LVAL_P(base_arg) >= 0) {
 		INIT_GMP_RETVAL(gmpnum_result);
-		if ((log10(Z_LVAL_P(base_arg)) * exp) > (double)ULONG_MAX) {
+		if ((log(Z_LVAL_P(base_arg)) * exp) > powmax) {
 			zend_value_error("base and exponent overflow");
 			RETURN_THROWS();
 		}
 		mpz_ui_pow_ui(gmpnum_result, Z_LVAL_P(base_arg), exp);
 	} else {
 		mpz_ptr gmpnum_base;
-		unsigned long gmpnum;
+		unsigned long int gmpnum;
 		FETCH_GMP_ZVAL(gmpnum_base, base_arg, temp_base, 1);
 		INIT_GMP_RETVAL(gmpnum_result);
 		gmpnum = mpz_get_ui(gmpnum_base);
-		if ((log10(gmpnum) * exp) > (double)ULONG_MAX) {
+		if ((log(gmpnum) * exp) > powmax) {
 			FREE_GMP_TEMP(temp_base);
 			zend_value_error("base and exponent overflow");
 			RETURN_THROWS();

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1284,37 +1284,23 @@ ZEND_FUNCTION(gmp_pow)
 
 	if (Z_TYPE_P(base_arg) == IS_LONG && Z_LVAL_P(base_arg) >= 0) {
 		INIT_GMP_RETVAL(gmpnum_result);
-		if (exp >= INT_MAX) {
-			mpz_t base_num, exp_num, mod;
-			mpz_init(base_num);
-			mpz_init(exp_num);
-			mpz_init(mod);
-			mpz_set_si(base_num, Z_LVAL_P(base_arg));
-			mpz_set_si(exp_num, exp);
-			mpz_set_ui(mod, UINT_MAX);
-			mpz_powm(gmpnum_result, base_num, exp_num, mod);
-			mpz_clear(mod);
-			mpz_clear(exp_num);
-			mpz_clear(base_num);
-		} else {
-			mpz_ui_pow_ui(gmpnum_result, Z_LVAL_P(base_arg), exp);
+		if ((log10(Z_LVAL_P(base_arg)) * exp) > (double)ULONG_MAX) {
+			zend_value_error("base and exponent overflow");
+			RETURN_THROWS();
 		}
+		mpz_ui_pow_ui(gmpnum_result, Z_LVAL_P(base_arg), exp);
 	} else {
 		mpz_ptr gmpnum_base;
+		unsigned long gmpnum;
 		FETCH_GMP_ZVAL(gmpnum_base, base_arg, temp_base, 1);
 		INIT_GMP_RETVAL(gmpnum_result);
-		if (exp >= INT_MAX) {
-			mpz_t exp_num, mod;
-			mpz_init(exp_num);
-			mpz_init(mod);
-			mpz_set_si(exp_num, exp);
-			mpz_set_ui(mod, UINT_MAX);
-			mpz_powm(gmpnum_result, gmpnum_base, exp_num, mod);
-			mpz_clear(mod);
-			mpz_clear(exp_num);
-		} else {
-			mpz_pow_ui(gmpnum_result, gmpnum_base, exp);
+		gmpnum = mpz_get_ui(gmpnum_base);
+		if ((log10(gmpnum) * exp) > (double)ULONG_MAX) {
+			FREE_GMP_TEMP(temp_base);
+			zend_value_error("base and exponent overflow");
+			RETURN_THROWS();
 		}
+		mpz_pow_ui(gmpnum_result, gmpnum_base, exp);
 		FREE_GMP_TEMP(temp_base);
 	}
 }

--- a/ext/gmp/tests/gmp_pow_32bits.phpt
+++ b/ext/gmp/tests/gmp_pow_32bits.phpt
@@ -3,7 +3,7 @@ gmp_pow() basic tests
 --EXTENSIONS--
 gmp
 --SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
 --FILE--
 <?php
 
@@ -18,19 +18,33 @@ try {
     echo $exception->getMessage() . "\n";
 }
 var_dump(gmp_strval(gmp_pow("-2",10)));
-var_dump(gmp_strval(gmp_pow(20,10)));
-var_dump(gmp_strval(gmp_pow(50,10)));
+try {
+    gmp_pow(20,10);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+try {
+    gmp_pow(50,10);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 try {
     gmp_pow(50,-5);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
-
-$n = gmp_init("20");
-var_dump(gmp_strval(gmp_pow($n,10)));
-$n = gmp_init("-20");
-var_dump(gmp_strval(gmp_pow($n,10)));
-
+try {
+    $n = gmp_init("20");
+    gmp_pow($n,10);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+try {
+    $n = gmp_init("-20");
+    gmp_pow($n,10);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 try {
     var_dump(gmp_pow(2,array()));
 } catch (TypeError $e) {
@@ -53,11 +67,11 @@ string(4) "1024"
 string(1) "1"
 gmp_pow(): Argument #2 ($exponent) must be greater than or equal to 0
 string(4) "1024"
-string(14) "10240000000000"
-string(17) "97656250000000000"
+base and exponent overflow
+base and exponent overflow
 gmp_pow(): Argument #2 ($exponent) must be greater than or equal to 0
-string(14) "10240000000000"
-string(14) "10240000000000"
+base and exponent overflow
+base and exponent overflow
 gmp_pow(): Argument #2 ($exponent) must be of type int, array given
 gmp_pow(): Argument #1 ($num) must be of type GMP|string|int, array given
 Done

--- a/ext/gmp/tests/gmp_pow_fpe.phpt
+++ b/ext/gmp/tests/gmp_pow_fpe.phpt
@@ -6,15 +6,17 @@ gmp
 <?php
 $g = gmp_init(256);
 
-var_dump(gmp_pow($g, PHP_INT_MAX));
-var_dump(gmp_pow(256, PHP_INT_MAX));
+try {
+	gmp_pow($g, PHP_INT_MAX);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	gmp_pow(256, PHP_INT_MAX);
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
 ?>
---EXPECTF--
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(%d) "%s"
-}
-object(GMP)#2 (1) {
-  ["num"]=>
-  string(%d) "%s"
-}
+--EXPECT--
+base and exponent overflow
+base and exponent overflow

--- a/ext/gmp/tests/gmp_pow_fpe.phpt
+++ b/ext/gmp/tests/gmp_pow_fpe.phpt
@@ -17,17 +17,19 @@ try {
 	echo $e->getMessage() . PHP_EOL;
 }
 
-var_dump(gmp_pow(gmp_add(gmp_mul(gmp_init(PHP_INT_MAX), gmp_init(PHP_INT_MAX)), 3), 256));
-var_dump(gmp_pow(gmp_init(PHP_INT_MAX), 256));
+try {
+    gmp_pow(gmp_add(gmp_mul(gmp_init(PHP_INT_MAX), gmp_init(PHP_INT_MAX)), 3), 256);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+    gmp_pow(gmp_init(PHP_INT_MAX), 256);
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
 ?>
 --EXPECTF--
 base and exponent overflow
 base and exponent overflow
-object(GMP)#%d (1) {
-  ["num"]=>
-  string(%d) "%s"
-}
-object(GMP)#%d (1) {
-  ["num"]=>
-  string(%d) "%s"
-}
+base and exponent overflow
+base and exponent overflow

--- a/ext/gmp/tests/gmp_pow_fpe.phpt
+++ b/ext/gmp/tests/gmp_pow_fpe.phpt
@@ -14,9 +14,20 @@ try {
 try {
 	gmp_pow(256, PHP_INT_MAX);
 } catch (\ValueError $e) {
-	echo $e->getMessage();
+	echo $e->getMessage() . PHP_EOL;
 }
+
+var_dump(gmp_pow(gmp_add(gmp_mul(gmp_init(PHP_INT_MAX), gmp_init(PHP_INT_MAX)), 3), 256));
+var_dump(gmp_pow(gmp_init(PHP_INT_MAX), 256));
 ?>
---EXPECT--
+--EXPECTF--
 base and exponent overflow
 base and exponent overflow
+object(GMP)#%d (1) {
+  ["num"]=>
+  string(%d) "%s"
+}
+object(GMP)#%d (1) {
+  ["num"]=>
+  string(%d) "%s"
+}


### PR DESCRIPTION
even without sanitizers, it is reproducible but with the following

```
<?php
$g = gmp_init(256);
var_dump(gmp_pow($g, PHP_INT_MAX));
```

we get this

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==286922==ERROR: AddressSanitizer: FPE on unknown address 0x03e8000460ca (pc 0x7faf6c69de5c bp 0x400000000000004 sp 0x7ffe9843c740 T0)
    #0 0x7faf6c69de5c in __pthread_kill_implementation nptl/pthread_kill.c:44
    #1 0x7faf6c649c81 in __GI_raise ../sysdeps/posix/raise.c:26
    #2 0x7faf6db9386c in __gmp_exception (/lib/x86_64-linux-gnu/libgmp.so.10+0xd86c) (BuildId: 1af68a49fe041a5bb48a2915c3d47541f713bb38)
    #3 0x7faf6db938d3 in __gmp_overflow_in_mpz (/lib/x86_64-linux-gnu/libgmp.so.10+0xd8d3) (BuildId: 1af68a49fe041a5bb48a2915c3d47541f713bb38)
    #4 0x7faf6dbac95c in __gmpz_realloc (/lib/x86_64-linux-gnu/libgmp.so.10+0x2695c) (BuildId: 1af68a49fe041a5bb48a2915c3d47541f713bb38)
    #5 0x7faf6dba9038 in __gmpz_n_pow_ui (/lib/x86_64-linux-gnu/libgmp.so.10+0x23038) (BuildId: 1af68a49fe041a5bb48a2915c3d47541f713bb38)
    #6 0x5565ae1ccd9f in zif_gmp_pow /home/dcarlier/Contribs/php-src/ext/gmp/gmp.c:1286
    #7 0x5565aee96ea9 in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:1312
    #8 0x5565af144320 in execute_ex /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:56075
    #9 0x5565af160f07 in zend_execute /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:60439
    #10 0x5565aed6fafe in zend_execute_scripts /home/dcarlier/Contribs/php-src/Zend/zend.c:1842
    #11 0x5565aeae70a8 in php_execute_script /home/dcarlier/Contribs/php-src/main/main.c:2578
    #12 0x5565af532f4e in do_cli /home/dcarlier/Contribs/php-src/sapi/cli/php_cli.c:964
    #13 0x5565af535877 in main /home/dcarlier/Contribs/php-src/sapi/cli/php_cli.c:1334
    #14 0x7faf6c633d67 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0x7faf6c633e24 in __libc_start_main_impl ../csu/libc-start.c:360
    #16 0x5565adc04040 in _start (/home/dcarlier/Contribs/php-src/sapi/cli/php+0x2604040) (BuildId: 949049955bdf8b7197390b1978a1dfc3ef6fdf38)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE nptl/pthread_kill.c:44 in __pthread_kill_implementation
==286922==ABORTING
```