### PR TITLE
Fix GH-18112: NULL access with preloading and INI option

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4662,6 +4662,11 @@ static zend_result accel_finish_startup_preload(bool in_child)
 		EG(class_table) = NULL;
 		EG(function_table) = NULL;
 		PG(report_memleaks) = orig_report_memleaks;
+#ifdef ZTS
+		/* Reset the virtual CWD state back to the original state created by virtual_cwd_startup().
+		 * This is necessary because the normal startup code assumes the CWD state is active. */
+		virtual_cwd_activate();
+#endif
 	} else {
 		zend_shared_alloc_unlock();
 		ret = FAILURE;


### PR DESCRIPTION
Preloading shutdown calls request shutdown which will deactivate the virtual cwd state. However, further startup code still assumes the state that was set by virtual_cwd_startup(). So we need to reactivate it manually.

Creating a test was a bit difficult because the INI setting I wanted to test this with is overridden by the test runner apparently. To reproduce the issue, create an empty file test.php and execute this in a ZTS build:
`php -d opcache.preload=./ext/opcache/tests/preload_class_alias_2.inc -d "error_log=" -d "allow_url_include=1" test.php`