### PR TITLE
Fix GH-16594: Assertion failure in DOM -> before

### DIFF
--- a/ext/dom/parentnode/tree.c
+++ b/ext/dom/parentnode/tree.c
@@ -239,8 +239,11 @@ static bool dom_is_pre_insert_valid_without_step_1(php_libxml_ref_obj *document,
 	ZEND_ASSERT(parentNode != NULL);
 
 	/* 1. If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
-	 *    => Impossible */
-	ZEND_ASSERT(!php_dom_pre_insert_is_parent_invalid(parentNode));
+	 *    => This is possible because we can grab children of attributes etc... (see e.g. GH-16594) */
+	if (php_dom_pre_insert_is_parent_invalid(parentNode)) {
+		php_dom_throw_error(HIERARCHY_REQUEST_ERR, dom_get_strict_error(document));
+		return false;
+	}
 
 	if (node->doc != documentNode) {
 		php_dom_throw_error(WRONG_DOCUMENT_ERR, dom_get_strict_error(document));

--- a/ext/dom/tests/gh16594.phpt
+++ b/ext/dom/tests/gh16594.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-16594 (Assertion failure in DOM -> before)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$v1 = new DOMText("wr");
+$v2 = new DOMDocument();
+$v6 = new DOMComment("aw");
+$v7 = new DOMAttr("r", "iL");
+
+$v9 = $v2->createElement("test");
+$v9->setAttributeNodeNS($v7);
+$v7->appendChild($v1);
+
+try {
+    $v1->before($v6);
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Hierarchy Request Error


### PR DESCRIPTION
The invalid parent condition can actually happen because PHP's DOM is allows to get children of e.g. attributes; something normally not possible.