### PR TITLE
Fix memory leak on ZEND_FFI_TYPE_CHAR conversion failure

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -807,6 +807,7 @@ again:
 			if (ZSTR_LEN(str) == 1) {
 				*(char*)ptr = ZSTR_VAL(str)[0];
 			} else {
+				zend_tmp_string_release(tmp_str);
 				zend_ffi_assign_incompatible(value, type);
 				return FAILURE;
 			}


### PR DESCRIPTION
The success path frees tmp_str, but the error path does not.

Found with help of a SA I'm developing.