### PR TITLE
Suppress MSVC C4995 warnings (deprecations)

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3269,9 +3269,9 @@ function toolset_setup_common_cflags()
 		// disable annoying warnings.  In addition, time_t defaults
 		// to 64-bit.  Ask for 32-bit.
 		if (TARGET_ARCH == 'x86') {
-			ADD_FLAG('CFLAGS', ' /wd4996 /D_USE_32BIT_TIME_T=1 ');
+			ADD_FLAG('CFLAGS', ' /wd4995 /wd4996 /D_USE_32BIT_TIME_T=1 ');
 		} else {
-			ADD_FLAG('CFLAGS', ' /wd4996 ');
+			ADD_FLAG('CFLAGS', ' /wd4995 /wd4996 ');
 		}
 
 		if (PHP_DEBUG == "yes") {


### PR DESCRIPTION
These have the same meaning as C4996[1] (which we already suppress), but are triggered by a different mechanism[2].  It makes no sense to suppress one, but not both.

Of course it would be better not to suppress either, but wrt the two C4995 warnings we see in php-src, that requires deprecation of using the ODBC cursor library[3], so might take a while.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996>
[2] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4995>
[3] <https://externals.io/message/126264>