### PR TITLE
Drop redundant macro definitions from mbfl_defs.h

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfl_defs.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_defs.h
@@ -31,18 +31,6 @@
 #ifndef MBFL_DEFS_H
 #define MBFL_DEFS_H
 
-#ifndef NULL
-#ifdef __cplusplus
-#define NULL (0L)
-#else
-#define NULL (void *)(0L)
-#endif
-#endif
-
-#ifndef SIZE_MAX
-#define SIZE_MAX	((size_t)~0)
-#endif
-
 #ifdef WIN32
 #ifdef MBFL_DLL_EXPORT
 #define MBFLAPI __declspec(dllexport)


### PR DESCRIPTION
These are defined by the standard include headers we already use. These cause conflicts which cause compiler warnings on some toolchains (see GH-17112).
This fixes the mbstring part of the issue.