### PR TITLE
Fix GH-17837: ::getColumnMeta() on unexecuted statement segfaults

### DIFF
--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -305,7 +305,7 @@ static int pdo_sqlite_stmt_col_meta(pdo_stmt_t *stmt, zend_long colno, zval *ret
 	const char *str;
 	zval flags;
 
-	if (!S->stmt) {
+	if (!S->stmt || !stmt->executed) {
 		return FAILURE;
 	}
 	if(colno >= sqlite3_column_count(S->stmt)) {

--- a/ext/pdo_sqlite/tests/gh17837.phpt
+++ b/ext/pdo_sqlite/tests/gh17837.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-17837 (::getColumnMeta() on unexecuted statement segfaults)
+--EXTENSIONS--
+pdo_sqlite
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$db = new PDO('sqlite::memory:');
+$stmt = $db->prepare('select :a, :b, ?');
+var_dump($stmt->getColumnMeta(0));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
We cannot properly get the column meta data of a statement which has been prepared, but has not yet been executed.  As such we bail out early, reporting failure.