### PR TITLE
Fix duplicate dynamic properties in hooked object iterator properties table

### DIFF
--- a/Zend/tests/property_hooks/oss-fuzz-1638179.phpt
+++ b/Zend/tests/property_hooks/oss-fuzz-1638179.phpt
@@ -1,0 +1,20 @@
+--TEST--
+OSS-Fuzz #69765: Duplicate dynamic properties in hooked object iterator properties table
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class C {
+    public $a {
+        get => 42;
+    }
+}
+
+$obj = new C();
+$b = &$obj->b;
+unset($b);
+echo json_encode($obj);
+
+?>
+--EXPECT--
+{"a":42,"b":null}

--- a/Zend/zend_property_hooks.c
+++ b/Zend/zend_property_hooks.c
@@ -44,7 +44,9 @@ static uint32_t zho_num_backed_props(zend_object *zobj)
 static zend_array *zho_build_properties_ex(zend_object *zobj, bool check_access, bool force_ptr, bool include_dynamic_props)
 {
 	zend_class_entry *ce = zobj->ce;
-	zend_array *properties = zend_new_array(ce->default_properties_count);
+	zend_array *properties = zend_new_array(include_dynamic_props && zobj->properties
+		? zend_hash_num_elements(zobj->properties)
+		: ce->default_properties_count);
 	zend_hash_real_init_mixed(properties);
 
 	/* Build list of parents */
@@ -105,7 +107,8 @@ skip_property:
 		zend_string *prop_name;
 		zval *prop_value;
 		ZEND_HASH_FOREACH_STR_KEY_VAL_FROM(zobj->properties, prop_name, prop_value, zho_num_backed_props(zobj)) {
-			Z_TRY_ADDREF_P(_zend_hash_append(properties, prop_name, prop_value));
+			zval *tmp = _zend_hash_append(properties, prop_name, prop_value);
+			Z_TRY_ADDREF_P(tmp);
 		} ZEND_HASH_FOREACH_END();
 	}
 


### PR DESCRIPTION
Ouch, Z_TRY_ADDREF_P() uses pz twice... Also make sure we actually reserve enough Buckets for all dynamic properties.

We should consider updating `Z_TRY_ADDREF_P()` and `Z_TRY_DELREF_P()` on `master`. Maybe the pattern is duplicated to reduce register pressure, I'm not sure. Maybe @dstogov can comment.