### PR TITLE
Fix GH-17941: Stack-use-after-return with lazy objects and hooks

### DIFF
--- a/Zend/tests/lazy_objects/gh17941.phpt
+++ b/Zend/tests/lazy_objects/gh17941.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-17941 (Stack-use-after-return with lazy objects and hooks)
+--FILE--
+<?php
+
+class SubClass {
+    public $prop {get => $this->prop; set($x) => $this->prop = $x;}
+}
+
+$rc = new ReflectionClass(SubClass::class);
+$obj = $rc->newLazyProxy(function ($object) {
+    echo "init\n";
+    return new SubClass;
+});
+
+function foo(SubClass $x) {
+    $x->prop = 1;
+    var_dump($x->prop);
+}
+
+foo($obj);
+
+?>
+--EXPECT--
+init
+int(1)

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1198,6 +1198,11 @@ lazy_init:;
 
 	variable_ptr = zend_std_write_property(zobj, name, &backup, cache_slot);
 	zval_ptr_dtor(&backup);
+
+	if (variable_ptr == &backup) {
+		variable_ptr = value;
+	}
+
 	return variable_ptr;
 }
 /* }}} */


### PR DESCRIPTION
zend_std_write_property() can return the variable pointer, but the code
    was using a local variable, and so a pointer to a local variable could
    be returned. Fix this by using the value pointer instead of the backup
    value was written.
