### PR TITLE
Fix GH-17951: Addition of max_memory_limit INI

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -317,23 +317,67 @@ static PHP_INI_MH(OnSetSerializePrecision)
 static PHP_INI_MH(OnChangeMemoryLimit)
 {
 	size_t value;
-	if (new_value) {
-		value = zend_ini_parse_uquantity_warn(new_value, entry->name);
-	} else {
-		value = Z_L(1)<<30;		/* effectively, no limit */
-	}
-	if (zend_set_memory_limit(value) == FAILURE) {
-		/* When the memory limit is reset to the original level during deactivation, we may be
-		 * using more memory than the original limit while shutdown is still in progress.
-		 * Ignore a failure for now, and set the memory limit when the memory manager has been
-		 * shut down and the minimal amount of memory is used. */
-		if (stage != ZEND_INI_STAGE_DEACTIVATE) {
-			zend_error(E_WARNING, "Failed to set memory limit to %zd bytes (Current memory usage is %zd bytes)", value, zend_memory_usage(true));
-			return FAILURE;
+
+    if (new_value) {
+        value = zend_ini_parse_uquantity_warn(new_value, entry->name);
+    } else {
+        value = Z_L(1) << 30; /* effectively, no limit */
+    }
+
+	/* If max_memory_limit is not set to unlimited, memory_limit cannot be set to unlimited. */
+	if (value == -1 && PG(max_memory_limit) != -1) {
+		if (PG(memory_limit) == 0) {
+			/* memory_limit exceeds max_memory_limit at INI parsing. */
+			zend_error(E_ERROR, "memory_limit cannot be set to unlimited when max_memory_limit (%zd bytes) is not unlimited", PG(max_memory_limit));
+			zend_bailout();
+			exit(1);
+		} else {
+			/* new memory_limit exceeds max_memory_limit at runtime. */
+			zend_error(E_WARNING, "Failed to set memory_limit to unlimited. memory_limit (currently: %zd bytes) cannot be set to unlimited if max_memory_limit (%zd bytes) is not unlimited", PG(memory_limit), PG(max_memory_limit));
 		}
+
+		return FAILURE;
 	}
-	PG(memory_limit) = value;
-	return SUCCESS;
+
+    /* Enforce max_memory_limit if not unlimited */
+    if (PG(max_memory_limit) != -1 && value > PG(max_memory_limit)) {
+		if (PG(memory_limit) == 0) {
+			/* memory_limit exceeds max_memory_limit at INI parsing. */
+			zend_error(E_ERROR, "memory_limit (%zd bytes) exceeds max_memory_limit (%zd bytes)", value, PG(max_memory_limit));
+			zend_bailout();
+			exit(1);
+		} else {
+			/* new memory_limit exceeds max_memory_limit at runtime. */
+			zend_error(E_WARNING, "Failed to set memory_limit to %zd bytes. memory_limit (currently: %zd bytes) cannot exceed max_memory_limit (%zd bytes)", value, PG(memory_limit), PG(max_memory_limit));
+		}
+
+		return FAILURE;
+    }
+
+    if (zend_set_memory_limit(value) == FAILURE) {
+        if (stage != ZEND_INI_STAGE_DEACTIVATE) {
+            zend_error(E_WARNING, "Failed to set memory limit to %zd bytes (Current memory usage is %zd bytes)", value, zend_memory_usage(true));
+            return FAILURE;
+        }
+    }
+
+    PG(memory_limit) = value;
+    return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH */
+static PHP_INI_MH(OnChangeMaxMemoryLimit)
+{
+	size_t value;
+    if (new_value) {
+        value = zend_ini_parse_uquantity_warn(new_value, entry->name);
+    } else {
+        value = Z_L(1) << 30; /* effectively, no limit */
+    }
+
+    PG(max_memory_limit) = value;
+    return SUCCESS;
 }
 /* }}} */
 
@@ -800,7 +844,10 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("mail.mixed_lf_and_crlf",			"0",		PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateBool,			mail_mixed_lf_and_crlf,			php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("mail.log",					NULL,		PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateMailLog,			mail_log,			php_core_globals,	core_globals)
 	PHP_INI_ENTRY("browscap",					NULL,		PHP_INI_SYSTEM,		OnChangeBrowscap)
-	PHP_INI_ENTRY("memory_limit",				"128M",		PHP_INI_ALL,		OnChangeMemoryLimit)
+
+	PHP_INI_ENTRY("max_memory_limit",		"-1",		PHP_INI_SYSTEM,		OnChangeMaxMemoryLimit)
+	PHP_INI_ENTRY("memory_limit",			"128M",		PHP_INI_ALL,		OnChangeMemoryLimit)
+
 	PHP_INI_ENTRY("precision",					"14",		PHP_INI_ALL,		OnSetPrecision)
 	PHP_INI_ENTRY("sendmail_from",				NULL,		PHP_INI_ALL,		NULL)
 	PHP_INI_ENTRY("sendmail_path",	DEFAULT_SENDMAIL_PATH,	PHP_INI_SYSTEM,		NULL)

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -72,6 +72,7 @@ struct _php_core_globals {
 	zend_long serialize_precision;
 
 	zend_long memory_limit;
+    zend_long max_memory_limit;
 	zend_long max_input_time;
 
 	char *error_log;

--- a/php.ini-development
+++ b/php.ini-development
@@ -436,6 +436,7 @@ max_input_time = 60
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
 memory_limit = 128M
+max_memory_limit = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/php.ini-production
+++ b/php.ini-production
@@ -438,6 +438,7 @@ max_input_time = 60
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
 memory_limit = 128M
+max_memory_limit = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/tests/basic/gh17951_ini_parse_1.phpt
+++ b/tests/basic/gh17951_ini_parse_1.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-17951 INI Parse 1
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=-1
+--FILE--
+<?php
+echo "OK";
+--EXPECT--
+OK

--- a/tests/basic/gh17951_ini_parse_2.phpt
+++ b/tests/basic/gh17951_ini_parse_2.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-17951 INI Parse 2
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=-1
+max_memory_limit=-1
+--FILE--
+<?php
+echo "OK";
+--EXPECT--
+OK

--- a/tests/basic/gh17951_ini_parse_3.phpt
+++ b/tests/basic/gh17951_ini_parse_3.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-17951 INI Parse 3
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=256M
+--FILE--
+<?php
+echo "OK";
+--EXPECT--
+OK

--- a/tests/basic/gh17951_ini_parse_4.phpt
+++ b/tests/basic/gh17951_ini_parse_4.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-17951 INI Parse 4
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=-1
+max_memory_limit=128M
+--FILE--
+<?php
+--EXPECTF--
+Fatal error: memory_limit cannot be set to unlimited when max_memory_limit (%d bytes) is not unlimited in %s

--- a/tests/basic/gh17951_ini_parse_5.phpt
+++ b/tests/basic/gh17951_ini_parse_5.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-17951 INI Parse 5
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=256M
+max_memory_limit=128M
+--FILE--
+<?php
+--EXPECTF--
+Fatal error: memory_limit (%d bytes) exceeds max_memory_limit (%d bytes) in %s

--- a/tests/basic/gh17951_runtime_change_1.phpt
+++ b/tests/basic/gh17951_runtime_change_1.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-17951 Runtime Change 1
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+ini_set('memory_limit', '256M');
+echo ini_get('memory_limit') . PHP_EOL . PHP_EOL;
+--EXPECT--
+256M

--- a/tests/basic/gh17951_runtime_change_2.phpt
+++ b/tests/basic/gh17951_runtime_change_2.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-17951 Runtime Change 2
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+ini_set('memory_limit', '512M');
+echo ini_get('memory_limit') . PHP_EOL . PHP_EOL;
+--EXPECT--
+512M

--- a/tests/basic/gh17951_runtime_change_3.phpt
+++ b/tests/basic/gh17951_runtime_change_3.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-17951 Runtime Change 3
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+ini_set('memory_limit', '1024M');
+echo ini_get('memory_limit');
+--EXPECTF--
+Warning: Failed to set memory_limit to %d bytes. memory_limit (currently: %d bytes) cannot exceed max_memory_limit (%d bytes) in %s
+128M

--- a/tests/basic/gh17951_runtime_change_4.phpt
+++ b/tests/basic/gh17951_runtime_change_4.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-17951 Runtime Change 4
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+ini_set('memory_limit', '-1');
+echo ini_get('memory_limit');
+--EXPECTF--
+Warning: Failed to set memory_limit to unlimited. memory_limit (currently: %d bytes) cannot be set to unlimited if max_memory_limit (%d bytes) is not unlimited in %s
+128M

--- a/tests/basic/gh17951_runtime_change_5.phpt
+++ b/tests/basic/gh17951_runtime_change_5.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-17951 Runtime Change 5
+--CREDITS--
+Frederik Milling Pytlick
+frederikpyt@protonmail.com
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+var_dump(ini_set('max_memory_limit', '128M'));
+var_dump(ini_set('max_memory_limit', '256M'));
+var_dump(ini_set('max_memory_limit', '512M'));
+var_dump(ini_set('max_memory_limit', '-1'));
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(false)


### PR DESCRIPTION
Added a new INI `max_memory_limit` which acts as a cap on how much you can raise `memory_limit` using `ini_set()` during runtime.