### PR TITLE
Preallocate space for Win64 shadow args

### DIFF
--- a/Zend/tests/bug54268.phpt
+++ b/Zend/tests/bug54268.phpt
@@ -8,14 +8,6 @@ $zend_mm_enabled = getenv("USE_ZEND_ALLOC");
 if ($zend_mm_enabled === "0") {
     die("skip Zend MM disabled");
 }
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/issues/15709";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
 ?>
 --FILE--
 <?php

--- a/Zend/tests/gh16508.phpt
+++ b/Zend/tests/gh16508.phpt
@@ -2,6 +2,17 @@
 GH-16508: Missing lineno in inheritance errors of delayed early bound classes
 --EXTENSIONS--
 opcache
+--SKIPIF--
+<?php
+$tracing = extension_loaded("Zend OPcache")
+    && ($conf = opcache_get_configuration()["directives"])
+    && array_key_exists("opcache.jit", $conf)
+    &&  $conf["opcache.jit"] === "tracing";
+if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
+    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
+    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
+}
+?>
 --INI--
 opcache.enable_cli=1
 --FILE--

--- a/Zend/tests/gh16508.phpt
+++ b/Zend/tests/gh16508.phpt
@@ -2,17 +2,6 @@
 GH-16508: Missing lineno in inheritance errors of delayed early bound classes
 --EXTENSIONS--
 opcache
---SKIPIF--
-<?php
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
-?>
 --INI--
 opcache.enable_cli=1
 --FILE--

--- a/Zend/tests/gh16509.phpt
+++ b/Zend/tests/gh16509.phpt
@@ -1,16 +1,5 @@
 --TEST--
 GH-16509: Incorrect lineno reported for function redeclaration
---SKIPIF--
-<?php
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
-?>
 --FILE--
 <?php
 

--- a/Zend/tests/gh8841.phpt
+++ b/Zend/tests/gh8841.phpt
@@ -1,16 +1,5 @@
 --TEST--
 GH-8841 (php-cli core dump calling a badly formed function)
