### PR TITLE
ext/sockets: socket_strerror follow-up on GH-16267 fix.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -370,7 +370,11 @@ char *sockets_strerror(int error) /* {{{ */
 
 #ifndef PHP_WIN32
 	if (error < -10000) {
-		error = -error - 10000;
+		if (error == INT_MIN) {
+			error = 2147473648;
+		} else {
+			error = -error - 10000;
+		}
 
 #ifdef HAVE_HSTRERROR
 		buf = hstrerror(error);

--- a/ext/sockets/tests/gh16267.phpt
+++ b/ext/sockets/tests/gh16267.phpt
@@ -3,20 +3,16 @@ GH-16267 - overflow on socket_strerror argument
 --EXTENSIONS--
 sockets
 --SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die('skip 64-bit only'); ?>
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
 --FILE--
 <?php
+var_dump(socket_strerror(-2147483648));
 try {
-	socket_strerror(PHP_INT_MIN);
-} catch (\ValueError $e) {
-	echo $e->getMessage() . PHP_EOL;
-}
-try {
-	socket_strerror(PHP_INT_MAX);
+	socket_strerror(2147483648);
 } catch (\ValueError $e) {
 	echo $e->getMessage() . PHP_EOL;
 }
 ?>
 --EXPECTF--
-socket_strerror(): Argument #1 ($error_code) must be between %s and %s
-socket_strerror(): Argument #1 ($error_code) must be between %s and %s
+string(%d) "%S"
+socket_strerror(): Argument #1 ($error_code) must be between %i and %d


### PR DESCRIPTION
boundaries should be INT_MIN <= val < INT_MAX in fact.