### PR TITLE
JIT: Don't reuse IP register for EX(call)

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -803,6 +803,9 @@ static bool zend_jit_may_be_modified(const zend_function *func, const zend_op_ar
 # pragma clang diagnostic ignored "-Wstring-compare"
 #endif
 
+static bool zend_jit_inc_call_level(uint8_t opcode);
+static bool zend_jit_dec_call_level(uint8_t opcode);
+
 #include "jit/zend_jit_ir.c"
 
 #if defined(__clang__)
@@ -1609,6 +1612,18 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 				call_level++;
 			}
 
+#if ZEND_DEBUG && 0
+			{
+				const void *handler;
+				if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+					handler = zend_get_opcode_handler_func(opline);
+				} else {
+					handler = opline->handler;
+				}
+				ir_RSTORE(8, jit_CONST_FUNC(&ctx, (uintptr_t)handler, IR_FASTCALL_FUNC));
+			}
+#endif
+
 			if (JIT_G(opt_level) >= ZEND_JIT_LEVEL_INLINE) {
 				switch (opline->opcode) {
 					case ZEND_PRE_INC:
@@ -1676,10 +1691,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						 && zend_jit_next_is_send_result(opline)) {
 							i++;
 							res_use_info = -1;
-							res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_RX, (opline+1)->result.var);
-							if (!zend_jit_reuse_ip(&ctx)) {
-								goto jit_failure;
-							}
+							res_addr = ZEND_ADDR_ARG(jit_EX_CALL(jit), (opline+1)->result.var);
 						} else {
 							res_use_info = -1;
 
@@ -1730,10 +1742,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						 && zend_jit_next_is_send_result(opline)) {
 							i++;
 							res_use_info = -1;
-							res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_RX, (opline+1)->result.var);
-							if (!zend_jit_reuse_ip(&ctx)) {
-								goto jit_failure;
-							}
+							res_addr = ZEND_ADDR_ARG(jit_EX_CALL(jit), (opline+1)->result.var);
 						} else {
 							res_use_info = -1;
 
@@ -1786,10 +1795,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 						if ((i + 1) <= end
 						 && zend_jit_next_is_send_result(opline)) {
 							i++;
-							res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_RX, (opline+1)->result.var);
-							if (!zend_jit_reuse_ip(&ctx)) {
-								goto jit_failure;
-							}
+							res_addr = ZEND_ADDR_ARG(jit_EX_CALL(jit), (opline+1)->result.var);
 						}
 						if (!zend_jit_concat(&ctx, opline,
 								op1_info, op2_info, res_addr,
@@ -2040,10 +2046,7 @@ static int zend_jit(const zend_op_array *op_array, zend_ssa *ssa, const zend_op 
 							 && zend_jit_next_is_send_result(opline)
 							 && (!(op1_info & MAY_HAVE_DTOR) || !(op1_info & MAY_BE_RC1))) {
 								i++;
-								res_addr = ZEND_ADDR_MEM_ZVAL(ZREG_RX, (opline+1)->result.var);
-								if (!zend_jit_reuse_ip(&ctx)) {
-									goto jit_failure;
-								}
+								res_addr = ZEND_ADDR_ARG(jit_EX_CALL(jit), (opline+1)->result.var);
 							}
 						}
 						if (!zend_jit_assign(&ctx, opline,

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -102,7 +102,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_runtime_jit(ZEND_OPCODE_HANDLE
 
 static int zend_jit_trace_op_len(const zend_op *opline);
 static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op *opline);
-static uint32_t zend_jit_trace_get_exit_point(const zend_op *to_opline, uint32_t flags);
+
+static uint32_t zend_jit_trace_get_exit_point(zend_jit_ctx *ctx, const zend_op *to_opline, uint32_t flags);
 static const void *zend_jit_trace_get_exit_addr(uint32_t n);
 static void zend_jit_trace_add_code(const void *start, uint32_t size);
 static zend_string *zend_jit_func_name(const zend_op_array *op_array);

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -64,6 +64,14 @@ typedef uintptr_t zend_jit_addr;
 #define Z_SSA_VAR(addr)  ((addr)>>_ZEND_ADDR_REG_SHIFT)
 #define Z_IR_REF(addr)   ((addr)>>_ZEND_ADDR_REG_SHIFT)
 
+#define ZEND_ADDR_ARG(call, var) ZEND_ADDR_REF_ZVAL(ir_ADD_OFFSET(call, var))
+
+#define Z_IS_ARG_ADDR(addr)                                         \
+	(Z_MODE(addr) == IS_REF_ZVAL && (                               \
+		Z_IR_REF(addr) == jit->call                                 \
+		|| (jit->ctx.ir_base[Z_IR_REF(addr)].op == IR_ADD           \
+			&& jit->ctx.ir_base[Z_IR_REF(addr)].op1 == jit->call)))
+
 #define Z_STORE(addr) \
 	((jit->ra && jit->ra[Z_SSA_VAR(addr)].ref) ? \
 		(jit->ra[Z_SSA_VAR(addr)].flags & ZREG_STORE) : \
@@ -242,9 +250,9 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_counter_helper(ZEND_OPCODE_H
 
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_copy_extra_args_helper(ZEND_OPCODE_HANDLER_ARGS);
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_copy_extra_args_helper_no_skip_recv(ZEND_OPCODE_HANDLER_ARGS);
-bool ZEND_FASTCALL zend_jit_deprecated_helper(OPLINE_D);
-bool ZEND_FASTCALL zend_jit_nodiscard_helper(OPLINE_D);
-bool ZEND_FASTCALL zend_jit_deprecated_nodiscard_helper(OPLINE_D);
+bool ZEND_FASTCALL zend_jit_deprecated_helper(zend_execute_data *call);
+bool ZEND_FASTCALL zend_jit_nodiscard_helper(zend_execute_data *call);
+bool ZEND_FASTCALL zend_jit_deprecated_nodiscard_helper(zend_execute_data *call);
 void ZEND_FASTCALL zend_jit_undefined_long_key(EXECUTE_DATA_D);
 void ZEND_FASTCALL zend_jit_undefined_long_key_ex(zend_long key EXECUTE_DATA_DC);
 void ZEND_FASTCALL zend_jit_undefined_string_key(EXECUTE_DATA_D);
@@ -448,6 +456,8 @@ typedef struct _zend_jit_trace_exit_info {
 	int32_t              poly_this_ref;
 	int8_t               poly_func_reg;
 	int8_t               poly_this_reg;
+	int32_t              call_ref;
+	int8_t               call_reg;
 } zend_jit_trace_exit_info;
 
 typedef struct _zend_jit_trace_stack {

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -27,6 +27,8 @@
 #include "Zend/Optimizer/zend_func_info.h"
 #include "Zend/Optimizer/zend_call_graph.h"
 
+typedef struct _zend_jit_ctx zend_jit_ctx;
+
 /* Address Encoding */
 typedef uintptr_t zend_jit_addr;
 

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -7964,7 +7964,7 @@ static int zend_jit_defined(zend_jit_ctx *jit, const zend_op *opline, uint8_t sm
 	return 1;
 }
 
-static int zend_jit_escape_if_undef(zend_jit_ctx *jit, int var, uint32_t flags, const zend_op *opline, int8_t reg, uint8_t call_reg)
+static int zend_jit_escape_if_undef(zend_jit_ctx *jit, int var, uint32_t flags, const zend_op *opline, int8_t reg, int8_t call_reg)
 {
 	zend_jit_addr reg_addr = ZEND_ADDR_REF_ZVAL(zend_jit_deopt_rload(jit, IR_ADDR, reg));
 	ir_ref if_def = ir_IF(jit_Z_TYPE(jit, reg_addr));

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -4394,7 +4394,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 
 			opline = p->opline;
 
-#if ZEND_DEBUG && 1
+#if ZEND_DEBUG && 0
 			{
 				const void *handler = ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->call_handler;
 				ir_RSTORE(8, jit_CONST_FUNC(&ctx, (uintptr_t)handler, IR_FASTCALL_FUNC));

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -4394,7 +4394,7 @@ static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t par
 
 			opline = p->opline;
 
-#if ZEND_DEBUG
+#if ZEND_DEBUG && 1
 			{
 				const void *handler = ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->call_handler;
 				ir_RSTORE(8, jit_CONST_FUNC(&ctx, (uintptr_t)handler, IR_FASTCALL_FUNC));

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -176,9 +176,8 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_copy_extra_args_helper_no_skip_re
 	return zend_jit_copy_extra_args_helper_ex(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU_EX false);
 }
 
-bool ZEND_FASTCALL zend_jit_deprecated_helper(OPLINE_D)
+bool ZEND_FASTCALL zend_jit_deprecated_helper(zend_execute_data *call)
 {
-	zend_execute_data *call = (zend_execute_data *) opline;
 	zend_function *fbc = call->func;
 
 	zend_deprecated_function(fbc);
@@ -204,9 +203,8 @@ bool ZEND_FASTCALL zend_jit_deprecated_helper(OPLINE_D)
 	return 1;
 }
 
-bool ZEND_FASTCALL zend_jit_nodiscard_helper(OPLINE_D)
+bool ZEND_FASTCALL zend_jit_nodiscard_helper(zend_execute_data *call)
 {
-	zend_execute_data *call = (zend_execute_data *) opline;
 	zend_function *fbc = call->func;
 
 	zend_nodiscard_function(fbc);
@@ -232,19 +230,18 @@ bool ZEND_FASTCALL zend_jit_nodiscard_helper(OPLINE_D)
 	return 1;
 }
 
-bool ZEND_FASTCALL zend_jit_deprecated_nodiscard_helper(OPLINE_D)
+bool ZEND_FASTCALL zend_jit_deprecated_nodiscard_helper(zend_execute_data *call)
 {
-	zend_execute_data *call = (zend_execute_data *) opline;
 	zend_function *fbc = call->func;
 
 	if (fbc->common.fn_flags & ZEND_ACC_DEPRECATED) {
-		if (zend_jit_deprecated_helper(OPLINE_C) == 0) {
+		if (zend_jit_deprecated_helper(call) == 0) {
 			return 0;
 		}
 	}
 
 	if (fbc->common.fn_flags & ZEND_ACC_NODISCARD) {
-		if (zend_jit_nodiscard_helper(OPLINE_C) == 0) {
+		if (zend_jit_nodiscard_helper(call) == 0) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
JIT [reuses](https://github.com/php/php-src/blob/32a45769d1f9af69e3583c6e2e9cf8d9b59de867/ext/opcache/jit/zend_jit_ir.c#L958) the IP/opline fixed register to store an `EX(call)` cache during function calls. This allows a sequence of `INIT_FCALL`, `SEND`, `SEND`, ..., `DO_FCALL` to access the current call directly via this register instead of repeatedly fetching it from `EX(call)`, and sometimes to avoid saving `EX(call)`.

My understanding is that we reuse IP out of convenience, as registers were assigned manually in the old JIT. Doing otherwise would have required to reserve a 3rd register at least in code generated between `INIT_FCALL` and `DO_FCALL`. This also reduces register pressure, especially on x32.

This has a few drawbacks:

* It may be confusing. For example, `zend_jit_trace_exit_stub` saves IP to `EX(opline)`, when it may be being reused for `EX(call)` (e.g. [here](https://github.com/php/php-src/blob/f396db94602e452b4cd1794dc933f2de79033290/ext/opcache/jit/zend_jit_trace.c#L8662-L8665))
* This would be a blocker if we hypothetically wanted to stop using a fixed register for IP
* The `EX(call)` cache is lost every time we need to save IP
* This conflicts with the last valid opline tracking (zend_jit_set_last_valid_opline): reusing IP also forgets the last valid opline.

Here I let IR allocate a register for the EX(call) cache, instead of storing it in the IP register.

`bench.php` shows no regression in executed instructions under valgrind, and a 1% improvement in wall time.

First commit passes `zend_jit_ctx` to `zend_jit_trace_get_exit_point()`, which creates a lot of noise. Second commit is smaller.

