### PR TITLE
Fix GH-17139: Fix zip_entry_name() crash on invalid entry.

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1257,6 +1257,7 @@ PHP_FUNCTION(zip_read)
 
 		zr_rsrc->zf = zip_fopen_index(rsrc_int->za, rsrc_int->index_current, 0);
 		if (zr_rsrc->zf) {
+			Z_ADDREF_P(zip_dp);
 			rsrc_int->index_current++;
 			RETURN_RES(zend_register_resource(zr_rsrc, le_zip_entry));
 		} else {

--- a/ext/zip/tests/gh17139.phpt
+++ b/ext/zip/tests/gh17139.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-17139 - zip_entry_name() crash
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+$zip = zip_open(__DIR__."/test_procedural.zip");
+if (!is_resource($zip)) die("Failure");
+// no need to bother looping over, the entry name should point to a dangling address from the first iteration
+$zip = zip_read($zip);
+var_dump(zip_entry_name($zip));
+?>
+--EXPECTF--
+Deprecated: Function zip_open() is deprecated in %s on line %d
+
+Deprecated: Function zip_read() is deprecated in %s on line %d
+
+Deprecated: Function zip_entry_name() is deprecated in %s on line %d
+string(3) "foo"


### PR DESCRIPTION
Increasing the GC refcount when reading the zip entry before zip_entry_name() fetches the info, leading to a dangling pointer otherwise.