### PR TITLE
Run stream_server_reneg_limit.phpt on Windows, too

### DIFF
--- a/ext/openssl/tests/stream_server_reneg_limit.phpt
+++ b/ext/openssl/tests/stream_server_reneg_limit.phpt
@@ -7,9 +7,6 @@ openssl
 if (!function_exists("proc_open")) die("skip no proc_open");
 exec('openssl help', $out, $code);
 if ($code > 0) die("skip couldn't locate openssl binary");
-if(substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip not suitable for Windows');
-}
 ?>
 --FILE--
 <?php
@@ -83,8 +80,9 @@ $clientCode = <<<'CODE'
     // Server settings only allow one per second (should result in disconnection)
     fwrite($stdin, "R\nR\nR\nR\n");
 
-    $lines = [];
-    while(!feof($stderr)) {
+    $r = [$stderr];
+    $w = $e = null;
+    while (stream_select($r, $w, $e, 1) > 0) {
         fgets($stderr);
     }
 


### PR DESCRIPTION
As is, the client code may block on Windows when trying to read STDERR; if that happens, neither the openssl nor the php processes would be terminated, causing further issues for the test suite.

We fix this by using `stream_select()` and only read if there is data available.  This may cause some delay until we hit the timeout, but it might be necessary to "empty" STDERR.

---

Tackling #16086 piecemeal might be a better idea.