### PR TITLE
Fix GH-16590: UAF in session_encode()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -391,6 +391,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      needing to create a zend_string.
    - The ext/session/php_session.h doesn't transitively include the
      ext/hash/php_hash.h header anymore.
+   - It is no longer allowed to return out of the PS_ENCODE_LOOP macro.
+     Instead, you should break out of the loop instead.
 
  i. ext/xml
    - Made the expat compatibility wrapper XML_GetCurrentByteIndex return a long

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1056,6 +1056,7 @@ PS_SERIALIZER_ENCODE_FUNC(php) /* {{{ */
 {
 	smart_str buf = {0};
 	php_serialize_data_t var_hash;
+	bool fail = false;
 	PS_ENCODE_VARS;
 
 	PHP_VAR_SERIALIZE_INIT(var_hash);
@@ -1065,11 +1066,16 @@ PS_SERIALIZER_ENCODE_FUNC(php) /* {{{ */
 		if (memchr(ZSTR_VAL(key), PS_DELIMITER, ZSTR_LEN(key))) {
 			PHP_VAR_SERIALIZE_DESTROY(var_hash);
 			smart_str_free(&buf);
-			return NULL;
+			fail = true;
+			break;
 		}
 		smart_str_appendc(&buf, PS_DELIMITER);
 		php_var_serialize(&buf, struc, &var_hash);
 	);
+
+	if (fail) {
+		return NULL;
+	}
 
 	smart_str_0(&buf);
 

--- a/ext/session/tests/gh16590.phpt
+++ b/ext/session/tests/gh16590.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-16590 (UAF in session_encode())
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--INI--
+session.use_cookies=0
+session.cache_limiter=
+session.serialize_handler=php
+session.save_handler=files
+--FILE--
+<?php
+
+class C {
+    function __serialize() {
+        $_SESSION = [];
+        return [];
+    }
+}
+
+session_start();
+
+$_SESSION['Lz'] = new C;
+for ($i = 0; $i < 2; $i++) {
+    $_SESSION[$i] = $i;
+}
+
+var_dump(session_encode());
+
+?>
+--EXPECTF--
+Warning: session_encode(): Skipping numeric key 0 in %s on line %d
+
+Warning: session_encode(): Skipping numeric key 1 in %s on line %d
+string(15) "Lz|O:1:"C":0:{}"


### PR DESCRIPTION
The `PS_ENCODE_LOOP` does not protect the session hash table that it iterates over. Change it by temporarily creating a copy.

Only applied on 8.4 because of the ABI break. That should be fine as no one should be writing malicious code like this in the first place.
Asking RMs for permission: @SakiTakamachi @NattyNarwhal @ericmann 