### PR TITLE
Fix GH-18431: Registering ZIP progress callback twice doesn't work

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3048,14 +3048,11 @@ PHP_METHOD(ZipArchive, registerProgressCallback)
 
 	obj = Z_ZIP_P(self);
 
-	/* free if called twice */
-	_php_zip_progress_callback_free(obj);
-
 	/* register */
-	ZVAL_COPY(&obj->progress_callback, &fci.function_name);
 	if (zip_register_progress_callback_with_state(intern, rate, _php_zip_progress_callback, _php_zip_progress_callback_free, obj)) {
 		RETURN_FALSE;
 	}
+	ZVAL_COPY(&obj->progress_callback, &fci.function_name);
 
 	RETURN_TRUE;
 }
@@ -3093,14 +3090,11 @@ PHP_METHOD(ZipArchive, registerCancelCallback)
 
 	obj = Z_ZIP_P(self);
 
-	/* free if called twice */
-	_php_zip_cancel_callback_free(obj);
-
 	/* register */
-	ZVAL_COPY(&obj->cancel_callback, &fci.function_name);
 	if (zip_register_cancel_callback_with_state(intern, _php_zip_cancel_callback, _php_zip_cancel_callback_free, obj)) {
 		RETURN_FALSE;
 	}
+	ZVAL_COPY(&obj->cancel_callback, &fci.function_name);
 
 	RETURN_TRUE;
 }

--- a/ext/zip/tests/gh18431.phpt
+++ b/ext/zip/tests/gh18431.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-18431 (Registering ZIP progress callback twice doesn't work)
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+$file = __DIR__ . '/gh18431.zip';
+$callback = var_dump(...);
+$zip = new ZipArchive;
+$zip->open($file, ZIPARCHIVE::CREATE);
+$zip->registerProgressCallback(0.5, $callback);
+$zip->registerProgressCallback(0.5, $callback);
+$zip->addFromString('foo', 'entry #1');
+?>
+--CLEAN--
+<?php
+$file = __DIR__ . '/gh18431.zip';
+@unlink($file);
+?>
+--EXPECT--
+float(0)
+float(1)


### PR DESCRIPTION
Libzip already cleans up the previous callback, so when that means:
1. The callback zval being already copied over the previous one causes libzip to clean up the new callback object. This is the root cause.
2. Our own code to clean the old callback is redundant.