### PR TITLE
Fix GH-12856: ReflectionClass::getStaticPropertyValue() returns UNDEF zval for uninitialized typed properties

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4128,7 +4128,7 @@ ZEND_METHOD(ReflectionClass, getStaticPropertyValue)
 	prop = zend_std_get_static_property(ce, name, BP_VAR_IS);
 	EG(fake_scope) = old_scope;
 
-	if (prop) {
+	if (prop && !Z_ISUNDEF_P(prop)) {
 		RETURN_COPY_DEREF(prop);
 	}
 
@@ -4136,8 +4136,13 @@ ZEND_METHOD(ReflectionClass, getStaticPropertyValue)
 		RETURN_COPY(def_value);
 	}
 
-	zend_throw_exception_ex(reflection_exception_ptr, 0,
-		"Property %s::$%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+	if (prop) {
+		zend_throw_exception_ex(reflection_exception_ptr, 0,
+			"Property %s::$%s is not initialized and no default was provided", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+	} else {
+		zend_throw_exception_ex(reflection_exception_ptr, 0,
+			"Property %s::$%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+	}
 }
 /* }}} */
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4137,8 +4137,8 @@ ZEND_METHOD(ReflectionClass, getStaticPropertyValue)
 	}
 
 	if (prop) {
-		zend_throw_exception_ex(reflection_exception_ptr, 0,
-			"Property %s::$%s is not initialized and no default was provided", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+		zend_throw_error(NULL,
+			"Typed property %s::$%s must not be accessed before initialization", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 	} else {
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
 			"Property %s::$%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));

--- a/ext/reflection/tests/gh12856.phpt
+++ b/ext/reflection/tests/gh12856.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-12856 (ReflectionClass::getStaticPropertyValue() returns UNDEF zval for uninitialized typed properties)
+--FILE--
+<?php
+
+class Bug {
+    private static $untyped;
+    private static int $typed1;
+    private static int $typed2 = 3;
+}
+
+$rc = new ReflectionClass(Bug::class);
+var_dump($rc->getStaticPropertyValue('untyped'));
+try {
+    var_dump($rc->getStaticPropertyValue('typed1'));
+} catch (ReflectionException $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($rc->getStaticPropertyValue('typed1', 1));
+var_dump($rc->getStaticPropertyValue('typed2'));
+
+?>
+--EXPECT--
+NULL
+Property Bug::$typed1 is not initialized and no default was provided
+int(1)
+int(3)

--- a/ext/reflection/tests/gh12856.phpt
+++ b/ext/reflection/tests/gh12856.phpt
@@ -13,7 +13,7 @@ $rc = new ReflectionClass(Bug::class);
 var_dump($rc->getStaticPropertyValue('untyped'));
 try {
     var_dump($rc->getStaticPropertyValue('typed1'));
-} catch (ReflectionException $e) {
+} catch (Error $e) {
     echo $e->getMessage(), "\n";
 }
 var_dump($rc->getStaticPropertyValue('typed1', 1));
@@ -22,6 +22,6 @@ var_dump($rc->getStaticPropertyValue('typed2'));
 ?>
 --EXPECT--
 NULL
-Property Bug::$typed1 is not initialized and no default was provided
+Typed property Bug::$typed1 must not be accessed before initialization
 int(1)
 int(3)


### PR DESCRIPTION
This issue has been open for a while, and it's easy to fix, we just have to agree what is right.
As per [my comment](https://github.com/php/php-src/issues/12856#issuecomment-1847694105), I sent an email to internals to see what people think: https://externals.io/message/126224