### PR TITLE
Add nightly job for x64 Windows with ASan enabled

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -30,7 +30,7 @@ if %errorlevel% neq 0 exit /b 3
 
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
-if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer
+if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer --enable-debug-pack
 
 set CFLAGS=/W1 /WX /w14013
 

--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -30,6 +30,7 @@ if %errorlevel% neq 0 exit /b 3
 
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
+if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer
 
 set CFLAGS=/W1 /WX /w14013
 

--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -133,9 +133,11 @@ for %%i in (ldap) do (
 
 set TEST_PHPDBG_EXECUTABLE=%PHP_BUILD_DIR%\phpdbg.exe
 
+if "%ASAN%" equ "1" set ASAN_OPTS=--asan
+
 mkdir c:\tests_tmp
 
-nmake test TESTS="%OPCACHE_OPTS% -g FAIL,BORK,LEAK,XLEAK --no-progress -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp %PARALLEL%"
+nmake test TESTS="%OPCACHE_OPTS% -g FAIL,BORK,LEAK,XLEAK %ASAN_OPTS% --no-progress -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp %PARALLEL%"
 
 set EXIT_CODE=%errorlevel%
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -963,10 +963,18 @@ jobs:
           - x64: true
             zts: true
             opcache: true
+            asan: false
           - x64: false
             zts: false
             opcache: false
-    name: "WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
+            asan: false
+          - x64: true
+            zts: true
+            opcache: true
+            asan: true
+            branch: 'master'
+            timeout: 120
+    name: "WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}${{ matrix.asan && '_ASAN' || ''}}"
     runs-on: windows-${{ inputs.windows_version }}
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
@@ -979,6 +987,7 @@ jobs:
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"
       PARALLEL: -j2
       OPCACHE: "${{ matrix.opcache && '1' || '0' }}"
+      ASAN: "${{ matrix.asan && '1' || '0' }}"
     steps:
       - name: git config
         run: git config --global core.autocrlf false && git config --global core.eol lf


### PR DESCRIPTION
It seems reasonable to have an ASan job on Windows, especially to be able to check Windows specific code.  Since the tests may take about 70 minutes, it doesn't make sense to add these for pushes, but for a nightly job that should be okay.

---

I expect some tests to fail yet (see PR #17086).
