### PR TITLE
Unify error handling of bad dictionary elements

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -810,9 +810,8 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 
 					zval *cur;
 					ZEND_HASH_FOREACH_VAL(dictionary, cur) {
-						zend_string *string = zval_get_string(cur);
-						ZEND_ASSERT(string);
-						if (EG(exception)) {
+						zend_string *string = zval_try_get_string(cur);
+						if (string == NULL) {
 							result = 0;
 							break;
 						}
@@ -855,6 +854,7 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 				return 0;
 		}
 	}
+	return 1;
 }
 
 /* {{{ Initialize an incremental inflate context with the specified encoding */

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -815,6 +815,8 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 							result = 0;
 							break;
 						}
+						*dictlen += ZSTR_LEN(string) + 1;
+						strings[total++] = string;
 						if (ZSTR_LEN(string) == 0) {
 							result = 0;
 							zend_argument_value_error(2, "must not contain empty strings");
@@ -825,10 +827,6 @@ static bool zlib_create_dictionary_string(HashTable *options, char **dict, size_
 							zend_argument_value_error(2, "must not contain strings with null bytes");
 							break;
 						}
-
-						*dictlen += ZSTR_LEN(string) + 1;
-						strings[total] = string;
-						total++;
 					} ZEND_HASH_FOREACH_END();
 
 					char *dictptr = emalloc(*dictlen);


### PR DESCRIPTION
As is, we have separate error handling and reporting for empty strings and strings containing NUL bytes.  For simpler error handling we merge both cases; while that is slightly worse regarding the error reporting, it shouldn't matter in practice, since users need to check the validity of the dictionary upfront anyway.

---

This is a follow-up to PR #16335, where @TimWolla and @Girgias made suggestions for further improvements. This is the "best" I could come up with.