### PR TITLE
Remove PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK from pcre compile options

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -42,6 +42,11 @@ PHP 8.5 UPGRADE NOTES
     have run and the output handlers have been cleaned up.
     This is a consequence of fixing GH-18033.
 
+- PCRE:
+  . The extension is compiled without semi-deprecated
+    PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK compile option.
+    https://github.com/PCRE2Project/pcre2/issues/736#issuecomment-2754024651
+
 - Intl:
   . The extension now requires at least ICU 57.1.
 

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -199,13 +199,6 @@ static void php_pcre_efree(void *block, void *data)
 	efree(block);
 }
 
-#ifdef PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK
-	/* pcre 10.38 needs PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK, disabled by default */
-#define PHP_PCRE_DEFAULT_EXTRA_COPTIONS PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK
-#else
-#define PHP_PCRE_DEFAULT_EXTRA_COPTIONS 0
-#endif
-
 #define PHP_PCRE_PREALLOC_MDATA_SIZE 32
 
 static void php_pcre_init_pcre2(uint8_t jit)
@@ -225,8 +218,6 @@ static void php_pcre_init_pcre2(uint8_t jit)
 			return;
 		}
 	}
-
-	pcre2_set_compile_extra_options(cctx, PHP_PCRE_DEFAULT_EXTRA_COPTIONS);
 
 	if (!mctx) {
 		mctx = pcre2_match_context_create(gctx);

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -581,7 +581,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, bo
 #else
 	uint32_t			 coptions = 0;
 #endif
-	uint32_t			 eoptions = PHP_PCRE_DEFAULT_EXTRA_COPTIONS;
+	uint32_t			 eoptions = 0;
 	PCRE2_UCHAR	         error[128];
 	PCRE2_SIZE           erroffset;
 	int                  errnumber;

--- a/ext/pcre/tests/bug70345.phpt
+++ b/ext/pcre/tests/bug70345.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Bug #70345 (Multiple vulnerabilities related to PCRE functions)
+--SKIPIF--
+<?php
+if (PCRE_VERSION_MAJOR == 10 && PCRE_VERSION_MINOR < 38) {
+    die("skip old pcre version");
+}
 --FILE--
 <?php
 $regex = '/(?=xyz\K)/';
@@ -14,8 +19,8 @@ preg_match($regex, $subject, $matches);
 var_dump($matches);
 ?>
 --EXPECTF--
+Warning: preg_split(): Compilation failed: \K is not allowed in lookarounds (but see PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK) at offset 9 in %s on line %d
 bool(false)
 
-Warning: preg_match(): Get subpatterns list failed in %s on line %d
-array(0) {
-}
+Warning: preg_match(): Compilation failed: \K is not allowed in lookarounds (but see PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK) at offset 12 in %s on line %d
+NULL

--- a/ext/pcre/tests/bug70345_old.phpt
+++ b/ext/pcre/tests/bug70345_old.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #70345 (Multiple vulnerabilities related to PCRE functions)
+--SKIPIF--
+<?php
+if (PCRE_VERSION_MAJOR != 10 || PCRE_VERSION_MINOR >= 38) {
+    die("skip new pcre version");
+}
+--FILE--
+<?php
+$regex = '/(?=xyz\K)/';
+$subject = "aaaaxyzaaaa";
+
+var_dump(preg_split($regex, $subject));
+
+$regex = '/(a(?=xyz\K))/';
+$subject = "aaaaxyzaaaa";
+preg_match($regex, $subject, $matches);
+
+var_dump($matches);
+?>
+--EXPECTF--
+bool(false)
+
+Warning: preg_match(): Get subpatterns list failed in %s on line %d
+array(0) {
+}


### PR DESCRIPTION
As recommended [1] by main pcre2 maintainer.

The `PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK ` compile option was introduced in https://github.com/php/php-src/commit/dd61002676cbb4ff222a743ffd18ea940bc0085d. I belive it was done mainly to fix 1 failing test, not to support some strong usecase. `\K` in lookaround is not much useful [2]. We should compile pcre2 with default options and remove this semi-deprecated option [3].

[1] https://github.com/PCRE2Project/pcre2/issues/736#issuecomment-2753974366
[2] https://github.com/PCRE2Project/pcre2/issues/736#issuecomment-2754110610
[3] https://github.com/PCRE2Project/pcre2/issues/736#issuecomment-2754024651