### PR TITLE
Fix GH-17153: SimpleXML crash when using autovivification on document

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -576,7 +576,10 @@ next_iter:
 				if (!member || Z_TYPE_P(member) == IS_LONG) {
 					newnode = xmlNewTextChild(mynode->parent, mynode->ns, mynode->name, value_str ? (xmlChar *)ZSTR_VAL(value_str) : NULL);
 				} else {
-					newnode = xmlNewTextChild(mynode, mynode->ns, (xmlChar *)Z_STRVAL_P(member), value_str ? (xmlChar *)ZSTR_VAL(value_str) : NULL);
+					/* Note: we cannot set the namespace here unconditionally because the parent may be a document.
+					 * Passing NULL will let libxml decide to either inherit the namespace or not set one at all,
+					 * depending on whether the parent is an element. */
+					newnode = xmlNewTextChild(mynode, NULL, (xmlChar *)Z_STRVAL_P(member), value_str ? (xmlChar *)ZSTR_VAL(value_str) : NULL);
 				}
 			} else if (!member || Z_TYPE_P(member) == IS_LONG) {
 				if (member && cnt < Z_LVAL_P(member)) {

--- a/ext/simplexml/tests/gh17153.phpt
+++ b/ext/simplexml/tests/gh17153.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-17153 (SimpleXML crash when using autovivification on document)
+--EXTENSIONS--
+dom
+simplexml
+xsl
+--FILE--
+<?php
+$sxe = simplexml_load_file(__DIR__ . '/../../xsl/tests/53965/collection.xml', SimpleXMLElement::class);
+$processor = new XSLTProcessor;
+$dom = new DOMDocument;
+$dom->load(__DIR__ . '/../../xsl/tests/53965/collection.xsl');
+$processor->importStylesheet($dom);
+$result = $processor->transformToDoc($sxe, SimpleXMLElement::class);
+$result->h = "x";
+var_dump($result);
+?>
+--EXPECT--
+object(SimpleXMLElement)#4 (4) {
+  ["h1"]=>
+  array(2) {
+    [0]=>
+    string(19) "Fight for your mind"
+    [1]=>
+    string(17) "Electric Ladyland"
+  }
+  ["h2"]=>
+  array(2) {
+    [0]=>
+    string(20) "by Ben Harper - 1995"
+    [1]=>
+    string(22) "by Jimi Hendrix - 1997"
+  }
+  ["hr"]=>
+  array(2) {
+    [0]=>
+    object(SimpleXMLElement)#5 (0) {
+    }
+    [1]=>
+    object(SimpleXMLElement)#6 (0) {
+    }
+  }
+  ["h"]=>
+  string(1) "x"
+}


### PR DESCRIPTION
In the case of a member string, `mynode` may also be a document, which doesn't have a namespace.