### PR TITLE
Fix GH-18294: assertion failure zend_jit_ir.c

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -13482,6 +13482,13 @@ static int zend_jit_assign_dim_op(zend_jit_ctx   *jit,
 					ref_path = ir_END();
 					ir_IF_TRUE_cold(if_typed);
 
+					if (Z_MODE(op3_addr) == IS_REG) {
+						zend_jit_addr real_addr = ZEND_ADDR_MEM_ZVAL(ZREG_FP, (opline+1)->op1.var);
+						if (!zend_jit_spill_store_inv(jit, op3_addr, real_addr, op1_data_info)) {
+							return 0;
+						}
+						op3_addr = real_addr;
+					}
 					arg2 = jit_ZVAL_ADDR(jit, op3_addr);
 					ir_CALL_3(IR_VOID, ir_CONST_FC_FUNC(zend_jit_assign_op_to_typed_ref),
 						reference, arg2, ir_CONST_FC_FUNC(binary_op));

--- a/ext/opcache/tests/jit/gh17190.phpt
+++ b/ext/opcache/tests/jit/gh17190.phpt
@@ -7,7 +7,9 @@ opcache.enable=1
 opcache.enable_cli=1
 opcache.file_update_protection=0
 opcache.jit_buffer_size=32M
-opcache.jit=function
+opcache.jit=1254
+opcache.jit_hot_func=1
+opcache.jit_hot_side_exit=1
 --FILE--
 <?php
 $a = [2147483647,2147483647,2147483647,3,0,0,32,2147483584,127];

--- a/ext/opcache/tests/jit/gh18294.phpt
+++ b/ext/opcache/tests/jit/gh18294.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-18294 (assertion failure zend_jit_ir.c)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.jit=1152
+opcache.jit_hot_func=1
+opcache.jit_hot_side_exit=1
+--FILE--
+<?php
+$a = [2147483647,2147483647,2147483647,3,0,0,32,2147483584,127];
+print_r(@bitwise_small_split($a));
+function bitwise_small_split($val) {
+    $split = 8;
+    $len = count($val);
+    while ($i != $len) {
+        if (!$overflow) {
+            $overflow = $split <= $remaining ? 0 : $split - $remaining;
+        } elseif (++$i != $len) {
+            $fusion[$i] >>= $overflow;
+        }
+    }
+    return $fusion;
+}
+?>
+--EXPECT--
+Array
+(
+    [1] => 0
+    [2] => 0
+    [3] => 0
+    [4] => 0
+    [5] => 0
+    [6] => 0
+    [7] => 0
+    [8] => 0
+)


### PR DESCRIPTION
The JIT helper `zend_jit_assign_op_to_typed_ref` expects a `zval*` as an
argument, so we have to store to the stack if OP1_DATA(=op3) is in a
register.

---

I also added a commit to fix reproducibility of a related test. These two commits will be merged as separate.