### PR TITLE
Fix MSVC C4267 warnings in gd.c

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1441,7 +1441,7 @@ PHP_FUNCTION(imagecreatefromstring)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (ZSTR_LEN(data) > INT_MAX) {
-		zend_argument_value_error(1, "must not have more than %d bytes", INT_MAX);
+		zend_argument_value_error(1, "is too long");
 	}
 
 	imtype = _php_image_type(data);


### PR DESCRIPTION
These warnings are about conversion from `size_t` to a smaller type[1], and in this case because `gdIOCtx` works with `int` lengths.  Two of these warnings are harmless, and we resolve them by using `size_t` in the first place, and adding a cast (plus an assertion), respectively.

The others actually hint at potential issues when reading image data with more than `INT_MAX` bytes; we catch that upfront, and throw a `ValueError` and a warning, respectively.

[1] <https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267>