### PR TITLE
Add runtime-enabled heap debugging capabilities

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -15,6 +15,7 @@
 */
 
 #include "zend_modules.h"
+#include "zend_types.h"
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -180,6 +181,19 @@ static ZEND_FUNCTION(zend_leak_variable)
 	}
 
 	Z_ADDREF_P(zv);
+}
+
+static ZEND_FUNCTION(zend_delref)
+{
+	zval *zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	Z_TRY_DELREF_P(zv);
+
+	RETURN_NULL();
 }
 
 /* Tests Z_PARAM_OBJ_OR_STR */

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -235,6 +235,8 @@ namespace {
 
     function zend_leak_bytes(int $bytes = 3): void {}
 
+    function zend_delref(mixed $variable): void {}
+
     function zend_string_or_object(object|string $param): object|string {}
 
     function zend_string_or_object_or_null(object|string|null $param): object|string|null {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3082e62e96d5f4383c98638513463c676a7c3a69 */
+ * Stub hash: 80b2dbc373baccd5ee4df047070d95e4c44effcd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -41,6 +41,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_leak_bytes, 0, 0, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bytes, IS_LONG, 0, "3")
 ZEND_END_ARG_INFO()
+
+#define arginfo_zend_delref arginfo_zend_leak_variable
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_zend_string_or_object, 0, 1, MAY_BE_OBJECT|MAY_BE_STRING)
 	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
@@ -264,6 +266,7 @@ static ZEND_FUNCTION(zend_create_unterminated_string);
 static ZEND_FUNCTION(zend_terminate_string);
 static ZEND_FUNCTION(zend_leak_variable);
 static ZEND_FUNCTION(zend_leak_bytes);
+static ZEND_FUNCTION(zend_delref);
 static ZEND_FUNCTION(zend_string_or_object);
 static ZEND_FUNCTION(zend_string_or_object_or_null);
 static ZEND_FUNCTION(zend_string_or_stdclass);
@@ -369,6 +372,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_terminate_string, arginfo_zend_terminate_string)
 	ZEND_FE(zend_leak_variable, arginfo_zend_leak_variable)
 	ZEND_FE(zend_leak_bytes, arginfo_zend_leak_bytes)
+	ZEND_FE(zend_delref, arginfo_zend_delref)
 	ZEND_FE(zend_string_or_object, arginfo_zend_string_or_object)
 	ZEND_FE(zend_string_or_object_or_null, arginfo_zend_string_or_object_or_null)
 	ZEND_FE(zend_string_or_stdclass, arginfo_zend_string_or_stdclass)

--- a/ext/zend_test/tests/opline_dangling.phpt
+++ b/ext/zend_test/tests/opline_dangling.phpt
@@ -6,6 +6,12 @@ https://github.com/php/php-src/pull/12758
 zend_test
 --ENV--
 USE_ZEND_ALLOC=1
+--SKIPIF--
+<?php
+if (getenv("ZEND_MM_DEBUG")) {
+    die("skip zend_test.observe_opline_in_zendmm not compatible with ZEND_MM_DEBUG");
+}
+?>
 --INI--
 zend_test.observe_opline_in_zendmm=1
 --FILE--

--- a/ext/zend_test/tests/opline_dangling_02.phpt
+++ b/ext/zend_test/tests/opline_dangling_02.phpt
@@ -4,6 +4,12 @@ possible segfault in `ZEND_FUNC_GET_ARGS`
 zend_test
 --ENV--
 USE_ZEND_ALLOC=1
+--SKIPIF--
+<?php
+if (getenv("ZEND_MM_DEBUG")) {
+    die("skip zend_test.observe_opline_in_zendmm not compatible with ZEND_MM_DEBUG");
+}
+?>
 --INI--
 zend_test.observe_opline_in_zendmm=1
 --FILE--


### PR DESCRIPTION
Debugging memory corruption issues in production can be difficult when it's not possible to use a debug build or ASAN/MSAN/Valgrind (e.g. for performance reasons).

This PR makes it possible to enable some basic heap debugging helpers without rebuilding PHP. This is controlled by the environment variable `ZEND_MM_DEBUG`. The env var takes a comma-separated list of parameters:

- `poison_free=byte`: Override freed blocks with the specified byte value (represented as a number)
- `poison_alloc=byte`: Override newly allocated blocks with the specified byte value (represented as a number)
- `padding=bytes`: Pad allocated blocks with the specified amount of bytes (if non-zero, a value >= 16 is recommended to not break alignments) 
- `check_freelists_on_shutdown=0|1`: Enable checking [freelist consistency](https://github.com/php/php-src/pull/14054) on shutdown

Example: `ZEND_MM_DEBUG=poison_free=0xbe,poison_alloc=0xeb,padding=16,check_freelists_on_shutdown=1 php ...`.

This is based on an idea of @TimWolla.

### Implementation

This is implemented by installing custom handlers when `ZEND_MM_DEBUG` is set.

### Overhead

This has zero overhead when `ZEND_MM_DEBUG` is not set. When `ZEND_MM_DEBUG` is set, the overhead is about 8.5% on the Symfony Demo benchmark.

### Goals:

 - Crash earlier after a memory corruption, to extract a useful backtrace
 - Be usable in production with reasonable overhead
 - Having zero overhead when not enabled

### Non-goals:

 - Replace debug builds, valgrind, ASAN, MSAN or other sanitizers