### PR TITLE
Unblock tests under ASan on Windows

### DIFF
--- a/ext/standard/tests/file/bug72035.phpt
+++ b/ext/standard/tests/file/bug72035.phpt
@@ -21,7 +21,7 @@ $cmd = "$cgi -n -C $fl";
 
 /* Need to run CGI with the env reset. */
 $desc = array(0 => array("pipe", "r"));
-$proc = proc_open($cmd, $desc, $pipes, getcwd(), array());
+$proc = proc_open($cmd, $desc, $pipes, getcwd(), array('PATH' => getenv('PATH')));
 if (is_resource($proc)) {
     echo stream_get_contents($pipes[0]);
 

--- a/ext/standard/tests/file/proc_open01.phpt
+++ b/ext/standard/tests/file/proc_open01.phpt
@@ -11,7 +11,7 @@ if ($php === false) {
 $proc = proc_open(
     "$php -n",
     array(0 => array('pipe', 'r'), 1 => array('pipe', 'w')),
-    $pipes, getcwd(), array(), array()
+    $pipes, getcwd(), array('PATH' => getenv('PATH')), array()
 );
 if ($proc === false) {
     print "something went wrong.\n";

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -44,7 +44,7 @@ fpassthru($pipes[1]);
 proc_close($proc);
 
 putenv('ENV_1=ENV_1');
-$env = ['ENV_2' => 'ENV_2'];
+$env = ['ENV_2' => 'ENV_2', 'PATH' => getenv('PATH')];
 $cmd = [$php, '-n', '-r', 'var_dump(getenv("ENV_1"), getenv("ENV_2"));'];
 
 echo "\nEnvironment inheritance:\n";

--- a/ext/standard/tests/streams/proc_open_bug60120.phpt
+++ b/ext/standard/tests/streams/proc_open_bug60120.phpt
@@ -30,7 +30,7 @@ $process = proc_open(
     ],
     $pipes,
     getcwd(),
-    [],
+    ['PATH' => getenv('PATH')],
     [
         'suppress_errors' => true,
         'bypass_shell' => false

--- a/ext/standard/tests/streams/proc_open_bug64438.phpt
+++ b/ext/standard/tests/streams/proc_open_bug64438.phpt
@@ -14,7 +14,7 @@ $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'))
 $stdin = str_repeat('*', 4097);
 
 $options = array_merge(array('suppress_errors' => true, 'bypass_shell' => false));
-$process = proc_open($cmd, $descriptors, $pipes, getcwd(), array(), $options);
+$process = proc_open($cmd, $descriptors, $pipes, getcwd(), array('PATH' => getenv('PATH')), $options);
 
 foreach ($pipes as $pipe) {
     stream_set_blocking($pipe, false);


### PR DESCRIPTION
These tests execute php.exe without passing the PATH, what might be a more general issues, but at least with ASan enabled, the required DLLs could usually not be found, resulting in the tests stalling.