### PR TITLE
Fix error handling during opcache compilation

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -128,6 +128,7 @@ mkdir %PHP_BUILD_DIR%\test_file_cache
 rem generate php.ini
 echo extension_dir=%PHP_BUILD_DIR% > %PHP_BUILD_DIR%\php.ini
 echo opcache.file_cache=%PHP_BUILD_DIR%\test_file_cache >> %PHP_BUILD_DIR%\php.ini
+echo opcache.record_warnings=1 >> %PHP_BUILD_DIR%\php.ini
 if "%OPCACHE%" equ "1" echo zend_extension=php_opcache.dll >> %PHP_BUILD_DIR%\php.ini
 rem work-around for some spawned PHP processes requiring OpenSSL and sockets
 echo extension=php_openssl.dll >> %PHP_BUILD_DIR%\php.ini

--- a/Zend/tests/inheritance/deprecation_to_exception_during_inheritance.phpt
+++ b/Zend/tests/inheritance/deprecation_to_exception_during_inheritance.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Deprecation promoted to exception should result in fatal error during inheritance
+Deprecation promoted to exception during inheritance
 --SKIPIF--
 <?php
 if (getenv('SKIP_PRELOAD')) die('skip Error handler not active during preloading');
@@ -17,7 +17,8 @@ $class = new class extends DateTime {
 
 ?>
 --EXPECTF--
-Fatal error: During inheritance of DateTime: Uncaught Exception: Return type of DateTime@anonymous::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s:%d
+Fatal error: Uncaught Exception: Return type of DateTime@anonymous::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s:%d
 Stack trace:
 #0 %s(%d): {closure:%s:%d}(8192, 'Return type of ...', '%s', 8)
-#1 {main} in %s on line %d
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/inheritance/deprecation_to_exception_during_inheritance_can_be_caught.phpt
+++ b/Zend/tests/inheritance/deprecation_to_exception_during_inheritance_can_be_caught.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Deprecation promoted to exception during inheritance
+--SKIPIF--
+<?php
+if (getenv('SKIP_PRELOAD')) die('skip Error handler not active during preloading');
+?>
+--FILE--
+<?php
+
+set_error_handler(function($code, $message) {
+    throw new Exception($message);
+});
+
+try {
+    class C extends DateTime {
+        public function getTimezone() {}
+        public function getTimestamp() {}
+    };
+} catch (Exception $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+
+var_dump(new C());
+
+?>
+--EXPECTF--
+Exception: Return type of C::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
+object(C)#%d (3) {
+  ["date"]=>
+  string(%d) "%s"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(3) "UTC"
+}

--- a/Zend/tests/inheritance/gh15907.phpt
+++ b/Zend/tests/inheritance/gh15907.phpt
@@ -16,6 +16,6 @@ class C implements Serializable {
 --EXPECTF--
 Fatal error: Uncaught Exception: C implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s:%d
 Stack trace:
-#0 %s(%d): {closure:%s:%d}(8192, 'C implements th...', '/home/arnaud/de...', 7)
+#0 %s(%d): {closure:%s:%d}(8192, 'C implements th...', '%s', 7)
 #1 {main}
   thrown in %s on line %d

--- a/Zend/tests/inheritance/gh15907.phpt
+++ b/Zend/tests/inheritance/gh15907.phpt
@@ -14,5 +14,8 @@ class C implements Serializable {
 
 ?>
 --EXPECTF--
-Fatal error: During inheritance of C, while implementing Serializable: Uncaught Exception: C implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s:%d
-%a
+Fatal error: Uncaught Exception: C implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s:%d
+Stack trace:
+#0 %s(%d): {closure:%s:%d}(8192, 'C implements th...', '/home/arnaud/de...', 7)
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1453,28 +1453,26 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 	}
 
 	/* Emit any delayed error before handling fatal error */
-	if ((type & E_FATAL_ERRORS) && !(type & E_DONT_BAIL)) {
-		if (EG(num_errors)) {
-			uint32_t num_errors = EG(num_errors);
-			zend_error_info **errors = EG(errors);
-			EG(num_errors) = 0;
-			EG(errors) = NULL;
+	if ((type & E_FATAL_ERRORS) && !(type & E_DONT_BAIL) && EG(num_errors)) {
+		uint32_t num_errors = EG(num_errors);
+		zend_error_info **errors = EG(errors);
+		EG(num_errors) = 0;
+		EG(errors) = NULL;
 
-			bool orig_record_errors = EG(record_errors);
-			EG(record_errors) = false;
+		bool orig_record_errors = EG(record_errors);
+		EG(record_errors) = false;
 
-			/* Disable user error handler before emitting delayed errors, as
-			 * it's unsafe to execute user code after a fatal error. */
-			int orig_user_error_handler_error_reporting = EG(user_error_handler_error_reporting);
-			EG(user_error_handler_error_reporting) = 0;
+		/* Disable user error handler before emitting delayed errors, as
+		 * it's unsafe to execute user code after a fatal error. */
+		int orig_user_error_handler_error_reporting = EG(user_error_handler_error_reporting);
+		EG(user_error_handler_error_reporting) = 0;
 
-			zend_emit_recorded_errors_ex(num_errors, errors);
+		zend_emit_recorded_errors_ex(num_errors, errors);
 
-			EG(user_error_handler_error_reporting) = orig_user_error_handler_error_reporting;
-			EG(record_errors) = orig_record_errors;
-			EG(num_errors) = num_errors;
-			EG(errors) = errors;
-		}
+		EG(user_error_handler_error_reporting) = orig_user_error_handler_error_reporting;
+		EG(record_errors) = orig_record_errors;
+		EG(num_errors) = num_errors;
+		EG(errors) = errors;
 	}
 
 	if (EG(record_errors)) {

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1452,6 +1452,31 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		return;
 	}
 
+	/* Emit any delayed error before handling fatal error */
+	if ((type & E_FATAL_ERRORS) && !(type & E_DONT_BAIL)) {
+		if (EG(num_errors)) {
+			uint32_t num_errors = EG(num_errors);
+			zend_error_info **errors = EG(errors);
+			EG(num_errors) = 0;
+			EG(errors) = NULL;
+
+			bool orig_record_errors = EG(record_errors);
+			EG(record_errors) = false;
+
+			/* Disable user error handler before emitting delayed errors, as
+			 * it's unsafe to execute user code after a fatal error. */
+			int orig_user_error_handler_error_reporting = EG(user_error_handler_error_reporting);
+			EG(user_error_handler_error_reporting) = 0;
+
+			zend_emit_recorded_errors_ex(num_errors, errors);
+
+			EG(user_error_handler_error_reporting) = orig_user_error_handler_error_reporting;
+			EG(record_errors) = orig_record_errors;
+			EG(num_errors) = num_errors;
+			EG(errors) = errors;
+		}
+	}
+
 	if (EG(record_errors)) {
 		zend_error_info *info = emalloc(sizeof(zend_error_info));
 		info->type = type;
@@ -1464,6 +1489,11 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		EG(num_errors)++;
 		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * EG(num_errors));
 		EG(errors)[EG(num_errors)-1] = info;
+
+		/* Do not process non-fatal recorded error */
+		if (!(type & E_FATAL_ERRORS) || (type & E_DONT_BAIL)) {
+			return;
+		}
 	}
 
 	// Always clear the last backtrace.
@@ -1752,13 +1782,18 @@ ZEND_API void zend_begin_record_errors(void)
 	EG(errors) = NULL;
 }
 
+ZEND_API void zend_emit_recorded_errors_ex(uint32_t num_errors, zend_error_info **errors)
+{
+	for (uint32_t i = 0; i < num_errors; i++) {
+		zend_error_info *error = errors[i];
+		zend_error_zstr_at(error->type, error->filename, error->lineno, error->message);
+	}
+}
+
 ZEND_API void zend_emit_recorded_errors(void)
 {
 	EG(record_errors) = false;
-	for (uint32_t i = 0; i < EG(num_errors); i++) {
-		zend_error_info *error = EG(errors)[i];
-		zend_error_zstr_at(error->type, error->filename, error->lineno, error->message);
-	}
+	zend_emit_recorded_errors_ex(EG(num_errors), EG(errors));
 }
 
 ZEND_API void zend_free_recorded_errors(void)

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -444,6 +444,7 @@ ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, 
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 ZEND_API void zend_begin_record_errors(void);
 ZEND_API void zend_emit_recorded_errors(void);
+ZEND_API void zend_emit_recorded_errors_ex(uint32_t num_errors, zend_error_info **errors);
 ZEND_API void zend_free_recorded_errors(void);
 END_EXTERN_C()
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1333,7 +1333,6 @@ ZEND_API zend_class_entry *zend_bind_class_in_slot(
 
 	ce = zend_do_link_class(ce, lc_parent_name, Z_STR_P(lcname));
 	if (ce) {
-		ZEND_ASSERT(!EG(exception));
 		zend_observer_class_linked_notify(ce, Z_STR_P(lcname));
 		return ce;
 	}

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -295,7 +295,8 @@ struct _zend_executor_globals {
 	size_t fiber_stack_size;
 
 	/* If record_errors is enabled, all emitted diagnostics will be recorded,
-	 * in addition to being processed as usual. */
+	 * and their processing is delayed until zend_emit_recorded_errors()
+	 * is called or a fatal diagnostic is emitted. */
 	bool record_errors;
 	uint32_t num_errors;
 	zend_error_info **errors;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1085,10 +1085,7 @@ static void ZEND_COLD emit_incompatible_method_error(
 				"Return type of %s should either be compatible with %s, "
 				"or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice",
 				ZSTR_VAL(child_prototype), ZSTR_VAL(parent_prototype));
-			if (EG(exception)) {
-				zend_exception_uncaught_error(
-					"During inheritance of %s", ZSTR_VAL(parent_scope->name));
-			}
+			ZEND_ASSERT(!EG(exception));
 		}
 	} else {
 		zend_error_at(E_COMPILE_ERROR, func_filename(child), func_lineno(child),
@@ -3759,6 +3756,7 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 	}
 
 	if (!orig_record_errors) {
+		zend_emit_recorded_errors();
 		zend_free_recorded_errors();
 	}
 	if (traits_and_interfaces) {

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -650,7 +650,17 @@ ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type)
 			}
 		}
 	} else {
+		bool orig_record_errors = EG(record_errors);
+		if (!orig_record_errors) {
+			zend_begin_record_errors();
+		}
+
 		op_array = zend_compile(ZEND_USER_FUNCTION);
+
+		if (!orig_record_errors) {
+			zend_emit_recorded_errors();
+			zend_free_recorded_errors();
+		}
 	}
 
 	zend_restore_lexical_state(&original_lex_state);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7926,7 +7926,7 @@ ZEND_VM_HANDLER(145, ZEND_DECLARE_CLASS_DELAYED, CONST, CONST)
 		if (zv) {
 			SAVE_OPLINE();
 			ce = zend_bind_class_in_slot(zv, lcname, Z_STR_P(RT_CONSTANT(opline, opline->op2)));
-			if (!ce) {
+			if (EG(exception)) {
 				HANDLE_EXCEPTION();
 			}
 		}
@@ -7950,7 +7950,7 @@ ZEND_VM_HANDLER(146, ZEND_DECLARE_ANON_CLASS, ANY, ANY, CACHE_SLOT)
 		if (!(ce->ce_flags & ZEND_ACC_LINKED)) {
 			SAVE_OPLINE();
 			ce = zend_do_link_class(ce, (OP2_TYPE == IS_CONST) ? Z_STR_P(RT_CONSTANT(opline, opline->op2)) : NULL, rtd_key);
-			if (!ce) {
+			if (EG(exception)) {
 				HANDLE_EXCEPTION();
 			}
 		}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3207,7 +3207,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DECLARE_ANON_CLASS_SPEC_HANDLE
 		if (!(ce->ce_flags & ZEND_ACC_LINKED)) {
 			SAVE_OPLINE();
 			ce = zend_do_link_class(ce, (opline->op2_type == IS_CONST) ? Z_STR_P(RT_CONSTANT(opline, opline->op2)) : NULL, rtd_key);
-			if (!ce) {
+			if (EG(exception)) {
 				HANDLE_EXCEPTION();
 			}
 		}
@@ -8002,7 +8002,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DECLARE_CLASS_DELAYED_SPEC_CON
 		if (zv) {
 			SAVE_OPLINE();
 			ce = zend_bind_class_in_slot(zv, lcname, Z_STR_P(RT_CONSTANT(opline, opline->op2)));
-			if (!ce) {
+			if (EG(exception)) {
 				HANDLE_EXCEPTION();
 			}
 		}

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1744,7 +1744,6 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	zend_persistent_script *new_persistent_script;
 	uint32_t orig_functions_count, orig_class_count;
 	zend_op_array *orig_active_op_array;
-	zval orig_user_error_handler;
 	zend_op_array *op_array;
 	bool do_bailout = false;
 	accel_time_t timestamp = 0;
@@ -1812,10 +1811,8 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	orig_active_op_array = CG(active_op_array);
 	orig_functions_count = EG(function_table)->nNumUsed;
 	orig_class_count = EG(class_table)->nNumUsed;
-	ZVAL_COPY_VALUE(&orig_user_error_handler, &EG(user_error_handler));
 
 	/* Override them with ours */
-	ZVAL_UNDEF(&EG(user_error_handler));
 	if (ZCG(accel_directives).record_warnings) {
 		zend_begin_record_errors();
 	}
@@ -1848,7 +1845,6 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 
 	/* Restore originals */
 	CG(active_op_array) = orig_active_op_array;
-	EG(user_error_handler) = orig_user_error_handler;
 	EG(record_errors) = 0;
 
 	if (!op_array) {

--- a/ext/opcache/tests/gh17422/001.phpt
+++ b/ext/opcache/tests/gh17422/001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECT--
+set_error_handler: "continue" targeting switch is equivalent to "break"
+OK: warning
+array(3) {
+  [0]=>
+  string(7) "001.php"
+  [1]=>
+  string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/002.phpt
+++ b/ext/opcache/tests/gh17422/002.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Throwing error handler
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+});
+
+try {
+	require __DIR__ . "/warning.inc";
+} catch (\Exception $e) {
+	echo "Caught: ", $e->getMessage(), PHP_EOL;
+}
+
+warning();
+
+?>
+--EXPECT--
+Caught: "continue" targeting switch is equivalent to "break"
+OK: warning
+array(3) {
+  [0]=>
+  string(7) "002.php"
+  [1]=>
+  string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/002.phpt
+++ b/ext/opcache/tests/gh17422/002.phpt
@@ -1,14 +1,7 @@
 --TEST--
 GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Throwing error handler
---INI--
-opcache.enable=1
-opcache.enable_cli=1
---EXTENSIONS--
-opcache
 --FILE--
 <?php
-
-require __DIR__ . "/shutdown.inc";
 
 set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
 	throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
@@ -26,11 +19,3 @@ warning();
 --EXPECT--
 Caught: "continue" targeting switch is equivalent to "break"
 OK: warning
-array(3) {
-  [0]=>
-  string(7) "002.php"
-  [1]=>
-  string(12) "shutdown.inc"
-  [2]=>
-  string(11) "warning.inc"
-}

--- a/ext/opcache/tests/gh17422/003.phpt
+++ b/ext/opcache/tests/gh17422/003.phpt
@@ -22,9 +22,11 @@ warning();
 ?>
 --EXPECTF--
 Fatal error: Allowed memory size of 2097152 bytes exhausted %s on line 6
-array(2) {
+array(3) {
   [0]=>
   string(7) "003.php"
   [1]=>
   string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
 }

--- a/ext/opcache/tests/gh17422/003.phpt
+++ b/ext/opcache/tests/gh17422/003.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Fatal Error
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	str_repeat('x', 1024 * 1024 * 1024);
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of 2097152 bytes exhausted %s on line 6
+array(2) {
+  [0]=>
+  string(7) "003.php"
+  [1]=>
+  string(12) "shutdown.inc"
+}

--- a/ext/opcache/tests/gh17422/003.phpt
+++ b/ext/opcache/tests/gh17422/003.phpt
@@ -1,18 +1,11 @@
 --TEST--
 GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Fatal Error
---INI--
-opcache.enable=1
-opcache.enable_cli=1
-memory_limit=2M
---EXTENSIONS--
-opcache
 --FILE--
 <?php
 
-require __DIR__ . "/shutdown.inc";
-
 set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
-	str_repeat('x', 1024 * 1024 * 1024);
+    function fatal_error() {}
+    function fatal_error() {}
 });
 
 require __DIR__ . "/warning.inc";
@@ -21,12 +14,4 @@ warning();
 
 ?>
 --EXPECTF--
-Fatal error: Allowed memory size of 2097152 bytes exhausted %s on line 6
-array(3) {
-  [0]=>
-  string(7) "003.php"
-  [1]=>
-  string(12) "shutdown.inc"
-  [2]=>
-  string(11) "warning.inc"
-}
+Fatal error: Cannot redeclare function fatal_error() (previously declared in %s:%d) in %s on line %d

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -28,9 +28,11 @@ warning();
 ?>
 --EXPECTF--
 Fatal error: Cannot redeclare %Swarning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
-array(2) {
+array(3) {
   [0]=>
   string(7) "004.php"
   [1]=>
   string(12) "shutdown.inc"
+  [2]=>
+  string(11) "warning.inc"
 }

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -1,15 +1,7 @@
 --TEST--
 GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - eval
---INI--
-opcache.enable=1
-opcache.enable_cli=1
-memory_limit=2M
---EXTENSIONS--
-opcache
 --FILE--
 <?php
-
-require __DIR__ . "/shutdown.inc";
 
 set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
 	eval(
@@ -27,12 +19,4 @@ warning();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare %Swarning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
-array(3) {
-  [0]=>
-  string(7) "004.php"
-  [1]=>
-  string(12) "shutdown.inc"
-  [2]=>
-  string(11) "warning.inc"
-}
+Fatal error: Cannot redeclare function warning() %s

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -27,7 +27,7 @@ warning();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare function warning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
+Fatal error: Cannot redeclare %Swarning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
 array(2) {
   [0]=>
   string(7) "004.php"

--- a/ext/opcache/tests/gh17422/004.phpt
+++ b/ext/opcache/tests/gh17422/004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - eval
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	eval(
+		<<<'PHP'
+			function warning() {
+				echo "NOK", PHP_EOL;
+			}
+			PHP
+	);
+});
+
+require __DIR__ . "/warning.inc";
+
+warning();
+
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare function warning() (previously declared in %s(8) : eval()'d code:1) in %swarning.inc on line 2
+array(2) {
+  [0]=>
+  string(7) "004.php"
+  [1]=>
+  string(12) "shutdown.inc"
+}

--- a/ext/opcache/tests/gh17422/005.phpt
+++ b/ext/opcache/tests/gh17422/005.phpt
@@ -1,15 +1,7 @@
 --TEST--
 GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - require
---INI--
-opcache.enable=1
-opcache.enable_cli=1
-memory_limit=2M
---EXTENSIONS--
-opcache
 --FILE--
 <?php
-
-require __DIR__ . "/shutdown.inc";
 
 set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
 	require_once __DIR__ . "/dummy.inc";
@@ -22,13 +14,3 @@ dummy();
 ?>
 --EXPECT--
 OK: dummy
-array(4) {
-  [0]=>
-  string(7) "005.php"
-  [1]=>
-  string(9) "dummy.inc"
-  [2]=>
-  string(12) "shutdown.inc"
-  [3]=>
-  string(11) "warning.inc"
-}

--- a/ext/opcache/tests/gh17422/005.phpt
+++ b/ext/opcache/tests/gh17422/005.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - require
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+memory_limit=2M
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+require __DIR__ . "/shutdown.inc";
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	require_once __DIR__ . "/dummy.inc";
+});
+
+require __DIR__ . "/warning.inc";
+
+dummy();
+
+?>
+--EXPECT--
+OK: dummy
+array(4) {
+  [0]=>
+  string(7) "005.php"
+  [1]=>
+  string(9) "dummy.inc"
+  [2]=>
+  string(12) "shutdown.inc"
+  [3]=>
+  string(11) "warning.inc"
+}

--- a/ext/opcache/tests/gh17422/006.phpt
+++ b/ext/opcache/tests/gh17422/006.phpt
@@ -3,7 +3,7 @@ GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Fi
 --INI--
 opcache.enable=1
 opcache.enable_cli=1
-opcache.file_cache={TMP}
+opcache.file_cache="{TMP}"
 opcache.file_cache_only=1
 opcache.record_warnings=1
 --EXTENSIONS--

--- a/ext/opcache/tests/gh17422/006.phpt
+++ b/ext/opcache/tests/gh17422/006.phpt
@@ -1,5 +1,13 @@
 --TEST--
-GH-17422 (OPcache bypasses the user-defined error handler for deprecations)
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - File cache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_cache={TMP}
+opcache.file_cache_only=1
+opcache.record_warnings=1
+--EXTENSIONS--
+opcache
 --FILE--
 <?php
 

--- a/ext/opcache/tests/gh17422/007.phpt
+++ b/ext/opcache/tests/gh17422/007.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Fatal after warning
+--FILE--
+<?php
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/warning-fatal.inc";
+
+warning();
+
+?>
+--EXPECTF--
+Warning: "continue" targeting switch is equivalent to "break" in %s on line %d
+
+Fatal error: Cannot redeclare function warning() (previously declared in %s:%d) in %s on line %d

--- a/ext/opcache/tests/gh17422/008.phpt
+++ b/ext/opcache/tests/gh17422/008.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Early binding warning
+--FILE--
+<?php
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/early-bind-warning.inc";
+
+?>
+--EXPECTF--
+set_error_handler: Return type of C::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

--- a/ext/opcache/tests/gh17422/009.phpt
+++ b/ext/opcache/tests/gh17422/009.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Early binding error after warning
+--FILE--
+<?php
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/early-bind-warning-error.inc";
+
+?>
+--EXPECTF--
+Deprecated: Return type of C::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
+
+Fatal error: Declaration of C::getTimestamp(C $arg): int must be compatible with DateTime::getTimestamp(): int in %s on line %d

--- a/ext/opcache/tests/gh17422/010.phpt
+++ b/ext/opcache/tests/gh17422/010.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Inheritance warning
+--FILE--
+<?php
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/link-warning.inc";
+
+?>
+--EXPECTF--
+set_error_handler: Return type of C::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

--- a/ext/opcache/tests/gh17422/011.phpt
+++ b/ext/opcache/tests/gh17422/011.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-17422 (OPcache bypasses the user-defined error handler for deprecations) - Inheritance error after warning
+--FILE--
+<?php
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) {
+	echo "set_error_handler: {$errstr}", PHP_EOL;
+});
+
+require __DIR__ . "/link-warning-error.inc";
+
+?>
+--EXPECTF--
+Deprecated: Return type of C::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
+
+Fatal error: Declaration of C::getTimestamp(C $arg): int must be compatible with DateTime::getTimestamp(): int %s on line %d

--- a/ext/opcache/tests/gh17422/dummy.inc
+++ b/ext/opcache/tests/gh17422/dummy.inc
@@ -1,0 +1,4 @@
+<?php
+function dummy() {
+    echo "OK: ", __FUNCTION__, PHP_EOL;
+}

--- a/ext/opcache/tests/gh17422/early-bind-warning-error.inc
+++ b/ext/opcache/tests/gh17422/early-bind-warning-error.inc
@@ -1,0 +1,6 @@
+<?php
+
+class C extends DateTime {
+    public function getTimezone() {}
+    public function getTimestamp(C $arg): int {}
+}

--- a/ext/opcache/tests/gh17422/early-bind-warning.inc
+++ b/ext/opcache/tests/gh17422/early-bind-warning.inc
@@ -1,0 +1,5 @@
+<?php
+
+class C extends DateTime {
+    public function getTimezone() {}
+}

--- a/ext/opcache/tests/gh17422/link-warning-error.inc
+++ b/ext/opcache/tests/gh17422/link-warning-error.inc
@@ -1,0 +1,8 @@
+<?php
+
+interface DisableEarlyBinding {}
+
+class C extends DateTime implements DisableEarlyBinding {
+    public function getTimezone() {}
+    public function getTimestamp(C $arg): int {}
+}

--- a/ext/opcache/tests/gh17422/link-warning.inc
+++ b/ext/opcache/tests/gh17422/link-warning.inc
@@ -1,7 +1,7 @@
 <?php
 
-interface DiableEarlyBinding {}
+interface DisableEarlyBinding {}
 
-class C extends DateTime implements DiableEarlyBinding {
+class C extends DateTime implements DisableEarlyBinding {
     public function getTimezone() {}
 }

--- a/ext/opcache/tests/gh17422/link-warning.inc
+++ b/ext/opcache/tests/gh17422/link-warning.inc
@@ -1,0 +1,7 @@
+<?php
+
+interface DiableEarlyBinding {}
+
+class C extends DateTime implements DiableEarlyBinding {
+    public function getTimezone() {}
+}

--- a/ext/opcache/tests/gh17422/shutdown.inc
+++ b/ext/opcache/tests/gh17422/shutdown.inc
@@ -1,6 +1,0 @@
-<?php
-register_shutdown_function(static function() {
-	$scripts = array_map(basename(...), array_keys(opcache_get_status()['scripts'] ?? []));
-	sort($scripts);
-	var_dump($scripts);
-});

--- a/ext/opcache/tests/gh17422/shutdown.inc
+++ b/ext/opcache/tests/gh17422/shutdown.inc
@@ -1,0 +1,6 @@
+<?php
+register_shutdown_function(static function() {
+	$scripts = array_map(basename(...), array_keys(opcache_get_status()['scripts'] ?? []));
+	sort($scripts);
+	var_dump($scripts);
+});

--- a/ext/opcache/tests/gh17422/warning-fatal.inc
+++ b/ext/opcache/tests/gh17422/warning-fatal.inc
@@ -1,0 +1,9 @@
+<?php
+function warning() {
+    switch (1) {
+        case 1:
+            echo "OK: ", __FUNCTION__, PHP_EOL;
+            continue;
+    }
+}
+function warning() {}

--- a/ext/opcache/tests/gh17422/warning.inc
+++ b/ext/opcache/tests/gh17422/warning.inc
@@ -1,0 +1,8 @@
+<?php
+function warning() {
+    switch (1) {
+        case 1:
+            echo "OK: ", __FUNCTION__, PHP_EOL;
+            continue;
+    }
+}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1355,11 +1355,11 @@ static void zend_accel_persist_class_table(HashTable *class_table)
 
 zend_error_info **zend_persist_warnings(uint32_t num_warnings, zend_error_info **warnings) {
 	if (warnings) {
-		warnings = zend_shared_memdup_free(warnings, num_warnings * sizeof(zend_error_info *));
+		warnings = zend_shared_memdup(warnings, num_warnings * sizeof(zend_error_info *));
 		for (uint32_t i = 0; i < num_warnings; i++) {
-			warnings[i] = zend_shared_memdup_free(warnings[i], sizeof(zend_error_info));
 			zend_accel_store_string(warnings[i]->filename);
 			zend_accel_store_string(warnings[i]->message);
+			warnings[i] = zend_shared_memdup(warnings[i], sizeof(zend_error_info));
 		}
 	}
 	return warnings;

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2054,6 +2054,7 @@ function generate_tmp_php_ini()
 
 				/* Fallback is implied, if filecache is enabled. */
 				INI.WriteLine("opcache.file_cache=" + dir);
+				INI.WriteLine("opcache.record_warnings=1");
 				INI.WriteLine("opcache.enable=1");
 				INI.WriteLine("opcache.enable_cli=1");
 			}


### PR DESCRIPTION
Possible fix for GH-17422
Based on https://github.com/php/php-src/pull/17627

### Current behavior

Currently, Opcache disables the user-defined error handler during compilation. When `opcache.record_errors` is enabled, errors are replayed when loading the script from cache later, this time without disabling the user-defined error handler.

### Changes

This PR makes the following changes:

Errors emitted during compilation are delayed and handled after compilation, when it's safe to execute user-defined error handlers. As before, when `opcache.record_errors` is enabled, errors are also replayed when loading the script from cache and user-defined error handler are called, if any.

This is done by changing the `EG(record_errors)` mechanism so that errors are not only recorded, but also delayed.

Class linking:

Since class linking uses the same mechanism, errors emitted during class linking are also delayed (with Opcache), and replayed after linking. Exceptions thrown by user-defined error handlers are not promoted to fatal errors anymore (when opcache is enabled).

Fatal errors:

Fatal errors are not safe to delay, so they are always processed immediately. Any delayed errors are also processed, but unfortunately it's not safe to execute user-defined error handlers at this point, so these errors still bypass them.

### Notes

This targets master because of the behavior changes.

We could apply the same behavior when opcache is disabled. (Edit: done)

UPGRADING draft:

```
Core:
 * Errors emitted during compilation and class linking are now handled
   after compilation or class linking. However, fatal errors emitted during
   compilation or class linking cause any delayed error to be handled
   immediately, without calling user-defined error handlers.
 * Exceptions thrown by user-defined error handlers during class linking
   are not promoted to fatal errors anymore and do not prevent linking.
```