### PR TITLE
Port "merged and expanded settings from gd.h and gdft.c"

### DIFF
--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -17,20 +17,6 @@ extern "C" {
 #define GD_EXTRA_VERSION ""
 #define GD_VERSION_STRING "2.0.35"
 
-#ifdef NETWARE
-/* default fontpath for netware systems */
-#define DEFAULT_FONTPATH "sys:/java/nwgfx/lib/x11/fonts/ttf;."
-#define PATHSEPARATOR ";"
-#elif defined(_WIN32)
-/* default fontpath for windows systems */
-#define DEFAULT_FONTPATH "c:\\winnt\\fonts;c:\\windows\\fonts;."
-#define PATHSEPARATOR ";"
-#else
-/* default fontpath for unix systems */
-#define DEFAULT_FONTPATH "/usr/X11R6/lib/X11/fonts/TrueType:/usr/X11R6/lib/X11/fonts/truetype:/usr/X11R6/lib/X11/fonts/TTF:/usr/share/fonts/TrueType:/usr/share/fonts/truetype:/usr/openwin/lib/X11/fonts/TrueType:/usr/X11R6/lib/X11/fonts/Type1:."
-#define PATHSEPARATOR ":"
-#endif
-
 /* gd.h: declarations file for the graphic-draw module.
  * Permission to use, copy, modify, and distribute this software and its
  * documentation for any purpose and without fee is hereby granted, provided

--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -90,16 +90,26 @@ gdImageStringFT (gdImage * im, int *brect, int fg, char *fontlist,
  * some last resort values that might match some Un*x system
  * if building this version of gd separate from graphviz.
  */
+
 #ifndef DEFAULT_FONTPATH
-#if defined(__APPLE__) || (defined(__MWERKS__) && defined(macintosh))
-#define DEFAULT_FONTPATH "/usr/share/fonts/truetype:/System/Library/Fonts:/Library/Fonts"
-#else
-#define DEFAULT_FONTPATH "/usr/share/fonts/truetype"
+#  if defined(_WIN32)
+#    define DEFAULT_FONTPATH "C:\\WINDOWS\\FONTS;C:\\WINNT\\FONTS"
+#  elif defined(__APPLE__) || (defined(__MWERKS__) && defined(macintosh))
+#    define DEFAULT_FONTPATH "/usr/share/fonts/truetype:/System/Library/Fonts:/Library/Fonts"
+#  else
+   /* default fontpath for unix systems  - whatever happened to standards ! */
+#    define DEFAULT_FONTPATH "/usr/X11R6/lib/X11/fonts/TrueType:/usr/X11R6/lib/X11/fonts/truetype:/usr/X11R6/lib/X11/fonts/TTF:/usr/share/fonts/TrueType:/usr/share/fonts/truetype:/usr/openwin/lib/X11/fonts/TrueType:/usr/X11R6/lib/X11/fonts/Type1:/usr/lib/X11/fonts/Type1:/usr/openwin/lib/X11/fonts/Type1"
+#  endif
 #endif
-#endif
+
 #ifndef PATHSEPARATOR
-#define PATHSEPARATOR ":"
+#  if defined(_WIN32)
+#    define PATHSEPARATOR ";"
+#  else
+#    define PATHSEPARATOR ":"
+#  endif
 #endif
+
 
 #ifndef TRUE
 #define FALSE 0


### PR DESCRIPTION
This commit[1] and the related part of the Netware removal[2] move the related definitions out of gd.h, and bring some updates.

[1] <https://github.com/libgd/libgd/commit/2a921c80fbdd1d684f32bf763c26e024052314e6>
[2] <https://github.com/libgd/libgd/commit/e6bb110663722836ba1e6986b27252bc4402a33c>

---

Note that this can be regarded as bugfix for macOS (where previously the *nix default path was used), but also a BC break, since the the current directory is removed from the default path (what doesn't matter for ZTS builds due to #17366, though). Thus, applying to master only appears to be sensible.