### PR TITLE
Fix GH-16770: Tracing JIT type mismatch when returning UNDEF

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -6673,6 +6673,9 @@ done:
 			 && (p+1)->op == ZEND_JIT_TRACE_VM) {
 				const zend_op *opline = (p+1)->opline - 1;
 				if (opline->result_type != IS_UNUSED) {
+					if (res_type == IS_UNDEF) {
+						res_type = IS_NULL;
+					}
 				    SET_STACK_TYPE(stack, EX_VAR_TO_NUM(opline->result.var), res_type, 1);
 				}
 			}

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -5404,6 +5404,9 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 							res_type = Z_TYPE_P(RT_CONSTANT(opline, opline->op1));
 						} else if (op1_type != IS_UNKNOWN) {
 							res_type = op1_type;
+							if (res_type == IS_UNDEF) {
+								res_type = IS_NULL;
+							}
 						}
 						if (op_array->type == ZEND_EVAL_CODE
 						 // TODO: support for top-level code
@@ -6673,9 +6676,6 @@ done:
 			 && (p+1)->op == ZEND_JIT_TRACE_VM) {
 				const zend_op *opline = (p+1)->opline - 1;
 				if (opline->result_type != IS_UNUSED) {
-					if (res_type == IS_UNDEF) {
-						res_type = IS_NULL;
-					}
 				    SET_STACK_TYPE(stack, EX_VAR_TO_NUM(opline->result.var), res_type, 1);
 				}
 			}

--- a/ext/opcache/tests/jit/gh16770.phpt
+++ b/ext/opcache/tests/jit/gh16770.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-16770 (Tracing JIT type mismatch when returning UNDEF)
+--INI--
+opcache.jit=1254
+opcache.jit_hot_loop=1
+opcache.jit_buffer_size=32M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+function ret_undef($k) {
+    return $undefined;
+}
+for ($i = 0; $i < 10; $i++) {
+    $output = ret_undef($i);
+}
+var_dump($output);
+?>
+--EXPECTF--
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+
+Warning: Undefined variable $undefined in %s on line %d
+NULL


### PR DESCRIPTION
When returning an UNDEF value, it actually becomes NULL. The following code took this into account:
https://github.com/php/php-src/blob/28344e0445bc2abae8dc5f1376aa0ff350e6d66d/ext/opcache/jit/zend_jit_trace.c#L2196-L2199

But the stack does not update the type to NULL, causing a mismatch.
Alternative would be to update the code I quoted above I think.