### PR TITLE
Fix GH-17442: Engine UAF with reference assign and dtor

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -14,6 +14,11 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 1. Internal API changes
 ========================
 
+- Zend
+  . Added ZEND_SAFE_ASSIGN_VALUE() macro to safely assign a value to a zval.
+  . Added zval_ptr_safe_dtor() to safely destroy a zval when a destructor
+    could interfere.
+
 ========================
 2. Build system changes
 ========================

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -15,7 +15,8 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 ========================
 
 - Zend
-  . Added ZEND_SAFE_ASSIGN_VALUE() macro to safely assign a value to a zval.
+  . Added zend_safe_assign_to_variable_noref() function to safely assign
+    a value to a non-reference zval.
   . Added zval_ptr_safe_dtor() to safely destroy a zval when a destructor
     could interfere.
 

--- a/Zend/tests/weakrefs/gh17442_1.phpt
+++ b/Zend/tests/weakrefs/gh17442_1.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17442 (Engine UAF with reference assign and dtor) - untyped
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$map = new WeakMap;
+$obj = new stdClass;
+$map[$obj] = new class {
+    function __destruct() {
+        throw new Exception("Test");
+    }
+};
+headers_sent($obj,$generator);
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Test in %s:%d
+Stack trace:
+#0 [internal function]: class@anonymous->__destruct()
+#1 %s(%d): headers_sent(NULL, 0)
+#2 {main}
+  thrown in %s on line %d

--- a/Zend/tests/weakrefs/gh17442_2.phpt
+++ b/Zend/tests/weakrefs/gh17442_2.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-17442 (Engine UAF with reference assign and dtor) - typed
+--CREDITS--
+YuanchengJiang
+nielsdos
+--FILE--
+<?php
+$map = new WeakMap;
+
+class Test {
+	public stdClass|string $obj;
+}
+
+$test = new Test;
+$test->obj = new stdClass;
+
+$map[$test->obj] = new class {
+    function __destruct() {
+		global $test;
+		var_dump($test->obj);
+        throw new Exception("Test");
+    }
+};
+
+headers_sent($test->obj);
+?>
+--EXPECTF--
+string(0) ""
+
+Fatal error: Uncaught Exception: Test in %s:%d
+Stack trace:
+#0 [internal function]: class@anonymous->__destruct()
+#1 %s(%d): headers_sent('')
+#2 {main}
+  thrown in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4666,7 +4666,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_ex(zend_reference *ref, zval *val
 		zval_ptr_dtor(val);
 		return FAILURE;
 	} else {
-		ZEND_SAFE_ASSIGN_VALUE(&ref->val, val);
+		zend_safe_assign_to_variable_noref(&ref->val, val);
 		return SUCCESS;
 	}
 }

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4666,8 +4666,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_ex(zend_reference *ref, zval *val
 		zval_ptr_dtor(val);
 		return FAILURE;
 	} else {
-		zval_ptr_dtor(&ref->val);
-		ZVAL_COPY_VALUE(&ref->val, val);
+		ZEND_SAFE_ASSIGN_VALUE(&ref->val, val);
 		return SUCCESS;
 	}
 }

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1097,22 +1097,6 @@ ZEND_API zend_result zend_try_assign_typed_ref_res(zend_reference *ref, zend_res
 ZEND_API zend_result zend_try_assign_typed_ref_zval(zend_reference *ref, zval *zv);
 ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, bool strict);
 
-#define ZEND_SAFE_ASSIGN_VALUE(zv, value) do { \
-	zval *_zv = zv; \
-	zval *_value = value; \
-	if (Z_REFCOUNTED_P(_zv)) { \
-		zend_refcounted *rc = Z_COUNTED_P(_zv); \
-		ZVAL_COPY_VALUE(_zv, _value); \
-		if (!GC_DELREF(rc)) { \
-			rc_dtor_func(rc); \
-		} else { \
-			gc_check_possible_root(rc); \
-		} \
-	} else { \
-		ZVAL_COPY_VALUE(_zv, _value); \
-	} \
-} while (0)
-
 #define _ZEND_TRY_ASSIGN_NULL(zv, is_ref) do { \
 	zval *_zv = zv; \
 	if (is_ref || UNEXPECTED(Z_ISREF_P(_zv))) { \

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1097,6 +1097,22 @@ ZEND_API zend_result zend_try_assign_typed_ref_res(zend_reference *ref, zend_res
 ZEND_API zend_result zend_try_assign_typed_ref_zval(zend_reference *ref, zval *zv);
 ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, bool strict);
 
+#define ZEND_SAFE_ASSIGN_VALUE(zv, value) do { \
+	zval *_zv = zv; \
+	zval *_value = value; \
+	if (Z_REFCOUNTED_P(_zv)) { \
+		zend_refcounted *rc = Z_COUNTED_P(_zv); \
+		ZVAL_COPY_VALUE(_zv, _value); \
+		if (!GC_DELREF(rc)) { \
+			rc_dtor_func(rc); \
+		} else { \
+			gc_check_possible_root(rc); \
+		} \
+	} else { \
+		ZVAL_COPY_VALUE(_zv, _value); \
+	} \
+} while (0)
+
 #define _ZEND_TRY_ASSIGN_NULL(zv, is_ref) do { \
 	zval *_zv = zv; \
 	if (is_ref || UNEXPECTED(Z_ISREF_P(_zv))) { \
@@ -1107,7 +1123,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_NULL(_zv); \
 } while (0)
 
