### PR TITLE
Guard config.w32.h from multiple inclusion

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2270,6 +2270,10 @@ function generate_config_h()
 
 	outfile = FSO.CreateTextFile("main/config.w32.h", true);
 
+	outfile.WriteLine("#ifndef CONFIG_W32_H");
+	outfile.WriteLine("#define CONFIG_W32_H");
+	outfile.WriteBlankLines(1);
+
 	indata = indata.replace(new RegExp("@PREFIX@", "g"), prefix);
 	outfile.Write(indata);
 
@@ -2317,6 +2321,8 @@ function generate_config_h()
 	outfile.WriteLine("#if __has_include(\"main/config.pickle.h\")");
 	outfile.WriteLine("#include \"main/config.pickle.h\"");
 	outfile.WriteLine("#endif");
+	outfile.WriteBlankLines(1);
+	outfile.WriteLine("#endif /* CONFIG_W32_H */");
 
 	outfile.Close();
 }


### PR DESCRIPTION
Besides that is generally good practice to avoid macro redefinitions (and symbol redeclarations), and we're doing this on POSIX platforms anyway, there is a particular issue regarding phpize builds, where config.w32.h actually includes config.pickle.h.  The latter overrides some macro definitions (e.g. `PHP_BUILD_SYSTEM`) to define the proper values, but if config.w32.h is included multiple times, different macro definitions eventually raise C4005 compiler warnings[1], which break builds with `/WX /W1` enabled.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005>