### PR TITLE
Fix GH-16808: Segmentation fault in RecursiveIteratorIterator->current() with a xml element input

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2539,7 +2539,11 @@ static zval *php_sxe_iterator_current_data(zend_object_iterator *iter) /* {{{ */
 {
 	php_sxe_iterator *iterator = (php_sxe_iterator *)iter;
 
-	return &iterator->sxe->iter.data;
+	zval *data = &iterator->sxe->iter.data;
+	if (Z_ISUNDEF_P(data)) {
+		return NULL;
+	}
+	return data;
 }
 /* }}} */
 

--- a/ext/simplexml/tests/gh16808.phpt
+++ b/ext/simplexml/tests/gh16808.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-16808 (Segmentation fault in RecursiveIteratorIterator->current() with a xml element input)
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+$sxe = new SimpleXMLElement("<root />");
+$test = new RecursiveIteratorIterator($sxe);
+var_dump($test->current());
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
When the current data is invalid, NULL must be returned. At least that's how the check in SPL works and how other extensions do this as well. If we don't do this, an UNDEF value gets propagated to a return value (misprinted as null); leading to issues.