### PR TITLE
fix compilation errors on Cygwin 

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -770,6 +770,7 @@ TSRM_API void *tsrm_get_ls_cache(void)
 	return tsrm_tls_get();
 }/*}}}*/
 
+#ifdef HAVE_JIT
 /* Returns offset of tsrm_ls_cache slot from Thread Control Block address */
 TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 {/*{{{*/
@@ -820,6 +821,7 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 	return 0;
 #endif
 }/*}}}*/
+#endif
 
 TSRM_API bool tsrm_is_main_thread(void)
 {/*{{{*/

--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -136,7 +136,9 @@ TSRM_API void *tsrm_set_new_thread_end_handler(tsrm_thread_end_func_t new_thread
 TSRM_API void *tsrm_set_shutdown_handler(tsrm_shutdown_func_t shutdown_handler);
 
 TSRM_API void *tsrm_get_ls_cache(void);
+#ifdef HAVE_JIT
 TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void);
+#endif
 TSRM_API bool tsrm_is_main_thread(void);
 TSRM_API bool tsrm_is_shutdown(void);
 TSRM_API const char *tsrm_api_name(void);


### PR DESCRIPTION
compilation errors when using the `--enable-opcache`, `--disable-opcache-jit`, and `--enable-zts` configure options on Cygwin.

The `tsrm_get_ls_cache_tcb_offset` function is used exclusively in JIT. When JIT is disabled, this function should also be disabled.

## Error
```shell
/usr/lib/gcc/x86_64-pc-cygwin/12/../../../../x86_64-pc-cygwin/bin/ld: warning: --export-dynamic is not supported for PE+ targets, did you mean --export-all-symbols?
/usr/lib/gcc/x86_64-pc-cygwin/12/../../../../x86_64-pc-cygwin/bin/ld: TSRM/TSRM.o: in function `tsrm_get_ls_cache_tcb_offset':
/cygdrive/d/a/swoole-cli/swoole-cli/TSRM/TSRM.c:769:(.text+0xc23): undefined reference to `_tsrm_ls_cache@gottpoff'
collect2: error: ld returned 1 exit status
make: *** [Makefile:291: bin/swoole-cli] Error 1
```

