### PR TITLE
ext/gd: imageaffinematrixget() strengthening `options` type check.

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -4138,15 +4138,33 @@ PHP_FUNCTION(imageaffinematrixget)
 				RETURN_THROWS();
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "x", sizeof("x") - 1)) != NULL) {
-				x = zval_get_double(tmp);
+			if ((tmp = zend_hash_str_find_deref(Z_ARRVAL_P(options), "x", sizeof("x") - 1)) != NULL) {
+				switch (Z_TYPE_P(tmp)) {
+				case IS_LONG:
+				case IS_DOUBLE:
+				case IS_STRING:
+					x = zval_get_double(tmp);
+					break;
+				default:
+					zend_argument_type_error(2, "must be a float for the \"x\" key, %s given", zend_zval_value_name(tmp));
+					RETURN_THROWS();
+				}
 			} else {
 				zend_argument_value_error(2, "must have an \"x\" key");
 				RETURN_THROWS();
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "y", sizeof("y") - 1)) != NULL) {
-				y = zval_get_double(tmp);
+			if ((tmp = zend_hash_str_find_deref(Z_ARRVAL_P(options), "y", sizeof("y") - 1)) != NULL) {
+				switch (Z_TYPE_P(tmp)) {
+				case IS_LONG:
+				case IS_DOUBLE:
+				case IS_STRING:
+					y = zval_get_double(tmp);
+					break;
+				default:
+					zend_argument_type_error(2, "must be a float for the \"y\" key, %s given", zend_zval_value_name(tmp));
+					RETURN_THROWS();
+				}
 			} else {
 				zend_argument_value_error(2, "must have a \"y\" key");
 				RETURN_THROWS();
@@ -4165,7 +4183,16 @@ PHP_FUNCTION(imageaffinematrixget)
 		case GD_AFFINE_SHEAR_VERTICAL: {
 			double angle;
 
-			angle = zval_get_double(options);
+			switch (Z_TYPE_P(options)) {
+			case IS_LONG:
+			case IS_DOUBLE:
+			case IS_STRING:
+				angle = zval_get_double(options);
+				break;
+			default:
+				zend_argument_type_error(2, "must be of type float, %s given", zend_zval_value_name(options));
+				RETURN_THROWS();
+			}
 
 			if (type == GD_AFFINE_SHEAR_HORIZONTAL) {
 				res = gdAffineShearHorizontal(affine, angle);

--- a/ext/gd/tests/imageaffinematrixget_errors.phpt
+++ b/ext/gd/tests/imageaffinematrixget_errors.phpt
@@ -1,0 +1,43 @@
+--TEST--
+imageaffinematrixget
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+class A{}
+$a = 10;
+try {
+	imageaffinematrixget(IMG_AFFINE_ROTATE, new A());
+} catch (\TypeError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+try {
+	imageaffinematrixget(IMG_AFFINE_SCALE, ["x" => new A(), "y" => 1]);
+} catch (\TypeError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+try {
+	imageaffinematrixget(IMG_AFFINE_SCALE, ["x" => 10, "y" => new A()]);
+} catch (\TypeError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+var_dump(imageaffinematrixget(IMG_AFFINE_SCALE, ["x" => &$a, "y" => &$a]));
+?>
+--EXPECT--
+imageaffinematrixget(): Argument #2 ($options) must be of type float, A given
+imageaffinematrixget(): Argument #2 ($options) must be a float for the "x" key, A given
+imageaffinematrixget(): Argument #2 ($options) must be a float for the "y" key, A given
+array(6) {
+  [0]=>
+  float(10)
+  [1]=>
+  float(0)
+  [2]=>
+  float(0)
+  [3]=>
+  float(10)
+  [4]=>
+  float(0)
+  [5]=>
+  float(0)
+}


### PR DESCRIPTION
to be also more in line with other imageaffine* calls.