### PR TITLE
Fix assertion failure in zend_std_read_property

### DIFF
--- a/Zend/tests/gh16615_001.phpt
+++ b/Zend/tests/gh16615_001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-16615 001 (Assertion failure in zend_std_read_property)
+--FILE--
+<?php
+
+class Foo {
+    public string $bar {
+        set => $value;
+    }
+}
+
+$reflector = new ReflectionClass(Foo::class);
+
+// Adds IS_PROP_LAZY to prop flags
+$foo = $reflector->newLazyGhost(function ($ghost) {
+    $ghost->bar = 'bar';
+});
+
+echo $foo->bar;
+
+?>
+--EXPECT--
+bar

--- a/Zend/tests/gh16615_002.phpt
+++ b/Zend/tests/gh16615_002.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-16615 002 (Assertion failure in zend_std_read_property)
+--FILE--
+<?php
+
+class Foo {
+    public string $bar {
+        set => $value;
+    }
+    public function __clone() {
+        try {
+            echo $this->bar;
+        } catch (Error $e) {
+            printf("%s: %s\n", $e::class, $e->getMessage());
+        }
+    }
+}
+
+// Adds IS_PROP_REINITABLE to prop flags
+clone new Foo();
+
+?>
+--EXPECT--
+Error: Typed property Foo::$bar must not be accessed before initialization

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -791,7 +791,7 @@ try_again:
 			if (UNEXPECTED(Z_TYPE_P(retval) == IS_UNDEF)) {
 				/* As hooked properties can't be unset, the only way to end up with an undef
 				 * value is via an uninitialized property. */
-				ZEND_ASSERT(Z_PROP_FLAG_P(retval) == IS_PROP_UNINIT);
+				ZEND_ASSERT(Z_PROP_FLAG_P(retval) & IS_PROP_UNINIT);
 				goto uninit_error;
 			}
 


### PR DESCRIPTION
Fixes GH-16615.

We assert that `Z_PROP_FLAG_P(retval)` is exactly `IS_PROP_UNINIT`, but this is a bit field and it may contain irrelevant bits. For instance, props may also have the `IS_PROP_LAZY` or `IS_PROP_REINITABLE` bits, which does not change the fact that the property is uninitialized:

``` php
<?php

class Foo {
    public string $bar {
        set => $value;
    }
    public function __clone() {
        // Assertion failure
        echo $this->bar;
    }
}

clone new Foo();
```

@nielsdos I didn't update the comment because it's still correct, and I think that using equality comparison was unintended.