### PR TITLE
handle apache DocumentRoot cyrillic encoding

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1035,8 +1035,17 @@ static void init_request_info(void)
 				/* Copy path portion in place to avoid memory leak.  Note
 				 * that this also affects what script_path_translated points
 				 * to. */
-				memmove(env_script_filename, p, strlen(p) + 1);
+				size_t plen = strlen(p);
+				memmove(env_script_filename, p, plen + 1);
 				apache_was_here = 1;
+				// If DocumentRoot contains cyrillic characters and PHP is invoked with SetHandler (not applicable to ProxySetMatch),
+				// then the cyrillic characters are urlencoded by apache, and we need to decode them, for example with
+				// DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
+				// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php.
+				// and we must decode it to /home/hans/web/cyrillicрф.ratma.net/public_html/index.php.
+				if(memchr(env_script_filename, '%', plen) != NULL){
+					plen = php_url_decode(env_script_filename, plen);
+				}
 			}
 			/* ignore query string if sent by Apache (RewriteRule) */
 			p = strchr(env_script_filename, '?');

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1119,19 +1119,19 @@ static void init_request_info(void)
 				char *ptr;
 
 				if (pt) {
-					// If DocumentRoot contains cyrillic characters and PHP is invoked with SetHandler (not applicable to ProxyPassMatch),
-					// then the cyrillic characters are urlencoded by apache, and we need to decode them, for example with
-					// DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
-					// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php.
-					// and we must decode it to /home/hans/web/cyrillicрф.ratma.net/public_html/index.php.
+					// If DocumentRoot contains special characters like '%' or  cyrillic 'рф' and PHP is invoked with SetHandler (not applicable to ProxyPassMatch),
+					// then the special characters are urlencoded by apache, and we need to decode them, for example with
+					// DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html/test%lol
+					// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/test%25lol/index.php.
+					// and we must decode it to /home/hans/web/cyrillicрф.ratma.net/public_html/test%lol/index.php.
 					if(apache_was_here && memchr(pt, '%', len)) {
 						len = php_raw_url_decode(pt, len);
 						ptr = &pt[len]; // php_raw_url_decode() writes a trailing null byte, &pt[len] is that null byte.
-						goto apache_cyrillic_jump;
+						goto apache_special_jump;
 					}
 					while ((ptr = strrchr(pt, '/')) || (ptr = strrchr(pt, '\\'))) {
 						*ptr = 0;
-						apache_cyrillic_jump:
+						apache_special_jump:
 						if (stat(pt, &st) == 0 && S_ISREG(st.st_mode)) {
 							/*
 							 * okay, we found the base script!

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1038,7 +1038,7 @@ static void init_request_info(void)
 				size_t plen = strlen(p);
 				memmove(env_script_filename, p, plen + 1);
 				apache_was_here = 1;
-				// If DocumentRoot contains cyrillic characters and PHP is invoked with SetHandler (not applicable to ProxySetMatch),
+				// If DocumentRoot contains cyrillic characters and PHP is invoked with SetHandler (not applicable to ProxyPassMatch),
 				// then the cyrillic characters are urlencoded by apache, and we need to decode them, for example with
 				// DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
 				// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php.

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1124,16 +1124,14 @@ static void init_request_info(void)
 					// DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
 					// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php.
 					// and we must decode it to /home/hans/web/cyrillicрф.ratma.net/public_html/index.php.
-					bool firstrun_apache_cyrillic_encoding = apache_was_here && memchr(pt, '%', len);
-					if(firstrun_apache_cyrillic_encoding) {
+					if(apache_was_here && memchr(pt, '%', len)) {
 						len = php_raw_url_decode(pt, len);
-					}					
+						ptr = &pt[len]; // php_raw_url_decode() writes a trailing null byte, &pt[len] is that null byte.
+						goto apache_cyrillic_jump;
+					}
 					while ((ptr = strrchr(pt, '/')) || (ptr = strrchr(pt, '\\'))) {
-						if(firstrun_apache_cyrillic_encoding) {
-							firstrun_apache_cyrillic_encoding = false;
-						} else {
-							*ptr = 0;
-						}
+						*ptr = 0;
+						apache_cyrillic_jump:
 						if (stat(pt, &st) == 0 && S_ISREG(st.st_mode)) {
 							/*
 							 * okay, we found the base script!

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1044,7 +1044,7 @@ static void init_request_info(void)
 				// env_script_filename contains /home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php.
 				// and we must decode it to /home/hans/web/cyrillicрф.ratma.net/public_html/index.php.
 				if(memchr(env_script_filename, '%', plen) != NULL){
-					plen = php_url_decode(env_script_filename, plen);
+					plen = php_raw_url_decode(env_script_filename, plen);
 				}
 			}
 			/* ignore query string if sent by Apache (RewriteRule) */


### PR DESCRIPTION
When Apache's DocumentRoot contains cyrillic characters like

```
DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
```

and PHP is invoked with SetHandler (*PS not applicable to ProxyPassMatch, the problem occurs with SetHandler specifically) like

```
DocumentRoot /home/hans/web/cyrillicрф.ratma.net/public_html
<FilesMatch \.php$>
    SetHandler "proxy:unix:/run/php/php8.3-fpm-cyrillicрф.ratma.net.sock"
</FilesMatch>
```
then apache will url-encode the cyrillic characters before sending it to fpm, so env_script_filename will contain
```
/home/hans/web/cyrillic%D1%80%D1%84.ratma.net/public_html/index.php
```
and we need to url-decode it to 
```
/home/hans/web/cyrillicрф.ratma.net/public_html/index.php
```
otherwise we hit that 
https://github.com/php/php-src/blob/c5d9c7da9e77b2ddafd96ba105024ef327b35deb/sapi/fpm/fpm/fpm_main.c#L1843-L1845

error code path.