### PR TITLE
Fix GH-17899: zend_test_compile_string crash on invalid script path.

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1334,7 +1334,12 @@ zend_string *accel_make_persistent_key(zend_string *str)
 		    EXPECTED((parent_script = zend_get_executed_filename_ex()) != NULL)) {
 
 			parent_script_len = ZSTR_LEN(parent_script);
-			while ((--parent_script_len > 0) && !IS_SLASH(ZSTR_VAL(parent_script)[parent_script_len]));
+			while (parent_script_len > 0) {
+				--parent_script_len;
+				if (IS_SLASH(ZSTR_VAL(parent_script)[parent_script_len])) {
+					break;
+				}
+			}
 
 			if (UNEXPECTED((size_t)(key_length + parent_script_len + 1) >= ZCG_KEY_LEN)) {
 				return NULL;

--- a/ext/zend_test/tests/gh17899.phpt
+++ b/ext/zend_test/tests/gh17899.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-17899 (zend_test_compile_string with opcache crash on invalid script path)
+--EXTENSIONS--
+zend_test
+--INI--
+opcache.enable_cli=1
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$source = '<?php
+require("sumfile.php");
+?>';
+try {zend_test_compile_string($source,$source,$c);} catch (Exception $e) { echo($e); }
+--EXPECTF--
+
+Warning: Undefined variable $c in %s on line %d
+
+Deprecated: zend_test_compile_string(): Passing null to parameter #3 ($position) of type int is deprecated in %s on line %d
+
+Warning: require(sumfile.php): Failed to open stream: No such file or directory in <?php
+require("sumfile.php");
+?> on line %d
+
+Fatal error: Uncaught Error: Failed opening required 'sumfile.php' (include_path='.%s') in <?php
+require("sumfile.php");
+?>:%d
+Stack trace:
+#0 %s(%d): zend_test_compile_string('<?php\nrequire("...', '<?php\nrequire("...', NULL)
+#1 {main}
+  thrown in <?php
+require("sumfile.php");
+?> on line %d
+


### PR DESCRIPTION
when opcache is enabled.