### PR TITLE
ext/intl: fix clang build.

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -742,7 +742,14 @@ AC_DEFUN([PHP_REQUIRE_CXX],[
   if test -z "$php_cxx_done"; then
     AC_PROG_CXX
     AC_PROG_CXXCPP
-    PHP_ADD_LIBRARY(stdc++)
+    case "$CXX" in
+      *clang++*)
+    	PHP_ADD_LIBRARY(c++)
+	;;
+      *)
+    	PHP_ADD_LIBRARY(stdc++)
+	;;
+    esac
     php_cxx_done=yes
   fi
 ])

--- a/build/php_cxx_compile_stdcxx.m4
+++ b/build/php_cxx_compile_stdcxx.m4
@@ -40,6 +40,11 @@ AC_DEFUN([PHP_CXX_COMPILE_STDCXX], [dnl
   dnl Cray's crayCC needs "-h std=c++11"
   for alternative in ${ax_cxx_compile_alternatives}; do
     for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+      case "$CXX" in
+        *clang++*)
+    	  switch="${switch} -stdlib=libc++"
+	  ;;
+      esac
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,


### PR DESCRIPTION
actually, with recent icu releases, this problem arises

```
checking whether clang++ supports C++17 features with -std=c++17... no
checking whether clang++ supports C++17 features with +std=c++17... no
checking whether clang++ supports C++17 features with -h std=c++17... no
checking whether clang++ supports C++17 features with -std=c++1z... no
checking whether clang++ supports C++17 features with +std=c++1z... no
checking whether clang++ supports C++17 features with -h std=c++1z... no
configure: error: *** A compiler with support for C++17 language features is required.
```

thus, proposing to falls into LLVM libc++ instead.