### PR TITLE
Fix GH-17736: Assertion failure zend_reference_destroy()

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3232,6 +3232,9 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 				return;
 			}
 		}
+	} else if (prop_op_type == IS_CONST) {
+		/* CE mismatch, make cache slot consistent */
+		cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
 	}
 
 	/* Pointer on property callback is required */
@@ -3267,7 +3270,7 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 
 		if (prop_op_type == IS_CONST) {
 			prop_info = CACHED_PTR_EX(cache_slot + 2);
-			if (prop_info && EXPECTED(zobj->ce == CACHED_PTR_EX(cache_slot))) {
+			if (prop_info) {
 				if (UNEXPECTED(!zend_handle_fetch_obj_flags(result, ptr, NULL, prop_info, flags))) {
 					goto end;
 				}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3267,7 +3267,7 @@ static zend_always_inline void zend_fetch_property_address(zval *result, zval *c
 
 		if (prop_op_type == IS_CONST) {
 			prop_info = CACHED_PTR_EX(cache_slot + 2);
-			if (prop_info) {
+			if (prop_info && EXPECTED(zobj->ce == CACHED_PTR_EX(cache_slot))) {
 				if (UNEXPECTED(!zend_handle_fetch_obj_flags(result, ptr, NULL, prop_info, flags))) {
 					goto end;
 				}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4399,6 +4399,7 @@ static zval *date_interval_get_property_ptr_ptr(zend_object *object, zend_string
 		zend_string_equals_literal(name, "days") ||
 		zend_string_equals_literal(name, "invert") ) {
 		/* Fallback to read_property. */
+		cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
 		ret = NULL;
 	} else {
 		ret = zend_std_get_property_ptr_ptr(object, name, type, cache_slot);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -303,6 +303,7 @@ static zval *dom_get_property_ptr_ptr(zend_object *object, zend_string *name, in
 		return zend_std_get_property_ptr_ptr(object, name, type, cache_slot);
 	}
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
 	return NULL;
 }
 

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -2084,7 +2084,7 @@ static void ZEND_FASTCALL zend_jit_fetch_obj_w_slow(zend_object *zobj)
 
 			if (opline->op2_type == IS_CONST) {
 				prop_info = CACHED_PTR_EX(cache_slot + 2);
-				if (!prop_info) {
+				if (!prop_info || !EXPECTED(zobj->ce == CACHED_PTR_EX(cache_slot))) {
 					break;
 				}
 			}

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -2084,7 +2084,7 @@ static void ZEND_FASTCALL zend_jit_fetch_obj_w_slow(zend_object *zobj)
 
 			if (opline->op2_type == IS_CONST) {
 				prop_info = CACHED_PTR_EX(cache_slot + 2);
-				if (!prop_info || !EXPECTED(zobj->ce == CACHED_PTR_EX(cache_slot))) {
+				if (!prop_info) {
 					break;
 				}
 			}

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2495,6 +2495,7 @@ static zval *pdo_row_get_property_ptr_ptr(zend_object *object, zend_string *name
 	ZEND_IGNORE_VALUE(type);
 	ZEND_IGNORE_VALUE(cache_slot);
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
 	return NULL;
 }
 

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -635,6 +635,8 @@ static zval *sxe_property_get_adr(zend_object *object, zend_string *zname, int f
 	SXE_ITER        type;
 	zval            member;
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
+
 	sxe = php_sxe_fetch_object(object);
 	GET_NODE(sxe, node);
 	if (UNEXPECTED(!node)) {

--- a/ext/simplexml/tests/gh17736.phpt
+++ b/ext/simplexml/tests/gh17736.phpt
@@ -4,7 +4,7 @@ GH-17736 (Assertion failure zend_reference_destroy())
 simplexml
 --FILE--
 <?php
-$o1 = new SimpleXMlElement('<a/>');
+$o1 = new SimpleXMLElement('<a/>');
 class C {
     public int $a = 1;
 }

--- a/ext/simplexml/tests/gh17736.phpt
+++ b/ext/simplexml/tests/gh17736.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-17736 (Assertion failure zend_reference_destroy())
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+$o1 = new SimpleXMlElement('<a/>');
+class C {
+    public int $a = 1;
+}
+function test($obj) {
+    $ref =& $obj->a;
+}
+$obj = new C;
+test($obj);
+test($o1);
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1861,6 +1861,7 @@ static zval *php_snmp_get_property_ptr_ptr(zend_object *object, zend_string *nam
 		return zend_std_get_property_ptr_ptr(object, name, type, cache_slot);
 	}
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
 	return NULL;
 }
 

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -844,6 +844,8 @@ static zval *spl_array_get_property_ptr_ptr(zend_object *object, zend_string *na
 
 	if ((intern->ar_flags & SPL_ARRAY_ARRAY_AS_PROPS) != 0
 		&& !zend_std_has_property(object, name, ZEND_PROPERTY_EXISTS, NULL)) {
+		cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
+
 		/* If object has offsetGet() overridden, then fallback to read_property,
 		 * which will call offsetGet(). */
 		zval member;

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -121,6 +121,8 @@ zval *xmlreader_get_property_ptr_ptr(zend_object *object, zend_string *name, int
 	zval *retval = NULL;
 	xmlreader_prop_handler *hnd = NULL;
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
+
 	obj = php_xmlreader_fetch_object(object);
 
 	if (obj->prop_handler != NULL) {

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -890,6 +890,8 @@ static zval *php_zip_get_property_ptr_ptr(zend_object *object, zend_string *name
 	zval *retval = NULL;
 	zip_prop_handler *hnd = NULL;
 
+	cache_slot[0] = cache_slot[1] = cache_slot[2] = NULL;
+
 	obj = php_zip_fetch_object(object);
 
 	if (obj->prop_handler != NULL) {


### PR DESCRIPTION
The cache slot for FETCH_OBJ_W in function `test` is primed for `C::$a`. The next call uses a simplexml instance and reuses the same cache slot. simplexml's get_property_ptr handler does not use the cache slot, so the old values remain in the cache slot. When `zend_handle_fetch_obj_flags` is called this is not guarded by a check for the class entry. So we end up using the prop_info from the property `C::$a` instead of the simplexml property.

This patch adds a check for the class entry. I placed the check as late as possible to avoid as much overhead as possible. An alternative solution is to write NULLs to the cache slot in the get_property_ptr handlers of extensions that don't use the cache slot, but that is not general: not only simplexml would need changes, maybe even third party extensions would need changes as well.