### PR TITLE
Fix GH-17187: unreachable program point in zend_hash

### DIFF
--- a/ext/xml/tests/gh17187_1.phpt
+++ b/ext/xml/tests/gh17187_1.phpt
@@ -1,0 +1,93 @@
+--TEST--
+GH-17187 (unreachable program point in zend_hash)
+--EXTENSIONS--
+xml
+--CREDITS--
+chongwick
+--FILE--
+<?php
+class ImmutableParser {
+    private $parser;
+    private $immutableData;
+    private $arrayCopy;
+
+    public function __construct() {
+        $this->parser = xml_parser_create();
+        xml_set_element_handler($this->parser, function ($parser, $name, $attrs) {
+            echo "open\n";
+            var_dump($name, $attrs);
+            $this->arrayCopy = [$this]; // Create cycle intentionally
+            $this->immutableData = $this->arrayCopy;
+        }, function ($parser, $name) {
+            echo "close\n";
+            var_dump($name);
+        });
+    }
+
+    public function parseXml($xml) {
+        $this->immutableData = array();
+        xml_parse_into_struct($this->parser, $xml, $this->immutableData, $this->immutableData);
+        return $this->immutableData;
+    }
+}
+$immutableParser = new ImmutableParser();
+$xml = "<container><child/></container>";
+$immutableData = $immutableParser->parseXml($xml);
+var_dump($immutableData);
+?>
+--EXPECT--
+open
+string(9) "CONTAINER"
+array(0) {
+}
+open
+string(5) "CHILD"
+array(0) {
+}
+close
+string(5) "CHILD"
+close
+string(9) "CONTAINER"
+array(5) {
+  [0]=>
+  object(ImmutableParser)#1 (3) {
+    ["parser":"ImmutableParser":private]=>
+    object(XMLParser)#2 (0) {
+    }
+    ["immutableData":"ImmutableParser":private]=>
+    *RECURSION*
+    ["arrayCopy":"ImmutableParser":private]=>
+    array(1) {
+      [0]=>
+      *RECURSION*
+    }
+  }
+  ["CHILD"]=>
+  array(1) {
+    [0]=>
+    int(1)
+  }
+  [1]=>
+  array(3) {
+    ["tag"]=>
+    string(5) "CHILD"
+    ["type"]=>
+    string(8) "complete"
+    ["level"]=>
+    int(2)
+  }
+  ["CONTAINER"]=>
+  array(1) {
+    [0]=>
+    int(2)
+  }
+  [2]=>
+  array(3) {
+    ["tag"]=>
+    string(9) "CONTAINER"
+    ["type"]=>
+    string(5) "close"
+    ["level"]=>
+    int(1)
+  }
+}

--- a/ext/xml/tests/gh17187_2.phpt
+++ b/ext/xml/tests/gh17187_2.phpt
@@ -1,0 +1,53 @@
+--TEST--
+GH-17187 (unreachable program point in zend_hash)
+--EXTENSIONS--
+xml
+--CREDITS--
+chongwick
+--FILE--
+<?php
+class ImmutableParser {
+    public $parser;
+    public $immutableData1;
+    public $immutableData2;
+
+    public function __construct() {
+        $this->parser = xml_parser_create();
+        xml_set_element_handler($this->parser, function ($parser, $name, $attrs) {
+            echo "open\n";
+            var_dump($name, $attrs);
+            $this->immutableData1 = 0xdead;
+            $this->immutableData2 = 0xbeef;
+        }, function ($parser, $name) {
+            echo "close\n";
+            var_dump($name);
+        });
+    }
+
+    public function parseXml($xml) {
+        $this->immutableData1 = array();
+        $this->immutableData2 = array();
+        xml_parse_into_struct($this->parser, $xml, $this->immutableData1, $this->immutableData2);
+    }
+}
+$immutableParser = new ImmutableParser();
+$xml = "<container><child/></container>";
+$immutableParser->parseXml($xml);
+var_dump($immutableParser->immutableData1);
+var_dump($immutableParser->immutableData2);
+?>
+--EXPECT--
+open
+string(9) "CONTAINER"
+array(0) {
+}
+open
+string(5) "CHILD"
+array(0) {
+}
+close
+string(5) "CHILD"
+close
+string(9) "CONTAINER"
+int(57005)
+int(48879)


### PR DESCRIPTION
A bunch of different issues:
1) The referenced value is copied without incrementing the refcount.
   The reason the refcount isn't incremented is because otherwise
   the array modifications would violate the RC1 constraints.
   Solve this by copying the reference itself instead and always
   read the referenced value.
2) No type checks on the array data, so malicious scripts could
   cause type confusion bugs.
3) Potential overflow when the arrays resize and we access ctag.