### PR TITLE
Fix destruction of dl'ed module classes

### DIFF
--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -107,6 +107,7 @@ PHP_MINIT_FUNCTION(dl_test)
 	register_class_DlTest();
 	ce = register_class_DlTestSuperClass();
 	register_class_DlTestSubClass(ce);
+	register_class_DlTestAliasedClass();
 
 	/* Test backwards compatibility */
 	if (getenv("PHP_DL_TEST_USE_OLD_REGISTER_INI_ENTRIES")) {

--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -92,10 +92,21 @@ PHP_METHOD(DlTest, test)
 	RETURN_STR(retval);
 }
 
+PHP_METHOD(DlTestSuperClass, test)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_NULL();
+}
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(dl_test)
 {
+	zend_class_entry *ce;
+
 	register_class_DlTest();
+	ce = register_class_DlTestSuperClass();
+	register_class_DlTestSubClass(ce);
 
 	/* Test backwards compatibility */
 	if (getenv("PHP_DL_TEST_USE_OLD_REGISTER_INI_ENTRIES")) {

--- a/ext/dl_test/dl_test.stub.php
+++ b/ext/dl_test/dl_test.stub.php
@@ -12,3 +12,11 @@ function dl_test_test2(string $str = ""): string {}
 class DlTest {
     public function test(string $str = ""): string {}
 }
+
+class DlTestSuperClass {
+    public int $a;
+    public function test(string $str = ""): string {}
+}
+
+class DlTestSubClass extends DlTestSuperClass {
+}

--- a/ext/dl_test/dl_test.stub.php
+++ b/ext/dl_test/dl_test.stub.php
@@ -20,3 +20,7 @@ class DlTestSuperClass {
 
 class DlTestSubClass extends DlTestSuperClass {
 }
+
+/** @alias DlTestClassAlias */
+class DlTestAliasedClass {
+}

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2dbacf5282b0f8e53923ac70495c2da43c7237e3 */
+ * Stub hash: 70c8eee05cd6efeedac013d60bd436eec91d43c1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -10,10 +10,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DlTest_test arginfo_dl_test_test2
 
+#define arginfo_class_DlTestSuperClass_test arginfo_dl_test_test2
+
 
 ZEND_FUNCTION(dl_test_test1);
 ZEND_FUNCTION(dl_test_test2);
 ZEND_METHOD(DlTest, test);
+ZEND_METHOD(DlTestSuperClass, test);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -28,12 +31,49 @@ static const zend_function_entry class_DlTest_methods[] = {
 	ZEND_FE_END
 };
 
+
+static const zend_function_entry class_DlTestSuperClass_methods[] = {
+	ZEND_ME(DlTestSuperClass, test, arginfo_class_DlTestSuperClass_test, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_DlTestSubClass_methods[] = {
+	ZEND_FE_END
+};
+
 static zend_class_entry *register_class_DlTest(void)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DlTest", class_DlTest_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DlTestSuperClass(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DlTestSuperClass", class_DlTestSuperClass_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	zval property_a_default_value;
+	ZVAL_UNDEF(&property_a_default_value);
+	zend_string *property_a_name = zend_string_init("a", sizeof("a") - 1, 1);
+	zend_declare_typed_property(class_entry, property_a_name, &property_a_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_a_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DlTestSubClass(zend_class_entry *class_entry_DlTestSuperClass)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DlTestSubClass", class_DlTestSubClass_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_DlTestSuperClass);
 
 	return class_entry;
 }

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70c8eee05cd6efeedac013d60bd436eec91d43c1 */
+ * Stub hash: 0641a8eeff00e6c8083fe4a8639f970e3ba80db9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -42,6 +42,11 @@ static const zend_function_entry class_DlTestSubClass_methods[] = {
 	ZEND_FE_END
 };
 
+
+static const zend_function_entry class_DlTestAliasedClass_methods[] = {
+	ZEND_FE_END
+};
+
 static zend_class_entry *register_class_DlTest(void)
 {
 	zend_class_entry ce, *class_entry;
@@ -74,6 +79,17 @@ static zend_class_entry *register_class_DlTestSubClass(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "DlTestSubClass", class_DlTestSubClass_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DlTestSuperClass);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DlTestAliasedClass(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DlTestAliasedClass", class_DlTestAliasedClass_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	zend_register_class_alias("DlTestClassAlias", class_entry);
 
 	return class_entry;
 }


### PR DESCRIPTION
During shutdown, we destroy classes of dl()'ed modules in `clean_module_classes()`:

https://github.com/php/php-src/blob/ff88701b77bd0f3aa738fef495e2e7cc9ad0f5e3/Zend/zend_API.c#L3278-L3281

Child classes of a module use structures of the parent class (such as inherited properties), which is destroyed earlier, so we have a use-after-free when destroying a child class:

```
==477311==ERROR: AddressSanitizer: heap-use-after-free on address 0x50600001b4c0 at pc 0x561078b05961 bp 0x7ffd20dfac20 sp 0x7ffd20dfac18
READ of size 8 at 0x50600001b4c0 thread T0
    #0 0x561078b05960 in destroy_zend_class Zend/zend_opcode.c:447:20
    #1 0x561078c4d44f in _zend_hash_del_el_ex Zend/zend_hash.c:1488:3
    #2 0x561078c4aae1 in _zend_hash_del_el Zend/zend_hash.c:1515:2
    #3 0x561078c5fcea in zend_hash_apply_with_argument Zend/zend_hash.c:2128:5
    #4 0x561078bd75c2 in clean_module_classes Zend/zend_API.c:3128:2
    #5 0x561078bd67cb in module_destructor Zend/zend_API.c:3165:3
    #6 0x561078bd9f91 in zend_post_deactivate_modules Zend/zend_API.c:3291:4
    #7 0x56107876a286 in php_request_shutdown main/main.c:1917:3
    #8 0x56107993f19a in do_cli sapi/cli/php_cli.c:1137:3
    #9 0x56107993a31a in main sapi/cli/php_cli.c:1341:18
    #10 0x7f75b4e2d247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #11 0x7f75b4e2d30a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x330a) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #12 0x561077601fc4 in _start (sapi/cli/php+0x201fc4) (BuildId: 06db8fea59ff1f83339934018c55f48156e833d6)

0x50600001b4c0 is located 32 bytes inside of 56-byte region [0x50600001b4a0,0x50600001b4d8)
freed by thread T0 here:
    #0 0x5610776a1b5a in free (sapi/cli/php+0x2a1b5a) (BuildId: 06db8fea59ff1f83339934018c55f48156e833d6)
    #1 0x561078b05c35 in destroy_zend_class Zend/zend_opcode.c:453:6
    #2 0x561078c4d44f in _zend_hash_del_el_ex Zend/zend_hash.c:1488:3
    #3 0x561078c4aae1 in _zend_hash_del_el Zend/zend_hash.c:1515:2
    #4 0x561078c5fcea in zend_hash_apply_with_argument Zend/zend_hash.c:2128:5
    #5 0x561078bd75c2 in clean_module_classes Zend/zend_API.c:3128:2
    #6 0x561078bd67cb in module_destructor Zend/zend_API.c:3165:3
    #7 0x561078bd9f91 in zend_post_deactivate_modules Zend/zend_API.c:3291:4
    #8 0x56107876a286 in php_request_shutdown main/main.c:1917:3
    #9 0x56107993f19a in do_cli sapi/cli/php_cli.c:1137:3
    #10 0x56107993a31a in main sapi/cli/php_cli.c:1341:18
    #11 0x7f75b4e2d247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #12 0x7f75b4e2d30a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x330a) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #13 0x561077601fc4 in _start (sapi/cli/php+0x201fc4) (BuildId: 06db8fea59ff1f83339934018c55f48156e833d6)
```

This was found by @TimWolla.

In this PR, I destroy classes in reverse order, as it is done in `zend_shutdown()`: https://github.com/php/php-src/blob/ff88701b77bd0f3aa738fef495e2e7cc9ad0f5e3/Zend/zend.c#L1175-L1176

I don't use `zend_hash_reverse_apply()` because I need to pass an argument to the callback, and because of [this comment](https://github.com/php/php-src/blob/ff88701b77bd0f3aa738fef495e2e7cc9ad0f5e3/Zend/zend_hash.h#L161).