### PR TITLE
Fix uouv when handling empty options in ZipArchive::addGlob()

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -354,13 +354,13 @@ typedef struct {
 #endif
 } zip_options;
 
+/* Expects opts to be zero-initialized. */
 static int php_zip_parse_options(HashTable *options, zip_options *opts)
 /* {{{ */
 {
 	zval *option;
 
 	/* default values */
-	memset(opts, 0, sizeof(zip_options));
 	opts->flags = ZIP_FL_OVERWRITE;
 	opts->comp_method = -1; /* -1 to not change default */
 #ifdef HAVE_ENCRYPTION
@@ -1732,7 +1732,7 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 	size_t  path_len = 1;
 	zend_long glob_flags = 0;
 	HashTable *options = NULL;
-	zip_options opts;
+	zip_options opts = {0};
 	int found;
 	zend_string *pattern;
 

--- a/ext/zip/tests/addGlob_empty_options.phpt
+++ b/ext/zip/tests/addGlob_empty_options.phpt
@@ -1,0 +1,22 @@
+--TEST--
+addGlob with empty options
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+touch($file = __DIR__ . '/addglob_empty_options.zip');
+
+$zip = new ZipArchive();
+$zip->open($file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob(__FILE__, 0, []);
+var_dump($zip->statIndex(0)['name'] === __FILE__);
+$zip->close();
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/addglob_empty_options.zip');
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Reported by OpenAI AARDVARK.