### PR TITLE
Drop intl on macOS + PHP 8.1 build

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -32,5 +32,4 @@ runs:
           libjpeg \
           libxslt \
           postgresql
-        brew reinstall icu4c@74
-        brew link icu4c gettext --force
+        brew link gettext --force

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -66,7 +66,6 @@ runs:
           --with-ffi \
           --enable-zend-test \
           --enable-dl-test=shared \
-          --enable-intl \
           --with-mhash \
           --with-sodium \
           --enable-dba \


### PR DESCRIPTION
Based on the discussion in GH-16286, drop the intl build from macOS + PHP 8.1, since we cannot build with supported intl versions without too many changes.

This PR will be merged into 8.1, and then merged as empty commits upwards.