### PR TITLE
Fix GH-16890: array_sum() with GMP can loose precision (LLP64)

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -32,6 +32,10 @@
 /* Needed for gmp_random() */
 #include "ext/random/php_random.h"
 
+#ifndef mpz_fits_si_p
+# define mpz_fits_si_p mpz_fits_slong_p
+#endif
+
 #define GMP_ROUND_ZERO      0
 #define GMP_ROUND_PLUSINF   1
 #define GMP_ROUND_MINUSINF  2

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -292,7 +292,7 @@ static zend_result gmp_cast_object(zend_object *readobj, zval *writeobj, int typ
 		return SUCCESS;
 	case _IS_NUMBER:
 		gmpnum = GET_GMP_OBJECT_FROM_OBJ(readobj)->num;
-		if (mpz_fits_slong_p(gmpnum)) {
+		if (mpz_fits_si_p(gmpnum)) {
 			ZVAL_LONG(writeobj, mpz_get_si(gmpnum));
 		} else {
 			ZVAL_DOUBLE(writeobj, mpz_get_d(gmpnum));

--- a/ext/gmp/tests/gh16890.phpt
+++ b/ext/gmp/tests/gh16890.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-16890 (array_sum() with GMP can loose precision (LLP64))
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+$large_int_string = (string) (PHP_INT_MAX - 1);
+var_dump(array_sum([new GMP($large_int_string), 1]) === PHP_INT_MAX);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
We must use `mpz_fits_si_p()` instead of `mpz_fits_slong_p()` since the latter is not suitable for LLP64 data models.

---

Note that I've targeted PHP-8.3 since I haven't been able to find a suitable test case. Still, I think the actual fix should go into PHP-8.2.
