### PR TITLE
Fix printf style issues in Windows specific code

### DIFF
--- a/Zend/zend_extensions.c
+++ b/Zend/zend_extensions.c
@@ -45,7 +45,7 @@ zend_result zend_load_extension(const char *path)
 #ifdef ZEND_WIN32
 	char *err;
 	if (!php_win32_image_compatible(handle, &err)) {
-		zend_error(E_CORE_WARNING, err);
+		zend_error(E_CORE_WARNING, "%s", err);
 		return FAILURE;
 	}
 #endif

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -3460,7 +3460,7 @@ void zend_jit_unprotect(void)
 		if (!VirtualProtect(dasm_buf, dasm_size, new, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%lu] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}
@@ -3487,7 +3487,7 @@ void zend_jit_protect(void)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%lu] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}
@@ -3731,7 +3731,7 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READWRITE, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%lu] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	} else {
@@ -3740,7 +3740,7 @@ void zend_jit_startup(void *buf, size_t size, bool reattached)
 		if (!VirtualProtect(dasm_buf, dasm_size, PAGE_EXECUTE_READ, &old)) {
 			DWORD err = GetLastError();
 			char *msg = php_win32_error_to_msg(err);
-			fprintf(stderr, "VirtualProtect() failed [%u] %s\n", err, msg);
+			fprintf(stderr, "VirtualProtect() failed [%lu] %s\n", err, msg);
 			php_win32_error_msg_free(msg);
 		}
 	}

