### PR TITLE
Fix GH-14732: date_sun_info() fails for non-finite values

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5111,6 +5111,10 @@ static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, bool calc_s
 	}
 	altitude = 90 - zenith;
 
+	if (!zend_finite(latitude) || !zend_finite(longitude)) {
+		RETURN_FALSE;
+	}
+
 	/* Initialize time struct */
 	tzi = get_timezone_info();
 	if (!tzi) {
@@ -5187,6 +5191,15 @@ PHP_FUNCTION(date_sun_info)
 		Z_PARAM_DOUBLE(latitude)
 		Z_PARAM_DOUBLE(longitude)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if (!zend_finite(latitude)) {
+		zend_argument_value_error(2, "must be finite");
+		RETURN_THROWS();
+	}
+	if (!zend_finite(longitude)) {
+		zend_argument_value_error(3, "must be finite");
+		RETURN_THROWS();
+	}
 
 	/* Initialize time struct */
 	tzi = get_timezone_info();

--- a/ext/date/tests/gh14732.phpt
+++ b/ext/date/tests/gh14732.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-14732 (date_sun_info() fails for non-finite values)
+--FILE--
+<?php
+try {
+    date_sun_info(1, NAN, 1);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+try {
+    date_sun_info(1, -INF, 1);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+try {
+    date_sun_info(1, 1, NAN);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+try {
+    date_sun_info(1, 1, INF);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), "\n";
+}
+var_dump(date_sunset(1, SUNFUNCS_RET_STRING, NAN, 1));
+var_dump(date_sunrise(1, SUNFUNCS_RET_STRING, 1, NAN));
+?>
+--EXPECTF--
+date_sun_info(): Argument #2 ($latitude) must be finite
+date_sun_info(): Argument #2 ($latitude) must be finite
+date_sun_info(): Argument #3 ($longitude) must be finite
+date_sun_info(): Argument #3 ($longitude) must be finite
+
+Deprecated: Function date_sunset() is deprecated in %s on line %d
+bool(false)
+
+Deprecated: Function date_sunrise() is deprecated in %s on line %d
+bool(false)


### PR DESCRIPTION
`timelib_astro_rise_set_altitude()` is not prepared to deal with non- finite values (`nan`, `inf` and `-inf`) for `lon` and `lat`; instead these trigger undefined behavior.  Thus we catch non-finite values before even calling that timelib function; for `date_sun_info()` we trigger `ValueError`s; for `date_sunrise()` and `date_sunset()` we silently return `false`, since these functions will be sunsetted anyway.

---

Note for merger:

<details><summary>Test expectations for PHP 8.4 and up</summary>

````
date_sun_info(): Argument #2 ($latitude) must be finite
date_sun_info(): Argument #2 ($latitude) must be finite
date_sun_info(): Argument #3 ($longitude) must be finite
date_sun_info(): Argument #3 ($longitude) must be finite

Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d

Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
bool(false)

Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in %s on line %d

Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in %s on line %d
bool(false)
````
</details>
