### PR TITLE
ext/pdo_firebird: Fixed GH-18276 - persistent connection - "zend_mm_heap corrupted" with `setAttribute()`

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -492,15 +492,15 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 	}
 
 	if (H->date_format) {
-		efree(H->date_format);
+		pefree(H->date_format, dbh->is_persistent);
 		H->date_format = NULL;
 	}
 	if (H->time_format) {
-		efree(H->time_format);
+		pefree(H->time_format, dbh->is_persistent);
 		H->time_format = NULL;
 	}
 	if (H->timestamp_format) {
-		efree(H->timestamp_format);
+		pefree(H->timestamp_format, dbh->is_persistent);
 		H->timestamp_format = NULL;
 	}
 
@@ -884,10 +884,10 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					return false;
 				}
 				if (H->date_format) {
-					efree(H->date_format);
+					pefree(H->date_format, dbh->is_persistent);
 					H->date_format = NULL;
 				}
-				spprintf(&H->date_format, 0, "%s", ZSTR_VAL(str));
+				H->date_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;
@@ -899,10 +899,10 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					return false;
 				}
 				if (H->time_format) {
-					efree(H->time_format);
+					pefree(H->time_format, dbh->is_persistent);
 					H->time_format = NULL;
 				}
-				spprintf(&H->time_format, 0, "%s", ZSTR_VAL(str));
+				H->time_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;
@@ -914,10 +914,10 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					return false;
 				}
 				if (H->timestamp_format) {
-					efree(H->timestamp_format);
+					pefree(H->timestamp_format, dbh->is_persistent);
 					H->timestamp_format = NULL;
 				}
-				spprintf(&H->timestamp_format, 0, "%s", ZSTR_VAL(str));
+				H->timestamp_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -493,15 +493,12 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 
 	if (H->date_format) {
 		pefree(H->date_format, dbh->is_persistent);
-		H->date_format = NULL;
 	}
 	if (H->time_format) {
 		pefree(H->time_format, dbh->is_persistent);
-		H->time_format = NULL;
 	}
 	if (H->timestamp_format) {
 		pefree(H->timestamp_format, dbh->is_persistent);
-		H->timestamp_format = NULL;
 	}
 
 	pefree(H, dbh->is_persistent);
@@ -887,7 +884,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					pefree(H->date_format, dbh->is_persistent);
 					H->date_format = NULL;
 				}
-				H->date_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
+				H->date_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;
@@ -902,7 +899,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					pefree(H->time_format, dbh->is_persistent);
 					H->time_format = NULL;
 				}
-				H->time_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
+				H->time_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;
@@ -917,7 +914,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 					pefree(H->timestamp_format, dbh->is_persistent);
 					H->timestamp_format = NULL;
 				}
-				H->timestamp_format = pestrdup(ZSTR_VAL(str), dbh->is_persistent);
+				H->timestamp_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
 			return true;

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -493,12 +493,15 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 
 	if (H->date_format) {
 		efree(H->date_format);
+		H->date_format = NULL;
 	}
 	if (H->time_format) {
 		efree(H->time_format);
+		H->time_format = NULL;
 	}
 	if (H->timestamp_format) {
 		efree(H->timestamp_format);
+		H->timestamp_format = NULL;
 	}
 
 	pefree(H, dbh->is_persistent);
@@ -882,6 +885,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 				}
 				if (H->date_format) {
 					efree(H->date_format);
+					H->date_format = NULL;
 				}
 				spprintf(&H->date_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);
@@ -896,6 +900,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 				}
 				if (H->time_format) {
 					efree(H->time_format);
+					H->time_format = NULL;
 				}
 				spprintf(&H->time_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);
@@ -910,6 +915,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 				}
 				if (H->timestamp_format) {
 					efree(H->timestamp_format);
+					H->timestamp_format = NULL;
 				}
 				spprintf(&H->timestamp_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);

--- a/ext/pdo_firebird/tests/gh18276.phpt
+++ b/ext/pdo_firebird/tests/gh18276.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-18276 (persistent connection - setAttribute(Pdo\Firebird::ATTR_DATE_FORMAT, ..) results in "zend_mm_heap corrupted")
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+
+require("testdb.inc");
+unset($dbh);
+
+for ($i = 0; $i < 2; $i++) {
+    $dbh = new PDO(
+        PDO_FIREBIRD_TEST_DSN,
+        PDO_FIREBIRD_TEST_USER,
+        PDO_FIREBIRD_TEST_PASS,
+        [
+            PDO::ATTR_PERSISTENT => true,
+        ],
+    );
+    // Avoid interned
+    $dbh->setAttribute(PDO::FB_ATTR_DATE_FORMAT, str_repeat('Y----m----d', 1));
+    $dbh->setAttribute(PDO::FB_ATTR_TIME_FORMAT, str_repeat('H::::i::::s', 1));
+    $dbh->setAttribute(PDO::FB_ATTR_TIMESTAMP_FORMAT, str_repeat('Y----m----d....H::::i::::s', 1));
+    unset($dbh);
+}
+
+echo 'done!';
+?>
+--EXPECT--
+done!

--- a/ext/pdo_firebird/tests/gh18276.phpt
+++ b/ext/pdo_firebird/tests/gh18276.phpt
@@ -23,9 +23,9 @@ for ($i = 0; $i < 2; $i++) {
         ],
     );
     // Avoid interned
-    $dbh->setAttribute(PDO::FB_ATTR_DATE_FORMAT, str_repeat('Y----m----d', 1));
-    $dbh->setAttribute(PDO::FB_ATTR_TIME_FORMAT, str_repeat('H::::i::::s', 1));
-    $dbh->setAttribute(PDO::FB_ATTR_TIMESTAMP_FORMAT, str_repeat('Y----m----d....H::::i::::s', 1));
+    $dbh->setAttribute(PDO::FB_ATTR_DATE_FORMAT, str_repeat('Y----m----d', random_int(1, 1)));
+    $dbh->setAttribute(PDO::FB_ATTR_TIME_FORMAT, str_repeat('H::::i::::s', random_int(1, 1)));
+    $dbh->setAttribute(PDO::FB_ATTR_TIMESTAMP_FORMAT, str_repeat('Y----m----d....H::::i::::s', random_int(1, 1)));
     unset($dbh);
 }
 


### PR DESCRIPTION
fixes #18276

The structure has changed slightly on master, so I don’t plan to apply the change the third commit to master.
I’ll follow up with a separate PR for changes targeting master.