### PR TITLE
[RFC] Add get_error_handler(), get_exception_handler() functions

### DIFF
--- a/Zend/tests/get_error_handler.phpt
+++ b/Zend/tests/get_error_handler.phpt
@@ -8,61 +8,81 @@ class C {
     static function handleStatic() {}
 }
 
+class Invokable {
+    public function __invoke() {
+    }
+}
+
 function foo() {}
 
-set_error_handler("foo");
-var_dump(get_error_handler());
+echo "No error handler\n";
+var_dump(get_error_handler() === null);
 
+echo "\nFunction string\n";
+set_error_handler('foo');
+var_dump(get_error_handler() === 'foo');
+
+echo "\nNULL\n";
 set_error_handler(null);
-var_dump(get_error_handler());
+var_dump(get_error_handler() === null);
 
+echo "\nStatic method array\n";
 set_error_handler([C::class, 'handleStatic']);
-var_dump(get_error_handler());
+var_dump(get_error_handler() === [C::class, 'handleStatic']);
 
+echo "\nStatic method string\n";
 set_error_handler('C::handleStatic');
-var_dump(get_error_handler());
+var_dump(get_error_handler() === 'C::handleStatic');
 
-set_error_handler([new C(), 'handle']);
-var_dump(get_error_handler());
+echo "\nInstance method array\n";
+set_error_handler([$c = new C(), 'handle']);
+var_dump(get_error_handler() === [$c, 'handle']);
 
-set_error_handler((new C())->handle(...));
-var_dump(get_error_handler());
+echo "\nFirst class callable method\n";
+set_error_handler($f = (new C())->handle(...));
+var_dump(get_error_handler() === $f);
 
-set_error_handler(function () {});
-var_dump(get_error_handler());
+echo "\nClosure\n";
+set_error_handler($f = function () {});
+var_dump(get_error_handler() === $f);
+
+echo "\nInvokable\n";
+set_error_handler($object = new Invokable());
+var_dump(get_error_handler() === $object);
+
+echo "\nStable return value\n";
+var_dump(get_error_handler() === get_error_handler());
 
 ?>
 ==DONE==
---EXPECTF--
-string(3) "foo"
+--EXPECT--
+No error handler
+bool(true)
+
+Function string
+bool(true)
+
 NULL
-array(2) {
-  [0]=>
-  string(1) "C"
-  [1]=>
-  string(12) "handleStatic"
-}
-string(15) "C::handleStatic"
-array(2) {
-  [0]=>
-  object(C)#%d (0) {
-  }
-  [1]=>
-  string(6) "handle"
-}
-object(Closure)#%d (2) {
-  ["function"]=>
-  string(9) "C::handle"
-  ["this"]=>
-  object(C)#%d (0) {
-  }
-}
-object(Closure)#%d (3) {
-  ["name"]=>
-  string(%d) "{closure:%s:%d}"
-  ["file"]=>
-  string(%d) "%s"
-  ["line"]=>
-  int(%d)
-}
+bool(true)
+
+Static method array
+bool(true)
+
+Static method string
+bool(true)
+
+Instance method array
+bool(true)
+
+First class callable method
+bool(true)
+
+Closure
+bool(true)
+
+Invokable
+bool(true)
+
+Stable return value
+bool(true)
 ==DONE==

--- a/Zend/tests/get_error_handler.phpt
+++ b/Zend/tests/get_error_handler.phpt
@@ -1,0 +1,68 @@
+--TEST--
+get_error_handler()
+--FILE--
+<?php
+
+class C {
+    function handle() {}
+    static function handleStatic() {}
+}
+
+function foo() {}
+
+set_error_handler("foo");
+var_dump(get_error_handler());
+
+set_error_handler(null);
+var_dump(get_error_handler());
+
+set_error_handler([C::class, 'handleStatic']);
+var_dump(get_error_handler());
+
+set_error_handler('C::handleStatic');
+var_dump(get_error_handler());
+
+set_error_handler([new C(), 'handle']);
+var_dump(get_error_handler());
+
+set_error_handler((new C())->handle(...));
+var_dump(get_error_handler());
+
+set_error_handler(function () {});
+var_dump(get_error_handler());
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+NULL
+array(2) {
+  [0]=>
+  string(1) "C"
+  [1]=>
+  string(12) "handleStatic"
+}
+string(15) "C::handleStatic"
+array(2) {
+  [0]=>
+  object(C)#%d (0) {
+  }
+  [1]=>
+  string(6) "handle"
+}
+object(Closure)#%d (2) {
+  ["function"]=>
+  string(9) "C::handle"
+  ["this"]=>
+  object(C)#%d (0) {
+  }
+}
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(%d)
+}
+==DONE==

--- a/Zend/tests/get_exception_handler.phpt
+++ b/Zend/tests/get_exception_handler.phpt
@@ -8,61 +8,80 @@ class C {
     static function handleStatic() {}
 }
 
+class Invokable {
+    public function __invoke() {
+    }
+}
+
 function foo() {}
 
-set_exception_handler("foo");
-var_dump(get_exception_handler());
+echo "No exception handler\n";
+var_dump(get_exception_handler() === null);
 
