### PR TITLE
Fix GH-17868: Cannot allocate memory with tracing JIT on 8.4.4

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -8675,7 +8675,9 @@ static int zend_jit_push_call_frame(zend_jit_ctx *jit, const zend_op *opline, co
 		// JIT: Z_CE(call->This) = called_scope;
 		ir_STORE(jit_CALL(rx, This), IR_NULL);
 	} else {
-		ir_ref object_or_called_scope, call_info, call_info2, object, if_cond;
+		ir_ref object_or_called_scope, call_info, call_info2, object;
+		ir_ref if_cond = IR_UNUSED;
+		ir_ref if_cond_user = IR_UNUSED;
 
 		if (opline->op2_type == IS_CV) {
 			// JIT: GC_ADDREF(closure);
@@ -8713,15 +8715,28 @@ static int zend_jit_push_call_frame(zend_jit_ctx *jit, const zend_op *opline, co
 		// JIT: Z_PTR(call->This) = object_or_called_scope;
 		ir_STORE(jit_CALL(rx, This.value.ptr), object_or_called_scope);
 
-		// JIT: if (closure->func.op_array.run_time_cache__ptr)
-		if_cond = ir_IF(ir_LOAD_A(ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func.op_array.run_time_cache__ptr))));
-		ir_IF_FALSE(if_cond);
+		if (!func) {
+			// JIT: if (closure->func.common.type & ZEND_USER_FUNCTION)
+			ir_ref type = ir_LOAD_U8(ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func.type)));
+			if_cond_user = ir_IF(ir_AND_U8(type, ir_CONST_U8(ZEND_USER_FUNCTION)));
+			ir_IF_TRUE(if_cond_user);
+		}
 
-		// JIT: zend_jit_init_func_run_time_cache_helper(closure->func);
-		ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_init_func_run_time_cache_helper),
-			ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func)));
+		if (!func || func->common.type == ZEND_USER_FUNCTION) {
+			// JIT: if (closure->func.op_array.run_time_cache__ptr)
+			if_cond = ir_IF(ir_LOAD_A(ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func.op_array.run_time_cache__ptr))));
+			ir_IF_FALSE(if_cond);
+	
+			// JIT: zend_jit_init_func_run_time_cache_helper(closure->func);
+			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_init_func_run_time_cache_helper),
+				ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func)));
 
-		ir_MERGE_WITH_EMPTY_TRUE(if_cond);
+			ir_MERGE_WITH_EMPTY_TRUE(if_cond);
+		}
+
+		if (!func) {
+			ir_MERGE_WITH_EMPTY_FALSE(if_cond_user);
+		}
 	}
 
 	// JIT: ZEND_CALL_NUM_ARGS(call) = num_args;

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -8722,15 +8722,9 @@ static int zend_jit_push_call_frame(zend_jit_ctx *jit, const zend_op *opline, co
 		}
 
 		if (!func || func->common.type == ZEND_USER_FUNCTION) {
-			// JIT: if (closure->func.op_array.run_time_cache__ptr)
-			if_cond = ir_IF(ir_LOAD_A(ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func.op_array.run_time_cache__ptr))));
-			ir_IF_FALSE(if_cond);
-
 			// JIT: zend_jit_init_func_run_time_cache_helper(closure->func);
 			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_init_func_run_time_cache_helper),
 				ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func)));
-
-			ir_MERGE_WITH_EMPTY_TRUE(if_cond);
 		}
 
 		if (!func) {

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -8675,8 +8675,7 @@ static int zend_jit_push_call_frame(zend_jit_ctx *jit, const zend_op *opline, co
 		// JIT: Z_CE(call->This) = called_scope;
 		ir_STORE(jit_CALL(rx, This), IR_NULL);
 	} else {
-		ir_ref object_or_called_scope, call_info, call_info2, object;
-		ir_ref if_cond = IR_UNUSED;
+		ir_ref object_or_called_scope, call_info, call_info2, object, if_cond;
 		ir_ref if_cond_user = IR_UNUSED;
 
 		if (opline->op2_type == IS_CV) {
@@ -8726,7 +8725,7 @@ static int zend_jit_push_call_frame(zend_jit_ctx *jit, const zend_op *opline, co
 			// JIT: if (closure->func.op_array.run_time_cache__ptr)
 			if_cond = ir_IF(ir_LOAD_A(ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func.op_array.run_time_cache__ptr))));
 			ir_IF_FALSE(if_cond);
-	
+
 			// JIT: zend_jit_init_func_run_time_cache_helper(closure->func);
 			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_init_func_run_time_cache_helper),
 				ir_ADD_OFFSET(func_ref, offsetof(zend_closure, func)));


### PR DESCRIPTION
The generated code tries to initialize the run time cache for even internal closures, but it should only initialize the run time cache for user closures. This results in an out of memory error because `op_array.cache_size` is a nonsense value.
We fix this by adding a check for the function type. If `func` is known, then we can check the type at code generation time.

This was already an issue before 28b448ac200ccbeafdb6927f263d08b22e643711, but became more visible after that commit.

This also needs fixing on PHP-8.3, I can backport this after this is handled for 8.4.