### PR TITLE
Fix `#[\Deprecated]` for `__call()` and `__callStatic()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ PHP                                                                        NEWS
     (nielsdos, ilutov)
   . Fix may_have_extra_named_args flag for ZEND_AST_UNPACK. (nielsdos)
   . Fix NULL arithmetic in System V shared memory emulation for Windows. (cmb)
+  . Fixed bug GH-17597 (#[\Deprecated] does not work for __call() and
+    __callStatic()). (timwolla)
 
 - DOM:
   . Fixed bug GH-17397 (Assertion failure ext/dom/php_dom.c). (nielsdos)

--- a/Zend/tests/attributes/deprecated/functions/magic_call.phpt
+++ b/Zend/tests/attributes/deprecated/functions/magic_call.phpt
@@ -1,0 +1,24 @@
+--TEST--
+#[\Deprecated]: __call() and __callStatic()
+--FILE--
+<?php
+
+class Clazz {
+	#[\Deprecated]
+	function __call(string $name, array $params) {
+	}
+
+	#[\Deprecated("due to some reason")]
+	static function __callStatic(string $name, array $params) {
+	}
+}
+
+$cls = new Clazz();
+$cls->test();
+Clazz::test2();
+
+?>
+--EXPECTF--
+Deprecated: Method Clazz::test() is deprecated in %s
+
+Deprecated: Method Clazz::test2() is deprecated, due to some reason in %s on line %d

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1617,7 +1617,12 @@ ZEND_API zend_function *zend_get_call_trampoline_func(const zend_class_entry *ce
 	func->fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE
 		| ZEND_ACC_PUBLIC
 		| ZEND_ACC_VARIADIC
-		| (fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE);
+		| (fbc->common.fn_flags & (ZEND_ACC_RETURN_REFERENCE|ZEND_ACC_DEPRECATED));
+	if (fbc->common.attributes) {
+		func->attributes = zend_array_dup(fbc->common.attributes);
+	} else {
+		func->attributes = NULL;
+	}
 	if (is_static) {
 		func->fn_flags |= ZEND_ACC_STATIC;
 	}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1619,7 +1619,8 @@ ZEND_API zend_function *zend_get_call_trampoline_func(const zend_class_entry *ce
 		| ZEND_ACC_VARIADIC
 		| (fbc->common.fn_flags & (ZEND_ACC_RETURN_REFERENCE|ZEND_ACC_DEPRECATED));
 	if (fbc->common.attributes) {
-		func->attributes = zend_array_dup(fbc->common.attributes);
+		func->attributes = fbc->common.attributes;
+		GC_TRY_ADDREF(func->attributes);
 	} else {
 		func->attributes = NULL;
 	}

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -339,6 +339,10 @@ ZEND_API bool ZEND_FASTCALL zend_asymmetric_property_has_set_access(const zend_p
 } while (0)
 
 #define zend_free_trampoline(func) do { \
+		if ((func)->common.attributes) { \
+			zend_array_destroy((func)->common.attributes); \
+			(func)->common.attributes = NULL; \
+		} \
 		if ((func) == &EG(trampoline)) { \
 			EG(trampoline).common.function_name = NULL; \
 		} else { \

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -339,11 +339,12 @@ ZEND_API bool ZEND_FASTCALL zend_asymmetric_property_has_set_access(const zend_p
 } while (0)
 
 #define zend_free_trampoline(func) do { \
-		if ((func)->common.attributes) { \
-			zend_array_destroy((func)->common.attributes); \
-			(func)->common.attributes = NULL; \
+		HashTable *attributes = (func)->common.attributes; \
+		if (attributes && !(GC_FLAGS(attributes) & GC_IMMUTABLE) && !GC_DELREF(attributes)) { \
+			zend_array_destroy(attributes); \
 		} \
 		if ((func) == &EG(trampoline)) { \
+			EG(trampoline).common.attributes = NULL; \
 			EG(trampoline).common.function_name = NULL; \
 		} else { \
 			efree(func); \


### PR DESCRIPTION
Fixes GH-17597.

/cc @beberlei 