### PR TITLE
Fix invalid target opline with jit->reuse_ip active

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -16811,6 +16811,9 @@ static int zend_jit_trace_end_loop(zend_jit_ctx *jit, int loop_ref, const void *
 
 static int zend_jit_trace_return(zend_jit_ctx *jit, bool original_handler, const zend_op *opline)
 {
+	if (!original_handler && jit->reuse_ip) {
+		zend_jit_set_ip(jit, opline);
+	}
 	if (GCC_GLOBAL_REGS) {
 		if (!original_handler) {
 			ir_TAILCALL(IR_VOID, ir_LOAD_A(jit_IP(jit)));

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7225,10 +7225,10 @@ done:
 			}
 			zend_jit_trace_link_to_root(&ctx, &zend_jit_traces[t->link], timeout_exit_addr);
 		} else {
-			zend_jit_trace_return(&ctx, 0, NULL);
+			zend_jit_trace_return(&ctx, 0, p->opline);
 		}
 	} else if (p->stop == ZEND_JIT_TRACE_STOP_RETURN) {
-		zend_jit_trace_return(&ctx, 0, NULL);
+		zend_jit_trace_return(&ctx, 0, p->opline);
 	} else {
 		// TODO: not implemented ???
 		ZEND_ASSERT(0 && p->stop);


### PR DESCRIPTION
When the JIT jumps out of tracing while reuse_ip is set, it will jump directly to the reused pointer, which might be e.g. EX(call) instead of EX(opline).

I honestly don't know how to properly give an isolated reproducer, but the gist is that the tracing JIT was bailing out on a DO_UCALL opcode...

I'm not sure whether that fix is correct, but at least I could no longer reproduce it later.