--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -90,7 +90,7 @@ void zend_shared_alloc_create_lock(void)
 {
 	memory_mutex = CreateMutex(NULL, FALSE, create_name_with_username(ACCEL_MUTEX_NAME));
 	if (!memory_mutex) {
-		zend_accel_error(ACCEL_LOG_FATAL, "Cannot create mutex (error %u)", GetLastError());
+		zend_accel_error(ACCEL_LOG_FATAL, "Cannot create mutex (error %lu)", GetLastError());
 		return;
 	}
 	ReleaseMutex(memory_mutex);

--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -177,7 +177,7 @@ PHPAPI int php_load_extension(const char *filename, int type, int start_now)
 
 #ifdef PHP_WIN32
 	if (!php_win32_image_compatible(handle, &err1)) {
-			php_error_docref(NULL, error_type, err1);
+			php_error_docref(NULL, error_type, "%s", err1);
 			efree(err1);
 			DL_UNLOAD(handle);
 			return FAILURE;

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -609,7 +609,7 @@ static void php_get_windows_cpu(char *buf, size_t bufsize)
 	GetSystemInfo(&SysInfo);
 	switch (SysInfo.wProcessorArchitecture) {
 		case PROCESSOR_ARCHITECTURE_INTEL :
-			snprintf(buf, bufsize, "i%d", SysInfo.dwProcessorType);
+			snprintf(buf, bufsize, "i%lu", SysInfo.dwProcessorType);
 			break;
 		case PROCESSOR_ARCHITECTURE_MIPS :
 			snprintf(buf, bufsize, "MIPS R%d000", SysInfo.wProcessorLevel);
@@ -671,7 +671,7 @@ PHPAPI zend_string *php_get_uname(char mode)
 	if (mode == 's') {
 		php_uname = "Windows NT";
 	} else if (mode == 'r') {
-		return strpprintf(0, "%d.%d", dwWindowsMajorVersion, dwWindowsMinorVersion);
+		return strpprintf(0, "%lu.%lu", dwWindowsMajorVersion, dwWindowsMinorVersion);
 	} else if (mode == 'n') {
 		php_uname = ComputerName;
 	} else if (mode == 'v') {
@@ -680,7 +680,7 @@ PHPAPI zend_string *php_get_uname(char mode)
 
 		ZEND_ASSERT(winver != NULL);
 
-		zend_string *build_with_version = strpprintf(0, "build %d (%s)", dwBuild, winver);
+		zend_string *build_with_version = strpprintf(0, "build %lu (%s)", dwBuild, winver);
 		efree(winver);
 		return build_with_version;
 	} else if (mode == 'm') {
@@ -702,7 +702,7 @@ PHPAPI zend_string *php_get_uname(char mode)
 			}
 		}
 
-		zend_string *build_with_all_info = strpprintf(0, "%s %s %d.%d build %d (%s) %s",
+		zend_string *build_with_all_info = strpprintf(0, "%s %s %lu.%lu build %lu (%s) %s",
 			"Windows NT", ComputerName, dwWindowsMajorVersion, dwWindowsMinorVersion, dwBuild,
 			winver ? winver: "unknown", wincpu);
 		efree(winver);

--- a/ext/standard/link.c
+++ b/ext/standard/link.c
@@ -73,7 +73,7 @@ PHP_FUNCTION(readlink)
 
 	if (ret == -1) {
 #ifdef PHP_WIN32
-		php_error_docref(NULL, E_WARNING, "readlink failed to read the symbolic link (%s), error %d", link, GetLastError());
+		php_error_docref(NULL, E_WARNING, "readlink failed to read the symbolic link (%s), error %ld", link, GetLastError());
 #else
 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -2191,7 +2191,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 #ifdef PHP_WIN32
 	char *img_err;
 	if (!php_win32_crt_compatible(&img_err)) {
-		php_error(E_CORE_WARNING, img_err);
+		php_error(E_CORE_WARNING, "%s", img_err);
 		efree(img_err);
 		return FAILURE;
 	}

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -378,7 +378,7 @@ static void php_load_zend_extension_cb(void *arg)
 
 #ifdef PHP_WIN32
 		if (!php_win32_image_compatible(handle, &err1)) {
-				php_error(E_CORE_WARNING, err1);
+				php_error(E_CORE_WARNING, "%s", err1);
 				efree(err1);
 				efree(libpath);
 				DL_UNLOAD(handle);

--- a/win32/codepage.c
+++ b/win32/codepage.c
@@ -610,7 +610,7 @@ PHP_FUNCTION(sapi_windows_cp_set)
 		cp = php_win32_cp_set_by_id((DWORD)id);
 	}
 	if (!cp) {
-		php_error_docref(NULL, E_WARNING, "Failed to switch to codepage %d", id);
+		php_error_docref(NULL, E_WARNING, "Failed to switch to codepage " ZEND_LONG_FMT, id);
 		RETURN_FALSE;
 	}
 

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -468,7 +468,7 @@ static zend_always_inline BOOL is_compatible(HMODULE handle, BOOL is_smaller, ch
 		if (GetModuleFileName(handle, buf, sizeof(buf)) != 0) {
 			spprintf(err, 0, format, buf, major, minor, PHP_LINKER_MAJOR, PHP_LINKER_MINOR);
 		} else {
-			spprintf(err, 0, "Can't retrieve the module name (error %u)", GetLastError());
+			spprintf(err, 0, "Can't retrieve the module name (error %lu)", GetLastError());
 		}
 		return FALSE;
 	}
@@ -493,7 +493,7 @@ PHP_WINUTIL_API BOOL php_win32_crt_compatible(char **err)
 # endif
 	HMODULE handle = GetModuleHandle(crt_name);
 	if (handle == NULL) {
-		spprintf(err, 0, "Can't get handle of module %s (error %u)", crt_name, GetLastError());
+		spprintf(err, 0, "Can't get handle of module %s (error %lu)", crt_name, GetLastError());
 		return FALSE;
 	}
 	return is_compatible(handle, FALSE, "'%s' %u.%u is not compatible with this PHP build linked with %d.%d", err);


### PR DESCRIPTION
A couple of calls pass strings as formats (`-Wformat-security`), and some others mix up types (`-Wformat`).

---

I found a few more, but these are in general code path, so that takes more time to figure out. Will try to follow-up.