### PR TITLE
Fix GH-16414: zend_test.observer.observe_function_names may segfault

### DIFF
--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -309,7 +309,7 @@ static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 	}
 	if (stage != PHP_INI_STAGE_STARTUP && stage != PHP_INI_STAGE_ACTIVATE && stage != PHP_INI_STAGE_DEACTIVATE && stage != PHP_INI_STAGE_SHUTDOWN) {
 		ZEND_HASH_FOREACH_STR_KEY(*p, funcname) {
-			if ((func = zend_hash_find_ptr(EG(function_table), funcname))) {
+			if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
 				void *old_handler;
 				zend_observer_remove_begin_handler(func, observer_begin, (zend_observer_fcall_begin_handler *)&old_handler);
 				zend_observer_remove_end_handler(func, observer_end, (zend_observer_fcall_end_handler *)&old_handler);
@@ -332,7 +332,7 @@ static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 		zend_string_release(str);
 		if (stage != PHP_INI_STAGE_STARTUP && stage != PHP_INI_STAGE_ACTIVATE && stage != PHP_INI_STAGE_DEACTIVATE && stage != PHP_INI_STAGE_SHUTDOWN) {
 			ZEND_HASH_FOREACH_STR_KEY(*p, funcname) {
-				if ((func = zend_hash_find_ptr(EG(function_table), funcname))) {
+				if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
 					zend_observer_add_begin_handler(func, observer_begin);
 					zend_observer_add_end_handler(func, observer_end);
 				}

--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -304,6 +304,9 @@ static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 	zend_array **p = (zend_array **) ZEND_INI_GET_ADDR();
 	zend_string *funcname;
 	zend_function *func;
+	if (!ZT_G(observer_enabled)) {
+		return FAILURE;
+	}
 	if (stage != PHP_INI_STAGE_STARTUP && stage != PHP_INI_STAGE_ACTIVATE && stage != PHP_INI_STAGE_DEACTIVATE && stage != PHP_INI_STAGE_SHUTDOWN) {
 		ZEND_HASH_FOREACH_STR_KEY(*p, funcname) {
 			if ((func = zend_hash_find_ptr(EG(function_table), funcname))) {

--- a/ext/zend_test/tests/gh16414.phpt
+++ b/ext/zend_test/tests/gh16414.phpt
@@ -2,6 +2,8 @@
 GH-16414 (zend_test.observer.observe_function_names may segfault)
 --EXTENSIONS--
 zend_test
+--INI--
+zend_test.observer.enabled=0
 --FILE--
 <?php
 function bar() {}

--- a/ext/zend_test/tests/gh16414.phpt
+++ b/ext/zend_test/tests/gh16414.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-16414 (zend_test.observer.observe_function_names may segfault)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+function bar() {}
+var_dump(ini_set("zend_test.observer.observe_function_names", "bar"));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
https://github.com/php/php-src/blob/5955ce898789ca691559baf69d8ab5a1d6136548/Zend/zend_observer.h#L62-L63

How would poor ext/zend_test know whether `zend_observer_fcall_register()` had been called? Can that function call be observed? ;)

Kidding aside, I don't think this patch is the proper fix (since the issue is related to ext/zend_test, and not really to observers). Instead, it should be possible to check whether an fcall has been registered; unfortunately, there appears to be no API for that, and `zend_observers_fcall_list` is static.

