### PR TITLE
Move ARG_ENABLE() "macros" out of confutils.js

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -396,3 +396,7 @@ ARG_ENABLE("native-intrinsics", "Comma separated list of intrinsic optimizations
 	might not work properly, if the chosen instruction sets are not available on the target \
 	processor.", "no");
 toolset_setup_intrinsic_cflags();
+
+ARG_ENABLE('snapshot-build', 'Build a snapshot: turns on everything it can and ignores build errors', 'no');
+
+ARG_ENABLE('vs-link-compat', 'Allow linking of libraries built with compatible versions of VS toolset', 'yes');

--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -143,3 +143,5 @@ ARG_ENABLE("native-intrinsics", "Comma separated list of intrinsic optimizations
 	might not work properly, if the optimizations are not available on the target \
 	processor.", "no");
 toolset_setup_intrinsic_cflags();
+
+ARG_ENABLE('vs-link-compat', 'Allow linking of libraries built with compatible versions of VS toolset', 'yes');

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2898,9 +2898,6 @@ function PHP_INSTALL_HEADERS(dir, headers_list)
 // and you can then build everything, ignoring fatal errors within a module
 // by running "nmake snap"
 PHP_SNAPSHOT_BUILD = "no";
-if (!MODE_PHPIZE) {
-	ARG_ENABLE('snapshot-build', 'Build a snapshot; turns on everything it can and ignores build errors', 'no');
-}
 
 function toolset_option_handle()
 {
@@ -3765,10 +3762,4 @@ function setup_verbosity()
 		CMD_MOD1 = "@";
 		CMD_MOD2 = "@";
 	}
-}
-
-try {
-	ARG_ENABLE('vs-link-compat', 'Allow linking of libraries built with compatible versions of VS toolset', 'yes');
-} catch (e) {
-	STDOUT.WriteLine("problem: " + e);
 }


### PR DESCRIPTION
While these "macros" work perfectly fine in confutils, it is somewhat strange to have these two there, while all others are in config.w32 files.

In particular, there is no need for a `MODE_PHPIZE` guard, since there are already config.w32 and config.w32.phpize.in.

However, we need to replace the semicolon the helptext, because the regex which parses ARG_(ENABLE|WITH) calls is restricted, and does not accept semicolons.

---

Note that I considered fixing the mentioned regex:

https://github.com/php/php-src/blob/18ab3b9e6dc546157d8670105f154331a16663db/win32/build/buildconf.js#L232

which doesn't do what it is supposed to do (the backslashes are consumed by the JScript string parser, so the parens are just grouping; a final semicolon is optional in JScript), but then saw https://github.com/php/pecl-console-termbox/blob/02a7c1c0a05614bd42e9d624aeda3be90d476f3a/config.w32, which works perfectly fine, although `ARG_ENABLE()` and `ARG_WITH()` are commented out. It would not work, though, if the comments were C-style comments.