### PR TITLE
zend_ast: Print placeholder value when printing `ZEND_AST_OP_ARRAY`

### DIFF
--- a/Zend/tests/closure_const_expr/attributes_ast_printing_runtime.phpt
+++ b/Zend/tests/closure_const_expr/attributes_ast_printing_runtime.phpt
@@ -1,0 +1,22 @@
+--TEST--
+AST printing for closures in attributes at runtime
+--FILE--
+<?php
+
+#[Attr(static function ($foo) {
+    echo $foo;
+})]
+function foo() { }
+
+$r = new ReflectionFunction('foo');
+foreach ($r->getAttributes() as $attribute) {
+    echo $attribute;
+}
+
+?>
+--EXPECT--
+Attribute [ Attr ] {
+  - Arguments [1] {
+    Argument #0 [ Closure({closure:foo():3}) ]
+  }
+}

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1885,6 +1885,11 @@ tail_call:
 			smart_str_appendl(str, ZSTR_VAL(name), ZSTR_LEN(name));
 			break;
 		}
+		case ZEND_AST_OP_ARRAY:
+			smart_str_appends(str, "Closure(");
+			smart_str_append(str, zend_ast_get_op_array(ast)->op_array->function_name);
+			smart_str_appends(str, ")");
+			break;
 		case ZEND_AST_CONSTANT_CLASS:
 			smart_str_appendl(str, "__CLASS__", sizeof("__CLASS__")-1);
 			break;


### PR DESCRIPTION
As per the discussion in GH-17120, we are printing a placeholder value only. The commit history of that PR also includes alternative implementations, should a different decision be desirable.

Fixes GH-17096
Closes GH-17120