### PR TITLE
Fix phpize on windows

### DIFF
--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -91,6 +91,7 @@ function find_config_w32(dirname)
 
 		deps = get_module_dep(contents);
 
+		n = "";
 		item = new Module_Item(n, c, dir_line, deps, contents);
 		MODULES.Add(n, item);
 	}


### PR DESCRIPTION
It seems like `n === undefined` must have worked on older versions of jscript, but currently it just causes the insertion to silently fail. This sets n to the current folder name, allowing phpize to include the local config.w32 files.
This just affects the standalone extension build mechanism.

Basing it on PHP 8.1, as it's purely build system. If that's wrong I'll just change the target to PHP-8.3.