### PR TITLE
Reintroduce proc_open_multiplex.phpt

### DIFF
--- a/ext/standard/tests/general_functions/proc_open_multiplex.phpt
+++ b/ext/standard/tests/general_functions/proc_open_multiplex.phpt
@@ -10,14 +10,14 @@ $desc = [
 ];
 $read_pipes = [];
 for ($i = 0; $i < 10; $i++) {
-    $procs[] = proc_open([$php, "-r", "usleep(100000 * (10 - $i)); echo 'hello$i';"], $desc, $pipes);
+    $procs[] = proc_open([$php, "-r", "usleep(10000 * (10 - $i)); echo 'hello$i';"], $desc, $pipes);
     $read_pipes[] = $pipes[1];
 }
 $out = [];
 $rset = $read_pipes;
 $wset = null;
 $eset = null;
-while (!empty($read_pipes) && ($selected = stream_select($rset, $wset, $eset, 2)) > 0) {
+while (!empty($read_pipes) && ($selected = stream_select($rset, $wset, $eset, 1)) > 0) {
     foreach ($rset as $pipe) {
         if ($selected === 10) {
             echo "stream_select() reported all pipes as ready\n";

--- a/ext/standard/tests/general_functions/proc_open_multiplex.phpt
+++ b/ext/standard/tests/general_functions/proc_open_multiplex.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Multiplexing of child output
+--FILE--
+<?php
+$php = getenv("TEST_PHP_EXECUTABLE");
+$desc = [
+    ["null"],
+    ["pipe", "w"],
+    ["null"]
+];
+$read_pipes = [];
+for ($i = 0; $i < 10; $i++) {
+    $procs[] = proc_open([$php, "-r", "usleep(100000 * (10 - $i)); echo 'hello$i';"], $desc, $pipes);
+    $read_pipes[] = $pipes[1];
+}
+$out = [];
+$rset = $read_pipes;
+$wset = null;
+$eset = null;
+while (!empty($read_pipes) && ($selected = stream_select($rset, $wset, $eset, 2)) > 0) {
+    foreach ($rset as $pipe) {
+        if ($selected === 10) {
+            echo "stream_select() reported all pipes as ready\n";
+            echo "Read:\n", implode("\n", $out);
+            exit;
+        }
+        $out[] = fread($pipe, 6);
+        unset($read_pipes[array_search($pipe, $read_pipes)]);
+    }
+    $rset = $read_pipes;
+}
+if ($selected === false) {
+    echo "stream_select() failed\n";
+    echo "Read:\n", implode("\n", $out);
+    exit;
+}
+sort($out);
+echo "Read:\n", implode("\n", $out);
+?>
+--EXPECT--
+Read:
+hello0
+hello1
+hello2
+hello3
+hello4
+hello5
+hello6
+hello7
+hello8
+hello9


### PR DESCRIPTION
The main intent of the test was to show the changed behavior on Windows; previously, `stream_select()` would return immediately there, reporting all pipes as ready; now, it only returns if at least one pipe is actually ready.

The original test case was overspecified; of course, we cannot assume that the pipes are ready one after the other; depending on the concrete `select(2)` implementation and the system scheduler, minor differences are to be expected.

Thus we relax the test expectations, and now require that not all pipes are reported ready after a single `stream_select()` call, and that the output contains all strings.  We also ensure that `stream_select()` doesn't fail (for whatever reason).  And in case of the test expectations not being met, we also output some diagnostics (most notably the output that has already been read).