### PR TITLE
Fix GH-15208: Segfault with breakpoint map and phpdbg_clear()

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -369,6 +369,7 @@ PHP_FUNCTION(phpdbg_clear)
 	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_FILE_OPLINE]);
 	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
 	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_METHOD]);
+	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_MAP]);
 	zend_hash_clean(&PHPDBG_G(bp)[PHPDBG_BREAK_COND]);
 } /* }}} */
 

--- a/sapi/phpdbg/tests/gh15208.phpt
+++ b/sapi/phpdbg/tests/gh15208.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-15208 (Segfault with breakpoint map and phpdbg_clear())
+--PHPDBG--
+r
+q
+--FILE--
+<?php
+phpdbg_break_method("foo", "bar");
+phpdbg_clear();
+?>
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Breakpoint #0 added at foo::bar]
+[Script ended normally]
+prompt>


### PR DESCRIPTION
It crashes because it's gonna try accessing the breakpoint which was cleared by user code in `phpdbg_clear();`. Not all breakpoint data was properly cleaned.

Replaces https://github.com/php/php-src/pull/15243
@devnexen It might still be worthwhile to add some extra exceptions to the phpdbg_break_* methods to make sure that an empty string cannot be used as a breakpoint, but that is not the root cause of this issue and may be master-only material.