### PR TITLE
Fix GH-18018: RC1 data returned from offsetGet causes UAF in ArrayObject

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -641,12 +641,14 @@ static bool spl_array_has_dimension_ex(bool check_inherited, zend_object *object
 		}
 	}
 
+	/* empty() check the value is not falsy, isset() only check it is not null */
+	bool result = check_empty ? zend_is_true(value) : Z_TYPE_P(value) != IS_NULL;
+
 	if (value == &rv) {
 		zval_ptr_dtor(&rv);
 	}
 
-	/* empty() check the value is not falsy, isset() only check it is not null */
-	return check_empty ? zend_is_true(value) : Z_TYPE_P(value) != IS_NULL;
+	return result;
 } /* }}} */
 
 static int spl_array_has_dimension(zend_object *object, zval *offset, int check_empty) /* {{{ */

--- a/ext/spl/tests/gh18018.phpt
+++ b/ext/spl/tests/gh18018.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-18018 (RC1 data returned from offsetGet causes UAF in ArrayObject)
+--FILE--
+<?php
+class Crap extends ArrayObject
+{
+    public function offsetGet($offset): mixed
+    {
+        return [random_int(1,1)];
+    }
+}
+
+$values = ['qux' => 1];
+
+$object = new Crap($values);
+
+var_dump(empty($object['qux']));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
We should first check truthiness and only after that destroy the value.