### PR TITLE
sapi/cli: Print non-default INI settings for `--ini=diff`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.5.0alpha1
 
 - CLI:
-  . Extended --ini to print INI settings changed from the builtin default.
+  . Add --ini=diff to print INI settings changed from the builtin default.
     (timwolla)
 
 - COM:

--- a/UPGRADING
+++ b/UPGRADING
@@ -114,7 +114,8 @@ PHP 8.5 UPGRADE NOTES
 - CLI:
   . Trying to set a process title that is too long with cli_set_process_title()
     will now fail instead of silently truncating the given title.
-  . --ini will now print INI settings changed from the builtin default.
+  . Added a new --ini=diff option to print INI settings changed from the builtin
+    default.
 
 ========================================
 4. Deprecated Functionality

--- a/sapi/cli/cli.h
+++ b/sapi/cli/cli.h
@@ -49,6 +49,7 @@ typedef enum php_cli_mode {
 	PHP_CLI_MODE_REFLECTION_EXT_INFO = 11,
 	PHP_CLI_MODE_REFLECTION_ZEND_EXTENSION = 12,
 	PHP_CLI_MODE_SHOW_INI_CONFIG = 13,
+	PHP_CLI_MODE_SHOW_INI_DIFF = 14,
 } php_cli_mode;
 
 typedef struct php_cli_server_context {

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -159,7 +159,7 @@ const opt_struct OPTIONS[] = {
 	{13,  1, "rzendextension"},
 	{14,  1, "ri"},
 	{14,  1, "rextinfo"},
-	{15,  0, "ini"},
+	{15,  2, "ini"},
 	/* Internal testing option -- may be changed or removed without notice,
 	 * including in patch releases. */
 	{16,  1, "repeat"},
@@ -502,6 +502,7 @@ static void php_cli_usage(char *argv0)
 				"                   starts with - or script is read from stdin\n"
 				"\n"
 				"  --ini            Show configuration file names\n"
+				"  --ini=diff       Show INI entries that differ from the built-in default\n"
 				"\n"
 				"  --rf <name>      Show information about function <name>.\n"
 				"  --rc <name>      Show information about class <name>.\n"
@@ -827,7 +828,15 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				reflection_what = php_optarg;
 				break;
 			case 15:
-				context.mode = PHP_CLI_MODE_SHOW_INI_CONFIG;
+				if (php_optarg) {
+					if (strcmp(php_optarg, "diff") == 0) {
+						context.mode = PHP_CLI_MODE_SHOW_INI_DIFF;
+					} else {
+						param_error = "Unknown argument for --ini\n";
+					}
+				} else {
+					context.mode = PHP_CLI_MODE_SHOW_INI_CONFIG;
+				}
 				break;
 			case 16:
 				num_repeats = atoi(php_optarg);
@@ -1106,7 +1115,10 @@ do_repeat:
 				zend_printf("Loaded Configuration File:         %s\n", php_ini_opened_path ? php_ini_opened_path : "(none)");
 				zend_printf("Scan for additional .ini files in: %s\n", php_ini_scanned_path  ? php_ini_scanned_path : "(none)");
 				zend_printf("Additional .ini files parsed:      %s\n", php_ini_scanned_files ? php_ini_scanned_files : "(none)");
-				zend_printf("\n");
+				break;
+			}
+		case PHP_CLI_MODE_SHOW_INI_DIFF:
+			{
 				zend_printf("Non-default INI settings:\n");
 				zend_ini_entry *ini_entry;
 				HashTable *sorted = zend_array_dup(EG(ini_directives));


### PR DESCRIPTION
This is a follow-up for php/php-src#17459, updating the command-line flag to not modify the behavior of `--ini`.

----------

see https://externals.io/message/126303