### PR TITLE
Free internal_runtime_cache on shutdown for NTS

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1210,6 +1210,10 @@ void zend_shutdown(void) /* {{{ */
 		CG(script_encoding_list) = NULL;
 		CG(script_encoding_list_size) = 0;
 	}
+	if (CG(internal_run_time_cache)) {
+		pefree(CG(internal_run_time_cache), 1);
+		CG(internal_run_time_cache) = NULL;
+	}
 #endif
 	zend_map_ptr_static_last = 0;
 	zend_map_ptr_static_size = 0;


### PR DESCRIPTION
The internal runtime cache is never freed for NTS builds; as a *stop*- *gap* measure we disable the leak detection.

---

The leak is detected by the CRT debug heap (e.g. when running the ext/zend_test test suite), likely as of 25d761623cd9eb2ed1c1e5fdefa122b89d428caf. I don't know whether that change introduced, or merely exhibited the issue.

