### PR TITLE
Fix GH-17280: ldap_search() fails when $attributes array has holes

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1498,7 +1498,7 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 			goto process;
 		}
 		if (!php_ldap_is_numerically_indexed_array(attributes)) {
-			zend_argument_value_error(4, "must be an array with numeric indices");
+			zend_argument_value_error(4, "must be an array with numeric keys");
 			RETURN_THROWS();
 		}
 		/* Allocate +1 as we need an extra entry to NULL terminate the list */
@@ -2319,7 +2319,7 @@ static void php_ldap_do_modify(INTERNAL_FUNCTION_PARAMETERS, int oper, int ext)
 				goto cleanup;
 			}
 			if (!php_ldap_is_numerically_indexed_array(Z_ARRVAL_P(attribute_values))) {
-				zend_argument_value_error(3, "must be an array of attribute values with numeric indices");
+				zend_argument_value_error(3, "must be an array of attribute values with numeric keys");
 				RETVAL_FALSE;
 				goto cleanup;
 			}
@@ -2612,7 +2612,7 @@ PHP_FUNCTION(ldap_modify_batch)
 		RETURN_THROWS();
 	}
 	if (!php_ldap_is_numerically_indexed_array(modifications)) {
-		zend_argument_value_error(3, "must be an array with numeric indices");
+		zend_argument_value_error(3, "must be an array with numeric keys");
 		RETURN_THROWS();
 	}
 
@@ -2707,7 +2707,7 @@ PHP_FUNCTION(ldap_modify_batch)
 			RETURN_THROWS();
 		}
 		if (!php_ldap_is_numerically_indexed_array(modification_values)) {
-			zend_argument_value_error(3, "the value for option \"" LDAP_MODIFY_BATCH_VALUES "\" must be an array with numeric indices");
+			zend_argument_value_error(3, "the value for option \"" LDAP_MODIFY_BATCH_VALUES "\" must be an array with numeric keys");
 			RETURN_THROWS();
 		}
 	} ZEND_HASH_FOREACH_END();

--- a/ext/ldap/tests/gh17280.phpt
+++ b/ext/ldap/tests/gh17280.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-17280 (ldap_search() fails when $attributes array has holes)
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+/* We are assuming 3333 is not connectable */
+$ldap = ldap_connect('ldap://127.0.0.1:3333');
+
+// Creating an array with a hole in it
+$attr = array_unique(['cn', 'uid', 'uid', 'mail']);
+var_dump(ldap_search($ldap, 'ou=people,dc=example,dc=com', 'uid=admin', $attr));
+
+?>
+--EXPECTF--
+Warning: ldap_search(): Search: Can't contact LDAP server in %s on line %d
+bool(false)

--- a/ext/ldap/tests/ldap_add_modify_delete_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_add_modify_delete_programming_errors.phpt
@@ -138,6 +138,6 @@ ValueError: ldap_add(): Argument #3 ($entry) key must not be empty
 ValueError: ldap_add(): Argument #3 ($entry) key must not contain any null bytes
 Error: Object of class stdClass could not be converted to string
 ValueError: ldap_add(): Argument #3 ($entry) list of attribute values must not be empty
-ValueError: ldap_add(): Argument #3 ($entry) must be a list of attribute values
+ValueError: ldap_add(): Argument #3 ($entry) must be an array of attribute values with numeric indices
 TypeError: LDAP value must be of type string|int|bool, array given
 Error: Object of class stdClass could not be converted to string

--- a/ext/ldap/tests/ldap_add_modify_delete_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_add_modify_delete_programming_errors.phpt
@@ -138,6 +138,6 @@ ValueError: ldap_add(): Argument #3 ($entry) key must not be empty
 ValueError: ldap_add(): Argument #3 ($entry) key must not contain any null bytes
 Error: Object of class stdClass could not be converted to string
 ValueError: ldap_add(): Argument #3 ($entry) list of attribute values must not be empty
-ValueError: ldap_add(): Argument #3 ($entry) must be an array of attribute values with numeric indices
+ValueError: ldap_add(): Argument #3 ($entry) must be an array of attribute values with numeric keys
 TypeError: LDAP value must be of type string|int|bool, array given
 Error: Object of class stdClass could not be converted to string

