### PR TITLE
Fix MYSQLND_HAVE_SSL preprocessor help texts

### DIFF
--- a/ext/mysqlnd/config.w32
+++ b/ext/mysqlnd/config.w32
@@ -37,7 +37,7 @@ if (PHP_MYSQLND != "no") {
 			AC_DEFINE("MYSQLND_COMPRESSION_ENABLED", 1, "Define to 1 if mysqlnd has compressed protocol support.");
 			AC_DEFINE("MYSQLND_SSL_SUPPORTED", 1, "Define to 1 if mysqlnd core SSL is enabled.");
 			if (CHECK_LIB("crypt32.lib", "mysqlnd")) {
-				AC_DEFINE("MYSQLND_HAVE_SSL", 1, "Define to 1 if mysqlnd extended SSL is enabled through OpenSSL.");
+				AC_DEFINE("MYSQLND_HAVE_SSL", 1, "Define to 1 if mysqlnd extended SSL is enabled through a system library.");
 				ADD_EXTENSION_DEP('mysqlnd', 'hash');
 			}
 		}

--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -66,7 +66,7 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
   AS_VAR_IF([PHP_MYSQLND_SSL], [no],,
     [PHP_SETUP_OPENSSL([MYSQLND_SHARED_LIBADD], [
       AC_DEFINE([MYSQLND_HAVE_SSL], [1],
-        [Define to 1 if mysqlnd extended SSL is enabled through OpenSSL.])
+        [Define to 1 if mysqlnd extended SSL is enabled through a system library.])
       PHP_ADD_EXTENSION_DEP(mysqlnd, hash)
     ])])
 


### PR DESCRIPTION
The MYSQLND_HAVE_SSL indicate that mysqlnd has extended SSL support enabled through either OpenSSL when building with Autotools, and through crypt32 library on Windows.

Fixes https://github.com/php/php-src/pull/15164#discussion_r1803834585