### PR TITLE
Fix curl_multi_exec() overflow message

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -214,8 +214,8 @@ PHP_FUNCTION(curl_multi_select)
 
 	mh = Z_CURL_MULTI_P(z_mh);
 
-	if (!(timeout >= 0.0 && timeout <= ((double)INT_MAX / 1000.0))) {
-		zend_argument_value_error(2, "must be between 0 and %d", (int)ceilf((double)INT_MAX / 1000));
+	if (!(timeout >= 0.0 && timeout <= (INT_MAX / 1000.0))) {
+		zend_argument_value_error(2, "must be between 0 and %f", INT_MAX / 1000.0);
 		RETURN_THROWS();
 	}
 

--- a/ext/curl/tests/gh15547.phpt
+++ b/ext/curl/tests/gh15547.phpt
@@ -24,6 +24,6 @@ $mh = curl_multi_init();
 var_dump(curl_multi_select($mh, 1000000));
 ?>
 --EXPECTF--
-curl_multi_select(): Argument #2 ($timeout) must be between %d and %d
-curl_multi_select(): Argument #2 ($timeout) must be between %d and %d
+curl_multi_select(): Argument #2 ($timeout) must be between %d and %f
+curl_multi_select(): Argument #2 ($timeout) must be between %d and %f
 int(0)


### PR DESCRIPTION
As is, passing `2147484` as `$timeout`, throws a `ValueError` stating the `$timeout` needs to be between 0 and 2147484, what is a confusing. Thus we report the proper threshold as float.

While we're at it we also drop the superfluous `(double)` cast, and rely on C's usual arithmetic conversions.

---

This is a follow-up on https://github.com/php/php-src/pull/15548/files#r1728773136 which also fixes a [MSVC C4305 warning](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305).