### PR TITLE
Properly check for required icu4c libraries

### DIFF
--- a/ext/intl/config.w32
+++ b/ext/intl/config.w32
@@ -3,7 +3,10 @@
 ARG_ENABLE("intl", "Enable internationalization support", "no");
 
 if (PHP_INTL != "no") {
-	if (CHECK_LIB("icuuc.lib", "intl", PHP_INTL) &&
+	if (CHECK_LIB("icudt.lib", "intl", PHP_INTL) &&
+		CHECK_LIB("icuin.lib", "intl", PHP_INTL) &&
+		CHECK_LIB("icuio.lib", "intl", PHP_INTL) &&
+		CHECK_LIB("icuuc.lib", "intl", PHP_INTL) &&
 					CHECK_HEADER_ADD_INCLUDE("unicode/utf.h", "CFLAGS_INTL")) {
 		// always build as shared - zend_strtod.c/ICU type conflict
 		EXTENSION("intl", "php_intl.c intl_convert.c intl_convertcpp.cpp intl_error.c ", true,
@@ -115,16 +118,9 @@ if (PHP_INTL != "no") {
 				codepointiterator_methods.cpp ",
 				"intl");
 
-		ADD_FLAG("LIBS_INTL", "icudt.lib icuin.lib icuio.lib");
-
 		/* Compat for ICU before 58.1.*/
-		if (CHECK_LIB("icule.lib", "intl", PHP_INTL)) {
-			ADD_FLAG("LIBS_INTL", "icule.lib");
-		}
-		if (CHECK_LIB("iculx.lib", "intl", PHP_INTL)) {
-			ADD_FLAG("LIBS_INTL", "iculx.lib");
-		}
-
+		CHECK_LIB("icule.lib", "intl", PHP_INTL);
+		CHECK_LIB("iculx.lib", "intl", PHP_INTL);
 		ADD_FLAG("CFLAGS_INTL", "/EHsc /DUNISTR_FROM_CHAR_EXPLICIT=explicit /DUNISTR_FROM_STRING_EXPLICIT=explicit /DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1 /DU_HIDE_OBSOLETE_UTF_OLD_H=1");
 		AC_DEFINE("HAVE_INTL", 1, "Internationalization support enabled");
 	} else {


### PR DESCRIPTION
Besides that just checking for icuuc.lib does not necessarily imply that the other libraries are available, doing it this way will not copy the PDBs to the build folder, so these are not available in the debug packages.  Furthermore, `CHECK_LIB` already adds the library to the flags, so there is no need to do this manually.

---

I consider the missing PDBs a bug, and as such targeted PHP-8.3; I'm fine with targeting PHP-8.4 or master, if anybody has concerns about that.