### PR TITLE
Fix visibility of whitespace in config output

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1106,9 +1106,17 @@ do_repeat:
 
 		case PHP_CLI_MODE_SHOW_INI_CONFIG:
 			{
-				zend_printf("Configuration File (php.ini) Path: %s\n", PHP_CONFIG_FILE_PATH);
-				zend_printf("Loaded Configuration File:         %s\n", php_ini_opened_path ? php_ini_opened_path : "(none)");
-				zend_printf("Scan for additional .ini files in: %s\n", php_ini_scanned_path  ? php_ini_scanned_path : "(none)");
+				zend_printf("Configuration File (php.ini) Path: `%s`\n", PHP_CONFIG_FILE_PATH);
+				if (php_ini_scanned_path) {
+					zend_printf("Loaded Configuration File:         `%s`\n", php_ini_scanned_path);
+				} else {
+					zend_printf("Loaded Configuration File:         (none)\n");
+				}
+				if (php_ini_opened_path) {
+					zend_printf("Scan for additional .ini files in: `%s`\n", php_ini_opened_path);
+				} else {
+					zend_printf("Scan for additional .ini files in: (none)\n");
+				}
 				zend_printf("Additional .ini files parsed:      %s\n", php_ini_scanned_files ? php_ini_scanned_files : "(none)");
 				break;
 			}

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1106,14 +1106,14 @@ do_repeat:
 
 		case PHP_CLI_MODE_SHOW_INI_CONFIG:
 			{
-				zend_printf("Configuration File (php.ini) Path: `%s`\n", PHP_CONFIG_FILE_PATH);
+				zend_printf("Configuration File (php.ini) Path: \"%s\"\n", PHP_CONFIG_FILE_PATH);
 				if (php_ini_scanned_path) {
-					zend_printf("Loaded Configuration File:         `%s`\n", php_ini_scanned_path);
+					zend_printf("Loaded Configuration File:         \"%s\"\n", php_ini_scanned_path);
 				} else {
 					zend_printf("Loaded Configuration File:         (none)\n");
 				}
 				if (php_ini_opened_path) {
-					zend_printf("Scan for additional .ini files in: `%s`\n", php_ini_opened_path);
+					zend_printf("Scan for additional .ini files in: \"%s\"\n", php_ini_opened_path);
 				} else {
 					zend_printf("Scan for additional .ini files in: (none)\n");
 				}


### PR DESCRIPTION
When a config var has whitespace (especially trailing whitespace) it is hard to see. This commit wraps the values (if they exist) in a character so the difference is visually observable:

Before:

```
$ export PHP_INI_SCAN_DIR="/opt/homebrew/etc/php/8.4/conf.d         "
$ ./sapi/cli/php --ini
Configuration File (php.ini) Path: /usr/local/lib
Loaded Configuration File:         /opt/homebrew/etc/php/8.4/conf.d         
Scan for additional .ini files in: (none)
Additional .ini files parsed:      (none)
```

> [!NOTE]  
> The above output has trailing whitespace that is not visible, you can see it if you copy it into an editor.

After:

```
$ ./sapi/cli/php --ini
Configuration File (php.ini) Path: "/usr/local/lib"
Loaded Configuration File:         "/opt/homebrew/etc/php/8.4/conf.d         "
Scan for additional .ini files in: (none)
Additional .ini files parsed:      (none)
```

Above the whitespace is now visible `/opt/homebrew/etc/php/8.4/conf.d         `.

Close #18390