### PR TITLE
Reduce excessive stack reserve for testing in CI

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -131,6 +131,10 @@ for %%i in (ldap) do (
 	del %PHP_BUILD_DIR%\php_%%i.dll
 )
 
+rem reduce excessive stack reserve for testing
+editbin /stack:8388608 %PHP_BUILD_DIR%\php.exe
+editbin /stack:8388608 %PHP_BUILD_DIR%\php-cgi.exe
+
 set TEST_PHPDBG_EXECUTABLE=%PHP_BUILD_DIR%\phpdbg.exe
 
 if "%ASAN%" equ "1" set ASAN_OPTS=--asan


### PR DESCRIPTION
For some reason the stack reserve of php.exe and php-cgi.exe is very large on Windows (64MB)[1].  While this might not be bad for production purposes, it causes stack_limit_014.phpt to be unbearably slow; the test may easily run for a minute, and due to a recent `stream_select()` improvement[2], that can cause a timeout, what triggers the test to be run again.  So this single test case may run for two minutes, and still might fail (happened a couple of times).

Instead of skipping the test in CI, we reduce the stack reserve to 8MB, what improves the performance of this test case (and maybe others), and should still be good enough for CI.

[1] <https://github.com/php/php-src/commit/54906c760fb578079b6783a2aa4184372a3179d3>
[2] <https://github.com/php/php-src/commit/b614b4a69ae7bab13c39af2f4a01dea846dfa307>