### PR TITLE
Fix GH-16411: gmp_export() can cause overflow

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1002,8 +1002,14 @@ ZEND_FUNCTION(gmp_export)
 	if (mpz_sgn(gmpnumber) == 0) {
 		RETVAL_EMPTY_STRING();
 	} else {
-		size_t bits_per_word = size * 8;
-		size_t count = (mpz_sizeinbase(gmpnumber, 2) + bits_per_word - 1) / bits_per_word;
+		ZEND_ASSERT(size > 0);
+		size_t size_in_base_2 = mpz_sizeinbase(gmpnumber, 2);
+		if (size > ZEND_LONG_MAX / 4 || size_in_base_2 > SIZE_MAX - (size_t) size * 8 + 1) {
+			zend_argument_value_error(2, "is too large for argument #1 ($num)");
+			RETURN_THROWS();
+		}
+		size_t bits_per_word = (size_t) size * 8;
+		size_t count = (size_in_base_2 + bits_per_word - 1) / bits_per_word;
 
 		zend_string *out_string = zend_string_safe_alloc(count, size, 0, 0);
 		mpz_export(ZSTR_VAL(out_string), NULL, order, size, endian, 0, gmpnumber);

--- a/ext/gmp/tests/gh16411.phpt
+++ b/ext/gmp/tests/gh16411.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-16411 (gmp_export() can cause overflow)
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+gmp_export(-9223372036854775808, 9223372036854775807, -9223372036854775808);
+?>
+--EXPECTF--
+Fatal error: Uncaught ValueError: gmp_export(): Argument #2 ($word_size) is too large for argument #1 ($num) in %s:%d
+%A


### PR DESCRIPTION
We need not only to avoid the signed overflow while calculating `bits_per_word` (reported issue), but also the unsigned overflow when calculating `count`.  While the former has a fixed threshold, the latter does not, since it also depends on the size in base 2.  Thus we use a somewhat unconventional error message.