### PR TITLE
Fix typo in PHPDoc: $attribute to $attributes

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1172,7 +1172,7 @@ class FuncInfo {
 
     /**
      * @param ArgInfo[] $args
-     * @param AttributeInfo[] $attribute
+     * @param AttributeInfo[] $attributes
      * @param FramelessFunctionInfo[] $framelessFunctionInfos
      */
     public function __construct(


### PR DESCRIPTION
This PR fixes a typo in the PHPDoc comments of the constructor.
The parameter name `$attribute` was used in the docblock, but the actual parameter in the implementation is `$attributes`.

This improves the accuracy and consistency of the documentation.