### PR TITLE
Fix GH-17469: UConverter::transcode() not hardcoding error handling.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,8 @@ PHP                                                                        NEWS
 
 - Intl:
   . Fixed bug GH-11874 (intl causing segfault in docker images). (nielsdos)
+  . Fixed bug GH-17469 (UConverter::transcode always emit E_WARNING on
+    invalid encoding). (David Carlier)
 
 - Opcache:
   . Fixed bug GH-17307 (Internal closure causes JIT failure). (nielsdos)

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -381,20 +381,23 @@ static bool php_converter_set_encoding(php_converter_object *objval,
 		if (objval) {
 			THROW_UFAILURE(objval, "ucnv_open", error);
 		} else {
-			php_error_docref(NULL, E_WARNING, "Error setting encoding: %d - %s", (int)error, u_errorName(error));
+			char *msg;
+			spprintf(&msg, 0, "Error setting encoding: %d - %s", (int)error, u_errorName(error));
+			intl_error_set(NULL, error, msg, 1);
+			efree(msg);
 		}
-		return 0;
+		return false;
 	}
 
 	if (objval && !php_converter_set_callbacks(objval, cnv)) {
-		return 0;
+		return false;
 	}
 
 	if (*pcnv) {
 		ucnv_close(*pcnv);
 	}
 	*pcnv = cnv;
-	return 1;
+	return true;
 }
 /* }}} */
 

--- a/ext/intl/tests/gh17469.phpt
+++ b/ext/intl/tests/gh17469.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-17469: UConverter::transcode() raises always E_WARNING regardless of INI settings
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === "Windows") die("skip currently unsupported on Windows");
+?>
+--FILE--
+<?php
+ini_set("intl.error_level", E_WARNING);
+ini_set("intl.use_exceptions", 0);
+UConverter::transcode("\x0a", 'nein!!', 'UTF-8');
+UConverter::transcode("\x0a", 'UTF-16BE', 'da!');
+
+ini_set("intl.error_level", 0);
+ini_set("intl.use_exceptions", 1);
+
+try {
+	UConverter::transcode("\x0a", 'nein!!', 'UTF-8');
+} catch (IntlException $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+try {
+	UConverter::transcode("\x0a", 'UTF-16BE', 'da!');
+} catch (IntlException $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECTF--
+
+Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line %d
+
+Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line 5
+Error setting encoding: 4 - U_FILE_ACCESS_ERROR
+Error setting encoding: 4 - U_FILE_ACCESS_ERROR


### PR DESCRIPTION
Respecting instead intl.use_exceptions/intl.error_level.