### PR TITLE
ext/mysqlnd: fix passing wrong parameter after a893a49

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -665,7 +665,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		}
 
 		mysqlnd_set_persistent_string(&conn->username, username.s, username.l, conn->persistent);
-		mysqlnd_set_persistent_string(&conn->password, username.s, password.l, conn->persistent);
+		mysqlnd_set_persistent_string(&conn->password, password.s, password.l, conn->persistent);
 		conn->port				= port;
 		mysqlnd_set_persistent_string(&conn->connect_or_select_db, database.s, database.l, conn->persistent);
 


### PR DESCRIPTION
Stumbled upon this. Looks like a wrong replacement in [a893a49](https://github.com/php/php-src/commit/a893a4901f6d52f7133c4cf35cc53acd0a8acc0d).