### PR TITLE
Fix GH-17900 and GH-8084

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -969,10 +969,6 @@ void php_mysqli_init(INTERNAL_FUNCTION_PARAMETERS, bool is_method)
 	MYSQLI_RESOURCE *mysqli_resource;
 	MY_MYSQL *mysql;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
-
 	if (is_method && (Z_MYSQLI_P(getThis()))->ptr) {
 		return;
 	}
@@ -1004,6 +1000,7 @@ void php_mysqli_init(INTERNAL_FUNCTION_PARAMETERS, bool is_method)
 /* {{{ Initialize mysqli and return a resource for use with mysql_real_connect */
 PHP_FUNCTION(mysqli_init)
 {
+	ZEND_PARSE_PARAMETERS_NONE();
 	php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
 }
 /* }}} */

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -72,12 +72,14 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, bool is_real_connect, b
 	}
 #endif
 
-	if (UNEXPECTED(in_ctor && (Z_MYSQLI_P(object))->ptr)) {
-		zend_throw_error(NULL, "Cannot call constructor twice");
-		return;
-	}
-
 	if (in_ctor && !ZEND_NUM_ARGS()) {
+		ZEND_PARSE_PARAMETERS_NONE();
+
+		if (UNEXPECTED(Z_MYSQLI_P(object)->ptr)) {
+			zend_throw_error(NULL, "Cannot call constructor twice");
+			return;
+		}
+
 		php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, in_ctor);
 		return;
 	}
@@ -89,10 +91,13 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, bool is_real_connect, b
 			RETURN_THROWS();
 		}
 
+		if (UNEXPECTED(in_ctor && Z_MYSQLI_P(object)->ptr)) {
+			zend_throw_error(NULL, "Cannot call constructor twice");
+			return;
+		}
+	
 		if (object) {
-#if ZEND_DEBUG
 			ZEND_ASSERT(instanceof_function(Z_OBJCE_P(object), mysqli_link_class_entry));
-#endif
 			mysqli_resource = (Z_MYSQLI_P(object))->ptr;
 			if (mysqli_resource && mysqli_resource->ptr) {
 				mysql = (MY_MYSQL*) mysqli_resource->ptr;
@@ -332,6 +337,7 @@ PHP_METHOD(mysqli, __construct)
 /* {{{ Initialize mysqli and return a resource for use with mysql_real_connect */
 PHP_METHOD(mysqli, init)
 {
+	ZEND_PARSE_PARAMETERS_NONE();
 	php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
 }
 /* }}} */

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -72,7 +72,12 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, bool is_real_connect, b
 	}
 #endif
 
-	if (getThis() && !ZEND_NUM_ARGS() && in_ctor) {
+	if (UNEXPECTED(in_ctor && (Z_MYSQLI_P(object))->ptr)) {
+		zend_throw_error(NULL, "Cannot call constructor twice");
+		return;
+	}
+
+	if (in_ctor && !ZEND_NUM_ARGS()) {
 		php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, in_ctor);
 		return;
 	}
@@ -85,7 +90,9 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, bool is_real_connect, b
 		}
 
 		if (object) {
+#if ZEND_DEBUG
 			ZEND_ASSERT(instanceof_function(Z_OBJCE_P(object), mysqli_link_class_entry));
+#endif
 			mysqli_resource = (Z_MYSQLI_P(object))->ptr;
 			if (mysqli_resource && mysqli_resource->ptr) {
 				mysql = (MY_MYSQL*) mysqli_resource->ptr;

--- a/ext/mysqli/tests/gh17900.phpt
+++ b/ext/mysqli/tests/gh17900.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-17900 (Assertion failure ext/mysqli/mysqli_prop.c)
+--EXTENSIONS--
+mysqli
+--FILE--
+<?php
+mysqli_report(MYSQLI_REPORT_OFF);
+$mysqli = new mysqli();
+try {
+    $mysqli->__construct('doesnotexist');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot call constructor twice

--- a/ext/mysqli/tests/mysqli_incomplete_initialization.phpt
+++ b/ext/mysqli/tests/mysqli_incomplete_initialization.phpt
@@ -12,8 +12,8 @@ $mysqli->close();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: mysqli object is not fully initialized in %s:%d
+Fatal error: Uncaught Error: Cannot call constructor twice in %s:%d
 Stack trace:
-#0 %s(%d): mysqli->close()
+#0 %s(%d): mysqli->__construct('doesnotexist')
 #1 {main}
   thrown in %s on line %d


### PR DESCRIPTION
Calling the constructor twice has no real world benefit. Block it to fix these two issues.
We also clean up the constructor code a bit:
`in_ctor` implies `object` exists, and some conditions are only possible with `object` set.

Closes GH-17900.
Closes GH-8084.