### PR TITLE
Improve performance of instantiating exceptions/errors

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -520,6 +520,7 @@ PHP 8.5 UPGRADE NOTES
   . Remove OPcodes for identity comparisons against booleans, particularly
     for the match(true) pattern.
   . Add OPcode specialization for `=== []` and `!== []` comparisons.
+  . Creating exception objects is now much faster.
 
 - ReflectionProperty:
   . Improved performance of the following methods: getValue(), getRawValue(),


### PR DESCRIPTION
The class structure is fixed, so it makes no sense to go through all the logic of looking up property info etc.
This patch introduces a local function `zend_obj_prop_num_checked()` to help with that.

For this benchmark:
```php
for ($i = 0; $i < 1000000; $i++)
   new Error;
```

On an i7-4790:
```
Benchmark 1: ./sapi/cli/php  x.php
  Time (mean ± σ):     141.6 ms ±   9.3 ms    [User: 138.7 ms, System: 2.0 ms]
  Range (min … max):   135.4 ms … 177.7 ms    20 runs

Benchmark 2: ../RELx64_old/sapi/cli/php x.php
  Time (mean ± σ):     214.1 ms ±   7.0 ms    [User: 207.6 ms, System: 5.0 ms]
  Range (min … max):   206.6 ms … 230.9 ms    13 runs

Summary
  ./sapi/cli/php  x.php ran
    1.51 ± 0.11 times faster than ../RELx64_old/sapi/cli/php x.php
```

For this benchmark:
```php
for ($i = 0; $i < 1000000; $i++)
    new Exception("message", 0, null);
```

On an i7-4790:
```
Benchmark 1: ./sapi/cli/php  x.php
  Time (mean ± σ):     184.3 ms ±   9.5 ms    [User: 181.2 ms, System: 1.8 ms]
  Range (min … max):   173.8 ms … 205.1 ms    15 runs

Benchmark 2: ../RELx64_old/sapi/cli/php x.php
  Time (mean ± σ):     253.7 ms ±   7.0 ms    [User: 247.6 ms, System: 4.6 ms]
  Range (min … max):   245.7 ms … 263.7 ms    11 runs

Summary
  ./sapi/cli/php  x.php ran
    1.38 ± 0.08 times faster than ../RELx64_old/sapi/cli/php x.php
```

For this benchmark:
```php
for ($i = 0; $i < 1000000; $i++)
    new ErrorException("message", 0, 0, "xyz", 0, null);
```

On an i7-4790:
```
Benchmark 1: ./sapi/cli/php  x.php
  Time (mean ± σ):     223.6 ms ±   7.7 ms    [User: 220.1 ms, System: 2.4 ms]
  Range (min … max):   216.9 ms … 242.5 ms    12 runs

Benchmark 2: ../RELx64_old/sapi/cli/php x.php
  Time (mean ± σ):     343.5 ms ±   8.1 ms    [User: 337.1 ms, System: 4.6 ms]
  Range (min … max):   337.3 ms … 362.8 ms    10 runs

Summary
  ./sapi/cli/php  x.php ran
    1.54 ± 0.06 times faster than ../RELx64_old/sapi/cli/php x.php
```