### PR TITLE
Reflection: indicate final and abstract properties in string output

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -932,6 +932,12 @@ static void _property_string(smart_str *str, zend_property_info *prop, const cha
 	if (!prop) {
 		smart_str_append_printf(str, "<dynamic> public $%s", prop_name);
 	} else {
+		if (prop->flags & ZEND_ACC_ABSTRACT) {
+			smart_str_appends(str, "abstract ");
+		}
+		if (prop->flags & ZEND_ACC_FINAL) {
+			smart_str_appends(str, "final ");
+		}
 		/* These are mutually exclusive */
 		switch (prop->flags & ZEND_ACC_PPP_MASK) {
 			case ZEND_ACC_PUBLIC:

--- a/ext/reflection/tests/abstract_property_indicated.phpt
+++ b/ext/reflection/tests/abstract_property_indicated.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Output of properties indicates if they are abstract
+--FILE--
+<?php
+
+abstract class Demo {
+    abstract public $a { get; }
+    public $b;
+}
+
+$class = new ReflectionClass(Demo::class);
+echo $class;
+
+$propA = new ReflectionProperty(Demo::class, 'a');
+echo $propA;
+
+$propB = new ReflectionProperty(Demo::class, 'b');
+echo $propB;
+?>
+--EXPECTF--
+Class [ <user> <iterateable> abstract class Demo ] {
+  @@ %s %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [2] {
+    Property [ abstract public $a ]
+    Property [ public $b = NULL ]
+  }
+
+  - Methods [0] {
+  }
+}
+Property [ abstract public $a ]
+Property [ public $b = NULL ]

--- a/ext/reflection/tests/asymmetric_visibility_flags.phpt
+++ b/ext/reflection/tests/asymmetric_visibility_flags.phpt
@@ -26,7 +26,7 @@ bool(true)
 bool(false)
 bool(true)
 bool(false)
-Property [ public private(set) int $bar ]
+Property [ final public private(set) int $bar ]
 bool(false)
 bool(true)
 bool(false)

--- a/ext/reflection/tests/final_property_indicated.phpt
+++ b/ext/reflection/tests/final_property_indicated.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Output of properties indicates if they are final
+--FILE--
+<?php
+
+class Demo {
+    final public $a;
+    public $b;
+}
+
+$class = new ReflectionClass(Demo::class);
+echo $class;
+
+$propA = new ReflectionProperty(Demo::class, 'a');
+echo $propA;
+
+$propB = new ReflectionProperty(Demo::class, 'b');
+echo $propB;
+?>
+--EXPECTF--
+Class [ <user> class Demo ] {
+  @@ %s %d-%d
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [2] {
+    Property [ final public $a = NULL ]
+    Property [ public $b = NULL ]
+  }
+
+  - Methods [0] {
+  }
+}
+Property [ final public $a = NULL ]
+Property [ public $b = NULL ]


### PR DESCRIPTION
Add "final" and "abstract" to the result of `_property_string()` when outputting the string representation of a `ReflectionClass` or `ReflectionProperty` instance