### PR TITLE
Implement zend_safe_address() for MSVC 64bit

### DIFF
--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -290,6 +290,19 @@ static zend_always_inline size_t zend_safe_address(size_t nmemb, size_t size, si
 	return (size_t) res;
 }
 
+#elif defined(_MSC_VER)
+
+static zend_always_inline size_t zend_safe_address(size_t nmemb, size_t size, size_t offset, bool *overflow)
+{
+	size_t res;
+	if (UNEXPECTED(FAILED(ULongLongMult(nmemb, size, &res)) || FAILED(ULongLongAdd(res, offset, &res)))) {
+		*overflow = 1;
+		return 0;
+	}
+	*overflow = 0;
+	return res;
+}
+
 #else
 
 static zend_always_inline size_t zend_safe_address(size_t nmemb, size_t size, size_t offset, bool *overflow)


### PR DESCRIPTION
The 32bit implementation seems to be okay, but we rather should avoid falling back to the double (pun intended) calculation for non `__GNUC__` systems.  We use the intsafe.h intrinsics instead for MSVC and compatible compilers.