### PR TITLE
Fix GH-16991: Getting typeinfo of non DISPATCH variant segfaults

### DIFF
--- a/ext/com_dotnet/com_typeinfo.c
+++ b/ext/com_dotnet/com_typeinfo.c
@@ -331,7 +331,7 @@ ITypeInfo *php_com_locate_typeinfo(zend_string *type_lib_name, php_com_dotnet_ob
 			if (obj->typeinfo) {
 				ITypeInfo_AddRef(obj->typeinfo);
 				return obj->typeinfo;
-			} else {
+			} else if (V_VT(&obj->v) == VT_DISPATCH) {
 				IDispatch_GetTypeInfo(V_DISPATCH(&obj->v), 0, LANG_NEUTRAL, &typeinfo);
 				if (typeinfo) {
 					return typeinfo;

--- a/ext/com_dotnet/tests/gh16991.phpt
+++ b/ext/com_dotnet/tests/gh16991.phpt
@@ -1,0 +1,10 @@
+--TEST--
+GH-16991 (Getting typeinfo of non DISPATCH variant segfaults)
+--EXTENSIONS--
+com_dotnet
+--FILE--
+<?php
+com_print_typeinfo(new variant("hello"));
+?>
+--EXPECTF--
+Warning: com_print_typeinfo(): Unable to find typeinfo using the parameters supplied in %s on line %d


### PR DESCRIPTION
We must not assume that any `VARIANT` implements `IDispatch`.