### PR TITLE
GitHub actions: add new automation to limit directory sizes

### DIFF
--- a/.github/actions/verify-directory-sizes/action.yml
+++ b/.github/actions/verify-directory-sizes/action.yml
@@ -1,0 +1,6 @@
+name: Verify directories are not too big
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: bash "${GITHUB_WORKSPACE}/.github/actions/verify-directory-sizes/script.sh"

--- a/.github/actions/verify-directory-sizes/script.sh
+++ b/.github/actions/verify-directory-sizes/script.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eu
+set +x
+
+# Bash script to check directory sizes, we want to keep each directory under
+# at most 1000 entries so that the GitHub online interface can be used to
+# browse without excluding files
+MAX_DIR_SIZE=0
+MAX_DIR_NAME=0
+
+# This is enforced limit
+DIR_SIZE_LIMIT=1000
+
+check_directory () {
+    local CURR_DIR=$1
+    local CURR_DIR_SIZE=$(ls -l $CURR_DIR | wc -l)
+    if [ "$CURR_DIR_SIZE" -gt "$DIR_SIZE_LIMIT" ]; then
+        # Show the same message but in red
+        echo -e "\033[0;31m$CURR_DIR has $CURR_DIR_SIZE entries\033[0m"
+    else
+        echo "$CURR_DIR has $CURR_DIR_SIZE entries"
+    fi
+    if [ "$CURR_DIR_SIZE" -gt "$MAX_DIR_SIZE" ]; then
+        MAX_DIR_SIZE=$CURR_DIR_SIZE
+        MAX_DIR_NAME=$CURR_DIR
+    fi
+
+    # Sending stderr to /dev/null is used to suppress errors about no such
+    # file or directory when a directory has no sub directories
+    local SUBDIRS=$(ls -d $CURR_DIR*/ 2>/dev/null)
+    for SUBDIR in $SUBDIRS
+    do
+        check_directory $SUBDIR
+    done
+}
+
+check_directory ./
+
+echo "Biggest directory: $MAX_DIR_NAME"
+echo "Size: $MAX_DIR_SIZE"
+
+if [ "$MAX_DIR_SIZE" -gt "$DIR_SIZE_LIMIT" ]; then
+    echo -e "\033[0;31mMaximum allowed size: $DIR_SIZE_LIMIT\033[0m"
+    # Action is unsuccessful
+    exit 1
+fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Verify generated files are up to date
         if: ${{ !matrix.asan }}
         uses: ./.github/actions/verify-generated-files
+      - name: Verify directories are not too big
+        if: ${{ !matrix.asan }}
+        uses: ./.github/actions/verify-directory-sizes
   LINUX_X32:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     name: LINUX_X32_DEBUG_ZTS


### PR DESCRIPTION
After discovering in August that Zend/tests had over 2500 entries, and that GitHub limits the display to only the first 1000 entries, I filed GH-15631 and sent a whole slew of patches to split up that directory and organize the tests a bit better. After the most recent patch, GH-17920, there are now once again fewer than 1,000 entries in that directory (for what seems to be the first time since the PHP 5.3 development cycle).

Add a new GitHub action to the test suite that will ensure that no directory gets above 1,000 items - while the Zend/tests directory was the only one that had already hit that limit, there isn't much harm in checking all of the directories, and some of the extensions have hundreds of tests already and could conceivably hit the limit at some point.

Closes GH-15631