### PR TITLE
Fix GH-17808: PharFileInfo refcount bug

### DIFF
--- a/ext/phar/tests/gh17808.phpt
+++ b/ext/phar/tests/gh17808.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-17808 (PharFileInfo refcount bug)
+--EXTENSIONS--
+phar
+--FILE--
+<?php
+$fname = __DIR__.'/tar/files/Structures_Graph-1.0.3.tgz';
+$tar = new PharData($fname);
+foreach (new RecursiveIteratorIterator($tar) as $file) {
+}
+var_dump("$file");
+var_dump(strlen($file->getContent()));
+unlink("$file");
+var_dump($file->getATime());
+?>
+--EXPECTF--
+string(%d) "phar:///%spackage.xml"
+int(6747)
+
+Warning: unlink(): phar error: "package.xml" in phar %s, has open file pointers, cannot unlink in %s on line %d
+int(33188)


### PR DESCRIPTION
PharFileInfo just takes a pointer from the manifest without refcounting anything. If the entry is then removed from the manifest while the PharFileInfo object still exists, we get a UAF.
We fix this by using the fp_refcount field. This is technically a behaviour change as the unlinking is now blocked, and potentially file modifications can be blocked as well. The alternative would be to have a field that indicates whether deletion is blocked, but similar corruption bugs may occur as well with file overwrites, so we increment fp_refcount instead.
This also fixes an issue where a destructor called multiple times resulted in a UAF as well, by moving the NULL'ing of the entry field out of the if.