### PR TITLE
zend_smart_string: Add `smart_string_append_printf()`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -21,6 +21,8 @@ PHP 8.5 INTERNALS UPGRADE NOTES
     could interfere.
   . zend_get_callable_name() now returns the name of the underlying function
     for fake closures.
+  . Added smart_string_append_printf() matching smart_str_append_printf() for
+    char* instead of zend_string*-based smart strings.
 
 ========================
 2. Build system changes

--- a/Zend/zend_smart_str.c
+++ b/Zend/zend_smart_str.c
@@ -131,6 +131,13 @@ ZEND_API void smart_str_append_printf(smart_str *dest, const char *format, ...) 
 	va_end(arg);
 }
 
+ZEND_API void smart_string_append_printf(smart_string *dest, const char *format, ...) {
+	va_list arg;
+	va_start(arg, format);
+	zend_printf_to_smart_string(dest, format, arg);
+	va_end(arg);
+}
+
 #define SMART_STRING_OVERHEAD   (ZEND_MM_OVERHEAD + 1)
 #define SMART_STRING_START_SIZE 256
 #define SMART_STRING_START_LEN  (SMART_STRING_START_SIZE - SMART_STRING_OVERHEAD)

--- a/Zend/zend_smart_string.h
+++ b/Zend/zend_smart_string.h
@@ -48,6 +48,9 @@
 #define smart_string_append_unsigned(str, val) \
 	smart_string_append_unsigned_ex((str), (val), 0)
 
+ZEND_API void smart_string_append_printf(smart_string *dest, const char *format, ...)
+	ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
+
 ZEND_API void ZEND_FASTCALL _smart_string_alloc_persistent(smart_string *str, size_t len);
 ZEND_API void ZEND_FASTCALL _smart_string_alloc(smart_string *str, size_t len);
 


### PR DESCRIPTION
This is for API parity with `smart_str_append_printf()`.