### PR TITLE
Fix GH-17645: FPM with httpd ProxyPass does not decode script path

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -817,6 +817,12 @@ enable_dl = Off
 ; https://php.net/fastcgi.impersonate
 ;fastcgi.impersonate = 1
 
+; Prevent decoding of SCRIPT_FILENAME when using Apache ProxyPass or
+; ProxyPassMatch. This should only be used if script file paths are already
+; stored in an encoded format on the file system.
+; Default is 0.
+;fastcgi.script_path_encoded = 1
+
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
 ; this feature.
 ;fastcgi.logging = 0

--- a/php.ini-production
+++ b/php.ini-production
@@ -819,6 +819,12 @@ enable_dl = Off
 ; https://php.net/fastcgi.impersonate
 ;fastcgi.impersonate = 1
 
+; Prevent decoding of SCRIPT_FILENAME when using Apache ProxyPass or
+; ProxyPassMatch. This should only be used if script file paths are already
+; stored in an encoded format on the file system.
+; Default is 0.
+;fastcgi.script_path_encoded = 1
+
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
 ; this feature.
 ;fastcgi.logging = 0

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-decoding.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-decoding.phpt
@@ -1,0 +1,54 @@
+--TEST--
+FPM: FastCGI change for Apache ProxyPass SCRIPT_FILENAME decoding (GH-17645)
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[cgi.fix_pathinfo] = yes
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$_SERVER["SCRIPT_NAME"] . "\n";
+echo \$_SERVER["ORIG_SCRIPT_NAME"] . "\n";
+echo \$_SERVER["SCRIPT_FILENAME"] . "\n";
+echo \$_SERVER["PATH_INFO"] . "\n";
+echo \$_SERVER["PHP_SELF"];
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName('+');
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(
+        uri: $scriptName . '/1%202',
+        scriptFilename: "proxy:fcgi://" . $tester->getAddr() . str_replace('+', '%2B', $sourceFilePath) . '/1%202',
+        scriptName: $scriptName . '/1 2'
+    )
+    ->expectBody([$scriptName, $scriptName . '/1 2', $sourceFilePath, '/1 2', $scriptName . '/1 2']);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-encoded.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-encoded.phpt
@@ -1,0 +1,55 @@
+--TEST--
+FPM: FastCGI change for Apache ProxyPass SCRIPT_FILENAME decoding - fallback (GH-17645)
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[cgi.fix_pathinfo] = yes
+php_admin_value[fastcgi.script_path_encoded] = yes
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$_SERVER["SCRIPT_NAME"] . "\n";
+echo \$_SERVER["ORIG_SCRIPT_NAME"] . "\n";
+echo \$_SERVER["SCRIPT_FILENAME"] . "\n";
+echo \$_SERVER["PATH_INFO"] . "\n";
+echo \$_SERVER["PHP_SELF"];
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName('%2B');
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(
+        uri: $scriptName . '/1%202',
+        scriptFilename: "proxy:fcgi://" . $tester->getAddr() . $sourceFilePath . '/1%202',
+        scriptName: $scriptName . '/1 2'
+    )
+    ->expectBody([$scriptName, $scriptName . '/1 2', $sourceFilePath, '/1 2', $scriptName . '/1 2']);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -47,7 +47,7 @@ class Tester
         self::FILE_EXT_LOG_ERR,
         self::FILE_EXT_LOG_SLOW,
         self::FILE_EXT_PID,
-        'src.php',
+        '*src.php',
         'ini',
         'skip.ini',
         '*.sock',
@@ -106,6 +106,11 @@ class Tester
      * @var string
      */
     private string $fileName;
+
+    /**
+     * @var string
+     */
+    private ?string $sourceFile = null;
 
     /**
      * @var resource
@@ -1483,21 +1488,27 @@ class Tester
     /**
      * Create a source code file.
      *
+     * @param string $nameSuffix
      * @return string
      */
-    public function makeSourceFile(): string
+    public function makeSourceFile(string $nameSuffix = ''): string
     {
-        return $this->makeFile('src.php', $this->code, overwrite: false);
+        if (is_null($this->sourceFile)) {
+            $this->sourceFile = $this->makeFile($nameSuffix . 'src.php', $this->code, overwrite: false);
+        }
+
+        return $this->sourceFile;
     }
 
     /**
      * Create a source file and script name.
      *
+     * @param string $nameSuffix
      * @return string[]
      */
-    public function createSourceFileAndScriptName(): array
+    public function createSourceFileAndScriptName(string $nameSuffix = ''): array
     {
-        $sourceFile = $this->makeFile('src.php', $this->code, overwrite: false);
+        $sourceFile = $this->makeSourceFile($nameSuffix);
 
         return [$sourceFile, '/' . basename($sourceFile)];
     }


### PR DESCRIPTION
This always decodes SCRIPT_FILENAME when Apache ProxyPass or ProxyPassMatch is used. It also introduces a new INI option fastcgi.script_path_encoded that allows using previous behavior of not decoding as there is a chance that some users could use encoded file paths in FS.