### PR TITLE
Remove pointless call to zval_ptr_dtor() in sqlite3

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2122,7 +2122,6 @@ static int php_sqlite3_authorizer(void *autharg, int action, const char *arg1, c
 
 	/* Free local return and argument values */
 	zval_ptr_dtor(&retval);
-	zval_ptr_dtor(&argv[0]);
 	zval_ptr_dtor(&argv[1]);
 	zval_ptr_dtor(&argv[2]);
 	zval_ptr_dtor(&argv[3]);


### PR DESCRIPTION
This is IS_LONG.