### PR TITLE
Fix GH-17330: SNMP::setSecurity segfaults when object had been closed.

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1660,6 +1660,10 @@ PHP_METHOD(SNMP, setSecurity)
 	zend_string *a1 = NULL, *a2 = NULL, *a3 = NULL, *a4 = NULL, *a5 = NULL, *a6 = NULL, *a7 = NULL;
 
 	snmp_object = Z_SNMP_P(object);
+	if (!snmp_object->session) {
+		zend_throw_error(NULL, "Invalid or uninitialized SNMP object");
+		RETURN_THROWS();
+	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|SSSSSS", &a1, &a2, &a3, &a4,&a5, &a6, &a7) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/snmp/tests/gh17330.phpt
+++ b/ext/snmp/tests/gh17330.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SNMP::setSecurity() segfault when the object had been closed.
+--EXTENSIONS--
+snmp
+--CREDITS--
+YuanchengJiang 
+--FILE--
+<?php
+$session = new SNMP(SNMP::VERSION_2c, "localhost", 'timeout_community_432');
+$session->close();
+try {
+	$session->setSecurity('authPriv', 'MD5', '', 'AES', '');
+} catch(Error $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+Invalid or uninitialized SNMP object


### PR DESCRIPTION
having new macro when the workflow needs to deal with an existing SNMP session.