### PR TITLE
Fix use-after-free in ArrayObject::unset() with destructor

### DIFF
--- a/Zend/tests/gh16646.phpt
+++ b/Zend/tests/gh16646.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-16646: Use-after-free in ArrayObject::unset() with destructor
+--FILE--
+<?php
+
+class B {
+    public $b;
+    function __construct($arg) {
+        $this->b = $arg;
+    }
+}
+
+class C {
+    function __destruct() {
+        global $arr;
+        echo __METHOD__, "\n";
+        $arr->exchangeArray([]);
+    }
+}
+
+$arr = new ArrayObject(new B(new C));
+unset($arr["b"]);
+var_dump($arr);
+
+?>
+--EXPECT--
+C::__destruct
+object(ArrayObject)#1 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(0) {
+  }
+}

--- a/Zend/tests/gh16646_2.phpt
+++ b/Zend/tests/gh16646_2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-16646: Use-after-free in ArrayObject::exchangeArray() with destructor
+--FILE--
+<?php
+
+class C {
+    function __destruct() {
+        global $arr;
+        echo __METHOD__, "\n";
+        $arr->exchangeArray([]);
+    }
+}
+
+$arr = new ArrayObject(new C);
+$arr->exchangeArray([]);
+var_dump($arr);
+
+?>
+--EXPECT--
+C::__destruct
+object(ArrayObject)#1 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(0) {
+  }
+}

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -555,13 +555,15 @@ static void spl_array_unset_dimension_ex(int check_inherited, zend_object *objec
 			if (Z_TYPE_P(data) == IS_INDIRECT) {
 				data = Z_INDIRECT_P(data);
 				if (Z_TYPE_P(data) != IS_UNDEF) {
-					zval_ptr_dtor(data);
+					zval garbage;
+					ZVAL_COPY_VALUE(&garbage, data);
 					ZVAL_UNDEF(data);
 					HT_FLAGS(ht) |= HASH_FLAG_HAS_EMPTY_IND;
 					zend_hash_move_forward_ex(ht, spl_array_get_pos_ptr(ht, intern));
 					if (spl_array_is_object(intern)) {
 						spl_array_skip_protected(intern, ht);
 					}
+					zval_ptr_dtor(&garbage);
 				}
 			} else {
 				zend_hash_del(ht, key.key);

--- a/ext/spl/tests/gh16646.phpt
+++ b/ext/spl/tests/gh16646.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-16646: Test
+--FILE--
+<?php
+
+class B {
+    public $b;
+    function __construct($arg) {
+        $this->b = $arg;
+    }
+}
+
+class C {
+    function __destruct() {
+        global $arr;
+        echo __METHOD__, "\n";
+        $arr->exchangeArray([]);
+    }
+}
+
+$arr = new ArrayObject(new B(new C));
+unset($arr["b"]);
+var_dump($arr);
+
+?>
+--EXPECT--
+C::__destruct
+object(ArrayObject)#1 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
Fixes GH-16646