### PR TITLE
Remove incorrect information from INI

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1158,10 +1158,7 @@ mysqli.allow_persistent = On
 ; https://php.net/mysqli.max-links
 mysqli.max_links = -1
 
-; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
-; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
-; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
-; at MYSQL_PORT.
+; Default port number for mysqli_connect().
 ; https://php.net/mysqli.default-port
 mysqli.default_port = 3306
 
@@ -1170,15 +1167,15 @@ mysqli.default_port = 3306
 ; https://php.net/mysqli.default-socket
 mysqli.default_socket =
 
-; Default host for mysqli_connect() (doesn't apply in safe mode).
+; Default host for mysqli_connect().
 ; https://php.net/mysqli.default-host
 mysqli.default_host =
 
-; Default user for mysqli_connect() (doesn't apply in safe mode).
+; Default user for mysqli_connect().
 ; https://php.net/mysqli.default-user
 mysqli.default_user =
 
-; Default password for mysqli_connect() (doesn't apply in safe mode).
+; Default password for mysqli_connect().
 ; Note that this is generally a *bad* idea to store passwords in this file.
 ; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
 ; and reveal this password!  And of course, any users with read access to this

--- a/php.ini-production
+++ b/php.ini-production
@@ -1160,10 +1160,7 @@ mysqli.allow_persistent = On
 ; https://php.net/mysqli.max-links
 mysqli.max_links = -1
 
-; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
-; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
-; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
-; at MYSQL_PORT.
+; Default port number for mysqli_connect().
 ; https://php.net/mysqli.default-port
 mysqli.default_port = 3306
 
@@ -1172,15 +1169,15 @@ mysqli.default_port = 3306
 ; https://php.net/mysqli.default-socket
 mysqli.default_socket =
 
-; Default host for mysqli_connect() (doesn't apply in safe mode).
+; Default host for mysqli_connect().
 ; https://php.net/mysqli.default-host
 mysqli.default_host =
 
-; Default user for mysqli_connect() (doesn't apply in safe mode).
+; Default user for mysqli_connect().
 ; https://php.net/mysqli.default-user
 mysqli.default_user =
 
-; Default password for mysqli_connect() (doesn't apply in safe mode).
+; Default password for mysqli_connect().
 ; Note that this is generally a *bad* idea to store passwords in this file.
 ; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
 ; and reveal this password!  And of course, any users with read access to this


### PR DESCRIPTION
Correct me if I'm wrong, but this was never true for mysqli. I think safe mode might have existed early on in the development, but the rest was never migrated from the old mysql extension. This just looks like a bad copy-paste. 