### PR TITLE
sapi/phpdbg: Remove 'R' option to register function

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -90,11 +90,6 @@ static void php_phpdbg_destroy_bp_condition(zval *data) /* {{{ */
 	efree(brake);
 } /* }}} */
 
-static void php_phpdbg_destroy_registered(zval *data) /* {{{ */
-{
-	zend_function_dtor(data);
-} /* }}} */
-
 static void php_phpdbg_destroy_file_source(zval *data) /* {{{ */
 {
 	phpdbg_file_source *source = (phpdbg_file_source *) Z_PTR_P(data);
@@ -164,7 +159,6 @@ static PHP_MINIT_FUNCTION(phpdbg) /* {{{ */
 	zend_hash_init(&PHPDBG_G(bp)[PHPDBG_BREAK_MAP], 8, NULL, NULL, 0);
 
 	zend_hash_init(&PHPDBG_G(seek), 8, NULL, NULL, 0);
-	zend_hash_init(&PHPDBG_G(registered), 8, NULL, php_phpdbg_destroy_registered, 0);
 
 	zend_hash_init(&PHPDBG_G(file_sources), 0, NULL, php_phpdbg_destroy_file_source, 0);
 	phpdbg_setup_watchpoints();
@@ -178,7 +172,6 @@ static PHP_MINIT_FUNCTION(phpdbg) /* {{{ */
 
 static PHP_MSHUTDOWN_FUNCTION(phpdbg) /* {{{ */
 {
-	zend_hash_destroy(&PHPDBG_G(registered));
 	phpdbg_destroy_watchpoints();
 
 	if (!(PHPDBG_G(flags) & PHPDBG_IS_QUITTING)) {

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -231,7 +231,6 @@ struct _phpdbg_oplog_list {
 /* {{{ structs */
 ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 	HashTable bp[PHPDBG_BREAK_TABLES];           /* break points */
-	HashTable registered;                        /* registered */
 	HashTable seek;                              /* seek oplines */
 	zend_execute_data *seek_ex;                  /* call frame of oplines to seek to */
 	zend_object *handled_exception;              /* last handled exception (prevent multiple handling of same exception) */

--- a/sapi/phpdbg/tests/exceptions_002.phpt
+++ b/sapi/phpdbg/tests/exceptions_002.phpt
@@ -4,7 +4,6 @@ Test exceptions in eval during exception
 r
 ev next_error()
 c
-
 q
 --EXPECTF--
 [Successful compilation of %s]
@@ -26,7 +25,6 @@ Stack trace:
 #0 %s(20): {closure:%s:%d}()
 #1 {main}
 [Script ended normally]
-prompt> [The stack contains nothing !]
 prompt> 
 --FILE--
 <?php


### PR DESCRIPTION
This functionality is broken and causes use after frees

Supersedes #17370 