### PR TITLE
RFC: Support Closures in constant expressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-16665 (\array and \callable should not be usable in
     class_alias). (nielsdos)
   . Added PHP_BUILD_DATE constant. (cmb)
+  . Added support for Closures in constant expressions. (timwolla,
+    Volker Dusch)
 
 - Curl:
   . Added curl_multi_get_handles(). (timwolla)

--- a/UPGRADING
+++ b/UPGRADING
@@ -44,6 +44,10 @@ PHP 8.5 UPGRADE NOTES
 2. New Features
 ========================================
 
+- Core:
+  . Added support for Closures in constant expressions.
+    RFC: https://wiki.php.net/rfc/closures_in_const_expr
+
 - DOM:
   . Added Dom\Element::$outerHTML.
 

--- a/Zend/tests/closure_const_expr/attributes.phpt
+++ b/Zend/tests/closure_const_expr/attributes.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Allow defining closures in attributes
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Attr {
+    public function __construct(public Closure $value) {
+      $value('foo');
+    }
+}
+
+#[Attr(static function () { })]
+#[Attr(static function (...$args) {
+  var_dump($args);
+})]
+class C {}
+
+foreach ((new ReflectionClass(C::class))->getAttributes() as $reflectionAttribute) {
+    var_dump($reflectionAttribute->newInstance());
+}
+
+?>
+--EXPECTF--
+object(Attr)#%d (1) {
+  ["value"]=>
+  object(Closure)#%d (3) {
+    ["name"]=>
+    string(%d) "{closure:%s:%d}"
+    ["file"]=>
+    string(%d) "%s"
+    ["line"]=>
+    int(%d)
+  }
+}
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+object(Attr)#%d (1) {
+  ["value"]=>
+  object(Closure)#%d (4) {
+    ["name"]=>
+    string(%d) "{closure:%s:%d}"
+    ["file"]=>
+    string(%d) "%s"
+    ["line"]=>
+    int(%d)
+    ["parameter"]=>
+    array(1) {
+      ["$args"]=>
+      string(10) "<optional>"
+    }
+  }
+}

--- a/Zend/tests/closure_const_expr/attributes_ast_printing.phpt
+++ b/Zend/tests/closure_const_expr/attributes_ast_printing.phpt
@@ -1,0 +1,41 @@
+--TEST--
+AST printing for closures in attributes
+--FILE--
+<?php
+
+// Do not use `false &&` to fully evaluate the function / class definition.
+
+try {
+    \assert(
+        !
+        #[Attr(static function ($foo) {
+            echo $foo;
+        })]
+        function () { }
+    );
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    \assert(
+        !
+        new #[Attr(static function ($foo) {
+            echo $foo;
+        })]
+        class {}
+    );
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+assert(!#[Attr(static function ($foo) {
+    echo $foo;
+})] function () {
+})
+assert(!new #[Attr(static function ($foo) {
+    echo $foo;
+})] class {
+})

--- a/Zend/tests/closure_const_expr/attributes_scope_001.phpt
+++ b/Zend/tests/closure_const_expr/attributes_scope_001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Closure in attribute may access private variables
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Attr {
+    public function __construct(public Closure $value) {}
+}
+
+#[Attr(static function (C $c) {
+    echo $c->secret, PHP_EOL;
+})]
+class C {
+    public function __construct(
+        private string $secret,
+    ) {}
+}
+
+foreach ((new ReflectionClass(C::class))->getAttributes() as $reflectionAttribute) {
+    ($reflectionAttribute->newInstance()->value)(new C('secret'));
+}
+
+?>
+--EXPECT--
+secret

--- a/Zend/tests/closure_const_expr/attributes_scope_002.phpt
+++ b/Zend/tests/closure_const_expr/attributes_scope_002.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Closure in attribute may not access unrelated private variables
+--EXTENSIONS--
+reflection
+--FILE--
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Attr {
+    public function __construct(public Closure $value) {}
+}
+
+#[Attr(static function (E $e) {
+    echo $e->secret, PHP_EOL;
+})]
+class C {
+}
+
+class E {
+    public function __construct(
+        private string $secret,
+    ) {}
+}
+
+foreach ((new ReflectionClass(C::class))->getAttributes() as $reflectionAttribute) {
+    ($reflectionAttribute->newInstance()->value)(new E('secret'));
+}
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot access private property E::$secret in %s:%d
+Stack trace:
+#0 %s(%d): C::{closure:%s:%d}(Object(E))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/closure_const_expr/basic.phpt
+++ b/Zend/tests/closure_const_expr/basic.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Allow defining Closures in const expressions.
+--FILE--
+<?php
+
+const Closure = static function () {
+    echo "called", PHP_EOL;
+};
+
+var_dump(Closure);
+(Closure)();
+
+?>
+--EXPECTF--
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(3)
+}
+called

