### PR TITLE
ext/standard: Remove `#[\NoDiscard]` from `flock()`

### DIFF
--- a/Zend/tests/attributes/nodiscard/005.phpt
+++ b/Zend/tests/attributes/nodiscard/005.phpt
@@ -1,17 +1,11 @@
 --TEST--
-#[\NoDiscard]: Native function and method.
+#[\NoDiscard]: Native method.
 --FILE--
 <?php
-
-$f = tmpfile();
-flock($f, LOCK_SH | LOCK_NB);
-fclose($f);
 
 $date = new DateTimeImmutable('now');
 $date->setTimestamp(0);
 
 ?>
 --EXPECTF--
-Warning: The return value of function flock() should either be used or intentionally ignored by casting it as (void), as locking the stream might have failed in %s on line %d
-
 Warning: The return value of method DateTimeImmutable::setTimestamp() should either be used or intentionally ignored by casting it as (void), as DateTimeImmutable::setTimestamp() does not modify the object itself in %s on line %d

--- a/Zend/tests/attributes/nodiscard/010.phpt
+++ b/Zend/tests/attributes/nodiscard/010.phpt
@@ -1,9 +1,7 @@
 --TEST--
-#[\NoDiscard]: execute_internal overwritten
+#[\NoDiscard]: Native function.
 --EXTENSIONS--
 zend_test
---INI--
-zend_test.observer.execute_internal=1
 --FILE--
 <?php
 
@@ -11,7 +9,4 @@ zend_test_nodiscard();
 
 ?>
 --EXPECTF--
-<!-- internal enter NoDiscard::__construct() -->
-
 Warning: The return value of function zend_test_nodiscard() should either be used or intentionally ignored by casting it as (void), custom message in %s on line %d
-<!-- internal enter zend_test_nodiscard() -->

--- a/ext/opcache/tests/nodiscard_001.phpt
+++ b/ext/opcache/tests/nodiscard_001.phpt
@@ -7,14 +7,13 @@ opcache.optimization_level=-1
 opcache.opt_debug_level=0x20000
 --EXTENSIONS--
 opcache
+zend_test
 --FILE--
 <?php
 
-$f = tmpfile();
-flock($f, LOCK_SH | LOCK_NB);
-(void)flock($f, LOCK_SH | LOCK_NB);
-$success = flock($f, LOCK_SH | LOCK_NB);
-fclose($f);
+zend_test_nodiscard();
+(void)zend_test_nodiscard();
+$success = zend_test_nodiscard();
 
 #[\NoDiscard]
 function test() {
@@ -28,38 +27,26 @@ $obj = test();
 ?>
 --EXPECTF--
 $_main:
-     ; (lines=29, args=0, vars=3, tmps=%d)
+     ; (lines=17, args=0, vars=2, tmps=%d)
      ; (after optimizer)
      ; %s
-0000 INIT_FCALL 0 %d string("tmpfile")
-0001 V3 = DO_ICALL
-0002 ASSIGN CV0($f) V3
-0003 INIT_FCALL 2 %d string("flock")
-0004 SEND_VAR CV0($f) 1
-0005 SEND_VAL int(5) 2
-0006 DO_FCALL_BY_NAME
-0007 INIT_FCALL 2 %d string("flock")
-0008 SEND_VAR CV0($f) 1
-0009 SEND_VAL int(5) 2
-0010 V3 = DO_ICALL
-0011 FREE V3
-0012 INIT_FCALL 2 %d string("flock")
-0013 SEND_VAR CV0($f) 1
-0014 SEND_VAL int(5) 2
-0015 V3 = DO_ICALL
-0016 ASSIGN CV1($success) V3
-0017 INIT_FCALL 1 %d string("fclose")
-0018 SEND_VAR CV0($f) 1
-0019 DO_ICALL
-0020 INIT_FCALL 0 %d string("test")
-0021 DO_FCALL_BY_NAME
-0022 INIT_FCALL 0 %d string("test")
-0023 V3 = DO_UCALL
-0024 FREE V3
-0025 INIT_FCALL 0 %d string("test")
-0026 V3 = DO_UCALL
-0027 ASSIGN CV2($obj) V3
-0028 RETURN int(1)
+0000 INIT_FCALL 0 %d string("zend_test_nodiscard")
+0001 DO_FCALL_BY_NAME
+0002 INIT_FCALL 0 %d string("zend_test_nodiscard")
+0003 V2 = DO_ICALL
+0004 FREE V2
+0005 INIT_FCALL 0 %d string("zend_test_nodiscard")
+0006 V2 = DO_ICALL
+0007 ASSIGN CV0($success) V2
+0008 INIT_FCALL 0 %d string("test")
+0009 DO_FCALL_BY_NAME
+0010 INIT_FCALL 0 %d string("test")
+0011 V2 = DO_UCALL
+0012 FREE V2
+0013 INIT_FCALL 0 %d string("test")
+0014 V2 = DO_UCALL
+0015 ASSIGN CV1($obj) V2
+0016 RETURN int(1)
 
 test:
      ; (lines=3, args=0, vars=0, tmps=%d)
@@ -71,6 +58,6 @@ test:
 LIVE RANGES:
      0: 0001 - 0002 (new)
 
-Warning: The return value of function flock() should either be used or intentionally ignored by casting it as (void), as locking the stream might have failed in %s on line %d
+Warning: The return value of function zend_test_nodiscard() should either be used or intentionally ignored by casting it as (void), custom message in %s on line %d
 
 Warning: The return value of function test() should either be used or intentionally ignored by casting it as (void) in %s on line %d

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2732,7 +2732,6 @@ function proc_nice(int $priority): bool {}
  * @param resource $stream
  * @param int $would_block
  */
-#[\NoDiscard(message: "as locking the stream might have failed")]
 function flock($stream, int $operation, &$would_block = null): bool {}
 
 /**

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 824ccb41163307bd0fad452b705a8222b6f42d09 */
+ * Stub hash: 85677dc3476d25b7820fd3a26fe39f2e9378b6e7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -3205,7 +3205,7 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_NICE)
 	ZEND_FE(proc_nice, arginfo_proc_nice)
 #endif
