### PR TITLE
Fix GH-17409: Assertion failure Zend/zend_hash.c:1730

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2189,8 +2189,8 @@ static void sxe_object_free_storage(zend_object *object)
 	sxe_object_free_iterxpath(sxe);
 
 	if (sxe->properties) {
-		zend_hash_destroy(sxe->properties);
-		FREE_HASHTABLE(sxe->properties);
+		ZEND_ASSERT(!(GC_FLAGS(sxe->properties) & IS_ARRAY_IMMUTABLE));
+		zend_hash_release(sxe->properties);
 	}
 }
 /* }}} */

--- a/ext/simplexml/tests/gh17409.phpt
+++ b/ext/simplexml/tests/gh17409.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17409 (Assertion failure Zend/zend_hash.c)
+--EXTENSIONS--
+simplexml
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$root = simplexml_load_string('<?xml version="1.0"?>
+<root xmlns:reserved="reserved-ns">
+<child reserved:attribute="Sample" />
+</root>
+');
+// Need to use $GLOBALS such that simplexml object is destroyed
+var_dump(array_merge_recursive($GLOBALS, $GLOBALS)["root"]);
+?>
+--EXPECT--
+array(1) {
+  ["child"]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
The array merging function may still hold the properties array while the object is already being destroyed. Therefore, we should take into account the refcount in simplexml's destruction code. It may be possible to trigger this in other ways too.