### PR TITLE
Force register_argc_argv to Off on FPM + Apache2 + default to false

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -753,7 +753,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("report_zend_debug",	"0",		PHP_INI_ALL,		OnUpdateBool,			report_zend_debug,		php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("output_buffering",		"0",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateLong,	output_buffering,		php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("output_handler",			NULL,		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateString,	output_handler,		php_core_globals,	core_globals)
-	STD_PHP_INI_BOOLEAN("register_argc_argv",	"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	register_argc_argv,		php_core_globals,	core_globals)
+	STD_PHP_INI_BOOLEAN("register_argc_argv",	"0",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	register_argc_argv,		php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("auto_globals_jit",		"1",		PHP_INI_PERDIR|PHP_INI_SYSTEM,	OnUpdateBool,	auto_globals_jit,	php_core_globals,	core_globals)
 	STD_PHP_INI_BOOLEAN("short_open_tag",	DEFAULT_SHORT_OPEN_TAG,	PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateBool,			short_tags,				zend_compiler_globals,	compiler_globals)
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -125,7 +125,7 @@
 ;   Production Value: 4096
 
 ; register_argc_argv
-;   Default Value: On
+;   Default Value: Off
 ;   Development Value: Off
 ;   Production Value: Off
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -125,7 +125,7 @@
 ;   Production Value: 4096
 
 ; register_argc_argv
-;   Default Value: On
+;   Default Value: Off
 ;   Development Value: Off
 ;   Production Value: Off
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1589,6 +1589,7 @@ int main(int argc, char *argv[])
 	zend_signal_startup();
 
 	sapi_startup(&cgi_sapi_module);
+    php_ini_builder_prepend_literal(&ini_builder, HARDCODED_INI);
 	cgi_sapi_module.php_ini_path_override = NULL;
 	cgi_sapi_module.php_ini_ignore_cwd = 1;
 


### PR DESCRIPTION
Fix #12344

Actually this PR outweighs my C-skills: the changes on the Apache2 and FPM SAPIs are not working, I submit them to ask for help: these SAPIs shouldn't allow setting register_argc_argv to On (like the CLI SAPI doesn't allow setting it to Off). I suppose the same could be said for the litespeed SAPI, but I know nothing about it.

Does this make sense to most? Anyone would be willing to help me make this happen? :pray: 