### PR TITLE
Fix GH-16769: php_pcntl_set_user_signal_infos aborts when a signal is…

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -874,6 +874,7 @@ static bool php_pcntl_set_user_signal_infos(
 	zval *user_signal_no;
 	ZEND_HASH_FOREACH_VAL(user_signals, user_signal_no) {
 		bool failed = true;
+		ZVAL_DEREF(user_signal_no);
 		zend_long tmp = zval_try_get_long(user_signal_no, &failed);
 
 		if (failed) {

--- a/ext/pcntl/tests/gh16769.phpt
+++ b/ext/pcntl/tests/gh16769.phpt
@@ -1,0 +1,18 @@
+--TEST--
+pcntl_sigwaitinfo abort when signals is an array with self-reference.
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php if (!function_exists("pcntl_sigwaitinfo")) die("skip pcntl_sigwaitinfo() not available"); ?>
+--FILE--
+<?php
+$a[0] = &$a;
+
+try {
+	pcntl_sigwaitinfo($a,$a);
+} catch(\TypeError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+pcntl_sigwaitinfo(): Argument #1 ($signals) signals must be of type int, array given


### PR DESCRIPTION
… a reference.