### PR TITLE
Fix memory leak when handling a too long path in ZipArchive::addGlob()

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1796,6 +1796,9 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 
 				if (opts.add_path) {
 					if ((opts.add_path_len + file_stripped_len) > MAXPATHLEN) {
+						if (basename) {
+							zend_string_release_ex(basename, 0);
+						}
 						php_error_docref(NULL, E_WARNING, "Entry name too long (max: %d, %zd given)",
 						MAXPATHLEN - 1, (opts.add_path_len + file_stripped_len));
 						zend_array_destroy(Z_ARR_P(return_value));

--- a/ext/zip/tests/addGlob_too_long_add_path_option.phpt
+++ b/ext/zip/tests/addGlob_too_long_add_path_option.phpt
@@ -1,0 +1,21 @@
+--TEST--
+addGlob with too long add_path option
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+touch($file = __DIR__ . '/addglob_too_long_add_path.zip');
+
+$zip = new ZipArchive();
+$zip->open($file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addGlob(__FILE__, 0, ['add_path' => str_repeat('A', PHP_MAXPATHLEN - 2)]);
+$zip->close();
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/addglob_too_long_add_path.zip');
+?>
+--EXPECTF--
+Warning: ZipArchive::addGlob(): Entry name too long (max: %d, %d given) in %s on line %d


### PR DESCRIPTION
Detected by staring at the code.