### PR TITLE
Fix ICU version specific skip reasons of intl tests

### DIFF
--- a/ext/intl/tests/breakiter_getPartsIterator_basic2.phpt
+++ b/ext/intl/tests/breakiter_getPartsIterator_basic2.phpt
@@ -4,7 +4,7 @@ IntlBreakIterator::getPartsIterator(): basic test, ICU >= 58.1
 intl
 --SKIPIF--
 <?php
-if (version_compare(INTL_ICU_VERSION, '57.1') <= 0) die('skip for ICU >= 58.1');
+if (version_compare(INTL_ICU_VERSION, '57.1') <= 0) die('skip for ICU > 57.1');
 ?>
 --FILE--
 <?php

--- a/ext/intl/tests/breakiter_preceding_basic2.phpt
+++ b/ext/intl/tests/breakiter_preceding_basic2.phpt
@@ -4,7 +4,7 @@ IntlBreakIterator::preceding(): basic test, ICU >= 58.1
 intl
 --SKIPIF--
 <?php
-if (version_compare(INTL_ICU_VERSION, '57.1') <= 0) die('skip for ICU >= 58.1');
+if (version_compare(INTL_ICU_VERSION, '57.1') <= 0) die('skip for ICU > 57.1');
 ?>
 --FILE--
 <?php

--- a/ext/intl/tests/bug69374.phpt
+++ b/ext/intl/tests/bug69374.phpt
@@ -3,7 +3,7 @@ IntlDateFormatter::formatObject(): returns wrong utf8 value when $format param i
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') < 0) die('skip for ICU >= 51.1.2'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') < 0) die('skip for ICU >= 50.1.2'); ?>
 --FILE--
 <?php
 $millitimestamp = 1428133423941.0; // 14:43:43 April 04 2015

--- a/ext/intl/tests/bug69398.phpt
+++ b/ext/intl/tests/bug69398.phpt
@@ -4,8 +4,8 @@ IntlDateFormatter::formatObject(): returns wrong value when time style is NONE.
 intl
 --SKIPIF--
 <?php
-if (version_compare(INTL_ICU_VERSION, '50.1.2') < 0) die('skip for ICU < 51.1.2');
-if (version_compare(INTL_ICU_VERSION, '74.1') >= 0) die('skip for ICU >= 74.1');
+if (version_compare(INTL_ICU_VERSION, '50.1.2') < 0) die('skip for ICU >= 50.1.2');
+if (version_compare(INTL_ICU_VERSION, '74.1') >= 0) die('skip for ICU < 74.1');
 ?>
 --FILE--
 <?php