--- a/Zend/tests/closure_const_expr/class_const.phpt
+++ b/Zend/tests/closure_const_expr/class_const.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Allow defining Closures in class constants.
+--FILE--
+<?php
+
+class C {
+    const Closure = static function () {
+        echo "called", PHP_EOL;
+    };
+}
+
+var_dump(C::Closure);
+(C::Closure)();
+
+?>
+--EXPECTF--
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(4)
+}
+called

--- a/Zend/tests/closure_const_expr/complex_array.phpt
+++ b/Zend/tests/closure_const_expr/complex_array.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Allow defining Closures wrapped in an array in const expressions.
+--FILE--
+<?php
+
+const Closure = [static function () {
+    echo "called", PHP_EOL;
+}, static function () {
+    echo "also called", PHP_EOL;
+}];
+
+var_dump(Closure);
+
+foreach (Closure as $closure) {
+    $closure();
+}
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  object(Closure)#%d (3) {
+    ["name"]=>
+    string(%d) "{closure:%s:%d}"
+    ["file"]=>
+    string(%d) "%s"
+    ["line"]=>
+    int(3)
+  }
+  [1]=>
+  object(Closure)#%d (3) {
+    ["name"]=>
+    string(%d) "{closure:%s:%d}"
+    ["file"]=>
+    string(%d) "%s"
+    ["line"]=>
+    int(5)
+  }
+}
+called
+also called

--- a/Zend/tests/closure_const_expr/complex_new.phpt
+++ b/Zend/tests/closure_const_expr/complex_new.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Allow defining Closures passed as constructor arguments in const expressions.
+--FILE--
+<?php
+
+class Dummy {
+  public function __construct(
+      public Closure $c,
+  ) {}
+}
+
+const Closure = new Dummy(static function () {
+  echo "called", PHP_EOL;
+});
+
+var_dump(Closure);
+
+(Closure->c)();
+
+?>
+--EXPECTF--
+object(Dummy)#%d (1) {
+  ["c"]=>
+  object(Closure)#%d (3) {
+    ["name"]=>
+    string(%d) "{closure:%s:%d}"
+    ["file"]=>
+    string(%d) "%s"
+    ["line"]=>
+    int(9)
+  }
+}
+called

--- a/Zend/tests/closure_const_expr/default_args.phpt
+++ b/Zend/tests/closure_const_expr/default_args.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closures in default argument
+--FILE--
+<?php
+
+function test(
+    Closure $name = static function () {
+        echo "default", PHP_EOL;
+    },
+) {
+    $name();
+}
+
+test();
+test(function () {
+    echo "explicit", PHP_EOL;
+});
+
+?>
+--EXPECT--
+default
+explicit

--- a/Zend/tests/closure_const_expr/disallows_non_static.phpt
+++ b/Zend/tests/closure_const_expr/disallows_non_static.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Disallows using non-static closures.
+--FILE--
+<?php
+
+class C {
+    public Closure $d = function () {
+        var_dump($this);
+    };
+}
+
+$foo = new C();
+var_dump($foo->d);
+($foo->d)();
+
+?>
+--EXPECTF--
+Fatal error: Closures in constant expressions must be static in %s on line %d

--- a/Zend/tests/closure_const_expr/disallows_using_variables.phpt
+++ b/Zend/tests/closure_const_expr/disallows_using_variables.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Disallows using variables.
+--FILE--
+<?php
+
+$foo = "bar";
+
+const Closure = static function () use ($foo) {
+    echo $foo, PHP_EOL;
+};
+
+var_dump(Closure);
+(Closure)();
+
+?>
+--EXPECTF--
+Fatal error: Cannot use(...) variables in constant expression in %s on line %d

--- a/Zend/tests/closure_const_expr/property_initializer.phpt
+++ b/Zend/tests/closure_const_expr/property_initializer.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Closure in property initializer
+--FILE--
+<?php
+
+class C {
+    public Closure $d = static function () {
+        echo "called", PHP_EOL;
+    };
+}
+
+$c = new C();
+var_dump($c->d);
+($c->d)();
+
+
+?>
+--EXPECTF--
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(4)
+}
+called

--- a/Zend/tests/closure_const_expr/property_initializer_scope_001.phpt
+++ b/Zend/tests/closure_const_expr/property_initializer_scope_001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Closure in property initializer may access private variables
+--FILE--
+<?php
+
+class C {
+    public Closure $d = static function (C $c) {
+        echo $c->secret, PHP_EOL;
+    };
+
+    public function __construct(
+        private string $secret,
+    ) {}
+}
+
+$c = new C('secret');
+($c->d)($c);
+
+
+?>
+--EXPECTF--
+secret

