### PR TITLE
improve range array overflow error message

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2880,7 +2880,7 @@ PHP_FUNCTION(array_fill_keys)
 			zend_value_error(\
 				"The supplied range exceeds the maximum array size by %lu elements: " \
 				"start=" ZEND_LONG_FMT ", end=" ZEND_LONG_FMT ", step=" ZEND_LONG_FMT ". " \
-				"Calculated size: %lu, Maximum size: %lu.", \
+				"Calculated size: " ZEND_LONG_FMT ", Maximum size: " ZEND_LONG_FMT ".", \
 				__excess, end, start, (_step), __calc_size + 1, (zend_ulong)HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2876,12 +2876,12 @@ PHP_FUNCTION(array_fill_keys)
 #define RANGE_CHECK_LONG_INIT_ARRAY(start, end, _step) do { \
 		zend_ulong __calc_size = ((zend_ulong) start - end) / (_step); \
 		if (__calc_size >= HT_MAX_SIZE - 1) { \
-			zend_ulong __excess = __calc_size - (HT_MAX_SIZE - 1); \
+			uint64_t __excess = __calc_size - (HT_MAX_SIZE - 1); \
 			zend_value_error(\
-				"The supplied range exceeds the maximum array size by %lu elements: " \
+				"The supplied range exceeds the maximum array size by %" PRIu64 " elements: " \
 				"start=" ZEND_LONG_FMT ", end=" ZEND_LONG_FMT ", step=" ZEND_LONG_FMT ". " \
-				"Calculated size: " ZEND_LONG_FMT ", Maximum size: " ZEND_LONG_FMT ".", \
-				__excess, end, start, (_step), __calc_size + 1, (zend_ulong)HT_MAX_SIZE); \
+				"Calculated size: %" PRIu64 ", Maximum size: %" PRIu64 ".", \
+				__excess, end, start, (_step), (uint64_t)__calc_size, (uint64_t)HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)(__calc_size + 1); \

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2880,7 +2880,7 @@ PHP_FUNCTION(array_fill_keys)
 			zend_value_error(\
 				"The supplied range exceeds the maximum array size by %" PRIu64 " elements: " \
 				"start=" ZEND_LONG_FMT ", end=" ZEND_LONG_FMT ", step=" ZEND_LONG_FMT ". " \
-				"Calculated size: %" PRIu64 ", Maximum size: %" PRIu64 ".", \
+				"Calculated size: %" PRIu64 ". Maximum size: %" PRIu64 ".", \
 				__excess, end, start, (_step), (uint64_t)__calc_size, (uint64_t)HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2861,8 +2861,11 @@ PHP_FUNCTION(array_fill_keys)
 #define RANGE_CHECK_DOUBLE_INIT_ARRAY(start, end, _step) do { \
 		double __calc_size = ((start - end) / (_step)) + 1; \
 		if (__calc_size >= (double)HT_MAX_SIZE) { \
+			double __exceed_by = __calc_size - (double)HT_MAX_SIZE; \
 			zend_value_error(\
-					"The supplied range exceeds the maximum array size: start=%0.1f end=%0.1f step=%0.1f", end, start, (_step)); \
+				"The supplied range exceeds the maximum array size by %.1f elements: " \
+				"start=%.1f, end=%.1f, step=%.1f. Max size: %.0f", \
+				__exceed_by, end, start, (_step), (double)HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)_php_math_round(__calc_size, 0, PHP_ROUND_HALF_UP); \
@@ -2873,8 +2876,12 @@ PHP_FUNCTION(array_fill_keys)
 #define RANGE_CHECK_LONG_INIT_ARRAY(start, end, _step) do { \
 		zend_ulong __calc_size = ((zend_ulong) start - end) / (_step); \
 		if (__calc_size >= HT_MAX_SIZE - 1) { \
+			zend_ulong __excess = __calc_size - (HT_MAX_SIZE - 1); \
 			zend_value_error(\
-					"The supplied range exceeds the maximum array size: start=" ZEND_LONG_FMT " end=" ZEND_LONG_FMT " step=" ZEND_LONG_FMT, end, start, (_step)); \
+				"The supplied range exceeds the maximum array size by %lu elements: " \
+				"start=" ZEND_LONG_FMT ", end=" ZEND_LONG_FMT ", step=" ZEND_LONG_FMT ". " \
+				"Calculated size: %lu, Maximum size: %lu.", \
+				__excess, end, start, (_step), __calc_size + 1, HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)(__calc_size + 1); \

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2881,7 +2881,7 @@ PHP_FUNCTION(array_fill_keys)
 				"The supplied range exceeds the maximum array size by %lu elements: " \
 				"start=" ZEND_LONG_FMT ", end=" ZEND_LONG_FMT ", step=" ZEND_LONG_FMT ". " \
 				"Calculated size: %lu, Maximum size: %lu.", \
-				__excess, end, start, (_step), __calc_size + 1, HT_MAX_SIZE); \
+				__excess, end, start, (_step), __calc_size + 1, (zend_ulong)HT_MAX_SIZE); \
 			RETURN_THROWS(); \
 		} \
 		size = (uint32_t)(__calc_size + 1); \

