### PR TITLE
ext/pdo_firebird: Fix label followed by declaration

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -886,7 +886,7 @@ static int pdo_firebird_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zva
 	switch (attr) {
 		default:
 			return 0;
-		case PDO_ATTR_CURSOR_NAME:
+		case PDO_ATTR_CURSOR_NAME: {
 			zend_string *str_val = zval_try_get_string(val);
 			if (str_val == NULL) {
 				return 0;
@@ -907,6 +907,7 @@ static int pdo_firebird_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zva
 			memcpy(S->name, ZSTR_VAL(str_val), ZSTR_LEN(str_val) + 1);
 			zend_string_release(str_val);
 			break;
+		}
 	}
 	return 1;
 }


### PR DESCRIPTION
This PR fixes a build failure in `pdo_firebird`.

After #17173, I get this error when compiling with gcc-9.

> error: a label can only be part of a statement and a declaration is not a statement.

Build failure: https://github.com/shivammathur/php-builder/actions/runs/12440286121/job/34735517472#step:5:3219

To fix this we can wrap the code in the switch case in brackets.