### PR TITLE
zend_execute: Suppress values in `UnhandledMatchError` for `zend.exception_ignore_args=1`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.3.18
 
+- Core:
+   Fixed bug GH-17618 (UnhandledMatchError does not take
+   zend.exception_ignore_args=1 into account). (timwolla)
 
 13 Feb 2025, PHP 8.3.17
 

--- a/Zend/tests/match/049.phpt
+++ b/Zend/tests/match/049.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Match expression error messages (zend.exception_ignore_args=1)
+--INI--
+zend.exception_ignore_args=1
+--FILE--
+<?php
+
+class Beep {}
+
+function test(mixed $var) {
+    try {
+        match($var) {};
+    } catch (UnhandledMatchError $e) {
+        print $e->getMessage() . PHP_EOL;
+    }
+}
+
+test(null);
+test(1);
+test(5.5);
+test(5.0);
+test("foo");
+test(true);
+test(false);
+test([1, 2, 3]);
+test(new Beep());
+// Testing long strings.
+test(str_repeat('e', 100));
+test(str_repeat("e\n", 100));
+?>
+--EXPECT--
+Unhandled match case of type null
+Unhandled match case of type int
+Unhandled match case of type float
+Unhandled match case of type float
+Unhandled match case of type string
+Unhandled match case of type bool
+Unhandled match case of type bool
+Unhandled match case of type array
+Unhandled match case of type Beep
+Unhandled match case of type string
+Unhandled match case of type string

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -872,7 +872,7 @@ ZEND_COLD void zend_match_unhandled_error(const zval *value)
 {
 	smart_str msg = {0};
 
-	if (Z_TYPE_P(value) <= IS_STRING) {
+	if (!EG(exception_ignore_args) && Z_TYPE_P(value) <= IS_STRING) {
 		smart_str_append_scalar(&msg, value, EG(exception_string_param_max_len));
 	} else {
 		smart_str_appendl(&msg, "of type ", sizeof("of type ")-1);


### PR DESCRIPTION
This PR spins out the “bugfix” part of #17601. The improved handling of `exception_string_param_max_len` is more of a feature request than a bugfix.

Fixes php/php-src#17618.