### PR TITLE
Improve mysqli test 066.phpt

### DIFF
--- a/ext/mysqli/tests/066.phpt
+++ b/ext/mysqli/tests/066.phpt
@@ -13,6 +13,17 @@ require_once 'skipifconnectfailure.inc';
     /*** test mysqli_connect 127.0.0.1 ***/
     $mysql = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
 
+    $mysql->query("SELECT 1/0, CAST('NULL' AS UNSIGNED)");
+    $i = 1;
+    if (($warning = $mysql->get_warnings())) {
+        do {
+            printf("Warning in strict mode $i\n");
+            printf("Error number: %s\n", $warning->errno);
+            printf("Message: %s\n", $warning->message);
+            $i++;
+        } while ($warning->next());
+    }
+
     if (!mysqli_query($mysql, "SET sql_mode=''"))
         printf("[002] Cannot set SQL-Mode, [%d] %s\n", mysqli_errno($mysql), mysqli_error($mysql));
 
@@ -24,7 +35,10 @@ require_once 'skipifconnectfailure.inc';
 
     if (($warning = $mysql->get_warnings())) {
         do {
-            printf("Warning\n");
+            printf("Warning $i\n");
+            printf("Error number: %s\n", $warning->errno);
+            printf("Message: %s\n", $warning->message);
+            $i++;
         } while ($warning->next());
     }
 
@@ -43,5 +57,13 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS test_warnings"))
 mysqli_close($link);
 ?>
 --EXPECT--
-Warning
+Warning in strict mode 1
+Error number: 1365
+Message: Division by 0
+Warning in strict mode 2
+Error number: 1292
+Message: Truncated incorrect INTEGER value: 'NULL'
+Warning 3
+Error number: 1048
+Message: Column 'a' cannot be null
 done!


### PR DESCRIPTION
I have noticed that we lack a test to check whether `next()` will traverse to the next object properly. 