### PR TITLE
Fix GH-16593: Assertion failure in DOM->replaceChild

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1093,6 +1093,13 @@ PHP_METHOD(DOMNode, replaceChild)
 		RETURN_FALSE;
 	}
 
+	/* This is already disallowed by libxml, but we should check it here to avoid
+	 * breaking assumptions and assertions. */
+	if ((oldchild->type == XML_ATTRIBUTE_NODE) != (newchild->type == XML_ATTRIBUTE_NODE)) {
+		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
+		RETURN_FALSE;
+	}
+
 	if (oldchild->parent != nodep) {
 		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
 		RETURN_FALSE;

--- a/ext/dom/tests/gh16593.phpt
+++ b/ext/dom/tests/gh16593.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-16593 (Assertion failure in DOM->replaceChild)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+$root = $doc->appendChild($doc->createElement('root'));
+$child = $root->appendChild($doc->createElement('child'));
+try {
+    $root->replaceChild($doc->createAttribute('foo'), $child);
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+echo $doc->saveXML();
+
+?>
+--EXPECT--
+Hierarchy Request Error
+<?xml version="1.0"?>
+<root><child/></root>


### PR DESCRIPTION
This is already forbidden by libxml, but this condition isn't properly checked; so the return value and lack of error makes it seem like it worked while it actually didn't. Furthermore, this can break assumptions and assertions later on.