--- a/ext/intl/tests/collator_get_sort_key_variant4.phpt
+++ b/ext/intl/tests/collator_get_sort_key_variant4.phpt
@@ -3,8 +3,8 @@ collator_get_sort_key() icu >= 54.1
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '55.1') >=  0) die('skip for ICU < 55.1'); ?>
 <?php if (version_compare(INTL_ICU_VERSION, '54.1') < 0) die('skip for ICU >= 54.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '55.1') >=  0) die('skip for ICU < 55.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/collator_get_sort_key_variant5.phpt
+++ b/ext/intl/tests/collator_get_sort_key_variant5.phpt
@@ -3,8 +3,8 @@ collator_get_sort_key() icu >= 55.1
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '56.1') >=  0) die('skip for ICU < 56.1'); ?>
 <?php if (version_compare(INTL_ICU_VERSION, '55.1') < 0) die('skip for ICU >= 55.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '56.1') >=  0) die('skip for ICU < 56.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/dateformat_create_cal_arg_variant4.phpt
+++ b/ext/intl/tests/dateformat_create_cal_arg_variant4.phpt
@@ -4,7 +4,7 @@ IntlDateFormatter: several forms of the calendar arg
 intl
 --SKIPIF--
 <?php if (version_compare(INTL_ICU_VERSION, '54.1') < 0) die('skip for ICU >= 54.1'); ?>
-<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU < 58.1'); ?>
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_formatObject_datetime_variant_icu72-1.phpt
+++ b/ext/intl/tests/dateformat_formatObject_datetime_variant_icu72-1.phpt
@@ -3,7 +3,7 @@ IntlDateFormatter::formatObject(): DateTime tests
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '72.1') < 0) die('skip for ICU < 72.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '72.1') < 0) die('skip for ICU >= 72.1'); ?>
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/dateformat_get_set_calendar_variant4.phpt
+++ b/ext/intl/tests/dateformat_get_set_calendar_variant4.phpt
@@ -4,7 +4,7 @@ IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject()
 intl
 --SKIPIF--
 <?php if (version_compare(INTL_ICU_VERSION, '54.1') < 0) die('skip for ICU >= 54.1'); ?>
-<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU < 58.1'); ?>
 --FILE--
 <?php
 ini_set("intl.error_level", E_WARNING);

--- a/ext/intl/tests/formatter_format2.phpt
+++ b/ext/intl/tests/formatter_format2.phpt
@@ -3,7 +3,7 @@ numfmt_format() icu >= 4.8
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '52.1') >=  0) die('skip for ICU <= 52.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '52.1') >=  0) die('skip for ICU < 52.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/formatter_format5.phpt
+++ b/ext/intl/tests/formatter_format5.phpt
@@ -3,8 +3,8 @@ numfmt_format() icu >= 54.1 && icu < 56.1
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '56.1') >=  0) die('skip for ICU < 56.1'); ?>
 <?php if (version_compare(INTL_ICU_VERSION, '54.1') < 0) die('skip for ICU >= 54.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '56.1') >=  0) die('skip for ICU < 56.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/formatter_format6.phpt
+++ b/ext/intl/tests/formatter_format6.phpt
@@ -3,8 +3,8 @@ numfmt_format() icu >= 56.1 && icu < 61.1
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '61.1') >= 0) die('skip for ICU < 61.1'); ?>
 <?php if (version_compare(INTL_ICU_VERSION, '56.1') < 0) die('skip for ICU >= 56.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '61.1') >= 0) die('skip for ICU < 61.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/locale_get_display_region2.phpt
+++ b/ext/intl/tests/locale_get_display_region2.phpt
@@ -3,7 +3,7 @@ locale_get_display_region() icu >= 4.8 && icu < 51.2
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') >=  0) die('skip for ICU <= 50.1.2'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '50.1.2') >=  0) die('skip for ICU < 50.1.2'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/rbbiter_getBinaryRules_basic2.phpt
+++ b/ext/intl/tests/rbbiter_getBinaryRules_basic2.phpt
@@ -3,7 +3,7 @@ IntlRuleBasedBreakIterator::getBinaryRules(): basic test icu >= 61.1 && icu < 68
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if(version_compare(INTL_ICU_VERSION, '61.1') < 0) print 'skip ICU >= 61.1 only'; ?>
+<?php if(version_compare(INTL_ICU_VERSION, '61.1') < 0) print 'skip for ICU >= 61.1'; ?>
 <?php if (version_compare(INTL_ICU_VERSION, '68.1') >= 0) die('skip for ICU < 68.1'); ?>
 --FILE--
 <?php

--- a/ext/intl/tests/spoofchecker_001.phpt
+++ b/ext/intl/tests/spoofchecker_001.phpt
@@ -4,7 +4,7 @@ spoofchecker suspicious character checker
 intl
 --SKIPIF--
 <?php if(!class_exists("Spoofchecker")) print 'skip'; ?>
-<?php if (version_compare(INTL_ICU_VERSION, '57.1') >= 0)die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '57.1') >= 0)die('skip for ICU < 57.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/spoofchecker_006.phpt
+++ b/ext/intl/tests/spoofchecker_006.phpt
@@ -4,7 +4,7 @@ spoofchecker suspicious character checker
 intl
 --SKIPIF--
 <?php if(!class_exists("Spoofchecker")) print 'skip'; ?>
-<?php if (version_compare(INTL_ICU_VERSION, '57.1') < 0) die('skip for ICU >= 58.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '57.1') < 0) die('skip for ICU >= 57.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/timezone_IDforWindowsID_basic.phpt
+++ b/ext/intl/tests/timezone_IDforWindowsID_basic.phpt
@@ -4,7 +4,7 @@ IntlTimeZone::getIDForWindowsID basic test
 intl
 --SKIPIF--
 <?php if (version_compare(INTL_ICU_VERSION, '52') < 0)die('skip for ICU >= 52'); ?>
-<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU < 58.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/timezone_windowsID_basic.phpt
+++ b/ext/intl/tests/timezone_windowsID_basic.phpt
@@ -4,7 +4,7 @@ IntlTimeZone::getWindowsID basic test
 intl
 --SKIPIF--
 <?php if (version_compare(INTL_ICU_VERSION, '52') < 0)die('skip for ICU >= 52'); ?>
-<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU < 58.1'); ?>
 --FILE--
 <?php
 

--- a/ext/intl/tests/uconverter_oop_callback.phpt
+++ b/ext/intl/tests/uconverter_oop_callback.phpt
@@ -3,7 +3,7 @@ UConverter::convert() w/ Callback Reasons
 --EXTENSIONS--
 intl
 --SKIPIF--
-<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU <= 57.1'); ?>
+<?php if (version_compare(INTL_ICU_VERSION, '58.1') >= 0) die('skip for ICU < 58.1'); ?>
 --FILE--
 <?php
 class MyConverter extends UConverter {


### PR DESCRIPTION
* Some tests have this backwards, probably reading "skip for ICU …". However, that is not how skip reasons are handled.
* Some test seems to have typos in the skip reason version.
* Some tests checked for a certain version, but reported the *presumably* next version, which is confusing at best.
* Some tests checked versions in descending order, what is not wrong, but confusing.
* Some tests had off by one errors.

For all tests, we assume that the skipif conditions are correct, and fix the reasons.

---

Note that I made this in preparation for #16659, to not completely loose my sanity.