### PR TITLE
Don't run proc_open_cmd.phpt in parallel with other tests

### DIFF
--- a/ext/standard/tests/general_functions/proc_open_cmd.phpt
+++ b/ext/standard/tests/general_functions/proc_open_cmd.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Harden against cmd.exe hijacking
+--CONFLICTS--
+all
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY !== "Windows") die("skip only for Windows");
@@ -18,6 +20,7 @@ if (($num = stream_select($read, $write, $except, 1000)) === false) {
         fpassthru($stream);
     }
 }
+@unlink("cmd.exe");
 ?>
 --EXPECTF--
 resource(%d) of type (process)


### PR DESCRIPTION
This test puts a fake cmd.exe in the CWD and removes it only after the test has finished.  We need to avoid that other tests are running while that fake cmd.exe is there, because they may use it instead of the proper cmd.exe.

We also unlink the fake cmd.exe as soon as possible, regardless of the test result.

---

We had a [collision in the nightly runs](https://github.com/php/php-src/actions/runs/12227284532/job/34103830222).