### PR TITLE
Fix GH-16406: Assertion failure in ext/phar/phar.c:2808

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2286,6 +2286,9 @@ no_copy:
 			newentry.tar_type = (entry->is_dir ? TAR_DIR : TAR_FILE);
 		}
 
+		/* The header offset is only used for unmodified zips.
+		 * Once modified, phar_zip_changed_apply_int() will update the header_offset. */
+		newentry.header_offset = 0;
 		newentry.is_modified = 1;
 		newentry.phar = phar;
 		newentry.old_flags = newentry.flags & ~PHAR_ENT_COMPRESSION_MASK; /* remove compression from old_flags */

--- a/ext/phar/tests/gh16406.phpt
+++ b/ext/phar/tests/gh16406.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-16406 (Assertion failure in ext/phar/phar.c:2808)
+--EXTENSIONS--
+phar
+zlib
+--INI--
+phar.readonly=0
+phar.require_hash=0
+--FILE--
+<?php
+$fname = __DIR__ . '/gh16406.phar';
+@unlink($fname . '.tar');
+@unlink($fname . '.gz');
+@unlink($fname);
+$file = '<?php __HALT_COMPILER(); ?>';
+$files['b'] = 'b';
+$files['c'] = 'c';
+include __DIR__.'/files/phar_test.inc';
+$phar = new Phar($fname);
+$phar->compressFiles(Phar::GZ);
+$phar = $phar->convertToExecutable(Phar::TAR);
+$phar = $phar->convertToExecutable(Phar::PHAR, Phar::GZ);
+var_dump($phar['b']->openFile()->fread(4096));
+var_dump($phar['c']->openFile()->fread(4096));
+?>
+--CLEAN--
+<?php
+$fname = __DIR__ . '/gh16406.phar';
+@unlink($fname . '.tar');
+@unlink($fname . '.gz');
+@unlink($fname);
+?>
+--EXPECT--
+string(1) "b"
+string(1) "c"


### PR DESCRIPTION
When copying entries during conversion in phar_convert_to_other(), the header offset is not reset. This didn't matter in the past as it wasn't used anyway in the particular use-case, but since 1bb2a4f9 this is actually used and sanity-checked.