### PR TITLE
Use preinstalled MySQL for Windows CI

### DIFF
--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -3,10 +3,12 @@ runs:
   using: composite
   steps:
     - name: Setup MySQL
-      shell: pwsh
+      shell: cmd
       run: |
-        choco install mysql -y --no-progress --params="/port:3306"
-        mysql.exe --port=3306 --user=root --password="" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'Password12!'; FLUSH PRIVILEGES;"
+        mysqld --initialize-insecure
+        mysqld --install
+        net start MySQL
+        mysql --port=3306 --user=root --password="" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'Password12!'; FLUSH PRIVILEGES;"
     - name: Setup MSSQL
       shell: pwsh
       run: |


### PR DESCRIPTION
Recent hosted GH Windows runners already have MySQL preinstalled, so there is no particular need to install it again via Chocolatey or other means.

If we ever need to address more specific needs, we may want to have a look at <https://github.com/ankane/setup-mysql>.

Closes GH-17561.