### PR TITLE
Implement GH-15680: Enhance zend_dump_op_array to Properly Represent Non-Printable Characters in String Literals

### DIFF
--- a/ext/opcache/tests/match/002.phpt
+++ b/ext/opcache/tests/match/002.phpt
@@ -44,16 +44,14 @@ test:
      ; (lines=2, args=0, vars=0, tmps=0)
      ; (after optimizer)
      ; %s
-0000 ECHO string("No match
-")
+0000 ECHO string("No match\n")
 0001 RETURN null
 
 test2:
      ; (lines=2, args=0, vars=0, tmps=0)
      ; (after optimizer)
      ; %s
-0000 ECHO string("No match
-")
+0000 ECHO string("No match\n")
 0001 RETURN null
 No match
 No match

--- a/ext/opcache/tests/opt/dce_009.phpt
+++ b/ext/opcache/tests/opt/dce_009.phpt
@@ -50,10 +50,8 @@ Loop::test:
      ; (lines=3, args=0, vars=0, tmps=0)
      ; (after optimizer)
      ; %sdce_009.php:4-10
-0000 ECHO string("Start
-")
-0001 ECHO string("Done
-")
+0000 ECHO string("Start\n")
+0001 ECHO string("Done\n")
 0002 RETURN null
 
 Loop::test2:

--- a/ext/opcache/tests/opt/sccp_032.phpt
+++ b/ext/opcache/tests/opt/sccp_032.phpt
@@ -36,8 +36,7 @@ $_main:
 0004 INIT_FCALL 1 %d string("var_export")
 0005 SEND_VAR CV0($x) 1
 0006 DO_ICALL
-0007 ECHO string("
-")
+0007 ECHO string("\n")
 0008 JMP 0003
 0009 FE_FREE V1
 0010 RETURN int(1)


### PR DESCRIPTION
Replaces GH-15730 as that PR became stale, I'll credit @WangYihang too.

Simpler patch than GH-15730, instead of introducing a new helper, reuse
smart_str_append_escaped(), this also removes the dependency on ext/standard.