### PR TITLE
[skip ci] Limit community composer --ignore-platform-reqs to master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,9 @@ on:
       branch:
         required: true
         type: string
+      community_composer_ignore_platform_reqs:
+        required: true
+        type: boolean
       community_verify_type_inference:
         required: true
         type: boolean
@@ -550,7 +553,7 @@ jobs:
             git clone "https://github.com/amphp/$repository.git" "amphp-$repository" --depth 1
             cd "amphp-$repository"
             git rev-parse HEAD
-            php /usr/bin/composer install --no-progress --ignore-platform-reqs
+            php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
             vendor/bin/phpunit || EXIT_CODE=$?
             if [ ${EXIT_CODE:-0} -gt 128 ]; then
               X=1;
@@ -564,7 +567,7 @@ jobs:
           git clone https://github.com/laravel/framework.git --depth=1
           cd framework
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress --ignore-platform-reqs
+          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           # Hack to disable a test that hangs
           php -r '$c = file_get_contents("tests/Filesystem/FilesystemTest.php"); $c = str_replace("public function testSharedGet()", "#[\\PHPUnit\\Framework\\Attributes\\Group('"'"'skip'"'"')]\n    public function testSharedGet()", $c); file_put_contents("tests/Filesystem/FilesystemTest.php", $c);'
           php vendor/bin/phpunit --exclude-group skip || EXIT_CODE=$?
@@ -581,7 +584,7 @@ jobs:
             git clone "https://github.com/reactphp/$repository.git" "reactphp-$repository" --depth 1
             cd "reactphp-$repository"
             git rev-parse HEAD
-            php /usr/bin/composer install --no-progress --ignore-platform-reqs
+            php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
             vendor/bin/phpunit || EXIT_CODE=$?
             if [ $[EXIT_CODE:-0} -gt 128 ]; then
               X=1;
@@ -595,7 +598,7 @@ jobs:
           git clone https://github.com/revoltphp/event-loop.git --depth=1
           cd event-loop
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress --ignore-platform-reqs
+          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           vendor/bin/phpunit || EXIT_CODE=$?
           if [ ${EXIT_CODE:-0} -gt 128 ]; then
             exit 1
@@ -606,7 +609,7 @@ jobs:
           git clone https://github.com/symfony/symfony.git --depth=1
           cd symfony
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress --ignore-platform-reqs
+          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           php ./phpunit install
           # Test causes a heap-buffer-overflow but I cannot reproduce it locally...
           php -r '$c = file_get_contents("src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php"); $c = str_replace("public function testSanitizeDeepNestedString()", "/** @group skip */\n    public function testSanitizeDeepNestedString()", $c); file_put_contents("src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php", $c);'
@@ -627,7 +630,7 @@ jobs:
           git clone https://github.com/sebastianbergmann/phpunit.git --branch=main --depth=1
           cd phpunit
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress --ignore-platform-reqs
+          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           php ./phpunit || EXIT_CODE=$?
           if [ ${EXIT_CODE:-0} -gt 128 ]; then
             exit 1
@@ -635,7 +638,7 @@ jobs:
       - name: 'Symfony Preloading'
         if: ${{ !cancelled() && !inputs.skip_symfony }}
         run: |
-          php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress --ignore-platform-reqs
+          php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           cd symfony_demo
           git rev-parse HEAD
           sed -i 's/PHP_SAPI/"cli-server"/g' var/cache/dev/App_KernelDevDebugContainer.preload.php
@@ -646,7 +649,7 @@ jobs:
           git clone https://github.com/WordPress/wordpress-develop.git wordpress --depth=1
           cd wordpress
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress --ignore-platform-reqs
+          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
           cp wp-tests-config-sample.php wp-tests-config.php
           sed -i 's/youremptytestdbnamehere/test/g' wp-tests-config.php
           sed -i 's/yourusernamehere/root/g' wp-tests-config.php

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -553,7 +553,7 @@ jobs:
             git clone "https://github.com/amphp/$repository.git" "amphp-$repository" --depth 1
             cd "amphp-$repository"
             git rev-parse HEAD
