### PR TITLE
ext/standard: Sync parameter names for fpow() to be identical to pow()

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3276,7 +3276,7 @@ function fdiv(float $num1, float $num2): float {}
 /**
  * @compile-time-eval
  */
-function fpow(float $num1, float $num2): float {}
+function fpow(float $num, float $exponent): float {}
 
 /* microtime.c */
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 504f4172ac1d64535719234888400063eb37361b */
+ * Stub hash: b15d2f9fa727a78e6fa4d5c60a65d8848f655fe2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1724,7 +1724,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_fdiv arginfo_fmod
 
-#define arginfo_fpow arginfo_fmod
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fpow, 0, 2, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, num, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, exponent, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
 
 #if defined(HAVE_GETTIMEOFDAY)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_microtime, 0, 0, MAY_BE_STRING|MAY_BE_DOUBLE)


### PR DESCRIPTION
I don't know how this did not get caught before, but I found this out while writing the docs for `fpow()`.
It should follow the same, more descriptive, parameter names of the `pow()` functions.

This needs RM approval, but I would hope this is uncontroversial @php/release-managers-84 