### PR TITLE
Make scheme part of parse_url comply with rfc3986

### DIFF
--- a/ext/standard/tests/url/parse_url_basic_011.phpt
+++ b/ext/standard/tests/url/parse_url_basic_011.phpt
@@ -15,20 +15,16 @@ var_dump(parse_url('magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C'));
 --EXPECT--
 *** Testing parse_url() :can not recognize port without scheme ***
 parse 127.0.0.1:9999?
-array(3) {
-  ["scheme"]=>
-  string(9) "127.0.0.1"
+array(2) {
   ["path"]=>
-  string(4) "9999"
+  string(14) "127.0.0.1:9999"
   ["query"]=>
   string(0) ""
 }
 parse 127.0.0.1:9999#
-array(3) {
-  ["scheme"]=>
-  string(9) "127.0.0.1"
+array(2) {
   ["path"]=>
-  string(4) "9999"
+  string(14) "127.0.0.1:9999"
   ["fragment"]=>
   string(0) ""
 }

--- a/ext/standard/tests/url/parse_url_rfc3986_scheme.phpt
+++ b/ext/standard/tests/url/parse_url_rfc3986_scheme.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test parse_url() function: Checks URL schemes should start with alpha characters.
+--FILE--
+<?php
+$urls = [
+  'valid-scheme://example.org',
+  '0invalid-scheme://example.org',
+  '-invalid-scheme://example.org',
+  '+invalid-scheme://example.org',
+  '.invalid-scheme://example.org'
+];
+foreach ($urls as $url) {
+  echo "parse {$url}\n";
+  var_dump(parse_url($url, PHP_URL_SCHEME));
+}
+?>
+--EXPECT--
+parse valid-scheme://example.org
+string(12) "valid-scheme"
+parse 0invalid-scheme://example.org
+NULL
+parse -invalid-scheme://example.org
+NULL
+parse +invalid-scheme://example.org
+NULL
+parse .invalid-scheme://example.org
+NULL

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -116,8 +116,8 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 		/* validate scheme */
 		p = s;
 		while (p < e) {
-			/* scheme = 1*[ lowalpha | digit | "+" | "-" | "." ] */
-			if (!isalpha(*p) && !isdigit(*p) && *p != '+' && *p != '.' && *p != '-') {
+			/* scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+			if (!isalpha(*p) && (p == s || !isdigit(*p) && *p != '+' && *p != '.' && *p != '-')) {
 				if (e + 1 < ue && e < binary_strcspn(s, ue, "?#")) {
 					goto parse_port;
 				} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -117,7 +117,7 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 		p = s;
 		while (p < e) {
 			/* scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
-			if (!isalpha(*p) && (p == s || !isdigit(*p) && *p != '+' && *p != '.' && *p != '-')) {
+			if (!isalpha(*p) && (p == s || (!isdigit(*p) && *p != '+' && *p != '.' && *p != '-'))) {
 				if (e + 1 < ue && e < binary_strcspn(s, ue, "?#")) {
 					goto parse_port;
 				} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */


### PR DESCRIPTION
According to the rfc3986 Section 3.1:

> Scheme names consist of a sequence of characters beginning with a
> letter and followed by any combination of letters, digits, plus
>  ("+"), period ("."), or hyphen ("-").

parse_url currently accepts schemes that start with non-alphabetic characters.