### PR TITLE
Fix GH-17831:  zend_test_compile_string crash on nul bytes check.

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -243,11 +243,15 @@ static ZEND_FUNCTION(zend_test_compile_string)
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
 		Z_PARAM_STR(source_string)
-		Z_PARAM_PATH_STR_EX(filename, 1, 0)
+		Z_PARAM_PATH_STR(filename)
 		Z_PARAM_LONG(position)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_op_array *op_array = NULL;
+
+	if (zend_str_has_nul_byte(filename)) {
+		return;
+	}
 
 	op_array = compile_string(source_string, ZSTR_VAL(filename), position);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -249,10 +249,6 @@ static ZEND_FUNCTION(zend_test_compile_string)
 
 	zend_op_array *op_array = NULL;
 
-	if (zend_str_has_nul_byte(filename)) {
-		return;
-	}
-
 	op_array = compile_string(source_string, ZSTR_VAL(filename), position);
 
 	if (op_array) {

--- a/ext/zend_test/tests/zend_test_compile_string.phpt
+++ b/ext/zend_test/tests/zend_test_compile_string.phpt
@@ -49,6 +49,7 @@ try {
 	echo $e->getMessage(), PHP_EOL;
 }
 
+zend_test_compile_string($x, $y, $z);
 
 $source_string = <<<EOF
 <?php
@@ -58,12 +59,24 @@ EOF;
 zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 
 ?>
---EXPECT--
+--EXPECTF--
 string(3) "php"
 #!/path/to/php
 string(3) "php"
 string(3) "php"
 string(3) "php"
 zend_test_compile_string(): Argument #2 ($filename) must not contain any null bytes
+
+Warning: Undefined variable $x in %s on line %d
+
+Warning: Undefined variable $y in %s on line %d
+
+Warning: Undefined variable $z in %s on line %d
+
+Deprecated: zend_test_compile_string(): Passing null to parameter #1 ($source_string) of type string is deprecated in %s on line %d
+
+Deprecated: zend_test_compile_string(): Passing null to parameter #2 ($filename) of type string is deprecated in %s on line %d
+
+Deprecated: zend_test_compile_string(): Passing null to parameter #3 ($position) of type int is deprecated in %s on line %d
 
 Parse error: syntax error, unexpected token "<", expecting end of file in Source string on line 1

--- a/ext/zend_test/tests/zend_test_compile_string.phpt
+++ b/ext/zend_test/tests/zend_test_compile_string.phpt
@@ -49,7 +49,7 @@ try {
 	echo $e->getMessage(), PHP_EOL;
 }
 
-zend_test_compile_string($x, $y, $z);
+zend_test_compile_string(null, null, null);
 
 $source_string = <<<EOF
 <?php
@@ -66,12 +66,6 @@ string(3) "php"
 string(3) "php"
 string(3) "php"
 zend_test_compile_string(): Argument #2 ($filename) must not contain any null bytes
-
-Warning: Undefined variable $x in %s on line %d
-
-Warning: Undefined variable $y in %s on line %d
-
-Warning: Undefined variable $z in %s on line %d
 
 Deprecated: zend_test_compile_string(): Passing null to parameter #1 ($source_string) of type string is deprecated in %s on line %d
 


### PR DESCRIPTION
happens with unset script path, now using zend_str_has_nul_bytes thereafter.