### PR TITLE
Do not exit to VM when setting undefined prop in constructor

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14971,8 +14971,9 @@ static int zend_jit_assign_obj(zend_jit_ctx         *jit,
 			ZEND_ASSERT(slow_inputs == IR_UNUSED);
 			goto slow_path;
 		}
+
 		// Undefined property with potential magic __get()/__set() or lazy object
-		if (JIT_G(trigger) == ZEND_JIT_ON_HOT_TRACE) {
+		if (JIT_G(trigger) == ZEND_JIT_ON_HOT_TRACE && prop_type != IS_UNDEF) {
 			int32_t exit_point = zend_jit_trace_get_exit_point(opline, ZEND_JIT_EXIT_TO_VM);
 			const void *exit_addr = zend_jit_trace_get_exit_addr(exit_point);
 


### PR DESCRIPTION
JIT'ed `ASSIGN_OBJ` expressions will exit to VM when the prop is undef. However, in a constructor it's very likely the case. Therefore most traces with `new` expressions will exit to VM:

```
<?php

class Foo {
    public function __construct(public int $a) {}
}

for ($i = 0; $i < 100; $i++) {
    new Foo($i);
}
```

```
---- TRACE 1 start (loop) $main() test.php:7
0007 T1 = IS_SMALLER CV0($i) int(100) ; op1(int)
0008 ;JMPNZ T1 0002
0002 V1 = NEW 1 string("Foo")
     >init Foo::__construct
0003 SEND_VAR CV0($i) 1 ; op1(int)
0004 DO_FCALL
     >enter Foo::__construct
0000  CV0($a) = RECV 1
0001  ASSIGN_OBJ THIS string("a") ; op3(int) val(undef)
0002  ;OP_DATA CV0($a)
0003  RETURN null
     <back test.php
0005 FREE V1 ; op1(object of class Foo)
0006 PRE_INC CV0($i) ; op1(int)
---- TRACE 1 stop (loop)
---- TRACE 1 compiled

     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
     TRACE 1 exit 3 Foo::__construct() test.php:4
---- EXIT 1/3 blacklisted
```

Here I ensure that we don't need to exit to VM when it's likely that the prop will be undef.

In the function JIT we compile a slow path to handle such properties, but not in the tracing JIT, assumingly to reduce code size. Here I enable compilation of the slow path in the tracing JIT when it's likely the prop will be undef. Quite conveniently we already record the prop type during tracing, so I use that to make the decision.

This results in a 1.20% wall time improvement on the symfony demo benchmark with 20 warmup requests.