### PR TITLE
Fail build_task.bat if main nmake failed

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -49,6 +49,7 @@ cmd /c configure.bat ^
 if %errorlevel% neq 0 exit /b 3
 
 nmake /NOLOGO
+if %errorlevel% neq 0 exit /b 3
 nmake /NOLOGO comtest.dll
 if %errorlevel% neq 0 exit /b 3
 


### PR DESCRIPTION
Otherwise we may not notice Windows CI build failures.