### PR TITLE
ext/pdo_sqlite: Add setAuthorizer method for custom authorization callbacks

### DIFF
--- a/ext/pdo_sqlite/pdo_sqlite.stub.php
+++ b/ext/pdo_sqlite/pdo_sqlite.stub.php
@@ -63,4 +63,7 @@ class Sqlite extends \PDO
         ?string $dbname = "main",
         int $flags = \Pdo\Sqlite::OPEN_READONLY
     ) {}
+
+    /** @return bool */
+    public function setAuthorizer(?callable $callback): bool {}
 }

--- a/ext/pdo_sqlite/sqlite_driver_arginfo.h
+++ b/ext/pdo_sqlite/sqlite_driver_arginfo.h
@@ -20,6 +20,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_SQLite_Ext_s
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO_SQLite_setAuthorizer, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateFunction);
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateAggregate);
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateCollation);

--- a/ext/pdo_sqlite/sqlite_driver_arginfo.h
+++ b/ext/pdo_sqlite/sqlite_driver_arginfo.h
@@ -27,10 +27,12 @@ ZEND_END_ARG_INFO()
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateFunction);
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateAggregate);
 ZEND_METHOD(PDO_SQLite_Ext, sqliteCreateCollation);
+ZEND_METHOD(PDO_SQLite_Ext, setAuthorizer);
 
 static const zend_function_entry class_PDO_SQLite_Ext_methods[] = {
 	ZEND_ME(PDO_SQLite_Ext, sqliteCreateFunction, arginfo_class_PDO_SQLite_Ext_sqliteCreateFunction, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDO_SQLite_Ext, sqliteCreateAggregate, arginfo_class_PDO_SQLite_Ext_sqliteCreateAggregate, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDO_SQLite_Ext, sqliteCreateCollation, arginfo_class_PDO_SQLite_Ext_sqliteCreateCollation, ZEND_ACC_PUBLIC)
+	ZEND_ME(PDO_SQLite_Ext, setAuthorizer, arginfo_class_PDO_SQLite_setAuthorizer, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };


### PR DESCRIPTION
This commit introduces a new method `setAuthorizer` to the PDO_SQLite extension, allowing users to set a custom authorization callback for SQLite operations. The implementation includes a new structure to handle the callback data and a function to process authorization requests. Additionally, the method can remove the authorizer by passing a NULL callback. This enhancement improves the flexibility and security of database interactions.

Fixes: #17321

```php
$pdo = new PDO('sqlite:/path/to/database.sqlite');
$sqlite = $pdo->sqlite;

// Set an authorizer callback
$sqlite->setAuthorizer(function(int $actionCode, string $param1, string $param2, string $param3) {
    // $actionCode: SQLITE_CREATE_INDEX, SQLITE_CREATE_TABLE, etc.
    // $param1, $param2, $param3: Parameters specific to the action
    
    // Allow the action
    return true; // SQLITE_OK
    
    // Deny the action
    return false; // SQLITE_DENY
});

// Remove the authorizer
$sqlite->setAuthorizer(null);