### PR TITLE
Fix handling of invalid iterator in zend_weakmap_iterator_get_current_get()

### DIFF
--- a/Zend/tests/gh16371.phpt
+++ b/Zend/tests/gh16371.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-16371: Assertion failure in zend_weakmap_iterator_get_current_key() for invalid iterator
+--FILE--
+<?php
+
+$map = new WeakMap();
+$it = $map->getIterator();
+
+print "# Empty WeakMap\n";
+
+var_dump($it->key());
+var_dump($it->current());
+var_dump($it->valid());
+
+$map = new WeakMap();
+$obj = new stdClass;
+$map[$obj] = 0;
+
+print "# Valid iterator\n";
+
+$it = $map->getIterator();
+var_dump($it->key());
+var_dump($it->current());
+var_dump($it->valid());
+
+print "# End of iterator\n";
+
+$it->next();
+var_dump($it->key());
+var_dump($it->current());
+var_dump($it->valid());
+
+?>
+--EXPECTF--
+# Empty WeakMap
+NULL
+NULL
+bool(false)
+# Valid iterator
+object(stdClass)#%d (0) {
+}
+int(0)
+bool(true)
+# End of iterator
+NULL
+NULL
+bool(false)

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -530,6 +530,10 @@ static void zend_weakmap_iterator_get_current_key(zend_object_iterator *obj_iter
 	zend_string *string_key;
 	zend_ulong num_key;
 	int key_type = zend_hash_get_current_key_ex(&wm->ht, &string_key, &num_key, pos);
+	if (key_type == HASH_KEY_NON_EXISTENT) {
+		ZVAL_NULL(key);
+		return;
+	}
 	if (key_type != HASH_KEY_IS_LONG) {
 		ZEND_ASSERT(0 && "Must have integer key");
 	}


### PR DESCRIPTION
Fixes GH-16371

WeakMap's implementation of `zend_object_iterator_funcs.get_current_key` doesn't handle invalid states.

Here I set the `key` to `NULL` in `zend_weakmap_iterator_get_current_get()` when there is no more elements. This matches other implementations of `zend_object_iterator_funcs.get_current_key` as well as the documentation of `Iterator::key`.