### PR TITLE
Fix memory leak when encoding check fails

### DIFF
--- a/ext/zlib/tests/leak_invalid_encoding_with_dict.phpt
+++ b/ext/zlib/tests/leak_invalid_encoding_with_dict.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Memory leak when passing a dictionary with invalid encoding
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+try {
+	inflate_init(123456, ["dictionary" => "dict"]);
+} catch (ValueError $e) {
+	echo $e->getMessage(), "\n";
+}
+try {
+	deflate_init(123456, ["dictionary" => "dict"]);
+} catch (ValueError $e) {
+	echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Encoding mode must be ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP or ZLIB_ENCODING_DEFLATE
+deflate_init(): Argument #1 ($encoding) must be one of ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP, or ZLIB_ENCODING_DEFLATE

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -879,10 +879,6 @@ PHP_FUNCTION(inflate_init)
 		RETURN_THROWS();
 	}
 
-	if (!zlib_create_dictionary_string(options, &dict, &dictlen)) {
-		RETURN_THROWS();
-	}
-
 	switch (encoding) {
 		case PHP_ZLIB_ENCODING_RAW:
 		case PHP_ZLIB_ENCODING_GZIP:
@@ -891,6 +887,10 @@ PHP_FUNCTION(inflate_init)
 		default:
 			zend_value_error("Encoding mode must be ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP or ZLIB_ENCODING_DEFLATE");
 			RETURN_THROWS();
+	}
+
+	if (!zlib_create_dictionary_string(options, &dict, &dictlen)) {
+		RETURN_THROWS();
 	}
 
 	object_init_ex(return_value, inflate_context_ce);
@@ -1132,10 +1132,6 @@ PHP_FUNCTION(deflate_init)
 			RETURN_THROWS();
 	}
 
-	if (!zlib_create_dictionary_string(options, &dict, &dictlen)) {
-		RETURN_THROWS();
-	}
-
 	switch (encoding) {
 		case PHP_ZLIB_ENCODING_RAW:
 		case PHP_ZLIB_ENCODING_GZIP:
@@ -1144,6 +1140,10 @@ PHP_FUNCTION(deflate_init)
 		default:
 			zend_argument_value_error(1, "must be one of ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP, or ZLIB_ENCODING_DEFLATE");
 			RETURN_THROWS();
+	}
+
+	if (!zlib_create_dictionary_string(options, &dict, &dictlen)) {
+		RETURN_THROWS();
 	}
 
 	object_init_ex(return_value, deflate_context_ce);


### PR DESCRIPTION
zlib_create_dictionary_string() allocates memory, so we can leak memory if there's an early exit before the assignment to the return value. Solve this by moving all validation upwards.

Found with an experimental static analysis tool I'm developing.