### PR TITLE
Add workflow to trigger windows builds

### DIFF
--- a/.github/workflows/windows-builds.yml
+++ b/.github/workflows/windows-builds.yml
@@ -1,0 +1,23 @@
+name: Windows builds
+run-name: Windows builds for ${{ inputs.tag || github.ref_name }}
+on:
+  push:
+    tags:
+      - 'php-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag version'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINDOWS_BUILDS_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          gh workflow run php.yml -R php/php-windows-builder -f php-version="${TAG#php-}"


### PR DESCRIPTION
This PR adds a workflow to trigger a workflow to run builds for windows when a tag is pushed.