### PR TITLE
Drop intel macOS build from push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -198,8 +198,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 13
-            arch: X64
           - os: 14
             arch: ARM64
     name: MACOS_${{ matrix.arch }}_DEBUG_NTS


### PR DESCRIPTION
This builds becomes less relevant as all currently sold Apple computers contain Apple Silicon CPUs. This build rarely fails in isolation anyway. For the time being, we'll keep the nightly builds in all configurations.