### PR TITLE
Fix GH-17208: bug64539-status-json-encoding.phpt fail on 32-bits

### DIFF
--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -598,7 +598,7 @@ int fpm_status_handle_request(void) /* {{{ */
 					time_buffer,
 					(unsigned long) (now_epoch - proc->start_epoch),
 					proc->requests,
-					duration.tv_sec * 1000000UL + duration.tv_usec,
+					(unsigned long) (duration.tv_sec * 1000000UL + duration.tv_usec),
 					proc->request_method[0] != '\0' ? proc->request_method : "-",
 					proc->request_uri[0] != '\0' ? proc->request_uri : "-",
 					query_string ? "?" : "",


### PR DESCRIPTION
The reason this breaks is because of a type mismatch. The following line uses fields of the timeval struct which are both 8 bytes on Alpine 32-bit, which results in a computed value of also 8 bytes: https://github.com/php/php-src/blob/b09ed9a0f25cda8c9eea9d140c01587cd50b4aa8/sapi/fpm/fpm/fpm_status.c#L611

However, it is passed to a format string which expects 4 bytes (`unsigned long` and thus the `%lu` format specifier is 4 bytes on Alpine 32-bit), resulting in argument corruption.
Since the value is generally small, truncating to 4 bytes is sufficient to fix this.