### PR TITLE
Fix GH-8038: DOM extension reflection version is incorrect

### DIFF
--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -56,11 +56,8 @@ extern zend_module_entry dom_module_entry;
 #include "xpath_callbacks.h"
 #include "zend_exceptions.h"
 #include "dom_ce.h"
-/* DOM API_VERSION, please bump it up, if you change anything in the API
-    therefore it's easier for the script-programmers to check, what's working how
-   Can be checked with phpversion("dom");
-*/
-#define DOM_API_VERSION "20031129"
+
+#define DOM_API_VERSION PHP_VERSION
 /* Define a custom type for iterating using an unused nodetype */
 #define DOM_NODESET XML_XINCLUDE_START
 


### PR DESCRIPTION
It doesn't appear to be reasonable to pretend that nothing in the DOM API would have changed in the last 21 years, and it's also not that reasonable to pretend that we would thoroughly bump that version in the future.  Thus we go with the common convention to use the `PHP_VERSION` for bundled extensions.

---

It might also make sense to rename to `PHP_DOM_VERSION` or something.