### PR TITLE
Remove support for unsupported MSVC versions

### DIFF
--- a/Zend/zend_config.w32.h
+++ b/Zend/zend_config.w32.h
@@ -38,9 +38,6 @@
 
 #include <float.h>
 
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 #define strcasecmp(s1, s2) _stricmp(s1, s2)
 #define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
 

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -307,9 +307,7 @@ char *alloca();
 
 #if defined(__GNUC__) && ZEND_GCC_VERSION >= 3004 && defined(__i386__)
 # define ZEND_FASTCALL __attribute__((fastcall))
-#elif defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER == 1700
-# define ZEND_FASTCALL __fastcall
-#elif defined(_MSC_VER) && _MSC_VER >= 1800
+#elif defined(_MSC_VER)
 # define ZEND_FASTCALL __vectorcall
 #else
 # define ZEND_FASTCALL

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -69,7 +69,7 @@
 /* Common */
 #include <time.h>
 
-#if (defined(PHP_WIN32) && defined(_MSC_VER) && _MSC_VER >= 1900)
+#if (defined(PHP_WIN32) && defined(_MSC_VER))
 #define timezone _timezone	/* timezone is called _timezone in LibC */
 #endif
 

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2950,7 +2950,7 @@ static xmlNodePtr to_xml_datetime_ex(encodeTypePtr type, zval *data, char *forma
 			(ta->tm_gmtoff < 0) ? '-' : '+',
 			labs(ta->tm_gmtoff / 3600), labs( (ta->tm_gmtoff % 3600) / 60 ));
 #else
-# if defined(__CYGWIN__) || (defined(PHP_WIN32) && defined(_MSC_VER) && _MSC_VER >= 1900)
+# if defined(__CYGWIN__) || (defined(PHP_WIN32) && defined(_MSC_VER))
 		snprintf(tzbuf, sizeof(tzbuf), "%c%02d:%02d", ((ta->tm_isdst ? _timezone - 3600:_timezone)>0)?'-':'+', abs((ta->tm_isdst ? _timezone - 3600 : _timezone) / 3600), abs(((ta->tm_isdst ? _timezone - 3600 : _timezone) % 3600) / 60));
 # else
 		snprintf(tzbuf, sizeof(tzbuf), "%c%02d:%02d", ((ta->tm_isdst ? timezone - 3600:timezone)>0)?'-':'+', abs((ta->tm_isdst ? timezone - 3600 : timezone) / 3600), abs(((ta->tm_isdst ? timezone - 3600 : timezone) % 3600) / 60));

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -123,21 +123,8 @@ PHPAPI struct lconv *localeconv_r(struct lconv *out)
 	tsrm_mutex_lock( locale_mutex );
 #endif
 
-/*  cur->locinfo is struct __crt_locale_info which implementation is
-	hidden in vc14. TODO revisit this and check if a workaround available
-	and needed. */
-#if defined(PHP_WIN32) && _MSC_VER < 1900 && defined(ZTS)
-	{
-		/* Even with the enabled per thread locale, localeconv
-			won't check any locale change in the master thread. */
-		_locale_t cur = _get_current_locale();
-		*out = *cur->locinfo->lconv;
-		_free_locale(cur);
-	}
-#else
 	/* localeconv doesn't return an error condition */
 	*out = *localeconv();
-#endif
 
 #ifdef ZTS
 	tsrm_mutex_unlock( locale_mutex );

--- a/win32/time.h
+++ b/win32/time.h
@@ -28,14 +28,6 @@ struct itimerval {
 	struct timeval it_value;	/* current value */
 };
 
-#if !defined(timespec) && _MSC_VER < 1900
-struct timespec
-{
-	time_t   tv_sec;   /* seconds */
-	long     tv_nsec;  /* nanoseconds */
-};
-#endif
-
 #define ITIMER_REAL    0		/*generates sigalrm */
 #define ITIMER_VIRTUAL 1		/*generates sigvtalrm */
 #define ITIMER_VIRT    1		/*generates sigvtalrm */


### PR DESCRIPTION
As of PHP 8.4.0, MSVC >= 1920 (aka. Visual Studio 2019 RTW 16.0) is required anyway[1], so we can clean up a bit.

[1] <https://github.com/php/php-src/commit/b3d6414b87cfebf503b5064a78ea1c5120ed638f>

---

I did not touch bundled libraries, but submitted https://github.com/derickr/timelib/pull/160.