### PR TITLE
Include relevant system headers before defining fallbacks

### DIFF
--- a/sapi/fpm/fpm/fpm_config.h
+++ b/sapi/fpm/fpm/fpm_config.h
@@ -2,6 +2,16 @@
 
 #include <php_config.h>
 
+#ifdef HAVE_ARPA_INET_H
+# include <arpa/inet.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+# include <sys/time.h>
+#endif
+
 /* Solaris does not have it */
 #ifndef INADDR_NONE
 # define INADDR_NONE (-1)


### PR DESCRIPTION
Otherwise we may define the fallbacks, and later inclusion of the system headers may attempt to redefine those.

Fixes GH-17112.

---

Note that I don't know if we need to include both arpa/inet.h and netinet/in.h to avoid this issue for `INADDR_NONE`, but it likely doesn't hurt, and #17124 seems to be a cleaner solution anyway (however, we cannot apply that to stable branches, so this is more a stop-gap measure).

cc @nielsdos (since you've fixed the other part of #17112).