### PR TITLE
On some systems, uniqid() is critically slow.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -588,6 +588,7 @@ AC_CHECK_FUNCS(m4_normalize([
   unsetenv
   usleep
   utime
+  uuidgen
   vasprintf
 ]))
 


### PR DESCRIPTION
If available, use uuidgen() system call instead of a loop on gettimeofday(), that improves performances lot.