### PR TITLE
Fix GH-17447: Assertion failure when array popping a self addressing variable

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3443,7 +3443,8 @@ PHP_FUNCTION(array_pop)
 				break;
 			}
 		}
-		RETVAL_COPY_DEREF(val);
+		RETVAL_COPY_VALUE(val);
+		ZVAL_UNDEF(val);
 
 		if (idx == (Z_ARRVAL_P(stack)->nNextFreeElement - 1)) {
 			Z_ARRVAL_P(stack)->nNextFreeElement = Z_ARRVAL_P(stack)->nNextFreeElement - 1;
@@ -3467,7 +3468,8 @@ PHP_FUNCTION(array_pop)
 				break;
 			}
 		}
-		RETVAL_COPY_DEREF(val);
+		RETVAL_COPY_VALUE(val);
+		ZVAL_UNDEF(val);
 
 		if (!p->key && (zend_long)p->h == (Z_ARRVAL_P(stack)->nNextFreeElement - 1)) {
 			Z_ARRVAL_P(stack)->nNextFreeElement = Z_ARRVAL_P(stack)->nNextFreeElement - 1;
@@ -3477,6 +3479,10 @@ PHP_FUNCTION(array_pop)
 		zend_hash_del_bucket(Z_ARRVAL_P(stack), p);
 	}
 	zend_hash_internal_pointer_reset(Z_ARRVAL_P(stack));
+
+	if (Z_ISREF_P(return_value)) {
+		zend_unwrap_reference(return_value);
+	}
 }
 /* }}} */
 

--- a/ext/standard/tests/array/gh17447.phpt
+++ b/ext/standard/tests/array/gh17447.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-17447 (Assertion failure when array poping a self addressing variable)
+--FILE--
+<?php
+$input[] = &$input;
+var_dump(array_pop($input), $input);
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}


### PR DESCRIPTION
This is the same bug as GH-16957, and fixed in the same way.