### PR TITLE
ext/bcmath: Simplify `bc_divide()` code

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.5.0alpha1
 
+- BCMath:
+  . Simplify `bc_divide()` code. (SakiTakamachi)
+
 - CLI:
   . Add --ini=diff to print INI settings changed from the builtin default.
     (timwolla)

--- a/ext/bcmath/libbcmath/src/convert.h
+++ b/ext/bcmath/libbcmath/src/convert.h
@@ -57,4 +57,32 @@ static inline void bc_convert_to_vector(BC_VECTOR *n_vector, const char *nend, s
 	}
 }
 
+static inline void bc_convert_to_vector_with_zero_pad(BC_VECTOR *n_vector, const char *nend, size_t nlen, size_t zeros)
+{
+	while (zeros >= BC_VECTOR_SIZE) {
+		*n_vector = 0;
+		n_vector++;
+		zeros -= BC_VECTOR_SIZE;
+	}
+
+	if (zeros > 0) {
+		*n_vector = 0;
+		BC_VECTOR base = BC_POW_10_LUT[zeros];
+		size_t tmp_len = MIN(BC_VECTOR_SIZE - zeros, nlen);
+		for (size_t i = 0; i < tmp_len; i++) {
+			*n_vector += *nend * base;
+			base *= BASE;
+			nend--;
+		}
+		n_vector++;
+		nlen -= tmp_len;
+	}
+
+	if (nlen == 0) {
+		return;
+	}
+
+	bc_convert_to_vector(n_vector, nend, nlen);
+}
+
 #endif

--- a/ext/bcmath/libbcmath/src/convert.h
+++ b/ext/bcmath/libbcmath/src/convert.h
@@ -34,11 +34,11 @@ static inline BC_VECTOR bc_partial_convert_to_vector(const char *n, size_t len)
 	}
 
 	BC_VECTOR num = 0;
-	BC_VECTOR base = 1;
+	BC_VECTOR digit_base_value = 1;
 
 	for (size_t i = 0; i < len; i++) {
-		num += *n * base;
-		base *= BASE;
+		num += *n * digit_base_value;
+		digit_base_value *= BASE;
 		n--;
 	}
 
