### PR TITLE
Fix GH-16523: FILTER_FLAG_HOSTNAME accepts ending hyphen

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -542,7 +542,7 @@ static int _php_filter_validate_domain(char * domain, size_t len, zend_long flag
 			/* Reset label length counter */
 			i = 1;
 		} else {
-			if (i > 63 || (hostname && *s != '-' && !isalnum((int)*(unsigned char *)s))) {
+			if (i > 63 || (hostname && (*s != '-' || *(s + 1) == '\0') && !isalnum((int)*(unsigned char *)s))) {
 				return 0;
 			}
 

--- a/ext/filter/tests/gh16523.phpt
+++ b/ext/filter/tests/gh16523.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16523 (FILTER_FLAG_HOSTNAME accepts ending hyphen)
+--EXTENSIONS--
+filter
+--FILE--
+<?php
+$domains = [
+    'a-.bc.com',
+    'a.bc-.com',
+    'a.bc.com-',
+];
+
+foreach ($domains as $domain) {
+    var_dump(filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME));
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
Domain name labels must not end with a hyphen, and that is also true for the last label.  Apparently, this has been overlooked so far.