### PR TITLE
ext/posix posix_ttyname/posix_isatty fd error handling update.

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -470,6 +470,7 @@ PHP_FUNCTION(posix_ttyname)
 		/* fd must fit in an int and be positive */
 		if (fd < 0 || fd > INT_MAX) {
 			php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be between 0 and %d", INT_MAX);
+			POSIX_G(last_error) = EBADF;
 			RETURN_FALSE;
 		}
 	}
@@ -532,6 +533,7 @@ PHP_FUNCTION(posix_isatty)
 
 	/* A valid file descriptor must fit in an int and be positive */
 	if (fd < 0 || fd > INT_MAX) {
+		php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be between 0 and %d", INT_MAX);
 		POSIX_G(last_error) = EBADF;
 		RETURN_FALSE;
 	}
@@ -1324,6 +1326,12 @@ PHP_FUNCTION(posix_fpathconf)
 				zend_zval_value_name(z_fd));
 			RETURN_THROWS();
 		}
+	}
+	/* fd must fit in an int and be positive */
+	if (fd < 0 || fd > INT_MAX) {
+		php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be between 0 and %d", INT_MAX);
+		POSIX_G(last_error) = EBADF;
+		RETURN_FALSE;
 	}
 
 	ret = fpathconf(fd, name);

--- a/ext/posix/tests/posix_fpathconf.phpt
+++ b/ext/posix/tests/posix_fpathconf.phpt
@@ -10,6 +10,7 @@ if (!function_exists("posix_pathconf")) die("skip only platforms with posix_path
 <?php
 var_dump(posix_fpathconf(-1, POSIX_PC_PATH_MAX));
 var_dump(posix_errno() != 0);
+var_dump(posix_strerror(posix_errno()));
 try {
 	posix_fpathconf("string arg", POSIX_PC_PATH_MAX);
 } catch (\TypeError $e) {
@@ -20,7 +21,10 @@ var_dump(posix_fpathconf($fd, POSIX_PC_PATH_MAX));
 fclose($fd);
 ?>
 --EXPECTF--
+
+Warning: posix_fpathconf(): Argument #1 ($file_descriptor) must be between 0 and %d in %s on line %d
 bool(false)
 bool(true)
+string(19) "Bad file descriptor"
 posix_fpathconf(): Argument #1 ($file_descriptor) must be of type int|resource, string given
 int(%d)

--- a/ext/posix/tests/posix_isatty_value_errors.phpt
+++ b/ext/posix/tests/posix_isatty_value_errors.phpt
@@ -20,10 +20,14 @@ foreach ($values as $value) {
     var_dump(posix_strerror(posix_get_last_error()));
 }
 ?>
---EXPECT--
+--EXPECTF--
+
+Warning: posix_isatty(): Argument #1 ($file_descriptor) must be between 0 and %d in %s on line %d
 bool(false)
 string(19) "Bad file descriptor"
 bool(false)
 string(19) "Bad file descriptor"
+
+Warning: posix_isatty(): Argument #1 ($file_descriptor) must be between 0 and %d in %s on line %d
 bool(false)
 string(19) "Bad file descriptor"

--- a/ext/posix/tests/posix_ttyname_value_errors.phpt
+++ b/ext/posix/tests/posix_ttyname_value_errors.phpt
@@ -16,11 +16,14 @@ $values = [
 
 foreach ($values as $value) {
     var_dump(posix_ttyname($value));
+    var_dump(posix_strerror(posix_get_last_error()));
 }
 ?>
 --EXPECTF--
 Warning: posix_ttyname(): Argument #1 ($file_descriptor) must be between 0 and %d in %s on line %d
 bool(false)
+string(19) "Bad file descriptor"
 
 Warning: posix_ttyname(): Argument #1 ($file_descriptor) must be between 0 and %d in %s on line %d
 bool(false)
+string(19) "Bad file descriptor"


### PR DESCRIPTION
Set to `EBADF` errno for posix_ttyname when out of ranges. posix_fpathconf now returns false on out of range file descriptors.