### PR TITLE
CI: FreeBSD on VM - set `copyback: false`

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -7,6 +7,7 @@ runs:
       with:
         release: '13.3'
         usesh: true
+        copyback: false
         # Temporarily disable sqlite, as FreeBSD ships it with disabled double quotes. We'll need to fix our tests.
         # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269889
         prepare: |


### PR DESCRIPTION
The `vmactions/freebsd-vm` GitHub action rsyncs the work dir to to the VM. This adds a lot of log output due to `rsync -v` usage.

Once the tests are compelte, the action copies the files _back_ by running `rsync` in reverse. However, we do not need these files back because we do not run any other steps that need access to the post-test files.

Setting `copyback: false` disables this, and cuts the log size by about 5,000 lines.