### PR TITLE
Fix GH-17503: Undefined float conversion in mb_convert_variables

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3092,7 +3092,7 @@ try_next_encoding:;
 	}
 
 	for (size_t i = 0; i < length; i++) {
-		double demerits = array[i].demerits * array[i].multiplier;
+		double demerits = array[i].demerits * (double) array[i].multiplier;
 		array[i].demerits = demerits < (double) UINT64_MAX ? (uint64_t) demerits : UINT64_MAX;
 	}
 

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3092,7 +3092,8 @@ try_next_encoding:;
 	}
 
 	for (size_t i = 0; i < length; i++) {
-		array[i].demerits *= array[i].multiplier;
+		float demerits = array[i].demerits * array[i].multiplier;
+		array[i].demerits = demerits < (float) UINT64_MAX ? (uint64_t) demerits : UINT64_MAX;
 	}
 
 	return length;

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3092,8 +3092,8 @@ try_next_encoding:;
 	}
 
 	for (size_t i = 0; i < length; i++) {
-		float demerits = array[i].demerits * array[i].multiplier;
-		array[i].demerits = demerits < (float) UINT64_MAX ? (uint64_t) demerits : UINT64_MAX;
+		double demerits = array[i].demerits * array[i].multiplier;
+		array[i].demerits = demerits < (double) UINT64_MAX ? (uint64_t) demerits : UINT64_MAX;
 	}
 
 	return length;

--- a/ext/mbstring/tests/gh17503.phpt
+++ b/ext/mbstring/tests/gh17503.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-17503 (Undefined float conversion in mb_convert_variables)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+$a = array_fill(0, 500, "<blah>");
+var_dump(mb_convert_variables("ASCII", ["UTF-8", "UTF-16"], $a));
+?>
+--EXPECT--
+string(5) "UTF-8"


### PR DESCRIPTION
Conversion of floating point to integer values is undefined if the integral part of the float value cannot be represented by the integer type.  We need to cater to that explicitly (in a manner similar to `zend_dval_to_lval_cap()`).