-	ZEND_RAW_FENTRY("flock", zif_flock, arginfo_flock, ZEND_ACC_NODISCARD, NULL, NULL)
+	ZEND_FE(flock, arginfo_flock)
 	ZEND_FE(get_meta_tags, arginfo_get_meta_tags)
 	ZEND_FE(pclose, arginfo_pclose)
 	ZEND_FE(popen, arginfo_popen)
@@ -4038,15 +4038,6 @@ static void register_basic_functions_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_utf8_decode_0_arg1, attribute_Deprecated_func_utf8_decode_0_arg1_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_utf8_decode_0->args[1].value, &attribute_Deprecated_func_utf8_decode_0_arg1);
 	attribute_Deprecated_func_utf8_decode_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
-
-	zend_string *attribute_name_NoDiscard_func_flock_0 = zend_string_init_interned("NoDiscard", sizeof("NoDiscard") - 1, 1);
-	zend_attribute *attribute_NoDiscard_func_flock_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "flock", sizeof("flock") - 1), attribute_name_NoDiscard_func_flock_0, 1);
-	zend_string_release(attribute_name_NoDiscard_func_flock_0);
-	zval attribute_NoDiscard_func_flock_0_arg0;
-	zend_string *attribute_NoDiscard_func_flock_0_arg0_str = zend_string_init("as locking the stream might have failed", strlen("as locking the stream might have failed"), 1);
-	ZVAL_STR(&attribute_NoDiscard_func_flock_0_arg0, attribute_NoDiscard_func_flock_0_arg0_str);
-	ZVAL_COPY_VALUE(&attribute_NoDiscard_func_flock_0->args[0].value, &attribute_NoDiscard_func_flock_0_arg0);
-	attribute_NoDiscard_func_flock_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -124,6 +124,13 @@ static ZEND_FUNCTION(zend_test_deprecated_attr)
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
+static ZEND_FUNCTION(zend_test_nodiscard)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_LONG(1);
+}
+
 static ZEND_FUNCTION(zend_test_deprecated_nodiscard)
 {
 	ZEND_PARSE_PARAMETERS_NONE();

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -218,6 +218,8 @@ namespace {
     #[\Deprecated(message: "custom message")]
     function zend_test_deprecated_attr(): void {}
 
+    #[\NoDiscard(message: "custom message")]
+    function zend_test_nodiscard(): int {}
 
     #[\Deprecated(message: "custom message")]
     #[\NoDiscard(message: "custom message 2")]

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eebe535d0295f707201ff751e38a5ad3837dbbd2 */
+ * Stub hash: bedc3883fbfe2491c95375beb13140e7fcfd83a5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -22,8 +22,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_zend_test_deprecated_attr arginfo_zend_test_void_return
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated_nodiscard, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_nodiscard, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_zend_test_deprecated_nodiscard arginfo_zend_test_nodiscard
 
 #define arginfo_zend_test_aliased arginfo_zend_test_void_return
 
@@ -131,7 +133,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_is_string_marked_as_va
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_zend_get_map_ptr_last arginfo_zend_test_deprecated_nodiscard
+#define arginfo_zend_get_map_ptr_last arginfo_zend_test_nodiscard
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_crash, 0, 0, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, message, IS_STRING, 1, "null")
@@ -189,7 +191,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_aliased_func arginfo_zend_test_void_return
 
-#define arginfo_class__ZendTestClass_is_object arginfo_zend_test_deprecated_nodiscard
+#define arginfo_class__ZendTestClass_is_object arginfo_zend_test_nodiscard
 
 #define arginfo_class__ZendTestClass___toString arginfo_zend_get_current_func_name
 
@@ -264,6 +266,7 @@ static ZEND_FUNCTION(zend_test_void_return);
 static ZEND_FUNCTION(zend_test_compile_string);
 static ZEND_FUNCTION(zend_test_deprecated);
 static ZEND_FUNCTION(zend_test_deprecated_attr);
+static ZEND_FUNCTION(zend_test_nodiscard);
 static ZEND_FUNCTION(zend_test_deprecated_nodiscard);
 static ZEND_FUNCTION(zend_create_unterminated_string);
 static ZEND_FUNCTION(zend_terminate_string);
@@ -360,6 +363,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("zend_test_deprecated_attr", zif_zend_test_deprecated_attr, arginfo_zend_test_deprecated_attr, ZEND_ACC_DEPRECATED, NULL, NULL)
 #else
 	ZEND_RAW_FENTRY("zend_test_deprecated_attr", zif_zend_test_deprecated_attr, arginfo_zend_test_deprecated_attr, ZEND_ACC_DEPRECATED)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("zend_test_nodiscard", zif_zend_test_nodiscard, arginfo_zend_test_nodiscard, ZEND_ACC_NODISCARD, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("zend_test_nodiscard", zif_zend_test_nodiscard, arginfo_zend_test_nodiscard, ZEND_ACC_NODISCARD)
 #endif
 #if (PHP_VERSION_ID >= 80400)
 	ZEND_RAW_FENTRY("zend_test_deprecated_nodiscard", zif_zend_test_deprecated_nodiscard, arginfo_zend_test_deprecated_nodiscard, ZEND_ACC_DEPRECATED|ZEND_ACC_NODISCARD, NULL, NULL)
@@ -571,6 +579,15 @@ static void register_test_symbols(int module_number)
 	ZVAL_STR(&attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0, attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_zend_test_deprecated_attr_0->args[0].value, &attribute_Deprecated_func_zend_test_deprecated_attr_0_arg0);
 	attribute_Deprecated_func_zend_test_deprecated_attr_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_string *attribute_name_NoDiscard_func_zend_test_nodiscard_0 = zend_string_init_interned("NoDiscard", sizeof("NoDiscard") - 1, 1);
+	zend_attribute *attribute_NoDiscard_func_zend_test_nodiscard_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_nodiscard", sizeof("zend_test_nodiscard") - 1), attribute_name_NoDiscard_func_zend_test_nodiscard_0, 1);
+	zend_string_release(attribute_name_NoDiscard_func_zend_test_nodiscard_0);
+	zval attribute_NoDiscard_func_zend_test_nodiscard_0_arg0;
+	zend_string *attribute_NoDiscard_func_zend_test_nodiscard_0_arg0_str = zend_string_init("custom message", strlen("custom message"), 1);
+	ZVAL_STR(&attribute_NoDiscard_func_zend_test_nodiscard_0_arg0, attribute_NoDiscard_func_zend_test_nodiscard_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_NoDiscard_func_zend_test_nodiscard_0->args[0].value, &attribute_NoDiscard_func_zend_test_nodiscard_0_arg0);
+	attribute_NoDiscard_func_zend_test_nodiscard_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_string *attribute_name_Deprecated_func_zend_test_deprecated_nodiscard_0 = zend_string_init_interned("Deprecated", sizeof("Deprecated") - 1, 1);
 	zend_attribute *attribute_Deprecated_func_zend_test_deprecated_nodiscard_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "zend_test_deprecated_nodiscard", sizeof("zend_test_deprecated_nodiscard") - 1), attribute_name_Deprecated_func_zend_test_deprecated_nodiscard_0, 1);


### PR DESCRIPTION
Closes #18235
Closes php/doc-en#4581 