### PR TITLE
Drop support for `-z` CLI/CGI option

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -358,9 +358,13 @@ PHP 8.5 UPGRADE NOTES
 ========================================
 
 - Core:
-  The high resolution timer (`hrtime()`) on macOS now uses the recommended
-  `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` API instead of
-  `mach_absolute_time()`.
+  . The high resolution timer (`hrtime()`) on macOS now uses the recommended
+    `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` API instead of
+    `mach_absolute_time()`.
+
+- CLI/CGI:
+  . The `-z` or `--zend-extension` option has been removed as it was
+    non-functional. Use `-d zend_extension=<path>` instead.
 
 ========================================
 14. Performance Improvements

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -158,7 +158,6 @@ static const opt_struct OPTIONS[] = {
 	{'w', 0, "strip"},
 	{'?', 0, "usage"},/* help alias (both '?' and 'usage') */
 	{'v', 0, "version"},
-	{'z', 1, "zend-extension"},
 	{'T', 1, "timing"},
 	{'-', 0, NULL} /* end of args */
 };
@@ -1042,7 +1041,6 @@ static void php_cgi_usage(char *argv0)
 				"  -s               Display colour syntax highlighted source.\n"
 				"  -v               Version number\n"
 				"  -w               Display source with stripped comments and whitespace.\n"
-				"  -z <file>        Load Zend extension <file>.\n"
 				"  -T <count>       Measure execution time of script repeated <count> times.\n",
 				prog, prog);
 }
@@ -2381,10 +2379,6 @@ parent_loop_end:
 
 						case 'w':
 							behavior = PHP_MODE_STRIP;
-							break;
-
-						case 'z': /* load extension file */
-							zend_load_extension(php_optarg);
 							break;
 
 						default:

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -303,13 +303,6 @@ Version number
 .PD 1
 .B \-w
 Output source with stripped comments and whitespace
-.TP
-.PD 0
-.B \-\-zend\-extension \fIfile\fP
-.TP
-.PD 1
-.B \-z \fIfile\fP
-Load Zend extension
 .IR file
 .TP
 .IR args.\|.\|.

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -148,7 +148,6 @@ const opt_struct OPTIONS[] = {
 	{'w', 0, "strip"},
 	{'?', 0, "usage"},/* help alias (both '?' and 'usage') */
 	{'v', 0, "version"},
-	{'z', 1, "zend-extension"},
 	{10,  1, "rf"},
 	{10,  1, "rfunction"},
 	{11,  1, "rc"},
@@ -496,7 +495,6 @@ static void php_cli_usage(char *argv0)
 				"  -s               Output HTML syntax highlighted source.\n"
 				"  -v               Version number\n"
 				"  -w               Output source with stripped comments and whitespace.\n"
-				"  -z <file>        Load Zend extension <file>.\n"
 				"\n"
 				"  args...          Arguments passed to script. Use -- args when first argument\n"
 				"                   starts with - or script is read from stdin\n"
@@ -800,9 +798,6 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				context.mode = PHP_CLI_MODE_STRIP;
 				break;
 
-			case 'z': /* load extension file */
-				zend_load_extension(php_optarg);
-				break;
 			case 'H':
 				hide_argv = true;
 				break;


### PR DESCRIPTION
This functionality didn't actually work.
This was discussed on the mailing list [1] and no one objected.

[1] https://externals.io/message/126368

Leaving this open for a little longer for the ML thread.