### PR TITLE
Simplify curl gc handlers

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -546,7 +546,9 @@ static HashTable *curl_get_gc(zend_object *object, zval **table, int *n)
 
 	zend_get_gc_buffer_use(gc_buffer, table, n);
 
-	return zend_std_get_properties(object);
+	/* CurlHandle can never have properties as it's final and has strict-properties on.
+	 * Avoid building a hash table. */
+	return NULL;
 }
 
 zend_result curl_cast_object(zend_object *obj, zval *result, int type)

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -594,7 +594,9 @@ static HashTable *curl_multi_get_gc(zend_object *object, zval **table, int *n)
 
 	zend_get_gc_buffer_use(gc_buffer, table, n);
 
-	return zend_std_get_properties(object);
+	/* CurlMultiHandle can never have properties as it's final and has strict-properties on.
+	 * Avoid building a hash table. */
+	return NULL;
 }
 
 static zend_object_handlers curl_multi_handlers;


### PR DESCRIPTION
Since these objects are final and have no dynamic properties, we don't have to build a property table.