### PR TITLE
Only patch libcurl.pc if it exists

### DIFF
--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -9,6 +9,7 @@ runs:
     - shell: bash
       run: |
         set -x
+        BREW_OPT="$(brew --prefix)"/opt
         export PATH="/usr/local/opt/bison/bin:$PATH"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/curl/lib/pkgconfig"
@@ -18,9 +19,7 @@ runs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxslt/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
-        if test -f "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"; then
-          sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
-        fi
+        sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
         ./buildconf --force
         ./configure \
           CFLAGS="-Wno-strict-prototypes -Wno-unused-but-set-variable -Wno-single-bit-bitfield-constant-conversion" \

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -18,7 +18,9 @@ runs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxslt/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
-        sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
+        if test -f "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"; then
+          sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
+        fi
         ./buildconf --force
         ./configure \
           CFLAGS="-Wno-strict-prototypes -Wno-unused-but-set-variable -Wno-single-bit-bitfield-constant-conversion" \


### PR DESCRIPTION
This is a follow-up to #16783, because of https://github.com/php/php-src/actions/runs/11823721167/job/32943620474#step:5:98. Apparently, the homegrew people [ship curl 8.11.0_1](https://github.com/php/php-src/actions/runs/11823720946/job/32943617471#step:3:90) now, and the .pc is gone (moved, removed, I don't know). Let's see.