### PR TITLE
array_filter: Remove unnecessary refcounting

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6549,32 +6549,25 @@ PHP_FUNCTION(array_filter)
 				if (!string_key) {
 					ZVAL_LONG(key, num_key);
 				} else {
-					ZVAL_STR_COPY(key, string_key);
+					ZVAL_STR(key, string_key);
 				}
 			}
 			if (use_type != ARRAY_FILTER_USE_KEY) {
-				ZVAL_COPY(&args[0], operand);
+				ZVAL_COPY_VALUE(&args[0], operand);
 			}
 			fci.params = args;
 
-			if (zend_call_function(&fci, &fci_cache) == SUCCESS) {
-				bool retval_true;
+			zend_result result = zend_call_function(&fci, &fci_cache);
+			ZEND_ASSERT(result == SUCCESS);
 
-				zval_ptr_dtor(&args[0]);
-				if (use_type == ARRAY_FILTER_USE_BOTH) {
-					zval_ptr_dtor(&args[1]);
-				}
-				retval_true = zend_is_true(&retval);
-				zval_ptr_dtor(&retval);
-				if (!retval_true) {
-					continue;
-				}
-			} else {
-				zval_ptr_dtor(&args[0]);
-				if (use_type == ARRAY_FILTER_USE_BOTH) {
-					zval_ptr_dtor(&args[1]);
-				}
-				return;
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+
+			bool retval_true = zend_is_true(&retval);
+			zval_ptr_dtor(&retval);
+			if (!retval_true) {
+				continue;
 			}
 		} else if (!zend_is_true(operand)) {
 			continue;


### PR DESCRIPTION
This syncs the implementation with the updated implementation of `array_find()` in php/php-src#17536. For the following test script:

    <?php

    $array = range(1, 8000);

    $result = 0;
    for ($i = 0; $i < 4000; $i++) {
    	$result += count(array_filter($array, static function ($item) {
    		return $item <= 4000;
    	}));
    }
    var_dump($result);

This change results in:

    Benchmark 1: /tmp/before array_filter.php
      Time (mean ± σ):     696.9 ms ±  16.3 ms    [User: 692.9 ms, System: 3.5 ms]
      Range (min … max):   681.6 ms … 731.5 ms    10 runs

    Benchmark 2: /tmp/after array_filter.php
      Time (mean ± σ):     637.5 ms ±   5.6 ms    [User: 633.6 ms, System: 3.8 ms]
      Range (min … max):   630.2 ms … 648.6 ms    10 runs

    Summary
      /tmp/after array_filter.php ran
        1.09 ± 0.03 times faster than /tmp/before array_filter.php

Or as reported by perf:

    # Samples: 2K of event 'cpu_core/cycles/'
    # Event count (approx.): 2567197440
    #
    # Overhead  Command  Shared Object         Symbol
    # ........  .......  ....................  ........................................................
    #
        37.02%  before   before                [.] zend_call_function
        15.50%  before   before                [.] execute_ex
        10.60%  before   before                [.] zif_array_filter
         9.43%  before   before                [.] zend_hash_index_add_new
         9.13%  before   before                [.] ZEND_IS_SMALLER_OR_EQUAL_SPEC_TMPVARCV_CONST_HANDLER
         8.46%  before   before                [.] zend_init_func_execute_data
         3.78%  before   before                [.] zval_add_ref
         3.47%  before   before                [.] zval_ptr_dtor
         1.17%  before   before                [.] zend_is_true

vs

    # Samples: 2K of event 'cpu_core/cycles/'
    # Event count (approx.): 2390202140
    #
    # Overhead  Command  Shared Object         Symbol
    # ........  .......  ....................  ........................................................
    #
        36.87%  after    after                 [.] zend_call_function
        20.46%  after    after                 [.] execute_ex
         8.22%  after    after                 [.] zend_init_func_execute_data
         7.94%  after    after                 [.] zend_hash_index_add_new
         7.89%  after    after                 [.] zif_array_filter
         6.28%  after    after                 [.] ZEND_IS_SMALLER_OR_EQUAL_SPEC_TMPVARCV_CONST_HANDLER
         3.95%  after    after                 [.] zval_add_ref
         2.23%  after    after                 [.] zend_is_true