### PR TITLE
Fix GH-16955: Use ephemeral ports for OpenSSL server client tests

### DIFF
--- a/ext/openssl/tests/ServerClientTestCase.inc
+++ b/ext/openssl/tests/ServerClientTestCase.inc
@@ -4,14 +4,19 @@ const WORKER_ARGV_VALUE = 'RUN_WORKER';
 
 const WORKER_DEFAULT_NAME = 'server';
 
-function phpt_notify($worker = WORKER_DEFAULT_NAME)
+function phpt_notify(string $worker = WORKER_DEFAULT_NAME, string $message = ""): void
 {
-    ServerClientTestCase::getInstance()->notify($worker);
+    ServerClientTestCase::getInstance()->notify($worker, $message);
 }
 
-function phpt_wait($worker = WORKER_DEFAULT_NAME, $timeout = null)
+function phpt_wait($worker = WORKER_DEFAULT_NAME, $timeout = null): ?string
 {
-    ServerClientTestCase::getInstance()->wait($worker, $timeout);
+    return ServerClientTestCase::getInstance()->wait($worker, $timeout);
+}
+
+function phpt_notify_server_start($server): void
+{
+    ServerClientTestCase::getInstance()->notify_server_start($server);
 }
 
 function phpt_has_sslv3() {
@@ -119,43 +124,73 @@ class ServerClientTestCase
         eval($code);
     }
 
-    public function run($masterCode, $workerCode)
+    /**
+     * Run client and all workers
+     *
+     * @param string       $clientCode The client PHP code
+     * @param string|array $workerCode
+     * @param bool         $ephemeral Select whether automatic port selection and automatic awaiting is used
+     * @return void
+     * @throws Exception
+     */
+    public function run(string $clientCode, string|array $workerCode, bool $ephemeral = true): void
     {
         if (!is_array($workerCode)) {
             $workerCode = [WORKER_DEFAULT_NAME => $workerCode];
         }
-        foreach ($workerCode as $worker => $code) {
+        reset($workerCode);
+        $code = current($workerCode);
+        $worker = key($workerCode);
+        while ($worker != null) {
             $this->spawnWorkerProcess($worker, $this->stripPhpTagsFromCode($code));
+            $code = next($workerCode);
+            if ($ephemeral) {
+                $addr = trim($this->wait($worker));
+                if (empty($addr)) {
+                    throw new \Exception("Failed server start");
+                }
+                if ($code === false) {
+                    $clientCode = preg_replace('/{{\s*ADDR\s*}}/', $addr, $clientCode);
+                } else {
+                    $code = preg_replace('/{{\s*ADDR\s*}}/', $addr, $code);
+                }
+            }
+            $worker = key($workerCode);
         }
-        eval($this->stripPhpTagsFromCode($masterCode));
+
+        eval($this->stripPhpTagsFromCode($clientCode));
         foreach ($workerCode as $worker => $code) {
             $this->cleanupWorkerProcess($worker);
         }
     }
 
-    public function wait($worker, $timeout = null)
+    public function wait($worker, $timeout = null): ?string
     {
         $handle = $this->isWorker ? STDIN : $this->workerStdOut[$worker];
         if ($timeout === null) {
-            fgets($handle);
-            return true;
+            return fgets($handle);
         }
 
         stream_set_blocking($handle, false);
         $read = [$handle];
         $result = stream_select($read, $write, $except, $timeout);
         if (!$result) {
-            return false;
+            return null;
         }
 
-        fgets($handle);
+        $result = fgets($handle);
         stream_set_blocking($handle, true);
-        return true;
+        return $result;
     }
 
-    public function notify($worker)
+    public function notify(string $worker, string $message = ""): void
     {
-        fwrite($this->isWorker ? STDOUT : $this->workerStdIn[$worker], "\n");
+        fwrite($this->isWorker ? STDOUT : $this->workerStdIn[$worker], "$message\n");
+    }
+
+    public function notify_server_start($server): void
+    {
+        echo stream_socket_get_name($server, false) . "\n";
     }
 }
 

