### PR TITLE
Fix leak of accel_shared_globals for file_cache_only

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3408,6 +3408,8 @@ void accel_shutdown(void)
 		/* Delay SHM detach */
 		orig_post_shutdown_cb = zend_post_shutdown_cb;
 		zend_post_shutdown_cb = accel_post_shutdown;
+	} else {
+		free(accel_shared_globals);
 	}
 
 	zend_compile_file = accelerator_orig_compile_file;


### PR DESCRIPTION
If `opcache.file_cache_only` is enabled, `accel_shared_globals` is allocated as true global, and we need to free that memory when we shut down the accelerator.

---

Leak can be detected when running e.g. ext/zend_test/tests/observer_declarations_file_cache.phpt with a leak detector.