### PR TITLE
ext/session: Fix cache_expire ini overflow/underflow.

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -710,6 +710,23 @@ static PHP_INI_MH(OnUpdateCookieLifetime) /* {{{ */
 }
 /* }}} */
 
+static PHP_INI_MH(OnUpdateCacheExpire)
+{
+	SESSION_CHECK_ACTIVE_STATE;
+	SESSION_CHECK_OUTPUT_STATE;
+
+#ifdef ZEND_ENABLE_ZVAL_LONG64
+	const zend_long maxexpire = ((ZEND_LONG_MAX - INT_MAX) / 60) - 1;
+#else
+	const zend_long maxexpire = ((ZEND_LONG_MAX / 2) / 60) - 1;
+#endif
+	zend_long v = (zend_long)atol(ZSTR_VAL(new_value));
+	if (v < 0 || v > maxexpire) {
+		return SUCCESS;
+	}
+	return OnUpdateLongGEZero(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
+}
+
 
 static PHP_INI_MH(OnUpdateSessionLong) /* {{{ */
 {
@@ -818,7 +835,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("session.use_strict_mode",  "0",         PHP_INI_ALL, OnUpdateSessionBool,   use_strict_mode,    php_ps_globals,    ps_globals)
 	STD_PHP_INI_ENTRY("session.referer_check",      "",          PHP_INI_ALL, OnUpdateSessionString, extern_referer_chk, php_ps_globals,    ps_globals)
 	STD_PHP_INI_ENTRY("session.cache_limiter",      "nocache",   PHP_INI_ALL, OnUpdateSessionString, cache_limiter,      php_ps_globals,    ps_globals)
-	STD_PHP_INI_ENTRY("session.cache_expire",       "180",       PHP_INI_ALL, OnUpdateSessionLong,   cache_expire,       php_ps_globals,    ps_globals)
+	STD_PHP_INI_ENTRY("session.cache_expire",       "180",       PHP_INI_ALL, OnUpdateCacheExpire,   cache_expire,       php_ps_globals,    ps_globals)
 	STD_PHP_INI_BOOLEAN("session.use_trans_sid",    "0",         PHP_INI_ALL, OnUpdateSessionBool,   use_trans_sid,      php_ps_globals,    ps_globals)
 	PHP_INI_ENTRY("session.sid_length",             "32",        PHP_INI_ALL, OnUpdateSidLength)
 	PHP_INI_ENTRY("session.sid_bits_per_character", "4",         PHP_INI_ALL, OnUpdateSidBits)

--- a/ext/session/tests/session_cache_expire_oflow.phpt
+++ b/ext/session/tests/session_cache_expire_oflow.phpt
@@ -1,0 +1,27 @@
+--TEST--
+session_cache_expire() overflow
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+
+ob_start();
+
+echo "*** Testing session_cache_expire() : overflow test ***\n";
+
+session_cache_limiter("public");
+var_dump(session_cache_expire(PHP_INT_MAX));
+session_start();
+var_dump(session_cache_expire() * 60);
+
+echo "Done";
+ob_end_flush();
+?>
+--EXPECT--
+*** Testing session_cache_expire() : overflow test ***
+int(180)
+int(10800)
+Done
+


### PR DESCRIPTION
Setting with PHP_INT_MIN/PHP_INT_MAX lead to these.

```
ext/session/session.c:1181:37: runtime error: signed integer overflow: -9223372036854775808 * 60 cannot be represented in type 'long int'
ext/session/session.c:1181:37: runtime error: signed integer overflow: 9223372036854775807 * 60 cannot be represented in type 'long int'
```