### PR TITLE
ext/bcmath: In the arm processor environment, NEON is used to use SIMD.

### DIFF
--- a/ext/bcmath/libbcmath/src/convert.c
+++ b/ext/bcmath/libbcmath/src/convert.c
@@ -24,7 +24,7 @@ char *bc_copy_and_toggle_bcd(char *restrict dest, const char *source, const char
 	const size_t bulk_shift = SWAR_REPEAT('0');
 
 #ifdef HAVE_BC_SIMD_128
-	/* SIMD SSE2 of NEON bulk shift + copy */
+	/* SIMD SSE2 or NEON bulk shift + copy */
 	bc_simd_128_t shift_vector = bc_simd_set_8x16('0');
 	while (source + sizeof(bc_simd_128_t) <= source_end) {
 		bc_simd_128_t bytes = bc_simd_load_8x16((const bc_simd_128_t *) source);

--- a/ext/bcmath/libbcmath/src/convert.c
+++ b/ext/bcmath/libbcmath/src/convert.c
@@ -17,24 +17,22 @@
 #include "bcmath.h"
 #include "convert.h"
 #include "private.h"
-#ifdef __SSE2__
-# include <emmintrin.h>
-#endif
+#include "simd.h"
 
 char *bc_copy_and_toggle_bcd(char *restrict dest, const char *source, const char *source_end)
 {
 	const size_t bulk_shift = SWAR_REPEAT('0');
 
-#ifdef __SSE2__
-	/* SIMD SSE2 bulk shift + copy */
-	__m128i shift_vector = _mm_set1_epi8('0');
-	while (source + sizeof(__m128i) <= source_end) {
-		__m128i bytes = _mm_loadu_si128((const __m128i *) source);
-		bytes = _mm_xor_si128(bytes, shift_vector);
-		_mm_storeu_si128((__m128i *) dest, bytes);
+#ifdef HAVE_BC_SIMD_128
+	/* SIMD SSE2 of NEON bulk shift + copy */
+	bc_simd_128_t shift_vector = bc_simd_set_8x16('0');
+	while (source + sizeof(bc_simd_128_t) <= source_end) {
+		bc_simd_128_t bytes = bc_simd_load_8x16((const bc_simd_128_t *) source);
+		bytes = bc_simd_xor_8x16(bytes, shift_vector);
+		bc_simd_store_8x16((bc_simd_128_t *) dest, bytes);
 
-		source += sizeof(__m128i);
-		dest += sizeof(__m128i);
+		source += sizeof(bc_simd_128_t);
+		dest += sizeof(bc_simd_128_t);
 	}
 #endif
 

--- a/ext/bcmath/libbcmath/src/simd.h
+++ b/ext/bcmath/libbcmath/src/simd.h
@@ -1,0 +1,59 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Saki Takamachi <saki@php.net>                               |
+   +----------------------------------------------------------------------+
+*/
+
+
+#ifndef _BCMATH_SIMD_H_
+#define _BCMATH_SIMD_H_
+
+#ifdef __SSE2__
+# include <emmintrin.h>
+  typedef __m128i bc_simd_128_t;
+# define HAVE_BC_SIMD_128
+# define bc_simd_set_8x16(x) _mm_set1_epi8(x)
+# define bc_simd_load_8x16(ptr) _mm_loadu_si128((const __m128i *) (ptr))
+# define bc_simd_xor_8x16(a, b) _mm_xor_si128(a, b)
+# define bc_simd_store_8x16(ptr, val) _mm_storeu_si128((__m128i *) (ptr), val)
+# define bc_simd_add_8x16(a, b) _mm_add_epi8(a, b)
+# define bc_simd_cmpeq_8x16(a, b) _mm_cmpeq_epi8(a, b)
+# define bc_simd_cmplt_8x16(a, b) _mm_cmplt_epi8(a, b)
+# define bc_simd_movemask_8x16(a) _mm_movemask_epi8(a)
+
+#elif defined(__aarch64__) || defined(_M_ARM64)
+# include <arm_neon.h>
+  typedef int8x16_t bc_simd_128_t;
+# define HAVE_BC_SIMD_128
+# define bc_simd_set_8x16(x) vdupq_n_s8(x)
+# define bc_simd_load_8x16(ptr) vld1q_s8((const int8_t *) (ptr))
+# define bc_simd_xor_8x16(a, b) veorq_s8(a, b)
+# define bc_simd_store_8x16(ptr, val) vst1q_s8((int8_t *) (ptr), val)
+# define bc_simd_add_8x16(a, b) vaddq_s8(a, b)
+# define bc_simd_cmpeq_8x16(a, b) (vreinterpretq_s8_u8(vceqq_s8(a, b)))
+# define bc_simd_cmplt_8x16(a, b) (vreinterpretq_s8_u8(vcltq_s8(a, b)))
+  static inline int bc_simd_movemask_8x16(int8x16_t vec)
+  {
+      /**
+       * based on code from
+       * https://community.arm.com/arm-community-blogs/b/servers-and-cloud-computing-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
+       */
+      uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(vreinterpretq_u8_s8(vec), 7));
+      uint32x4_t paired16 = vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
+      uint64x2_t paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
+      uint8x16_t paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
+      return vgetq_lane_u8(paired64, 0) | ((int) vgetq_lane_u8(paired64, 8) << 8);
+  }
+#endif
+
+#endif

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -37,7 +37,7 @@
 #include <stddef.h>
 
 /* Convert strings to bc numbers.  Base 10 only.*/
-static const char *bc_count_digits(const char *str, const char *end)
+static inline const char *bc_count_digits(const char *str, const char *end)
 {
 	/* Process in bulk */
 #ifdef HAVE_BC_SIMD_128

--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -32,30 +32,28 @@
 #include "bcmath.h"
 #include "convert.h"
 #include "private.h"
+#include "simd.h"
 #include <stdbool.h>
 #include <stddef.h>
-#ifdef __SSE2__
-# include <emmintrin.h>
-#endif
 
 /* Convert strings to bc numbers.  Base 10 only.*/
 static const char *bc_count_digits(const char *str, const char *end)
 {
 	/* Process in bulk */
-#ifdef __SSE2__
-	const __m128i offset = _mm_set1_epi8((signed char) (SCHAR_MIN - '0'));
+#ifdef HAVE_BC_SIMD_128
+	const bc_simd_128_t offset = bc_simd_set_8x16((signed char) (SCHAR_MIN - '0'));
 	/* we use the less than comparator, so add 1 */
-	const __m128i threshold = _mm_set1_epi8(SCHAR_MIN + ('9' + 1 - '0'));
+	const bc_simd_128_t threshold = bc_simd_set_8x16(SCHAR_MIN + ('9' + 1 - '0'));
 
-	while (str + sizeof(__m128i) <= end) {
-		__m128i bytes = _mm_loadu_si128((const __m128i *) str);
+	while (str + sizeof(bc_simd_128_t) <= end) {
+		bc_simd_128_t bytes = bc_simd_load_8x16((const bc_simd_128_t *) str);
 		/* Wrapping-add the offset to the bytes, such that all bytes below '0' are positive and others are negative.
 		 * More specifically, '0' will be -128 and '9' will be -119. */
-		bytes = _mm_add_epi8(bytes, offset);
+		bytes = bc_simd_add_8x16(bytes, offset);
 		/* Now mark all bytes that are <= '9', i.e. <= -119, i.e. < -118, i.e. the threshold. */
-		bytes = _mm_cmplt_epi8(bytes, threshold);
+		bytes = bc_simd_cmplt_8x16(bytes, threshold);
 
-		int mask = _mm_movemask_epi8(bytes);
+		int mask = bc_simd_movemask_8x16(bytes);
 		if (mask != 0xffff) {
 			/* At least one of the bytes is not within range. Move to the first offending byte. */
 #ifdef PHP_HAVE_BUILTIN_CTZL
@@ -65,7 +63,7 @@ static const char *bc_count_digits(const char *str, const char *end)
 #endif
 		}
 
-		str += sizeof(__m128i);
+		str += sizeof(bc_simd_128_t);
 	}
 #endif
 
@@ -79,19 +77,19 @@ static const char *bc_count_digits(const char *str, const char *end)
 static inline const char *bc_skip_zero_reverse(const char *scanner, const char *stop)
 {
 	/* Check in bulk */
-#ifdef __SSE2__
-	const __m128i c_zero_repeat = _mm_set1_epi8('0');
-	while (scanner - sizeof(__m128i) >= stop) {
-		scanner -= sizeof(__m128i);
-		__m128i bytes = _mm_loadu_si128((const __m128i *) scanner);
+#ifdef HAVE_BC_SIMD_128
+	const bc_simd_128_t c_zero_repeat = bc_simd_set_8x16('0');
+	while (scanner - sizeof(bc_simd_128_t) >= stop) {
+		scanner -= sizeof(bc_simd_128_t);
+		bc_simd_128_t bytes = bc_simd_load_8x16((const bc_simd_128_t *) scanner);
 		/* Checks if all numeric strings are equal to '0'. */
-		bytes = _mm_cmpeq_epi8(bytes, c_zero_repeat);
+		bytes = bc_simd_cmpeq_8x16(bytes, c_zero_repeat);
 
-		int mask = _mm_movemask_epi8(bytes);
+		int mask = bc_simd_movemask_8x16(bytes);
 		/* The probability of having 16 trailing 0s in a row is very low, so we use EXPECTED. */
 		if (EXPECTED(mask != 0xffff)) {
 			/* Move the pointer back and check each character in loop. */
-			scanner += sizeof(__m128i);
+			scanner += sizeof(bc_simd_128_t);
 			break;
 		}
 	}


### PR DESCRIPTION
Looking at the assembly code, it appears that the original `bc_count_digits()` was treated as inline on Arm because the amount of code was small.
This change increased the amount of code and made it no longer inline, which made it a bit slower, so I specified it as inline.

# Benchmarks

## When `bc_count_digits()` is made an inline function

1:
```
for ($i = 0; $i < 4000000; $i++) {
    bcadd('1.23456789', '-2.12345678', 10);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/1.php
  Time (mean ± σ):     236.6 ms ±   1.2 ms    [User: 231.8 ms, System: 2.8 ms]
  Range (min … max):   234.6 ms … 239.2 ms    12 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/1.php
  Time (mean ± σ):     235.5 ms ±   1.9 ms    [User: 230.0 ms, System: 3.5 ms]
  Range (min … max):   233.2 ms … 241.0 ms    12 runs
 
Summary
  '/master/sapi/cli/php /mount/bc/1.php' ran
    1.00 ± 0.01 times faster than '/php-dev2/sapi/cli/php /mount/bc/1.php'
```

2:
```
for ($i = 0; $i < 4000000; $i++) {
    bcadd('12345678901234567890.12345678901234567890', '-212345678901234567890.12345678901234567890', 20);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/2.php
  Time (mean ± σ):     321.0 ms ±   0.7 ms    [User: 315.9 ms, System: 3.1 ms]
  Range (min … max):   319.8 ms … 322.3 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/2.php
  Time (mean ± σ):     423.4 ms ±   2.1 ms    [User: 418.1 ms, System: 3.2 ms]
  Range (min … max):   421.9 ms … 429.3 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/2.php' ran
    1.32 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/2.php'
```

3:
```
for ($i = 0; $i < 400000; $i++) {
    bcadd(str_repeat('12345678', 100), str_repeat('12345678', 100), 0);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/3.php
  Time (mean ± σ):     178.0 ms ±   1.9 ms    [User: 173.1 ms, System: 3.0 ms]
  Range (min … max):   175.0 ms … 182.5 ms    16 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/3.php
  Time (mean ± σ):     572.6 ms ±   4.5 ms    [User: 566.7 ms, System: 3.6 ms]
  Range (min … max):   566.8 ms … 581.0 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/3.php' ran
    3.22 ± 0.04 times faster than '/master/sapi/cli/php /mount/bc/3.php'
```


## If `bc_count_digits()` is not an inline function

1:
```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/1.php
  Time (mean ± σ):     249.9 ms ±   1.0 ms    [User: 244.0 ms, System: 3.8 ms]
  Range (min … max):   248.6 ms … 251.2 ms    11 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/1.php
  Time (mean ± σ):     233.5 ms ±   1.0 ms    [User: 228.1 ms, System: 3.3 ms]
  Range (min … max):   231.1 ms … 234.6 ms    12 runs
 
Summary
  '/master/sapi/cli/php /mount/bc/1.php' ran
    1.07 ± 0.01 times faster than '/php-dev2/sapi/cli/php /mount/bc/1.php'
```

2:
```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/2.php
  Time (mean ± σ):     332.8 ms ±   1.7 ms    [User: 327.7 ms, System: 3.0 ms]
  Range (min … max):   329.8 ms … 335.1 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/2.php
  Time (mean ± σ):     423.5 ms ±   1.2 ms    [User: 418.5 ms, System: 2.8 ms]
  Range (min … max):   421.2 ms … 425.3 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/2.php' ran
    1.27 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/2.php'
```

3:
```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/3.php
  Time (mean ± σ):     178.1 ms ±   0.4 ms    [User: 172.9 ms, System: 3.2 ms]
  Range (min … max):   177.5 ms … 178.7 ms    16 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/3.php
  Time (mean ± σ):     569.2 ms ±   2.3 ms    [User: 563.6 ms, System: 3.2 ms]
  Range (min … max):   566.3 ms … 573.4 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/3.php' ran
    3.20 ± 0.02 times faster than '/master/sapi/cli/php /mount/bc/3.php'
```