### PR TITLE
Fix inline zend_string using struct padding

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -223,8 +223,7 @@ typedef struct _zend_accel_globals {
 	const zend_op          *cache_opline;
 	zend_persistent_script *cache_persistent_script;
 	/* preallocated buffer for keys */
-	zend_string             key;
-	char                    _key[MAXPATHLEN * 8];
+	zend_string            *key;
 } zend_accel_globals;
 
 typedef struct _zend_string_table {


### PR DESCRIPTION
As explained by Snape3058: On 64-bit machines, we typically have 7 bytes of padding between the zend_string.val[0] char and the following char[]. This means that zend_string.val[1-7] write to and read from the struct padding, which is a bad idea.

Allocate the given string separately instead.

Fixes GH-17564