### PR TITLE
Fix memory leak in phpdbg calling registered function

### DIFF
--- a/sapi/phpdbg/phpdbg_lexer.l
+++ b/sapi/phpdbg/phpdbg_lexer.l
@@ -160,8 +160,9 @@ INPUT       ("\\"[#"']|["]("\\\\"|"\\"["]|[^\n\000"])*["]|[']("\\"[']|"\\\\"|[^\
 
 <NORMAL>{GENERIC_ID} {
 	phpdbg_init_param(yylval, STR_PARAM);
-	yylval->str = estrndup(yytext, yyleng - unescape_string(yytext));
-	yylval->len = yyleng;
+	size_t len = yyleng - unescape_string(yytext);
+	yylval->str = estrndup(yytext, len);
+	yylval->len = len;
 	return T_ID;
 }
 

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -189,6 +189,9 @@ static inline int phpdbg_call_register(phpdbg_param_t *stack) /* {{{ */
 
 			zval_ptr_dtor_str(&fci.function_name);
 			efree(lc_name);
+			if (fci.named_params) {
+				zend_array_destroy(fci.named_params);
+			}
 
 			return SUCCESS;
 		}

--- a/sapi/phpdbg/tests/register_function_leak.phpt
+++ b/sapi/phpdbg/tests/register_function_leak.phpt
@@ -1,0 +1,24 @@
+--TEST--
+registering a function and calling it leaks arguments memory
+--FILE--
+<?php
+echo "Done\n";
+?>
+--PHPDBG--
+register var_dump
+var_dump "a" "b"
+register flush
+flush
+r
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Registered var_dump]
+prompt> string(1) "a"
+string(1) "b"
+
+prompt> [Registered flush]
+prompt> 
+prompt> Done
+[Script ended normally]
+prompt>


### PR DESCRIPTION
The named arguments array is never cleaned up, so a trivial memory leak.
I first had to partially fix GH-17387 though to prevent crashing...

This was detected using an experimental static analyser I'm developing.