### PR TITLE
Drop duplicate macro definitions

### DIFF
--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -23,23 +23,6 @@
 
 #include "php_dns.h"
 
-#define PHP_DNS_NUM_TYPES	12	/* Number of DNS Types Supported by PHP currently */
-
-#define PHP_DNS_A      0x00000001
-#define PHP_DNS_NS     0x00000002
-#define PHP_DNS_CNAME  0x00000010
-#define PHP_DNS_SOA    0x00000020
-#define PHP_DNS_PTR    0x00000800
-#define PHP_DNS_HINFO  0x00001000
-#define PHP_DNS_MX     0x00004000
-#define PHP_DNS_TXT    0x00008000
-#define PHP_DNS_A6     0x01000000
-#define PHP_DNS_SRV    0x02000000
-#define PHP_DNS_NAPTR  0x04000000
-#define PHP_DNS_AAAA   0x08000000
-#define PHP_DNS_ANY    0x10000000
-#define PHP_DNS_ALL    (PHP_DNS_A|PHP_DNS_NS|PHP_DNS_CNAME|PHP_DNS_SOA|PHP_DNS_PTR|PHP_DNS_HINFO|PHP_DNS_MX|PHP_DNS_TXT|PHP_DNS_A6|PHP_DNS_SRV|PHP_DNS_NAPTR|PHP_DNS_AAAA)
-
 PHP_FUNCTION(dns_get_mx) /* {{{ */
 {
 	char *hostname;


### PR DESCRIPTION
Apparently, these have been overlooked when the macro definitions have been moved from dns.c to php_dns.h[1].

[1] <https://github.com/php/php-src/commit/6f2f228e4ada762067bd5c22b7cab35623fe49cd>