### PR TITLE
Don't evaluate GMP comparison multiple times

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -480,7 +480,8 @@ static int gmp_compare(zval *op1, zval *op2) /* {{{ */
 		return ZEND_UNCOMPARABLE;
 	}
 
-	return ZEND_THREEWAY_COMPARE(mpz_cmp(gmp_op1, gmp_op2), 0);
+	int ret = mpz_cmp(gmp_op1, gmp_op2); /* avoid multiple evaluations */
+	return ZEND_THREEWAY_COMPARE(ret, 0);
 }
 /* }}} */
 
@@ -1422,7 +1423,8 @@ ZEND_FUNCTION(gmp_cmp)
 		GMP_Z_PARAM_INTO_MPZ_PTR(gmpnum_b)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_LONG(ZEND_THREEWAY_COMPARE(mpz_cmp(gmpnum_a, gmpnum_b), 0));
+	int ret = mpz_cmp(gmpnum_a, gmpnum_b); /* avoid multiple evaluations */
+	RETURN_LONG(ZEND_THREEWAY_COMPARE(ret, 0));
 }
 /* }}} */
 


### PR DESCRIPTION
ZEND_THREEWAY_COMPARE evaluates its operands multiple times.