### PR TITLE
Fix GH-16908: _ZendTestMagicCallForward does not handle references well

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -902,9 +902,12 @@ static ZEND_METHOD(_ZendTestMagicCallForward, __call)
 
 	ZEND_IGNORE_VALUE(arguments);
 
-	zval func;
+	zval func, rv;
 	ZVAL_STR(&func, name);
-	call_user_function(NULL, NULL, &func, return_value, 0, NULL);
+	call_user_function(NULL, NULL, &func, &rv, 0, NULL);
+
+	ZVAL_COPY_DEREF(return_value, &rv);
+	zval_ptr_dtor(&rv);
 }
 
 PHP_INI_BEGIN()

--- a/ext/zend_test/tests/gh16908.phpt
+++ b/ext/zend_test/tests/gh16908.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-16908 (_ZendTestMagicCallForward does not handle references well)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$cls = new _ZendTestMagicCallForward();
+function &foo() {
+}
+$cls->foo()->x ??= 42;
+?>
+--EXPECTF--
+Notice: Only variable references should be returned by reference in %s on line %d
+
+Notice: Only variable references should be returned by reference in %s on line %d
+
+Fatal error: Uncaught Error: Attempt to assign property "x" on null in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
This testing code was never meant to be used this way, but fixing this will at least stop fuzzers from complaining about this, so might still be worthwhile.