### PR TITLE
Fix GH-17518: offset overflow phar extractTo()

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -4306,7 +4306,7 @@ static int extract_helper(phar_archive_data *archive, zend_string *search, char 
 			if (FAILURE == phar_extract_file(overwrite, entry, pathto, pathto_len, error)) return -1;
 			extracted++;
 		} ZEND_HASH_FOREACH_END();
-	} else if ('/' == ZSTR_VAL(search)[ZSTR_LEN(search) - 1]) {
+	} else if (ZSTR_LEN(search) > 0 && '/' == ZSTR_VAL(search)[ZSTR_LEN(search) - 1]) {
 		/* ends in "/" -- extract all entries having that prefix */
 		ZEND_HASH_MAP_FOREACH_PTR(&archive->manifest, entry) {
 			if (0 != strncmp(ZSTR_VAL(search), entry->filename, ZSTR_LEN(search))) continue;

--- a/ext/phar/tests/gh17518.phpt
+++ b/ext/phar/tests/gh17518.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-17518 (offset overflow phar extractTo())
+--EXTENSIONS--
+phar
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+$fname = __DIR__.'/gh17518.phar.php';
+$phar = new Phar($fname);
+$phar['a'] = 'b';
+try {
+    $phar->extractTo(__DIR__ . '/gh17518', '');
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__.'/gh17518.phar.php');
+?>
+--EXPECTF--
+PharException: phar error: attempted to extract non-existent file or directory "" from phar "%sgh17518.phar.php"


### PR DESCRIPTION
`search` can be the empty string, so we need to check the length before checking the last char.