### PR TITLE
Port clip_1d() clipping rectangle improvement of libgd 2.0.26

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -2796,13 +2796,13 @@ void gdImageFilledPolygon (gdImagePtr im, gdPointPtr p, int n, int c)
 	}
 	pmaxy = maxy;
 	/* 2.0.16: Optimization by Ilia Chipitsine -- don't waste time offscreen */
-	if (miny < 0) {
-		miny = 0;
+	/* 2.0.26: clipping rectangle is even better */
+	if (miny < im->cy1) {
+		miny = im->cy1;
 	}
-	if (maxy >= gdImageSY(im)) {
-		maxy = gdImageSY(im) - 1;
+	if (maxy > im->cy2) {
+		maxy = im->cy2;
 	}
-
 	/* Fix in 1.3: count a vertex only once */
 	for (y = miny; y <= maxy; y++) {
 		/*1.4           int interLast = 0; */


### PR DESCRIPTION
This is not a functional change, but rather a performance improvement, to avoid unnecessary calls of `gdImageSetPixel()` which would be no-ops due to positions outside of the clipping bounds.