### PR TITLE
Fix GH-16843: Windows phpize builds ignore source subfolders

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1614,8 +1614,15 @@ function ADD_SOURCES(dir, file_list, target, obj_dir)
 		if (obj_dir == null) {
 			if (MODE_PHPIZE) {
 				/* In the phpize mode, the subdirs are always relative to BUID_DIR.
-					No need to differentiate by extension, only one gets built. */
-				var build_dir = (dirname ? dirname : "").replace(new RegExp("^..\\\\"), "");
+					No need to differentiate by extension, only one gets built.
+					We still need to cater to subfolders, though. */
+				if (dir.charAt(configure_module_dirname.length) === "\\" &&
+					dir.substr(0, configure_module_dirname.length) === configure_module_dirname) {
+					var reldir = dir.substr(configure_module_dirname.length + 1);
+					var build_dir = (dirname ? (reldir + "\\" + dirname) : reldir).replace(new RegExp("^..\\\\"), "");
+				} else {
+					var build_dir = (dirname ? dirname : "").replace(new RegExp("^..\\\\"), "");
+				}
 			} else {
 				var build_dir = (dirname ? (dir + "\\" + dirname) : dir).replace(new RegExp("^..\\\\"), "");
 			}


### PR DESCRIPTION
phpize builds on Windows ignore the paths of extension sources, and build all object files in the same folder.  This can't work if there are multiple source files with the same base name stored in separate folders and registered as such (e.g. cls/worker.c and src/worker.c). While extension authors can work around by avoiding duplicate base names, they may not even be aware of the problem because on POSIX systems, the object files are usually placed right besides the sources.

Thus we take the relative path (from `configure_module_dirname`) of the source files into account even for phpize builds.  Since this may break some extension builds (especially those which use Makefile fragments), we do not apply this fix to stable branches.