### PR TITLE
Move iconv const check into autoconf

### DIFF
--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -83,6 +83,17 @@ int main(void) {
   AS_VAR_IF([php_cv_iconv_errno], [yes],,
     [AC_MSG_FAILURE([The iconv check failed, 'errno' is missing.])])
 
+  AC_CACHE_CHECK([if iconv input parameter is const (non-standard)], [php_cv_iconv_const],
+    [AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+#include <iconv.h>
+
+size_t iconv(iconv_t cd, const char **src, size_t *srcleft, char **dst, size_t *dstleft);
+    ])],
+    [php_cv_iconv_const=const],
+    [php_cv_iconv_const=])])
+  AC_DEFINE_UNQUOTED([ICONV_CONST], [$php_cv_iconv_const],
+    [Define to const if iconv's input is const.])
+
   AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore],
     [AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <iconv.h>

--- a/ext/iconv/config.w32
+++ b/ext/iconv/config.w32
@@ -11,6 +11,7 @@ if (PHP_ICONV != "no") {
 
 		AC_DEFINE("HAVE_ICONV", 1, "Define to 1 if the PHP extension 'iconv' is available.");
 		AC_DEFINE("HAVE_LIBICONV", 1, "Define to 1 if you have the 'libiconv' function.");
+		AC_DEFINE("ICONV_CONST", "", "Define to const if iconv's input is const.");
 		AC_DEFINE("ICONV_ALIASED_LIBICONV", 1, "Define to 1 if 'iconv()' is aliased to 'libiconv()'.");
 		AC_DEFINE("PHP_ICONV_IMPL", "\"libiconv\"", "The iconv implementation.");
 		ADD_FLAG("CFLAGS_ICONV", "/D PHP_ICONV_EXPORTS ");

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -43,14 +43,6 @@
 #undef iconv
 #endif
 
-#if defined(__NetBSD__)
-// unfortunately, netbsd has still the old non posix conformant signature
-// libiconv tends to match the eventual system's iconv too.
-#define ICONV_CONST const
-#else
-#define ICONV_CONST
-#endif
-
 #include "zend_smart_str.h"
 #include "ext/standard/base64.h"
 #include "ext/standard/quot_print.h"


### PR DESCRIPTION
Some systems (older NetBSD pre-10, Solaris) may have a non-standard const parameter with iconv. Instead of hardcoding the OS check, move this to a feature check performed by autoconf.

autoconf doesn't have a nicer way of checking this (well, except for AM_ICONV, which is part of gettext and we're presumably not using it), so we have to repeat the function signature and check for it with a mismatched signature.

Tested on NetBSD/amd64 9.4 (for const) and macOS/arm64 14 (for non-const).