### PR TITLE
run-tests: update minimum required PHP version.

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -26,7 +26,7 @@
 /* Let there be no top-level code beyond this point:
  * Only functions and classes, thanks!
  *
- * Minimum required PHP version: 7.4.0
+ * Minimum required PHP version: 8.0.0
  */
 
 function show_usage(): void


### PR DESCRIPTION
The use of Union Types in https://github.com/php/php-src/blob/master/run-tests.php#L3161 is only supported in PHP >= 8.0.0

I believe the information should be updated, or Union Types should be removed.