### PR TITLE
Fix GH-16432: PHP-FPM 8.2 SIGSEGV in fpm_get_status

### DIFF
--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -62,7 +62,8 @@ int fpm_status_export_to_zval(zval *status)
 
 	/* copy the scoreboard not to bother other processes */
 	scoreboard = *scoreboard_p;
-	struct fpm_scoreboard_proc_s procs[scoreboard.nprocs];
+	struct fpm_scoreboard_proc_s *procs = safe_emalloc(
+			sizeof(struct fpm_scoreboard_proc_s), scoreboard.nprocs, 0);
 
 	struct fpm_scoreboard_proc_s *proc_p;
 	for(i=0; i<scoreboard.nprocs; i++) {
@@ -131,6 +132,8 @@ int fpm_status_export_to_zval(zval *status)
 		add_next_index_zval(&fpm_proc_stats, &fpm_proc_stat);
 	}
 	add_assoc_zval(status, "procs", &fpm_proc_stats);
+	efree(procs);
+
 	return 0;
 }
 /* }}} */

--- a/sapi/fpm/tests/gh16432-status-high-nprocs.phpt
+++ b/sapi/fpm/tests/gh16432-status-high-nprocs.phpt
@@ -1,0 +1,46 @@
+--TEST--
+FPM: GH-16432 - fpm_get_status segfault on high nprocs
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+log_level = notice
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 12800
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 1
+catch_workers_output = yes
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(empty(fpm_get_status()));
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName();
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody('bool(false)');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
This fixes GH-16432 which happens when high number of max_children and fpm_get_status is used. The procs need to be allocated on heap in this case.