### PR TITLE
ext/gd: imagecrop rect argument overflow fixes.

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3560,6 +3560,26 @@ PHP_FUNCTION(imagecrop)
 		RETURN_THROWS();
 	}
 
+	if ((rect.width > 0 && rect.x > INT_MAX - rect.width)) {
+		zend_argument_value_error(2, "overflow with \"x\" and \"width\" keys");
+		RETURN_THROWS();
+	}
+
+	if ((rect.width < 0 && rect.x < INT_MIN - rect.width)) {
+		zend_argument_value_error(2, "underflow with \"x\" and \"width\" keys");
+		RETURN_THROWS();
+	}
+
+	if ((rect.height > 0 && rect.y > INT_MAX - rect.height)) {
+		zend_argument_value_error(2, "overflow with \"y\" and \"height\" keys");
+		RETURN_THROWS();
+	}
+
+	if ((rect.height < 0 && rect.y < INT_MIN - rect.height)) {
+		zend_argument_value_error(2, "underflow with \"y\" and \"height\" keys");
+		RETURN_THROWS();
+	}
+
 	im_crop = gdImageCrop(im, &rect);
 
 	if (im_crop == NULL) {

--- a/ext/gd/tests/imagecrop_overflow.phpt
+++ b/ext/gd/tests/imagecrop_overflow.phpt
@@ -1,0 +1,45 @@
+--TEST--
+imagecrop() overflows when the combo  x/width or y/height is over INT_MAX or under INT_MIN.
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+$img = imagecreatetruecolor(10, 10);
+
+$arr = array("x" => 2147483647, "y" => 2147483647, "width" => 10, "height" => 10);
+
+try {
+	imagecrop($img, $arr);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+$arr = array("x" => -2147483648, "y" => 0, "width" => -10, "height" => 10);
+
+try {
+	imagecrop($img, $arr);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+$arr = array("x" => 1, "y" => 2147483647, "width" => 10, "height" => 10);
+
+try {
+	imagecrop($img, $arr);
+} catch (\ValueError $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+$arr = array("x" => 1, "y" => -2147483648, "width" => 10, "height" => -10);
+
+try {
+	imagecrop($img, $arr);
+} catch (\ValueError $e) {
+	echo $e->getMessage();
+}
+?>
+--EXPECT--
+imagecrop(): Argument #2 ($rectangle) overflow with "x" and "width" keys
+imagecrop(): Argument #2 ($rectangle) underflow with "x" and "width" keys
+imagecrop(): Argument #2 ($rectangle) overflow with "y" and "height" keys
+imagecrop(): Argument #2 ($rectangle) underflow with "y" and "height" keys

--- a/ext/gd/tests/imagecrop_overflow.phpt
+++ b/ext/gd/tests/imagecrop_overflow.phpt
@@ -6,7 +6,7 @@ gd
 <?php
 $img = imagecreatetruecolor(10, 10);
 
-$arr = array("x" => 2147483647, "y" => 2147483647, "width" => 10, "height" => 10);
+$arr = ["x" => 2147483647, "y" => 2147483647, "width" => 10, "height" => 10];
 
 try {
 	imagecrop($img, $arr);
@@ -14,7 +14,7 @@ try {
 	echo $e->getMessage() . PHP_EOL;
 }
 
-$arr = array("x" => -2147483648, "y" => 0, "width" => -10, "height" => 10);
+$arr = ["x" => -2147483648, "y" => 0, "width" => -10, "height" => 10];
 
 try {
 	imagecrop($img, $arr);
@@ -22,7 +22,7 @@ try {
 	echo $e->getMessage() . PHP_EOL;
 }
 
-$arr = array("x" => 1, "y" => 2147483647, "width" => 10, "height" => 10);
+$arr = ["x" => 1, "y" => 2147483647, "width" => 10, "height" => 10];
 
 try {
 	imagecrop($img, $arr);
@@ -30,7 +30,7 @@ try {
 	echo $e->getMessage() . PHP_EOL;
 }
 
-$arr = array("x" => 1, "y" => -2147483648, "width" => 10, "height" => -10);
+$arr = ["x" => 1, "y" => -2147483648, "width" => 10, "height" => -10];
 
 try {
 	imagecrop($img, $arr);


### PR DESCRIPTION
```
ext/gd/libgd/gd.c:2275:14: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
    #0 0x5d6a2103e1db in php_gd_gdImageCopy /home/dcarlier/Contribs/php-src/ext/gd/libgd/gd.c:2275
    #1 0x5d6a210a2b63 in gdImageCrop /home/dcarlier/Contribs/php-src/ext/gd/libgd/gd_crop.c:57
    #2 0x5d6a21018ca4 in zif_imagecrop /home/dcarlier/Contribs/php-src/ext/gd/gd.c:3575
    #3 0x5d6a21e46e7a in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:1337
    #4 0x5d6a221188da in execute_ex /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:57246
    #5 0x5d6a221366bd in zend_execute /home/dcarlier/Contribs/php-src/Zend/zend_vm_execute.h:61634
    #6 0x5d6a21d107a6 in zend_execute_scripts /home/dcarlier/Contribs/php-src/Zend/zend.c:1895
    #7 0x5d6a21a63409 in php_execute_script /home/dcarlier/Contribs/php-src/main/main.c:2529
    #8 0x5d6a22516d5e in do_cli /home/dcarlier/Contribs/php-src/sapi/cli/php_cli.c:966
    #9 0x5d6a2251981d in main /home/dcarlier/Contribs/php-src/sapi/cli/php_cli.c:1341
    #10 0x7f10d002a3b7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7f10d002a47a in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x5d6a20a06da4 in _start (/home/dcarlier/Contribs/php-src/sapi/cli/php+0x2806da4) (BuildId: d9a79c7e0e4872311439d7313cb3a81fe04190a2)
```