### PR TITLE
Fix GH-15834: Segfault with hook "simple get" cache slot and minimal JIT

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -1316,7 +1316,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 	uint32_t target_label, target_label2;
 	uint32_t op1_info, op1_def_info, op2_info, res_info, res_use_info, op1_mem_info;
 	zend_jit_addr op1_addr, op1_def_addr, op2_addr, op2_def_addr, res_addr;
-	zend_class_entry *ce;
+	zend_class_entry *ce = NULL;
 	bool ce_is_instanceof;
 	bool on_this;
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2719,7 +2719,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 					/* If a simple hook is called, exit to the VM. */
 					ir_ref if_hook_enter = ir_IF(jit_CMP_IP(jit, IR_EQ, opline + 1));
 					ir_IF_FALSE(if_hook_enter);
-					if (GCC_GLOBAL_REGS || zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+					if (GCC_GLOBAL_REGS) {
 						ir_TAILCALL(IR_VOID, ir_LOAD_A(jit_IP(jit)));
 					} else {
 						ir_RETURN(ir_CONST_I32(1)); /* ZEND_VM_ENTER */

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2710,6 +2710,23 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						call_level--;
 					}
 					break;
+				case ZEND_FETCH_OBJ_R:
+					if (!zend_jit_handler(&ctx, opline,
+						zend_may_throw(opline, ssa_op, op_array, ssa))) {
+						goto jit_failure;
+					}
+
+					/* If a simple hook is called, exit to the VM. */
+					ir_ref if_hook_enter = ir_IF(jit_CMP_IP(jit, IR_EQ, opline + 1));
+					ir_IF_FALSE(if_hook_enter);
+					if (GCC_GLOBAL_REGS || zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+						ir_TAILCALL(IR_VOID, ir_LOAD_A(jit_IP(jit)));
+					} else {
+						ir_RETURN(ir_CONST_I32(1)); /* ZEND_VM_ENTER */
+					}
+					ir_IF_TRUE(if_hook_enter);
+
+					break;
 				default:
 					if (!zend_jit_handler(&ctx, opline,
 							zend_may_throw(opline, ssa_op, op_array, ssa))) {

--- a/ext/opcache/tests/jit/gh15834.phpt
+++ b/ext/opcache/tests/jit/gh15834.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-15834 (Segfault with hook "simple get" cache slot and minimal JIT)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=1111
+--FILE--
+<?php
+class A {
+    public $_prop = 1;
+    public $prop {
+        get => $this->_prop;
+    }
+}
+
+$a = new A;
+for ($i=0;$i<5;$i++) {
+    echo $a->prop;
+    $a->_prop++;
+}
+?>
+--EXPECT--
+12345


### PR DESCRIPTION
The FETCH_OBJ_R VM handler has an optimization that directly enters into a hook if it is a simpler getter hook. This is not compatible with the minimal JIT because the minimal JIT will try to continue executing the opcodes after the FETCH_OBJ_R.
To solve this, we check whether the opcode is still the expected one after the execution of the VM handler. If it is not, we know that we are going to execute a simple hook. In that case, exit to the VM.

Normally, I wouldn't care too much about this issue, because it is in minimal JIT. However, someone had this cause a crash to them by accident: https://github.com/php/php-src/issues/17767