### PR TITLE
Fix lineno for inheritance errors of early bound classes

### DIFF
--- a/Zend/tests/gh16508.phpt
+++ b/Zend/tests/gh16508.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16508: Missing lineno in inheritance errors of delayed early bound classes
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable_cli=1
+--FILE--
+<?php
+
+new Test2;
+
+class Test2 extends Test {}
+
+abstract class Test {
+    abstract function foo();
+}
+
+?>
+--EXPECTF--
+Fatal error: Class Test2 contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Test::foo) in %s on line 5

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3222,6 +3222,8 @@ ZEND_API zend_class_entry *zend_try_early_bind(zend_class_entry *ce, zend_class_
 		CG(current_linking_class) = is_cacheable ? ce : NULL;
 
 		zend_try{
+			CG(zend_lineno) = ce->info.user.line_start;
+
 			if (is_cacheable) {
 				zend_begin_record_errors();
 			}


### PR DESCRIPTION
Fixes GH-16508

Note to self: The error changes in PHP 8.4 (methods -> method). Adjust when merging.