### PR TITLE
Adjust static inline functions which don't inline

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -29,17 +29,17 @@
 
 ZEND_API zend_ast_process_t zend_ast_process = NULL;
 
-static inline void *zend_ast_alloc(size_t size) {
+static void *zend_ast_alloc(size_t size) {
 	return zend_arena_alloc(&CG(ast_arena), size);
 }
 
-static inline void *zend_ast_realloc(void *old, size_t old_size, size_t new_size) {
+static void *zend_ast_realloc(void *old, size_t old_size, size_t new_size) {
 	void *new = zend_ast_alloc(new_size);
 	memcpy(new, old, old_size);
 	return new;
 }
 
-static inline size_t zend_ast_list_size(uint32_t children) {
+static size_t zend_ast_list_size(uint32_t children) {
 	return sizeof(zend_ast_list) - sizeof(zend_ast *) + sizeof(zend_ast *) * children;
 }
 
@@ -494,7 +494,7 @@ zend_ast *zend_ast_create_concat_op(zend_ast *op0, zend_ast *op1) {
 	return zend_ast_create_binary_op(ZEND_CONCAT, op0, op1);
 }
 
-static inline bool is_power_of_two(uint32_t n) {
+static zend_always_inline bool is_power_of_two(uint32_t n) {
 	return ((n != 0) && (n == (n & (~n + 1))));
 }
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1053,7 +1053,7 @@ flf_clean:;
 	Z_FLF_PARAM_FREE_STR(2, property_tmp)
 }
 
-static inline void _class_exists_impl(zval *return_value, zend_string *name, bool autoload, int flags, int skip_flags) /* {{{ */
+static zend_always_inline void _class_exists_impl(zval *return_value, zend_string *name, bool autoload, int flags, int skip_flags) /* {{{ */
 {
 	zend_string *lcname;
 	zend_class_entry *ce;
@@ -1088,7 +1088,7 @@ static inline void _class_exists_impl(zval *return_value, zend_string *name, boo
 }
 /* {{{ */
 
-static inline void class_exists_impl(INTERNAL_FUNCTION_PARAMETERS, int flags, int skip_flags) /* {{{ */
+static void class_exists_impl(INTERNAL_FUNCTION_PARAMETERS, int flags, int skip_flags) /* {{{ */
 {
 	zend_string *name;
 	bool autoload = true;
@@ -1386,7 +1386,7 @@ ZEND_FUNCTION(get_exception_handler)
 	}
 }
 
-static inline void get_declared_class_impl(INTERNAL_FUNCTION_PARAMETERS, int flags) /* {{{ */
+static void get_declared_class_impl(INTERNAL_FUNCTION_PARAMETERS, int flags) /* {{{ */
 {
 	zend_string *key;
 	zval *zv;

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -213,7 +213,7 @@ static zend_always_inline void clear_link_to_root(zend_generator *generator) {
 }
 
 /* Check if the node 'generator' is running in a fiber */
-static inline bool check_node_running_in_fiber(zend_generator *generator) {
+static bool check_node_running_in_fiber(zend_generator *generator) {
 	ZEND_ASSERT(generator->execute_data);
 
 	if (EXPECTED(generator->flags & ZEND_GENERATOR_IN_FIBER)) {
@@ -872,7 +872,7 @@ try_again:
 }
 /* }}} */
 
-static inline void zend_generator_ensure_initialized(zend_generator *generator) /* {{{ */
+static void zend_generator_ensure_initialized(zend_generator *generator) /* {{{ */
 {
 	if (UNEXPECTED(Z_TYPE(generator->value) == IS_UNDEF) && EXPECTED(generator->execute_data) && EXPECTED(generator->node.parent == NULL)) {
 		zend_generator_resume(generator);
@@ -881,7 +881,7 @@ static inline void zend_generator_ensure_initialized(zend_generator *generator) 
 }
 /* }}} */
 
-static inline void zend_generator_rewind(zend_generator *generator) /* {{{ */
+static void zend_generator_rewind(zend_generator *generator) /* {{{ */
 {
 	zend_generator_ensure_initialized(generator);
 

--- a/ext/hash/hash_gost.c
+++ b/ext/hash/hash_gost.c
@@ -203,7 +203,7 @@
 		AA(v, l, r); \
 	}
 
-static inline void Gost(PHP_GOST_CTX *context, uint32_t data[8])
+static void Gost(PHP_GOST_CTX *context, uint32_t data[8])
 {
 	int i;
 	uint32_t l, r, t, key[8], u[8], v[8], w[8], s[8], *h = context->state, *m = data;

--- a/ext/hash/hash_snefru.c
+++ b/ext/hash/hash_snefru.c
@@ -37,7 +37,7 @@ void ph(uint32_t h[16])
 }
 #endif
 
-static inline void Snefru(uint32_t input[16])
+static void Snefru(uint32_t input[16])
 {
 	static const int shifts[4] = {16, 8, 16, 24};
 	int b, index, rshift, lshift;

--- a/ext/hash/hash_tiger.c
+++ b/ext/hash/hash_tiger.c
@@ -132,7 +132,7 @@
 }
 /* }}} */
 
-static inline void TigerFinalize(PHP_TIGER_CTX *context)
+static void TigerFinalize(PHP_TIGER_CTX *context)
 {
 	context->passed += (uint64_t) context->length << 3;
 

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -90,7 +90,7 @@ bool php_json_is_valid_double(double d) /* {{{ */
 }
 /* }}} */
 
-static inline void php_json_encode_double(smart_str *buf, double d, int options) /* {{{ */
+static void php_json_encode_double(smart_str *buf, double d, int options) /* {{{ */
 {
 	size_t len;
 	char num[ZEND_DOUBLE_MAX_LENGTH];

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -230,7 +230,7 @@ static ZEND_FUNCTION(accel_chdir)
 	ZCG(cwd_check) = true;
 }
 
-static inline zend_string* accel_getcwd(void)
+static zend_string* accel_getcwd(void)
 {
 	if (ZCG(cwd)) {
 		return ZCG(cwd);

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -100,7 +100,7 @@ ZEND_STATIC_ASSERT(
 #define twist(m,u,v)  (m ^ (mixBits(u,v) >> 1) ^ ((uint32_t)(-(int32_t)(loBit(v))) & 0x9908b0dfU))
 #define twist_php(m,u,v)  (m ^ (mixBits(u,v) >> 1) ^ ((uint32_t)(-(int32_t)(loBit(u))) & 0x9908b0dfU))
 
-static inline void mt19937_reload(php_random_status_state_mt19937 *state)
+static void mt19937_reload(php_random_status_state_mt19937 *state)
 {
 	uint32_t *p = state->state;
 

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1249,7 +1249,7 @@ static zend_function *spl_dual_it_get_method(zend_object **object, zend_string *
 
 #define APPENDIT_CHECK_CTOR(intern) SPL_CHECK_CTOR(intern, AppendIterator)
 
-static inline zend_result spl_dual_it_fetch(spl_dual_it_object *intern, int check_more);
+static zend_result spl_dual_it_fetch(spl_dual_it_object *intern, int check_more);
 
 static inline zend_result spl_cit_check_flags(zend_long flags)
 {
@@ -1481,7 +1481,7 @@ static inline zend_result spl_dual_it_valid(spl_dual_it_object *intern)
 	return intern->inner.iterator->funcs->valid(intern->inner.iterator);
 }
 
-static inline zend_result spl_dual_it_fetch(spl_dual_it_object *intern, int check_more)
+static zend_result spl_dual_it_fetch(spl_dual_it_object *intern, int check_more)
 {
 	zval *data;
 
@@ -2125,7 +2125,7 @@ static inline zend_result spl_limit_it_valid(spl_dual_it_object *intern)
 	}
 }
 
-static inline void spl_limit_it_seek(spl_dual_it_object *intern, zend_long pos)
+static void spl_limit_it_seek(spl_dual_it_object *intern, zend_long pos)
 {
 	zval  zpos;
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -818,7 +818,7 @@ PHP_FUNCTION(rsort)
 }
 /* }}} */
 
-static inline int php_array_user_compare_unstable(Bucket *f, Bucket *s) /* {{{ */
+static int php_array_user_compare_unstable(Bucket *f, Bucket *s) /* {{{ */
 {
 	zval args[2];
 	zval retval;
@@ -923,7 +923,7 @@ PHP_FUNCTION(uasort)
 }
 /* }}} */
 
-static inline int php_array_user_key_compare_unstable(Bucket *f, Bucket *s) /* {{{ */
+static int php_array_user_key_compare_unstable(Bucket *f, Bucket *s) /* {{{ */
 {
 	zval args[2];
 	zval retval;
@@ -1614,7 +1614,7 @@ PHP_FUNCTION(array_walk_recursive)
  * 0 = return boolean
  * 1 = return key
  */
-static inline void _php_search_array(zval *return_value, zval *value, zval *array, bool strict, int behavior) /* {{{ */
+static zend_always_inline void _php_search_array(zval *return_value, zval *value, zval *array, bool strict, int behavior) /* {{{ */
 {
 	zval *entry; /* pointer to array entry */
 	zend_ulong num_idx;
@@ -1706,7 +1706,7 @@ static inline void _php_search_array(zval *return_value, zval *value, zval *arra
  * 0 = return boolean
  * 1 = return key
  */
-static inline void php_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior)
+static void php_search_array(INTERNAL_FUNCTION_PARAMETERS, int behavior)
 {
 	zval *value,		/* value to check for */
 		 *array;		/* array to check in */

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -45,7 +45,7 @@ static const char hexchars[] = "0123456789abcdef";
 static const char HEXCHARS[] = "0123456789ABCDEF";
 
 /* php_spintf_appendchar() {{{ */
-inline static void
+static void
 php_sprintf_appendchar(zend_string **buffer, size_t *pos, char add)
 {
 	if ((*pos + 1) >= ZSTR_LEN(*buffer)) {
@@ -58,7 +58,7 @@ php_sprintf_appendchar(zend_string **buffer, size_t *pos, char add)
 /* }}} */
 
 /* php_spintf_appendchar() {{{ */
-inline static void
+static void
 php_sprintf_appendchars(zend_string **buffer, size_t *pos, char *add, size_t len)
 {
 	if ((*pos + len) >= ZSTR_LEN(*buffer)) {
@@ -77,7 +77,7 @@ php_sprintf_appendchars(zend_string **buffer, size_t *pos, char *add, size_t len
 /* }}} */
 
 /* php_spintf_appendstring() {{{ */
-inline static void
+static void
 php_sprintf_appendstring(zend_string **buffer, size_t *pos, char *add,
 						   size_t min_width, size_t max_width, char padding,
 						   size_t alignment, size_t len, bool neg, int expprec, int always_sign)
@@ -134,7 +134,7 @@ php_sprintf_appendstring(zend_string **buffer, size_t *pos, char *add,
 /* }}} */
 
 /* php_spintf_appendint() {{{ */
-inline static void
+static void
 php_sprintf_appendint(zend_string **buffer, size_t *pos, zend_long number,
 						size_t width, char padding, size_t alignment,
 						int always_sign)
@@ -178,7 +178,7 @@ php_sprintf_appendint(zend_string **buffer, size_t *pos, zend_long number,
 /* }}} */
 
 /* php_spintf_appenduint() {{{ */
-inline static void
+static void
 php_sprintf_appenduint(zend_string **buffer, size_t *pos,
 					   zend_ulong number,
 					   size_t width, char padding, size_t alignment)
@@ -210,7 +210,7 @@ php_sprintf_appenduint(zend_string **buffer, size_t *pos,
 /* }}} */
 
 /* php_spintf_appenddouble() {{{ */
-inline static void
+static void
 php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 						 double number,
 						 size_t width, char padding,
@@ -318,7 +318,7 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 /* }}} */
 
 /* php_spintf_appendd2n() {{{ */
-inline static void
+static void
 php_sprintf_append2n(zend_string **buffer, size_t *pos, zend_long number,
 					 size_t width, char padding, size_t alignment, int n,
 					 const char *chartable, int expprec)

--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -86,7 +86,7 @@ static char *get_default_charset(void) {
 /* }}} */
 
 /* {{{ get_next_char */
-static inline unsigned int get_next_char(
+static unsigned int get_next_char(
 		enum entity_charset charset,
 		const unsigned char *str,
 		size_t str_len,
@@ -451,7 +451,7 @@ static inline unsigned char unimap_bsearch(const uni_to_enc *table, unsigned cod
 /* }}} */
 
 /* {{{ map_from_unicode */
-static inline zend_result map_from_unicode(unsigned code, enum entity_charset charset, unsigned *res)
+static zend_result map_from_unicode(unsigned code, enum entity_charset charset, unsigned *res)
 {
 	unsigned char found;
 	const uni_to_enc *table;
@@ -1381,7 +1381,7 @@ PHP_FUNCTION(htmlentities)
 /* }}} */
 
 /* {{{ write_s3row_data */
-static inline void write_s3row_data(
+static void write_s3row_data(
 	const entity_stage3_row *r,
 	unsigned orig_cp,
 	enum entity_charset charset,

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -82,7 +82,7 @@
 #define HTTP_WRAPPER_REDIRECTED     2
 #define HTTP_WRAPPER_KEEP_METHOD    4
 
-static inline void strip_header(char *header_bag, char *lc_header_bag,
+static void strip_header(char *header_bag, char *lc_header_bag,
 		const char *lc_header_name)
 {
 	char *lc_header_start = strstr(lc_header_bag, lc_header_name);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1495,7 +1495,7 @@ PHPAPI size_t php_dirname(char *path, size_t len)
 }
 /* }}} */
 
-static inline void _zend_dirname(zval *return_value, zend_string *str, zend_long levels)
+static void _zend_dirname(zval *return_value, zend_string *str, zend_long levels)
 {
 	zend_string *ret;
 
@@ -1740,7 +1740,7 @@ PHP_FUNCTION(stristr)
 }
 /* }}} */
 
-static inline void _zend_strstr(zval *return_value, zend_string *haystack, zend_string *needle, bool part)
+static void _zend_strstr(zval *return_value, zend_string *haystack, zend_string *needle, bool part)
 {
 	const char *found = NULL;
 	zend_long found_offset;
@@ -1884,7 +1884,7 @@ PHP_FUNCTION(str_ends_with)
 }
 /* }}} */
 
-static inline void _zend_strpos(zval *return_value, zend_string *haystack, zend_string *needle, zend_long offset)
+static void _zend_strpos(zval *return_value, zend_string *haystack, zend_string *needle, zend_long offset)
 {
 	const char *found = NULL;
 
@@ -2218,7 +2218,7 @@ PHP_FUNCTION(chunk_split)
 }
 /* }}} */
 
-static inline void _zend_substr(zval *return_value, zend_string *str, zend_long f, bool len_is_null, zend_long l)
+static void _zend_substr(zval *return_value, zend_string *str, zend_long f, bool len_is_null, zend_long l)
 {
 	if (f < 0) {
 		/* if "from" position is negative, count start position from the end

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -801,7 +801,7 @@ static inline void php_var_serialize_string(smart_str *buf, char *str, size_t le
 }
 /* }}} */
 
-static inline bool php_var_serialize_class_name(smart_str *buf, zval *struc) /* {{{ */
+static bool php_var_serialize_class_name(smart_str *buf, zval *struc) /* {{{ */
 {
 	char b[32];
 	PHP_CLASS_ATTRIBUTES;

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -296,7 +296,7 @@ SAPI_API SAPI_POST_READER_FUNC(sapi_read_standard_form_data)
 }
 
 
-static inline char *get_default_content_type(uint32_t prefix_len, uint32_t *len)
+static char *get_default_content_type(uint32_t prefix_len, uint32_t *len)
 {
 	char *mimetype, *charset, *content_type;
 	uint32_t mimetype_len, charset_len;

--- a/main/output.c
+++ b/main/output.c
@@ -52,7 +52,7 @@ static inline bool php_output_lock_error(int op);
 static inline void php_output_op(int op, const char *str, size_t len);
 
 static inline php_output_handler *php_output_handler_init(zend_string *name, size_t chunk_size, int flags);
-static inline php_output_handler_status_t php_output_handler_op(php_output_handler *handler, php_output_context *context);
+static php_output_handler_status_t php_output_handler_op(php_output_handler *handler, php_output_context *context);
 static inline bool php_output_handler_append(php_output_handler *handler, const php_output_buffer *buf);
 static inline zval *php_output_handler_status(php_output_handler *handler, zval *entry);
 
@@ -898,7 +898,7 @@ static inline bool php_output_handler_append(php_output_handler *handler, const 
 
 /* {{{ static php_output_handler_status_t php_output_handler_op(php_output_handler *handler, php_output_context *context)
  * Output handler operation dispatcher, applying context op to the php_output_handler handler */
-static inline php_output_handler_status_t php_output_handler_op(php_output_handler *handler, php_output_context *context)
+static php_output_handler_status_t php_output_handler_op(php_output_handler *handler, php_output_context *context)
 {
 	php_output_handler_status_t status;
 	int original_op = context->op;

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1016,7 +1016,7 @@ static void phpdbg_welcome(bool cleaning) /* {{{ */
 	}
 } /* }}} */
 
-static inline void phpdbg_sigint_handler(int signo) /* {{{ */
+static void phpdbg_sigint_handler(int signo) /* {{{ */
 {
 	if (!(PHPDBG_G(flags) & PHPDBG_IS_INTERACTIVE)) {
 		/* set signalled only when not interactive */

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -32,7 +32,7 @@ static inline phpdbg_breakbase_t *phpdbg_find_breakpoint_symbol(zend_function*);
 static inline phpdbg_breakbase_t *phpdbg_find_breakpoint_method(zend_op_array*);
 static inline phpdbg_breakbase_t *phpdbg_find_breakpoint_opline(phpdbg_opline_ptr_t);
 static inline phpdbg_breakbase_t *phpdbg_find_breakpoint_opcode(uint8_t);
-static inline phpdbg_breakbase_t *phpdbg_find_conditional_breakpoint(zend_execute_data *execute_data); /* }}} */
+static phpdbg_breakbase_t *phpdbg_find_conditional_breakpoint(zend_execute_data *execute_data); /* }}} */
 
 /*
 * Note:
@@ -823,7 +823,7 @@ PHPDBG_API void phpdbg_set_breakpoint_opline_ex(phpdbg_opline_ptr_t opline) /* {
 	}
 } /* }}} */
 
-static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, const phpdbg_param_t *param, const char *expr, size_t expr_len, zend_ulong hash) /* {{{ */
+static void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, const phpdbg_param_t *param, const char *expr, size_t expr_len, zend_ulong hash) /* {{{ */
 {
 	phpdbg_breakcond_t new_break;
 	uint32_t cops = CG(compiler_options);
@@ -1092,7 +1092,7 @@ static inline bool phpdbg_find_breakpoint_param(phpdbg_param_t *param, zend_exec
 	return 0;
 } /* }}} */
 
-static inline phpdbg_breakbase_t *phpdbg_find_conditional_breakpoint(zend_execute_data *execute_data) /* {{{ */
+static phpdbg_breakbase_t *phpdbg_find_conditional_breakpoint(zend_execute_data *execute_data) /* {{{ */
 {
 	phpdbg_breakcond_t *bp;
 	int breakpoint = FAILURE;

--- a/sapi/phpdbg/phpdbg_frame.c
+++ b/sapi/phpdbg/phpdbg_frame.c
@@ -25,7 +25,7 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 
-static inline void phpdbg_append_individual_arg(smart_str *s, uint32_t i, zend_function *func, zval *arg) {
+static void phpdbg_append_individual_arg(smart_str *s, uint32_t i, zend_function *func, zval *arg) {
 	const zend_arg_info *arginfo = func->common.arg_info;
 	char *arg_name = NULL;
 

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -91,7 +91,7 @@ const phpdbg_command_t phpdbg_prompt_commands[] = {
 	PHPDBG_END_COMMAND
 }; /* }}} */
 
-static inline int phpdbg_call_register(phpdbg_param_t *stack) /* {{{ */
+static int phpdbg_call_register(phpdbg_param_t *stack) /* {{{ */
 {
 	phpdbg_param_t *name = NULL;
 


### PR DESCRIPTION
These are found by adding `-Winline` on gcc. The flag is accepted on clang for compatibility with gcc, but it doesn't do anything.

Mostly, this removes `inline` from the declarations. For local static functions, there is no point in adding `inline`. This stems from either a misunderstanding of what it means, or alternatively is a holdover from ancient times where it may have meant something (note it still means something in a _header_ file, but not a source file). A compiler is free to inline a static function, and specifying inline doesn't make the compiler inline the function. These pointless `inline`s  make it harder to analyze failed inlining, so I remove them.

However, for select functions, this changes them to `zend_always_inline` instead. This is because these functions didn't inline, but probably should for performance reasons. For instance, `_class_exists_impl` is used in multiple frameless function handlers. I think in these cases, the authors were _hoping_ they'd be inlined due to fact that are important for performance. There's also `_php_search_array`, which is used with constant args on a variety of functions. It fails to inline due to its size, but if it _did_ inline, it would cut large amounts of code out, so forcing the inlining seemed worth it. 

There's also `i_get_exception_base` which was removed. Again, the compiler is free to inline `zend_get_exception_base` if it wants to, and `static inline` doesn't make the compiler inline it. This function often failed to inline in my `-Winline` report. Alternatively this could be made `zend_always_inline`, but since this is related to exceptions--which are supposed to be rare to begin with--it seemed more prudent to not force the compiler to inline it.

----

This work is split out from #15075, so that's why it might seem like déjà vu.

There are still some `-Winline` failures, but they are in things I'd prefer not to change such as pcre or xxhash.