### PR TITLE
Remove pointless ZVAL_UNDEF() in isset path

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -877,7 +877,6 @@ try_again:
 
 		if (!((*guard) & IN_ISSET)) {
 			GC_ADDREF(zobj);
-			ZVAL_UNDEF(&tmp_result);
 
 			*guard |= IN_ISSET;
 			zend_std_call_issetter(zobj, name, &tmp_result);


### PR DESCRIPTION
This will already be set to UNDEF by zend_call_function, called via zend_std_call_issetter.