### PR TITLE
Merge JMP_FRAMELESS cache slots in Optimizer/compact_literals

### DIFF
--- a/Zend/Optimizer/compact_literals.c
+++ b/Zend/Optimizer/compact_literals.c
@@ -777,6 +777,9 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 					break;
 				case ZEND_DECLARE_ANON_CLASS:
 				case ZEND_DECLARE_CLASS_DELAYED:
+					opline->extended_value = cache_size;
+					cache_size += sizeof(void *);
+					break;
 				case ZEND_JMP_FRAMELESS:
 					// op1 func
 					if (jmp_slot[opline->op1.constant] >= 0) {


### PR DESCRIPTION
This avoids repeated lookups in the function table for the same function name.
Although this optimization is observable, i.e. defining a function via an include in between 2 JMP_FRAMELESS for the same function, this cannot be relied on already as far as I know if the optimizer runs.