### PR TITLE
Remove disable_native_prepares

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -295,7 +295,7 @@ static bool pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *
 			execute_only = 1;
 		}
 	} else {
-		emulate = H->disable_native_prepares || H->emulate_prepares;
+		emulate = H->emulate_prepares;
 		execute_only = H->disable_prepares;
 	}
 

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -44,10 +44,7 @@ typedef struct {
 	pdo_pgsql_error_info	einfo;
 	Oid 		pgoid;
 	unsigned int	stmt_counter;
-	/* The following two variables have the same purpose. Unfortunately we need
-	   to keep track of two different attributes having the same effect. */
 	bool		emulate_prepares;
-	bool		disable_native_prepares; /* deprecated since 5.6 */
 	bool		disable_prepares;
 	HashTable       *lob_streams;
 	zend_fcall_info_cache *notice_callback;


### PR DESCRIPTION
I believe this is just a leftover after the deprecated constant got removed. 