### PR TITLE
ext/gd: backport optional PNG support to 8.3

### DIFF
--- a/ext/gd/tests/bug22544-mb.phpt
+++ b/ext/gd/tests/bug22544-mb.phpt
@@ -2,6 +2,12 @@
 Bug #22544 (TrueColor transparency in PNG images).
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
     $image = imageCreateTruecolor(640, 100);

--- a/ext/gd/tests/bug22544.phpt
+++ b/ext/gd/tests/bug22544.phpt
@@ -2,6 +2,12 @@
 Bug #22544 (TrueColor transparency in PNG images).
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
     $image = imageCreateTruecolor(640, 100);

--- a/ext/gd/tests/bug24155.phpt
+++ b/ext/gd/tests/bug24155.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists("imagerotate")) die("skip requires imagerotate function");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug24155.phpt
+++ b/ext/gd/tests/bug24155.phpt
@@ -4,7 +4,7 @@ Bug #24155 (gdImageRotate270 rotation problem).
 gd
 --SKIPIF--
 <?php
-    if (!function_exists("imagerotate")) die("skip requires bundled GD library\n");
+    if (!function_exists("imagerotate")) die("skip requires imagerotate function");
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug24155.phpt
+++ b/ext/gd/tests/bug24155.phpt
@@ -4,7 +4,6 @@ Bug #24155 (gdImageRotate270 rotation problem).
 gd
 --SKIPIF--
 <?php
-    if (!function_exists("imagerotate")) die("skip requires imagerotate function");
     if (!(imagetypes() & IMG_PNG)) {
         die("skip No PNG support");
     }

--- a/ext/gd/tests/bug27582_1.phpt
+++ b/ext/gd/tests/bug27582_1.phpt
@@ -2,6 +2,12 @@
 Bug #27582 (ImageFillToBorder() on alphablending image looses alpha on fill color)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $dest = dirname(realpath(__FILE__)) . '/bug27582.png';

--- a/ext/gd/tests/bug39366.phpt
+++ b/ext/gd/tests/bug39366.phpt
@@ -2,10 +2,6 @@
 Bug #39366 (imagerotate does not respect alpha with angles>45)
 --EXTENSIONS--
 gd
---SKIPIF--
-<?php
-    if (!function_exists("imagerotate")) die("skip requires imagerotate function");
-?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/bug39366.phpt
+++ b/ext/gd/tests/bug39366.phpt
@@ -4,7 +4,7 @@ Bug #39366 (imagerotate does not respect alpha with angles>45)
 gd
 --SKIPIF--
 <?php
