### PR TITLE
Refresh zend mm shadow key on fork

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -148,3 +148,7 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 ========================
 5. SAPI changes
 ========================
+
+- SAPIs must now call php_child_init() after a fork. If php-src code was
+  executed in other threads than the one initiating the fork,
+  refresh_memory_manager() must be called in every such thread.

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2572,8 +2572,10 @@ ZEND_API void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 		p->free_map[0] = (1L << ZEND_MM_FIRST_PAGE) - 1;
 		p->map[0] = ZEND_MM_LRUN(ZEND_MM_FIRST_PAGE);
 
+#if ZEND_DEBUG
 		ZEND_ASSERT(getpid() == heap->pid
 				&& "heap was re-used without calling zend_mm_refresh_key_child() after a fork");
+#endif
 
 		zend_mm_refresh_key(heap);
 	}

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2034,7 +2034,7 @@ static void zend_mm_init_key(zend_mm_heap *heap)
 	zend_mm_refresh_key(heap);
 }
 
-static void zend_mm_refresh_key_child(zend_mm_heap *heap)
+ZEND_API void zend_mm_refresh_key_child(zend_mm_heap *heap)
 {
 	uintptr_t old_key = heap->shadow_key;
 

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -317,6 +317,8 @@ struct _zend_mm_storage {
 ZEND_API zend_mm_storage *zend_mm_get_storage(zend_mm_heap *heap);
 ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void *data, size_t data_size);
 
+ZEND_API void zend_mm_refresh_key_child(zend_mm_heap *heap);
+
 /*
 
 // The following example shows how to use zend_mm_heap API with custom storage

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -220,6 +220,7 @@ ZEND_API bool zend_alloc_in_memory_limit_error_reporting(void);
 
 ZEND_API void start_memory_manager(void);
 ZEND_API void shutdown_memory_manager(bool silent, bool full_shutdown);
+ZEND_API void refresh_memory_manager(void);
 ZEND_API bool is_zend_mm(void);
 ZEND_API bool is_zend_ptr(const void *ptr);
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -32,6 +32,7 @@
 #include "php_signal.h"
 #include "php_ticks.h"
 #include "zend_fibers.h"
+#include "main/php_main.h"
 
 #if defined(HAVE_GETPRIORITY) || defined(HAVE_SETPRIORITY) || defined(HAVE_WAIT3)
 #include <sys/wait.h>
@@ -297,7 +298,7 @@ PHP_FUNCTION(pcntl_fork)
 
 		}
 	} else if (id == 0) {
-		zend_max_execution_timer_init();
+		php_child_init();
 	}
 
 	RETURN_LONG((zend_long) id);
@@ -1560,7 +1561,7 @@ PHP_FUNCTION(pcntl_rfork)
 			php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
 	} else if (pid == 0) {
-		zend_max_execution_timer_init();
+		php_child_init();
 	}
 
 	RETURN_LONG((zend_long) pid);
@@ -1605,7 +1606,7 @@ PHP_FUNCTION(pcntl_forkx)
 			php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
 	} else if (pid == 0) {
-		zend_max_execution_timer_init();
+		php_child_init();
 	}
 
 	RETURN_LONG((zend_long) pid);

--- a/main/main.c
+++ b/main/main.c
@@ -1816,6 +1816,12 @@ static void sigchld_handler(int apar)
 /* }}} */
 #endif
 
+PHPAPI void php_child_init(void)
+{
+	refresh_memory_manager();
+	zend_max_execution_timer_init();
+}
+
 /* {{{ php_request_startup */
 zend_result php_request_startup(void)
 {

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -49,6 +49,7 @@ ZEND_ATTRIBUTE_CONST PHPAPI const char *php_build_provider(void);
 PHPAPI char *php_get_version(sapi_module_struct *sapi_module);
 PHPAPI void php_print_version(sapi_module_struct *sapi_module);
 
+PHPAPI void php_child_init(void);
 PHPAPI zend_result php_request_startup(void);
 PHPAPI void php_request_shutdown(void *dummy);
 PHPAPI zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_module);

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -752,6 +752,7 @@ zend_first_try {
 static void php_apache_child_init(apr_pool_t *pchild, server_rec *s)
 {
 	apr_pool_cleanup_register(pchild, NULL, php_apache_child_shutdown, apr_pool_cleanup_null);
+	php_child_init();
 }
 
 #ifdef ZEND_SIGNALS

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2041,6 +2041,8 @@ consult the installation file that came with this distribution, or visit \n\
 						 */
 						parent = 0;
 
+						php_child_init();
+
 						/* don't catch our signals */
 						sigaction(SIGTERM, &old_term, 0);
 						sigaction(SIGQUIT, &old_quit, 0);

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2530,6 +2530,7 @@ static void php_cli_server_startup_workers(void) {
 #if defined(HAVE_PRCTL) || defined(HAVE_PROCCTL)
 				php_cli_server_worker_install_pdeathsig();
 #endif
+				php_child_init();
 				return;
 			} else {
 				php_cli_server_workers[php_cli_server_worker] = pid;

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -253,6 +253,9 @@ int fpm_php_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 		limit_extensions = wp->limit_extensions;
 		wp->limit_extensions = NULL;
 	}
+
+	php_child_init();
+
 	return 0;
 }
 /* }}} */

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1395,6 +1395,8 @@ void start_children( int children )
             switch( pid ) {
             case 0: /* children process */
 
+                php_child_init();
+
                 /* don't catch our signals */
                 sigaction( SIGTERM, &old_term, 0 );
                 sigaction( SIGQUIT, &old_quit, 0 );

--- a/sapi/litespeed/lscriu.c
+++ b/sapi/litespeed/lscriu.c
@@ -85,6 +85,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lscriu.h"
 
 #include <Zend/zend_portability.h>
+#include "main/php_main.h"
 
 #define  LSCRIU_PATH    256
 
@@ -459,6 +460,7 @@ static void LSCRIU_CloudLinux_Checkpoint(void)
     else {
         s_restored = 1;
         LSAPI_reset_server_state();
+        php_child_init();
         /*
          Here we have restored the php process, so we should to tell (via
          semaphore) mod_lsapi that we are started and ready to receive data.
@@ -532,6 +534,7 @@ static void LSCRIU_try_checkpoint(int *forked_pid)
         LSCRIU_Wait_Dump_Finish_Or_Restored(iPidParent);
         LSCRIU_Restored_Error(0, "Restored!");
         LSAPI_reset_server_state();
+        php_child_init();
         s_restored = 1;
     }
     else {


### PR DESCRIPTION
The memory manager is cleaned up after each request by calling `shutdown_memory_manager()`. At the same time, this prepares the manager for the next request, and the [shadow key](https://github.com/php/php-src/pull/14054) is refreshed.

Unfortunately, in forking SAPIs the first request of every child process inherits the memory manager of the parent process, including the shadow key. As a result, a leak of the shadow key during the first request of one process gives away the shadow key used during the first request of other processes. This does _not_ defeat shadow pointers, but this makes the key refresh mechanism less useful.

Here I ensure that we refresh the shadow key after a fork. The memory manager is not empty at this point (we perform allocations after `shutdown_memory_manager()`), so we have to recompute any shadow pointers with the new key.

I'm targeting 8.4, but this is too risky and not critical enough for the last RC. I would like to merge this in 8.4.1.

Edit: now targeting 8.5.

ZTS: We assume that the forked process has only one thread, as anything else would be unsafe. If a SAPI forks a process running more than one thread, it is its responsibility to call `refresh_memory_manager()` in each PHP thread of the child process.

NB: I can't test litespeed.

UPGRADING.INTERNALS:
```
 * SAPIs must call `php_child_init()` after a fork. If the forked process runs multiple threads, `refresh_memory_manager()` must be called in each PHP thread of the child process.
```

Credits: This was a known issue (https://github.com/php/php-src/pull/14054#issuecomment-2085450926), but this was also independently discovered and reported by @GhostFrankWu @KpwnZ.