### PR TITLE
Fix GH-16839: Error on building Opcache JIT for Windows ARM64

### DIFF
--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -3,7 +3,7 @@ ARG_ENABLE("opcache", "whether to enable Zend OPcache support", "yes");
 
 if (PHP_OPCACHE != "no") {
 
-	ARG_ENABLE("opcache-jit", "whether to enable JIT", "yes");
+	ARG_ENABLE("opcache-jit", "whether to enable JIT (not supported for ARM64)", "yes");
 
 	ZEND_EXTENSION('opcache', "\
 		ZendAccelerator.c \
@@ -23,7 +23,9 @@ if (PHP_OPCACHE != "no") {
 	ADD_EXTENSION_DEP('opcache', 'pcre');
 
 	if (PHP_OPCACHE_JIT == "yes") {
-		if (CHECK_HEADER_ADD_INCLUDE("ir/ir.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
+		if (TARGET_ARCH == 'arm64') {
+			WARNING("JIT not enabled; not yet supported for ARM64");
+		} else if (CHECK_HEADER_ADD_INCLUDE("ir/ir.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
 			var dasm_flags = (X64 ? "-D X64=1" : "") + (X64 ? " -D X64WIN=1" : "") + " -D WIN=1";
 			var ir_target = (X64 ? "IR_TARGET_X64" : "IR_TARGET_X86");
 			var ir_src = "ir_strtab.c ir_cfg.c ir_sccp.c ir_gcm.c ir_ra.c ir_save.c \


### PR DESCRIPTION
OPcache JIT does not support Windows ARM64, so we should not allow `--enable-opcache-jit` in the first place.

Due to the way `ARG_ENABLE()` is handled on Windows, we do not attempt to suppress the configure option, but just do not enable JIT when the user attempts to, and adapt the help text.