### PR TITLE
Exclude unused functions from compilation units

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4410,6 +4410,7 @@ static void preload_load(void)
 	}
 }
 
+#ifndef ZEND_WIN32
 static zend_result accel_preload(const char *config, bool in_child)
 {
 	zend_file_handle file_handle;
@@ -4665,7 +4666,6 @@ static void preload_send_header(sapi_header_struct *sapi_header, void *server_co
 {
 }
 
-#ifndef ZEND_WIN32
 static zend_result accel_finish_startup_preload(bool in_child)
 {
 	zend_result ret = SUCCESS;

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -776,6 +776,7 @@ static zend_result convert_command_to_use_shell(wchar_t **cmdw, size_t cmdw_len)
 }
 #endif
 
+#ifndef PHP_WIN32
 /* Convert command parameter array passed as first argument to `proc_open` into command string */
 static zend_string* get_command_from_array(HashTable *array, char ***argv, int num_elems)
 {
@@ -807,6 +808,7 @@ static zend_string* get_command_from_array(HashTable *array, char ***argv, int n
 	(*argv)[i] = NULL;
 	return command;
 }
+#endif
 
 static descriptorspec_item* alloc_descriptor_array(HashTable *descriptorspec)
 {
@@ -1177,6 +1179,7 @@ static void close_all_descriptors(descriptorspec_item *descriptors, int ndesc)
 	}
 }
 
+#ifndef PHP_WIN32
 static void efree_argv(char **argv)
 {
 	if (argv) {
@@ -1188,6 +1191,7 @@ static void efree_argv(char **argv)
 		efree(argv);
 	}
 }
+#endif
 
 /* {{{ Execute a command, with specified files used for input/output */
 PHP_FUNCTION(proc_open)

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -221,6 +221,7 @@ static void print_extensions(void) /* {{{ */
 #define STDERR_FILENO 2
 #endif
 
+#ifdef PHP_WRITE_STDOUT
 static inline bool sapi_cli_select(php_socket_t fd)
 {
 	fd_set wfd;
@@ -238,6 +239,7 @@ static inline bool sapi_cli_select(php_socket_t fd)
 
 	return ret != -1;
 }
+#endif
 
 PHP_CLI_API ssize_t sapi_cli_single_write(const char *str, size_t str_length) /* {{{ */
 {

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -851,6 +851,7 @@ typedef struct {
 	int fd;
 } php_stdio_stream_data;
 
+#ifndef _WIN32
 static ssize_t phpdbg_stdiop_write(php_stream *stream, const char *buf, size_t count) {
 	php_stdio_stream_data *data = (php_stdio_stream_data*)stream->abstract;
 
@@ -877,6 +878,7 @@ static ssize_t phpdbg_stdiop_write(php_stream *stream, const char *buf, size_t c
 
 	return PHPDBG_G(php_stdiop_write)(stream, buf, count);
 }
+#endif
 
 /* copied from sapi/cli/php_cli.c cli_register_file_handles */
 void phpdbg_register_file_handles(void) /* {{{ */


### PR DESCRIPTION
This avoids Clang complaining with `-Wunused-function`.