### PR TITLE
Fix GH-17216: Trampoline crash on error

### DIFF
--- a/Zend/tests/named_params/gh17216.phpt
+++ b/Zend/tests/named_params/gh17216.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17216 (Trampoline crash on error)
+--FILE--
+<?php
+class TrampolineTest {
+    public function __call(string $name, array $arguments) {
+        var_dump($name, $arguments);
+    }
+}
+$o = new TrampolineTest();
+$callback = [$o, 'trampoline'];
+$array = ["a" => "b", 1];
+try {
+    forward_static_call_array($callback, $array);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+echo "Done\n";
+?>
+--EXPECT--
+Cannot use positional argument after named argument
+Done

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -842,7 +842,11 @@ zend_result zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_
 						ZEND_CALL_NUM_ARGS(call) = i;
 cleanup_args:
 						zend_vm_stack_free_args(call);
+						if (ZEND_CALL_INFO(call) & ZEND_CALL_HAS_EXTRA_NAMED_PARAMS) {
+							zend_free_extra_named_params(call->extra_named_params);
+						}
 						zend_vm_stack_free_call_frame(call);
+						zend_release_fcall_info_cache(fci_cache);
 						return SUCCESS;
 					}
 				}


### PR DESCRIPTION
```
Zend/zend_execute_API.c:518: void shutdown_executor(void): Assertion `(((zend_executor_globals *) (((char*) _tsrm_ls_cache)+(executor_globals_offset)))->trampoline).common.function_name == ((void*)0) || (((zend_compiler_globals *) (((char*) _tsrm_ls_cache)+(compiler_globals_offset)))->unclean_shutdown)' failed.
```

The error handling is incomplete on argument cleanup.
1. The fci is not cleared which means that zend_free_trampoline() is never called.
2. The cleaning for extra named arguments was missing, resulting in memory leak.