### PR TITLE
Fix GH-17246: Nested shm protections cause segfault

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2153,7 +2153,10 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 		 */
 		from_shared_memory = false;
 		if (persistent_script) {
+			/* See GH-17246: we disable GC so that user code cannot be executed during the optimizer run. */
+			bool orig_gc_state = gc_enable(false);
 			persistent_script = cache_script_in_shared_memory(persistent_script, key, &from_shared_memory);
+			gc_enable(orig_gc_state);
 		}
 
 		/* Caching is disabled, returning op_array;

--- a/ext/opcache/tests/jit/gh17246.inc
+++ b/ext/opcache/tests/jit/gh17246.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Need to cause a trace exit, so extend non existent class
+class MyXSLTProcessor extends NonExistentClass {
+    public function registerCycle() {
+        [[$this]]; // Non trivial array
+    }
+}

--- a/ext/opcache/tests/jit/gh17246.phpt
+++ b/ext/opcache/tests/jit/gh17246.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-17246 (Nested shm protections cause segfault)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.protect_memory=1
+opcache.jit_buffer_size=32M
+opcache.jit=1254
+--FILE--
+<?php
+
+class Test
+{
+    private $field;
+
+    public function __construct()
+    {
+        $this->field = function() {};
+    }
+
+    public function __destruct()
+    {
+        // Necessary because we need to invoke tracing JIT during destruction
+    }
+}
+
+for ($i = 0; $i < 10000; ++$i) {
+    $obj = new Test();
+}
+
+require __DIR__.'/gh17246.inc';
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "NonExistentClass" not found in %s:%d
+Stack trace:
+#0 %s(%d): require()
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
This bug happens because of a nested `SHM_UNPROTECT()` sequence. In particular:
```
unprotect memory at ext/opcache/ZendAccelerator.c:2127
protect memory at ext/opcache/ZendAccelerator.c:2160
unprotect memory at ext/opcache/ZendAccelerator.c:2164
unprotect memory at ext/opcache/jit/zend_jit_trace.c:7464
^^^ Nested
protect memory at ext/opcache/jit/zend_jit_trace.c:7591
^^^ Problem is here: it should not protect again due to the nested unprotect
protect memory at ext/opcache/ZendAccelerator.c:2191
^^^ This one should actually protect, not the previous one
```

The reason this nesting happen is because:
1. We try to include the script, this eventually calls `cache_script_in_shared_memory`
2. `zend_optimize_script` will eventually run SCCP as part of the DFA pass.
3. SCCP will try to replace constants, but can also run destructors when a partial array is destructed here:

https://github.com/php/php-src/blob/4e9cde758eadf30cc4d596d6398c2c34c64197b4/Zend/Optimizer/sccp.c#L2387-L2389

In this case, this destruction invokes the tracing JIT, leading to the nested unprotects.

This patch adds a counter to track the nesting level of shm protections. This is a simple solution to the problem. An alternative is not JITting during SCCP, but that would be a leaky abstraction. I also think this solution is more general.
One downside is an extra check in case `protect_memory` is set, but production configuration usually don't have this enabled. It may be possible to combine the `protect_memory` and `shm_nesting_level` field in some way, but that will make more complicated code.