### PR TITLE
Fix memory leak in php_openssl_pkey_from_zval()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3525,6 +3525,7 @@ static EVP_PKEY *php_openssl_pkey_from_zval(
 		} else {
 			ZVAL_COPY(&tmp, zphrase);
 			if (!try_convert_to_string(&tmp)) {
+				zval_ptr_dtor(&tmp);
 				return NULL;
 			}
 

--- a/ext/openssl/tests/php_openssl_pkey_from_zval_leak.phpt
+++ b/ext/openssl/tests/php_openssl_pkey_from_zval_leak.phpt
@@ -1,0 +1,23 @@
+--TEST--
+php_openssl_pkey_from_zval memory leak
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+class StrFail {
+    public function __toString(): string {
+        throw new Error('create a leak');
+    }
+}
+
+$key = ["", new StrFail];
+try {
+    openssl_pkey_export_to_file($key, "doesnotmatter");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+create a leak


### PR DESCRIPTION
Detected using an experimental static analyser I'm developing.