### PR TITLE
Drop special casing for IIS to cover TLS protocol error

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -208,32 +208,6 @@ typedef struct _php_openssl_netstream_data_t {
 	unsigned _spare:31;
 } php_openssl_netstream_data_t;
 
-/* it doesn't matter that we do some hash traversal here, since it is done only
- * in an error condition arising from a network connection problem */
-static int php_openssl_is_http_stream_talking_to_iis(php_stream *stream) /* {{{ */
-{
-	if (Z_TYPE(stream->wrapperdata) == IS_ARRAY &&
-		stream->wrapper &&
-		strcasecmp(stream->wrapper->wops->label, "HTTP") == 0
-	) {
-		/* the wrapperdata is an array zval containing the headers */
-		zval *tmp;
-
-#define SERVER_MICROSOFT_IIS	"Server: Microsoft-IIS"
-#define SERVER_GOOGLE "Server: GFE/"
-
-		ZEND_HASH_FOREACH_VAL(Z_ARRVAL(stream->wrapperdata), tmp) {
-			if (zend_string_equals_literal_ci(Z_STR_P(tmp), SERVER_MICROSOFT_IIS)) {
-				return 1;
-			} else if (zend_string_equals_literal_ci(Z_STR_P(tmp), SERVER_GOOGLE)) {
-				return 1;
-			}
-		} ZEND_HASH_FOREACH_END();
-	}
-	return 0;
-}
-/* }}} */
-
 static int php_openssl_handle_ssl_error(php_stream *stream, int nr_bytes, bool is_init) /* {{{ */
 {
 	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
@@ -258,7 +232,7 @@ static int php_openssl_handle_ssl_error(php_stream *stream, int nr_bytes, bool i
 		case SSL_ERROR_SYSCALL:
 			if (ERR_peek_error() == 0) {
 				if (nr_bytes == 0) {
-					if (!php_openssl_is_http_stream_talking_to_iis(stream) && ERR_get_error() != 0) {
+					if (ERR_get_error() != 0) {
 						php_error_docref(NULL, E_WARNING, "SSL: fatal protocol error");
 					}
 					SSL_set_shutdown(sslsock->ssl_handle, SSL_SENT_SHUTDOWN|SSL_RECEIVED_SHUTDOWN);


### PR DESCRIPTION
This had been introduced to fix bug 23220[1], although it is not even clear that IIS caused the problem (some comments mention that this happened with Apache).

Anyhow, in hindsight it seems to be a bad idea to brush warnings about improper implementation of the *TLS* protocol under the carpet; if a server does not properly implement TLS, users should be aware of that, and report that to the respective developers.

[1] <https://bugs.php.net/bug.php?id=23220>

---

The remaining `ERR_get_error() != 0` condition is also somehow fishy; it was supposed to be a fix for https://bugs.php.net/bug.php?id=41770, but the OP claimed it wouldn't fix their issue. And even more confusing: that check is in a branch that is only executed if `ERR_peek_error() == 0`, so the warning appears to be unreachable.

And from the [OpenSSL 1.1.1 documentation](https://docs.openssl.org/1.1.1/man3/SSL_get_error/#bugs);

> The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected EOF from the peer. This will be properly reported as SSL_ERROR_SSL with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the OpenSSL 3.0 release because it is truly a TLS protocol error to terminate the connection without a SSL_shutdown().

