### PR TITLE
ext/pdo_firebird: (master) Fixed GH-18276 - persistent connection - "zend_mm_heap corrupted" with setAttribute()

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -599,13 +599,13 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 	}
 
 	if (H->date_format) {
-		zend_string_release_ex(H->date_format, false);
+		zend_string_release(H->date_format);
 	}
 	if (H->time_format) {
-		zend_string_release_ex(H->time_format, false);
+		zend_string_release(H->time_format);
 	}
 	if (H->timestamp_format) {
-		zend_string_release_ex(H->timestamp_format, false);
+		zend_string_release(H->timestamp_format);
 	}
 
 	if (H->einfo.errmsg) {
@@ -1086,12 +1086,15 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 
 		case PDO_FB_ATTR_DATE_FORMAT:
 			{
-				zend_string *str = zval_try_get_string(val);
-				if (UNEXPECTED(!str)) {
+				zend_string *strval = zval_try_get_string(val);
+				if (UNEXPECTED(!strval)) {
 					return false;
 				}
+				zend_string *str = zend_string_dup(strval, dbh->is_persistent);
+				zend_string_release_ex(strval, false);
+
 				if (H->date_format) {
-					zend_string_release_ex(H->date_format, false);
+					zend_string_release(H->date_format);
 				}
 				H->date_format = str;
 			}
@@ -1099,12 +1102,15 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 
 		case PDO_FB_ATTR_TIME_FORMAT:
 			{
-				zend_string *str = zval_try_get_string(val);
-				if (UNEXPECTED(!str)) {
+				zend_string *strval = zval_try_get_string(val);
+				if (UNEXPECTED(!strval)) {
 					return false;
 				}
+				zend_string *str = zend_string_dup(strval, dbh->is_persistent);
+				zend_string_release_ex(strval, false);
+
 				if (H->time_format) {
-					zend_string_release_ex(H->time_format, false);
+					zend_string_release(H->time_format);
 				}
 				H->time_format = str;
 			}
@@ -1112,12 +1118,15 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 
 		case PDO_FB_ATTR_TIMESTAMP_FORMAT:
 			{
-				zend_string *str = zval_try_get_string(val);
-				if (UNEXPECTED(!str)) {
+				zend_string *strval = zval_try_get_string(val);
+				if (UNEXPECTED(!strval)) {
 					return false;
 				}
+				zend_string *str = zend_string_dup(strval, dbh->is_persistent);
+				zend_string_release_ex(strval, false);
+
 				if (H->timestamp_format) {
-					zend_string_release_ex(H->timestamp_format, false);
+					zend_string_release(H->timestamp_format);
 				}
 				H->timestamp_format = str;
 			}

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1250,7 +1250,12 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 		case PDO_FB_ATTR_DATE_FORMAT:
 			if (H->date_format) {
-				ZVAL_STR_COPY(val, H->date_format);
+				if (dbh->is_persistent) {
+					zend_string *str = zend_string_dup(H->date_format, false);
+					ZVAL_STR(val, str);
+				} else {
+					ZVAL_STR_COPY(val, H->date_format);
+				}
 			} else {
 				ZVAL_STRING(val, PDO_FB_DEF_DATE_FMT);
 			}
@@ -1258,7 +1263,12 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 		case PDO_FB_ATTR_TIME_FORMAT:
 			if (H->time_format) {
-				ZVAL_STR_COPY(val, H->time_format);
+				if (dbh->is_persistent) {
+					zend_string *str = zend_string_dup(H->time_format, false);
+					ZVAL_STR(val, str);
+				} else {
+					ZVAL_STR_COPY(val, H->time_format);
+				}
 			} else {
 				ZVAL_STRING(val, PDO_FB_DEF_TIME_FMT);
 			}
@@ -1266,7 +1276,12 @@ static int pdo_firebird_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 		case PDO_FB_ATTR_TIMESTAMP_FORMAT:
 			if (H->timestamp_format) {
-				ZVAL_STR_COPY(val, H->timestamp_format);
+				if (dbh->is_persistent) {
+					zend_string *str = zend_string_dup(H->timestamp_format, false);
+					ZVAL_STR(val, str);
+				} else {
+					ZVAL_STR_COPY(val, H->timestamp_format);
+				}
 			} else {
 				ZVAL_STRING(val, PDO_FB_DEF_TIMESTAMP_FMT);
 			}

--- a/ext/pdo_firebird/tests/gh18276.phpt
+++ b/ext/pdo_firebird/tests/gh18276.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-18276 (persistent connection - setAttribute(Pdo\Firebird::ATTR_DATE_FORMAT, ..) results in "zend_mm_heap corrupted")
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+
+require("testdb.inc");
+unset($dbh);
+
+for ($i = 0; $i < 2; $i++) {
+    $dbh = new PDO(
+        PDO_FIREBIRD_TEST_DSN,
+        PDO_FIREBIRD_TEST_USER,
+        PDO_FIREBIRD_TEST_PASS,
+        [
+            PDO::ATTR_PERSISTENT => true,
+        ],
+    );
+    // Avoid interned
+    $dbh->setAttribute(PDO::FB_ATTR_DATE_FORMAT, str_repeat('Y----m----d', random_int(1, 1)));
+    $dbh->setAttribute(PDO::FB_ATTR_TIME_FORMAT, str_repeat('H::::i::::s', random_int(1, 1)));
+    $dbh->setAttribute(PDO::FB_ATTR_TIMESTAMP_FORMAT, str_repeat('Y----m----d....H::::i::::s', random_int(1, 1)));
+    unset($dbh);
+}
+
+echo 'done!';
+?>
+--EXPECT--
+done!


### PR DESCRIPTION
fixes https://github.com/php/php-src/issues/18276

This fixes for master. For pre-8.4 branches, fix with #18280
The tests are exactly the same as in #18280  (I committed it just to make sure the CI passed).