--- a/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
@@ -80,7 +80,7 @@ try {
 TypeError: ldap_list(): Argument #1 ($ldap) must be of type LDAP\Connection|array, int given
 TypeError: ldap_list(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
 TypeError: ldap_list(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
-ValueError: ldap_list(): Argument #4 ($attributes) must be an array with numeric indices
+ValueError: ldap_list(): Argument #4 ($attributes) must be an array with numeric keys
 TypeError: ldap_list(): Argument #4 ($attributes) must be a list of strings, int given
 ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes
 ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes

--- a/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
+++ b/ext/ldap/tests/ldap_list_read_search_programming_errors.phpt
@@ -80,7 +80,7 @@ try {
 TypeError: ldap_list(): Argument #1 ($ldap) must be of type LDAP\Connection|array, int given
 TypeError: ldap_list(): Argument #2 ($base) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
 TypeError: ldap_list(): Argument #3 ($filter) must be of type string when argument #1 ($ldap) is an LDAP\Connection instance
-ValueError: ldap_list(): Argument #4 ($attributes) must be a list
+ValueError: ldap_list(): Argument #4 ($attributes) must be an array with numeric indices
 TypeError: ldap_list(): Argument #4 ($attributes) must be a list of strings, int given
 ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes
 ValueError: ldap_list(): Argument #4 ($attributes) must not contain strings with any null bytes

--- a/ext/ldap/tests/ldap_modify_batch_programming_error.phpt
+++ b/ext/ldap/tests/ldap_modify_batch_programming_error.phpt
@@ -216,19 +216,6 @@ try {
     echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
 
-$modification_values_not_list2 = [
-    [
-        "attrib"  => "attrib1",
-        "modtype" => LDAP_MODIFY_BATCH_ADD,
-        "values"  => $not_list2,
-    ],
-];
-try {
-    var_dump(ldap_modify_batch($ldap, $valid_dn, $modification_values_not_list2));
-} catch (Throwable $e) {
-    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
-}
-
 $modification_missing_attrib_key = [
     [
         "modtype" => LDAP_MODIFY_BATCH_ADD,
@@ -257,8 +244,8 @@ try {
 --EXPECT--
 ValueError: ldap_modify_batch(): Argument #2 ($dn) must not contain any null bytes
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must not be empty
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must be a list
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must be a list
+ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must be an array with numeric indices
+ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must only contain the keys "attrib", "modtype", and "values"
 TypeError: ldap_modify_batch(): Argument #3 ($modifications_info) must only contain arrays
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must not contain the "values" option when option "modtype" is LDAP_MODIFY_BATCH_REMOVE_ALL
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must only contain the keys "attrib", "modtype", and "values"
@@ -270,7 +257,6 @@ ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modificatio
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "values" option when the "modtype" option is not LDAP_MODIFY_BATCH_REMOVE_ALL
 TypeError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be of type array, string given
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must not be empty
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be a list
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be a list
+ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be an array with numeric indices
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "attrib" option
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "modtype" option

--- a/ext/ldap/tests/ldap_modify_batch_programming_error.phpt
+++ b/ext/ldap/tests/ldap_modify_batch_programming_error.phpt
@@ -244,7 +244,7 @@ try {
 --EXPECT--
 ValueError: ldap_modify_batch(): Argument #2 ($dn) must not contain any null bytes
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must not be empty
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must be an array with numeric indices
+ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) must be an array with numeric keys
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must only contain the keys "attrib", "modtype", and "values"
 TypeError: ldap_modify_batch(): Argument #3 ($modifications_info) must only contain arrays
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must not contain the "values" option when option "modtype" is LDAP_MODIFY_BATCH_REMOVE_ALL
@@ -257,6 +257,6 @@ ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modificatio
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "values" option when the "modtype" option is not LDAP_MODIFY_BATCH_REMOVE_ALL
 TypeError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be of type array, string given
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must not be empty
-ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be an array with numeric indices
+ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) the value for option "values" must be an array with numeric keys
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "attrib" option
 ValueError: ldap_modify_batch(): Argument #3 ($modifications_info) a modification entry must contain the "modtype" option

--- a/ext/ldap/tests/ldap_search_error.phpt
+++ b/ext/ldap/tests/ldap_search_error.phpt
@@ -20,7 +20,7 @@ $result = ldap_search($link, $dn, $filter);
 var_dump($result);
 
 try {
-    $result = ldap_search($link, $dn, $filter, array(1 => 'top'));
+    $result = ldap_search($link, $dn, $filter, array('foo' => 'top'));
     var_dump($result);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
@@ -60,7 +60,7 @@ try {
 --EXPECTF--
 Warning: ldap_search(): Search: No such object in %s on line %d
 bool(false)
-ldap_search(): Argument #4 ($attributes) must be a list
+ldap_search(): Argument #4 ($attributes) must be an array with numeric keys
 ldap_search(): Argument #1 ($ldap) must not be empty
 ldap_search(): Argument #2 ($base) must be the same size as argument #1
 ldap_search(): Argument #3 ($filter) must be the same size as argument #1


### PR DESCRIPTION
We relax the constraint that the array must be a list. What really matters is that it only has numeric keys. As shown in the example code, it's really easy to accidentally create a non-list array, so it makes sense to relax the constraint.
There are 3 cases left where the array is checked to be a list, in php_ldap_do_search, but I believe this makes sense to keep because the indices of those arrays have a meaning because they should match between different arrays. In that case it will prevent programmer errors.