### PR TITLE
Fix swapped variables

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1107,13 +1107,13 @@ do_repeat:
 		case PHP_CLI_MODE_SHOW_INI_CONFIG:
 			{
 				zend_printf("Configuration File (php.ini) Path: \"%s\"\n", PHP_CONFIG_FILE_PATH);
-				if (php_ini_scanned_path) {
-					zend_printf("Loaded Configuration File:         \"%s\"\n", php_ini_scanned_path);
+				if (php_ini_opened_path) {
+					zend_printf("Loaded Configuration File:         \"%s\"\n", php_ini_opened_path);
 				} else {
 					zend_printf("Loaded Configuration File:         (none)\n");
 				}
-				if (php_ini_opened_path) {
-					zend_printf("Scan for additional .ini files in: \"%s\"\n", php_ini_opened_path);
+				if (php_ini_scanned_path) {
+					zend_printf("Scan for additional .ini files in: \"%s\"\n", php_ini_scanned_path);
 				} else {
 					zend_printf("Scan for additional .ini files in: (none)\n");
 				}


### PR DESCRIPTION
In #18527, I accidentally swapped the values. This is before my modification:

```
zend_printf("Configuration File (php.ini) Path: %s\n", PHP_CONFIG_FILE_PATH);
zend_printf("Loaded Configuration File:         %s\n", php_ini_opened_path ? php_ini_opened_path : "(none)");
zend_printf("Scan for additional .ini files in: %s\n", php_ini_scanned_path  ? php_ini_scanned_path : "(none)");
```

- "Loaded Configuration File" should be `php_ini_opened_path`
- "Scan for additional .ini files in" shoudl be `php_ini_scanned_path`