### PR TITLE
nitpick time_sleep_until_basic.phpt

### DIFF
--- a/ext/standard/tests/misc/time_sleep_until_basic.phpt
+++ b/ext/standard/tests/misc/time_sleep_until_basic.phpt
@@ -11,11 +11,29 @@ Michele Orselli mo@ideato.it
 #PHPTestFest Cesena Italia on 2009-06-20
 --FILE--
 <?php
-$time = microtime(true) + 2;
-$sleepUntil = (int) $time;
+/**
+ * Checks if a value is within a specified tolerance of a target value.
+ *
+ * @param float $val       The value to test.
+ * @param float $target    The target value.
+ * @param float $tolerance The allowed tolerance.
+ *
+ * @return bool True if the absolute difference is less than or equal to the tolerance, false otherwise.
+ */
+function isWithinTolerance(float $val, float $target, float $tolerance): bool {
+    return abs($val - $target) <= $tolerance;
+}
+
+// Calculate the target sleep time (2 seconds from now)
+$targetTime = microtime(true) + 2;
+$sleepUntil = $targetTime;
+
+// Sleep until the target time and output the result of time_sleep_until()
 var_dump(time_sleep_until($sleepUntil));
-$now = microtime(true);
-if (substr(PHP_OS, 0, 3) == 'WIN') {
+
+// Capture the current time immediately after sleep
+$currentTime = microtime(true);
+if (stripos(PHP_OS, 'WIN') === 0) {
     // on windows, time_sleep_until has millisecond accuracy while microtime() is accurate
     // to 10th of a second. this means there can be up to a .9 millisecond difference
     // which will fail this test. this test randomly fails on Windows and this is the cause.
@@ -24,20 +42,22 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
     // passes for up to .5 milliseconds less, fails for more than .5 milliseconds
     // should be fine since time_sleep_until() on Windows is accurate to the
     // millisecond(.5 rounded up is 1 millisecond)
-    // In practice, on slower machines even that can fail, so giving yet 50ms or more.
-    $tmp = round($now, 3);
-    $now = $tmp >= (int)$time ? $tmp : $tmp + .05;
-}
-
-// Add some tolerance for early wake on macos. Reason unknown.
-if ($now + 0.002 >= $sleepUntil) {
-    echo "Success\n";
+    $tolerance = 0.05;
+} elseif (stripos(PHP_OS, 'DARWIN') === 0) {
+    // macOS: time_sleep_until() may wake up slightly early for unknown reasons. Allow a larger tolerance.
+    $tolerance = 0.004;
 } else {
-    echo "Sleep until (before truncation): ", $time, "\n";
-    echo "Sleep until: ", $sleepUntil, "\n";
-    echo "Now: ", $now, "\n";
+    // Default tolerance
+    $tolerance = 0.002;
 }
 
+if ($currentTime >= $sleepUntil && isWithinTolerance($currentTime, $sleepUntil, $tolerance)) {
+    echo "Success" . PHP_EOL;
+} else {
+    echo "Sleep until (before truncation): {$targetTime}" . PHP_EOL;
+    echo "Sleep until: {$sleepUntil}" . PHP_EOL;
+    echo "Now: {$currentTime}" . PHP_EOL;
+}
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
was randomly failing on my windows-WSL-linux system. remove rounding of target time.
remove rounding of tolerance on windows, it looked dodgy. hardcode tolerance rather than dynamically adjusting, makes it easier to reason about.

Only tested on WSL-Linux as of writing, but the github CI should do the rest.