--- a/ext/standard/tests/array/range/range_bug70239_2.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_2.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECT--
-The supplied range exceeds the maximum array size by 9223372035781033984 elements: start=0, end=9223372036854775807, step=1. Calculated size: 9223372036854775807. Maximum size: 1073741824.
+--EXPECTF--
+The supplied range exceeds the maximum array size by %d elements: start=0, end=%d, step=1. Calculated size: %d. Maximum size: %d.

--- a/ext/standard/tests/array/range/range_bug70239_2.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_2.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-The supplied range exceeds the maximum array size: start=0 end=%d step=1
+--EXPECT--
+The supplied range exceeds the maximum array size by %d elements: start=0, end=%d, step=1. Calculated size: %d, Maximum size: %d.

--- a/ext/standard/tests/array/range/range_bug70239_2.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_2.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-The supplied range exceeds the maximum array size by %d elements: start=0, end=%d, step=1. Calculated size: %d, Maximum size: %d.
+--EXPECT--
+The supplied range exceeds the maximum array size by 9223372035781033984 elements: start=0, end=9223372036854775807, step=1. Calculated size: 9223372036854775807. Maximum size: 1073741824.

--- a/ext/standard/tests/array/range/range_bug70239_2.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_2.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 The supplied range exceeds the maximum array size by %d elements: start=0, end=%d, step=1. Calculated size: %d, Maximum size: %d.

--- a/ext/standard/tests/array/range/range_bug70239_3.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_3.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 The supplied range exceeds the maximum array size by %d elements: start=-%d, end=0, step=1. Calculated size: %d, Maximum size: %d.

--- a/ext/standard/tests/array/range/range_bug70239_3.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_3.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-The supplied range exceeds the maximum array size: start=-%d end=0 step=1
+--EXPECT--
+The supplied range exceeds the maximum array size by %d elements: start=-%d, end=0, step=1. Calculated size: %d, Maximum size: %d.

--- a/ext/standard/tests/array/range/range_bug70239_3.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_3.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-The supplied range exceeds the maximum array size by %d elements: start=-%d, end=0, step=1. Calculated size: %d, Maximum size: %d.
+--EXPECT--
+The supplied range exceeds the maximum array size by 9223372035781033985 elements: start=-9223372036854775808, end=0, step=1. Calculated size: 9223372036854775808. Maximum size: 1073741824.

--- a/ext/standard/tests/array/range/range_bug70239_3.phpt
+++ b/ext/standard/tests/array/range/range_bug70239_3.phpt
@@ -8,5 +8,5 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECT--
-The supplied range exceeds the maximum array size by 9223372035781033985 elements: start=-9223372036854775808, end=0, step=1. Calculated size: 9223372036854775808. Maximum size: 1073741824.
+--EXPECTF--
+The supplied range exceeds the maximum array size by %d elements: start=-%d, end=0, step=1. Calculated size: %d. Maximum size: %d.

--- a/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
+++ b/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
@@ -15,4 +15,4 @@ try {
 ?>
 --EXPECTF--
 The supplied range exceeds the maximum array size by %f elements: start=0.0, end=%f, step=0.1. Max size: %d
-The supplied range exceeds the maximum array size by 18446744072635809792 elements: start=-9223372036854775808, end=9223372036854775807, step=1. Calculated size: 18446744073709551615. Maximum size: 1073741824.
+The supplied range exceeds the maximum array size by %d elements: start=-%d, end=%d, step=1. Calculated size: %d. Maximum size: %d.

--- a/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
+++ b/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
@@ -14,5 +14,5 @@ try {
 }
 ?>
 --EXPECTF--
-The supplied range exceeds the maximum array size: start=0.0 end=100000000000.0 step=0.1
-The supplied range exceeds the maximum array size: start=-%d end=%d step=1
+The supplied range exceeds the maximum array size by %f elements: start=0.0, end=%f, step=0.1. Max size: %d
+The supplied range exceeds the maximum array size by %f elements: start=-%f, end=%f, step=1. Calculated size: %d, Maximum size: %d.

--- a/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
+++ b/ext/standard/tests/array/range/range_inputs_float_small_step_exhaustion.phpt
@@ -15,4 +15,4 @@ try {
 ?>
 --EXPECTF--
 The supplied range exceeds the maximum array size by %f elements: start=0.0, end=%f, step=0.1. Max size: %d
-The supplied range exceeds the maximum array size by %f elements: start=-%f, end=%f, step=1. Calculated size: %d, Maximum size: %d.
+The supplied range exceeds the maximum array size by 18446744072635809792 elements: start=-9223372036854775808, end=9223372036854775807, step=1. Calculated size: 18446744073709551615. Maximum size: 1073741824.


### PR DESCRIPTION
added info about "how much it exceeded" and the maximum allowable array size.

Makes debugging easier when encountering this specific issue.