### PR TITLE
Fix GH-16388: UB when freeing a cloned _ZendTestFiber

### DIFF
--- a/ext/zend_test/fiber.c
+++ b/ext/zend_test/fiber.c
@@ -352,4 +352,5 @@ void zend_test_fiber_init(void)
 	zend_test_fiber_handlers = std_object_handlers;
 	zend_test_fiber_handlers.dtor_obj = zend_test_fiber_object_destroy;
 	zend_test_fiber_handlers.free_obj = zend_test_fiber_object_free;
+	zend_test_fiber_handlers.clone_obj = NULL;
 }

--- a/ext/zend_test/tests/gh16388.phpt
+++ b/ext/zend_test/tests/gh16388.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-16388 (UB when freeing a cloned _ZendTestFiber)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$fiber = new _ZendTestFiber(function (): int {});
+clone $fiber;
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Trying to clone an uncloneable object of class _ZendTestFiber in %s:%d
+%A


### PR DESCRIPTION
Since there is no need to clone instances of this test class, we prevent cloning in the first place.

---

The issue has likely been introduced via 94ee4f9834743ca74f6c9653863273277ce6c61a (which had been reverted from PHP-8.2 later); anyway, PHP-8.2 is not affected.