### PR TITLE
Split gd_color.c[ch] (sync with upstream)

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -219,6 +219,7 @@ if test "$PHP_GD" != "no"; then
     extra_sources=m4_normalize(["
       libgd/gd_avif.c
       libgd/gd_bmp.c
+      libgd/gd_color.c
       libgd/gd_color_match.c
       libgd/gd_crop.c
       libgd/gd_filter.c

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -53,7 +53,7 @@ if (PHP_GD != "no") {
 
 		EXTENSION("gd", "gd.c", null, "-Iext/gd/libgd");
 		ADD_SOURCES("ext/gd/libgd", "gd2copypal.c gd.c \
-			gdcache.c gdfontg.c gdfontl.c gdfontmb.c gdfonts.c gdfontt.c \
+			gdcache.c gd_color.c gdfontg.c gdfontl.c gdfontmb.c gdfonts.c gdfontt.c \
 			gdft.c gd_gd2.c gd_gd.c gd_gif_in.c gd_gif_out.c gdhelpers.c gd_io.c gd_io_dp.c \
 			gd_io_file.c gd_io_ss.c gd_jpeg.c gdkanji.c gd_png.c gd_ss.c \
 			gdtables.c gd_topal.c gd_wbmp.c gdxpm.c wbmp.c gd_xbm.c gd_security.c gd_transform.c \

--- a/ext/gd/libgd/gd_color.c
+++ b/ext/gd/libgd/gd_color.c
@@ -1,0 +1,35 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gd.h"
+#include "gd_color.h"
+
+/**
+ * The threshold method works relatively well but it can be improved.
+ * Maybe L*a*b* and Delta-E will give better results (and a better
+ * granularity).
+ */
+int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold)
+{
+	const int dr = gdImageRed(im, col1) - gdImageRed(im, col2);
+	const int dg = gdImageGreen(im, col1) - gdImageGreen(im, col2);
+	const int db = gdImageBlue(im, col1) - gdImageBlue(im, col2);
+	const int da = gdImageAlpha(im, col1) - gdImageAlpha(im, col2);
+	const int dist = dr * dr + dg * dg + db * db + da * da;
+
+	return 100.0 * dist < threshold * 195075.0;
+}
+
+/*
+ * To be implemented when we have more image formats.
+ * Buffer like gray8 gray16 or rgb8 will require some tweak
+ * and can be done in this function (called from the autocrop
+ * function. (Pierre)
+ */
+#if 0
+static int colors_equal (const int col1, const in col2)
+{
+
+}
+#endif

--- a/ext/gd/libgd/gd_color.h
+++ b/ext/gd/libgd/gd_color.h
@@ -1,0 +1,14 @@
+#ifndef GD_COLOR_H
+#define GD_COLOR_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ext/gd/libgd/gd_crop.c
+++ b/ext/gd/libgd/gd_crop.c
@@ -24,9 +24,9 @@
 #include <math.h>
 
 #include "gd.h"
+#include "gd_color.h"
 
 static int gdGuessBackgroundColorFromCorners(gdImagePtr im, int *color);
-static int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold);
 
 /**
  * Function: gdImageCrop
@@ -291,27 +291,3 @@ static int gdGuessBackgroundColorFromCorners(gdImagePtr im, int *color)
 		return 0;
 	}
 }
-
-static int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold)
-{
-	const int dr = gdImageRed(im, col1) - gdImageRed(im, col2);
-	const int dg = gdImageGreen(im, col1) - gdImageGreen(im, col2);
-	const int db = gdImageBlue(im, col1) - gdImageBlue(im, col2);
-	const int da = gdImageAlpha(im, col1) - gdImageAlpha(im, col2);
-	const int dist = dr * dr + dg * dg + db * db + da * da;
-
-	return (100.0 * dist / 195075) < threshold;
-}
-
-/*
- * To be implemented when we have more image formats.
- * Buffer like gray8 gray16 or rgb8 will require some tweak
- * and can be done in this function (called from the autocrop
- * function. (Pierre)
- */
-#if 0
-static int colors_equal (const int col1, const in col2)
-{
-
-}
-#endif


### PR DESCRIPTION
I have no idea why this has diverged in the first place. [Upstream introduced gd_color.[ch]](https://github.com/libgd/libgd/commit/b14559beb715a5acfffff3adfd2d55501944efa1) already in 2008, while [we have cropping support](https://github.com/php/php-src/commit/a991360344ed5bca7c20f74a10891d0fc52f0c9f) only since 2013. Anyhow, syncing with upstream now is better than never.

The code is the same, except for https://github.com/libgd/libgd/commit/d500229d7a4016f054cc689dfab0ab1177709731, what I don't understand, since there has been no int division in the first place due to usual arithmetic conversions, but at least there is not even a minor BC break. (Also note that this calculation doesn't make much sense, see https://github.com/libgd/libgd/issues/334).

One caveat, though: gd_color.h is now exported (see #16070; need to work on that).