### PR TITLE
Fix GH-17201: Dom\TokenList issues with interned string replace

### DIFF
--- a/ext/dom/tests/gh17201.phpt
+++ b/ext/dom/tests/gh17201.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-17201 (Dom\TokenList issues with interned string replace)
+--EXTENSIONS--
+dom
+--INI--
+opcache.protect_memory=1
+--FILE--
+<?php
+$dom = DOM\XMLDocument::createFromString('<root class="AA B C"/>');
+$element = $dom->documentElement;
+$list = $element->classList;
+$list->replace('AA', 'AB'); // Use interned string
+foreach ($list as $entry) {
+    var_dump($entry);
+}
+?>
+--EXPECT--
+string(2) "AB"
+string(1) "B"
+string(1) "C"

--- a/ext/dom/token_list.c
+++ b/ext/dom/token_list.c
@@ -583,7 +583,8 @@ PHP_METHOD(Dom_TokenList, replace)
 		/* It already exists, remove token instead. */
 		zend_hash_del_bucket(token_set, bucket);
 	} else {
-		Z_STR(bucket->val) = new_token;
+		/* Need to use ZVAL_STR instead of Z_STR to reset the type flags. */
+		ZVAL_STR(&bucket->val, new_token);
 	}
 
 	/* 5. Run the update steps. */


### PR DESCRIPTION
If a bucket previously had a non-interned string, and is now replaced with an interned string, then the type flags still incorrectly state it's a non-interned string. This leads to the refcount being edited for interned strings, which in turn can lead to a crash when protect_memory is set.