### PR TITLE
Fix use-of-uninitialized-value of EG(last_fatal_error_backtrace) with ZTS

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1050,6 +1050,8 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	CG(map_ptr_last) = 0;
 #endif /* ZTS */
 	EG(error_reporting) = E_ALL & ~E_NOTICE;
+	EG(fatal_error_backtrace_on) = false;
+	ZVAL_UNDEF(&EG(last_fatal_error_backtrace));
 
 	zend_interned_strings_init();
 	zend_startup_builtin_functions();


### PR DESCRIPTION
Static variables are zeroed, but ts memory is not. Hence, we need to do it ourselves.

See https://github.com/php/php-src/actions/runs/13043905843/job/36391169998.