### PR TITLE
Drop superfluous php_com_dotnet_object.ce

### DIFF
--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -307,7 +307,7 @@ static zend_function *com_method_get(zend_object **object_ptr, zend_string *name
 		f.type = ZEND_INTERNAL_FUNCTION;
 		f.num_args = 0;
 		f.arg_info = NULL;
-		f.scope = obj->ce;
+		f.scope = obj->zo.ce;
 		f.fn_flags = ZEND_ACC_CALL_VIA_HANDLER;
 		f.function_name = zend_string_copy(name);
 		f.handler = PHP_FN(com_method_handler);
@@ -392,7 +392,7 @@ static zend_string* com_class_name_get(const zend_object *object)
 {
 	php_com_dotnet_object *obj = (php_com_dotnet_object *)object;
 
-	return zend_string_copy(obj->ce->name);
+	return zend_string_copy(obj->zo.ce->name);
 }
 
 /* This compares two variants for equality */
@@ -625,7 +625,6 @@ zend_object* php_com_object_new(zend_class_entry *ce)
 
 	VariantInit(&obj->v);
 	obj->code_page = CP_ACP;
-	obj->ce = ce;
 
 	zend_object_std_init(&obj->zo, ce);
 

--- a/ext/com_dotnet/com_misc.c
+++ b/ext/com_dotnet/com_misc.c
@@ -50,7 +50,6 @@ PHP_COM_DOTNET_API void php_com_wrap_dispatch(zval *z, IDispatch *disp,
 	obj = emalloc(sizeof(*obj));
 	memset(obj, 0, sizeof(*obj));
 	obj->code_page = codepage;
-	obj->ce = php_com_variant_class_entry;
 	obj->zo.ce = php_com_variant_class_entry;
 
 	VariantInit(&obj->v);
@@ -72,7 +71,6 @@ PHP_COM_DOTNET_API void php_com_wrap_variant(zval *z, VARIANT *v,
 	obj = emalloc(sizeof(*obj));
 	memset(obj, 0, sizeof(*obj));
 	obj->code_page = codepage;
-	obj->ce = php_com_variant_class_entry;
 	obj->zo.ce = php_com_variant_class_entry;
 
 	VariantInit(&obj->v);

--- a/ext/com_dotnet/com_misc.c
+++ b/ext/com_dotnet/com_misc.c
@@ -50,7 +50,6 @@ PHP_COM_DOTNET_API void php_com_wrap_dispatch(zval *z, IDispatch *disp,
 	obj = emalloc(sizeof(*obj));
 	memset(obj, 0, sizeof(*obj));
 	obj->code_page = codepage;
-	obj->zo.ce = php_com_variant_class_entry;
 
 	VariantInit(&obj->v);
 	V_VT(&obj->v) = VT_DISPATCH;
@@ -71,7 +70,6 @@ PHP_COM_DOTNET_API void php_com_wrap_variant(zval *z, VARIANT *v,
 	obj = emalloc(sizeof(*obj));
 	memset(obj, 0, sizeof(*obj));
 	obj->code_page = codepage;
-	obj->zo.ce = php_com_variant_class_entry;
 
 	VariantInit(&obj->v);
 	VariantCopyInd(&obj->v, v);

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -35,8 +35,6 @@ typedef struct _php_com_dotnet_object {
 
 	ITypeInfo *typeinfo;
 
-	zend_class_entry *ce;
-
    	/* associated event sink */
 	IDispatch *sink_dispatch;
 	GUID sink_id;


### PR DESCRIPTION
This is readily available via the `zend_object` (i.e. `zo.ce`), so there is no need to duplicate it.