### PR TITLE
Fix GH-17727: JIT SEGV on OOM in dtor when creating backtrace

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -9327,6 +9327,7 @@ static int zend_jit_init_static_method_call(zend_jit_ctx         *jit,
 			ir_IF_FALSE_cold(if_static);
 		}
 
+		jit_SET_EX_OPLINE(jit, opline);
 		ref = ir_CALL_3(IR_ADDR, ir_CONST_FC_FUNC(zend_jit_push_this_method_call_frame),
 				scope_ref,
 				func_ref,

--- a/ext/opcache/tests/jit/gh17727.phpt
+++ b/ext/opcache/tests/jit/gh17727.phpt
@@ -15,6 +15,7 @@ arnaud-lb
 YuanchengJiang
 --FILE--
 <?php
+$str = str_repeat('a', 1024 * 1024 * 1.25);
 class DestructableObject
 {
     public function __destruct()
@@ -27,7 +28,4 @@ $_ = new DestructableObject();
 --EXPECTF--
 Fatal error: Allowed memory size of 2097152 bytes exhausted %s
 Stack trace:
-#0 %s(%d): DestructableObject->__destruct()
 %A
-#%d [internal function]: DestructableObject->__destruct()
-#%d {main}

--- a/ext/opcache/tests/jit/gh17727.phpt
+++ b/ext/opcache/tests/jit/gh17727.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-17727 (JIT SEGV on OOM in dtor when creating backtrace)
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--INI--
+opcache.jit=1254
+fatal_error_backtraces=1
+memory_limit=2M
+--CREDITS--
+arnaud-lb
+YuanchengJiang
+--FILE--
+<?php
+class DestructableObject
+{
+    public function __destruct()
+    {
+        DestructableObject::__destruct();
+    }
+}
+$_ = new DestructableObject();
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of 2097152 bytes exhausted %s
+Stack trace:
+#0 %s(%d): DestructableObject->__destruct()
+%A
+#%d [internal function]: DestructableObject->__destruct()
+#%d {main}


### PR DESCRIPTION
This became visible after GH-17056 was merged, but technically the lack of setting the opline is also present on lower branches. We set the opline to mirror the SAVE_OPLINE() from ZEND_INIT_STATIC_METHOD_CALL().

Targeting master, but I can merge into 8.4 (except the test) and make equivalent changes to 8.3 if wanted.