### PR TITLE
Avoid string duplications in sqlite drivers

### DIFF
--- a/ext/pdo_sqlite/php_pdo_sqlite_int.h
+++ b/ext/pdo_sqlite/php_pdo_sqlite_int.h
@@ -30,7 +30,7 @@ struct pdo_sqlite_func {
 	struct pdo_sqlite_func *next;
 
 	int argc;
-	const char *funcname;
+	zend_string *funcname;
 
 	/* accelerated callback references */
 	zend_fcall_info_cache func;
@@ -41,7 +41,7 @@ struct pdo_sqlite_func {
 struct pdo_sqlite_collation {
 	struct pdo_sqlite_collation *next;
 
-	const char *name;
+	zend_string *name;
 	zend_fcall_info_cache callback;
 };
 

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -44,7 +44,7 @@ struct php_sqlite3_bound_param  {
 typedef struct _php_sqlite3_func {
 	struct _php_sqlite3_func *next;
 
-	const char *func_name;
+	zend_string *func_name;
 	int argc;
 
 	zend_fcall_info_cache func;
@@ -56,7 +56,7 @@ typedef struct _php_sqlite3_func {
 typedef struct _php_sqlite3_collation {
 	struct _php_sqlite3_collation *next;
 
-	const char *collation_name;
+	zend_string *collation_name;
 	zend_fcall_info_cache cmp_func;
 } php_sqlite3_collation;
 


### PR DESCRIPTION
These string duplications are necessary to unregister the callback later. We can just keep using zend_string to avoid memory duplications.