### PR TITLE
Optimize JSON string encoding

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -457,6 +457,9 @@ PHP 8.5 UPGRADE NOTES
 14. Performance Improvements
 ========================================
 
+- JSON:
+  . Encoding JSON strings without special characters is now faster.
+
 - ReflectionProperty:
   . Improved performance of the following methods: getValue(), getRawValue(),
     isInitialized(), setValue(), setRawValue().

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -61,6 +61,10 @@ PHP 8.5 INTERNALS UPGRADE NOTES
     is still valid. This is useful when a GC cycle is collected and the
     database object can be destroyed prior to destroying the statement.
 
+- ext/standard
+  . Added `php_next_utf8_char_mb()` to decode the next UTF-8 multibyte
+    codepoint (i.e. >= 2 bytes).
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/standard/html.h
+++ b/ext/standard/html.h
@@ -48,5 +48,6 @@ PHPAPI zend_string *php_escape_html_entities(const unsigned char *old, size_t ol
 PHPAPI zend_string *php_escape_html_entities_ex(const unsigned char *old, size_t oldlen, int all, int flags, const char *hint_charset, bool double_encode, bool quiet);
 PHPAPI zend_string *php_unescape_html_entities(zend_string *str, int all, int flags, const char *hint_charset);
 PHPAPI unsigned int php_next_utf8_char(const unsigned char *str, size_t str_len, size_t *cursor, zend_result *status);
+PHPAPI unsigned int php_next_utf8_char_mb(const unsigned char *str, unsigned char c, size_t str_len, size_t *cursor);
 
 #endif /* HTML_H */


### PR DESCRIPTION
* Split out a specialized function to decode multibyte UTF-8 sequences

  Decoding purely multibyte UTF-8 is common for example in the case of
JSON. Furthermore, we want to avoid the switch on the character set in
such hot code. Finally, we also add UNEXPECTED markers to move code to
the cold section which reduces pressure on the µop and instruction
caches.

* Optimize JSON string encoding

  There are a couple of optimizations that work together:
  - We now use the specialized php_next_utf8_char_mb() helper function to
  avoid pressure on the µop and instruction cache.
  - It no longer emits UTF-8 bytes under PHP_JSON_UNESCAPED_UNICODE until
  it actually has to. By emitting in bulk, this improves performance.
  - Code layout tweaks
    * Use a specialized php_json_append() and assertions to avoid
    allocating the initial buffer, as this is already done upfront.
    * Factor out the call to smart_str_extend() to above the UTF-16 check
    to avoid code bloat.
  - Use SIMD, either with SSE2 or SSE4.2. A resolver is used when SSE4.2
  is not configured at compile time.

Here's a graph where I test different input strings.
The tests take an input string and repeat it using `str_repeat`, and then perform `200000` calls to `json_encode` with no flags. If `(no escape)` is in the label, then we pass `JSON_UNESCAPED_UNICODE` as a flag.
The first four bars show the very short strings where performance improvements won't be able to do much and no SIMD is possible. The performance difference and overhead of this approach is IMO negligible in those cases.
Next we test some extreme cases. The best case happens when a string doesn't need escaping or anything special. We can see when we need to do escaping or UTF-8 validation/escaping that the performance win is still there, but not as pronounced.
In some extreme UTF-8 (`éa*200`) the performance is slightly lower but when compared to the total execution time this shouldn't be noticeable. The last two bars show that the performance when using `JSON_UNESCAPED_UNICODE` is improved as well, which is hopefully the common way people work with UTF-8 in JSON.

Benchmarks done on an i7-4790 on Linux with the SSE4.2 resolver (so not the theoretical optimum, but a likely default).

![out](https://github.com/user-attachments/assets/c1357e56-34bf-4c0c-a142-8c4f538ee88b)

The benchmark gist is here: https://gist.github.com/nielsdos/51f32ca9d4610b802d0ea65e7af6ae16