### PR TITLE
Fix Clang style nits

### DIFF
--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -83,7 +83,7 @@ void zend_startup_hrtime(void);
 static zend_always_inline zend_hrtime_t zend_hrtime(void)
 {
 #if ZEND_HRTIME_PLATFORM_WINDOWS
-	LARGE_INTEGER lt = {0};
+	LARGE_INTEGER lt = {{0}};
 	QueryPerformanceCounter(&lt);
 	return (zend_hrtime_t)((zend_hrtime_t)lt.QuadPart * zend_hrtime_timer_scale);
 #elif ZEND_HRTIME_PLATFORM_APPLE_GETTIME_NSEC

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -75,7 +75,7 @@
 # define LOCK_UN 2
 static int zend_file_cache_flock(int fd, int op)
 {
-	OVERLAPPED offset = {0,0,0,0,NULL};
+	OVERLAPPED offset = {0, 0, {{0}}, NULL};
 	if (op == LOCK_EX) {
 		if (LockFileEx((HANDLE)_get_osfhandle(fd),
 		               LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &offset) == TRUE) {

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -758,7 +758,7 @@ static int php_openssl_win_cert_verify_callback(X509_STORE_CTX *x509_store_ctx, 
 	}
 
 	{ /* Then verify it against a policy */
-		SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_policy_params = {sizeof(SSL_EXTRA_CERT_CHAIN_POLICY_PARA)};
+		SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_policy_params = {{sizeof(SSL_EXTRA_CERT_CHAIN_POLICY_PARA)}};
 		CERT_CHAIN_POLICY_PARA chain_policy_params = {sizeof(CERT_CHAIN_POLICY_PARA)};
 		CERT_CHAIN_POLICY_STATUS chain_policy_status = {sizeof(CERT_CHAIN_POLICY_STATUS)};
 		BOOL verify_result;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -807,7 +807,7 @@ PHP_FUNCTION(putenv)
 			valw = php_win32_cp_any_to_w(value);
 		}
 		/* valw may be NULL, but the failed conversion still needs to be checked. */
-		if (!keyw || !valw && value) {
+		if (!keyw || (!valw && value)) {
 			tsrm_env_unlock();
 			free(pe.putenv_string);
 			zend_string_release(pe.key);

--- a/ext/standard/flock_compat.c
+++ b/ext/standard/flock_compat.c
@@ -104,8 +104,7 @@ PHPAPI int php_flock(int fd, int operation)
 {
 	HANDLE hdl = (HANDLE) _get_osfhandle(fd);
 	DWORD low = 0xFFFFFFFF, high = 0xFFFFFFFF;
-	OVERLAPPED offset =
-	{0, 0, 0, 0, NULL};
+	OVERLAPPED offset = {0, 0, {{0}}, NULL};
 	DWORD err;
 
 	if (INVALID_HANDLE_VALUE == hdl) {

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -531,7 +531,7 @@ PHPAPI zend_string *php_resolve_path(const char *filename, size_t filename_lengt
 		   IS_ABSOLUTE_PATH doesn't care about this path form till now. It
 		   might be a big thing to extend, thus just a local handling for
 		   now. */
-		filename_length >=2 && IS_SLASH(filename[0]) && !IS_SLASH(filename[1]) ||
+		(filename_length >=2 && IS_SLASH(filename[0]) && !IS_SLASH(filename[1])) ||
 #endif
 	    !path ||
 	    !*path) {

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -840,9 +840,9 @@ static int do_cli(int argc, char **argv) /* {{{ */
 			is essential to mitigate buggy console info. */
 			interactive = php_win32_console_is_own() &&
 				!(script_file ||
-					argc > php_optind && context.mode != PHP_CLI_MODE_CLI_DIRECT &&
+					(argc > php_optind && context.mode != PHP_CLI_MODE_CLI_DIRECT &&
 					context.mode != PHP_CLI_MODE_PROCESS_STDIN &&
-					strcmp(argv[php_optind-1],"--")
+					strcmp(argv[php_optind-1],"--"))
 				);
 		}
 #endif

--- a/win32/fnmatch.c
+++ b/win32/fnmatch.c
@@ -137,8 +137,8 @@ PHPAPI int fnmatch(const char *pattern, const char *string, int flags)
 				  tolower((unsigned char)*string)))
 				;
 			else if ((flags & FNM_PREFIX_DIRS) && *string == EOS &&
-			     (c == '/' && string != stringstart ||
-			     string == stringstart+1 && *stringstart == '/') )
+			     ((c == '/' && string != stringstart) ||
+			     (string == stringstart+1 && *stringstart == '/')))
 				return (0);
 			else
 				return (FNM_NOMATCH);

--- a/win32/readdir.c
+++ b/win32/readdir.c
@@ -59,7 +59,7 @@ DIR *opendir(const char *dir)
 		wcscpy(filespecw, resolvedw);
 		index = resolvedw_len - 1;
 	}
-	if (index >= 0 && filespecw[index] == L'/' || index == 0 && filespecw[index] == L'\\')
+	if ((index >= 0 && filespecw[index] == L'/') || (index == 0 && filespecw[index] == L'\\'))
 		filespecw[index] = L'\0';
 	wcscat(filespecw, L"\\*");
 

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -459,7 +459,7 @@ static zend_always_inline BOOL is_compatible(HMODULE handle, BOOL is_smaller, ch
 		This check is to be extended as new VS versions come out. */
 	DWORD core_minor = (DWORD)(PHP_LINKER_MINOR/10);
 	DWORD comp_minor = (DWORD)(minor/10);
-	if (14 == major && (is_smaller ? core_minor < comp_minor : core_minor > comp_minor) || PHP_LINKER_MAJOR != major)
+	if ((14 == major && (is_smaller ? core_minor < comp_minor : core_minor > comp_minor)) || PHP_LINKER_MAJOR != major)
 #else
 	if (PHP_LINKER_MAJOR != major)
 #endif


### PR DESCRIPTION
This addresses all `-Wlogical-op-parentheses` and `-Wmissing-braces` warnings across the whole code base (all Windows specific code).