### PR TITLE
Fix leak+crash with sapi_windows_set_ctrl_handler()

### DIFF
--- a/sapi/cli/tests/sapi_windows_set_ctrl_handler_leak.phpt
+++ b/sapi/cli/tests/sapi_windows_set_ctrl_handler_leak.phpt
@@ -1,0 +1,28 @@
+--TEST--
+sapi_windows_set_ctrl_handler() leak bug
+--SKIPIF--
+<?php
+include "skipif.inc";
+
+if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')
+  die("skip this test is for Windows platforms only");
+?>
+--FILE--
+<?php
+
+class Test {
+	public function set() {
+		sapi_windows_set_ctrl_handler(self::cb(...));
+	}
+	public function cb() {
+	}
+}
+
+$test = new Test;
+$test->set();
+
+echo "Done\n";
+
+?>
+--EXPECT--
+Done

--- a/win32/globals.c
+++ b/win32/globals.c
@@ -63,5 +63,7 @@ PHP_RSHUTDOWN_FUNCTION(win32_core_globals)
 {/*{{{*/
 	closelog();
 
+	php_win32_signal_ctrl_handler_request_shutdown();
+
 	return SUCCESS;
 }/*}}}*/

--- a/win32/signal.h
+++ b/win32/signal.h
@@ -10,6 +10,7 @@
 #define	SIGPROF	27				/* profiling time alarm */
 
 PHP_WINUTIL_API void php_win32_signal_ctrl_handler_init(void);
+PHP_WINUTIL_API void php_win32_signal_ctrl_handler_request_shutdown(void);
 PHP_WINUTIL_API void php_win32_signal_ctrl_handler_shutdown(void);
 
 #endif /* PHP_WIN32_SIGNAL_H */


### PR DESCRIPTION
The ctrl_handler is never destroyed. We have to destroy it at request end so we avoid leaking it and also avoid keeping a reference to previous request memory in a next request. The latter can result in a crash and can be demonstrated with this script and `--repeat 2`:

```php
class Test {
	public function set() {
		sapi_windows_set_ctrl_handler(self::cb(...));
	}
	public function cb() {
	}
}

$test = new Test;
$test->set();
sleep(3);
```
When you hit CTRL+C in the second request you can crash.

This patch resolves both the leak and crash by destroying the ctrl_handler after a request.