--- a/ext/openssl/tests/bug46127.phpt
+++ b/ext/openssl/tests/bug46127.phpt
@@ -11,14 +11,14 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug46127.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $sock = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($sock);
 
     $link = stream_socket_accept($sock);
     fwrite($link, "Sending bug 46127\n");
@@ -26,7 +26,7 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
 
     $clientCtx = stream_context_create(['ssl' => [
@@ -34,7 +34,6 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false
     ]]);
 
-    phpt_wait();
     $sock = stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx);
 
     echo fgets($sock);

--- a/ext/openssl/tests/bug48182.phpt
+++ b/ext/openssl/tests/bug48182.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug48182.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug48182-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $client = @stream_socket_accept($server, 1);
 
@@ -30,14 +30,13 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'bug48182';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'cafile' => '%s',
         'peer_name' => '%s'
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 10, $clientFlags, $clientCtx);
 
     $data = "Sending data over to SSL server in async mode with contents like Hello World\n";

--- a/ext/openssl/tests/bug54992.phpt
+++ b/ext/openssl/tests/bug54992.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug54992.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug54992-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -28,7 +28,7 @@ $serverCode = sprintf($serverCode, $certFile);
 $peerName = 'bug54992_actual_peer_name';
 $wrongPeerName = 'bug54992_expected_peer_name';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -36,7 +36,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx);
 
     var_dump($client);
@@ -61,5 +60,5 @@ Warning: stream_socket_client(): Peer certificate CN=`bug54992_actual_peer_name'
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)

--- a/ext/openssl/tests/bug62890.phpt
+++ b/ext/openssl/tests/bug62890.phpt
@@ -19,8 +19,8 @@ $serverCode = <<<'CODE'
         'security_level' => 1,
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
     @stream_socket_accept($server, 3);
 CODE;
 $serverCode = sprintf($serverCode, $certFile);
@@ -33,9 +33,7 @@ $clientCode = <<<'CODE'
         'security_level' => 1,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/bug65538_001.phpt
+++ b/ext/openssl/tests/bug65538_001.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug65538_001.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug65538_001-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $client = @stream_socket_accept($server);
     if ($client) {
@@ -41,13 +41,12 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'bug65538_001';
 $clientCode = <<<'CODE'
-    $serverUri = "https://127.0.0.1:64321/";
+    $serverUri = "https://{{ ADDR }}/";
     $clientCtx = stream_context_create(['ssl' => [
         'cafile' => 'file://%s',
         'peer_name' => '%s',
     ]]);
 
-    phpt_wait();
     $html = file_get_contents($serverUri, false, $clientCtx);
 
     var_dump($html);

--- a/ext/openssl/tests/bug65538_003.phpt
+++ b/ext/openssl/tests/bug65538_003.phpt
@@ -17,14 +17,14 @@ $cacertFile = 'bug65538_003-ca.pem';
 $cacertPhar = __DIR__ . DIRECTORY_SEPARATOR . 'bug65538_003-ca.phar.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $client = @stream_socket_accept($server);
     if ($client) {
@@ -46,13 +46,12 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'bug65538_003';
 $clientCode = <<<'CODE'
-    $serverUri = "https://127.0.0.1:64321/";
+    $serverUri = "https://{{ ADDR }}/";
     $clientCtx = stream_context_create(['ssl' => [
         'cafile' => 'phar://%s/%s',
         'peer_name' => '%s',
     ]]);
 
-    phpt_wait();
     $html = file_get_contents($serverUri, false, $clientCtx);
 
     var_dump($html);

--- a/ext/openssl/tests/bug65729.phpt
+++ b/ext/openssl/tests/bug65729.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug65729.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug65729-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $expected_names = ['foo.test.com.sg', 'foo.test.com', 'FOO.TEST.COM', 'foo.bar.test.com'];
     foreach ($expected_names as $name) {
@@ -29,10 +29,8 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
-
-    phpt_wait();
 
     $expected_names = ['foo.test.com.sg', 'foo.test.com', 'FOO.TEST.COM', 'foo.bar.test.com'];
     foreach ($expected_names as $expected_name) {
@@ -65,7 +63,7 @@ Warning: stream_socket_client(): Peer certificate CN=`*.test.com' did not match 
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)
 resource(%d) of type (stream)
 resource(%d) of type (stream)
