### PR TITLE
ext/pdo: Remove refcount field from _pdo_stmt_t

### DIFF
--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -605,7 +605,6 @@ struct _pdo_stmt_t {
 	/* for lazy fetches, we always return the same lazy object handle.
 	 * Let's keep it here. */
 	zval lazy_object_ref;
-	zend_ulong refcount;
 
 	/* defaults for fetches */
 	enum pdo_fetch_type default_fetch_type;


### PR DESCRIPTION
It is unused