### PR TITLE
Fix GH-18037: SEGV Zend/zend_execute.c

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -4209,6 +4209,7 @@ static int zend_jit_handler(zend_jit_ctx *jit, const zend_op *opline, int may_th
 		case ZEND_ASSIGN_STATIC_PROP_OP:
 		case ZEND_ASSIGN_STATIC_PROP_REF:
 		case ZEND_ASSIGN_OBJ_REF:
+		case ZEND_FRAMELESS_ICALL_3:
 			zend_jit_set_last_valid_opline(jit, opline + 2);
 			break;
 		default:

--- a/ext/opcache/tests/jit/gh18037.phpt
+++ b/ext/opcache/tests/jit/gh18037.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-18037 (SEGV Zend/zend_execute.c)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=1201
+--FILE--
+<?php
+function test_helper()
+{
+    $list = [];
+    \in_array($list[0], $list, true) !== $list->matches();
+}
+
+test_helper();
+?>
+--EXPECTF--
+Warning: Undefined array key 0 in %s on line %d
+
+Fatal error: Uncaught Error: Call to a member function matches() on array in %s:%d
+Stack trace:
+#0 %s(%d): test_helper()
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
A frameless icall with 3 arguments is a special case because it uses OP_DATA, but this was not added to the list, so the opline pointed to the wrong address resulting in UBSAN report or crash.