### PR TITLE
Get rid of HASH_OF() in ext/dom

### DIFF
--- a/ext/dom/dom_iterators.c
+++ b/ext/dom/dom_iterators.c
@@ -177,7 +177,7 @@ static void php_dom_iterator_move_forward(zend_object_iterator *iter) /* {{{ */
 		if (objmap->nodetype != XML_ENTITY_NODE &&
 			objmap->nodetype != XML_NOTATION_NODE) {
 			if (objmap->nodetype == DOM_NODESET) {
-				HashTable *nodeht = HASH_OF(&objmap->baseobj_zv);
+				HashTable *nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
 				zval *entry;
 				zend_hash_move_forward_ex(nodeht, &iterator->pos);
 				if ((entry = zend_hash_get_current_data_ex(nodeht, &iterator->pos))) {
@@ -275,7 +275,7 @@ zend_object_iterator *php_dom_get_iterator(zend_class_entry *ce, zval *object, i
 		if (objmap->nodetype != XML_ENTITY_NODE &&
 			objmap->nodetype != XML_NOTATION_NODE) {
 			if (objmap->nodetype == DOM_NODESET) {
-				nodeht = HASH_OF(&objmap->baseobj_zv);
+				nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
 				zend_hash_internal_pointer_reset_ex(nodeht, &iterator->pos);
 				if ((entry = zend_hash_get_current_data_ex(nodeht, &iterator->pos))) {
 					ZVAL_COPY(&iterator->curobj, entry);

--- a/ext/dom/nodelist.c
+++ b/ext/dom/nodelist.c
@@ -72,7 +72,7 @@ zend_long php_dom_get_nodelist_length(dom_object *obj)
 	}
 
 	if (objmap->nodetype == DOM_NODESET) {
-		HashTable *nodeht = HASH_OF(&objmap->baseobj_zv);
+		HashTable *nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
 		return zend_hash_num_elements(nodeht);
 	}
 
@@ -145,7 +145,7 @@ void php_dom_nodelist_get_item_into_zval(dom_nnodemap_object *objmap, zend_long 
 				itemnode = php_dom_libxml_hash_iter(objmap, index);
 			} else {
 				if (objmap->nodetype == DOM_NODESET) {
-					HashTable *nodeht = HASH_OF(&objmap->baseobj_zv);
+					HashTable *nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
 					zval *entry = zend_hash_index_find(nodeht, index);
 					if (entry) {
 						ZVAL_COPY(return_value, entry);


### PR DESCRIPTION
The cases where this is used are only where an array is possible, so we can replace them with Z_ARRVAL_P. This reduces some overhead.