### PR TITLE
Fix RCn array modification violation with ArrayObject serialize

### DIFF
--- a/Zend/tests/gh17935.phpt
+++ b/Zend/tests/gh17935.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-17935: RCn array modification violation with ArrayObject serialize
+--FILE--
+<?php
+
+$o = new ArrayObject();
+$o['a'] = 'a';
+$s = $o->__serialize();
+$o['b'] = 'b';
+var_dump($o, $s);
+
+?>
+--EXPECT--
+object(ArrayObject)#1 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(2) {
+    ["a"]=>
+    string(1) "a"
+    ["b"]=>
+    string(1) "b"
+  }
+}
+array(4) {
+  [0]=>
+  int(0)
+  [1]=>
+  array(1) {
+    ["a"]=>
+    string(1) "a"
+  }
+  [2]=>
+  array(0) {
+  }
+  [3]=>
+  NULL
+}

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1774,7 +1774,7 @@ PHP_METHOD(ArrayObject, __serialize)
 	if (intern->ar_flags & SPL_ARRAY_IS_SELF) {
 		ZVAL_NULL(&tmp);
 	} else {
-		ZVAL_COPY(&tmp, &intern->array);
+		ZVAL_DUP(&tmp, &intern->array);
 	}
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &tmp);
 


### PR DESCRIPTION
We seem to be assuming that the ArrayObject has exclusive access to the underlying array value. The existing RC hacks seems peculiar and should be investigated...

Fixes GH-17935

Honestly, not sure if this is worth fixing.