### PR TITLE
Drop misleading comments about undefined behavior

### DIFF
--- a/Zend/zend_bitset.h
+++ b/Zend/zend_bitset.h
@@ -60,7 +60,6 @@ ZEND_ATTRIBUTE_CONST static zend_always_inline int zend_ulong_ntz(zend_ulong num
 #else
 	if (!BitScanForward(&index, num)) {
 #endif
-		/* undefined behavior */
 		return SIZEOF_ZEND_LONG * 8;
 	}
 
@@ -98,7 +97,6 @@ ZEND_ATTRIBUTE_CONST static zend_always_inline int zend_ulong_nlz(zend_ulong num
 #else
 	if (!BitScanReverse(&index, num)) {
 #endif
-		/* undefined behavior */
 		return SIZEOF_ZEND_LONG * 8;
 	}
 


### PR DESCRIPTION
There is no undefined behavior here.  If `BitScan*()` returns zero, the value written to the first parameter is undefined, but we return a reasonable value.

---

This came up in #17527.

While having a closer look, I found that `zend_ulong_ntz()` and `zend_ulong_nlz()` are documented to behave differently if the argument is zero. While the latter states that for zero the result is undefined, the former states that for zero, LEN would be returned:

https://github.com/php/php-src/blob/ce53dab2722611c2e87d680b9be43e187d82219f/Zend/zend_bitset.h#L47

While this is actually true on Windows, and for the fallback implementation, it is apparently not the case when `__builtin_ctzl()` or `__builtin_ctzll()` are used. From https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html:

> Returns the number of trailing 0-bits in x, starting at the least significant bit position. If x is 0, the result is undefined.

So at least the comment should be fixed, and I would put in assert regarding the pre-condition, but see https://github.com/php/php-src/pull/17506#discussion_r1922533709 (I'm not sure whether *all* callers use the function accordingly). Also, in that case the Windows implementation would not need to check the return value.

Possible alternative: define the functions for `num == 0`.