### PR TITLE
Rewrite http gh16810 test to not be online

### DIFF
--- a/ext/standard/tests/http/gh16810.phpt
+++ b/ext/standard/tests/http/gh16810.phpt
@@ -1,16 +1,23 @@
 --TEST--
-Bug #79265 variation: "host:" not at start of header
+GH-16809 (fopen HTTP wrapper timeout stream context option overflow)
 --INI--
 allow_url_fopen=1
 --SKIPIF--
 <?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
 --FILE--
 <?php
-$uri = "http://www.example.com";
+$serverCode = <<<'CODE'
+echo 1;
+CODE;
+
+include __DIR__."/../../../../sapi/cli/tests/php_cli_server.inc";
+php_cli_server_start($serverCode, null, []);
+
+$uri = "http://" . PHP_CLI_SERVER_ADDRESS . '/test';
 $config = [
-'http' => [
-'timeout' => PHP_INT_MIN,
-],
+    'http' => [
+        'timeout' => PHP_INT_MIN,
+    ],
 ];
 $ctx = stream_context_create($config);
 var_dump(fopen($uri, "r", false, $ctx));
@@ -22,5 +29,5 @@ var_dump(fopen($uri, "r", false, $ctx));
 --EXPECTF--
 resource(%d) of type (stream)
 
-Warning: fopen(http://www.example.com): Failed to open stream: timeout must be lower than %d in %s on line %d
+Warning: fopen(http://%s): Failed to open stream: timeout must be lower than %d in %s on line %d
 bool(false)


### PR DESCRIPTION
This changes the test to not access external resources but use php cli server