### PR TITLE
Fix some MariaDB test failures

### DIFF
--- a/ext/mysqli/tests/063.phpt
+++ b/ext/mysqli/tests/063.phpt
@@ -29,6 +29,6 @@ require_once('skipifconnectfailure.inc');
 
     $mysql->close();
 ?>
---EXPECT--
+--EXPECTF--
 string(3) "foo"
-Unknown column 'invalid' in 'field list'
+Unknown column 'invalid' in '%r(SELECT|field list)%r'

--- a/ext/mysqli/tests/bug71863.phpt
+++ b/ext/mysqli/tests/bug71863.phpt
@@ -30,4 +30,4 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS test_bug_71863"))
 mysqli_close($link);
 ?>
 --EXPECTF--
-%AUnknown column 'owner_id' in 'where clause'
+%AUnknown column 'owner_id' in '%r(WHERE|where clause)%r'

--- a/ext/mysqli/tests/mysqli_stmt_datatype_change.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_datatype_change.phpt
@@ -65,7 +65,7 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS type_change"))
 
 mysqli_close($link);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 ---- Row 1
@@ -80,7 +80,7 @@ NULL
 ALTER
 bool(true)
 bool(false)
-string(34) "Unknown column 'a' in 'field list'"
+string(%d) "Unknown column 'a' in '%r(SELECT|field list)%r'"
 ---- Row 1
 bool(false)
 int(2)


### PR DESCRIPTION
Allow other wording too such that these mysqli tests pass.