### PR TITLE
Add --enable-rtld-deepbind configure flag, disable it by default except for apache

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -164,7 +164,7 @@
 
 # if defined(RTLD_GROUP) && defined(RTLD_WORLD) && defined(RTLD_PARENT)
 #  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL | RTLD_GROUP | RTLD_WORLD | RTLD_PARENT)
-# elif defined(RTLD_DEEPBIND) && !defined(__SANITIZE_ADDRESS__) && !__has_feature(memory_sanitizer)
+# elif defined(RTLD_DEEPBIND) && !defined(__SANITIZE_ADDRESS__) && !__has_feature(memory_sanitizer) && defined(PHP_USE_RTLD_DEEPBIND)
 #  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL | RTLD_DEEPBIND)
 # else
 #  define DL_LOAD(libname)			dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL)

--- a/configure.ac
+++ b/configure.ac
@@ -868,6 +868,23 @@ AS_VAR_IF([PHP_RTLD_NOW], [yes],
     [Define to 1 if 'dlopen()' uses the 'RTLD_NOW' mode flag instead of
     'RTLD_LAZY'.])])
 
+if test "$PHP_SAPI" = "apache2handler"; then
+  PHP_RTLD_DEEPBIND_DEFAULT=yes
+else
+  PHP_RTLD_DEEPBIND_DEFAULT=no
+fi
+
+PHP_ARG_ENABLE([rtld-deepbind],
+  [whether to dlopen extensions with RTLD_DEEPBIND],
+  [AS_HELP_STRING([--enable-rtld-deepbind],
+    [Use dlopen with RTLD_DEEPBIND])],
+  [$PHP_RTLD_DEEPBIND_DEFAULT],
+  [$PHP_RTLD_DEEPBIND_DEFAULT])
+
+if test "$PHP_RTLD_DEEPBIND" = "yes"; then
+  AC_DEFINE(PHP_USE_RTLD_DEEPBIND, 1, [ Use dlopen with RTLD_DEEPBIND ])
+fi
+
 PHP_ARG_WITH([layout],
   [layout of installed files],
   [AS_HELP_STRING([--with-layout=TYPE],


### PR DESCRIPTION
This pull request adds an --enable-rtld-deepbind flag, which enables the use of RTLD_DEEPBIND for dlopen, and changes the default behavior of dlopen to use RTLD_DEEPBIND *only* when compiling the Apache SAPI.

Re: https://github.com/php/php-src/issues/10670, https://github.com/php/php-src/pull/11094

This fixes compatibility with custom allocators like jemalloc on newer glibc versions, while still retaining the old DEEPBIND behavior for apache, which seems to have been the [reason why it was added](https://github.com/php/php-src/issues/10670#issuecomment-1503458109).