### PR TITLE
sapi: Fix some variable shadowing

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -968,9 +968,9 @@ static int sapi_cgi_deactivate(void)
 	return SUCCESS;
 }
 
-static int php_cgi_startup(sapi_module_struct *sapi_module)
+static int php_cgi_startup(sapi_module_struct *sapi_module_ptr)
 {
-	return php_module_startup(sapi_module, &cgi_module_entry);
+	return php_module_startup(sapi_module_ptr, &cgi_module_entry);
 }
 
 /* {{{ sapi_module_struct cgi_sapi_module */
@@ -1518,23 +1518,23 @@ PHP_INI_BEGIN()
 PHP_INI_END()
 
 /* {{{ php_cgi_globals_ctor */
-static void php_cgi_globals_ctor(php_cgi_globals_struct *php_cgi_globals)
+static void php_cgi_globals_ctor(php_cgi_globals_struct *php_cgi_globals_ptr)
 {
 #if defined(ZTS) && defined(PHP_WIN32)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
-	php_cgi_globals->rfc2616_headers = 0;
-	php_cgi_globals->nph = 0;
-	php_cgi_globals->check_shebang_line = 1;
-	php_cgi_globals->force_redirect = 1;
-	php_cgi_globals->redirect_status_env = NULL;
-	php_cgi_globals->fix_pathinfo = 1;
-	php_cgi_globals->discard_path = 0;
-	php_cgi_globals->fcgi_logging = 1;
+	php_cgi_globals_ptr->rfc2616_headers = 0;
+	php_cgi_globals_ptr->nph = 0;
+	php_cgi_globals_ptr->check_shebang_line = 1;
+	php_cgi_globals_ptr->force_redirect = 1;
+	php_cgi_globals_ptr->redirect_status_env = NULL;
+	php_cgi_globals_ptr->fix_pathinfo = 1;
+	php_cgi_globals_ptr->discard_path = 0;
+	php_cgi_globals_ptr->fcgi_logging = 1;
 #ifdef PHP_WIN32
-	php_cgi_globals->impersonate = 0;
+	php_cgi_globals_ptr->impersonate = 0;
 #endif
-	zend_hash_init(&php_cgi_globals->user_config_cache, 8, NULL, user_config_cache_entry_dtor, 1);
+	zend_hash_init(&php_cgi_globals_ptr->user_config_cache, 8, NULL, user_config_cache_entry_dtor, 1);
 }
 /* }}} */
 
@@ -2548,11 +2548,11 @@ do_repeat:
 					break;
 				case PHP_MODE_HIGHLIGHT:
 					{
-						zend_syntax_highlighter_ini syntax_highlighter_ini;
+						zend_syntax_highlighter_ini default_syntax_highlighter_ini;
 
 						if (open_file_for_scanning(&file_handle) == SUCCESS) {
-							php_get_highlight_struct(&syntax_highlighter_ini);
-							zend_highlight(&syntax_highlighter_ini);
+							php_get_highlight_struct(&default_syntax_highlighter_ini);
+							zend_highlight(&default_syntax_highlighter_ini);
 						}
 					}
 					break;

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -392,9 +392,9 @@ static void sapi_cli_send_header(sapi_header_struct *sapi_header, void *server_c
 }
 /* }}} */
 
-static int php_cli_startup(sapi_module_struct *sapi_module) /* {{{ */
+static int php_cli_startup(sapi_module_struct *sapi_module_ptr) /* {{{ */
 {
-	return php_module_startup(sapi_module, NULL);
+	return php_module_startup(sapi_module_ptr, NULL);
 }
 /* }}} */
 
