### PR TITLE
Fix zend_max_execution_timer.h cannot be included by the C++ extension.

### DIFF
--- a/Zend/zend_max_execution_timer.h
+++ b/Zend/zend_max_execution_timer.h
@@ -21,8 +21,10 @@
 
 #include "zend_long.h"
 
+BEGIN_EXTERN_C()
 /* Must be called after calls to fork() */
 ZEND_API void zend_max_execution_timer_init(void);
+END_EXTERN_C()
 void zend_max_execution_timer_settime(zend_long seconds);
 void zend_max_execution_timer_shutdown(void);
 


### PR DESCRIPTION
In the Swoole extension, including zend_max_execution_timer.h and calling the zend_max_execution_timer_init function leads to an undefined symbol error. This function should be exported in C symbol format.

```
php: symbol lookup error: swoole.so: undefined symbol: _Z29zend_max_execution_timer_initv
```