### PR TITLE
Fix GH-17234: Numeric parent hook call fails with assertion

### DIFF
--- a/Zend/tests/property_hooks/gh17234.phpt
+++ b/Zend/tests/property_hooks/gh17234.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-17234 (Numeric parent hook call fails with assertion)
+--FILE--
+<?php
+class ParentC {}
+class Child extends ParentC {
+    public $a {
+        get {
+            return parent::${0}::get ();
+        }
+    }
+}
+?>
+--EXPECTF--
+Fatal error: Must not use parent::$0::get() in a different property ($a) in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5098,7 +5098,8 @@ static bool zend_compile_parent_property_hook_call(znode *result, zend_ast *ast,
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot create Closure for parent property hook call");
 	}
 
-	zend_string *property_name = zend_ast_get_str(class_ast->child[1]);
+	zval *property_hook_name_zv = zend_ast_get_zval(class_ast->child[1]);
+	zend_string *property_name = zval_get_string(property_hook_name_zv);
 	zend_string *hook_name = zend_ast_get_str(method_ast);
 	zend_property_hook_kind hook_kind = zend_get_property_hook_kind_from_name(hook_name);
 	ZEND_ASSERT(hook_kind != (uint32_t)-1);
@@ -5122,7 +5123,6 @@ static bool zend_compile_parent_property_hook_call(znode *result, zend_ast *ast,
 	zend_op *opline = get_next_op();
 	opline->opcode = ZEND_INIT_PARENT_PROPERTY_HOOK_CALL;
 	opline->op1_type = IS_CONST;
-	zend_string_copy(property_name);
 	opline->op1.constant = zend_add_literal_string(&property_name);
 	opline->op2.num = hook_kind;
 


### PR DESCRIPTION
The current code expects the property name to be a string, but it can also be a number via the {} syntax. Handle this consistently to a string by using zval_get_string which will do the type coercion and refcount update (instead of assuming string and doing an explicit string copy).