### PR TITLE
basic_functions: update error_log documentation [skip ci]

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1336,7 +1336,7 @@ PHP_FUNCTION(get_cfg_var)
 error options:
 	0 = send to php_error_log (uses syslog or file depending on ini setting)
 	1 = send via email to 3rd parameter 4th option = additional headers
-	2 = send via tcp/ip to 3rd parameter (name or ip:port)
+	2 = no longer an option
 	3 = save to file in 3rd parameter
 	4 = send to SAPI logger directly
 */


### PR DESCRIPTION
Sending to a TCP/IP address is not an option anymore, and it hasn't been since before the file was created in this repo in 1999 (257de2b). Based on php/doc-en@d522d135a1b0ad485006dd2e8b5231cd2fb6df57 it appears that this feature was part of PHP 3 and removed before PHP 4. I tried to track down the original code to find when it was actually removed but wasn't able to find a PHP 3 repository.