### PR TITLE
Fix GH-18212: fseek with SEEK_CUR and negative offset crash on debug

### DIFF
--- a/ext/standard/tests/file/gh18212.phpt
+++ b/ext/standard/tests/file/gh18212.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-18212: fseek with SEEK_CUR and negative offset leads to negative file stream position.
+--FILE--
+<?php
+$fp = fopen('php://input', 'r+');
+var_dump(fseek($fp, -1, SEEK_SET));
+var_dump(fseek($fp, -32, SEEK_CUR));
+fclose($fp);
+?>
+--EXPECT--
+int(-1)
+int(-1)
+

--- a/ext/standard/tests/file/stream_rfc2397_007.phpt
+++ b/ext/standard/tests/file/stream_rfc2397_007.phpt
@@ -118,7 +118,7 @@ int(2)
 bool(false)
 ===S:-10,C===
 int(-1)
-bool(false)
+int(2)
 bool(false)
 ===S:3,S===
 int(0)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1390,6 +1390,10 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 				}
  				whence = SEEK_SET;
 				break;
+			case SEEK_SET:
+				if (offset < 0) {
+					return -1;
+				}
 		}
 		ret = stream->ops->seek(stream, offset, whence, &stream->position);
 


### PR DESCRIPTION
Triggers the assertion as with SEEK_CUR the stream position is set to a negative value so we force the failure without affecting its position instead.