### PR TITLE
PHP-8.4 is now for PHP 8.4.2-dev

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -20,7 +20,7 @@
 #ifndef ZEND_H
 #define ZEND_H
 
-#define ZEND_VERSION "4.4.1-dev"
+#define ZEND_VERSION "4.4.2-dev"
 
 #define ZEND_ENGINE_3
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ dnl Basic autoconf initialization, generation of config.nice.
 dnl ----------------------------------------------------------------------------
 
 AC_PREREQ([2.68])
-AC_INIT([PHP],[8.4.1-dev],[https://github.com/php/php-src/issues],[php],[https://www.php.net])
+AC_INIT([PHP],[8.4.2-dev],[https://github.com/php/php-src/issues],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([main/php_version.h])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER

--- a/main/php_version.h
+++ b/main/php_version.h
@@ -2,7 +2,7 @@
 /* edit configure.ac to change version number */
 #define PHP_MAJOR_VERSION 8
 #define PHP_MINOR_VERSION 4
-#define PHP_RELEASE_VERSION 1
+#define PHP_RELEASE_VERSION 2
 #define PHP_EXTRA_VERSION "-dev"
-#define PHP_VERSION "8.4.1-dev"
-#define PHP_VERSION_ID 80401
+#define PHP_VERSION "8.4.2-dev"
+#define PHP_VERSION_ID 80402


### PR DESCRIPTION
Since we released 8.4.1 already we need to update the versions in the code on PHP-8.4 branch.