### PR TITLE
8.2 branch is security fixes only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,7 @@ Currently, we have the following branches in use:
 | master    | Active development branch for PHP 8.5, which is open for backwards incompatible changes and major internal API changes. |
 | PHP-8.4   | Is used to release the PHP 8.4.x series. This is a current stable version and is open for bugfixes only. |
 | PHP-8.3   | Is used to release the PHP 8.3.x series. This is a current stable version and is open for bugfixes only. |
-| PHP-8.2   | Is used to release the PHP 8.2.x series. This is a current stable version and is open for bugfixes only. |
+| PHP-8.2   | Is used to release the PHP 8.2.x series. This is an old stable version and is open for security fixes only. |
 | PHP-8.1   | Is used to release the PHP 8.1.x series. This is an old stable version and is open for security fixes only. |
 | PHP-8.0   | This branch is closed. |
 | PHP-7.4   | This branch is closed. |


### PR DESCRIPTION
Based on the explanation on https://www.php.net/supported-versions.php, 8.2 moved into security fixes only on 31 Dec 2024.