### PR TITLE
Fix memory leaks in array_any() / array_all()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6628,7 +6628,8 @@ static zend_result php_array_find(const HashTable *array, zend_fcall_info fci, z
 		ZVAL_COPY(&args[0], operand);
 
 		zend_result result = zend_call_function(&fci, &fci_cache);
-		if (EXPECTED(result == SUCCESS)) {
+		ZEND_ASSERT(result == SUCCESS);
+		if (EXPECTED(!Z_ISUNDEF(retval))) {
 			int retval_true;
 
 			retval_true = zend_is_true(&retval);
@@ -6656,7 +6657,7 @@ static zend_result php_array_find(const HashTable *array, zend_fcall_info fci, z
 		zval_ptr_dtor(&args[0]);
 		zval_ptr_dtor(&args[1]);
 
-		if (UNEXPECTED(result != SUCCESS)) {
+		if (UNEXPECTED(Z_ISUNDEF(retval))) {
 			return FAILURE;
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -6725,7 +6726,11 @@ PHP_FUNCTION(array_any)
 		RETURN_THROWS();
 	}
 
-	RETURN_BOOL(Z_TYPE_P(return_value) != IS_UNDEF);
+	bool retval = !Z_ISUNDEF_P(return_value);
+	if (Z_TYPE_P(return_value) == IS_STRING) {
+		zval_ptr_dtor_str(return_value);
+	}
+	RETURN_BOOL(retval);
 }
 /* }}} */
 
@@ -6745,7 +6750,11 @@ PHP_FUNCTION(array_all)
 		RETURN_THROWS();
 	}
 
-	RETURN_BOOL(Z_TYPE_P(return_value) == IS_UNDEF);
+	bool retval = Z_ISUNDEF_P(return_value);
+	if (Z_TYPE_P(return_value) == IS_STRING) {
+		zval_ptr_dtor_str(return_value);
+	}
+	RETURN_BOOL(retval);
 }
 /* }}} */
 


### PR DESCRIPTION
The return value is overwritten, but if the key was not an interned string we should destroy it.