### PR TITLE
Fail early in *nix build script

### DIFF
--- a/ext/fileinfo/generate_patch.sh
+++ b/ext/fileinfo/generate_patch.sh
@@ -3,7 +3,7 @@
 VERSION=5.45
 
 # Go to fileinfo extension directory.
-cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+cd "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)" || exit
 
 if [ ! -d libmagic.orig ]; then
   mkdir libmagic.orig


### PR DESCRIPTION
Adding one more [1] exit early safeguard in *nix build scripts:

Given the initial cd into the build tree fails (the project root),
   the `buildconf` script exits with non-zero status (failure).

Additionally quoting the pathname to cd into and the empty CD_PATH parameter for portability, also for systems that are using a non-portable pathname [2] for the build tree.

[1]: https://github.com/php/php-src/pull/16717
[2]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_271