### PR TITLE
Use ZendMM for libgmp

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -533,7 +533,7 @@ static void *gmp_realloc(void *ptr, size_t old_size, size_t new_size)
 
 static void gmp_free(void *ptr, size_t size)
 {
-	efree(ptr);
+	efree_size(ptr, size);
 }
 
 /* {{{ ZEND_GINIT_FUNCTION */

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -521,6 +521,21 @@ exit:
 }
 /* }}} */
 
+static void *gmp_alloc(size_t size)
+{
+	return emalloc(size);
+}
+
+static void *gmp_realloc(void *ptr, size_t old_size, size_t new_size)
+{
+	return erealloc(ptr, new_size);
+}
+
+static void gmp_free(void *ptr, size_t size)
+{
+	efree(ptr);
+}
+
 /* {{{ ZEND_GINIT_FUNCTION */
 static ZEND_GINIT_FUNCTION(gmp)
 {
@@ -550,6 +565,8 @@ ZEND_MINIT_FUNCTION(gmp)
 	gmp_object_handlers.compare = gmp_compare;
 
 	register_gmp_symbols(module_number);
+
+	mp_set_memory_functions(gmp_alloc, gmp_realloc, gmp_free);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
As is, ext/gmp uses the default memory allocator of the underlying libgmp; this allocator is fallible, but contrary to ZendMM, it `abort()`s without giving us an opportunity to do a cleaner shutdown. Furthermore, the libgmp allocator obviously doesn't heed memory_limit. Thus we install wrappers of the ZendMM API as libgmp allocator.

---

I've targeted `master` since this might be seen as new feature; it might also been seen as bug fix, though.