### PR TITLE
Fix Clang sanitizers on Windows

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3734,7 +3734,7 @@ function add_asan_opts(cflags_name, libs_name, ldflags_name)
 	var lib_dir = get_clang_lib_dir();
 
 	if (!!cflags_name) {
-		ADD_FLAG(cflags_name, "-fsanitize=address,undefined");
+		ADD_FLAG(cflags_name, "-fsanitize=address,undefined -fno-sanitize=function");
 	}
 	if (!!libs_name) {
 		if (TARGET_ARCH == 'x64') {


### PR DESCRIPTION
As is, sanitizers (ASan and UBSan) can't be enabled for somewhat recent versions of LLVM, and even for older version it would not work for custom installation folders.

Furthermore we cater to https://github.com/php/php-src/issues/17462.