@@ -74,5 +72,5 @@ Warning: stream_socket_client(): Peer certificate CN=`*.test.com' did not match 
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)

--- a/ext/openssl/tests/bug68265.phpt
+++ b/ext/openssl/tests/bug68265.phpt
@@ -12,29 +12,27 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug68265.pem.tmp';
 $san = 'DNS:debs.ak-online.be., DNS:debs.ak-online.net.';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     stream_socket_accept($server, 30);
 CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => false,
         'verify_peer_name' => true,
         'peer_name' => 'debs.ak-online.net',
     ]]);
-
-    phpt_wait();
 
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));
 CODE;

--- a/ext/openssl/tests/bug68879.phpt
+++ b/ext/openssl/tests/bug68879.phpt
@@ -12,29 +12,27 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug68879.pem.tmp';
 $san = 'DNS:test.com, DNS:www.test.com, DNS:subdomain.test.com, IP:0:0:0:0:0:FFFF:A02:1, IP:10.2.0.1';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     stream_socket_accept($server, 30);
 CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => false,
         'verify_peer_name' => true,
         'peer_name' => '10.2.0.1',
     ]]);
-
-    phpt_wait();
 
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 30, $clientFlags, $clientCtx));
 CODE;

--- a/ext/openssl/tests/bug68920.phpt
+++ b/ext/openssl/tests/bug68920.phpt
@@ -11,14 +11,14 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug68920.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     stream_socket_accept($server, 30);
     stream_socket_accept($server, 30);
@@ -28,10 +28,8 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
-
-    phpt_wait();
 
     $ctx = stream_context_create(['ssl' => ['verify_peer'=> false, 'peer_fingerprint' => true]]);
     $sock = stream_socket_client($serverUri, $errno, $errstr, 30, $clientFlags, $ctx);

--- a/ext/openssl/tests/bug69215.phpt
+++ b/ext/openssl/tests/bug69215.phpt
@@ -13,7 +13,7 @@ $clientCertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug69215-client.pem.tmp';
 $serverCertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug69215-server.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -24,14 +24,14 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     stream_socket_accept($server, 30);
 CODE;
 $serverCode = sprintf($serverCode, $serverCertFile, $caCertFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -40,8 +40,6 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => true,
         'peer_name' => 'bug69215-server',
     ]]);
-
-    phpt_wait();
 
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));
 CODE;

--- a/ext/openssl/tests/bug72333.phpt
+++ b/ext/openssl/tests/bug72333.phpt
@@ -14,8 +14,8 @@ $serverCode = <<<'CODE'
     $context = stream_context_create(['ssl' => ['local_cert' => '%s']]);
 
     $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
-    $fp = stream_socket_server("ssl://127.0.0.1:10011", $errornum, $errorstr, $flags, $context);
-    phpt_notify();
+    $fp = stream_socket_server("ssl://127.0.0.1:0", $errornum, $errorstr, $flags, $context);
+    phpt_notify_server_start($fp);
     $conn = stream_socket_accept($fp);
     $total = 100000;
     $result = fread($conn, $total);
@@ -40,8 +40,7 @@ $peerName = 'bug72333';
 $clientCode = <<<'CODE'
     $context = stream_context_create(['ssl' => ['verify_peer' => false, 'peer_name' => '%s']]);
 
-    phpt_wait();
-    $fp = stream_socket_client("ssl://127.0.0.1:10011", $errornum, $errorstr, 3000, STREAM_CLIENT_CONNECT, $context);
+    $fp = stream_socket_client("ssl://{{ ADDR }}", $errornum, $errorstr, 3000, STREAM_CLIENT_CONNECT, $context);
     stream_set_blocking($fp, false);
 
     function blocking_fwrite($fp, $buf) {

--- a/ext/openssl/tests/bug73072.phpt
+++ b/ext/openssl/tests/bug73072.phpt
@@ -18,9 +18,9 @@ $serverCode = <<<'CODE'
         ]
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64322', $errno, $errstr, $flags, $ctx);
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
-    phpt_notify();
     @stream_socket_accept($server, 3);
     // if there is a segfault, this won't be called
     fwrite(STDERR, "done\n");
@@ -33,11 +33,9 @@ $clientCode = <<<'CODE'
         'capture_peer_cert' => true
     ];
 
-    phpt_wait();
-
     $ctxArr['peer_name'] = 'domain1.com';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    @stream_socket_client("tls://127.0.0.1:64322", $errno, $errstr, 1, $flags, $ctx);
+    @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
 CODE;
 
 include 'ServerClientTestCase.inc';

--- a/ext/openssl/tests/bug74159.phpt
+++ b/ext/openssl/tests/bug74159.phpt
@@ -15,7 +15,7 @@ $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug74159-ca.pem.tmp';
 // not really reliable on more powerful machine but cover different
 // scenarios which might be useful. More reliable test is bug72333.phpt
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:10012";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -23,7 +23,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $client = stream_socket_accept($server, 1);
 
@@ -73,15 +73,13 @@ $clientCode = <<<'CODE'
         exit("$errstr\n");
     });
 
-    $serverUri = "tcp://127.0.0.1:10012";
+    $serverUri = "tcp://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
         'cafile' => '%s',
         'peer_name' => '%s',
     ]]);
-
-    phpt_wait();
 
     $fp = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
 

--- a/ext/openssl/tests/bug76705.phpt
+++ b/ext/openssl/tests/bug76705.phpt
@@ -9,20 +9,20 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 --FILE--
 <?php
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64323";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => __DIR__ . '/bug76705.pem'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64323";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer'       => true,
@@ -33,7 +33,6 @@ $clientCode = <<<'CODE'
         ]
     ]]);
 
-    phpt_wait();
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx));
 CODE;
 

--- a/ext/openssl/tests/capture_peer_cert_001.phpt
+++ b/ext/openssl/tests/capture_peer_cert_001.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'capture_peer_cert_001.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'capture_peer_cert_001-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -27,14 +27,13 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'capture_peer_cert_001';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'capture_peer_cert' => true,
         'cafile' => '%s'
     ]]);
 
-    phpt_wait();
     $client = @stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
     $cert = stream_context_get_options($clientCtx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);

--- a/ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
+++ b/ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'openssl_peer_fingerprint_basic.pem.
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'openssl_peer_fingerprint_basic-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -28,7 +28,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'openssl_peer_fingerprint_basic';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer'       => true,
@@ -36,8 +36,6 @@ $clientCode = <<<'CODE'
         'capture_peer_cert' => true,
         'peer_name'         => '%s',
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'peer_fingerprint', '%s');
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx));
@@ -75,6 +73,6 @@ Warning: stream_socket_client(): peer_fingerprint match failure in %s on line %d
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)
 resource(%d) of type (stream)

--- a/ext/openssl/tests/peer_verification.phpt
+++ b/ext/openssl/tests/peer_verification.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'peer_verification.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'peer_verification-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < 5; $i++) {
         @stream_socket_accept($server, 1);
@@ -29,11 +29,9 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'peer_verification';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $caFile = '%s';
-
-    phpt_wait();
 
     // Expected to fail -- untrusted server cert and no CA File present
     var_dump(@stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags));

--- a/ext/openssl/tests/san_ipv6_peer_matching.phpt
+++ b/ext/openssl/tests/san_ipv6_peer_matching.phpt
@@ -17,14 +17,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'san_ipv6_peer_matching.pem.tmp';
 $san = 'IP:2001:db8:85a3:8d3:1319:8a2e:370:7348';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://[::1]:64324";
+    $serverUri = "ssl://[::1]:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -32,13 +32,11 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://[::1]:64324";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => false,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'peer_name', '2001:db8:85a3:8d3:1319:8a2e:370:7348');
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));
@@ -65,5 +63,5 @@ Warning: stream_socket_client(): Unable to locate peer certificate CN in %s on l
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://[::1]:64324 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://[::1]:%d (Unknown error) in %s on line %d
 bool(false)

--- a/ext/openssl/tests/san_peer_matching.phpt
+++ b/ext/openssl/tests/san_peer_matching.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'san_peer_matching.pem.tmp';
 $san = 'DNS:example.org, DNS:www.example.org, DNS:test.example.org';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -27,13 +27,11 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => false,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'peer_name', 'example.org');
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));
@@ -60,5 +58,5 @@ Warning: stream_socket_client(): Unable to locate peer certificate CN in %s on l
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)

--- a/ext/openssl/tests/session_meta_capture.phpt
+++ b/ext/openssl/tests/session_meta_capture.phpt
@@ -12,7 +12,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -20,7 +20,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -31,7 +31,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'session_meta_capture';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -39,8 +39,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
         'security_level' => 0,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT);
     $stream = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);

--- a/ext/openssl/tests/session_meta_capture_tlsv13.phpt
+++ b/ext/openssl/tests/session_meta_capture_tlsv13.phpt
@@ -13,7 +13,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture_tlsv13.pem.tmp
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture_tlsv13-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -21,7 +21,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -29,15 +29,13 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'session_meta_capture_tlsv13';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
         'cafile' => '%s',
         'peer_name' => '%s'
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT);
     $stream = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
@@ -52,6 +50,11 @@ $certificateGenerator->saveNewCertAsFileWithKey($peerName, $certFile);
 
 include 'ServerClientTestCase.inc';
 ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture_tlsv13.pem.tmp');
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'session_meta_capture_tlsv13-ca.pem.tmp');
 ?>
 --EXPECT--
 string(7) "TLSv1.3"

--- a/ext/openssl/tests/sni_server.phpt
+++ b/ext/openssl/tests/sni_server.phpt
@@ -19,8 +19,8 @@ $serverCode = <<<'CODE'
         ]
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i=0; $i < 3; $i++) {
         @stream_socket_accept($server, 3);
@@ -34,23 +34,21 @@ $clientCode = <<<'CODE'
         'capture_peer_cert' => true
     ];
 
-    phpt_wait();
-
     $ctxArr['peer_name'] = 'cs.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 
     $ctxArr['peer_name'] = 'uk.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 
     $ctxArr['peer_name'] = 'us.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 CODE;

--- a/ext/openssl/tests/sni_server_key_cert.phpt
+++ b/ext/openssl/tests/sni_server_key_cert.phpt
@@ -28,8 +28,8 @@ $serverCode = <<<'CODE'
         ]
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i=0; $i < 3; $i++) {
         @stream_socket_accept($server, 3);
@@ -43,23 +43,21 @@ $clientCode = <<<'CODE'
         'capture_peer_cert' => true
     ];
 
-    phpt_wait();
-
     $ctxArr['peer_name'] = 'cs.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 
     $ctxArr['peer_name'] = 'uk.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 
     $ctxArr['peer_name'] = 'us.php.net';
     $ctx = stream_context_create(['ssl' => $ctxArr]);
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 1, $flags, $ctx);
     $cert = stream_context_get_options($ctx)['ssl']['peer_certificate'];
     var_dump(openssl_x509_parse($cert)['subject']['CN']);
 CODE;

--- a/ext/openssl/tests/stream_crypto_flags_001.phpt
+++ b/ext/openssl/tests/stream_crypto_flags_001.phpt
@@ -12,7 +12,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_001.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_001-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -20,7 +20,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -30,7 +30,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'stream_crypto_flags_001';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -38,8 +38,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
         'security_level' => 0,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT);
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));

--- a/ext/openssl/tests/stream_crypto_flags_002.phpt
+++ b/ext/openssl/tests/stream_crypto_flags_002.phpt
@@ -12,7 +12,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_002.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_002-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -20,7 +20,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -31,7 +31,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'stream_crypto_flags_002';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -39,8 +39,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
         'security_level' => 0,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT);
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx));

--- a/ext/openssl/tests/stream_crypto_flags_003.phpt
+++ b/ext/openssl/tests/stream_crypto_flags_003.phpt
@@ -13,7 +13,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_003.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_003-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -24,7 +24,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -35,7 +35,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'stream_crypto_flags_003';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -43,8 +43,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
         'security_level' => 0,
     ]]);
-
-    phpt_wait();
 
     stream_context_set_option($clientCtx, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
     var_dump(stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx));

--- a/ext/openssl/tests/stream_crypto_flags_004.phpt
+++ b/ext/openssl/tests/stream_crypto_flags_004.phpt
@@ -12,7 +12,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_004.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_crypto_flags_004-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -21,7 +21,7 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
     @stream_socket_accept($server, 1);
@@ -32,7 +32,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'stream_crypto_flags_004';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -40,8 +40,6 @@ $clientCode = <<<'CODE'
         'peer_name' => '%s',
         'security_level' => 0,
     ]]);
-
-    phpt_wait();
 
     // Should succeed because the SSLv23 handshake here is compatible with the
     // TLSv1 hello method employed in the server

--- a/ext/openssl/tests/stream_security_level.phpt
+++ b/ext/openssl/tests/stream_security_level.phpt
@@ -19,7 +19,7 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_security_level.pem.tmp';
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_security_level-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64322";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
@@ -29,14 +29,14 @@ $serverCode = <<<'CODE'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64322";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'security_level' => %d,
@@ -45,7 +45,6 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
 
     var_dump($client);
@@ -71,5 +70,5 @@ error:%s:SSL routines:%S:certificate verify failed in %s : eval()'d code on line
 
 Warning: stream_socket_client(): Failed to enable crypto in %s : eval()'d code on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64322 (Unknown error) in %s : eval()'d code on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s : eval()'d code on line %d
 bool(false)

--- a/ext/openssl/tests/stream_server_reneg_limit.phpt
+++ b/ext/openssl/tests/stream_server_reneg_limit.phpt
@@ -99,7 +99,7 @@ $certificateGenerator = new CertificateGenerator();
 $certificateGenerator->saveNewCertAsFileWithKey('stream_security_level', $certFile);
 
 include 'ServerClientTestCase.inc';
-ServerClientTestCase::getInstance()->run($serverCode, $clientCode);
+ServerClientTestCase::getInstance()->run($serverCode, $clientCode, false);
 ?>
 --CLEAN--
 <?php

--- a/ext/openssl/tests/stream_verify_peer_name_001.phpt
+++ b/ext/openssl/tests/stream_verify_peer_name_001.phpt
@@ -11,14 +11,14 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_verify_peer_name_001.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -26,14 +26,13 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $peerName = 'stream_verify_peer_name_001';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => false,
         'peer_name' => '%s'
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
 
     var_dump($client);

--- a/ext/openssl/tests/stream_verify_peer_name_002.phpt
+++ b/ext/openssl/tests/stream_verify_peer_name_002.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_verify_peer_name_002.pem.tmp
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_verify_peer_name_002-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -27,7 +27,7 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $actualPeerName = 'stream_verify_peer_name_002';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
@@ -35,7 +35,6 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx);
 
     var_dump($client);

--- a/ext/openssl/tests/stream_verify_peer_name_003.phpt
+++ b/ext/openssl/tests/stream_verify_peer_name_003.phpt
@@ -12,14 +12,14 @@ $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_verify_peer_name_003.pem.tmp
 $cacertFile = __DIR__ . DIRECTORY_SEPARATOR . 'stream_verify_peer_name_003-ca.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s'
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     @stream_socket_accept($server, 1);
 CODE;
@@ -27,14 +27,13 @@ $serverCode = sprintf($serverCode, $certFile);
 
 $actualPeerName = 'stream_verify_peer_name_003';
 $clientCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://{{ ADDR }}";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'verify_peer' => true,
         'cafile' => '%s'
     ]]);
 
-    phpt_wait();
     $client = stream_socket_client($serverUri, $errno, $errstr, 1, $clientFlags, $clientCtx);
 
     var_dump($client);
@@ -59,5 +58,5 @@ Warning: stream_socket_client(): Peer certificate CN=`stream_verify_peer_name_00
 
 Warning: stream_socket_client(): Failed to enable crypto in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:64321 (Unknown error) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to ssl://127.0.0.1:%d (Unknown error) in %s on line %d
 bool(false)

