### PR TITLE
Fix tests: Prevent stack overflow during dtor

### DIFF
--- a/ext/json/tests/gh15168.phpt
+++ b/ext/json/tests/gh15168.phpt
@@ -31,6 +31,10 @@ var_dump(json_encode($firstNode, depth: 500000));
 var_dump(json_last_error());
 var_dump(json_last_error_msg());
 
+while ($next = $firstNode->next) {
+    $firstNode->next = $next->next;
+}
+
 ?>
 --EXPECT--
 bool(false)

--- a/ext/standard/tests/serialize/gh15169.phpt
+++ b/ext/standard/tests/serialize/gh15169.phpt
@@ -30,6 +30,11 @@ try {
 } catch (Error $e) {
     echo $e->getMessage(), "\n";
 }
+
+while ($next = $firstNode->next) {
+    $firstNode->next = $next->next;
+}
+
 ?>
 --EXPECT--
 Maximum call stack size reached. Infinite recursion?


### PR DESCRIPTION
This fixes GH-16528.

On s390x the stack is smaller and/or the object dtor code uses more stack, which causes the destruction of deeply nested objects to crash in these tests. Here I ensure that objects are released one by one to avoid recursive dtor.