### PR TITLE
Fix GH-17921 socket_read/socket_recv overflows on buffer size.

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -884,7 +884,7 @@ PHP_FUNCTION(socket_read)
 	ENSURE_SOCKET_VALID(php_sock);
 
 	/* overflow check */
-	if ((length + 1) < 2) {
+	if (length <= 0 || length == ZEND_LONG_MAX) {
 		RETURN_FALSE;
 	}
 
@@ -1326,7 +1326,7 @@ PHP_FUNCTION(socket_recv)
 	ENSURE_SOCKET_VALID(php_sock);
 
 	/* overflow check */
-	if ((len + 1) < 2) {
+	if (len <= 0 || len == ZEND_LONG_MAX) {
 		RETURN_FALSE;
 	}
 

--- a/ext/sockets/tests/gh17921.phpt
+++ b/ext/sockets/tests/gh17921.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-16267 - overflow on socket_strerror argument
+--EXTENSIONS--
+sockets
+--FILE--
+<?php
+$s_c_l = socket_create_listen(0);
+var_dump(socket_read($s_c_l, PHP_INT_MAX));
+var_dump(socket_read($s_c_l, PHP_INT_MIN));
+$a = "";
+var_dump(socket_recv($s_c_l, $a, PHP_INT_MAX, 0));
+var_dump(socket_recv($s_c_l, $a, PHP_INT_MIN, 0));
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
update the existing checks to be more straightforward instead of counting on undefined behavior.