-            php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+            php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
             vendor/bin/phpunit || EXIT_CODE=$?
             if [ ${EXIT_CODE:-0} -gt 128 ]; then
               X=1;
@@ -567,7 +567,7 @@ jobs:
           git clone https://github.com/laravel/framework.git --depth=1
           cd framework
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           # Hack to disable a test that hangs
           php -r '$c = file_get_contents("tests/Filesystem/FilesystemTest.php"); $c = str_replace("public function testSharedGet()", "#[\\PHPUnit\\Framework\\Attributes\\Group('"'"'skip'"'"')]\n    public function testSharedGet()", $c); file_put_contents("tests/Filesystem/FilesystemTest.php", $c);'
           php vendor/bin/phpunit --exclude-group skip || EXIT_CODE=$?
@@ -584,7 +584,7 @@ jobs:
             git clone "https://github.com/reactphp/$repository.git" "reactphp-$repository" --depth 1
             cd "reactphp-$repository"
             git rev-parse HEAD
-            php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+            php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
             vendor/bin/phpunit || EXIT_CODE=$?
             if [ $[EXIT_CODE:-0} -gt 128 ]; then
               X=1;
@@ -598,7 +598,7 @@ jobs:
           git clone https://github.com/revoltphp/event-loop.git --depth=1
           cd event-loop
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           vendor/bin/phpunit || EXIT_CODE=$?
           if [ ${EXIT_CODE:-0} -gt 128 ]; then
             exit 1
@@ -609,7 +609,7 @@ jobs:
           git clone https://github.com/symfony/symfony.git --depth=1
           cd symfony
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           php ./phpunit install
           # Test causes a heap-buffer-overflow but I cannot reproduce it locally...
           php -r '$c = file_get_contents("src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php"); $c = str_replace("public function testSanitizeDeepNestedString()", "/** @group skip */\n    public function testSanitizeDeepNestedString()", $c); file_put_contents("src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php", $c);'
@@ -630,7 +630,7 @@ jobs:
           git clone https://github.com/sebastianbergmann/phpunit.git --branch=main --depth=1
           cd phpunit
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           php ./phpunit || EXIT_CODE=$?
           if [ ${EXIT_CODE:-0} -gt 128 ]; then
             exit 1
@@ -638,7 +638,7 @@ jobs:
       - name: 'Symfony Preloading'
         if: ${{ !cancelled() && !inputs.skip_symfony }}
         run: |
-          php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           cd symfony_demo
           git rev-parse HEAD
           sed -i 's/PHP_SAPI/"cli-server"/g' var/cache/dev/App_KernelDevDebugContainer.preload.php
@@ -649,7 +649,7 @@ jobs:
           git clone https://github.com/WordPress/wordpress-develop.git wordpress --depth=1
           cd wordpress
           git rev-parse HEAD
-          php /usr/bin/composer install --no-progress  ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' }}
+          php /usr/bin/composer install --no-progress ${{ inputs.community_composer_ignore_platform_reqs && '--ignore-platform-reqs' || '' }}
           cp wp-tests-config-sample.php wp-tests-config.php
           sed -i 's/youremptytestdbnamehere/test/g' wp-tests-config.php
           sed -i 's/yourusernamehere/root/g' wp-tests-config.php

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -50,6 +50,7 @@ jobs:
         (((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9) && '24.04')
         || '22.04' }}
       branch: ${{ matrix.branch.ref }}
+      community_composer_ignore_platform_reqs: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9 }}
       community_verify_type_inference: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       libmysqlclient_with_mysqli: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1) }}
       run_alpine: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}


### PR DESCRIPTION
This flag may accidentally install versions of dependencies that no longer support the given PHP version. Only pass this flag for master (or versions recently released). This version will need to be bumped manually a few weeks/months after GA.