### PR TITLE
Fix GH-17839 Negative SSE + fractions results in wrong timestamp

### DIFF
--- a/ext/date/lib/timelib.c
+++ b/ext/date/lib/timelib.c
@@ -173,6 +173,11 @@ timelib_long timelib_date_to_int(timelib_time *d, int *error)
 
 	ts = d->sse;
 
+	// adjust negative sse with fractions
+	if (ts < 0 && d->us) {
+		ts = ts + 1;
+	}
+
 	if (ts < TIMELIB_LONG_MIN || ts > TIMELIB_LONG_MAX) {
 		if (error) {
 			*error = 1;
@@ -182,7 +187,7 @@ timelib_long timelib_date_to_int(timelib_time *d, int *error)
 	if (error) {
 		*error = 0;
 	}
-	return (timelib_long) d->sse;
+	return (timelib_long) ts;
 }
 
 void timelib_decimal_hour_to_hms(double h, int *hour, int *min, int *sec)

--- a/ext/date/tests/gh17839.phpt
+++ b/ext/date/tests/gh17839.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug GH-17839 Negative SSE + fractions results in wrong timestamp
+--FILE--
+<?php
+
+$dt1 = new DateTime('@1.1');
+$dt2 = new DateTime('@-1.1');
+var_dump($dt1, $dt1->getTimestamp());
+var_dump($dt2, $dt2->getTimestamp());
+--EXPECTF--
+object(DateTime)#%d (%d) {
+  ["date"]=>
+  string(26) "1970-01-01 00:00:01.100000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+int(1)
+object(DateTime)#%d (%d) {
+  ["date"]=>
+  string(26) "1969-12-31 23:59:58.900000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+int(-1)


### PR DESCRIPTION
See #17839