### PR TITLE
Ninja support on Windows

### DIFF
--- a/ext/json/ninja.frag.w32
+++ b/ext/json/ninja.frag.w32
@@ -1,0 +1,9 @@
+rule re2c_ext_json
+  command = ${RE2C} ${RE2C_FLAGS} -t ext/json/php_json_scanner_defs.h -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
+
+build ext\json\json_scanner.c ext\json\php_json_scanner_defs.h: re2c_ext_json ext\json\json_scanner.re ext\json\json_parser.tab.h
+
+rule bison_ext_json
+  command = ${BISON} ${BISON_FLAGS} --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c
+
+build ext\json\json_parser.tab.c ext\json\json_parser.tab.h: bison_ext_json ext\json\json_parser.y

--- a/ext/opcache/jit/ninja.frag.w32
+++ b/ext/opcache/jit/ninja.frag.w32
@@ -1,0 +1,59 @@
+rule ext_opcache_jit_1
+  command = ${PHP_CL} /nologo /Fo${BUILD_DIR}\ /Fd${BUILD_DIR}\ /Fp${BUILD_DIR}\ /FR${BUILD_DIR} /Fe${BUILD_DIR}\minilua.exe ext\opcache\jit\ir\dynasm\minilua.c
+
+build ${BUILD_DIR}\minilua.exe: ext_opcache_jit_1 ext\opcache\jit\ir\dynasm\minilua.c
+
+#	@if exist $(BUILD_DIR)\\minilua.exe del $(BUILD_DIR)\\minilua.exe
+#	$(PHP_CL) /Fo$(BUILD_DIR)\ /Fd$(BUILD_DIR)\ /Fp$(BUILD_DIR)\ /FR$(BUILD_DIR) /Fe$(BUILD_DIR)\minilua.exe ext\opcache\jit\ir\dynasm\minilua.c
+
+rule ext_opcache_jit_2
+  command = cmd /c ${BUILD_DIR}\\minilua.exe ext/opcache/jit/ir/dynasm/dynasm.lua ${DASM_FLAGS} -o $out ext/opcache/jit/ir/ir_x86.dasc
+
+build ext\opcache\jit\ir\ir_emit_x86.h: ext_opcache_jit_2 ext\opcache\jit\ir\ir_x86.dasc ${BUILD_DIR}\\minilua.exe
+
+#	@if exist ext\opcache\jit\ir\ir_emit_x86.h del ext\opcache\jit\ir\ir_emit_x86.h
+#	$(BUILD_DIR)\\minilua.exe ext/opcache/jit/ir/dynasm/dynasm.lua $(DASM_FLAGS) -o $@ ext/opcache/jit/ir/ir_x86.dasc
+
+rule ext_opcache_jit_3
+    command = ${PHP_CL} /nologo /D ${IR_TARGET} /Fo${BUILD_DIR}\ /Fd${BUILD_DIR}\ /Fp${BUILD_DIR}\ /Fe${BUILD_DIR}\\gen_ir_fold_hash.exe ext\opcache\jit\ir\gen_ir_fold_hash.c
+
+build ${BUILD_DIR}\gen_ir_fold_hash.exe: ext_opcache_jit_3 ext\opcache\jit\ir\gen_ir_fold_hash.c ext\opcache\jit\ir\ir_strtab.c
+
+#	@if exist $(BUILD_DIR)\\gen_ir_fold_hash.exe del $(BUILD_DIR)\\gen_ir_fold_hash.exe
+#	$(PHP_CL) /D $(IR_TARGET) /Fo$(BUILD_DIR)\ /Fd$(BUILD_DIR)\ /Fp$(BUILD_DIR)\ /Fe$(BUILD_DIR)\\gen_ir_fold_hash.exe ext\opcache\jit\ir\gen_ir_fold_hash.c
+
+rule ext_opcache_jit_4
+  command = cmd /c ${BUILD_DIR}\\gen_ir_fold_hash.exe < ext\opcache\jit\ir\ir_fold.h > ext\opcache\jit\ir\ir_fold_hash.h
+
+build ext\opcache\jit\ir\ir_fold_hash.h: ext_opcache_jit_4 ${BUILD_DIR}\\gen_ir_fold_hash.exe ext\opcache\jit\ir\ir_fold.h ext\opcache\jit\ir\ir.h
+
+build ${BUILD_DIR}\ext\opcache\jit\ir\ir.obj: cc_ext_opcache_jit_ir ext\opcache\jit\ir\ir.c | ext\opcache\jit\ir\ir_fold_hash.h
+
+build ${BUILD_DIR}\ext\opcache\jit\ir\ir_emit.obj: cc_ext_opcache_jit_ir ext\opcache\jit\ir\ir_emit.c | ext\opcache\jit\ir\ir_emit_x86.h
+
+
+#	@if exist ext\opcache\jit\ir\ir_fold_hash.h del ext\opcache\jit\ir\ir_fold_hash.h
+#	$(BUILD_DIR)\\gen_ir_fold_hash.exe < ext\opcache\jit\ir\ir_fold.h > ext\opcache\jit\ir\ir_fold_hash.h
+
+# ${BUILD_DIR}\ext\opcache\jit\ir\ir_ra.obj: $
+# 	ext\opcache\jit\ir\ir.h $
+# 	ext\opcache\jit\ir\ir_private.h $
+# 	ext\opcache\jit\ir\ir_x86.h
+
+# ${BUILD_DIR}\ext\opcache\jit\ir\ir_emit.obj: $
+# 	ext\opcache\jit\ir\ir.h $
+# 	ext\opcache\jit\ir\ir_private.h $
+# 	ext\opcache\jit\ir\ir_x86.h $
+# 	ext\opcache\jit\ir\ir_emit_x86.h
+
+# ${BUILD_DIR}\ext\opcache\jit\ir\ir.obj: $
+# 	ext\opcache\jit\ir\ir.h $
+# 	ext\opcache\jit\ir\ir_private.h $
+# 	ext\opcache\jit\ir\ir_fold.h $
+# 	ext\opcache\jit\ir\ir_fold_hash.h
+
+# ${BUILD_DIR}\ext\opcache\jit\zend_jit.obj: $
+# 	ext\opcache\jit\zend_jit_ir.c $
+# 	ext\opcache\jit\zend_jit_helpers.c $
+# 	ext\opcache\jit\ir\ir.h $
+# 	ext\opcache\jit\ir\ir_builder.h

