### PR TITLE
streams: Fix php_stream_from_{res|zval}_no_verify() APIs actually throwing TypeErrors

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -771,11 +771,17 @@ is_string:
 		} else if (Z_TYPE(retval) == IS_RESOURCE) {
 			php_stream *stream;
 			php_stream_from_zval_no_verify(stream, &retval);
-			if (stream == NULL) {
+			if (UNEXPECTED(stream == NULL)) {
+				zval callable;
+				zend_get_callable_zval_from_fcc(&LIBXML(entity_loader_callback), &callable);
+
+				zend_string *callable_name = zend_get_callable_name(&callable);
 				php_libxml_ctx_error(context,
-						"The user entity loader callback '%s' has returned a "
+						"The user entity loader callback \"%s\" has returned a "
 						"resource, but it is not a stream",
-						ZSTR_VAL(LIBXML(entity_loader_callback).function_handler->common.function_name));
+						ZSTR_VAL(callable_name));
+				zend_string_release(callable_name);
+				zval_dtor(&callable);
 			} else {
 				/* TODO: allow storing the encoding in the stream context? */
 				xmlCharEncoding enc = XML_CHAR_ENCODING_NONE;

--- a/ext/libxml/tests/libxml_get_external_entity_loader_error_callback_name.phpt
+++ b/ext/libxml/tests/libxml_get_external_entity_loader_error_callback_name.phpt
@@ -36,5 +36,8 @@ try {
 }
 
 ?>
---EXPECT--
-string(73) "DOMDocument::validate(): supplied resource is not a valid stream resource"
+--EXPECTF--
+Warning: DOMDocument::validate(): The user entity loader callback "Handler::handle" has returned a resource, but it is not a streamFailed to load external entity "-//FOO/BAR" in %s on line %d
+
+Warning: DOMDocument::validate(): Could not load the external subset "http://example.com/foobar" in %s on line %d
+bool(false)

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -422,7 +422,8 @@ static zend_result php_posix_stream_get_fd(zval *zfp, zend_long *ret) /* {{{ */
 
 	php_stream_from_zval_no_verify(stream, zfp);
 
-	if (stream == NULL) {
+	if (UNEXPECTED(stream == NULL)) {
+		zend_argument_type_error(1, "must be an open stream resource");
 		return FAILURE;
 	}
 

--- a/ext/posix/tests/posix_ttyname_error_wrongparams.phpt
+++ b/ext/posix/tests/posix_ttyname_error_wrongparams.phpt
@@ -27,4 +27,4 @@ try {
 ?>
 --EXPECT--
 bool(false)
-posix_ttyname(): supplied resource is not a valid stream resource
+posix_ttyname(): Argument #1 ($file_descriptor) must be an open stream resource

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -282,8 +282,8 @@ END_EXTERN_C()
 		return; \
 	} \
 } while (0)
-#define php_stream_from_res_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2((res), "stream", php_file_le_stream(), php_file_le_pstream())
-#define php_stream_from_zval_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2_ex((pzval), "stream", php_file_le_stream(), php_file_le_pstream())
+#define php_stream_from_res_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2((res), NULL, php_file_le_stream(), php_file_le_pstream())
+#define php_stream_from_zval_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2_ex((pzval), NULL, php_file_le_stream(), php_file_le_pstream())
 
 BEGIN_EXTERN_C()
 


### PR DESCRIPTION
If we pass a string as the `resource_type_name` parameter instead of `NULL` then a TypeError is emitted.