### PR TITLE
Fix GH-17017: OOB read when starting up file cache

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3331,7 +3331,7 @@ static zend_result accel_post_startup(void)
 	}
 
 	if ( ZCG(accel_directives).file_cache ) {
-		zend_accel_error(ACCEL_LOG_INFO, "opcache.file_cache running with PHP build ID: %s", zend_system_id);
+		zend_accel_error(ACCEL_LOG_INFO, "opcache.file_cache running with PHP build ID: %.32s", zend_system_id);
 
 		zend_stat_t buf = {0};
 


### PR DESCRIPTION
`zend_system_id` is not zero-terminated; as such we must constrain the number of characters we print.

---

We should probably replace the magic `32` with some macro.