### PR TITLE
Removed `<mmintrin.h>`

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -30,7 +30,6 @@
 #if defined(__AVX2__)
 # include <immintrin.h>
 #elif defined( __SSE2__)
-# include <mmintrin.h>
 # include <emmintrin.h>
 #endif
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 #ifdef __SSE2__
-# include <mmintrin.h>
 # include <emmintrin.h>
 #endif
 #if defined(__AVX2__)


### PR DESCRIPTION
If `<emmintrin.h>` is loaded, `<mmintrin.h>` is not required.