### PR TITLE
ext/intl: Add DECIMAL_COMPACT_SHORT and DECIMAL_COMPACT_LONG for NumberFormatter

### DIFF
--- a/ext/intl/formatter/formatter.stub.php
+++ b/ext/intl/formatter/formatter.stub.php
@@ -11,6 +11,10 @@ class NumberFormatter
     public const int PATTERN_DECIMAL = UNKNOWN;
     /** @cvalue UNUM_DECIMAL */
     public const int DECIMAL = UNKNOWN;
+    /** @cvalue UNUM_DECIMAL_COMPACT_SHORT */
+    public const int DECIMAL_COMPACT_SHORT = UNKNOWN;
+    /** @cvalue UNUM_DECIMAL_COMPACT_LONG */
+    public const int DECIMAL_COMPACT_LONG = UNKNOWN;
     /** @cvalue UNUM_CURRENCY */
     public const int CURRENCY = UNKNOWN;
     /** @cvalue UNUM_PERCENT */

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: caaa6ff408bfd88ec9bb998ffd753f4de971ccff */
+ * Stub hash: 05ab9fb3ba33163b2100e2773d70f67e110ecefc */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumberFormatter___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -136,6 +136,18 @@ static zend_class_entry *register_class_NumberFormatter(void)
 	zend_string *const_DECIMAL_name = zend_string_init_interned("DECIMAL", sizeof("DECIMAL") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_DECIMAL_name, &const_DECIMAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_DECIMAL_name);
+
+	zval const_DECIMAL_COMPACT_SHORT_value;
+	ZVAL_LONG(&const_DECIMAL_COMPACT_SHORT_value, UNUM_DECIMAL_COMPACT_SHORT);
+	zend_string *const_DECIMAL_COMPACT_SHORT_name = zend_string_init_interned("DECIMAL_COMPACT_SHORT", sizeof("DECIMAL_COMPACT_SHORT") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_DECIMAL_COMPACT_SHORT_name, &const_DECIMAL_COMPACT_SHORT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_DECIMAL_COMPACT_SHORT_name);
+
+	zval const_DECIMAL_COMPACT_LONG_value;
+	ZVAL_LONG(&const_DECIMAL_COMPACT_LONG_value, UNUM_DECIMAL_COMPACT_LONG);
+	zend_string *const_DECIMAL_COMPACT_LONG_name = zend_string_init_interned("DECIMAL_COMPACT_LONG", sizeof("DECIMAL_COMPACT_LONG") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_DECIMAL_COMPACT_LONG_name, &const_DECIMAL_COMPACT_LONG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_DECIMAL_COMPACT_LONG_name);
 
 	zval const_CURRENCY_value;
 	ZVAL_LONG(&const_CURRENCY_value, UNUM_CURRENCY);

--- a/ext/intl/tests/formatter_format_decimal_compact.phpt
+++ b/ext/intl/tests/formatter_format_decimal_compact.phpt
@@ -1,0 +1,57 @@
+--TEST--
+numfmt_format_currency() icu >= 4.8
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+function ut_main()
+{
+    $locales = array(
+        'en_UK',
+        'en_US',
+        'ru',
+        'zh_CN',
+        'ro',
+        'uk',
+        'en',
+        'bg'
+    );
+
+    $number = 1234567.89;
+
+    $res_str = '';
+    foreach( $locales as $locale )
+    {
+        $fmt = ut_nfmt_create( $locale, NumberFormatter::DECIMAL_COMPACT_SHORT );
+        $res_str .= "$locale: short = " . ut_nfmt_format ($fmt, $number) . "\n";
+
+        $fmt = ut_nfmt_create( $locale, NumberFormatter::DECIMAL_COMPACT_LONG );
+        $res_str .= "$locale: long = " . ut_nfmt_format ($fmt, $number) . "\n";
+    }
+    return $res_str;
+}
+
+include_once( 'ut_common.inc' );
+
+// Run the test
+ut_run();
+
+?>
+--EXPECTF--
+en_UK: short = 1.2M
+en_UK: long = 1.2 million
+en_US: short = 1.2M
+en_US: long = 1.2 million
+ru: short = 1,2 млн
+ru: long = 1,2 миллиона
+zh_CN: short = 123万
+zh_CN: long = 123万
+ro: short = 1,2 mil.
+ro: long = 1,2 milioane
+uk: short = 1,2 млн
+uk: long = 1,2 мільйона
+en: short = 1.2M
+en: long = 1.2 million
+bg: short = 1,2 млн.
+bg: long = 1,2 милиона


### PR DESCRIPTION
This PR introduces two new constants, DECIMAL_COMPACT_SHORT and DECIMAL_COMPACT_LONG, in the NumberFormatter class. These constants are mapped to ICU’s UNUM_DECIMAL_COMPACT_SHORT and UNUM_DECIMAL_COMPACT_LONG.

Although ICU has supported these since version 57, they were not previously exposed in PHP's NumberFormatter class. This update addresses that by adding them.