### PR TITLE
ext/hash: tests for md5 and sha1 compatibility

### DIFF
--- a/ext/hash/tests/md5.phpt
+++ b/ext/hash/tests/md5.phpt
@@ -6,9 +6,11 @@ echo hash('md5', '') . "\n";
 echo hash('md5', 'a') . "\n";
 echo hash('md5', '012345678901234567890123456789012345678901234567890123456789') . "\n";
 echo hash('md5', str_repeat('a', 1000000)) . "\n";
+var_dump(hash('md5', 'string') === md5('string'));
 ?>
 --EXPECT--
 d41d8cd98f00b204e9800998ecf8427e
 0cc175b9c0f1b6a831c399e269772661
 1ced811af47ead374872fcca9d73dd71
 7707d6ae4e027c70eea2a935c2296f21
+bool(true)

--- a/ext/hash/tests/sha1.phpt
+++ b/ext/hash/tests/sha1.phpt
@@ -10,6 +10,7 @@ echo hash('sha1', '012345678901234567890123456789012345678901234567890123456789'
 echo hash('sha1', 'abc') . "\n";
 echo hash('sha1', 'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq') . "\n";
 echo hash('sha1', str_repeat('a', 1000000)) . "\n";
+var_dump(hash('sha1', 'string') === sha1('string')) . "\n";
 ?>
 --EXPECT--
 da39a3ee5e6b4b0d3255bfef95601890afd80709
@@ -18,3 +19,4 @@ f52e3c2732de7bea28f216d877d78dae1aa1ac6a
 a9993e364706816aba3e25717850c26c9cd0d89d
 84983e441c3bd26ebaae4aa1f95129e5e54670f1
 34aa973cd4c4daa4f61eeb2bdbad27316534016f
+bool(true)


### PR DESCRIPTION
I didn't find cases where we compare the result from the standalone sha1 or md5 and `hash(algo)` functions.