### PR TITLE
Prevent using system DLLs when running the tests

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -5,11 +5,6 @@ if /i "%GITHUB_ACTIONS%" neq "True" (
     exit /b 3
 )
 
-del /f /q C:\Windows\System32\libcrypto-1_1-x64.dll >NUL 2>NUL
-if %errorlevel% neq 0 exit /b 3
-del /f /q C:\Windows\System32\libssl-1_1-x64.dll >NUL 2>NUL
-if %errorlevel% neq 0 exit /b 3
-
 call %~dp0find-target-branch.bat
 set STABILITY=staging
 set DEPS_DIR=%PHP_BUILD_CACHE_BASE_DIR%\deps-%BRANCH%-%PHP_SDK_VS%-%PHP_SDK_ARCH%

--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -137,6 +137,8 @@ for %%i in (ldap oci8_12c pdo_oci) do (
 
 set TEST_PHPDBG_EXECUTABLE=%PHP_BUILD_DIR%\phpdbg.exe
 
+copy /-y %DEPS_DIR%\bin\*.dll %PHP_BUILD_DIR%\*
+
 mkdir c:\tests_tmp
 
 nmake test TESTS="%OPCACHE_OPTS% -g FAIL,BORK,LEAK,XLEAK --no-progress -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp --bless %PARALLEL%"


### PR DESCRIPTION
The search order for DLLs on Windows is (simplified):

* the application folder
* the system folder
* all folders in the `PATH`

(The full details are documented on Microsoft Learn[1].)

As is, we're adding `deps\bin` to the `PATH` when running the tests, but any DLLs in the system folder take precedence, so these would be used instead of our intended dependencies.  To mitigate that, we copy over all DLLs from `deps\bin` to our application folder (i.e. where php.exe, php-cgi.exe and phpdbg.exe are placed).

Since we're doing this, there is no more need to attempt to remove the OpenSSL DLLs in the system folder (what seems to be a bad idea anyway).

[1] <https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order>

---

Again, not sure which branch to target; went with PHP-8.3 as a compromise.

See https://github.com/php/php-src/actions/runs/13263835929/job/37026288607 for the problem this is trying to solve (in a more general way than just to cater to OpenSLL; there might be others in the system folder, too).