### PR TITLE
Fix GH-18309: ipv6 filter integer overflow

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -762,7 +762,8 @@ static int _php_filter_validate_ipv6(const char *str, size_t str_len, int ip[8])
 {
 	int compressed_pos = -1;
 	int blocks = 0;
-	unsigned int num, n, i;
+	unsigned int num, n;
+	int i;
 	char *ipv4;
 	const char *end;
 	int ip4elm[4];

--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -762,7 +762,7 @@ static int _php_filter_validate_ipv6(const char *str, size_t str_len, int ip[8])
 {
 	int compressed_pos = -1;
 	int blocks = 0;
-	int num, n, i;
+	unsigned int num, n, i;
 	char *ipv4;
 	const char *end;
 	int ip4elm[4];

--- a/ext/filter/tests/gh18309.phpt
+++ b/ext/filter/tests/gh18309.phpt
@@ -1,0 +1,10 @@
+--TEST--
+GH-18309 (ipv6 filter integer overflow)
+--EXTENSIONS--
+filter
+--FILE--
+<?php
+var_dump(filter_var('fffffffffffffffffffffffffffffffffffff::', FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
The intermediate computation can cause a signed integer overflow, but the input is correctly rejected later on by the check on variable `n`. Solve this by using an unsigned number.