### PR TITLE
Improve internal function argument parsing performance by reducing code bloat

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -27,6 +27,8 @@ PHP 8.5 INTERNALS UPGRADE NOTES
     runtime.
   . Removed the cache_slot argument of zend_check_user_type_slow() because
     now it only relies on the CE cache.
+  . Changed several zend_parse_arg_*_{weak,slow} functions to no longer have an
+    output pointer argument, but instead return a struct or a sentinel value.
 
 ========================
 2. Build system changes

--- a/Zend/zend_frameless_function.h
+++ b/Zend/zend_frameless_function.h
@@ -65,7 +65,7 @@
 		dest_ht = NULL; \
 		ZVAL_COPY(&str_tmp, arg ## arg_num); \
 		arg ## arg_num = &str_tmp; \
-		if (!zend_flf_parse_arg_str_slow(arg ## arg_num, &dest_str, arg_num)) { \
+		if (!(dest_str = zend_flf_parse_arg_str_slow(arg ## arg_num, arg_num))) { \
 			zend_wrong_parameter_type_error(arg_num, Z_EXPECTED_ARRAY_OR_STRING, arg ## arg_num); \
 			goto flf_clean; \
 		} \

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5501,18 +5501,22 @@ ZEND_VM_C_LABEL(send_array):
 			uint32_t skip = opline->extended_value;
 			uint32_t count = zend_hash_num_elements(ht);
 			zend_long len;
+			zend_opt_long result;
 			if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
 				len = Z_LVAL_P(op2);
 			} else if (Z_TYPE_P(op2) == IS_NULL) {
 				len = count - skip;
 			} else if (EX_USES_STRICT_TYPES()
-					|| !zend_parse_arg_long_weak(op2, &len, /* arg_num */ 3)) {
+					|| !(result = zend_parse_arg_long_weak(op2, /* arg_num */ 3)).has_value) {
 				zend_type_error(
 					"array_slice(): Argument #3 ($length) must be of type ?int, %s given",
 					zend_zval_value_name(op2));
 				FREE_OP2();
 				FREE_OP1();
 				HANDLE_EXCEPTION();
+			} else {
+				ZEND_ASSERT(result.has_value);
+				len = result.value;
 			}
 
 			if (len < 0) {
@@ -8718,7 +8722,7 @@ ZEND_VM_COLD_CONST_HANDLER(121, ZEND_STRLEN, CONST|TMPVAR|CV, ANY)
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1))) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2627,18 +2627,22 @@ send_array:
 			uint32_t skip = opline->extended_value;
 			uint32_t count = zend_hash_num_elements(ht);
 			zend_long len;
+			zend_opt_long result;
 			if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
 				len = Z_LVAL_P(op2);
 			} else if (Z_TYPE_P(op2) == IS_NULL) {
 				len = count - skip;
 			} else if (EX_USES_STRICT_TYPES()
-					|| !zend_parse_arg_long_weak(op2, &len, /* arg_num */ 3)) {
+					|| !(result = zend_parse_arg_long_weak(op2, /* arg_num */ 3)).has_value) {
 				zend_type_error(
 					"array_slice(): Argument #3 ($length) must be of type ?int, %s given",
 					zend_zval_value_name(op2));
 				FREE_OP(opline->op2_type, opline->op2.var);
 				FREE_OP(opline->op1_type, opline->op1.var);
 				HANDLE_EXCEPTION();
+			} else {
+				ZEND_ASSERT(result.has_value);
+				len = result.value;
 			}
 
 			if (len < 0) {
@@ -5967,7 +5971,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_CONST
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1))) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -15576,7 +15580,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_TMPVAR_HANDLER(ZEN
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1))) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -41544,7 +41548,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_STRLEN_SPEC_CV_HANDLER(ZEND_OP
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1))) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -1183,8 +1183,14 @@ static zend_result bcmath_number_parse_num(const zval *zv, zend_object **obj, ze
 				*lval = 0;
 				return FAILURE;
 
-			default:
-				return zend_parse_arg_long_slow(zv, lval, 1 /* dummy */) ? SUCCESS : FAILURE;
+			default: {
+				zend_opt_long result = zend_parse_arg_long_slow(zv, 1 /* dummy */);
+				if (result.has_value) {
+					*lval = result.value;
+					return SUCCESS;
+				}
+				return FAILURE;
+			}
 		}
 	}
 }

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5438,7 +5438,7 @@ PHP_FUNCTION(date_default_timezone_get)
  */
 static void php_do_date_sunrise_sunset(INTERNAL_FUNCTION_PARAMETERS, bool calc_sunset)
 {
-	double latitude, longitude, zenith, gmt_offset, altitude;
+	double latitude, longitude, zenith, gmt_offset = 0, altitude;
 	bool latitude_is_null = 1, longitude_is_null = 1, zenith_is_null = 1, gmt_offset_is_null = 1;
 	double h_rise, h_set, N;
 	timelib_sll rise, set, transit;

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -137,15 +137,15 @@ static bool gmp_zend_parse_arg_into_mpz_ex(
 	 * but operator overloading with objects should behave as if a
 	 * method was called, thus strict types should apply. */
 	if (!ZEND_ARG_USES_STRICT_TYPES()) {
-		zend_long lval = 0;
 		if (is_operator && Z_TYPE_P(arg) == IS_NULL) {
 			return false;
 		}
-		if (!zend_parse_arg_long_weak(arg, &lval, arg_num)) {
+		zend_opt_long result = zend_parse_arg_long_weak(arg, arg_num);
+		if (!result.has_value) {
 			return false;
 		}
 
-		mpz_set_si(*destination_mpz_ptr, lval);
+		mpz_set_si(*destination_mpz_ptr, result.value);
 
 		return true;
 	}

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2317,7 +2317,7 @@ out:
 PHP_FUNCTION(mb_substr)
 {
 	zend_string *str, *encoding = NULL;
-	zend_long from, len;
+	zend_long from, len = 0;
 	size_t real_from, real_len;
 	bool len_is_null = true;
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2790,7 +2790,7 @@ PHP_FUNCTION(openssl_pkcs7_sign)
 	X509 *cert = NULL;
 	zend_object *cert_obj;
 	zend_string *cert_str;
-	zval *zprivkey, * zheaders;
+	zval *zprivkey, * zheaders = NULL;
 	zval * hval;
 	EVP_PKEY * privkey = NULL;
 	zend_long flags = PKCS7_DETACHED;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1900,7 +1900,7 @@ PHP_FUNCTION(pg_fetch_result)
 {
 	zval *result;
 	zend_string *field_name;
-	zend_long row, field_offset = 0;
+	zend_long row = 0, field_offset = 0;
 	bool row_is_null = false;
 	PGresult *pgsql_result;
 	pgsql_result_handle *pg_result;
@@ -2236,7 +2236,7 @@ static void php_pgsql_data_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type, bo
 {
 	zval *result;
 	zend_string *field_name;
-	zend_long row, field_offset = 0;
+	zend_long row = 0, field_offset = 0;
 	bool row_is_null = false;
 	PGresult *pgsql_result;
 	pgsql_result_handle *pg_result;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1727,7 +1727,7 @@ PHPAPI void session_adapt_url(const char *url, size_t url_len, char **new_url, s
 PHP_FUNCTION(session_set_cookie_params)
 {
 	HashTable *options_ht;
-	zend_long lifetime_long;
+	zend_long lifetime_long = 0;
 	zend_string *lifetime = NULL, *path = NULL, *domain = NULL, *samesite = NULL;
 	bool secure = 0, secure_null = 1;
 	bool httponly = 0, httponly_null = 1;

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2313,9 +2313,9 @@ PHP_FUNCTION(substr_replace)
 	zend_string *str, *repl_str;
 	HashTable *str_ht, *repl_ht;
 	HashTable *from_ht;
-	zend_long from_long;
+	zend_long from_long = 0;
 	HashTable *len_ht = NULL;
-	zend_long len_long;
+	zend_long len_long = 0;
 	bool len_is_null = 1;
 	zend_long l = 0;
 	zend_long f;


### PR DESCRIPTION
The goal of this PR is to reduce some of the code bloat induced by fast-ZPP. Reduced code bloat results in fewer cache misses (and better DSB coverage), and fewer instructions executed.
This is an initial proposal, it may be possible to optimize this further.

If we take a look at a simple function:
```c
PHP_FUNCTION(twice) {
    zend_long foo;
    ZEND_PARSE_PARAMETERS_START(1, 1)
        Z_PARAM_LONG(foo)
    ZEND_PARSE_PARAMETERS_END();
    RETURN_LONG(foo * 2);
}
```

We obtain the following assembly on x86-64 in the non-cold blocks:
```s
<+0>:	push   %r12
<+2>:	push   %rbp
<+3>:	push   %rbx
<+4>:	sub    $0x10,%rsp
<+8>:	mov    %fs:0x28,%r12
<+17>:	mov    %r12,0x8(%rsp)
<+22>:	mov    0x2c(%rdi),%r12d
<+26>:	cmp    $0x1,%r12d
<+30>:	jne    0x22beaf <zif_twice-3212257>
<+36>:	cmpb   $0x4,0x58(%rdi)
<+40>:	mov    %rsi,%rbp
<+43>:	jne    0x53c2f0 <zif_twice+96>
<+45>:	mov    0x50(%rdi),%rax
<+49>:	add    %rax,%rax
<+52>:	movl   $0x4,0x8(%rbp)
<+59>:	mov    %rax,0x0(%rbp)
<+63>:	mov    0x8(%rsp),%rax
<+68>:	sub    %fs:0x28,%rax
<+77>:	jne    0x53c312 <zif_twice+130>
<+79>:	add    $0x10,%rsp
<+83>:	pop    %rbx
<+84>:	pop    %rbp
<+85>:	pop    %r12
<+87>:	ret
<+88>:	nopl   0x0(%rax,%rax,1)
<+96>:	lea    0x50(%rdi),%rbx
<+100>:	mov    %rsp,%rsi
<+103>:	mov    $0x1,%edx
<+108>:	mov    %rbx,%rdi
<+111>:	call   0x620240 <zend_parse_arg_long_slow>
<+116>:	test   %al,%al
<+118>:	je     0x22be96 <zif_twice.cold>
<+124>:	mov    (%rsp),%rax
<+128>:	jmp    0x53c2c1 <zif_twice+49>
<+130>:	call   0x201050 <__stack_chk_fail@plt>
```

Notice how we get the stack protector overhead in this function and also have to reload the parsed value on the slow path. This happens because the parsed value is returned via a pointer. If instead we were to return struct with a value pair (similar to optional in C++ / Option in Rust), then the values are returned via registers. This means that we no longer have stack protector overhead and we also don't need to reload a value, resulting in better register usage. This is the resulting assembly for the sample function after this patch:
```s
<+0>:	push   %r12
<+2>:	push   %rbp
<+3>:	push   %rbx
<+4>:	mov    0x2c(%rdi),%r12d
<+8>:	cmp    $0x1,%r12d
<+12>:	jne    0x22d482 <zif_twice-3205454>
<+18>:	cmpb   $0x4,0x58(%rdi)
<+22>:	mov    %rsi,%rbp
<+25>:	jne    0x53be08 <zif_twice+56>
<+27>:	mov    0x50(%rdi),%rax
<+31>:	add    %rax,%rax
<+34>:	movl   $0x4,0x8(%rbp)
<+41>:	mov    %rax,0x0(%rbp)
<+45>:	pop    %rbx
<+46>:	pop    %rbp
<+47>:	pop    %r12
<+49>:	ret
<+50>:	nopw   0x0(%rax,%rax,1)
<+56>:	lea    0x50(%rdi),%rbx
<+60>:	mov    $0x1,%esi
<+65>:	mov    %rbx,%rdi
<+68>:	call   0x61e7b0 <zend_parse_arg_long_slow>
<+73>:	test   %dl,%dl
<+75>:	je     0x22d46a <zif_twice.cold>
<+81>:	jmp    0x53bdef <zif_twice+31>
```

The following uses the default benchmark programs we use in CI. Each program is ran on php-cgi with the appropriate `-T` argument, then repeated 15 times. It shows a small performance improvement on Symfony both with and without JIT, and a small improvement on WordPress with JIT.
For WordPress, the difference is small as my CPU is bottlenecked on some other stuff as well.
Results obtained on an i7-4790 with 32GiB RAM.

| Test                            | Old Mean | Old Stddev | New Mean | New Stddev |
|---------------------------------|----------|------------|----------|------------|
| Symfony, no JIT (-T10,50)       | 0.5324   | 0.0050     | 0.5272   | 0.0042     |
| Symfony, tracing JIT (-T10,50)  | 0.5301   | 0.0029     | 0.5264   | 0.0036     |
| WordPress, no JIT (-T5,25)      | 0.7408   | 0.0049     | 0.7404   | 0.0048     |
| WordPress, tracing JIT (-T5,25) | 0.6814   | 0.0052     | 0.6770   | 0.0055     |

I was not able to measure any meaningful difference for our micro benchmarks `Zend/bench.php` and `Zend/micro_bench.php`.

The Valgrind instruction counts also show a decrease: -0.19% on Symfony without JIT, and -0.14% on WordPress without JIT (see CI).