### PR TITLE
Remove useless code in ext-enchant

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -89,7 +89,7 @@ zend_module_entry enchant_module_entry = {
 	"enchant",
 	ext_functions,
 	PHP_MINIT(enchant),
-	PHP_MSHUTDOWN(enchant),
+	NULL,
 	NULL,	/* Replace with NULL if there's nothing to do at request start */
 	NULL,	/* Replace with NULL if there's nothing to do at request end */
 	PHP_MINFO(enchant),
@@ -209,13 +209,6 @@ PHP_MINIT_FUNCTION(enchant)
 
 	register_enchant_symbols(module_number);
 
-	return SUCCESS;
-}
-/* }}} */
-
-/* {{{ PHP_MSHUTDOWN_FUNCTION */
-PHP_MSHUTDOWN_FUNCTION(enchant)
-{
 	return SUCCESS;
 }
 /* }}} */
@@ -353,13 +346,11 @@ PHP_FUNCTION(enchant_broker_set_dict_path)
 
 	switch (dict_type) {
 		case PHP_ENCHANT_MYSPELL:
-			PHP_ENCHANT_GET_BROKER;
 			enchant_broker_set_param(pbroker->pbroker, "enchant.myspell.dictionary.path", (const char *)value);
 			RETURN_TRUE;
 			break;
 
 		case PHP_ENCHANT_ISPELL:
-			PHP_ENCHANT_GET_BROKER;
 			enchant_broker_set_param(pbroker->pbroker, "enchant.ispell.dictionary.path", (const char *)value);
 			RETURN_TRUE;
 			break;
@@ -389,12 +380,10 @@ PHP_FUNCTION(enchant_broker_get_dict_path)
 
 	switch (dict_type) {
 		case PHP_ENCHANT_MYSPELL:
-			PHP_ENCHANT_GET_BROKER;
 			value = enchant_broker_get_param(pbroker->pbroker, "enchant.myspell.dictionary.path");
 			break;
 
 		case PHP_ENCHANT_ISPELL:
-			PHP_ENCHANT_GET_BROKER;
 			value = enchant_broker_get_param(pbroker->pbroker, "enchant.ispell.dictionary.path");
 			break;
 


### PR DESCRIPTION
The MSHUTDOWN() does nothing, and the GET_BROKER macros are duplicated.