### PR TITLE
Labeler: Add labeler glob patterns for CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,19 @@
         - scripts/**/*
         - win32/build/**/*
 
+"Category: CI":
+  - changed-files:
+      - any-glob-to-any-file:
+          - .circleci/*
+          - .github/actions/**/*
+          - .github/CODEOWNERS
+          - .github/setup_hmailserver.php
+          - .github/nightly_matrix.php
+          - .github/scripts/*
+          - .github/scripts/**/*
+          - .github/labeler.yml
+          - .github/workflows/*
+
 "Extension: bcmath":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
We have a "Category: CI" label in GH issues and PRs, but there is no labeler rule to automatically mark PRs as such.

This adds a labeler rule to automatically add the "Category: CI" label if the PR changes _any_ file in:

  - `.circleci/*`
  - `.github/actions/**/*`
  - `.github/CODEOWNERS`
  - `.github/setup_hmailserver.php`
  - `.github/nightly_matrix.php`
  - `.github/scripts/*`
  - `.github/scripts/**/*`
  - `.github/labeler.yml`
  - `.github/workflows/*`