### PR TITLE
Fix RC tracking of op1 of FETCH_OBJ and INIT_METHOD_CALL

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -1968,6 +1968,10 @@ static uint32_t get_ssa_alias_types(zend_ssa_alias_kind alias) {
 					/* TODO: support for array keys and ($str . "")*/   \
 					__type |= MAY_BE_RCN;                               \
 				}                                                       \
+				if ((__type & MAY_BE_RC1) && (__type & MAY_BE_OBJECT)) {\
+					/* TODO: object may be captured by magic handlers */\
+					__type |= MAY_BE_RCN;                               \
+				}                                                       \
 				if (__ssa_var->alias) {									\
 					__type |= get_ssa_alias_types(__ssa_var->alias);	\
 				}														\

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14426,6 +14426,7 @@ result_fetched:
 		ir_MERGE_list(slow_inputs);
 		jit_SET_EX_OPLINE(jit, opline);
 
+		op1_info |= MAY_BE_RC1 | MAY_BE_RCN; /* object may be captured/released in magic handler */
 		if (opline->opcode == ZEND_FETCH_OBJ_W) {
 			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_fetch_obj_w_slow), obj_ref);
 			ir_END_list(end_inputs);

--- a/ext/opcache/tests/jit/gh17151_1.phpt
+++ b/ext/opcache/tests/jit/gh17151_1.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17151: ZEND_FETCH_OBJ_R may modify RC of op1
+--FILE--
+<?php
+
+class C {
+    public function __get($name) {
+        return $this;
+    }
+}
+
+function test() {
+    $x = (new C)->bar;
+    var_dump($x);
+}
+
+test();
+
+?>
+--EXPECTF--
+object(C)#%d (0) {
+}

--- a/ext/opcache/tests/jit/gh17151_2.phpt
+++ b/ext/opcache/tests/jit/gh17151_2.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-17151: ZEND_FETCH_OBJ_R may modify RC of op1
+--FILE--
+<?php
+
+class C {
+    public static $prop;
+
+    public function __get($name) {
+        C::$prop = null;
+    }
+
+    public function __destruct() {
+        echo __METHOD__, "\n";
+    }
+}
+
+function test() {
+    C::$prop = new C();
+    C::$prop->bar;
+}
+
+test();
+echo "Done\n";
+
+?>
+--EXPECT--
+C::__destruct
+Done

--- a/ext/opcache/tests/jit/gh17151_3.phpt
+++ b/ext/opcache/tests/jit/gh17151_3.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-17151: Method calls may modify RC of ZEND_INIT_METHOD_CALL op1
+--FILE--
+<?php
+
+class C {
+    public static $prop;
+
+    public function storeThis() {
+        self::$prop = $this;
+    }
+}
+
+function test() {
+    $c = new C();
+    $c->storeThis();
+    $c = null;
+}
+
+test();
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Fixes GH-17151

We may want to backport this to older branches.