### PR TITLE
Fix GH-17577: JIT packed type guard crash

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -4162,12 +4162,15 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 			}
 
 			if ((info & MAY_BE_PACKED_GUARD) != 0
+			 && (info & MAY_BE_GUARD) == 0
 			 && (trace_buffer->stop == ZEND_JIT_TRACE_STOP_LOOP
 			  || trace_buffer->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_CALL
 			  || trace_buffer->stop == ZEND_JIT_TRACE_STOP_RECURSIVE_RET)
 			 && (ssa->vars[i].use_chain != -1
 			  || (ssa->vars[i].phi_use_chain
 			   && !(ssa->var_info[ssa->vars[i].phi_use_chain->ssa_var].type & MAY_BE_PACKED_GUARD)))) {
+				ZEND_ASSERT(STACK_TYPE(stack, i) == IS_ARRAY);
+
 				if (!zend_jit_packed_guard(&dasm_state, opline, EX_NUM_TO_VAR(i), info)) {
 					goto jit_failure;
 				}

--- a/ext/opcache/tests/jit/gh17577.phpt
+++ b/ext/opcache/tests/jit/gh17577.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-17577 (JIT packed type guard crash)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit_buffer_size=16M
+opcache.jit_hot_func=1
+--FILE--
+<?php
+$a = array(
+    array(1,2,3),
+    0,
+);
+function my_dump($var) {
+}
+foreach($a as $b) {
+    for ($i = 0; $i < 3; $i++) {
+        my_dump($b[$i]);
+    }
+}
+?>
+--EXPECTF--
+Warning: Trying to access array offset on int in %s on line %d
+
+Warning: Trying to access array offset on int in %s on line %d
+
+Warning: Trying to access array offset on int in %s on line %d


### PR DESCRIPTION
When a guard check is created for a variable to check if it's a packed array, it is possible that there was no prior type check for that variable. This happens in the global scope for example when the variable aliases. In the test, this causes a dereference of address 8 because the integer element in `$a` is interpreted as an array address and zend_array.u.flags is at offset 8.

This patch adds a check to see if the guard is handled.

If we were not able to determine or guard the type is array, then we also cannot know the array is packed.
An alternative I thought about was emitting a type check in this branch, but that can cause incorrect guard motion in case of aliasing. In such case we also shouldn't clear the `MAY_BE_PACKED_GUARD` like it does now.