### PR TITLE
Fix GH-18417: Windows SHM reattachment fails when increasing memory_consumption or jit_buffer_size

### DIFF
--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -69,9 +69,9 @@ static void zend_win_error_message(int type, char *msg, int err)
 	php_win32_error_msg_free(buf);
 }
 
-static char *create_name_with_username(char *name)
+static char *create_name_with_username(const char *name, size_t unique_id)
 {
-	static char newname[MAXPATHLEN + 1 + 32 + 1 + 20 + 1 + 32 + 1];
+	static char newname[MAXPATHLEN + 1 + 32 + 1 + 20 + 1 + 32 + sizeof("ffffffffffffffff")-1 + 1];
 	char *p = newname;
 	p += strlcpy(newname, name, MAXPATHLEN + 1);
 	*(p++) = '@';
@@ -82,7 +82,11 @@ static char *create_name_with_username(char *name)
 	*(p++) = '@';
 	memcpy(p, zend_system_id, 32);
 	p += 32;
-	*(p++) = '\0';
+	if (unique_id) {
+		p += snprintf(p, sizeof("ffffffffffffffff"), "%zx", unique_id) + 1;
+	} else {
+		*(p++) = '\0';
+	}
 	ZEND_ASSERT(p - newname <= sizeof(newname));
 
 	return newname;
@@ -90,7 +94,7 @@ static char *create_name_with_username(char *name)
 
 void zend_shared_alloc_create_lock(void)
 {
-	memory_mutex = CreateMutex(NULL, FALSE, create_name_with_username(ACCEL_MUTEX_NAME));
+	memory_mutex = CreateMutex(NULL, FALSE, create_name_with_username(ACCEL_MUTEX_NAME, 0));
 	if (!memory_mutex) {
 		zend_accel_error(ACCEL_LOG_FATAL, "Cannot create mutex (error %u)", GetLastError());
 		return;
@@ -224,7 +228,7 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 	   can be called before the child process is killed. In this case, the mapping will fail
 	   and we have to sleep some time (until the child releases the mapping object) and retry.*/
 	do {
-		memfile = OpenFileMapping(FILE_MAP_READ|FILE_MAP_WRITE|FILE_MAP_EXECUTE, 0, create_name_with_username(ACCEL_FILEMAP_NAME));
+		memfile = OpenFileMapping(FILE_MAP_READ|FILE_MAP_WRITE|FILE_MAP_EXECUTE, 0, create_name_with_username(ACCEL_FILEMAP_NAME, requested_size));
 		if (memfile == NULL) {
 			err = GetLastError();
 			break;
@@ -269,7 +273,7 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 	(*shared_segments_p)[0] = shared_segment;
 
 	memfile	= CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_EXECUTE_READWRITE | SEC_COMMIT, size_high, size_low,
-								create_name_with_username(ACCEL_FILEMAP_NAME));
+								create_name_with_username(ACCEL_FILEMAP_NAME, requested_size));
 	if (memfile == NULL) {
 		err = GetLastError();
 		zend_shared_alloc_unlock_win32();

--- a/ext/opcache/tests/gh18417.phpt
+++ b/ext/opcache/tests/gh18417.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-18417 (Windows SHM reattachment fails when increasing memory_consumption or jit_buffer_size)
+--SKIPIF--
+<?php
+$extDir = ini_get('extension_dir');
+if (!file_exists($extDir . '/php_opcache.dll')) {
+    die('skip Opcache DLL not found in extension_dir (Windows-only)');
+}
+?>
+--FILE--
+<?php
+$memory_consumption = (int) ini_get("opcache.memory_consumption");
+$new_memory_consumption = $memory_consumption * 2;
+$extension_dir = ini_get("extension_dir");
+
+$descriptorspec = [
+    0 => ["pipe", "r"],
+    1 => ["pipe", "w"],
+    2 => ["pipe", "w"],
+];
+
+$proc = proc_open([
+    PHP_BINARY,
+    "-n",
+    "-d", "extension_dir=$extension_dir",
+    "-d", "zend_extension=opcache",
+    "-d", "opcache.memory_consumption=$new_memory_consumption",
+    "-d", "opcache.enable=1",
+    "-d", "opcache.enable_cli=1",
+    "-r",
+    "echo 1;"
+], $descriptorspec, $pipes);
+
+echo stream_get_contents($pipes[1]);
+echo stream_get_contents($pipes[2]);
+
+proc_close($proc);
+?>
+--EXPECT--
+1


### PR DESCRIPTION
When a first PHP process launches, Opcache creates a shared file mapping to use as a shm region. The size of this mapping is set by opcache.memory_consumption.
When a new PHP process launches while the old one is still running, Opcache tries to reattach to the shm.
When reattaching it tries to map the requested size (i.e. set by opcache.memory_consumption). However, if the new requested size is larger than the size used in the original file mapping, then the call to VirtualProtect() will fail and the new PHP process will fail to launch.
It's not possible to resize the virtual region on Windows, unless relying on undocumented APIs like `NtExtendSection` but then we would sitll need to communicate that to the first process.

This issue is the root cause of Psalm end-to-end tests failing in GH-18417: Psalm estimates the required memory sizes and relaunches itself with more memory requested, if its estimate is below the currently allocated shared memory. This causes a crash on startup and the tests fail.

To solve this, we need to make the mappings unique per requested size. There are two ideas:
1. Include in zend_system_id. However, this also affects other things and may be too overkill.
2. Include it in the filename, this is an easy local change. I went with this option.