### PR TITLE
allow urlencode(int)

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3715,7 +3715,7 @@ function parse_url(string $url, int $component = -1): int|string|array|null|fals
  * @compile-time-eval
  * @refcount 1
  */
-function urlencode(string $string): string {}
+function urlencode(string|int $string): string {}
 
 /**
  * @compile-time-eval
@@ -3727,7 +3727,7 @@ function urldecode(string $string): string {}
  * @compile-time-eval
  * @refcount 1
  */
-function rawurlencode(string $string): string {}
+function rawurlencode(string|int $string): string {}
 
 /**
  * @compile-time-eval

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e277d3a5699db6aeedb08642720be841dc37d683 */
+ * Stub hash: f7c38f9d4e4ac96c42e7b1ec2046d79c565c64b4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2077,11 +2077,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_parse_url, 0, 1, MAY_BE_LONG|MAY
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, component, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
-#define arginfo_urlencode arginfo_base64_encode
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_urlencode, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_MASK(0, string, MAY_BE_STRING|MAY_BE_LONG, NULL)
+ZEND_END_ARG_INFO()
 
 #define arginfo_urldecode arginfo_base64_encode
 
-#define arginfo_rawurlencode arginfo_base64_encode
+#define arginfo_rawurlencode arginfo_urlencode
 
 #define arginfo_rawurldecode arginfo_base64_encode
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -552,13 +552,28 @@ PHPAPI zend_string *php_url_encode(char const *s, size_t len)
 /* {{{ URL-encodes string */
 PHP_FUNCTION(urlencode)
 {
-	zend_string *in_str;
+    zend_string *in_str = NULL;
+    zend_long    in_long;
+    zend_string *tmpstr = NULL;
+    zend_string *encoded_str;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STR(in_str)
-	ZEND_PARSE_PARAMETERS_END();
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STR_OR_LONG(in_str, in_long)
+    ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_STR(php_url_encode(ZSTR_VAL(in_str), ZSTR_LEN(in_str)));
+    if (in_str == NULL) {
+        /* Input is an integer */
+        in_str = tmpstr = zend_long_to_str(in_long);
+    }
+
+    encoded_str = php_url_encode(ZSTR_VAL(in_str), ZSTR_LEN(in_str));
+
+    /* Release the temporary string if we allocated one */
+    if (tmpstr != NULL) {
+        zend_string_release(tmpstr);
+    }
+
+    RETURN_STR(encoded_str);
 }
 /* }}} */
 
@@ -614,13 +629,29 @@ PHPAPI zend_string *php_raw_url_encode(char const *s, size_t len)
 /* {{{ URL-encodes string */
 PHP_FUNCTION(rawurlencode)
 {
-	zend_string *in_str;
+    zend_string *in_str = NULL;
+    zend_long    in_long;
+    zend_string *tmpstr = NULL;
+    zend_string *encoded_str;
 
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STR(in_str)
-	ZEND_PARSE_PARAMETERS_END();
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STR_OR_LONG(in_str, in_long)
+    ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_STR(php_raw_url_encode(ZSTR_VAL(in_str), ZSTR_LEN(in_str)));
+    if (in_str == NULL) {
+        /* Input is an integer */
+        in_str = tmpstr = zend_long_to_str(in_long);
+    }
+
+    encoded_str = php_raw_url_encode(ZSTR_VAL(in_str), ZSTR_LEN(in_str));
+
+
+    /* Release the temporary string if we allocated one */
+    if (tmpstr != NULL) {
+        zend_string_release(tmpstr);
+    }
+
+    RETURN_STR(encoded_str);
 }
 /* }}} */
 

--- a/tests/strings/001.phpt
+++ b/tests/strings/001.phpt
@@ -2,7 +2,7 @@
 String functions
 --FILE--
 <?php
-
+declare(strict_types=1);
 echo "Testing strtok: ";
 
 $str = "testing 1/2\\3";
@@ -202,6 +202,11 @@ if (strlen($ui1) == strlen($ui2) && strlen($ui1) == $len && $ui1 != $ui2) {
     echo("failed!\n");
 }
 
+echo "testing (raw)urlencode(int)\n";
+var_dump(urlencode(1));
+var_dump(rawurlencode(1));
+
+
 ?>
 --EXPECT--
 Testing strtok: passed
@@ -221,3 +226,6 @@ Testing addslashes: passed
 Testing stripslashes: passed
 Testing uniqid(true): passed
 Testing uniqid(false): passed
+testing (raw)urlencode(int)
+string(1) "1"
+string(1) "1"


### PR DESCRIPTION
in strict mode it's kindof annoying to have to cast-to-string when you have a string|int variable you need to urlencode. There is no ambiguity as to how to urlencode integers, so it shouldn't be a problem.
```
TypeError: urlencode(): Argument #1 ($string) must be of type string, int given
```
has happened to me enough times now that I bothered to make PR to allow it.

Fwiw the integer path could be micro-optimized to bypass php_raw_url_encode() entirely, at least when the integer is not negative, but for brevity, I didn't bother micro-optimizing it.