### PR TITLE
Fix GH-17408: Assertion failure Zend/zend_exceptions.c

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -193,7 +193,6 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception) /*
 		zend_exception_set_previous(exception, EG(exception));
 		EG(exception) = exception;
 		if (previous) {
-			ZEND_ASSERT(is_handle_exception_set() && "HANDLE_EXCEPTION not set?");
 			return;
 		}
 	}

--- a/ext/zend_test/tests/gh17408.phpt
+++ b/ext/zend_test/tests/gh17408.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-17408 (Assertion failure Zend/zend_exceptions.c)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+function test() {
+    $resource = zend_test_create_throwing_resource();
+    zend_test_create_throwing_resource();
+}
+test();
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Throwing resource destructor called in %s:%d
+Stack trace:
+#0 %s(%d): test()
+#1 {main}
+
+Next Exception: Throwing resource destructor called in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
`zend_test_create_throwing_resource` sets the exception in the `test` call frame and unwinds to `main`. It then throws for the `resource` variable and verifies that the exception opline is set. However, it wasn't set in `main`, it was set at the `test` call frame and rethrown later. The assertion is too conservative, but the end result is right, so drop the assertion.