### PR TITLE
Free the trampoline when deprecation on materializing `__callStatic()` of trait throws

### DIFF
--- a/Zend/tests/gh_17728.phpt
+++ b/Zend/tests/gh_17728.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-17728: Assertion failure when calling static method of trait with `__callStatic()` with throwing error handler
+--FILE--
+<?php
+
+set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) {
+    throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+});
+
+trait Foo {
+    public static function __callStatic($method, $args) {
+        var_dump($method);
+    }
+}
+
+try {
+    Foo::bar();
+} catch (ErrorException $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Calling static trait method Foo::bar is deprecated, it should only be called on a class using the trait

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1541,23 +1541,27 @@ ZEND_API zend_function *zend_std_get_static_method(zend_class_entry *ce, zend_st
 	if (EXPECTED(fbc)) {
 		if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_ABSTRACT)) {
 			zend_abstract_method_call(fbc);
-			if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
-				zend_string_release_ex(fbc->common.function_name, 0);
-				zend_free_trampoline(fbc);
-			}
-			fbc = NULL;
+			goto fail;
 		} else if (UNEXPECTED(fbc->common.scope->ce_flags & ZEND_ACC_TRAIT)) {
 			zend_error(E_DEPRECATED,
 				"Calling static trait method %s::%s is deprecated, "
 				"it should only be called on a class using the trait",
 				ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
 			if (EG(exception)) {
-				return NULL;
+				goto fail;
 			}
 		}
 	}
 
 	return fbc;
+
+ fail:
+	if (UNEXPECTED(fbc->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
+		zend_string_release_ex(fbc->common.function_name, 0);
+		zend_free_trampoline(fbc);
+	}
+
+	return NULL;
 }
 /* }}} */
 


### PR DESCRIPTION
Fixes php/php-src#17728