### PR TITLE
Fix stubs of DateTimeZone->getTransitions

### DIFF
--- a/Zend/tests/parameter_default_values/internal_declaration_error_const.phpt
+++ b/Zend/tests/parameter_default_values/internal_declaration_error_const.phpt
@@ -10,4 +10,4 @@ class MyDateTimeZone extends DateTimeZone
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of MyDateTimeZone::getTransitions(): array|false must be compatible with DateTimeZone::getTransitions(int $timestampBegin = PHP_INT_MIN, int $timestampEnd = PHP_INT_MAX): array|false in %s on line %d
+Fatal error: Declaration of MyDateTimeZone::getTransitions(): array|false must be compatible with DateTimeZone::getTransitions(int $timestampBegin = PHP_INT_MIN, int $timestampEnd = 2147483647): array|false in %s on line %d

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -227,7 +227,7 @@ function timezone_offset_get(DateTimeZone $object, DateTimeInterface $datetime):
  * @refcount 1
  */
 function timezone_transitions_get(
-    DateTimeZone $object, int $timestampBegin = PHP_INT_MIN, int $timestampEnd = PHP_INT_MAX): array|false {}
+    DateTimeZone $object, int $timestampBegin = PHP_INT_MIN, int $timestampEnd = 2147483647): array|false {}
 
 /**
  * @return array<string, float|string>|false
@@ -615,7 +615,7 @@ class DateTimeZone
      * @tentative-return-type
      * @alias timezone_transitions_get
      */
-    public function getTransitions(int $timestampBegin = PHP_INT_MIN, int $timestampEnd = PHP_INT_MAX): array|false {}
+    public function getTransitions(int $timestampBegin = PHP_INT_MIN, int $timestampEnd = 2147483647): array|false {}
 
     /**
      * @return array<string, float|string>|false

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 093743b4fe7a698d1262cc1a81b60a85064fdccb */
+ * Stub hash: 4e61617ca7c877aa3811d674d47850f23157074b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -175,7 +175,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_timezone_transitions_get, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, object, DateTimeZone, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampBegin, IS_LONG, 0, "PHP_INT_MIN")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampEnd, IS_LONG, 0, "PHP_INT_MAX")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampEnd, IS_LONG, 0, "2147483647")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_timezone_location_get, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -436,7 +436,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DateTimeZone_getTransitions, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampBegin, IS_LONG, 0, "PHP_INT_MIN")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampEnd, IS_LONG, 0, "PHP_INT_MAX")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timestampEnd, IS_LONG, 0, "2147483647")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeZone_getLocation arginfo_class_DateTime_getLastErrors

--- a/ext/reflection/tests/internal_parameter_default_value/ReflectionParameter_getDefaultValueConstantName_Internal.phpt
+++ b/ext/reflection/tests/internal_parameter_default_value/ReflectionParameter_getDefaultValueConstantName_Internal.phpt
@@ -47,7 +47,7 @@ NULL
 NULL
 ----------
 string(11) "PHP_INT_MIN"
-string(11) "PHP_INT_MAX"
+NULL
 ----------
 string(17) "DateTimeZone::ALL"
 NULL


### PR DESCRIPTION
The default value of `timestamp_end` is `INT32_MAX` and not `ZEND_LONG_MAX`.

Additionally, changing the default to `ZEND_LONG_MAX` would result in an OOM error on calling the function without params.