### PR TITLE
Fix GH-18400: http_build_query type error is inaccurate

### DIFF
--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -246,7 +246,7 @@ PHP_FUNCTION(http_build_query)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (UNEXPECTED(Z_TYPE_P(formdata) == IS_OBJECT && (Z_OBJCE_P(formdata)->ce_flags & ZEND_ACC_ENUM))) {
-		zend_argument_type_error(1, "must be of type array, %s given", zend_zval_value_name(formdata));
+		zend_argument_type_error(1, "must not be an enum, %s given", zend_zval_value_name(formdata));
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/tests/http/gh15650.phpt
+++ b/ext/standard/tests/http/gh15650.phpt
@@ -33,4 +33,4 @@ try {
 --EXPECT--
 e1=hello+world%21&e2=42
 ValueError: Unbacked enum E3 cannot be converted to a string
-TypeError: http_build_query(): Argument #1 ($data) must be of type array, E1 given
+TypeError: http_build_query(): Argument #1 ($data) must not be an enum, E1 given


### PR DESCRIPTION
Objects are also accepted still, so the error message is misleading.