### PR TITLE
Fix GH-18438: Handling of empty data and errors in ZipArchive::addPattern

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -761,6 +761,10 @@ int php_zip_pcre(zend_string *regexp, char *path, int path_len, zval *return_val
 
 		re = pcre_get_compiled_regex(regexp, &capture_count);
 		if (!re) {
+			for (i = 0; i < files_cnt; i++) {
+				zend_string_release_ex(namelist[i], 0);
+			}
+			efree(namelist);
 			php_error_docref(NULL, E_WARNING, "Invalid expression");
 			return -1;
 		}
@@ -1837,6 +1841,10 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 #endif
 			}
 		}
+	} else if (found == 0) {
+		RETURN_EMPTY_ARRAY();
+	} else {
+		RETURN_FALSE;
 	}
 }
 /* }}} */

--- a/ext/zip/tests/gh18438.phpt
+++ b/ext/zip/tests/gh18438.phpt
@@ -1,0 +1,50 @@
+--TEST--
+GH-18438 (Handling of empty data and errors in ZipArchive::addPattern)
+--EXTENSIONS--
+zip
+--SKIPIF--
+<?php
+if (PHP_ZTS) die("skip not for ZTS because of path prefixing breaking custom wrapper test");
+?>
+--FILE--
+<?php
+class CustomStreamWrapper {
+    public $context;
+    function dir_closedir(): bool {
+        return true;
+    }
+    function dir_opendir(string $path, int $options): bool {
+        return true;
+    }
+    function dir_readdir(): string|false {
+        return false;
+    }
+    function dir_rewinddir(): bool {
+        return false;
+    }
+}
+
+$file = __DIR__ . '/gh18438.zip';
+$zip = new ZipArchive;
+$zip->open($file, ZIPARCHIVE::CREATE);
+var_dump($zip->addPattern('/nomatches/'));
+var_dump($zip->addPattern('/invalid'));
+
+stream_wrapper_register('custom', CustomStreamWrapper::class);
+var_dump($zip->addPattern('/invalid', 'custom://'));
+?>
+--CLEAN--
+<?php
+$file = __DIR__ . '/gh18438.zip';
+@unlink($file);
+?>
+--EXPECTF--
+array(0) {
+}
+
+Warning: ZipArchive::addPattern(): No ending delimiter '/' found in %s on line %d
+
+Warning: ZipArchive::addPattern(): Invalid expression in %s on line %d
+bool(false)
+array(0) {
+}


### PR DESCRIPTION
There is a ZPP arginfo violation because the empty return or error return is not always properly handled.
And there is also a memory leak if creating the regular expression instance fails.

Found with help of an experimental SA I'm developing.