### PR TITLE
Fix array_all function description in array.c

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6719,7 +6719,7 @@ PHP_FUNCTION(array_any)
 }
 /* }}} */
 
-/* {{{ Search within an array and returns true if an element is found. */
+/* {{{ Search within an array and returns true only if all elements are found. */
 PHP_FUNCTION(array_all)
 {
 	zval *array = NULL;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6699,7 +6699,7 @@ PHP_FUNCTION(array_find_key)
 }
 /* }}} */
 
-/* {{{ Search within an array and returns true if an element is found. */
+/* {{{ Checks if at least one array element satisfies a callback function. */
 PHP_FUNCTION(array_any)
 {
 	zval *array = NULL;
@@ -6719,7 +6719,7 @@ PHP_FUNCTION(array_any)
 }
 /* }}} */
 
-/* {{{ Search within an array and returns true only if all elements are found. */
+/* {{{ Checks if all array elements satisfy a callback function. */
 PHP_FUNCTION(array_all)
 {
 	zval *array = NULL;


### PR DESCRIPTION
The prior descriptions were identical for both functions `array_any` and `array_all`, which could create confusion.