### PR TITLE
ext/gmp: Improve parsing of parameters

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -481,7 +481,8 @@ static int gmp_compare(zval *op1, zval *op2) /* {{{ */
 		}
 		return ZEND_UNCOMPARABLE;
 	}
-	return mpz_cmp(gmp_op1, gmp_op2);
+
+	return ZEND_THREEWAY_COMPARE(mpz_cmp(gmp_op1, gmp_op2), 0);
 }
 /* }}} */
 
@@ -1436,7 +1437,7 @@ ZEND_FUNCTION(gmp_cmp)
 		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_b)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_LONG(mpz_cmp(gmpnum_a, gmpnum_b));
+	RETURN_LONG(ZEND_THREEWAY_COMPARE(mpz_cmp(gmpnum_a, gmpnum_b), 0));
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1262,33 +1262,23 @@ GMP_BINARY_OP_FUNCTION_EX(gmp_or, mpz_ior);
 /* {{{ Calculates factorial function */
 ZEND_FUNCTION(gmp_fact)
 {
-	zval *a_arg;
+	mpz_ptr gmpnum;
 	mpz_ptr gmpnum_result;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_ZVAL(a_arg)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (Z_TYPE_P(a_arg) == IS_LONG) {
-		if (Z_LVAL_P(a_arg) < 0) {
-			zend_argument_value_error(1, "must be greater than or equal to 0");
-			RETURN_THROWS();
-		}
-	} else {
-		mpz_ptr gmpnum;
-		gmp_temp_t temp_a;
-
-		FETCH_GMP_ZVAL(gmpnum, a_arg, temp_a, 1);
-		FREE_GMP_TEMP(temp_a);
-
-		if (mpz_sgn(gmpnum) < 0) {
-			zend_argument_value_error(1, "must be greater than or equal to 0");
-			RETURN_THROWS();
-		}
+	if (mpz_sgn(gmpnum) < 0) {
+		zend_argument_value_error(1, "must be greater than or equal to 0");
+		RETURN_THROWS();
 	}
 
+	// TODO: Check that we don't an int that is larger than an unsigned long?
+	// Could use mpz_fits_slong_p() if we revert to using mpz_get_si()
+
 	INIT_GMP_RETVAL(gmpnum_result);
-	mpz_fac_ui(gmpnum_result, zval_get_long(a_arg));
+	mpz_fac_ui(gmpnum_result, mpz_get_ui(gmpnum));
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1666,14 +1666,14 @@ ZEND_FUNCTION(gmp_kronecker)
 /* {{{ Compares two numbers */
 ZEND_FUNCTION(gmp_cmp)
 {
-	zval *a_arg, *b_arg;
+	mpz_ptr gmpnum_a, gmpnum_b;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_ZVAL(a_arg)
-		Z_PARAM_ZVAL(b_arg)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_a)
+		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_b)
 	ZEND_PARSE_PARAMETERS_END();
 
-	gmp_cmp(return_value, a_arg, b_arg, /* is_operator */ false);
+	RETURN_LONG(mpz_cmp(gmpnum_a, gmpnum_b));
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -231,6 +231,16 @@ static bool gmp_zend_parse_arg_into_mpz(
  */
 typedef void (*gmp_unary_op_t)(mpz_ptr, mpz_srcptr);
 
+#define GMP_UNARY_OP_FUNCTION(name) \
+	ZEND_FUNCTION(gmp_##name) { \
+		mpz_ptr gmpnum_a, gmpnum_result; \
+		ZEND_PARSE_PARAMETERS_START(1, 1) \
+			GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_a) \
+		ZEND_PARSE_PARAMETERS_END(); \
+		INIT_GMP_RETVAL(gmpnum_result); \
+		mpz_##name(gmpnum_result, gmpnum_a); \
+	}
+
 typedef void (*gmp_unary_ui_op_t)(mpz_ptr, gmp_ulong);
 
 typedef void (*gmp_binary_op_t)(mpz_ptr, mpz_srcptr, mpz_srcptr);
@@ -273,9 +283,6 @@ static void gmp_mpz_gcd_ui(mpz_ptr a, mpz_srcptr b, gmp_ulong c) {
 #define gmp_binary_op(op)         _gmp_binary_ui_op(INTERNAL_FUNCTION_PARAM_PASSTHRU, op, NULL, 0)
 #define gmp_binary_ui_op_no_zero(op, uop) \
 	_gmp_binary_ui_op(INTERNAL_FUNCTION_PARAM_PASSTHRU, op, uop, 1)
-
-/* Unary operations */
-#define gmp_unary_op(op)         _gmp_unary_op(INTERNAL_FUNCTION_PARAM_PASSTHRU, op)
 
 static void gmp_free_object_storage(zend_object *obj) /* {{{ */
 {
@@ -959,19 +966,6 @@ static inline void gmp_zval_unary_op(zval *return_value, zval *a_arg, gmp_unary_
 }
 /* }}} */
 
-/* {{{ _gmp_unary_op */
-static inline void _gmp_unary_op(INTERNAL_FUNCTION_PARAMETERS, gmp_unary_op_t gmp_op)
-{
-	zval *a_arg;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_ZVAL(a_arg)
-	ZEND_PARSE_PARAMETERS_END();
-
-	gmp_zval_unary_op(return_value, a_arg, gmp_op);
-}
-/* }}} */
-
 static bool gmp_verify_base(zend_long base, uint32_t arg_num)
 {
 	if (base && (base < 2 || base > GMP_MAX_BASE)) {
@@ -1298,18 +1292,13 @@ ZEND_FUNCTION(gmp_divexact)
 /* }}} */
 
 /* {{{ Negates a number */
-ZEND_FUNCTION(gmp_neg)
-{
-	gmp_unary_op(mpz_neg);
-}
-/* }}} */
-
+GMP_UNARY_OP_FUNCTION(neg);
 /* {{{ Calculates absolute value */
-ZEND_FUNCTION(gmp_abs)
-{
-	gmp_unary_op(mpz_abs);
-}
-/* }}} */
+GMP_UNARY_OP_FUNCTION(abs);
+/* {{{ Calculates one's complement of a */
+GMP_UNARY_OP_FUNCTION(com);
+/* {{{ Finds next prime of a */
+GMP_UNARY_OP_FUNCTION(nextprime);
 
 /* {{{ Calculates factorial function */
 ZEND_FUNCTION(gmp_fact)
@@ -1844,20 +1833,6 @@ ZEND_FUNCTION(gmp_and)
 ZEND_FUNCTION(gmp_or)
 {
 	gmp_binary_op(mpz_ior);
-}
-/* }}} */
-
-/* {{{ Calculates one's complement of a */
-ZEND_FUNCTION(gmp_com)
-{
-	gmp_unary_op(mpz_com);
-}
-/* }}} */
-
-/* {{{ Finds next prime of a */
-ZEND_FUNCTION(gmp_nextprime)
-{
-	gmp_unary_op(mpz_nextprime);
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -194,7 +194,6 @@ static void gmp_cmp(zval *return_value, zval *a_arg, zval *b_arg, bool is_operat
  * include parameter parsing.
  */
 typedef void (*gmp_unary_op_t)(mpz_ptr, mpz_srcptr);
-typedef mp_bitcnt_t (*gmp_unary_opl_t)(mpz_srcptr);
 
 typedef void (*gmp_unary_ui_op_t)(mpz_ptr, gmp_ulong);
 
@@ -241,7 +240,6 @@ static void gmp_mpz_gcd_ui(mpz_ptr a, mpz_srcptr b, gmp_ulong c) {
 
 /* Unary operations */
 #define gmp_unary_op(op)         _gmp_unary_op(INTERNAL_FUNCTION_PARAM_PASSTHRU, op)
-#define gmp_unary_opl(op)         _gmp_unary_opl(INTERNAL_FUNCTION_PARAM_PASSTHRU, op)
 
 static void gmp_free_object_storage(zend_object *obj) /* {{{ */
 {
@@ -925,23 +923,6 @@ static inline void _gmp_unary_op(INTERNAL_FUNCTION_PARAMETERS, gmp_unary_op_t gm
 	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_zval_unary_op(return_value, a_arg, gmp_op);
-}
-/* }}} */
-
-/* {{{ _gmp_unary_opl */
-static inline void _gmp_unary_opl(INTERNAL_FUNCTION_PARAMETERS, gmp_unary_opl_t gmp_op)
-{
-	zval *a_arg;
-	mpz_ptr gmpnum_a;
-	gmp_temp_t temp_a;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_ZVAL(a_arg)
-	ZEND_PARSE_PARAMETERS_END();
-
-	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
-	RETVAL_LONG(gmp_op(gmpnum_a));
-	FREE_GMP_TEMP(temp_a);
 }
 /* }}} */
 
@@ -1841,7 +1822,6 @@ ZEND_FUNCTION(gmp_cmp)
 /* {{{ Gets the sign of the number */
 ZEND_FUNCTION(gmp_sign)
 {
-	/* Can't use gmp_unary_opl here, because mpz_sgn is a macro */
 	zval *a_arg;
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
@@ -2110,7 +2090,17 @@ ZEND_FUNCTION(gmp_testbit)
 /* {{{ Calculates the population count of a */
 ZEND_FUNCTION(gmp_popcount)
 {
-	gmp_unary_opl(mpz_popcount);
+	zval *a_arg;
+	mpz_ptr gmpnum_a;
+	gmp_temp_t temp_a;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
+
+	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
+	RETVAL_LONG(mpz_popcount(gmpnum_a));
+	FREE_GMP_TEMP(temp_a);
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -192,6 +192,24 @@ static bool gmp_zend_parse_arg_into_mpz_ex(
 		mpz_set_si(*destination_mpz_ptr, Z_LVAL_P(arg));
 		return true;
 	}
+
+	/* This function is also used by the do_operation object hook,
+	 * but operator overloading with objects should behave as if a
+	 * method was called, thus strict types should apply. */
+	if (!ZEND_ARG_USES_STRICT_TYPES()) {
+		zend_long lval = 0;
+		if (is_operator && Z_TYPE_P(arg) == IS_NULL) {
+			return false;
+		}
+		if (!zend_parse_arg_long_weak(arg, &lval, arg_num)) {
+			return false;
+		}
+
+		mpz_set_si(*destination_mpz_ptr, lval);
+
+		return true;
+	}
+
 	return false;
 }
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1303,7 +1303,7 @@ ZEND_FUNCTION(gmp_perfect_square)
 		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_a)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_BOOL((mpz_perfect_square_p(gmpnum_a) != 0));
+	RETURN_BOOL(mpz_perfect_square_p(gmpnum_a) != 0);
 }
 /* }}} */
 
@@ -1316,7 +1316,7 @@ ZEND_FUNCTION(gmp_perfect_power)
 		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_a)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_BOOL((mpz_perfect_power_p(gmpnum_a) != 0));
+	RETURN_BOOL(mpz_perfect_power_p(gmpnum_a) != 0);
 }
 /* }}} */
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -135,22 +135,6 @@ typedef struct _gmp_temp {
 		mpz_clear(temp.num); \
 	}
 
-#define FETCH_GMP_ZVAL_DEP_DEP(gmpnumber, zval, temp, dep1, dep2, arg_pos) \
-if (IS_GMP(zval)) {                                               \
-	gmpnumber = GET_GMP_FROM_ZVAL(zval);                          \
-	temp.is_used = 0;                                             \
-} else {                                                          \
-	mpz_init(temp.num);                                           \
-	if (convert_to_gmp(temp.num, zval, 0, arg_pos) == FAILURE) {  \
-		mpz_clear(temp.num);                                      \
-		FREE_GMP_TEMP(dep1);                                      \
-		FREE_GMP_TEMP(dep2);                                      \
-		RETURN_THROWS();                                          \
-	}                                                             \
-	temp.is_used = 1;                                             \
-	gmpnumber = temp.num;                                         \
-}
-
 #define FETCH_GMP_ZVAL_DEP(gmpnumber, zval, temp, dep, arg_pos)   \
 if (IS_GMP(zval)) {                                               \
 	gmpnumber = GET_GMP_FROM_ZVAL(zval);                          \

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -427,25 +427,13 @@ static zend_result shift_operator_helper(gmp_binary_ui_op_t op, zval *return_val
 		return FAILURE;
 	} else {
 		mpz_ptr gmpnum_op, gmpnum_result;
-		gmp_temp_t temp;
 
-		/* We do not use FETCH_GMP_ZVAL(...); here as we don't use convert_to_gmp()
-		 * as we want to handle the emitted exception ourself.  */
-		if (UNEXPECTED(!IS_GMP(op1))) {
-			if (UNEXPECTED(Z_TYPE_P(op1) != IS_LONG)) {
-				goto typeof_op_failure;
-			}
-			mpz_init(temp.num);
-			mpz_set_si(temp.num, Z_LVAL_P(op1));
-			temp.is_used = 1;
-			gmpnum_op = temp.num;
-		} else {
-			gmpnum_op = GET_GMP_FROM_ZVAL(op1);
-			temp.is_used = 0;
+		if (!gmp_zend_parse_arg_into_mpz_ex(op1, &gmpnum_op, 1, true)) {
+			goto typeof_op_failure;
 		}
+
 		INIT_GMP_RETVAL(gmpnum_result);
 		op(gmpnum_result, gmpnum_op, (gmp_ulong) shift);
-		FREE_GMP_TEMP(temp);
 		return SUCCESS;
 	}
 

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -888,9 +888,10 @@ static inline void _gmp_binary_ui_op(INTERNAL_FUNCTION_PARAMETERS, gmp_binary_op
 {
 	zval *a_arg, *b_arg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_zval_binary_ui_op(
 		return_value, a_arg, b_arg, gmp_op, gmp_ui_op, check_b_zero, /* is_operator */ false);
@@ -919,9 +920,9 @@ static inline void _gmp_unary_op(INTERNAL_FUNCTION_PARAMETERS, gmp_unary_op_t gm
 {
 	zval *a_arg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_zval_unary_op(return_value, a_arg, gmp_op);
 }
@@ -934,9 +935,9 @@ static inline void _gmp_unary_opl(INTERNAL_FUNCTION_PARAMETERS, gmp_unary_opl_t 
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 	RETVAL_LONG(gmp_op(gmpnum_a));
@@ -1071,9 +1072,12 @@ ZEND_FUNCTION(gmp_export)
 	mpz_ptr gmpnumber;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|ll", &gmpnumber_arg, &size, &options) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 3)
+		Z_PARAM_ZVAL(gmpnumber_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(size)
+		Z_PARAM_LONG(options)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (!gmp_import_export_validate(size, options, &order, &endian)) {
 		RETURN_THROWS();
@@ -1111,9 +1115,9 @@ ZEND_FUNCTION(gmp_intval)
 	mpz_ptr gmpnum;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &gmpnumber_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(gmpnumber_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum, gmpnumber_arg, temp_a, 1);
 	RETVAL_LONG(mpz_get_si(gmpnum));
@@ -1129,9 +1133,11 @@ ZEND_FUNCTION(gmp_strval)
 	mpz_ptr gmpnum;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &gmpnumber_arg, &base) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ZVAL(gmpnumber_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(base)
+	ZEND_PARSE_PARAMETERS_END();
 
 	/* Although the maximum base in general in GMP is 62, mpz_get_str()
 	 * is explicitly limited to -36 when dealing with negative bases. */
@@ -1175,9 +1181,12 @@ ZEND_FUNCTION(gmp_div_qr)
 	zval *a_arg, *b_arg;
 	zend_long round = GMP_ROUND_ZERO;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz|l", &a_arg, &b_arg, &round) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(round)
+	ZEND_PARSE_PARAMETERS_END();
 
 	switch (round) {
 	case GMP_ROUND_ZERO:
@@ -1202,9 +1211,12 @@ ZEND_FUNCTION(gmp_div_r)
 	zval *a_arg, *b_arg;
 	zend_long round = GMP_ROUND_ZERO;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz|l", &a_arg, &b_arg, &round) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(round)
+	ZEND_PARSE_PARAMETERS_END();
 
 	switch (round) {
 	case GMP_ROUND_ZERO:
@@ -1232,9 +1244,12 @@ ZEND_FUNCTION(gmp_div_q)
 	zval *a_arg, *b_arg;
 	zend_long round = GMP_ROUND_ZERO;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz|l", &a_arg, &b_arg, &round) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(round)
+	ZEND_PARSE_PARAMETERS_END();
 
 	switch (round) {
 	case GMP_ROUND_ZERO:
@@ -1291,9 +1306,9 @@ ZEND_FUNCTION(gmp_fact)
 	zval *a_arg;
 	mpz_ptr gmpnum_result;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(a_arg) == IS_LONG) {
 		if (Z_LVAL_P(a_arg) < 0) {
@@ -1325,9 +1340,10 @@ ZEND_FUNCTION(gmp_binomial)
 	zend_long k;
 	mpz_ptr gmpnum_result;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &n_arg, &k) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(n_arg)
+		Z_PARAM_LONG(k)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (k < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");
@@ -1355,9 +1371,10 @@ ZEND_FUNCTION(gmp_pow)
 	gmp_temp_t temp_base;
 	zend_long exp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &base_arg, &exp) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(base_arg)
+		Z_PARAM_LONG(exp)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (exp < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");
@@ -1398,9 +1415,11 @@ ZEND_FUNCTION(gmp_powm)
 	int use_ui = 0;
 	gmp_temp_t temp_base, temp_exp, temp_mod;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zzz", &base_arg, &exp_arg, &mod_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_ZVAL(base_arg)
+		Z_PARAM_ZVAL(exp_arg)
+		Z_PARAM_ZVAL(mod_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_base, base_arg, temp_base, 1);
 
@@ -1446,9 +1465,9 @@ ZEND_FUNCTION(gmp_sqrt)
 	mpz_ptr gmpnum_a, gmpnum_result;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 
@@ -1472,9 +1491,9 @@ ZEND_FUNCTION(gmp_sqrtrem)
 	gmp_temp_t temp_a;
 	zval result1, result2;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 
@@ -1504,9 +1523,10 @@ ZEND_FUNCTION(gmp_root)
 	mpz_ptr gmpnum_a, gmpnum_result;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &a_arg, &nth) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_LONG(nth)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (nth <= 0) {
 		zend_argument_value_error(2, "must be greater than 0");
@@ -1536,9 +1556,10 @@ ZEND_FUNCTION(gmp_rootrem)
 	gmp_temp_t temp_a;
 	zval result1, result2;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &a_arg, &nth) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_LONG(nth)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (nth <= 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 1");
@@ -1581,9 +1602,9 @@ ZEND_FUNCTION(gmp_perfect_square)
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 
@@ -1599,9 +1620,9 @@ ZEND_FUNCTION(gmp_perfect_power)
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 
@@ -1618,9 +1639,11 @@ ZEND_FUNCTION(gmp_prob_prime)
 	zend_long reps = 10;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &gmpnumber_arg, &reps) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ZVAL(gmpnumber_arg)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(reps)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, gmpnumber_arg, temp_a, 1);
 
@@ -1651,9 +1674,10 @@ ZEND_FUNCTION(gmp_gcdext)
 	gmp_temp_t temp_a, temp_b;
 	zval result_g, result_s, result_t;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 	FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, 2);
@@ -1681,9 +1705,10 @@ ZEND_FUNCTION(gmp_invert)
 	gmp_temp_t temp_a, temp_b;
 	int res;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(b_arg) == IS_LONG && Z_LVAL_P(b_arg) == 0) {
 		zend_throw_exception_ex(zend_ce_division_by_zero_error, 0, "Division by zero");
@@ -1718,9 +1743,10 @@ ZEND_FUNCTION(gmp_jacobi)
 	mpz_ptr gmpnum_a, gmpnum_b;
 	gmp_temp_t temp_a, temp_b;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 	FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, 2);
@@ -1739,9 +1765,10 @@ ZEND_FUNCTION(gmp_legendre)
 	mpz_ptr gmpnum_a, gmpnum_b;
 	gmp_temp_t temp_a, temp_b;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 	FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, 2);
@@ -1762,9 +1789,10 @@ ZEND_FUNCTION(gmp_kronecker)
 	bool use_a_si = 0, use_b_si = 0;
 	int result;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(a_arg) == IS_LONG && Z_TYPE_P(b_arg) != IS_LONG) {
 		use_a_si = 1;
@@ -1801,9 +1829,10 @@ ZEND_FUNCTION(gmp_cmp)
 {
 	zval *a_arg, *b_arg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_cmp(return_value, a_arg, b_arg, /* is_operator */ false);
 }
@@ -1817,9 +1846,9 @@ ZEND_FUNCTION(gmp_sign)
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &a_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(a_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 
@@ -1850,9 +1879,9 @@ ZEND_FUNCTION(gmp_random_seed)
 	zval *seed;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &seed) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(seed)
+	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_init_random();
 
@@ -1907,9 +1936,10 @@ ZEND_FUNCTION(gmp_random_range)
 	mpz_t gmpnum_range;
 	gmp_temp_t temp_a, temp_b;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &min_arg, &max_arg) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(min_arg)
+		Z_PARAM_ZVAL(max_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	gmp_init_random();
 
@@ -2061,9 +2091,10 @@ ZEND_FUNCTION(gmp_testbit)
 	mpz_ptr gmpnum_a;
 	gmp_temp_t temp_a;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &a_arg, &index) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_LONG(index)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (index < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");
@@ -2090,9 +2121,10 @@ ZEND_FUNCTION(gmp_hamdist)
 	mpz_ptr gmpnum_a, gmpnum_b;
 	gmp_temp_t temp_a, temp_b;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &a_arg, &b_arg) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_ZVAL(b_arg)
+	ZEND_PARSE_PARAMETERS_END();
 
 	FETCH_GMP_ZVAL(gmpnum_a, a_arg, temp_a, 1);
 	FETCH_GMP_ZVAL_DEP(gmpnum_b, b_arg, temp_b, temp_a, 2);
@@ -2112,9 +2144,10 @@ ZEND_FUNCTION(gmp_scan0)
 	gmp_temp_t temp_a;
 	zend_long start;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &a_arg, &start) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_LONG(start)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (start < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");
@@ -2136,9 +2169,10 @@ ZEND_FUNCTION(gmp_scan1)
 	gmp_temp_t temp_a;
 	zend_long start;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &a_arg, &start) == FAILURE){
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(a_arg)
+		Z_PARAM_LONG(start)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (start < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");

--- a/ext/gmp/php_gmp.h
+++ b/ext/gmp/php_gmp.h
@@ -32,6 +32,7 @@ ZEND_MODULE_INFO_D(gmp);
 ZEND_BEGIN_MODULE_GLOBALS(gmp)
 	bool rand_initialized;
 	gmp_randstate_t rand_state;
+	mpz_t zpp_arg[3];
 ZEND_END_MODULE_GLOBALS(gmp)
 
 #define GMPG(v) ZEND_MODULE_GLOBALS_ACCESSOR(gmp, v)

--- a/ext/gmp/tests/bug32773.phpt
+++ b/ext/gmp/tests/bug32773.phpt
@@ -22,5 +22,5 @@ try {
 --EXPECT--
 10 + 0 = 10
 10 + "0" = 10
-Division by zero
+gmp_div(): Argument #2 ($num2) Division by zero
 gmp_div_qr(): Argument #2 ($num2) Division by zero

--- a/ext/gmp/tests/bug32773.phpt
+++ b/ext/gmp/tests/bug32773.phpt
@@ -23,4 +23,4 @@ try {
 10 + 0 = 10
 10 + "0" = 10
 Division by zero
-Division by zero
+gmp_div_qr(): Argument #2 ($num2) Division by zero

--- a/ext/gmp/tests/gmp_cmp.phpt
+++ b/ext/gmp/tests/gmp_cmp.phpt
@@ -26,7 +26,7 @@ try {
 echo "Done\n";
 ?>
 --EXPECT--
-int(2)
+int(1)
 int(0)
 int(-1)
 int(0)

--- a/ext/gmp/tests/gmp_cmp.phpt
+++ b/ext/gmp/tests/gmp_cmp.phpt
@@ -5,17 +5,27 @@ gmp
 --FILE--
 <?php
 
-var_dump(gmp_cmp(123123,-123123));
-var_dump(gmp_cmp("12345678900987654321","12345678900987654321"));
-var_dump(gmp_cmp("12345678900987654321","123456789009876543211"));
-var_dump(gmp_cmp(0,0));
-var_dump(gmp_cmp(1231222,0));
-var_dump(gmp_cmp(0,345355));
+function cmp_helper($l, $r) {
+    echo 'gmp(', var_export($l, true), ', ', var_export($r, true), '): ';
+    $r = gmp_cmp($l, $r);
+    echo match (true) {
+        $r === 0 => "equals\n",
+        $r < 0 => "right greater than left\n",
+        $r > 0 => "left greater than right\n",
+    };
+}
+
+cmp_helper(123123,-123123);
+cmp_helper("12345678900987654321","12345678900987654321");
+cmp_helper("12345678900987654321","123456789009876543211");
+cmp_helper(0,0);
+cmp_helper(1231222,0);
+cmp_helper(0,345355);
 
 $n = gmp_init("827278512385463739");
 var_dump(gmp_cmp(0,$n) < 0);
 $n1 = gmp_init("827278512385463739");
-var_dump(gmp_cmp($n1,$n));
+var_dump(gmp_cmp($n1,$n) === 0);
 
 try {
     var_dump(gmp_cmp(array(),array()));
@@ -26,13 +36,13 @@ try {
 echo "Done\n";
 ?>
 --EXPECT--
-int(1)
-int(0)
-int(-1)
-int(0)
-int(1)
-int(-1)
+gmp(123123, -123123): left greater than right
+gmp('12345678900987654321', '12345678900987654321'): equals
+gmp('12345678900987654321', '123456789009876543211'): right greater than left
+gmp(0, 0): equals
+gmp(1231222, 0): left greater than right
+gmp(0, 345355): right greater than left
 bool(true)
-int(0)
+bool(true)
 gmp_cmp(): Argument #1 ($num1) must be of type GMP|string|int, array given
 Done

--- a/ext/gmp/tests/gmp_div_q.phpt
+++ b/ext/gmp/tests/gmp_div_q.phpt
@@ -46,7 +46,7 @@ object(GMP)#1 (1) {
   ["num"]=>
   string(1) "0"
 }
-Division by zero
+gmp_div_q(): Argument #2 ($num2) Division by zero
 object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"

--- a/ext/gmp/tests/gmp_div_qr.phpt
+++ b/ext/gmp/tests/gmp_div_qr.phpt
@@ -60,8 +60,8 @@ array(2) {
     string(1) "0"
   }
 }
-Division by zero
-Division by zero
+gmp_div_qr(): Argument #2 ($num2) Division by zero
+gmp_div_qr(): Argument #2 ($num2) Division by zero
 array(2) {
   [0]=>
   object(GMP)#2 (1) {

--- a/ext/gmp/tests/gmp_div_r.phpt
+++ b/ext/gmp/tests/gmp_div_r.phpt
@@ -46,7 +46,7 @@ object(GMP)#1 (1) {
   ["num"]=>
   string(1) "0"
 }
-Division by zero
+gmp_div_r(): Argument #2 ($num2) Division by zero
 object(GMP)#3 (1) {
   ["num"]=>
   string(5) "12653"

--- a/ext/gmp/tests/gmp_divexact.phpt
+++ b/ext/gmp/tests/gmp_divexact.phpt
@@ -42,7 +42,7 @@ echo "Done\n";
 ?>
 --EXPECT--
 string(1) "0"
-Division by zero
+gmp_divexact(): Argument #2 ($num2) Division by zero
 string(2) "10"
 string(3) "512"
 string(19) "5000000000000000000"

--- a/ext/gmp/tests/gmp_invert.phpt
+++ b/ext/gmp/tests/gmp_invert.phpt
@@ -6,7 +6,6 @@ gmp
 <?php
 
 var_dump(gmp_strval(gmp_invert(123123,5467624)));
-var_dump(gmp_strval(gmp_invert(123123,"3333334345467624")));
 var_dump(gmp_strval(gmp_invert("12312323213123123",7624)));
 
 try {
@@ -22,9 +21,11 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 
-var_dump(gmp_strval(gmp_invert(0,28347)));
-var_dump(gmp_strval(gmp_invert(-12,456456)));
-var_dump(gmp_strval(gmp_invert(234234,-435345)));
+echo "No inverse modulo\n";
+var_dump(gmp_invert(123123,"3333334345467624"));
+var_dump(gmp_invert(0,28347));
+var_dump(gmp_invert(-12,456456));
+var_dump(gmp_invert(234234,-435345));
 
 $n = gmp_init("349827349623423452345");
 $n1 = gmp_init("3498273496234234523451");
@@ -52,13 +53,14 @@ echo "Done\n";
 ?>
 --EXPECT--
 string(7) "2293131"
-string(1) "0"
 string(4) "5827"
 Division by zero
 Division by zero
-string(1) "0"
-string(1) "0"
-string(1) "0"
+No inverse modulo
+bool(false)
+bool(false)
+bool(false)
+bool(false)
 string(22) "3498273496234234523441"
 string(1) "1"
 gmp_invert(): Argument #1 ($num1) must be of type GMP|string|int, array given

--- a/ext/gmp/tests/gmp_mod.phpt
+++ b/ext/gmp/tests/gmp_mod.phpt
@@ -42,7 +42,7 @@ object(GMP)#2 (1) {
   ["num"]=>
   string(1) "0"
 }
-Modulo by zero
+gmp_mod(): Argument #2 ($num2) Modulo by zero
 gmp_mod(): Argument #1 ($num1) must be of type GMP|string|int, array given
 object(GMP)#4 (1) {
   ["num"]=>

--- a/ext/gmp/tests/gmp_strval.phpt
+++ b/ext/gmp/tests/gmp_strval.phpt
@@ -66,7 +66,7 @@ echo "Done\n";
 ?>
 --EXPECT--
 gmp_strval(): Argument #1 ($num) is not an integer string
-gmp_strval(): Argument #2 ($base) must be between 2 and 62, or -2 and -36
+gmp_strval(): Argument #1 ($num) is not an integer string
 gmp_strval(): Argument #1 ($num) must be of type GMP|string|int, resource given
 string(7) "9765456"
 gmp_strval(): Argument #2 ($base) must be between 2 and 62, or -2 and -36


### PR DESCRIPTION
This PR should be reviewed commit by commit to actually understand what is going on.

The basic idea is to create, and use, a custom Fast ZPP specifier to parse arguments into an `mpz_ptr` structure. To prevent issues with cleaning up, and improve efficiency as recommended by the GMP documentation, we create some module global `mpz_ptr` that we initialize and clean once that we can use during ZPP, without needing to worry about clean-up.

This new model greatly simplifies the extension and how to handle parameters, as they will always be `mpz_ptr` structures.

The first couple of commits are some fixes and preliminary refactorings, the main one being to convert all relevant calls to Fast ZPP.

I have not benchmarked this, but I would not be surprised if this improves performance of the extension.

This should allow some easier refactoring of the operator overloading handlers to behave more sensibly and not just throw `Error`s all the time.
