### PR TITLE
Fix GH-18108 gen_stub: Using $this when not in object context

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -2174,7 +2174,7 @@ class EvaluatedValue
             static function (Expr $expr) use ($allConstInfos, &$isUnknownConstValue) {
                 // $expr is a ConstFetch with a name of a C macro here
                 if (!$expr instanceof Expr\ConstFetch) {
-                    throw new Exception($this->getVariableTypeName() . " " . $this->name->__toString() . " has an unsupported value");
+                    throw new Exception("Expression at line " . $expr->getStartLine() . " must be a global, non-magic constant");
                 }
 
                 $constName = $expr->name->__toString();


### PR DESCRIPTION
Fix for https://github.com/php/php-src/issues/18108

Reproducer in `./ext/zend_test/test.stub.php`:

```
 /** @var string */
const TEMP_TEST = __FILE__;
```

The new error message will be the following:

```
In ./ext/zend_test/test.stub.php:
Expression at line 12 must be a global, non-magic constant
```