### PR TITLE
GH-16447: improve enums' error when missing interface's hooked properties

### DIFF
--- a/Zend/tests/property_hooks/gh16447_1.phpt
+++ b/Zend/tests/property_hooks/gh16447_1.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-16447: Enum error messages should not suggest adding methods (get)
+--FILE--
+<?php
+
+interface I {
+    public string $prop { get; }
+}
+
+enum E implements I {}
+
+?>
+--EXPECTF--
+Fatal error: Enum E cannot implement interface I that contains hooked property I::$prop in %s on line %d

--- a/Zend/tests/property_hooks/gh16447_2.phpt
+++ b/Zend/tests/property_hooks/gh16447_2.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-16447: Enum error messages should not suggest adding methods (set)
+--FILE--
+<?php
+
+interface I {
+    public string $prop { set; }
+}
+
+enum E implements I {}
+
+?>
+--EXPECTF--
+Fatal error: Enum E cannot implement interface I that contains hooked property I::$prop in %s on line %d

--- a/Zend/tests/property_hooks/gh16447_3.phpt
+++ b/Zend/tests/property_hooks/gh16447_3.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-16447: Enum error messages should not suggest adding methods ($name get allowed)
+--FILE--
+<?php
+
+interface I {
+    public string $name { get; }
+}
+
+enum E implements I {}
+
+?>
+OKAY
+--EXPECT--
+OKAY

--- a/Zend/tests/property_hooks/gh16447_4.phpt
+++ b/Zend/tests/property_hooks/gh16447_4.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-16447: Enum error messages should not suggest adding methods ($value get allowed on backed enum)
+--FILE--
+<?php
+
+interface I {
+    public string $value { get; }
+}
+
+enum E: string implements I {}
+
+?>
+OKAY
+--EXPECT--
+OKAY

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3002,6 +3002,18 @@ void zend_verify_abstract_class(zend_class_entry *ce) /* {{{ */
 					const zend_function *fn = prop_info->hooks[i];
 					if (fn && (fn->common.fn_flags & ZEND_ACC_ABSTRACT)) {
 						zend_verify_abstract_class_function(fn, &ai);
+						// Short-circuit on enums that cannot have hooked
+						// properties
+						if (ce->ce_flags & ZEND_ACC_ENUM) {
+							zend_error_noreturn(
+								E_ERROR,
+								"Enum %s cannot implement interface %s that contains hooked property %s::$%s",
+								ZSTR_VAL(ce->name),
+								ZSTR_VAL(prop_info->ce->name),
+								ZSTR_VAL(prop_info->ce->name),
+								ZSTR_VAL(prop_info->name)
+							);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Enums cannot have properties, and so can not be made to satisfy the interface at all; show a clearer error message than the suggestion to implement the hooked properties.