### PR TITLE
fileinfo: Stop calling `finfo_close()` in tests

### DIFF
--- a/ext/fileinfo/tests/bug79756.phpt
+++ b/ext/fileinfo/tests/bug79756.phpt
@@ -7,7 +7,6 @@ fileinfo
 $filename = __DIR__ . '/bug79756.xls';
 $finfo = finfo_open(FILEINFO_MIME);
 $mime = finfo_file($finfo, $filename);
-finfo_close($finfo);
 echo $mime;
 ?>
 --EXPECT--

--- a/ext/fileinfo/tests/cve-2014-1943-mb.phpt
+++ b/ext/fileinfo/tests/cve-2014-1943-mb.phpt
@@ -15,13 +15,11 @@ $m =  "0           byte        x\n".
 file_put_contents($fd, $a);
 $fi = finfo_open(FILEINFO_NONE);
 var_dump(finfo_file($fi, $fd));
-finfo_close($fi);
 
 file_put_contents($fd, $b);
 file_put_contents($fm, $m);
 $fi = finfo_open(FILEINFO_NONE, $fm);
 var_dump(finfo_file($fi, $fd));
-finfo_close($fi);
 ?>
 Done
 --CLEAN--

--- a/ext/fileinfo/tests/cve-2014-1943.phpt
+++ b/ext/fileinfo/tests/cve-2014-1943.phpt
@@ -15,13 +15,11 @@ $m =  "0           byte        x\n".
 file_put_contents($fd, $a);
 $fi = finfo_open(FILEINFO_NONE);
 var_dump(finfo_file($fi, $fd));
-finfo_close($fi);
 
 file_put_contents($fd, $b);
 file_put_contents($fm, $m);
 $fi = finfo_open(FILEINFO_NONE, $fm);
 var_dump(finfo_file($fi, $fd));
-finfo_close($fi);
 ?>
 Done
 --CLEAN--

--- a/ext/fileinfo/tests/cve-2014-3538-mb.phpt
+++ b/ext/fileinfo/tests/cve-2014-3538-mb.phpt
@@ -19,7 +19,6 @@ $fi = finfo_open(FILEINFO_NONE);
 $t = microtime(true);
 var_dump(finfo_file($fi, $fd));
 $t = microtime(true) - $t;
-finfo_close($fi);
 if ($t < 3) {
     echo "Ok\n";
 } else {

--- a/ext/fileinfo/tests/cve-2014-3538-nojit.phpt
+++ b/ext/fileinfo/tests/cve-2014-3538-nojit.phpt
@@ -23,7 +23,6 @@ $fi = finfo_open(FILEINFO_NONE);
 $t = microtime(true);
 var_dump(finfo_file($fi, $fd));
 $t = microtime(true) - $t;
-finfo_close($fi);
 if ($t < 1.5) {
     echo "Ok\n";
 } else {

--- a/ext/fileinfo/tests/cve-2014-3538.phpt
+++ b/ext/fileinfo/tests/cve-2014-3538.phpt
@@ -19,7 +19,6 @@ $fi = finfo_open(FILEINFO_NONE);
 $t = microtime(true);
 var_dump(finfo_file($fi, $fd));
 $t = microtime(true) - $t;
-finfo_close($fi);
 if ($t < 1.5) {
     echo "Ok\n";
 } else {

--- a/ext/fileinfo/tests/finfo_buffer_basic-mb.phpt
+++ b/ext/fileinfo/tests/finfo_buffer_basic-mb.phpt
@@ -27,7 +27,6 @@ foreach( $options as $option ) {
     foreach( $buffers as $string ) {
         var_dump( finfo_buffer( $finfo, $string, $option ) );
     }
-    finfo_close( $finfo );
 }
 
 ?>

--- a/ext/fileinfo/tests/finfo_buffer_basic.phpt
+++ b/ext/fileinfo/tests/finfo_buffer_basic.phpt
@@ -27,7 +27,6 @@ foreach( $options as $option ) {
     foreach( $buffers as $string ) {
         var_dump( finfo_buffer( $finfo, $string, $option ) );
     }
-    finfo_close( $finfo );
 }
 
 ?>

--- a/ext/fileinfo/tests/finfo_set_flags_basic-mb.phpt
+++ b/ext/fileinfo/tests/finfo_set_flags_basic-mb.phpt
@@ -12,8 +12,6 @@ echo "*** Testing finfo_set_flags() : basic functionality ***\n";
 var_dump( finfo_set_flags( $finfo, FILEINFO_NONE ) );
 var_dump( finfo_set_flags( $finfo, FILEINFO_SYMLINK ) );
 
-finfo_close( $finfo );
-
 // OO way
 $finfo = new finfo( FILEINFO_NONE, $magicFile );
 var_dump( $finfo->set_flags( FILEINFO_MIME ) );

--- a/ext/fileinfo/tests/finfo_set_flags_basic.phpt
+++ b/ext/fileinfo/tests/finfo_set_flags_basic.phpt
@@ -12,8 +12,6 @@ echo "*** Testing finfo_set_flags() : basic functionality ***\n";
 var_dump( finfo_set_flags( $finfo, FILEINFO_NONE ) );
 var_dump( finfo_set_flags( $finfo, FILEINFO_SYMLINK ) );
 
-finfo_close( $finfo );
-
 // OO way
 $finfo = new finfo( FILEINFO_NONE, $magicFile );
 var_dump( $finfo->set_flags( FILEINFO_MIME ) );

--- a/ext/fileinfo/tests/finfo_upstream.phpt
+++ b/ext/fileinfo/tests/finfo_upstream.phpt
@@ -18,7 +18,6 @@ foreach($lst as $p) {
 	if ($i !== $exp) {
 		echo "'$p' failed\nexp: '$exp'\ngot: '$i'\n";
 	} 
-	finfo_close($finfo);
 }
 
 echo "==DONE==";


### PR DESCRIPTION
This function is a noop and will be proposed for deprecation. This patch removes the useless calls.

Spun out of #18396.