### PR TITLE
Use unsigned int for the reference count APIs in ext/libxml

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -22,6 +22,9 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 3. Module changes
 ========================
 
+- ext/libxml
+  . The refcount APIs now return an `unsigned int` instead of an `int`.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1283,10 +1283,7 @@ PHP_METHOD(DOMDocument, __construct)
 		}
 	}
 	intern->document = NULL;
-	if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, docp) == -1) {
-		/* docp is always non-null so php_libxml_increment_doc_ref() never returns -1 */
-		ZEND_UNREACHABLE();
-	}
+	php_libxml_increment_doc_ref((php_libxml_node_object *)intern, docp);
 	php_libxml_increment_node_ptr((php_libxml_node_object *)intern, (xmlNodePtr)docp, (void *)intern);
 }
 /* }}} end DOMDocument::__construct */
@@ -1495,9 +1492,7 @@ static void php_dom_finish_loading_document(zval *this, zval *return_value, xmlD
 			}
 		}
 		intern->document = NULL;
-		if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc) == -1) {
-			RETURN_FALSE;
-		}
+		php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc);
 		intern->document->doc_props = doc_prop;
 		intern->document->class_type = class_type;
 	}

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1291,9 +1291,9 @@ PHP_LIBXML_API xmlNodePtr php_libxml_import_node(zval *object)
 	return node;
 }
 
-PHP_LIBXML_API int php_libxml_increment_node_ptr(php_libxml_node_object *object, xmlNodePtr node, void *private_data)
+PHP_LIBXML_API unsigned int php_libxml_increment_node_ptr(php_libxml_node_object *object, xmlNodePtr node, void *private_data)
 {
-	int ret_refcount = -1;
+	unsigned int ret_refcount = 0;
 
 	if (object != NULL && node != NULL) {
 		if (object->node != NULL) {
@@ -1323,11 +1323,11 @@ PHP_LIBXML_API int php_libxml_increment_node_ptr(php_libxml_node_object *object,
 	return ret_refcount;
 }
 
-PHP_LIBXML_API int php_libxml_decrement_node_ptr_ref(php_libxml_node_ptr *ptr)
+PHP_LIBXML_API unsigned int php_libxml_decrement_node_ptr_ref(php_libxml_node_ptr *ptr)
 {
 	ZEND_ASSERT(ptr != NULL);
 
-	int ret_refcount = --ptr->refcount;
+	unsigned int ret_refcount = --ptr->refcount;
 	if (ret_refcount == 0) {
 		if (ptr->node != NULL) {
 			ptr->node->_private = NULL;
@@ -1341,17 +1341,17 @@ PHP_LIBXML_API int php_libxml_decrement_node_ptr_ref(php_libxml_node_ptr *ptr)
 	return ret_refcount;
 }
 
-PHP_LIBXML_API int php_libxml_decrement_node_ptr(php_libxml_node_object *object)
+PHP_LIBXML_API unsigned int php_libxml_decrement_node_ptr(php_libxml_node_object *object)
 {
 	if (object != NULL && object->node != NULL) {
 		return php_libxml_decrement_node_ptr_ref(object->node);
 	}
-	return -1;
+	return 0;
 }
 
-PHP_LIBXML_API int php_libxml_increment_doc_ref(php_libxml_node_object *object, xmlDocPtr docp)
+PHP_LIBXML_API unsigned int php_libxml_increment_doc_ref(php_libxml_node_object *object, xmlDocPtr docp)
 {
-	int ret_refcount = -1;
+	unsigned int ret_refcount = 0;
 
 	if (object->document != NULL) {
 		object->document->refcount++;
@@ -1372,9 +1372,9 @@ PHP_LIBXML_API int php_libxml_increment_doc_ref(php_libxml_node_object *object, 
 	return ret_refcount;
 }
 
-PHP_LIBXML_API int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *document)
+PHP_LIBXML_API unsigned int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *document)
 {
-	int ret_refcount = --document->refcount;
+	unsigned int ret_refcount = --document->refcount;
 	if (ret_refcount == 0) {
 		if (document->private_data != NULL) {
 			document->private_data->dtor(document->private_data);
@@ -1395,9 +1395,9 @@ PHP_LIBXML_API int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *doc
 	return ret_refcount;
 }
 
-PHP_LIBXML_API int php_libxml_decrement_doc_ref(php_libxml_node_object *object)
+PHP_LIBXML_API unsigned int php_libxml_decrement_doc_ref(php_libxml_node_object *object)
 {
-	int ret_refcount = -1;
+	unsigned int ret_refcount = 0;
 
 	if (object != NULL && object->document != NULL) {
 		ret_refcount = php_libxml_decrement_doc_ref_directly(object->document);
@@ -1445,7 +1445,7 @@ PHP_LIBXML_API void php_libxml_node_decrement_resource(php_libxml_node_object *o
 	if (object != NULL && object->node != NULL) {
 		php_libxml_node_ptr *obj_node = (php_libxml_node_ptr *) object->node;
 		xmlNodePtr nodep = obj_node->node;
-		int ret_refcount = php_libxml_decrement_node_ptr(object);
+		unsigned int ret_refcount = php_libxml_decrement_node_ptr(object);
 		if (ret_refcount == 0) {
 			php_libxml_node_free_resource(nodep);
 		} else {

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -189,12 +189,12 @@ typedef enum {
 	PHP_LIBXML_CTX_WARNING = 2,
 } php_libxml_error_level;
 
-PHP_LIBXML_API int php_libxml_increment_node_ptr(php_libxml_node_object *object, xmlNodePtr node, void *private_data);
-PHP_LIBXML_API int php_libxml_decrement_node_ptr(php_libxml_node_object *object);
-PHP_LIBXML_API int php_libxml_decrement_node_ptr_ref(php_libxml_node_ptr *ptr);
-PHP_LIBXML_API int php_libxml_increment_doc_ref(php_libxml_node_object *object, xmlDocPtr docp);
-PHP_LIBXML_API int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *document);
-PHP_LIBXML_API int php_libxml_decrement_doc_ref(php_libxml_node_object *object);
+PHP_LIBXML_API unsigned int php_libxml_increment_node_ptr(php_libxml_node_object *object, xmlNodePtr node, void *private_data);
+PHP_LIBXML_API unsigned int php_libxml_decrement_node_ptr(php_libxml_node_object *object);
+PHP_LIBXML_API unsigned int php_libxml_decrement_node_ptr_ref(php_libxml_node_ptr *ptr);
+PHP_LIBXML_API unsigned int php_libxml_increment_doc_ref(php_libxml_node_object *object, xmlDocPtr docp);
+PHP_LIBXML_API unsigned int php_libxml_decrement_doc_ref_directly(php_libxml_ref_obj *document);
+PHP_LIBXML_API unsigned int php_libxml_decrement_doc_ref(php_libxml_node_object *object);
 PHP_LIBXML_API xmlNodePtr php_libxml_import_node(zval *object);
 PHP_LIBXML_API zval *php_libxml_register_export(zend_class_entry *ce, php_libxml_export_node export_function);
 /* When an explicit freeing of node and children is required */


### PR DESCRIPTION
Also removes impossible conditions.