### PR TITLE
Fix nightly workflow dispatch

### DIFF
--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -1,6 +1,12 @@
 <?php
 
-const BRANCHES = ['master', 'PHP-8.4', 'PHP-8.3', 'PHP-8.2', 'PHP-8.1'];
+const BRANCHES = [
+    ['ref' => 'master', 'version' => [8, 5]],
+    ['ref' => 'PHP-8.4', 'version' => [8, 4]],
+    ['ref' => 'PHP-8.3', 'version' => [8, 3]],
+    ['ref' => 'PHP-8.2', 'version' => [8, 2]],
+    ['ref' => 'PHP-8.1', 'version' => [8, 1]],
+];
 
 function get_branch_commit_cache_file_path(): string {
     return dirname(__DIR__) . '/branch-commit-cache.json';
@@ -15,19 +21,29 @@ function get_branches() {
 
     $changed_branches = [];
     foreach (BRANCHES as $branch) {
-        $previous_commit_hash = $branch_commit_map[$branch] ?? null;
-        $current_commit_hash = trim(shell_exec('git rev-parse origin/' . $branch));
+        $previous_commit_hash = $branch_commit_map[$branch['ref']] ?? null;
+        $current_commit_hash = trim(shell_exec('git rev-parse origin/' . $branch['ref']));
 
         if ($previous_commit_hash !== $current_commit_hash) {
             $changed_branches[] = $branch;
         }
 
-        $branch_commit_map[$branch] = $current_commit_hash;
+        $branch_commit_map[$branch['ref']] = $current_commit_hash;
     }
 
     file_put_contents($branch_commit_cache_file, json_encode($branch_commit_map));
 
     return $changed_branches;
+}
+
+function get_current_version(): array {
+    $file = dirname(__DIR__) . '/main/php_version.h';
+    $content = file_get_contents($file);
+    preg_match('(^#define PHP_MAJOR_VERSION (?<num>\d+)$)m', $content, $matches);
+    $major = (int) $matches['num'];
+    preg_match('(^#define PHP_MINOR_VERSION (?<num>\d+)$)m', $content, $matches);
+    $minor = (int) $matches['num'];
+    return [$major, $minor];
 }
 
 $trigger = $argv[1] ?? 'schedule';
@@ -40,7 +56,9 @@ if ($discard_cache) {
     @unlink(get_branch_commit_cache_file_path());
 }
 $branch = $argv[3] ?? 'master';
-$branches = $branch === 'master' ? get_branches() : [$branch];
+$branches = $branch === 'master'
+    ? get_branches()
+    : [['ref' => $branch, 'version' => get_current_version()]];
 
 $f = fopen(getenv('GITHUB_OUTPUT'), 'a');
 fwrite($f, 'branches=' . json_encode($branches, JSON_UNESCAPED_SLASHES) . "\n");

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -36,78 +36,22 @@ jobs:
         uses: ./.github/actions/notify-slack
         with:
           token: ${{ secrets.ACTION_MONITORING_SLACK }}
-  NIGHTLY_MASTER:
-    name: master
+  NIGHTLY:
     needs: GENERATE_MATRIX
-    if: contains(needs.GENERATE_MATRIX.outputs.branches, 'master')
+    name: ${{ matrix.branch.ref }}
+    if: ${{ needs.GENERATE_MATRIX.outputs.branches != '[]' }}
     uses: ./.github/workflows/nightly.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.GENERATE_MATRIX.outputs.branches) }}
     with:
       asan_ubuntu_version: '20.04'
-      branch: master
-      community_verify_type_inference: true
-      libmysqlclient_with_mysqli: false
-      run_alpine: true
-      run_macos_arm64: true
-      ubuntu_version: '22.04'
-      windows_version: '2022'
-    secrets: inherit
-  NIGHTLY_84:
-    name: PHP-8.4
-    needs: GENERATE_MATRIX
-    if: contains(needs.GENERATE_MATRIX.outputs.branches, 'PHP-8.4')
-    uses: ./.github/workflows/nightly.yml
-    with:
-      asan_ubuntu_version: '20.04'
-      branch: PHP-8.4
-      community_verify_type_inference: true
-      libmysqlclient_with_mysqli: false
-      run_alpine: true
-      run_macos_arm64: true
-      ubuntu_version: '22.04'
-      windows_version: '2022'
-    secrets: inherit
-  NIGHTLY_83:
-    name: PHP-8.3
-    needs: GENERATE_MATRIX
-    if: contains(needs.GENERATE_MATRIX.outputs.branches, 'PHP-8.3')
-    uses: ./.github/workflows/nightly.yml
-    with:
-      asan_ubuntu_version: '20.04'
-      branch: PHP-8.3
-      community_verify_type_inference: false
-      libmysqlclient_with_mysqli: false
-      run_alpine: false
-      run_macos_arm64: false
-      ubuntu_version: '22.04'
-      windows_version: '2019'
-    secrets: inherit
-  NIGHTLY_82:
-    name: PHP-8.2
-    needs: GENERATE_MATRIX
-    if: contains(needs.GENERATE_MATRIX.outputs.branches, 'PHP-8.2')
-    uses: ./.github/workflows/nightly.yml
-    with:
-      asan_ubuntu_version: '20.04'
-      branch: PHP-8.2
-      community_verify_type_inference: false
-      libmysqlclient_with_mysqli: false
-      run_alpine: false
-      run_macos_arm64: false
-      ubuntu_version: '20.04'
-      windows_version: '2019'
-    secrets: inherit
-  NIGHTLY_81:
-    name: PHP-8.1
-    needs: GENERATE_MATRIX
-    if: contains(needs.GENERATE_MATRIX.outputs.branches, 'PHP-8.1')
-    uses: ./.github/workflows/nightly.yml
-    with:
-      asan_ubuntu_version: '20.04'
-      branch: PHP-8.1
-      community_verify_type_inference: false
-      libmysqlclient_with_mysqli: true
-      run_alpine: false
-      run_macos_arm64: false
-      ubuntu_version: '20.04'
-      windows_version: '2019'
+      branch: ${{ matrix.branch.ref }}
+      community_verify_type_inference: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
+      libmysqlclient_with_mysqli: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1) }}
+      run_alpine: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
+      run_macos_arm64: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
+      ubuntu_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 3) || matrix.branch.version[0] >= 9) && '22.04' || '20.04' }}
+      windows_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9) && '2022' || '2019' }}
     secrets: inherit


### PR DESCRIPTION
Unfortunately, we need to re-add the `get_current_version()` logic since we have no way to know what version we are operating on otherwise. This also means I had to replace the inputs again with version expressions.