### PR TITLE
Fix reference support for intltz_get_offset()

### DIFF
--- a/ext/intl/tests/intltz_get_offset_references.phpt
+++ b/ext/intl/tests/intltz_get_offset_references.phpt
@@ -1,0 +1,26 @@
+--TEST--
+intltz_get_offset references
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+$tz = IntlTimeZone::createTimeZone('Europe/Brussels');
+
+class Test {
+  public string $a, $b;
+}
+$test = new Test;
+$test->a = $test->b = "hello";
+
+$rawOffset =& $test->a;
+$dstOffset =& $test->b;
+intltz_get_offset($tz, 0.0, true, $rawOffset, $dstOffset);
+var_dump($test);
+?>
+--EXPECT--
+object(Test)#2 (2) {
+  ["a"]=>
+  &string(7) "3600000"
+  ["b"]=>
+  &string(1) "0"
+}

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -419,7 +419,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_offset)
 	TIMEZONE_METHOD_INIT_VARS;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
-			"Odbz/z/", &object, TimeZone_ce_ptr, &date, &local, &rawOffsetArg,
+			"Odbzz", &object, TimeZone_ce_ptr, &date, &local, &rawOffsetArg,
 			&dstOffsetArg) == FAILURE) {
 		RETURN_THROWS();
 	}
@@ -431,10 +431,8 @@ U_CFUNC PHP_FUNCTION(intltz_get_offset)
 
 	INTL_METHOD_CHECK_STATUS(to, "intltz_get_offset: error obtaining offset");
 
-	zval_ptr_dtor(rawOffsetArg);
-	ZVAL_LONG(rawOffsetArg, rawOffset);
-	zval_ptr_dtor(dstOffsetArg);
-	ZVAL_LONG(dstOffsetArg, dstOffset);
+	ZEND_TRY_ASSIGN_REF_LONG(rawOffsetArg, rawOffset);
+	ZEND_TRY_ASSIGN_REF_LONG(dstOffsetArg, dstOffset);
 
 	RETURN_TRUE;
 }


### PR DESCRIPTION
It should use the helper macros such that types are properly respected.