### PR TITLE
Fix fallback paths in fast_long_{add,sub}_function

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -722,11 +722,13 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	 * have read the values of op1 and op2.
 	 */
 
+	zend_long sum = (zend_long) ((zend_ulong) Z_LVAL_P(op1) + (zend_ulong) Z_LVAL_P(op2));
+
 	if (UNEXPECTED((Z_LVAL_P(op1) & LONG_SIGN_MASK) == (Z_LVAL_P(op2) & LONG_SIGN_MASK)
-		&& (Z_LVAL_P(op1) & LONG_SIGN_MASK) != (((zend_ulong) Z_LVAL_P(op1) + (zend_ulong) Z_LVAL_P(op2)) & LONG_SIGN_MASK))) {
+		&& (Z_LVAL_P(op1) & LONG_SIGN_MASK) != (sum & LONG_SIGN_MASK))) {
 		ZVAL_DOUBLE(result, (double) Z_LVAL_P(op1) + (double) Z_LVAL_P(op2));
 	} else {
-		ZVAL_LONG(result, Z_LVAL_P(op1) + Z_LVAL_P(op2));
+		ZVAL_LONG(result, sum);
 	}
 #endif
 }
@@ -810,11 +812,13 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 	 * have read the values of op1 and op2.
 	 */
 
+	zend_long sub = (zend_long) ((zend_ulong) Z_LVAL_P(op1) - (zend_ulong) Z_LVAL_P(op2));
+
 	if (UNEXPECTED((Z_LVAL_P(op1) & LONG_SIGN_MASK) != (Z_LVAL_P(op2) & LONG_SIGN_MASK)
-		&& (Z_LVAL_P(op1) & LONG_SIGN_MASK) != (((zend_ulong) Z_LVAL_P(op1) - (zend_ulong) Z_LVAL_P(op2)) & LONG_SIGN_MASK))) {
+		&& (Z_LVAL_P(op1) & LONG_SIGN_MASK) != (sub & LONG_SIGN_MASK))) {
 		ZVAL_DOUBLE(result, (double) Z_LVAL_P(op1) - (double) Z_LVAL_P(op2));
 	} else {
-		ZVAL_LONG(result, Z_LVAL_P(op1) - Z_LVAL_P(op2));
+		ZVAL_LONG(result, sub);
 	}
 #endif
 }

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -49,7 +49,7 @@
 #include "zend_multiply.h"
 #include "zend_object_handlers.h"
 
-#define LONG_SIGN_MASK (((zend_ulong)1) << (8*sizeof(zend_long)-1))
+#define LONG_SIGN_MASK ZEND_LONG_MIN
 
 BEGIN_EXTERN_C()
 ZEND_API zend_result ZEND_FASTCALL add_function(zval *result, zval *op1, zval *op2);


### PR DESCRIPTION
This was asked to be checked in https://github.com/php/php-src/pull/17472#issuecomment-2591325036

There are 2 issues:
1) The add/sub in the if can cause integer overflow UB warning, and can be fixed by using zend_ulong
   for the add/sub.
2) fast_long_sub_function() has a problem when result aliases.
   This is fixed in the same way as fast_long_add_function() works.