### PR TITLE
Skip tests if ldap_set_rebind_proc() is not available

### DIFF
--- a/ext/ldap/tests/ldap_set_rebind_proc_basic.phpt
+++ b/ext/ldap/tests/ldap_set_rebind_proc_basic.phpt
@@ -6,7 +6,10 @@ Patrick Allaert <patrickallaert@php.net>
 --EXTENSIONS--
 ldap
 --SKIPIF--
-<?php require_once('skipifbindfailure.inc'); ?>
+<?php
+if (!function_exists('ldap_set_rebind_proc')) die("skip ldap_set_rebind_proc() not available");
+require_once('skipifbindfailure.inc');
+?>
 --FILE--
 <?php
 require "connect.inc";

--- a/ext/ldap/tests/ldap_unbind_variation.phpt
+++ b/ext/ldap/tests/ldap_unbind_variation.phpt
@@ -6,7 +6,10 @@ Patrick Allaert <patrickallaert@php.net>
 --EXTENSIONS--
 ldap
 --SKIPIF--
-<?php require_once('skipifbindfailure.inc'); ?>
+<?php
+if (!function_exists('ldap_set_rebind_proc')) die("skip ldap_set_rebind_proc() not available");
+require_once('skipifbindfailure.inc');
+?>
 --FILE--
 <?php
 require "connect.inc";


### PR DESCRIPTION
This is already done by ldap_set_rebind_proc_error.phpt, but not by the other two affected tests.

---

Note that while [ldap_set_rebind_proc_error.phpt](https://github.com/php/php-src/blob/master/ext/ldap/tests/ldap_set_rebind_proc_error.phpt) has this check right, it, the check for the server being available is borked, because it mixes URI and hostname.

https://github.com/php/php-src/blob/228c27112a0ea23b51b6bb92b33ecc8a73c5dbb3/ext/ldap/tests/connect.inc#L10