### PR TITLE
ext/pdo_odbc: Do not populate message if there is no driver error

### DIFF
--- a/ext/pdo/tests/bug_38253.phpt
+++ b/ext/pdo/tests/bug_38253.phpt
@@ -43,18 +43,18 @@ PDOTest::dropTableIfExists($db, "test38253");
 --EXPECTF--
 Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: No fetch class specified in %s on line %d
 
-Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error%s on line %d
+Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error in %s on line %d
 array(0) {
 }
 
 Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: No fetch function specified in %s on line %d
 
-Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error%s on line %d
+Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error in %s on line %d
 array(0) {
 }
 
 Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error: No fetch-into object specified. in %s on line %d
 
-Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error%s on line %d
+Warning: PDOStatement::fetchAll(): SQLSTATE[HY000]: General error in %s on line %d
 array(0) {
 }

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -41,6 +41,11 @@ static void pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *in
 		einfo = &S->einfo;
 	}
 
+	/* If we don't have a driver error do not populate the info array */
+	if (strlen(einfo->last_err_msg) == 0) {
+		return;
+	}
+
 	message = strpprintf(0, "%s (%s[%ld] at %s:%d)",
 				einfo->last_err_msg,
 				einfo->what, (long) einfo->last_error,


### PR DESCRIPTION
@NattyNarwhal do you have instructions on how to set a DB on Linux/Fedora?

I think the double warning is an existing bug in PDO anyway, but I'm still confused as to why it is printing NULL bytes here.