### PR TITLE
ext/sockets: Adding TCP_FUNCTION_BLK socket option for FreeBSD.

### DIFF
--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -640,6 +640,13 @@ const TCP_KEEPINTVL = UNKNOWN;
  */
 const TCP_KEEPCNT = UNKNOWN;
 #endif
+#ifdef TCP_FUNCTION_BLK
+/**
+ * @var int
+ * @cvalue TCP_FUNCTION_BLK
+ */
+const TCP_FUNCTION_BLK = UNKNOWN;
+#endif
 /**
  * @var int
  * @cvalue PHP_NORMAL_READ

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4fdd210a2de6f3b5df10caf5ac7fefa6aa71926c */
+ * Stub hash: 341bf3dfc486ca410cf1e15e1e22b0c60734277b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -556,6 +556,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(TCP_KEEPIDLE)
 	REGISTER_LONG_CONSTANT("TCP_KEEPCNT", TCP_KEEPCNT, CONST_PERSISTENT);
+#endif
+#if defined(TCP_FUNCTION_BLK)
+	REGISTER_LONG_CONSTANT("TCP_FUNCTION_BLK", TCP_FUNCTION_BLK, CONST_PERSISTENT);
 #endif
 	REGISTER_LONG_CONSTANT("PHP_NORMAL_READ", PHP_NORMAL_READ, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("PHP_BINARY_READ", PHP_BINARY_READ, CONST_PERSISTENT);

--- a/ext/sockets/tests/socket_set_option_tsf.phpt
+++ b/ext/sockets/tests/socket_set_option_tsf.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test if socket_set_option() works, option:TCP_FUNCTION_BLK
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+
+if (!defined("TCP_FUNCTION_BLK")) {
+	die('SKIP on platforms not supporting TCP_FUNCTION_BLK');
+}
+?>
+--FILE--
+<?php
+$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+if (!$socket) {
+        die('Unable to create AF_INET socket [socket]');
+}
+socket_set_option( $socket, SOL_TCP, TCP_FUNCTION_BLK, "nochancetoexist");
+// TCP/RACK and other alternate stacks are not present by default, at least `freebsd` is.
+var_dump(socket_set_option( $socket, SOL_TCP, TCP_FUNCTION_BLK, "freebsd"));
+var_dump(socket_get_option( $socket, SOL_TCP, TCP_FUNCTION_BLK));
+socket_close($socket);
+?>
+--EXPECTF--
+Warning: socket_set_option(): Unable to set socket option [2]: No such file or directory in %s on line %d
+bool(true)
+array(2) {
+  ["function_set_name"]=>
+  string(7) "freebsd"
+  ["pcbcnt"]=>
+  int(%d)
+}


### PR DESCRIPTION
Allows to select an alternate TCP stack. For example with RACK, a fast loss detection relying on timestamp per packet.

While it works system-wide, it can also apply in an individual socket level too.