### PR TITLE
Drop bogus ext/libxml dependency on ext/iconv

### DIFF
--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -4,8 +4,7 @@ ARG_WITH("libxml", "LibXML support", "yes");
 
 if (PHP_LIBXML == "yes") {
 	if (CHECK_LIB("libxml2_a_dll.lib;libxml2_a.lib", "libxml") &&
-			((PHP_ICONV == "no" || PHP_ICONV_SHARED) && CHECK_LIB("libiconv_a.lib;iconv_a.lib;libiconv.lib;iconv.lib", "libxml")
-			|| (PHP_ICONV == "yes" && !PHP_ICONV_SHARED)) &&
+			((PHP_ICONV != "no" && !PHP_ICONV_SHARED) || CHECK_LIB("libiconv_a.lib;iconv_a.lib;libiconv.lib;iconv.lib", "libxml")) &&
 			CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
 			CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2")) {
 

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -4,10 +4,10 @@ ARG_WITH("libxml", "LibXML support", "yes");
 
 if (PHP_LIBXML == "yes") {
 	if (CHECK_LIB("libxml2_a_dll.lib;libxml2_a.lib", "libxml") &&
-			CHECK_LIB("libiconv_a.lib;iconv_a.lib;libiconv.lib;iconv.lib", "libxml") &&
+			((PHP_ICONV == "no" || PHP_ICONV_SHARED) && CHECK_LIB("libiconv_a.lib;iconv_a.lib;libiconv.lib;iconv.lib", "libxml")
+			|| (PHP_ICONV == "yes" && !PHP_ICONV_SHARED)) &&
 			CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
-			CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
-			ADD_EXTENSION_DEP('libxml', 'iconv')) {
+			CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2")) {
 
 		if (GREP_HEADER("libxml/xmlversion.h", "#define\\s+LIBXML_VERSION\\s+(\\d+)", PHP_PHP_BUILD + "\\include\\libxml2") &&
 				+RegExp.$1 >= 20904) {


### PR DESCRIPTION
There is no such dependency; only libxml2 depends on libiconv.  So when php_libxml.dll is built, it needs to be linked against libiconv, or, when ext/iconv has been configured as static extension, against php8.dll.

---

Note that I'm not happy with having php8.dll serving as drop-in DLL for a couple of libraries (grep for `ADD_DEF_FILE`), but this is what we already have. We may revisit this issue later.