### PR TITLE
Support --enable-sanitizer for MSVC builds

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -356,8 +356,20 @@ if (PHP_SECURITY_FLAGS == "yes") {
 }
 
 ARG_WITH("uncritical-warn-choke", "Disable some uncritical warnings", "yes");
-ARG_ENABLE("sanitizer", "Enable ASan and UBSan extensions", "no");
-if (CLANG_TOOLSET) {
+ARG_ENABLE("sanitizer", "Enable ASan (and UBSan) extensions", "no");
+if (PHP_SANITIZER == "yes" && PHP_DEBUG == "yes") {
+	ERROR("Use of both --enable-sanitizer and --enable-debug not allowed.");
+}
+if (PHP_SANITIZER == "yes" && PHP_DEBUG_PACK == "no") {
+	ERROR("--enable-sanitizer requires --enable-debug-pack");
+}
+if (VS_TOOLSET) {
+	if (PHP_SANITIZER == "yes") {
+		if (COMPILER_NUMERIC_VERSION < 1929) {
+			ERROR("MSVC at least 16.0 required for sanitation plugins");
+		}
+	}
+} else if (CLANG_TOOLSET) {
 	if (PHP_UNCRITICAL_WARN_CHOKE != "no") {
 		ADD_FLAG("CFLAGS", "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-missing-braces " +
 		"-Wno-logical-op-parentheses -Wno-msvc-include -Wno-invalid-source-encoding -Wno-unknown-pragmas " +

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1246,6 +1246,8 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir)
 	if (PHP_SANITIZER == "yes") {
 		if (CLANG_TOOLSET) {
 			add_asan_opts("CFLAGS_" + SAPI, "LIBS_" + SAPI, (is_lib ? "ARFLAGS_" : "LDFLAGS_") + SAPI);
+		} else if (VS_TOOLSET) {
+			ADD_FLAG("CFLAGS", "/fsanitize=address");
 		}
 	}
 
@@ -3442,8 +3444,12 @@ function toolset_setup_build_mode()
 			ADD_FLAG("LDFLAGS", "/incremental:no /debug /opt:ref,icf");
 		}
 		ADD_FLAG("CFLAGS", "/LD /MD");
-		if (PHP_SANITIZER == "yes" && CLANG_TOOLSET) {
-			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
+		if (PHP_SANITIZER == "yes") {
+			if (VS_TOOLSET) {
+				ADD_FLAG("CFLAGS", "/Ox /U NDebug /U NDEBUG /D ZEND_DEBUG=1");
+			} else if (CLANG_TOOLSET) {
+				ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
+			}
 		} else {
 			// Equivalent to Release_TSInline build -> best optimization
 			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /GF /D ZEND_DEBUG=0");


### PR DESCRIPTION
While it is already possible to enable ASan for MSVC (assuming Visual Studio 2019 16.10 or later) by passing `/fsanitizer=address` in the `CFLAGS`, it is only usable if `ZEND_DEBUG` is also enabled; otherwise there are `STATUS_BACK_STACK` errors all the time.

Since it makes some sense to combine ASan instrumentation with debug assertions enabled anyway (typical for fuzzing), we support the configure option `--enable-sanitizer`, which is already supported for Clang builds, also for MSVC builds.  Note that MSVC supports only ASan for now; contrary to Clang which additionally supports UBSan on Windows.

Since ASan reports can be pretty useless without debug symbol information, we require such builds to also produce PDBs (i.e. `--enable-debug-pack`), but forbid actual debug builds (for performance reasons, and because the way it is implemented it would not make sense; that was already an issue with Clang builds with sanitizers enabled).

---

Note that there are basically no changes regarding Clang sanitizers (besides that `--enable-debug --enable-sanitzer` is explicitly forbidden; previously that would not properly enable sanitizers anyway). I have some doubts that the flags which are set for Clang sanitizers make much sense (they even might not properly work), but that could be addressed by another patch (if anyone cares about that).

Also note that phpize builds do not properly support sanitizers (with or without this patch). It is not even quite clear how that should be done (probably, if a phpize build uses an instrumented PHP build, the extension should automaticallybe instrumented as well). On the other hand, it might not make much sense to support this for phpize at all; after all, we do not provide prebuilt ASan instrumentation on Windows, and those who want to use this, might be better off doing in-tree builds, anyway. I'm not sure, but I guess it's pretty much the same for phpize builds on POSIX; these use release builds of PHP (neither ASan instrumented nor debug builds).

My main reason for suggesting this change is to be able to have ASan builds running in CI (and possibly for fuzz testing). See #15978 for a CI run. Since this is pretty slow (tests take more than an hour), it is unsuitable for pushes, but appears to be a sensible addition for nightly runs, particularly to catch memory issues in Windows only code paths.

If one needs a full debug build with ASan instrumentation for whatever reason, it is still possible to set `CFLAGS=/fsanitizer=address` and to `configure --enable-debug`.