### PR TITLE
standard: Take `zend.assertions` into account for dynamic calls to `assert()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,8 @@ PHP                                                                        NEWS
 
 - Standard:
   . Fixed bug GH-17403 (Potential deadlock when putenv fails). (nielsdos)
+  . Fixed bug GH-18509 (Dynamic calls to assert() ignore zend.assertions).
+    (timwolla)
 
 - Windows:
   . Fix leak+crash with sapi_windows_set_ctrl_handler(). (nielsdos)

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -178,7 +178,11 @@ PHP_FUNCTION(assert)
 	zend_string *description_str = NULL;
 	zend_object *description_obj = NULL;
 
-	if (!ASSERTG(active)) {
+	/* EG(assertions) <= 0 is only reachable by dynamic calls to assert(),
+	 * since calls known at compile time will skip the entire call when
+	 * assertions are disabled.
+	 */
+	if (!ASSERTG(active) || EG(assertions) <= 0) {
 		RETURN_TRUE;
 	}
 

--- a/ext/standard/tests/assert/gh18509.phpt
+++ b/ext/standard/tests/assert/gh18509.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-18509: Dynamic calls to assert() ignore zend.assertions
+--INI--
+zend.assertions=0
+--FILE--
+<?php
+
+$c = "assert";
+
+$c(false);
+
+var_dump(array_map(assert(...), [true, true, false]));
+
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  bool(true)
+  [1]=>
+  bool(true)
+  [2]=>
+  bool(true)
+}


### PR DESCRIPTION
Fixes php/php-src#18509.