### PR TITLE
Resolve MSVC C4244 level 2 warnings

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -31,7 +31,7 @@ if %errorlevel% neq 0 exit /b 3
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 
-set CFLAGS=/W1 /WX /w14013
+set CFLAGS=/W2 /WX /w14013 /wd4146 /wd4305
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -7496,10 +7496,10 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 		case ZEND_FFI_TYPE_FLOAT:
 			if (val->kind == ZEND_FFI_VAL_UINT32 || val->kind == ZEND_FFI_VAL_UINT64) {
 				val->kind = ZEND_FFI_VAL_FLOAT;
-				val->d = val->u64;
+				val->d = (zend_ffi_double) val->u64;
 			} else if (val->kind == ZEND_FFI_VAL_INT32 || val->kind == ZEND_FFI_VAL_INT64) {
 				val->kind = ZEND_FFI_VAL_FLOAT;
-				val->d = val->i64;
+				val->d = (zend_ffi_double) val->i64;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_FLOAT;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
@@ -7512,10 +7512,10 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 		case ZEND_FFI_TYPE_DOUBLE:
 			if (val->kind == ZEND_FFI_VAL_UINT32 || val->kind == ZEND_FFI_VAL_UINT64) {
 				val->kind = ZEND_FFI_VAL_DOUBLE;
-				val->d = val->u64;
+				val->d = (zend_ffi_double) val->u64;
 			} else if (val->kind == ZEND_FFI_VAL_INT32 || val->kind == ZEND_FFI_VAL_INT64) {
 				val->kind = ZEND_FFI_VAL_DOUBLE;
-				val->d = val->i64;
+				val->d = (zend_ffi_double) val->i64;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_DOUBLE;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
@@ -7551,7 +7551,7 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 				val->kind = ZEND_FFI_VAL_UINT32;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_UINT32;
-				val->u64 = val->d;
+				val->u64 = (uint64_t) val->d;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
 				val->kind = ZEND_FFI_VAL_UINT32;
 				val->u64 = val->ch;
@@ -7566,7 +7566,7 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 				val->kind = ZEND_FFI_VAL_INT32;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_INT32;
-				val->i64 = val->d;
+				val->i64 = (uint64_t) val->d;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
 				val->kind = ZEND_FFI_VAL_INT32;
 				val->i64 = val->ch;
@@ -7579,7 +7579,7 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 				val->kind = ZEND_FFI_VAL_UINT64;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_UINT64;
-				val->u64 = val->d;
+				val->u64 = (uint64_t) val->d;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
 				val->kind = ZEND_FFI_VAL_UINT64;
 				val->u64 = val->ch;
@@ -7596,7 +7596,7 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 				val->ch = val->i64;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_CHAR;
-				val->ch = val->d;
+				val->ch = (char) val->d;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
 			} else {
 				val->kind = ZEND_FFI_VAL_ERROR;
@@ -7607,7 +7607,7 @@ void zend_ffi_expr_cast(zend_ffi_val *val, zend_ffi_dcl *dcl) /* {{{ */
 				val->kind = ZEND_FFI_VAL_UINT32;
 			} else if (val->kind == ZEND_FFI_VAL_FLOAT || val->kind == ZEND_FFI_VAL_DOUBLE || val->kind == ZEND_FFI_VAL_LONG_DOUBLE) {
 				val->kind = ZEND_FFI_VAL_UINT32;
-				val->u64 = val->d;
+				val->u64 = (uint64_t) val->d;
 			} else if (val->kind == ZEND_FFI_VAL_CHAR) {
 				val->kind = ZEND_FFI_VAL_UINT32;
 				val->u64 = val->ch;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -4017,7 +4017,7 @@ PHP_FUNCTION(imageaffine)
 		if ((zval_affine_elem = zend_hash_index_find(Z_ARRVAL_P(z_affine), i)) != NULL) {
 			switch (Z_TYPE_P(zval_affine_elem)) {
 				case IS_LONG:
-					affine[i] = Z_LVAL_P(zval_affine_elem);
+					affine[i] = (double) Z_LVAL_P(zval_affine_elem);
 					if (affine[i] < INT_MIN || affine[i] > INT_MAX) {
 						zend_argument_value_error(2, "element %i must be between %d and %d", i, INT_MIN, INT_MAX);
 						RETURN_THROWS();
@@ -4195,7 +4195,7 @@ PHP_FUNCTION(imageaffinematrixconcat)
 		if ((tmp = zend_hash_index_find(Z_ARRVAL_P(z_m1), i)) != NULL) {
 			switch (Z_TYPE_P(tmp)) {
 				case IS_LONG:
-					m1[i]  = Z_LVAL_P(tmp);
+					m1[i]  = (double) Z_LVAL_P(tmp);
 					break;
 				case IS_DOUBLE:
 					m1[i] = Z_DVAL_P(tmp);
@@ -4212,7 +4212,7 @@ PHP_FUNCTION(imageaffinematrixconcat)
 		if ((tmp = zend_hash_index_find(Z_ARRVAL_P(z_m2), i)) != NULL) {
 			switch (Z_TYPE_P(tmp)) {
 				case IS_LONG:
-					m2[i]  = Z_LVAL_P(tmp);
+					m2[i]  = (double) Z_LVAL_P(tmp);
 					break;
 				case IS_DOUBLE:
 					m2[i] = Z_DVAL_P(tmp);

--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -1134,7 +1134,7 @@ void gdImageLine (gdImagePtr im, int x1, int y1, int x2, int y2, int color)
 TBB: but watch out for /0! */
 			double ac = cos (atan2 (dy, dx));
 			if (ac != 0) {
-				wid = thick / ac;
+				wid = (int) (thick / ac);
 			} else {
 				wid = 1;
 			}
@@ -1198,7 +1198,7 @@ TBB: but watch out for /0! */
 		   TBB: but watch out for /0! */
 		double as = sin (atan2 (dy, dx));
 		if (as != 0) {
-			wid = thick / as;
+			wid = (int) (thick / as);
 		} else {
 			wid = 1;
 		}
@@ -1388,7 +1388,7 @@ void gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int y2, int color
 		TBB: but watch out for /0! */
 		double as = sin(atan2(dy, dx));
 		if (as != 0) {
-			wid = thick / as;
+			wid = (int) (thick / as);
 		} else {
 			wid = 1;
 		}
@@ -1437,7 +1437,7 @@ void gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int y2, int color
 		TBB: but watch out for /0! */
 		double as = sin (atan2 (dy, dx));
 		if (as != 0) {
-			wid = thick / as;
+			wid = (int) (thick / as);
 		} else {
 			wid = 1;
 		}
@@ -2827,7 +2827,7 @@ void gdImageFilledPolygon (gdImagePtr im, gdPointPtr p, int n, int c)
 			 * same footprint.
 			 */
 			if (y >= y1 && y < y2) {
-				im->polyInts[ints++] = (float) ((y - y1) * (x2 - x1)) / (float) (y2 - y1) + 0.5 + x1;
+				im->polyInts[ints++] = (int) ((float) ((y - y1) * (x2 - x1)) / (float) (y2 - y1) + 0.5 + x1);
 			} else if (y == pmaxy && y == y2) {
 				im->polyInts[ints++] = x2;
 			}

--- a/ext/gd/libgd/gd_avif.c
+++ b/ext/gd/libgd/gd_avif.c
@@ -81,7 +81,7 @@ static int quality2Quantizer(int quality) {
 
 	float scaleFactor = (float) AVIF_QUANTIZER_WORST_QUALITY / (float) MAX_QUALITY;
 
-	return round(scaleFactor * (MAX_QUALITY - clampedQuality));
+	return (int) round(scaleFactor * (MAX_QUALITY - clampedQuality));
 }
 
 /*
@@ -103,7 +103,7 @@ static avifBool setEncoderTilesAndThreads(avifEncoder *encoder, avifRGBImage *rg
 
 	// The number of tiles in any dimension will always be a power of 2. We can only specify log(2)tiles.
 
-	tilesLog2 = floor(log2(tiles));
+	tilesLog2 = (int) floor(log2(tiles));
 
 	// If the image's width is greater than the height, use more tile columns
 	// than tile rows to make the tile size close to a square.

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -2137,8 +2137,7 @@ gdImagePtr gdImageRotateInterpolated(const gdImagePtr src, const float angle, in
 	/* round to two decimals and keep the 100x multiplication to use it in the common square angles
 	   case later. Keep the two decimal precisions so smaller rotation steps can be done, useful for
 	   slow animations. */
-	const int angle_rounded = fmod((int) floorf(angle * 100), 360 * 100);
-
+	const int angle_rounded = (int) fmod((int) floorf(angle * 100), 360 * 100);
 	if (bgcolor < 0) {
 		return NULL;
 	}

--- a/ext/gd/libgd/gd_webp.c
+++ b/ext/gd/libgd/gd_webp.c
@@ -156,7 +156,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	if (quality >= gdWebpLossless) {
 		out_size = WebPEncodeLosslessRGBA(argb, gdImageSX(im), gdImageSY(im), gdImageSX(im) * 4, &out);
 	} else {
-		out_size = WebPEncodeRGBA(argb, gdImageSX(im), gdImageSY(im), gdImageSX(im) * 4, quality, &out);
+		out_size = WebPEncodeRGBA(argb, gdImageSX(im), gdImageSY(im), gdImageSX(im) * 4, (float) quality, &out);
 	}
 
 	if (out_size == 0) {

--- a/ext/intl/collator/collator_convert.c
+++ b/ext/intl/collator/collator_convert.c
@@ -290,7 +290,7 @@ zval* collator_convert_string_to_double( zval* str, zval *rv )
 	zval* num = collator_convert_string_to_number( str, rv );
 	if( Z_TYPE_P(num) == IS_LONG )
 	{
-		ZVAL_DOUBLE( num, Z_LVAL_P( num ) );
+		ZVAL_DOUBLE( num, (double) Z_LVAL_P( num ) );
 	}
 
 	return num;

--- a/ext/intl/formatter/formatter_parse.c
+++ b/ext/intl/formatter/formatter_parse.c
@@ -76,7 +76,7 @@ PHP_FUNCTION( numfmt_parse )
 		case FORMAT_TYPE_INT64:
 			val64 = unum_parseInt64(FORMATTER_OBJECT(nfo), sstr, sstr_len, position_p, &INTL_DATA_ERROR_CODE(nfo));
 			if(val64 > ZEND_LONG_MAX || val64 < ZEND_LONG_MIN) {
-				RETVAL_DOUBLE(val64);
+				RETVAL_DOUBLE((double) val64);
 			} else {
 				RETVAL_LONG((zend_long)val64);
 			}

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3348,7 +3348,7 @@ try_next_encoding:;
 	}
 
 	for (size_t i = 0; i < length; i++) {
-		array[i].demerits *= array[i].multiplier;
+		array[i].demerits *= (uint64_t) array[i].multiplier;
 	}
 
 	return length;

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -848,7 +848,7 @@ ZEND_FUNCTION(opcache_get_configuration)
 	add_assoc_long(&directives,   "opcache.jit_max_recursive_returns", JIT_G(max_recursive_returns));
 	add_assoc_long(&directives,   "opcache.jit_max_root_traces", JIT_G(max_root_traces));
 	add_assoc_long(&directives,   "opcache.jit_max_side_traces", JIT_G(max_side_traces));
-	add_assoc_long(&directives,   "opcache.jit_prof_threshold", JIT_G(prof_threshold));
+	add_assoc_long(&directives,   "opcache.jit_prof_threshold", (zend_long) JIT_G(prof_threshold));
 	add_assoc_long(&directives,   "opcache.jit_max_trace_length", JIT_G(max_trace_length));
 #endif
 

--- a/ext/random/gammasection.c
+++ b/ext/random/gammasection.c
@@ -51,8 +51,8 @@ static double gamma_max(double x, double y)
 
 static void splitint64(uint64_t v, double *vhi, double *vlo)
 {
-	*vhi = v >> 2;
-	*vlo = v & UINT64_C(0x3);
+	*vhi = (double) (v >> 2);
+	*vlo = (double) (v & UINT64_C(0x3));
 }
 
 static uint64_t ceilint(double a, double b, double g)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -473,7 +473,7 @@ PHPAPI zend_long php_mt_rand_common(zend_long min, zend_long max)
 	/* This is an inlined version of the RAND_RANGE_BADSCALING macro that does not invoke UB when encountering
 	 * (max - min) > ZEND_LONG_MAX.
 	 */
-	zend_ulong offset = (double) ( (double) max - min + 1.0) * (r / (PHP_MT_RAND_MAX + 1.0));
+	zend_ulong offset = (zend_ulong) (((double) max - min + 1.0) * (r / (PHP_MT_RAND_MAX + 1.0)));
 
 	return (zend_long) (offset + min);
 }

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -256,7 +256,7 @@ PHP_METHOD(Random_Randomizer, getInt)
 		/* This is an inlined version of the RAND_RANGE_BADSCALING macro that does not invoke UB when encountering
 		 * (max - min) > ZEND_LONG_MAX.
 		 */
-		zend_ulong offset = (double) ( (double) max - min + 1.0) * (r / (PHP_MT_RAND_MAX + 1.0));
+		zend_ulong offset = (zend_ulong) (((double) max - min + 1.0) * (r / (PHP_MT_RAND_MAX + 1.0)));
 
 		result = (zend_long) (offset + min);
 	} else {

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1028,7 +1028,7 @@ static zval *to_zval_double(zval *ret, encodeTypePtr type, xmlNodePtr data)
 			whiteSpace_collapse(data->children->content);
 			switch (is_numeric_string((char*)data->children->content, strlen((char*)data->children->content), &lval, &dval, 0)) {
 				case IS_LONG:
-					ZVAL_DOUBLE(ret, lval);
+					ZVAL_DOUBLE(ret, (double) lval);
 					break;
 				case IS_DOUBLE:
 					ZVAL_DOUBLE(ret, dval);


### PR DESCRIPTION
[Level 2 C4244 warnings](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244) hint at possible loss of data. So far this PR silences them by explicitly casting, what actually may be appropriate in some cases (possibly for FFI); in some other cases the warnings might be bogus, in which case we may want to add suitable assertions. There may be some cases, though, which hint at edge case bugs (in which case these should better be fixed).

It would be great if we can properly solve this. Maybe some of the code owners can have a look?

Note that the change to the CFLAGS for CI is not supposed to be committed; it's just to see whether I've missed some of these warnings when testing locally.