### PR TITLE
fix GH-8533: dynamic libphp linking on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 # Libtool library files generated during build process
 *.la
 
+# Mac shared library files generated during build process
+*.dylib
+
 # Directories created by Libtool for storing generated library files
 .libs/
 

--- a/NEWS
+++ b/NEWS
@@ -200,6 +200,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-17224 (UAF in importNode). (nielsdos)
 
 - Embed:
+  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
   . Make build command for program using embed portable. (dunglas)
 
 - FFI:

--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ PHP                                                                        NEWS
   . Fix weird unpack behaviour in DOM. (nielsdos)
 
 - Embed:
-  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
+  . Fixed bug GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
 
 - GD:
   . Fixed bug GH-17984 (calls with arguments as array with references).

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@ PHP                                                                        NEWS
 - Treewide:
   . Fixed bug GH-17736 (Assertion failure zend_reference_destroy()). (nielsdos)
 
+- Embed:
+  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
+
 27 Feb 2025, PHP 8.3.18RC1
 
 - BCMath:
@@ -200,7 +203,6 @@ PHP                                                                        NEWS
   . Fixed bug GH-17224 (UAF in importNode). (nielsdos)
 
 - Embed:
-  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
   . Make build command for program using embed portable. (dunglas)
 
 - FFI:

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ PHP                                                                        NEWS
 - DOM:
   . Fix weird unpack behaviour in DOM. (nielsdos)
 
+- Embed:
+  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
+
 - GD:
   . Fixed bug GH-17984 (calls with arguments as array with references).
     (David Carlier)
@@ -15,9 +18,6 @@ PHP                                                                        NEWS
 
 - Treewide:
   . Fixed bug GH-17736 (Assertion failure zend_reference_destroy()). (nielsdos)
-
-- Embed:
-  . Fixed GH-8533 (Unable to link dynamic libphp on Mac). (Kévin Dunglas)
 
 27 Feb 2025, PHP 8.3.18RC1
 

--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -19,6 +19,10 @@ libphp.la: $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS)
 	$(LIBTOOL) --tag=CC --mode=link $(CC) $(LIBPHP_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) -rpath $(phptempdir) $(EXTRA_LDFLAGS) $(LDFLAGS) $(PHP_RPATHS) $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@
 	-@$(LIBTOOL) --silent --tag=CC --mode=install cp $@ $(phptempdir)/$@ >/dev/null 2>&1
 
