### PR TITLE
Fix Lazy Objects Reflection API: add getRawValueWithoutLazyInitialization(), isLazy()

### DIFF
--- a/Zend/tests/lazy_objects/getRawValueWithoutLazyInitialization.phpt
+++ b/Zend/tests/lazy_objects/getRawValueWithoutLazyInitialization.phpt
@@ -1,0 +1,113 @@
+--TEST--
+Lazy objects: getRawValueWithoutLazyInitialization() fetches raw value without triggering initialization
+--FILE--
+<?php
+
+class C {
+    public int $a;
+    public $b = 2;
+}
+
+$reflector = new ReflectionClass(C::class);
+$propA = $reflector->getProperty('a');
+$propB = $reflector->getProperty('b');
+
+$obj = $reflector->newLazyGhost(function () {
+    throw new \Exception('initializer');
+});
+
+print "# Ghost: Lazy properties\n";
+
+$isLazy = null;
+var_dump($propA->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$isLazy = null;
+var_dump($propB->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+print "# Ghost: Initialized properties\n";
+
+$propA->setRawValueWithoutLazyInitialization($obj, 1);
+
+$isLazy = null;
+var_dump($propA->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$propB->skipLazyInitialization($obj);
+
+$isLazy = null;
+var_dump($propB->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$obj = $reflector->newLazyProxy(function () {
+    throw new \Exception('initializer');
+});
+
+print "# Proxy: Lazy properties\n";
+
+$isLazy = null;
+var_dump($propA->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$isLazy = null;
+var_dump($propB->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+print "# Proxy: Initialized properties\n";
+
+$propA->setRawValueWithoutLazyInitialization($obj, 1);
+
+$isLazy = null;
+var_dump($propA->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$propB->skipLazyInitialization($obj);
+
+$isLazy = null;
+var_dump($propB->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+$obj = $reflector->newLazyProxy(function () {
+    return new C();
+});
+$reflector->initializeLazyObject($obj);
+
+print "# Initialized Proxy\n";
+
+try {
+    $propA->getRawValueWithoutLazyInitialization($obj, $isLazy);
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+$isLazy = null;
+var_dump($propB->getRawValueWithoutLazyInitialization($obj, $isLazy));
+var_dump($isLazy);
+
+?>
+--EXPECT--
+# Ghost: Lazy properties
+NULL
+bool(true)
+NULL
+bool(true)
+# Ghost: Initialized properties
+int(1)
+bool(false)
+int(2)
+bool(false)
+# Proxy: Lazy properties
+NULL
+bool(true)
+NULL
+bool(true)
+# Proxy: Initialized properties
+int(1)
+bool(false)
+int(2)
+bool(false)
+# Initialized Proxy
+Error: Typed property C::$a must not be accessed before initialization
+int(2)
+bool(false)

--- a/Zend/tests/lazy_objects/getRawValueWithoutLazyInitialization_non_lazy.phpt
+++ b/Zend/tests/lazy_objects/getRawValueWithoutLazyInitialization_non_lazy.phpt
@@ -1,0 +1,140 @@
+--TEST--
+Lazy objects: getRawValueWithoutLazyInitialization() behaves like getRawValue() on non-lazy objects
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class C {
+    public static $static = 'static';
+
+    public int $a;
+    public $b;
+    public $c {
+        get { return 'c'; }
+    }
+    public $d {
+        get { return $this->d; }
+        set($value) { $this->d = $value; }
+    }
+}
+
+class D extends C {
+    public function __get($name) {
+        return ord($name);
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+$propA = $reflector->getProperty('a');
+$propB = $reflector->getProperty('b');
+$propC = $reflector->getProperty('c');
+$propD = $reflector->getProperty('d');
+$propStatic = $reflector->getProperty('static');
+
+$obj = new C();
+$obj->dynamic = 1;
+$propDynamic = new ReflectionProperty($obj, 'dynamic');
+
+$obj = new C();
+
+print "# Non initialized properties\n";
+
+try {
+    $propA->getRawValueWithoutLazyInitialization($obj);
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+var_dump($propB->getRawValueWithoutLazyInitialization($obj));
+
+try {
+    var_dump($propC->getRawValueWithoutLazyInitialization($obj));
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+var_dump($propD->getRawValueWithoutLazyInitialization($obj));
+
+print "# Initialized properties\n";
+
+$obj->a = 1;
+$obj->b = new stdClass;
+$obj->d = 4;
+
+var_dump($propA->getRawValueWithoutLazyInitialization($obj));
+
+var_dump($propB->getRawValueWithoutLazyInitialization($obj));
+
+try {
+    var_dump($propC->getRawValueWithoutLazyInitialization($obj));
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+var_dump($propD->getRawValueWithoutLazyInitialization($obj));
+
+try {
+    $propStatic->getRawValueWithoutLazyInitialization($obj);
+} catch (ReflectionException $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+var_dump($propDynamic->getRawValueWithoutLazyInitialization($obj));
+
+print "# Unset properties and __get()\n";
+
+$obj = new D();
+unset($obj->a);
+unset($obj->b);
+
+var_dump($propA->getRawValueWithoutLazyInitialization($obj));
+
+var_dump($propB->getRawValueWithoutLazyInitialization($obj));
+
+print "# References\n";
+
+$obj = new C();
+$obj->b = &$obj;
+
+var_dump($propB->getRawValueWithoutLazyInitialization($obj));
+
+print "# Internal class\n";
+
+$reflector = new ReflectionClass(Exception::class);
+$propMessage = $reflector->getProperty('message');
+
+$obj = new Exception('hello');
+
+var_dump($propMessage->getRawValueWithoutLazyInitialization($obj));
+
+?>
+--EXPECTF--
+# Non initialized properties
+Error: Typed property C::$a must not be accessed before initialization
+NULL
+Error: Must not read from virtual property C::$c
+NULL
+# Initialized properties
+int(1)
+object(stdClass)#%d (0) {
+}
+Error: Must not read from virtual property C::$c
+int(4)
+ReflectionException: May not use getRawValueWithoutLazyInitialization on static properties
+
+Warning: Undefined property: C::$dynamic in %s on line %d
+NULL
+# Unset properties and __get()
+int(97)
+int(98)
+# References
+object(C)#%d (2) {
+  ["a"]=>
+  uninitialized(int)
+  ["b"]=>
+  *RECURSION*
+  ["d"]=>
+  NULL
+}
+# Internal class
+string(5) "hello"

--- a/Zend/tests/lazy_objects/isLazy.phpt
+++ b/Zend/tests/lazy_objects/isLazy.phpt
@@ -1,0 +1,101 @@
+--TEST--
+Lazy Objects: ReflectionProperty::isLazy()
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class C {
+    public static $staticProp;
+    public int $typed;
+    public $untyped;
+    public $virtual {
+        get {}
+    }
+}
+
+function testProps(ReflectionClass $reflector, object $obj) {
+    foreach (['staticProp', 'typed', 'untyped', 'virtual', 'dynamic'] as $name) {
+        if ('dynamic' === $name) {
+            $tmp = new C();
+            $tmp->dynamic = 1;
+            $pr = new ReflectionProperty($tmp, $name);
+        } else {
+            $pr = $reflector->getProperty($name);
+        }
+        printf("%s: %d\n", $name, $pr->isLazy($obj));
+    }
+}
+
+$reflector = new ReflectionClass(C::class);
+
+print "# Ghost\n";
+
+$obj = $reflector->newLazyGhost(function () { });
+
+testProps($reflector, $obj);
+
+$pr = $reflector->getProperty('typed');
+$pr->skipLazyInitialization($obj);
+printf("typed (skipped): %d\n", $pr->isLazy($obj));
+
+print "# Initialized Ghost\n";
+
+$reflector->initializeLazyObject($obj);
+
+testProps($reflector, $obj);
+
+print "# Proxy\n";
+
+$obj = $reflector->newLazyProxy(function () {
+    return new C();
+});
+
+testProps($reflector, $obj);
+
+$pr = $reflector->getProperty('typed');
+$pr->skipLazyInitialization($obj);
+printf("typed (skipped prop): %d\n", $pr->isLazy($obj));
+
+print "# Initialized Proxy\n";
+
+$reflector->initializeLazyObject($obj);
+
+testProps($reflector, $obj);
+
+print "# Internal\n";
+
+$obj = (new DateTime())->diff(new DateTime());
+$reflector = new ReflectionClass(DateInterval::class);
+$pr = new ReflectionProperty($obj, 'y');
+printf("y: %d\n", $pr->isLazy($obj));
+
+?>
+--EXPECT--
+# Ghost
+staticProp: 0
+typed: 1
+untyped: 1
+virtual: 0
+dynamic: 0
+typed (skipped): 0
+# Initialized Ghost
+staticProp: 0
+typed: 0
+untyped: 0
+virtual: 0
+dynamic: 0
+# Proxy
+staticProp: 0
+typed: 1
+untyped: 1
+virtual: 0
+dynamic: 0
+typed (skipped prop): 0
+# Initialized Proxy
+staticProp: 0
+typed: 0
+untyped: 0
+virtual: 0
+dynamic: 0
+# Internal
+y: 0

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -502,6 +502,10 @@ class ReflectionProperty implements Reflector
 
     public function skipLazyInitialization(object $object): void {}
 
+    public function getRawValueWithoutLazyInitialization(object $object): mixed {}
+
+    public function isLazy(object $object): bool {}
+
     /** @tentative-return-type */
     public function isInitialized(?object $object = null): bool {}
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 273777e0bc50a3d5059bb2db7b0a1e293b26e338 */
+ * Stub hash: 6d00f21a2021996bc076c27dcb74debfee09560b */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -398,6 +398,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_skipLazyInitialization, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionProperty_getRawValueWithoutLazyInitialization arginfo_class_ReflectionProperty_getRawValue
+
+#define arginfo_class_ReflectionProperty_isLazy arginfo_class_ReflectionClass_isUninitializedLazyObject
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionProperty_isInitialized, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, object, IS_OBJECT, 1, "null")
@@ -843,6 +847,8 @@ ZEND_METHOD(ReflectionProperty, getRawValue);
 ZEND_METHOD(ReflectionProperty, setRawValue);
 ZEND_METHOD(ReflectionProperty, setRawValueWithoutLazyInitialization);
 ZEND_METHOD(ReflectionProperty, skipLazyInitialization);
+ZEND_METHOD(ReflectionProperty, getRawValueWithoutLazyInitialization);
+ZEND_METHOD(ReflectionProperty, isLazy);
 ZEND_METHOD(ReflectionProperty, isInitialized);
 ZEND_METHOD(ReflectionProperty, isPublic);
 ZEND_METHOD(ReflectionProperty, isPrivate);
@@ -1140,6 +1146,8 @@ static const zend_function_entry class_ReflectionProperty_methods[] = {
 	ZEND_ME(ReflectionProperty, setRawValue, arginfo_class_ReflectionProperty_setRawValue, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, setRawValueWithoutLazyInitialization, arginfo_class_ReflectionProperty_setRawValueWithoutLazyInitialization, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, skipLazyInitialization, arginfo_class_ReflectionProperty_skipLazyInitialization, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, getRawValueWithoutLazyInitialization, arginfo_class_ReflectionProperty_getRawValueWithoutLazyInitialization, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, isLazy, arginfo_class_ReflectionProperty_isLazy, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isInitialized, arginfo_class_ReflectionProperty_isInitialized, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isPublic, arginfo_class_ReflectionProperty_isPublic, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, isPrivate, arginfo_class_ReflectionProperty_isPrivate, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
This is a bug fix for a design flaw in the Lazy Objects Reflection API:

The API provides `ReflectionProperty::setRawValueWithoutLazyInitialization()` and `ReflectionProperty::skipLazyInitialization()`, but does not provide any way to fetch the value of a property without triggering initialization, or to check if a property is lazy.

A workaround is to cast the object as array (with `(array) $obj`), but this is slower than needed and is used in performance-critical code in Doctrine, for instance.

This PR fixes this by adding the methods `ReflectionProperty::getRawValueWithoutLazyInitialization(object $obj)` and `ReflectionProperty::isLazy(object $obj).

`getRawValueWithoutLazyInitialization()` returns `NULL` if the property is lazy, and behaves like `getRawValue()` otherwise.

