### PR TITLE
skip new test when offline

### DIFF
--- a/ext/standard/tests/http/gh16810.phpt
+++ b/ext/standard/tests/http/gh16810.phpt
@@ -3,7 +3,10 @@ Bug #79265 variation: "host:" not at start of header
 --INI--
 allow_url_fopen=1
 --SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+<?php
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
+if (getenv("SKIP_ONLINE_TESTS")) die("skip test requiring internet connection");
+?>
 --FILE--
 <?php
 $uri = "http://www.example.com";


### PR DESCRIPTION
Failing in offline build

```
001- resource(%d) of type (stream)
001+ Warning: fopen(): php_network_getaddresses: getaddrinfo for www.example.com failed: Temporary failure in name resolution in /builddir/build/BUILD/php84-php-8.4.3_RC1-build/php-8.4.3RC1/ext/standard/tests/http/gh16810.php on line 9
002+ 
003+ Warning: fopen(http://www.example.com): Failed to open stream: php_network_getaddresses: getaddrinfo for www.example.com failed: Temporary failure in name resolution in /builddir/build/BUILD/php84-php-8.4.3_RC1-build/php-8.4.3RC1/ext/standard/tests/http/gh16810.php on line 9
004+ bool(false)
     
     Warning: fopen(http://www.example.com): Failed to open stream: timeout must be lower than %d in %s on line %d
     bool(false)

```

ping @devnexen (as added by you)