### PR TITLE
Fix GH-17145: DOM memory leak

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -2375,7 +2375,7 @@ void php_dom_get_content_into_zval(const xmlNode *nodep, zval *return_value, boo
 		case XML_ATTRIBUTE_NODE: {
 			bool free;
 			xmlChar *value = php_libxml_attr_value((const xmlAttr *) nodep, &free);
-			RETURN_STRING_FAST((const char *) value);
+			RETVAL_STRING_FAST((const char *) value);
 			if (free) {
 				xmlFree(value);
 			}

--- a/ext/dom/tests/gh17145.phpt
+++ b/ext/dom/tests/gh17145.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17145 (DOM memory leak)
+--EXTENSIONS--
+dom
+--CREDITS--
+YuanchengJiang
+--SKIPIF--
+<?php
+if (LIBXML_VERSION < 21300) die("skip Upstream libxml bug causes incorrect output, fixed in GNOME/libxml2@b8597f4");
+?>
+--FILE--
+<?php
+$element = new DOMElement("N", "W", "y");
+$attr = new DOMAttr("c" , "n");
+$doc = new DOMDocument();
+$doc->appendChild($element);
+$element->setAttributeNodeNS($attr);
+$attr->appendChild($doc->createEntityReference('amp'));
+echo $attr->value;
+?>
+--EXPECT--
+n&


### PR DESCRIPTION
Because the use of RETURN instead of RETVAL, the freeing code could not be executed. This only is triggerable if the content of the attribute is mixed text and entities, so it wasn't noticed earlier.