### PR TITLE
Fix memory leaks in fuzzer modules detected by cppchecker #18081

### DIFF
--- a/sapi/fuzzer/fuzzer-json.c
+++ b/sapi/fuzzer/fuzzer-json.c
@@ -15,8 +15,6 @@
    +----------------------------------------------------------------------+
  */
 
-
-
 #include "fuzzer.h"
 
 #include "Zend/zend.h"
@@ -31,13 +29,14 @@
 #include "ext/json/php_json_parser.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-	char *data = malloc(Size+1);
-	memcpy(data, Data, Size);
-	data[Size] = '\0';
 
-	if (fuzzer_request_startup() == FAILURE) {
+	if (fuzzer_request_startup() == FAILURE){
 		return 0;
 	}
+
+	char *data = malloc(Size + 1);
+	memcpy(data, Data, Size);
+	data[Size] = '\0';
 
 	for (int option = 0; option <=1; ++option) {
 		zval result;

--- a/sapi/fuzzer/fuzzer-mbregex.c
+++ b/sapi/fuzzer/fuzzer-mbregex.c
@@ -30,14 +30,15 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #ifdef HAVE_MBREGEX
-	char *args[2];
-	char *data = malloc(Size+1);
-	memcpy(data, Data, Size);
-	data[Size] = '\0';
 
 	if (fuzzer_request_startup() == FAILURE) {
 		return 0;
 	}
+
+	char *args[2];
+	char *data = malloc(Size+1);
+	memcpy(data, Data, Size);
+	data[Size] = '\0';
 
 	fuzzer_setup_dummy_frame();
 

--- a/sapi/fuzzer/fuzzer-unserialize.c
+++ b/sapi/fuzzer/fuzzer-unserialize.c
@@ -30,13 +30,14 @@
 #include "ext/standard/php_var.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-	unsigned char *orig_data = malloc(Size+1);
-	memcpy(orig_data, Data, Size);
-	orig_data[Size] = '\0';
 
 	if (fuzzer_request_startup() == FAILURE) {
 		return 0;
 	}
+
+	unsigned char *orig_data = malloc(Size+1);
+	memcpy(orig_data, Data, Size);
+	orig_data[Size] = '\0';
 
 	fuzzer_setup_dummy_frame();
 

--- a/sapi/fuzzer/fuzzer-unserializehash.c
+++ b/sapi/fuzzer/fuzzer-unserializehash.c
@@ -34,14 +34,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t FullSize) {
 	}
 	++Start;
 
+	if (fuzzer_request_startup() == FAILURE) {
+		return 0;
+	}
+
 	size_t Size = (Data + FullSize) - Start;
 	unsigned char *orig_data = malloc(Size+1);
 	memcpy(orig_data, Start, Size);
 	orig_data[Size] = '\0';
-
-	if (fuzzer_request_startup() == FAILURE) {
-		return 0;
-	}
 
 	fuzzer_setup_dummy_frame();
 


### PR DESCRIPTION
This PR fixes  #18081.

This pull request addresses several memory leak issues detected by cppchecker in the following files:

- **fuzzer-json.c (line 39):**  
  Added a `free(data)` call to release the allocated memory before returning.

- **fuzzer-mbregex.c (line 39):**  
  Implemented a similar fix by freeing the allocated memory for `data` when `fuzzer_request_startup()` fails.

- **fuzzer-unserialize.c (line 38):**  
  Now frees `orig_data` before returning when an error is detected.

- **fuzzer-unserializehash.c (line 43):**  
  Modified the error path to call `free(orig_data)` if `fuzzer_request_startup()` fails.

These changes ensure that memory allocated is properly released if `fuzzer_request_startup()` fails, preventing memory leaks.
