### PR TITLE
remove wrappers in session ext

### DIFF
--- a/ext/session/mod_user_class.c
+++ b/ext/session/mod_user_class.c
@@ -34,7 +34,6 @@
 		RETURN_FALSE;						\
 	}
 
-/* {{{ Wraps the old open handler */
 PHP_METHOD(SessionHandler, open)
 {
 	char *save_path = NULL, *session_name = NULL;
@@ -60,9 +59,7 @@ PHP_METHOD(SessionHandler, open)
 
 	RETURN_BOOL(SUCCESS == ret);
 }
-/* }}} */
 
-/* {{{ Wraps the old close handler */
 PHP_METHOD(SessionHandler, close)
 {
 	zend_result ret;
@@ -84,9 +81,7 @@ PHP_METHOD(SessionHandler, close)
 
 	RETURN_BOOL(SUCCESS == ret);
 }
-/* }}} */
 
-/* {{{ Wraps the old read handler */
 PHP_METHOD(SessionHandler, read)
 {
 	zend_string *val;
@@ -104,9 +99,7 @@ PHP_METHOD(SessionHandler, read)
 
 	RETURN_STR(val);
 }
-/* }}} */
 
-/* {{{ Wraps the old write handler */
 PHP_METHOD(SessionHandler, write)
 {
 	zend_string *key, *val;
@@ -119,9 +112,7 @@ PHP_METHOD(SessionHandler, write)
 
 	RETURN_BOOL(SUCCESS == PS(default_mod)->s_write(&PS(mod_data), key, val, PS(gc_maxlifetime)));
 }
-/* }}} */
 
-/* {{{ Wraps the old destroy handler */
 PHP_METHOD(SessionHandler, destroy)
 {
 	zend_string *key;
@@ -134,9 +125,7 @@ PHP_METHOD(SessionHandler, destroy)
 
 	RETURN_BOOL(SUCCESS == PS(default_mod)->s_destroy(&PS(mod_data), key));
 }
-/* }}} */
 
-/* {{{ Wraps the old gc handler */
 PHP_METHOD(SessionHandler, gc)
 {
 	zend_long maxlifetime;
@@ -153,9 +142,7 @@ PHP_METHOD(SessionHandler, gc)
 	}
 	RETURN_LONG(nrdels);
 }
-/* }}} */
 
-/* {{{ Wraps the old create_sid handler */
 PHP_METHOD(SessionHandler, create_sid)
 {
 	zend_string *id;
@@ -170,4 +157,3 @@ PHP_METHOD(SessionHandler, create_sid)
 
 	RETURN_STR(id);
 }
-/* }}} */

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1908,6 +1908,7 @@ PHP_FUNCTION(session_get_cookie_params)
 	add_assoc_string(return_value, "samesite", PS(cookie_samesite));
 }
 
+/* Return the current session name. If new name is given, the session name is replaced with new name */
 PHP_FUNCTION(session_name)
 {
 	zend_string *name = NULL;
@@ -1936,6 +1937,7 @@ PHP_FUNCTION(session_name)
 	}
 }
 
+/* Return the current module name used for accessing session data. If newname is given, the module name is replaced with newname */
 PHP_FUNCTION(session_module_name)
 {
 	zend_string *name = NULL;
@@ -2211,6 +2213,7 @@ PHP_FUNCTION(session_set_save_handler)
 	RETURN_TRUE;
 }
 
+/* Return the current save path passed to module_name. If newname is given, the save path is replaced with newname */
 PHP_FUNCTION(session_save_path)
 {
 	zend_string *name = NULL;
@@ -2239,6 +2242,7 @@ PHP_FUNCTION(session_save_path)
 	}
 }
 
+/* Return the current session id. If newid is given, the session id is replaced with newid */
 PHP_FUNCTION(session_id)
 {
 	zend_string *name = NULL;
@@ -2278,6 +2282,7 @@ PHP_FUNCTION(session_id)
 	}
 }
 
+/* Update the current session id with a newly generated one. If delete_old_session is set to true, remove the old session. */
 PHP_FUNCTION(session_regenerate_id)
 {
 	bool del_ses = 0;
@@ -2391,6 +2396,7 @@ PHP_FUNCTION(session_regenerate_id)
 	RETURN_TRUE;
 }
 
+/* Generate new session ID. Intended for user save handlers. */
 PHP_FUNCTION(session_create_id)
 {
 	zend_string *prefix = NULL, *new_id;
@@ -2445,6 +2451,7 @@ PHP_FUNCTION(session_create_id)
 	RETVAL_STR(smart_str_extract(&id));
 }
 
+/* Return the current cache limiter. If new_cache_limited is given, the current cache_limiter is replaced with new_cache_limiter */
 PHP_FUNCTION(session_cache_limiter)
 {
 	zend_string *limiter = NULL;
@@ -2473,6 +2480,7 @@ PHP_FUNCTION(session_cache_limiter)
 	}
 }
 
+/* Return the current cache expire. If new_cache_expire is given, the current cache_expire is replaced with new_cache_expire */
 PHP_FUNCTION(session_cache_expire)
 {
 	zend_long expires;
@@ -2503,6 +2511,7 @@ PHP_FUNCTION(session_cache_expire)
 	}
 }
 
+/* Serializes the current setup and returns the serialized representation */
 PHP_FUNCTION(session_encode)
 {
 	zend_string *enc;
@@ -2519,6 +2528,7 @@ PHP_FUNCTION(session_encode)
 	RETURN_STR(enc);
 }
 
+/* Deserializes data and reinitializes the variables */
 PHP_FUNCTION(session_decode)
 {
 	zend_string *str = NULL;
@@ -2702,6 +2712,7 @@ PHP_FUNCTION(session_write_close)
 	RETURN_TRUE;
 }
 
