### PR TITLE
Fix FD getting code on big endian

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -434,9 +434,9 @@ static int php_posix_stream_get_fd(zval *zfp, zend_long *ret) /* {{{ */
 	 */
 	php_socket_t fd = -1;
 	if (php_stream_can_cast(stream, PHP_STREAM_AS_FD_FOR_SELECT | PHP_STREAM_CAST_INTERNAL) == SUCCESS) {
-		php_stream_cast(stream, PHP_STREAM_AS_FD_FOR_SELECT | PHP_STREAM_CAST_INTERNAL, (void*)&fd, 0);
+		php_stream_cast(stream, PHP_STREAM_AS_FD_FOR_SELECT | PHP_STREAM_CAST_INTERNAL, (void**)&fd, 0);
 	} else if (php_stream_can_cast(stream, PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL) == SUCCESS) {
-		php_stream_cast(stream, PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL, (void*)&fd, 0);
+		php_stream_cast(stream, PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL, (void**)&fd, 0);
 	} else {
 		php_error_docref(NULL, E_WARNING, "Could not use stream of type '%s'",
 				stream->ops->label);


### PR DESCRIPTION
stream casting as FD returns a php_socket_t, which is an int, but zend_long is 64-bit (on those platforms). This works on LE by accidental (unless it forgets to clear the high word), but is fatal on big endian.

fb2443ac5c9990f1cc9adb3e8781b50cd6f03d54 in master seems to have made this obvious, but the issue exists in earlier versions too. Fixes a regression introduced by that commit on big endian. (see GH-17258 for CI there)
