### PR TITLE
Skip parse_ini_file_variation6.phpt on Windows

### DIFF
--- a/ext/standard/tests/file/parse_ini_file_variation6.phpt
+++ b/ext/standard/tests/file/parse_ini_file_variation6.phpt
@@ -2,6 +2,11 @@
 Test parse_ini_file() function : variation - various absolute and relative paths
 --CREDITS--
 Dave Kelsey <d_kelsey@uk.ibm.com>
+--SKIPIF--
+<?php
+if(substr(PHP_OS, 0, 3) == "WIN")
+  die("skip Only run on Windows");
+?>
 --FILE--
 <?php
 echo "*** Testing parse_ini_file() : variation ***\n";


### PR DESCRIPTION
While the test obviously succeeds on Windows, it may occasionally conflict with parse_ini_file_variation6-win32.phpt[1], so we skip it like we do for many other of these tests which have win32 pendants.

[1] <https://github.com/php/php-src/actions/runs/12077554275/job/33680647284#step:6:119>

---

This is almost indentical to #16722; basically the same test, but with backslashes on Windows, and forward slashes on POSIX platforms.