+/* Abort session and end session. Session data will not be written */
 PHP_FUNCTION(session_abort)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2715,6 +2726,7 @@ PHP_FUNCTION(session_abort)
 	RETURN_TRUE;
 }
 
+/* Reset session data from saved session data */
 PHP_FUNCTION(session_reset)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2737,6 +2749,7 @@ PHP_FUNCTION(session_status)
 	RETURN_LONG(PS(session_status));
 }
 
+/* Registers session_write_close() as a shutdown function */
 PHP_FUNCTION(session_register_shutdown)
 {
 	php_shutdown_function_entry shutdown_function_entry = {

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -105,7 +105,7 @@ static zend_result php_session_abort(void);
 static int my_module_number = 0;
 
 /* Dispatched by RINIT and by php_session_destroy */
-static inline void php_rinit_session_globals(void) /* {{{ */
+static inline void php_rinit_session_globals(void)
 {
 	/* Do NOT init PS(mod_user_names) here! */
 	/* TODO: These could be moved to MINIT and removed. These should be initialized by php_rshutdown_session_globals() always when execution is finished. */
@@ -120,9 +120,8 @@ static inline void php_rinit_session_globals(void) /* {{{ */
 	PS(module_number) = my_module_number;
 	ZVAL_UNDEF(&PS(http_session_vars));
 }
-/* }}} */
 
-static inline void php_session_headers_already_sent_error(int severity, const char *message) { /* {{{ */
+static inline void php_session_headers_already_sent_error(int severity, const char *message) {
 	const char *output_start_filename = php_output_get_start_filename();
 	int output_start_lineno = php_output_get_start_lineno();
 	if (output_start_filename != NULL) {
@@ -131,9 +130,8 @@ static inline void php_session_headers_already_sent_error(int severity, const ch
 		php_error_docref(NULL, severity, "%s", message);
 	}
 }
-/* }}} */
 
-static inline void php_session_session_already_started_error(int severity, const char *message) { /* {{{ */
+static inline void php_session_session_already_started_error(int severity, const char *message) {
 	if (PS(session_started_filename) != NULL) {
 		php_error_docref(NULL, severity, "%s (started from %s on line %"PRIu32")", message, ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
 	} else if (PS(auto_start)) {
@@ -143,9 +141,8 @@ static inline void php_session_session_already_started_error(int severity, const
 		php_error_docref(NULL, severity, "%s", message);
 	}
 }
-/* }}} */
 
-static inline void php_session_cleanup_filename(void) /* {{{ */
+static inline void php_session_cleanup_filename(void)
 {
 	if (PS(session_started_filename)) {
 		zend_string_release(PS(session_started_filename));
@@ -153,10 +150,9 @@ static inline void php_session_cleanup_filename(void) /* {{{ */
 		PS(session_started_lineno) = 0;
 	}
 }
-/* }}} */
 
 /* Dispatched by RSHUTDOWN and by php_session_destroy */
-static void php_rshutdown_session_globals(void) /* {{{ */
+static void php_rshutdown_session_globals(void)
 {
 	/* Do NOT destroy PS(mod_user_names) here! */
 	if (!Z_ISUNDEF(PS(http_session_vars))) {
@@ -189,9 +185,8 @@ static void php_rshutdown_session_globals(void) /* {{{ */
 	/* Set session status to prevent error while restoring save handler INI value. */
 	PS(session_status) = php_session_none;
 }
-/* }}} */
 
-PHPAPI zend_result php_session_destroy(void) /* {{{ */
+PHPAPI zend_result php_session_destroy(void)
 {
 	zend_result retval = SUCCESS;
 
@@ -212,9 +207,8 @@ PHPAPI zend_result php_session_destroy(void) /* {{{ */
 
 	return retval;
 }
-/* }}} */
 
-PHPAPI void php_add_session_var(zend_string *name) /* {{{ */
+PHPAPI void php_add_session_var(zend_string *name)
 {
 	IF_SESSION_VARS() {
 		zval *sess_var = Z_REFVAL(PS(http_session_vars));
@@ -226,9 +220,8 @@ PHPAPI void php_add_session_var(zend_string *name) /* {{{ */
 		}
 	}
 }
-/* }}} */
 
-PHPAPI zval* php_set_session_var(zend_string *name, zval *state_val, php_unserialize_data_t *var_hash) /* {{{ */
+PHPAPI zval* php_set_session_var(zend_string *name, zval *state_val, php_unserialize_data_t *var_hash)
 {
 	IF_SESSION_VARS() {
 		zval *sess_var = Z_REFVAL(PS(http_session_vars));
@@ -237,16 +230,14 @@ PHPAPI zval* php_set_session_var(zend_string *name, zval *state_val, php_unseria
 	}
 	return NULL;
 }
-/* }}} */
 
-PHPAPI zval* php_get_session_var(zend_string *name) /* {{{ */
+PHPAPI zval* php_get_session_var(zend_string *name)
 {
 	IF_SESSION_VARS() {
 		return zend_hash_find(Z_ARRVAL_P(Z_REFVAL(PS(http_session_vars))), name);
 	}
 	return NULL;
 }
-/* }}} */
 
 PHPAPI zval* php_get_session_var_str(const char *name, size_t name_len)
 {
@@ -256,7 +247,7 @@ PHPAPI zval* php_get_session_var_str(const char *name, size_t name_len)
 	return NULL;
 }
 
-static void php_session_track_init(void) /* {{{ */
+static void php_session_track_init(void)
 {
 	zval session_vars;
 	zend_string *var_name = ZSTR_INIT_LITERAL("_SESSION", 0);
@@ -273,9 +264,8 @@ static void php_session_track_init(void) /* {{{ */
 	zend_hash_update_ind(&EG(symbol_table), var_name, &PS(http_session_vars));
 	zend_string_release_ex(var_name, 0);
 }
-/* }}} */
 
-static zend_string *php_session_encode(void) /* {{{ */
+static zend_string *php_session_encode(void)
 {
 	IF_SESSION_VARS() {
         ZEND_ASSERT(PS(serializer));
@@ -285,7 +275,6 @@ static zend_string *php_session_encode(void) /* {{{ */
 	}
 	return NULL;
 }
-/* }}} */
 
 static ZEND_COLD void php_session_cancel_decode(void)
 {
@@ -294,7 +283,7 @@ static ZEND_COLD void php_session_cancel_decode(void)
 	php_error_docref(NULL, E_WARNING, "Failed to decode session object. Session has been destroyed");
 }
 
-static zend_result php_session_decode(zend_string *data) /* {{{ */
+static zend_result php_session_decode(zend_string *data)
 {
     ZEND_ASSERT(PS(serializer));
 	zend_result result = SUCCESS;
@@ -309,7 +298,6 @@ static zend_result php_session_decode(zend_string *data) /* {{{ */
 	} zend_end_try();
 	return result;
 }
-/* }}} */
 
 /*
  * Note that we cannot use the BASE64 alphabet here, because
@@ -319,7 +307,7 @@ static zend_result php_session_decode(zend_string *data) /* {{{ */
 
 static const char hexconvtab[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-";
 
-static void bin_to_readable(unsigned char *in, size_t inlen, char *out, size_t outlen, char nbits) /* {{{ */
+static void bin_to_readable(unsigned char *in, size_t inlen, char *out, size_t outlen, char nbits)
 {
 	unsigned char *p, *q;
 	unsigned short w;
@@ -353,9 +341,8 @@ static void bin_to_readable(unsigned char *in, size_t inlen, char *out, size_t o
 
 	*out = '\0';
 }
-/* }}} */
 
-PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
+PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS)
 {
 	unsigned char rbuf[PS_MAX_SID_LENGTH];
 	zend_string *outid;
@@ -374,12 +361,11 @@ PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
 
 	return outid;
 }
-/* }}} */
 
 /* Default session id char validation function allowed by ps_modules.
  * If you change the logic here, please also update the error message in
  * ps_modules appropriately */
-PHPAPI zend_result php_session_valid_key(const char *key) /* {{{ */
+PHPAPI zend_result php_session_valid_key(const char *key)
 {
 	size_t len;
 	const char *p;
@@ -406,10 +392,9 @@ PHPAPI zend_result php_session_valid_key(const char *key) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
 
-static zend_long php_session_gc(bool immediate) /* {{{ */
+static zend_long php_session_gc(bool immediate)
 {
 	zend_long num = -1;
 	bool collect = immediate;
@@ -425,9 +410,9 @@ static zend_long php_session_gc(bool immediate) /* {{{ */
 		}
 	}
 	return num;
-} /* }}} */
+}
 
-static zend_result php_session_initialize(void) /* {{{ */
+static zend_result php_session_initialize(void)
 {
 	zend_string *val = NULL;
 
@@ -520,9 +505,8 @@ static zend_result php_session_initialize(void) /* {{{ */
 	}
 	return SUCCESS;
 }
-/* }}} */
 
-static void php_session_save_current_state(int write) /* {{{ */
+static void php_session_save_current_state(int write)
 {
 	zend_result ret = FAILURE;
 
@@ -578,9 +562,8 @@ static void php_session_save_current_state(int write) /* {{{ */
 		PS(mod)->s_close(&PS(mod_data));
 	}
 }
-/* }}} */
 
-static void php_session_normalize_vars(void) /* {{{ */
+static void php_session_normalize_vars(void)
 {
 	PS_ENCODE_VARS;
 
@@ -594,13 +577,12 @@ static void php_session_normalize_vars(void) /* {{{ */
 		);
 	}
 }
-/* }}} */
 
 /* *************************
    * INI Settings/Handlers *
    ************************* */
 
-static PHP_INI_MH(OnUpdateSaveHandler) /* {{{ */
+static PHP_INI_MH(OnUpdateSaveHandler)
 {
 	const ps_module *tmp;
 	int err_type = E_ERROR;
@@ -634,9 +616,8 @@ static PHP_INI_MH(OnUpdateSaveHandler) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateSerializer) /* {{{ */
+static PHP_INI_MH(OnUpdateSerializer)
 {
 	const ps_serializer *tmp;
 
@@ -664,9 +645,8 @@ static PHP_INI_MH(OnUpdateSerializer) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateSaveDir) /* {{{ */
+static PHP_INI_MH(OnUpdateSaveDir)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
@@ -697,10 +677,9 @@ static PHP_INI_MH(OnUpdateSaveDir) /* {{{ */
 
 	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
 
-static PHP_INI_MH(OnUpdateName) /* {{{ */
+static PHP_INI_MH(OnUpdateName)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
@@ -729,10 +708,9 @@ static PHP_INI_MH(OnUpdateName) /* {{{ */
 
 	return OnUpdateStringUnempty(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
 
-static PHP_INI_MH(OnUpdateCookieLifetime) /* {{{ */
+static PHP_INI_MH(OnUpdateCookieLifetime)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
@@ -751,37 +729,32 @@ static PHP_INI_MH(OnUpdateCookieLifetime) /* {{{ */
 	}
 	return OnUpdateLongGEZero(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
 
-static PHP_INI_MH(OnUpdateSessionLong) /* {{{ */
+static PHP_INI_MH(OnUpdateSessionLong)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
 	return OnUpdateLong(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
-
-static PHP_INI_MH(OnUpdateSessionString) /* {{{ */
+static PHP_INI_MH(OnUpdateSessionString)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
 	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
 
-static PHP_INI_MH(OnUpdateSessionBool) /* {{{ */
+static PHP_INI_MH(OnUpdateSessionBool)
 {
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
 	return OnUpdateBool(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
-/* }}} */
 
 
-static PHP_INI_MH(OnUpdateSidLength) /* {{{ */
+static PHP_INI_MH(OnUpdateSidLength)
 {
 	zend_long val;
 	char *endptr = NULL;
@@ -802,9 +775,8 @@ static PHP_INI_MH(OnUpdateSidLength) /* {{{ */
 	php_error_docref(NULL, E_WARNING, "session.configuration \"session.sid_length\" must be between 22 and 256");
 	return FAILURE;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateSidBits) /* {{{ */
+static PHP_INI_MH(OnUpdateSidBits)
 {
 	zend_long val;
 	char *endptr = NULL;
@@ -825,9 +797,8 @@ static PHP_INI_MH(OnUpdateSidBits) /* {{{ */
 	php_error_docref(NULL, E_WARNING, "session.configuration \"session.sid_bits_per_character\" must be between 4 and 6");
 	return FAILURE;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateSessionGcProbability) /* {{{ */
+static PHP_INI_MH(OnUpdateSessionGcProbability)
 {
     SESSION_CHECK_ACTIVE_STATE;
     SESSION_CHECK_OUTPUT_STATE;
@@ -844,9 +815,8 @@ static PHP_INI_MH(OnUpdateSessionGcProbability) /* {{{ */
 
     return SUCCESS;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateSessionDivisor) /* {{{ */
+static PHP_INI_MH(OnUpdateSessionDivisor)
 {
     SESSION_CHECK_ACTIVE_STATE;
     SESSION_CHECK_OUTPUT_STATE;
@@ -863,9 +833,8 @@ static PHP_INI_MH(OnUpdateSessionDivisor) /* {{{ */
 
     return SUCCESS;
 }
-/* }}} */
 
-static PHP_INI_MH(OnUpdateRfc1867Freq) /* {{{ */
+static PHP_INI_MH(OnUpdateRfc1867Freq)
 {
 	int tmp = ZEND_ATOL(ZSTR_VAL(new_value));
 	if(tmp < 0) {
@@ -882,7 +851,7 @@ static PHP_INI_MH(OnUpdateRfc1867Freq) /* {{{ */
 		PS(rfc1867_freq) = tmp;
 	}
 	return SUCCESS;
-} /* }}} */
+}
 
 static PHP_INI_MH(OnUpdateUseOnlyCookies)
 {
@@ -918,7 +887,6 @@ static PHP_INI_MH(OnUpdateRefererCheck)
 	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 
-/* {{{ PHP_INI */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("session.save_path",          "",          PHP_INI_ALL, OnUpdateSaveDir,       save_path,          php_ps_globals,    ps_globals)
 	STD_PHP_INI_ENTRY("session.name",               "PHPSESSID", PHP_INI_ALL, OnUpdateName,          session_name,       php_ps_globals,    ps_globals)
@@ -961,12 +929,11 @@ PHP_INI_BEGIN()
 	/* Commented out until future discussion */
 	/* PHP_INI_ENTRY("session.encode_sources", "globals,track", PHP_INI_ALL, NULL) */
 PHP_INI_END()
-/* }}} */
 
 /* ***************
    * Serializers *
    *************** */
-PS_SERIALIZER_ENCODE_FUNC(php_serialize) /* {{{ */
+PS_SERIALIZER_ENCODE_FUNC(php_serialize)
 {
 	smart_str buf = {0};
 	php_serialize_data_t var_hash;
@@ -978,9 +945,8 @@ PS_SERIALIZER_ENCODE_FUNC(php_serialize) /* {{{ */
 	}
 	return buf.s;
 }
-/* }}} */
 
-PS_SERIALIZER_DECODE_FUNC(php_serialize) /* {{{ */
+PS_SERIALIZER_DECODE_FUNC(php_serialize)
 {
 	const char *endptr = val + vallen;
 	zval session_vars;
@@ -1010,13 +976,12 @@ PS_SERIALIZER_DECODE_FUNC(php_serialize) /* {{{ */
 	zend_string_release_ex(var_name, 0);
 	return result || !vallen ? SUCCESS : FAILURE;
 }
-/* }}} */
 
 #define PS_BIN_NR_OF_BITS 8
 #define PS_BIN_UNDEF (1<<(PS_BIN_NR_OF_BITS-1))
 #define PS_BIN_MAX (PS_BIN_UNDEF-1)
 
-PS_SERIALIZER_ENCODE_FUNC(php_binary) /* {{{ */
+PS_SERIALIZER_ENCODE_FUNC(php_binary)
 {
 	smart_str buf = {0};
 	php_serialize_data_t var_hash;
@@ -1036,9 +1001,8 @@ PS_SERIALIZER_ENCODE_FUNC(php_binary) /* {{{ */
 
 	return buf.s;
 }
-/* }}} */
 
-PS_SERIALIZER_DECODE_FUNC(php_binary) /* {{{ */
+PS_SERIALIZER_DECODE_FUNC(php_binary)
 {
 	const char *p;
 	const char *endptr = val + vallen;
@@ -1077,11 +1041,10 @@ PS_SERIALIZER_DECODE_FUNC(php_binary) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
 #define PS_DELIMITER '|'
 
-PS_SERIALIZER_ENCODE_FUNC(php) /* {{{ */
+PS_SERIALIZER_ENCODE_FUNC(php)
 {
 	smart_str buf = {0};
 	php_serialize_data_t var_hash;
@@ -1111,9 +1074,8 @@ PS_SERIALIZER_ENCODE_FUNC(php) /* {{{ */
 	PHP_VAR_SERIALIZE_DESTROY(var_hash);
 	return buf.s;
 }
-/* }}} */
 
-PS_SERIALIZER_DECODE_FUNC(php) /* {{{ */
+PS_SERIALIZER_DECODE_FUNC(php)
 {
 	const char *p, *q;
 	const char *endptr = val + vallen;
@@ -1160,7 +1122,6 @@ break_outer_loop:
 
 	return retval;
 }
-/* }}} */
 
 #define MAX_SERIALIZERS 32
 #define PREDEFINED_SERIALIZERS 3
@@ -1171,7 +1132,7 @@ static ps_serializer ps_serializers[MAX_SERIALIZERS + 1] = {
 	PS_SERIALIZER_ENTRY(php_binary)
 };
 
-PHPAPI zend_result php_session_register_serializer(const char *name, zend_string *(*encode)(PS_SERIALIZER_ENCODE_ARGS), zend_result (*decode)(PS_SERIALIZER_DECODE_ARGS)) /* {{{ */
+PHPAPI zend_result php_session_register_serializer(const char *name, zend_string *(*encode)(PS_SERIALIZER_ENCODE_ARGS), zend_result (*decode)(PS_SERIALIZER_DECODE_ARGS))
 {
 	zend_result ret = FAILURE;
 
@@ -1187,7 +1148,6 @@ PHPAPI zend_result php_session_register_serializer(const char *name, zend_string
 	}
 	return ret;
 }
-/* }}} */
 
 /* *******************
    * Storage Modules *
@@ -1201,7 +1161,7 @@ static const ps_module *ps_modules[MAX_MODULES + 1] = {
 	ps_user_ptr
 };
 
-PHPAPI zend_result php_session_register_module(const ps_module *ptr) /* {{{ */
+PHPAPI zend_result php_session_register_module(const ps_module *ptr)
 {
 	int ret = FAILURE;
 
@@ -1214,7 +1174,6 @@ PHPAPI zend_result php_session_register_module(const ps_module *ptr) /* {{{ */
 	}
 	return ret;
 }
-/* }}} */
 
 /* Dummy PS module function */
 /* We consider any ID valid (thus also implying that a session with such an ID exists),
@@ -1253,7 +1212,7 @@ static const char *week_days[] = {
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
 };
 
-static inline void strcpy_gmt(char *ubuf, time_t *when) /* {{{ */
+static inline void strcpy_gmt(char *ubuf, time_t *when)
 {
 	char buf[MAX_STR];
 	struct tm tm, *res;
@@ -1274,9 +1233,8 @@ static inline void strcpy_gmt(char *ubuf, time_t *when) /* {{{ */
 	memcpy(ubuf, buf, n);
 	ubuf[n] = '\0';
 }
-/* }}} */
 
-static inline void last_modified(void) /* {{{ */
+static inline void last_modified(void)
 {
 	const char *path;
 	zend_stat_t sb = {0};
@@ -1294,10 +1252,9 @@ static inline void last_modified(void) /* {{{ */
 		ADD_HEADER(buf);
 	}
 }
-/* }}} */
 
 #define EXPIRES "Expires: "
-CACHE_LIMITER_FUNC(public) /* {{{ */
+CACHE_LIMITER_FUNC(public)
 {
 	char buf[MAX_STR + 1];
 	struct timeval tv;
@@ -1314,9 +1271,8 @@ CACHE_LIMITER_FUNC(public) /* {{{ */
 
 	last_modified();
 }
-/* }}} */
 
-CACHE_LIMITER_FUNC(private_no_expire) /* {{{ */
+CACHE_LIMITER_FUNC(private_no_expire)
 {
 	char buf[MAX_STR + 1];
 
@@ -1325,16 +1281,14 @@ CACHE_LIMITER_FUNC(private_no_expire) /* {{{ */
 
 	last_modified();
 }
-/* }}} */
 
-CACHE_LIMITER_FUNC(private) /* {{{ */
+CACHE_LIMITER_FUNC(private)
 {
 	ADD_HEADER("Expires: Thu, 19 Nov 1981 08:52:00 GMT");
 	CACHE_LIMITER(private_no_expire)();
 }
-/* }}} */
 
-CACHE_LIMITER_FUNC(nocache) /* {{{ */
+CACHE_LIMITER_FUNC(nocache)
 {
 	ADD_HEADER("Expires: Thu, 19 Nov 1981 08:52:00 GMT");
 
@@ -1344,7 +1298,6 @@ CACHE_LIMITER_FUNC(nocache) /* {{{ */
 	/* For HTTP/1.0 conforming clients */
 	ADD_HEADER("Pragma: no-cache");
 }
-/* }}} */
 
 static const php_session_cache_limiter_t php_session_cache_limiters[] = {
 	CACHE_LIMITER_ENTRY(public)
@@ -1354,7 +1307,7 @@ static const php_session_cache_limiter_t php_session_cache_limiters[] = {
 	{0}
 };
 
-static int php_session_cache_limiter(void) /* {{{ */
+static int php_session_cache_limiter(void)
 {
 	const php_session_cache_limiter_t *lim;
 
@@ -1376,7 +1329,6 @@ static int php_session_cache_limiter(void) /* {{{ */
 
 	return -1;
 }
-/* }}} */
 
 /* *********************
    * Cookie Management *
@@ -1425,7 +1377,7 @@ static void php_session_remove_cookie(void) {
 	efree(session_cookie);
 }
 
-static zend_result php_session_send_cookie(void) /* {{{ */
+static zend_result php_session_send_cookie(void)
 {
 	smart_str ncookie = {0};
 	zend_string *date_fmt = NULL;
@@ -1499,9 +1451,8 @@ static zend_result php_session_send_cookie(void) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-PHPAPI const ps_module *_php_find_ps_module(const char *name) /* {{{ */
+PHPAPI const ps_module *_php_find_ps_module(const char *name)
 {
 	const ps_module *ret = NULL;
 	const ps_module **mod;
@@ -1515,9 +1466,8 @@ PHPAPI const ps_module *_php_find_ps_module(const char *name) /* {{{ */
 	}
 	return ret;
 }
-/* }}} */
 
-PHPAPI const ps_serializer *_php_find_ps_serializer(const char *name) /* {{{ */
+PHPAPI const ps_serializer *_php_find_ps_serializer(const char *name)
 {
 	const ps_serializer *ret = NULL;
 	const ps_serializer *mod;
@@ -1530,7 +1480,6 @@ PHPAPI const ps_serializer *_php_find_ps_serializer(const char *name) /* {{{ */
 	}
 	return ret;
 }
-/* }}} */
 
 static void ppid2sid(zval *ppid) {
 	ZVAL_DEREF(ppid);
@@ -1544,7 +1493,7 @@ static void ppid2sid(zval *ppid) {
 }
 
 
-PHPAPI zend_result php_session_reset_id(void) /* {{{ */
+PHPAPI zend_result php_session_reset_id(void)
 {
 	int module_number = PS(module_number);
 	zval *sid, *data, *ppid;
@@ -1614,10 +1563,9 @@ PHPAPI zend_result php_session_reset_id(void) /* {{{ */
 	}
 	return SUCCESS;
 }
-/* }}} */
 
 
-PHPAPI zend_result php_session_start(void) /* {{{ */
+PHPAPI zend_result php_session_start(void)
 {
 	zval *ppid;
 	zval *data;
@@ -1724,9 +1672,8 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-PHPAPI zend_result php_session_flush(int write) /* {{{ */
+PHPAPI zend_result php_session_flush(int write)
 {
 	if (PS(session_status) == php_session_active) {
 		php_session_save_current_state(write);
@@ -1735,14 +1682,13 @@ PHPAPI zend_result php_session_flush(int write) /* {{{ */
 	}
 	return FAILURE;
 }
-/* }}} */
 
 PHPAPI php_session_status php_get_session_status(void)
 {
 	return PS(session_status);
 }
 
-static zend_result php_session_abort(void) /* {{{ */
+static zend_result php_session_abort(void)
 {
 	if (PS(session_status) == php_session_active) {
 		if (PS(mod_data) || PS(mod_user_implemented)) {
@@ -1753,9 +1699,8 @@ static zend_result php_session_abort(void) /* {{{ */
 	}
 	return FAILURE;
 }
-/* }}} */
 
-static zend_result php_session_reset(void) /* {{{ */
+static zend_result php_session_reset(void)
 {
 	if (PS(session_status) == php_session_active
 		&& php_session_initialize() == SUCCESS) {
@@ -1763,26 +1708,22 @@ static zend_result php_session_reset(void) /* {{{ */
 	}
 	return FAILURE;
 }
-/* }}} */
 
 
 /* This API is not used by any PHP modules including session currently.
    session_adapt_url() may be used to set Session ID to target url without
    starting "URL-Rewriter" output handler. */
-PHPAPI void session_adapt_url(const char *url, size_t url_len, char **new_url, size_t *new_len) /* {{{ */
+PHPAPI void session_adapt_url(const char *url, size_t url_len, char **new_url, size_t *new_len)
 {
 	if (APPLY_TRANS_SID && (PS(session_status) == php_session_active)) {
 		*new_url = php_url_scanner_adapt_single_url(url, url_len, PS(session_name), ZSTR_VAL(PS(id)), new_len, 1);
 	}
 }
-/* }}} */
 
 /* ********************************
    * Userspace exported functions *
    ******************************** */
 
-/* {{{ session_set_cookie_params(array options)
-   Set session cookie parameters */
 PHP_FUNCTION(session_set_cookie_params)
 {
 	HashTable *options_ht;
@@ -1950,9 +1891,7 @@ cleanup:
 		if (samesite) zend_string_release(samesite);
 	}
 }
-/* }}} */
 
-/* {{{ Return the session cookie parameters */
 PHP_FUNCTION(session_get_cookie_params)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -1968,9 +1907,7 @@ PHP_FUNCTION(session_get_cookie_params)
 	add_assoc_bool(return_value, "httponly", PS(cookie_httponly));
 	add_assoc_string(return_value, "samesite", PS(cookie_samesite));
 }
-/* }}} */
 
-/* {{{ Return the current session name. If new name is given, the session name is replaced with new name */
 PHP_FUNCTION(session_name)
 {
 	zend_string *name = NULL;
@@ -1998,9 +1935,7 @@ PHP_FUNCTION(session_name)
 		zend_string_release_ex(ini_name, 0);
 	}
 }
-/* }}} */
 
-/* {{{ Return the current module name used for accessing session data. If newname is given, the module name is replaced with newname */
 PHP_FUNCTION(session_module_name)
 {
 	zend_string *name = NULL;
@@ -2048,7 +1983,6 @@ PHP_FUNCTION(session_module_name)
 		zend_string_release_ex(ini_name, 0);
 	}
 }
-/* }}} */
 
 static bool can_session_handler_be_changed(void) {
 	if (PS(session_status) == php_session_active) {
@@ -2108,7 +2042,6 @@ static inline void set_user_save_handler_ini(void) {
 		SESSION_SET_USER_HANDLER_PROCEDURAL(struct_name, fci); \
 	}
 
-/* {{{ Sets user-level functions */
 PHP_FUNCTION(session_set_save_handler)
 {
 	/* OOP Version */
@@ -2277,9 +2210,7 @@ PHP_FUNCTION(session_set_save_handler)
 
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Return the current save path passed to module_name. If newname is given, the save path is replaced with newname */
 PHP_FUNCTION(session_save_path)
 {
 	zend_string *name = NULL;
@@ -2307,9 +2238,7 @@ PHP_FUNCTION(session_save_path)
 		zend_string_release_ex(ini_name, 0);
 	}
 }
-/* }}} */
 
-/* {{{ Return the current session id. If newid is given, the session id is replaced with newid */
 PHP_FUNCTION(session_id)
 {
 	zend_string *name = NULL;
@@ -2348,9 +2277,7 @@ PHP_FUNCTION(session_id)
 		PS(id) = zend_string_copy(name);
 	}
 }
-/* }}} */
 
-/* {{{ Update the current session id with a newly generated one. If delete_old_session is set to true, remove the old session. */
 PHP_FUNCTION(session_regenerate_id)
 {
 	bool del_ses = 0;
@@ -2463,9 +2390,7 @@ PHP_FUNCTION(session_regenerate_id)
 
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Generate new session ID. Intended for user save handlers. */
 PHP_FUNCTION(session_create_id)
 {
 	zend_string *prefix = NULL, *new_id;
@@ -2519,9 +2444,7 @@ PHP_FUNCTION(session_create_id)
 	}
 	RETVAL_STR(smart_str_extract(&id));
 }
-/* }}} */
 
-/* {{{ Return the current cache limiter. If new_cache_limited is given, the current cache_limiter is replaced with new_cache_limiter */
 PHP_FUNCTION(session_cache_limiter)
 {
 	zend_string *limiter = NULL;
@@ -2549,9 +2472,7 @@ PHP_FUNCTION(session_cache_limiter)
 		zend_string_release_ex(ini_name, 0);
 	}
 }
-/* }}} */
 
-/* {{{ Return the current cache expire. If new_cache_expire is given, the current cache_expire is replaced with new_cache_expire */
 PHP_FUNCTION(session_cache_expire)
 {
 	zend_long expires;
@@ -2581,9 +2502,7 @@ PHP_FUNCTION(session_cache_expire)
 		zend_string_release_ex(ini_value, 0);
 	}
 }
-/* }}} */
 
-/* {{{ Serializes the current setup and returns the serialized representation */
 PHP_FUNCTION(session_encode)
 {
 	zend_string *enc;
@@ -2599,9 +2518,7 @@ PHP_FUNCTION(session_encode)
 
 	RETURN_STR(enc);
 }
-/* }}} */
 
-/* {{{ Deserializes data and reinitializes the variables */
 PHP_FUNCTION(session_decode)
 {
 	zend_string *str = NULL;
@@ -2620,7 +2537,6 @@ PHP_FUNCTION(session_decode)
 	}
 	RETURN_TRUE;
 }
