### PR TITLE
zend_hrtime: Fix build for macOS without `clock_gettime_nsec_np()`

### DIFF
--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -66,7 +66,7 @@ BEGIN_EXTERN_C()
 
 ZEND_API extern double zend_hrtime_timer_scale;
 
-#elif ZEND_HRTIME_PLATFORM_APPLE
+#elif ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE
 
 # include <mach/mach_time.h>
 # include <string.h>


### PR DESCRIPTION
One declaration was missed in https://github.com/php/php-src/pull/17089 and because of that complication is failing.

Example:

> /Users/x/php-src/Zend/zend_hrtime.h:92:47: error: use of undeclared identifier 'zend_hrtime_timerlib_info'
>    92 |         return (zend_hrtime_t)mach_absolute_time() * zend_hrtime_timerlib_info.numer / zend_hrtime_timerlib_info.denom;