@@ -951,11 +951,11 @@ do_repeat:
 			break;
 		case PHP_CLI_MODE_HIGHLIGHT:
 			{
-				zend_syntax_highlighter_ini syntax_highlighter_ini;
+				zend_syntax_highlighter_ini default_syntax_highlighter_ini;
 
 				if (open_file_for_scanning(&file_handle) == SUCCESS) {
-					php_get_highlight_struct(&syntax_highlighter_ini);
-					zend_highlight(&syntax_highlighter_ini);
+					php_get_highlight_struct(&default_syntax_highlighter_ini);
+					zend_highlight(&default_syntax_highlighter_ini);
 				}
 				goto out;
 			}
@@ -1155,7 +1155,7 @@ int main(int argc, char *argv[])
 	char *ini_path_override = NULL;
 	struct php_ini_builder ini_builder;
 	int ini_ignore = 0;
-	sapi_module_struct *sapi_module = &cli_sapi_module;
+	sapi_module_struct *sapi_module_ptr = &cli_sapi_module;
 
 	/*
 	 * Do not move this initialization. It needs to happen before argv is used
@@ -1234,7 +1234,7 @@ int main(int argc, char *argv[])
 				break;
 #ifndef PHP_CLI_WIN32_NO_CONSOLE
 			case 'S':
-				sapi_module = &cli_server_sapi_module;
+				sapi_module_ptr = &cli_server_sapi_module;
 				cli_server_sapi_module.additional_functions = server_additional_functions;
 				break;
 #endif
@@ -1247,7 +1247,7 @@ int main(int argc, char *argv[])
 				exit_status = 1;
 				goto out;
 			case 'i': case 'v': case 'm':
-				sapi_module = &cli_sapi_module;
+				sapi_module_ptr = &cli_sapi_module;
 				goto exit_loop;
 			case 'e': /* enable extended info output */
 				use_extended_info = 1;
@@ -1256,25 +1256,25 @@ int main(int argc, char *argv[])
 	}
 exit_loop:
 
-	sapi_module->ini_defaults = sapi_cli_ini_defaults;
-	sapi_module->php_ini_path_override = ini_path_override;
-	sapi_module->phpinfo_as_text = 1;
-	sapi_module->php_ini_ignore_cwd = 1;
-	sapi_startup(sapi_module);
+	sapi_module_ptr->ini_defaults = sapi_cli_ini_defaults;
+	sapi_module_ptr->php_ini_path_override = ini_path_override;
+	sapi_module_ptr->phpinfo_as_text = 1;
+	sapi_module_ptr->php_ini_ignore_cwd = 1;
+	sapi_startup(sapi_module_ptr);
 	sapi_started = 1;
 
-	sapi_module->php_ini_ignore = ini_ignore;
+	sapi_module_ptr->php_ini_ignore = ini_ignore;
 
-	sapi_module->executable_location = argv[0];
+	sapi_module_ptr->executable_location = argv[0];
 
