### PR TITLE
Remove always-false intern checks

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -170,10 +170,6 @@ static void php_snmp_object_free_storage(zend_object *object) /* {{{ */
 {
 	php_snmp_object *intern = php_snmp_fetch_object(object);
 
-	if (!intern) {
-		return;
-	}
-
 	snmp_session_free(&(intern->session));
 
 	zend_object_std_dtor(&intern->zo);

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1047,9 +1047,6 @@ static void php_zip_object_free_storage(zend_object *object) /* {{{ */
 	ze_zip_object * intern = php_zip_fetch_object(object);
 	int i;
 
-	if (!intern) {
-		return;
-	}
 	if (intern->za) {
 		if (zip_close(intern->za) != 0) {
 			php_error_docref(NULL, E_WARNING, "Cannot destroy the zip context: %s", zip_strerror(intern->za));


### PR DESCRIPTION
This pointer derived from zend_object can never be NULL.