### PR TITLE
ext/sockets: adding SO_BUSY_POLL socket option for Linux.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -145,6 +145,7 @@ PHP                                                                        NEWS
   . socket_getsockname/socket_create/socket_bind handled AF_PACKET family socket.
     (David Carlier)
   . Added IP_BINDANY for a socket to bind to any address. (David Carlier)
+  . Added SO_BUSY_POOL to reduce packets poll latency. (David Carlier)
 
 - Sodium:
   . Fix overall theorical overflows on zend_string buffer allocations.

--- a/UPGRADING
+++ b/UPGRADING
@@ -301,6 +301,7 @@ PHP 8.5 UPGRADE NOTES
   . TCP_BBR_ALGORITHM (FreeBSD only).
   . AF_PACKET (Linux only).
   . IP_BINDANY (FreeBSD/NetBSD/OpenBSD only).
+  . SO_BUSY_POLL (Linux only).
 
 ========================================
 11. Changes to INI File Handling

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -454,6 +454,13 @@ const SO_BPF_EXTENSIONS = UNKNOWN;
  */
 const SO_EXCLBIND = UNKNOWN;
 #endif
+#ifdef SO_BUSY_POLL
+/**
+ * @var int
+ * @cvalue SO_BUSY_POLL
+ */
+const SO_BUSY_POLL = UNKNOWN;
+#endif
 #ifdef SKF_AD_OFF
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aac197335037777d31d83d4a4040bbfcd0c55813 */
+ * Stub hash: 42d486d2666d23569e70860e2b1ef203161792b3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -475,6 +475,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(SO_EXCLBIND)
 	REGISTER_LONG_CONSTANT("SO_EXCLBIND", SO_EXCLBIND, CONST_PERSISTENT);
+#endif
+#if defined(SO_BUSY_POLL)
+	REGISTER_LONG_CONSTANT("SO_BUSY_POLL", SO_BUSY_POLL, CONST_PERSISTENT);
 #endif
 #if defined(SKF_AD_OFF)
 	REGISTER_LONG_CONSTANT("SKF_AD_OFF", SKF_AD_OFF, CONST_PERSISTENT);


### PR DESCRIPTION
To possibly reduce the latency when polling packets by activating it from the network interface for N microseconds.
The kernel by doing so, increase the CPU(s) activity bound to the socket significantly.
Note that not only the kernel needs to have support enabled for it (which the average distribution usually does) but the network interface itself needs to support it too. If not, it is just a no-op.