### PR TITLE
fileinfo: Remove `php_fileinfo` struct

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -234,6 +234,11 @@ PHP_FUNCTION(finfo_set_flags)
 		RETURN_THROWS();
 	}
 
+	if (!Z_FINFO_P(self)->magic) {
+		zend_throw_error(NULL, "Invalid finfo object");
+		RETURN_THROWS();
+	}
+
 	/* We do not check the return value as it can only ever fail if options contains MAGIC_PRESERVE_ATIME
 	 * and the system neither has utime(3) nor utimes(2). Something incredibly unlikely. */
 	magic_setflags(Z_FINFO_P(self)->magic, options);
@@ -301,6 +306,11 @@ PHP_FUNCTION(finfo_file)
 		RETURN_THROWS();
 	}
 
+	if (!Z_FINFO_P(self)->magic) {
+		zend_throw_error(NULL, "Invalid finfo object");
+		RETURN_THROWS();
+	}
+
 	struct magic_set *magic = Z_FINFO_P(self)->magic;
 
 	if (UNEXPECTED(ZSTR_LEN(path) == 0)) {
@@ -343,6 +353,11 @@ PHP_FUNCTION(finfo_buffer)
 	zval *dummy_context = NULL;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OS|lr!", &self, finfo_class_entry, &buffer, &options, &dummy_context) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (!Z_FINFO_P(self)->magic) {
+		zend_throw_error(NULL, "Invalid finfo object");
 		RETURN_THROWS();
 	}
 

--- a/ext/fileinfo/tests/finfo_uninitialized.phpt
+++ b/ext/fileinfo/tests/finfo_uninitialized.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Fileinfo uninitialized object
+--EXTENSIONS--
+fileinfo
+--FILE--
+<?php
+
+$finfo = (new ReflectionClass('finfo'))->newInstanceWithoutConstructor();
+
+try {
+	var_dump(finfo_set_flags($finfo, FILEINFO_NONE));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+try {
+	var_dump($finfo->set_flags(FILEINFO_NONE));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+try {
+	var_dump(finfo_file($finfo, __FILE__));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+try {
+	var_dump($finfo->file(__FILE__));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+try {
+	var_dump(finfo_buffer($finfo, file_get_contents(__FILE__)));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+try {
+	var_dump($finfo->file(file_get_contents(__FILE__)));
+} catch (Error $e) {
+	echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Error: Invalid finfo object
+Error: Invalid finfo object
+Error: Invalid finfo object
+Error: Invalid finfo object
+Error: Invalid finfo object
+Error: Invalid finfo object


### PR DESCRIPTION
See individual commits, but can be squashed.