### PR TITLE
Stick with icu4c 74.2

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -33,4 +33,5 @@ runs:
           libjpeg \
           libxslt \
           postgresql
+        brew reinstall icu4c@74
         brew link icu4c gettext --force

--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -21,7 +21,6 @@ runs:
           webp \
           freetype \
           intltool \
-          icu4c \
           libiconv \
           zlib \
           t1lib \

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -18,7 +18,7 @@ runs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxml2/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxslt/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c@74/lib/pkgconfig"
         sed -i -e 's/Requires.private:.*//g' "$BREW_OPT/curl/lib/pkgconfig/libcurl.pc"
         ./buildconf --force
         ./configure \


### PR DESCRIPTION
Note that this is a stop-gap measure to hopefully get CI back to green on macOS. It should not be merged up.

Anyhow, even if this works, [icu4c@74 is already deprecated](https://formulae.brew.sh/formula/icu4c@74). Not sure if we can keep it until PHP-8.1 is EOL.