@@ -1129,7 +1145,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_FALSE(_zv); \
 } while (0)
 
@@ -1151,7 +1167,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_TRUE(_zv); \
 } while (0)
 
@@ -1173,7 +1189,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_BOOL(_zv, bval); \
 } while (0)
 
@@ -1195,7 +1211,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_LONG(_zv, lval); \
 } while (0)
 
@@ -1217,7 +1233,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_DOUBLE(_zv, dval); \
 } while (0)
 
@@ -1239,7 +1255,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_EMPTY_STRING(_zv); \
 } while (0)
 
@@ -1261,7 +1277,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_STR(_zv, str); \
 } while (0)
 
@@ -1283,7 +1299,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_NEW_STR(_zv, str); \
 } while (0)
 
@@ -1305,7 +1321,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_STRING(_zv, string); \
 } while (0)
 
@@ -1327,7 +1343,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_STRINGL(_zv, string, len); \
 } while (0)
 
@@ -1349,7 +1365,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_ARR(_zv, arr); \
 } while (0)
 
@@ -1371,7 +1387,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_RES(_zv, res); \
 } while (0)
 
@@ -1393,7 +1409,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_COPY_VALUE(_zv, other_zv); \
 } while (0)
 
@@ -1415,7 +1431,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_COPY_VALUE(_zv, other_zv); \
 } while (0)
 
@@ -1447,7 +1463,7 @@ ZEND_API zend_result zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval
 		} \
 		_zv = &ref->val; \
 	} \
-	zval_ptr_dtor(_zv); \
+	zval_ptr_safe_dtor(_zv); \
 	ZVAL_COPY_VALUE(_zv, other_zv); \
 } while (0)
 
@@ -1485,10 +1501,7 @@ static zend_always_inline zval *zend_try_array_init_size(zval *zv, uint32_t size
 		}
 		zv = &ref->val;
 	}
-	zval garbage;
-	ZVAL_COPY_VALUE(&garbage, zv);
-	ZVAL_NULL(zv);
-	zval_ptr_dtor(&garbage);
+	zval_ptr_safe_dtor(zv);
 	ZVAL_ARR(zv, arr);
 	return zv;
 }

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -212,11 +212,7 @@ static zend_always_inline void zend_safe_assign_to_variable_noref(zval *variable
 		ZEND_ASSERT(Z_TYPE_P(variable_ptr) != IS_REFERENCE);
 		zend_refcounted *ref = Z_COUNTED_P(variable_ptr);
 		ZVAL_COPY_VALUE(variable_ptr, value);
-		if (!GC_DELREF(ref)) {
-			rc_dtor_func(ref);
-		} else {
-			gc_check_possible_root(ref);
-		}
+		GC_DTOR_NO_REF(ref);
 	} else {
 		ZVAL_COPY_VALUE(variable_ptr, value);
 	}

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -207,6 +207,21 @@ static zend_always_inline zval* zend_assign_to_variable_ex(zval *variable_ptr, z
 	return variable_ptr;
 }
 
+static zend_always_inline void zend_safe_assign_to_variable_noref(zval *variable_ptr, zval *value) {
+	if (Z_REFCOUNTED_P(variable_ptr)) {
+		ZEND_ASSERT(Z_TYPE_P(variable_ptr) != IS_REFERENCE);
+		zend_refcounted *ref = Z_COUNTED_P(variable_ptr);
+		ZVAL_COPY_VALUE(variable_ptr, value);
+		if (!GC_DELREF(ref)) {
+			rc_dtor_func(ref);
+		} else {
+			gc_check_possible_root(ref);
+		}
+	} else {
+		ZVAL_COPY_VALUE(variable_ptr, value);
+	}
+}
+
 ZEND_API zend_result ZEND_FASTCALL zval_update_constant(zval *pp);
 ZEND_API zend_result ZEND_FASTCALL zval_update_constant_ex(zval *pp, zend_class_entry *scope);
 ZEND_API zend_result ZEND_FASTCALL zval_update_constant_with_ctx(zval *pp, zend_class_entry *scope, zend_ast_evaluate_ctx *ctx);

--- a/Zend/zend_variables.c
+++ b/Zend/zend_variables.c
@@ -85,6 +85,20 @@ ZEND_API void zval_ptr_dtor(zval *zval_ptr) /* {{{ */
 }
 /* }}} */
 
+ZEND_API void zval_ptr_safe_dtor(zval *zval_ptr)
+{
+	if (Z_REFCOUNTED_P(zval_ptr)) {
+		zend_refcounted *ref = Z_COUNTED_P(zval_ptr);
+
+		if (GC_DELREF(ref) == 0) {
+			ZVAL_NULL(zval_ptr);
+			rc_dtor_func(ref);
+		} else {
+			gc_check_possible_root(ref);
+		}
+	}
+}
+
 ZEND_API void zval_internal_ptr_dtor(zval *zval_ptr) /* {{{ */
 {
 	if (Z_REFCOUNTED_P(zval_ptr)) {

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -78,6 +78,7 @@ static zend_always_inline void zval_ptr_dtor_str(zval *zval_ptr)
 }
 
 ZEND_API void zval_ptr_dtor(zval *zval_ptr);
+ZEND_API void zval_ptr_safe_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
 /* Kept for compatibility */


### PR DESCRIPTION
Need to protect the object zval in this case by using the `garbage` zval trick.
I don't really like doing this, but at least the code in the test isn't completely pathological and the assign_ref operations aren't super common on hot code I would think; so I can live a bit with that.