### PR TITLE
Drop superfluous enum forward declaration

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4469,7 +4469,6 @@ PHP_FUNCTION(mb_send_mail)
 	bool suppress_content_transfer_encoding = false;
 
 	char *p;
-	enum mbfl_no_encoding;
 	const mbfl_encoding *tran_cs,	/* transfer text charset */
 						*head_enc,	/* header transfer encoding */
 						*body_enc;	/* body transfer encoding */


### PR DESCRIPTION
Besides that it is not needed, it is not proper C, and Clang warns that "forward references to 'enum' types are a Microsoft extension" (`-Wmicrosoft-enum-forward-reference`).

---

Frankly, I have no idea what that forward declaration is supposed to do, and that this apparently hasn't come up so far.