### PR TITLE
Unify headers already sent/session already started error handler

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -83,7 +83,7 @@ zend_class_entry *php_session_update_timestamp_iface_entry;
 
 #define SESSION_CHECK_ACTIVE_STATE	\
 	if (PS(session_status) == php_session_active) {	\
-		php_error_docref(NULL, E_WARNING, "Session ini settings cannot be changed when a session is active");	\
+		php_session_session_already_started_error(E_WARNING, "Session ini settings cannot be changed when a session is active");	\
 		return FAILURE;	\
 	}
 
@@ -1798,7 +1798,7 @@ PHP_FUNCTION(session_set_cookie_params)
 	}
 
 	if (PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session cookie parameters cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session cookie parameters cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -1970,7 +1970,7 @@ PHP_FUNCTION(session_name)
 	}
 
 	if (name && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session name cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session name cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -2000,7 +2000,7 @@ PHP_FUNCTION(session_module_name)
 	}
 
 	if (name && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session save handler module cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session save handler module cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -2041,7 +2041,7 @@ PHP_FUNCTION(session_module_name)
 
 static bool can_session_handler_be_changed(void) {
 	if (PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session save handler cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session save handler cannot be changed when a session is active");
 		return false;
 	}
 
@@ -2281,7 +2281,7 @@ PHP_FUNCTION(session_save_path)
 	}
 
 	if (name && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session save path cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session save path cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -2310,7 +2310,7 @@ PHP_FUNCTION(session_id)
 	}
 
 	if (name && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session ID cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session ID cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -2352,7 +2352,7 @@ PHP_FUNCTION(session_regenerate_id)
 	}
 
 	if (PS(session_status) != php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session ID cannot be regenerated when there is no active session");
+		php_session_session_already_started_error(E_WARNING, "Session ID cannot be regenerated when there is no active session");
 		RETURN_FALSE;
 	}
 
@@ -2523,7 +2523,7 @@ PHP_FUNCTION(session_cache_limiter)
 	}
 
 	if (limiter && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session cache limiter cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session cache limiter cannot be changed when a session is active");
 		RETURN_FALSE;
 	}
 
@@ -2553,7 +2553,7 @@ PHP_FUNCTION(session_cache_expire)
 	}
 
 	if (!expires_is_null && PS(session_status) == php_session_active) {
-		php_error_docref(NULL, E_WARNING, "Session cache expiration cannot be changed when a session is active");
+		php_session_session_already_started_error(E_WARNING, "Session cache expiration cannot be changed when a session is active");
 		RETURN_LONG(PS(cache_expire));
 	}
 

--- a/ext/session/tests/014.phpt
+++ b/ext/session/tests/014.phpt
@@ -35,8 +35,8 @@ session_destroy();
 --EXPECTF--
 <a href="/link">
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 <a href="/link">
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 <a href="/link">

