### PR TITLE
Adapt tests to Windows 11

### DIFF
--- a/ext/standard/tests/file/rename_variation-win32.phpt
+++ b/ext/standard/tests/file/rename_variation-win32.phpt
@@ -61,7 +61,7 @@ bool(false)
 bool(true)
 -- Iteration 2 --
 
-Warning: rename(%s/rename_variation-win32/rename_variation.tmp/,%s/rename_variation2.tmp): The filename, directory name, or volume label syntax is incorrect (code: 123) in %s on line %d
+Warning: rename(%s/rename_variation-win32/rename_variation.tmp/,%s/rename_variation2.tmp): %rThe filename, directory name, or volume label syntax is incorrect|The directory name is invalid%r (code: %r123|267%r) in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/standard/tests/file/unlink_variation8-win32.phpt
+++ b/ext/standard/tests/file/unlink_variation8-win32.phpt
@@ -95,10 +95,10 @@ file removed
 Warning: unlink(%s/BADDIR/file.tmp): No such file or directory in %s on line %d
 -- removing unlinkVar8.tmp/file.tmp/ --
 
-Warning: unlink(unlinkVar8.tmp/file.tmp/): No such file or directory in %s on line %d
+Warning: unlink(unlinkVar8.tmp/file.tmp/): %rNo such file or directory|Not a directory%r in %s on line %d
 -- removing %s/unlinkVar8.tmp/file.tmp/ --
 
-Warning: unlink(%s/unlinkVar8.tmp/file.tmp/): No such file or directory in %s on line %d
+Warning: unlink(%s/unlinkVar8.tmp/file.tmp/): %rNo such file or directory|Not a directory%r in %s on line %d
 -- removing unlinkVar8.tmp//file.tmp --
 file removed
 -- removing %s//unlinkVar8.tmp//file.tmp --

--- a/ext/standard/tests/file/unlink_variation9-win32.phpt
+++ b/ext/standard/tests/file/unlink_variation9-win32.phpt
@@ -97,10 +97,10 @@ file removed
 Warning: unlink(%s\BADDIR\file.tmp): No such file or directory in %s on line %d
 -- removing unlinkVar9.tmp\file.tmp\ --
 
-Warning: unlink(unlinkVar9.tmp\file.tmp\): No such file or directory in %s on line %d
+Warning: unlink(unlinkVar9.tmp\file.tmp\): %rNo such file or directory|Not a directory%r in %s on line %d
 -- removing %s\unlinkVar9.tmp\file.tmp\ --
 
-Warning: unlink(%s\unlinkVar9.tmp\file.tmp\): No such file or directory in %s on line %d
+Warning: unlink(%s\unlinkVar9.tmp\file.tmp\): %rNo such file or directory|Not a directory%r in %s on line %d
 -- removing unlinkVar9.tmp\\file.tmp --
 file removed
 -- removing %s\\unlinkVar9.tmp\\file.tmp --


### PR DESCRIPTION
Apparently, one of the more recent patch releases of Windows 10 (confirmed for Windows 10.0.26100, but may affect older versions, too) changed treatment of filenames with trailing slashes to be recognized explicitly as directories, and no longer as invalid file or directory.

We adapt the affected test cases.

---

Not sure which version to target; chose PHP-8.3 as a compromise.

See https://github.com/php/php-src/actions/runs/13269603448/job/37045678895 for the test failures.