--- a/ext/openssl/tests/streams_crypto_method.phpt
+++ b/ext/openssl/tests/streams_crypto_method.phpt
@@ -11,14 +11,14 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 $certFile = __DIR__ . DIRECTORY_SEPARATOR . 'streams_crypto_method.pem.tmp';
 
 $serverCode = <<<'CODE'
-    $serverUri = "ssl://127.0.0.1:64321";
+    $serverUri = "ssl://127.0.0.1:0";
     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
     $serverCtx = stream_context_create(['ssl' => [
         'local_cert' => '%s',
     ]]);
 
     $server = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
-    phpt_notify();
+    phpt_notify_server_start($server);
 
     $client = @stream_socket_accept($server);
     if ($client) {
@@ -39,7 +39,7 @@ CODE;
 $serverCode = sprintf($serverCode, $certFile);
 
 $clientCode = <<<'CODE'
-    $serverUri = "https://127.0.0.1:64321/";
+    $serverUri = "https://{{ ADDR }}/";
     $clientFlags = STREAM_CLIENT_CONNECT;
     $clientCtx = stream_context_create(['ssl' => [
         'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
@@ -47,7 +47,6 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false
     ]]);
 
-    phpt_wait();
     echo file_get_contents($serverUri, false, $clientCtx);
 CODE;
 

--- a/ext/openssl/tests/tls_min_v1.0_max_v1.1_wrapper.phpt
+++ b/ext/openssl/tests/tls_min_v1.0_max_v1.1_wrapper.phpt
@@ -19,8 +19,8 @@ $serverCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i=0; $i < (phpt_has_sslv3() ? 6 : 5); $i++) {
         @stream_socket_accept($server, 3);
@@ -36,24 +36,22 @@ $clientCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.0://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.1://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("ssl://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("ssl://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tls_wrapper.phpt
+++ b/ext/openssl/tests/tls_wrapper.phpt
@@ -18,8 +18,8 @@ $serverCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < (phpt_has_sslv3() ? 6 : 5); $i++) {
         @stream_socket_accept($server, 3);
@@ -35,24 +35,22 @@ $clientCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.0://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.1://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("ssl://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("ssl://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tls_wrapper_with_tls_v1.3.phpt
+++ b/ext/openssl/tests/tls_wrapper_with_tls_v1.3.phpt
@@ -18,8 +18,8 @@ $serverCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tls://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < (phpt_has_sslv3() ? 7 : 6); $i++) {
         @stream_socket_accept($server, 3);
@@ -35,27 +35,25 @@ $clientCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.0://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.1://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("ssl://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("ssl://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tls://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tlsv1.0_wrapper.phpt
+++ b/ext/openssl/tests/tlsv1.0_wrapper.phpt
@@ -17,8 +17,8 @@ $serverCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    $server = stream_socket_server('tlsv1.0://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tlsv1.0://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < (phpt_has_sslv3() ? 3 : 2); $i++) {
         @stream_socket_accept($server, 3);
@@ -34,15 +34,13 @@ $clientCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.0://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tlsv1.1_wrapper.phpt
+++ b/ext/openssl/tests/tlsv1.1_wrapper.phpt
@@ -17,8 +17,8 @@ $serverCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    $server = stream_socket_server('tlsv1.1://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tlsv1.1://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < (phpt_has_sslv3() ? 3 : 2); $i++) {
         @stream_socket_accept($server, 3);
@@ -34,15 +34,13 @@ $clientCode = <<<'CODE'
         'security_level' => 0,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.1://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tlsv1.2_wrapper.phpt
+++ b/ext/openssl/tests/tlsv1.2_wrapper.phpt
@@ -16,8 +16,8 @@ $serverCode = <<<'CODE'
         'local_cert' => '%s',
     ]]);
 
