### PR TITLE
Fix GH-16595: Another UAF in DOM -> cloneNode

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -893,7 +893,7 @@ Since:
 PHP_METHOD(DOMNode, insertBefore)
 {
 	zval *id, *node, *ref = NULL;
-	xmlNodePtr child, new_child, parentp, refp;
+	xmlNodePtr child, new_child, parentp, refp = NULL;
 	dom_object *intern, *childobj, *refpobj;
 	int ret, stricterror;
 

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -918,18 +918,21 @@ PHP_METHOD(DOMNode, insertBefore)
 		RETURN_FALSE;
 	}
 
-	if (child->doc == NULL && parentp->doc != NULL) {
-		childobj->document = intern->document;
-		php_libxml_increment_doc_ref((php_libxml_node_object *)childobj, NULL);
-	}
-
+	/* Fetch and perform sanity checks before modifying reference pointers. */
 	if (ref != NULL) {
 		DOM_GET_OBJ(refp, ref, xmlNodePtr, refpobj);
 		if (refp->parent != parentp) {
 			php_dom_throw_error(NOT_FOUND_ERR, stricterror);
 			RETURN_FALSE;
 		}
+	}
 
+	if (child->doc == NULL && parentp->doc != NULL) {
+		childobj->document = intern->document;
+		php_libxml_increment_doc_ref((php_libxml_node_object *)childobj, NULL);
+	}
+
+	if (ref != NULL) {
 		if (child->parent != NULL) {
 			xmlUnlinkNode(child);
 		}


### PR DESCRIPTION
We need to perform all sanity checks before doing any modification. I don't have a reliable and easy test for this on 8.2, but I have one for 8.4.