### PR TITLE
Minor refactorings to zend_exceptions()

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -540,7 +540,6 @@ static void _build_trace_string(smart_str *str, const HashTable *ht, uint32_t nu
 	file = zend_hash_find_known_hash(ht, ZSTR_KNOWN(ZEND_STR_FILE));
 	if (file) {
 		if (UNEXPECTED(Z_TYPE_P(file) != IS_STRING)) {
-			/* This is a typed property and can only happen if modified via ArrayObject */
 			zend_error(E_WARNING, "File name is not a string");
 			smart_str_appends(str, "[unknown file]: ");
 		} else{
@@ -550,7 +549,6 @@ static void _build_trace_string(smart_str *str, const HashTable *ht, uint32_t nu
 				if (EXPECTED(Z_TYPE_P(tmp) == IS_LONG)) {
 					line = Z_LVAL_P(tmp);
 				} else {
-					/* This is a typed property and can only happen if modified via ArrayObject */
 					zend_error(E_WARNING, "Line is not an int");
 				}
 			}
@@ -585,7 +583,6 @@ static void _build_trace_string(smart_str *str, const HashTable *ht, uint32_t nu
 				ZSTR_LEN(str->s) -= 2; /* remove last ', ' */
 			}
 		} else {
-			/* The trace property is typed and private */
 			zend_error(E_WARNING, "args element is not an array");
 		}
 	}

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -72,7 +72,7 @@ extern ZEND_API void (*zend_throw_exception_hook)(zend_object *ex);
 /* show an exception using zend_error(severity,...), severity should be E_ERROR */
 ZEND_API ZEND_COLD zend_result zend_exception_error(zend_object *exception, int severity);
 ZEND_NORETURN void zend_exception_uncaught_error(const char *prefix, ...) ZEND_ATTRIBUTE_FORMAT(printf, 1, 2);
-ZEND_API zend_string *zend_trace_to_string(HashTable *trace, bool include_main);
+ZEND_API zend_string *zend_trace_to_string(const HashTable *trace, bool include_main);
 
 ZEND_API ZEND_COLD zend_object *zend_create_unwind_exit(void);
 ZEND_API ZEND_COLD zend_object *zend_create_graceful_exit(void);


### PR DESCRIPTION
I was planning on removing a bunch of `zval_get_long()` and `zval_get_string()` calls to properties as those are typed properties, however not sure it is wise to remove them as `ArrayObject` can in theory mess them up.