### PR TITLE
Make SplFixedArray::jsonSerialize() an implementation alias of SplFixedArray::toArray()

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -872,18 +872,6 @@ PHP_METHOD(SplFixedArray, getIterator)
 	zend_create_internal_iterator_zval(return_value, ZEND_THIS);
 }
 
-PHP_METHOD(SplFixedArray, jsonSerialize)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	spl_fixedarray_object *intern = Z_SPLFIXEDARRAY_P(ZEND_THIS);
-	array_init_size(return_value, intern->array.size);
-	for (zend_long i = 0; i < intern->array.size; i++) {
-		zend_hash_next_index_insert_new(Z_ARR_P(return_value), &intern->array.elements[i]);
-		Z_TRY_ADDREF(intern->array.elements[i]);
-	}
-}
-
 static void spl_fixedarray_it_dtor(zend_object_iterator *iter)
 {
 	zval_ptr_dtor(&iter->data);

--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -55,5 +55,8 @@ class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable, JsonSe
 
     public function getIterator(): Iterator {}
 
+    /**
+     * @implementation-alias SplFixedArray::toArray
+     */
     public function jsonSerialize(): array {}
 }

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c01c9337e58601ff9e6c85072a62f68cc7fec9ba */
+ * Stub hash: 0c838fed60b29671fe04e63315ab662d8cb16f0c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
@@ -68,7 +68,6 @@ ZEND_METHOD(SplFixedArray, offsetGet);
 ZEND_METHOD(SplFixedArray, offsetSet);
 ZEND_METHOD(SplFixedArray, offsetUnset);
 ZEND_METHOD(SplFixedArray, getIterator);
-ZEND_METHOD(SplFixedArray, jsonSerialize);
 
 static const zend_function_entry class_SplFixedArray_methods[] = {
 	ZEND_ME(SplFixedArray, __construct, arginfo_class_SplFixedArray___construct, ZEND_ACC_PUBLIC)
@@ -85,7 +84,7 @@ static const zend_function_entry class_SplFixedArray_methods[] = {
 	ZEND_ME(SplFixedArray, offsetSet, arginfo_class_SplFixedArray_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, offsetUnset, arginfo_class_SplFixedArray_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, getIterator, arginfo_class_SplFixedArray_getIterator, ZEND_ACC_PUBLIC)
-	ZEND_ME(SplFixedArray, jsonSerialize, arginfo_class_SplFixedArray_jsonSerialize, ZEND_ACC_PUBLIC)
+	ZEND_RAW_FENTRY("jsonSerialize", zim_SplFixedArray_toArray, arginfo_class_SplFixedArray_jsonSerialize, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_FE_END
 };
 


### PR DESCRIPTION
This reduces code duplication and can then use the optimized version.