### PR TITLE
Fix use-of-uninitialized-value with exception on deprecated const access

### DIFF
--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -380,6 +380,7 @@ static zend_always_inline zend_constant* _zend_quick_get_constant(
 				zend_deprecated_constant(c, c->name);
 				CONST_UNPROTECT_RECURSION(c);
 				if (EG(exception)) {
+					ZVAL_UNDEF(EX_VAR(opline->result.var));
 					return NULL;
 				}
 			}


### PR DESCRIPTION
Caught by various tests in nightly. https://github.com/php/php-src/actions/runs/14767850964/job/41462688558

The use-of-uninitialized-value happens on this line:

https://github.com/php/php-src/blob/178fc2db82de5e1f6950c061d68770938c0d4a0f/Zend/zend_vm_def.h#L8192

It happens because because the ZEND_HANDLE_EXCEPTION handler assumes the result has already been initialized and potentially needs to be freed. To fix this, simply initialize the result to NULL, like we already do a few lines above.