-    $server = stream_socket_server('tlsv1.2://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tlsv1.2://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i = 0; $i < (phpt_has_sslv3() ? 3 : 2); $i++) {
         @stream_socket_accept($server, 3);
@@ -32,15 +32,13 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("sslv3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("sslv3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.1://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.1://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/openssl/tests/tlsv1.3_wrapper.phpt
+++ b/ext/openssl/tests/tlsv1.3_wrapper.phpt
@@ -17,8 +17,8 @@ $serverCode = <<<'CODE'
         'local_cert' => '%s',
     ]]);
 
-    $server = stream_socket_server('tlsv1.3://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
-    phpt_notify();
+    $server = stream_socket_server('tlsv1.3://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+    phpt_notify_server_start($server);
 
     for ($i=0; $i < 3; $i++) {
         @stream_socket_accept($server, 3);
@@ -33,15 +33,13 @@ $clientCode = <<<'CODE'
         'verify_peer_name' => false,
     ]]);
 
-    phpt_wait();
-
-    $client = stream_socket_client("tlsv1.3://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = stream_socket_client("tlsv1.3://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.0://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.0://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 
-    $client = @stream_socket_client("tlsv1.2://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    $client = @stream_socket_client("tlsv1.2://{{ ADDR }}", $errno, $errstr, 3, $flags, $ctx);
     var_dump($client);
 CODE;
 

--- a/ext/standard/tests/streams/stream_context_tcp_nodelay_server.phpt
+++ b/ext/standard/tests/streams/stream_context_tcp_nodelay_server.phpt
@@ -2,6 +2,13 @@
 stream context tcp_nodelay server
 --EXTENSIONS--
 sockets
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) die("skip no proc_open");
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die('skip sockets ext currently does not work in worker on Windows');
+}
+?>
 --FILE--
 <?php
 $serverCode = <<<'CODE'
