### PR TITLE
Fix segfault raise by bad from_xml callback

### DIFF
--- a/ext/soap/php_packet_soap.c
+++ b/ext/soap/php_packet_soap.c
@@ -192,6 +192,7 @@ int parse_packet_soap(zval *this_ptr, char *buffer, int buffer_size, sdlFunction
 			if (tmp != NULL && tmp->children != NULL) {
 				zval zv;
 				master_to_zval(&zv, get_conversion(IS_STRING), tmp);
+				convert_to_string(&zv)
 				faultstring = Z_STR(zv);
 			}
 
@@ -199,6 +200,7 @@ int parse_packet_soap(zval *this_ptr, char *buffer, int buffer_size, sdlFunction
 			if (tmp != NULL && tmp->children != NULL) {
 				zval zv;
 				master_to_zval(&zv, get_conversion(IS_STRING), tmp);
+				convert_to_string(&zv)
 				faultactor = Z_STR(zv);
 			}
 
@@ -222,6 +224,7 @@ int parse_packet_soap(zval *this_ptr, char *buffer, int buffer_size, sdlFunction
 				if (tmp != NULL && tmp->children != NULL) {
 					zval zv;
 					master_to_zval(&zv, get_conversion(IS_STRING), tmp);
+					convert_to_string(&zv)
 					faultstring = Z_STR(zv);
 				}
 			}

--- a/ext/soap/tests/bugs/bug66049.phpt
+++ b/ext/soap/tests/bugs/bug66049.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Fix #66049 Typemap can break parsing in parse_packet_soap leading to a segfault
+--EXTENSIONS--
+soap
+--INI--
+soap.wsdl_cache_enabled=0
+--FILE--
+<?php
+function soap_string_from_xml($str)
+    { 
+    echo "soap_string_from_xml\n";
+
+	// Should return an string
+    return 2.3; 
+    }
+
+class TestSoapClient extends SoapClient {
+    function __doRequest($request, $location, $action, $version, $one_way = 0): ?string {
+        $res='<?xml version="1.0" encoding="UTF-8"?>
+            <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+            <SOAP-ENV:Body>
+            <SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>not present</faultstring>
+            </SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+        return $res;
+    }
+}
+
+try {
+    $client=new TestSoapClient(null, [
+        'uri' => 'test://',
+        'location' => 'test://',
+        'typemap' => [[
+            "type_ns" => "http://www.w3.org/2001/XMLSchema",
+            "type_name" => "string",
+            "from_xml" => "soap_string_from_xml"
+         ]]]);
+    $client->Mist("");
+} catch (SoapFault $e) {
+    var_dump($e->faultstring);
+    var_dump($e->faultcode);
+}
+?>
+Done
+--EXPECT--
+soap_string_from_xml
+string(3) "2.3"
+string(15) "SOAP-ENV:Server"
+Done


### PR DESCRIPTION
Raised by 
```
function soap_string_from_xml($str)
    { 
    echo "soap_string_from_xml\n";

	// Should return an object
    return 2.3; 
    }

class TestSoapClient extends SoapClient {
    function __doRequest($request, $location, $action, $version, $one_way = 0): ?string {
        $res='<?xml version="1.0" encoding="UTF-8"?>
            <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
            <SOAP-ENV:Body>
            <SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>not present</faultstring>
            </SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>';
        return $res;
    }
}

try {
    $client=new TestSoapClient(null, [
        'uri' => 'test://',
        'location' => 'test://',
        'typemap' => [[
            "type_ns" => "http://www.w3.org/2001/XMLSchema",
            "type_name" => "string",
            "from_xml" => "soap_string_from_xml"
         ]]]);
    $client->Mist("");
} catch (SoapFault $e) {
    var_dump($e->faultstring);
    var_dump($e->faultcode);
}

```

Backtrace
```
(gdb) bt
#0  0x00007ffff700125d in __strlen_avx2 () from /usr/lib64/../lib64/libc.so.6
#1  0x0000000000946fdd in set_soap_fault (obj=0x7fffffffa300, fault_code_ns=0x0, fault_code=0x1e6b750 "SOAP-ENV:Server", 
    fault_string=0x400266666666667e <error: Cannot access memory at address 0x400266666666667e>, fault_actor=0x0, fault_detail=0x7fffffffa3d0, name=0x0) at /work/build/php83/ext/soap/soap.c:2781
#2  0x0000000000946e02 in add_soap_fault_ex (fault=0x7fffffffa300, obj=0x7ffff4c150e0, fault_code=0x1e6b750 "SOAP-ENV:Server", 
    fault_string=0x400266666666667e <error: Cannot access memory at address 0x400266666666667e>, fault_actor=0x0, fault_detail=0x7fffffffa3d0) at /work/build/php83/ext/soap/soap.c:2754
#3  0x0000000000946f20 in add_soap_fault (obj=0x7ffff4c150e0, fault_code=0x1e6b750 "SOAP-ENV:Server", fault_string=0x400266666666667e <error: Cannot access memory at address 0x400266666666667e>, 
    fault_actor=0x0, fault_detail=0x7fffffffa3d0) at /work/build/php83/ext/soap/soap.c:2771
#4  0x0000000000962c33 in parse_packet_soap (this_ptr=0x7ffff4c150e0, 
    buffer=0x7ffff4c6c798 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>n"..., buffer_size=277, fn=0x0, fn_name=0x7ffff4c8e218 "Mist", return_value=0x7fffffffa9f0, soap_headers=0x0) at /work/build/php83/ext/soap/php_packet_soap.c:234
#5  0x000000000094531b in do_soap_call (execute_data=0x7ffff4c150c0, this_ptr=0x7ffff4c150e0, function=0x7ffff4c8e218 "Mist", function_len=4, arg_count=1, real_args=0x7ffff4c600c0, 
    return_value=0x7fffffffa9f0, location=0x7ffff4c8e118 "test://", soap_action=0x0, call_uri=0x7ffff4c8e0d8 "test://", soap_headers=0x0, output_headers=0x0)
    at /work/build/php83/ext/soap/soap.c:2323
#6  0x0000000000945e86 in soap_client_call_impl (execute_data=0x7ffff4c150c0, return_value=0x7fffffffa9f0, is_soap_call=false) at /work/build/php83/ext/soap/soap.c:2493
#7  0x0000000000945f1b in zim_SoapClient___call (execute_data=0x7ffff4c150c0, return_value=0x7fffffffa9f0) at /work/build/php83/ext/soap/soap.c:2508
#8  0x0000000000bcf860 in ZEND_CALL_TRAMPOLINE_SPEC_OBSERVER_HANDLER () at /work/build/php83/Zend/zend_vm_execute.h:3629
#9  0x0000000000c3e03b in execute_ex (ex=0x7ffff4c15020) at /work/build/php83/Zend/zend_vm_execute.h:57386
#10 0x0000000000c42651 in zend_execute (op_array=0x7ffff4c90000, return_value=0x0) at /work/build/php83/Zend/zend_vm_execute.h:61634
#11 0x0000000000b8951a in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /work/build/php83/Zend/zend.c:1895
#12 0x0000000000ae75b3 in php_execute_script (primary_file=0x7fffffffd2e0) at /work/build/php83/main/main.c:2529
#13 0x0000000000cf8865 in do_cli (argc=2, argv=0x1c333a0) at /work/build/php83/sapi/cli/php_cli.c:966
#14 0x0000000000cf93bc in main (argc=2, argv=0x1c333a0) at /work/build/php83/sapi/cli/php_cli.c:1341
```

This is related to a bad callback return type, but should not raise a segfault.
Mostly a sanity check.


Reported 10 years ago as https://bugs.php.net/bug.php?id=66049 and never fixed