### PR TITLE
ext/sockets: conversions internal changes.

### DIFF
--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -86,7 +86,7 @@ typedef struct {
 	/* zval info */
 	const char *name;
 	unsigned name_size;
-	int required;
+	bool required;
 
 	/* structure info */
 	size_t field_offset; /* 0 to pass full structure, e.g. when more than
@@ -584,9 +584,9 @@ static void to_zval_read_sin_addr(const char *data, zval *zv, res_context *ctx)
 	Z_STRLEN_P(zv) = strlen(Z_STRVAL_P(zv));
 }
 static const field_descriptor descriptors_sockaddr_in[] = {
-		{"family", sizeof("family"), 0, offsetof(struct sockaddr_in, sin_family), from_zval_write_sa_family, to_zval_read_sa_family},
-		{"addr", sizeof("addr"), 0, offsetof(struct sockaddr_in, sin_addr), from_zval_write_sin_addr, to_zval_read_sin_addr},
-		{"port", sizeof("port"), 0, offsetof(struct sockaddr_in, sin_port), from_zval_write_net_uint16, to_zval_read_net_uint16},
+		{"family", sizeof("family"), false, offsetof(struct sockaddr_in, sin_family), from_zval_write_sa_family, to_zval_read_sa_family},
+		{"addr", sizeof("addr"), false, offsetof(struct sockaddr_in, sin_addr), from_zval_write_sin_addr, to_zval_read_sin_addr},
+		{"port", sizeof("port"), false, offsetof(struct sockaddr_in, sin_port), from_zval_write_net_uint16, to_zval_read_net_uint16},
 		{0}
 };
 static void from_zval_write_sockaddr_in(const zval *container, char *sockaddr, ser_context *ctx)
@@ -635,11 +635,11 @@ static void to_zval_read_sin6_addr(const char *data, zval *zv, res_context *ctx)
 	Z_STRLEN_P(zv) = strlen(Z_STRVAL_P(zv));
 }
 static const field_descriptor descriptors_sockaddr_in6[] = {
-		{"family", sizeof("family"), 0, offsetof(struct sockaddr_in6, sin6_family), from_zval_write_sa_family, to_zval_read_sa_family},
-		{"addr", sizeof("addr"), 0, offsetof(struct sockaddr_in6, sin6_addr), from_zval_write_sin6_addr, to_zval_read_sin6_addr},
-		{"port", sizeof("port"), 0, offsetof(struct sockaddr_in6, sin6_port), from_zval_write_net_uint16, to_zval_read_net_uint16},
-		{"flowinfo", sizeof("flowinfo"), 0, offsetof(struct sockaddr_in6, sin6_flowinfo), from_zval_write_uint32, to_zval_read_uint32},
-		{"scope_id", sizeof("scope_id"), 0, offsetof(struct sockaddr_in6, sin6_scope_id), from_zval_write_uint32, to_zval_read_uint32},
+		{"family", sizeof("family"), false, offsetof(struct sockaddr_in6, sin6_family), from_zval_write_sa_family, to_zval_read_sa_family},
+		{"addr", sizeof("addr"), false, offsetof(struct sockaddr_in6, sin6_addr), from_zval_write_sin6_addr, to_zval_read_sin6_addr},
+		{"port", sizeof("port"), false, offsetof(struct sockaddr_in6, sin6_port), from_zval_write_net_uint16, to_zval_read_net_uint16},
+		{"flowinfo", sizeof("flowinfo"), false, offsetof(struct sockaddr_in6, sin6_flowinfo), from_zval_write_uint32, to_zval_read_uint32},
+		{"scope_id", sizeof("scope_id"), false, offsetof(struct sockaddr_in6, sin6_scope_id), from_zval_write_uint32, to_zval_read_uint32},
 		{0}
 };
 static void from_zval_write_sockaddr_in6(const zval *container, char *sockaddr6, ser_context *ctx)
@@ -1269,10 +1269,11 @@ static void from_zval_write_ifindex(const zval *zv, char *uinteger, ser_context 
 #elif defined(SIOCGIFINDEX)
 		{
 			struct ifreq ifr;
-			if (strlcpy(ifr.ifr_name, ZSTR_VAL(str), sizeof(ifr.ifr_name))
-					>= sizeof(ifr.ifr_name)) {
+			if (ZSTR_LEN(str) >= sizeof(ifr.ifr_name)) {
 				do_from_zval_err(ctx, "the interface name \"%s\" is too large ", ZSTR_VAL(str));
-			} else if (ioctl(ctx->sock->bsd_socket, SIOCGIFINDEX, &ifr) < 0) {
+			}
+			memcpy(ifr.ifr_name, ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+			if (ioctl(ctx->sock->bsd_socket, SIOCGIFINDEX, &ifr) < 0) {
 				if (errno == ENODEV) {
 					do_from_zval_err(ctx, "no interface with name \"%s\" could be "
 							"found", ZSTR_VAL(str));
@@ -1301,8 +1302,8 @@ static void from_zval_write_ifindex(const zval *zv, char *uinteger, ser_context 
 
 /* CONVERSIONS for struct in6_pktinfo */
 static const field_descriptor descriptors_in6_pktinfo[] = {
-		{"addr", sizeof("addr"), 1, offsetof(struct in6_pktinfo, ipi6_addr), from_zval_write_sin6_addr, to_zval_read_sin6_addr},
-		{"ifindex", sizeof("ifindex"), 1, offsetof(struct in6_pktinfo, ipi6_ifindex), from_zval_write_ifindex, to_zval_read_unsigned},
+		{"addr", sizeof("addr"), true, offsetof(struct in6_pktinfo, ipi6_addr), from_zval_write_sin6_addr, to_zval_read_sin6_addr},
+		{"ifindex", sizeof("ifindex"), true, offsetof(struct in6_pktinfo, ipi6_ifindex), from_zval_write_ifindex, to_zval_read_unsigned},
 		{0}
 };
 void from_zval_write_in6_pktinfo(const zval *container, char *in6_pktinfo_c, ser_context *ctx)
@@ -1321,25 +1322,25 @@ void to_zval_read_in6_pktinfo(const char *data, zval *zv, res_context *ctx)
 #if defined(SO_PASSCRED) || defined(LOCAL_CREDS_PERSISTENT) || defined(LOCAL_CREDS)
 static const field_descriptor descriptors_ucred[] = {
 #if defined(LOCAL_CREDS_PERSISTENT)
-		{"pid", sizeof("pid"), 1, offsetof(struct sockcred2, sc_pid), from_zval_write_pid_t, to_zval_read_pid_t},
-		{"uid", sizeof("uid"), 1, offsetof(struct sockcred2, sc_euid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"pid", sizeof("pid"), true, offsetof(struct sockcred2, sc_pid), from_zval_write_pid_t, to_zval_read_pid_t},
+		{"uid", sizeof("uid"), true, offsetof(struct sockcred2, sc_euid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* the type gid_t is the same as uid_t: */
-		{"gid", sizeof("gid"), 1, offsetof(struct sockcred2, sc_egid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"gid", sizeof("gid"), true, offsetof(struct sockcred2, sc_egid), from_zval_write_uid_t, to_zval_read_uid_t},
 #elif defined(LOCAL_CREDS)
-		{"pid", sizeof("pid"), 1, offsetof(struct sockcred, sc_pid), from_zval_write_pid_t, to_zval_read_pid_t},
-		{"uid", sizeof("uid"), 1, offsetof(struct sockcred, sc_euid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"pid", sizeof("pid"), true, offsetof(struct sockcred, sc_pid), from_zval_write_pid_t, to_zval_read_pid_t},
+		{"uid", sizeof("uid"), true, offsetof(struct sockcred, sc_euid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* the type gid_t is the same as uid_t: */
-		{"gid", sizeof("gid"), 1, offsetof(struct sockcred, sc_egid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"gid", sizeof("gid"), true, offsetof(struct sockcred, sc_egid), from_zval_write_uid_t, to_zval_read_uid_t},
 #elif defined(HAVE_STRUCT_CMSGCRED)
-		{"pid", sizeof("pid"), 1, offsetof(struct cmsgcred, cmcred_pid), from_zval_write_pid_t, to_zval_read_pid_t},
-		{"uid", sizeof("uid"), 1, offsetof(struct cmsgcred, cmcred_uid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"pid", sizeof("pid"), true, offsetof(struct cmsgcred, cmcred_pid), from_zval_write_pid_t, to_zval_read_pid_t},
+		{"uid", sizeof("uid"), true, offsetof(struct cmsgcred, cmcred_uid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* assume the type gid_t is the same as uid_t: */
-		{"gid", sizeof("gid"), 1, offsetof(struct cmsgcred, cmcred_gid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"gid", sizeof("gid"), true, offsetof(struct cmsgcred, cmcred_gid), from_zval_write_uid_t, to_zval_read_uid_t},
 #elif defined(SO_PASSCRED)
-		{"pid", sizeof("pid"), 1, offsetof(struct ucred, pid), from_zval_write_pid_t, to_zval_read_pid_t},
-		{"uid", sizeof("uid"), 1, offsetof(struct ucred, uid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"pid", sizeof("pid"), true, offsetof(struct ucred, pid), from_zval_write_pid_t, to_zval_read_pid_t},
+		{"uid", sizeof("uid"), true, offsetof(struct ucred, uid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* assume the type gid_t is the same as uid_t: */
-		{"gid", sizeof("gid"), 1, offsetof(struct ucred, gid), from_zval_write_uid_t, to_zval_read_uid_t},
+		{"gid", sizeof("gid"), true, offsetof(struct ucred, gid), from_zval_write_uid_t, to_zval_read_uid_t},
 #endif
 		{0}
 };


### PR DESCRIPTION
following up on strlcpy removal work too.