### PR TITLE
ext/gd/tests/gh17373.phpt: skip if imagefttext() is not available

### DIFF
--- a/ext/gd/tests/gh17373.phpt
+++ b/ext/gd/tests/gh17373.phpt
@@ -2,6 +2,10 @@
 Bug GH-17373 (imagefttext() ignores clipping rect for palette images)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+if(!function_exists('imagefttext')) die('skip imagefttext() not available');
+?>
 --FILE--
 <?php
 $im = imagecreate(64, 32);


### PR DESCRIPTION
This test calls `imagefttext()`, which may not be available if libgd was built without freetype support.

Closes GH-17891

(Thanks @cmb69)