### PR TITLE
[skip ci] Run all branches in nightly on Monday

### DIFF
--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -154,7 +154,10 @@ function get_current_version(): array {
 
 $trigger = $argv[1] ?? 'schedule';
 $attempt = (int) ($argv[2] ?? 1);
-$discard_cache = ($trigger === 'schedule' && $attempt !== 1) || $trigger === 'workflow_dispatch';
+$monday = date('w', time()) === '1';
+$discard_cache = $monday
+    || ($trigger === 'schedule' && $attempt !== 1)
+    || $trigger === 'workflow_dispatch';
 if ($discard_cache) {
     @unlink(get_branch_commit_cache_file_path());
 }


### PR DESCRIPTION
See GH-16286. The objective is to identify failed builds in security branches semi-early. Previously, they would only be run when a fix was backported, which would almost always result in a red build.