### PR TITLE
zend_generator: Fix zend_object std layout for zend_generator (draft)(cannot-pass-tests)

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4435,7 +4435,7 @@ zend_execute_data *zend_vm_stack_copy_call_frame(zend_execute_data *call, uint32
 static zend_always_inline zend_generator *zend_get_running_generator(EXECUTE_DATA_D) /* {{{ */
 {
 	/* The generator object is stored in EX(return_value) */
-	zend_generator *generator = (zend_generator *) EX(return_value);
+	zend_generator *generator = zend_generator_from_obj((zend_object *)EX(return_value));
 	/* However control may currently be delegated to another generator.
 	 * That's the one we're interested in. */
 	return generator;

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -829,7 +829,7 @@ static HashTable *zend_fiber_object_gc(zend_object *object, zval **table, int *n
 		HashTable *symTable;
 		if (ZEND_CALL_INFO(ex) & ZEND_CALL_GENERATOR) {
 			/* The generator object is stored in ex->return_value */
-			zend_generator *generator = (zend_generator*)ex->return_value;
+			zend_generator *generator = zend_generator_from_obj((zend_object *)ex->return_value);
 			/* There are two cases to consider:
 			 * - If the generator is currently running, the Generator's GC
 			 *   handler will ignore it because it is not collectable. However,

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -56,8 +56,6 @@ struct _zend_generator_node {
 };
 
 struct _zend_generator {
-	zend_object std;
-
 	/* The suspended execution context. */
 	zend_execute_data *execute_data;
 
@@ -94,6 +92,8 @@ struct _zend_generator {
 
 	/* ZEND_GENERATOR_* flags */
 	uint8_t flags;
+
+	zend_object std;
 };
 
 static const uint8_t ZEND_GENERATOR_CURRENTLY_RUNNING = 0x1;
@@ -135,6 +135,11 @@ static zend_always_inline zend_generator *zend_generator_get_current(zend_genera
 }
 
 HashTable *zend_generator_frame_gc(zend_get_gc_buffer *gc_buffer, zend_generator *generator);
+
+static zend_always_inline zend_generator *zend_generator_from_obj(zend_object *obj)
+{
+	return (zend_generator *) ((char *) obj - XtOffsetOf(zend_generator, std));
+}
 
 END_EXTERN_C()
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4620,7 +4620,7 @@ ZEND_VM_HANDLER(139, ZEND_GENERATOR_CREATE, ANY, ANY)
 		memcpy(gen_execute_data, execute_data, used_stack);
 
 		/* Save execution context in generator object. */
-		generator = (zend_generator *) Z_OBJ_P(EX(return_value));
+		generator = zend_generator_from_obj(Z_OBJ_P(EX(return_value)));
 		generator->func = gen_execute_data->func;
 		generator->execute_data = gen_execute_data;
 		generator->frozen_call_stack = NULL;
@@ -8452,7 +8452,7 @@ ZEND_VM_C_LABEL(yield_from_try_again):
 	} else if (OP1_TYPE != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
-			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
+			zend_generator *new_gen = zend_generator_from_obj(Z_OBJ_P(val));
 
 			Z_ADDREF_P(val);
 			FREE_OP1();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2237,7 +2237,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_GENERATOR_CREATE_SPEC_HANDLER(
 		memcpy(gen_execute_data, execute_data, used_stack);
 
 		/* Save execution context in generator object. */
-		generator = (zend_generator *) Z_OBJ_P(EX(return_value));
+		generator = zend_generator_from_obj(Z_OBJ_P(EX(return_value)));
 		generator->func = gen_execute_data->func;
 		generator->execute_data = gen_execute_data;
 		generator->frozen_call_stack = NULL;
@@ -5807,7 +5807,7 @@ yield_from_try_again:
 	} else if (IS_CONST != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
-			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
+			zend_generator *new_gen = zend_generator_from_obj(Z_OBJ_P(val));
 
 			Z_ADDREF_P(val);
 
@@ -15411,7 +15411,7 @@ yield_from_try_again:
 	} else if ((IS_TMP_VAR|IS_VAR) != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
-			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
+			zend_generator *new_gen = zend_generator_from_obj(Z_OBJ_P(val));
 
 			Z_ADDREF_P(val);
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -41508,7 +41508,7 @@ yield_from_try_again:
 	} else if (IS_CV != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
-			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
+			zend_generator *new_gen = zend_generator_from_obj(Z_OBJ_P(val));
 
 			Z_ADDREF_P(val);
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2255,7 +2255,7 @@ ZEND_METHOD(ReflectionGenerator, __construct)
 ZEND_METHOD(ReflectionGenerator, getTrace)
 {
 	zend_long options = DEBUG_BACKTRACE_PROVIDE_OBJECT;
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_generator *root_generator;
 	zend_execute_data *ex_backup = EG(current_execute_data);
 	zend_execute_data *ex = generator->execute_data;
@@ -2290,7 +2290,7 @@ ZEND_METHOD(ReflectionGenerator, getTrace)
 /* {{{ */
 ZEND_METHOD(ReflectionGenerator, getExecutingLine)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_execute_data *ex = generator->execute_data;
 
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -2304,7 +2304,7 @@ ZEND_METHOD(ReflectionGenerator, getExecutingLine)
 /* {{{ */
 ZEND_METHOD(ReflectionGenerator, getExecutingFile)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_execute_data *ex = generator->execute_data;
 
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -2318,7 +2318,7 @@ ZEND_METHOD(ReflectionGenerator, getExecutingFile)
 /* {{{ */
 ZEND_METHOD(ReflectionGenerator, getFunction)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_function *func = generator->func;
 
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -2338,7 +2338,7 @@ ZEND_METHOD(ReflectionGenerator, getFunction)
 /* {{{ */
 ZEND_METHOD(ReflectionGenerator, getThis)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_execute_data *ex = generator->execute_data;
 
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -2356,7 +2356,7 @@ ZEND_METHOD(ReflectionGenerator, getThis)
 /* {{{ */
 ZEND_METHOD(ReflectionGenerator, getExecutingGenerator)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_execute_data *ex = generator->execute_data;
 	zend_generator *current;
 
@@ -2371,7 +2371,7 @@ ZEND_METHOD(ReflectionGenerator, getExecutingGenerator)
 
 ZEND_METHOD(ReflectionGenerator, isClosed)
 {
-	zend_generator *generator = (zend_generator *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
+	zend_generator *generator = zend_generator_from_obj(Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj));
 	zend_execute_data *ex = generator->execute_data;
 
 	ZEND_PARSE_PARAMETERS_NONE();

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1007,7 +1007,7 @@ PHPDBG_COMMAND(generator) /* {{{ */
 		i = param->num;
 		zend_object **obj = EG(objects_store).object_buckets + i;
 		if (i < EG(objects_store).top && *obj && IS_OBJ_VALID(*obj) && (*obj)->ce == zend_ce_generator) {
-			zend_generator *gen = (zend_generator *) *obj;
+			zend_generator *gen = zend_generator_from_obj(*obj);
 			if (gen->execute_data) {
 				if (zend_generator_get_current(gen)->flags & ZEND_GENERATOR_CURRENTLY_RUNNING) {
 					phpdbg_error("Generator currently running");
@@ -1024,7 +1024,7 @@ PHPDBG_COMMAND(generator) /* {{{ */
 		for (i = 0; i < EG(objects_store).top; i++) {
 			zend_object *obj = EG(objects_store).object_buckets[i];
 			if (obj && IS_OBJ_VALID(obj) && obj->ce == zend_ce_generator) {
-				zend_generator *gen = (zend_generator *) obj, *current = zend_generator_get_current(gen);
+				zend_generator *gen = zend_generator_from_obj(obj), *current = zend_generator_get_current(gen);
 				if (gen->execute_data) {
 					zend_string *s = phpdbg_compile_stackframe(gen->execute_data);
 					phpdbg_out("#%d: %.*s", i, (int) ZSTR_LEN(s), ZSTR_VAL(s));


### PR DESCRIPTION
Please refer to https://github.com/php/php-src/issues/17598 for more details.

This patch tries to fix the zend_object layout problem for zend_generator according to the requirements since PHP 7.