### PR TITLE
run-tests: drop hrtime() polyfill

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -784,23 +784,6 @@ function main(): void
     }
 }
 
-if (!function_exists("hrtime")) {
-    /**
-     * @return array|float|int
-     */
-    function hrtime(bool $as_num = false)
-    {
-        $t = microtime(true);
-
-        if ($as_num) {
-            return $t * 1000000000;
-        }
-
-        $s = floor($t);
-        return [0 => $s, 1 => ($t - $s) * 1000000000];
-    }
-}
-
 function verify_config(string $php): void
 {
     if (empty($php) || !file_exists($php)) {


### PR DESCRIPTION
https://www.php.net/hrtime seems to be available since 7.3+, so I think we don't need this polyfill anymore