### PR TITLE
Elevate C4013 to level 1

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -31,7 +31,7 @@ if %errorlevel% neq 0 exit /b 3
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 
-set CFLAGS=/W1 /WX
+set CFLAGS=/W1 /WX /w14013
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^


### PR DESCRIPTION
C4013 warns about undefined functions[1], but for some reason is only a level 3 warning, and such suppressed by default (usually there will be link error afterwards, though).  It appears to be sensible to elevate the warning to level 1, so it will be converted to a compile error.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013>

---

Note that PHP-8.4 and master are already C4013 clean, but PHP-8.3 (or only PHP-8.2) are not.