### PR TITLE
Fix clang compiler detection on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3125,7 +3125,7 @@ function toolset_get_compiler_name(short)
 		var command = 'cmd /c ""' + PHP_CL + '" -v"';
 		var full = execute(command + '" 2>&1"');
 
-		ERROR(full.split(/\n/)[0].replace(/\s/g, ' '));
+		return full.split(/\n/)[0].replace(/\s/g, ' ');
 	}
 
 	WARNING("Unsupported toolset");


### PR DESCRIPTION
A previous commit[1] left a "debug" statement, which causes clang builds on Windows to fail always.

[1] <https://github.com/php/php-src/commit/b3d6414b87cfebf503b5064a78ea1c5120ed638f>

---

This bug was unintentional, but is rather revealing: apparently nobody builds with clang on Windows.