### PR TITLE
Limit the number of filters

### DIFF
--- a/tests/security/bug10453.phpt
+++ b/tests/security/bug10453.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #10453 (using a high amount of filters for nefarious purposes)
+--FILE--
+<?php
+$fp = fopen('php://output', 'w');
+for($i=0; $i<10; $i++)
+    stream_filter_append($fp, 'string.rot13');
+fwrite($fp, "This is a test.\n");
+
+$fp = fopen('php://filter/write=string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13|string.rot13/resource=php://output', 'w');
+fwrite($fp, "This is a test.\n");
+?>
+--EXPECTF--
+This is a test.
+
+Fatal error: Uncaught Exception: Unable to apply filter, maximum number (5) reached in %s
+Stack trace:
+#0 %s: fopen('php://filter/wr...', 'w')
+#1 {main}
+  thrown in %s


### PR DESCRIPTION
Chaining filters is becoming an increasingly popular primitive to exploit PHP applications. Limiting the usage of only a few of them at the time should, if not close entirely, make it significantly less attractive.

I hardcoded the number of filters to `5` for now, but this can be changed to an ini preference if wanted/needed, albeit I fail to see a valid usecase for anything requiring chaining 5 filters or more. I'd love to keep it hardcoded, and to lower the number to 3.

This should close #10453

/cc @arnaud-lb @cfreal