### PR TITLE
zend_hrtime: Use `clock_gettime_nsec_np()` for macOS if available

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ PHP                                                                        NEWS
   . Added PHP_BUILD_DATE constant. (cmb)
   . Added support for Closures in constant expressions. (timwolla,
     Volker Dusch)
+  . Use `clock_gettime_nsec_np()` for high resolution timer on macOS
+    if available. (timwolla)
 
 - Curl:
   . Added curl_multi_get_handles(). (timwolla)

--- a/UPGRADING
+++ b/UPGRADING
@@ -180,6 +180,11 @@ PHP 8.5 UPGRADE NOTES
 13. Other Changes
 ========================================
 
+- Core:
+  The high resolution timer (`hrtime()`) on macOS now uses the recommended
+  `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` API instead of
+  `mach_absolute_time()`.
+
 ========================================
 14. Performance Improvements
 ========================================

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -151,6 +151,11 @@ AC_CHECK_FUNCS(m4_normalize([
   pthread_stackseg_np
 ]))
 
+AC_CHECK_DECL([clock_gettime_nsec_np],
+  [AC_DEFINE([HAVE_CLOCK_GETTIME_NSEC_NP], [1],
+    [Define to 1 if you have the declaration of 'clock_gettime_nsec_np'.])],,
+  [#include <time.h>])
+
 dnl
 dnl Check for sigsetjmp. If sigsetjmp is defined as a macro, use AC_CHECK_DECL
 dnl as a fallback since AC_CHECK_FUNC cannot detect macros.

--- a/Zend/zend_hrtime.c
+++ b/Zend/zend_hrtime.c
@@ -33,7 +33,7 @@
 
 ZEND_API double zend_hrtime_timer_scale = .0;
 
-#elif ZEND_HRTIME_PLATFORM_APPLE
+#elif ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE
 
 # include <mach/mach_time.h>
 # include <string.h>
@@ -62,7 +62,7 @@ void zend_startup_hrtime(void)
 		zend_hrtime_timer_scale = (double)ZEND_NANO_IN_SEC / (zend_hrtime_t)tf.QuadPart;
 	}
 
-#elif ZEND_HRTIME_PLATFORM_APPLE
+#elif ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE
 
 	mach_timebase_info(&zend_hrtime_timerlib_info);
 


### PR DESCRIPTION
This is completely untested, because I do not have macOS available.

------------------

As per the Apple developer documentation:

> Prefer to use the equivalent clock_gettime_nsec_np(CLOCK_UPTIME_RAW) in
> nanoseconds.

and also

> This API has the potential of being misused to access device signals to try
> to identify the device or user, also known as fingerprinting. Regardless of
> whether a user gives your app permission to track, fingerprinting is not
> allowed. When you use this API in your app or third-party SDK (an SDK not
> provided by Apple), declare your usage and the reason for using the API in
> your app or third-party SDK’s PrivacyInfo.xcprivacy file.

see https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time