### PR TITLE
Fix tests with non-GNU iconv

### DIFF
--- a/ext/iconv/tests/bug48147.phpt
+++ b/ext/iconv/tests/bug48147.phpt
@@ -2,6 +2,16 @@
 Bug #48147 (iconv with //IGNORE cuts the string)
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+// POSIX 2024 standardizes "//IGNORE", but does NOT say that
+// it should ignore invalid input sequences, only untranslatable
+// ones. The GNU implementations have however historically skipped
+// invalid input sequences when it is used.
+if (ICONV_IMPL != "libiconv" && ICONV_IMPL != "glibc") {
+    die("skip iconv will not //IGNORE invalid input sequences");
+}
+?>
 --FILE--
 <?php
 $text = "aa\xC3\xC3\xC3\xB8aa";

--- a/ext/iconv/tests/bug52211.phpt
+++ b/ext/iconv/tests/bug52211.phpt
@@ -1,5 +1,16 @@
 --TEST--
 Bug #52211 (iconv() returns part of string on error)
+--SKIPIF--
+<?php
+// The two GNU iconvs (glibc and libiconv) fail if the input sequence
+// cannot be converted to the target charset, but most others
+// (including musl, FreeBSD, NetBSD, and Solaris) do not. POSIX says
+// that "iconv() shall perform an implementation-defined conversion on
+// the character," so this is likely to remain a GNUism.
+if (ICONV_IMPL != "libiconv" && ICONV_IMPL != "glibc") {
+    die("skip iconv impl may not fail on unconvertable sequences");
+}
+?>
 --EXTENSIONS--
 iconv
 --FILE--

--- a/ext/iconv/tests/bug76249.phpt
+++ b/ext/iconv/tests/bug76249.phpt
@@ -7,13 +7,13 @@ iconv
 $fh = fopen('php://memory', 'rw');
 fwrite($fh, "abc");
 rewind($fh);
-if (false === @stream_filter_append($fh, 'convert.iconv.ucs-2/utf8//IGNORE', STREAM_FILTER_READ, [])) {
-    stream_filter_append($fh, 'convert.iconv.ucs-2/utf-8//IGNORE', STREAM_FILTER_READ, []);
+if (false === @stream_filter_append($fh, 'convert.iconv.ucs-2/utf8', STREAM_FILTER_READ, [])) {
+    stream_filter_append($fh, 'convert.iconv.ucs-2/utf-8', STREAM_FILTER_READ, []);
 }
 var_dump(stream_get_contents($fh));
 ?>
 DONE
 --EXPECTF--
-Warning: stream_get_contents(): iconv stream filter ("ucs-2"=>"utf%A8//IGNORE"): invalid multibyte sequence in %sbug76249.php on line %d
+Warning: stream_get_contents(): iconv stream filter ("ucs-2"=>"utf%A8"): invalid multibyte sequence in %sbug76249.php on line %d
 string(0) ""
 DONE

--- a/ext/iconv/tests/eucjp2iso2022jp.phpt
+++ b/ext/iconv/tests/eucjp2iso2022jp.phpt
@@ -2,6 +2,16 @@
 EUC-JP to ISO-2022-JP
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+// ISO-2022-JP is a stateful encoding, so the right answer is not
+// unique. In particular, musl (type "unknown") is known to have an
+// inefficient encoding for it that does not agree with the expected
+// output below.
+if (ICONV_IMPL == "unknown") {
+    die("skip byte-comparison of stateful encoding with unknown iconv");
+}
+?>
 --INI--
 error_reporting=2039
 --FILE--

--- a/ext/iconv/tests/iconv_mime_encode.phpt
+++ b/ext/iconv/tests/iconv_mime_encode.phpt
@@ -2,6 +2,16 @@
 iconv_mime_encode()
 --EXTENSIONS--
 iconv
+--SKIPIF--
+<?php
+// ISO-2022-JP is a stateful encoding, so the right answer is not
+// unique. In particular, musl (type "unknown") is known to have an
+// inefficient encoding for it that does not agree with the expected
+// output below.
+if (ICONV_IMPL == "unknown") {
+    die("skip byte-comparison of stateful encoding with unknown iconv");
+}
+?>
 --INI--
 iconv.internal_charset=iso-8859-1
 --FILE--


### PR DESCRIPTION
Get the iconv test suite passing with musl. This fixes some of https://github.com/php/php-src/issues/13696

Many of these issues relate to the `//IGNORE` suffix that can be appended to the target charset during conversion. This `//IGNORE` was [recently standardized in POSIX 2024](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/iconv.html), but there are still some pitfalls:

* The standard says that `//IGNORE` will ignore untranslatable sequences (valid input sequences that cannot be represented in the target charset), but sequences that are a priori invalid should instead cause an `EILSEQ` -- even in earlier versions of the standard.
* The two GNU implementations have always ignored that, and have returned an `EILSEQ` for invalid input sequences. Their `//IGNORE` allows these errors to be ignored. In other words, the two GNU implementations have never conformed to POSIX.
* Other implementations may conform to POSIX, but not the 2024 version yet. In particular, musl follows the earlier standards and will e.g. replace untranslatable sequences by a `*` rather than fail. But it does not yet implement `//IGNORE`, and will simply crash if it encounters `//IGNORE` in the charset name.

So, what is done here:

* Two of our tests rely on the non-standard (GNU) illegal input sequence `//IGNORE` behavior. These get SKIPIFs.
* One test uses `//IGNORE`, but it has no effect on the output. Here the `//IGNORE` was simply dropped.
* Two ISO-2022-JP tests are looking for GNU output, but that encoding is stateful and there is no single correct answer. The musl answer is different. Rather than whitelist the GNU implementations here, I've blacklisted "unknown" implementations, which includes musl. (I don't see a good way to fix these tests otherwise.)

@petk @arnaud-lb 