--- a/ext/pdo/ninja.frag.w32
+++ b/ext/pdo/ninja.frag.w32
@@ -1,0 +1,7 @@
+rule re2c_ext_pdo
+  command = ${RE2C} ${RE2C_FLAGS} -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re
+
+build ext\pdo\pdo_sql_parser.c: re2c_ext_pdo ext\pdo\pdo_sql_parser.re
+
+#	cd $(PHP_SRC_DIR)
+#	$(RE2C) $(RE2C_FLAGS) -o ext/pdo/pdo_sql_parser.c ext/pdo/pdo_sql_parser.re

--- a/ext/pdo_mysql/ninja.frag.w32
+++ b/ext/pdo_mysql/ninja.frag.w32
@@ -1,0 +1,7 @@
+rule re2c_pdo_mysql
+  command = ${RE2C} ${RE2C_FLAGS} -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re
+
+build ext\pdo_mysql\mysql_sql_parser.c: re2c_pdo_mysql ext\pdo_mysql\mysql_sql_parser.re
+
+#	cd $(PHP_SRC_DIR)
+#	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_mysql/mysql_sql_parser.c ext/pdo_mysql/mysql_sql_parser.re

--- a/ext/pdo_pgsql/ninja.frag.w32
+++ b/ext/pdo_pgsql/ninja.frag.w32
@@ -1,0 +1,7 @@
+rule re2c_ext_pdo_pgsql
+  command = ${RE2C} ${RE2C_FLAGS} -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re
+
+build ext\pdo_pgsql\pgsql_sql_parser.c: re2c_ext_pdo_pgsql ext\pdo_pgsql\pgsql_sql_parser.re
+
+#	cd $(PHP_SRC_DIR)
+#	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_pgsql/pgsql_sql_parser.c ext/pdo_pgsql/pgsql_sql_parser.re

--- a/ext/pdo_sqlite/ninja.frag.w32
+++ b/ext/pdo_sqlite/ninja.frag.w32
@@ -1,0 +1,7 @@
+rule re2c_ext_pdo_sqlite
+  command = ${RE2C} ${RE2C_FLAGS} -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re
+
+build ext\pdo_sqlite\sqlite_sql_parser.c: re2c_ext_pdo_sqlite ext\pdo_sqlite\sqlite_sql_parser.re
+
+#	cd $(PHP_SRC_DIR)
+#	$(RE2C) $(RE2C_FLAGS) -o ext/pdo_sqlite/sqlite_sql_parser.c ext/pdo_sqlite/sqlite_sql_parser.re

--- a/ext/phar/ninja.frag.w32
+++ b/ext/phar/ninja.frag.w32
@@ -1,0 +1,4 @@
+rule re2c_ext_phar
+  command = ${RE2C} ${RE2C_FLAGS} -b -o ext/phar/phar_path_check.c ext/phar/phar_path_check.re
+
+build ext\phar\phar_path_check.c: re2c_ext_phar ext\phar\phar_path_check.re

