### PR TITLE
Internalize gdImageScale*() and gdImageRotate*() helpers (sync with upstream)

### DIFF
--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -718,11 +718,6 @@ void gdImageCopyResized(gdImagePtr dst, gdImagePtr src, int dstX, int dstY, int 
 	substituted automatically. */
 void gdImageCopyResampled(gdImagePtr dst, gdImagePtr src, int dstX, int dstY, int srcX, int srcY, int dstW, int dstH, int srcW, int srcH);
 
-gdImagePtr gdImageRotate90(gdImagePtr src, int ignoretransparent);
-gdImagePtr gdImageRotate180(gdImagePtr src, int ignoretransparent);
-gdImagePtr gdImageRotate270(gdImagePtr src, int ignoretransparent);
-gdImagePtr gdImageRotateInterpolated(const gdImagePtr src, const float angle, int bgcolor);
-
 gdImagePtr gdImageClone(gdImagePtr src);
 
 void gdImageSetBrush(gdImagePtr im, gdImagePtr brush);
@@ -882,17 +877,8 @@ gdImagePtr gdImageCropThreshold(gdImagePtr im, const unsigned int color, const f
 int gdImageSetInterpolationMethod(gdImagePtr im, gdInterpolationMethod id);
 gdInterpolationMethod gdImageGetInterpolationMethod(gdImagePtr im);
 
-gdImagePtr gdImageScaleBilinear(gdImagePtr im, const unsigned int new_width, const unsigned int new_height);
-gdImagePtr gdImageScaleBicubic(gdImagePtr src_img, const unsigned int new_width, const unsigned int new_height);
-gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, const unsigned int height);
-gdImagePtr gdImageScaleNearestNeighbour(gdImagePtr im, const unsigned int width, const unsigned int height);
-gdImagePtr gdImageScaleTwoPass(const gdImagePtr pOrigImage, const unsigned int uOrigWidth, const unsigned int uOrigHeight, const unsigned int uNewWidth, const unsigned int uNewHeight);
 gdImagePtr gdImageScale(const gdImagePtr src, const unsigned int new_width, const unsigned int new_height);
 
-gdImagePtr gdImageRotateNearestNeighbour(gdImagePtr src, const float degrees, const int bgColor);
-gdImagePtr gdImageRotateBilinear(gdImagePtr src, const float degrees, const int bgColor);
-gdImagePtr gdImageRotateBicubicFixed(gdImagePtr src, const float degrees, const int bgColor);
-gdImagePtr gdImageRotateGeneric(gdImagePtr src, const float degrees, const int bgColor);
 gdImagePtr gdImageRotateInterpolated(const gdImagePtr src, const float angle, int bgcolor);
 
 typedef enum {

--- a/ext/gd/libgd/gd_intern.h
+++ b/ext/gd/libgd/gd_intern.h
@@ -10,5 +10,11 @@
 #define MAX3(a,b,c) ((a)<(b)?(MAX(b,c)):(MAX(a,c)))
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-#endif
+/* Internal prototypes: */
 
+/* gd_rotate.c */
+gdImagePtr gdImageRotate90(gdImagePtr src, int ignoretransparent);
+gdImagePtr gdImageRotate180(gdImagePtr src, int ignoretransparent);
+gdImagePtr gdImageRotate270(gdImagePtr src, int ignoretransparent);
+
+#endif

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -1069,10 +1069,6 @@ gdImageScaleTwoPass(const gdImagePtr src, const unsigned int src_width, const un
 	gdImagePtr dst;
 	int scale_pass_res;
 
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
-
 	/* Convert to truecolor if it isn't; this code requires it. */
 	if (!src->trueColor) {
 		gdImagePaletteToTrueColor(src);
@@ -1127,10 +1123,6 @@ gdImageScaleNearestNeighbour(gdImagePtr im, const unsigned int width, const unsi
 	unsigned long  dst_offset_y = 0;
 	unsigned int i;
 
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
-
 	dst_img = gdImageCreateTrueColor(new_width, new_height);
 
 	if (dst_img == NULL) {
@@ -1183,10 +1175,6 @@ static gdImagePtr gdImageScaleBilinearPalette(gdImagePtr im, const unsigned int 
 	long i;
 	gdImagePtr new_img;
 	const int transparent = im->transparent;
-
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
 
 	new_img = gdImageCreateTrueColor(new_width, new_height);
 	if (new_img == NULL) {
@@ -1284,10 +1272,6 @@ static gdImagePtr gdImageScaleBilinearTC(gdImagePtr im, const unsigned int new_w
 	int dst_offset_v = 0;
 	long i;
 	gdImagePtr new_img;
-
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
 
 	new_img = gdImageCreateTrueColor(new_width, new_height);
 	if (!new_img){
@@ -1388,10 +1372,6 @@ gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, const unsigne
 	unsigned int dst_offset_x;
 	unsigned int dst_offset_y = 0;
 	long i;
-
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
 
 	/* impact perf a bit, but not that much. Implementation for palette
 	   images can be done at a later point.
@@ -1671,10 +1651,6 @@ gdImageRotateNearestNeighbour(gdImagePtr src, const float degrees, const int bgC
     gdRotatedImageSize(src, degrees, &bbox);
     new_width = bbox.width;
     new_height = bbox.height;
-
-	if (new_width == 0 || new_height == 0) {
-		return NULL;
-	}
 
 	dst = gdImageCreateTrueColor(new_width, new_height);
 	if (!dst) {

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -67,14 +67,31 @@ TODO:
 # include <emmintrin.h>
 #endif
 
-#ifndef MIN
-#define MIN(a,b) ((a)<(b)?(a):(b))
-#endif
-#define MIN3(a,b,c) ((a)<(b)?(MIN(a,c)):(MIN(b,c)))
-#ifndef MAX
-#define MAX(a,b) ((a)<(b)?(b):(a))
-#endif
-#define MAX3(a,b,c) ((a)<(b)?(MAX(b,c)):(MAX(a,c)))
+static gdImagePtr gdImageScaleBilinear(gdImagePtr im,
+                                       const unsigned int new_width,
+                                       const unsigned int new_height);
+static gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src,
+                                           const unsigned int width,
+                                           const unsigned int height);
+static gdImagePtr gdImageScaleNearestNeighbour(gdImagePtr im,
+                                               const unsigned int width, const unsigned int height);
+static gdImagePtr gdImageScaleTwoPass(const gdImagePtr pOrigImage,
+                                      const unsigned int uOrigWidth,
+                                      const unsigned int uOrigHeight,
+                                      const unsigned int uNewWidth,
+                                      const unsigned int uNewHeight);
+static gdImagePtr gdImageRotateNearestNeighbour(gdImagePtr src,
+                                                const float degrees,
+                                                const int bgColor);
+static gdImagePtr gdImageRotateBilinear(gdImagePtr src,
+                                        const float degrees,
+                                        const int bgColor);
+static gdImagePtr gdImageRotateBicubicFixed(gdImagePtr src,
+                                            const float degrees,
+                                            const int bgColor);
+static gdImagePtr gdImageRotateGeneric(gdImagePtr src,
+                                       const float degrees,
+                                       const int bgColor);
 
 /* only used here, let do a generic fixed point integers later if required by other
    part of GD */
@@ -1045,7 +1062,8 @@ static inline int _gdScaleVert (const gdImagePtr pSrc, const unsigned int src_wi
 	return 1;
 }
 
-gdImagePtr gdImageScaleTwoPass(const gdImagePtr src, const unsigned int src_width, const unsigned int src_height, const unsigned int new_width, const unsigned int new_height)
+static gdImagePtr
+gdImageScaleTwoPass(const gdImagePtr src, const unsigned int src_width, const unsigned int src_height, const unsigned int new_width, const unsigned int new_height)
 {
 	gdImagePtr tmp_im;
 	gdImagePtr dst;
@@ -1094,7 +1112,8 @@ gdImagePtr gdImageScaleTwoPass(const gdImagePtr src, const unsigned int src_widt
 	Integer only implementation, good to have for common usages like pre scale very large
 	images before using another interpolation methods for the last step.
 */
-gdImagePtr gdImageScaleNearestNeighbour(gdImagePtr im, const unsigned int width, const unsigned int height)
+static gdImagePtr
+gdImageScaleNearestNeighbour(gdImagePtr im, const unsigned int width, const unsigned int height)
 {
 	const unsigned long new_width = MAX(1, width);
 	const unsigned long new_height = MAX(1, height);
@@ -1340,7 +1359,8 @@ static gdImagePtr gdImageScaleBilinearTC(gdImagePtr im, const unsigned int new_w
 	return new_img;
 }
 
-gdImagePtr gdImageScaleBilinear(gdImagePtr im, const unsigned int new_width, const unsigned int new_height)
+static gdImagePtr
+gdImageScaleBilinear(gdImagePtr im, const unsigned int new_width, const unsigned int new_height)
 {
 	if (im->trueColor) {
 		return gdImageScaleBilinearTC(im, new_width, new_height);
@@ -1349,7 +1369,8 @@ gdImagePtr gdImageScaleBilinear(gdImagePtr im, const unsigned int new_width, con
 	}
 }
 
-gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, const unsigned int height)
+static gdImagePtr
+gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, const unsigned int height)
 {
 	const long new_width = MAX(1, width);
 	const long new_height = MAX(1, height);
@@ -1628,7 +1649,8 @@ static int gdRotatedImageSize(gdImagePtr src, const float angle, gdRectPtr bbox)
     return GD_TRUE;
 }
 
-gdImagePtr gdImageRotateNearestNeighbour(gdImagePtr src, const float degrees, const int bgColor)
+static gdImagePtr
+gdImageRotateNearestNeighbour(gdImagePtr src, const float degrees, const int bgColor)
 {
 	float _angle = ((float) (-degrees / 180.0f) * (float)M_PI);
 	const int src_w  = gdImageSX(src);
@@ -1685,7 +1707,8 @@ gdImagePtr gdImageRotateNearestNeighbour(gdImagePtr src, const float degrees, co
 	return dst;
 }
 
-gdImagePtr gdImageRotateGeneric(gdImagePtr src, const float degrees, const int bgColor)
+static gdImagePtr
+gdImageRotateGeneric(gdImagePtr src, const float degrees, const int bgColor)
 {
 	float _angle = ((float) (-degrees / 180.0f) * (float)M_PI);
 	const int src_w  = gdImageSX(src);
@@ -1751,7 +1774,8 @@ gdImagePtr gdImageRotateGeneric(gdImagePtr src, const float degrees, const int b
 	return dst;
 }
 
-gdImagePtr gdImageRotateBilinear(gdImagePtr src, const float degrees, const int bgColor)
+static gdImagePtr
+gdImageRotateBilinear(gdImagePtr src, const float degrees, const int bgColor)
 {
 	float _angle = (float)((- degrees / 180.0f) * M_PI);
 	const unsigned int src_w = gdImageSX(src);
@@ -1866,7 +1890,8 @@ gdImagePtr gdImageRotateBilinear(gdImagePtr src, const float degrees, const int 
 	return dst;
 }
 
-gdImagePtr gdImageRotateBicubicFixed(gdImagePtr src, const float degrees, const int bgColor)
+static gdImagePtr
+gdImageRotateBicubicFixed(gdImagePtr src, const float degrees, const int bgColor)
 {
 	const float _angle = (float)((- degrees / 180.0f) * M_PI);
 	const int src_w = gdImageSX(src);


### PR DESCRIPTION
See individual commit messages for details.

Obviously, this is a BC break, and as such should be mentioned in UPGRADING.INTERNALS, but it's long overdue for parity with external libgd.

Note that I wanted to sync a bit more in this file, but looks like some issues in gd.c should be addressed first.
