### PR TITLE
Fix GH-17746: Signed integer overflow when setting ATTR_TIMEOUT

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -292,6 +292,10 @@ static bool pdo_sqlite_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			if (!pdo_get_long_param(&lval, val)) {
 				return false;
 			}
+			if (lval > INT_MAX / 1000) {
+				return false;
+			}
+			lval = MAX(lval, 0);
 			sqlite3_busy_timeout(H->db, lval * 1000);
 			return true;
 		case PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES:

--- a/ext/pdo_sqlite/tests/gh17746.phpt
+++ b/ext/pdo_sqlite/tests/gh17746.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-17746 (Signed integer overflow when setting ATTR_TIMEOUT)
+--EXTENSIONS--
+pdo_sqlite
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$pdo = new PDO("sqlite::memory:");
+var_dump($pdo->setAttribute(PDO::ATTR_TIMEOUT, -1));
+var_dump($pdo->setAttribute(PDO::ATTR_TIMEOUT, intdiv(0x7fffffff, 1000) + 1));
+?>
+--EXPECT--
+bool(true)
+bool(false)


### PR DESCRIPTION
`::setAttribute(PDO::ATTR_TIMEOUT, …)` accepts a timeout in seconds, but `sqlite3_busy_timeout()`[1] expects the timeout in milliseconds, which is an `int`.  To avoid signed overflow, we reject values larger than the allowed range.

We also cater to negative values by simply clamping those to zero, since `sqlite3_busy_timeout()` handles negative values the same as zero.

[1] <https://www.sqlite.org/c3ref/busy_timeout.html>

---

@nielsdos said:

> I wonder if we should warn in that case to notify the user that no timeout actually was applied.

I'm not sure about this, since that may raise an exception with `ERRMODE_EXCEPTION` (and possibly even with `ERRMODE_WARNING` due to a global error handler), and *might* break working code (not working as intended, but somehow working). Perhaps it's better to postpone that to the master branch.