### PR TITLE
implement r/w locks to improve performance

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -448,9 +448,9 @@ PHP_RSHUTDOWN_FUNCTION(basic) /* {{{ */
 		BG(strtok_string) = NULL;
 	}
 #ifdef HAVE_PUTENV
-	tsrm_env_lock();
+	tsrm_env_lock(true);
 	zend_hash_destroy(&BG(putenv_ht));
-	tsrm_env_unlock();
+	tsrm_env_unlock(true);
 #endif
 
 	if (BG(umask) != -1) {
@@ -687,7 +687,7 @@ PHPAPI zend_string *php_getenv(const char *str, size_t str_len) {
 		}
 	}
 #else
-	tsrm_env_lock();
+	tsrm_env_lock(false);
 
 	/* system method returns a const */
 	char *ptr = getenv(str);
@@ -696,7 +696,7 @@ PHPAPI zend_string *php_getenv(const char *str, size_t str_len) {
 		result = zend_string_init(ptr, strlen(ptr), 0);
 	}
 
-	tsrm_env_unlock();
+	tsrm_env_unlock(false);
 	return result;
 #endif
 }
@@ -772,7 +772,7 @@ PHP_FUNCTION(putenv)
 		pe.key = zend_string_init(setting, setting_len, 0);
 	}
 
-	tsrm_env_lock();
+	tsrm_env_lock(true);
 	zend_hash_del(&BG(putenv_ht), pe.key);
 
 	/* find previous value */
@@ -807,7 +807,7 @@ PHP_FUNCTION(putenv)
 		}
 		/* valw may be NULL, but the failed conversion still needs to be checked. */
 		if (!keyw || !valw && value) {
-			tsrm_env_unlock();
+			tsrm_env_unlock(true);
 			free(pe.putenv_string);
 			zend_string_release(pe.key);
 			free(keyw);
@@ -835,7 +835,7 @@ PHP_FUNCTION(putenv)
 			tzset();
 		}
 #endif
-		tsrm_env_unlock();
+		tsrm_env_unlock(true);
 #ifdef PHP_WIN32
 		free(keyw);
 		free(valw);

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -968,7 +968,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 		SECTION("Environment");
 		php_info_print_table_start();
 		php_info_print_table_header(2, "Variable", "Value");
-		tsrm_env_lock();
+		tsrm_env_lock(false);
 		for (env=environ; env!=NULL && *env !=NULL; env++) {
 			tmp1 = estrdup(*env);
 			if (!(tmp2=strchr(tmp1,'='))) { /* malformed entry? */
@@ -980,7 +980,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 			php_info_print_table_row(2, tmp1, tmp2);
 			efree(tmp1);
 		}
-		tsrm_env_unlock();
+		tsrm_env_unlock(false);
 		php_info_print_table_end();
 	}
 

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -628,7 +628,7 @@ static zend_always_inline void import_environment_variable(HashTable *ht, char *
 
 static void _php_import_environment_variables(zval *array_ptr)
 {
-	tsrm_env_lock();
+	tsrm_env_lock(false);
 
 #ifndef PHP_WIN32
 	for (char **env = environ; env != NULL && *env != NULL; env++) {
@@ -646,7 +646,7 @@ static void _php_import_environment_variables(zval *array_ptr)
 	FreeEnvironmentStringsW(environmentw);
 #endif
 
-	tsrm_env_unlock();
+	tsrm_env_unlock(false);
 }
 
 static void _php_load_environment_variables(zval *array_ptr)

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -234,7 +234,7 @@ static void litespeed_php_import_environment_variables(zval *array_ptr)
         return;
     }
 
-    tsrm_env_lock();
+    tsrm_env_lock(false);
     for (env = environ; env != NULL && *env != NULL; env++) {
         p = strchr(*env, '=');
         if (!p) {               /* malformed entry? */
@@ -249,7 +249,7 @@ static void litespeed_php_import_environment_variables(zval *array_ptr)
         t[nlen] = '\0';
         add_variable(t, nlen, p + 1, strlen( p + 1 ), array_ptr);
     }
-    tsrm_env_unlock();
+    tsrm_env_unlock(false);
     if (t != buf && t != NULL) {
         efree(t);
     }


### PR DESCRIPTION
While investigating some performance issues with FrankenPHP, @AlliBalliBaba discovered that environment access takes an exclusive lock before accessing the environment. This PR makes a small ABI break to `tsrm_env_unlock` and `tsrm_env_lock` to indicate whether the environment will be modified. This will take a shared lock for reading (so that multiple threads can read at once) and an exclusive lock on writing.

This change should increase performance for ZTS builds (especially those using modern frameworks that make heavy use of environment variables): https://github.com/dunglas/frankenphp/pull/1080#discussion_r1796155640 increasing performance by ~2x under load for the litespeed SAPI.