### PR TITLE
ext/standard: inet_ntop internal change.

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -544,7 +544,8 @@ PHP_FUNCTION(inet_ntop)
 	char *address;
 	size_t address_len;
 	int af = AF_INET;
-	char buffer[40];
+	socklen_t buffersize = INET_ADDRSTRLEN;
+	char buffer[INET6_ADDRSTRLEN];
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STRING(address, address_len)
@@ -553,13 +554,14 @@ PHP_FUNCTION(inet_ntop)
 #ifdef HAVE_IPV6
 	if (address_len == 16) {
 		af = AF_INET6;
+		buffersize = INET6_ADDRSTRLEN;
 	} else
 #endif
 	if (address_len != 4) {
 		RETURN_FALSE;
 	}
 
-	if (!inet_ntop(af, address, buffer, sizeof(buffer))) {
+	if (!inet_ntop(af, address, buffer, buffersize)) {
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
The actual buffer size is too small for ipv6, should be INET6_ADDRSTRLEN (46) also the size of the buffer should be set accordingly to the family.