### PR TITLE
Elevate Windows CI to /W3 (sans C4018/C4267)

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -32,7 +32,7 @@ if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer --enable-debug-pack
 
-set CFLAGS=/W2 /WX /w14013 /wd4146 /wd4244
+set CFLAGS=/W3 /WX /wd4018 /wd4146 /wd4244 /wd4267
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^

--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -32,6 +32,10 @@ if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 if "%ASAN%" equ "1" set ADD_CONF=%ADD_CONF% --enable-sanitizer --enable-debug-pack
 
+rem C4018: comparison: signed/unsigned mismatch
+rem C4146: unary minus operator applied to unsigned type
+rem C4244: type conversion, possible loss of data
+rem C4267: 'size_t' type conversion, possible loss of data
 set CFLAGS=/W3 /WX /wd4018 /wd4146 /wd4244 /wd4267
 
 cmd /c configure.bat ^


### PR DESCRIPTION
C4018[1] is about unsigned/signed comparisons; C4267[2] is about conversion from `size_t` to a "smaller" type.  We likely should resolve these warnings in the long run, but for now, it seems like a no brainer to elevate to `/W3` even if we have to exempt two additional categories of warnings, since we can catch some others.  And we no longer need to elevate C4010[3] to a higher level to catch it.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018>
[2] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267>
[3] <https://learn.microsoft.com/de-de/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013>