### PR TITLE
add more bindings from libxcrypt 4.4

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -115,6 +115,12 @@ PHPAPI php_basic_globals basic_globals;
 #include "php_fopen_wrappers.h"
 #include "streamsfuncs.h"
 #include "zend_frameless_function.h"
+#ifdef HAVE_CRYPT_H
+# if defined(CRYPT_R_GNU_SOURCE) && !defined(_GNU_SOURCE)
+#  define _GNU_SOURCE
+# endif
+# include <crypt.h>
+#endif
 #include "basic_functions_arginfo.h"
 
 #if __has_feature(memory_sanitizer)

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2111,6 +2111,61 @@ function crc32(string $string): int {}
 /** @refcount 1 */
 function crypt(#[\SensitiveParameter] string $string, string $salt): string {}
 
+#ifdef HAVE_XCRYPT_4_4
+/* prefix for algo used by crypt_gensalt */
+/** @var string */
+const CRYPT_PREFIX_STD_DES = '';
+/** @var string */
+const CRYPT_PREFIX_EXT_DES = '_';
+/** @var string */
+const CRYPT_PREFIX_MD5 = '$1$';
+/** @var string */
+const CRYPT_PREFIX_BLOWFISH = '$2y$';
+/** @var string */
+const CRYPT_PREFIX_SHA256 = '$5$';
+/** @var string */
+const CRYPT_PREFIX_SHA512 = '$6$';
+/** @var string */
+const CRYPT_PREFIX_SCRYPT = '$7$';
+/** @var string */
+const CRYPT_PREFIX_GOST_YESCRYPT = '$gy$';
+/** @var string */
+const CRYPT_PREFIX_YESCRYPT = '$y$';
+
+/* return code from crypt_checksalt */
+/**
+ * @var int
+ * @cvalue CRYPT_SALT_OK
+ */
+const CRYPT_SALT_OK = UNKNOWN;
+/**
+ * @var int
+ * @cvalue CRYPT_SALT_INVALID
+ */
+const CRYPT_SALT_INVALID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue CRYPT_SALT_METHOD_DISABLED
+ */
+const CRYPT_SALT_METHOD_DISABLED = UNKNOWN;
+/**
+ * @var int
+ * @cvalue CRYPT_SALT_METHOD_LEGACY
+ */
+const CRYPT_SALT_METHOD_LEGACY = UNKNOWN;
+/**
+ * @var int
+ * @cvalue CRYPT_SALT_TOO_CHEAP
+ */
+const CRYPT_SALT_TOO_CHEAP = UNKNOWN;
+
+function crypt_gensalt(?string $prefix = null, int $count = 0): ?string {}
+
+function crypt_preferred_method(): ?string {}
+
+function crypt_checksalt(string $salt): int {}
+#endif
+
 /* datetime.c */
 
 #ifdef HAVE_STRPTIME

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e277d3a5699db6aeedb08642720be841dc37d683 */
+ * Stub hash: 00ae851416ff17c3b066c31c073de5e0b510d91f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -614,6 +614,20 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_crypt, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, salt, IS_STRING, 0)
 ZEND_END_ARG_INFO()
+
+#if defined(HAVE_XCRYPT_4_4)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_crypt_gensalt, 0, 0, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prefix, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_crypt_preferred_method, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_crypt_checksalt, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, salt, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 #if defined(HAVE_STRPTIME)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strptime, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -2457,6 +2471,11 @@ ZEND_FUNCTION(sys_getloadavg);
 ZEND_FUNCTION(get_browser);
 ZEND_FUNCTION(crc32);
 ZEND_FUNCTION(crypt);
+#if defined(HAVE_XCRYPT_4_4)
+ZEND_FUNCTION(crypt_gensalt);
+ZEND_FUNCTION(crypt_preferred_method);
+ZEND_FUNCTION(crypt_checksalt);
+#endif
 #if defined(HAVE_STRPTIME)
 ZEND_FUNCTION(strptime);
 #endif
