### PR TITLE
Elevate Windows CI to /W2 (sans C4146/C4244)

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -32,7 +32,7 @@ if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer --enable-debug-pack
 
-set CFLAGS=/W1 /WX /w14013
+set CFLAGS=/W2 /WX /w14013 /wd4146 /wd4244
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^


### PR DESCRIPTION
C4146[1] is about unary minus applied to unsigned operands; that behavior is well defined, and apparently used deliberately in the code base.

C4244[2] is about possible loss of data when converting to another arithmetic type.  This is addressed by another PR[3].

Anyhow, it seems like a no brainer to elevate to `/W2` even if we have to exempt two categories of warnings, since we can catch some others.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170>
[2] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244>
[3] <https://github.com/php/php-src/pull/17076>