### PR TITLE
Fix lineno in function redeclaration error

### DIFF
--- a/Zend/tests/gh16509.inc
+++ b/Zend/tests/gh16509.inc
@@ -1,0 +1,7 @@
+<?php
+
+function test() {
+
+
+    echo 'foo';
+}

--- a/Zend/tests/gh16509.phpt
+++ b/Zend/tests/gh16509.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-16509: Incorrect lineno reported for function redeclaration
+--FILE--
+<?php
+
+include __DIR__ . '/gh16509.inc';
+include __DIR__ . '/gh16509.inc';
+
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare function test() (previously declared in %sgh16509.inc:3) in %sgh16509.inc on line 3

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1278,7 +1278,7 @@ static zend_never_inline ZEND_COLD ZEND_NORETURN void do_bind_function_error(zen
 		zend_error_noreturn(error_level, "Cannot redeclare function %s() (previously declared in %s:%d)",
 					op_array ? ZSTR_VAL(op_array->function_name) : ZSTR_VAL(old_function->common.function_name),
 					ZSTR_VAL(old_function->op_array.filename),
-					old_function->op_array.opcodes[0].lineno);
+					old_function->op_array.line_start);
 	} else {
 		zend_error_noreturn(error_level, "Cannot redeclare function %s()",
 			op_array ? ZSTR_VAL(op_array->function_name) : ZSTR_VAL(old_function->common.function_name));
@@ -8362,6 +8362,7 @@ static zend_op_array *zend_compile_func_decl_ex(
 	} else if (toplevel) {
 		/* Only register the function after a successful compile */
 		if (UNEXPECTED(zend_hash_add_ptr(CG(function_table), lcname, op_array) == NULL)) {
+			CG(zend_lineno) = decl->start_lineno;
 			do_bind_function_error(lcname, op_array, true);
 		}
 	}

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -175,13 +175,13 @@ failure:
 	function2 = Z_PTR_P(t);
 	CG(in_compilation) = 1;
 	zend_set_compiled_filename(function1->op_array.filename);
-	CG(zend_lineno) = function1->op_array.opcodes[0].lineno;
+	CG(zend_lineno) = function1->op_array.line_start;
 	if (function2->type == ZEND_USER_FUNCTION
 		&& function2->op_array.last > 0) {
 		zend_error_noreturn(E_ERROR, "Cannot redeclare function %s() (previously declared in %s:%d)",
 				   ZSTR_VAL(function1->common.function_name),
 				   ZSTR_VAL(function2->op_array.filename),
-				   (int)function2->op_array.opcodes[0].lineno);
+				   (int)function2->op_array.line_start);
 	} else {
 		zend_error_noreturn(E_ERROR, "Cannot redeclare function %s()", ZSTR_VAL(function1->common.function_name));
 	}


### PR DESCRIPTION
We were previously using the lineno of the first instruction, rather than the start of the function itself.

Fixes GH-16509