### PR TITLE
Add CONFLICT all to random port test

### DIFF
--- a/ext/standard/tests/network/bug20134.phpt
+++ b/ext/standard/tests/network/bug20134.phpt
@@ -2,6 +2,8 @@
 Bug #20134 (UDP reads from invalid ports)
 --INI--
 default_socket_timeout=1
+--CONFLICTS--
+all
 --FILE--
 <?php
 


### PR DESCRIPTION
If we're very unlucky, we can get the same port opened as an ephemeral port by some other test.

Presumably happened in the last nightly. https://github.com/php/php-src/actions/runs/13148355594/job/36691200380