### PR TITLE
Fix GH-16535: UAF when using document as a child

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -873,6 +873,12 @@ static bool dom_node_check_legacy_insertion_validity(xmlNodePtr parentp, xmlNode
 		return false;
 	}
 
+	/* Documents can never be a child. */
+	if (child->type == XML_DOCUMENT_NODE || child->type == XML_HTML_DOCUMENT_NODE) {
+		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
+		return false;
+	}
+
 	return true;
 }
 

--- a/ext/dom/tests/gh16535.phpt
+++ b/ext/dom/tests/gh16535.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-16535 (UAF when using document as a child)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$v2 = new DOMDocument("t");
+
+$v2->loadHTML("t");
+$v4 = $v2->createElement('foo');
+try {
+    $v4->appendChild($v2);
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+$v2->loadHTML("oU");
+echo $v2->saveXML();
+
+?>
+--EXPECT--
+Hierarchy Request Error
+<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>oU</p></body></html>


### PR DESCRIPTION
Documents can never be children of any node.