### PR TITLE
Fix GH-16477 (Segmentation fault when calling __debugInfo() after failed SplFileObject::__constructor)

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2053,10 +2053,9 @@ PHP_METHOD(SplFileObject, __construct)
 		RETURN_THROWS();
 	}
 
-	// TODO This should probably take a copy:
-	// intern->file_name = zend_string_copy(file_name);
-	intern->file_name = file_name;
 	intern->u.file.open_mode = zend_string_copy(open_mode);
+	/* file_name and zcontext are copied by spl_filesystem_file_open() */
+	intern->file_name = file_name;
 	intern->u.file.zcontext = stream_context;
 
 	/* spl_filesystem_file_open() can generate E_WARNINGs which we want to promote to exceptions */
@@ -2098,7 +2097,7 @@ PHP_METHOD(SplTempFileObject, __construct)
 
 	/* Prevent reinitialization of Object */
 	if (intern->u.file.stream) {
-		zend_throw_error(NULL, "cannot call constructor twice");
+		zend_throw_error(NULL, "Cannot call constructor twice");
 		RETURN_THROWS();
 	}
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2047,13 +2047,7 @@ PHP_METHOD(SplFileObject, __construct)
 	size_t path_len;
 	zend_error_handling error_handling;
 
-	intern->u.file.open_mode = ZSTR_CHAR('r');
-
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|Sbr!",
-			&intern->file_name, &open_mode,
-			&use_include_path, &intern->u.file.zcontext) == FAILURE) {
-		intern->u.file.open_mode = NULL;
-		intern->file_name = NULL;
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|Sbr!", &intern->file_name, &open_mode, &use_include_path, &intern->u.file.zcontext) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -2093,6 +2087,12 @@ PHP_METHOD(SplTempFileObject, __construct)
 	zend_error_handling error_handling;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &max_memory) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	/* Prevent reinitialization of Object */
+	if (intern->u.file.stream) {
+		zend_throw_error(NULL, "cannot call constructor twice");
 		RETURN_THROWS();
 	}
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2042,16 +2042,22 @@ static void spl_filesystem_file_rewind(zval * this_ptr, spl_filesystem_object *i
 PHP_METHOD(SplFileObject, __construct)
 {
 	spl_filesystem_object *intern = spl_filesystem_from_obj(Z_OBJ_P(ZEND_THIS));
+	zend_string *file_name = NULL;
 	zend_string *open_mode = ZSTR_CHAR('r');
+	zval *stream_context = NULL;
 	bool use_include_path = 0;
 	size_t path_len;
 	zend_error_handling error_handling;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|Sbr!", &intern->file_name, &open_mode, &use_include_path, &intern->u.file.zcontext) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|Sbr!", &file_name, &open_mode, &use_include_path, &stream_context) == FAILURE) {
 		RETURN_THROWS();
 	}
 
+	// TODO This should probably take a copy:
+	// intern->file_name = zend_string_copy(file_name);
+	intern->file_name = file_name;
 	intern->u.file.open_mode = zend_string_copy(open_mode);
+	intern->u.file.zcontext = stream_context;
 
 	/* spl_filesystem_file_open() can generate E_WARNINGs which we want to promote to exceptions */
 	zend_replace_error_handling(EH_THROW, spl_ce_RuntimeException, &error_handling);

--- a/ext/spl/tests/gh16477-2.phpt
+++ b/ext/spl/tests/gh16477-2.phpt
@@ -15,5 +15,5 @@ $obj->__debugInfo();
 ?>
 DONE
 --EXPECT--
-Error: cannot call constructor twice
+Error: Cannot call constructor twice
 DONE

--- a/ext/spl/tests/gh16477-2.phpt
+++ b/ext/spl/tests/gh16477-2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-16477-2: Memory leak when calling SplTempFileObject::__constructor() twice
+--FILE--
+<?php
+
+$obj = new SplTempFileObject();
+
+try {
+    $obj->__construct();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+$obj->__debugInfo();
+
+?>
+DONE
+--EXPECT--
+Error: cannot call constructor twice
+DONE

--- a/ext/spl/tests/gh16477.phpt
+++ b/ext/spl/tests/gh16477.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-16477: Segmentation fault when calling __debugInfo() after failed SplFileObject::__constructor
+--FILE--
+<?php
+
+$obj = new SplFileObject(__FILE__);
+
+try {
+    $obj->__construct();
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+$obj->__debugInfo();
+
+?>
+DONE
+--EXPECT--
+ArgumentCountError: SplFileObject::__construct() expects at least 1 argument, 0 given
+DONE


### PR DESCRIPTION
Also fix a memory leak when reinitializing SplFileTemp