### PR TITLE
Improve performance of array_map()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6738,8 +6738,6 @@ PHP_FUNCTION(array_map)
 	if (n_arrays == 1) {
 		zend_ulong num_key;
 		zend_string *str_key;
-		zval *zv, arg;
-		int ret;
 
 		if (Z_TYPE(arrays[0]) != IS_ARRAY) {
 			zend_argument_type_error(2, "must be of type array, %s given", zend_zval_value_name(&arrays[0]));
@@ -6756,15 +6754,14 @@ PHP_FUNCTION(array_map)
 		array_init_size(return_value, maxlen);
 		zend_hash_real_init(Z_ARRVAL_P(return_value), HT_IS_PACKED(Z_ARRVAL(arrays[0])));
 
-		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL(arrays[0]), num_key, str_key, zv) {
-			fci.retval = &result;
-			fci.param_count = 1;
-			fci.params = &arg;
+		fci.retval = &result;
+		fci.param_count = 1;
 
-			ZVAL_COPY(&arg, zv);
-			ret = zend_call_function(&fci, &fci_cache);
-			i_zval_ptr_dtor(&arg);
-			if (ret != SUCCESS || Z_TYPE(result) == IS_UNDEF) {
+		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL(arrays[0]), num_key, str_key, fci.params) {
+			zend_result ret = zend_call_function(&fci, &fci_cache);
+			ZEND_ASSERT(ret == SUCCESS);
+			ZEND_IGNORE_VALUE(ret);
+			if (Z_TYPE(result) == IS_UNDEF) {
 				zend_array_destroy(Z_ARR_P(return_value));
 				RETURN_NULL();
 			}
@@ -6874,7 +6871,11 @@ PHP_FUNCTION(array_map)
 				fci.param_count = n_arrays;
 				fci.params = params;
 
-				if (zend_call_function(&fci, &fci_cache) != SUCCESS || Z_TYPE(result) == IS_UNDEF) {
+				zend_result ret = zend_call_function(&fci, &fci_cache);
+				ZEND_ASSERT(ret == SUCCESS);
+				ZEND_IGNORE_VALUE(ret);
+
+				if (Z_TYPE(result) == IS_UNDEF) {
 					efree(array_pos);
 					zend_array_destroy(Z_ARR_P(return_value));
 					for (i = 0; i < n_arrays; i++) {


### PR DESCRIPTION
The refcounting and destruction is not necessary because zend_call_function will make a copy anyway. And zend_call_function only returns FAILURE if EG(active) is false in which case array_map shouldn't have been called in the first place.

This also adds a fast path for packed arrays (even with holes). By separating the paths of packed/hashed arrays the hashed array iteration is very very slightly faster as well but not by much.

For this script:
```php
$array = range(1, 10000);

for ($i = 0; $i < 800; $i++) {
    array_map(static function ($item) {
            return $item * 2;
    }, $array);
}
```

On an intel i7-1185G7:
```
Benchmark 1: ./sapi/cli/php map.php
  Time (mean ± σ):     127.5 ms ±   3.2 ms    [User: 124.1 ms, System: 3.2 ms]
  Range (min … max):   125.1 ms … 138.1 ms    23 runs
  
Benchmark 2: ./sapi/cli/php_old map.php
  Time (mean ± σ):     148.6 ms ±   3.3 ms    [User: 144.9 ms, System: 3.5 ms]
  Range (min … max):   145.6 ms … 160.6 ms    20 runs
  
Summary
  ./sapi/cli/php map.php ran
    1.17 ± 0.04 times faster than ./sapi/cli/php_old map.php
```