### PR TITLE
Fix memory leak when destroying PDORow

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2506,6 +2506,7 @@ void pdo_row_free_storage(zend_object *std)
 		ZVAL_UNDEF(&row->stmt->lazy_object_ref);
 		OBJ_RELEASE(&row->stmt->std);
 	}
+	zend_object_std_dtor(std);
 }
 
 zend_object *pdo_row_new(zend_class_entry *ce)

--- a/ext/pdo_sqlite/tests/gh18114.phpt
+++ b/ext/pdo_sqlite/tests/gh18114.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-18114 (pdo lazy object crash)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = new PDO('sqlite::memory:');
+$x = $db->query('select 1 as queryString');
+$data = $x->fetch(PDO::FETCH_LAZY);
+foreach ($data as $entry) {
+    var_dump($entry);
+}
+var_dump((array) $data);
+echo "Done\n";
+?>
+--EXPECT--
+array(0) {
+}
+Done


### PR DESCRIPTION
This should call zend_object_std_dtor() to clean the property table etc. This also has a semantic influence because previously weak refs were not notified for example.

This fixes the final issue in GH-18114 (the crash was master-only and fixed already).
Closes GH-18114.