### PR TITLE
ext/mysqli: Use tempnam to make tracefiles unique

### DIFF
--- a/ext/mysqli/tests/mysqli_debug.phpt
+++ b/ext/mysqli/tests/mysqli_debug.phpt
@@ -19,8 +19,10 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
 <?php
     require_once 'connect.inc';
 
+    $trace_file = tempnam(sys_get_temp_dir(), "mysqli_debug_phpt");
+
     // NOTE: documentation is not clear on this: function always return NULL or TRUE
-    if (true !== ($tmp = mysqli_debug(sprintf('d:t:O,%s/mysqli_debug_phpt.trace', sys_get_temp_dir()))))
+    if (true !== ($tmp = mysqli_debug(sprintf('d:t:O,%s', $trace_file))))
         printf("[002] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
     // table.inc will create a database connection and run some SQL queries, therefore
@@ -28,7 +30,6 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     require_once 'table.inc';
 
     clearstatcache();
-    $trace_file = sprintf('%s/mysqli_debug_phpt.trace', sys_get_temp_dir());
     if (!file_exists($trace_file))
         printf("[003] Trace file '%s' has not been created\n", $trace_file);
     if (filesize($trace_file) < 50)

--- a/ext/mysqli/tests/mysqli_debug_append.phpt
+++ b/ext/mysqli/tests/mysqli_debug_append.phpt
@@ -21,7 +21,9 @@ if (substr(PHP_OS, 0, 3) == 'WIN') die("skip this test is not for Windows platfo
 <?php
     require_once 'connect.inc';
 
-    if (true !== ($tmp = mysqli_debug(sprintf('d:t:O,%s/mysqli_debug_phpt.trace', sys_get_temp_dir()))))
+    $trace_file = tempnam(sys_get_temp_dir(), "mysqli_debug_phpt");
+
+    if (true !== ($tmp = mysqli_debug(sprintf('d:t:O,%s', $trace_file))))
         printf("[001] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
     // table.inc will create a database connection and run some SQL queries, therefore
@@ -29,7 +31,6 @@ if (substr(PHP_OS, 0, 3) == 'WIN') die("skip this test is not for Windows platfo
     require_once 'table.inc';
 
     clearstatcache();
-    $trace_file = sprintf('%s/mysqli_debug_phpt.trace', sys_get_temp_dir());
     if (!file_exists($trace_file))
         printf("[002] Trace file '%s' has not been created\n", $trace_file);
     if (filesize($trace_file) < 50)

--- a/ext/mysqli/tests/mysqli_debug_control_string.phpt
+++ b/ext/mysqli/tests/mysqli_debug_control_string.phpt
@@ -53,7 +53,7 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
         unlink($trace_file);
     }
 
-    $trace_file = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, 'mysqli_debug_phpt.trace');
+    $trace_file = tempnam(sys_get_temp_dir(), "mysqli_debug_phpt");
     try_control_string($link, 't:,,:o,' . $trace_file, $trace_file, 10);
     try_control_string($link, ':' . chr(0) . 'A,' . $trace_file, $trace_file, 20);
     try_control_string($link, 't:o,' . $trace_file . ':abc', $trace_file, 30);

--- a/ext/mysqli/tests/mysqli_debug_mysqlnd_control_string.phpt
+++ b/ext/mysqli/tests/mysqli_debug_mysqlnd_control_string.phpt
@@ -57,7 +57,7 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
         return trim(substr(file_get_contents($trace_file), 0, 100024));
     }
 
-    $trace_file = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, 'mysqli_debug_phpt.trace');
+    $trace_file = tempnam(sys_get_temp_dir(), "mysqli_debug_phpt");
 
     $trace = try_control_string($link, 't:O,' . $trace_file, $trace_file, 10);
     if (!strstr($trace, 'SELECT * FROM test') && !strstr($trace, 'mysql_real_query'))
@@ -218,5 +218,5 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
-[083][control string 'n:O,%smysqli_debug_phpt.trace'] Trace file has not been written.
+[083][control string 'n:O,%s'] Trace file has not been written.
 done%s

--- a/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
+++ b/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
@@ -65,7 +65,7 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
         '_mysqlnd_pemalloc',
         '_mysqlnd_perealloc',
     );
-    $trace_file = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, 'mysqli_debug_phpt.trace');
+    $trace_file = tempnam(sys_get_temp_dir(), "mysqli_debug_phpt");
 
     $trace = try_control_string($link, 't:m:O,' . $trace_file, $trace_file, 10);
     if (!strstr($trace, 'SELECT * FROM test') && !strstr($trace, 'mysql_real_query'))


### PR DESCRIPTION
While a CONFLICTS acts as a barrier currently, it'd be nice to remove that. In addition, if multiple users run the test on the same system, it'd be owned by one user if a cleanup isn't run properly. The right solution for temporary files is tempnam and friends instead to generate a unique filename per invocation.

mysqli_debug_ini.phpt is not yet treated with this, because it uses an --INI-- section instead; generating a unique name here is trickier.