### PR TITLE
Update test expectation for different Firebird version

### DIFF
--- a/ext/pdo_firebird/tests/transaction_access_mode.phpt
+++ b/ext/pdo_firebird/tests/transaction_access_mode.phpt
@@ -135,7 +135,7 @@ $dbh = getDbConnection();
 @$dbh->exec('DROP TABLE transaction_access_mode');
 unset($dbh);
 ?>
---EXPECT--
+--EXPECTF--
 ========== Set attr in construct ==========
 OK: writable
 OK: readonly
@@ -157,7 +157,7 @@ array(1) {
 readonly
 bool(true)
 OK: readonly
-SQLSTATE[42000]: Syntax error or access violation: -817 attempted update during read-only transaction
+SQLSTATE[%r(42000|25006)%r]: %r(Read only sql transaction|Syntax error or access violation)%r: -817 attempted update during read-only transaction
 array(1) {
   [0]=>
   array(2) {


### PR DESCRIPTION
libfbclient 5.0.1 with server 4.0.1 has a different error message and code.
> Read only sql transaction