### PR TITLE
Fix: Remove unused code and improve regex patterns in mail_util.inc

### DIFF
--- a/ext/standard/tests/mail/mail_util.inc
+++ b/ext/standard/tests/mail/mail_util.inc
@@ -143,7 +143,7 @@ class MailBox
 
         $this->mailConnecter->send(self::SEARCH, "UID SEARCH SUBJECT \"{$subject}\"");
         $res = $this->mailConnecter->getResponse(self::SEARCH);
-        preg_match('/SEARCH ([0-9 ]+)/is', $res, $matches);
+        preg_match('/SEARCH ([0-9 ]+)/i', $res, $matches);
         return isset($matches[1]) ? explode(' ', trim($matches[1])) : [];
     }
 
@@ -166,8 +166,7 @@ class MailBox
             if (!$line) {
                 continue;
             }
-            $items = explode(':', $line);
-            preg_match('/^(.+?):(.+?)$/', $line, $matches);
+            preg_match('/^(.+?):(.+)$/', $line, $matches);
             $key = trim($matches[1] ?? '');
             $val = trim($matches[2] ?? '');
             if (!$key || !$val || $val === self::FETCH_HEADERS.' OK UID completed' || $val === ')') {


### PR DESCRIPTION
### What this PR does
This PR removes unused code and simplifies regex patterns in `mail_util.inc`, which is part of the standard tests for the `ext/standard` extension. These changes enhance code readability, maintainability, and remove redundant operations without affecting functionality.

### Details of the changes
1. Removed the unused `$items` variable from the `getHeaders` function.
2. Removed unnecessary lazy quantifiers (`?`) in regex patterns.
3. Removed the unused `s` flag in regex patterns, as it serves no purpose here.