### PR TITLE
main/streams: Move definitions to reduce ext/standard dependency and add new API

### DIFF
--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -36,7 +36,6 @@ PHPAPI PHP_FUNCTION(fpassthru);
 
 PHP_MINIT_FUNCTION(user_streams);
 
-PHPAPI int php_le_stream_context(void);
 PHPAPI zend_result php_copy_file(const char *src, const char *dest);
 PHPAPI zend_result php_copy_file_ex(const char *src, const char *dest, int src_flags);
 PHPAPI zend_result php_copy_file_ctx(const char *src, const char *dest, int src_flags, php_stream_context *ctx);

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -285,6 +285,10 @@ END_EXTERN_C()
 #define php_stream_from_res_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2((res), "stream", php_file_le_stream(), php_file_le_pstream())
 #define php_stream_from_zval_no_verify(xstr, pzval)	(xstr) = (php_stream*)zend_fetch_resource2_ex((pzval), "stream", php_file_le_stream(), php_file_le_pstream())
 
+static zend_always_inline php_stream* php_stream_from_zval_no_verify_no_error(zval *zval) {
+	return (php_stream*)zend_fetch_resource2_ex(zval, NULL, php_file_le_stream(), php_file_le_pstream());
+}
+
 BEGIN_EXTERN_C()
 
 static zend_always_inline bool php_stream_zend_parse_arg_into_stream(zval *arg, php_stream **destination_stream_ptr, bool check_null)

--- a/main/streams/php_stream_context.h
+++ b/main/streams/php_stream_context.h
@@ -53,6 +53,7 @@ struct _php_stream_context {
 };
 
 BEGIN_EXTERN_C()
+PHPAPI int php_le_stream_context(void);
 PHPAPI void php_stream_context_free(php_stream_context *context);
 PHPAPI php_stream_context *php_stream_context_alloc(void);
 PHPAPI zval *php_stream_context_get_option(php_stream_context *context,

--- a/main/streams/php_stream_context.h
+++ b/main/streams/php_stream_context.h
@@ -25,14 +25,17 @@ typedef void (*php_stream_notification_func)(php_stream_context *context,
 
 #define PHP_STREAM_NOTIFIER_PROGRESS	1
 
+/* TODO: Remove dependence on ext/standard/file.h for the default context global */
+#define php_stream_context_get_default(without_context) \
+	(without_context) ? NULL : FG(default_context) ? FG(default_context) : \
+		(FG(default_context) = php_stream_context_alloc())
+
 /* Attempt to fetch context from the zval passed,
    If no context was passed, use the default context
    The default context has not yet been created, do it now. */
 #define php_stream_context_from_zval(zcontext, nocontext) ( \
 		(zcontext) ? zend_fetch_resource_ex(zcontext, "Stream-Context", php_le_stream_context()) : \
-		(nocontext) ? NULL : \
-		FG(default_context) ? FG(default_context) : \
-		(FG(default_context) = php_stream_context_alloc()) )
+		php_stream_context_get_default(nocontext))
 
 #define php_stream_context_to_zval(context, zval) { ZVAL_RES(zval, (context)->res); GC_ADDREF((context)->res); }
 


### PR DESCRIPTION
This includes some of the commits of #17964 and a new inline function instead of doing #18079.