### PR TITLE
Fix GH-17162: zend_array_try_init() with dtor can cause engine UAF

### DIFF
--- a/Zend/tests/gh17162.phpt
+++ b/Zend/tests/gh17162.phpt
@@ -8,8 +8,7 @@ class Test {
         $box->value = null;
     }
 }
-$box = new stdClass();
-$box->value = new Test;
+$box = [new Test];
 // Using getimagesize() for the test because it's always available,
 // but any function that uses zend_try_array_init() would work.
 try {

--- a/Zend/tests/gh17162.phpt
+++ b/Zend/tests/gh17162.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17162 (zend_array_try_init() with dtor can cause engine UAF)
+--FILE--
+<?php
+class Test {
+    function __destruct() {
+        global $box;
+        $box->value = null;
+    }
+}
+$box = new stdClass();
+$box->value = new Test;
+// Using getimagesize() for the test because it's always available,
+// but any function that uses zend_try_array_init() would work.
+try {
+    getimagesize("dummy", $box);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Attempt to assign property "value" on null

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1478,7 +1478,10 @@ static zend_always_inline zval *zend_try_array_init_size(zval *zv, uint32_t size
 		}
 		zv = &ref->val;
 	}
-	zval_ptr_dtor(zv);
+	zval garbage;
+	ZVAL_COPY_VALUE(&garbage, zv);
+	ZVAL_NULL(zv);
+	zval_ptr_dtor(&garbage);
 	ZVAL_ARR(zv, arr);
 	return zv;
 }


### PR DESCRIPTION
The destructor can change the object and cause a UAF. We make the object inaccessible prior to destruction such that it is protected against the overwrite. This is also consistent with the behaviour if we were to comment out the call to `getimagesize()`.