### PR TITLE
Fix GH-17224: UAF in importNode

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -809,14 +809,14 @@ PHP_METHOD(DOMDocument, importNode)
 			xmlNsPtr nsptr = NULL;
 			xmlNodePtr root = xmlDocGetRootElement(docp);
 
-			nsptr = xmlSearchNsByHref (nodep->doc, root, nodep->ns->href);
+			nsptr = xmlSearchNsByHref (docp, root, nodep->ns->href);
 			if (nsptr == NULL || nsptr->prefix == NULL) {
 				int errorcode;
 				nsptr = dom_get_ns(root, (char *) nodep->ns->href, &errorcode, (char *) nodep->ns->prefix);
 
 				/* If there is no root, the namespace cannot be attached to it, so we have to attach it to the old list. */
 				if (nsptr != NULL && root == NULL) {
-					php_libxml_set_old_ns(nodep->doc, nsptr);
+					php_libxml_set_old_ns(docp, nsptr);
 				}
 			}
 			retnodep->ns = nsptr;

--- a/ext/dom/tests/gh17224.phpt
+++ b/ext/dom/tests/gh17224.phpt
@@ -1,0 +1,67 @@
+--TEST--
+GH-17224 (UAF in importNode)
+--EXTENSIONS--
+dom
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$aDOM = new DOMDocument();
+$fromdom = new DOMDocument();
+$fromdom->loadXML('<data xmlns:ai="http://test.org" ai:attr="namespaced" />');
+$attr = $fromdom->firstChild->attributes->item(0);
+$att = $aDOM->importNode($attr);
+$doc = new DOMDocument;
+$fromdom->load(__DIR__."/book.xml");
+unset($attr);
+var_dump($att);
+?>
+--EXPECTF--
+object(DOMAttr)#%d (%d) {
+  ["specified"]=>
+  bool(true)
+  ["schemaTypeInfo"]=>
+  NULL
+  ["name"]=>
+  string(4) "attr"
+  ["value"]=>
+  string(10) "namespaced"
+  ["ownerElement"]=>
+  NULL
+  ["nodeName"]=>
+  string(7) "ai:attr"
+  ["nodeValue"]=>
+  string(10) "namespaced"
+  ["nodeType"]=>
+  int(2)
+  ["parentNode"]=>
+  NULL
+  ["parentElement"]=>
+  NULL
+  ["childNodes"]=>
+  string(22) "(object value omitted)"
+  ["firstChild"]=>
+  string(22) "(object value omitted)"
+  ["lastChild"]=>
+  string(22) "(object value omitted)"
+  ["previousSibling"]=>
+  NULL
+  ["nextSibling"]=>
+  NULL
+  ["attributes"]=>
+  NULL
+  ["isConnected"]=>
+  bool(false)
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["namespaceURI"]=>
+  string(15) "http://test.org"
+  ["prefix"]=>
+  string(2) "ai"
+  ["localName"]=>
+  string(4) "attr"
+  ["baseURI"]=>
+  NULL
+  ["textContent"]=>
+  string(10) "namespaced"
+}


### PR DESCRIPTION
Wrong document pointer is used for the namespace copy.