### PR TITLE
opcache_get_configuration() properly reports jit_prof_threshold

### DIFF
--- a/ext/opcache/tests/opcache_jit_prof_threshold.phpt
+++ b/ext/opcache/tests/opcache_jit_prof_threshold.phpt
@@ -1,0 +1,19 @@
+--TEST--
+opcache_get_configuration() properly reports jit_prof_threshold
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (!isset(opcache_get_configuration()["directives"]["opcache.jit_prof_threshold"])) die("skip no JIT");
+?>
+--FILE--
+<?php
+$expected = 1 / 128; // needs to be exactly representable as IEEE double
+ini_set("opcache.jit_prof_threshold", $expected);
+$actual = opcache_get_configuration()["directives"]["opcache.jit_prof_threshold"];
+var_dump($actual);
+var_dump($actual === $expected);
+?>
+--EXPECTF--
+float(0.0078125)
+bool(true)

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -849,7 +849,7 @@ ZEND_FUNCTION(opcache_get_configuration)
 	add_assoc_long(&directives,   "opcache.jit_max_recursive_returns", JIT_G(max_recursive_returns));
 	add_assoc_long(&directives,   "opcache.jit_max_root_traces", JIT_G(max_root_traces));
 	add_assoc_long(&directives,   "opcache.jit_max_side_traces", JIT_G(max_side_traces));
-	add_assoc_long(&directives,   "opcache.jit_prof_threshold", JIT_G(prof_threshold));
+	add_assoc_double(&directives,   "opcache.jit_prof_threshold", JIT_G(prof_threshold));
 	add_assoc_long(&directives,   "opcache.jit_max_trace_length", JIT_G(max_trace_length));
 #endif
 


### PR DESCRIPTION
The `jit_prof_threshold` is a float, supposed to be in range [0, 1], and usually very small (the default is 0.005).  Reporting it as int is meaningless.