+echo "\nFunction string\n";
+set_exception_handler('foo');
+var_dump(get_exception_handler() === 'foo');
+
+echo "\nNULL\n";
 set_exception_handler(null);
-var_dump(get_exception_handler());
+var_dump(get_exception_handler() === null);
 
+echo "\nStatic method array\n";
 set_exception_handler([C::class, 'handleStatic']);
-var_dump(get_exception_handler());
+var_dump(get_exception_handler() === [C::class, 'handleStatic']);
 
+echo "\nStatic method string\n";
 set_exception_handler('C::handleStatic');
-var_dump(get_exception_handler());
+var_dump(get_exception_handler() === 'C::handleStatic');
 
-set_exception_handler([new C(), 'handle']);
-var_dump(get_exception_handler());
+echo "\nInstance method array\n";
+set_exception_handler([$c = new C(), 'handle']);
+var_dump(get_exception_handler() === [$c, 'handle']);
 
-set_exception_handler((new C())->handle(...));
-var_dump(get_exception_handler());
+echo "\nFirst class callable method\n";
+set_exception_handler($f = (new C())->handle(...));
+var_dump(get_exception_handler() === $f);
 
-set_exception_handler(function () {});
-var_dump(get_exception_handler());
+echo "\nClosure\n";
+set_exception_handler($f = function () {});
+var_dump(get_exception_handler() === $f);
 
-?>
-==DONE==
---EXPECTF--
-string(3) "foo"
+echo "\nInvokable\n";
+set_exception_handler($object = new Invokable());
+var_dump(get_exception_handler() === $object);
+
+echo "\nStable return value\n";
+var_dump(get_exception_handler() === get_exception_handler());
+
+?>==DONE==
+--EXPECT--
+No exception handler
+bool(true)
+
+Function string
+bool(true)
+
 NULL
-array(2) {
-  [0]=>
-  string(1) "C"
-  [1]=>
-  string(12) "handleStatic"
-}
-string(15) "C::handleStatic"
-array(2) {
-  [0]=>
-  object(C)#%d (0) {
-  }
-  [1]=>
-  string(6) "handle"
-}
-object(Closure)#%d (2) {
-  ["function"]=>
-  string(9) "C::handle"
-  ["this"]=>
-  object(C)#%d (0) {
-  }
-}
-object(Closure)#%d (3) {
-  ["name"]=>
-  string(%d) "{closure:%s:%d}"
-  ["file"]=>
-  string(%d) "%s"
-  ["line"]=>
-  int(%d)
-}
+bool(true)
+
+Static method array
+bool(true)
+
+Static method string
+bool(true)
+
+Instance method array
+bool(true)
+
+First class callable method
+bool(true)
+
+Closure
+bool(true)
+
+Invokable
+bool(true)
+
+Stable return value
+bool(true)
 ==DONE==

--- a/Zend/tests/get_exception_handler.phpt
+++ b/Zend/tests/get_exception_handler.phpt
@@ -1,0 +1,68 @@
+--TEST--
+get_exception_handler()
+--FILE--
+<?php
+
+class C {
+    function handle() {}
+    static function handleStatic() {}
+}
+
+function foo() {}
+
+set_exception_handler("foo");
+var_dump(get_exception_handler());
+
+set_exception_handler(null);
+var_dump(get_exception_handler());
+
+set_exception_handler([C::class, 'handleStatic']);
+var_dump(get_exception_handler());
+
+set_exception_handler('C::handleStatic');
+var_dump(get_exception_handler());
+
+set_exception_handler([new C(), 'handle']);
+var_dump(get_exception_handler());
+
+set_exception_handler((new C())->handle(...));
+var_dump(get_exception_handler());
+
+set_exception_handler(function () {});
+var_dump(get_exception_handler());
+
+?>
+==DONE==
+--EXPECTF--
+string(3) "foo"
+NULL
+array(2) {
+  [0]=>
+  string(1) "C"
+  [1]=>
+  string(12) "handleStatic"
+}
+string(15) "C::handleStatic"
+array(2) {
+  [0]=>
+  object(C)#%d (0) {
+  }
+  [1]=>
+  string(6) "handle"
+}
+object(Closure)#%d (2) {
+  ["function"]=>
+  string(9) "C::handle"
+  ["this"]=>
+  object(C)#%d (0) {
+  }
+}
+object(Closure)#%d (3) {
+  ["name"]=>
+  string(%d) "{closure:%s:%d}"
+  ["file"]=>
+  string(%d) "%s"
+  ["line"]=>
+  int(%d)
+}
+==DONE==

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1323,6 +1323,15 @@ ZEND_FUNCTION(restore_error_handler)
 }
 /* }}} */
 
+ZEND_FUNCTION(get_error_handler)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
+		RETURN_ZVAL(&EG(user_error_handler), 1, 0);
+	}
+}
+
 /* {{{ Sets a user-defined exception handler function. Returns the previously defined exception handler, or false on error */
 ZEND_FUNCTION(set_exception_handler)
 {
@@ -1368,6 +1377,15 @@ ZEND_FUNCTION(restore_exception_handler)
 	RETURN_TRUE;
 }
 /* }}} */
