### PR TITLE
Don't pass -fwrapv to clang on Windows

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -5,9 +5,6 @@ PHP_DATE = "yes";
 ADD_SOURCES("ext/date/lib", "astro.c timelib.c dow.c parse_date.c parse_posix.c parse_tz.c tm2unixtime.c unixtime2tm.c parse_iso_intervals.c interval.c", "date");
 
 ADD_FLAG('CFLAGS_DATE', "/wd4244");
-if (CLANG_TOOLSET) {
-    ADD_FLAG('CFLAGS_BD_EXT_DATE_LIB', "-fwrapv");
-}
 
 var tl_config = FSO.CreateTextFile("ext/date/lib/timelib_config.h", true);
 tl_config.WriteLine("#include \"config.w32.h\"");


### PR DESCRIPTION
This is apparently not supported there; the VS supplied clang version 18.1.8, reports:

`clang-cl: warning: unknown argument ignored in clang-cl: '-fwrapv' [-Wunknown-argument]`

---

I should have actually tested https://github.com/php/php-src/pull/17060#issuecomment-2521793451 before suggesting. Sorry for the noise!