### PR TITLE
Ensure charset in tests

### DIFF
--- a/ext/mysqli/tests/functions/mysqli_character_set_name.phpt
+++ b/ext/mysqli/tests/functions/mysqli_character_set_name.phpt
@@ -13,6 +13,8 @@ require_once dirname(__DIR__) . "/test_setup/test_helpers.inc";
 
 $link = default_mysqli_connect();
 
+mysqli_set_charset($link, 'utf8mb4');
+
 $result = mysqli_query($link, 'SELECT @@character_set_connection AS charset, @@collation_connection AS collation');
 $tmp = mysqli_fetch_assoc($result);
 mysqli_free_result($result);

--- a/ext/mysqli/tests/functions/mysqli_character_set_name_oo.phpt
+++ b/ext/mysqli/tests/functions/mysqli_character_set_name_oo.phpt
@@ -13,6 +13,8 @@ require_once dirname(__DIR__) . "/test_setup/test_helpers.inc";
 
 $link = default_mysqli_connect();
 
+$link->set_charset('utf8mb4');
+
 $result = $link->query('SELECT @@character_set_connection AS charset, @@collation_connection AS collation');
 $tmp = $result->fetch_assoc();
 $result->free_result();


### PR DESCRIPTION
The `utf8mb3` charset is a total mess. In the past, it was an alias for `utf8`. Now, it's the other way around `utf8` is an alias for `utf8mb3`. PHP for the moment still reports `utf8` and so our test will report a mismatch if the default charset is `utf8mb3`. We can avoid it by setting a different charset that doesn't have this problem. 