### PR TITLE
Fix GH-16665: \array and \callable should not be usable

### DIFF
--- a/Zend/tests/gh16665_1.phpt
+++ b/Zend/tests/gh16665_1.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-16665 (\array should not be usable)
+--FILE--
+<?php
+class_alias('stdClass', 'array');
+?>
+--EXPECTF--
+Fatal error: Cannot use "array" as a class alias as it is reserved in %s on line %d

--- a/Zend/tests/gh16665_2.phpt
+++ b/Zend/tests/gh16665_2.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-16665 (\callable should not be usable)
+--FILE--
+<?php
+class_alias('stdClass', 'callable');
+?>
+--EXPECTF--
+Fatal error: Cannot use "callable" as a class alias as it is reserved in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -214,6 +214,10 @@ static const struct reserved_class_name reserved_class_names[] = {
 	{ZEND_STRL("iterable")},
 	{ZEND_STRL("object")},
 	{ZEND_STRL("mixed")},
+	/* These are not usable as class names because they're proper tokens,
+	 * but they are here for class aliases. */
+	{ZEND_STRL("array")},
+	{ZEND_STRL("callable")},
 	{NULL, 0}
 };
 


### PR DESCRIPTION
This list was initially introduced in 53a40386, but never included array or callable. I suppose this is because int & friends are not actual tokens, while array and callable are. This means it was never possible to do class array, which is probably the reason this was overlooked.