### PR TITLE
Fix GH-17643: FPM with httpd ProxyPass encoded PATH_INFO env

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1153,6 +1153,7 @@ static void init_request_info(void)
 							}
 
 							if (tflag) {
+								char *decoded_path_info = NULL;
 								if (orig_path_info) {
 									char old;
 
@@ -1174,7 +1175,6 @@ static void init_request_info(void)
 									 * As we can extract PATH_INFO from PATH_TRANSLATED
 									 * it is probably also in SCRIPT_NAME and need to be removed
 									 */
-									char *decoded_path_info = NULL;
 									size_t decoded_path_info_len = 0;
 									if (strchr(path_info, '%')) {
 										decoded_path_info = estrdup(path_info);
@@ -1197,11 +1197,13 @@ static void init_request_info(void)
 										env_script_name[env_script_file_info_start] = 0;
 										SG(request_info).request_uri = FCGI_PUTENV(request, "SCRIPT_NAME", env_script_name);
 									}
-									if (decoded_path_info) {
-										efree(decoded_path_info);
-									}
 								}
-								env_path_info = FCGI_PUTENV(request, "PATH_INFO", path_info);
+								if (decoded_path_info) {
+									env_path_info = FCGI_PUTENV(request, "PATH_INFO", decoded_path_info);
+									efree(decoded_path_info);
+								} else {
+									env_path_info = FCGI_PUTENV(request, "PATH_INFO", path_info);
+								}
 							}
 							if (!orig_script_filename ||
 								strcmp(orig_script_filename, pt) != 0) {

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded-plus.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded-plus.phpt
@@ -39,7 +39,7 @@ $tester
         scriptFilename: "proxy:fcgi://" . $tester->getAddr() . $sourceFilePath . '/1%20+2',
         scriptName: $scriptName . '/1 +2'
     )
-    ->expectBody([$scriptName, $scriptName . '/1 +2', $sourceFilePath, '/1%20+2', $scriptName . '/1%20+2']);
+    ->expectBody([$scriptName, $scriptName . '/1 +2', $sourceFilePath, '/1 +2', $scriptName . '/1 +2']);
 $tester->terminate();
 $tester->close();
 

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded.phpt
@@ -39,7 +39,7 @@ $tester
         scriptFilename: "proxy:fcgi://" . $tester->getAddr() . $sourceFilePath . '/1%202',
         scriptName: $scriptName . '/1 2'
     )
-    ->expectBody([$scriptName, $scriptName . '/1 2', $sourceFilePath, '/1%202', $scriptName . '/1%202']);
+    ->expectBody([$scriptName, $scriptName . '/1 2', $sourceFilePath, '/1 2', $scriptName . '/1 2']);
 $tester->terminate();
 $tester->close();
 


### PR DESCRIPTION
This is a fix for GH-17643. It changes the current test because when I was creating them I didn't realised that this is actually completely inconsistent with handler and usual nginx behavior.

There is a chance of a tiny BC break if someone relies on this but if someone is really aware of this behaviour, then they most likely just decode it. It is much more likely that this can actually cause issues to someone. That's why it should be fixed as a bug fix.