--- a/ext/session/tests/bug73100.phpt
+++ b/ext/session/tests/bug73100.phpt
@@ -22,7 +22,7 @@ try {
 --EXPECTF--
 bool(true)
 
-Warning: session_module_name(): Session save handler module cannot be changed when a session is active in %s on line %d
+Warning: session_module_name(): Session save handler module cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(true)
 session_module_name(): Argument #1 ($module) cannot be "user"
 ===DONE===

--- a/ext/session/tests/session_cache_limiter_variation1.phpt
+++ b/ext/session/tests/session_cache_limiter_variation1.phpt
@@ -30,7 +30,7 @@ string(7) "nocache"
 bool(true)
 string(7) "nocache"
 
-Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active in %s on line %d
+Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(7) "nocache"
 bool(true)

--- a/ext/session/tests/session_cache_limiter_variation2.phpt
+++ b/ext/session/tests/session_cache_limiter_variation2.phpt
@@ -29,7 +29,7 @@ string(7) "nocache"
 bool(true)
 string(7) "nocache"
 
-Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active in %s on line %d
+Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(7) "nocache"
 bool(true)

--- a/ext/session/tests/session_cache_limiter_variation3.phpt
+++ b/ext/session/tests/session_cache_limiter_variation3.phpt
@@ -28,7 +28,7 @@ string(7) "nocache"
 bool(true)
 string(7) "nocache"
 
-Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active in %s on line %d
+Warning: session_cache_limiter(): Session cache limiter cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(7) "nocache"
 bool(true)

--- a/ext/session/tests/session_id_error2.phpt
+++ b/ext/session/tests/session_id_error2.phpt
@@ -31,7 +31,7 @@ string(4) "test"
 string(10) "1234567890"
 bool(true)
 
-Warning: session_id(): Session ID cannot be changed when a session is active in %s on line %d
+Warning: session_id(): Session ID cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 bool(true)
 string(0) ""

--- a/ext/session/tests/session_ini_set.phpt
+++ b/ext/session/tests/session_ini_set.phpt
@@ -118,67 +118,67 @@ string(1) "4"
 string(1) "1"
 string(15) "session started"
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 
-Warning: ini_set(): Session ini settings cannot be changed when a session is active in %s on line %d
+Warning: ini_set(): Session ini settings cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 Done

--- a/ext/session/tests/session_save_path_variation1.phpt
+++ b/ext/session/tests/session_save_path_variation1.phpt
@@ -40,7 +40,7 @@ string(%d) "%stests"
 bool(true)
 string(%d) "%stests"
 
-Warning: session_save_path(): Session save path cannot be changed when a session is active in %s on line %d
+Warning: session_save_path(): Session save path cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(%d) "%stests"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_basic.phpt
+++ b/ext/session/tests/session_set_cookie_params_basic.phpt
@@ -25,7 +25,7 @@ ob_end_flush();
 bool(true)
 bool(true)
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation1.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation1.phpt
@@ -38,7 +38,7 @@ string(4) "3600"
 bool(true)
 string(4) "3600"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(4) "3600"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation2.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation2.phpt
@@ -36,7 +36,7 @@ string(4) "/foo"
 bool(true)
 string(4) "/foo"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(4) "/foo"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation3.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation3.phpt
@@ -36,7 +36,7 @@ string(4) "blah"
 bool(true)
 string(4) "blah"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(4) "blah"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation4.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation4.phpt
@@ -36,7 +36,7 @@ string(1) "0"
 bool(true)
 string(1) "0"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(1) "0"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation5.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation5.phpt
@@ -36,7 +36,7 @@ string(1) "0"
 bool(true)
 string(1) "0"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(1) "0"
 bool(true)

--- a/ext/session/tests/session_set_cookie_params_variation6.phpt
+++ b/ext/session/tests/session_set_cookie_params_variation6.phpt
@@ -36,7 +36,7 @@ string(7) "nothing"
 bool(true)
 string(7) "nothing"
 
-Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active in %s on line %d
+Warning: session_set_cookie_params(): Session cookie parameters cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 string(7) "nothing"
 bool(true)

--- a/ext/session/tests/session_start_variation9.phpt
+++ b/ext/session/tests/session_start_variation9.phpt
@@ -26,7 +26,7 @@ ob_end_flush();
 *** Testing session_start() : variation ***
 string(%d) "%s"
 
-Notice: session_start(): Ignoring session_start() because a session is already automatically active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (session started automatically) in %s on line %d
 bool(true)
 string(%d) "%s"
 bool(true)

--- a/ext/session/tests/user_session_module/bug80889a.phpt
+++ b/ext/session/tests/user_session_module/bug80889a.phpt
@@ -33,6 +33,6 @@ var_dump($initHandler, $setHandler);
 --EXPECTF--
 Deprecated: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in %s on line %d
 
-Warning: session_set_save_handler(): Session save handler cannot be changed after headers have already been sent in %s on line %d
+Warning: session_set_save_handler(): Session save handler cannot be changed after headers have already been sent (sent from %s on line %d) in %s on line %d
 string(8) "whatever"
 string(8) "whatever"

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation2.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation2.phpt
@@ -30,6 +30,6 @@ bool(true)
 
 Deprecated: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in %s on line %d
 
-Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active in %s on line %d
+Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active (started from %s on line %d) in %s on line %d
 bool(false)
 bool(true)

--- a/ext/session/tests/user_session_module/session_set_save_handler_variation3.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_variation3.phpt
@@ -29,10 +29,10 @@ rmdir($path);
 *** Testing session_set_save_handler() : variation ***
 int(2)
 
-Warning: session_save_path(): Session save path cannot be changed when a session is active in %s on line %d
+Warning: session_save_path(): Session save path cannot be changed when a session is active (session started automatically) in %s on line %d
 
 Deprecated: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in %s on line %d
 
-Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active in %s on line %d
+Warning: session_set_save_handler(): Session save handler cannot be changed when a session is active (session started automatically) in %s on line %d
 bool(false)
 bool(true)


### PR DESCRIPTION
Unifies the error formatting for when a session was already started or headers were already sent in ext/session. This is an evolution of GH-16378, motivated by the fact some places were neglected with the additional checks. The additional checks add a lot of noise, so it's turned into a function.

This doesn't change control flow, as the error conditions as well as if any deinit needs to be happen is different per call site.