### PR TITLE
Define PHP_HAVE_BUILTIN_EXPECT for Clang on Windows

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -370,6 +370,7 @@ if (VS_TOOLSET) {
 		}
 	}
 } else if (CLANG_TOOLSET) {
+	AC_DEFINE("PHP_HAVE_BUILTIN_EXPECT", 1, "Define to 1 if the compiler supports '__builtin_expect'.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SADDL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_saddl_overflow'.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SADDLL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_saddll_overflow'.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SSUBL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_ssubl_overflow'.");


### PR DESCRIPTION
Clang supports `__builtin_expect()` at least as of 4.0.0, which is the (theoretical) minimum required on Windows, so we define it unconditionally.  This also solves some macro redefinition warnings in JIT-IR.