### PR TITLE
Run labeler only in php/php-src repository

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'php/php-src'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
This is primarily to disable it in our security repo...