### PR TITLE
relax test for zlib-ng

### DIFF
--- a/ext/standard/tests/filters/gh13264.phpt
+++ b/ext/standard/tests/filters/gh13264.phpt
@@ -45,5 +45,5 @@ array(4) {
   ["line"]=>
   int(%d)
 }
-string(7) "Hello 6"
+string(%d) "Hello%s"
 


### PR DESCRIPTION
Test failing with zlilb-ng 2.2

```
========DIFF========
--
       ["line"]=>
       int(%d)
     }
012- string(7) "Hello 6"
012+ string(6) "Hello "
========DONE========
FAIL GH-81475: Memory leak during stream filter failure [ext/standard/tests/filters/gh13264.phpt] 

```