### PR TITLE
Add FFI::offsetof()

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4431,6 +4431,37 @@ ZEND_METHOD(FFI, alignof) /* {{{ */
 }
 /* }}} */
 
+ZEND_METHOD(FFI, offsetof)
+{
+	zval *zv;
+	zend_ffi_type *type;
+	zend_string *field_name;
+
+	ZEND_FFI_VALIDATE_API_RESTRICTION();
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(zv)
+		Z_PARAM_STR(field_name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	type = zend_ffi_type_from_cdata_or_ctype(zv);
+	if (UNEXPECTED(!type)) {
+		RETURN_THROWS();
+	}
+
+	if (UNEXPECTED(type->kind != ZEND_FFI_TYPE_STRUCT)) {
+		zend_argument_value_error(1, "must be a struct/union");
+		RETURN_THROWS();
+	}
+
+	const zend_ffi_field *field = zend_hash_find_ptr(&type->record.fields, field_name);
+	if (UNEXPECTED(!field)) {
+		zend_argument_value_error(2, "does not exist");
+		RETURN_THROWS();
+	}
+
+	RETURN_LONG(field->offset);
+}
+
 ZEND_METHOD(FFI, memcpy) /* {{{ */
 {
 	zval *zv1, *zv2;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4378,6 +4378,21 @@ ZEND_METHOD(FFI, addr) /* {{{ */
 }
 /* }}} */
 
+static zend_ffi_type *zend_ffi_type_from_cdata_or_ctype(zval *zv)
+{
+	ZVAL_DEREF(zv);
+	if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_cdata_ce) {
+		zend_ffi_cdata *cdata = (zend_ffi_cdata*)Z_OBJ_P(zv);
+		return ZEND_FFI_TYPE(cdata->type);
+	} else if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_ctype_ce) {
+		zend_ffi_ctype *ctype = (zend_ffi_ctype*)Z_OBJ_P(zv);
+		return ZEND_FFI_TYPE(ctype->type);
+	} else {
+		zend_wrong_parameter_class_error(1, "FFI\\CData or FFI\\CType", zv);
+		return NULL;
+	}
+}
+
 ZEND_METHOD(FFI, sizeof) /* {{{ */
 {
 	zval *zv;
@@ -4388,15 +4403,8 @@ ZEND_METHOD(FFI, sizeof) /* {{{ */
 		Z_PARAM_ZVAL(zv);
 	ZEND_PARSE_PARAMETERS_END();
 
-	ZVAL_DEREF(zv);
-	if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_cdata_ce) {
-		zend_ffi_cdata *cdata = (zend_ffi_cdata*)Z_OBJ_P(zv);
-		type = ZEND_FFI_TYPE(cdata->type);
-	} else if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_ctype_ce) {
-		zend_ffi_ctype *ctype = (zend_ffi_ctype*)Z_OBJ_P(zv);
-		type = ZEND_FFI_TYPE(ctype->type);
-	} else {
-		zend_wrong_parameter_class_error(1, "FFI\\CData or FFI\\CType", zv);
+	type = zend_ffi_type_from_cdata_or_ctype(zv);
+	if (UNEXPECTED(!type)) {
 		RETURN_THROWS();
 	}
 
@@ -4414,15 +4422,8 @@ ZEND_METHOD(FFI, alignof) /* {{{ */
 		Z_PARAM_ZVAL(zv);
 	ZEND_PARSE_PARAMETERS_END();
 
-	ZVAL_DEREF(zv);
-	if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_cdata_ce) {
-		zend_ffi_cdata *cdata = (zend_ffi_cdata*)Z_OBJ_P(zv);
-		type = ZEND_FFI_TYPE(cdata->type);
-	} else if (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ffi_ctype_ce) {
-		zend_ffi_ctype *ctype = (zend_ffi_ctype*)Z_OBJ_P(zv);
-		type = ZEND_FFI_TYPE(ctype->type);
-	} else {
-		zend_wrong_parameter_class_error(1, "FFI\\CData or FFI\\CType", zv);
+	type = zend_ffi_type_from_cdata_or_ctype(zv);
+	if (UNEXPECTED(!type)) {
 		RETURN_THROWS();
 	}
 

--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -42,6 +42,9 @@ namespace {
         /** @prefer-ref $ptr */
         public static function alignof(FFI\CData|FFI\CType $ptr): int {}
 
+        /** @prefer-ref $ptr */
+        public static function offsetof(FFI\CData|FFI\CType $ptr, string $field): int {}
+
         /**
          * @param FFI\CData|string $from
          * @prefer-ref $to

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d3626f5d39317876fc7d4f240b0758f17f3472c8 */
+ * Stub hash: 09f1604c352537e10c009c174c29355efa066490 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")
@@ -51,6 +51,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_FFI_sizeof, 0, 1, IS_LONG,
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_FFI_alignof arginfo_class_FFI_sizeof
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_FFI_offsetof, 0, 2, IS_LONG, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(ZEND_SEND_PREFER_REF, ptr, FFI\\CData|FFI\\CType, 0, NULL)
+	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_FFI_memcpy, 0, 3, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(ZEND_SEND_PREFER_REF, to, FFI\\CData, 0)
@@ -133,6 +138,7 @@ ZEND_METHOD(FFI, arrayType);
 ZEND_METHOD(FFI, addr);
 ZEND_METHOD(FFI, sizeof);
 ZEND_METHOD(FFI, alignof);
+ZEND_METHOD(FFI, offsetof);
 ZEND_METHOD(FFI, memcpy);
 ZEND_METHOD(FFI, memcmp);
 ZEND_METHOD(FFI, memset);
@@ -168,6 +174,7 @@ static const zend_function_entry class_FFI_methods[] = {
 	ZEND_ME(FFI, addr, arginfo_class_FFI_addr, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, sizeof, arginfo_class_FFI_sizeof, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, alignof, arginfo_class_FFI_alignof, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(FFI, offsetof, arginfo_class_FFI_offsetof, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, memcpy, arginfo_class_FFI_memcpy, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, memcmp, arginfo_class_FFI_memcmp, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(FFI, memset, arginfo_class_FFI_memset, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)


### PR DESCRIPTION
I don't know if you think this is useful too.

I think it is useful for a couple of different applications:
- Some object oriented / generic features are implemented by using field
  offsets (e.g. container_of like in the Linux kernel).
- Tracking extra allocation data, this is where the first "offsetof()"
  feature request comes from: https://bugs.php.net/bug.php?id=79066
- Serialization/deserialization purposes with direct pointer arithmetic

Would resolve https://bugs.php.net/bug.php?id=79066