### PR TITLE
Fix typo in "private" function name (Windows configuration)

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -93,7 +93,7 @@ if (VS_TOOLSET) {
 }
 
 // General link flags
-toolset_setup_common_ldlags();
+toolset_setup_common_ldflags();
 
 // General libs
 toolset_setup_common_libs();

--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -67,7 +67,7 @@ if (VS_TOOLSET && PHP_MP != 'disable') {
 ARG_WITH("snapshot-template", "Path to snapshot builder template dir", "no");
 
 // General link flags
-toolset_setup_common_ldlags();
+toolset_setup_common_ldflags();
 
 // General libs
 toolset_setup_common_libs();

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3388,7 +3388,7 @@ function toolset_setup_intrinsic_cflags()
 	}
 }
 
-function toolset_setup_common_ldlags()
+function toolset_setup_common_ldflags()
 {
 	var envLDFLAGS = WshShell.Environment("PROCESS").Item("LDFLAGS");
 


### PR DESCRIPTION
This typo is particularly annoying if you search for "ldflags", because you won't find this function.