### PR TITLE
Fix GH-16454: Unhandled INF in date_sunset() with tiny $utcOffset

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5140,6 +5140,9 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, bool calc_s
 	if (N > 24 || N < 0) {
 		N -= floor(N / 24) * 24;
 	}
+	if (N > 24 || N < 0) {
+		RETURN_FALSE;
+	}
 
 	switch (retformat) {
 		case SUNFUNCS_RET_STRING:

--- a/ext/date/tests/gh16454.phpt
+++ b/ext/date/tests/gh16454.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-16454 (Unhandled INF in date_sunset() with tiny $utcOffset)
+--FILE--
+<?php
+var_dump(date_sunrise(0, SUNFUNCS_RET_STRING, 61, -150, 90, PHP_FLOAT_MAX));
+var_dump(date_sunrise(0, SUNFUNCS_RET_STRING, 61, -150, 90, -PHP_FLOAT_MAX));
+var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, PHP_FLOAT_MAX));
+var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, -PHP_FLOAT_MAX));
+?>
+--EXPECTF--
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
+
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+bool(false)
+
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
+
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+bool(false)
+
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
+
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+bool(false)
+
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
+
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+bool(false)

--- a/ext/date/tests/gh16454.phpt
+++ b/ext/date/tests/gh16454.phpt
@@ -8,22 +8,14 @@ var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, PHP_FLOAT_MAX));
 var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, -PHP_FLOAT_MAX));
 ?>
 --EXPECTF--
-Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
-
 Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 bool(false)
 
-Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
-
 Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 bool(false)
-
-Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
 
 Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 bool(false)
-
-Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d
 
 Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
 bool(false)

--- a/ext/date/tests/gh16454.phpt
+++ b/ext/date/tests/gh16454.phpt
@@ -8,14 +8,14 @@ var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, PHP_FLOAT_MAX));
 var_dump(date_sunset(0, SUNFUNCS_RET_STRING, 61, -150, 90, -PHP_FLOAT_MAX));
 ?>
 --EXPECTF--
-Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+Deprecated: Function date_sunrise() is deprecated in %s on line %d
 bool(false)
 
-Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+Deprecated: Function date_sunrise() is deprecated in %s on line %d
 bool(false)
 
-Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+Deprecated: Function date_sunset() is deprecated in %s on line %d
 bool(false)
 
-Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
+Deprecated: Function date_sunset() is deprecated in %s on line %d
 bool(false)


### PR DESCRIPTION
After normalization, `N` is supposed to be in range [0, 24], but for very large and very small `$utcOffset` this is not necessarily the case, since the normalization might yied `-inf` or `inf`.  If that happens, we let the function fail silently, since it is highly unlikely that such `$utcOffset`s are passed in practice.