### PR TITLE
Fix GH-17040: SimpleXML's unset can break DOM objects

### DIFF
--- a/ext/simplexml/tests/gh17040.phpt
+++ b/ext/simplexml/tests/gh17040.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-17040 (SimpleXML's unset can break DOM objects)
+--EXTENSIONS--
+dom
+simplexml
+--FILE--
+<?php
+$dom = new DOMDocument;
+$tag = $dom->appendChild($dom->createElement("style"));
+$html = simplexml_import_dom($tag);
+unset($html[0]);
+$tag->append("foo");
+echo $dom->saveXML(), "\n";
+echo $dom->saveXML($tag), "\n";
+var_dump($html);
+?>
+--EXPECT--
+<?xml version="1.0"?>
+
+<style>foo</style>
+object(SimpleXMLElement)#3 (1) {
+  [0]=>
+  string(3) "foo"
+}


### PR DESCRIPTION
Don't free the underlying nodes if we still have objects pointing to them, otherwise the objects are left with a NULL node pointer.