### PR TITLE
Remove superfluous determination of cURL version

### DIFF
--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -3,16 +3,6 @@
 ARG_WITH("curl", "cURL support", "no");
 
 if (PHP_CURL != "no") {
-	var ver_num = NaN;
-	var f = PHP_PHP_BUILD + "/include/curl/curlver.h";
-	if (FSO.FileExists(f)) {
-		var reg = /LIBCURL_VERSION_NUM\s+(0x[a-z0-9]+)/gi;
-		var m = reg.exec(file_get_contents(PHP_PHP_BUILD + "/include/curl/curlver.h"));
-		if (!!m && m.length >= 2) {
-			ver_num = parseInt(m[1]);
-		}
-	}
-
 	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "curl", PHP_CURL) &&
 		CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_CURL") &&
 		SETUP_OPENSSL("curl", PHP_CURL) >= 2 &&
@@ -20,7 +10,6 @@ if (PHP_CURL != "no") {
 		CHECK_LIB("wldap32.lib", "curl", PHP_CURL) &&
 		(((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "curl", PHP_CURL))) ||
 			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "curl", PHP_CURL)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))) &&
-		!isNaN(ver_num) &&
 		(CHECK_LIB("normaliz.lib", "curl", PHP_CURL) &&
 		 CHECK_LIB("libssh2.lib", "curl", PHP_CURL) &&
 		 CHECK_LIB("nghttp2.lib", "curl", PHP_CURL))


### PR DESCRIPTION
This was originally meant to distinguish between libcurl 7.59.0 and earlier; only the latter would need to be linked against normalize.lib, libssh2.lib and nghttp2.lib[1].  That would only have catered to our builds, and might not have been correct anyway.  However, the version check was wrong (paren error), and has been removed in the meantime[2].

Given that cURL 7.59.0 is rather old, we do not reinstate the version check, but rather drop the now superfluous (and improper) determination of the cURL version.  A nice bonus is that we get rid of some global variables.

[1] <https://github.com/php/php-src/commit/a1ba3007a452fb2618526ed7159236362219a208>
[2] <https://github.com/php/php-src/commit/94a12d5b315aa73a24b96cfebb4fd38b8e9b800e>