### PR TITLE
Exclude further dependencies from dist

### DIFF
--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -62,10 +62,13 @@ function get_depends($module)
         'msvcr90.dll',
         'wldap32.dll',
         'vcruntime140.dll',
+        'vcruntime140_1.dll',
         'msvcp140.dll',
         );
     static $no_dist_re = array(
         "api-ms-win-crt-.+\.dll",
+        "api-ms-win-core-.+\.dll",
+        "clang_rt.asan_dynamic-.+\.dll",
     );
     global $build_dir, $extra_dll_deps, $ext_targets, $sapi_targets, $pecl_targets, $phpdll, $per_module_deps, $pecl_dll_deps;
 


### PR DESCRIPTION
These are Windows/Visual Studio DLLs which are not supposed to be distributed, and would usually not even be found in the configured paths.

---

This is just to avoid some superfluous warnings.