### PR TITLE
ext/mysql: Don't mention errors for optional part of the test

### DIFF
--- a/ext/mysqli/tests/mysqli_get_client_stats.phpt
+++ b/ext/mysqli/tests/mysqli_get_client_stats.phpt
@@ -922,14 +922,14 @@ if (!mysqli_query($link, "DROP TABLE IF EXISTS non_result_set_queries_test"))
 if (!mysqli_query($link, "DROP TABLE IF EXISTS client_stats_test"))
 	printf("[c004] Cannot drop table, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-if (!mysqli_query($link, "DROP DATABASE IF EXISTS mysqli_get_client_stats_"))
-	printf("[c005] Cannot drop table, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+// These tests are optional if the database and server fail to create them;
+// for example, if the user the tests run as are unprivileged. If we didn't
+// run those before, then errors like no permissions here are spurious.
+mysqli_query($link, "DROP DATABASE IF EXISTS mysqli_get_client_stats_");
 
-if (!mysqli_query($link, "DROP DATABASE IF EXISTS mysqli_get_client_stats"))
-	printf("[c006] Cannot drop table, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+mysqli_query($link, "DROP DATABASE IF EXISTS mysqli_get_client_stats");
 
-if (!mysqli_query($link, "DROP SERVER IF EXISTS myself"))
-	printf("[c007] Cannot drop table, [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+mysqli_query($link, "DROP SERVER IF EXISTS myself");
 
 mysqli_close($link);
 ?>


### PR DESCRIPTION
If the user we're running the tests as in MySQL is an unprivileged user, we skip the CREATE DATABASE and CREATE SERVER tests. However, the cleanup code still assumes they're there, and will fail with instead.

Instead, we simply don't print the messages for the equivalent DROP calls. However, we still do for TABLE, since if we can't run anything in the test database as the user we're running as, far more tests will fail.

I don't know if this is the best approach; silencing the errors for when those tests do run is unwise.

----

This PR is because of GH-17258; currently, the runner is running in the same system as MySQL, so running it unprivileged seemed wise. This should benefit other platforms wanting to run tests not as root now though; the only thing needed is to grant privileges to a user for a database (oh, and change binary logging off or allow it for functions).