### PR TITLE
Fix GH-17654: Multiple classes using same trait causes function JIT crash

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -9200,9 +9200,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			func = call_info->callee_func;
 		}
 		if ((op_array->fn_flags & ZEND_ACC_TRAIT_CLONE)
-		 && JIT_G(current_frame)
-		 && JIT_G(current_frame)->call
-		 && !JIT_G(current_frame)->call->func) {
+		 && (!JIT_G(current_frame) ||
+		     !JIT_G(current_frame)->call ||
+		     !JIT_G(current_frame)->call->func)) {
 			call_info = NULL; func = NULL; /* megamorphic call from trait */
 		}
 	}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9931,9 +9931,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			func = call_info->callee_func;
 		}
 		if ((op_array->fn_flags & ZEND_ACC_TRAIT_CLONE)
-		 && JIT_G(current_frame)
-		 && JIT_G(current_frame)->call
-		 && !JIT_G(current_frame)->call->func) {
+		 && (!JIT_G(current_frame) ||
+		     !JIT_G(current_frame)->call ||
+		     !JIT_G(current_frame)->call->func)) {
 			call_info = NULL; func = NULL; /* megamorphic call from trait */
 		}
 	}

--- a/ext/opcache/tests/jit/gh17654.phpt
+++ b/ext/opcache/tests/jit/gh17654.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-17654 (JIT OPcache with CRTO Modes XX14, XX34, XX15 and XX35 Crash The Application)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=1214
+opcache.jit_buffer_size=16M
+--FILE--
+<?php
+trait TestTrait {
+	public function addUnit(string $x) {
+		self::addRawUnit($this, $x);
+	}
+
+	public function addRawUnit(self $data, string $x) {
+		var_dump($x);
+	}
+}
+
+class Test {
+	use TestTrait;
+}
+
+class Test2 {
+	use TestTrait;
+}
+
+function main()
+{
+	(new Test2)->addUnit("test2");
+	(new Test)->addUnit("test");
+}
+
+main();
+?>
+--EXPECT--
+string(5) "test2"
+string(4) "test"


### PR DESCRIPTION
This test has two classes that use the same trait. In function JIT mode the same cache slot will be used. This causes problems because it is primed for the first class and then reused for the second class, resulting in an incorrect type check failure.

The current check for a megamorphic trait call requires current_frame to not be NULL, but this is only set in tracing mode and not in function mode.

This patch corrects the check.
This also needs to be fixed in 8.4, but the port to 8.4 is trivial.