### PR TITLE
Revert "Port XML_GetCurrentByteIndex to public APIs"

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -709,21 +709,8 @@ XML_GetCurrentColumnNumber(XML_Parser parser)
 PHP_XML_API int
 XML_GetCurrentByteIndex(XML_Parser parser)
 {
-	/* We have to temporarily disable the encoder to satisfy the note from the manual:
-	 * "This function returns byte index according to UTF-8 encoded text disregarding if input is in another encoding."
-	 * Although that should probably be corrected at one point? (TODO) */
-	xmlCharEncodingHandlerPtr encoder = NULL;
-	xmlParserInputPtr input = parser->parser->input;
-	if (input->buf) {
-		encoder = input->buf->encoder;
-		input->buf->encoder = NULL;
-	}
-	long result = xmlByteConsumed(parser->parser);
-	if (encoder) {
-		input->buf->encoder = encoder;
-	}
-	/* TODO: at one point this should return long probably to make sure that files greater than 2 GiB are handled correctly. */
-	return (int) result;
+	return parser->parser->input->consumed +
+			(parser->parser->input->cur - parser->parser->input->base);
 }
 
 PHP_XML_API int


### PR DESCRIPTION
This reverts commit 8dc799aac7b3c5f7be639c0f15d3f294a7b194a7.

Originally, this was going to be deprecated in libxml2 2.14, but this didn't end up happening in the end, and the replacement function that we used got deprecated instead. So fix the deprecation warning by reverting to the original code.