### PR TITLE
GDB: Import gdb.printing

### DIFF
--- a/main/debug_gdb_scripts.c
+++ b/main/debug_gdb_scripts.c
@@ -698,6 +698,7 @@ asm(
     ".ascii \"\\\"\\\"\\\"\\n\"\n"
     ".ascii \"\\n\"\n"
     ".ascii \"import gdb\\n\"\n"
+    ".ascii \"import gdb.printing\\n\"\n"
     ".ascii \"import re\\n\"\n"
     ".ascii \"\\n\"\n"
     ".ascii \"pp_set = gdb.printing.RegexpCollectionPrettyPrinter(\\\"php\\\")\\n\"\n"

--- a/scripts/gdb/php_gdb.py
+++ b/scripts/gdb/php_gdb.py
@@ -28,6 +28,7 @@ Then you can interact with that variable:
 """
 
 import gdb
+import gdb.printing
 import re
 
 pp_set = gdb.printing.RegexpCollectionPrettyPrinter("php")


### PR DESCRIPTION
Nested modules are not imported by default since gdb version 16 for some reason