### PR TITLE
Fix condition to check for config.w32 in phpize

### DIFF
--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -203,7 +203,7 @@ if (buildconf_process_args() == 0) {
 	WScript.Quit(3);
 }
 
-if (FSO.FileExists("config.w32")) {
+if (!FSO.FileExists("config.w32")) {
 	STDERR.WriteLine("Cannot find config.w32");
 	STDERR.WriteLine("Must be run from the root of the extension source");
 	WScript.Quit(10);


### PR DESCRIPTION
This PR fixes the condition to check for config.w32 in phpize.

This was added in https://github.com/php/php-src/pull/17100.