### PR TITLE
ext/sockets: socket_create_listen() check port value beforehand.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -680,6 +680,11 @@ PHP_FUNCTION(socket_create_listen)
 		Z_PARAM_LONG(backlog)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (port < 0 || port > USHRT_MAX) {
+		zend_argument_value_error(1, "must be between 0 and %u", USHRT_MAX);
+		RETURN_THROWS();
+	}
+
 	object_init_ex(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -217,7 +217,7 @@ zend_module_entry sockets_module_entry = {
 ZEND_GET_MODULE(sockets)
 #endif
 
-static bool php_open_listen_sock(php_socket *sock, int port, int backlog) /* {{{ */
+static bool php_open_listen_sock(php_socket *sock, unsigned short port, int backlog) /* {{{ */
 {
 	struct sockaddr_in  la = {0};
 	struct hostent	    *hp;
@@ -232,7 +232,7 @@ static bool php_open_listen_sock(php_socket *sock, int port, int backlog) /* {{{
 
 	memcpy((char *) &la.sin_addr, hp->h_addr, hp->h_length);
 	la.sin_family = hp->h_addrtype;
-	la.sin_port = htons((unsigned short) port);
+	la.sin_port = htons(port);
 
 	sock->bsd_socket = socket(PF_INET, SOCK_STREAM, 0);
 	sock->blocking = 1;
@@ -688,7 +688,7 @@ PHP_FUNCTION(socket_create_listen)
 	object_init_ex(return_value, socket_ce);
 	php_sock = Z_SOCKET_P(return_value);
 
-	if (!php_open_listen_sock(php_sock, port, backlog)) {
+	if (!php_open_listen_sock(php_sock, (unsigned short)port, backlog)) {
 		zval_ptr_dtor(return_value);
 		RETURN_FALSE;
 	}

--- a/ext/sockets/tests/socket_create_listen_invalid_port.phpt
+++ b/ext/sockets/tests/socket_create_listen_invalid_port.phpt
@@ -1,0 +1,24 @@
+--TEST--
+socket_create_listen() using invalid ports
+--EXTENSIONS--
+sockets
+--FILE--
+<?php
+var_dump(socket_create_listen(0));
+
+try {
+	socket_create_listen(-1);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	socket_create_listen(65536);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+object(Socket)#1 (0) {
+}
+socket_create_listen(): Argument #1 ($port) must be between 0 and 65535
+socket_create_listen(): Argument #1 ($port) must be between 0 and 65535


### PR DESCRIPTION
port is a 16 bit field, limited to the 65535 value then. Note that 0 is a valid case for ephemeral port.