### PR TITLE
Fix GH-16723: CURLMOPT_PUSHFUNCTION issues

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1284,13 +1284,13 @@ void _php_setup_easy_copy_handlers(php_curl *ch, php_curl *source)
 	ch->handlers.read->res = source->handlers.read->res;
 
 	if (ZEND_FCC_INITIALIZED(source->handlers.read->fcc)) {
-		zend_fcc_dup(&source->handlers.read->fcc, &source->handlers.read->fcc);
+		zend_fcc_dup(&ch->handlers.read->fcc, &source->handlers.read->fcc);
 	}
 	if (ZEND_FCC_INITIALIZED(source->handlers.write->fcc)) {
-		zend_fcc_dup(&source->handlers.write->fcc, &source->handlers.write->fcc);
+		zend_fcc_dup(&ch->handlers.write->fcc, &source->handlers.write->fcc);
 	}
 	if (ZEND_FCC_INITIALIZED(source->handlers.write_header->fcc)) {
-		zend_fcc_dup(&source->handlers.write_header->fcc, &source->handlers.write_header->fcc);
+		zend_fcc_dup(&ch->handlers.write_header->fcc, &source->handlers.write_header->fcc);
 	}
 
 	curl_easy_setopt(ch->cp, CURLOPT_ERRORBUFFER,       ch->err.str);

--- a/ext/curl/tests/curl_pushfunction_trampoline.phpt
+++ b/ext/curl/tests/curl_pushfunction_trampoline.phpt
@@ -60,6 +60,7 @@ sort($responses);
 print_r($responses);
 ?>
 --EXPECT--
+Trampoline for trampoline
 Array
 (
     [0] => main response


### PR DESCRIPTION
We copy the source handler's FCCs to those of the destination.

We also fix the erroneous test assumption that the trampoline wouldn't
be called.