### PR TITLE
Fix GH-16996: 8.4 tracing JIT phpseclib failures

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -1334,7 +1334,7 @@ static void zend_jit_def_reg(zend_jit_ctx *jit, zend_jit_addr addr, ir_ref val)
 	/* Negative "var" has special meaning for IR */
 	if (val > 0) {
 		if (jit->ctx.binding) {
-			ir_ref old = ir_binding_find(jit, val);
+			ir_ref old = ir_binding_find(&jit->ctx, val);
 			if (old && old != -EX_NUM_TO_VAR(jit->ssa->vars[var].var)) {
 				val = ir_emit2(&jit->ctx, IR_OPT(IR_COPY, jit->ctx.ir_base[val].type), val, 1);
 			}

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -1332,8 +1332,16 @@ static void zend_jit_def_reg(zend_jit_ctx *jit, zend_jit_addr addr, ir_ref val)
 	ZEND_ASSERT(jit->ra && jit->ra[var].ref == IR_NULL);
 
 	/* Negative "var" has special meaning for IR */
-	if (val > 0 && !zend_jit_spilling_may_cause_conflict(jit, var, val)) {
-		val = ir_bind(&jit->ctx, -EX_NUM_TO_VAR(jit->ssa->vars[var].var), val);
+	if (val > 0) {
+		if (jit->ctx.binding) {
+			ir_ref old = ir_binding_find(jit, val);
+			if (old && old != -EX_NUM_TO_VAR(jit->ssa->vars[var].var)) {
+				val = ir_emit2(&jit->ctx, IR_OPT(IR_COPY, jit->ctx.ir_base[val].type), val, 1);
+			}
+		}
+		if (!zend_jit_spilling_may_cause_conflict(jit, var, val)) {
+			val = ir_bind(&jit->ctx, -EX_NUM_TO_VAR(jit->ssa->vars[var].var), val);
+		}
 	}
 	jit->ra[var].ref = val;
 


### PR DESCRIPTION
This prevents conflicts caused by spilling to bound PHP stack slots by creating copies.