--- a/ext/standard/ninja.frag.w32
+++ b/ext/standard/ninja.frag.w32
@@ -1,0 +1,15 @@
+rule re2c_ext_standard_1
+  command = ${RE2C} ${RE2C_FLAGS} -b -o ext/standard/var_unserializer.c ext/standard/var_unserializer.re
+
+build ext\standard\var_unserializer.c: re2c_ext_standard_1 ext\standard\var_unserializer.re
+
+rule re2c_ext_standard_2
+  command = ${RE2C} ${RE2C_FLAGS} -b -o ext/standard/url_scanner_ex.c ext/standard/url_scanner_ex.re
+
+build ext\standard\url_scanner_ex.c: re2c_ext_standard_2 ext\standard\url_scanner_ex.re
+
+#$(BUILD_DIR)\ext\standard\basic_functions.obj: $(PHP_SRC_DIR)\Zend\zend_language_parser.h
+
+#$(PHP_SRC_DIR)\ext\standard\tests\helpers\bad_cmd.exe: $(PHP_SRC_DIR)\ext\standard\tests\helpers\bad_cmd.c
+#	cd $(PHP_SRC_DIR)\ext\standard\tests\helpers
+#	$(PHP_CL) /nologo bad_cmd.c

--- a/win32/build/build.ninja
+++ b/win32/build/build.ninja
@@ -1,0 +1,77 @@
+#  +----------------------------------------------------------------------+
+#  | Copyright (c) The PHP Group                                          |
+#  +----------------------------------------------------------------------+
+#  | This source file is subject to version 3.01 of the PHP license,      |
+#  | that is bundled with this package in the file LICENSE, and is        |
+#  | available through the world-wide-web at the following url:           |
+#  | https://www.php.net/license/3_01.txt                                 |
+#  | If you did not receive a copy of the PHP license and are unable to   |
+#  | obtain it through the world-wide-web, please send a note to          |
+#  | license@php.net so we can mail you a copy immediately.               |
+#  +----------------------------------------------------------------------+
+#  | Author: Wez Furlong <wez@thebrainroom.com>                           |
+#  +----------------------------------------------------------------------+
+#
+# This is the ninja template for the win32 build
+
+CC="${PHP_CL}"
+LD="${LINK}"
+MC="${MC}"
+MT="${MT}"
+RE2C="${RE2C}"
+PGOMGR="${PGOMGR}"
+PHP_BUILD=${PHP_BUILD}
+
+# See https://ninja-build.org/manual.html#_deps
+# msvc_deps_prefix = Hinweis: Einlesen der Datei:
+
+MCFILE=${BUILD_DIR}\wsyslog.rc
+
+rule bison_php
+  command = ${BISON} ${BISON_FLAGS} --output=$out -v -d $in
+  description = bison $in
+
+build Zend\zend_ini_parser.c: bison_php Zend\zend_ini_parser.y
+build Zend\zend_language_parser.c: bison_php Zend\zend_language_parser.y
+build sapi\phpdbg\phpdbg_parser.c: bison_php sapi\phpdbg\phpdbg_parser.y
+
+rule re2c_php_ini
+  command = ${RE2C} ${RE2C_FLAGS} --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l
+  description = re2c $in
+
+build Zend\zend_ini_scanner.c | Zend\zend_ini_scanner_defs.h: re2c_php_ini Zend\zend_ini_scanner.l
+
+rule re2c_php_language
+  command = ${RE2C} ${RE2C_FLAGS} --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l
+  description = re2c $in
+
+build Zend\zend_language_scanner.c Zend\zend_language_scanner_defs.h: re2c_php_language Zend\zend_language_scanner.l
+
+rule re2c_phpdbg
+  command = ${RE2C} ${RE2C_FLAGS} -cbdFo sapi/phpdbg/phpdbg_lexer.c sapi/phpdbg/phpdbg_lexer.l
+  description = re2c $in
+
+build sapi\phpdbg\phpdbg_lexer.c: re2c_phpdbg sapi\phpdbg\phpdbg_lexer.l
+
+rule mc_php
+  command = ${MC} -h win32\ -r ${BUILD_DIR}\ -x ${BUILD_DIR}\ $in
+  description = mc $in
+
+build ${MCFILE}: mc_php win32\build\wsyslog.mc
+
+PHPDLL_RES=${BUILD_DIR}\${PHPDLL}.res
+
+# FIXME: why isn't that defined in Makefile?
+RC=rc.exe
+
+rule rc_php
+  command = ${RC} /nologo /fo $out /d FILE_DESCRIPTION="\"PHP Script Interpreter\"" /d FILE_NAME="\"${PHPDLL}\"" /d PRODUCT_NAME="\"PHP Script Interpreter\"" /I${BUILD_DIR} /d MC_INCLUDE="\"${MCFILE}\"" $in
+  description = rc $in
+
+build ${PHPDLL_RES}: rc_php win32\build\template.rc || ${BUILD_DIR}\\wsyslog.rc
+
+rule ld_php
+  command = ${LD} ${PHP_GLOBAL_OBJS_RESP} ${STATIC_EXT_OBJS_RESP} ${STATIC_EXT_LIBS} ${LIBS} ${ASM_OBJS} ${PHPDLL_RES} /out:$out ${PHP8_PGD_OPTION} ${PHP_LDFLAGS} ${LDFLAGS} ${STATIC_EXT_LDFLAGS}
+  description = ld $out
+
+build ${BUILD_DIR}\${PHPLIB}: phony ${BUILD_DIR}\${PHPDLL}

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -275,6 +275,14 @@ MFO.WriteLine('\t$(PHP_ASSEMBLER) $(FIBER_ASM_FLAGS) $(BUILD_DIR)\\Zend\\jump_$(
 MFO.WriteLine('$(BUILD_DIR)\\Zend\\make_' + FIBER_ASM_ABI + '.obj: Zend\\asm\\make_' + FIBER_ASM_ABI + '.asm');
 MFO.WriteLine('\t$(PHP_ASSEMBLER) $(FIBER_ASM_FLAGS) $(BUILD_DIR)\\Zend\\make_$(FIBER_ASM_ABI).obj Zend\\asm\\make_$(FIBER_ASM_ABI).asm');
 
+NFO.WriteBlankLines(1);
+NFO.WriteLine('rule as_fiber');
+NFO.WriteLine('  command = cmd /c ${PHP_ASSEMBLER} ${FIBER_ASM_FLAGS} $out $in > NUL');
+NFO.WriteLine('  description = as $in');
+NFO.WriteBlankLines(1);
+NFO.WriteLine('build ${BUILD_DIR}\\Zend\\jump_' + FIBER_ASM_ABI + '.obj: as_fiber Zend\\asm\\jump_' + FIBER_ASM_ABI + '.asm');
+NFO.WriteLine('build ${BUILD_DIR}\\Zend\\make_' + FIBER_ASM_ABI + '.obj: as_fiber Zend\\asm\\make_' + FIBER_ASM_ABI + '.asm');
+
 ADD_FLAG("CFLAGS_BD_ZEND", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 if (VS_TOOLSET && VCVERS >= 1914) {
 	ADD_FLAG("CFLAGS_BD_ZEND", "/d2FuncCache1");


### PR DESCRIPTION
Contrary to many other make implementations, NMake does not support parallel builds. Instead, MS enabled cl.exe for parallel compilation (`/MP`), but that is not allowed for debug builds, likely due to the [documented limitation](https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes):

> Most options are incompatible because if they were permitted, the concurrently executing compilers would write their output at the same time to the console or to a particular file. As a result, the output would intermix and be garbled.

This implies that debug builds are particularly slow (on my machine, unoptimized debug builds are only minimally faster than fully optimized release builds; they are likely slower on more powerful machines).

Now Visual Studio ships [Ninja](https://ninja-build.org/) as part of its CMake support, and Ninja supports parallel builds. Thus I've hacked support for generating a build.ninja into our Windows build tooling; just enough to be able to do a minimal build (`configure --disable-all --enable-cli --enable-debug`), and was pleasantly surprised that this improved build time by a factor of three (again, I expect even more impressive results with a more powerful machine). Release builds are also slightly faster (about 10% percent).

Since Ninja supports header dependencies almost fully automatically, I've added support for that as well, so it's no longer necessary to take care of that yourself (i.e. when making a change to a header, `nmake` would do nothing; you need to touch relevant files, and for changes to a Zend header, you usually need to `nmake clean && nmake` – terrible UX). This works currently for German VS installations only (see comment below).

Another benefit of using Ninja instead of NMake is the console output during building. While our NMake output is pretty verbose for debug builds, Ninja is terse, usually only showing one line of progress, and only in case of a build failure showing the whole command that failed.

To round this up, there is still of lot of work to be done, but before doing that, I would like to gauge interest in Ninja support – and maybe there are already other alternatives readily available.

Maybe @nielsdos, @arnaud-lb and @bukka are interested in this.

TODO:

- [ ] gitignore generated files
- [ ] support for non English compiler output (`msvc_deps_prefix`)
- [ ] `--enable-ninja` configure flag
- [ ] [embed manifests](https://learn.microsoft.com/en-us/cpp/build/understanding-manifest-generation-for-c-cpp-programs)