### PR TITLE
ext/dba/tests/gh16390.phpt: skip if inifile is disabled

### DIFF
--- a/ext/dba/tests/gh16390.phpt
+++ b/ext/dba/tests/gh16390.phpt
@@ -2,6 +2,11 @@
 GH-16390 (dba_open() can segfault for "pathless" streams)
 --EXTENSIONS--
 dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('inifile');
+?>
 --FILE--
 <?php
 $file = 'data:text/plain;z=y;uri=eviluri;mediatype=wut?;mediatype2=hello,somedata';


### PR DESCRIPTION
This test reads an ini "file" from a string, and expects a warning about locking. But if inifile support is disabled, then you'll get

```
Warning: dba_open(): Handler "inifile" is not available in /path/to/ext/dba/tests/gh16390.php on line 3
```

instead. We skip the test if inifile support is disabled.