### PR TITLE
Relax final+private warning for trait methods with inherited final

### DIFF
--- a/Zend/tests/gh17214.phpt
+++ b/Zend/tests/gh17214.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-17214: Relax final+private warning for trait methods with inherited final
+--FILE--
+<?php
+
+trait MyTrait
+{
+    final protected function someMethod(): void {}
+}
+
+class Test
+{
+    use MyTrait {
+        someMethod as private anotherMethod;
+    }
+
+    public function __construct()
+    {
+        $this->anotherMethod();
+    }
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/traits/gh12854.phpt
+++ b/Zend/tests/traits/gh12854.phpt
@@ -40,8 +40,6 @@ foreach (['pub', 'prot', 'priv', 'final1', 'final2', 'final3'] as $method) {
 ?>
 --EXPECTF--
 Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
-
-Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
 --- Method: pub ---
 bool(true)
 bool(true)

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2048,9 +2048,11 @@ static void zend_fixup_trait_method(zend_function *fn, zend_class_entry *ce) /* 
 
 static void zend_traits_check_private_final_inheritance(uint32_t original_fn_flags, zend_function *fn_copy, zend_string *name)
 {
-	/* If the function was originally already private+final, then it will have already been warned about.
-	 * If the function became private+final only after applying modifiers, we need to emit the same warning. */
-	if ((original_fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) != (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
+	/* If the function was originally already private+final, then it will have
+	 * already been warned about. Only emit this error when the used trait method
+	 * explicitly became final, avoiding errors for `as private` where it was
+	 * already final. */
+	if (!(original_fn_flags & ZEND_ACC_FINAL)
 		&& (fn_copy->common.fn_flags & (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)) == (ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
 		&& !zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME)) {
 		zend_error(E_COMPILE_WARNING, "Private methods cannot be final as they are never overridden by other classes");


### PR DESCRIPTION
Fixes GH-17214

Small note: I thought we'd have to support `as final private`, which would not work with this approach. But then noticed that strangely the grammar only allows for a single modifier for the trait alias. Thus, we luckily don't need to handle the case where both final and the visibility can change.