### PR TITLE
Fix NULL deref on high modification key

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2785,12 +2785,12 @@ PHP_FUNCTION(ldap_modify_batch)
 	ldap_mods = safe_emalloc((num_mods+1), sizeof(LDAPMod *), 0);
 
 	/* for each modification */
-	for (i = 0; i < num_mods; i++) {
+	i = 0;
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(mods), fetched) {
 		/* allocate the modification struct */
 		ldap_mods[i] = safe_emalloc(1, sizeof(LDAPMod), 0);
 
 		/* fetch the relevant data */
-		fetched = zend_hash_index_find(Z_ARRVAL_P(mods), i);
 		mod = fetched;
 
 		_ldap_hash_fetch(mod, LDAP_MODIFY_BATCH_ATTRIB, &attrib);
@@ -2855,7 +2855,9 @@ PHP_FUNCTION(ldap_modify_batch)
 			/* NULL-terminate values */
 			ldap_mods[i]->mod_bvalues[num_modvals] = NULL;
 		}
-	}
+
+		i++;
+	} ZEND_HASH_FOREACH_END();
 
 	/* NULL-terminate modifications */
 	ldap_mods[num_mods] = NULL;

--- a/ext/ldap/tests/ldap_modify_batch_error.phpt
+++ b/ext/ldap/tests/ldap_modify_batch_error.phpt
@@ -60,6 +60,16 @@ $mods = array(
 );
 
 var_dump(ldap_modify_batch($link, "dc=my-domain,$base", $mods));
+
+// high key with invalid attribute type
+$mods = [
+    99999 => [
+        "attrib"  => "weirdAttribute",
+        "modtype" => LDAP_MODIFY_BATCH_ADD,
+        "values"  => ["value1"],
+    ],
+];
+var_dump(ldap_modify_batch($link, "dc=my-domain,$base", $mods));
 ?>
 --CLEAN--
 <?php
@@ -77,6 +87,9 @@ Warning: ldap_modify_batch(): Batch Modify: Invalid DN syntax in %s on line %d
 bool(false)
 
 Warning: ldap_modify_batch(): Batch Modify: Naming violation in %s on line %d
+bool(false)
+
+Warning: ldap_modify_batch(): Batch Modify: Undefined attribute type in %s on line %d
 bool(false)
 
 Warning: ldap_modify_batch(): Batch Modify: Undefined attribute type in %s on line %d


### PR DESCRIPTION
We should re-index in the loop.
Reported by OpenAI AARDVARK.