### PR TITLE
GH-16317: allow `__debugInfo()` overrides in mysqli classes

### DIFF
--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -342,6 +342,10 @@ static int mysqli_object_has_property(zend_object *object, zend_string *name, in
 
 HashTable *mysqli_object_get_debug_info(zend_object *object, int *is_temp)
 {
+	/* GH-16317: allow subclasses to use __debugInfo() */
+	if (object->ce->__debugInfo != NULL) {
+		return zend_std_get_debug_info(object, is_temp);
+	}
 	mysqli_object *obj = php_mysqli_fetch_object(object);
 	HashTable *retval, *props = obj->prop_handler;
 	mysqli_prop_handler *entry;

--- a/ext/mysqli/tests/gh16317.phpt
+++ b/ext/mysqli/tests/gh16317.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-16317 (__debugInfo() overrides don't work)
+--EXTENSIONS--
+mysqli
+--FILE--
+<?php
+
+class subclass_mysqli extends mysqli {
+    public function __construct() {}
+    public function __debugInfo(): array {
+        return ['a' => 'b'];
+    }
+}
+var_dump( new subclass_mysqli() );
+
+class subclass_mysqli_result extends mysqli_result {
+    public function __construct() {}
+    public function __debugInfo(): array {
+        return ['o' => 'p'];
+    }
+}
+var_dump( new subclass_mysqli_result() );
+
+class subclass_mysqli_stmt extends mysqli_stmt {
+    public function __construct() {}
+    public function __debugInfo(): array {
+        return ['x' => 'y'];
+    }
+}
+var_dump( new subclass_mysqli_stmt() );
+
+?>
+--EXPECT--
+object(subclass_mysqli)#1 (1) {
+  ["a"]=>
+  string(1) "b"
+}
+object(subclass_mysqli_result)#1 (1) {
+  ["o"]=>
+  string(1) "p"
+}
+object(subclass_mysqli_stmt)#1 (1) {
+  ["x"]=>
+  string(1) "y"
+}


### PR DESCRIPTION
For classes that extend `mysqli`, `mysqli_result`, or `mysqli_statement`, and define a `__debugInfo()` magic method, use it.