### PR TITLE
Deprecate mhash constants

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1189,7 +1189,7 @@ static void mhash_init(INIT_FUNC_ARGS)
 		}
 
 		len = slprintf(buf, 127, "MHASH_%s", algorithm.mhash_name);
-		zend_register_long_constant(buf, len, algorithm.value, CONST_PERSISTENT, module_number);
+		zend_register_long_constant(buf, len, algorithm.value, CONST_PERSISTENT|CONST_DEPRECATED, module_number);
 	}
 
 	/* TODO: this cause #69823 zend_register_internal_module(&mhash_module_entry); */

--- a/ext/hash/tests/mhash_001.phpt
+++ b/ext/hash/tests/mhash_001.phpt
@@ -35,55 +35,77 @@ foreach ($supported_hash_al as $hash=>$wanted) {
 }
 ?>
 --EXPECTF--
+Deprecated: Constant MHASH_MD5 is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_MD5
 ok
 
+
+Deprecated: Constant MHASH_SHA1 is deprecated in %s on line %d
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_SHA1
 ok
 
 
+Deprecated: Constant MHASH_HAVAL256 is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL256
 ok
 
+
+Deprecated: Constant MHASH_HAVAL192 is deprecated in %s on line %d
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL192
 ok
 
 
+Deprecated: Constant MHASH_HAVAL224 is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL224
 ok
 
+
+Deprecated: Constant MHASH_HAVAL160 is deprecated in %s on line %d
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL160
 ok
 
 
+Deprecated: Constant MHASH_RIPEMD160 is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_RIPEMD160
 ok
 
+
+Deprecated: Constant MHASH_GOST is deprecated in %s on line %d
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_GOST
 ok
 
 
+Deprecated: Constant MHASH_TIGER is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_TIGER
 ok
 
 
+Deprecated: Constant MHASH_CRC32 is deprecated in %s on line %d
+
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32
 ok
 
+
+Deprecated: Constant MHASH_CRC32B is deprecated in %s on line %d
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32B

--- a/ext/hash/tests/mhash_003.phpt
+++ b/ext/hash/tests/mhash_003.phpt
@@ -35,55 +35,77 @@ foreach ($supported_hash_al as $hash=>$wanted) {
 }
 ?>
 --EXPECTF--
+Deprecated: Constant MHASH_MD5 is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_MD5
 ok
 
+
+Deprecated: Constant MHASH_SHA1 is deprecated in %s on line %d
 
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_SHA1
 ok
 
 
+Deprecated: Constant MHASH_HAVAL256 is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL256
 ok
 
+
+Deprecated: Constant MHASH_HAVAL224 is deprecated in %s on line %d
 
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL224
 ok
 
 
+Deprecated: Constant MHASH_HAVAL192 is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL192
 ok
 
+
+Deprecated: Constant MHASH_HAVAL160 is deprecated in %s on line %d
 
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_HAVAL160
 ok
 
 
+Deprecated: Constant MHASH_RIPEMD160 is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_RIPEMD160
 ok
 
+
+Deprecated: Constant MHASH_GOST is deprecated in %s on line %d
 
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_GOST
 ok
 
 
+Deprecated: Constant MHASH_TIGER is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_TIGER
 ok
 
 
+Deprecated: Constant MHASH_CRC32 is deprecated in %s on line %d
+
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32
 ok
 
+
+Deprecated: Constant MHASH_CRC32B is deprecated in %s on line %d
 
 Deprecated: Function mhash_keygen_s2k() is deprecated since 8.1 in %s on line %d
 MHASH_CRC32B

--- a/ext/hash/tests/mhash_004.phpt
+++ b/ext/hash/tests/mhash_004.phpt
@@ -12,6 +12,7 @@ var_dump($algo);
 
 ?>
 --EXPECTF--
+Deprecated: Constant MHASH_MD5 is deprecated in %s on line %d
 int(1)
 
 Deprecated: Function mhash() is deprecated since 8.1 in %s on line %d


### PR DESCRIPTION
The mhash functions already have been deprecated as of PHP 8.1.0[1], but the respective constants appear to have been missed.  We catch up on that.

[1] <https://wiki.php.net/rfc/deprecations_php_8_1#mhash_function_family>