### PR TITLE
run-tests.php: Remove extra env vars in the generated .sh file

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2723,6 +2723,8 @@ $output
     if (!$passed || $leaked) {
         // write .sh
         if (strpos($log_format, 'S') !== false) {
+            // Unset all environment variables so that we don't inherit extra
+            // ones from the parent process.
             $env_lines = ['unset $(env | cut -d= -f1)'];
             foreach ($env as $env_var => $env_val) {
                 if (strval($env_val) === '') {

--- a/run-tests.php
+++ b/run-tests.php
@@ -2723,8 +2723,12 @@ $output
     if (!$passed || $leaked) {
         // write .sh
         if (strpos($log_format, 'S') !== false) {
-            $env_lines = [];
+            $env_lines = ['unset $(env | cut -d= -f1)'];
             foreach ($env as $env_var => $env_val) {
+                if (strval($env_val) === '') {
+                    // proc_open does not pass empty env vars
+                    continue;
+                }
                 $env_lines[] = "export $env_var=" . escapeshellarg($env_val ?? "");
             }
             $exported_environment = "\n" . implode("\n", $env_lines) . "\n";
@@ -2733,7 +2737,7 @@ $output
 {$exported_environment}
 case "$1" in
 "gdb")
-    gdb --args {$orig_cmd}
+    gdb -ex 'unset environment LINES' -ex 'unset environment COLUMNS' --args {$orig_cmd}
     ;;
 "lldb")
     lldb -- {$orig_cmd}


### PR DESCRIPTION
`run-tests.php` conveniently generates a `.sh` file for each failed test.

The file starts by setting environment variables to the value they had during the test run.

Unfortunately, sometimes extra env vars will sneak in and prevent reproduction:

 - Variables are inherited from the process that executes the `.sh` file
 - The `.sh` file exports empty variables, but `proc_open()` does not
 - When running under `gdb`, the variables `LINES` and `COLUMNS` are set

Here I ensure that these variables do not sneak in anymore in these cases when using the `.sh` file.