### PR TITLE
Hide xfail/xleak test summary

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -3144,18 +3144,6 @@ SLOW TEST SUMMARY
         $failed_test_summary .= "=====================================================================\n";
     }
 
-    if (count($PHP_FAILED_TESTS['XFAILED'])) {
-        $failed_test_summary .= '
-=====================================================================
-EXPECTED FAILED TEST SUMMARY
----------------------------------------------------------------------
-';
-        foreach ($PHP_FAILED_TESTS['XFAILED'] as $failed_test_data) {
-            $failed_test_summary .= $failed_test_data['test_name'] . $failed_test_data['info'] . "\n";
-        }
-        $failed_test_summary .= "=====================================================================\n";
-    }
-
     if (count($PHP_FAILED_TESTS['BORKED'])) {
         $failed_test_summary .= '
 =====================================================================
@@ -3200,19 +3188,6 @@ LEAKED TEST SUMMARY
 ---------------------------------------------------------------------
 ';
         foreach ($PHP_FAILED_TESTS['LEAKED'] as $failed_test_data) {
-            $failed_test_summary .= $failed_test_data['test_name'] . $failed_test_data['info'] . "\n";
-        }
-
-        $failed_test_summary .= "=====================================================================\n";
-    }
-
-    if (count($PHP_FAILED_TESTS['XLEAKED'])) {
-        $failed_test_summary .= '
-=====================================================================
-EXPECTED LEAK TEST SUMMARY
----------------------------------------------------------------------
-';
-        foreach ($PHP_FAILED_TESTS['XLEAKED'] as $failed_test_data) {
             $failed_test_summary .= $failed_test_data['test_name'] . $failed_test_data['info'] . "\n";
         }
 


### PR DESCRIPTION
We don't show succeeding tests in the summary, and for all intents and purposes, these tests have succeeded, in that they behave as expected. I've seen the output confuse people on multiple occasions, for example GH-17105.