### PR TITLE
Fix GH-16433: Large values for openssl_csr_sign() $days overflow

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3200,6 +3200,11 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
+	if (num_days < 0 || num_days > LONG_MAX / 86400) {
+		php_error_docref(NULL, E_WARNING, "Days must be between 0 and %ld", LONG_MAX / 86400);
+		goto cleanup;
+	}
+
 	if (PHP_SSL_REQ_PARSE(&req, args) == FAILURE) {
 		goto cleanup;
 	}
@@ -3251,7 +3256,7 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 	X509_gmtime_adj(X509_getm_notBefore(new_cert), 0);
-	X509_gmtime_adj(X509_getm_notAfter(new_cert), 60*60*24*(long)num_days);
+	X509_gmtime_adj(X509_getm_notAfter(new_cert), 60*60*24*num_days);
 	i = X509_set_pubkey(new_cert, key);
 	if (!i) {
 		php_openssl_store_errors();

--- a/ext/openssl/tests/gh16433.phpt
+++ b/ext/openssl/tests/gh16433.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-16433 (Large values for openssl_csr_sign() $days overflow)
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$privkey = openssl_pkey_new();
+$csr = openssl_csr_new([], $privkey);
+var_dump(openssl_csr_sign($csr, null, $privkey, PHP_INT_MAX));
+var_dump(openssl_csr_sign($csr, null, $privkey, -1));
+?>
+--EXPECTF--
+Warning: openssl_csr_sign(): Days must be between 0 and %d in %s on line %d
+bool(false)
+
+Warning: openssl_csr_sign(): Days must be between 0 and %d in %s on line %d
+bool(false)


### PR DESCRIPTION
The `offset_sec` parameter of `X509_gmtime_adj()` expects a `long`, but the `$days` parameter of `openssl_csr_sign()` a `zend_long`.  We must avoid signed integer overflow (UB), but also must not silently truncate. Thus we check the given `$days` for the permissible range, and bail out otherwise.

---

Note that the lower bound (`0`) is somewhat arbitrary; we could allow values >= `LONG_MIN / 86400`. I don't know if that makes sense, though (maybe for testing purposes?)

Also note that I've used `E_WARNING` for consistency with the rest, but that should probably propagated to a `ValueError`.