### PR TITLE
Fix GH-18322: SplObjectStorage debug handler mismanages memory

### DIFF
--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -340,12 +340,10 @@ static inline HashTable* spl_object_storage_debug_info(zend_object *obj) /* {{{ 
 
 	ZEND_HASH_FOREACH_PTR(&intern->storage, element) {
 		array_init(&tmp);
-		/* Incrementing the refcount of obj and inf would confuse the garbage collector.
-		 * Prefer to null the destructor */
-		Z_ARRVAL_P(&tmp)->pDestructor = NULL;
 		zval obj;
-		ZVAL_OBJ(&obj, element->obj);
+		ZVAL_OBJ_COPY(&obj, element->obj);
 		add_assoc_zval_ex(&tmp, "obj", sizeof("obj") - 1, &obj);
+		Z_TRY_ADDREF(element->inf);
 		add_assoc_zval_ex(&tmp, "inf", sizeof("inf") - 1, &element->inf);
 		zend_hash_next_index_insert(Z_ARRVAL(storage), &tmp);
 	} ZEND_HASH_FOREACH_END();

--- a/ext/spl/tests/gh18322.phpt
+++ b/ext/spl/tests/gh18322.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-18322 (SplObjectStorage debug handler mismanages memory)
+--FILE--
+<?php
+
+$stor = new SplObjectStorage();
+$obj = new stdClass;
+$stor[$obj] = 1;
+
+$tmp = $stor->__debugInfo();
+$tmp2 = $tmp[array_key_first($tmp)];
+unset($tmp); // Drop $tmp2 RC to 1
+$tmp2[0]['obj'] = new stdClass;
+var_dump($tmp2);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(2) {
+    ["obj"]=>
+    object(stdClass)#3 (0) {
+    }
+    ["inf"]=>
+    int(1)
+  }
+}


### PR DESCRIPTION
This hack was once necessary before there was a proper get_gc handler, but now it breaks the engine constraints.