### PR TITLE
Fix GH-16932: wrong FPM status output

### DIFF
--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -201,7 +201,7 @@ void fpm_request_end(void)
 	fpm_scoreboard_proc_release(proc);
 
 	/* memory_peak */
-	fpm_scoreboard_update_commit(0, 0, 0, 0, 0, 0, 0, proc->memory, FPM_SCOREBOARD_ACTION_SET, NULL);
+	fpm_scoreboard_update_commit(-1, -1, -1, -1, -1, -1, -1, proc->memory, FPM_SCOREBOARD_ACTION_SET, NULL);
 }
 
 void fpm_request_finished(void)

--- a/sapi/fpm/tests/gh16932-scoreboard-reset.phpt
+++ b/sapi/fpm/tests/gh16932-scoreboard-reset.phpt
@@ -1,0 +1,56 @@
+--TEST--
+FPM: GH-16932 - scoreboard fields are reset after the request
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+pid = {{FILE:PID}}
+[unconfined]
+listen = {{ADDR}}
+pm.status_path = /status
+pm = dynamic
+pm.max_children = 2
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 1
+EOT;
+
+$code = <<<EOT
+<?php
+echo "hi!";
+EOT;
+
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start(extensions: ['pcntl']);
+$tester->expectLogStartNotices();
+$tester->request();
+$tester->request();
+$tester->request();
+$tester->request();
+$tester
+    ->request(uri: '/status', query: 'json')
+    ->expectJsonBodyPatternForStatusField('accepted conn', '5');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -149,6 +149,29 @@ class Response extends BaseResponse
     }
 
     /**
+     * Expect status field with value that matches the supplied pattern.
+     *
+     * @param string $fieldName
+     * @param string $pattern
+     *
+     * @return Response
+     */
+    public function expectJsonBodyPatternForStatusField(string $fieldName, string $pattern): Response
+    {
+        $rawData = $this->getBody('application/json');
+        $data = json_decode($rawData, true);
+        if (preg_match('|' . $pattern . '|', $data[$fieldName]) > 0) {
+            return $this;
+        }
+
+        $this->error(
+            "Field $fieldName did not match pattern $pattern in status data '$rawData'"
+        );
+
+        return $this;
+    }
+
+    /**
      * Expect that one of the processes in json status process list has a field with value that
      * matches the supplied pattern.
      *
@@ -167,7 +190,7 @@ class Response extends BaseResponse
             );
         }
         foreach ($data['processes'] as $process) {
-            if (preg_match('|' . $pattern . '|', $process[$fieldName]) !== false) {
+            if (preg_match('|' . $pattern . '|', $process[$fieldName]) > 0) {
                 return $this;
             }
         }


### PR DESCRIPTION
This fixes GH-16932 and contains a test that should hopefully prevent this happening again in the future. We actually have high resource tests that were failing but as I'm usually working on lower branches so I have not run them on master and PHP-8.4 for some time. I will start running those more regularly especially when merging new features for FPM. 