### PR TITLE
Disallow asymmetric visibility on static properties

### DIFF
--- a/Zend/tests/asymmetric_visibility/static_props.phpt
+++ b/Zend/tests/asymmetric_visibility/static_props.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Asymmetric visibility on static props
+--FILE--
+<?php
+
+class C {
+    public private(set) static int $prop;
+}
+
+?>
+--EXPECTF--
+Fatal error: Static property may not have asymmetric visibility in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8598,6 +8598,10 @@ static void zend_compile_prop_decl(zend_ast *ast, zend_ast *type_ast, uint32_t f
 		zend_error_noreturn(E_COMPILE_ERROR, "Property cannot be both final and private");
 	}
 
+	if ((flags & ZEND_ACC_STATIC) && (flags & ZEND_ACC_PPP_SET_MASK)) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Static property may not have asymmetric visibility");
+	}
+
 	if (ce->ce_flags & ZEND_ACC_INTERFACE) {
 		if (flags & ZEND_ACC_FINAL) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Property in interface cannot be final");


### PR DESCRIPTION
https://wiki.php.net/rfc/asymmetric-visibility-v2#static_properties

> Static properties
>
> This functionality applies only to object properties. It does not apply to static properties. For various implementation reasons that is far harder, and also far less useful. It has therefore been omitted from this RFC.

This check was forgotten in the original implementation. Relaxing this restriction shouldn't be hard, but needs some work. We either need to prevent merging of cache slots for R/RW/W, or we need to introduce an additional check when writing to the property indirectly.