### PR TITLE
Add a custom Fast ZPP specifier for php_streams

### DIFF
--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -303,16 +303,15 @@ static PHP_MINFO_FUNCTION(bz2)
 /* {{{ Reads up to length bytes from a BZip2 stream, or 1024 bytes if length is not specified */
 PHP_FUNCTION(bzread)
 {
-	zval *bz;
 	zend_long len = 1024;
 	php_stream *stream;
 	zend_string *data;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &bz, &len)) {
-		RETURN_THROWS();
-	}
-
-	php_stream_from_zval(stream, bz);
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(len)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (len  < 0) {
 		zend_argument_value_error(2, "must be greater than or equal to 0");
@@ -563,17 +562,14 @@ PHP_FUNCTION(bzdecompress)
    The central error handling interface, does the work for bzerrno, bzerrstr and bzerror */
 static void php_bz2_error(INTERNAL_FUNCTION_PARAMETERS, int opt)
 {
-	zval         *bzp;     /* BZip2 Resource Pointer */
 	php_stream   *stream;
 	const char   *errstr;  /* Error string */
 	int           errnum;  /* Error number */
 	struct php_bz2_stream_data_t *self;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &bzp) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	php_stream_from_zval(stream, bzp);
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		PHP_Z_PARAM_STREAM(stream)
+	ZEND_PARSE_PARAMETERS_END();
 
 	if (!php_stream_is(stream, PHP_STREAM_IS_BZIP2)) {
 		zend_argument_type_error(1, "must be a bz2 stream");

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -566,7 +566,7 @@ PHP_FUNCTION(ftp_systype)
 /* {{{ Retrieves a file from the FTP server and writes it to an open file */
 PHP_FUNCTION(ftp_fget)
 {
-	zval		*z_ftp, *z_file;
+	zval		*z_ftp;
 	ftpbuf_t	*ftp;
 	ftptype_t	xtype;
 	php_stream	*stream;
@@ -574,11 +574,16 @@ PHP_FUNCTION(ftp_fget)
 	size_t		file_len;
 	zend_long		mode=FTPTYPE_IMAGE, resumepos=0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ors|ll", &z_ftp, php_ftp_ce, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 5)
+		Z_PARAM_OBJECT_OF_CLASS(z_ftp, php_ftp_ce)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_STRING(file, file_len)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(mode)
+		Z_PARAM_LONG(resumepos)
+	ZEND_PARSE_PARAMETERS_END();
+
 	GET_FTPBUF(ftp, z_ftp);
-	php_stream_from_res(stream, Z_RES_P(z_file));
 	XTYPE(xtype, mode);
 
 	/* ignore autoresume if autoseek is switched off */
@@ -610,7 +615,7 @@ PHP_FUNCTION(ftp_fget)
 /* {{{ Retrieves a file from the FTP server asynchronly and writes it to an open file */
 PHP_FUNCTION(ftp_nb_fget)
 {
-	zval		*z_ftp, *z_file;
+	zval		*z_ftp;
 	ftpbuf_t	*ftp;
 	ftptype_t	xtype;
 	php_stream	*stream;
@@ -618,11 +623,16 @@ PHP_FUNCTION(ftp_nb_fget)
 	size_t		file_len;
 	zend_long		mode=FTPTYPE_IMAGE, resumepos=0, ret;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ors|ll", &z_ftp, php_ftp_ce, &z_file, &file, &file_len, &mode, &resumepos) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 5)
+		Z_PARAM_OBJECT_OF_CLASS(z_ftp, php_ftp_ce)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_STRING(file, file_len)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(mode)
+		Z_PARAM_LONG(resumepos)
+	ZEND_PARSE_PARAMETERS_END();
+
 	GET_FTPBUF(ftp, z_ftp);
-	php_stream_from_res(stream, Z_RES_P(z_file));
 	XTYPE(xtype, mode);
 
 	/* ignore autoresume if autoseek is switched off */
@@ -848,7 +858,7 @@ PHP_FUNCTION(ftp_nb_continue)
 /* {{{ Stores a file from an open file to the FTP server */
 PHP_FUNCTION(ftp_fput)
 {
-	zval		*z_ftp, *z_file;
+	zval		*z_ftp;
 	ftpbuf_t	*ftp;
 	ftptype_t	xtype;
 	size_t		remote_len;
@@ -856,11 +866,16 @@ PHP_FUNCTION(ftp_fput)
 	php_stream	*stream;
 	char		*remote;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Osr|ll", &z_ftp, php_ftp_ce, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 5)
+		Z_PARAM_OBJECT_OF_CLASS(z_ftp, php_ftp_ce)
+		Z_PARAM_STRING(remote, remote_len)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(mode)
+		Z_PARAM_LONG(startpos)
+	ZEND_PARSE_PARAMETERS_END();
+
 	GET_FTPBUF(ftp, z_ftp);
-	php_stream_from_zval(stream, z_file);
 	XTYPE(xtype, mode);
 
 	/* ignore autoresume if autoseek is switched off */
@@ -895,7 +910,7 @@ PHP_FUNCTION(ftp_fput)
 /* {{{ Stores a file from an open file to the FTP server nbronly */
 PHP_FUNCTION(ftp_nb_fput)
 {
-	zval		*z_ftp, *z_file;
+	zval		*z_ftp;
 	ftpbuf_t	*ftp;
 	ftptype_t	xtype;
 	size_t		remote_len;
@@ -904,11 +919,16 @@ PHP_FUNCTION(ftp_nb_fput)
 	php_stream	*stream;
 	char		*remote;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Osr|ll", &z_ftp, php_ftp_ce, &remote, &remote_len, &z_file, &mode, &startpos) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(3, 5)
+		Z_PARAM_OBJECT_OF_CLASS(z_ftp, php_ftp_ce)
+		Z_PARAM_STRING(remote, remote_len)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(mode)
+		Z_PARAM_LONG(startpos)
+	ZEND_PARSE_PARAMETERS_END();
+
 	GET_FTPBUF(ftp, z_ftp);
-	php_stream_from_res(stream, Z_RES_P(z_file));
 	XTYPE(xtype, mode);
 
 	/* ignore autoresume if autoseek is switched off */

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -707,18 +707,20 @@ PHP_FUNCTION(hash_update)
 /* {{{ Pump data into the hashing algorithm from an open stream */
 PHP_FUNCTION(hash_update_stream)
 {
-	zval *zhash, *zstream;
+	zend_object *hash_obj;
 	php_hashcontext_object *hash;
 	php_stream *stream = NULL;
 	zend_long length = -1, didread = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Or|l", &zhash, php_hashcontext_ce, &zstream, &length) == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_OBJ_OF_CLASS(hash_obj, php_hashcontext_ce)
+		PHP_Z_PARAM_STREAM(stream)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(length)
+	ZEND_PARSE_PARAMETERS_END();
 
-	hash = php_hashcontext_from_object(Z_OBJ_P(zhash));
+	hash = php_hashcontext_from_object(hash_obj);
 	PHP_HASHCONTEXT_VERIFY(hash);
-	php_stream_from_zval(stream, zstream);
 
 	while (length) {
 		char buf[1024];

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -6265,21 +6265,18 @@ PHP_FUNCTION(pg_put_copy_end)
 
 PHP_FUNCTION(pg_socket_poll)
 {
-	zval *z_socket;
 	php_stream *stream;
 	php_socket_t socket;
 	zend_long read, write;
 	zend_long ts = -1;
 
 	ZEND_PARSE_PARAMETERS_START(3, 4)
-		Z_PARAM_RESOURCE(z_socket)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(read)
 		Z_PARAM_LONG(write)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(ts)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, z_socket);
 
 	if (php_stream_cast(stream, PHP_STREAM_AS_SOCKETD, (void **)&socket, 0)) {
 		zend_argument_type_error(1, "invalid resource socket");

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -860,17 +860,15 @@ PHP_FUNCTION(fprintf)
 	php_stream *stream;
 	char *format;
 	size_t format_len;
-	zval *arg1, *args;
-	int argc;
+	zval *args = NULL;
+	int argc = 0;
 	zend_string *result;
 
 	ZEND_PARSE_PARAMETERS_START(2, -1)
-		Z_PARAM_RESOURCE(arg1)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_STRING(format, format_len)
 		Z_PARAM_VARIADIC('*', args, argc)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, arg1);
 
 	result = php_formatted_print(format, format_len, args, argc, 2);
 	if (result == NULL) {
@@ -890,18 +888,16 @@ PHP_FUNCTION(vfprintf)
 	php_stream *stream;
 	char *format;
 	size_t format_len;
-	zval *arg1, *args;
+	zval *args;
 	zend_array *array;
 	int argc;
 	zend_string *result;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
-		Z_PARAM_RESOURCE(arg1)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_STRING(format, format_len)
 		Z_PARAM_ARRAY_HT(array)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, arg1);
 
 	args = php_formatted_print_get_array(array, &argc);
 

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -265,11 +265,10 @@ PHP_FUNCTION(stream_socket_accept)
 	php_timeout_ull conv;
 	struct timeval tv;
 	php_stream *stream = NULL, *clistream = NULL;
-	zval *zstream;
 	zend_string *errstr = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_DOUBLE_OR_NULL(timeout, timeout_is_null)
 		Z_PARAM_ZVAL(zpeername)
@@ -281,8 +280,6 @@ PHP_FUNCTION(stream_socket_accept)
 		zend_argument_value_error(2, "must be a finite value");
 		RETURN_THROWS();
 	}
-
-	php_stream_from_zval(stream, zstream);
 
 	/* prepare the timeout value for use */
 	struct timeval *tv_pointer;
@@ -328,16 +325,13 @@ PHP_FUNCTION(stream_socket_accept)
 PHP_FUNCTION(stream_socket_get_name)
 {
 	php_stream *stream;
-	zval *zstream;
 	bool want_peer;
 	zend_string *name = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_BOOL(want_peer)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	if (0 != php_stream_xport_get_name(stream, want_peer,
 				&name,
@@ -359,7 +353,6 @@ PHP_FUNCTION(stream_socket_get_name)
 PHP_FUNCTION(stream_socket_sendto)
 {
 	php_stream *stream;
-	zval *zstream;
 	zend_long flags = 0;
 	char *data, *target_addr = NULL;
 	size_t datalen, target_addr_len = 0;
@@ -367,13 +360,12 @@ PHP_FUNCTION(stream_socket_sendto)
 	socklen_t sl = 0;
 
 	ZEND_PARSE_PARAMETERS_START(2, 4)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_STRING(data, datalen)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(flags)
 		Z_PARAM_STRING(target_addr, target_addr_len)
 	ZEND_PARSE_PARAMETERS_END();
-	php_stream_from_zval(stream, zstream);
 
 	if (target_addr_len) {
 		/* parse the address */
@@ -391,7 +383,7 @@ PHP_FUNCTION(stream_socket_sendto)
 PHP_FUNCTION(stream_socket_recvfrom)
 {
 	php_stream *stream;
-	zval *zstream, *zremote = NULL;
+	zval *zremote = NULL;
 	zend_string *remote_addr = NULL;
 	zend_long to_read = 0;
 	zend_string *read_buf;
@@ -399,14 +391,12 @@ PHP_FUNCTION(stream_socket_recvfrom)
 	int recvd;
 
 	ZEND_PARSE_PARAMETERS_START(2, 4)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(to_read)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(flags)
 		Z_PARAM_ZVAL(zremote)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	if (zremote) {
 		ZEND_TRY_ASSIGN_REF_NULL(zremote);
@@ -441,13 +431,12 @@ PHP_FUNCTION(stream_socket_recvfrom)
 PHP_FUNCTION(stream_get_contents)
 {
 	php_stream *stream;
-	zval *zsrc;
 	zend_long maxlen, desiredpos = -1L;
 	bool maxlen_is_null = 1;
 	zend_string *contents;
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
-		Z_PARAM_RESOURCE(zsrc)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG_OR_NULL(maxlen, maxlen_is_null)
 		Z_PARAM_LONG(desiredpos)
@@ -459,8 +448,6 @@ PHP_FUNCTION(stream_get_contents)
 		zend_argument_value_error(2, "must be greater than or equal to -1");
 		RETURN_THROWS();
 	}
-
-	php_stream_from_zval(stream, zsrc);
 
 	if (desiredpos >= 0) {
 		int		seek_res = 0;
@@ -494,15 +481,14 @@ PHP_FUNCTION(stream_get_contents)
 PHP_FUNCTION(stream_copy_to_stream)
 {
 	php_stream *src, *dest;
-	zval *zsrc, *zdest;
 	zend_long maxlen, pos = 0;
 	bool maxlen_is_null = 1;
 	size_t len;
 	int ret;
 
 	ZEND_PARSE_PARAMETERS_START(2, 4)
-		Z_PARAM_RESOURCE(zsrc)
-		Z_PARAM_RESOURCE(zdest)
+		PHP_Z_PARAM_STREAM(src)
+		PHP_Z_PARAM_STREAM(dest)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG_OR_NULL(maxlen, maxlen_is_null)
 		Z_PARAM_LONG(pos)
@@ -511,9 +497,6 @@ PHP_FUNCTION(stream_copy_to_stream)
 	if (maxlen_is_null) {
 		maxlen = PHP_STREAM_COPY_ALL;
 	}
-
-	php_stream_from_zval(src, zsrc);
-	php_stream_from_zval(dest, zdest);
 
 	if (pos > 0 && php_stream_seek(src, pos, SEEK_SET) < 0) {
 		php_error_docref(NULL, E_WARNING, "Failed to seek to position " ZEND_LONG_FMT " in the stream", pos);
@@ -532,14 +515,11 @@ PHP_FUNCTION(stream_copy_to_stream)
 /* {{{ Retrieves header/meta data from streams/file pointers */
 PHP_FUNCTION(stream_get_meta_data)
 {
-	zval *zstream;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	array_init(return_value);
 
@@ -1235,7 +1215,6 @@ PHP_FUNCTION(stream_context_create)
 /* {{{ streams filter functions */
 static void apply_filter_to_stream(int append, INTERNAL_FUNCTION_PARAMETERS)
 {
-	zval *zstream;
 	php_stream *stream;
 	char *filtername;
 	size_t filternamelen;
@@ -1245,14 +1224,12 @@ static void apply_filter_to_stream(int append, INTERNAL_FUNCTION_PARAMETERS)
 	int ret;
 
 	ZEND_PARSE_PARAMETERS_START(2, 4)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_STRING(filtername, filternamelen)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(read_write)
 		Z_PARAM_ZVAL(filterparams)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	if ((read_write & PHP_STREAM_FILTER_ALL) == 0) {
 		/* Chain not specified.
@@ -1358,12 +1335,11 @@ PHP_FUNCTION(stream_get_line)
 	char *str = NULL;
 	size_t str_len = 0;
 	zend_long max_length;
-	zval *zstream;
 	zend_string *buf;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(max_length)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING(str, str_len)
@@ -1377,8 +1353,6 @@ PHP_FUNCTION(stream_get_line)
 		max_length = PHP_SOCK_CHUNK_SIZE;
 	}
 
-	php_stream_from_zval(stream, zstream);
-
 	if ((buf = php_stream_get_record(stream, max_length, str, str_len))) {
 		RETURN_STR(buf);
 	} else {
@@ -1391,16 +1365,13 @@ PHP_FUNCTION(stream_get_line)
 /* {{{ Set blocking/non-blocking mode on a socket or stream */
 PHP_FUNCTION(stream_set_blocking)
 {
-	zval *zstream;
 	bool block;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_BOOL(block)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	if (php_stream_set_option(stream, PHP_STREAM_OPTION_BLOCKING, block, NULL) == -1) {
 		RETURN_FALSE;
@@ -1415,20 +1386,17 @@ PHP_FUNCTION(stream_set_blocking)
 #if defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32)
 PHP_FUNCTION(stream_set_timeout)
 {
-	zval *socket;
 	zend_long seconds, microseconds = 0;
 	struct timeval t;
 	php_stream *stream;
 	int argc = ZEND_NUM_ARGS();
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
-		Z_PARAM_RESOURCE(socket)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(seconds)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(microseconds)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, socket);
 
 #ifdef PHP_WIN32
 	t.tv_sec = (long)seconds;
@@ -1462,18 +1430,15 @@ PHP_FUNCTION(stream_set_timeout)
 /* {{{ Set file write buffer */
 PHP_FUNCTION(stream_set_write_buffer)
 {
-	zval *arg1;
 	int ret;
 	zend_long arg2;
 	size_t buff;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(arg1)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(arg2)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, arg1);
 
 	buff = arg2;
 
@@ -1493,11 +1458,10 @@ PHP_FUNCTION(stream_set_chunk_size)
 {
 	int			ret;
 	zend_long		csize;
-	zval		*zstream;
 	php_stream	*stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(csize)
 	ZEND_PARSE_PARAMETERS_END();
 
@@ -1514,8 +1478,6 @@ PHP_FUNCTION(stream_set_chunk_size)
 		RETURN_THROWS();
 	}
 
-	php_stream_from_zval(stream, zstream);
-
 	ret = php_stream_set_option(stream, PHP_STREAM_OPTION_SET_CHUNK_SIZE, (int)csize, NULL);
 
 	RETURN_LONG(ret > 0 ? (zend_long)ret : (zend_long)EOF);
@@ -1525,18 +1487,15 @@ PHP_FUNCTION(stream_set_chunk_size)
 /* {{{ Set file read buffer */
 PHP_FUNCTION(stream_set_read_buffer)
 {
-	zval *arg1;
 	int ret;
 	zend_long arg2;
 	size_t buff;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(arg1)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(arg2)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, arg1);
 
 	buff = arg2;
 
@@ -1555,20 +1514,17 @@ PHP_FUNCTION(stream_set_read_buffer)
 PHP_FUNCTION(stream_socket_enable_crypto)
 {
 	zend_long cryptokind = 0;
-	zval *zstream, *zsessstream = NULL;
 	php_stream *stream, *sessstream = NULL;
 	bool enable, cryptokindnull = 1;
 	int ret;
 
 	ZEND_PARSE_PARAMETERS_START(2, 4)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_BOOL(enable)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG_OR_NULL(cryptokind, cryptokindnull)
-		Z_PARAM_RESOURCE_OR_NULL(zsessstream)
+		PHP_Z_PARAM_STREAM_OR_NULL(sessstream)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zstream);
 
 	if (enable) {
 		if (cryptokindnull) {
@@ -1580,10 +1536,6 @@ PHP_FUNCTION(stream_socket_enable_crypto)
 			}
 
 			cryptokind = Z_LVAL_P(val);
-		}
-
-		if (zsessstream) {
-			php_stream_from_zval(sessstream, zsessstream);
 		}
 
 		if (php_stream_xport_crypto_setup(stream, cryptokind, sessstream) < 0) {
@@ -1658,13 +1610,10 @@ PHP_FUNCTION(stream_is_local)
 PHP_FUNCTION(stream_supports_lock)
 {
 	php_stream *stream;
-	zval *zsrc;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_RESOURCE(zsrc)
+		PHP_Z_PARAM_STREAM(stream)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zsrc);
 
 	if (!php_stream_supports_lock(stream)) {
 		RETURN_FALSE;
@@ -1676,15 +1625,12 @@ PHP_FUNCTION(stream_supports_lock)
 /* {{{ Check if a stream is a TTY. */
 PHP_FUNCTION(stream_isatty)
 {
-	zval *zsrc;
 	php_stream *stream;
 	php_socket_t fileno;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_RESOURCE(zsrc)
+		PHP_Z_PARAM_STREAM(stream)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zsrc);
 
 	/* get the fd.
 	 * NB: Most other code will NOT use the PHP_STREAM_CAST_INTERNAL flag when casting.
@@ -1718,18 +1664,15 @@ PHP_FUNCTION(stream_isatty)
 */
 PHP_FUNCTION(sapi_windows_vt100_support)
 {
-	zval *zsrc;
 	php_stream *stream;
 	bool enable, enable_is_null = 1;
 	zend_long fileno;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_RESOURCE(zsrc)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL_OR_NULL(enable, enable_is_null)
 	ZEND_PARSE_PARAMETERS_END();
-
-	php_stream_from_zval(stream, zsrc);
 
 	/* get the fd.
 	 * NB: Most other code will NOT use the PHP_STREAM_CAST_INTERNAL flag when casting.
@@ -1785,11 +1728,10 @@ PHP_FUNCTION(sapi_windows_vt100_support)
 PHP_FUNCTION(stream_socket_shutdown)
 {
 	zend_long how;
-	zval *zstream;
 	php_stream *stream;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_RESOURCE(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_LONG(how)
 	ZEND_PARSE_PARAMETERS_END();
 
@@ -1799,8 +1741,6 @@ PHP_FUNCTION(stream_socket_shutdown)
 	    zend_argument_value_error(2, "must be one of STREAM_SHUT_RD, STREAM_SHUT_WR, or STREAM_SHUT_RDWR");
 		RETURN_THROWS();
 	}
-
-	php_stream_from_zval(stream, zstream);
 
 	RETURN_BOOL(php_stream_xport_shutdown(stream, (stream_shutdown_t)how) == 0);
 }

--- a/ext/standard/tests/file/fwrite.phpt
+++ b/ext/standard/tests/file/fwrite.phpt
@@ -17,12 +17,20 @@ var_dump(fwrite($fp, "data", -1));
 var_dump(fwrite($fp, "data", 100000));
 fclose($fp);
 
-var_dump(fwrite($fp, "data", -1));
+try {
+    var_dump(fwrite($fp, "data", -1));
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 
 var_dump(file_get_contents($filename));
 
-@unlink($filename);
 echo "Done\n";
+?>
+--CLEAN--
+<?php
+$filename = __DIR__."/fwrite.dat";
+@unlink($filename);
 ?>
 --EXPECTF--
 int(0)
@@ -31,6 +39,6 @@ Notice: fwrite(): Write of 4 bytes failed with errno=9 Bad file descriptor in %s
 bool(false)
 int(0)
 int(4)
-int(0)
+TypeError: fwrite(): supplied resource is not a valid stream resource
 string(4) "data"
 Done

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -439,7 +439,7 @@ PHP_FUNCTION(stream_bucket_append)
 /* {{{ Create a new bucket for use on the current stream */
 PHP_FUNCTION(stream_bucket_new)
 {
-	zval *zstream, zbucket;
+	zval zbucket;
 	php_stream *stream;
 	char *buffer;
 	char *pbuffer;
@@ -447,11 +447,10 @@ PHP_FUNCTION(stream_bucket_new)
 	php_stream_bucket *bucket;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_ZVAL(zstream)
+		PHP_Z_PARAM_STREAM(stream)
 		Z_PARAM_STRING(buffer, buffer_len)
 	ZEND_PARSE_PARAMETERS_END();
 
-	php_stream_from_zval(stream, zstream);
 	pbuffer = pemalloc(buffer_len, php_stream_is_persistent(stream));
 
 	memcpy(pbuffer, buffer, buffer_len);


### PR DESCRIPTION
This is based on an old idea from @sgolemon.
This would reduce the complexity of the conversion from resources to opaque objects for streams when we finally get round to it.

The approach is similar to the one I did for the GMP extension functions that need to handle a complex union of types which doesn't warrant a dedicated Zend ZPP specifier.

Some obvious follow-ups:
 - A custom Fast ZPP specifier for stream contexts
 - A custom Fast ZPP specifier for stream resource or non-empty string path