### PR TITLE
Support alternative color quantization algorithms

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -233,6 +233,7 @@ if test "$PHP_GD" != "no"; then
       libgd/gd_io.c
       libgd/gd_jpeg.c
       libgd/gd_matrix.c
+      libgd/gd_nnquant.c
       libgd/gd_pixelate.c
       libgd/gd_png.c
       libgd/gd_rotate.c

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -58,7 +58,7 @@ if (PHP_GD != "no") {
 			gd_io_file.c gd_io_ss.c gd_jpeg.c gdkanji.c gd_png.c gd_ss.c \
 			gdtables.c gd_topal.c gd_wbmp.c gdxpm.c wbmp.c gd_xbm.c gd_security.c gd_transform.c \
 			gd_filter.c gd_pixelate.c gd_rotate.c gd_color_match.c gd_webp.c gd_avif.c \
-			gd_crop.c gd_interpolation.c gd_matrix.c gd_bmp.c gd_tga.c", "gd");
+			gd_crop.c gd_interpolation.c gd_matrix.c gd_bmp.c gd_tga.c gd_nnquant.c", "gd");
 		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Define to 1 if gd extension uses GD library bundled in PHP.");
 		AC_DEFINE('HAVE_GD_PNG', 1, "Define to 1 if gd extension has PNG support.");
 		AC_DEFINE('HAVE_GD_BMP', 1, "Define to 1 if gd extension has BMP support.");

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -26,6 +26,11 @@ if (PHP_GD != "no") {
 			AC_DEFINE('HAVE_XPM', 1, "Define to 1 if you have the xpm library.");
 			AC_DEFINE('HAVE_GD_XPM', 1, "Define to 1 if gd extension has XPM support.");
 		}
+		if (CHECK_LIB("imagequant.lib", "gd", PHP_GD) &&
+			CHECK_HEADER_ADD_INCLUDE("libimagequant.h", "CFLAGS_GD", PHP_GD)
+		) {
+			AC_DEFINE('HAVE_LIBIMAGEQUANT', 1, "Define to 1 if you have the libimagequant library.");
+		}
 		if (PHP_LIBWEBP != "no") {
 			if ((CHECK_LIB("libwebp_a.lib", "gd", PHP_GD) || CHECK_LIB("libwebp.lib", "gd", PHP_GD)) &&
 				CHECK_HEADER_ADD_INCLUDE("decode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp") &&

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -817,8 +817,8 @@ PHP_FUNCTION(imagetruecolortopalettesetmethod)
 
 	im = php_gd_libgdimageptr_from_zval_p(IM);
 
-	if (method <= GD_QUANT_DEFAULT || method >= GD_QUANT_LIQ) {
-		zend_argument_value_error(2, "must be one of the GD_QUANT_* constants");
+	if (method < GD_QUANT_DEFAULT || method > GD_QUANT_LIQ) {
+		zend_argument_value_error(2, "must be one of the IMG_QUANT_* constants");
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -801,6 +801,68 @@ PHP_FUNCTION(imagecolormatch)
 }
 /* }}} */
 
+PHP_FUNCTION(imagetruecolortopalettesetmethod)
+{
+	zval *IM;
+	zend_long method;
+	zend_long speed = 0;
+	gdImagePtr im;
+
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_OBJECT_OF_CLASS(IM, gd_image_ce)
+		Z_PARAM_LONG(method)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(speed)
+	ZEND_PARSE_PARAMETERS_END();
+
+	im = php_gd_libgdimageptr_from_zval_p(IM);
+
+	if (method <= GD_QUANT_DEFAULT || method >= GD_QUANT_LIQ) {
+		zend_argument_value_error(2, "must be one of the GD_QUANT_* constants");
+		RETURN_THROWS();
+	}
+
+	if (speed < 0 || speed > 10) {
+		zend_argument_value_error(3, "must be between 0 and 10");
+		RETURN_THROWS();
+	}
+
+	if (gdImageTrueColorToPaletteSetMethod(im, method, speed)) {
+		RETURN_TRUE;
+	} else {
+		php_error_docref(NULL, E_WARNING, "Couldn't set quantization method");
+		RETURN_FALSE;
+	}
+}
+
+PHP_FUNCTION(imagetruecolortopalettesetquality)
+{
+	zval *IM;
+	zend_long min_quality;
+	zend_long max_quality;
+	gdImagePtr im;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_OBJECT_OF_CLASS(IM, gd_image_ce)
+		Z_PARAM_LONG(min_quality)
+		Z_PARAM_LONG(max_quality)
+	ZEND_PARSE_PARAMETERS_END();
+
+	im = php_gd_libgdimageptr_from_zval_p(IM);
+
+	if (min_quality < 1 || min_quality > 100) {
+		zend_argument_value_error(2, "must be between 1 and 100");
+		RETURN_THROWS();
+	}
+
+	if (max_quality < 1 || max_quality > 100) {
+		zend_argument_value_error(3, "must be between 1 and 100");
+		RETURN_THROWS();
+	}
+
+	gdImageTrueColorToPaletteSetQuality (im, min_quality, max_quality);
+}
+
 /* {{{ Set line thickness for drawing lines, ellipses, rectangles, polygons etc. */
 PHP_FUNCTION(imagesetthickness)
 {

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -177,6 +177,30 @@ const IMG_EFFECT_MULTIPLY = UNKNOWN;
 
 /**
  * @var int
+ * @cvalue GD_QUANT_DEFAULT
+ */
+const IMG_QUANT_DEFAULT = UNKNOWN;
+
+/**
+ * @var int
+ * @cvalue GD_QUANT_JQUANT
+ */
+const IMG_QUANT_JQUANT = UNKNOWN;
+
+/**
+ * @var int
+ * @cvalue GD_QUANT_NEUQUANT
+ */
+const IMG_QUANT_NEUQUANT = UNKNOWN;
+
+/**
+ * @var int
+ * @cvalue GD_QUANT_LIQ
+ */
+const IMG_QUANT_LIQ = UNKNOWN;
+
+/**
+ * @var int
  * @cvalue GD_CROP_DEFAULT
  */
 const IMG_CROP_DEFAULT = UNKNOWN;
@@ -497,6 +521,10 @@ function imagetruecolortopalette(GdImage $image, bool $dither, int $num_colors):
 function imagepalettetotruecolor(GdImage $image): bool {}
 
 function imagecolormatch(GdImage $image1, GdImage $image2): bool {}
+
+function imagetruecolortopalettesetmethod(GdImage $image, int $method, int $speed = 0): bool {}
+
+function imagetruecolortopalettesetquality(GdImage $image, int $min_quality, int $max_quality): void {}
 
 function imagesetthickness(GdImage $image, int $thickness): bool {}
 

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0f8a22bff1d123313f37da400500e573baace837 */
+ * Stub hash: 6df1e68080ceef570af08c72636be6428c0668eb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -33,6 +33,18 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolormatch, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, image1, GdImage, 0)
 	ZEND_ARG_OBJ_INFO(0, image2, GdImage, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagetruecolortopalettesetmethod, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, speed, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagetruecolortopalettesetquality, 0, 3, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
+	ZEND_ARG_TYPE_INFO(0, min_quality, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, max_quality, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagesetthickness, 0, 2, _IS_BOOL, 0)
@@ -575,6 +587,8 @@ ZEND_FUNCTION(imageistruecolor);
 ZEND_FUNCTION(imagetruecolortopalette);
 ZEND_FUNCTION(imagepalettetotruecolor);
 ZEND_FUNCTION(imagecolormatch);
+ZEND_FUNCTION(imagetruecolortopalettesetmethod);
+ZEND_FUNCTION(imagetruecolortopalettesetquality);
 ZEND_FUNCTION(imagesetthickness);
 ZEND_FUNCTION(imagefilledellipse);
 ZEND_FUNCTION(imagefilledarc);
@@ -711,6 +725,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imagetruecolortopalette, arginfo_imagetruecolortopalette)
 	ZEND_FE(imagepalettetotruecolor, arginfo_imagepalettetotruecolor)
 	ZEND_FE(imagecolormatch, arginfo_imagecolormatch)
+	ZEND_FE(imagetruecolortopalettesetmethod, arginfo_imagetruecolortopalettesetmethod)
+	ZEND_FE(imagetruecolortopalettesetquality, arginfo_imagetruecolortopalettesetquality)
 	ZEND_FE(imagesetthickness, arginfo_imagesetthickness)
 	ZEND_FE(imagefilledellipse, arginfo_imagefilledellipse)
 	ZEND_FE(imagefilledarc, arginfo_imagefilledarc)
@@ -879,6 +895,10 @@ static void register_gd_symbols(int module_number)
 #if defined(gdEffectMultiply)
 	REGISTER_LONG_CONSTANT("IMG_EFFECT_MULTIPLY", gdEffectMultiply, CONST_PERSISTENT);
 #endif
+	REGISTER_LONG_CONSTANT("IMG_QUANT_DEFAULT", GD_QUANT_DEFAULT, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("IMG_QUANT_JQUANT", GD_QUANT_JQUANT, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("IMG_QUANT_NEUQUANT", GD_QUANT_NEUQUANT, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("IMG_QUANT_LIQ", GD_QUANT_LIQ, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IMG_CROP_DEFAULT", GD_CROP_DEFAULT, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IMG_CROP_TRANSPARENT", GD_CROP_TRANSPARENT, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("IMG_CROP_BLACK", GD_CROP_BLACK, CONST_PERSISTENT);

--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -1020,6 +1020,11 @@ gdImagePtr gdImageClone (gdImagePtr src) {
 	dst->res_x = src->res_x;
 	dst->res_y = src->res_y;
 
+	dst->paletteQuantizationMethod     = src->paletteQuantizationMethod;
+	dst->paletteQuantizationSpeed      = src->paletteQuantizationSpeed;
+	dst->paletteQuantizationMinQuality = src->paletteQuantizationMinQuality;
+	dst->paletteQuantizationMaxQuality = src->paletteQuantizationMaxQuality;
+
 	dst->interpolation_id = src->interpolation_id;
 	dst->interpolation    = src->interpolation;
 

--- a/ext/gd/libgd/gd_nnquant.c
+++ b/ext/gd/libgd/gd_nnquant.c
@@ -309,7 +309,7 @@ static int contest(nn_quant *nnq, int al, int b, int g, int r)
 	double bestd,bestbiasd;
 	register int *p,*f, *n;
 
-	bestd = ~(((int) 1)<<31);
+	bestd = INT_MAX;
 	bestbiasd = bestd;
 	bestpos = 0;
 	bestbiaspos = bestpos;

--- a/ext/gd/libgd/gd_nnquant.c
+++ b/ext/gd/libgd/gd_nnquant.c
@@ -1,0 +1,613 @@
+/* NeuQuant Neural-Net Quantization Algorithm
+ * ------------------------------------------
+ *
+ * Copyright (c) 1994 Anthony Dekker
+ *
+ * NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994.
+ * See "Kohonen neural networks for optimal colour quantization"
+ * in "Network: Computation in Neural Systems" Vol. 5 (1994) pp 351-367.
+ * for a discussion of the algorithm.
+ * See also  http://members.ozemail.com.au/~dekker/NEUQUANT.HTML
+ *
+ * Any party obtaining a copy of these files from the author, directly or
+ * indirectly, is granted, free of charge, a full and unrestricted irrevocable,
+ * world-wide, paid up, royalty-free, nonexclusive right and license to deal
+ * in this software and documentation files (the "Software"), including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons who receive
+ * copies from any such party to do so, with the only requirement being
+ * that this copyright notice remain intact.
+ *
+ *
+ * Modified to process 32bit RGBA images.
+ * Stuart Coyle 2004-2007
+ * From: http://pngnq.sourceforge.net/
+ *
+ * Ported to libgd by Pierre A. Joye
+ * (and make it thread safety by droping static and  global variables)
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <stdlib.h>
+#include <string.h>
+#include "gd.h"
+#include "gdhelpers.h"
+#include "gd_errors.h"
+
+#include "gd_nnquant.h"
+
+/* Network Definitions
+   ------------------- */
+
+#define maxnetpos	(MAXNETSIZE-1)
+#define netbiasshift	4			/* bias for colour values */
+#define ncycles		100			/* no. of learning cycles */
+
+/* defs for freq and bias */
+#define intbiasshift    16			/* bias for fractions */
+#define intbias		(((int) 1)<<intbiasshift)
+#define gammashift  	10			/* gamma = 1024 */
+#define gamma   	(((int) 1)<<gammashift)
+#define betashift  	10
+#define beta		(intbias>>betashift)	/* beta = 1/1024 */
+#define betagamma	(intbias<<(gammashift-betashift))
+
+/* defs for decreasing radius factor */
+#define initrad		(MAXNETSIZE>>3)		/* for 256 cols, radius starts */
+#define radiusbiasshift	6			/* at 32.0 biased by 6 bits */
+#define radiusbias	(((int) 1)<<radiusbiasshift)
+#define initradius	(initrad*radiusbias)	/* and decreases by a */
+#define radiusdec	30			/* factor of 1/30 each cycle */
+
+/* defs for decreasing alpha factor */
+#define alphabiasshift	10			/* alpha starts at 1.0 */
+#define initalpha	(((int) 1)<<alphabiasshift)
+
+/* radbias and alpharadbias used for radpower calculation */
+#define radbiasshift	8
+#define radbias		(((int) 1)<<radbiasshift)
+#define alpharadbshift  (alphabiasshift+radbiasshift)
+#define alpharadbias    (((int) 1)<<alpharadbshift)
+
+#define ALPHA 0
+#define RED 1
+#define BLUE 2
+#define GREEN 3
+
+typedef int nq_pixel[5];
+
+typedef struct {
+	/* biased by 10 bits */
+	int alphadec;
+
+	/* lengthcount = H*W*3 */
+	int lengthcount;
+
+	/* sampling factor 1..30 */
+	int samplefac;
+
+	/* Number of colours to use. Made a global instead of #define */
+	int netsize;
+
+	/* for network lookup - really 256 */
+	int netindex[256];
+
+	/* ABGRc */
+	/* the network itself */
+	nq_pixel network[MAXNETSIZE];
+
+	/* bias and freq arrays for learning */
+	int bias[MAXNETSIZE];
+	int freq[MAXNETSIZE];
+
+	/* radpower for precomputation */
+	int radpower[initrad];
+
+	/* the input image itself */
+	unsigned char *thepicture;
+} nn_quant;
+
+/* Initialise network in range (0,0,0,0) to (255,255,255,255) and set parameters
+   ----------------------------------------------------------------------- */
+static void initnet(nn_quant *nnq, unsigned char *thepic, int len, int sample, int colours)
+{
+	register int i;
+	register int *p;
+
+	/* Clear out network from previous runs */
+	/* thanks to Chen Bin for this fix */
+	memset((void*)nnq->network, 0, sizeof(nq_pixel)*MAXNETSIZE);
+
+	nnq->thepicture = thepic;
+	nnq->lengthcount = len;
+	nnq->samplefac = sample;
+	nnq->netsize = colours;
+
+	for (i=0; i < nnq->netsize; i++) {
+		p = nnq->network[i];
+		p[0] = p[1] = p[2] = p[3] = (i << (netbiasshift+8)) / nnq->netsize;
+		nnq->freq[i] = intbias / nnq->netsize;	/* 1/netsize */
+		nnq->bias[i] = 0;
+	}
+}
+
+/* -------------------------- */
+
+/* Unbias network to give byte values 0..255 and record
+ * position i to prepare for sort
+ */
+/* -------------------------- */
+
+static void unbiasnet(nn_quant *nnq)
+{
+	int i,j,temp;
+
+	for (i=0; i < nnq->netsize; i++) {
+		for (j=0; j<4; j++) {
+			/* OLD CODE: network[i][j] >>= netbiasshift; */
+			/* Fix based on bug report by Juergen Weigert jw@suse.de */
+			temp = (nnq->network[i][j] + (1 << (netbiasshift - 1))) >> netbiasshift;
+			if (temp > 255) temp = 255;
+			nnq->network[i][j] = temp;
+		}
+		nnq->network[i][4] = i;			/* record colour no */
+	}
+}
+
+/* Output colormap to unsigned char ptr in RGBA format */
+static void getcolormap(nn_quant *nnq, unsigned char *map)
+{
+	int i,j;
+	for(j=0; j < nnq->netsize; j++) {
+		for (i=3; i>=0; i--) {
+			*map = nnq->network[j][i];
+			map++;
+		}
+	}
+}
+
+/* Insertion sort of network and building of netindex[0..255] (to do after unbias)
+   ------------------------------------------------------------------------------- */
+static void inxbuild(nn_quant *nnq)
+{
+	register int i,j,smallpos,smallval;
+	register int *p,*q;
+	int previouscol,startpos;
+
+	previouscol = 0;
+	startpos = 0;
+	for (i=0; i < nnq->netsize; i++) {
+		p = nnq->network[i];
+		smallpos = i;
+		smallval = p[2];			/* index on g */
+		/* find smallest in i..netsize-1 */
+		for (j=i+1; j < nnq->netsize; j++) {
+			q = nnq->network[j];
+			if (q[2] < smallval) {		/* index on g */
+				smallpos = j;
+				smallval = q[2];	/* index on g */
+			}
+		}
+		q = nnq->network[smallpos];
+		/* swap p (i) and q (smallpos) entries */
+		if (i != smallpos) {
+			j = q[0];
+			q[0] = p[0];
+			p[0] = j;
+			j = q[1];
+			q[1] = p[1];
+			p[1] = j;
+			j = q[2];
+			q[2] = p[2];
+			p[2] = j;
+			j = q[3];
+			q[3] = p[3];
+			p[3] = j;
+			j = q[4];
+			q[4] = p[4];
+			p[4] = j;
+		}
+		/* smallval entry is now in position i */
+		if (smallval != previouscol) {
+			nnq->netindex[previouscol] = (startpos+i)>>1;
+			for (j=previouscol+1; j<smallval; j++) nnq->netindex[j] = i;
+			previouscol = smallval;
+			startpos = i;
+		}
+	}
+	nnq->netindex[previouscol] = (startpos+maxnetpos)>>1;
+	for (j=previouscol+1; j<256; j++) nnq->netindex[j] = maxnetpos; /* really 256 */
+}
+
+
+/* Search for ABGR values 0..255 (after net is unbiased) and return colour index
+	 ---------------------------------------------------------------------------- */
+static unsigned int inxsearch(nn_quant *nnq, int al, int b, int g, int r)
+{
+	register int i, j, dist, a, bestd;
+	register int *p;
+	unsigned int best;
+
+	bestd = 1000;		/* biggest possible dist is 256*3 */
+	best = 0;
+	i = nnq->netindex[g];	/* index on g */
+	j = i-1;		/* start at netindex[g] and work outwards */
+
+	while ((i<nnq->netsize) || (j>=0)) {
+		if (i< nnq->netsize) {
+			p = nnq->network[i];
+			dist = p[2] - g;		/* inx key */
+			if (dist >= bestd) i = nnq->netsize;	/* stop iter */
+			else {
+				i++;
+				if (dist<0) dist = -dist;
+				a = p[1] - b;
+				if (a<0) a = -a;
+				dist += a;
+				if (dist<bestd) {
+					a = p[3] - r;
+					if (a<0) a = -a;
+					dist += a;
+				}
+				if(dist<bestd) {
+					a = p[0] - al;
+					if (a<0) a = -a;
+					dist += a;
+				}
+				if (dist<bestd) {
+					bestd=dist;
+					best=p[4];
+				}
+			}
+		}
+
+		if (j>=0) {
+			p = nnq->network[j];
+			dist = g - p[2]; /* inx key - reverse dif */
+			if (dist >= bestd) j = -1; /* stop iter */
+			else {
+				j--;
+				if (dist<0) dist = -dist;
+				a = p[1] - b;
+				if (a<0) a = -a;
+				dist += a;
+				if (dist<bestd) {
+					a = p[3] - r;
+					if (a<0) a = -a;
+					dist += a;
+				}
+				if(dist<bestd) {
+					a = p[0] - al;
+					if (a<0) a = -a;
+					dist += a;
+				}
+				if (dist<bestd) {
+					bestd=dist;
+					best=p[4];
+				}
+			}
+		}
+	}
+
+	return(best);
+}
+
+/* Search for biased ABGR values
+   ---------------------------- */
+static int contest(nn_quant *nnq, int al, int b, int g, int r)
+{
+	/* finds closest neuron (min dist) and updates freq */
+	/* finds best neuron (min dist-bias) and returns position */
+	/* for frequently chosen neurons, freq[i] is high and bias[i] is negative */
+	/* bias[i] = gamma*((1/netsize)-freq[i]) */
+
+	register int i,dist,a,biasdist,betafreq;
+	unsigned int bestpos,bestbiaspos;
+	double bestd,bestbiasd;
+	register int *p,*f, *n;
+
+	bestd = ~(((int) 1)<<31);
+	bestbiasd = bestd;
+	bestpos = 0;
+	bestbiaspos = bestpos;
+	p = nnq->bias;
+	f = nnq->freq;
+
+	for (i=0; i< nnq->netsize; i++) {
+		n = nnq->network[i];
+		dist = n[0] - al;
+		if (dist<0) dist = -dist;
+		a = n[1] - b;
+		if (a<0) a = -a;
+		dist += a;
+		a = n[2] - g;
+		if (a<0) a = -a;
+		dist += a;
+		a = n[3] - r;
+		if (a<0) a = -a;
+		dist += a;
+		if (dist<bestd) {
+			bestd=dist;
+			bestpos=i;
+		}
+		biasdist = dist - ((*p)>>(intbiasshift-netbiasshift));
+		if (biasdist<bestbiasd) {
+			bestbiasd=biasdist;
+			bestbiaspos=i;
+		}
+		betafreq = (*f >> betashift);
+		*f++ -= betafreq;
+		*p++ += (betafreq<<gammashift);
+	}
+	nnq->freq[bestpos] += beta;
+	nnq->bias[bestpos] -= betagamma;
+	return(bestbiaspos);
+}
+
+
+/* Move neuron i towards biased (a,b,g,r) by factor alpha
+	 ---------------------------------------------------- */
+
+static void altersingle(nn_quant *nnq, int alpha, int i, int al, int b, int g, int r)
+{
+	register int *n;
+
+	n = nnq->network[i];	/* alter hit neuron */
+	*n -= (alpha*(*n - al)) / initalpha;
+	n++;
+	*n -= (alpha*(*n - b)) / initalpha;
+	n++;
+	*n -= (alpha*(*n - g)) / initalpha;
+	n++;
+	*n -= (alpha*(*n - r)) / initalpha;
+}
+
+
+/* Move adjacent neurons by precomputed alpha*(1-((i-j)^2/[r]^2)) in radpower[|i-j|]
+	 --------------------------------------------------------------------------------- */
+
+static void alterneigh(nn_quant *nnq, int rad, int i, int al, int b,int g, int r)
+{
+	register int j,k,lo,hi,a;
+	register int *p, *q;
+
+	lo = i-rad;
+	if (lo<-1) lo=-1;
+	hi = i+rad;
+	if (hi>nnq->netsize) hi=nnq->netsize;
+
+	j = i+1;
+	k = i-1;
+	q = nnq->radpower;
+	while ((j<hi) || (k>lo)) {
+		a = (*(++q));
+		if (j<hi) {
+			p = nnq->network[j];
+			*p -= (a*(*p - al)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - b)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - g)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - r)) / alpharadbias;
+			j++;
+		}
+		if (k>lo) {
+			p = nnq->network[k];
+			*p -= (a*(*p - al)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - b)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - g)) / alpharadbias;
+			p++;
+			*p -= (a*(*p - r)) / alpharadbias;
+			k--;
+		}
+	}
+}
+
+
+/* Main Learning Loop
+   ------------------ */
+
+static void learn(nn_quant *nnq, int verbose) /* Stu: N.B. added parameter so that main() could control verbosity. */
+{
+	register int i,j,al,b,g,r;
+	int radius,rad,alpha,step,delta,samplepixels;
+	register unsigned char *p;
+	unsigned char *lim;
+
+	nnq->alphadec = 30 + ((nnq->samplefac-1)/3);
+	p = nnq->thepicture;
+	lim = nnq->thepicture + nnq->lengthcount;
+	samplepixels = nnq->lengthcount/(4 * nnq->samplefac);
+	/* here's a problem with small images: samplepixels < ncycles => delta = 0 */
+	delta = samplepixels/ncycles;
+	/* kludge to fix */
+	if(delta==0) delta = 1;
+	alpha = initalpha;
+	radius = initradius;
+
+	rad = radius >> radiusbiasshift;
+
+	for (i=0; i<rad; i++)
+		nnq->radpower[i] = alpha*(((rad*rad - i*i)*radbias)/(rad*rad));
+
+	if (verbose) gd_error_ex(GD_NOTICE, "beginning 1D learning: initial radius=%d\n", rad);
+
+	if ((nnq->lengthcount%prime1) != 0) step = 4*prime1;
+	else {
+		if ((nnq->lengthcount%prime2) !=0) step = 4*prime2;
+		else {
+			if ((nnq->lengthcount%prime3) !=0) step = 4*prime3;
+			else step = 4*prime4;
+		}
+	}
+
+	i = 0;
+	while (i < samplepixels) {
+		al = p[ALPHA] << netbiasshift;
+		b = p[BLUE] << netbiasshift;
+		g = p[GREEN] << netbiasshift;
+		r = p[RED] << netbiasshift;
+		j = contest(nnq, al,b,g,r);
+
+		altersingle(nnq, alpha,j,al,b,g,r);
+		if (rad) alterneigh(nnq, rad,j,al,b,g,r);   /* alter neighbours */
+
+		p += step;
+		while (p >= lim) p -= nnq->lengthcount;
+
+		i++;
+		if (i%delta == 0) {                    /* FPE here if delta=0*/
+			alpha -= alpha / nnq->alphadec;
+			radius -= radius / radiusdec;
+			rad = radius >> radiusbiasshift;
+			if (rad <= 1) rad = 0;
+			for (j=0; j<rad; j++)
+				nnq->radpower[j] = alpha*(((rad*rad - j*j)*radbias)/(rad*rad));
+		}
+	}
+	if (verbose) gd_error_ex(GD_NOTICE, "finished 1D learning: final alpha=%f !\n",((float)alpha)/initalpha);
+}
+
+/**
+ * Function: gdImageNeuQuant
+ *
+ * Creates a new palette image from a truecolor image
+ *
+ * This is the same as calling <gdImageCreatePaletteFromTrueColor> with the
+ * quantization method <GD_QUANT_NEUQUANT>.
+ *
+ * Parameters:
+ *   im            - The image.
+ *   max_color     - The number of desired palette entries.
+ *   sample_factor - The quantization precision between 1 (highest quality) and
+ *                   10 (fastest).
+ *
+ * Returns:
+ *   A newly create palette image; NULL on failure.
+ */
+gdImagePtr gdImageNeuQuant(gdImagePtr im, const int max_color, int sample_factor)
+{
+	const int newcolors = max_color;
+	const int verbose = 1;
+
+	int bot_idx, top_idx; /* for remapping of indices */
+	int remap[MAXNETSIZE];
+	int i,x;
+
+	unsigned char map[MAXNETSIZE][4];
+	unsigned char *d;
+
+	nn_quant *nnq = NULL;
+
+	int row;
+	unsigned char *rgba = NULL;
+	gdImagePtr dst = NULL;
+
+	/* Default it to 3 */
+	if (sample_factor < 1) {
+		sample_factor = 3;
+	}
+	/* Start neuquant */
+	/* Pierre:
+	 * This implementation works with aligned contiguous buffer only
+	 * Upcoming new buffers are contiguous and will be much faster.
+	 * let don't bloat this code to support our good "old" 31bit format.
+	 * It also lets us convert palette image, if one likes to reduce
+	 * a palette
+	 */
+	if (overflow2(gdImageSX(im), gdImageSY(im))
+	        || overflow2(gdImageSX(im) * gdImageSY(im), 4)) {
+		goto done;
+	}
+	rgba = (unsigned char *) gdMalloc(gdImageSX(im) * gdImageSY(im) * 4);
+	if (!rgba) {
+		goto done;
+	}
+
+	d = rgba;
+	for (row = 0; row < gdImageSY(im); row++) {
+		int *p = im->tpixels[row];
+		register int c;
+
+		for (i = 0; i < gdImageSX(im); i++) {
+			c = *p;
+			*d++ = gdImageAlpha(im, c);
+			*d++ = gdImageRed(im, c);
+			*d++ = gdImageBlue(im, c);
+			*d++ = gdImageGreen(im, c);
+			p++;
+		}
+	}
+
+	nnq = (nn_quant *) gdMalloc(sizeof(nn_quant));
+	if (!nnq) {
+		goto done;
+	}
+
+	initnet(nnq, rgba, gdImageSY(im) * gdImageSX(im) * 4, sample_factor, newcolors);
+
+	learn(nnq, verbose);
+	unbiasnet(nnq);
+	getcolormap(nnq, (unsigned char*)map);
+	inxbuild(nnq);
+	/* remapping colormap to eliminate opaque tRNS-chunk entries... */
+	for (top_idx = newcolors-1, bot_idx = x = 0;  x < newcolors;  ++x) {
+		if (map[x][3] == 255) { /* maxval */
+			remap[x] = top_idx--;
+		} else {
+			remap[x] = bot_idx++;
+		}
+	}
+	if (bot_idx != top_idx + 1) {
+		gd_error("  internal logic error: remapped bot_idx = %d, top_idx = %d\n",
+			 bot_idx, top_idx);
+		goto done;
+	}
+
+	dst = gdImageCreate(gdImageSX(im), gdImageSY(im));
+	if (!dst) {
+		goto done;
+	}
+
+	for (x = 0; x < newcolors; ++x) {
+		dst->red[remap[x]] = map[x][0];
+		dst->green[remap[x]] = map[x][1];
+		dst->blue[remap[x]] = map[x][2];
+		dst->alpha[remap[x]] = map[x][3];
+		dst->open[remap[x]] = 0;
+		dst->colorsTotal++;
+	}
+
+	/* Do each image row */
+	for ( row = 0; row < gdImageSY(im); ++row ) {
+		int offset;
+		unsigned char *p = dst->pixels[row];
+
+		/* Assign the new colors */
+		offset = row * gdImageSX(im) * 4;
+		for(i=0; i < gdImageSX(im); i++) {
+			p[i] = remap[
+			           inxsearch(nnq, rgba[i * 4 + offset + ALPHA],
+			                     rgba[i * 4 + offset + BLUE],
+			                     rgba[i * 4 + offset + GREEN],
+			                     rgba[i * 4 + offset + RED])
+			       ];
+		}
+	}
+
+done:
+	if (rgba) {
+		gdFree(rgba);
+	}
+
+	if (nnq) {
+		gdFree(nnq);
+	}
+	return dst;
+}

--- a/ext/gd/libgd/gd_nnquant.h
+++ b/ext/gd/libgd/gd_nnquant.h
@@ -1,0 +1,16 @@
+/* maximum number of colours that can be used.
+  actual number is now passed to initcolors */
+#define MAXNETSIZE	256
+
+/* For 256 colours, fixed arrays need 8kb, plus space for the image
+   ---------------------------------------------------------------- */
+
+
+/* four primes near 500 - assume no image has a length so large */
+/* that it is divisible by all four primes */
+#define prime1		499
+#define prime2		491
+#define prime3		487
+#define prime4		503
+
+#define minpicturebytes	(4*prime4)		/* minimum size for input image */

--- a/ext/gd/libgd/gd_topal.c
+++ b/ext/gd/libgd/gd_topal.c
@@ -39,6 +39,10 @@
 #include "gd.h"
 #include "gdhelpers.h"
 
+#ifdef HAVE_LIBIMAGEQUANT
+#include <libimagequant.h>
+#endif
+
 /* (Re)define some defines known by libjpeg */
 #define QUANT_2PASS_SUPPORTED
 
@@ -1552,7 +1556,7 @@ static void *malloc16(size_t size)
 	void *p;
 	return posix_memalign(&p, 16, size) == 0 ? p : NULL;
 #else
-	return _aligned_malloc(16, size);
+	return _aligned_malloc(size, 16);
 #endif
 }
 #endif

--- a/ext/gd/tests/bug67325.phpt
+++ b/ext/gd/tests/bug67325.phpt
@@ -14,6 +14,7 @@ if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.3', '<=')) {
 $filename = __DIR__ . DIRECTORY_SEPARATOR . 'bug67325.jpg';
 
 $im = imagecreatefromjpeg($filename);
+imagetruecolortopalettesetmethod($im, IMG_QUANT_JQUANT);
 imagetruecolortopalette($im, 0, 256);
 
 $white = 0;

--- a/ext/gd/tests/imagetruecolortopalette_basic.phpt
+++ b/ext/gd/tests/imagetruecolortopalette_basic.phpt
@@ -24,6 +24,7 @@ $b = imagecolorallocate($image,0,255,255);
 $half =  imagefilledarc ( $image, 75, 75, 70, 70, 0, 180, $a, IMG_ARC_PIE );
 $half2 =  imagefilledarc ( $image, 75, 55, 80, 70, 0, -180, $b, IMG_ARC_PIE );
 
+imagetruecolortopalettesetmethod($image, IMG_QUANT_JQUANT);
 var_dump(imagetruecolortopalette($image, true, 2));
 
 include_once __DIR__ . '/func.inc';

--- a/ext/gd/tests/imagetruecolortopalette_methods.phpt
+++ b/ext/gd/tests/imagetruecolortopalette_methods.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Different quantization methods produce similar results
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+require_once __DIR__ . "/similarity.inc";
+
+$im1 = imagecreatefromjpeg(__DIR__ . "/conv_test.jpg");
+imagetruecolortopalettesetmethod($im1, IMG_QUANT_DEFAULT);
+imagetruecolortopalette($im1, false, 64);
+imagepalettetotruecolor($im1);
+
+$im2 = imagecreatefromjpeg(__DIR__ . "/conv_test.jpg");
+imagetruecolortopalettesetmethod($im2, IMG_QUANT_NEUQUANT);
+@imagetruecolortopalette($im2, false, 64); // NeuQuant emits diagnostic notices
+imagepalettetotruecolor($im2);
+
+var_dump(calc_image_dissimilarity($im1, $im2) < 5e5);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
As is, ext/gd only supports the default color quantization algorithm, which is used for `imagetruecolortopalette()`.  However, libgd supports alternative algorithms as of GD 2.1.0, namely NeuQuant (which is built in) and libimagequant (which is used by pngquant).

We add support for these alternative color quantization algorithms as small wrappers around the two respective libgd functions, introducing also a couple of constants.  We also add the nnquant module to our bundled libgd.

---

TODO:
- [ ] port https://github.com/libgd/libgd/pull/916
- [ ] port https://github.com/libgd/libgd/pull/918?
- [ ] add more tests (maybe for gd_info())?
- [ ] add support for libimagequant to bundled libgd (no-go for official Windows binaries since GPL, though)
- [ ] info about available quantization methods (gdinfo, phpinfo)
- [ ] add libimagequant to some CI jobs?

References:
https://libgd.github.io/manuals/2.3.3/files/gd_topal-c.html