### PR TITLE
ext/mysqli: Drop table at beginning for `mysqli_fetch_all_data_types_variation.phpt`

### DIFF
--- a/ext/mysqli/tests/fetch/mysqli_fetch_all_data_types_variation.phpt
+++ b/ext/mysqli/tests/fetch/mysqli_fetch_all_data_types_variation.phpt
@@ -13,6 +13,12 @@ require_once dirname(__DIR__) . "/test_setup/test_helpers.inc";
 
 $link = default_mysqli_connect();
 
+try {
+    mysqli_query($link, "DROP TABLE test_mysqli_fetch_all_data_types_variation");
+} catch (mysqli_sql_exception $e) {
+    // harmless, to avoid table already existing if the test gets wedged and then done again with persistent DB instance
+}
+
 function func_mysqli_fetch_all(
     mysqli $link,
     string $engine,


### PR DESCRIPTION
If the table exists already (i.e. cleanup fails to run on a persistent database instance), then the test will fail to run.

Currently being seen on ppc64 CI:
https://github.com/php/php-src/actions/runs/14721423150/job/41315888822

(Ideally, this test would be run with a fresh DB instance, but I need to figure out the containerization story.)