-    if (!function_exists("imagerotate")) die("skip requires bundled GD library\n");
+    if (!function_exists("imagerotate")) die("skip requires imagerotate function");
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug39780_extern.phpt
+++ b/ext/gd/tests/bug39780_extern.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (GD_BUNDLED) die("skip requires extern GD\n");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug43073.phpt
+++ b/ext/gd/tests/bug43073.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if(!function_exists('imagettftext')) die('skip imagettftext() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug43475.phpt
+++ b/ext/gd/tests/bug43475.phpt
@@ -7,6 +7,9 @@ gd
     if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
         die("skip test requires GD 2.2.2 or higher");
     }
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug43828.phpt
+++ b/ext/gd/tests/bug43828.phpt
@@ -7,6 +7,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
     die("skip test requires GD 2.2.2 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug45799.phpt
+++ b/ext/gd/tests/bug45799.phpt
@@ -2,6 +2,12 @@
 Bug #45799 (imagepng() crashes on empty image).
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $img = imagecreate(500,500);

--- a/ext/gd/tests/bug47946.phpt
+++ b/ext/gd/tests/bug47946.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.5', '<=')) die('skip upstream fix not yet released');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug48732-mb.phpt
+++ b/ext/gd/tests/bug48732-mb.phpt
@@ -6,6 +6,9 @@ gd
 <?php
     if(!function_exists('imagefttext')) die('skip imagefttext() not available');
     if (substr(PHP_OS, 0, 3) == 'WIN') die('skip UTF-8 font file names not yet supported on Windows');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug48732.phpt
+++ b/ext/gd/tests/bug48732.phpt
@@ -2,9 +2,13 @@
 Bug #48732 (TTF Bounding box wrong for letters below baseline)
 --EXTENSIONS--
 gd
+
 --SKIPIF--
 <?php
     if(!function_exists('imagefttext')) die('skip imagefttext() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug50194.phpt
+++ b/ext/gd/tests/bug50194.phpt
@@ -5,7 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!function_exists('imagettftext')) die('skip imagettftext() not available');
-//die('skip freetype issues');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug51498.phpt
+++ b/ext/gd/tests/bug51498.phpt
@@ -7,6 +7,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, "2.3.0") < 0) {
     die("skip test requires GD 2.3.0 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug52070.phpt
+++ b/ext/gd/tests/bug52070.phpt
@@ -2,6 +2,12 @@
 Bug #52070 (imagedashedline() - dashed line sometimes is not visible)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $im = imagecreate(1200, 800);

--- a/ext/gd/tests/bug53504.phpt
+++ b/ext/gd/tests/bug53504.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if(!function_exists('imageftbbox')) die('skip imageftbbox() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug64641.phpt
+++ b/ext/gd/tests/bug64641.phpt
@@ -7,6 +7,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
     die("skip test requires GD 2.2.2 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug66005.phpt
+++ b/ext/gd/tests/bug66005.phpt
@@ -2,6 +2,12 @@
 Bug #66005 (imagecopy does not support 1bit transparency on truecolor images)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $dest = imagecreatetruecolor(150, 50);

--- a/ext/gd/tests/bug72482_2.phpt
+++ b/ext/gd/tests/bug72482_2.phpt
@@ -2,6 +2,12 @@
 Bug 72482 (Ilegal write/read access caused by gdImageAALine overflow)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/bug72604.phpt
+++ b/ext/gd/tests/bug72604.phpt
@@ -2,6 +2,12 @@
 Bug #72604 (imagearc() ignores thickness for full arcs)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $im = imagecreatetruecolor(100, 100);

--- a/ext/gd/tests/bug72913.phpt
+++ b/ext/gd/tests/bug72913.phpt
@@ -2,6 +2,12 @@
 Bug #72913 (imagecopy() loses single-color transparency on palette images)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $base64 = 'iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAABnRSTlMAAAAAAABu'

--- a/ext/gd/tests/bug73213.phpt
+++ b/ext/gd/tests/bug73213.phpt
@@ -2,6 +2,12 @@
 Bug #73213 (Integer overflow in imageline() with antialiasing)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/bug73272.phpt
+++ b/ext/gd/tests/bug73272.phpt
@@ -2,6 +2,12 @@
 Bug #73272 (imagescale() is not affected by, but affects imagesetinterpolation())
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/bug73549.phpt
+++ b/ext/gd/tests/bug73549.phpt
@@ -2,6 +2,12 @@
 Bug #73549 (Use after free when stream is passed to imagepng)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $stream = fopen(__DIR__ . DIRECTORY_SEPARATOR . 'bug73549.png', 'w');

--- a/ext/gd/tests/bug73614.phpt
+++ b/ext/gd/tests/bug73614.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.5', '<=')) die('skip upstream bugfix not yet released');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug74031.phpt
+++ b/ext/gd/tests/bug74031.phpt
@@ -2,6 +2,12 @@
 (Bug #74031) ReflectionFunction for imagepng returns wrong number of parameters
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/bug75124.phpt
+++ b/ext/gd/tests/bug75124.phpt
@@ -7,6 +7,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.5', '<')) {
     die('skip only for bundled libgd or external libgd >= 2.2.5');
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/bug77943.phpt
+++ b/ext/gd/tests/bug77943.phpt
@@ -2,6 +2,12 @@
 Bug #77943 (imageantialias($image, false); does not work)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . '/func.inc';

--- a/ext/gd/tests/bug79945.phpt
+++ b/ext/gd/tests/bug79945.phpt
@@ -4,6 +4,9 @@ Bug #79945 (using php wrappers in imagecreatefrompng causes segmentation fault)
 gd
 --SKIPIF--
 <?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 set_error_handler(function($errno, $errstr) {
     if (str_contains($errstr, 'Cannot cast a filtered stream on this system')) {
         die('skip: fopencookie not support on this system');

--- a/ext/gd/tests/imagearc_basic.phpt
+++ b/ext/gd/tests/imagearc_basic.phpt
@@ -5,6 +5,12 @@ Edgar Ferreira da Silva <contato [at] edgarfs [dot] com [dot] br>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagearc_variation1.phpt
+++ b/ext/gd/tests/imagearc_variation1.phpt
@@ -5,6 +5,12 @@ Edgar Ferreira da Silva <contato [at] edgarfs [dot] com [dot] br>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagearc_variation2.phpt
+++ b/ext/gd/tests/imagearc_variation2.phpt
@@ -5,6 +5,12 @@ Edgar Ferreira da Silva <contato [at] edgarfs [dot] com [dot] br>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagechar_basic.phpt
+++ b/ext/gd/tests/imagechar_basic.phpt
@@ -5,6 +5,12 @@ Rafael Dohms <rdohms [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/imagecharup_basic.phpt
+++ b/ext/gd/tests/imagecharup_basic.phpt
@@ -5,6 +5,12 @@ Rafael Dohms <rdohms [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/imagecolorallocatealpha_basic.phpt
+++ b/ext/gd/tests/imagecolorallocatealpha_basic.phpt
@@ -9,6 +9,9 @@ gd
     if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
         die("skip test requires GD 2.2.2 or higher");
     }
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecolorset_basic.phpt
+++ b/ext/gd/tests/imagecolorset_basic.phpt
@@ -5,6 +5,12 @@ Erick Belluci Tedeschi <erickbt86 [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 // Create a 300x100 image

--- a/ext/gd/tests/imageconvolution_basic.phpt
+++ b/ext/gd/tests/imageconvolution_basic.phpt
@@ -5,6 +5,12 @@ Guilherme Blanco <guilhermeblanco [at] hotmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/imagecopyresampled_basic.phpt
+++ b/ext/gd/tests/imagecopyresampled_basic.phpt
@@ -2,6 +2,12 @@
 imagecopyresampled()
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagecreatefrombmp_basic.phpt
+++ b/ext/gd/tests/imagecreatefrombmp_basic.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecreatefromstring_bmp.phpt
+++ b/ext/gd/tests/imagecreatefromstring_bmp.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecreatefromtga_basic.phpt
+++ b/ext/gd/tests/imagecreatefromtga_basic.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!(imagetypes() & IMG_TGA)) die('skip TGA support required');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecreatefromtga_variation.phpt
+++ b/ext/gd/tests/imagecreatefromtga_variation.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!(imagetypes() & IMG_TGA)) die('skip TGA support required');
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecreatetruecolor_basic.phpt
+++ b/ext/gd/tests/imagecreatetruecolor_basic.phpt
@@ -7,6 +7,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists("imagecreatetruecolor")) die("skip GD Version not compatible");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagecrop_auto.phpt
+++ b/ext/gd/tests/imagecrop_auto.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
 if (!function_exists('imagecrop')) die( 'skip GD imagecropauto not present; skipping test' );
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagedashedline_basic.phpt
+++ b/ext/gd/tests/imagedashedline_basic.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists('imagedashedline')) die('skip imagedashedline() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imageellipse_basic.phpt
+++ b/ext/gd/tests/imageellipse_basic.phpt
@@ -5,6 +5,12 @@ Ivan Rosolen <contato [at] ivanrosolen [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagefilledarc_basic.phpt
+++ b/ext/gd/tests/imagefilledarc_basic.phpt
@@ -10,6 +10,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
     die("skip test requires GD 2.2.2 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagefilledarc_variation1.phpt
+++ b/ext/gd/tests/imagefilledarc_variation1.phpt
@@ -10,6 +10,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
     die("skip test requires GD 2.2.2 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagefilledarc_variation2.phpt
+++ b/ext/gd/tests/imagefilledarc_variation2.phpt
@@ -10,6 +10,9 @@ gd
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
     die("skip test requires GD 2.2.2 or higher");
 }
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagefilledellipse_basic.phpt
+++ b/ext/gd/tests/imagefilledellipse_basic.phpt
@@ -2,6 +2,12 @@
 Testing imagefilledellipse() of GD library
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagefilledpolygon_basic.phpt
+++ b/ext/gd/tests/imagefilledpolygon_basic.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists('imagefilledpolygon')) die('skip imagefilledpolygon() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagefilltoborder_basic.phpt
+++ b/ext/gd/tests/imagefilltoborder_basic.phpt
@@ -5,6 +5,12 @@ Ivan Rosolen <contato [at] ivanrosolen [dot] com>
 #testfest PHPSP on 2009-06-30
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 // Create a image

--- a/ext/gd/tests/imagefilter.phpt
+++ b/ext/gd/tests/imagefilter.phpt
@@ -4,7 +4,7 @@ imagefilter() function test
 gd
 --SKIPIF--
 <?php
-    if (!function_exists("imagefilter")) die("skip requires bundled GD library\n");
+    if (!function_exists("imagefilter")) die("skip requires imagefilter function");
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagefilter.phpt
+++ b/ext/gd/tests/imagefilter.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists("imagefilter")) die("skip requires imagefilter function");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagegammacorrect_basic.phpt
+++ b/ext/gd/tests/imagegammacorrect_basic.phpt
@@ -10,6 +10,9 @@ gd
     if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
         die("skip test requires GD 2.2.2 or higher");
     }
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagegammacorrect_variation1.phpt
+++ b/ext/gd/tests/imagegammacorrect_variation1.phpt
@@ -10,6 +10,9 @@ gd
     if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
         die("skip test requires GD 2.2.2 or higher");
     }
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagegammacorrect_variation2.phpt
+++ b/ext/gd/tests/imagegammacorrect_variation2.phpt
@@ -2,6 +2,12 @@
 Apply imagegammacorrect() to a step wedge
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/imageopenpolygon_basic.phpt
+++ b/ext/gd/tests/imageopenpolygon_basic.phpt
@@ -2,6 +2,12 @@
 imageopenpolygon(): basic test
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/imagepolygon_aa.phpt
+++ b/ext/gd/tests/imagepolygon_aa.phpt
@@ -2,6 +2,12 @@
 antialiased imagepolygon()
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';

--- a/ext/gd/tests/imagepolygon_basic.phpt
+++ b/ext/gd/tests/imagepolygon_basic.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists('imagepolygon')) die('skip imagepolygon() not available');
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagerectangle_basic.phpt
+++ b/ext/gd/tests/imagerectangle_basic.phpt
@@ -5,6 +5,12 @@ Ivan Rosolen <contato [at] ivanrosolen [dot] com>
 #testfest PHPSP on 2009-06-30
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 // Create a image

--- a/ext/gd/tests/imageresolution_png.phpt
+++ b/ext/gd/tests/imageresolution_png.phpt
@@ -2,6 +2,12 @@
 Set and get image resolution of PNG images
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $filename = __DIR__ . DIRECTORY_SEPARATOR . 'imageresolution_png.png';

--- a/ext/gd/tests/imagerotate_overflow.phpt
+++ b/ext/gd/tests/imagerotate_overflow.phpt
@@ -2,12 +2,6 @@
 imagerotate() overflow with negative numbers
 --EXTENSIONS--
 gd
---SKIPIF--
-<?php
-    if (!function_exists('imagerotate')) {
-        die("skip imagerotate() not available.");
-    }
-?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/imagesetbrush_basic.phpt
+++ b/ext/gd/tests/imagesetbrush_basic.phpt
@@ -5,6 +5,12 @@ Erick Belluci Tedeschi <erickbt86 [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 // Create the brush image

--- a/ext/gd/tests/imagesetthickness_basic.phpt
+++ b/ext/gd/tests/imagesetthickness_basic.phpt
@@ -7,6 +7,9 @@ gd
 --SKIPIF--
 <?php
     if (!function_exists("imagecreatetruecolor")) die("skip GD Version not compatible");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagestring_basic.phpt
+++ b/ext/gd/tests/imagestring_basic.phpt
@@ -5,6 +5,12 @@ Rafael Dohms <rdohms [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/imagestringup_basic.phpt
+++ b/ext/gd/tests/imagestringup_basic.phpt
@@ -5,6 +5,12 @@ Rafael Dohms <rdohms [at] gmail [dot] com>
 #testfest PHPSP on 2009-06-20
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 $image = imagecreatetruecolor(180, 30);

--- a/ext/gd/tests/imagetruecolortopalette_basic.phpt
+++ b/ext/gd/tests/imagetruecolortopalette_basic.phpt
@@ -10,6 +10,9 @@ gd
         die("skip test requires GD 2.2.2 or higher");
     }
     if (!function_exists("imagecreatetruecolor")) die("skip GD Version not compatible");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/libgd00086_extern.phpt
+++ b/ext/gd/tests/libgd00086_extern.phpt
@@ -5,6 +5,9 @@ gd
 --SKIPIF--
 <?php
     if (GD_BUNDLED) die("skip requires external GD library\n");
+    if (!(imagetypes() & IMG_PNG)) {
+        die("skip No PNG support");
+    }
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/test_image_equals_file_palette.phpt
+++ b/ext/gd/tests/test_image_equals_file_palette.phpt
@@ -2,6 +2,12 @@
 test_image_equals_file(): comparing palette images
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if (!(imagetypes() & IMG_PNG)) {
+    die("skip No PNG support");
+}
+?>
 --FILE--
 <?php
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'func.inc';


### PR DESCRIPTION
This was merged a long time ago but I didn't know the rules back then and targeted 8.4. It's a bug fix so I think it belongs.

I've been patching until now but every time I upgrade 8.3.x our CI yells at me for having a 40KiB patch.
