### PR TITLE
Fix GH-17198: SplFixedArray assertion failure with get_object_vars

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -239,10 +239,14 @@ static HashTable* spl_fixedarray_object_get_properties_for(zend_object *obj, zen
 	zval *const elements = intern->array.elements;
 	HashTable *ht = zend_new_array(size);
 
-	for (zend_long i = 0; i < size; i++) {
-		Z_TRY_ADDREF_P(&elements[i]);
-		zend_hash_next_index_insert(ht, &elements[i]);
+	/* The array elements are not *real properties*. */
+	if (purpose != ZEND_PROP_PURPOSE_GET_OBJECT_VARS) {
+		for (zend_long i = 0; i < size; i++) {
+			Z_TRY_ADDREF_P(&elements[i]);
+			zend_hash_next_index_insert(ht, &elements[i]);
+		}
 	}
+
 	if (source_properties && zend_hash_num_elements(source_properties) > 0) {
 		zend_long nkey;
 		zend_string *skey;

--- a/ext/spl/tests/gh17198.phpt
+++ b/ext/spl/tests/gh17198.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-17198 (SplFixedArray assertion failure with get_object_vars)
+--FILE--
+<?php
+#[AllowDynamicProperties]
+class MySplFixedArray extends SplFixedArray {
+}
+$array = new MySplFixedArray(2);
+$array->{0} = [];
+var_dump(get_object_vars($array));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
Because the properties table contains both a numeric index and a string index that map to 0 in a symbol table, this causes an assertion failure. Looking at the manual page of get_object_vars(), it seems that only real properties must be included. Given that SplFixedArray's elements are not accessible like properties, they should be excluded. This restores PHP 8.3 behaviour. The reason that this didn't cause problems on 8.3 is because it used a different handler (get_properties).