### PR TITLE
ext/bcmath - Fixed GH-16978: Avoid unnecessary padding with leading zeros

### DIFF
--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -436,6 +436,7 @@ bool bc_divide(bc_num numerator, bc_num divisor, bc_num *quot, size_t scale)
 			numerator_bottom_extension = 0;
 			numeratorend -= scale_diff > numerator_top_extension ? scale_diff - numerator_top_extension : 0;
 		}
+		numerator_top_extension = MIN(numerator_top_extension, scale);
 	} else {
 		numerator_bottom_extension += scale - numerator_scale;
 	}

--- a/ext/bcmath/tests/gh16978.phpt
+++ b/ext/bcmath/tests/gh16978.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-16978 Stack buffer overflow ext/bcmath/libbcmath/src/div.c:464:12 in bc_divide
+--EXTENSIONS--
+bcmath
+--FILE--
+<?php
+echo bcpow('10', '-112', 10) . "\n";
+echo bcdiv('1', '10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 1);
+?>
+--EXPECT--
+0.0000000000
+0.0


### PR DESCRIPTION
Fixed an issue where leading zeros were padded beyond the allocated memory.

fixes #16978 