### PR TITLE
Fixed GH-18348: `fputcsv` incorrectly escapes when quote char is both enclosure and escape char

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1788,16 +1788,11 @@ PHPAPI ssize_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, cha
 		) {
 			char *ch = ZSTR_VAL(field_str);
 			char *end = ch + ZSTR_LEN(field_str);
-			int escaped = 0;
 
 			smart_str_appendc(&csvline, enclosure);
 			while (ch < end) {
-				if (escape_char != PHP_CSV_NO_ESCAPE && *ch == escape_char) {
-					escaped = 1;
-				} else if (!escaped && *ch == enclosure) {
+				if (*ch == enclosure) {
 					smart_str_appendc(&csvline, enclosure);
-				} else {
-					escaped = 0;
 				}
 				smart_str_appendc(&csvline, *ch);
 				ch++;

--- a/ext/standard/tests/file/gh18348.phpt
+++ b/ext/standard/tests/file/gh18348.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-18348 (fputcsv incorrectly escapes when quote char is both enclosure and escape char)
+--FILE--
+<?php
+
+$fp = fopen ('php://temp', 'r+');
+
+fputcsv($fp, ['J"a"n'], ',', '"', 'a');
+fputcsv($fp, ['He said "Hello"'], ',', '"', '"');
+fputcsv($fp, ['Line1\\Line2'], ',', '"', '\\');
+
+rewind($fp);
+echo stream_get_contents($fp);
+?>
+--EXPECT--
+"J""a""n"
+"He said ""Hello"""
+"Line1\Line2"


### PR DESCRIPTION
Fixes #18348