### PR TITLE
Fix ZEND_MATCH_ERROR misoptimization

### DIFF
--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -640,6 +640,7 @@ bool zend_optimizer_replace_by_const(zend_op_array *op_array,
 				case ZEND_SWITCH_LONG:
 				case ZEND_SWITCH_STRING:
 				case ZEND_MATCH:
+				case ZEND_MATCH_ERROR:
 				case ZEND_JMP_NULL: {
 					zend_op *end = op_array->opcodes + op_array->last;
 					while (opline < end) {
@@ -652,6 +653,7 @@ bool zend_optimizer_replace_by_const(zend_op_array *op_array,
 								&& opline->opcode != ZEND_SWITCH_LONG
 								&& opline->opcode != ZEND_SWITCH_STRING
 								&& opline->opcode != ZEND_MATCH
+								&& opline->opcode != ZEND_MATCH_ERROR
 								&& opline->opcode != ZEND_JMP_NULL
 								&& (opline->opcode != ZEND_FREE
 									|| opline->extended_value != ZEND_FREE_ON_RETURN);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -877,6 +877,7 @@ static bool keeps_op1_alive(zend_op *opline) {
 	 || opline->opcode == ZEND_SWITCH_LONG
 	 || opline->opcode == ZEND_SWITCH_STRING
 	 || opline->opcode == ZEND_MATCH
+	 || opline->opcode == ZEND_MATCH_ERROR
 	 || opline->opcode == ZEND_FETCH_LIST_R
 	 || opline->opcode == ZEND_FETCH_LIST_W
 	 || opline->opcode == ZEND_COPY_TMP) {

--- a/ext/opcache/tests/gh17106.phpt
+++ b/ext/opcache/tests/gh17106.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-17106: ZEND_MATCH_ERROR misoptimization
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable_cli=1
+opcache.optimization_level=-1
+--FILE--
+<?php
+
+const X = 2;
+
+var_dump(7 ?? match (X) {});
+var_dump(null ?? match (X) { 2 => 2 });
+var_dump(match (X) { 2 => 2 });
+
+?>
+--EXPECT--
+int(7)
+int(2)
+int(2)


### PR DESCRIPTION
op1 of ZEND_MATCH_ERROR, which refers to the match expression, is not freed by MATCH_ERROR itself. Instead, it is freed by ZEND_HANDLE_EXCEPTION. For normal control flow, a FREE is placed at the end of the match expression.

Since FREE may appear after MATCH_ERROR in the opcode sequence, we need to correctly handle op1 of MATCH_ERROR as alive.

Fixes GH-17106