### PR TITLE
Fix GH-16397: Segmentation fault when comparing FFI object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-16409 (Segfault in exif_thumbnail when not dealing with a
     real file). (nielsdos, cmb)
 
+- FFI:
+  . Fixed bug GH-16397 (Segmentation fault when comparing FFI object).
+    (nielsdos)
+
 - GD:
   . Fixed bug GH-16334 (imageaffine overflow on matrix elements).
     (David Carlier)

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2922,6 +2922,12 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 }
 /* }}} */
 
+static int zend_fake_compare_objects(zval *o1, zval *o2)
+{
+	zend_throw_error(zend_ffi_exception_ce, "Cannot compare FFI objects");
+	return ZEND_UNCOMPARABLE;
+}
+
 static zend_never_inline int zend_ffi_disabled(void) /* {{{ */
 {
 	zend_throw_error(zend_ffi_exception_ce, "FFI API is restricted by \"ffi.enable\" configuration directive");
@@ -5367,7 +5373,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_handlers.has_dimension        = zend_fake_has_dimension;
 	zend_ffi_handlers.unset_dimension      = zend_fake_unset_dimension;
 	zend_ffi_handlers.get_method           = zend_ffi_get_func;
-	zend_ffi_handlers.compare              = NULL;
+	zend_ffi_handlers.compare              = zend_fake_compare_objects;
 	zend_ffi_handlers.cast_object          = zend_fake_cast_object;
 	zend_ffi_handlers.get_debug_info       = NULL;
 	zend_ffi_handlers.get_closure          = NULL;

--- a/ext/ffi/tests/gh16397.phpt
+++ b/ext/ffi/tests/gh16397.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-16397 (Segmentation fault when comparing FFI object)
+--EXTENSIONS--
+ffi
+--FILE--
+<?php
+$ffi = FFI::cdef();
+try {
+    var_dump($ffi != 1);
+} catch (FFI\Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot compare FFI objects


### PR DESCRIPTION
`compare` is a required handler [1], but this handler was set to NULL. Throw an exception when trying to compare FFI objects.

[1] https://github.com/php/php-src/blob/35c8a010c6633a2a1ba7c16a0cf83affa07b819e/Zend/zend_object_handlers.h#L231C1-L231C64