### PR TITLE
Fix GH-17509: Apache parent and subrequest double bailout

### DIFF
--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -311,6 +311,7 @@ struct _zend_executor_globals {
 #define EG_FLAGS_IN_SHUTDOWN			(1<<0)
 #define EG_FLAGS_OBJECT_STORE_NO_REUSE	(1<<1)
 #define EG_FLAGS_IN_RESOURCE_SHUTDOWN	(1<<2)
+#define EG_FLAGS_IN_EXECUTOR_SHUTDOWN	(1<<3)
 
 struct _zend_ini_scanner_globals {
 	zend_file_handle *yy_in;

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -1204,6 +1204,10 @@ verify:
 
 CWD_API zend_result virtual_chdir(const char *path) /* {{{ */
 {
+	if (CWDG(cwd).cwd == NULL) {
+		return FAILURE;
+	}
+
 	return virtual_file_ex(&CWDG(cwd), path, php_is_dir_ok, CWD_REALPATH) ? FAILURE : SUCCESS;
 }
 /* }}} */

--- a/main/main.c
+++ b/main/main.c
@@ -1846,7 +1846,11 @@ void php_request_shutdown(void *dummy)
 {
 	bool report_memleaks;
 
-	EG(flags) |= EG_FLAGS_IN_SHUTDOWN;
+	if (EG(flags) & EG_FLAGS_IN_EXECUTOR_SHUTDOWN) {
+		return;
+	}
+
+	EG(flags) |= EG_FLAGS_IN_SHUTDOWN | EG_FLAGS_IN_EXECUTOR_SHUTDOWN;
 
 	report_memleaks = PG(report_memleaks);
 


### PR DESCRIPTION
What happens is that `zend_first_try` sets `EG(bailout)` to `NULL`. If that happens in subrequest that shares the globals with parent request, then the `EG(bailout)` gets reset for the parent and if there is a bailout in the parent, it fails because the jump address is not set. I think that technically we don't really need `zend_first_try` but I guess it's kind of a protection against extra jump after the last bailout. This restores the parent bailout at the end of the handler so parent knows where to jump.