### PR TITLE
Fix GH-18114: pdo lazy object crash

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -212,6 +212,7 @@ static void pdo_get_lazy_object(pdo_stmt_t *stmt, zval *return_value) /* {{{ */
 		pdo_row_t *row = zend_object_alloc(sizeof(pdo_row_t), pdo_row_ce);
 		row->stmt = stmt;
 		zend_object_std_init(&row->std, pdo_row_ce);
+		object_properties_init(&row->std, pdo_row_ce);
 		stmt->lazy_object_ref = &row->std;
 		GC_ADDREF(&stmt->std);
 		GC_DELREF(&row->std);
@@ -2405,6 +2406,7 @@ static zend_object *pdo_row_new(zend_class_entry *ce)
 {
 	pdo_row_t *row = zend_object_alloc(sizeof(pdo_row_t), ce);
 	zend_object_std_init(&row->std, ce);
+	object_properties_init(&row->std, pdo_row_ce);
 
 	return &row->std;
 }

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2406,7 +2406,7 @@ static zend_object *pdo_row_new(zend_class_entry *ce)
 {
 	pdo_row_t *row = zend_object_alloc(sizeof(pdo_row_t), ce);
 	zend_object_std_init(&row->std, ce);
-	object_properties_init(&row->std, pdo_row_ce);
+	object_properties_init(&row->std, ce);
 
 	return &row->std;
 }

--- a/ext/pdo_sqlite/tests/gh18114.phpt
+++ b/ext/pdo_sqlite/tests/gh18114.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-18114 (pdo lazy object crash)
+--EXTENSIONS--
+pdo_sqlite
+--XLEAK--
+See https://github.com/php/php-src/issues/18114#issuecomment-2738069692, will be fixed in a later PR on lower branches
+--FILE--
+<?php
+$db = new PDO('sqlite::memory:');
+$x = $db->query('select 1 as queryString');
+foreach ($x->fetch(PDO::FETCH_LAZY) as $entry) {
+    var_dump($entry);
+}
+echo "Done\n";
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
Since 0537968, the properties are no longer initialized. So we call object_properties_init to handle that correctly. Lower branches have a memory leak, but that requires a separate fix.