### PR TITLE
Drop useless and not quite correct cast

### DIFF
--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -260,7 +260,7 @@ static void php_parserr(PDNS_RECORD pRec, int type_to_fetch, int store, bool raw
 
 				for(i=0; i < 8; i++) {
 					if (out[i] != 0) {
-						if (tp > (uint8_t *)buf) {
+						if (tp > buf) {
 							in_v6_break = 0;
 							tp[0] = ':';
 							tp++;


### PR DESCRIPTION
A while ago, the cast has been changed from `u_char *` to `uint8_t *`, but neither makes sense, and causes Clang to complain with `-Wcompare-distinct-pointer-types`.