### PR TITLE
Improve fix for GH-16889

### DIFF
--- a/ext/standard/tests/general_functions/proc_open_multiplex.phpt
+++ b/ext/standard/tests/general_functions/proc_open_multiplex.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Multiplexing of child output
+--FILE--
+<?php
+$php = getenv("TEST_PHP_EXECUTABLE");
+$desc = [
+    ["null"],
+    ["pipe", "w"],
+    ["null"]
+];
+$read_pipes = [];
+for ($i = 0; $i < 10; $i++) {
+    $procs[] = proc_open([$php, "-r", "usleep(100000 * (10 - $i)); echo 'hello$i';"], $desc, $pipes);
+    $read_pipes[] = $pipes[1];
+}
+$rset = $read_pipes;
+$wset = null;
+$eset = null;
+while (!empty($read_pipes) && stream_select($rset, $wset, $eset, 2) > 0) {
+    foreach ($rset as $pipe) {
+        echo fread($pipe, 6), "\n";
+        unset($read_pipes[array_search($pipe, $read_pipes)]);
+    }
+    $rset = $read_pipes;
+}
+?>
+--EXPECT--
+hello9
+hello8
+hello7
+hello6
+hello5
+hello4
+hello3
+hello2
+hello1
+hello0


### PR DESCRIPTION
The original patch[1] cared only about pipe handles in the rset, but would be problematic if there are other handles (e.g. files in the rset, or pipes/files in the other sets), because `php_select()` would return immediately, reporting all non read-pipe handles as ready, but possibly never reporting read-pipe handles.

We fix this by applying different logic for the case where only pipe handles are supplied in the rset, but no handles in the wset or eset. In this case `php_select()` only returns when actually one of the handles is ready, or when the timeout expires.  To avoid busy looping in this case, we sleep for a short amount of time.  This matches POSIX behavior.

In all other cases, `php_select()` behaves as before (i.e. prior to the original fix), that is it returns immediately, reporting all handles as ready.

We also add a test case that demonstrates multiplexing the output of a couple of child processes.

See also the discussion on <https://github.com/php/php-src/pull/16917>.

[1] <https://github.com/php/php-src/commit/b614b4a69ae7bab13c39af2f4a01dea846dfa307>

---

If we merge this, it deservers a mention in UPGRADING.