### PR TITLE
Fix use of magic const within const expr cast

### DIFF
--- a/Zend/tests/oss_fuzz_410939023.phpt
+++ b/Zend/tests/oss_fuzz_410939023.phpt
@@ -1,0 +1,11 @@
+--TEST--
+OSS-Fuzz #410939023: Use of magic const within const expr cast
+--FILE--
+<?php
+
+const C = (string)__METHOD__;
+var_dump(C);
+
+?>
+--EXPECT--
+string(0) ""

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -12127,6 +12127,9 @@ static void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 			zend_eval_const_expr(&ast->child[0]);
 			zend_eval_const_expr(&ast->child[1]);
 			return;
+		case ZEND_AST_CAST:
+			zend_eval_const_expr(&ast->child[0]);
+			return;
 		default:
 			return;
 	}


### PR DESCRIPTION
Fixes OSS-Fuzz #410939023

We should also actually try performing the cast at compile time. I'll take a look later.