### PR TITLE
main: Voidify php_startup_ticks()

### DIFF
--- a/main/php_ticks.c
+++ b/main/php_ticks.c
@@ -23,10 +23,9 @@ struct st_tick_function
 	void *arg;
 };
 
-int php_startup_ticks(void)
+void php_startup_ticks(void)
 {
 	zend_llist_init(&PG(tick_functions), sizeof(struct st_tick_function), NULL, 1);
-	return SUCCESS;
 }
 
 void php_deactivate_ticks(void)

--- a/main/php_ticks.h
+++ b/main/php_ticks.h
@@ -17,7 +17,7 @@
 #ifndef PHP_TICKS_H
 #define PHP_TICKS_H
 
-int php_startup_ticks(void);
+void php_startup_ticks(void);
 void php_deactivate_ticks(void);
 void php_shutdown_ticks(php_core_globals *core_globals);
 void php_run_ticks(int count);


### PR DESCRIPTION
As it always returns SUCCESS and we ignored the return value anyway