### PR TITLE
Fail phpize early if config.w32 is missing

### DIFF
--- a/win32/build/phpize.bat
+++ b/win32/build/phpize.bat
@@ -1,6 +1,7 @@
 @echo off
 SET PHP_BUILDCONF_PATH=%~dp0
 cscript /nologo /e:jscript %PHP_BUILDCONF_PATH%\script\phpize.js %*
+IF ERRORLEVEL 0 exit /b 3
 IF NOT EXIST configure.bat (
 	echo Error generating configure script, configure script was not copied
 	exit /b 3

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -17,6 +17,7 @@
 // This generates a configure script for win32 build
 
 var STDOUT = WScript.StdOut;
+var STDERR = WScript.StdErr;
 
 var FSO = WScript.CreateObject("Scripting.FileSystemObject");
 var C = FSO.CreateTextFile("configure.js", true);
@@ -201,6 +202,13 @@ function buildconf_process_args()
 if (buildconf_process_args() == 0) {
 	WScript.Quit(3);
 }
+
+if (FSO.FileExists("config.w32")) {
+	STDERR.WriteLine("Cannot find config.w32");
+	STDERR.WriteLine("Must be run from the root of the extension source");
+	WScript.Quit(10);
+}
+
 STDOUT.WriteLine("Rebuilding configure.js");
 STDOUT.WriteLine(PHP_DIR);
 


### PR DESCRIPTION
On Windows, phpize happily builds configure even if there is no config.w32, but running configure then error with "Must be run from the root of the extension source".  This is confusing.

We bring phpize's behavior on par with POSIX systems, where the missing config.m4 is detected and reported right away.