+libphp.dylib: libphp.la
+	$(LIBTOOL) --tag=CC --mode=link $(CC) -dynamiclib $(LIBPHP_CFLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) -rpath $(phptempdir) -install_name @rpath/$@ $(EXTRA_LDFLAGS) $(LDFLAGS) $(PHP_RPATHS) $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@
+	-@$(LIBTOOL) --silent --tag=CC --mode=install cp $@ $(phptempdir)/$@ >/dev/null 2>&1
+
 libs/libphp.bundle: $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS)
 	$(CC) $(MH_BUNDLE_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(PHP_GLOBAL_OBJS:.lo=.o) $(PHP_SAPI_OBJS:.lo=.o) $(PHP_FRAMEWORKS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@ && cp $@ libs/libphp.so
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -765,6 +765,23 @@ AC_DEFUN([PHP_BUILD_SHARED],[
 ])
 
 dnl
+dnl PHP_BUILD_SHARED_DYLIB
+dnl
+AC_DEFUN([PHP_BUILD_SHARED_DYLIB],[
+  PHP_BUILD_PROGRAM
+  OVERALL_TARGET=libphp.dylib
+  php_sapi_module=shared
+
+  php_c_pre=$shared_c_pre
+  php_c_meta=$shared_c_meta
+  php_c_post=$shared_c_post
+  php_cxx_pre=$shared_cxx_pre
+  php_cxx_meta=$shared_cxx_meta
+  php_cxx_post=$shared_cxx_post
+  php_lo=$shared_lo
+])
+
+dnl
 dnl PHP_BUILD_STATIC
 dnl
 AC_DEFUN([PHP_BUILD_STATIC],[
@@ -876,6 +893,7 @@ AC_DEFUN([PHP_SELECT_SAPI],[
     case "$2" in
     static[)] PHP_BUILD_STATIC;;
     shared[)] PHP_BUILD_SHARED;;
+    shared-dylib[)] PHP_BUILD_SHARED_DYLIB;;
     bundle[)] PHP_BUILD_BUNDLE;;
     esac
     install_sapi="install-sapi"

--- a/build/php.m4
+++ b/build/php.m4
@@ -768,17 +768,8 @@ dnl
 dnl PHP_BUILD_SHARED_DYLIB
 dnl
 AC_DEFUN([PHP_BUILD_SHARED_DYLIB],[
-  PHP_BUILD_PROGRAM
+  PHP_BUILD_SHARED
   OVERALL_TARGET=libphp.dylib
-  php_sapi_module=shared
-
-  php_c_pre=$shared_c_pre
-  php_c_meta=$shared_c_meta
-  php_c_post=$shared_c_post
-  php_cxx_pre=$shared_cxx_pre
-  php_cxx_meta=$shared_cxx_meta
-  php_cxx_post=$shared_cxx_post
-  php_lo=$shared_lo
 ])
 
 dnl

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -11,8 +11,10 @@ if test "$PHP_EMBED" != "no"; then
   case "$PHP_EMBED" in
     yes|shared)
       LIBPHP_CFLAGS="-shared"
-      PHP_EMBED_TYPE=shared
-      AS_CASE(["$host_alias"], [*darwin*], [SAPI_SHARED="libs/libphp.dylib"], [])
+      AS_CASE(["$host_alias"], [*darwin*], [
+        SAPI_SHARED="libs/libphp.dylib"
+        PHP_EMBED_TYPE=shared-dylib
+      ], [PHP_EMBED_TYPE=shared])
       INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(prefix)/lib; \$(INSTALL) -m 0755 $SAPI_SHARED \$(INSTALL_ROOT)\$(prefix)/lib"
       ;;
     static)
@@ -27,9 +29,6 @@ if test "$PHP_EMBED" != "no"; then
   if test "$PHP_EMBED_TYPE" != "no"; then
     PHP_SUBST(LIBPHP_CFLAGS)
     PHP_SELECT_SAPI(embed, $PHP_EMBED_TYPE, php_embed.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-    if test "$SAPI_SHARED" = "libs/libphp.dylib"; then
-      OVERALL_TARGET=libphp.dylib
-    fi
     PHP_INSTALL_HEADERS([sapi/embed/php_embed.h])
   fi
   AC_MSG_RESULT([$PHP_EMBED_TYPE])

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -12,6 +12,7 @@ if test "$PHP_EMBED" != "no"; then
     yes|shared)
       LIBPHP_CFLAGS="-shared"
       PHP_EMBED_TYPE=shared
+      AS_CASE(["$host_alias"], [*darwin*], [SAPI_SHARED="libs/libphp.dylib"], [])
       INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(prefix)/lib; \$(INSTALL) -m 0755 $SAPI_SHARED \$(INSTALL_ROOT)\$(prefix)/lib"
       ;;
     static)
@@ -26,6 +27,9 @@ if test "$PHP_EMBED" != "no"; then
   if test "$PHP_EMBED_TYPE" != "no"; then
     PHP_SUBST(LIBPHP_CFLAGS)
     PHP_SELECT_SAPI(embed, $PHP_EMBED_TYPE, php_embed.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+    if test "$SAPI_SHARED" = "libs/libphp.dylib"; then
+      OVERALL_TARGET=libphp.dylib
+    fi
     PHP_INSTALL_HEADERS([sapi/embed/php_embed.h])
   fi
   AC_MSG_RESULT([$PHP_EMBED_TYPE])


### PR DESCRIPTION
Closes #8533.

Tested as functional on macOS 15.2 (Sequoia), but this should work on older versions too.