### PR TITLE
CI: remove leftover Cirrus CI references

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,6 @@ on:
       - '**/README.*'
       - CONTRIBUTING.md
       - CODING_STANDARDS.md
-      - .cirrus.yml
       - .travis.yml
       - travis/*
       - .circleci/*
@@ -27,7 +26,6 @@ on:
       - '**/README.*'
       - CONTRIBUTING.md
       - CODING_STANDARDS.md
-      - .cirrus.yml
       - .travis.yml
       - travis/*
       - .circleci/*

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -32,7 +32,6 @@ explained at the end of this document in
 
     - https://travis-ci.com/github/php/php-src
     - https://dev.azure.com/phpazuredevops/PHP/
-    - https://cirrus-ci.com/github/php/php-src
 
     It is recommended to do so a couple of days before the packaging day, to
     have enough time to investigate failures, communicate with the authors and

--- a/ext/standard/tests/file/disk_free_space_basic.phpt
+++ b/ext/standard/tests/file/disk_free_space_basic.phpt
@@ -3,7 +3,6 @@ Test disk_free_space and its alias diskfreespace() functions : basic functionali
 --SKIPIF--
 <?php
 if (getenv("TRAVIS") === "true") die("skip inaccurate on TravisCI");
-if (getenv('CIRRUS_CI')) die('skip Inaccurate on Cirrus');
 ?>
 --INI--
 memory_limit=32M

--- a/sapi/cli/tests/upload_2G.phpt
+++ b/sapi/cli/tests/upload_2G.phpt
@@ -36,8 +36,6 @@ if (getenv('TRAVIS')) {
     die("skip Fails intermittently on travis");
 }
 
-if (getenv('CIRRUS_CI')) die('skip Fails on Cirrus');
-
 if (getenv('SKIP_PERF_SENSITIVE')) {
     die("skip Test may be very slow if PHP is instrumented");
 }


### PR DESCRIPTION
Follow-up to php/php-src#16822, now that php-src no longer uses Cirrus CI, some small leftover references to Cirrus CI and some tests that were skipped on Cirrus CI can now be adjusted.