### PR TITLE
Fix GH-16932 Scoreboard reset at end of request

### DIFF
--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -201,7 +201,7 @@ void fpm_request_end(void)
 	fpm_scoreboard_proc_release(proc);
 
 	/* memory_peak */
-	fpm_scoreboard_update_commit(0, 0, 0, 0, 0, 0, 0, proc->memory, FPM_SCOREBOARD_ACTION_SET, NULL);
+	fpm_scoreboard_update_commit(0, 0, 0, 0, 0, 0, 0, proc->memory, FPM_SCOREBOARD_ACTION_INC, NULL);
 }
 
 void fpm_request_finished(void)


### PR DESCRIPTION
Scoreboard was updated with FPM_SCOREBOARD_ACTION_SET in PR#14153 causing all metrics to be reset at the end of request. Use FPM_SCOREBOARD_ACTION_INC instead to ensure we only update peak memory

Fixes #16932 