### PR TITLE
zend: gcc 15 will support counted_by(x) instead.

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -338,9 +338,7 @@ char *alloca();
 # define HAVE_BUILTIN_CONSTANT_P
 #endif
 
-#if __has_attribute(element_count)
-#define ZEND_ELEMENT_COUNT(m) __attribute__((element_count(m)))
-#elif __has_attribute(counted_by)
+#if __has_attribute(counted_by)
 #define ZEND_ELEMENT_COUNT(m) __attribute__((counted_by(m)))
 #else
 #define ZEND_ELEMENT_COUNT(m)


### PR DESCRIPTION
gcc gave up on the initial patchset for `element_count` and went by `counted_by` since last october.