### PR TITLE
ext/standard: Implement list_filter()

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1877,6 +1877,8 @@ function array_reduce(array $array, callable $callback, mixed $initial = null): 
 
 function array_filter(array $array, ?callable $callback = null, int $mode = 0): array {}
 
+function list_filter(array $array, ?callable $callback = null, int $mode = 0): array {}
+
 function array_find(array $array, callable $callback): mixed {}
 
 function array_find_key(array $array, callable $callback): mixed {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 85677dc3476d25b7820fd3a26fe39f2e9378b6e7 */
+ * Stub hash: f2a8b629fe3e2ee7f7d9d8163e6536f811ee8c7c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -335,6 +335,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_filter, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
+
+#define arginfo_list_filter arginfo_array_filter
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_find, 0, 2, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
@@ -2380,6 +2382,7 @@ ZEND_FUNCTION(array_sum);
 ZEND_FUNCTION(array_product);
 ZEND_FUNCTION(array_reduce);
 ZEND_FUNCTION(array_filter);
+ZEND_FUNCTION(list_filter);
 ZEND_FUNCTION(array_find);
 ZEND_FUNCTION(array_find_key);
 ZEND_FUNCTION(array_any);
@@ -2973,6 +2976,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("array_product", zif_array_product, arginfo_array_product, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(array_reduce, arginfo_array_reduce)
 	ZEND_FE(array_filter, arginfo_array_filter)
+	ZEND_FE(list_filter, arginfo_list_filter)
 	ZEND_FE(array_find, arginfo_array_find)
 	ZEND_FE(array_find_key, arginfo_array_find_key)
 	ZEND_FE(array_any, arginfo_array_any)

--- a/ext/standard/tests/general_functions/list_array.phpt
+++ b/ext/standard/tests/general_functions/list_array.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test list_filter() function
+--FILE--
+<?php
+
+$array1 = [1,0,2,3,4];
+$array2 = ['a' => 1, 'b' => 2, 'c' => 3];
+
+var_dump(array_is_list($array1));
+var_dump(array_is_list(array_filter($array1)));
+var_dump(array_is_list(list_filter($array1)));
+
+
+var_dump(array_is_list($array2));
+var_dump(array_is_list(array_filter($array2)));
+var_dump(array_is_list(list_filter($array2)));
+
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)
+bool(true)


### PR DESCRIPTION
There are a few array functions that return arrays, without the option to return a list, even when we pass lists to them.

I would like to propose adding such functions to the core. One of them is `list_filter()` that is equivalent of `array_filter()`. I will prepare RFC later if the reception is positive.

Next functions would be:
- list_diff
- list_merge
- list_unique
- list_intersect