### PR TITLE
Fix GH-16883: gzopen() does not use the default stream context when opening HTTP URLs

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -155,6 +155,8 @@ PHP 8.5 UPGRADE NOTES
   . The "use_include_path" argument for the
     gzfile, gzopen and readgzfile functions had been changed
     from int to boolean.
+  . gzfile, gzopen and readgzfile functions now respect the default
+    stream context.
 
 ========================================
 6. New Functions

--- a/ext/zlib/tests/gh16883.phpt
+++ b/ext/zlib/tests/gh16883.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-16883 (gzopen() does not use the default stream context when opening HTTP URLs)
+--EXTENSIONS--
+zlib
+--INI--
+allow_url_fopen=1
+--SKIPIF--
+<?php
+if (!file_exists(__DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc")) {
+    echo "skip sapi/cli/tests/php_cli_server.inc required but not found";
+}
+?>
+--FILE--
+<?php
+require __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
+
+$code = <<<'PHP'
+echo $_SERVER['HTTP_USER_AGENT'], "\n";
+PHP;
+
+php_cli_server_start($code);
+
+stream_context_set_default([
+	'http' => array(
+		'user_agent' => 'dummy',
+	)
+]);
+
+$f = gzopen('http://'.PHP_CLI_SERVER_HOSTNAME.':'.PHP_CLI_SERVER_PORT, 'r');
+var_dump(stream_get_contents($f));
+
+var_dump(gzfile('http://'.PHP_CLI_SERVER_HOSTNAME.':'.PHP_CLI_SERVER_PORT, 'r'));
+
+var_dump(readgzfile('http://'.PHP_CLI_SERVER_HOSTNAME.':'.PHP_CLI_SERVER_PORT, 'r'));
+
+?>
+--EXPECT--
+string(6) "dummy
+"
+array(1) {
+  [0]=>
+  string(6) "dummy
+"
+}
+dummy
+int(6)

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -28,6 +28,7 @@
 #include "ext/standard/info.h"
 #include "php_zlib.h"
 #include "zlib_arginfo.h"
+#include "ext/standard/file.h"
 
 /*
  * zlib include files can define the following preprocessor defines which rename
@@ -621,7 +622,7 @@ PHP_FUNCTION(gzfile)
 	}
 
 	/* using a stream here is a bit more efficient (resource wise) than php_gzopen_wrapper */
-	stream = php_stream_gzopen(NULL, filename, "rb", flags, NULL, NULL STREAMS_CC);
+	stream = php_stream_gzopen(NULL, filename, "rb", flags, NULL, php_stream_context_from_zval(NULL, false) STREAMS_CC);
 
 	if (!stream) {
 		/* Error reporting is already done by stream code */
@@ -659,7 +660,7 @@ PHP_FUNCTION(gzopen)
 		flags |= USE_PATH;
 	}
 
-	stream = php_stream_gzopen(NULL, filename, mode, flags, NULL, NULL STREAMS_CC);
+	stream = php_stream_gzopen(NULL, filename, mode, flags, NULL, php_stream_context_from_zval(NULL, false) STREAMS_CC);
 
 	if (!stream) {
 		RETURN_FALSE;
@@ -686,7 +687,7 @@ PHP_FUNCTION(readgzfile)
 		flags |= USE_PATH;
 	}
 
-	stream = php_stream_gzopen(NULL, filename, "rb", flags, NULL, NULL STREAMS_CC);
+	stream = php_stream_gzopen(NULL, filename, "rb", flags, NULL, php_stream_context_from_zval(NULL, false) STREAMS_CC);
 
 	if (!stream) {
 		RETURN_FALSE;


### PR DESCRIPTION
Otherwise it's not possible to control the context; it's also consistent with how the standard open functions work.