### PR TITLE
Fix GH-17428: Assertion failure ext/opcache/jit/zend_jit_ir.c:8940

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2622,10 +2622,9 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 					/* THROW and EXIT may be used in the middle of BB */
 					/* don't generate code for the rest of BB */
 
-					/* Skip current opline for call_level computation
-					 * Don't include last opline because end of loop already checks call level of last opline */
+					/* Skip current opline for call_level computation. */
 					i++;
-					for (; i < end; i++) {
+					for (; i <= end; i++) {
 						opline = op_array->opcodes + i;
 						if (zend_jit_inc_call_level(opline->opcode)) {
 							call_level++;
@@ -2633,8 +2632,8 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							call_level--;
 						}
 					}
-					opline = op_array->opcodes + i;
-					break;
+					opline = op_array->opcodes + end;
+					goto done_no_dec_call_level;
 				/* stackless execution */
 				case ZEND_INCLUDE_OR_EVAL:
 				case ZEND_DO_FCALL:
@@ -2727,6 +2726,7 @@ done:
 			if (zend_jit_dec_call_level(opline->opcode)) {
 				call_level--;
 			}
+done_no_dec_call_level:;
 		}
 		zend_jit_bb_end(&ctx, b);
 	}

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2622,9 +2622,10 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 					/* THROW and EXIT may be used in the middle of BB */
 					/* don't generate code for the rest of BB */
 
-					/* Skip current opline for call_level computation. */
+					/* Skip current opline for call_level computation because it does not influence call_level.
+					 * Don't include last opline because end of loop already checks call level of last opline. */
 					i++;
-					for (; i <= end; i++) {
+					for (; i < end; i++) {
 						opline = op_array->opcodes + i;
 						if (zend_jit_inc_call_level(opline->opcode)) {
 							call_level++;
@@ -2633,7 +2634,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						}
 					}
 					opline = op_array->opcodes + end;
-					goto done_no_dec_call_level;
+					break;
 				/* stackless execution */
 				case ZEND_INCLUDE_OR_EVAL:
 				case ZEND_DO_FCALL:
@@ -2726,7 +2727,6 @@ done:
 			if (zend_jit_dec_call_level(opline->opcode)) {
 				call_level--;
 			}
-done_no_dec_call_level:;
 		}
 		zend_jit_bb_end(&ctx, b);
 	}

--- a/ext/opcache/tests/jit/gh17428.phpt
+++ b/ext/opcache/tests/jit/gh17428.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-17428 (Assertion failure ext/opcache/jit/zend_jit_ir.c:8940)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=1205
+--FILE--
+<?php
+new EmptyIterator();
+srand(1000);
+error_reporting(E_ALL);
+testConversion('', '');
+testConversion('', '');
+testConversion('', '');
+testConversion('', '');
+testConversion('', '');
+function testRoundTrip($data) {
+}
+for ($iterations = 0; $iterations < 100; $iterations++) {
+    $strlen = rand(1, 100);
+    $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    $randstring = '';
+    for ($i = 0; $i < $strlen; $i++) {
+        $randstring .= $characters[rand(0, strlen($characters) - 1)];
+    }
+    die($randstring);
+}
+echo "Done!\n";
+throw new Hello(new stdClass);
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to undefined function testConversion() in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
The code to update the call_level in that case skips the opline itself, as that opline is handled by the tail handler, and then wants to set the opline to the last opline of the block because the code below the switch will update the call_level for that opline.
However, the test has a block with a single opline (THROW). The block after that has ZEND_INIT_FCALL. Because `i` points to ZEND_DO_FCALL now, it erroneously updates the call_level after the switch. Although it suffices to change `i` to `end` (none of the opcodes here occur in `zend_jit_dec_call_level`), I added a goto label and changed the loop to handle all call_level updates. This seems more robust for the future in case the list of opcodes changes.