### PR TITLE
Fix is_zend_ptr() huge block comparison

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2457,8 +2457,8 @@ ZEND_API bool is_zend_ptr(const void *ptr)
 
 	zend_mm_huge_list *block = AG(mm_heap)->huge_list;
 	while (block) {
-		if (ptr >= (void*)block
-				&& ptr < (void*)((char*)block + block->size)) {
+		if (ptr >= block->ptr
+				&& ptr < (void*)((char*)block->ptr + block->size)) {
 			return 1;
 		}
 		block = block->next;


### PR DESCRIPTION
We should compare the block memory allocation range, not the block metadata pointer (See zend_mm_add_huge_block).
This caused random test failure for ext/ffi/tests/gh14626.phpt when the malloc() performed by the FFI code lies close to the block metadata, and the size of the block is large enough.

This random crash was reported by https://github.com/php/php-src/issues/16902#issuecomment-2498310452
It only reproduced on 32-bit in like 1/12 tries on average on my system, so a bit hard to reproduce. Did not test on 64-bit but probably even harder to reproduce.