### PR TITLE
Remove unused strcasecmp definition

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -31,7 +31,7 @@
 #include "libmbfl/config.h"
 
 #ifdef HAVE_STRINGS_H
-	/* For strcasecmp */
+	/* For strncasecmp */
 	#include <strings.h>
 #endif
 
@@ -53,13 +53,6 @@
 #include "filters/mbfilter_ucs2.h"
 #include "filters/mbfilter_htmlent.h"
 #include "filters/mbfilter_singlebyte.h"
-
-#ifndef HAVE_STRCASECMP
-#ifdef HAVE_STRICMP
-#define strcasecmp stricmp
-#endif
-#endif
-
 
 static const mbfl_encoding *mbfl_encoding_ptr_list[] = {
 	&mbfl_encoding_base64,


### PR DESCRIPTION
The strcasecmp usage was removed via
dc5f3b95627526d2e5729ae779e7bc82ee5fa3f3.