### PR TITLE
zlib: use zend_string_{extend,truncate} over *_realloc

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -991,7 +991,7 @@ PHP_FUNCTION(inflate_add)
 			case Z_OK:
 				if (ctx->Z.avail_out == 0) {
 					/* more output buffer space needed; realloc and try again */
-					out = zend_string_realloc(out, ZSTR_LEN(out) + CHUNK_SIZE, 0);
+					out = zend_string_extend(out, ZSTR_LEN(out) + CHUNK_SIZE, 0);
 					ctx->Z.avail_out = CHUNK_SIZE;
 					ctx->Z.next_out = (Bytef *) ZSTR_VAL(out) + buffer_used;
 					break;
@@ -1003,7 +1003,7 @@ PHP_FUNCTION(inflate_add)
 			case Z_BUF_ERROR:
 				if (flush_type == Z_FINISH && ctx->Z.avail_out == 0) {
 					/* more output buffer space needed; realloc and try again */
-					out = zend_string_realloc(out, ZSTR_LEN(out) + CHUNK_SIZE, 0);
+					out = zend_string_extend(out, ZSTR_LEN(out) + CHUNK_SIZE, 0);
 					ctx->Z.avail_out = CHUNK_SIZE;
 					ctx->Z.next_out = (Bytef *) ZSTR_VAL(out) + buffer_used;
 					break;
@@ -1039,7 +1039,7 @@ PHP_FUNCTION(inflate_add)
 	} while (1);
 
 complete:
-	out = zend_string_realloc(out, buffer_used, 0);
+	out = zend_string_truncate(out, buffer_used, 0);
 	ZSTR_VAL(out)[buffer_used] = 0;
 	RETURN_STR(out);
 }
@@ -1228,7 +1228,7 @@ PHP_FUNCTION(deflate_add)
 		if (ctx->Z.avail_out == 0) {
 			/* more output buffer space needed; realloc and try again */
 			/* adding 64 more bytes solved every issue I have seen    */
-			out = zend_string_realloc(out, ZSTR_LEN(out) + 64, 0);
+			out = zend_string_extend(out, ZSTR_LEN(out) + 64, 0);
 			ctx->Z.avail_out = 64;
 			ctx->Z.next_out = (Bytef *) ZSTR_VAL(out) + buffer_used;
 		}


### PR DESCRIPTION
These cases seemed obvious enough to me to confidently change as an outsider. There are a few more cases of zend_string_realloc still in other parts of the engine.

Note that `deflate_add` is possibly missing a `zend_string_truncate` step at the end of it, similar to what `inflate_add` has. Or alternatively `inflate_add` is doing an unnecessary `zend_string_truncate`. They don't match, in any case.