@@ -12,36 +19,25 @@ $serverCode = <<<'CODE'
     ]);
 
     $server = stream_socket_server(
-        "tcp://127.0.0.1:9099", $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $ctxt);
+        "tcp://127.0.0.1:0", $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $ctxt);
+    phpt_notify_server_start($server);
 
-    $client = stream_socket_accept($server);
+    $conn = stream_socket_accept($server);
 
-    var_dump(socket_get_option(
-                socket_import_stream($server),
-                    SOL_TCP, TCP_NODELAY) > 0);
+    $si = socket_get_option(socket_import_stream($server), SOL_TCP, TCP_NODELAY) > 0 ? "nodelay": "delay";
+    $ci = socket_get_option(socket_import_stream($conn), SOL_TCP, TCP_NODELAY) > 0 ? "nodelay": "delay";
 
-    var_dump(socket_get_option(
-                socket_import_stream($client),
-                    SOL_TCP, TCP_NODELAY) > 0);
-
-    fclose($client);
-    fclose($server);
+    phpt_notify(message:"server-$si:conn-$ci");
 CODE;
 
 $clientCode = <<<'CODE'
-    $test = stream_socket_client(
-        "tcp://127.0.0.1:9099", $errno, $errstr, 10);
+    $test = stream_socket_client("tcp://{{ ADDR }}", $errno, $errstr, 10);
 
-    sleep(1);
-
-    fclose($test);
+    echo phpt_wait();
 CODE;
 
-include sprintf(
-    "%s/../../../openssl/tests/ServerClientTestCase.inc",
-    __DIR__);
-ServerClientTestCase::getInstance()->run($serverCode, $clientCode);
+include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
 --EXPECT--
-bool(false)
-bool(true)
+server-delay:conn-nodelay


### PR DESCRIPTION
This introduces usage of ephemeral port for majority of OpenSSL test.

The only tests that need more work are following:

- stream_server_reneg_limit.phpt - quite manual reneg test - might need some update anyway
- bug77390 - proxy scenario - it needs more work in empheral port support
- ext/standard/tests/streams/stream_context_tcp_nodelay_server.phpt - this is a bit non standard test - need to figure out how to best address it there