### PR TITLE
Drop --with-uncritical-warn-choke configuration option

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -355,7 +355,6 @@ if (PHP_SECURITY_FLAGS == "yes") {
 	ADD_FLAG("LDFLAGS", "/NXCOMPAT /DYNAMICBASE ");
 }
 
-ARG_WITH("uncritical-warn-choke", "Disable some uncritical warnings", "yes");
 ARG_ENABLE("sanitizer", "Enable ASan (and UBSan) extensions", "no");
 if (PHP_SANITIZER == "yes" && PHP_DEBUG == "yes") {
 	ERROR("Use of both --enable-sanitizer and --enable-debug not allowed.");
@@ -377,11 +376,6 @@ if (VS_TOOLSET) {
 	AC_DEFINE("PHP_HAVE_BUILTIN_SSUBLL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_ssubll_overflow'.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SMULL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_smull_overflow '.");
 	AC_DEFINE("PHP_HAVE_BUILTIN_SMULLL_OVERFLOW", 1, "Define to 1 if the compiler supports '__builtin_smulll_overflow'.");
-	if (PHP_UNCRITICAL_WARN_CHOKE != "no") {
-		ADD_FLAG("CFLAGS", "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-missing-braces " +
-		"-Wno-logical-op-parentheses -Wno-msvc-include -Wno-invalid-source-encoding -Wno-unknown-pragmas " +
-		"-Wno-unused-command-line-argument -Wno-unused-function -Wno-ignored-pragma-optimize");
-	}
 
 	if (PHP_SANITIZER == "yes") {
 		if (COMPILER_NUMERIC_VERSION < 500) {

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3305,6 +3305,7 @@ function toolset_setup_common_cflags()
 
 		ADD_FLAG("CFLAGS", "/Zc:wchar_t");
 	} else if (CLANG_TOOLSET) {
+		ADD_FLAG("CFLAGS", "-Wno-deprecated-declarations");
 		if (TARGET_ARCH == 'x86') {
 			ADD_FLAG('CFLAGS', '-m32');
 		} else {


### PR DESCRIPTION
This selection of suppressed warnings is pretty arbitrary, and apparently disabling it does not raise any more warning for whole php-src (except for `-Wno-deprecated-declarations`).  As such it appears to be pretty useless, and it seems to be more appropriate to let users select which warnings to suppress via manually set `CFLAGS`.

Since we already apply `/wd4996`[1] when building with MSVC, and there are indeed plenty of deprecation warnings, for now, we apply `-Wno-deprecated-declarations` for Clang builds unconditionally.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996>

---

Note that I'm planning to have a closer look at the deprecations soon. It seems it's possible to just suppress some of these (such as the deprecated POSIX function names) by setting some compile time flags, which appears to a be nice improvement over suppressing all deprecation warnings.