### PR TITLE
ext/bcmath: If size of `BC_VECTOR` array is within 64 bytes, stack area is now used

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - BCMath:
   . Simplify `bc_divide()` code. (SakiTakamachi)
   . If the result is 0, n_scale is set to 0. (SakiTakamachi)
+  . If size of BC_VECTOR array is within 64 bytes, stack area is now used.
+    (SakiTakamachi)
 
 - CLI:
   . Add --ini=diff to print INI settings changed from the builtin default.

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -260,7 +260,15 @@ static void bc_do_div(
 	size_t quot_arr_size = numerator_arr_size - divisor_arr_size + 1;
 	size_t quot_real_arr_size = MIN(quot_arr_size, (quot_size + BC_VECTOR_SIZE - 1) / BC_VECTOR_SIZE);
 
-	BC_VECTOR *numerator_vectors = safe_emalloc(numerator_arr_size + divisor_arr_size + quot_arr_size, sizeof(BC_VECTOR), 0);
+	BC_VECTOR stack_vectors[BC_STACK_VECTOR_SIZE];
+	size_t allocation_arr_size = numerator_arr_size + divisor_arr_size + quot_arr_size;
+
+	BC_VECTOR *numerator_vectors;
+	if (allocation_arr_size <= BC_STACK_VECTOR_SIZE) {
+		numerator_vectors = stack_vectors;
+	} else {
+		numerator_vectors = safe_emalloc(allocation_arr_size, sizeof(BC_VECTOR), 0);
+	}
 	BC_VECTOR *divisor_vectors = numerator_vectors + numerator_arr_size;
 	BC_VECTOR *quot_vectors = divisor_vectors + divisor_arr_size;
 
@@ -302,7 +310,9 @@ static void bc_do_div(
 		quot_vectors[i] /= BASE;
 	}
 
-	efree(numerator_vectors);
+	if (allocation_arr_size > BC_STACK_VECTOR_SIZE) {
+		efree(numerator_vectors);
+	}
 }
 
 static inline void bc_divide_by_one(bc_num numerator, bc_num *quot, size_t quot_scale)

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -64,6 +64,9 @@
 #  define BC_LITTLE_ENDIAN 1
 #endif
 
+/* 64-bytes for 64-bit */
+#define BC_STACK_VECTOR_SIZE 8
+
 /*
  * Adding more than this many times may cause uint32_t/uint64_t to overflow.
  * Typically this is 1844 for 64bit and 42 for 32bit.


### PR DESCRIPTION
# Benchmark

## Multiplication

### Codes

1 (Has no effect since this code using the fast path):
```
for ($i = 0; $i < 5000000; $i++) {
    bcmul('1.2345678', '2.1234567', 7);
}
```

2 (Affected by this change):
```
for ($i = 0; $i < 3000000; $i++) {
    bcmul('1234567890123456', '9234567890123456', 0);
}
```

3 (Does not use stack):
```
for ($i = 0; $i < 6000; $i++) {
    bcmul(str_repeat('1234567890', 300), str_repeat('9876543210', 300), 0);
}
```

### Results

Example 1 is not affected by this change, so there is no speed change. A positive effect can be seen in example 2, where the requested size is very close to `64 bytes`.
I thought that Example 3, which does not use a stack, would be slower due to the increased number of branches, but there was almost no change and the impact seems to be negligible.

1:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/mul/1.php
  Time (mean ± σ):     695.0 ms ±   6.9 ms    [User: 682.4 ms, System: 6.1 ms]
  Range (min … max):   688.5 ms … 711.6 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/mul/1.php
  Time (mean ± σ):     699.3 ms ±   2.6 ms    [User: 687.8 ms, System: 6.0 ms]
  Range (min … max):   696.2 ms … 703.6 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/mul/1.php' ran
    1.01 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/mul/1.php'
```

2:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/mul/2.php
  Time (mean ± σ):     450.6 ms ±   7.1 ms    [User: 439.3 ms, System: 6.1 ms]
  Range (min … max):   444.1 ms … 465.7 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/mul/2.php
  Time (mean ± σ):     484.3 ms ±   4.6 ms    [User: 474.6 ms, System: 4.5 ms]
  Range (min … max):   476.6 ms … 490.4 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/mul/2.php' ran
    1.07 ± 0.02 times faster than '/master/sapi/cli/php /mount/bc/mul/2.php'
```

3:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/mul/3.php
  Time (mean ± σ):     544.1 ms ±   4.0 ms    [User: 532.7 ms, System: 6.1 ms]
  Range (min … max):   540.9 ms … 554.4 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/mul/3.php
  Time (mean ± σ):     546.9 ms ±   4.0 ms    [User: 534.7 ms, System: 6.5 ms]
  Range (min … max):   541.3 ms … 553.8 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/mul/3.php' ran
    1.01 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/mul/3.php'
```


## Divide

### Codes

1 (Affected by this change (with fast path)):
```
for ($i = 0; $i < 2000000; $i++) {
    bcdiv('1.23', '2', 5);
}
```

2 (Affected by this change (with standard path)):
```
for ($i = 0; $i < 3000000; $i++) {
    bcdiv('1234567890123456', '1234567891234', 0);
}
```

3 (Does not use stack):
```
for ($i = 0; $i < 4000; $i++) {
    bcdiv(str_repeat('1234567890', 300), str_repeat('9876543210', 300), 1000);
}
```

### Results

Examples 1 and 2 are affected by this change and show a positive effect.
Example 3, which doesn't use the stack, is also somehow faster...

1:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/1.php
  Time (mean ± σ):     285.9 ms ±   1.8 ms    [User: 275.4 ms, System: 5.6 ms]
  Range (min … max):   282.0 ms … 289.1 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/1.php
  Time (mean ± σ):     303.7 ms ±   2.8 ms    [User: 292.5 ms, System: 5.9 ms]
  Range (min … max):   300.3 ms … 308.3 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/1.php' ran
    1.06 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/div/1.php'
```

2:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/2.php
  Time (mean ± σ):     497.4 ms ±   2.8 ms    [User: 485.8 ms, System: 6.2 ms]
  Range (min … max):   493.6 ms … 501.4 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/2.php
  Time (mean ± σ):     531.1 ms ±   8.0 ms    [User: 520.4 ms, System: 5.2 ms]
  Range (min … max):   523.3 ms … 550.8 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/2.php' ran
    1.07 ± 0.02 times faster than '/master/sapi/cli/php /mount/bc/div/2.php'
```

3:
```
Benchmark 1: /php-dev/sapi/cli/php /mount/bc/div/3.php
  Time (mean ± σ):     383.8 ms ±   4.0 ms    [User: 372.5 ms, System: 6.1 ms]
  Range (min … max):   376.7 ms … 388.6 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/div/3.php
  Time (mean ± σ):     401.5 ms ±   3.0 ms    [User: 389.4 ms, System: 6.8 ms]
  Range (min … max):   397.9 ms … 407.3 ms    10 runs
 
Summary
  '/php-dev/sapi/cli/php /mount/bc/div/3.php' ran
    1.05 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/div/3.php'
```