### PR TITLE
Fix GH-17747: Exception on reading property in register-based FETCH_OBJ_R breaks JIT

### DIFF
--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1965,7 +1965,12 @@ static zval* ZEND_FASTCALL zend_jit_fetch_obj_r_slow_ex(zend_object *zobj)
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
 
 	retval = zobj->handlers->read_property(zobj, name, BP_VAR_R, cache_slot, result);
-	if (retval == result && UNEXPECTED(Z_ISREF_P(retval))) {
+	if (retval != result) {
+		/* On exception, we may free the result in the ZEND_HANDLE_EXCEPTION VM handler
+		 * so we need to initialize the result.
+		 * We don't need to copy because we use the return value directly as a register. */
+		ZVAL_UNDEF(result);
+	} else if (UNEXPECTED(Z_ISREF_P(retval))) {
 		zend_unwrap_reference(retval);
 	}
 	return retval;
@@ -2017,7 +2022,12 @@ static zval* ZEND_FASTCALL zend_jit_fetch_obj_is_slow_ex(zend_object *zobj)
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
 
 	retval = zobj->handlers->read_property(zobj, name, BP_VAR_IS, cache_slot, result);
-	if (retval == result && UNEXPECTED(Z_ISREF_P(retval))) {
+	if (retval != result) {
+		/* On exception, we may free the result in the ZEND_HANDLE_EXCEPTION VM handler
+		 * so we need to initialize the result.
+		 * We don't need to copy because we use the return value directly as a register. */
+		ZVAL_UNDEF(result);
+	} else if (UNEXPECTED(Z_ISREF_P(retval))) {
 		zend_unwrap_reference(retval);
 	}
 	return retval;

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1965,12 +1965,7 @@ static zval* ZEND_FASTCALL zend_jit_fetch_obj_r_slow_ex(zend_object *zobj)
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
 
 	retval = zobj->handlers->read_property(zobj, name, BP_VAR_R, cache_slot, result);
-	if (retval != result) {
-		/* On exception, we may free the result in the ZEND_HANDLE_EXCEPTION VM handler
-		 * so we need to initialize the result.
-		 * We don't need to copy because we use the return value directly as a register. */
-		ZVAL_UNDEF(result);
-	} else if (UNEXPECTED(Z_ISREF_P(retval))) {
+	if (retval == result && UNEXPECTED(Z_ISREF_P(retval))) {
 		zend_unwrap_reference(retval);
 	}
 	return retval;
@@ -2022,12 +2017,7 @@ static zval* ZEND_FASTCALL zend_jit_fetch_obj_is_slow_ex(zend_object *zobj)
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
 
 	retval = zobj->handlers->read_property(zobj, name, BP_VAR_IS, cache_slot, result);
-	if (retval != result) {
-		/* On exception, we may free the result in the ZEND_HANDLE_EXCEPTION VM handler
-		 * so we need to initialize the result.
-		 * We don't need to copy because we use the return value directly as a register. */
-		ZVAL_UNDEF(result);
-	} else if (UNEXPECTED(Z_ISREF_P(retval))) {
+	if (retval == result && UNEXPECTED(Z_ISREF_P(retval))) {
 		zend_unwrap_reference(retval);
 	}
 	return retval;

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14539,7 +14539,11 @@ result_fetched:
 	}
 
 	if (may_throw) {
-		zend_jit_check_exception(jit);
+		if (Z_MODE(res_addr) == IS_REG) {
+			zend_jit_check_exception_undef_result(jit, opline);
+		} else {
+			zend_jit_check_exception(jit);
+		}
 	}
 
 	return 1;

--- a/ext/opcache/tests/jit/gh17747.phpt
+++ b/ext/opcache/tests/jit/gh17747.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-17747 (Exception on reading property in register-based FETCH_OBJ_R breaks JIT)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=function
+--FILE--
+<?php
+class C {
+    public int $a;
+    public function test() {
+        var_dump($this->a);
+    }
+}
+$test = new C;
+$test->test();
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Typed property C::$a must not be accessed before initialization in %s:%d
+Stack trace:
+#0 %s(%d): C->test()
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
When read_property fails, it may return `&EG(uninitialized_zval)`, and the exception is handled in the VM. The VM will try to `zval_ptr_dtor_nogc` the result, but the result was never set, resulting in dtor'ing garbage data. To solve this, we check when a different zval* was returned and initialize the result with UNDEF. We don't need to copy as the slow_ex handler return values are used directly in a register.