### PR TITLE
Fix GH-18033: NULL-ptr dereference when using register_tick_function in destructor

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -38,6 +38,9 @@ PHP 8.5 UPGRADE NOTES
     resources that were indirectly collected through cycles.
   . It is now allowed to substitute static with self or the concrete class name
     in final subclasses.
+  . The tick handlers are now deactivated after all shutdown functions, destructors
+    have run and the output handlers have been cleaned up.
+    This is a consequence of fixing GH-18033.
 
 - Intl:
   . The extension now requires at least ICU 57.1.

--- a/Zend/tests/declare/gh18033_1.phpt
+++ b/Zend/tests/declare/gh18033_1.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-18033 (NULL-ptr dereference when using register_tick_function in destructor)
+--DESCRIPTION--
+Needs --repeat 2 or something similar to reproduce
+--CREDITS--
+clesmian
+--FILE--
+<?php
+class Foo {
+  function __destruct() {
+    declare(ticks=1);
+    register_tick_function(
+       function() { }
+    );
+    echo "In destructor\n";
+  }
+}
+
+$bar = new Foo;
+echo "Done\n";
+?>
+--EXPECT--
+Done
+In destructor

--- a/Zend/tests/declare/gh18033_2.phpt
+++ b/Zend/tests/declare/gh18033_2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-18033 (NULL-ptr dereference when using register_tick_function in ob_start)
+--DESCRIPTION--
+Needs --repeat 2 or something similar to reproduce
+--CREDITS--
+clesmian
+--FILE--
+<?php
+ob_start(function() {
+    declare(ticks=1);
+    register_tick_function(
+       function() { }
+    );
+});
+?>
+--EXPECT--

--- a/main/main.c
+++ b/main/main.c
@@ -1904,8 +1904,6 @@ void php_request_shutdown(void *dummy)
 	 */
 	EG(current_execute_data) = NULL;
 
-	php_deactivate_ticks();
-
 	/* 0. Call any open observer end handlers that are still open after a zend_bailout */
 	if (ZEND_OBSERVER_ENABLED) {
 		zend_observer_fcall_end_all();
@@ -1925,6 +1923,8 @@ void php_request_shutdown(void *dummy)
 	zend_try {
 		php_output_end_all();
 	} zend_end_try();
+
+	php_deactivate_ticks();
 
 	/* 4. Reset max_execution_time (no longer executing php code after response sent) */
 	zend_try {


### PR DESCRIPTION
The problem is that `php_request_shutdown` calls `php_deactivate_ticks` prior to running destructors and the shutdown functions and finalizing output handlers.
So if a destructor or shutdown function re-registers a tick function, then the user tick functions handler will be added back to `PG(tick_functions)`. When the next request happens, the list `PG(tick_functions)` still contains an entry to call the user tick functions (added in the previous request during shutdown). This causes a NULL deref eventually because `run_user_tick_functions` assumes that if it is called then `BG(user_tick_functions)` must be non-NULL.

Fix this by moving the tick handler deactivation.