### PR TITLE
Remove wrapping comments in ext/skeleton

### DIFF
--- a/ext/ext_skel.php
+++ b/ext/ext_skel.php
@@ -18,14 +18,11 @@
 
 /* $Id$ */
 
-/* {{{ error */
 function error($message) {
     printf('Error: %s%s', $message, PHP_EOL);
     exit;
 }
-/* }}} */
 
-/* {{{ print_help */
 function print_help() {
     if (PHP_OS_FAMILY != 'Windows') {
         $file_prefix = './';
@@ -114,9 +111,7 @@ OPTIONS
 HELP;
     exit;
 }
-/* }}} */
 
-/* {{{ task */
 function task($label, $callback) {
     printf('%s... ', $label);
 
@@ -124,9 +119,7 @@ function task($label, $callback) {
 
     printf('done%s', PHP_EOL);
 }
-/* }}} */
 
-/* {{{ print_success */
 function print_success() {
     global $options;
 
@@ -148,9 +141,7 @@ function print_success() {
     printf('%smake test%2$s%2$s', $make_prefix, PHP_EOL);
     printf('Thank you for using PHP!%s', PHP_EOL);
 }
-/* }}} */
 
-/* {{{ process_args */
 function process_args($argv, $argc) {
     $options = [
             'unix'		=> true,
@@ -230,9 +221,7 @@ function process_args($argv, $argc) {
 
     return $options;
 }
-/* }}} */
 
-/* {{{ process_source_tags */
 function process_source_tags($file, $short_name) {
     global $options;
 
@@ -286,9 +275,7 @@ HEADER;
         error('Unable to save contents to file: ' . $short_name);
     }
 }
-/* }}} */
 
-/* {{{ copy_config_scripts */
 function copy_config_scripts() {
     global $options;
 
@@ -314,9 +301,7 @@ function copy_config_scripts() {
         process_source_tags($new_config_script, $config_script);
     }
 }
-/* }}} */
 
-/* {{{ copy_sources */
 function copy_sources() {
     global $options;
 
@@ -335,9 +320,7 @@ function copy_sources() {
         process_source_tags($options['dir'] . $options['ext'] . DIRECTORY_SEPARATOR . $dst_file, $dst_file);
     }
 }
-/* }}} */
 
-/* {{{ copy_tests */
 function copy_tests() {
     global $options;
 
@@ -361,8 +344,6 @@ function copy_tests() {
         process_source_tags($options['dir'] . $options['ext'] . DIRECTORY_SEPARATOR . $new_test, $new_test);
     }
 }
-/* }}} */
-
 
 if (PHP_SAPI != 'cli') {
     error('This script is only suited for CLI');

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -16,16 +16,13 @@
 	ZEND_PARSE_PARAMETERS_END()
 #endif
 
-/* {{{ void test1() */
 PHP_FUNCTION(test1)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	php_printf("The extension %s is loaded and working!\r\n", "%EXTNAME%");
 }
-/* }}} */
 
-/* {{{ string test2( [ string $var ] ) */
 PHP_FUNCTION(test2)
 {
 	char *var = "World";
@@ -41,9 +38,7 @@ PHP_FUNCTION(test2)
 
 	RETURN_STR(retval);
 }
-/* }}}*/
 
-/* {{{ PHP_RINIT_FUNCTION */
 PHP_RINIT_FUNCTION(%EXTNAME%)
 {
 #if defined(ZTS) && defined(COMPILE_DL_%EXTNAMECAPS%)
@@ -52,18 +47,14 @@ PHP_RINIT_FUNCTION(%EXTNAME%)
 
 	return SUCCESS;
 }
-/* }}} */
 
-/* {{{ PHP_MINFO_FUNCTION */
 PHP_MINFO_FUNCTION(%EXTNAME%)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "%EXTNAME% support", "enabled");
 	php_info_print_table_end();
 }
-/* }}} */
 
-/* {{{ %EXTNAME%_module_entry */
 zend_module_entry %EXTNAME%_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"%EXTNAME%",					/* Extension name */
@@ -76,7 +67,6 @@ zend_module_entry %EXTNAME%_module_entry = {
 	PHP_%EXTNAMECAPS%_VERSION,		/* Version */
 	STANDARD_MODULE_PROPERTIES
 };
-/* }}} */
 
 #ifdef COMPILE_DL_%EXTNAMECAPS%
 # ifdef ZTS


### PR DESCRIPTION
Removes wrapping comments in the `ext/skeleton`. This style is outdated and isn't followed in the whole codebase, so it's better for new extensions not to follow it.