### PR TITLE
ext/soap: fix `make check` being invoked in `ext/soap`

### DIFF
--- a/ext/soap/tests/gh15711.phpt
+++ b/ext/soap/tests/gh15711.phpt
@@ -33,7 +33,7 @@ class TestSoapClient extends SoapClient {
     }
 }
 
-$client = new TestSoapClient('ext/soap/tests/gh15711.wsdl', ['classmap' => ['book' => 'book']]);
+$client = new TestSoapClient(__DIR__ . '/gh15711.wsdl', ['classmap' => ['book' => 'book']]);
 
 echo "--- Test with backed enum ---\n";
 


### PR DESCRIPTION
On NixOS we run `make` & `make check` inside `ext/soap` which broke the test like this:

    001+ Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing WSDL: Couldn't load from 'ext/soap/tests/gh15711.wsdl' : failed to load "ext/soap/tests/gh15711.wsdl": No such file or directory
    002+  in /build/php-8.3.13/ext/soap/tests/gh15711.php:29
    003+ Stack trace:
    004+ #0 /build/php-8.3.13/ext/soap/tests/gh15711.php(29): SoapClient->__construct('ext/soap/tests/...', Array)
    005+ #1 {main}
    006+   thrown in /build/php-8.3.13/ext/soap/tests/gh15711.php on line 29

Fix is to make the path dependant on `__DIR__` as it's the case in other testcases including WSDLs.