### PR TITLE
Fix OSS-Fuzz #403308724

### DIFF
--- a/Zend/tests/property_hooks/oss_fuzz_403308724.phpt
+++ b/Zend/tests/property_hooks/oss_fuzz_403308724.phpt
@@ -1,0 +1,30 @@
+--TEST--
+OSS-Fuzz #403308724
+--FILE--
+<?php
+class Base {
+    public $y { get => 1; }
+}
+
+class Test extends Base {
+    public $y {
+        get => [new class {
+            public $inner {get => __PROPERTY__;}
+        }, parent::$y::get()];
+    }
+}
+
+$test = new Test;
+$y = $test->y;
+var_dump($y);
+var_dump($y[0]->inner);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  object(class@anonymous)#2 (0) {
+  }
+  [1]=>
+  int(1)
+}
+string(5) "inner"

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8645,7 +8645,7 @@ static void zend_compile_prop_decl(zend_ast *ast, zend_ast *type_ast, uint32_t f
 		/* FIXME: This is a dirty fix to maintain ABI compatibility. We don't
 		 * have an actual property info yet, but we really only need the name
 		 * anyway. We should convert this to a zend_string. */
-		ZEND_ASSERT(!CG(context).active_property_info);
+		const zend_property_info *old_active_property_info = CG(context).active_property_info;
 		zend_property_info dummy_prop_info = { .name = name };
 		CG(context).active_property_info = &dummy_prop_info;
 
@@ -8742,7 +8742,7 @@ static void zend_compile_prop_decl(zend_ast *ast, zend_ast *type_ast, uint32_t f
 			zend_compile_attributes(&info->attributes, attr_ast, 0, ZEND_ATTRIBUTE_TARGET_PROPERTY, 0);
 		}
 
-		CG(context).active_property_info = NULL;
+		CG(context).active_property_info = old_active_property_info;
 	}
 }
 /* }}} */


### PR DESCRIPTION
Because hooks can be nested (via anon classes) without starting a new context (at least at the point we set the property information), we need to restore the old property info in case of nested hooks.