### PR TITLE
Don't forward declare static functions in sendmail.h

### DIFF
--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -111,6 +111,15 @@ static char *ErrorMessages[] =
 #define PHP_WIN32_MAIL_DOT_PATTERN	"\n."
 #define PHP_WIN32_MAIL_DOT_REPLACE	"\n.."
 
+static int SendText(char *RPath, const char *Subject, const char *mailTo, char *mailCc, char *mailBcc, const char *data,
+                    const char *headers, char *headers_lc, char **error_message);
+static int MailConnect();
+static int PostHeader(char *RPath, const char *Subject, const char *mailTo, char *xheaders);
+static int Post(LPCSTR msg);
+static int Ack(char **server_response);
+static unsigned long GetAddr(LPSTR szHost);
+static int FormatEmailAddress(char* Buf, char* EmailAddress, char* FormatString);
+
 /* This function is meant to unify the headers passed to to mail()
  * This means, use PCRE to transform single occurrences of \n or \r in \r\n
  * As a second step we also eliminate all \r\n occurrences which are:

--- a/win32/sendmail.h
+++ b/win32/sendmail.h
@@ -36,14 +36,5 @@ PHPAPI int TSendMail(const char *host, int *error, char **error_message,
 			  const char *headers, const char *Subject, const char *mailTo, const char *data,
 			  char *mailCc, char *mailBcc, char *mailRPath);
 PHPAPI void TSMClose(void);
-static int SendText(char *RPath, const char *Subject, const char *mailTo, char *mailCc, char *mailBcc, const char *data,
-			 const char *headers, char *headers_lc, char **error_message);
 PHPAPI char *GetSMErrorText(int index);
-
-static int MailConnect();
-static int PostHeader(char *RPath, const char *Subject, const char *mailTo, char *xheaders);
-static int Post(LPCSTR msg);
-static int Ack(char **server_response);
-static unsigned long GetAddr(LPSTR szHost);
-static int FormatEmailAddress(char* Buf, char* EmailAddress, char* FormatString);
 #endif							/* sendmail_h */


### PR DESCRIPTION
sendmail.h is not only included by sendmail.c, but also by php_win32_globals.h, because that header uses some of the defined macros.  However, the forward declarations of the static functions are not needed anywhere else than in sendmail.c, and Clang warns about the unused functions elsewhere (`-Wunused-function`).  Thus we move the forward declarations to sendmail.c.