### PR TITLE
Support building a shared php8embed.dll

### DIFF
--- a/sapi/embed/config.w32
+++ b/sapi/embed/config.w32
@@ -5,6 +5,10 @@ ARG_ENABLE('embed', 'Embedded SAPI library', 'no');
 var PHP_EMBED_PGO = false;
 
 if (PHP_EMBED != "no") {
-	SAPI('embed', 'php_embed.c', 'php' + PHP_VERSION + 'embed.lib', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	SAPI('embed', 'php_embed.c', 'php' + PHP_VERSION + 'embed.' + (PHP_EMBED_SHARED ? 'dll' : 'lib'), '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	if (PHP_EMBED_SHARED) {
+		ADD_FLAG("CFLAGS_EMBED", "/DPHP_EMBED_EXPORTS");
+		AC_DEFINE("PHP_EMBED_SHARED", 1, "Define to 1 if you have a shared embed SAPI.");
+	}
 	PHP_INSTALL_HEADERS("sapi/embed", "php_embed.h");
 }

--- a/sapi/embed/php_embed.h
+++ b/sapi/embed/php_embed.h
@@ -38,7 +38,13 @@
 #ifndef PHP_WIN32
     #define EMBED_SAPI_API SAPI_API
 #else
-    #define EMBED_SAPI_API
+# if defined(PHP_EMBED_EXPORTS)
+#  define EMBED_SAPI_API __declspec(dllexport)
+# elif defined(PHP_EMBED_SHARED)
+#  define EMBED_SAPI_API __declspec(dllimport)
+# else
+#  define EMBED_SAPI_API
+# endif
 #endif
 
 #ifdef ZTS

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -509,7 +509,7 @@ can be built that way. \
 			if (force) {
 				STDOUT.WriteLine("snapshot: forcing " + arg.optname + " on");
 				argval = "yes";
-				shared = true;
+				shared = arg.optname != "embed";
 			}
 		}
 


### PR DESCRIPTION
So far only static php8embed.lib has been supported on Windows, while on POSIX the choice was up to the user.  Now, `--enable-embed=shared` is also supported on Windows.

For BC reasons we stick with static as default; the resulting embed library can be used like before.  To avoid that snapshot builds now build a shared library, we add an exemption to confutils.js.

To properly support a static and a shared library, respectively, we do the customary `__declspec` dance.