### PR TITLE
Fix GH-17154: Memory leak on rl_line_buffer when no history (libedit).

### DIFF
--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -74,10 +74,7 @@ ZEND_GET_MODULE(readline)
 
 PHP_MINIT_FUNCTION(readline)
 {
-#if HAVE_LIBREADLINE
-		/* libedit don't need this call which set the tty in cooked mode */
 	using_history();
-#endif
 	ZVAL_UNDEF(&_readline_completion);
 #if HAVE_RL_CALLBACK_READ_CHAR
 	ZVAL_UNDEF(&_prepped_callback);

--- a/ext/readline/tests/gh17154.phpt
+++ b/ext/readline/tests/gh17154.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-17154 readline_write_history()/readline_read_history(): memory leak
+--EXTENSIONS--my
+readline
+--FILE--
+<?php
+readline_info('line_buffer', 'val');
+readline_write_history("myhistory");
+var_dump(readline_read_history("myhistory"));
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
When there is no history, any subsequent history api call initialising it will call rl_initialise() thus we lose the previous value in the process.
At module init time, we also call using_history() like with readline.