### PR TITLE
ext/pgsql: introducing pg_result_verbose_error().

### DIFF
--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -31,6 +31,9 @@ if test "$PHP_PGSQL" != "no"; then
   PHP_CHECK_LIBRARY([pq], [PQclosePrepared],
     [AC_DEFINE([HAVE_PG_CLOSE_STMT], [1], [PostgreSQL 17 or later])],,
     [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQresultVerboseErrorMessage],
+    [AC_DEFINE([HAVE_PG_RESULT_VERBOSE_ERROR_MESSAGE], [1], [PostgreSQL 14 or later])],,
+    [$PGSQL_LIBS])
 
   old_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $PGSQL_CFLAGS"

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -973,6 +973,10 @@ namespace {
 #ifdef HAVE_PG_CLOSE_STMT
     function pg_close_stmt(Pgsql\Connection $connection, string $statement_name): Pgsql\Result|false {}
 #endif
+#ifdef HAVE_PG_RESULT_ERROR_MESSAGE
+    /** @refcount 1 */
+    function pg_result_verbose_error(PgSql\Result $result, int $verbosity, int $visibility): string|false {}
+#endif
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 13be2a3c9a4ef4a72c0a67019b7400418752b603 */
+ * Stub hash: d2d1653309c442627202d28ae27dcb4d6a828a24 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -502,6 +502,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_close_stmt, 0, 2, Pgsql\\
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_PG_RESULT_ERROR_MESSAGE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_result_verbose_error, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, result, PgSql\\Result, 0)
+	ZEND_ARG_TYPE_INFO(0, verbosity, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, visibility, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_FUNCTION(pg_connect);
 ZEND_FUNCTION(pg_pconnect);
 ZEND_FUNCTION(pg_connect_poll);
@@ -607,6 +615,9 @@ ZEND_FUNCTION(pg_set_chunked_rows_size);
 #endif
 #if defined(HAVE_PG_CLOSE_STMT)
 ZEND_FUNCTION(pg_close_stmt);
+#endif
+#if defined(HAVE_PG_RESULT_ERROR_MESSAGE)
+ZEND_FUNCTION(pg_result_verbose_error);
 #endif
 
 static const zend_function_entry ext_functions[] = {
@@ -738,6 +749,9 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_PG_CLOSE_STMT)
 	ZEND_FE(pg_close_stmt, arginfo_pg_close_stmt)
+#endif
+#if defined(HAVE_PG_RESULT_ERROR_MESSAGE)
+	ZEND_FE(pg_result_verbose_error, arginfo_pg_result_verbose_error)
 #endif
 	ZEND_FE_END
 };


### PR DESCRIPTION
unlike pg_set_error_context_visibility()/pg_set_error_verbosity(), it is affecting only a particular PgSql\Result instance rather than the whole PgSql\Connection, e.g. debugging a problematic SQL request. Available since postgresql 14.