### PR TITLE
zend_ulong_ntz/zend_ulong_ntz little optimisation for windows.

### DIFF
--- a/Zend/zend_bitset.h
+++ b/Zend/zend_bitset.h
@@ -56,9 +56,9 @@ ZEND_ATTRIBUTE_CONST static zend_always_inline int zend_ulong_ntz(zend_ulong num
 	unsigned long index;
 
 #if defined(_WIN64)
-	if (!BitScanForward64(&index, num)) {
+	if (UNEXPECTED(!BitScanForward64(&index, num))) {
 #else
-	if (!BitScanForward(&index, num)) {
+	if (UNEXPECTED(!BitScanForward(&index, num))) {
 #endif
 		/* undefined behavior */
 		return SIZEOF_ZEND_LONG * 8;
@@ -94,9 +94,9 @@ ZEND_ATTRIBUTE_CONST static zend_always_inline int zend_ulong_nlz(zend_ulong num
 	unsigned long index;
 
 #if defined(_WIN64)
-	if (!BitScanReverse64(&index, num)) {
+	if (UNEXPECTED(!BitScanReverse64(&index, num))) {
 #else
-	if (!BitScanReverse(&index, num)) {
+	if (UNEXPECTED(!BitScanReverse(&index, num))) {
 #endif
 		/* undefined behavior */
 		return SIZEOF_ZEND_LONG * 8;


### PR DESCRIPTION
because of the unix code path, UB is avoided beforehand thus errors with 0 mask for the windows api is unlikely.