### PR TITLE
Make empty_fcall_info_cache a macro

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -690,11 +690,11 @@ ZEND_API zend_result _call_user_function_impl(zval *object, zval *function_name,
 #define call_user_function_named(function_table, object, function_name, retval_ptr, param_count, params, named_params) \
 	_call_user_function_impl(object, function_name, retval_ptr, param_count, params, named_params)
 
-ZEND_API extern const zend_fcall_info empty_fcall_info;
-
 #ifndef __cplusplus
+# define empty_fcall_info (zend_fcall_info) {0}
 # define empty_fcall_info_cache (zend_fcall_info_cache) {0}
 #else
+# define empty_fcall_info zend_fcall_info {0}
 # define empty_fcall_info_cache zend_fcall_info_cache {0}
 #endif
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -691,7 +691,12 @@ ZEND_API zend_result _call_user_function_impl(zval *object, zval *function_name,
 	_call_user_function_impl(object, function_name, retval_ptr, param_count, params, named_params)
 
 ZEND_API extern const zend_fcall_info empty_fcall_info;
-ZEND_API extern const zend_fcall_info_cache empty_fcall_info_cache;
+
+#ifndef __cplusplus
+# define empty_fcall_info_cache (zend_fcall_info_cache) {0}
+#else
+# define empty_fcall_info_cache zend_fcall_info_cache {0}
+#endif
 
 /** Build zend_call_info/cache from a zval*
  *
@@ -800,7 +805,7 @@ static zend_always_inline void zend_fcc_dtor(zend_fcall_info_cache *fcc)
 	if (fcc->closure) {
 		OBJ_RELEASE(fcc->closure);
 	}
-	memcpy(fcc, &empty_fcall_info_cache, sizeof(zend_fcall_info_cache));
+	*fcc = empty_fcall_info_cache;
 }
 
 ZEND_API void zend_get_callable_zval_from_fcc(const zend_fcall_info_cache *fcc, zval *callable);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -55,7 +55,6 @@ ZEND_API zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_n
 
 /* true globals */
 ZEND_API const zend_fcall_info empty_fcall_info = {0};
-ZEND_API const zend_fcall_info_cache empty_fcall_info_cache = {0};
 
 #ifdef ZEND_WIN32
 ZEND_TLS HANDLE tq_timer = NULL;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -53,9 +53,6 @@ ZEND_API void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
 ZEND_API zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_name);
 
-/* true globals */
-ZEND_API const zend_fcall_info empty_fcall_info = {0};
-
 #ifdef ZEND_WIN32
 ZEND_TLS HANDLE tq_timer = NULL;
 #endif


### PR DESCRIPTION
See https://github.com/php/php-src/pull/18273, a constant may cause unnecessary cache misses.