### PR TITLE
ext/sockets: UDP_SEGMENT support.

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE([sockets],
 
 if test "$PHP_SOCKETS" != "no"; then
   AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname sockatmark])
-  AC_CHECK_HEADERS([sys/sockio.h linux/filter.h linux/if_packet.h linux/if_ether.h])
+  AC_CHECK_HEADERS([sys/sockio.h linux/filter.h linux/if_packet.h linux/if_ether.h linux/udp.h])
   AC_DEFINE([HAVE_SOCKETS], [1],
     [Define to 1 if the PHP extension 'sockets' is available.])
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -2300,6 +2300,22 @@ PHP_FUNCTION(socket_set_option)
 		}
 #endif
 
+#if defined(UDP_SEGMENT)
+		case UDP_SEGMENT: {
+			ov = zval_get_long(arg4);
+
+			// UDP segmentation offload maximum size or 0 to disable it
+			if (ov < 0 || ov > USHRT_MAX) {
+				zend_argument_value_error(4, "must be of between 0 and %u", USHRT_MAX);
+				RETURN_FALSE;
+			}
+
+			optlen = sizeof(ov);
+			opt_ptr = &ov;
+			break;
+		}
+#endif
+
 		default:
 default_case:
 			ov = zval_get_long(arg4);

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -70,6 +70,9 @@
 # if defined(HAVE_LINUX_IF_ETHER_H)
 #  include <linux/if_ether.h>
 # endif
+# if defined(HAVE_LINUX_UDP_H)
+#  include <linux/udp.h>
+# endif
 #endif
 
 #include <stddef.h>

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -2022,6 +2022,14 @@ const ETH_P_LOOP = UNKNOWN;
 const ETH_P_ALL = UNKNOWN;
 #endif
 
+#ifdef UDP_SEGMENT
+/**
+ * @var int
+ * @cvalue UDP_SEGMENT
+ */
+const UDP_SEGMENT = UNKNOWN;
+#endif
+
 /**
  * @strict-properties
  * @not-serializable

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 42d486d2666d23569e70860e2b1ef203161792b3 */
+ * Stub hash: 0ff66adfea41b603b9d58f1f0a82a950f4034cc4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -1107,6 +1107,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(ETH_P_ALL)
 	REGISTER_LONG_CONSTANT("ETH_P_ALL", ETH_P_ALL, CONST_PERSISTENT);
+#endif
+#if defined(UDP_SEGMENT)
+	REGISTER_LONG_CONSTANT("UDP_SEGMENT", UDP_SEGMENT, CONST_PERSISTENT);
 #endif
 }
 

--- a/ext/sockets/tests/socket_cmsg_udp_segment.phpt
+++ b/ext/sockets/tests/socket_cmsg_udp_segment.phpt
@@ -1,0 +1,26 @@
+--TEST--
+UDP_SEGMENT setsockopt(), can't really test is as the kernel support might not be enabled.
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+if (!defined('UDP_SEGMENT')) { die('skip UDP_SEGMENT is not defined'); }
+?>
+--FILE--
+<?php
+$src = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+
+try {
+	socket_setopt($src, SOL_UDP, UDP_SEGMENT, -1);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+try {
+	socket_setopt($src, SOL_UDP, UDP_SEGMENT, 65536);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+socket_setopt(): Argument #4 ($value) must be of between 0 and 65535
+socket_setopt(): Argument #4 ($value) must be of between 0 and 65535


### PR DESCRIPTION
UDP segmentation offload is an optimisation attempt by sending multiple large enough datagrams over UDP which reduces syscalls as by default, they have to be broke down in small UDP packets, it is better if the hardware supports it, other handed down to the software implementation.