### PR TITLE
Get rid of separate DOM HashPosition member

### DIFF
--- a/ext/dom/dom_iterators.c
+++ b/ext/dom/dom_iterators.c
@@ -189,9 +189,8 @@ static void php_dom_iterator_move_forward(zend_object_iterator *iter) /* {{{ */
 			objmap->nodetype != XML_NOTATION_NODE) {
 			if (objmap->nodetype == DOM_NODESET) {
 				HashTable *nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
-				zval *entry;
-				zend_hash_move_forward_ex(nodeht, &iterator->pos);
-				if ((entry = zend_hash_get_current_data_ex(nodeht, &iterator->pos))) {
+				zval *entry = zend_hash_index_find(nodeht, iterator->index);
+				if (entry) {
 					zval_ptr_dtor(&iterator->curobj);
 					ZVAL_COPY(&iterator->curobj, entry);
 					return;
@@ -263,8 +262,6 @@ zend_object_iterator *php_dom_get_iterator(zend_class_entry *ce, zval *object, i
 	dom_object *intern;
 	dom_nnodemap_object *objmap;
 	xmlNodePtr curnode=NULL;
-	HashTable *nodeht;
-	zval *entry;
 	php_dom_iterator *iterator;
 
 	if (by_ref) {
@@ -284,9 +281,9 @@ zend_object_iterator *php_dom_get_iterator(zend_class_entry *ce, zval *object, i
 		if (objmap->nodetype != XML_ENTITY_NODE &&
 			objmap->nodetype != XML_NOTATION_NODE) {
 			if (objmap->nodetype == DOM_NODESET) {
-				nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
-				zend_hash_internal_pointer_reset_ex(nodeht, &iterator->pos);
-				if ((entry = zend_hash_get_current_data_ex(nodeht, &iterator->pos))) {
+				HashTable *nodeht = Z_ARRVAL_P(&objmap->baseobj_zv);
+				zval *entry = zend_hash_index_find(nodeht, 0);
+				if (entry) {
 					ZVAL_COPY(&iterator->curobj, entry);
 				}
 			} else {

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -97,7 +97,6 @@ typedef struct dom_nnodemap_object {
 typedef struct {
 	zend_object_iterator intern;
 	zval curobj;
-	HashPosition pos;
 	/* intern->index is only updated for FE_* opcodes, not for e.g. unpacking,
 	 * yet we need to track the position of the node relative to the start. */
 	zend_ulong index;


### PR DESCRIPTION
Besides the fact that this is only used for DOM_NODESET and thus makes no sense of being on the iterator itself, it's also redundant now that we have the index member.

This is one of the first steps of cleaning up the DOM iterator code.