### PR TITLE
[ci skip] Update EXTENSIONS and CODEOWNERS for ext/soap

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@
 /ext/random @TimWolla @zeriyoshi
 /ext/session @Girgias
 /ext/simplexml @nielsdos
+/ext/soap @nielsdos
 /ext/sockets @devnexen
 /ext/spl @Girgias
 /ext/standard @bukka

--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -193,7 +193,8 @@ SINCE:               5.0
 -------------------------------------------------------------------------------
 EXTENSION:           soap
 PRIMARY MAINTAINER:  Dmitry Stogov <dmitry@php.net> (2004 - 2018)
-MAINTENANCE:         Maintained
+                     Niels Dossche <nielsdos@php.net> (2024 - 2024)
+MAINTENANCE:         Odd fixes
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           xml


### PR DESCRIPTION
De facto, I do the maintenance. But since many bugs are blocked by not having reproducers and there's some fundamental issues in the extension, this should get the "odd fixes" status instead. The "odd fixes" description should perhaps also be updated to include a statement about "limited willpower to debug"...