### PR TITLE
Fix Clang builds regarding undefined function call

### DIFF
--- a/Zend/zend_call_stack.h
+++ b/Zend/zend_call_stack.h
@@ -25,6 +25,10 @@
 # include <pthread.h>
 #endif
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 #ifdef ZEND_CHECK_STACK_LIMIT
 
 typedef struct _zend_call_stack {
@@ -38,7 +42,7 @@ ZEND_API bool zend_call_stack_get(zend_call_stack *stack);
 
 /** Returns an approximation of the current stack position */
 static zend_always_inline void *zend_call_stack_position(void) {
-#ifdef ZEND_WIN32
+#ifdef _MSC_VER
 	return _AddressOfReturnAddress();
 #elif defined(PHP_HAVE_BUILTIN_FRAME_ADDRESS)
 	return __builtin_frame_address(0);


### PR DESCRIPTION
While MSVC is apparently fine using `_AddressOfReturnAddress()` without including intrin.h, Clang complains that the function is undefined.  So we include the header, if `_MSC_VER` is defined, what is the case for MSVC and clang-cl, but not for some other compilers on Windows (e.g. GCC).

---

Note that this is related to https://github.com/php/php-src/commit/36857ab52b8cafc91650ccc55053abe6b517f092. It is indeed correct, that `-fmodules` declares some intrinsics (without `-fmodules`, hash_sha_ni.c and possibly others fail to build, even when I'm including intrin.h there). However, there are apparently no longer conflicting declarations in Clang (tested with 18.1.8), and without the include, I'm getting:

````
In file included from Zend\zend_constants.c:21:
In file included from Zend\zend_constants.h:23:
In file included from Zend\zend_globals.h:42:
Zend\zend_call_stack.h(46,9): error: call to undeclared library function '_AddressOfReturnAddress' with type 'void *(void)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   46 |         return _AddressOfReturnAddress();
      |                ^
Zend\zend_call_stack.h(46,9): note: include the header <intrin.h> or explicitly provide a declaration for '_AddressOfReturnAddress'
1 error generated.
````

PS: note that Clang does not (yet) support `__builtin_frame_address()`.