### PR TITLE
Fix potential OOB when checking for trailing spaces

### DIFF
--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -56,10 +56,10 @@ PHP_WINUTIL_API void php_win32_error_msg_free(char *msg)
 
 int php_win32_check_trailing_space(const char * path, const size_t path_len)
 {/*{{{*/
-	if (path_len > MAXPATHLEN - 1) {
+	if (path_len == 0 || path_len > MAXPATHLEN - 1) {
 		return 1;
 	}
-	if (path && path_len > 0) {
+	if (path) {
 		if (path[0] == ' ' || path[path_len - 1] == ' ') {
 			return 0;
 		} else {

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -59,7 +59,7 @@ int php_win32_check_trailing_space(const char * path, const size_t path_len)
 	if (path_len > MAXPATHLEN - 1) {
 		return 1;
 	}
-	if (path) {
+	if (path && path_len > 0) {
 		if (path[0] == ' ' || path[path_len - 1] == ' ') {
 			return 0;
 		} else {


### PR DESCRIPTION
If `path_len` is zero, we must not access `path`, let alone try to subtract `-1` from it.

Since `path` and `path_len` are supposed to come from a `zend_string`, this is not a security issue.

---

Note that I'm not 100% sure whether the patch is correct, since `php_win32_check_trailing_space` apparently does not only check for *trailing* spaces, but also for *leading* spaces.