### PR TITLE
Change default setting for zend.exception_ignore_args

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -417,6 +417,10 @@ PHP 8.5 UPGRADE NOTES
   . The high resolution timer (`hrtime()`) on macOS now uses the recommended
     `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` API instead of
     `mach_absolute_time()`.
+  . Exceptions now exclude arguments passed in the stack trace. If the old
+    behaviour is desired, then set `zend.exception_ignore_args=0` in INI
+    settings.
+    RFC: https://wiki.php.net/rfc/exception_ignore_args_default_value
 
 - CLI/CGI:
   . The `-z` or `--zend-extension` option has been removed as it was

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -269,7 +269,7 @@ ZEND_INI_BEGIN()
 #ifdef ZEND_SIGNALS
 	STD_ZEND_INI_BOOLEAN("zend.signal_check", SIGNAL_CHECK_DEFAULT, ZEND_INI_SYSTEM, OnUpdateBool, check, zend_signal_globals_t, zend_signal_globals)
 #endif
-	STD_ZEND_INI_BOOLEAN("zend.exception_ignore_args",	"0",	ZEND_INI_ALL,		OnUpdateBool, exception_ignore_args, zend_executor_globals, executor_globals)
+	STD_ZEND_INI_BOOLEAN("zend.exception_ignore_args",	"1",	ZEND_INI_ALL,		OnUpdateBool, exception_ignore_args, zend_executor_globals, executor_globals)
 	STD_ZEND_INI_ENTRY("zend.exception_string_param_max_len",	"15",	ZEND_INI_ALL,	OnSetExceptionStringParamMaxLen,	exception_string_param_max_len,		zend_executor_globals,	executor_globals)
 	STD_ZEND_INI_ENTRY("fiber.stack_size",		NULL,			ZEND_INI_ALL,		OnUpdateFiberStackSize,		fiber_stack_size,	zend_executor_globals, 		executor_globals)
 #ifdef ZEND_CHECK_STACK_LIMIT

--- a/ext/soap/tests/bugs/bug62900.phpt
+++ b/ext/soap/tests/bugs/bug62900.phpt
@@ -72,24 +72,24 @@ foreach ($combinations as list($wsdl, $xsd)) {
 --EXPECTF--
 Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
 Stack trace:
-#0 %s(%d): SoapClient->__construct(%s)
+#0 %s(%d): SoapClient->__construct()
 #1 {main}
   thrown in %s on line %d
 
 Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', missing 'targetNamespace', expected 'http://www.w3.org/XML/1998/namespace' in %s:%d
 Stack trace:
-#0 %s(%d): SoapClient->__construct(%s)
+#0 %s(%d): SoapClient->__construct()
 #1 {main}
   thrown in %s on line %d
 
 Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing Schema: can't import schema from '%sbug62900.xsd', unexpected 'targetNamespace'='http://www.w3.org/XML/1998/namespacex', expected no 'targetNamespace' in %s:%d
 Stack trace:
-#0 %s(%d): SoapClient->__construct(%s)
+#0 %s(%d): SoapClient->__construct()
 #1 {main}
   thrown in %s on line %d
 
 Fatal error: Uncaught SoapFault exception: [WSDL] SOAP-ERROR: Parsing WSDL: Couldn't bind to service in %s:%d
 Stack trace:
-#0 %s(%d): SoapClient->__construct(%s)
+#0 %s(%d): SoapClient->__construct()
 #1 {main}
   thrown in %s on line %d

--- a/php.ini-development
+++ b/php.ini-development
@@ -161,7 +161,7 @@
 
 ; zend.exception_ignore_args
 ;   Default Value: On
-;   Development Value: Off
+;   Development Value: On
 ;   Production Value: On
 
 ; zend.exception_string_param_max_len
@@ -378,10 +378,10 @@ zend.enable_gc = On
 ; Allows to include or exclude arguments from stack traces generated for exceptions.
 ; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
-; Default Value: Off
-; Development Value: Off
+; Default Value: On
+; Development Value: On
 ; Production Value: On
-zend.exception_ignore_args = Off
+zend.exception_ignore_args = On
 
 ; Allows setting the maximum string length in an argument of a stringified stack trace
 ; to a value between 0 and 1000000.

--- a/php.ini-development
+++ b/php.ini-development
@@ -160,7 +160,7 @@
 ;   Production Value: -1
 
 ; zend.exception_ignore_args
-;   Default Value: Off
+;   Default Value: On
 ;   Development Value: Off
 ;   Production Value: On
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -160,7 +160,7 @@
 ;   Production Value: -1
 
 ; zend.exception_ignore_args
-;   Default Value: Off
+;   Default Value: On
 ;   Development Value: Off
 ;   Production Value: On
 
@@ -378,7 +378,7 @@ zend.enable_gc = On
 ; Allows to include or exclude arguments from stack traces generated for exceptions.
 ; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
-; Default Value: Off
+; Default Value: On
 ; Development Value: Off
 ; Production Value: On
 zend.exception_ignore_args = On

--- a/php.ini-production
+++ b/php.ini-production
@@ -161,7 +161,7 @@
 
 ; zend.exception_ignore_args
 ;   Default Value: On
-;   Development Value: Off
+;   Development Value: On
 ;   Production Value: On
 
 ; zend.exception_string_param_max_len
@@ -379,7 +379,7 @@ zend.enable_gc = On
 ; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
 ; Default Value: On
-; Development Value: Off
+; Development Value: On
 ; Production Value: On
 zend.exception_ignore_args = On
 


### PR DESCRIPTION
The default setting for `zend.exception_ignore_args` (On) should be the safest setting rather than the setting more convenient to developers (Off).

This setting was introduced in PHP 7.4 to hide arguments passed into methods which cause a stacktrace to be displayed.

It is not _well_ documented in the PHP documentation and many people are unaware of its purpose. Whilst it is not a perfect solution, where a production site does display a stack trace it would be best to do so _without_ all args being dispalyed.

In this case I feel that PHP should fail _safe_ and require that developers actively _disable_ this setting when they _do_ want args (either in php.ini, or through `ini_set()` calls).

Happy to raise this as an RFC if this is required -- I'm uncertain whether this change requires one from reading the RFC documentation.

---------------

RFC: https://wiki.php.net/rfc/exception_ignore_args_default_value