### PR TITLE
Replace __forceinline with zend_always_inline in win32/

### DIFF
--- a/win32/codepage.c
+++ b/win32/codepage.c
@@ -35,7 +35,7 @@ ZEND_TLS const struct php_win32_cp *orig_in_cp = NULL;
 
 #include "cp_enc_map.c"
 
-__forceinline static wchar_t *php_win32_cp_to_w_int(const char* in, size_t in_len, size_t *out_len, UINT cp, DWORD flags)
+zend_always_inline static wchar_t *php_win32_cp_to_w_int(const char* in, size_t in_len, size_t *out_len, UINT cp, DWORD flags)
 {/*{{{*/
 	wchar_t *ret;
 	int ret_len, tmp_len;
@@ -241,7 +241,7 @@ PW32CP wchar_t *php_win32_cp_conv_ascii_to_w(const char* in, size_t in_len, size
 }/*}}}*/
 #undef ASCII_FAIL_RETURN
 
-__forceinline static char *php_win32_cp_from_w_int(const wchar_t* in, size_t in_len, size_t *out_len, UINT cp, DWORD flags)
+zend_always_inline static char *php_win32_cp_from_w_int(const wchar_t* in, size_t in_len, size_t *out_len, UINT cp, DWORD flags)
 {/*{{{*/
 	int r;
 	int target_len, tmp_len;
@@ -306,7 +306,7 @@ PW32CP char *php_win32_cp_conv_from_w(DWORD cp, DWORD flags, const wchar_t* in, 
 }/*}}}*/
 
 /* This is only usable after the startup phase*/
-__forceinline static char *php_win32_cp_get_enc(void)
+zend_always_inline static char *php_win32_cp_get_enc(void)
 {/*{{{*/
 	char *enc = NULL;
 	const zend_encoding *zenc;

--- a/win32/codepage.h
+++ b/win32/codepage.h
@@ -76,7 +76,7 @@ PW32CP wchar_t *php_win32_cp_env_any_to_w(const char* env);
 /* This function tries to make the best guess to convert any
    given string to a wide char, also preferring the fastest code
    path to unicode. It returns NULL on fail. */
-__forceinline static wchar_t *php_win32_cp_conv_any_to_w(const char* in, size_t in_len, size_t *out_len)
+zend_always_inline static wchar_t *php_win32_cp_conv_any_to_w(const char* in, size_t in_len, size_t *out_len)
 {/*{{{*/
 	wchar_t *ret = NULL;
 
@@ -117,7 +117,7 @@ __forceinline static wchar_t *php_win32_cp_conv_any_to_w(const char* in, size_t 
 /* This function converts from unicode function output back to PHP. If
 	the PHP's current charset is not compatible with unicode, so the currently
 	configured CP will be used. */
-__forceinline static char *php_win32_cp_conv_w_to_any(const wchar_t* in, size_t in_len, size_t *out_len)
+zend_always_inline static char *php_win32_cp_conv_w_to_any(const wchar_t* in, size_t in_len, size_t *out_len)
 {/*{{{*/
 	return php_win32_cp_conv_w_to_cur(in, in_len, out_len);
 }/*}}}*/

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -172,7 +172,7 @@ PW32IO php_win32_ioutil_normalization_result php_win32_ioutil_normalize_path_w(w
 
 /* Keep these functions aliased for case some additional handling
    is needed later. */
-__forceinline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in, size_t in_len, size_t *out_len)
+zend_always_inline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in, size_t in_len, size_t *out_len)
 {/*{{{*/
 	wchar_t *mb, *ret;
 	size_t mb_len, dir_len = 0;
@@ -268,7 +268,7 @@ __forceinline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in, siz
 #define php_win32_ioutil_cur_to_w php_win32_cp_cur_to_w
 #define php_win32_ioutil_w_to_any php_win32_cp_w_to_any
 #define php_win32_ioutil_conv_w_to_any php_win32_cp_conv_w_to_any
-/*__forceinline static char *php_win32_ioutil_w_to_any(wchar_t* w_source_ptr)
+/*zend_always_inline static char *php_win32_ioutil_w_to_any(wchar_t* w_source_ptr)
 {
 	return php_win32_cp_w_to_any(w_source_ptr);
 }*/
@@ -292,7 +292,7 @@ PW32IO wchar_t *php_win32_ioutil_realpath_w_ex0(const wchar_t *path, wchar_t *re
 PW32IO int php_win32_ioutil_symlink_w(const wchar_t *target, const wchar_t *link);
 PW32IO int php_win32_ioutil_link_w(const wchar_t *target, const wchar_t *link);
 
-__forceinline static int php_win32_ioutil_access(const char *path, mode_t mode)
+zend_always_inline static int php_win32_ioutil_access(const char *path, mode_t mode)
 {/*{{{*/
 	PHP_WIN32_IOUTIL_INIT_W(path)
 	int ret, err;
@@ -317,7 +317,7 @@ __forceinline static int php_win32_ioutil_access(const char *path, mode_t mode)
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_open(const char *path, int flags, ...)
+zend_always_inline static int php_win32_ioutil_open(const char *path, int flags, ...)
 {/*{{{*/
 	mode_t mode = 0;
 	PHP_WIN32_IOUTIL_INIT_W(path)
@@ -352,7 +352,7 @@ __forceinline static int php_win32_ioutil_open(const char *path, int flags, ...)
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_unlink(const char *path)
+zend_always_inline static int php_win32_ioutil_unlink(const char *path)
 {/*{{{*/
 	PHP_WIN32_IOUTIL_INIT_W(path)
 	int ret = -1;
@@ -376,7 +376,7 @@ __forceinline static int php_win32_ioutil_unlink(const char *path)
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_rmdir(const char *path)
+zend_always_inline static int php_win32_ioutil_rmdir(const char *path)
 {/*{{{*/
 	PHP_WIN32_IOUTIL_INIT_W(path)
 	int ret = 0;
@@ -403,7 +403,7 @@ __forceinline static int php_win32_ioutil_rmdir(const char *path)
 	return ret;
 }/*}}}*/
 
-__forceinline static FILE *php_win32_ioutil_fopen(const char *patha, const char *modea)
+zend_always_inline static FILE *php_win32_ioutil_fopen(const char *patha, const char *modea)
 {/*{{{*/
 	FILE *ret;
 	wchar_t modew[16] = {0};
@@ -435,7 +435,7 @@ __forceinline static FILE *php_win32_ioutil_fopen(const char *patha, const char 
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_rename(const char *oldnamea, const char *newnamea)
+zend_always_inline static int php_win32_ioutil_rename(const char *oldnamea, const char *newnamea)
 {/*{{{*/
 	wchar_t *oldnamew;
 	wchar_t *newnamew;
@@ -479,7 +479,7 @@ __forceinline static int php_win32_ioutil_rename(const char *oldnamea, const cha
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_chdir(const char *patha)
+zend_always_inline static int php_win32_ioutil_chdir(const char *patha)
 {/*{{{*/
 	int ret;
 	wchar_t *pathw = php_win32_ioutil_any_to_w(patha);
@@ -504,7 +504,7 @@ __forceinline static int php_win32_ioutil_chdir(const char *patha)
 	return ret;
 }/*}}}*/
 
-__forceinline static char *php_win32_ioutil_getcwd(char *buf, size_t len)
+zend_always_inline static char *php_win32_ioutil_getcwd(char *buf, size_t len)
 {/*{{{*/
 	wchar_t tmp_bufw[PHP_WIN32_IOUTIL_MAXPATHLEN];
 	char *tmp_bufa = NULL;
@@ -544,7 +544,7 @@ __forceinline static char *php_win32_ioutil_getcwd(char *buf, size_t len)
 }/*}}}*/
 
 /* TODO improve with usage of native APIs, split for _a and _w. */
-__forceinline static int php_win32_ioutil_chmod(const char *patha, int mode)
+zend_always_inline static int php_win32_ioutil_chmod(const char *patha, int mode)
 {/*{{{*/
 	wchar_t *pathw = php_win32_ioutil_any_to_w(patha);
 	int err = 0;
@@ -571,7 +571,7 @@ __forceinline static int php_win32_ioutil_chmod(const char *patha, int mode)
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_mkdir(const char *path, mode_t mode)
+zend_always_inline static int php_win32_ioutil_mkdir(const char *path, mode_t mode)
 {/*{{{*/
 	int ret;
 	DWORD err = 0;
@@ -596,7 +596,7 @@ __forceinline static int php_win32_ioutil_mkdir(const char *path, mode_t mode)
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_symlink(const char *target, const char *link)
+zend_always_inline static int php_win32_ioutil_symlink(const char *target, const char *link)
 {/*{{{*/
 	wchar_t *targetw, *linkw;
 	int ret;
@@ -622,7 +622,7 @@ __forceinline static int php_win32_ioutil_symlink(const char *target, const char
 	return ret;
 }/*}}}*/
 
-__forceinline static int php_win32_ioutil_link(const char *target, const char *link)
+zend_always_inline static int php_win32_ioutil_link(const char *target, const char *link)
 {/*{{{*/
 	wchar_t *targetw, *linkw;
 	int ret;
@@ -649,7 +649,7 @@ __forceinline static int php_win32_ioutil_link(const char *target, const char *l
 
 PW32IO char *realpath(const char *path, char *resolved);
 
-__forceinline static char *php_win32_ioutil_realpath_ex0(const char *path, char *resolved, PBY_HANDLE_FILE_INFORMATION info)
+zend_always_inline static char *php_win32_ioutil_realpath_ex0(const char *path, char *resolved, PBY_HANDLE_FILE_INFORMATION info)
 {/*{{{*/
 	wchar_t retw[PHP_WIN32_IOUTIL_MAXPATHLEN];
 	char *reta;
@@ -694,7 +694,7 @@ __forceinline static char *php_win32_ioutil_realpath_ex0(const char *path, char 
 	return resolved;
 }/*}}}*/
 
-__forceinline static char *php_win32_ioutil_realpath(const char *path, char *resolved)
+zend_always_inline static char *php_win32_ioutil_realpath(const char *path, char *resolved)
 {/*{{{*/
 	return php_win32_ioutil_realpath_ex0(path, resolved, NULL);
 }/*}}}*/
@@ -758,7 +758,7 @@ typedef struct {
 PW32IO int php_win32_ioutil_stat_ex_w(const wchar_t *path, size_t path_len, php_win32_ioutil_stat_t *buf, int lstat);
 PW32IO int php_win32_ioutil_fstat(int fd, php_win32_ioutil_stat_t *buf);
 
-__forceinline static int php_win32_ioutil_stat_ex(const char *path, php_win32_ioutil_stat_t *buf, int lstat)
+zend_always_inline static int php_win32_ioutil_stat_ex(const char *path, php_win32_ioutil_stat_t *buf, int lstat)
 {/*{{{*/
 	size_t pathw_len;
 	wchar_t *pathw = php_win32_ioutil_conv_any_to_w(path, PHP_WIN32_CP_IGNORE_LEN, &pathw_len);
@@ -780,7 +780,7 @@ __forceinline static int php_win32_ioutil_stat_ex(const char *path, php_win32_io
 
 PW32IO ssize_t php_win32_ioutil_readlink_w(const wchar_t *path, wchar_t *buf, size_t buf_len);
 
-__forceinline static ssize_t php_win32_ioutil_readlink(const char *path, char *buf, size_t buf_len)
+zend_always_inline static ssize_t php_win32_ioutil_readlink(const char *path, char *buf, size_t buf_len)
 {/*{{{*/
 	size_t pathw_len, ret_buf_len;
 	wchar_t *pathw = php_win32_ioutil_conv_any_to_w(path, PHP_WIN32_CP_IGNORE_LEN, &pathw_len);


### PR DESCRIPTION
`__forceinline` is MSVC specific (and also understood by Clang on Windows), but the code in win32/ should not be constrained to these compilers.  Since we already have `zend_always_inline`, we use this instead.

---

The motivation is to make the win32/ more portable, since there are other relevant compilers than MSVC and Clang on Windows (e.g. MinGW GCC). While this commit doesn't really change anything in this regard, it makes it simpler to do so.

Note that I have deliberately not touched some bundled libraries using `__forceinline`, because it may make updating these a bit harder, and more importantly, because they already use `__forceinline` only if `_MSC_VER` is defined.

Also note that I consider the use of `zend_always_inline` generally doubtful, because it (a) does not necessarily enforce inlining (what might easily be overlooked), and (b) the programmer doesn't know better than the compiler (maybe for some tiny amount of time, but the next commit/compiler version may make that moot; profile guided optimization is likely the better judge).

We should probably have a look at our uses of `__inline` which appear to be outdated.