### PR TITLE
Fix memory leak in openssl_sign() when passing invalid algorithm

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -6959,6 +6959,7 @@ PHP_FUNCTION(openssl_sign)
 		mdtype = php_openssl_get_evp_md_from_algo(method_long);
 	}
 	if (!mdtype) {
+		EVP_PKEY_free(pkey);
 		php_error_docref(NULL, E_WARNING, "Unknown digest algorithm");
 		RETURN_FALSE;
 	}

--- a/ext/openssl/tests/openssl_sign_invalid_algorithm.phpt
+++ b/ext/openssl/tests/openssl_sign_invalid_algorithm.phpt
@@ -1,0 +1,18 @@
+--TEST--
+openssl_sign: invalid algorithm
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$dir = __DIR__;
+$file_pub = $dir . '/bug37820cert.pem';
+$file_key = $dir . '/bug37820key.pem';
+
+$priv_key = file_get_contents($file_key);
+$priv_key_id = openssl_get_privatekey($priv_key);
+
+$data = "some custom data";
+openssl_sign($data, $signature, $priv_key_id, "invalid algo");
+?>
+--EXPECTF--
+Warning: openssl_sign(): Unknown digest algorithm in %s on line %d


### PR DESCRIPTION
Detected using an experimental static analysis I'm developing.