### PR TITLE
Fix curl_basic_022.phpt for libcurl 8.12.0

### DIFF
--- a/ext/curl/tests/curl_basic_022.phpt
+++ b/ext/curl/tests/curl_basic_022.phpt
@@ -11,10 +11,10 @@ curl_setopt($ch, CURLOPT_COOKIELIST, 'Set-Cookie: C2=v2; expires=Thu, 31-Dec-203
 var_dump(curl_getinfo($ch, CURLINFO_COOKIELIST));
 
 ?>
---EXPECT--
+--EXPECTF--
 array(2) {
   [0]=>
-  string(38) ".php.net	TRUE	/	FALSE	2145916799	C1	v1"
+  string(38) ".php.net	TRUE	/	FALSE	%d	C1	v1"
   [1]=>
-  string(38) ".php.net	TRUE	/	FALSE	2145916799	C2	v2"
+  string(38) ".php.net	TRUE	/	FALSE	%d	C2	v2"
 }


### PR DESCRIPTION
Due to a deliberate change in libcurl, the expiration is now capped to at most 400 days.  We could solve this by choosing another date roughly a year in the future, but would need to update the test next year. This would be especially annoying for security branches.

Another option would be to actually parse the cookie list lines, but that might not be worth the trouble.  Instead we just ignore the exact timestamp created by libcurl.

[1] <https://github.com/curl/curl/pull/15937>