### PR TITLE
Fix GH-16957: Assertion failure in array_shift with self-referencing array

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3513,7 +3513,8 @@ PHP_FUNCTION(array_shift)
 			}
 			idx++;
 		}
-		RETVAL_COPY_DEREF(val);
+		ZVAL_COPY_VALUE(return_value, val);
+		ZVAL_UNDEF(val);
 
 		/* Delete the first value */
 		zend_hash_packed_del_val(Z_ARRVAL_P(stack), val);
@@ -3567,7 +3568,8 @@ PHP_FUNCTION(array_shift)
 			}
 			idx++;
 		}
-		RETVAL_COPY_DEREF(val);
+		ZVAL_COPY_VALUE(return_value, val);
+		ZVAL_UNDEF(val);
 
 		/* Delete the first value */
 		zend_hash_del_bucket(Z_ARRVAL_P(stack), p);
@@ -3591,6 +3593,10 @@ PHP_FUNCTION(array_shift)
 	}
 
 	zend_hash_internal_pointer_reset(Z_ARRVAL_P(stack));
+
+	if (Z_ISREF_P(return_value)) {
+		zend_unwrap_reference(return_value);
+	}
 }
 /* }}} */
 

--- a/ext/standard/tests/array/gh16957.phpt
+++ b/ext/standard/tests/array/gh16957.phpt
@@ -1,0 +1,41 @@
+--TEST--
+GH-16957 (Assertion failure in array_shift with self-referencing array)
+--FILE--
+<?php
+$new_array = array(&$new_array, 1, 'two');
+var_dump($shifted = array_shift($new_array));
+var_dump($new_array);
+var_dump($new_array === $shifted);
+
+$new_array2 = array(&$new_array2, 2 => 1, 300 => 'two');
+var_dump($shifted = array_shift($new_array2));
+var_dump($new_array2);
+var_dump($new_array2 === $shifted);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "two"
+}
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "two"
+}
+bool(true)
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "two"
+}
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  string(3) "two"
+}
+bool(true)


### PR DESCRIPTION
We have an RC1 violation because we're immediately dereferencing and copying the resulting array in the test case. Instead, transfer the lifetime using ZVAL_COPY_VALUE and unwrap only after the internal iterator is reset.

Targeting 8.3 because it's an unlikely bug to hit and 8.2 is almost EOL.