### PR TITLE
ext/sockets: socket_bind() check port validity.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -1288,6 +1288,11 @@ PHP_FUNCTION(socket_bind)
 	php_sock = Z_SOCKET_P(arg1);
 	ENSURE_SOCKET_VALID(php_sock);
 
+	if (port < 0 || port > USHRT_MAX) {
+		zend_argument_value_error(3, "must be between 0 and %u", USHRT_MAX);
+		RETURN_THROWS();
+	}
+
 	switch(php_sock->type) {
 		case AF_UNIX:
 			{

--- a/ext/sockets/tests/socket_bind_invalid_port.phpt
+++ b/ext/sockets/tests/socket_bind_invalid_port.phpt
@@ -1,0 +1,23 @@
+--TEST--
+socket_bind() with invalid ports.
+--EXTENSIONS--
+sockets
+--FILE--
+<?php
+    $s_c     = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+    try {
+    	socket_bind($s_c, '0.0.0.0', -1);
+    } catch (\ValueError $e) {
+	    echo $e->getMessage() . PHP_EOL;
+    }
+
+    try {
+    	socket_bind($s_c, '0.0.0.0', 65536);
+    } catch (\ValueError $e) {
+	    echo $e->getMessage() . PHP_EOL;
+    }
+?>
+--EXPECT--
+socket_bind(): Argument #3 ($port) must be between 0 and 65535
+socket_bind(): Argument #3 ($port) must be between 0 and 65535


### PR DESCRIPTION
range from ephemeral port (0) to max unsigned 16 bits.