### PR TITLE
Reuse EG(windows_version_info) in php_get_uname()

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -659,10 +659,10 @@ PHPAPI zend_string *php_get_uname(char mode)
 	ZEND_ASSERT(php_is_valid_uname_mode(mode));
 #ifdef PHP_WIN32
 	char tmp_uname[256];
-	DWORD dwBuild=0;
-	DWORD dwVersion = GetVersion();
-	DWORD dwWindowsMajorVersion =  (DWORD)(LOBYTE(LOWORD(dwVersion)));
-	DWORD dwWindowsMinorVersion =  (DWORD)(HIBYTE(LOWORD(dwVersion)));
+	OSVERSIONINFOEX osvi = EG(windows_version_info);
+	DWORD dwWindowsMajorVersion = osvi.dwMajorVersion;
+	DWORD dwWindowsMinorVersion = osvi.dwMinorVersion;
+	DWORD dwBuild = osvi.dwBuildNumber;
 	DWORD dwSize = MAX_COMPUTERNAME_LENGTH + 1;
 	char ComputerName[MAX_COMPUTERNAME_LENGTH + 1];
 
@@ -676,7 +676,6 @@ PHPAPI zend_string *php_get_uname(char mode)
 		php_uname = ComputerName;
 	} else if (mode == 'v') {
 		char *winver = php_get_windows_name();
-		dwBuild = (DWORD)(HIWORD(dwVersion));
 
 		ZEND_ASSERT(winver != NULL);
 
@@ -693,7 +692,6 @@ PHPAPI zend_string *php_get_uname(char mode)
 		ZEND_ASSERT(winver != NULL);
 
 		php_get_windows_cpu(wincpu, sizeof(wincpu));
-		dwBuild = (DWORD)(HIWORD(dwVersion));
 
 		/* Windows "version" 6.2 could be Windows 8/Windows Server 2012, but also Windows 8.1/Windows Server 2012 R2 */
 		if (dwWindowsMajorVersion == 6 && dwWindowsMinorVersion == 2) {


### PR DESCRIPTION
There is no need to retrieve the Windows OS version information again, since it is already available via `EG(windows_version_info)`.