### PR TITLE
Fix GH-17137: Segmentation fault ext/phar/phar.c

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -1504,6 +1504,7 @@ int phar_create_or_parse_filename(char *fname, size_t fname_len, char *alias, si
 			}
 		}
 
+		ZEND_ASSERT(!mydata->is_persistent);
 		mydata->alias = alias ? estrndup(alias, alias_len) : estrndup(mydata->fname, fname_len);
 		mydata->alias_len = alias ? alias_len : fname_len;
 	}

--- a/ext/phar/tests/gh17137.phpt
+++ b/ext/phar/tests/gh17137.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-17137 (Segmentation fault ext/phar/phar.c)
+--EXTENSIONS--
+phar
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+$file = __DIR__ . DIRECTORY_SEPARATOR . 'gh17137.phar';
+$phar = new Phar($file);
+var_dump($phar, $phar->decompress());
+echo "OK\n";
+?>
+--EXPECT--
+object(Phar)#1 (3) {
+  ["pathName":"SplFileInfo":private]=>
+  string(0) ""
+  ["glob":"DirectoryIterator":private]=>
+  bool(false)
+  ["subPathName":"RecursiveDirectoryIterator":private]=>
+  string(0) ""
+}
+object(Phar)#2 (3) {
+  ["pathName":"SplFileInfo":private]=>
+  string(0) ""
+  ["glob":"DirectoryIterator":private]=>
+  bool(false)
+  ["subPathName":"RecursiveDirectoryIterator":private]=>
+  string(0) ""
+}
+OK


### PR DESCRIPTION
Commit edae2431 attempted to fix a leak and double free, but didn't properly understand what was going on, causing a reference count mistake and subsequent segfault in this case.

The first mistake of that commit is that the reference count should've been increased because we're reusing a phar object. The error handling path should've gotten changed instead to undo this refcount increase instead of not refcounting at all (root cause of this bug).

The second mistake is that the alias isn't supposed to be transferred or whatever, that just doesn't make sense. The reason the test bug69958.phpt originally leaked is because in the non-reuse case we borrowed the alias and otherwise we own the alias. If we own the alias the alias information shouldn't get deleted anyway as that would desync the alias map.

Fixing these will reveal a third issue in which the alias memory is not always properly in sync with the persistence-ness of the phar, fix this as well.