### PR TITLE
Fix GH-17516: SplFileTempObject::getPathInfo() crash on invalid class.

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1368,6 +1368,9 @@ PHP_METHOD(SplFileInfo, getPathInfo)
 
 	if (ce == NULL) {
 		ce = intern->info_class;
+	} else if (!instanceof_function(ce, spl_ce_SplFileInfo)) {
+		zend_argument_type_error(1, "must be a class name derived from %s or null, %s given", ZSTR_VAL(spl_ce_SplFileInfo->name), ZSTR_VAL(ce->name));
+		RETURN_THROWS();
 	}
 
 	path = spl_filesystem_object_get_pathname(intern);

--- a/ext/spl/tests/gh17516.phpt
+++ b/ext/spl/tests/gh17516.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-17516 SplTempFileObject::getPathInfo() crashes on invalid class ID.
+--FILE--
+<?php
+$cls = new SplTempFileObject();
+class SplFileInfoChild extends SplFileInfo {}
+class BadSplFileInfo {}
+
+var_dump($cls->getPathInfo('SplFileInfoChild'));
+
+try {
+	$cls->getPathInfo('BadSplFileInfo');
+} catch (\TypeError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+object(SplFileInfoChild)#2 (2) {
+  ["pathName":"SplFileInfo":private]=>
+  string(4) "php:"
+  ["fileName":"SplFileInfo":private]=>
+  string(4) "php:"
+}
+SplFileInfo::getPathInfo(): Argument #1 ($class) must be a class name derived from SplFileInfo or null, BadSplFileInfo given


### PR DESCRIPTION
This no longer caught the case where a non SplFileInfo/inherited class of was passed since the refactoring in 8.4.