### PR TITLE
Fix snmp_session_error.phpt for 32bit machines

### DIFF
--- a/ext/snmp/tests/snmp_session_error.phpt
+++ b/ext/snmp/tests/snmp_session_error.phpt
@@ -35,6 +35,7 @@ try {
 }
 try {
 	new SNMP(SNMP::VERSION_1, "$hostname:$port", $community, $timeout, PHP_INT_MAX);
+	echo PHP_INT_SIZE, "\n"; // no exception on 32bit machines
 } catch (\ValueError $e) {
 	echo $e->getMessage(), PHP_EOL;
 }
@@ -60,7 +61,7 @@ SNMP::__construct(): Argument #2 ($hostname) remote port must be between 0 and 6
 SNMP::__construct(): Argument #2 ($hostname) remote port must be between 0 and 65535
 SNMP::__construct(): Argument #2 ($hostname) length must be lower than 128
 SNMP::__construct(): Argument #4 ($timeout) must be between -1 and %d
-SNMP::__construct(): Argument #5 ($retries) must be between -1 and %d
+%r(SNMP::__construct\(\): Argument #5 \(\$retries\) must be between -1 and %d|4)%r
 SNMP::__construct(): Argument #2 ($hostname) must not contain any null bytes
 SNMP::__construct(): Argument #3 ($community) must not be empty
 SNMP::__construct(): Argument #3 ($community) must not contain any null bytes


### PR DESCRIPTION
For `$retries === PHP_INT_MAX` there is no exception on 32bit machines. To avoid splitting the tests, or even not running it on 32bit, we work around.

---

Fails in nightlies: https://github.com/php/php-src/actions/runs/13001856123/job/36261956882 (apparently the Windows x64 job is the only 32bit job running SNMP tests).