### PR TITLE
Fixed `pdo_firebird_handle_factory` to check `ret` when starting a transaction

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -684,7 +684,7 @@ static bool firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
 
 			/* make all parameters nullable */
 			unsigned int i;
-			XSQLVAR* var;			
+			XSQLVAR* var;
 			for (i = 0, var = S->in_sqlda->sqlvar; i < S->in_sqlda->sqld; i++, var++) {
 				/* The low bit of sqltype indicates that the parameter can take a NULL value */
 				var->sqltype |= 1;
@@ -1431,7 +1431,7 @@ static int pdo_firebird_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* 
 				"HY000", H->isc_status[1], errmsg);
 	}
 
-	if (dbh->auto_commit && !H->tr) {
+	if (ret && dbh->auto_commit && !H->tr) {
 		ret = php_firebird_begin_transaction(dbh, /* auto commit mode */ true);
 	}
 


### PR DESCRIPTION
Changed to not execute php_firebird_begin_transaction if transaction cannot be started successfully