### PR TITLE
Fix `-Wpointer-type-mismatch` warning

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -3052,7 +3052,7 @@ static void *dlsym_loaded(char *symbol)
 	return addr;
 }
 # undef DL_FETCH_SYMBOL
-# define DL_FETCH_SYMBOL(h, s) (h == NULL ? dlsym_loaded(s) : GetProcAddress(h, s))
+# define DL_FETCH_SYMBOL(h, s) (h == NULL ? dlsym_loaded(s) : (void*) GetProcAddress(h, s))
 #endif
 
 ZEND_METHOD(FFI, cdef) /* {{{ */


### PR DESCRIPTION
`GetProcAddress()` returns a `FARPROC` (aka. `long long (*)()`) which is not compatible with `void *` per the specs.  However, on Windows they are, so we silence the warning with a cast.