### PR TITLE
Fail configure for libxml 2 >= 2.13.0

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2035,7 +2035,7 @@ dnl
 dnl Common setup macro for libxml.
 dnl
 AC_DEFUN([PHP_SETUP_LIBXML], [
-  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0])
+  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0 libxml-2.0 < 2.13.0])
 
   PHP_EVAL_INCLINE($LIBXML_CFLAGS)
   PHP_EVAL_LIBLINE($LIBXML_LIBS, $1)


### PR DESCRIPTION
While we should not make changes to a security branch to support new libxml2 versions, we should at least fail early to avoid confusion; see GH-16863.

---

Note that this is not supposed to be merged up, since the compatibility issues has been resolved for PHP-8.2.

cc @nielsdos