### PR TITLE
Fix potential leaks when writing to BIO fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5742,8 +5742,8 @@ PHP_FUNCTION(openssl_pkcs7_read)
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zcert, bio_buf->data, bio_buf->length);
 				add_index_zval(zout, i, &zcert);
-				BIO_free(bio_out);
 			}
+			BIO_free(bio_out);
 		}
 	}
 
@@ -5757,8 +5757,8 @@ PHP_FUNCTION(openssl_pkcs7_read)
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zcert, bio_buf->data, bio_buf->length);
 				add_index_zval(zout, i, &zcert);
-				BIO_free(bio_out);
 			}
+			BIO_free(bio_out);
 		}
 	}
 
@@ -6383,8 +6383,8 @@ PHP_FUNCTION(openssl_cms_read)
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zcert, bio_buf->data, bio_buf->length);
 				add_index_zval(zout, i, &zcert);
-				BIO_free(bio_out);
 			}
+			BIO_free(bio_out);
 		}
 	}
 
@@ -6398,8 +6398,8 @@ PHP_FUNCTION(openssl_cms_read)
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zcert, bio_buf->data, bio_buf->length);
 				add_index_zval(zout, i, &zcert);
-				BIO_free(bio_out);
 			}
+			BIO_free(bio_out);
 		}
 	}
 


### PR DESCRIPTION
When the BIO is created but writing fails, these can leak.

Detected using an experimental static analysis I'm developing.