+
+ZEND_FUNCTION(get_exception_handler)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+		RETURN_ZVAL(&EG(user_exception_handler), 1, 0);
+	}
+}
 
 static inline void get_declared_class_impl(INTERNAL_FUNCTION_PARAMETERS, int flags) /* {{{ */
 {

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1328,7 +1328,7 @@ ZEND_FUNCTION(get_error_handler)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
-		RETURN_ZVAL(&EG(user_error_handler), 1, 0);
+		RETURN_COPY(&EG(user_error_handler));
 	}
 }
 
@@ -1383,7 +1383,7 @@ ZEND_FUNCTION(get_exception_handler)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
-		RETURN_ZVAL(&EG(user_exception_handler), 1, 0);
+		RETURN_COPY(&EG(user_exception_handler));
 	}
 }
 

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -117,14 +117,14 @@ function set_error_handler(?callable $callback, int $error_levels = E_ALL) {}
 
 function restore_error_handler(): true {}
 
-function get_error_handler(): mixed {}
+function get_error_handler(): ?callable {}
 
 /** @return callable|null */
 function set_exception_handler(?callable $callback) {}
 
 function restore_exception_handler(): true {}
 
-function get_exception_handler(): mixed {}
+function get_exception_handler(): ?callable {}
 
 /**
  * @return array<int, string>

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -117,10 +117,14 @@ function set_error_handler(?callable $callback, int $error_levels = E_ALL) {}
 
 function restore_error_handler(): true {}
 
+function get_error_handler(): mixed {}
+
 /** @return callable|null */
 function set_exception_handler(?callable $callback) {}
 
 function restore_exception_handler(): true {}
+
+function get_exception_handler(): mixed {}
 
 /**
  * @return array<int, string>

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f9a6466d527e6abcd48cc36fb6a5d8434f3eb7bb */
+ * Stub hash: a24761186f1ddf758e648b0a764826537cbd33b9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_exit, 0, 0, IS_NEVER, 0)
 	ZEND_ARG_TYPE_MASK(0, status, MAY_BE_STRING|MAY_BE_LONG, "0")
@@ -148,7 +148,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_restore_error_handler, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_error_handler, 0, 0, IS_MIXED, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_error_handler, 0, 0, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_set_exception_handler, 0, 0, 1)

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3dbc84896823c9aaa9ac8aeef8841266920c3e50 */
+ * Stub hash: f9a6466d527e6abcd48cc36fb6a5d8434f3eb7bb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_exit, 0, 0, IS_NEVER, 0)
 	ZEND_ARG_TYPE_MASK(0, status, MAY_BE_STRING|MAY_BE_LONG, "0")
@@ -148,11 +148,16 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_restore_error_handler, 0, 0, IS_TRUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_error_handler, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_set_exception_handler, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_restore_exception_handler arginfo_restore_error_handler
+
+#define arginfo_get_exception_handler arginfo_get_error_handler
 
 #define arginfo_get_declared_classes arginfo_func_get_args
 
@@ -272,8 +277,10 @@ ZEND_FUNCTION(get_included_files);
 ZEND_FUNCTION(trigger_error);
 ZEND_FUNCTION(set_error_handler);
 ZEND_FUNCTION(restore_error_handler);
+ZEND_FUNCTION(get_error_handler);
 ZEND_FUNCTION(set_exception_handler);
 ZEND_FUNCTION(restore_exception_handler);
+ZEND_FUNCTION(get_exception_handler);
 ZEND_FUNCTION(get_declared_classes);
 ZEND_FUNCTION(get_declared_traits);
 ZEND_FUNCTION(get_declared_interfaces);
@@ -336,8 +343,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("user_error", zif_trigger_error, arginfo_user_error, 0, NULL, NULL)
 	ZEND_FE(set_error_handler, arginfo_set_error_handler)
 	ZEND_FE(restore_error_handler, arginfo_restore_error_handler)
+	ZEND_FE(get_error_handler, arginfo_get_error_handler)
 	ZEND_FE(set_exception_handler, arginfo_set_exception_handler)
 	ZEND_FE(restore_exception_handler, arginfo_restore_exception_handler)
+	ZEND_FE(get_exception_handler, arginfo_get_exception_handler)
 	ZEND_FE(get_declared_classes, arginfo_get_declared_classes)
 	ZEND_FE(get_declared_traits, arginfo_get_declared_traits)
 	ZEND_FE(get_declared_interfaces, arginfo_get_declared_interfaces)


### PR DESCRIPTION
Currently, the only way to fetch the current error and exception handlers is to push a new one before restoring it:

``` php
$current_error_handler = set_error_handler('valid_callback');
restore_error_handler();
```

This PR adds `get_error_handler()`, `get_exception_handler()` functions to address this use-case. They return the last value passed to `set_error_handler()` or `set_exception_handler()`, respectively, or `NULL` if no handler was set.

RFC: https://wiki.php.net/rfc/get-error-exception-handler

Related: https://github.com/symfony/symfony/pull/58372#discussion_r1773407604.

cc @lyrixx @nicolas-grekas 