### PR TITLE
Fix a number of typos in comments / docs

### DIFF
--- a/ext/dom/lexbor/lexbor/css/syntax/state_res.h
+++ b/ext/dom/lexbor/lexbor/css/syntax/state_res.h
@@ -49,7 +49,7 @@ lxb_css_syntax_state_res_map[256] =
     lxb_css_syntax_state_hash, /* 0x23; '#'; Pound sign */
     lxb_css_syntax_state_delim, /* 0x24; '$'; Dollar sign */
     lxb_css_syntax_state_delim, /* 0x25; '%'; Percentage sign */
-    lxb_css_syntax_state_delim, /* 0x26; '&'; Commericial and */
+    lxb_css_syntax_state_delim, /* 0x26; '&'; Commercial and */
     lxb_css_syntax_state_string, /* 0x27; '''; Apostrophe */
     lxb_css_syntax_state_lparenthesis, /* 0x28; '('; Left bracket */
     lxb_css_syntax_state_rparenthesis, /* 0x29; ')'; Right bracket */

--- a/ext/dom/lexbor/lexbor/css/syntax/state_res.h
+++ b/ext/dom/lexbor/lexbor/css/syntax/state_res.h
@@ -49,7 +49,7 @@ lxb_css_syntax_state_res_map[256] =
     lxb_css_syntax_state_hash, /* 0x23; '#'; Pound sign */
     lxb_css_syntax_state_delim, /* 0x24; '$'; Dollar sign */
     lxb_css_syntax_state_delim, /* 0x25; '%'; Percentage sign */
-    lxb_css_syntax_state_delim, /* 0x26; '&'; Ampersand */
+    lxb_css_syntax_state_delim, /* 0x26; '&'; Commericial and */
     lxb_css_syntax_state_string, /* 0x27; '''; Apostrophe */
     lxb_css_syntax_state_lparenthesis, /* 0x28; '('; Left bracket */
     lxb_css_syntax_state_rparenthesis, /* 0x29; ')'; Right bracket */

--- a/ext/dom/lexbor/lexbor/css/syntax/state_res.h
+++ b/ext/dom/lexbor/lexbor/css/syntax/state_res.h
@@ -49,7 +49,7 @@ lxb_css_syntax_state_res_map[256] =
     lxb_css_syntax_state_hash, /* 0x23; '#'; Pound sign */
     lxb_css_syntax_state_delim, /* 0x24; '$'; Dollar sign */
     lxb_css_syntax_state_delim, /* 0x25; '%'; Percentage sign */
-    lxb_css_syntax_state_delim, /* 0x26; '&'; Commercial and */
+    lxb_css_syntax_state_delim, /* 0x26; '&'; Ampersand */
     lxb_css_syntax_state_string, /* 0x27; '''; Apostrophe */
     lxb_css_syntax_state_lparenthesis, /* 0x28; '('; Left bracket */
     lxb_css_syntax_state_rparenthesis, /* 0x29; ')'; Right bracket */

