### PR TITLE
Properly initialize _override executor globals

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -803,6 +803,8 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	executor_globals->record_errors = false;
 	executor_globals->num_errors = 0;
 	executor_globals->errors = NULL;
+	executor_globals->filename_override = NULL;
+	executor_globals->lineno_override = 0;
 #ifdef ZEND_MAX_EXECUTION_TIMERS
 	executor_globals->pid = 0;
 	executor_globals->oldact = (struct sigaction){0};

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -804,7 +804,7 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
 	executor_globals->num_errors = 0;
 	executor_globals->errors = NULL;
 	executor_globals->filename_override = NULL;
-	executor_globals->lineno_override = 0;
+	executor_globals->lineno_override = -1;
 #ifdef ZEND_MAX_EXECUTION_TIMERS
 	executor_globals->pid = 0;
 	executor_globals->oldact = (struct sigaction){0};


### PR DESCRIPTION
These have been introduced a while ago[1], but their initialization has been overlooked.  Since we cannot rely on TLS variables to be zeroed, we catch up on this.

[1] <https://github.com/php/php-src/commit/e3ef7bbbb87bcbf6154a0a4854127b9cea8f92ff>

---

Notice<ins>d</ins> this due to https://github.com/php/php-src/actions/runs/11615281464/job/32345470147#step:6:79. Since extensions might access `EG(filename_override)` and `EG_(lineno_override)` we better fix this for all affected PHP versions.

cc @iluuu1994 