### PR TITLE
ext/pgsql: adding pg_service() alongside other connection infos.

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -312,9 +312,6 @@ static const func_info_t func_infos[] = {
 	F1("pg_host", MAY_BE_STRING),
 	F1("pg_version", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
 	F1("pg_jit", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
-#if defined(HAVE_PG_SERVICE)
-	F1("pg_service", MAY_BE_STRING),
-#endif
 	F1("pg_parameter_status", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("pg_query", MAY_BE_OBJECT|MAY_BE_FALSE),
 	F1("pg_query_params", MAY_BE_OBJECT|MAY_BE_FALSE),

--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -312,6 +312,9 @@ static const func_info_t func_infos[] = {
 	F1("pg_host", MAY_BE_STRING),
 	F1("pg_version", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
 	F1("pg_jit", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_NULL),
+#if defined(HAVE_PG_SERVICE)
+	F1("pg_service", MAY_BE_STRING),
+#endif
 	F1("pg_parameter_status", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("pg_query", MAY_BE_OBJECT|MAY_BE_FALSE),
 	F1("pg_query_params", MAY_BE_OBJECT|MAY_BE_FALSE),

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -31,6 +31,9 @@ if test "$PHP_PGSQL" != "no"; then
   PHP_CHECK_LIBRARY([pq], [PQclosePrepared],
     [AC_DEFINE([HAVE_PG_CLOSE_STMT], [1], [PostgreSQL 17 or later])],,
     [$PGSQL_LIBS])
+  PHP_CHECK_LIBRARY([pq], [PQservice],
+    [AC_DEFINE([HAVE_PG_SERVICE], [1], [PostgreSQL 18 or later])],,
+    [$PGSQL_LIBS])
 
   old_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $PGSQL_CFLAGS"

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -907,6 +907,7 @@ PHP_FUNCTION(pg_close)
 #define PHP_PG_HOST 6
 #define PHP_PG_VERSION 7
 #define PHP_PG_JIT 8
+#define PHP_PG_SERVICE 9
 
 /* php_pgsql_get_link_info */
 static void php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type)
@@ -991,6 +992,12 @@ static void php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type
 			PQclear(res);
 			return;
 		}
+#if defined(HAVE_PG_SERVICE)
+		case PHP_PG_SERVICE: {
+			result = PQservice(pgsql);
+			break;
+		}
+#endif
 		EMPTY_SWITCH_DEFAULT_CASE()
 	}
 	if (result) {
@@ -1046,6 +1053,13 @@ PHP_FUNCTION(pg_jit)
 {
 	php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAM_PASSTHRU,PHP_PG_JIT);
 }
+
+#if defined(HAVE_PG_SERVICE)
+PHP_FUNCTION(pg_service)
+{
+	php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAM_PASSTHRU,PHP_PG_SERVICE);
+}
+#endif
 
 /* Returns the value of a server parameter */
 PHP_FUNCTION(pg_parameter_status)

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -509,7 +509,6 @@ namespace {
     function pg_jit(?PgSql\Connection $connection = null): array {}
 
 #ifdef HAVE_PG_SERVICE
-    /** @refcount 1 */
     function pg_service(?PgSql\Connection $connection = null): string {}
 #endif
     /**

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -508,6 +508,10 @@ namespace {
      */
     function pg_jit(?PgSql\Connection $connection = null): array {}
 
+#ifdef HAVE_PG_SERVICE
+    /** @refcount 1 */
+    function pg_service(?PgSql\Connection $connection = null): string {}
+#endif
     /**
      * @param PgSql\Connection|string $connection
      * @refcount 1

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 49e3493be11a5da1ed9a57339f14f92f34bf5d1b */
+ * Stub hash: ea2f06b6ff6fb8d9e3207831bf773f53f17b3788 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -37,6 +37,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_version, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_jit arginfo_pg_version
+
+#if defined(HAVE_PG_SERVICE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_service, 0, 0, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, connection, PgSql\\Connection, 1, "null")
+ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_parameter_status, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
@@ -514,6 +520,9 @@ ZEND_FUNCTION(pg_tty);
 ZEND_FUNCTION(pg_host);
 ZEND_FUNCTION(pg_version);
 ZEND_FUNCTION(pg_jit);
+#if defined(HAVE_PG_SERVICE)
+ZEND_FUNCTION(pg_service);
+#endif
 ZEND_FUNCTION(pg_parameter_status);
 ZEND_FUNCTION(pg_ping);
 ZEND_FUNCTION(pg_query);
@@ -623,6 +632,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(pg_host, arginfo_pg_host)
 	ZEND_FE(pg_version, arginfo_pg_version)
 	ZEND_FE(pg_jit, arginfo_pg_jit)
+#if defined(HAVE_PG_SERVICE)
+	ZEND_FE(pg_service, arginfo_pg_service)
+#endif
 	ZEND_FE(pg_parameter_status, arginfo_pg_parameter_status)
 	ZEND_FE(pg_ping, arginfo_pg_ping)
 	ZEND_FE(pg_query, arginfo_pg_query)

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ea2f06b6ff6fb8d9e3207831bf773f53f17b3788 */
+ * Stub hash: 3cf44ca06d11cad086829d3d04900ade3cacb88b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)

--- a/ext/pgsql/tests/pg_service.phpt
+++ b/ext/pgsql/tests/pg_service.phpt
@@ -1,0 +1,19 @@
+--TEST--
+PostgreSQL connection service field support
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php 
+include("inc/skipif.inc"); 
+if (!function_exists("pg_service")) die("skip pg_service unsupported");
+?>
+--FILE--
+<?php
+include('inc/config.inc');
+
+$db = pg_connect($conn_str);
+var_dump(pg_service($db));
+pg_close($db);
+?>
+--EXPECTF--
+string(%d) "%A"


### PR DESCRIPTION
returns the ongoing name of the service, if there is. available since postgres 18