--- a/ext/gd/libgd/gd.h
+++ b/ext/gd/libgd/gd.h
@@ -50,7 +50,7 @@ extern "C" {
 	pixels are represented by integers, which
 	must be 32 bits wide or more.
 
-	True colors are repsented as follows:
+	True colors are represented as follows:
 
 	ARGB
 

--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -400,7 +400,7 @@ static void *fontFetch (char **error, void *key)
 	fontlist = gdEstrdup(a->fontlist);
 
 	/*
-	 * Must use gd_strtok_r becasuse strtok() isn't thread safe
+	 * Must use gd_strtok_r because strtok() isn't thread safe
 	 */
 	for (name = gd_strtok_r (fontlist, LISTSEPARATOR, &strtok_ptr); name; name = gd_strtok_r (0, LISTSEPARATOR, &strtok_ptr)) {
 		char *strtok_ptr_path;

--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -28,7 +28,7 @@
 #endif
 #endif
 
-/* number of antialised colors for indexed bitmaps */
+/* number of antialiased colors for indexed bitmaps */
 /* overwrite Windows GDI define in case of windows build */
 #ifdef NUMCOLORS
 #undef NUMCOLORS
@@ -400,7 +400,7 @@ static void *fontFetch (char **error, void *key)
 	fontlist = gdEstrdup(a->fontlist);
 
 	/*
-	 * Must use gd_strtok_r because strtok() isn't thread safe
+	 * Must use gd_strtok_r becasuse strtok() isn't thread safe
 	 */
 	for (name = gd_strtok_r (fontlist, LISTSEPARATOR, &strtok_ptr); name; name = gd_strtok_r (0, LISTSEPARATOR, &strtok_ptr)) {
 		char *strtok_ptr_path;
@@ -760,7 +760,7 @@ static char * gdft_draw_bitmap (gdCache_head_t *tc_cache, gdImage * im, int fg, 
 					 */
 					*pixel = (fg < 0) ? -fg : fg;
 				} else {
-					/* find antialised color */
+					/* find antialiased color */
 					tc_key.bgcolor = *pixel;
 					tc_elem = (tweencolor_t *) gdCacheGet(tc_cache, &tc_key);
 					*pixel = tc_elem->tweencolor;

--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -284,7 +284,7 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 	} else {
 		char *s = ZCG(accel_directives).mmap_base;
 
-		/* skip leading 0x, %p assumes hexdecimal format anyway */
+		/* skip leading 0x, %p assumes hexadecimal format anyway */
 		if (*s == '0' && *(s + 1) == 'x') {
 			s += 2;
 		}

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -528,7 +528,7 @@ PHP_FUNCTION(spl_autoload_register)
 	if (ZEND_FCI_INITIALIZED(fci)) {
 		if (!fcc.function_handler) {
 			/* Call trampoline has been cleared by zpp. Refetch it, because we want to deal
-			 * with it outselves. It is important that it is not refetched on every call,
+			 * with it ourselves. It is important that it is not refetched on every call,
 			 * because calls may occur from different scopes. */
 			zend_is_callable_ex(&fci.function_name, NULL, IS_CALLABLE_SUPPRESS_DEPRECATIONS, NULL, &fcc, NULL);
 		}
@@ -591,7 +591,7 @@ PHP_FUNCTION(spl_autoload_unregister)
 
 	if (!fcc.function_handler) {
 		/* Call trampoline has been cleared by zpp. Refetch it, because we want to deal
-		 * with it outselves. It is important that it is not refetched on every call,
+		 * with it ourselves. It is important that it is not refetched on every call,
 		 * because calls may occur from different scopes. */
 		zend_is_callable_ex(&fci.function_name, NULL, 0, NULL, &fcc, NULL);
 	}

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -764,7 +764,7 @@ PHP_METHOD(SplDoublyLinkedList, offsetUnset)
 	element = spl_ptr_llist_offset(intern->llist, index, intern->flags & SPL_DLLIST_IT_LIFO);
 
 	if (element != NULL) {
-		/* connect the neightbors */
+		/* connect the neighbors */
 		if (element->prev) {
 			element->prev->next = element->next;
 		}

--- a/ext/standard/crc32_x86.c
+++ b/ext/standard/crc32_x86.c
@@ -66,7 +66,7 @@ static uint8_t pclmul_shuf_mask_table[16] = {
 /* Folding of 128-bit data chunks */
 #define CRC32_FOLDING_BLOCK_SIZE (16)
 
-/* PCLMUL version of non-relfected crc32 */
+/* PCLMUL version of non-reflected crc32 */
 ZEND_INTRIN_SSE4_2_PCLMUL_FUNC_DECL(size_t crc32_pclmul_batch(uint32_t *crc, const unsigned char *p, size_t nr, const crc32_pclmul_consts *consts));
 size_t crc32_pclmul_batch(uint32_t *crc, const unsigned char *p, size_t nr, const crc32_pclmul_consts *consts)
 {
@@ -183,7 +183,7 @@ size_t crc32_pclmul_batch(uint32_t *crc, const unsigned char *p, size_t nr, cons
 	return (nr_in - nr); /* the nr processed */
 }
 
-/* PCLMUL version of relfected crc32 */
+/* PCLMUL version of reflected crc32 */
 ZEND_INTRIN_SSE4_2_PCLMUL_FUNC_DECL(size_t crc32_pclmul_reflected_batch(uint32_t *crc, const unsigned char *p, size_t nr, const crc32_pclmul_consts *consts));
 size_t crc32_pclmul_reflected_batch(uint32_t *crc, const unsigned char *p, size_t nr, const crc32_pclmul_consts *consts)
 {

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -39,7 +39,7 @@
 
 #if defined(__APPLE__)
   /*
-   Apple statvfs has an interger overflow in libc copying to statvfs.
+   Apple statvfs has an integer overflow in libc copying to statvfs.
    cvt_statfs_to_statvfs(struct statfs *from, struct statvfs *to) {
    to->f_blocks = (fsblkcnt_t)from->f_blocks;
    */

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -38,7 +38,7 @@
 #ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
 /* Only defined on glibc >= 2.29, FreeBSD CURRENT, musl >= 1.1.24,
  * MacOS Catalina or later..
- * It should be posible to modify this so it is also
+ * It should be possible to modify this so it is also
  * used in older systems when $cwd == NULL but care must be taken
  * as at least glibc < 2.24 has a legacy implementation known
  * to be really buggy.


### PR DESCRIPTION
Was reading the sources, came across a few minor typos - mostly in comments. This PR fixes them.