### PR TITLE
Fix bug77578.phpt

### DIFF
--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -56,7 +56,7 @@ void free_zend_constant(zval *zv)
 			zend_string_release_ex(c->name, 1);
 		}
 		if (c->filename) {
-			zend_string_release_ex(c->filename, 1);
+			zend_string_release(c->filename);
 		}
 		free(c);
 	}

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -56,7 +56,7 @@ void free_zend_constant(zval *zv)
 			zend_string_release_ex(c->name, 1);
 		}
 		if (c->filename) {
-			zend_string_release(c->filename);
+			zend_string_release_ex(c->filename, 1);
 		}
 		free(c);
 	}

--- a/ext/com_dotnet/tests/bug77578.phpt
+++ b/ext/com_dotnet/tests/bug77578.phpt
@@ -6,18 +6,33 @@ com_dotnet
 <?php
 // To actually be able to verify the crash during shutdown on Windows, we have
 // to execute a PHP subprocess, and check its exit status.
+
+// First we determine whether com_dotnet would be loaded in the subprocess
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
-$extension_dir = escapeshellarg(ini_get("extension_dir"));
 $script = <<<SCRIPT
-if (!extension_loaded('com_dotnet')) dl('com_dotnet');
+echo extension_loaded('com_dotnet') ? 'yes' : 'no';
+SCRIPT;
+exec("$php -r \"$script\"", $output);
+var_dump(isset($output[0]));
+$loaded = $output[0] === "yes";
+$output = null;
+
+// Then we run the subprocess with com_dotnet loaded
+$script = <<<SCRIPT
 ini_set('com.autoregister_typelib', '1');
 new COM('WbemScripting.SWbemLocator');
 SCRIPT;
-$command = "$php -d extension_dir=$extension_dir -r \"$script\"";
+if ($loaded) {
+    $command = "$php -r \"$script\"";
+} else {
+    $extension_dir = escapeshellarg(ini_get("extension_dir"));
+    $command = "$php -d extension_dir=$extension_dir -d extension=com_dotnet -r \"$script\"";
+}
 exec($command, $output, $status);
 var_dump($output, $status);
 ?>
 --EXPECT--
+bool(true)
 array(0) {
 }
 int(0)


### PR DESCRIPTION
The test fails since PR #15847 has been merged. This patch should fix the test, but is certainly not complete. I haven't had the time to look closer into this issue, but it seems that the assumption that a persistent constant also has a persistent filename is not generally valid (in this case, `dl()` is involved). So this needs closer investigation, but this fix might be pulled to  get CI back to green.