### PR TITLE
ext/mysqli: Skip test that needs superuser

### DIFF
--- a/ext/mysqli/tests/mysqli_get_client_stats.phpt
+++ b/ext/mysqli/tests/mysqli_get_client_stats.phpt
@@ -4,7 +4,33 @@ mysqli_get_client_stats()
 mysqli
 --SKIPIF--
 <?PHP
-require_once 'skipifconnectfailure.inc';
+    require_once __DIR__ . '/test_setup/test_helpers.inc';
+    $link = mysqli_connect_or_skip();
+    // We run some operations that need CREATE SERVER and CREATE DATABASE in
+    // this test, so check if we can do that. We don't check if we can merely
+    // create a table; if that doesn't work with the provided database, many
+    // more tests would fail.
+
+    // It seems DML can be privilege checked on prepare, but DML can't be, so
+    // we need to execute and clean up.
+    try {
+        $sql = "CREATE DATABASE mysqli_get_client_stats";
+        $stmt = mysqli_query($link, $sql);
+        $stmt->close();
+         mysqli_query($link, "DROP DATABASE mysqli_get_client_stats");
+    } catch (\mysqli_sql_exception) {
+        die("skip don't have create database privilege");
+    }
+    try {
+        $sql = sprintf("CREATE SERVER myself FOREIGN DATA WRAPPER mysql OPTIONS (user '%s', password '%s', database '%s')",
+            get_default_user(), get_default_password(), get_default_database());
+        $stmt = mysqli_query($link, $sql);
+        $stmt->close();
+        mysqli_query($link, "DROP SERVER myself");
+    } catch(\mysqli_sql_exception) {
+        die("skip don't have create server privilege");
+    }
+    mysqli_close($link);
 ?>
 --INI--
 mysqlnd.collect_statistics=1


### PR DESCRIPTION
This test needs CREATE DATABASE and CREATE SERVER, and will fail in the cleanup step if it doesn't have it. If the test is running as a user that can't do these, then we should skip instead of borking.

Alternative to GH-17466.