### PR TITLE
Sync exif and mbstring INI settings

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -915,6 +915,7 @@ default_socket_timeout = 60
 ;
 ;extension=bz2
 ;extension=curl
+;extension=exif
 ;extension=ffi
 ;extension=ftp
 ;extension=fileinfo
@@ -924,7 +925,6 @@ default_socket_timeout = 60
 ;extension=intl
 ;extension=ldap
 ;extension=mbstring
-;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
 ;extension=odbc
 ;extension=openssl

--- a/php.ini-production
+++ b/php.ini-production
@@ -917,6 +917,7 @@ default_socket_timeout = 60
 ;
 ;extension=bz2
 ;extension=curl
+;extension=exif
 ;extension=ffi
 ;extension=ftp
 ;extension=fileinfo
@@ -926,7 +927,6 @@ default_socket_timeout = 60
 ;extension=intl
 ;extension=ldap
 ;extension=mbstring
-;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
 ;extension=odbc
 ;extension=openssl


### PR DESCRIPTION
A follow-up of 9ee9c0e6748157198d0180920454bc203ee439a5 (GH-16062)

The mbstring extension is added as ZEND_MOD_OPTIONAL dependency at runtime, so INI directives configuration order here is no longer relevant and can be done in any way.