### PR TITLE
gen_stub: drop support for `@refcount 0` with scalar return

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1155,9 +1155,7 @@ class MethodName implements FunctionOrMethodName {
 }
 
 class ReturnInfo {
-    // REFCOUNT_SCALAR (formerly REFCOUNT_0) is automatically applied for
-    // scalars, and not allowed for non-scalars
-    const REFCOUNT_SCALAR = "0";
+    const REFCOUNT_0 = "0";
     const REFCOUNT_1 = "1";
     const REFCOUNT_N = "N";
 
@@ -1201,12 +1199,14 @@ class ReturnInfo {
         $isScalarType = $type !== null && $type->isScalar();
 
         if ($refcount === null) {
-            $this->refcount = $isScalarType ? self::REFCOUNT_SCALAR : self::REFCOUNT_N;
+            $this->refcount = $isScalarType ? self::REFCOUNT_0 : self::REFCOUNT_N;
             return;
         }
 
         if ($isScalarType) {
-            throw new Exception("@refcount is not permitted on functions returning scalar values");
+            throw new Exception(
+                "@refcount on functions returning scalar values is redundant and not permitted"
+            );
         }
 
         if (!in_array($refcount, ReturnInfo::REFCOUNTS_NONSCALAR, true)) {


### PR DESCRIPTION
Currenty, if `@refcount` is omitted, it is assumed to be 0 for scalar return types and "N" otherwise. On the other hand, if `@refcount` is provided, for a scalar return type it *must* be 0, and for a non-scalar return type it *must not* be 0. In other words, the ref count will be 0 if and only if the return type is scalar, regardless of whether the `@refcount` tag is used.

In that case, adding `@refcount 0` does nothing, and since its presence suggests it does something (why would a developer add code that does nothing?) it is confusing and should be removed. As it happens, there are currently no uses of `@refcount 0` in php-src, but why should we allow future uses?

Removing this support also allows simplifying the code a bit.

In the process, I also renamed some of the constants for clarity.