### PR TITLE
Disable tsrm_ls_cache usage on Cygwin

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -778,7 +778,7 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 	return 0;
 #elif defined(__x86_64__) && defined(__GNUC__) && !defined(__FreeBSD__) && \
 	!defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__MUSL__) && \
-	!defined(__HAIKU__)
+	!defined(__HAIKU__) && !defined(__CYGWIN__)
 	size_t ret;
 
 	asm ("movq _tsrm_ls_cache@gottpoff(%%rip),%0"
@@ -786,7 +786,7 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 	return ret;
 #elif defined(__i386__) && defined(__GNUC__) && !defined(__FreeBSD__) && \
 	!defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__MUSL__) && \
-	!defined(__HAIKU__)
+	!defined(__HAIKU__) && !defined(__CYGWIN__)
 	size_t ret;
 
 	asm ("leal _tsrm_ls_cache@ntpoff,%0"


### PR DESCRIPTION
Otherwise, `--enable-opache-jit` won't even build there.

---

Note that this is supposed to supersede #16568.