### PR TITLE
Fix GH-17855: CURL_STATICLIB flag set even if linked with shared lib

### DIFF
--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -13,7 +13,8 @@ if (PHP_CURL != "no") {
 		}
 	}
 
-	if (CHECK_LIB("libcurl_a.lib;libcurl.lib", "curl", PHP_CURL) &&
+	var curl_location;
+	if ((curl_location = CHECK_LIB("libcurl_a.lib;libcurl.lib", "curl", PHP_CURL)) &&
 		CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_CURL") &&
 		SETUP_OPENSSL("curl", PHP_CURL) > 0 &&
 		CHECK_LIB("winmm.lib", "curl", PHP_CURL) &&
@@ -28,7 +29,10 @@ if (PHP_CURL != "no") {
 		) {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
-		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB /D PHP_CURL_EXPORTS=1");
+		ADD_FLAG("CFLAGS_CURL", "/D PHP_CURL_EXPORTS=1");
+		if (curl_location.match(/libcurl_a\.lib$/)) {
+			ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB");
+		}
 		PHP_INSTALL_HEADERS("ext/curl", "php_curl.h");
 		// TODO: check for curl_version_info
 	} else {


### PR DESCRIPTION
We must define `CURL_STATICLIB` only when building against a static libcurl.  The detection relies on our usual naming conventions, what should be revised in the future (possibly using pkg-config, or switching to CMake).