### PR TITLE
Add sanitity checks regarding num_args and arg_info

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3709,6 +3709,7 @@ static uint32_t zend_get_arg_num(zend_function *fn, zend_string *arg_name) {
 			}
 		}
 	} else {
+		ZEND_ASSERT(fn->common.num_args == 0 || fn->internal_function.arg_info);
 		for (uint32_t i = 0; i < fn->common.num_args; i++) {
 			zend_internal_arg_info *arg_info = &fn->internal_function.arg_info[i];
 			size_t len = strlen(arg_info->name);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5304,6 +5304,7 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 			}
 		}
 	} else {
+		ZEND_ASSERT(num_args == 0 || fbc->internal_function.arg_info);
 		for (uint32_t i = 0; i < num_args; i++) {
 			zend_internal_arg_info *arg_info = &fbc->internal_function.arg_info[i];
 			size_t len = strlen(arg_info->name);


### PR DESCRIPTION
`num_args > 0` implies that `arg_info != NULL`.  We explicitly assert that during compilation and execution to make it easier for developers to not miss this[1].

[1] <https://github.com/php/php-src/issues/16266>