### PR TITLE
Fix bug and add test for dba_open same file twice

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -57,6 +57,7 @@ ZEND_BEGIN_MODULE_GLOBALS(dba)
 	const char *default_handler;
 	const dba_handler *default_hptr;
 	HashTable connections;
+	int connection_counter;
 ZEND_END_MODULE_GLOBALS(dba)
 
 ZEND_DECLARE_MODULE_GLOBALS(dba)
@@ -571,7 +572,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 
 	char *resource_key;
 	size_t resource_key_len = spprintf(&resource_key, 0,
-		"dba_%d_%s_%s_%s", persistent, ZSTR_VAL(path), ZSTR_VAL(mode), handler_str ? ZSTR_VAL(handler_str) : ""
+		"dba_%d_%d_%s_%s_%s", persistent, persistent ? 0 : DBA_G(connection_counter)++, ZSTR_VAL(path), ZSTR_VAL(mode), handler_str ? ZSTR_VAL(handler_str) : ""
 	);
 
 	if (persistent) {

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -57,7 +57,7 @@ ZEND_BEGIN_MODULE_GLOBALS(dba)
 	const char *default_handler;
 	const dba_handler *default_hptr;
 	HashTable connections;
-	int connection_counter;
+	unsigned int connection_counter;
 ZEND_END_MODULE_GLOBALS(dba)
 
 ZEND_DECLARE_MODULE_GLOBALS(dba)
@@ -572,7 +572,7 @@ static void php_dba_open(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
 
 	char *resource_key;
 	size_t resource_key_len = spprintf(&resource_key, 0,
-		"dba_%d_%d_%s_%s_%s", persistent, persistent ? 0 : DBA_G(connection_counter)++, ZSTR_VAL(path), ZSTR_VAL(mode), handler_str ? ZSTR_VAL(handler_str) : ""
+		"dba_%d_%u_%s_%s_%s", persistent, persistent ? 0 : DBA_G(connection_counter)++, ZSTR_VAL(path), ZSTR_VAL(mode), handler_str ? ZSTR_VAL(handler_str) : ""
 	);
 
 	if (persistent) {

--- a/ext/dba/tests/dba_duplicateopen.phpt
+++ b/ext/dba/tests/dba_duplicateopen.phpt
@@ -11,23 +11,23 @@ check_skip('cdb_make');
 test.cdb
 --FILE--
 <?php
-    echo "database handler: cdb\n";
-    $handler = 'cdb';
-    $db_filename = __DIR__.'/test.cdb';
-    if (($db_file=dba_open($db_filename, "r", $handler))!==FALSE) {
-        echo dba_fetch(1, $db_file);
-        if (($db_file2=dba_open($db_filename, "r", $handler))!==FALSE) {
-            echo dba_fetch(1, $db_file2);
-            echo dba_fetch(2, $db_file2);
-            dba_close($db_file2);
-        } else {
-            echo "Error opening database 2nd time\n";
-        }
-        echo dba_fetch(2, $db_file);
-        dba_close($db_file);
+echo "database handler: cdb\n";
+$handler = 'cdb';
+$db_filename = __DIR__.'/test.cdb';
+if (($db_file=dba_open($db_filename, "r", $handler))!==FALSE) {
+    echo dba_fetch(1, $db_file);
+    if (($db_file2=dba_open($db_filename, "r", $handler))!==FALSE) {
+        echo dba_fetch(1, $db_file2);
+        echo dba_fetch(2, $db_file2);
+        dba_close($db_file2);
     } else {
-        echo "Error opening database\n";
+        echo "Error opening database 2nd time\n";
     }
+    echo dba_fetch(2, $db_file);
+    dba_close($db_file);
+} else {
+    echo "Error opening database\n";
+}
 ?>
 --EXPECT--
 database handler: cdb

--- a/ext/dba/tests/dba_duplicateopen.phpt
+++ b/ext/dba/tests/dba_duplicateopen.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DBA open same read only file multiple times
+--EXTENSIONS--
+dba
+--SKIPIF--
+<?php
+require_once __DIR__ . '/setup/setup_dba_tests.inc';
+check_skip('cdb_make');
+?>
+--CONFLICTS--
+test.cdb
+--FILE--
+<?php
+    echo "database handler: cdb\n";
+    $handler = 'cdb';
+    $db_filename = __DIR__.'/test.cdb';
+    if (($db_file=dba_open($db_filename, "r", $handler))!==FALSE) {
+        echo dba_fetch(1, $db_file);
+        if (($db_file2=dba_open($db_filename, "r", $handler))!==FALSE) {
+            echo dba_fetch(1, $db_file2);
+            echo dba_fetch(2, $db_file2);
+            dba_close($db_file2);
+        } else {
+            echo "Error opening database 2nd time\n";
+        }
+        echo dba_fetch(2, $db_file);
+        dba_close($db_file);
+    } else {
+        echo "Error opening database\n";
+    }
+?>
+--EXPECT--
+database handler: cdb
+1122


### PR DESCRIPTION
When doing dba_open twice with the same file then dba_open tries to insert the same key into its hash table which triggers an assertion in a debug build and causes memory corruption in production.

A small reproduction script is

```php
<?php
$a = dba_open("ext/dba/tests/test.cdb", "r");
$b = dba_open("ext/dba/tests/test.cdb", "r");
var_dump($a, $b);
```

The solution I chose is to add a counter to the keys generated with dba_open (but no dba_popen) to avoid key collisions.