### PR TITLE
Drop superfluous readline test skip conditions

### DIFF
--- a/ext/readline/tests/bug69054.phpt
+++ b/ext/readline/tests/bug69054.phpt
@@ -2,8 +2,6 @@
 Bug #69054 (Null dereference in readline_(read|write)_history() without parameters)
 --EXTENSIONS--
 readline
---SKIPIF--
-<?php if (!function_exists('readline_add_history')) die("skip"); ?>
 --INI--
 open_basedir="{TMP}"
 --FILE--

--- a/ext/readline/tests/libedit_write_history_001-win32.phpt
+++ b/ext/readline/tests/libedit_write_history_001-win32.phpt
@@ -3,7 +3,7 @@ readline_write_history(): Basic test
 --EXTENSIONS--
 readline
 --SKIPIF--
-<?php if (!function_exists('readline_add_history')) die("skip");
+<?php
 if (READLINE_LIB != "libedit") die("skip libedit only");
 if(substr(PHP_OS, 0, 3) != 'WIN' ) {
     die('skip windows only test');

--- a/ext/readline/tests/libedit_write_history_001.phpt
+++ b/ext/readline/tests/libedit_write_history_001.phpt
@@ -3,7 +3,7 @@ readline_write_history(): Basic test
 --EXTENSIONS--
 readline
 --SKIPIF--
-<?php if (!function_exists('readline_add_history')) die("skip");
+<?php
 if (READLINE_LIB != "libedit") die("skip libedit only");
 if(substr(PHP_OS, 0, 3) == 'WIN' ) {
     die('skip not for windows');

--- a/ext/readline/tests/readline_read_history_error_001.phpt
+++ b/ext/readline/tests/readline_read_history_error_001.phpt
@@ -5,7 +5,6 @@ Pedro Manoel Evangelista <pedro.evangelista at gmail dot com>
 --EXTENSIONS--
 readline
 --SKIPIF--
-<?php if (!function_exists('readline_read_history')) die('skip readline_read_history function does not exist'); ?>
 <?php if (!READLINE_LIB != "libedit") die('skip READLINE_LIB != "libedit"'); ?>
 --FILE--
 <?php

--- a/ext/readline/tests/readline_read_history_open_basedir_001.phpt
+++ b/ext/readline/tests/readline_read_history_open_basedir_001.phpt
@@ -2,8 +2,6 @@
 readline_read_history(): Test that open_basedir is respected
 --EXTENSIONS--
 readline
---SKIPIF--
-<?php if (!function_exists('readline_read_history')) die("skip"); ?>
 --INI--
 open_basedir=/tmp/some-sandbox
 --FILE--

--- a/ext/readline/tests/readline_without_input.phpt
+++ b/ext/readline/tests/readline_without_input.phpt
@@ -5,10 +5,6 @@ Jonathan Stevens <info at jonathanstevens dot be>
 User Group: PHP-WVL & PHPGent #PHPTestFest
 --EXTENSIONS--
 readline
---SKIPIF--
-<?php
-if (!function_exists('readline')) die("skip readline() not available");
-?>
 --FILE--
 <?php
 var_dump(readline());

--- a/ext/readline/tests/readline_write_history_001.phpt
+++ b/ext/readline/tests/readline_write_history_001.phpt
@@ -3,7 +3,7 @@ readline_write_history(): Basic test
 --EXTENSIONS--
 readline
 --SKIPIF--
-<?php if (!function_exists('readline_add_history')) die("skip");
+<?php
 if (READLINE_LIB == "libedit") die("skip readline only");
 if (getenv('SKIP_REPEAT')) die("skip readline has global state");
 ?>

--- a/ext/readline/tests/readline_write_history_open_basedir_001.phpt
+++ b/ext/readline/tests/readline_write_history_open_basedir_001.phpt
@@ -2,8 +2,6 @@
 readline_write_history(): Test that open_basedir is respected
 --EXTENSIONS--
 readline
---SKIPIF--
-<?php if (!function_exists('readline_write_history')) die("skip"); ?>
 --INI--
 open_basedir=/tmp/some-sandbox
 --FILE--


### PR DESCRIPTION
The `--EXTENSIONS--` section already ensures that ext/readline is available, so there's no need to additionally check for unconditionally available readline functions.