### PR TITLE
Fix i386 release build warning

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/actions/configure-x32
         with:
           configurationParameters: >-
-            --enable-debug
+            --disable-debug
             --enable-zts
       - name: make
         run: make -j$(/usr/bin/nproc) >/dev/null

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ env:
   CXX: ccache g++
 jobs:
   LINUX_X64:
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     services:
       mysql:
         image: mysql:8.3
@@ -183,7 +183,7 @@ jobs:
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
   MACOS_DEBUG_NTS:
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +226,7 @@ jobs:
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
   WINDOWS:
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     name: WINDOWS_X64_ZTS
     runs-on: windows-2022
     timeout-minutes: 50
@@ -254,7 +254,7 @@ jobs:
         run: .github/scripts/windows/test.bat
   BENCHMARKING:
     name: BENCHMARKING
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     runs-on: ubuntu-24.04
     timeout-minutes: 50
     steps:

--- a/main/getopt.c
+++ b/main/getopt.c
@@ -97,7 +97,7 @@ PHPAPI int php_getopt(int argc, char* const *argv, const opt_struct opts[], char
 		arg_start = 2;
 
 		/* Check for <arg>=<val> */
-		if ((pos = php_memnstr(&argv[*optind][arg_start], "=", 1, argv[*optind]+arg_end)) != NULL) {
+		if ((pos = memchr(&argv[*optind][arg_start], '=', arg_end - arg_start)) != NULL) {
 			arg_end = pos-&argv[*optind][arg_start];
 			arg_start++;
 		} else {


### PR DESCRIPTION
`--disable-debug` is added temporarily to catch the error in CI.

https://github.com/php/php-src/actions/runs/11734433568/job/32690495546#logs

![image](https://github.com/user-attachments/assets/6259c5c1-0a38-4eb5-8ebf-24ce1c051616)
