### PR TITLE
Fix DOM tests for upcoming libxml2 serializer changes

### DIFF
--- a/ext/dom/tests/DOMElement_toggleAttribute.phpt
+++ b/ext/dom/tests/DOMElement_toggleAttribute.phpt
@@ -87,7 +87,7 @@ echo "Checking toggled namespace:\n";
 var_dump($dom->documentElement->getAttribute('xmlns:anotheron'));
 
 ?>
---EXPECT--
+--EXPECTF--
 Invalid Character Error
 --- Selected attribute tests (HTML) ---
 bool(false)
@@ -95,10 +95,10 @@ bool(false)
 <html id="test"></html>
 bool(true)
 <!DOCTYPE HTML>
-<html id="test" selected></html>
+<html id="test" selected%r(="")?%r></html>
 bool(true)
 <!DOCTYPE HTML>
-<html id="test" selected></html>
+<html id="test" selected%r(="")?%r></html>
 bool(false)
 <!DOCTYPE HTML>
 <html id="test"></html>

--- a/ext/dom/tests/gh10234.phpt
+++ b/ext/dom/tests/gh10234.phpt
@@ -55,7 +55,7 @@ $document->documentElement->textContent = "quote 'test'";
 var_dump($document->documentElement->textContent);
 var_dump($document->saveHTML());
 ?>
---EXPECT--
+--EXPECTF--
 -- Attribute tests --
 string(38) "<element attribute="value"></element>
 "
@@ -67,10 +67,10 @@ string(13) "hello & world"
 string(50) "<element attribute="hello &amp; world"></element>
 "
 string(9) "<b>hi</b>"
-string(54) "<element attribute="&lt;b&gt;hi&lt;/b&gt;"></element>
+string(%d) "<element attribute=%r("&lt;b&gt;hi&lt;\/b&gt;"|"<b>hi<\/b>")%r></element>
 "
 string(12) "quote "test""
-string(45) "<element attribute='quote "test"'></element>
+string(%d) "<element attribute=%r('quote "test"'|"quote &quot;test&quot;")%r></element>
 "
 string(12) "quote 'test'"
 string(45) "<element attribute="quote 'test'"></element>


### PR DESCRIPTION
DOM HTML serializer will be closer compliant to HTML5 in the next libxml2 version, so the tests need to be adapted.
Ref: https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/309