### PR TITLE
Add non-NULL assertion to zend_get_gc_buffer_add_obj()

### DIFF
--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -134,6 +134,8 @@ static zend_always_inline void zend_get_gc_buffer_add_zval(
 
 static zend_always_inline void zend_get_gc_buffer_add_obj(
 		zend_get_gc_buffer *gc_buffer, zend_object *obj) {
+	ZEND_ASSERT(obj != NULL);
+
 	if (UNEXPECTED(gc_buffer->cur == gc_buffer->end)) {
 		zend_get_gc_buffer_grow(gc_buffer);
 	}


### PR DESCRIPTION
This would've saved me time when fixing the nightly failure in Laravel [1].

[1] e306a2e0