### PR TITLE
Fix GH-17989: mb_output_handler crash with unset http_output_conv_mimetypes

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1567,7 +1567,9 @@ PHP_FUNCTION(mb_output_handler)
 		char *mimetype = NULL;
 
 		/* Analyze mime type */
-		if (SG(sapi_headers).mimetype && _php_mb_match_regex(MBSTRG(http_output_conv_mimetypes), SG(sapi_headers).mimetype, strlen(SG(sapi_headers).mimetype))) {
+		if (SG(sapi_headers).mimetype
+		 && MBSTRG(http_output_conv_mimetypes)
+		 && _php_mb_match_regex(MBSTRG(http_output_conv_mimetypes), SG(sapi_headers).mimetype, strlen(SG(sapi_headers).mimetype))) {
 			char *s;
 			if ((s = strchr(SG(sapi_headers).mimetype, ';')) == NULL) {
 				mimetype = estrdup(SG(sapi_headers).mimetype);

--- a/ext/mbstring/tests/gh17989.phpt
+++ b/ext/mbstring/tests/gh17989.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-17989 (mb_output_handler crash with unset http_output_conv_mimetypes)
+--EXTENSIONS--
+mbstring
+--INI--
+mbstring.http_output_conv_mimetypes=
+--FILE--
+<?php
+echo "set mime type via this echo\n";
+ob_start('mb_output_handler');
+echo "hi";
+ob_flush();
+?>
+--EXPECT--
+set mime type via this echo
+hi


### PR DESCRIPTION
The INI option can be NULL or invalid, resulting in a NULL global. So we have to add a NULL check.