### PR TITLE
Relax timezone_IDforWindowsID_basic2.phpt expectations

### DIFF
--- a/ext/intl/tests/timezone_IDforWindowsID_basic2.phpt
+++ b/ext/intl/tests/timezone_IDforWindowsID_basic2.phpt
@@ -25,7 +25,7 @@ foreach ($tzs as $tz => $regions) {
   }
 }
 ?>
---EXPECT--
+--EXPECTF--
 ** Gnomeregan
 bool(false)
 Error: intltz_get_windows_id: Unknown windows timezone: U_ILLEGAL_ARGUMENT_ERROR
@@ -36,7 +36,7 @@ string(19) "America/Los_Angeles"
 string(17) "America/Vancouver"
 string(19) "America/Los_Angeles"
 string(19) "America/Los_Angeles"
-string(7) "PST8PDT"
+string(%d) "%r(PST8PDT|America\/Los_Angeles)%r"
 ** Romance Standard Time
 string(12) "Europe/Paris"
 string(15) "Europe/Brussels"


### PR DESCRIPTION
Apparently, some ICU versions report "America/Los_Angeles" for the `ZZ` case, what matches the behavior of ICU 76.1 (on Windows).  Possibly, there has been some bug fix backport on some systems.  Anyhow, either seems fine, so we're not picky about that.

---

Maybe we should merge this test case with timezone_IDforWindowsID_basic_icu76_1.phpt right away. And possibly we short apply the fix to PHP-8.1+.