### PR TITLE
Add check for constant PGRES_TUPLES_CHUNK to fix compilation failures

### DIFF
--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -28,17 +28,21 @@ if test "$PHP_PGSQL" != "no"; then
       [Define to 1 if libpq has the 'PQsocketPoll' function (PostgreSQL 17 or
       later).])],,
     [$PGSQL_LIBS])
-  PHP_CHECK_LIBRARY([pq], [PQsetChunkedRowsMode],
-    [AC_DEFINE([HAVE_PG_SET_CHUNKED_ROWS_SIZE], [1],
-      [Define to 1 if libpq has the 'PQsetChunkedRowsMode' function (PostgreSQL
-      17 or later).])],,
-    [$PGSQL_LIBS])
   PHP_CHECK_LIBRARY([pq], [PQclosePrepared],
     [AC_DEFINE([HAVE_PG_CLOSE_STMT], [1], [PostgreSQL 17 or later])],,
     [$PGSQL_LIBS])
 
   old_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $PGSQL_CFLAGS"
+
+  AC_CHECK_DECLS([PGRES_TUPLES_CHUNK],
+    PHP_CHECK_LIBRARY([pq], [PQsetChunkedRowsMode],
+      [AC_DEFINE([HAVE_PG_SET_CHUNKED_ROWS_SIZE], [1],
+        [Define to 1 if libpq has the 'PQsetChunkedRowsMode' function (PostgreSQL
+        17 or later).])],,
+      [$PGSQL_LIBS]),,
+      [#include <libpq-fe.h>]
+  )
 
   dnl Available since PostgreSQL 12.
   AC_CACHE_CHECK([if PGVerbosity enum has PQERRORS_SQLSTATE],


### PR DESCRIPTION
We have an OpenSUSE 15.6 installation with libpq5 installed (the current version being libpq5-17.2-..., i.e. compatible with postgresql17).
But as the current version of postgis does not work properly with postgresql17 so we are currently stuck with the packages postgresql16 and postgresql16-devel.

The file ext/pgsql/config.m4 only checks for the function PQsetChunkedRowsMode but the header files of postgresql16-devel does not define the constant PGRES_TUPLES_CHUNK in libpq-fe.h which leads to a compilation failure.

I added a check for PGRES_TUPLES_CHUNK to avoid this while keeping the feature enabled if the include file declares the constant.