### PR TITLE
ext/sockets: adding BSD IP_BINDANY constant.

### DIFF
--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -1915,6 +1915,13 @@ const TCP_QUICKACK = UNKNOWN;
  */
 const TCP_REPAIR = UNKNOWN;
 #endif
+#if defined(IP_BINDANY)
+/**
+ * @var int
+ * @cvalue IP_BINDANY
+ */
+const IP_BINDANY = UNKNOWN;
+#endif
 #if defined(IP_DONTFRAG)
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0be24cb2f268ab3d43121637ae451d8da4b50410 */
+ * Stub hash: aac197335037777d31d83d4a4040bbfcd0c55813 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -1059,6 +1059,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(TCP_REPAIR)
 	REGISTER_LONG_CONSTANT("TCP_REPAIR", TCP_REPAIR, CONST_PERSISTENT);
+#endif
+#if defined(IP_BINDANY)
+	REGISTER_LONG_CONSTANT("IP_BINDANY", IP_BINDANY, CONST_PERSISTENT);
 #endif
 #if defined(IP_DONTFRAG)
 	REGISTER_LONG_CONSTANT("IP_DONTFRAG", IP_DONTFRAG, CONST_PERSISTENT);


### PR DESCRIPTION
Simply allows the socket to bind to any address, including one not bound to any network interface.