### PR TITLE
Cleanup iterator instantiation code

### DIFF
--- a/ext/dom/documenttype.c
+++ b/ext/dom/documenttype.c
@@ -23,6 +23,7 @@
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 #include "dom_properties.h"
+#include "internal_helpers.h"
 
 /* {{{ name	string
 readonly=yes
@@ -47,7 +48,7 @@ zend_result dom_documenttype_entities_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlDtdPtr, dtdptr, obj);
 
-	php_dom_create_iterator(retval, DOM_DTD_NAMEDNODEMAP, php_dom_follow_spec_intern(obj));
+	object_init_ex(retval, dom_get_dtd_namednodemap_ce(php_dom_follow_spec_intern(obj)));
 
 	xmlHashTable *entityht = (xmlHashTable *) dtdptr->entities;
 
@@ -68,7 +69,7 @@ zend_result dom_documenttype_notations_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlDtdPtr, dtdptr, obj);
 
-	php_dom_create_iterator(retval, DOM_DTD_NAMEDNODEMAP, php_dom_follow_spec_intern(obj));
+	object_init_ex(retval, dom_get_dtd_namednodemap_ce(php_dom_follow_spec_intern(obj)));
 
 	xmlHashTable *notationht = (xmlHashTable *) dtdptr->notations;
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -809,7 +809,7 @@ PHP_METHOD(Dom_Element, removeAttributeNode)
 Modern spec URL: https://dom.spec.whatwg.org/#concept-getelementsbytagname
 Since:
 */
-static void dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAMETERS, bool modern)
+static void dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAMETERS, zend_class_entry *iter_ce)
 {
 	dom_object *intern, *namednode;
 	zend_string *name;
@@ -825,23 +825,19 @@ static void dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAMETERS, b
 
 	DOM_GET_THIS_INTERN(intern);
 
-	if (modern) {
-		php_dom_create_iterator(return_value, DOM_HTMLCOLLECTION, true);
-	} else {
-		php_dom_create_iterator(return_value, DOM_NODELIST, false);
-	}
+	object_init_ex(return_value, iter_ce);
 	namednode = Z_DOMOBJ_P(return_value);
 	dom_namednode_iter(intern, 0, namednode, NULL, name, NULL);
 }
 
 PHP_METHOD(DOMElement, getElementsByTagName)
 {
-	dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+	dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAM_PASSTHRU, dom_nodelist_class_entry);
 }
 
 PHP_METHOD(Dom_Element, getElementsByTagName)
 {
-	dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+	dom_element_get_elements_by_tag_name(INTERNAL_FUNCTION_PARAM_PASSTHRU, dom_html_collection_class_entry);
 }
 /* }}} end dom_element_get_elements_by_tag_name */
 
@@ -1236,7 +1232,7 @@ PHP_METHOD(Dom_Element, setAttributeNodeNS)
 Modern spec URL: https://dom.spec.whatwg.org/#concept-getelementsbytagnamens
 Since: DOM Level 2
 */
