### PR TITLE
allow ldap_get_option to retrieve global option

### DIFF
--- a/ext/ldap/ldap.stub.php
+++ b/ext/ldap/ldap.stub.php
@@ -740,7 +740,7 @@ namespace {
     function ldap_rename_ext(LDAP\Connection $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAP\Result|false {}
 
     /** @param array|string|int $value */
-    function ldap_get_option(LDAP\Connection $ldap, int $option, &$value = null): bool {}
+    function ldap_get_option(?LDAP\Connection $ldap, int $option, &$value = null): bool {}
 
     /** @param array|string|int|bool $value */
     function ldap_set_option(?LDAP\Connection $ldap, int $option, $value): bool {}

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7415695a7ae90e6abd45617baf8a9ecf9232b801 */
+ * Stub hash: edd31d6c19c01bee6ddb04c747640c97f0bacba6 */
 
 #if defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\Connection, MAY_BE_FALSE)
@@ -217,7 +217,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAP\
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_option, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 1)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, value, "null")
 ZEND_END_ARG_INFO()

--- a/ext/ldap/tests/ldap_get_option_package_basic.phpt
+++ b/ext/ldap/tests/ldap_get_option_package_basic.phpt
@@ -7,6 +7,10 @@ ldap
 --FILE--
 <?php
 require "connect.inc";
+
+$result = ldap_get_option(NULL, LDAP_OPT_X_TLS_PACKAGE, $optionval);
+var_dump(in_array($optionval, ['GnuTLS', 'OpenSSL', 'MozNSS']));
+
 $link = ldap_connect($uri);
 
 $result = ldap_get_option($link, LDAP_OPT_X_TLS_PACKAGE, $optionval);
@@ -14,4 +18,5 @@ var_dump(in_array($optionval, ['GnuTLS', 'OpenSSL', 'MozNSS']));
 
 ?>
 --EXPECT--
+bool(true)
 bool(true)

--- a/ext/ldap/tests/ldap_start_tls_basic2.phpt
+++ b/ext/ldap/tests/ldap_start_tls_basic2.phpt
@@ -1,0 +1,36 @@
+--TEST--
+ldap_start_tls() - Basic ldap_start_tls test with TLS_CACERTFILE
+--EXTENSIONS--
+ldap
+--SKIPIF--
+<?php
+require_once __DIR__ .'/skipifbindfailure.inc'; 
+if (!ldap_get_option(NULL, LDAP_OPT_X_TLS_CACERTFILE, $val)) die('skip missing TLS_CACERTFILE');
+?>
+--FILE--
+<?php
+require_once "connect.inc";
+
+// CI uses self signed certificate
+
+// No cert option
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_start_tls($link));
+
+// No cert check
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+ldap_set_option($link, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER);
+var_dump(@ldap_start_tls($link));
+
+// With cert check
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+ldap_set_option($link, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_DEMAND);
+var_dump(@ldap_start_tls($link));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/ext/ldap/tests/ldaps_basic2.phpt
+++ b/ext/ldap/tests/ldaps_basic2.phpt
@@ -1,0 +1,56 @@
+--TEST--
+ldap_connect() - Basic ldaps test with TLS_CACERTFILE
+--EXTENSIONS--
+ldap
+--SKIPIF--
+<?php
+require_once __DIR__ .'/skipifbindfailure.inc'; 
+if (!ldap_get_option(NULL, LDAP_OPT_X_TLS_CACERTFILE, $val)) die('skip missing TLS_CACERTFILE');
+?>
+--FILE--
+<?php
+require_once "connect.inc";
+
+$uri = "ldaps://$host:636";
+
+// CI uses self signed certificate
+
+// No cert option
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_bind($link, $user, $passwd));
+ldap_unbind($link);
+
+// No cert check
+ldap_set_option(null, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_ALLOW);
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_bind($link, $user, $passwd));
+ldap_unbind($link);
+
+// No change to TLS options
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_bind($link, $user, $passwd));
+ldap_unbind($link);
+
+// With cert check
+ldap_set_option(null, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_DEMAND);
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_bind($link, $user, $passwd));
+ldap_unbind($link);
+
+// No change to TLS options
+$link = ldap_connect($uri);
+ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
+var_dump(@ldap_bind($link, $user, $passwd));
+ldap_unbind($link);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Allow `NULL` for `LDAP\Connection` for global options retrival
This makes `ldap_get_option` consistent `with ldap_set_option`

Also add more ldaps/tls tests with TLS_CACERTFILE
to improve coverage after #18529