### PR TITLE
Remove more unused local variables

### DIFF
--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -249,7 +249,6 @@ static void function_dtor(zval *zv)
 static PHP_FUNCTION(com_method_handler)
 {
 	zval *object = getThis();
-	zend_string *method = EX(func)->common.function_name;
 	zval *args = NULL;
 	php_com_dotnet_object *obj = CDNO_FETCH(object);
 	int nargs;

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -88,12 +88,11 @@ static int pdo_odbc_utf82ucs2(pdo_stmt_t *stmt, int is_unicode, const char *buf,
 	return PDO_ODBC_CONV_NOT_REQUIRED;
 }
 
-static int pdo_odbc_ucs22utf8(pdo_stmt_t *stmt, int is_unicode, zval *result)
+static int pdo_odbc_ucs22utf8(int is_unicode, zval *result)
 {
 #ifdef PHP_WIN32
 	ZEND_ASSERT(Z_TYPE_P(result) == IS_STRING);
 	if (is_unicode && Z_STRLEN_P(result) != 0) {
-		pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 		DWORD ret;
 
 		ret = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR) Z_STRVAL_P(result), Z_STRLEN_P(result)/sizeof(WCHAR), NULL, 0, NULL, NULL);
@@ -502,7 +501,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 
 					if (P->len >= 0) {
 							ZVAL_STRINGL(parameter, P->outbuf, P->len);
-							switch (pdo_odbc_ucs22utf8(stmt, P->is_unicode, parameter)) {
+							switch (pdo_odbc_ucs22utf8(P->is_unicode, parameter)) {
 								case PDO_ODBC_CONV_FAIL:
 									/* something fishy, but allow it to come back as binary */
 								case PDO_ODBC_CONV_NOT_REQUIRED:
@@ -751,7 +750,7 @@ in_data:
 	}
 
 unicode_conv:
-	switch (pdo_odbc_ucs22utf8(stmt, C->is_unicode, result)) {
+	switch (pdo_odbc_ucs22utf8(C->is_unicode, result)) {
 		case PDO_ODBC_CONV_FAIL:
 			/* oh well.  They can have the binary version of it */
 		case PDO_ODBC_CONV_NOT_REQUIRED:

--- a/sapi/phpdbg/phpdbg_win.c
+++ b/sapi/phpdbg/phpdbg_win.c
@@ -26,7 +26,6 @@ int mprotect(void *addr, size_t size, int protection) {
 
 int phpdbg_exception_handler_win32(EXCEPTION_POINTERS *xp) {
 	EXCEPTION_RECORD *xr = xp->ExceptionRecord;
-	CONTEXT *xc = xp->ContextRecord;
 
 	switch (xr->ExceptionCode) {
 		case EXCEPTION_ACCESS_VIOLATION:


### PR DESCRIPTION
Since `pdo_odbc_ucs22utf8()` doesn't actually use the `stmt`, we drop this parameter as well.