-/* }}} */
 
 static zend_result php_session_start_set_ini(zend_string *varname, zend_string *new_value) {
 	zend_result ret;
@@ -2634,7 +2550,6 @@ static zend_result php_session_start_set_ini(zend_string *varname, zend_string *
 	return ret;
 }
 
-/* {{{ Begin session */
 PHP_FUNCTION(session_start)
 {
 	zval *options = NULL;
@@ -2722,9 +2637,7 @@ PHP_FUNCTION(session_start)
 
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Destroy the current session and all data associated with it */
 PHP_FUNCTION(session_destroy)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2733,9 +2646,7 @@ PHP_FUNCTION(session_destroy)
 
 	RETURN_BOOL(php_session_destroy() == SUCCESS);
 }
-/* }}} */
 
-/* {{{ Unset all registered variables */
 PHP_FUNCTION(session_unset)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2755,9 +2666,7 @@ PHP_FUNCTION(session_unset)
 	}
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Perform GC and return number of deleted sessions */
 PHP_FUNCTION(session_gc)
 {
 	zend_long num;
@@ -2778,10 +2687,8 @@ PHP_FUNCTION(session_gc)
 
 	RETURN_LONG(num);
 }
-/* }}} */
 
 
-/* {{{ Write session data and end session */
 PHP_FUNCTION(session_write_close)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2794,9 +2701,7 @@ PHP_FUNCTION(session_write_close)
 	php_session_flush(1);
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Abort session and end session. Session data will not be written */
 PHP_FUNCTION(session_abort)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2809,9 +2714,7 @@ PHP_FUNCTION(session_abort)
 	php_session_abort();
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Reset session data from saved session data */
 PHP_FUNCTION(session_reset)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2824,9 +2727,7 @@ PHP_FUNCTION(session_reset)
 	php_session_reset();
 	RETURN_TRUE;
 }
