### PR TITLE
ext/sockets: socket_addrinfo_lookup and other few internal changes

### DIFF
--- a/ext/sockets/tests/socket_getaddrinfo_error.phpt
+++ b/ext/sockets/tests/socket_getaddrinfo_error.phpt
@@ -84,6 +84,26 @@ try {
 } catch (\ValueError $e) {
 	echo $e->getMessage() . PHP_EOL;
 }
+try {
+	socket_addrinfo_lookup('127.0.0.1', 2000, [
+		AF_INET,
+		SOCK_DGRAM,
+		0,
+		0,
+	]);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+try {
+	socket_addrinfo_lookup('127.0.0.1', 2000, array(
+		'ai_family' => AF_INET,
+		'ai_socktype' => SOCK_DGRAM,
+		0,
+		0,
+	));
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
 ?>
 --EXPECTF--
 socket_addrinfo_lookup(): Argument #3 ($hints) "ai_family" key must be of type int, stdClass given
@@ -94,3 +114,5 @@ socket_addrinfo_lookup(): Argument #3 ($hints) "ai_family" key must be between 0
 socket_addrinfo_lookup(): Argument #3 ($hints) "ai_socktype" key must be between 0 and %d
 socket_addrinfo_lookup(): Argument #3 ($hints) "ai_flags" key must be between 0 and %d
 socket_addrinfo_lookup(): Argument #3 ($hints) "ai_protocol" key must be between 0 and %d
+socket_addrinfo_lookup(): Argument #3 ($hints) must only contain array keys "ai_flags", "ai_socktype", "ai_protocol", or "ai_family"
+socket_addrinfo_lookup(): Argument #3 ($hints) must only contain array keys "ai_flags", "ai_socktype", "ai_protocol", or "ai_family"


### PR DESCRIPTION
- socket_addrinfo_lookup throws when hints is an indexed array.
- socket_get_option hardcoding size outputs to user when data
  size known.