### PR TITLE
Ignore xmlDefaultExternalEntityLoader leaks

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -721,7 +721,10 @@ static xmlParserInputPtr _php_libxml_external_entity_loader(const char *URL,
 
 	/* no custom user-land callback set up; delegate to original loader */
 	if (!ZEND_FCC_INITIALIZED(LIBXML(entity_loader_callback))) {
-		return _php_libxml_default_entity_loader(URL, ID, context);
+		ZEND_IGNORE_LEAKS_BEGIN();
+		ret = _php_libxml_default_entity_loader(URL, ID, context);
+		ZEND_IGNORE_LEAKS_END();
+		return ret;
 	}
 
 	if (ID != NULL) {


### PR DESCRIPTION
At least on Windows with libxml2 2.11.9, calling the default entity loader leaks a couple of bytes.  Since we cannot do anything about that, we ignore these leaks.

---

These leaks can be detected when running ext/zend_test/tests/observer_error_04.phpt with Windows debug heap enabled (`configure --enable-debug`; `set PHP_WIN32_DEBUG_HEAP=1`; and the usual environment variables). The leaks also can be seen ten soap tests.

With this patch, no further leaks are detected in ext/soap/tests, but I found some in ext/dom/tests; need to check this.