### PR TITLE
ext/gmp: Check for valid bit index/start consistently

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -1524,6 +1524,10 @@ ZEND_FUNCTION(gmp_random_range)
 }
 /* }}} */
 
+static bool gmp_is_bit_index_valid(zend_long index) {
+	return index >= 0 && (index / GMP_NUMB_BITS < INT_MAX);
+}
+
 /* {{{ Sets or clear bit in a */
 ZEND_FUNCTION(gmp_setbit)
 {
@@ -1536,12 +1540,8 @@ ZEND_FUNCTION(gmp_setbit)
 		RETURN_THROWS();
 	}
 
-	if (index < 0) {
-		zend_argument_value_error(2, "must be greater than or equal to 0");
-		RETURN_THROWS();
-	}
-	if (index / GMP_NUMB_BITS >= INT_MAX) {
-		zend_argument_value_error(2, "must be less than %d * %d", INT_MAX, GMP_NUMB_BITS);
+	if (!gmp_is_bit_index_valid(index)) {
+		zend_argument_value_error(2, "must be between 0 and %d * %d", INT_MAX, GMP_NUMB_BITS);
 		RETURN_THROWS();
 	}
 
@@ -1566,8 +1566,8 @@ ZEND_FUNCTION(gmp_clrbit)
 		RETURN_THROWS();
 	}
 
-	if (index < 0) {
-		zend_argument_value_error(2, "must be greater than or equal to 0");
+	if (!gmp_is_bit_index_valid(index)) {
+		zend_argument_value_error(2, "must be between 0 and %d * %d", INT_MAX, GMP_NUMB_BITS);
 		RETURN_THROWS();
 	}
 
@@ -1587,8 +1587,8 @@ ZEND_FUNCTION(gmp_testbit)
 		Z_PARAM_LONG(index)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (index < 0) {
-		zend_argument_value_error(2, "must be greater than or equal to 0");
+	if (!gmp_is_bit_index_valid(index)) {
+		zend_argument_value_error(2, "must be between 0 and %d * %d", INT_MAX, GMP_NUMB_BITS);
 		RETURN_THROWS();
 	}
 
@@ -1634,8 +1634,8 @@ ZEND_FUNCTION(gmp_scan0)
 		Z_PARAM_LONG(start)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (start < 0) {
-		zend_argument_value_error(2, "must be greater than or equal to 0");
+	if (!gmp_is_bit_index_valid(start)) {
+		zend_argument_value_error(2, "must be between 0 and %d * %d", INT_MAX, GMP_NUMB_BITS);
 		RETURN_THROWS();
 	}
 
@@ -1654,8 +1654,8 @@ ZEND_FUNCTION(gmp_scan1)
 		Z_PARAM_LONG(start)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (start < 0) {
-		zend_argument_value_error(2, "must be greater than or equal to 0");
+	if (!gmp_is_bit_index_valid(start)) {
+		zend_argument_value_error(2, "must be between 0 and %d * %d", INT_MAX, GMP_NUMB_BITS);
 		RETURN_THROWS();
 	}
 

--- a/ext/gmp/tests/gmp_clrbit.phpt
+++ b/ext/gmp/tests/gmp_clrbit.phpt
@@ -44,11 +44,11 @@ try {
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
 string(1) "0"
-gmp_clrbit(): Argument #2 ($index) must be greater than or equal to 0
+gmp_clrbit(): Argument #2 ($index) must be between 0 and %d * %d
 string(2) "-1"
-gmp_clrbit(): Argument #2 ($index) must be greater than or equal to 0
+gmp_clrbit(): Argument #2 ($index) must be between 0 and %d * %d
 string(7) "1000000"
 string(7) "1000000"
 string(30) "238462734628347239571822592658"

--- a/ext/gmp/tests/gmp_scan0.phpt
+++ b/ext/gmp/tests/gmp_scan0.phpt
@@ -27,8 +27,8 @@ try {
 
 echo "Done\n";
 ?>
---EXPECT--
-gmp_scan0(): Argument #2 ($start) must be greater than or equal to 0
+--EXPECTF--
+gmp_scan0(): Argument #2 ($start) must be between 0 and %d * %d
 int(2)
 int(0)
 int(5)

--- a/ext/gmp/tests/gmp_scan1.phpt
+++ b/ext/gmp/tests/gmp_scan1.phpt
@@ -27,8 +27,8 @@ try {
 
 echo "Done\n";
 ?>
---EXPECT--
-gmp_scan1(): Argument #2 ($start) must be greater than or equal to 0
+--EXPECTF--
+gmp_scan1(): Argument #2 ($start) must be between 0 and %d * %d
 int(1)
 int(12)
 int(9)

--- a/ext/gmp/tests/gmp_setbit.phpt
+++ b/ext/gmp/tests/gmp_setbit.phpt
@@ -50,9 +50,9 @@ try {
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
 string(2) "-1"
-gmp_setbit(): Argument #2 ($index) must be greater than or equal to 0
+gmp_setbit(): Argument #2 ($index) must be between 0 and %d * %d
 string(1) "5"
 string(1) "1"
 string(1) "7"

--- a/ext/gmp/tests/gmp_setbit_long.phpt
+++ b/ext/gmp/tests/gmp_setbit_long.phpt
@@ -41,5 +41,5 @@ FFFFFFFF
 3FFFFFFFF
 FFFFFFFFF
 3FFFFFFFFF
-gmp_setbit(): Argument #2 ($index) must be less than %d * %d
+gmp_setbit(): Argument #2 ($index) must be between 0 and %d * %d
 Done

--- a/ext/gmp/tests/gmp_testbit.phpt
+++ b/ext/gmp/tests/gmp_testbit.phpt
@@ -47,13 +47,13 @@ var_dump(gmp_strval($n));
 
 echo "Done\n";
 ?>
---EXPECT--
-gmp_testbit(): Argument #2 ($index) must be greater than or equal to 0
+--EXPECTF--
+gmp_testbit(): Argument #2 ($index) must be between 0 and %d * %d
 bool(false)
 bool(false)
 bool(false)
 bool(true)
-gmp_testbit(): Argument #2 ($index) must be greater than or equal to 0
+gmp_testbit(): Argument #2 ($index) must be between 0 and %d * %d
 bool(false)
 bool(true)
 string(7) "1000002"


### PR DESCRIPTION
We were doing this only for `gmp_setbit()` which is a bit odd.