@@ -3053,6 +3072,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(get_browser, arginfo_get_browser)
 	ZEND_RAW_FENTRY("crc32", zif_crc32, arginfo_crc32, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(crypt, arginfo_crypt)
+#if defined(HAVE_XCRYPT_4_4)
+	ZEND_FE(crypt_gensalt, arginfo_crypt_gensalt)
+	ZEND_FE(crypt_preferred_method, arginfo_crypt_preferred_method)
+	ZEND_FE(crypt_checksalt, arginfo_crypt_checksalt)
+#endif
 #if defined(HAVE_STRPTIME)
 	ZEND_RAW_FENTRY("strptime", zif_strptime, arginfo_strptime, ZEND_ACC_DEPRECATED, NULL, NULL)
 #endif
@@ -3989,6 +4013,48 @@ static void register_basic_functions_symbols(int module_number)
 #endif
 #if defined(HAVE_NL_LANGINFO) && defined(CODESET)
 	REGISTER_LONG_CONSTANT("CODESET", CODESET, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_STD_DES", "", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_EXT_DES", "_", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_MD5", "$1$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_BLOWFISH", "$2y$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_SHA256", "$5$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_SHA512", "$6$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_SCRYPT", "$7$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_GOST_YESCRYPT", "$gy$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_STRING_CONSTANT("CRYPT_PREFIX_YESCRYPT", "$y$", CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_LONG_CONSTANT("CRYPT_SALT_OK", CRYPT_SALT_OK, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_LONG_CONSTANT("CRYPT_SALT_INVALID", CRYPT_SALT_INVALID, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_LONG_CONSTANT("CRYPT_SALT_METHOD_DISABLED", CRYPT_SALT_METHOD_DISABLED, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_LONG_CONSTANT("CRYPT_SALT_METHOD_LEGACY", CRYPT_SALT_METHOD_LEGACY, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_XCRYPT_4_4)
+	REGISTER_LONG_CONSTANT("CRYPT_SALT_TOO_CHEAP", CRYPT_SALT_TOO_CHEAP, CONST_PERSISTENT);
 #endif
 
 

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -93,8 +93,14 @@ AS_VAR_IF([PHP_EXTERNAL_LIBCRYPT], [no], [
 ], [
 AC_SEARCH_LIBS([crypt], [crypt],
   [AC_DEFINE([HAVE_CRYPT], [1],
-    [Define to 1 if you have the 'crypt' function.])],
-  [AC_MSG_FAILURE([Cannot use external libcrypt as crypt() is missing.])])
+    [Define to 1 if you have the 'crypt' function.])]
+
+AC_SEARCH_LIBS([crypt_gensalt_rn], [crypt],
+  AC_SEARCH_LIBS([crypt_preferred_method], [crypt],
+    AC_SEARCH_LIBS([crypt_checksalt], [crypt],
+    [AC_DEFINE([HAVE_XCRYPT_4_4], [1],
+      [Define to 1 if you have the 'crypt_gensalt_rn', 'crypt_preferred_method' and 'crypt_checksalt' functions.])]
+))))
 
 AC_SEARCH_LIBS([crypt_r], [crypt],
   [AC_DEFINE([HAVE_CRYPT_R], [1],

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -230,3 +230,55 @@ PHP_FUNCTION(crypt)
 	RETURN_STR(result);
 }
 /* }}} */
+
+#ifdef HAVE_XCRYPT_4_4
+/* {{{ Generates a salt for algo */
+PHP_FUNCTION(crypt_gensalt)
+{
+	char salt[CRYPT_GENSALT_OUTPUT_SIZE + 1];
+	char *prefix = NULL;
+	size_t prefix_len = 0;
+	zend_long count = 0;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STRING(prefix, prefix_len)
+		Z_PARAM_LONG(count)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (crypt_gensalt_rn(prefix, (unsigned long)count, NULL, 0, salt, CRYPT_GENSALT_OUTPUT_SIZE)) {
+		RETURN_STRING(salt);
+	}
+	RETURN_NULL();
+}
+/* }}} */
+
+/* {{{ Get preferred hasing method prefix */
+PHP_FUNCTION(crypt_preferred_method)
+{
+	const char *prefix;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	prefix = crypt_preferred_method();
+	if (prefix) {
+		RETURN_STRING(prefix);
+	}
+	RETURN_NULL();
+}
+/* }}} */
+
+/* {{{ Determine whether the user's passphrase should be re-hashed using the currently preferred hashing method */
+PHP_FUNCTION(crypt_checksalt)
+{
+	char *salt;
+	size_t salt_len;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STRING(salt, salt_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(crypt_checksalt(salt));
+}
+/* }}} */
+#endif

--- a/ext/standard/tests/crypt/crypt_checksalt.phpt
+++ b/ext/standard/tests/crypt/crypt_checksalt.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test crypt_checksalt
+--SKIPIF--
+<?php if (!function_exists('crypt_checksalt')) die('skip needs external libxcrypt >= 4.4'); ?>
+--FILE--
+<?php
+// salt with old algo is OK or LEGACY
+$r = crypt_checksalt(crypt_gensalt(CRYPT_PREFIX_STD_DES));
+var_dump($r === CRYPT_SALT_METHOD_LEGACY || $r === CRYPT_SALT_OK);
+
+// salt with default algo is OK
+$r = crypt_checksalt(crypt_gensalt());
+var_dump($r === CRYPT_SALT_OK);
+
+// bad salt is INVALID
+$r = crypt_checksalt("!not_a_valid_hash");
+var_dump($r === CRYPT_SALT_INVALID);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/crypt/crypt_gensalt.phpt
+++ b/ext/standard/tests/crypt/crypt_gensalt.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test crypt_gensalt
+--SKIPIF--
+<?php if (!function_exists('crypt_gensalt')) die('skip needs external libxcrypt >= 4.4'); ?>
+--FILE--
+<?php
+var_dump(crypt_gensalt(CRYPT_PREFIX_STD_DES));
+var_dump(crypt_gensalt(CRYPT_PREFIX_EXT_DES));
+var_dump(crypt_gensalt(CRYPT_PREFIX_MD5));
+var_dump(crypt_gensalt(CRYPT_PREFIX_BLOWFISH));
+var_dump(crypt_gensalt(CRYPT_PREFIX_SHA256));
+var_dump(crypt_gensalt(CRYPT_PREFIX_SHA512));
+var_dump(crypt_gensalt(CRYPT_PREFIX_SCRYPT));
+var_dump(crypt_gensalt(CRYPT_PREFIX_GOST_YESCRYPT));
+var_dump(crypt_gensalt(CRYPT_PREFIX_YESCRYPT));
+
+?>
+--EXPECTF--
+string(2) "%s"
+string(9) "_%s"
+string(11) "$1$%s"
+string(29) "$2y$%s"
+string(19) "$5$%s"
+string(19) "$6$%s"
+string(36) "$7$%s"
+string(30) "$gy$%s"
+string(29) "$y$j%s"

--- a/ext/standard/tests/crypt/crypt_preferred_method.phpt
+++ b/ext/standard/tests/crypt/crypt_preferred_method.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test crypt_preferred_method
+--SKIPIF--
+<?php if (!function_exists('crypt_preferred_method')) die('skip needs external libxcrypt >= 4.4'); ?>
+--FILE--
+<?php
+var_dump(crypt_preferred_method());
+?>
+--EXPECTF--
+string(%d) "$%s$"
+


### PR DESCRIPTION
This PR add 3 functions

* `crypt_gensalt` (since libxcrypt 4.0)
* `crypt_checksalt`  (since libxcrypt 4.3)
* `crypt_preferred_method`  (since libxcrypt 4.4)

And make new algo usable (providing the expecting salt, with algo options, may be complex)

* `$y$ `(yescrypt) (since libxcrypt 4.2.0)
* `$gy$` (ghost-yescrypt) (since libxcrypt 4.3.0)

Examples

```
$hash = crypt("secret", crypt_gensalt());
$hash = crypt("secret", crypt_gensalt(crypt_preferred_method()));
$hash = crypt("secret", crypt_gensalt(CRYPT_PREFIX_BLOWFISH));
```

Target is libxcrypt 4.4 only, released in 2018