### PR TITLE
Fix use-after-free in SplObjectStorage::setInfo()

### DIFF
--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -746,8 +746,10 @@ PHP_METHOD(SplObjectStorage, setInfo)
 	if ((element = zend_hash_get_current_data_ptr_ex(&intern->storage, &intern->pos)) == NULL) {
 		RETURN_NULL();
 	}
-	zval_ptr_dtor(&element->inf);
+	zval garbage;
+	ZVAL_COPY_VALUE(&garbage, &element->inf);
 	ZVAL_COPY(&element->inf, inf);
+	zval_ptr_dtor(&garbage);
 } /* }}} */
 
 /* {{{ Moves position forward */

--- a/ext/spl/tests/gh16479.phpt
+++ b/ext/spl/tests/gh16479.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-16479: Test
+--FILE--
+<?php
+
+class C {
+    function __destruct() {
+        global $store;
+        $store->removeAll($store);
+    }
+}
+
+$o = new stdClass;
+$store = new SplObjectStorage;
+$store[$o] = new C;
+$store->setInfo(1);
+var_dump($store);
+
+?>
+--EXPECT--
+object(SplObjectStorage)#2 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
Fixes GH-16479

I looked at the other cases of `zval_ptr_dtor()` in this file (and ext/spl/spl_fixedarray.c) and they look correct.