### PR TITLE
Fix GH-16501: gmp_random_bits overflow.

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1803,15 +1803,21 @@ ZEND_FUNCTION(gmp_random_bits)
 		RETURN_THROWS();
 	}
 
-	if (bits <= 0) {
-		zend_argument_value_error(1, "must be greater than or equal to 1");
+#if SIZEOF_SIZE_T == 4
+	const zend_long maxbits = ULONG_MAX / GMP_NUMB_BITS;
+#else
+	const zend_long maxbits = INT_MAX;
+#endif
+
+	if (bits <= 0 || bits > maxbits) {
+		zend_argument_value_error(1, "must be between 1 and " ZEND_LONG_FMT, maxbits);
 		RETURN_THROWS();
 	}
 
 	INIT_GMP_RETVAL(gmpnum_result);
 	gmp_init_random();
 
-	mpz_urandomb(gmpnum_result, GMPG(rand_state), bits);
+	mpz_urandomb(gmpnum_result, GMPG(rand_state), (mp_bitcnt_t)bits);
 }
 /* }}} */
 

--- a/ext/gmp/tests/gh16501.phpt
+++ b/ext/gmp/tests/gh16501.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-16501 (gmp_random_bits overflow)
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+try {
+	gmp_random_bits(PHP_INT_MAX);
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECTF--
+gmp_random_bits(): Argument #1 ($bits) must be between 1 and %d

--- a/ext/gmp/tests/gmp_random_bits.phpt
+++ b/ext/gmp/tests/gmp_random_bits.phpt
@@ -40,7 +40,7 @@ while (1) {
 
 echo "Done\n";
 ?>
---EXPECT--
-gmp_random_bits(): Argument #1 ($bits) must be greater than or equal to 1
-gmp_random_bits(): Argument #1 ($bits) must be greater than or equal to 1
+--EXPECTF--
+gmp_random_bits(): Argument #1 ($bits) must be between 1 and %d
+gmp_random_bits(): Argument #1 ($bits) must be between 1 and %d
 Done


### PR DESCRIPTION
we do the same calculation in advance as mpz_realloc overflow check to avoid abort.