### PR TITLE
Remove "Notify Slack" on ppc nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,11 +76,6 @@ jobs:
         with:
           runTestsParameters: >-
             --asan -x
-      - name: Notify Slack
-        if: failure()
-        uses: ./.github/actions/notify-slack
-        with:
-          token: ${{ secrets.ACTION_MONITORING_SLACK }}
   ALPINE:
     if: inputs.run_alpine
     name: ALPINE_X64_ASAN_UBSAN_DEBUG_ZTS


### PR DESCRIPTION
We get weird failures at here ([for example](https://github.com/php/php-src/actions/runs/13711835359/job/38349721080)), and Ilija was talking about possibly removing it in general.