### PR TITLE
Fix GH-16849: Error dialog causes process to hang

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2070,8 +2070,9 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 		_set_invalid_parameter_handler(old_invalid_parameter_handler);
 	}
 
-	/* Disable the message box for assertions.*/
+	/* Disable the message box for assertions and errors.*/
 	_CrtSetReportMode(_CRT_ASSERT, 0);
+	_CrtSetReportMode(_CRT_ERROR, 0);
 #else
 	php_os = PHP_OS;
 #endif


### PR DESCRIPTION
If `_DEBUG` is set, assertion failures and errors are directed to a debug message window by default[1].  That causes a process to hang, since these dialogs are modal.  While we already cater to assertion failures, errors have apparently been overlooked.

We choose a minimal fix for BC reasons; although passing `0` as `reportMode` is undocumented, it obviously works fine for a long time. We may consider to improve on this for the `master` branch.

[1] <https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/crtsetreportmode>