### PR TITLE
Update return types of transliterator_get_error_code(), transliterator_get_error_message(), TransLiterator::getErrorCode(), and TransLiterator::getErrorMessage()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -214,12 +214,15 @@ PHP 8.5 UPGRADE NOTES
 - Intl:
   . IntlDateFormatter::setTimeZone()/datefmt_set_timezone()
     throws an IntlException on uninitialised classes/clone failures.
-
   . grapheme_extract() properly assigns $next value when skipping over
     invalid starting bytes. Previously there were cases where it would
     point to the start of the grapheme boundary instead of the end.
   . Locale:: methods throw a ValueError when locale inputs contain null
     bytes.
+  . transliterator_get_error_code(), transliterator_get_error_message()
+    TransLiterator::getErrorCode(), and TransLiterator::getErrorMessage()
+    have dropped the false from the return type union. Returning false
+    was actually never possible.
 
 - libxml:
   . libxml_set_external_entity_loader() now has a formal return type of true.

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -637,6 +637,6 @@ function transliterator_create_inverse(Transliterator $transliterator): ?Transli
 
 function transliterator_transliterate(Transliterator|string $transliterator, string $string, int $start = 0, int $end = -1): string|false {}
 
-function transliterator_get_error_code(Transliterator $transliterator): int|false {}
+function transliterator_get_error_code(Transliterator $transliterator): int {}
 
-function transliterator_get_error_message(Transliterator $transliterator): string|false {}
+function transliterator_get_error_message(Transliterator $transliterator): string {}

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: adcf3b6ef720a518087efedbe2b62b10ad4b2624 */
+ * Stub hash: 70b621ef9169fd3b913347adc0baf3626584a2c3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -792,11 +792,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_transliterator_transliterate, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_transliterator_get_error_code, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_transliterator_get_error_code, 0, 1, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, transliterator, Transliterator, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_transliterator_get_error_message, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_transliterator_get_error_message, 0, 1, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, transliterator, Transliterator, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/intl/transliterator/transliterator.stub.php
+++ b/ext/intl/transliterator/transliterator.stub.php
@@ -49,11 +49,11 @@ class Transliterator
      * @tentative-return-type
      * @alias transliterator_get_error_code
      */
-    public function getErrorCode(): int|false {}
+    public function getErrorCode(): int {}
 
     /**
      * @tentative-return-type
      * @alias transliterator_get_error_message
      */
-    public function getErrorMessage(): string|false {}
+    public function getErrorMessage(): string {}
 }

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82af60e0faf01941fbf580da8957a867eda46384 */
+ * Stub hash: 300bcc64e5ddaf469bfe4a12e65a6677bf2aea88 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Transliterator___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -26,10 +26,10 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_Transliterator_t
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_Transliterator_getErrorCode, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Transliterator_getErrorCode, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_Transliterator_getErrorMessage, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Transliterator_getErrorMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Transliterator, __construct);

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -437,8 +437,6 @@ PHP_FUNCTION( transliterator_get_error_code )
 
 	/* Fetch the object (without resetting its last error code ). */
 	to = Z_INTL_TRANSLITERATOR_P( object );
-	if (to == NULL )
-		RETURN_FALSE;
 
 	RETURN_LONG( (zend_long) TRANSLITERATOR_ERROR_CODE( to ) );
 }
@@ -460,8 +458,6 @@ PHP_FUNCTION( transliterator_get_error_message )
 
 	/* Fetch the object (without resetting its last error code ). */
 	to = Z_INTL_TRANSLITERATOR_P( object );
-	if (to == NULL )
-		RETURN_FALSE;
 
 	/* Return last error message. */
 	message = intl_error_get_message( TRANSLITERATOR_ERROR_P( to ) );


### PR DESCRIPTION
Returning false is impossible.