### PR TITLE
Fail early in *nix configuration build script

### DIFF
--- a/build/genif.sh
+++ b/build/genif.sh
@@ -32,7 +32,7 @@ header_list=
 olddir=$(pwd)
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")/../" && pwd -P)" || exit
 
 module_ptrs="$(echo $extensions | $AWK -f ./build/order_by_dep.awk)"
 

--- a/buildconf
+++ b/buildconf
@@ -8,9 +8,9 @@ force=0
 debug=0
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)" || exit
 
-php_extra_version=$(grep '^AC_INIT(' configure.ac)
+php_extra_version=$(grep '^AC_INIT(' configure.ac) || exit
 case "$php_extra_version" in
   *-dev*)
     dev=1

--- a/scripts/dev/credits
+++ b/scripts/dev/credits
@@ -3,7 +3,7 @@
 # Generate credits_*.h headers from the ext/*/CREDITS and sapi/*/CREDITS files.
 
 # Go to project root directory
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")/../../" && pwd -P)" || exit
 
 awkprog='
 BEGIN { FS = "\n|\r\n|\r"; RS = "" }

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -41,7 +41,7 @@ SED=${SED:-sed}
 MAKE=${MAKE:-make}
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")/../../" && pwd -P)" || exit
 
 # Check required bison version from the configure.ac file.
 required_bison_version=$($SED -n 's/PHP_PROG_BISON(\[\([0-9\.]*\)\].*/\1/p' configure.ac)

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -15,7 +15,7 @@ if [[ $($tar --version) == *"bsdtar"* ]]; then
 fi
 
 # Go to project root directory.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")/../../" && pwd -P)" || exit
 
 # Process options and arguments.
 while :; do


### PR DESCRIPTION
Adding two exit early safeguards in the *nix configuration build script:

1) Given the initial cd into the build tree fails (the project root),
   the `buildconf` script exits with non-zero status (failure).
2) Given the grep command does not exist or `configure.ac` AC_INIT [1]
   expectations are unmet, the buildconf script exits non-zero.

Additionally quoting the pathname to cd into and the empty CD_PATH parameter for portability, also for systems that are using a non-portable pathname [2] for the build tree.

Rationale:

CD-ing into the project root should always prematurely exit w/ FAILURE as a required precondition for its invocation has not been met. This should never go unnoticed as it always requires user intervention.

Similar and more specifically to the PHP build on *nix systems, the grep command is required early to obtain the `php_extra_version` from configure.ac.  Previously, if the grep command is missing (or failing due to not matching the line with the AC_INIT macro [1]), the internal dev parameter would always be zero (0) which can easily result in the situation that the configure script is not being rebuilt. This is cumbersome as the rebuild of a configure script is more likely required with checked-out dev versions under change rather than an already properly set-up build environment on a dedicated build or release system. Missing the fact that either the grep utility is missing or the expectation of having the AC_INIT macro in configure.ac is unmet should never go unnoticed as it always requires user intervention.

[1]: https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html
[2]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_271