### PR TITLE
Fix GH-16429: Segmentation fault (access null pointer) in SoapClient

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2210,8 +2210,8 @@ static xmlNodePtr to_xml_array(encodeTypePtr type, zval *data, int style, xmlNod
 
 		iter = ce->get_iterator(ce, data, 0);
 
-		if (EG(exception)) {
-			goto iterator_done;
+		if (!iter) {
+			goto iterator_failed_to_get;
 		}
 
 		if (iter->funcs->rewind) {
@@ -2251,6 +2251,7 @@ static xmlNodePtr to_xml_array(encodeTypePtr type, zval *data, int style, xmlNod
 		}
 iterator_done:
 		OBJ_RELEASE(&iter->std);
+iterator_failed_to_get:
 		if (EG(exception)) {
 			zval_ptr_dtor(&array_copy);
 			ZVAL_UNDEF(&array_copy);

--- a/ext/soap/tests/bugs/gh16429.phpt
+++ b/ext/soap/tests/bugs/gh16429.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-16429 (Segmentation fault (access null pointer) in SoapClient)
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+function gen() {
+    var_dump(str_repeat("x", yield));
+}
+$gen = gen();
+$gen->send(10);
+$fusion = $gen;
+$client = new SoapClient(__DIR__."/../interop/Round2/GroupB/round2_groupB.wsdl",array("trace"=>1,"exceptions"=>0));
+try {
+    $client->echo2DStringArray($fusion);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+string(10) "xxxxxxxxxx"
+Cannot traverse an already closed generator


### PR DESCRIPTION
If get_iterator() fails, we should not destroy the object. Also changes the check to a NULL check to be more defensive, and to match the VM.