### PR TITLE
Fix GH-17067: glob:// wrapper doesn't cater to CWD for ZTS builds

### DIFF
--- a/ext/standard/tests/streams/gh17067.phpt
+++ b/ext/standard/tests/streams/gh17067.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17067 (glob:// wrapper doesn't cater to CWD for ZTS builds)
+--FILE--
+<?php
+$dir = __DIR__ . "/gh17067";
+mkdir($dir);
+touch("$dir/foo");
+
+chdir($dir);
+var_dump(scandir("glob://*"));
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . "/gh17067";
+@unlink("$dir/foo");
+@rmdir($dir);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(3) "foo"
+}

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -261,15 +261,17 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, const cha
 	}
 
 #ifdef ZTS
-	/* strip prepended CWD */
-	for (i = 0; i < pglob->glob.gl_pathc; i++) {
-		char *p = pglob->glob.gl_pathv[i];
-		char *q = p + cwd_skip;
-		char *e = p + strlen(pglob->glob.gl_pathv[i]) - 1;
-		while (q <= e) {
-			*p++ = *q++;
+	if (cwd_skip > 0) {
+		/* strip prepended CWD */
+		for (i = 0; i < pglob->glob.gl_pathc; i++) {
+			char *p = pglob->glob.gl_pathv[i];
+			char *q = p + cwd_skip;
+			char *e = p + strlen(pglob->glob.gl_pathv[i]) - 1;
+			while (q <= e) {
+				*p++ = *q++;
+			}
+			*p = '\0';
 		}
-		*p = '\0';
 	}
 #endif
 

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -225,7 +225,7 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, const cha
 			*opened_path = zend_string_init(path, strlen(path), 0);
 		}
 	}
-
+	const char *pattern = path;
 #ifdef ZTS
 	char cwd[MAXPATHLEN];
 	char work_pattern[MAXPATHLEN];
@@ -244,14 +244,13 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, const cha
 		cwd_skip = strlen(cwd)+1;
 
 		snprintf(work_pattern, MAXPATHLEN, "%s%c%s", cwd, DEFAULT_SLASH, path);
+		pattern = work_pattern;
 	}
-#else
-	char *work_pattern = path;
 #endif
 
 	pglob = ecalloc(1, sizeof(*pglob));
 
-	if (0 != (ret = glob(work_pattern, pglob->flags & GLOB_FLAGMASK, NULL, &pglob->glob))) {
+	if (0 != (ret = glob(pattern, pglob->flags & GLOB_FLAGMASK, NULL, &pglob->glob))) {
 #ifdef GLOB_NOMATCH
 		if (GLOB_NOMATCH != ret)
 #endif


### PR DESCRIPTION
`glob(3)` doesn't know the virtual CWD of PHP, so we need to pass an absolute path for ZTS builds.  In lack of a reusable routine, we copy the code from `glob()` and adapt as needed.

---

In my opinion, there should be some routine (likely in zend_virtual_cwd) which makes a path absolute, but without normalization or even getting the real path (just quickly prepending the VCWD if necessary). I'm not quite convinced that we should introduce that routine for stable branches, though.