-static void dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAMETERS, bool modern)
+static void dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAMETERS, zend_class_entry *iter_ce)
 {
 	dom_object *intern, *namednode;
 	zend_string *uri, *name;
@@ -1261,23 +1257,19 @@ static void dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAMETERS
 
 	DOM_GET_THIS_INTERN(intern);
 
-	if (modern) {
-		php_dom_create_iterator(return_value, DOM_HTMLCOLLECTION, true);
-	} else {
-		php_dom_create_iterator(return_value, DOM_NODELIST, false);
-	}
+	object_init_ex(return_value, iter_ce);
 	namednode = Z_DOMOBJ_P(return_value);
 	dom_namednode_iter(intern, 0, namednode, NULL, name, uri);
 }
 
 PHP_METHOD(DOMElement, getElementsByTagNameNS)
 {
-	dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+	dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAM_PASSTHRU, dom_nodelist_class_entry);
 }
 
 PHP_METHOD(Dom_Element, getElementsByTagNameNS)
 {
-	dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+	dom_element_get_elements_by_tag_name_ns(INTERNAL_FUNCTION_PARAM_PASSTHRU, dom_html_collection_class_entry);
 }
 /* }}} end dom_element_get_elements_by_tag_name_ns */
 

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -281,7 +281,7 @@ zend_result dom_node_child_nodes_read(dom_object *obj, zval *retval)
 {
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
-	php_dom_create_iterator(retval, DOM_NODELIST, php_dom_follow_spec_intern(obj));
+	object_init_ex(retval, dom_get_nodelist_ce(php_dom_follow_spec_intern(obj)));
 	dom_object *intern = Z_DOMOBJ_P(retval);
 	dom_namednode_iter(obj, XML_ELEMENT_NODE, intern, NULL, NULL, NULL);
 
@@ -415,7 +415,7 @@ zend_result dom_node_attributes_read(dom_object *obj, zval *retval)
 	DOM_PROP_NODE(xmlNodePtr, nodep, obj);
 
 	if (nodep->type == XML_ELEMENT_NODE) {
-		php_dom_create_iterator(retval, DOM_NAMEDNODEMAP, php_dom_follow_spec_intern(obj));
+		object_init_ex(retval, dom_get_namednodemap_ce(php_dom_follow_spec_intern(obj)));
 		dom_object *intern = Z_DOMOBJ_P(retval);
 		dom_namednode_iter(obj, XML_ATTRIBUTE_NODE, intern, NULL, NULL, NULL);
 	} else {

--- a/ext/dom/parentnode/css_selectors.c
+++ b/ext/dom/parentnode/css_selectors.c
@@ -245,7 +245,7 @@ void dom_parent_node_query_selector_all(xmlNodePtr thisp, dom_object *intern, zv
 		zend_array_destroy(list);
 		RETURN_THROWS();
 	} else {
-		php_dom_create_iterator(return_value, DOM_NODELIST, true);
+		object_init_ex(return_value, dom_modern_nodelist_class_entry);
 		dom_object *ret_obj = Z_DOMOBJ_P(return_value);
 		dom_nnodemap_object *mapptr = (dom_nnodemap_object *) ret_obj->ptr;
 		ZVAL_ARR(&mapptr->baseobj_zv, list);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1623,27 +1623,6 @@ zend_object *dom_nnodemap_objects_new(zend_class_entry *class_type)
 	return &intern->std;
 }
 
-void php_dom_create_iterator(zval *return_value, dom_iterator_type iterator_type, bool modern) /* {{{ */
-{
-	zend_class_entry *ce;
-
-	if (iterator_type == DOM_NAMEDNODEMAP) {
-		ce = dom_get_namednodemap_ce(modern);
-	} else if (iterator_type == DOM_HTMLCOLLECTION) {
-		/* This only exists in modern DOM. */
-		ZEND_ASSERT(modern);
-		ce = dom_html_collection_class_entry;
-	} else if (iterator_type == DOM_DTD_NAMEDNODEMAP) {
-		ce = dom_get_dtd_namednodemap_ce(modern);
-	} else {
-		ZEND_ASSERT(iterator_type == DOM_NODELIST);
-		ce = dom_get_nodelist_ce(modern);
-	}
-
-	object_init_ex(return_value, ce);
-}
-/* }}} */
-
 static zend_always_inline zend_class_entry *dom_get_element_ce(const xmlNode *node, bool modern)
 {
 	if (modern) {

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -109,13 +109,6 @@ typedef struct {
 	dom_object dom;
 } dom_object_namespace_node;
 
-typedef enum dom_iterator_type {
-	DOM_NODELIST,
-	DOM_NAMEDNODEMAP,
-	DOM_DTD_NAMEDNODEMAP,
-	DOM_HTMLCOLLECTION,
-} dom_iterator_type;
-
 struct php_dom_libxml_ns_mapper;
 typedef struct php_dom_libxml_ns_mapper php_dom_libxml_ns_mapper;
 
@@ -151,7 +144,6 @@ int dom_hierarchy(xmlNodePtr parent, xmlNodePtr child);
 bool dom_has_feature(zend_string *feature, zend_string *version);
 bool dom_node_is_read_only(const xmlNode *node);
 bool dom_node_children_valid(const xmlNode *node);
-void php_dom_create_iterator(zval *return_value, dom_iterator_type iterator_type, bool modern);
 void dom_namednode_iter(dom_object *basenode, int ntype, dom_object *intern, xmlHashTablePtr ht, zend_string *local, zend_string *ns);
 xmlNodePtr create_notation(const xmlChar *name, const xmlChar *ExternalID, const xmlChar *SystemID);
 xmlNode *php_dom_libxml_hash_iter(dom_nnodemap_object *objmap, int index);

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -24,6 +24,7 @@
 #include "php_dom.h"
 #include "namespace_compat.h"
 #include "private_data.h"
+#include "internal_helpers.h"
 
 #define PHP_DOM_XPATH_QUERY 0
 #define PHP_DOM_XPATH_EVALUATE 1
@@ -371,7 +372,7 @@ static void php_xpath_eval(INTERNAL_FUNCTION_PARAMETERS, int type, bool modern) 
 			} else {
 				ZVAL_EMPTY_ARRAY(&retval);
 			}
-			php_dom_create_iterator(return_value, DOM_NODELIST, modern);
+			object_init_ex(return_value, dom_get_nodelist_ce(modern));
 			nodeobj = Z_DOMOBJ_P(return_value);
 			dom_xpath_iter(&retval, nodeobj);
 			break;


### PR DESCRIPTION
Just using object_init_ex() directly makes the code a bit simpler and avoids unnecessary indirections.