### PR TITLE
Allow Closures to reuse their run_time_cache when opcache is enabled

### DIFF
--- a/Zend/tests/closures/closure_069.phpt
+++ b/Zend/tests/closures/closure_069.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Closure: Binding + RT cache edge cases
+--FILE--
+<?php
+
+// cache_size may be zero
+$f = function () {};
+$f();
+$g = $f->bindTo(new class {});
+
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -733,10 +733,29 @@ static ZEND_NAMED_FUNCTION(zend_closure_internal_handler) /* {{{ */
 }
 /* }}} */
 
+static zend_class_entry *zend_closure_rt_cache_scope(zend_function *func, void **run_time_cache, bool is_fake, zend_class_entry *default_scope)
+{
+	ZEND_ASSERT(!(func->op_array.fn_flags & ZEND_ACC_HEAP_RT_CACHE));
+
+	if (is_fake) {
+		return func->op_array.scope;
+	}
+
+	/* Zero RT cache is valid for any scope */
+	if (func->op_array.cache_size == 0) {
+		return default_scope;
+	}
+
+	ZEND_ASSERT(func->common.fn_flags & ZEND_ACC_CLOSURE);
+	ZEND_ASSERT(!(func->common.fn_flags & ZEND_ACC_FAKE_CLOSURE));
+
+	return CACHED_PTR_EX(run_time_cache - 1);
+}
+
 static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_entry *scope, zend_class_entry *called_scope, zval *this_ptr, bool is_fake) /* {{{ */
 {
 	zend_closure *closure;
-	void *ptr;
+	void **ptr;
 
 	object_init_ex(res, zend_ce_closure);
 
@@ -777,19 +796,22 @@ static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_en
 		/* Runtime cache is scope-dependent, so we cannot reuse it if the scope changed */
 		ptr = ZEND_MAP_PTR_GET(func->op_array.run_time_cache);
 		if (!ptr
-			|| func->common.scope != scope
 			|| (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE)
+			|| zend_closure_rt_cache_scope(func, ptr, is_fake, scope) != scope
 		) {
-			if (!ptr
-			 && (func->common.fn_flags & ZEND_ACC_CLOSURE)
-			 && (func->common.scope == scope ||
-			     !(func->common.fn_flags & ZEND_ACC_IMMUTABLE))) {
+			if (func->op_array.cache_size == 0) {
+				ptr = zend_arena_alloc(&CG(arena), 0);
+				ZEND_MAP_PTR_SET(func->op_array.run_time_cache, ptr);
+				closure->func.op_array.fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
+			} else if (!ptr
+			 && func->common.fn_flags & ZEND_ACC_CLOSURE) {
+				ZEND_ASSERT(!(func->common.fn_flags & ZEND_ACC_FAKE_CLOSURE));
 				/* If a real closure is used for the first time, we create a shared runtime cache
-				 * and remember which scope it is for. */
-				if (func->common.scope != scope) {
-					func->common.scope = scope;
-				}
-				ptr = zend_arena_alloc(&CG(arena), func->op_array.cache_size);
+				 * and remember which scope it is for. The scope is stored in
+				 * an extra slot before the run_time_cache. */
+				size_t extra_slot_size = sizeof(void*);
+				ptr = zend_arena_alloc(&CG(arena), func->op_array.cache_size + extra_slot_size) + extra_slot_size;
+				CACHE_PTR_EX(ptr - 1, scope);
 				ZEND_MAP_PTR_SET(func->op_array.run_time_cache, ptr);
 				closure->func.op_array.fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
 			} else {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8306,12 +8306,6 @@ static zend_op_array *zend_compile_func_decl_ex(
 
 	if (decl->kind == ZEND_AST_CLOSURE || decl->kind == ZEND_AST_ARROW_FUNC) {
 		op_array->fn_flags |= ZEND_ACC_CLOSURE;
-		/* Set the closure scope at compile time as an optimization to
-		 * prevent creating a separate runtime cache for every initialization
-		 * of this closure. Most closures are expected not to change their
-		 * scope in practice.
-		 */
-		op_array->scope = CG(active_class_entry);
 	}
 
 	if (is_hook) {
@@ -8467,6 +8461,15 @@ static zend_op_array *zend_compile_func_decl_ex(
 
 	/* Pop the loop variable stack separator */
 	zend_stack_del_top(&CG(loop_var_stack));
+
+	if (op_array->fn_flags & ZEND_ACC_CLOSURE) {
+		/* Set the closure scope at compile time as an optimization to
+		 * prevent creating a separate runtime cache for every initialization
+		 * of this closure. Most closures are expected not to change their
+		 * scope in practice.
+		 */
+		op_array->scope = CG(active_class_entry);
+	}
 
 	if (level == FUNC_DECL_LEVEL_TOPLEVEL) {
 		zend_observer_function_declared_notify(op_array, lcname);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8462,15 +8462,6 @@ static zend_op_array *zend_compile_func_decl_ex(
 	/* Pop the loop variable stack separator */
 	zend_stack_del_top(&CG(loop_var_stack));
 
-	if (op_array->fn_flags & ZEND_ACC_CLOSURE) {
-		/* Set the closure scope at compile time as an optimization to
-		 * prevent creating a separate runtime cache for every initialization
-		 * of this closure. Most closures are expected not to change their
-		 * scope in practice.
-		 */
-		op_array->scope = CG(active_class_entry);
-	}
-
 	if (level == FUNC_DECL_LEVEL_TOPLEVEL) {
 		zend_observer_function_declared_notify(op_array, lcname);
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8306,6 +8306,12 @@ static zend_op_array *zend_compile_func_decl_ex(
 
 	if (decl->kind == ZEND_AST_CLOSURE || decl->kind == ZEND_AST_ARROW_FUNC) {
 		op_array->fn_flags |= ZEND_ACC_CLOSURE;
+		/* Set the closure scope at compile time as an optimization to
+		 * prevent creating a separate runtime cache for every initialization
+		 * of this closure. Most closures are expected not to change their
+		 * scope in practice.
+		 */
+		op_array->scope = CG(active_class_entry);
 	}
 
 	if (is_hook) {

--- a/ext/zend_test/tests/observer_closure_04.phpt
+++ b/ext/zend_test/tests/observer_closure_04.phpt
@@ -1,0 +1,126 @@
+--TEST--
+Observer: Closures keep their runtime cache when not rebinding
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+class Foo {
+  private static $value = "x";
+  function static() {
+    (static function () {
+      echo Foo::$value, PHP_EOL;
+    })();
+  }
+  function non_static() {
+    (function () {
+      echo Foo::$value, PHP_EOL;
+    })();
+  }
+  function rebind() {
+    ((function () {
+      try {
+        echo Foo::$value, PHP_EOL;
+      } catch (Error $e) {
+        echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+      }
+    })->bindTo(null, null))();
+  }
+}
+
+$obj = new Foo();
+$obj->static();
+$obj->static();
+$obj->non_static();
+$obj->non_static();
+$obj->rebind();
+$obj->rebind();
+
+$closure = function () {
+  echo Foo::$value, PHP_EOL;
+};
+
+($closure->bindTo(null, Foo::class))();
+($closure->bindTo(null, Foo::class))();
+
+$boundClosure = $closure->bindTo(null, Foo::class);
+$boundClosure();
+$boundClosure();
+
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init Foo::static() -->
+  <Foo::static>
+    <!-- init Foo::{closure:Foo::static():6}() -->
+    <Foo::{closure:Foo::static():6}>
+x
+    </Foo::{closure:Foo::static():6}>
+  </Foo::static>
+  <Foo::static>
+    <Foo::{closure:Foo::static():6}>
+x
+    </Foo::{closure:Foo::static():6}>
+  </Foo::static>
+  <!-- init Foo::non_static() -->
+  <Foo::non_static>
+    <!-- init Foo::{closure:Foo::non_static():11}() -->
+    <Foo::{closure:Foo::non_static():11}>
+x
+    </Foo::{closure:Foo::non_static():11}>
+  </Foo::non_static>
+  <Foo::non_static>
+    <Foo::{closure:Foo::non_static():11}>
+x
+    </Foo::{closure:Foo::non_static():11}>
+  </Foo::non_static>
+  <!-- init Foo::rebind() -->
+  <Foo::rebind>
+    <!-- init Closure::bindTo() -->
+    <Closure::bindTo>
+    </Closure::bindTo>
+    <!-- init {closure:Foo::rebind():16}() -->
+    <{closure:Foo::rebind():16}>
+Error:       <!-- init Error::getMessage() -->
+      <Error::getMessage>
+      </Error::getMessage>
+Cannot access private property Foo::$value
+    </{closure:Foo::rebind():16}>
+  </Foo::rebind>
+  <Foo::rebind>
+    <Closure::bindTo>
+    </Closure::bindTo>
+    <!-- init {closure:Foo::rebind():16}() -->
+    <{closure:Foo::rebind():16}>
+Error:       <Error::getMessage>
+      </Error::getMessage>
+Cannot access private property Foo::$value
+    </{closure:Foo::rebind():16}>
+  </Foo::rebind>
+  <Closure::bindTo>
+  </Closure::bindTo>
+  <!-- init Foo::{closure:%s:%d}() -->
+  <Foo::{closure:%s:%d}>
+x
+  </Foo::{closure:%s:%d}>
+  <Closure::bindTo>
+  </Closure::bindTo>
+  <!-- init Foo::{closure:%s:%d}() -->
+  <Foo::{closure:%s:%d}>
+x
+  </Foo::{closure:%s:%d}>
+  <Closure::bindTo>
+  </Closure::bindTo>
+  <!-- init Foo::{closure:%s:%d}() -->
+  <Foo::{closure:%s:%d}>
+x
+  </Foo::{closure:%s:%d}>
+  <Foo::{closure:%s:%d}>
+x
+  </Foo::{closure:%s:%d}>
+</file '%s'>


### PR DESCRIPTION
Possible alternative fix for GH-10782

This implements the approach described in https://github.com/php/php-src/issues/10782#issuecomment-1458132038:
> may be storing "scope" in the first slot of the closure's run_time_cache

Unfortunately this results in a small regression on the Symfony benchmark (0.20% wall time, 0.03% icount).

