### PR TITLE
Implement request #77761 (openssl_x509_parse does not create entries for public key type and size)

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -40,6 +40,12 @@ PHP 8.5 UPGRADE NOTES
 - DOM:
   . Added Dom\Element::$outerHTML.
 
+- OpenSSL:
+  . openssl_x509_parse() now outputs information about the public key.
+    The output contains an additional subarray "publicKey" with the entries
+    "bits", "type", and "groupName". The last one is only applicable for
+    public keys that have a group.
+
 - XSL:
   . The $namespace argument of XSLTProcessor::getParameter(),
     XSLTProcessor::setParameter() and XSLTProcessor::removeParameter()

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2143,9 +2143,17 @@ PHP_FUNCTION(openssl_x509_parse)
 		zval public_key_zv;
 		array_init(&public_key_zv);
 
+#if PHP_OPENSSL_API_VERSION >= 0x30000
 		int group_name_read = EVP_PKEY_get_group_name(public_key, gname, sizeof(gname), &gname_length);
-		int bits = EVP_PKEY_get_bits(public_key);
 		const char *type = EVP_PKEY_get0_type_name(public_key);
+#else
+		int group_name_read = 0;
+		(void) gname;
+		gname_length = 0;
+		const char *type = OBJ_nid2sn(EVP_PKEY_base_id(public_key));
+#endif
+
+		int bits = EVP_PKEY_bits(public_key);
 
 		if (bits > 0 && type) {
 			add_assoc_long(&public_key_zv, "bits", bits);

--- a/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
+++ b/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
@@ -17,9 +17,16 @@ var_dump(openssl_x509_parse($cert, false));
 ?>
 --EXPECTF--
 bool(true)
-array(16) {
+array(17) {
   ["name"]=>
   string(96) "/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net"
+  ["publicKey"]=>
+  array(2) {
+    ["bits"]=>
+    int(1024)
+    ["type"]=>
+    string(3) "RSA"
+  }
   ["subject"]=>
   array(5) {
     ["C"]=>
@@ -173,9 +180,16 @@ serial:AE:C5:56:CC:72:37:50:A2%A"
     string(7) "CA:TRUE"
   }
 }
-array(16) {
+array(17) {
   ["name"]=>
   string(96) "/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net"
+  ["publicKey"]=>
+  array(2) {
+    ["bits"]=>
+    int(1024)
+    ["type"]=>
+    string(3) "RSA"
+  }
   ["subject"]=>
   array(5) {
     ["countryName"]=>

--- a/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
+++ b/ext/openssl/tests/openssl_x509_parse_basic_openssl32.phpt
@@ -25,7 +25,7 @@ array(17) {
     ["bits"]=>
     int(1024)
     ["type"]=>
-    string(3) "RSA"
+    string(%d) "%r(RSA|rsaEncryption)%r"
   }
   ["subject"]=>
   array(5) {
@@ -188,7 +188,7 @@ array(17) {
     ["bits"]=>
     int(1024)
     ["type"]=>
-    string(3) "RSA"
+    string(%d) "%r(RSA|rsaEncryption)%r"
   }
   ["subject"]=>
   array(5) {

--- a/ext/openssl/tests/req77761.phpt
+++ b/ext/openssl/tests/req77761.phpt
@@ -1,0 +1,144 @@
+--TEST--
+Request #77761 (openssl_x509_parse does not create entries for public key type and size)
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+$certificate = <<<CERT
+-----BEGIN CERTIFICATE-----
+MIIB3zCCAYWgAwIBAgIUWoRHmceFhGk6IaNQUFDPYTnQ4I4wCgYIKoZIzj0EAwIw
+RTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu
+dGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDExMDMxNjQzNDVaFw0yNTExMDMx
+NjQzNDVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYD
+VQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAASGaV0Ce416vnEYfiC/nvq7FH8NhsrxCxIS2LVoCfpvSgmzH/klEfkT
+omzMzA6cLbSFKGhfDWUwPlKF/XsxZ+oTo1MwUTAdBgNVHQ4EFgQUC3+muHeWsFHk
+DtVB32pu2X/WIgAwHwYDVR0jBBgwFoAUC3+muHeWsFHkDtVB32pu2X/WIgAwDwYD
+VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBo3HaOgyzimwwJApw5ijqI
+9b8qdPx7kMsCFElxjYXn7QIhAMTWsw/AWP/Acq8YSQJMyUJ9H/ZmppHrZWLnQkc8
+W+mj
+-----END CERTIFICATE-----
+CERT;
+
+print_r(openssl_x509_parse($certificate));
+
+?>
+--EXPECT--
+Array
+(
+    [name] => /C=AU/ST=Some-State/O=Internet Widgits Pty Ltd
+    [publicKey] => Array
+        (
+            [bits] => 256
+            [type] => EC
+            [groupName] => prime256v1
+        )
+
+    [subject] => Array
+        (
+            [C] => AU
+            [ST] => Some-State
+            [O] => Internet Widgits Pty Ltd
+        )
+
+    [hash] => 9da13359
+    [issuer] => Array
+        (
+            [C] => AU
+            [ST] => Some-State
+            [O] => Internet Widgits Pty Ltd
+        )
+
+    [version] => 2
+    [serialNumber] => 0x5A844799C78584693A21A3505050CF6139D0E08E
+    [serialNumberHex] => 5A844799C78584693A21A3505050CF6139D0E08E
+    [validFrom] => 241103164345Z
+    [validTo] => 251103164345Z
+    [validFrom_time_t] => 1730652225
+    [validTo_time_t] => 1762188225
+    [signatureTypeSN] => ecdsa-with-SHA256
+    [signatureTypeLN] => ecdsa-with-SHA256
+    [signatureTypeNID] => 794
+    [purposes] => Array
+        (
+            [1] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => sslclient
+                )
+
+            [2] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => sslserver
+                )
+
+            [3] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => nssslserver
+                )
+
+            [4] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => smimesign
+                )
+
+            [5] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => smimeencrypt
+                )
+
+            [6] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => crlsign
+                )
+
+            [7] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => any
+                )
+
+            [8] => Array
+                (
+                    [0] => 1
+                    [1] => 1
+                    [2] => ocsphelper
+                )
+
+            [9] => Array
+                (
+                    [0] => 
+                    [1] => 1
+                    [2] => timestampsign
+                )
+
+            [10] => Array
+                (
+                    [0] => 
+                    [1] => 1
+                    [2] => codesign
+                )
+
+        )
+
+    [extensions] => Array
+        (
+            [subjectKeyIdentifier] => 0B:7F:A6:B8:77:96:B0:51:E4:0E:D5:41:DF:6A:6E:D9:7F:D6:22:00
+            [authorityKeyIdentifier] => 0B:7F:A6:B8:77:96:B0:51:E4:0E:D5:41:DF:6A:6E:D9:7F:D6:22:00
+            [basicConstraints] => CA:TRUE
+        )
+
+)

