### PR TITLE
Disallow calls to abstract `__call()` / `__callStatic()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-17618 (UnhandledMatchError does not take
     zend.exception_ignore_args=1 into account). (timwolla)
   . Fix fallback paths in fast_long_{add,sub}_function. (nielsdos)
+  . Fixed bug GH-17718 (Calling static methods on an interface that has
+    `__callStatic` is allowed). (timwolla)
 
 - LDAP:
   . Fixed bug GH-17704 (ldap_search fails when $attributes contains a

--- a/Zend/tests/gh_17718_001.phpt
+++ b/Zend/tests/gh_17718_001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-17718: Disallow calling abstract `__callStatic()` trampoline on an interface
+--FILE--
+<?php
+
+interface Foo {
+    public static function __callStatic($method, $args);
+}
+
+Foo::bar();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot call abstract method Foo::bar() in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/gh_17718_002.phpt
+++ b/Zend/tests/gh_17718_002.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-17718: Disallow calling abstract `__callStatic()` trampoline on an abstract class
+--FILE--
+<?php
+
+abstract class Foo {
+    abstract public static function __callStatic($method, $args);
+}
+
+Foo::bar();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot call abstract method Foo::bar() in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1348,7 +1348,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(const zend_class_entry *ce
 	func->fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE
 		| ZEND_ACC_PUBLIC
 		| ZEND_ACC_VARIADIC
-		| (fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE);
+		| (fbc->common.fn_flags & (ZEND_ACC_RETURN_REFERENCE|ZEND_ACC_ABSTRACT));
 	if (is_static) {
 		func->fn_flags |= ZEND_ACC_STATIC;
 	}
@@ -1541,6 +1541,10 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, zend_st
 	if (EXPECTED(fbc)) {
 		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_ABSTRACT)) {
 			zend_abstract_method_call(fbc);
+			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
+				zend_string_release_ex(fbc->common.function_name, 0);
+				zend_free_trampoline(fbc);
+			}
 			fbc = NULL;
 		} else if (UNEXPECTED(fbc->common.scope->ce_flags & ZEND_ACC_TRAIT)) {
 			zend_error(E_DEPRECATED,


### PR DESCRIPTION
Fixes php/php-src#17718