### PR TITLE
ext/posix: adding POSIX_SC_OPEN_MAX constant.

### DIFF
--- a/ext/posix/posix.stub.php
+++ b/ext/posix/posix.stub.php
@@ -303,6 +303,13 @@ const POSIX_PC_ALLOC_SIZE_MIN = UNKNOWN;
  */
 const POSIX_PC_SYMLINK_MAX = UNKNOWN;
 #endif
+#ifdef _SC_OPEN_MAX
+/**
+ * @var int
+ * @cvalue _SC_OPEN_MAX
+ */
+const POSIX_SC_OPEN_MAX = UNKNOWN;
+#endif
 
 function posix_kill(int $process_id, int $signal): bool {}
 

--- a/ext/posix/posix_arginfo.h
+++ b/ext/posix/posix_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82caf527a8ec686bc450e5d782bb79275d5a13e3 */
+ * Stub hash: 25e0aa769d72988ebca07fff96c8ed1fcb6b7d5e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_kill, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
@@ -460,5 +460,8 @@ static void register_posix_symbols(int module_number)
 #endif
 #if defined(_PC_SYMLINK_MAX)
 	REGISTER_LONG_CONSTANT("POSIX_PC_SYMLINK_MAX", _PC_SYMLINK_MAX, CONST_PERSISTENT);
+#endif
+#if defined(_SC_OPEN_MAX)
+	REGISTER_LONG_CONSTANT("POSIX_SC_OPEN_MAX", _SC_OPEN_MAX, CONST_PERSISTENT);
 #endif
 }

--- a/ext/posix/tests/posix_sysconf.phpt
+++ b/ext/posix/tests/posix_sysconf.phpt
@@ -7,8 +7,10 @@ posix
 var_dump(posix_sysconf(-1));
 var_dump(posix_errno() != 0);
 var_dump(posix_sysconf(POSIX_SC_NPROCESSORS_ONLN));
+var_dump(posix_sysconf(POSIX_SC_OPEN_MAX) >= 256);
 ?>
 --EXPECTF--
 int(-1)
 bool(false)
 int(%d)
+bool(true)


### PR DESCRIPTION
returns the number of file descriptors that a process can handle. e.g. useful after pcntl_fork() to close all the file descriptors up to that boundary.