### PR TITLE
gen_stub: fix `PropertyInfo::getString()` version compatibility

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3061,7 +3061,7 @@ class PropertyInfo extends VariableLike
         ];
         // If not set, use the current latest version
         $allVersions = ALL_PHP_VERSION_IDS;
-        $minPhp = $phpVersionIdMinimumCompatibility ?? end($allVersions);
+        $minPhp = $this->phpVersionIdMinimumCompatibility ?? end($allVersions);
         if ($minPhp < PHP_80_VERSION_ID) {
             // No known strings in 7.0
             return $result;


### PR DESCRIPTION
I forgot a `$this->` in #15751