### PR TITLE
Test stream_context_tcp_nodelay_server on Windows

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -97,8 +97,9 @@ rem generate php.ini
 echo extension_dir=%PHP_BUILD_DIR% > %PHP_BUILD_DIR%\php.ini
 echo opcache.file_cache=%PHP_BUILD_DIR%\test_file_cache >> %PHP_BUILD_DIR%\php.ini
 if "%OPCACHE%" equ "1" echo zend_extension=php_opcache.dll >> %PHP_BUILD_DIR%\php.ini
-rem work-around for some spawned PHP processes requiring OpenSSL
+rem work-around for some spawned PHP processes requiring OpenSSL and sockets
 echo extension=php_openssl.dll >> %PHP_BUILD_DIR%\php.ini
+echo extension=php_sockets.dll >> %PHP_BUILD_DIR%\php.ini
 
 rem remove ext dlls for which tests are not supported
 for %%i in (imap ldap oci8_12c pdo_firebird pdo_oci snmp) do (

--- a/ext/standard/tests/streams/stream_context_tcp_nodelay_server.phpt
+++ b/ext/standard/tests/streams/stream_context_tcp_nodelay_server.phpt
@@ -5,9 +5,6 @@ sockets
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip sockets ext currently does not work in worker on Windows');
-}
 ?>
 --FILE--
 <?php
@@ -32,12 +29,12 @@ CODE;
 
 $clientCode = <<<'CODE'
     $test = stream_socket_client("tcp://{{ ADDR }}", $errno, $errstr, 10);
-
     echo phpt_wait();
 CODE;
 
 include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
 ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
---EXPECT--
+--EXPECTF--
 server-delay:conn-nodelay
+


### PR DESCRIPTION
This is to fix stream_context_tcp_nodelay_server which currently does not have socket extension available on Windows in worker.