---SKIPIF--
-<?php
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
-?>
 --FILE--
 <?php
 register_shutdown_function(function() {

--- a/Zend/tests/gh9407.phpt
+++ b/Zend/tests/gh9407.phpt
@@ -1,16 +1,5 @@
 --TEST--
 GH-9407: LSP error in eval'd code refers to wrong class for static type
---SKIPIF--
-<?php
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
-?>
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_014.phpt
+++ b/Zend/tests/stack_limit/stack_limit_014.phpt
@@ -4,14 +4,6 @@ Stack limit 014 - Fuzzer
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
 if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
 ?>
 --EXTENSIONS--
 zend_test

--- a/Zend/tests/traits/bugs/gh13177.phpt
+++ b/Zend/tests/traits/bugs/gh13177.phpt
@@ -1,16 +1,5 @@
 --TEST--
 GH-13177 (PHP 8.3.2: final private constructor not allowed when used in trait)
---SKIPIF--
-<?php
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/issues/15709";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3628,9 +3628,11 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 	}
 
 	zend_jit_unprotect();
-	zend_jit_setup();
+	zend_jit_setup(reattached);
 	zend_jit_protect();
-	zend_jit_init_handlers();
+	if (!reattached) {
+		zend_jit_init_handlers();
+	}
 
 	zend_jit_trace_startup(reattached);
 

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -10409,7 +10409,7 @@ static int zend_jit_do_fcall(zend_jit_ctx *jit, const zend_op *opline, const zen
 				if (!jit->ctx.fixed_call_stack_size) {
 					sp = ir_RLOAD_A(IR_REG_SP);
 				} else {
-#ifdef _WIN32
+#ifdef _WIN64
 					sp = jit_ADD_OFFSET(jit, ir_RLOAD_A(IR_REG_SP), IR_SHADOW_ARGS);
 #else
 					sp = ir_RLOAD_A(IR_REG_SP);

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -3233,7 +3233,7 @@ static void zend_jit_setup_unwinder(void)
 	static const unsigned char uw_data[] = {
 		0x01, // UBYTE: 3 Version , UBYTE: 5 Flags
 		0x10, // UBYTE Size of prolog
-		0x09, // UBYTE Count of unwind codes
+		0x0a, // UBYTE Count of unwind codes
 		0x00, // UBYTE: 4 Frame Register, UBYTE: 4 Frame Register offset (scaled)
 		// USHORT * n Unwind codes array
 		0x10, 0x82, // c: subq $0x48, %rsp
@@ -3245,15 +3245,44 @@ static void zend_jit_setup_unwinder(void)
 		0x03, 0x60, // 2: pushq %rsi
 		0x02, 0x50, // 1: pushq %rbp
 		0x01, 0x30, // 0: pushq %rbx
+		0x00, 0x00,
+	};
+	static const unsigned char uw_data_exitcall[] = {
+		0x01, // UBYTE: 3 Version , UBYTE: 5 Flags
+		0x10, // UBYTE Size of prolog
+		0x0a, // UBYTE Count of unwind codes
+		0x00, // UBYTE: 4 Frame Register, UBYTE: 4 Frame Register offset (scaled)
+		// USHORT * n Unwind codes array
+		0x10, 0x01, 0x2f, 0x00, // c: subq 376, %rsp ; 0x48 + 32+16*8+16*8+8+8
+		0x0c, 0xf0, // a: pushq %r15
+		0x0a, 0xe0, // 8: pushq %r14
+		0x08, 0xd0, // 6: pushq %r13
+		0x06, 0xc0, // 4: pushq %r12
+		0x04, 0x70, // 3: pushq %rdi
+		0x03, 0x60, // 2: pushq %rsi
+		0x02, 0x50, // 1: pushq %rbp
+		0x01, 0x30, // 0: pushq %rbx
 	};
 
 	zend_jit_uw_func = (PRUNTIME_FUNCTION)*dasm_ptr;
-	*dasm_ptr = (char*)*dasm_ptr + ZEND_MM_ALIGNED_SIZE_EX(sizeof(RUNTIME_FUNCTION) + sizeof(uw_data), 16);
+	*dasm_ptr = (char*)*dasm_ptr + ZEND_MM_ALIGNED_SIZE_EX(sizeof(RUNTIME_FUNCTION) * 4 +
+		sizeof(uw_data) + sizeof(uw_data_exitcall) + sizeof(uw_data), 16);
 
-	zend_jit_uw_func->BeginAddress = 0;
-	zend_jit_uw_func->EndAddress = (uintptr_t)dasm_end - (uintptr_t)dasm_buf;
-	zend_jit_uw_func->UnwindData = (uintptr_t)zend_jit_uw_func + sizeof(RUNTIME_FUNCTION) - (uintptr_t)dasm_buf;
-	memcpy((char*)zend_jit_uw_func + sizeof(RUNTIME_FUNCTION), uw_data, sizeof(uw_data));
+	zend_jit_uw_func[0].BeginAddress = 0;
+	zend_jit_uw_func[1].BeginAddress = (uintptr_t)zend_jit_stub_handlers[jit_stub_trace_exit] - (uintptr_t)dasm_buf;
+	zend_jit_uw_func[2].BeginAddress = (uintptr_t)zend_jit_stub_handlers[jit_stub_undefined_offset] - (uintptr_t)dasm_buf;
+
+	zend_jit_uw_func[0].EndAddress = zend_jit_uw_func[1].BeginAddress;
+	zend_jit_uw_func[1].EndAddress = zend_jit_uw_func[2].BeginAddress;
+	zend_jit_uw_func[2].EndAddress = (uintptr_t)dasm_end - (uintptr_t)dasm_buf;
+
+	zend_jit_uw_func[0].UnwindData = (uintptr_t)zend_jit_uw_func  - (uintptr_t)dasm_buf + sizeof(RUNTIME_FUNCTION) * 4;
+	zend_jit_uw_func[1].UnwindData = zend_jit_uw_func[0].UnwindData + sizeof(uw_data);
+	zend_jit_uw_func[2].UnwindData = zend_jit_uw_func[1].UnwindData + sizeof(uw_data_exitcall);
+
+	memcpy((char*)dasm_buf + zend_jit_uw_func[0].UnwindData, uw_data, sizeof(uw_data));
+	memcpy((char*)dasm_buf + zend_jit_uw_func[1].UnwindData, uw_data_exitcall, sizeof(uw_data_exitcall));
+	memcpy((char*)dasm_buf + zend_jit_uw_func[2].UnwindData, uw_data, sizeof(uw_data));
 
 #ifdef ZEND_JIT_RT_UNWINDER
 	RtlInstallFunctionTableCallback(
@@ -3264,7 +3293,7 @@ static void zend_jit_setup_unwinder(void)
 		NULL,
 		NULL);
 #else
-	RtlAddFunctionTable(zend_jit_uw_func, 1, (uintptr_t)dasm_buf);
+	RtlAddFunctionTable(zend_jit_uw_func, 3, (uintptr_t)dasm_buf);
 #endif
 }
 #endif

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -3299,7 +3299,7 @@ static void zend_jit_setup_unwinder(void)
 #endif
 
 
-static void zend_jit_setup(void)
+static void zend_jit_setup(bool reattached)
 {
 #if defined(IR_TARGET_X86)
 	if (!zend_cpu_supports_sse2()) {
@@ -3504,7 +3504,9 @@ static void zend_jit_setup(void)
 	}
 
 	zend_jit_calc_trace_prologue_size();
-	zend_jit_setup_stubs();
+	if (!reattached) {
+		zend_jit_setup_stubs();
+	}
 	JIT_G(debug) = debug;
 
 #ifdef _WIN64

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -3229,7 +3229,7 @@ static PRUNTIME_FUNCTION zend_jit_unwind_callback(DWORD64 pc, PVOID context)
 
 static void zend_jit_setup_unwinder(void)
 {
-	/* Hardcoded SEH unwinf data for JIT-ed PHP functions with "fixed stack frame" */
+	/* Hardcoded SEH unwind data for JIT-ed PHP functions with "fixed stack frame" */
 	static const unsigned char uw_data[] = {
 		0x01, // UBYTE: 3 Version , UBYTE: 5 Flags
 		0x10, // UBYTE Size of prolog

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -3233,7 +3233,7 @@ static void zend_jit_setup_unwinder(void)
 	static const unsigned char uw_data[] = {
 		0x01, // UBYTE: 3 Version , UBYTE: 5 Flags
 		0x10, // UBYTE Size of prolog
-		0x0a, // UBYTE Count of unwind codes
+		0x09, // UBYTE Count of unwind codes
 		0x00, // UBYTE: 4 Frame Register, UBYTE: 4 Frame Register offset (scaled)
 		// USHORT * n Unwind codes array
 		0x10, 0x82, // c: subq $0x48, %rsp

--- a/ext/spl/tests/gh14639.phpt
+++ b/ext/spl/tests/gh14639.phpt
@@ -7,14 +7,6 @@ memory_limit=2M
 if (getenv("USE_ZEND_ALLOC") === "0") {
     die("skip Zend MM disabled");
 }
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
 ?>
 --FILE--
 <?php

--- a/tests/lang/bug45392.phpt
+++ b/tests/lang/bug45392.phpt
@@ -5,14 +5,6 @@ Bug #45392 (ob_start()/ob_end_clean() and memory_limit)
 if (getenv("USE_ZEND_ALLOC") === "0") {
     die("skip Zend MM disabled");
 }
-$tracing = extension_loaded("Zend OPcache")
-    && ($conf = opcache_get_configuration()["directives"])
-    && array_key_exists("opcache.jit", $conf)
-    &&  $conf["opcache.jit"] === "tracing";
-if (PHP_OS_FAMILY === "Windows" && PHP_INT_SIZE == 8 && $tracing) {
-    $url = "https://github.com/php/php-src/pull/14919#issuecomment-2259003979";
-    die("xfail Test fails on Windows x64 (VS17) and tracing JIT; see $url");
-}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Otherwise "fixed_call_stack" doesn't make sense