### PR TITLE
Fix callable variance check

### DIFF
--- a/Zend/tests/type_declarations/callable/callable_004.phpt
+++ b/Zend/tests/type_declarations/callable/callable_004.phpt
@@ -1,0 +1,19 @@
+--TEST--
+callable type#004
+--FILE--
+<?php
+
+interface Foo {}
+
+class P {
+    public function test(Foo|callable $foo) {}
+}
+
+class C extends P {
+    public function test(Foo|callable $foo) {}
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -499,8 +499,6 @@ static inheritance_status zend_is_class_subtype_of_type(
 		} else if (fe_ce == zend_ce_closure) {
 			track_class_dependency(fe_ce, fe_class_name);
 			return INHERITANCE_SUCCESS;
-		} else {
-			return INHERITANCE_ERROR;
 		}
 	}
 


### PR DESCRIPTION
Caused by GH-15492. While the parent might contain callable, it may also contain other types. zend_is_class_subtype_of_type() may be checking a member that is not callable itself. Fall back to the normal class subtype check.

Discovered by a failing Laravel test in nightly.