### PR TITLE
Skip file_put_contents_variation7.phpt on Windows

### DIFF
--- a/ext/standard/tests/file/file_put_contents_variation7.phpt
+++ b/ext/standard/tests/file/file_put_contents_variation7.phpt
@@ -2,6 +2,11 @@
 Test file_put_contents() function : usage variation - various absolute and relative paths
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
+--SKIPIF--
+<?php
+if(substr(PHP_OS, 0, 3) == "WIN")
+  die("skip Not for Windows");
+?>
 --FILE--
 <?php
 echo "*** Testing file_put_contents() : usage variation ***\n";


### PR DESCRIPTION
While the test obviously succeeds on Windows, it may occasionally conflict with file_put_contents_variation7-win32.phpt[1], so we skip it like we do for many other of these tests which have win32 pendants.

[1] <https://github.com/php/php-src/actions/runs/11527743659/job/32093951818>

---

It might be a good idea to actually drop the Windows specific ext/standard/tests/file tests; or at least to reduce their number. In this case, the

<details><summary>tests mostly differ wrt DIRECTORY_SEPARATOR</summary>

````diff
$ diff -u file_put_contents_variation7.phpt file_put_contents_variation7-win32.phpt
--- file_put_contents_variation7.phpt   2024-11-07 13:48:03.788622800 +0100
+++ file_put_contents_variation7-win32.phpt     2022-08-31 13:34:34.558404900 +0200
@@ -4,8 +4,8 @@
 Dave Kelsey <d_kelsey@uk.ibm.com>
 --SKIPIF--
 <?php
-if(substr(PHP_OS, 0, 3) == "WIN")
-  die("skip Not for Windows");
+if(substr(PHP_OS, 0, 3) != "WIN")
+  die("skip Only run on Windows");
 ?>
 --FILE--
 <?php
@@ -15,31 +15,34 @@
 $subDir = "filePutContentsVar7Sub";
 $absMainDir = __DIR__."/".$mainDir;
 mkdir($absMainDir);
-$absSubDir = $absMainDir."/".$subDir;
+$absSubDir = $absMainDir."\\".$subDir;
 mkdir($absSubDir);

 $old_dir_path = getcwd();
 chdir(__DIR__);
+$unixifiedDir = '/'.substr(str_replace('\\','/',$absSubDir),3);


 // Note invalid dirs in p8 result in (The system cannot find the path specified.)
 // rather than No Such File or Directory in php.net
 $allDirs = array(
   // absolute paths
-  "$absSubDir/",
-  "$absSubDir/../".$subDir,
-  "$absSubDir//.././".$subDir,
-  "$absSubDir/../../".$mainDir."/./".$subDir,
-  "$absSubDir/..///".$subDir."//..//../".$subDir,
-  "$absSubDir/BADDIR",
+  "$absSubDir\\",
+  "$absSubDir\\..\\".$subDir,
+  "$absSubDir\\\\..\\.\\".$subDir,
+  "$absSubDir\\..\\..\\".$mainDir."\\.\\".$subDir,
+  "$absSubDir\\..\\\\\\".$subDir."\\\\..\\\\..\\".$subDir,
+  "$absSubDir\\BADDIR",

   // relative paths
-  $mainDir."/".$subDir,
-  $mainDir."//".$subDir,
-   $mainDir."///".$subDir,
-  "./".$mainDir."/../".$mainDir."/".$subDir,
+  $mainDir."\\".$subDir,
+  $mainDir."\\\\".$subDir,
+   $mainDir."\\\\\\".$subDir,
+  ".\\".$mainDir."\\..\\".$mainDir."\\".$subDir,
   "BADDIR",

+  // unixifed path
+  $unixifiedDir,
 );

 $filename = 'FileGetContentsVar7.tmp';
@@ -50,7 +53,7 @@
   $j = $i+1;
   $dir = $allDirs[$i];
   echo "\n-- Iteration $j --\n";
-  $res = file_put_contents($dir."/".$filename, ($data . $i));
+  $res = file_put_contents($dir."\\".$filename, ($data . $i));
   if ($res !== false) {
       $in = file_get_contents($absFile);
       if ($in == ($data . $i)) {
@@ -90,12 +93,12 @@

 -- Iteration 5 --

-Warning: file_put_contents(%sfilePutContentsVar7.dir/filePutContentsVar7Sub/..///filePutContentsVar7Sub//..//../filePutContentsVar7Sub/FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
+Warning: file_put_contents(%sfilePutContentsVar7.dir\filePutContentsVar7Sub\..\\\filePutContentsVar7Sub\\..\\..\filePutContentsVar7Sub\FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
 No data written

 -- Iteration 6 --

-Warning: file_put_contents(%sfilePutContentsVar7.dir/filePutContentsVar7Sub/BADDIR/FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
+Warning: file_put_contents(%sfilePutContentsVar7.dir\filePutContentsVar7Sub\BADDIR\FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
 No data written

 -- Iteration 7 --
@@ -112,7 +115,10 @@

 -- Iteration 11 --

-Warning: file_put_contents(BADDIR/FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
+Warning: file_put_contents(BADDIR\FileGetContentsVar7.tmp): Failed to open stream: %s in %s on line %d
 No data written

+-- Iteration 12 --
+Data written correctly
+
 *** Done ***
````
</details>

Windows is fine with either backslashes and slashes; if we want to be strict, we could actually use `DIRECTORY_SEPARATOR`.

Dropping the win32 variants would avoid that the tests differ over time. And it would help a bit to keep the test suite better manageable.