@@ -67,15 +67,15 @@ static inline void bc_convert_to_vector_with_zero_pad(BC_VECTOR *n_vector, const
 
 	if (zeros > 0) {
 		*n_vector = 0;
-		BC_VECTOR base = BC_POW_10_LUT[zeros];
-		size_t tmp_len = MIN(BC_VECTOR_SIZE - zeros, nlen);
-		for (size_t i = 0; i < tmp_len; i++) {
-			*n_vector += *nend * base;
-			base *= BASE;
+		BC_VECTOR digit_base_value = BC_POW_10_LUT[zeros];
+		size_t len_to_write = MIN(BC_VECTOR_SIZE - zeros, nlen);
+		for (size_t i = 0; i < len_to_write; i++) {
+			*n_vector += *nend * digit_base_value;
+			digit_base_value *= BASE;
 			nend--;
 		}
 		n_vector++;
-		nlen -= tmp_len;
+		nlen -= len_to_write;
 	}
 
 	if (nlen == 0) {

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -317,12 +317,8 @@ static inline void bc_divide_by_pow_10(
 	const char *numeratorptr, size_t numerator_readable_size, bc_num *quot, size_t quot_size, size_t quot_scale)
 {
 	char *qptr = (*quot)->n_value;
-	if (quot_size <= quot_scale) {
-		/* int is 0 */
+	for (size_t i = quot_size; i <= quot_scale; i++) {
 		*qptr++ = 0;
-		for (size_t i = quot_size; i < quot_scale; i++) {
-			*qptr++ = 0;
-		}
 	}
 
 	size_t numerator_use_size = quot_size > numerator_readable_size ? numerator_readable_size : quot_size;

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -37,10 +37,6 @@
 #include <string.h>
 #include "zend_alloc.h"
 
-static const BC_VECTOR POW_10_LUT[9] = {
-	1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000
-};
-
 /*
  * This function should be used when the divisor is not split into multiple chunks, i.e. when the size of the array is one.
  * This is because the algorithm can be simplified.
@@ -174,8 +170,8 @@ static inline void bc_standard_div(
 		divisor_top_digits = BC_VECTOR_SIZE;
 	}
 
-	size_t high_part_shift = POW_10_LUT[BC_VECTOR_SIZE - divisor_top_digits + 1];
-	size_t low_part_shift = POW_10_LUT[divisor_top_digits - 1];
+	size_t high_part_shift = BC_POW_10_LUT[BC_VECTOR_SIZE - divisor_top_digits + 1];
+	size_t low_part_shift = BC_POW_10_LUT[divisor_top_digits - 1];
 	BC_VECTOR divisor_high_part = divisor_vectors[divisor_top_index] * high_part_shift + divisor_vectors[divisor_top_index - 1] / low_part_shift;
 	for (size_t i = 0; i < quot_arr_size; i++) {
 		BC_VECTOR numerator_high_part = numerator_vectors[numerator_top_index - i] * high_part_shift + numerator_vectors[numerator_top_index - i - 1] / low_part_shift;
@@ -281,7 +277,7 @@ static void bc_do_div(
 	size_t numerator_read = 0;
 	if (numerator_bottom_read_len < BC_VECTOR_SIZE) {
 		numerator_read = MIN(numerator_bottom_read_len, numerator_readable_len);
-		base = POW_10_LUT[numerator_bottom_extension];
+		base = BC_POW_10_LUT[numerator_bottom_extension];
 		numerator_vectors[numerator_vector_count] = 0;
 		for (size_t i = 0; i < numerator_read; i++) {
 			numerator_vectors[numerator_vector_count] += *numerator * base;

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -420,7 +420,7 @@ bool bc_divide(bc_num numerator, bc_num divisor, bc_num *quot, size_t scale)
 	/* If divisor is 1 here, return the result of adjusting the decimal point position of numerator. */
 	if (divisor_size == 1 && *divisorptr == 1) {
 		bc_divide_by_pow_10(numeratorptr, numerator_readable_size, quot, quot_size, quot_scale);
-		(*quot)->n_sign = numerator->n_sign == divisor->n_sign ? PLUS : MINUS;;
+		(*quot)->n_sign = numerator->n_sign == divisor->n_sign ? PLUS : MINUS;
 		return true;
 	}
 

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -51,7 +51,7 @@ static inline void bc_fast_div(
 {
 	size_t numerator_top_index = numerator_arr_size - 1;
 	size_t quot_top_index = quot_arr_size - 1;
-	for (size_t i = 0; i < quot_arr_size - 1; i++) {
+	for (size_t i = 0; i < quot_top_index; i++) {
 		if (numerator_vectors[numerator_top_index - i] < divisor_vector) {
 			quot_vectors[quot_top_index - i] = 0;
 			/* numerator_vectors[numerator_top_index - i] < divisor_vector, so there will be no overflow. */

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -430,7 +430,6 @@ bool bc_divide(bc_num numerator, bc_num divisor, bc_num *quot, size_t scale)
 	_bc_rm_leading_zeros(*quot);
 	if (bc_is_zero(*quot)) {
 		(*quot)->n_sign = PLUS;
-		(*quot)->n_scale = 0;
 	} else {
 		(*quot)->n_sign = numerator->n_sign == divisor->n_sign ? PLUS : MINUS;
 	}

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -433,8 +433,8 @@ bool bc_divide(bc_num numerator, bc_num divisor, bc_num *quot, size_t scale)
 
 	_bc_rm_leading_zeros(*quot);
 	if (bc_is_zero(*quot)) {
-		bc_free_num(quot);
-		goto quot_zero;
+		(*quot)->n_sign = PLUS;
+		(*quot)->n_scale = 0;
 	} else {
 		(*quot)->n_sign = numerator->n_sign == divisor->n_sign ? PLUS : MINUS;
 	}

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -35,6 +35,9 @@
 #include <stddef.h>
 #include "zend_portability.h"
 
+#ifndef _BCMATH_PRIV_H_
+#define _BCMATH_PRIV_H_
+
 /* This will be 0x01010101 for 32-bit and 0x0101010101010101 for 64-bit */
 #define SWAR_ONES (~((size_t) 0) / 0xFF)
 /* This repeats a byte `x` into an entire 32/64-bit word.
@@ -67,9 +70,15 @@
  */
 #define BC_VECTOR_NO_OVERFLOW_ADD_COUNT (~((BC_VECTOR) 0) / (BC_VECTOR_BOUNDARY_NUM * BC_VECTOR_BOUNDARY_NUM))
 
+static const BC_VECTOR BC_POW_10_LUT[9] = {
+	1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000
+};
+
 
 /* routines */
 bcmath_compare_result _bc_do_compare (bc_num n1, bc_num n2, size_t scale, bool use_sign);
 bc_num _bc_do_add (bc_num n1, bc_num n2);
 bc_num _bc_do_sub (bc_num n1, bc_num n2);
 void _bc_rm_leading_zeros (bc_num num);
+
+#endif


### PR DESCRIPTION
While writing the code to make the `bc_num` struct hold the data as `BC_VECTOR*` instead of a `char*`, I realized that the code for `bc_divide()` could be significantly simplified.

Unfortunately, I won't use the structure change because it slows things down, but I'll try to simplify the code.
As you know, the code was too complicated and I didn't know where the bug was, so simplifying the code is a good thing.

## benchmarks

When comparing the speed with the master, it is slightly faster.

1.php:
```
for ($i = 0; $i < 2000000; $i++) {
    bcdiv('1.23', '2', 5);
}
```

2.php:
```
for ($i = 0; $i < 2000000; $i++) {
    bcdiv('5.2345678', '2.1234567', 10);
}
```

3.php:
```
for ($i = 0; $i < 2000000; $i++) {
    bcdiv('12345678.901234', '1.2345678912', 10);
}
```

results 1:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/1.php
  Time (mean ± σ):     309.7 ms ±   7.3 ms    [User: 296.4 ms, System: 6.9 ms]
  Range (min … max):   303.8 ms … 329.5 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/1.php
  Time (mean ± σ):     317.2 ms ±  10.1 ms    [User: 304.7 ms, System: 6.3 ms]
  Range (min … max):   309.6 ms … 342.5 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/1.php' ran
    1.02 ± 0.04 times faster than '/master/sapi/cli/php /mount/bc/div/1.php'
```

results 2:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/2.php
  Time (mean ± σ):     372.0 ms ±   3.3 ms    [User: 361.4 ms, System: 4.6 ms]
  Range (min … max):   366.6 ms … 377.6 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/2.php
  Time (mean ± σ):     391.9 ms ±   3.9 ms    [User: 379.5 ms, System: 6.3 ms]
  Range (min … max):   387.7 ms … 401.0 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/2.php' ran
    1.05 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/div/2.php'
```

results 3:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/3.php
  Time (mean ± σ):     492.0 ms ±   5.0 ms    [User: 479.6 ms, System: 6.4 ms]
  Range (min … max):   485.6 ms … 503.8 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/3.php
  Time (mean ± σ):     507.0 ms ±   7.3 ms    [User: 495.0 ms, System: 6.1 ms]
  Range (min … max):   497.5 ms … 519.7 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/3.php' ran
    1.03 ± 0.02 times faster than '/master/sapi/cli/php /mount/bc/div/3.php'
```
