### PR TITLE
Fix GH-17373: imagefttext() ignores clipping rect for palette images

### DIFF
--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -720,7 +720,7 @@ static char * gdft_draw_bitmap (gdCache_head_t *tc_cache, gdImage * im, int fg, 
 		y = pen_y + row;
 
 		/* clip if out of bounds */
-		if (y >= im->sy || y < 0) {
+		if (y > im->cy2 || y < im->cy1) {
 			continue;
 		}
 
@@ -743,7 +743,7 @@ static char * gdft_draw_bitmap (gdCache_head_t *tc_cache, gdImage * im, int fg, 
 				x = pen_x + col;
 
 				/* clip if out of bounds */
-				if (x >= im->sx || x < 0) {
+				if (x > im->cx2 || x < im->cx1) {
 					continue;
 				}
 				/* get pixel location in gd buffer */

--- a/ext/gd/tests/gh17373.phpt
+++ b/ext/gd/tests/gh17373.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug GH-17373 (imagefttext() ignores clipping rect for palette images)
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+$im = imagecreate(64, 32);
+$bg = imagecolorallocate($im, 0, 0, 0);
+$fg = imagecolorallocate($im, 255, 255, 255);
+imagefilledrectangle($im, 0, 0, 63, 31, $bg);
+imagesetclip($im, 32, 0, 63, 31);
+imagefttext($im, 16, 0, 10, 23, $fg, __DIR__ . "/Tuffy.ttf", "hello");
+
+imagesetclip($im, 0, 0, 63, 31);
+$count = 0;
+for ($j = 0; $j < 31; $j++) {
+    for ($i = 0; $i < 31; $i++) {
+        if (imagecolorat($im, $i, $j) !== $bg) {
+            $count++;
+        }
+    }
+}
+var_dump($count);
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
We apply the same fix that has been applied to external libgd at least as of 2.0.29.

To avoid issues regarding minor FreeType rendering differences, the test case does not compare against an image, but rather checks that all pixels outside the clipping rect have the background color.