### PR TITLE
Fix GH-16630: UAF in lexer with encoding translation and heredocs

### DIFF
--- a/Zend/tests/gh16630.phpt
+++ b/Zend/tests/gh16630.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-16630 (UAF in lexer with encoding translation and heredocs)
+--EXTENSIONS--
+mbstring
+--INI--
+zend.multibyte=On
+zend.script_encoding=ISO-8859-1
+internal_encoding=EUC-JP
+--FILE--
+<?php
+$data3 = <<<CODE
+heredoc
+text
+CODE;
+echo $data3;
+?>
+--EXPECT--
+heredoc
+text

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -275,7 +275,7 @@ ZEND_API void zend_restore_lexical_state(zend_lex_state *lex_state)
 	CG(zend_lineno) = lex_state->lineno;
 	zend_restore_compiled_filename(lex_state->filename);
 
-	if (SCNG(script_filtered)) {
+	if (SCNG(script_filtered) && SCNG(script_filtered) != lex_state->script_filtered) {
 		efree(SCNG(script_filtered));
 		SCNG(script_filtered) = NULL;
 	}


### PR DESCRIPTION
zend_save_lexical_state() can be nested multiple times, for example for the parser initialization and then in the heredoc lexing. The input should not be freed if we restore to the same filtered string.