### PR TITLE
Avoid duplicate build rules

### DIFF
--- a/sapi/cli/config.w32
+++ b/sapi/cli/config.w32
@@ -4,7 +4,8 @@ ARG_ENABLE('cli', 'Build CLI version of PHP', 'yes');
 ARG_ENABLE('cli-win32', 'Build console-less CLI version of PHP', 'no');
 
 if (PHP_CLI == "yes") {
-	SAPI('cli', 'php_cli.c php_http_parser.c php_cli_server.c php_cli_process_title.c ps_title.c', 'php.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	SAPI('cli', 'php_cli.c php_http_parser.c php_cli_server.c', 'php.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	ADD_SOURCES(configure_module_dirname, 'php_cli_process_title.c ps_title.c', 'cli');
 	ADD_FLAG("LIBS_CLI", "ws2_32.lib");
 	ADD_FLAG("LIBS_CLI", "shell32.lib");
 	ADD_FLAG("LDFLAGS_CLI", "/stack:67108864");
@@ -17,7 +18,8 @@ if (PHP_CLI == "yes") {
 }
 
 if (PHP_CLI_WIN32 == "yes") {
-	SAPI('cli_win32', 'cli_win32.c php_cli_process_title.c ps_title.c', 'php-win.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	SAPI('cli_win32', 'cli_win32.c', 'php-win.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	ADD_SOURCES(configure_module_dirname, ' php_cli_process_title.c ps_title.c', 'cli_win32', undefined, PHP_CLI == "yes");
 	ADD_FLAG("LDFLAGS_CLI_WIN32", "/stack:67108864");
 	ADD_FLAG("LIBS_CLI_WIN32", "shell32.lib");
 }

--- a/sapi/phpdbg/config.w32
+++ b/sapi/phpdbg/config.w32
@@ -26,7 +26,7 @@ if (PHP_PHPDBG == "yes") {
 }
 
 if (PHP_PHPDBGS == "yes") {
-	SAPI('phpdbgs', PHPDBG_SOURCES, PHPDBG_DLL, '/D PHP_PHPDBG_EXPORTS');
+	SAPI('phpdbgs', PHPDBG_SOURCES, PHPDBG_DLL, PHPDBG_CFLAGS, undefined, PHP_PHPDBG == "yes");
 	ADD_FLAG("LIBS_PHPDBGS", "ws2_32.lib user32.lib");
 	ADD_FLAG("CFLAGS_PHPDBGS", "/D YY_NO_UNISTD_H");
 


### PR DESCRIPTION
On Windows, the cli and phpdbg SAPIs have variants (cli-win32 and phpdbgs, respectively) which are build by default.  However, the variants share some files, what leads to duplicate build rules in the generated Makefile.  NMake throws warning U4004[1], but proceeds happily, ignoring the second build rule.  That means that different flags for duplicate rules are ignored, hinting at a potential problem.

We solve this by introducing an additional (optional) argument to `SAPI()` and `ADD_SOURCES()` which can be used to avoid such duplicate build rules.  It's left to the SAPI maintainers to make sure that appropriate rules are created.  We fix this for phpdbgs right away, which currently couldn't be build without phpdbg due to the missing define; we remove the unused `PHP_PHPDBG_EXPORTS` flag altogether.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/nmake-warning-u4004>

---

Note that I tried to solve this without even touching confutils.js, but failed. While this solution isn't particularly great, it solves the duplicate rules problem without any BC implications for users.

Also note that `PHPDBG_API` is not properly handled on Windows; due to missing `__declspec(dllimport)` there is a minimal performance impact, and variables couldn't be accessed at all (but there are none anyway). I'll try to follow up with a "fix".