### PR TITLE
Fix GH-17223: Memory leak in libxml encoding handling

### DIFF
--- a/ext/dom/tests/gh17223.phpt
+++ b/ext/dom/tests/gh17223.phpt
@@ -5,7 +5,8 @@ dom
 --FILE--
 <?php
 $doc = new DOMDocument("1.0", "Shift-JIS");
-$doc->save("%00");
+@$doc->save("%00");
+echo "Done\n";
 ?>
---EXPECTF--
-Warning: DOMDocument::save(): URI must not contain percent-encoded NUL bytes in %s on line %d
+--EXPECT--
+Done

--- a/ext/dom/tests/gh17223.phpt
+++ b/ext/dom/tests/gh17223.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-17223 (Memory leak in libxml encoding handling)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument(str_repeat(chr(223), 65537) . str_repeat(chr(8), 17) . str_repeat(chr(133), 257), str_repeat(chr(62), 257));
+$doc->save("%00");
+?>
+--EXPECTF--
+Warning: DOMDocument::save(): URI must not contain percent-encoded NUL bytes in %s on line %d

--- a/ext/dom/tests/gh17223.phpt
+++ b/ext/dom/tests/gh17223.phpt
@@ -4,7 +4,7 @@ GH-17223 (Memory leak in libxml encoding handling)
 dom
 --FILE--
 <?php
-$doc = new DOMDocument(str_repeat(chr(223), 65537) . str_repeat(chr(8), 17) . str_repeat(chr(133), 257), str_repeat(chr(62), 257));
+$doc = new DOMDocument("1.0", "Shift-JIS");
 $doc->save("%00");
 ?>
 --EXPECTF--

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -590,11 +590,11 @@ php_libxml_output_buffer_create_filename(const char *URI,
 	char *unescaped = NULL;
 
 	if (URI == NULL)
-		return(NULL);
+		goto err;
 
 	if (strstr(URI, "%00")) {
 		php_error_docref(NULL, E_WARNING, "URI must not contain percent-encoded NUL bytes");
-		return NULL;
+		goto err;
 	}
 
 	puri = xmlParseURI(URI);
@@ -615,7 +615,7 @@ php_libxml_output_buffer_create_filename(const char *URI,
 	}
 
 	if (context == NULL) {
-		return(NULL);
+		goto err;
 	}
 
 	/* Allocate the Output buffer front-end. */
@@ -627,6 +627,11 @@ php_libxml_output_buffer_create_filename(const char *URI,
 	}
 
 	return(ret);
+
+err:
+	/* Similarly to __xmlOutputBufferCreateFilename we should also close the encoder on failure. */
+	xmlCharEncCloseFunc(encoder);
+	return NULL;
 }
 
 static void _php_libxml_free_error(void *ptr)


### PR DESCRIPTION
This was a bug in both libxml and PHP.
We follow up with the same change as done in GNOME/libxml2@b3871dd138.

Changing away from `xmlOutputBufferCreateFilenameDefault` is not possible yet because this is a stable branch and would break BC.