### PR TITLE
Report Windows Server 2025 in php_uname

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -271,7 +271,9 @@ static char* php_get_windows_name()
 						major = "Windows 10";
 					}
 				} else {
-					if (osvi.dwBuildNumber >= 20348) {
+					if (osvi.dwBuildNumber >= 26100) {
+						major = "Windows Server 2025";
+					} else if (osvi.dwBuildNumber >= 20348) {
 						major = "Windows Server 2022";
 					} else if (osvi.dwBuildNumber >= 19042) {
 						major = "Windows Server, version 20H2";


### PR DESCRIPTION
Windows Server 2025 was released on 2024-11-01 with a major [build number of 26100](https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info) (matching Windows 11 24H2). With this patch `php_uname` will return the correct version string (currently `Windows Server 2022`).

Previous related PR for Windows Server 2022 and earlier: https://github.com/php/php-src/pull/7816

I'm targeting `master` but please let me know if I should choose `PHP-8.4` or something else as the base branch.