### PR TITLE
Fix GH-16601: Memory leak in Reflection constructors

### DIFF
--- a/ext/reflection/tests/ReflectionExtension_double_construct.phpt
+++ b/ext/reflection/tests/ReflectionExtension_double_construct.phpt
@@ -1,0 +1,20 @@
+--TEST--
+ReflectionExtension double construct call
+--FILE--
+<?php
+
+$r = new ReflectionExtension('standard');
+var_dump($r);
+$r->__construct('standard');
+var_dump($r);
+
+?>
+--EXPECT--
+object(ReflectionExtension)#1 (1) {
+  ["name"]=>
+  string(8) "standard"
+}
+object(ReflectionExtension)#1 (1) {
+  ["name"]=>
+  string(8) "standard"
+}

--- a/ext/reflection/tests/ReflectionObject_double_construct.phpt
+++ b/ext/reflection/tests/ReflectionObject_double_construct.phpt
@@ -1,0 +1,21 @@
+--TEST--
+ReflectionObject double construct call
+--FILE--
+<?php
+
+$obj = new stdClass;
+$r = new ReflectionObject($obj);
+var_dump($r);
+$r->__construct($obj);
+var_dump($r);
+
+?>
+--EXPECT--
+object(ReflectionObject)#2 (1) {
+  ["name"]=>
+  string(8) "stdClass"
+}
+object(ReflectionObject)#2 (1) {
+  ["name"]=>
+  string(8) "stdClass"
+}

--- a/ext/reflection/tests/ReflectionParameter_double_construct.phpt
+++ b/ext/reflection/tests/ReflectionParameter_double_construct.phpt
@@ -1,0 +1,27 @@
+--TEST--
+ReflectionParameter double construct call
+--FILE--
+<?php
+
+$closure = function (int $x): void {};
+$r = new ReflectionParameter($closure, 'x');
+var_dump($r);
+$r->__construct($closure, 'x');
+var_dump($r);
+$r->__construct('ord', 'character');
+var_dump($r);
+
+?>
+--EXPECT--
+object(ReflectionParameter)#2 (1) {
+  ["name"]=>
+  string(1) "x"
+}
+object(ReflectionParameter)#2 (1) {
+  ["name"]=>
+  string(1) "x"
+}
+object(ReflectionParameter)#2 (1) {
+  ["name"]=>
+  string(9) "character"
+}

--- a/ext/reflection/tests/ReflectionProperty_double_construct.phpt
+++ b/ext/reflection/tests/ReflectionProperty_double_construct.phpt
@@ -1,0 +1,24 @@
+--TEST--
+ReflectionProperty double construct call
+--FILE--
+<?php
+
+$r = new ReflectionProperty(Exception::class, 'message');
+var_dump($r);
+$r->__construct(Exception::class, 'message');
+var_dump($r);
+
+?>
+--EXPECT--
+object(ReflectionProperty)#1 (2) {
+  ["name"]=>
+  string(7) "message"
+  ["class"]=>
+  string(9) "Exception"
+}
+object(ReflectionProperty)#1 (2) {
+  ["name"]=>
+  string(7) "message"
+  ["class"]=>
+  string(9) "Exception"
+}


### PR DESCRIPTION
Additionally fixes wrong behaviour in ReflectionParameter when you first have a construction that uses an object and the subsequent doesn't.