### PR TITLE
Fix flaky conneciton count in mysql test

### DIFF
--- a/ext/mysqli/tests/bug73462.phpt
+++ b/ext/mysqli/tests/bug73462.phpt
@@ -1,17 +1,10 @@
 --TEST--
 Bug #73462 (Persistent connections don't set $connect_errno)
 --EXTENSIONS--
-mysqli
+all
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-/*
- * TODO: this test is flaky with persistent connections on PPC CI runner
- * [001] Expected '8711' got '8712'.
- */
-if (gethostname() == "php-ci-ppc64be") {
-    die("SKIP test is flaky");
-}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Mark this test as conflicting with "all" to run it in isolation. Otherwise, other tests may influence the servers connection count.

Context: https://github.com/php/php-src/actions/runs/13801750596/job/38605337488