--- a/Zend/tests/closure_const_expr/property_initializer_scope_002.phpt
+++ b/Zend/tests/closure_const_expr/property_initializer_scope_002.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Closure in property initializer may not access unrelated private variables
+--FILE--
+<?php
+
+class C {
+    public Closure $d = static function (E $e) {
+        echo $e->secret, PHP_EOL;
+    };
+
+    
+}
+
+class E {
+    public function __construct(
+        private string $secret,
+    ) {}
+}
+
+$c = new C();
+($c->d)(new E('secret'));
+
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot access private property E::$secret in %s:%d
+Stack trace:
+#0 %s(%d): C::{closure:%s:%d}(Object(E))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/closure_const_expr/static_initalizer.phpt
+++ b/Zend/tests/closure_const_expr/static_initalizer.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Closure in static initializer
+--FILE--
+<?php
+
+function foo() {
+    static $closure = static function () {
+        echo "called", PHP_EOL;
+    };
+
+    var_dump($closure);
+    $closure();
+}
+
+foo();
+
+?>
+--EXPECTF--
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(17) "{closure:foo():4}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(4)
+}
+called

--- a/Zend/tests/closure_const_expr/static_property_initializer.phpt
+++ b/Zend/tests/closure_const_expr/static_property_initializer.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Closure in static property initializer
+--FILE--
+<?php
+
+class C {
+    public static Closure $d = static function () {
+        echo "called", PHP_EOL;
+    };
+}
+
+var_dump(C::$d);
+(C::$d)();
+
+
+?>
+--EXPECTF--
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(4)
+}
+called

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -35,6 +35,7 @@ enum _zend_ast_kind {
 	/* special nodes */
 	ZEND_AST_ZVAL = 1 << ZEND_AST_SPECIAL_SHIFT,
 	ZEND_AST_CONSTANT,
+	ZEND_AST_OP_ARRAY,
 	ZEND_AST_ZNODE,
 
 	/* declaration nodes */
@@ -362,7 +363,7 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	if (ast->kind == ZEND_AST_ZVAL) {
 		zval *zv = zend_ast_get_zval(ast);
 		return Z_LINENO_P(zv);
-	} else if (ast->kind == ZEND_AST_CONSTANT) {
+	} else if (ast->kind == ZEND_AST_CONSTANT || ast->kind == ZEND_AST_OP_ARRAY) {
 		zval *zv = &((zend_ast_zval *) ast)->val;
 		return Z_LINENO_P(zv);
 	} else {

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -363,6 +363,9 @@ static void zend_file_cache_serialize_ast(zend_ast                 *ast,
 				zend_file_cache_serialize_ast(tmp, script, info, buf);
 			}
 		}
+	} else if (ast->kind == ZEND_AST_OP_ARRAY) {
+		/* The op_array itself will be serialized as part of the dynamic_func_defs. */
+		SERIALIZE_PTR(Z_PTR(((zend_ast_zval*)ast)->val));
 	} else {
 		uint32_t children = zend_ast_get_num_children(ast);
 		for (i = 0; i < children; i++) {
@@ -1242,6 +1245,9 @@ static void zend_file_cache_unserialize_ast(zend_ast                *ast,
 				zend_file_cache_unserialize_ast(list->child[i], script, buf);
 			}
 		}
+	} else if (ast->kind == ZEND_AST_OP_ARRAY) {
+		/* The op_array itself will be unserialized as part of the dynamic_func_defs. */
+		UNSERIALIZE_PTR(Z_PTR(((zend_ast_zval*)ast)->val));
 	} else {
 		uint32_t children = zend_ast_get_num_children(ast);
 		for (i = 0; i < children; i++) {

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -188,6 +188,10 @@ static zend_ast *zend_persist_ast(zend_ast *ast)
 			}
 		}
 		node = (zend_ast *) copy;
+	} else if (ast->kind == ZEND_AST_OP_ARRAY) {
+		zend_ast_zval *copy = zend_shared_memdup(ast, sizeof(zend_ast_zval));
+		zend_persist_op_array(&copy->val);
+		node = (zend_ast *) copy;
 	} else {
 		uint32_t children = zend_ast_get_num_children(ast);
 		node = zend_shared_memdup(ast, zend_ast_size(children));

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -86,6 +86,9 @@ static void zend_persist_ast_calc(zend_ast *ast)
 				zend_persist_ast_calc(list->child[i]);
 			}
 		}
+	} else if (ast->kind == ZEND_AST_OP_ARRAY) {
+		ADD_SIZE(sizeof(zend_ast_zval));
+		zend_persist_op_array_calc(&((zend_ast_zval*)(ast))->val);
 	} else {
 		uint32_t children = zend_ast_get_num_children(ast);
 		ADD_SIZE(zend_ast_size(children));


### PR DESCRIPTION
Most notably this allows to use Closures as Attribute parameters.

RFC: https://wiki.php.net/rfc/closures_in_const_expr