### PR TITLE
Fix incorrect filename of dl()'d internal consts

### DIFF
--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -504,11 +504,12 @@ ZEND_API zend_result zend_register_constant(zend_constant *c)
 		name = c->name;
 	}
 
-	zend_string *filename = zend_get_executed_filename_ex();
-	if (filename == NULL) {
-		c->filename = NULL;
-	} else {
-		c->filename = zend_string_copy(filename);
+	c->filename = NULL;
+	if (ZEND_CONSTANT_MODULE_NUMBER(c) == PHP_USER_CONSTANT) {
+		zend_string *filename = zend_get_executed_filename_ex();
+		if (filename) {
+			c->filename = zend_string_copy(filename);
+		}
 	}
 
 	/* Check if the user is trying to define any special constant */

--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -94,6 +94,8 @@ PHP_MINIT_FUNCTION(dl_test)
 		fprintf(stderr, "DL TEST MINIT\n");
 	}
 
+	register_dl_test_symbols(module_number);
+
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/dl_test/dl_test.stub.php
+++ b/ext/dl_test/dl_test.stub.php
@@ -8,3 +8,6 @@
 function dl_test_test1(): void {}
 
 function dl_test_test2(string $str = ""): string {}
+
+/** @var int */
+const DL_TEST_CONST = 42;

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 547ddbc21e9aa853b491cb17e902bbbb9cc2df00 */
+ * Stub hash: e1154d736a190512ecf51e30719d53e685ca5513 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -16,3 +16,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(dl_test_test2, arginfo_dl_test_test2)
 	ZEND_FE_END
 };
+
+static void register_dl_test_symbols(int module_number)
+{
+	REGISTER_LONG_CONSTANT("DL_TEST_CONST", 42, CONST_PERSISTENT);
+}


### PR DESCRIPTION
We should only attempt to fetch the current filename for user constants. dl() may attempt to register internal constants after execution has already started, thus incorrectly linking the user file invoking dl().

See GH-16663