### PR TITLE
Fix cve-2014-3538 test

### DIFF
--- a/ext/fileinfo/tests/cve-2014-3538-mb.phpt
+++ b/ext/fileinfo/tests/cve-2014-3538-mb.phpt
@@ -32,7 +32,7 @@ if ($t < 3) {
 Done
 --CLEAN--
 <?php
-@unlink(__DIR__.'/cve-2014-3538.data');
+@unlink(__DIR__.'/cve-2014-3538私はガラスを食べられます.data');
 ?>
 --EXPECTF--
 string(%d) "%s"

--- a/ext/fileinfo/tests/cve-2014-3538-nojit.phpt
+++ b/ext/fileinfo/tests/cve-2014-3538-nojit.phpt
@@ -13,7 +13,7 @@ if (getenv('SKIP_PERF_SENSITIVE'))
 pcre.jit=0
 --FILE--
 <?php
-$fd = __DIR__.'/cve-2014-3538.data';
+$fd = __DIR__.'/cve-2014-3538-nojit.data';
 
 file_put_contents($fd,
   'try:' .
@@ -24,7 +24,7 @@ $t = microtime(true);
 var_dump(finfo_file($fi, $fd));
 $t = microtime(true) - $t;
 finfo_close($fi);
-if ($t < 1) {
+if ($t < 1.5) {
     echo "Ok\n";
 } else {
     printf("Failed, time=%.2f\n", $t);
@@ -34,7 +34,7 @@ if ($t < 1) {
 Done
 --CLEAN--
 <?php
-//@unlink(__DIR__.'/cve-2014-3538.data');
+@unlink(__DIR__.'/cve-2014-3538-nojit.data');
 ?>
 --EXPECTF--
 string(%d) "%s"


### PR DESCRIPTION
Make sure we have a unique test file to work with, and increase the time for the nojit version to match the default version.

Closes GH-17600