### PR TITLE
Fix GH-17797: zend_test_compile_string crash on invalid script path.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ PHP                                                                        NEWS
   . Fix fallback paths in fast_long_{add,sub}_function. (nielsdos)
   . Fixed bug GH-17718 (Calling static methods on an interface that has
     `__callStatic` is allowed). (timwolla)
+  . Fixed bug GH-17797 (zend_test_compile_string crash on invalid
+    script path). (David Carlier)
 
 - FPM:
   . Fixed bug GH-17643 (FPM with httpd ProxyPass encoded PATH_INFO env).

--- a/ext/zend_test/tests/gh17797.phpt
+++ b/ext/zend_test/tests/gh17797.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-17797 (zend_test_compile_string crash on invalid script path)
+--EXTENSIONS--
+zend_test
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$source = '<?php
+require("sumfile.php");
+?>';
+try {zend_test_compile_string($source,$source,$c);} catch (Exception $e) { echo($e); }
+--EXPECTF--
+
+Warning: Undefined variable $c in %s on line %d
+
+Deprecated: zend_test_compile_string(): Passing null to parameter #3 ($position) of type int is deprecated in %s on line %d
+
+Warning: require(sumfile.php): Failed to open stream: No such file or directory in <?php
+require("sumfile.php");
+?> on line %d
+
+Fatal error: Uncaught Error: Failed opening required 'sumfile.php' (include_path='.%s') in <?php
+require("sumfile.php");
+?>:%d
+Stack trace:
+#0 %s(%d): zend_test_compile_string('<?php\nrequire("...', '<?php\nrequire("...', NULL)
+#1 {main}
+  thrown in <?php
+require("sumfile.php");
+?> on line %d

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -603,7 +603,13 @@ PHPAPI zend_string *php_resolve_path(const char *filename, size_t filename_lengt
 		const char *exec_fname = ZSTR_VAL(exec_filename);
 		size_t exec_fname_length = ZSTR_LEN(exec_filename);
 
-		while ((--exec_fname_length < SIZE_MAX) && !IS_SLASH(exec_fname[exec_fname_length]));
+		while (exec_fname_length > 0) {
+			--exec_fname_length;
+			if (IS_SLASH(exec_fname[exec_fname_length])) {
+				break;
+			}
+		}
+
 		if (exec_fname_length > 0 &&
 			filename_length < (MAXPATHLEN - 2) &&
 		    exec_fname_length + 1 + filename_length + 1 < MAXPATHLEN) {


### PR DESCRIPTION
When looking for the last slash of the script path, it leads to underflow being promoted to SIZE_MAX being way beyond MAXPATHLEN.