### PR TITLE
Fix compiler warning (the comparison will always evaluate as ‘true’ for ZEND_OBSERVER_DATA(func) != NULL)

### DIFF
--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -315,7 +315,7 @@ static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 	}
 	if (stage != PHP_INI_STAGE_STARTUP && stage != PHP_INI_STAGE_ACTIVATE && stage != PHP_INI_STAGE_DEACTIVATE && stage != PHP_INI_STAGE_SHUTDOWN) {
 		ZEND_HASH_FOREACH_STR_KEY(*p, funcname) {
-			if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
+			if ((func = zend_hash_find_ptr(EG(function_table), funcname))) {
 				void *old_handler;
 				zend_observer_remove_begin_handler(func, observer_begin, (zend_observer_fcall_begin_handler *)&old_handler);
 				zend_observer_remove_end_handler(func, observer_end, (zend_observer_fcall_end_handler *)&old_handler);
@@ -338,7 +338,7 @@ static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 		zend_string_release(str);
 		if (stage != PHP_INI_STAGE_STARTUP && stage != PHP_INI_STAGE_ACTIVATE && stage != PHP_INI_STAGE_DEACTIVATE && stage != PHP_INI_STAGE_SHUTDOWN) {
 			ZEND_HASH_FOREACH_STR_KEY(*p, funcname) {
-				if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
+				if ((func = zend_hash_find_ptr(EG(function_table), funcname))) {
 					zend_observer_add_begin_handler(func, observer_begin);
 					zend_observer_add_end_handler(func, observer_end);
 				}


### PR DESCRIPTION
This fixes the following warning with gcc 14:

```
ext/zend_test/observer.c: In function ‘zend_test_observer_OnUpdateCommaList’:
ext/zend_test/observer.c:318:115: error: the comparison will always evaluate as ‘true’ for the pointer operand in ‘(((long unsigned int)func->common.run_time_cache__ptr & 1) != 0 ? (void **)*((void **)compiler_globals.map_ptr_base + (sizetype)func->common.run_time_cache__ptr) : func->common.run_time_cache__ptr) + (((unsigned char)func->type) != 1 ? (sizetype)((long unsigned int)zend_observer_fcall_op_array_extension * 8) : (sizetype)((long unsigned int)zend_observer_fcall_internal_function_extension * 8))’ must not be NULL [-Werror=address]
  318 |                         if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
      |                                                                                                                   ^~
ext/zend_test/observer.c:341:123: error: the comparison will always evaluate as ‘true’ for the pointer operand in ‘(((long unsigned int)func->common.run_time_cache__ptr & 1) != 0 ? (void **)*((void **)compiler_globals.map_ptr_base + (sizetype)func->common.run_time_cache__ptr) : func->common.run_time_cache__ptr) + (((unsigned char)func->type) != 1 ? (sizetype)((long unsigned int)zend_observer_fcall_op_array_extension * 8) : (sizetype)((long unsigned int)zend_observer_fcall_internal_function_extension * 8))’ must not be NULL [-Werror=address]
  341 |                                 if ((func = zend_hash_find_ptr(EG(function_table), funcname)) && ZEND_OBSERVER_DATA(func) != NULL) {
      |                                                                                                                           ^~
```

This looks similar to #13923, but I believe that the warning is right in this case: `ZEND_OBSERVER_DATA(func)` can not be `NULL` as it takes the address of `ZEND_OP_ARRAY_EXTENSION(...)`.