### PR TITLE
Fix GH-11591: AppendIterator fails to iterate with an empty generator

### DIFF
--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -872,15 +872,6 @@ try_again:
 }
 /* }}} */
 
-static inline void zend_generator_ensure_initialized(zend_generator *generator) /* {{{ */
-{
-	if (UNEXPECTED(Z_TYPE(generator->value) == IS_UNDEF) && EXPECTED(generator->execute_data) && EXPECTED(generator->node.parent == NULL)) {
-		zend_generator_resume(generator);
-		generator->flags |= ZEND_GENERATOR_AT_FIRST_YIELD;
-	}
-}
-/* }}} */
-
 static inline void zend_generator_rewind(zend_generator *generator) /* {{{ */
 {
 	zend_generator_ensure_initialized(generator);

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -105,6 +105,14 @@ static const uint8_t ZEND_GENERATOR_IN_FIBER          = 0x10;
 void zend_register_generator_ce(void);
 ZEND_API void zend_generator_close(zend_generator *generator, bool finished_execution);
 ZEND_API void zend_generator_resume(zend_generator *generator);
+static inline void zend_generator_ensure_initialized(zend_generator *generator) /* {{{ */
+{
+	if (UNEXPECTED(Z_TYPE(generator->value) == IS_UNDEF) && EXPECTED(generator->execute_data) && EXPECTED(generator->node.parent == NULL)) {
+		zend_generator_resume(generator);
+		generator->flags |= ZEND_GENERATOR_AT_FIRST_YIELD;
+	}
+}
+/* }}} */
 
 ZEND_API void zend_generator_restore_call_stack(zend_generator *generator);
 ZEND_API zend_execute_data* zend_generator_freeze_call_stack(zend_execute_data *execute_data);

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -21,6 +21,7 @@
 #include "php.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"
+#include "zend_generators.h"
 #include "ext/pcre/php_pcre.h"
 
 #include "spl_iterators.h"
@@ -2812,6 +2813,15 @@ PHP_METHOD(AppendIterator, append)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &it, zend_ce_iterator) == FAILURE) {
 		RETURN_THROWS();
+	}
+
+	if (instanceof_function(Z_OBJCE_P(it), zend_ce_generator)) {
+		zend_generator *gen = (zend_generator*)Z_OBJ_P(it);
+		zend_generator_ensure_initialized(gen);
+		if (gen->execute_data == NULL) {
+			/* Skip an empty generator */
+			return;
+		}
 	}
 
 	SPL_FETCH_AND_CHECK_DUAL_IT(intern, ZEND_THIS);

--- a/ext/spl/tests/gh11591.phpt
+++ b/ext/spl/tests/gh11591.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug GH-11591 (Inconsistent behaviour with AppendIterator and empty generators)
+--FILE--
+<?php
+function yieldEmpty()
+{
+    yield from [];
+}
+
+$iterator = new AppendIterator();
+$iterator->append(yieldEmpty());
+
+foreach ($iterator as $item) {
+    var_dump($item);
+}
+?>
+--EXPECT--


### PR DESCRIPTION
Appending an empty generator is virtually a no-op, except that the generator gets consumed and is no longer available.
With this PR, `AppendIterator::apend` terminates early if its argument is an empty generator.