### PR TITLE
GH-18572: infinite stack recursion in fallback object comparison.

### DIFF
--- a/Zend/tests/gh18519.phpt
+++ b/Zend/tests/gh18519.phpt
@@ -3,6 +3,8 @@ GH-18519: Nested object comparison leading to stack overflow
 --FILE--
 <?php
 
+error_reporting(E_ALL & ~E_DEPRECATED);
+
 class Node {
     public $next;
     // forcing dynamic property creation is key

--- a/Zend/tests/gh18519.phpt
+++ b/Zend/tests/gh18519.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-18519: Nested object comparison leading to stack overflow
+--FILE--
+<?php
+
+class Node {
+    public $next;
+    // forcing dynamic property creation is key
+}
+
+$first = new Node();
+$first->previous = $first;
+$first->next = $first;
+
+$cur = $first;
+
+for ($i = 0; $i < 50000; $i++) {
+    $new = new Node();
+    $new->previous = $cur;
+    $cur->next = $new;
+    $new->next = $first;
+    $first->previous = $new;
+    $cur = $new;
+}
+
+try {
+	// Force comparison manually to trigger zend_hash_compare
+	$first == $cur;
+} catch(Error $e) {
+	echo $e->getMessage(). PHP_EOL;
+}
+?>
+--EXPECT--
+Object compare - stack limit reached

--- a/Zend/tests/gh18519.phpt
+++ b/Zend/tests/gh18519.phpt
@@ -7,8 +7,7 @@ if (getenv('SKIP_ASAN')) die('skip as it fatally crash');
 --FILE--
 <?php
 
-error_reporting(E_ALL & ~E_DEPRECATED);
-
+#[AllowDynamicProperties]
 class Node {
     public $next;
     // forcing dynamic property creation is key
@@ -37,4 +36,4 @@ try {
 }
 ?>
 --EXPECTREGEX--
-(Object compare - stack limit reached|Fatal error: Nesting level too deep - recursive dependency?.+)
+(Maximum call stack size reached during object comparison|Fatal error: Nesting level too deep - recursive dependency?.+)

--- a/Zend/tests/gh18519.phpt
+++ b/Zend/tests/gh18519.phpt
@@ -1,5 +1,9 @@
 --TEST--
 GH-18519: Nested object comparison leading to stack overflow
+--SKIPIF--
+<?php
+if (getenv('SKIP_ASAN')) die('skip as it fatally crash');
+?>
 --FILE--
 <?php
 
@@ -32,5 +36,5 @@ try {
 	echo $e->getMessage(). PHP_EOL;
 }
 ?>
---EXPECT--
-Object compare - stack limit reached
+--EXPECTREGEX--
+(Object compare - stack limit reached|Fatal error: Nesting level too deep - recursive dependency?.+)

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1724,7 +1724,7 @@ ZEND_API int zend_std_compare_objects(zval *o1, zval *o2) /* {{{ */
 	zend_object *zobj1, *zobj2;
 
 	if (zend_objects_check_stack_limit()) {
-		zend_throw_error(NULL, "Object compare - stack limit reached");
+		zend_throw_error(NULL, "Maximum call stack size reached during object comparison");
 		return ZEND_UNCOMPARABLE;
 	}
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -42,6 +42,15 @@
 #define IN_UNSET	ZEND_GUARD_PROPERTY_UNSET
 #define IN_ISSET	ZEND_GUARD_PROPERTY_ISSET
 
+static zend_always_inline bool zend_objects_check_stack_limit(void)
+{
+#ifdef ZEND_CHECK_STACK_LIMIT
+	return zend_call_stack_overflowed(EG(stack_limit));
+#else
+	return false;
+#endif
+}
+
 /*
   __X accessors explanation:
 
@@ -1713,6 +1722,11 @@ ZEND_API zend_function *zend_std_get_constructor(zend_object *zobj) /* {{{ */
 ZEND_API int zend_std_compare_objects(zval *o1, zval *o2) /* {{{ */
 {
 	zend_object *zobj1, *zobj2;
+
+	if (zend_objects_check_stack_limit()) {
+		zend_throw_error(NULL, "Object compare - stack limit reached");
+		return ZEND_UNCOMPARABLE;
+	}
 
 	if (Z_TYPE_P(o1) != Z_TYPE_P(o2)) {
 		/* Object and non-object */


### PR DESCRIPTION
With nested objects and recursive comparisons, it is for now unavoidable to have a stack overflow we do some early damage control attempt early on with zend.max_allowed_stack_size check but ultimately more a band-aid than a definitive solution.