### PR TITLE
Fix memory leak on error return of collation callback in pdo_sqlite

### DIFF
--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -352,6 +352,7 @@ static int php_sqlite_collation_callback(void *context, int string1_len, const v
 			zend_type_error("%s(): Return value of the callback must be of type int, %s returned",
 				ZSTR_VAL(func_name), zend_zval_value_name(&retval));
 			zend_string_release(func_name);
+			zval_ptr_dtor(&retval);
 			return FAILURE;
 		}
 		if (Z_LVAL(retval) > 0) {
@@ -359,7 +360,6 @@ static int php_sqlite_collation_callback(void *context, int string1_len, const v
 		} else if (Z_LVAL(retval) < 0) {
 			ret = -1;
 		}
-		zval_ptr_dtor(&retval);
 	}
 
 	zval_ptr_dtor(&zargs[0]);


### PR DESCRIPTION
We should destroy it when it's not IS_LONG, not when it's IS_LONG.