### PR TITLE
Fix may_have_extra_named_args flag for ZEND_AST_UNPACK

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3661,6 +3661,12 @@ static uint32_t zend_compile_args(
 					"Cannot use argument unpacking after named arguments");
 			}
 
+			/* Unpack may contain named arguments. */
+			may_have_undef = 1;
+			if (!fbc || (fbc->common.fn_flags & ZEND_ACC_VARIADIC)) {
+				*may_have_extra_named_args = 1;
+			}
+
 			uses_arg_unpack = 1;
 			fbc = NULL;
 
@@ -3669,11 +3675,6 @@ static uint32_t zend_compile_args(
 			opline->op2.num = arg_count;
 			opline->result.var = EX_NUM_TO_VAR(arg_count - 1);
 
-			/* Unpack may contain named arguments. */
-			may_have_undef = 1;
-			if (!fbc || (fbc->common.fn_flags & ZEND_ACC_VARIADIC)) {
-				*may_have_extra_named_args = 1;
-			}
 			continue;
 		}
 


### PR DESCRIPTION
The check for `!fbc || (fbc->common.fn_flags & ZEND_ACC_VARIADIC)` is performed after `fbc` is set to NULL, so this always returns true. This results in `ZEND_FCALL_MAY_HAVE_EXTRA_NAMED_PARAMS` always being set for unpack sends. Fix it by moving the flag updates to the point before setting `fbc` to NULL.