### PR TITLE
Adapt tests for libxml2 >= 2.13.0

### DIFF
--- a/ext/dom/tests/dom004.phpt
+++ b/ext/dom/tests/dom004.phpt
@@ -9,7 +9,7 @@ in_array('compress.zlib', stream_get_wrappers()) or die('skip compress.zlib wrap
 --FILE--
 <?php
 $dom = new domdocument;
-$dom->load("compress.zlib://".__DIR__."/book.xml.gz");
+$dom->load("compress.zlib://" . str_replace("\\", "/", __DIR__) . "/book.xml.gz");
 print $dom->saveXML();
 ?>
 --EXPECT--

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -423,10 +423,11 @@ static void *php_libxml_streams_IO_open_wrapper(const char *filename, const char
 			(xmlStrncmp(BAD_CAST uri->scheme, BAD_CAST "file", 4) == 0))) {
 		resolved_path = xmlURIUnescapeString(filename, 0, NULL);
 		isescaped = 1;
-#if LIBXML_VERSION >= 20902 && defined(PHP_WIN32)
+#if LIBXML_VERSION >= 20902 && LIBXML_VERSION < 21300 && defined(PHP_WIN32)
 		/* Libxml 2.9.2 prefixes local paths with file:/ instead of file://,
 			thus the php stream wrapper will fail on a valid case. For this
-			reason the prefix is rather better cut off. */
+			reason the prefix is rather better cut off.
+			As of libxml 2.13.0 this issue is resolved. */
 		{
 			size_t pre_len = sizeof("file:/") - 1;
 

--- a/ext/libxml/tests/bug69753-mb.phpt
+++ b/ext/libxml/tests/bug69753-mb.phpt
@@ -1,12 +1,11 @@
 --TEST--
 Bug #69753 - libXMLError::file contains invalid URI
---XFAIL--
-Awaiting upstream fix: https://gitlab.gnome.org/GNOME/libxml2/-/issues/611
 --EXTENSIONS--
 dom
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) != 'WIN') die("skip this test is for Windows platforms only");
+if (version_compare(LIBXML_DOTTED_VERSION, "2.13.0") < 0) die("skip fails for libxml2 < 2.13.0; https://gitlab.gnome.org/GNOME/libxml2/-/issues/611");
 ?>
 --FILE--
 <?php
@@ -17,4 +16,4 @@ $error = libxml_get_last_error();
 var_dump($error->file);
 ?>
 --EXPECTF--
-string(%d) "file:///%s/ext/libxml/tests/bug69753.xml"
+string(%d) "%s\ext\libxml\tests\bug69753私はガラスを食べられます.xml"

--- a/ext/libxml/tests/bug69753.phpt
+++ b/ext/libxml/tests/bug69753.phpt
@@ -1,12 +1,11 @@
 --TEST--
 Bug #69753 - libXMLError::file contains invalid URI
---XFAIL--
-Awaiting upstream fix: https://gitlab.gnome.org/GNOME/libxml2/-/issues/611
 --EXTENSIONS--
 dom
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) != 'WIN') die("skip this test is for Windows platforms only");
+if (version_compare(LIBXML_DOTTED_VERSION, "2.13.0") < 0) die("skip fails for libxml2 < 2.13.0; https://gitlab.gnome.org/GNOME/libxml2/-/issues/611");
 ?>
 --FILE--
 <?php
@@ -17,4 +16,4 @@ $error = libxml_get_last_error();
 var_dump($error->file);
 ?>
 --EXPECTF--
-string(%d) "file:///%s/ext/libxml/tests/bug69753.xml"
+string(%d) "%s\ext\libxml\tests\bug69753.xml"


### PR DESCRIPTION
libxml2 2.13.0 introduced some relevant changes regarding the treatment of file paths on Windows[1].  Thus we un-xfail bug69753.phpt and its companion, and we adjust dom004.phpt.

[1] <https://gitlab.gnome.org/GNOME/libxml2/-/commit/8ab1b122c47bfced2b59f52351507ebc1eb50218>

---

I've tested locally against [libxml2 2.13.4](https://github.com/winlibs/winlib-builder/actions/runs/11443719874), and found no other issues for the seven test suites relevant for libxml.

I've targeted PHP-8.4 since I consider it somewhat unlikely that we're going to update stable branches to libxml2 2.13. Can rebase, though, if desired.

@nielsdos, I think https://gitlab.gnome.org/GNOME/libxml2/-/issues/611 is sufficiently fixed.

Not sure if we should update af2b0669110ead1d946237500d1e0a4151f0e450, since it's a pretty cheap comparison.