### PR TITLE
Patch libcurl.pc for macOS builds

### DIFF
--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -18,6 +18,7 @@ runs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libxslt/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/icu4c/lib/pkgconfig"
+        sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
         ./buildconf --force
         ./configure \
           --enable-option-checking=fatal \


### PR DESCRIPTION
cURL 8.11.0 added a couple of packages to `Requires.private`, but these packages are irrelevant when building against a shared libcurl.  For some reason, these private requirements are checked when we're doing `pkg-config --cflags` (that happens with the preinstalled pkg-config 0.29.2, as well as with pkgconf 2.3.0.  To avoid further messing with these packages, we just drop the `Requires.private` line from libcurl.pc.

---

See also #16741.