### PR TITLE
Fix parser expectation error for amp token

### DIFF
--- a/Zend/tests/gh18026.phpt
+++ b/Zend/tests/gh18026.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-18026: Confusing "amp" reference in parser error
+--FILE--
+<?php
+
+class Demo {
+    private (set) mixed $v1;
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected token ")", expecting token "&" in %s on line %d

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1819,6 +1819,14 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 		return sizeof("\"\\\"")-1;
 	}
 
+	/* We used "amp" as a dummy label to avoid a duplicate token literal warning. */
+	if (strcmp(toktype, "\"amp\"") == 0) {
+		if (yyres) {
+			yystpcpy(yyres, "token \"&\"");
+		}
+		return sizeof("token \"&\"")-1;
+	}
+
 	/* Strip off the outer quote marks */
 	if (toktype_len >= 2 && *toktype == '"') {
 		toktype++;


### PR DESCRIPTION
Currently, this is only handled for the "unexpected token" part of the message, but not the "expected" part.

Fixes GH-18026