### PR TITLE
Refactor uncompress() loop in php_handle_swc()

### DIFF
--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -165,7 +165,7 @@ static struct gfxinfo *php_handle_swc(php_stream * stream)
 	long bits;
 	unsigned char a[64];
 	unsigned long len=64, szlength;
-	int factor = 1,maxfactor = 16;
+	int factor = 1,maxfactor = 1 << 15;
 	int status = 0;
 	unsigned char *b, *buf = NULL;
 	zend_string *bufz;
@@ -197,13 +197,13 @@ static struct gfxinfo *php_handle_swc(php_stream * stream)
 		/*
 		 * zlib::uncompress() wants to know the output data length
 		 * if none was given as a parameter
-		 * we try from input length * 2 up to input length * 2^8
+		 * we try from input length * 2 up to input length * 2^15
 		 * doubling it whenever it wasn't big enough
-		 * that should be eneugh for all real life cases
+		 * that should be enough for all real life cases
 		*/
 
 		do {
-			szlength = ZSTR_LEN(bufz) * (1<<factor++);
+			szlength = ZSTR_LEN(bufz) * (factor <<= 1);
 			buf = erealloc(buf, szlength);
 			status = uncompress(buf, &szlength, (unsigned char *) ZSTR_VAL(bufz), ZSTR_LEN(bufz));
 		} while ((status==Z_BUF_ERROR)&&(factor<maxfactor));


### PR DESCRIPTION
As is, MSVC raises C4334[1] to hint at a potential code issue.  We could solve this with a cast, but actually the code is unclear as is because `factor` is not the factor, but rather the factor`s power. Thus we refactor the loop variant, and also fix the comment.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334>