### PR TITLE
Reflection: show the type of object constants used as default properties

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,10 @@ PHP                                                                        NEWS
 - PHPDBG:
   . Fixed bug GH-15901 (phpdbg: Assertion failure on i funcs). (cmb)
 
+- Reflection:
+  . Fixed bug GH-15902 (Core dumped in ext/reflection/php_reflection.c).
+    (DanielEScherzer)
+
 - SimpleXML:
   . Fixed bug GH-15837 (Segmentation fault in ext/simplexml/simplexml.c).
     (nielsdos)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -643,8 +643,9 @@ static int format_default_value(smart_str *str, zval *value) {
 		} ZEND_HASH_FOREACH_END();
 		smart_str_appendc(str, ']');
 	} else if (Z_TYPE_P(value) == IS_OBJECT) {
-		/* This branch may only be reached for default properties; show enum names,
-			or the type of non-enums (GH-15902) */
+		/* This branch is reached if the constant AST was already evaluated and
+		 * resulted in an object; show enum names, or the type of non-enums
+		 * (GH-15902) */
 		zend_object *obj = Z_OBJ_P(value);
 		zend_class_entry *class = obj->ce;
 		if (class->ce_flags & ZEND_ACC_ENUM) {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -643,13 +643,19 @@ static int format_default_value(smart_str *str, zval *value) {
 		} ZEND_HASH_FOREACH_END();
 		smart_str_appendc(str, ']');
 	} else if (Z_TYPE_P(value) == IS_OBJECT) {
-		/* This branch may only be reached for default properties, which don't support arbitrary objects. */
+		/* This branch may only be reached for default properties; show enum names,
+			or the type of non-enums (GH-15902) */
 		zend_object *obj = Z_OBJ_P(value);
 		zend_class_entry *class = obj->ce;
-		ZEND_ASSERT(class->ce_flags & ZEND_ACC_ENUM);
-		smart_str_append(str, class->name);
-		smart_str_appends(str, "::");
-		smart_str_append(str, Z_STR_P(zend_enum_fetch_case_name(obj)));
+		if (class->ce_flags & ZEND_ACC_ENUM) {
+			smart_str_append(str, class->name);
+			smart_str_appends(str, "::");
+			smart_str_append(str, Z_STR_P(zend_enum_fetch_case_name(obj)));
+		} else {
+			smart_str_appends(str, "object(");
+			smart_str_append(str, class->name);
+			smart_str_appends(str, ")");
+		}
 	} else {
 		ZEND_ASSERT(Z_TYPE_P(value) == IS_CONSTANT_AST);
 		zend_string *ast_str = zend_ast_export("", Z_ASTVAL_P(value), "");

--- a/ext/reflection/tests/gh15902/ReflectionClass-callable.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionClass-callable.phpt
@@ -1,0 +1,37 @@
+--TEST--
+ReflectionClass object default property - used to say "callable"
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+define('FOO', new stdClass);
+
+new C;
+
+$reflector = new ReflectionClass(C::class);
+echo $reflector;
+?>
+--EXPECTF--
+Class [ <user> class C ] {
+  @@ %sReflectionClass-callable.php %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [1] {
+    Property [ public stdClass $a = object(stdClass) ]
+  }
+
+  - Methods [0] {
+  }
+}

--- a/ext/reflection/tests/gh15902/ReflectionClass-class.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionClass-class.phpt
@@ -1,0 +1,38 @@
+--TEST--
+ReflectionClass object default property - used to say "__CLASS__"
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+$reflector = new ReflectionClass(C::class);
+
+define('FOO', new stdClass);
+new C;
+
+echo $reflector;
+
+?>
+--EXPECTF--
+Class [ <user> class C ] {
+  @@ %sReflectionClass-class.php %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [1] {
+    Property [ public stdClass $a = object(stdClass) ]
+  }
+
+  - Methods [0] {
+  }
+}

--- a/ext/reflection/tests/gh15902/ReflectionProperty-callable.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionProperty-callable.phpt
@@ -1,0 +1,20 @@
+--TEST--
+ReflectionProperty object default - used to say "callable"
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+define('FOO', new stdClass);
+
+new C;
+
+$reflector = new ReflectionProperty(C::class, 'a');
+echo $reflector;
+
+?>
+--EXPECTF--
+Property [ public stdClass $a = object(stdClass) ]

--- a/ext/reflection/tests/gh15902/ReflectionProperty-class.phpt
+++ b/ext/reflection/tests/gh15902/ReflectionProperty-class.phpt
@@ -1,0 +1,20 @@
+--TEST--
+ReflectionProperty object default - used to say "__CLASS__"
+--INI--
+opcache.enable_cli=0
+--FILE--
+<?php
+
+class C {
+	public stdClass $a = FOO;
+}
+$reflector = new ReflectionProperty(C::class, 'a');
+
+define('FOO', new stdClass);
+new C;
+
+echo $reflector;
+
+?>
+--EXPECTF--
+Property [ public stdClass $a = object(stdClass) ]


### PR DESCRIPTION
When a property default is based on a global constant, show the type of the default. Previously, `format_default_value()` assumed that non-scalar and non-array defaults were always going to be `IS_CONSTANT_AST` pointers, and when the AST expression had been evaluated and produced an object, depending on when the `ReflectionClass` or `ReflectionProperty` instance had been created, the default was shown as one of `callable` or `__CLASS__`.

Instead, if the default value is an object (`IS_OBJECT`), show the type of that object.

Add test cases for both of the `callable` and `__CLASS__` cases to confirm that they now properly show the type of the constant.

Closes GH-15902