### PR TITLE
Make missing trait error recoverable

### DIFF
--- a/Zend/tests/traits/bugs/missing-trait.phpt
+++ b/Zend/tests/traits/bugs/missing-trait.phpt
@@ -12,4 +12,7 @@ $test = new TraitsTest();
 
 ?>
 --EXPECTF--
-Fatal error: Trait "THello" not found in %s on line %d
+Fatal error: Uncaught Error: Trait "THello" not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/error_002.phpt
+++ b/Zend/tests/traits/error_002.phpt
@@ -9,4 +9,7 @@ class A {
 
 ?>
 --EXPECTF--
-Fatal error: Trait "abc" not found in %s on line %d
+Fatal error: Uncaught Error: Trait "abc" not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/error_003.phpt
+++ b/Zend/tests/traits/error_003.phpt
@@ -12,4 +12,7 @@ class A {
 
 ?>
 --EXPECTF--
-Fatal error: A cannot use abc - it is not a trait in %s on line %d
+Fatal error: Uncaught Error: A cannot use abc - it is not a trait in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/error_004.phpt
+++ b/Zend/tests/traits/error_004.phpt
@@ -12,4 +12,7 @@ class A {
 
 ?>
 --EXPECTF--
-Fatal error: A cannot use abc - it is not a trait in %s on line %d
+Fatal error: Uncaught Error: A cannot use abc - it is not a trait in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/error_005.phpt
+++ b/Zend/tests/traits/error_005.phpt
@@ -12,4 +12,7 @@ class A {
 
 ?>
 --EXPECTF--
-Fatal error: A cannot use abc - it is not a trait in %s on line %d
+Fatal error: Uncaught Error: A cannot use abc - it is not a trait in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/error_006.phpt
+++ b/Zend/tests/traits/error_006.phpt
@@ -12,4 +12,7 @@ class A {
 
 ?>
 --EXPECTF--
-Fatal error: A cannot use abc - it is not a trait in %s on line %d
+Fatal error: Uncaught Error: A cannot use abc - it is not a trait in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/traits/gh17959.phpt
+++ b/Zend/tests/traits/gh17959.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-17959: Missing trait error is recoverable
+--FILE--
+<?php
+
+try {
+    class C {
+        use MissingTrait;
+    }
+} catch (Error $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+
+?>
+===DONE===
+--EXPECT--
+Error: Trait "MissingTrait" not found
+===DONE===

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3541,7 +3541,7 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 				return NULL;
 			}
 			if (UNEXPECTED(!(trait->ce_flags & ZEND_ACC_TRAIT))) {
-				zend_error_noreturn(E_ERROR, "%s cannot use %s - it is not a trait", ZSTR_VAL(ce->name), ZSTR_VAL(trait->name));
+				zend_throw_error(NULL, "%s cannot use %s - it is not a trait", ZSTR_VAL(ce->name), ZSTR_VAL(trait->name));
 				free_alloca(traits_and_interfaces, use_heap);
 				return NULL;
 			}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3535,7 +3535,7 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 
 		for (i = 0; i < ce->num_traits; i++) {
 			zend_class_entry *trait = zend_fetch_class_by_name(ce->trait_names[i].name,
-				ce->trait_names[i].lc_name, ZEND_FETCH_CLASS_TRAIT);
+				ce->trait_names[i].lc_name, ZEND_FETCH_CLASS_TRAIT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(trait == NULL)) {
 				free_alloca(traits_and_interfaces, use_heap);
 				return NULL;


### PR DESCRIPTION
We were already handling NULL as a case, but seem to have forgotten to pass the ZEND_FETCH_CLASS_EXCEPTION flag.

Fixes GH-17959