### PR TITLE
Detect misuse of ZEND_MAP_PTR_NEW()

### DIFF
--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -146,6 +146,9 @@ struct _zend_compiler_globals {
 	void   *map_ptr_base;
 	size_t  map_ptr_size;
 	size_t  map_ptr_last;
+#if ZEND_DEBUG
+	bool    map_ptr_locked;
+#endif
 
 	HashTable *delayed_variance_obligations;
 	HashTable *delayed_autoloads;

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -515,6 +515,9 @@ void zend_shared_alloc_lock(void)
 #endif
 
 	ZCG(locked) = 1;
+#if ZEND_DEBUG
+	CG(map_ptr_locked) = true;
+#endif
 }
 
 void zend_shared_alloc_unlock(void)
@@ -530,6 +533,9 @@ void zend_shared_alloc_unlock(void)
 	mem_write_unlock.l_len = 1;
 #endif
 
+#if ZEND_DEBUG
+	CG(map_ptr_locked) = false;
+#endif
 	ZCG(locked) = 0;
 
 #ifndef ZEND_WIN32


### PR DESCRIPTION
`ZEND_MAP_PTR_NEW()` is only safe during startup and when the opcache shm is locked, however it's easy to forget about that and to misuse it.  Similarly, `ZEND_MAP_PTR_NEW_STATIC()` can only be used during startup.

Here I add a assertions to check that we are only using `ZEND_MAP_PTR_NEW()` and `ZEND_MAP_PTR_NEW_STATIC()` when it's safe to do so.