### PR TITLE
Fix GH-16533: Segfault when adding attribute to parent that is not an element

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -872,6 +872,11 @@ static bool dom_node_check_legacy_insertion_validity(xmlNodePtr parentp, xmlNode
 		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
 		return false;
 	}
+	/* Attributes must be in elements. */
+	if (child->type == XML_ATTRIBUTE_NODE && parentp->type != XML_ELEMENT_NODE) {
+		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
+		return false;
+	}
 
 	return true;
 }

--- a/ext/dom/tests/gh16533.phpt
+++ b/ext/dom/tests/gh16533.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16533 (Segfault when adding attribute to parent that is not an element)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+try {
+    $doc->appendChild($doc->createAttribute('foo'));
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo $doc->saveXML();
+
+?>
+--EXPECT--
+Hierarchy Request Error
+<?xml version="1.0"?>


### PR DESCRIPTION
Attributes are only valid as children of elements. This bug goes back all the way.