### PR TITLE
ext/pdo: Use memcpy instead of strlcpy for copying default error code

### DIFF
--- a/ext/pdo/php_pdo_error.h
+++ b/ext/pdo/php_pdo_error.h
@@ -22,13 +22,17 @@
 PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt);
 
 #define PDO_DBH_CLEAR_ERR()             do { \
-	strlcpy(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
+	ZEND_ASSERT(sizeof(dbh->error_code) == sizeof(PDO_ERR_NONE)); \
+	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
 	if (dbh->query_stmt) { \
 		dbh->query_stmt = NULL; \
 		zval_ptr_dtor(&dbh->query_stmt_zval); \
 	} \
 } while (0)
-#define PDO_STMT_CLEAR_ERR()    strcpy(stmt->error_code, PDO_ERR_NONE)
+#define PDO_STMT_CLEAR_ERR() do { \
+	ZEND_ASSERT(sizeof(stmt->error_code) == sizeof(PDO_ERR_NONE)); \
+	memcpy(stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
+} while (0)
 #define PDO_HANDLE_DBH_ERR()    if (strcmp(dbh->error_code, PDO_ERR_NONE)) { pdo_handle_error(dbh, NULL); }
 #define PDO_HANDLE_STMT_ERR()   if (strcmp(stmt->error_code, PDO_ERR_NONE)) { pdo_handle_error(stmt->dbh, stmt); }
 


### PR DESCRIPTION
They have identical sizes, so there is no need for 'extra' safety.

See https://nrk.neocities.org/articles/not-a-fan-of-strlcpy for a rationale against the usage of strlcpy