--- a/ext/openssl/tests/req77761.phpt
+++ b/ext/openssl/tests/req77761.phpt
@@ -21,124 +21,18 @@ W+mj
 -----END CERTIFICATE-----
 CERT;
 
-print_r(openssl_x509_parse($certificate));
+$publicKey = openssl_x509_parse($certificate)["publicKey"];
+var_dump($publicKey["bits"]);
+var_dump($publicKey["type"] === "EC" || $publicKey["type"] === "id-ecPublicKey");
+
+if (OPENSSL_VERSION_NUMBER >= 0x30000000) {
+    var_dump($publicKey["groupName"] === "prime256v1");
+} else {
+    var_dump(true);
+}
 
 ?>
 --EXPECT--
-Array
-(
-    [name] => /C=AU/ST=Some-State/O=Internet Widgits Pty Ltd
-    [publicKey] => Array
-        (
-            [bits] => 256
-            [type] => EC
-            [groupName] => prime256v1
-        )
-
-    [subject] => Array
-        (
-            [C] => AU
-            [ST] => Some-State
-            [O] => Internet Widgits Pty Ltd
-        )
-
-    [hash] => 9da13359
-    [issuer] => Array
-        (
-            [C] => AU
-            [ST] => Some-State
-            [O] => Internet Widgits Pty Ltd
-        )
-
-    [version] => 2
-    [serialNumber] => 0x5A844799C78584693A21A3505050CF6139D0E08E
-    [serialNumberHex] => 5A844799C78584693A21A3505050CF6139D0E08E
-    [validFrom] => 241103164345Z
-    [validTo] => 251103164345Z
-    [validFrom_time_t] => 1730652225
-    [validTo_time_t] => 1762188225
-    [signatureTypeSN] => ecdsa-with-SHA256
-    [signatureTypeLN] => ecdsa-with-SHA256
-    [signatureTypeNID] => 794
-    [purposes] => Array
-        (
-            [1] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => sslclient
-                )
-
-            [2] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => sslserver
-                )
-
-            [3] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => nssslserver
-                )
-
-            [4] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => smimesign
-                )
-
-            [5] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => smimeencrypt
-                )
-
-            [6] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => crlsign
-                )
-
-            [7] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => any
-                )
-
-            [8] => Array
-                (
-                    [0] => 1
-                    [1] => 1
-                    [2] => ocsphelper
-                )
-
-            [9] => Array
-                (
-                    [0] => 
-                    [1] => 1
-                    [2] => timestampsign
-                )
-
-            [10] => Array
-                (
-                    [0] => 
-                    [1] => 1
-                    [2] => codesign
-                )
-
-        )
-
-    [extensions] => Array
-        (
-            [subjectKeyIdentifier] => 0B:7F:A6:B8:77:96:B0:51:E4:0E:D5:41:DF:6A:6E:D9:7F:D6:22:00
-            [authorityKeyIdentifier] => 0B:7F:A6:B8:77:96:B0:51:E4:0E:D5:41:DF:6A:6E:D9:7F:D6:22:00
-            [basicConstraints] => CA:TRUE
-        )
-
-)
+int(256)
+bool(true)
+bool(true)


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=77761

This adds a new subarray to the output named "publicKey" that can contain subentries "type", "bits", and "groupName". The latter is only applicable for public key that have a group.