-/* }}} */
 
-/* {{{ Returns the current session status */
 PHP_FUNCTION(session_status)
 {
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -2835,9 +2736,7 @@ PHP_FUNCTION(session_status)
 
 	RETURN_LONG(PS(session_status));
 }
-/* }}} */
 
-/* {{{ Registers session_write_close() as a shutdown function */
 PHP_FUNCTION(session_register_shutdown)
 {
 	php_shutdown_function_entry shutdown_function_entry = {
@@ -2869,13 +2768,12 @@ PHP_FUNCTION(session_register_shutdown)
 		php_error_docref(NULL, E_WARNING, "Session shutdown function cannot be registered");
 	}
 }
-/* }}} */
 
 /* ********************************
    * Module Setup and Destruction *
    ******************************** */
 
-static zend_result php_rinit_session(bool auto_start) /* {{{ */
+static zend_result php_rinit_session(bool auto_start)
 {
 	php_rinit_session_globals();
 
@@ -2909,13 +2807,12 @@ static zend_result php_rinit_session(bool auto_start) /* {{{ */
 	}
 
 	return SUCCESS;
-} /* }}} */
+}
 
-static PHP_RINIT_FUNCTION(session) /* {{{ */
+static PHP_RINIT_FUNCTION(session)
 {
 	return php_rinit_session(PS(auto_start));
 }
