### PR TITLE
Mark tests using port 64324 as conflicting

### DIFF
--- a/ext/openssl/tests/san_ipv6_peer_matching.phpt
+++ b/ext/openssl/tests/san_ipv6_peer_matching.phpt
@@ -2,8 +2,6 @@
 IPv6 Peer verification matches SAN names
 --EXTENSIONS--
 openssl
---CONFLICTS--
-port64324
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");

--- a/ext/openssl/tests/san_ipv6_peer_matching.phpt
+++ b/ext/openssl/tests/san_ipv6_peer_matching.phpt
@@ -2,6 +2,8 @@
 IPv6 Peer verification matches SAN names
 --EXTENSIONS--
 openssl
+--CONFLICTS--
+port64324
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");

--- a/ext/standard/tests/streams/bug51056.phpt
+++ b/ext/standard/tests/streams/bug51056.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #51056 (fread() on blocking stream will block even if data is available)
+--CONFLICTS--
+port64324
 --FILE--
 <?php
 

--- a/ext/standard/tests/streams/bug51056.phpt
+++ b/ext/standard/tests/streams/bug51056.phpt
@@ -1,12 +1,10 @@
 --TEST--
 Bug #51056 (fread() on blocking stream will block even if data is available)
---CONFLICTS--
-port64324
 --FILE--
 <?php
 
 $serverCode = <<<'CODE'
-$server = stream_socket_server('tcp://127.0.0.1:64324');
+$server = stream_socket_server('tcp://127.0.0.1:64327');
 phpt_notify();
 
 $conn = stream_socket_accept($server);
@@ -25,7 +23,7 @@ $clientCode = <<<'CODE'
 
 phpt_wait();
 
-$fp = fsockopen("tcp://127.0.0.1:64324");
+$fp = fsockopen("tcp://127.0.0.1:64327");
 
 while (!feof($fp)) {
     $data = fread($fp, 256);


### PR DESCRIPTION
Alternatively, we could choose another port, but that likely will conflict with some other test in the future.  The proper solution would be to use ephemeral ports[1], but our OpenSSL `ServerClientTestCase` does not support this yet.

[1] <https://github.com/php/php-src/commit/6ab4e330ac032389d370a722e54ee63aafaa9728>

---

In the long run, we should probably unify the different test servers anyway.

PS: found via https://github.com/php/php-src/actions/runs/11925029888/job/33236457305