### PR TITLE
Fix GH-16473: dom_import_simplexml stub is wrong

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -933,4 +933,4 @@ class DOMXPath
 }
 #endif
 
-function dom_import_simplexml(object $node): DOMElement {}
+function dom_import_simplexml(object $node): DOMAttr|DOMElement {}

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7d4dc9e1a3736f2ac9082c32bf5260dfa58b1aa0 */
+ * Stub hash: 6d1c16a61f23de241f72f3559a9987d2f4a9c6fd */
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dom_import_simplexml, 0, 1, DOMAttr|DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/dom/tests/gh16473.phpt
+++ b/ext/dom/tests/gh16473.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-16473 (dom_import_simplexml stub is wrong)
+--EXTENSIONS--
+dom
+simplexml
+--FILE--
+<?php
+$root = simplexml_load_string('<root xmlns:x="urn:x" x:attr="foo"/>');
+$attr = $root->attributes('urn:x');
+var_dump(dom_import_simplexml($attr)->textContent);
+?>
+--EXPECT--
+string(3) "foo"


### PR DESCRIPTION
It's been wrong since PHP 8.0 at least, and the signature was inherited in 8.4-dev to the new DOM methods.

Note for self: when merging up also fix the variant in the Dom namespace in 8.4-dev.