-	if (sapi_module == &cli_sapi_module) {
+	if (sapi_module_ptr == &cli_sapi_module) {
 		php_ini_builder_prepend_literal(&ini_builder, HARDCODED_INI);
 	}
 
-	sapi_module->ini_entries = php_ini_builder_finish(&ini_builder);
+	sapi_module_ptr->ini_entries = php_ini_builder_finish(&ini_builder);
 
 	/* startup after we get the above ini override so we get things right */
-	if (sapi_module->startup(sapi_module) == FAILURE) {
+	if (sapi_module_ptr->startup(sapi_module_ptr) == FAILURE) {
 		/* there is no way to see if we must call zend_ini_deactivate()
 		 * since we cannot check if EG(ini_directives) has been initialized
 		 * because the executor's constructor does not set initialize it.
@@ -1305,7 +1305,7 @@ exit_loop:
 
 	zend_first_try {
 #ifndef PHP_CLI_WIN32_NO_CONSOLE
-		if (sapi_module == &cli_sapi_module) {
+		if (sapi_module_ptr == &cli_sapi_module) {
 #endif
 			exit_status = do_cli(argc, argv);
 #ifndef PHP_CLI_WIN32_NO_CONSOLE

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -510,9 +510,9 @@ const zend_function_entry server_additional_functions[] = {
 	PHP_FE_END
 };
 
-static int sapi_cli_server_startup(sapi_module_struct *sapi_module) /* {{{ */
+static int sapi_cli_server_startup(sapi_module_struct *sapi_module_ptr) /* {{{ */
 {
-	return php_module_startup(sapi_module, &cli_server_module_entry);
+	return php_module_startup(sapi_module_ptr, &cli_server_module_entry);
 } /* }}} */
 
 static size_t sapi_cli_server_ub_write(const char *str, size_t str_length) /* {{{ */
@@ -2353,14 +2353,14 @@ static zend_result php_cli_server_dispatch(php_cli_server *server, php_cli_serve
 }
 /* }}} */
 
-static void php_cli_server_mime_type_ctor(php_cli_server *server, const php_cli_server_ext_mime_type_pair *mime_type_map) /* {{{ */
+static void php_cli_server_mime_type_ctor(php_cli_server *server, const php_cli_server_ext_mime_type_pair *mime_type_map_ptr) /* {{{ */
 {
 	const php_cli_server_ext_mime_type_pair *pair;
 
 	zend_hash_init(&server->extension_mime_types, 0, NULL, NULL, 1);
 	GC_MAKE_PERSISTENT_LOCAL(&server->extension_mime_types);
 
-	for (pair = mime_type_map; pair->ext; pair++) {
+	for (pair = mime_type_map_ptr; pair->ext; pair++) {
 		size_t ext_len = strlen(pair->ext);
 		zend_hash_str_add_ptr(&server->extension_mime_types, pair->ext, ext_len, (void*)pair->mime_type);
 	}
@@ -2396,7 +2396,7 @@ static void php_cli_server_dtor(php_cli_server *server) /* {{{ */
 			 do {
 				if (waitpid(php_cli_server_workers[php_cli_server_worker],
 						   &php_cli_server_worker_status,
-						   0) == FAILURE) {
+						   0) == (pid_t) -1) {
 					/* an extremely bad thing happened */
 					break;
 				}

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1124,8 +1124,8 @@ int main(int argc, char **argv) /* {{{ */
 	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
 	char *sapi_name;
 	struct php_ini_builder ini_builder;
-	char **zend_extensions = NULL;
-	zend_ulong zend_extensions_len = 0L;
+	char **zend_extensions_list = NULL;
+	size_t zend_extensions_len = 0;
 	bool ini_ignore;
 	char *ini_override;
 	char *exec = NULL;
@@ -1177,8 +1177,6 @@ phpdbg_main:
 	php_ini_builder_init(&ini_builder);
 	ini_ignore = 0;
 	ini_override = NULL;
-	zend_extensions = NULL;
-	zend_extensions_len = 0L;
 	init_file = NULL;
 	init_file_len = 0;
 	init_file_default = 1;
@@ -1216,10 +1214,12 @@ phpdbg_main:
 
 			case 'z':
 				zend_extensions_len++;
-				if (zend_extensions) {
-					zend_extensions = realloc(zend_extensions, sizeof(char*) * zend_extensions_len);
-				} else zend_extensions = malloc(sizeof(char*) * zend_extensions_len);
-				zend_extensions[zend_extensions_len-1] = strdup(php_optarg);
+				if (zend_extensions_list) {
+					zend_extensions_list = realloc(zend_extensions_list, sizeof(char*) * zend_extensions_len);
+				} else {
+					zend_extensions_list = malloc(sizeof(char*) * zend_extensions_len);
+				}
+				zend_extensions_list[zend_extensions_len-1] = strdup(php_optarg);
 			break;
 
 			/* begin phpdbg options */
@@ -1316,19 +1316,19 @@ phpdbg_main:
 	php_ini_builder_prepend_literal(&ini_builder, phpdbg_ini_hardcoded);
 
 	if (zend_extensions_len) {
-		zend_ulong zend_extension = 0L;
+		size_t zend_extension_index = 0;
 
-		while (zend_extension < zend_extensions_len) {
-			const char *ze = zend_extensions[zend_extension];
+		while (zend_extension_index < zend_extensions_len) {
+			const char *ze = zend_extensions_list[zend_extension_index];
 			size_t ze_len = strlen(ze);
 
 			php_ini_builder_unquoted(&ini_builder, "zend_extension", strlen("zend_extension"), ze, ze_len);
 
-			free(zend_extensions[zend_extension]);
-			zend_extension++;
+			free(zend_extensions_list[zend_extension_index]);
+			zend_extension_index++;
 		}
 
-		free(zend_extensions);
+		free(zend_extensions_list);
 	}
 
 	phpdbg->ini_entries = php_ini_builder_finish(&ini_builder);

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -193,8 +193,10 @@ int phpdbg_do_parse(phpdbg_param_t *stack, char *input);
 
 #define phpdbg_try_access \
 	{                                                            \
+		ZEND_DIAGNOSTIC_IGNORED_START("-Wshadow") \
 		JMP_BUF *__orig_bailout = PHPDBG_G(sigsegv_bailout); \
 		JMP_BUF __bailout;                                   \
+		ZEND_DIAGNOSTIC_IGNORED_END \
                                                                      \
 		PHPDBG_G(sigsegv_bailout) = &__bailout;              \
 		if (SETJMP(__bailout) == 0) {

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -1510,28 +1510,28 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 			phpdbg_out(SEPARATE "\n");
 			phpdbg_out("Opline Breakpoints:\n");
 			ZEND_HASH_MAP_FOREACH_PTR(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], brake) {
-				const char *type;
+				const char *str_type;
 				switch (brake->type) {
 					case PHPDBG_BREAK_METHOD_OPLINE:
-						type = "method";
+						str_type = "method";
 						goto print_opline;
 					case PHPDBG_BREAK_FUNCTION_OPLINE:
-						type = "function";
+						str_type = "function";
 						goto print_opline;
 					case PHPDBG_BREAK_FILE_OPLINE:
-						type = "method";
+						str_type = "method";
 
 					print_opline: {
 						if (brake->type == PHPDBG_BREAK_METHOD_OPLINE) {
-							type = "method";
+							str_type = "method";
 						} else if (brake->type == PHPDBG_BREAK_FUNCTION_OPLINE) {
-							type = "function";
+							str_type = "function";
 						} else if (brake->type == PHPDBG_BREAK_FILE_OPLINE) {
-							type = "file";
+							str_type = "file";
 						}
 
 						phpdbg_writeln("#%d\t\t#"ZEND_ULONG_FMT"\t\t(%s breakpoint)%s",
-							brake->id, brake->opline, type,
+							brake->id, brake->opline, str_type,
 							((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 					} break;
 

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -310,9 +310,9 @@ int phpdbg_watchpoint_segfault_handler(siginfo_t *info, void *context) {
 # if defined(__GNUC__) && !defined(__clang__)
 __attribute__((no_sanitize_address))
 # endif
-void *phpdbg_watchpoint_userfaultfd_thread(void *phpdbg_globals) {
+void *phpdbg_watchpoint_userfaultfd_thread(void *phpdbg_globals_ptr) {
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-	zend_phpdbg_globals *globals = (zend_phpdbg_globals *) phpdbg_globals;
+	zend_phpdbg_globals *globals = (zend_phpdbg_globals *) phpdbg_globals_ptr;
 
 	struct uffd_msg fault_msg = {0};
 	while (read(globals->watch_userfaultfd, &fault_msg, sizeof(fault_msg)) == sizeof(fault_msg)) {


### PR DESCRIPTION
sapi_module, mime_type_map, zend_extensions, php_cgi_globals, and phpdbg_globals are true globals which are being shadowed

Split out of #16461