-/* }}} */
 
 #define SESSION_FREE_USER_HANDLER(struct_name) \
 	if (!Z_ISUNDEF(PS(mod_user_names).struct_name)) { \
@@ -2924,7 +2821,7 @@ static PHP_RINIT_FUNCTION(session) /* {{{ */
 	}
 
 
-static PHP_RSHUTDOWN_FUNCTION(session) /* {{{ */
+static PHP_RSHUTDOWN_FUNCTION(session)
 {
 	if (PS(session_status) == php_session_active) {
 		zend_try {
@@ -2947,9 +2844,8 @@ static PHP_RSHUTDOWN_FUNCTION(session) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-static PHP_GINIT_FUNCTION(ps) /* {{{ */
+static PHP_GINIT_FUNCTION(ps)
 {
 #if defined(COMPILE_DL_SESSION) && defined(ZTS)
 	ZEND_TSRMLS_CACHE_UPDATE();
@@ -2995,9 +2891,8 @@ static PHP_GINIT_FUNCTION(ps) /* {{{ */
 	}
 	php_random_pcgoneseq128xslrr64_seed128(ps_globals->random.state, seed);
 }
-/* }}} */
 
-static PHP_MINIT_FUNCTION(session) /* {{{ */
+static PHP_MINIT_FUNCTION(session)
 {
 	zend_register_auto_global(zend_string_init_interned("_SESSION", sizeof("_SESSION") - 1, 1), 0, NULL);
 
@@ -3027,9 +2922,8 @@ static PHP_MINIT_FUNCTION(session) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-static PHP_MSHUTDOWN_FUNCTION(session) /* {{{ */
+static PHP_MSHUTDOWN_FUNCTION(session)
 {
 	UNREGISTER_INI_ENTRIES();
 
@@ -3048,9 +2942,8 @@ static PHP_MSHUTDOWN_FUNCTION(session) /* {{{ */
 
 	return SUCCESS;
 }
-/* }}} */
 
-static PHP_MINFO_FUNCTION(session) /* {{{ */
+static PHP_MINFO_FUNCTION(session)
 {
 	const ps_module **mod;
 	ps_serializer *ser;
@@ -3097,19 +2990,17 @@ static PHP_MINFO_FUNCTION(session) /* {{{ */
 
 	DISPLAY_INI_ENTRIES();
 }
-/* }}} */
 
-static const zend_module_dep session_deps[] = { /* {{{ */
+static const zend_module_dep session_deps[] = {
 	ZEND_MOD_OPTIONAL("spl")
 	ZEND_MOD_END
 };
-/* }}} */
 
 /* ************************
    * Upload hook handling *
    ************************ */
 
-static bool early_find_sid_in(zval *dest, int where, php_session_rfc1867_progress *progress) /* {{{ */
+static bool early_find_sid_in(zval *dest, int where, php_session_rfc1867_progress *progress)
 {
 	zval *ppid;
 
@@ -3125,9 +3016,9 @@ static bool early_find_sid_in(zval *dest, int where, php_session_rfc1867_progres
 	}
 
 	return 0;
-} /* }}} */
+}
 
-static void php_session_rfc1867_early_find_sid(php_session_rfc1867_progress *progress) /* {{{ */
+static void php_session_rfc1867_early_find_sid(php_session_rfc1867_progress *progress)
 {
 
 	if (PS(use_cookies)) {
@@ -3142,9 +3033,9 @@ static void php_session_rfc1867_early_find_sid(php_session_rfc1867_progress *pro
 	}
 	sapi_module.treat_data(PARSE_GET, NULL, NULL);
 	early_find_sid_in(&progress->sid, TRACK_VARS_GET, progress);
-} /* }}} */
+}
 
-static bool php_check_cancel_upload(php_session_rfc1867_progress *progress) /* {{{ */
+static bool php_check_cancel_upload(php_session_rfc1867_progress *progress)
 {
 	zval *progress_ary, *cancel_upload;
 
@@ -3158,9 +3049,9 @@ static bool php_check_cancel_upload(php_session_rfc1867_progress *progress) /* {
 		return 0;
 	}
 	return Z_TYPE_P(cancel_upload) == IS_TRUE;
-} /* }}} */
+}
 
-static void php_session_rfc1867_update(php_session_rfc1867_progress *progress, int force_update) /* {{{ */
+static void php_session_rfc1867_update(php_session_rfc1867_progress *progress, int force_update)
 {
 	if (!force_update) {
 		if (Z_LVAL_P(progress->post_bytes_processed) < progress->next_update) {
@@ -3192,9 +3083,9 @@ static void php_session_rfc1867_update(php_session_rfc1867_progress *progress, i
 		zend_hash_update(Z_ARRVAL_P(sess_var), progress->key.s, &progress->data);
 	}
 	php_session_flush(1);
-} /* }}} */
+}
 
-static void php_session_rfc1867_cleanup(php_session_rfc1867_progress *progress) /* {{{ */
+static void php_session_rfc1867_cleanup(php_session_rfc1867_progress *progress)
 {
 	php_session_initialize();
 	PS(session_status) = php_session_active;
@@ -3204,9 +3095,9 @@ static void php_session_rfc1867_cleanup(php_session_rfc1867_progress *progress) 
 		zend_hash_del(Z_ARRVAL_P(sess_var), progress->key.s);
 	}
 	php_session_flush(1);
-} /* }}} */
+}
 
-static zend_result php_session_rfc1867_callback(unsigned int event, void *event_data, void **extra) /* {{{ */
+static zend_result php_session_rfc1867_callback(unsigned int event, void *event_data, void **extra)
 {
 	php_session_rfc1867_progress *progress;
 	zend_result retval = SUCCESS;
@@ -3388,8 +3279,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 		return FAILURE;
 	}
 	return retval;
-
-} /* }}} */
+}
 
 zend_module_entry session_module_entry = {
 	STANDARD_MODULE_HEADER_EX,


### PR DESCRIPTION
Removes comment wrappers in session ext. Unnecessary noise and AFAIK they are not used anymore.