### PR TITLE
Fix JIT for overridden properties with added hooks

### DIFF
--- a/Zend/Optimizer/zend_inference.h
+++ b/Zend/Optimizer/zend_inference.h
@@ -31,6 +31,7 @@
 #define MAY_BE_PACKED_GUARD         (1<<27) /* needs packed array guard */
 #define MAY_BE_CLASS_GUARD          (1<<27) /* needs class guard */
 #define MAY_BE_GUARD                (1<<28) /* needs type guard */
+#define MAY_BE_NEW_HOOKS_GUARD      (1<<29) /* object has new guards compared to comp-time class */
 
 #define MAY_HAVE_DTOR \
 	(MAY_BE_OBJECT|MAY_BE_RESOURCE \

--- a/Zend/tests/gh17376.phpt
+++ b/Zend/tests/gh17376.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-17376: Child classes may add hooks to plain properties
+--FILE--
+<?php
+
+class A {
+    public $prop = 1;
+}
+
+class B extends A {
+    public $prop {
+        get => 2;
+    }
+}
+
+function test(A $a) {
+    var_dump($a->prop);
+}
+
+test(new A);
+test(new B);
+
+?>
+--EXPECT--
+int(1)
+int(2)

--- a/Zend/tests/gh17376.phpt
+++ b/Zend/tests/gh17376.phpt
@@ -8,19 +8,70 @@ class A {
 }
 
 class B extends A {
-    public $prop {
-        get => 2;
+    public $prop = 1 {
+        get {
+            echo __METHOD__, "\n";
+            return $this->prop;
+        }
+        set {
+            echo __METHOD__, "\n";
+            $this->prop = $value;
+        }
     }
 }
 
 function test(A $a) {
+    echo "read\n";
     var_dump($a->prop);
+    echo "write\n";
+    $a->prop = 42;
+    echo "read-write\n";
+    $a->prop += 43;
+    echo "pre-inc\n";
+    ++$a->prop;
+    echo "pre-dec\n";
+    --$a->prop;
+    echo "post-inc\n";
+    $a->prop++;
+    echo "post-dec\n";
+    $a->prop--;
 }
 
+echo "A\n";
 test(new A);
+echo "\nB\n";
 test(new B);
 
 ?>
 --EXPECT--
+A
+read
 int(1)
-int(2)
+write
+read-write
+pre-inc
+pre-dec
+post-inc
+post-dec
+
+B
+read
+B::$prop::get
+int(1)
+write
+B::$prop::set
+read-write
+B::$prop::get
+B::$prop::set
+pre-inc
+B::$prop::get
+B::$prop::set
+pre-dec
+B::$prop::get
+B::$prop::set
+post-inc
+B::$prop::get
+B::$prop::set
+post-dec
+B::$prop::get
+B::$prop::set

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1653,11 +1653,6 @@ void zend_build_properties_info_table(zend_class_entry *ce)
 			table, parent_table,
 			sizeof(zend_property_info *) * ce->parent->default_properties_count
 		);
-
-		/* Child did not add any new properties, we are done */
-		if (ce->default_properties_count == ce->parent->default_properties_count) {
-			return;
-		}
 	}
 
 	ZEND_HASH_MAP_FOREACH_PTR(&ce->properties_info, prop) {


### PR DESCRIPTION
Fixes GH-17376

The change in `zend_build_properties_info_table()` is needed to keep overridden property infos up-to-date in child classes that only override properties but add no new ones. The behavior is currently inconsistent, which is itself probably a bug.

It would be faster to only compare the class itself instead of the property info, but being pessimistic may lead to picking the slow path too often, which would be much more expensive. @dstogov Maybe you have some better suggestion.