### PR TITLE
Use empheral port for mysqli fake server tests

### DIFF
--- a/ext/mysqli/tests/fake_server.inc
+++ b/ext/mysqli/tests/fake_server.inc
@@ -615,9 +615,11 @@ class my_mysqli_fake_server_conn
 
 class my_mysqli_fake_server_process
 {
+    private int $port;
+
     public function __construct(private $process, private array $pipes) {}
 
-    public function terminate(bool $wait = false)
+    public function terminate(bool $wait = false): void
     {
         if ($wait) {
             $this->wait();
@@ -625,9 +627,18 @@ class my_mysqli_fake_server_process
         proc_terminate($this->process);
     }
 
-    public function wait()
+    public function wait(): void
     {
-        echo fgets($this->pipes[1]);
+        $line = fgets($this->pipes[1]);
+        if (preg_match('/\[\*\] Server started on \d+\.\d+\.\d+\.\d+:(\d+)/', $line, $matches)) {
+            $this->port = (int)$matches[1];
+        }
+        echo $line;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port ?? throw new RuntimeException("Port not set");
     }
 }
 
@@ -807,15 +818,20 @@ function my_mysqli_test_query_response_row_read_two_fields(my_mysqli_fake_server
     }
 }
 
-function run_fake_server(string $test_function, $port = 33305): void
+function run_fake_server(string $test_function, int|string $port = 0): int
 {
-    $address = '127.0.0.1';
+    $host = '127.0.0.1';
 
-    $socket = @stream_socket_server("tcp://$address:$port", $errno, $errstr);
+    $socket = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
     if (!$socket) {
         die("Failed to create socket: $errstr ($errno)\n");
     }
-    echo "[*] Server started\n";
+    if (intval($port) === 0) {
+        $address = stream_socket_get_name($socket, false);
+        list($host, $port) = explode(":", $address);
+    }
+
+    echo "[*] Server started on $host:$port\n";
 
     try {
         $conn = new my_mysqli_fake_server_conn($socket);
@@ -832,7 +848,7 @@ function run_fake_server(string $test_function, $port = 33305): void
 }
 
 
-function run_fake_server_in_background($test_function, $port = 33305): my_mysqli_fake_server_process
+function run_fake_server_in_background($test_function, $port = 0): my_mysqli_fake_server_process
 {
     $command = [PHP_BINARY, '-n', __FILE__, 'mysqli_fake_server', $test_function, $port];
 
@@ -852,5 +868,5 @@ function run_fake_server_in_background($test_function, $port = 33305): my_mysqli
 }
 
 if (isset($argv) && $argc > 2 && $argv[1] == 'mysqli_fake_server') {
-    run_fake_server($argv[2], $argv[3] ?? '33305');
+    run_fake_server($argv[2], $argv[3] ?? 0);
 }

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-auth-message.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-auth-message.phpt
@@ -6,16 +6,15 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('auth_response_message_over_read', $port);
+$process = run_fake_server_in_background('auth_response_message_over_read');
 $process->wait();
 
 try {
-    $conn = new mysqli( $servername, $username, $password, "", $port );
+    $conn = new mysqli( $servername, $username, $password, "", $process->getPort());
     $info = mysqli_info($conn);
     var_dump($info);
 } catch (Exception $e) {
@@ -27,12 +26,12 @@ $process->terminate();
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31
 [*] Sending - Malicious OK Auth Response [Extract heap through buffer over-read]: 0900000200000002000000fcff
 
 Warning: mysqli::__construct(): OK packet message length is past the packet size in %s on line %d
-Unknown error while trying to connect via tcp://127.0.0.1:33305
+Unknown error while trying to connect via tcp://127.0.0.1:%d
 done!

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-def.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-def.phpt
@@ -6,16 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('tabular_response_def_over_read', $port);
+$process = run_fake_server_in_background('tabular_response_def_over_read');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Running query on the fake server...\n";
 
@@ -34,7 +32,7 @@ $process->terminate();
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-filename.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-filename.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('upsert_response_filename_over_read', $port);
+$process = run_fake_server_in_background('upsert_response_filename_over_read');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 echo "[*] Running query on the fake server...\n";
 
 $result = $conn->query("SELECT * from users");
@@ -27,7 +26,7 @@ $process->terminate();
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-query-len-overflow.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-query-len-overflow.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('query_response_row_length_overflow', $port);
+$process = run_fake_server_in_background('query_response_row_length_overflow');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Query the fake server...\n";
 $sql = "SELECT strval, strval FROM data";
@@ -33,7 +32,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-bit.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-bit.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_bit', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_bit');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT bitval, timval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-date.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-date.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_date', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_date');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, datval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-datetime.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-datetime.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_datetime', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_datetime');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, dtival FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-double.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-double.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_double', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_double');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, dblval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-float.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-float.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_float', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_float');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, fltval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-int.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-int.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_int', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_int');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, intval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-no-space.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-no-space.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_no_space', $port);
+$process = run_fake_server_in_background('stmt_response_row_no_space');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, strval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-string.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-string.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_string', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_string');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT item FROM items");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-time.phpt
+++ b/ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-time.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_over_read_time', $port);
+$process = run_fake_server_in_background('stmt_response_row_over_read_time');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 echo "[*] Preparing statement on the fake server...\n";
 $stmt = $conn->prepare("SELECT strval, timval FROM data");
@@ -36,7 +35,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/protocol_query_row_fetch_data.phpt
+++ b/ext/mysqli/tests/protocol_query_row_fetch_data.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('query_response_row_read_two_fields', $port);
+$process = run_fake_server_in_background('query_response_row_read_two_fields');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 function my_query($conn, $field)
 {
@@ -39,8 +38,8 @@ $process->terminate(true);
 
 print "done!";
 ?>
---EXPECT--
-[*] Server started
+--EXPECTF--
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31

--- a/ext/mysqli/tests/protocol_stmt_row_fetch_data.phpt
+++ b/ext/mysqli/tests/protocol_stmt_row_fetch_data.phpt
@@ -6,15 +6,14 @@ mysqli
 <?php
 require_once 'fake_server.inc';
 
-$port = 33305;
 $servername = "127.0.0.1";
 $username = "root";
 $password = "";
 
-$process = run_fake_server_in_background('stmt_response_row_read_two_fields', $port);
+$process = run_fake_server_in_background('stmt_response_row_read_two_fields');
 $process->wait();
 
-$conn = new mysqli($servername, $username, $password, "", $port);
+$conn = new mysqli($servername, $username, $password, "", $process->getPort());
 
 function my_query($conn, $field)
 {
@@ -41,7 +40,7 @@ $process->terminate(true);
 print "done!";
 ?>
 --EXPECTF--
-[*] Server started
+[*] Server started on 127.0.0.1:%d
 [*] Connection established
 [*] Sending - Server Greeting: 580000000a352e352e352d31302e352e31382d4d6172696144420003000000473e3f6047257c6700fef7080200ff81150000000000000f0000006c6b55463f49335f686c6431006d7973716c5f6e61746976655f70617373776f7264
 [*] Received: 6900000185a21a00000000c0080000000000000000000000000000000000000000000000726f6f7400006d7973716c5f6e61746976655f70617373776f7264002c0c5f636c69656e745f6e616d65076d7973716c6e640c5f7365727665725f686f7374093132372e302e302e31


### PR DESCRIPTION
This should hopefully fix issue with address already being used in those tests. It means it's an attempt to fix #16875 .