### PR TITLE
Avoid registering top functions with opcache_compile_file()

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9120,8 +9120,7 @@ static void zend_compile_class_decl(znode *result, zend_ast *ast, bool toplevel)
 	}
 
 	/* We currently don't early-bind classes that implement interfaces or use traits */
-	if (!ce->num_interfaces && !ce->num_traits && !ce->num_hooked_prop_variance_checks
-	 && !(CG(compiler_options) & ZEND_COMPILE_WITHOUT_EXECUTION)) {
+	if (!ce->num_interfaces && !ce->num_traits && !ce->num_hooked_prop_variance_checks) {
 		if (toplevel) {
 			if (extends_ast) {
 				zend_class_entry *parent_ce = zend_lookup_class_ex(

--- a/ext/opcache/tests/gh16668/gh16668.inc
+++ b/ext/opcache/tests/gh16668/gh16668.inc
@@ -1,0 +1,9 @@
+<?php
+
+function test() {
+    echo __FUNCTION__, "()\n";
+}
+
+function a() {}
+function b() {}
+function c() {}

--- a/ext/opcache/tests/gh16668/gh16668.phpt
+++ b/ext/opcache/tests/gh16668/gh16668.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16668: opcache_compile_file() mistakenly declares top functions
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+opcache_compile_file(__DIR__ . '/gh16668.inc');
+opcache_compile_file(__DIR__ . '/gh16668.inc');
+var_dump(function_exists('test'));
+require __DIR__ . '/gh16668.inc';
+var_dump(function_exists('test'));
+test();
+?>
+--EXPECT--
+bool(false)
+bool(true)
+test()

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -981,9 +981,7 @@ ZEND_FUNCTION(opcache_compile_file)
 
 	CG(compiler_options) = orig_compiler_options;
 
-	if(op_array != NULL) {
-		destroy_op_array(op_array);
-		efree(op_array);
+	if (op_array == (void *) -1) {
 		RETVAL_TRUE;
 	} else {
 		RETVAL_FALSE;

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -373,6 +373,12 @@ static void zend_accel_do_delayed_early_binding(
 
 zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script, int from_shared_memory)
 {
+	if (CG(compiler_options) & ZEND_COMPILE_WITHOUT_EXECUTION) {
+		/* Not a pretty API, but we need to distinguish between successful and
+		 * unsuccessful compilations. */
+		return (void *) -1;
+	}
+
 	zend_op_array *op_array;
 
 	op_array = (zend_op_array *) emalloc(sizeof(zend_op_array));


### PR DESCRIPTION
Previously, this only worked for classes. It worked by preventing early binding, and then declaring the class at runtime. Instead of doing that, we now avoid calling zend_accel_load_script() completely, which prevents the functions from being added to the function table.

This is breaking, and may thus only be applied to master. I will also notify the list and see whether there are concerns.

Fixes GH-16668