### PR TITLE
Fix GH-16385: Unexpected null returned by session_set_cookie_params

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1668,10 +1668,6 @@ PHP_FUNCTION(session_set_cookie_params)
 	zend_result result;
 	int found = 0;
 
-	if (!PS(use_cookies)) {
-		return;
-	}
-
 	ZEND_PARSE_PARAMETERS_START(1, 5)
 		Z_PARAM_ARRAY_HT_OR_LONG(options_ht, lifetime_long)
 		Z_PARAM_OPTIONAL
@@ -1680,6 +1676,11 @@ PHP_FUNCTION(session_set_cookie_params)
 		Z_PARAM_BOOL_OR_NULL(secure, secure_null)
 		Z_PARAM_BOOL_OR_NULL(httponly, httponly_null)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if (!PS(use_cookies)) {
+		php_error_docref(NULL, E_WARNING, "Session cookies cannot be used when session.use_cookies is disabled");
+		RETURN_FALSE;
+	}
 
 	if (PS(session_status) == php_session_active) {
 		php_error_docref(NULL, E_WARNING, "Session cookie parameters cannot be changed when a session is active");

--- a/ext/session/tests/gh16385.phpt
+++ b/ext/session/tests/gh16385.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-16385 (Unexpected null returned by session_set_cookie_params)
+--EXTENSIONS--
+session
+--INI--
+session.use_cookies=0
+--FILE--
+<?php
+var_dump(session_set_cookie_params(3600, "/foo"));
+?>
+--EXPECTF--
+Warning: session_set_cookie_params(): Session cookies cannot be used when session.use_cookies is disabled in %s on line %d
+bool(false)


### PR DESCRIPTION
Two issues:
1) The check happened before ZPP checks
2) The `return;` statement caused NULL to be returned while this
   function can only return booleans. An exception seems not acceptable
   in stable versions, but a warning may do.