### PR TITLE
Move ARG_(WITH|ENABLE) to the toplevel

### DIFF
--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -1,9 +1,8 @@
 ARG_ENABLE("opcache", "whether to enable Zend OPcache support", "yes");
+ARG_ENABLE("opcache-jit", "whether to enable JIT", "yes");
 
 
 if (PHP_OPCACHE != "no") {
-
-	ARG_ENABLE("opcache-jit", "whether to enable JIT", "yes");
 
 	ZEND_EXTENSION('opcache', "\
 		ZendAccelerator.c \

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -355,15 +355,15 @@ if (PHP_SECURITY_FLAGS == "yes") {
 	ADD_FLAG("LDFLAGS", "/NXCOMPAT /DYNAMICBASE ");
 }
 
+ARG_WITH("uncritical-warn-choke", "Disable some uncritical warnings", "yes");
+ARG_ENABLE("sanitizer", "Enable ASan and UBSan extensions", "no");
 if (CLANG_TOOLSET) {
-	ARG_WITH("uncritical-warn-choke", "Disable some uncritical warnings", "yes");
 	if (PHP_UNCRITICAL_WARN_CHOKE != "no") {
 		ADD_FLAG("CFLAGS", "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-missing-braces " +
 		"-Wno-logical-op-parentheses -Wno-msvc-include -Wno-invalid-source-encoding -Wno-unknown-pragmas " +
 		"-Wno-unused-command-line-argument -Wno-unused-function -Wno-ignored-pragma-optimize");
 	}
 
-	ARG_ENABLE("sanitizer", "Enable ASan and UBSan extensions", "no");
 	if (PHP_SANITIZER == "yes") {
 		if (COMPILER_NUMERIC_VERSION < 500) {
 			ERROR("Clang at least 5.0.0 required for sanitation plugins");


### PR DESCRIPTION
`buildconf` (and `phpize`) have special treatment for these "macros". When configure.js is built, all config.w32 are grepped, these "macros" are appended to configure.js, and all config.w32 contents are appended with the "macros" commented out.  That means that for `configure` they are in the toplevel anyway, so having them inside of `if` statements in config.w32 is confusing.

Note that this matches autoconf behavior.