### PR TITLE
ext/pcntl: Fix pcntl_setcpuaffinity exception type for invalid cpu id.

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1721,7 +1721,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 				cpu = (zend_long)tmp;
 			} else {
 				zend_string *wcpu = zval_get_string_func(ncpu);
-				zend_argument_value_error(2, "cpu id invalid type (%s)", ZSTR_VAL(wcpu));
+				zend_argument_type_error(2, "cpu id invalid type (%s)", ZSTR_VAL(wcpu));
 				zend_string_release(wcpu);
 				PCNTL_CPU_DESTROY(mask);
 				RETURN_THROWS();

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1720,9 +1720,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 
 				cpu = (zend_long)tmp;
 			} else {
-				zend_string *wcpu = zval_get_string_func(ncpu);
-				zend_argument_type_error(2, "cpu id invalid type (%s)", ZSTR_VAL(wcpu));
-				zend_string_release(wcpu);
+				zend_argument_type_error(2, "value must be of type int|string, %s given", zend_zval_value_name(ncpu));
 				PCNTL_CPU_DESTROY(mask);
 				RETURN_THROWS();
 			}

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -64,6 +64,4 @@ pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid value (def)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (%d)
 pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id must be between 0 and %d (-1024)
 pcntl_getcpuaffinity(): Argument #1 ($process_id) invalid process (-1024)
-
-Warning: Array to string conversion in %s on line %d
-pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) cpu id invalid type (Array)
+pcntl_setcpuaffinity(): Argument #2 ($cpu_ids) value must be of type int|string, array given

--- a/ext/pcntl/tests/pcntl_cpuaffinity.phpt
+++ b/ext/pcntl/tests/pcntl_cpuaffinity.phpt
@@ -48,7 +48,7 @@ try {
 
 try {
 	pcntl_setcpuaffinity(null, [1, array(1)]);
-} catch (\ValueError $e) {
+} catch (\TypeError $e) {
 	echo $e->getMessage();
 }
 ?>


### PR DESCRIPTION
found while working [on the doc](https://github.com/php/doc-en/pull/4346).