### PR TITLE
Solve C4267 warnings in win32/ioutil for x64

### DIFF
--- a/win32/ioutil.c
+++ b/win32/ioutil.c
@@ -281,7 +281,8 @@ PW32IO int php_win32_ioutil_close(int fd)
 
 PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode)
 {/*{{{*/
-	size_t path_len, dir_len = 0;
+	size_t path_len;
+	DWORD dir_len = 0;
 	const wchar_t *my_path;
 
 	if (!path) {
@@ -336,7 +337,7 @@ PW32IO int php_win32_ioutil_mkdir_w(const wchar_t *path, mode_t mode)
 			dst = _tmp + PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW;
 #ifndef ZTS
 			if (dir_len > 0) {
-				size_t len = GetCurrentDirectoryW(dir_len, dst);
+				DWORD len = GetCurrentDirectoryW(dir_len, dst);
 				if (len == 0 || len + 1 != dir_len) {
 					free(tmp);
 					free(_tmp);

--- a/win32/ioutil.h
+++ b/win32/ioutil.h
@@ -175,7 +175,8 @@ PW32IO php_win32_ioutil_normalization_result php_win32_ioutil_normalize_path_w(w
 zend_always_inline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in, size_t in_len, size_t *out_len)
 {/*{{{*/
 	wchar_t *mb, *ret;
-	size_t mb_len, dir_len = 0;
+	size_t mb_len;
+	DWORD dir_len = 0;
 
 	mb = php_win32_cp_conv_any_to_w(in, in_len, &mb_len);
 	if (!mb) {
@@ -227,8 +228,8 @@ zend_always_inline static wchar_t *php_win32_ioutil_conv_any_to_w(const char* in
 			memcpy(ret, PHP_WIN32_IOUTIL_LONG_PATH_PREFIXW, PHP_WIN32_IOUTIL_LONG_PATH_PREFIX_LENW * sizeof(wchar_t));
 #ifndef ZTS
 			if (dir_len > 0) {
-				size_t len = GetCurrentDirectoryW(dir_len, dst);
-				if (len == 0 || len + 1 != dir_len) {
+				DWORD len = GetCurrentDirectoryW(dir_len, dst);
+				if (len == 0 || len != dir_len - 1) {
 					free(ret);
 					free(mb);
 					return NULL;


### PR DESCRIPTION
C4267[1] are about conversion from `size_t` to a "smaller" type, causing potential loss of data (aka. truncation).

In this case we can solve that cleanly (i.e. without casting and further checks) by changing the affected variables to be of type `DWORD`.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267>

---

Considering the [full list of C4267](https://github.com/php/php-src/pull/17665#issuecomment-2629475568) this is just a drop in the bucket, but as they are saying, constant dripping wears the stone. :)