### PR TITLE
Fix simple typo in http_fopen_wrapper.c

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -832,7 +832,7 @@ finish:
 					if (decode) {
 						transfer_encoding = php_stream_filter_create("dechunk", NULL, php_stream_is_persistent(stream));
 						if (transfer_encoding) {
-							/* don't store transfer-encodeing header */
+							/* don't store transfer-encoding header */
 							continue;
 						}
 					}


### PR DESCRIPTION
There is a cute typo, `transfer-encodeing` in the comment.