### PR TITLE
opcache: Do not disable userland error handlers in `opcache_compile_file()`

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1728,7 +1728,6 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	zend_persistent_script *new_persistent_script;
 	uint32_t orig_functions_count, orig_class_count;
 	zend_op_array *orig_active_op_array;
-	zval orig_user_error_handler;
 	zend_op_array *op_array;
 	bool do_bailout = false;
 	accel_time_t timestamp = 0;
@@ -1796,10 +1795,8 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	orig_active_op_array = CG(active_op_array);
 	orig_functions_count = EG(function_table)->nNumUsed;
 	orig_class_count = EG(class_table)->nNumUsed;
-	ZVAL_COPY_VALUE(&orig_user_error_handler, &EG(user_error_handler));
 
 	/* Override them with ours */
-	ZVAL_UNDEF(&EG(user_error_handler));
 	if (ZCG(accel_directives).record_warnings) {
 		zend_begin_record_errors();
 	}
@@ -1825,7 +1822,6 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 
 	/* Restore originals */
 	CG(active_op_array) = orig_active_op_array;
-	EG(user_error_handler) = orig_user_error_handler;
 	EG(record_errors) = 0;
 
 	if (!op_array) {

--- a/ext/opcache/tests/gh17422/001.phpt
+++ b/ext/opcache/tests/gh17422/001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECT--
+set_error_handler: "continue" targeting switch is equivalent to "break"
+OK: warning
+array(3) {
+  [0]=>
+  string(7) "001.php"
+  [1]=>
+  string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/002.phpt
+++ b/ext/opcache/tests/gh17422/002.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Throwing error handler
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+});
+
+try {
+	require __DIR__ . "/warning.inc";
+} catch (\Exception $e) {
+	echo "Caught: ", $e->getMessage(), PHP_EOL;
+}
+
+warning();
+
+?>
+--EXPECT--
+Caught: "continue" targeting switch is equivalent to "break"
+OK: warning
+array(3) {
+  [0]=>
+  string(7) "002.php"
+  [1]=>
+  string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/003.phpt
+++ b/ext/opcache/tests/gh17422/003.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Fatal Error
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	str_repeat('x', 1024 * 1024 * 1024);
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of 2097152 bytes exhausted %s on line 6
+array(2) {
+  [0]=>
+  string(7) "003.php"
+  [1]=>
+  string(12) "shutdown.inc"
+}

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -27,7 +27,7 @@ warning();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare function warning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
+Fatal error: Cannot redeclare %Swarning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
 array(2) {
   [0]=>
   string(7) "004.php"

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - eval
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	eval(
+		<<<'PHP'
+			function warning() {
+				echo "NOK", PHP_EOL;
+			}
+			PHP
+	);
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare function warning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
+array(2) {
+  [0]=>
+  string(7) "004.php"
+  [1]=>
+  string(12) "shutdown.inc"
+}

--- a/ext/opcache/tests/gh17422/005.phpt
+++ b/ext/opcache/tests/gh17422/005.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - require
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	require_once __DIR__ . "/dummy.inc";
+});
+
+require __DIR__ . "/warning.inc";
+
+dummy();
+
+?>
+--EXPECT--
+OK: dummy
+array(4) {
+  [0]=>
+  string(7) "005.php"
+  [1]=>
+  string(9) "dummy.inc"
+  [2]=>
+  string(12) "shutdown.inc"
+  [3]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/dummy.inc
+++ b/ext/opcache/tests/gh17422/dummy.inc
@@ -1,0 +1,4 @@
+<?php
+function dummy() {
+    echo "OK: ", __FUNCTION__, PHP_EOL;
+}

--- a/ext/opcache/tests/gh17422/shutdown.inc
+++ b/ext/opcache/tests/gh17422/shutdown.inc
@@ -1,0 +1,6 @@
+<?php
+register_shutdown_function(static function() {
+	$scripts = array_map(basename(...), array_keys(opcache_get_status()['scripts'] ?? []));
+	sort($scripts);
+	var_dump($scripts);
+});

--- a/ext/opcache/tests/gh17422/warning.inc
+++ b/ext/opcache/tests/gh17422/warning.inc
@@ -1,0 +1,8 @@
+<?php
+function warning() {
+    switch (1) {
+        case 1:
+            echo "OK: ", __FUNCTION__, PHP_EOL;
+            continue;
+    }
+}


### PR DESCRIPTION
The logic to disable userland error handlers existed since the first commit including OPcache in php-src. The reason unfortunately is not explained. No existing tests require that userland error handlers do not trigger in `opcache_compile_file()`. The newly added tests are intended to exercise all possible kinds of edge-cases that might arise and cause issues (e.g. throwing Exceptions, performing a bailout, or loading a different file from within the error handler).

They all pass for both `--repeat 1` and `--repeat 2`, as well as with OPcache enabled and without OPcache enabled (in the latter case with the exception of the `opcache_get_status()` verification). The list of cached files at the end of execution also matches my expectations.

Therefore it seems that disabling the userland error handler when compiling a file with OPcache is not (or at least no longer) necessary.

Fixes php/php-src#17422.