### PR TITLE
Fix GH-17122: memory leak in regex

### DIFF
--- a/ext/pcre/tests/gh17122.phpt
+++ b/ext/pcre/tests/gh17122.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-17122 (memory leak in regex)
+--FILE--
+<?php
+preg_match('|(?P<name>)(\d+)|', 0xffffffff, $m1);
+var_dump($m1);
+\preg_match('|(?P<name2>)(\d+)|', 0, $m2);
+var_dump($m2);
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  string(10) "4294967295"
+  ["name"]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+  [2]=>
+  string(10) "4294967295"
+}
+array(4) {
+  [0]=>
+  string(1) "0"
+  ["name2"]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+  [2]=>
+  string(1) "0"
+}


### PR DESCRIPTION
Because the subpattern names are persistent, and the fact that the symbol table destruction is skipped when using fast_shutdown, this means the refcounts will not be updated for the destruction of the arrays that hold the subpattern name keys.
~~To solve this, detect this situation and duplicate the strings.
An alternative is always destroying the symbol table, but that changes engine behaviour.~~ New solution: see below