### PR TITLE
Only quote `php --ini` values when out is a tty

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,9 @@ PHP                                                                        NEWS
   . Drop support for -z CLI/CGI flag. (nielsdos)
   . Fixed GH-17956 - development server 404 page does not adapt to mobiles.
     (pascalchevrel)
+  . Changed `php --ini` to quotes some values with double quotes, to
+    help humans debug unexpected whitespace, when stdout is a tty.
+    (schneems)
 
 - CURL:
   . Added CURLFOLLOW_ALL, CURLFOLLOW_OBEYCODE and CURLFOLLOW_FIRSTONLY

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1106,17 +1106,29 @@ do_repeat:
 
 		case PHP_CLI_MODE_SHOW_INI_CONFIG:
 			{
-				zend_printf("Configuration File (php.ini) Path: \"%s\"\n", PHP_CONFIG_FILE_PATH);
-				if (php_ini_opened_path) {
-					zend_printf("Loaded Configuration File:         \"%s\"\n", php_ini_opened_path);
-				} else {
-					zend_printf("Loaded Configuration File:         (none)\n");
-				}
-				if (php_ini_scanned_path) {
-					zend_printf("Scan for additional .ini files in: \"%s\"\n", php_ini_scanned_path);
-				} else {
-					zend_printf("Scan for additional .ini files in: (none)\n");
-				}
+				int is_tty = 0;
+				#ifdef HAVE_UNISTD_H
+					is_tty = isatty(STDOUT_FILENO);
+				#elif defined(PHP_WIN32)
+					is_tty = php_win32_consofileno_is_console(STDOUT_FILENO) && php_win32_console_fileno_has_vt100(STDOUT_FILENO);
+				#endif
+				char *quote = is_tty ? "\"" : "";
+
+				zend_printf("Configuration File (php.ini) Path: %s%s%s\n",
+					quote,
+					PHP_CONFIG_FILE_PATH,
+					quote
+				);
+				zend_printf("Loaded Configuration File:         %s%s%s\n",
+					php_ini_opened_path ? quote : "",
+					php_ini_opened_path ? php_ini_opened_path : "(none)",
+					php_ini_opened_path ? quote : ""
+				);
+				zend_printf("Scan for additional .ini files in: %s%s%s\n",
+					php_ini_scanned_path ? quote : "",
+					php_ini_scanned_path ? php_ini_scanned_path : "(none)",
+					php_ini_scanned_path ? quote : ""
+				);
 				zend_printf("Additional .ini files parsed:      %s\n", php_ini_scanned_files ? php_ini_scanned_files : "(none)");
 				break;
 			}


### PR DESCRIPTION
A comment in #18527 mentioned that many scripts use `php—-ini` to bootstrap information about the system. Searching on GitHub confirms that many places will not work with quotes out of the box: https://github.com/search?q=content%3A%22php%20--ini%22&type=code.

Many seem to be variants on this pattern

```
$ echo "extension=mongodb.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
```

To preserve these existing scripts, we can detect when the output is a TTY to optionally quote them. This is the new behavior:

Output is a tty:

```
$ make -j$(nproc) &> /dev/null && env PHP_INI_SCAN_DIR="/opt/homebrew/etc/php/8.4/conf.d         " PHPRC="/opt/homebrew/etc/php/8.4" ./sapi/cli/php --ini
Configuration File (php.ini) Path: "/usr/local/lib"
Loaded Configuration File:         "/opt/homebrew/etc/php/8.4/php.ini"
Scan for additional .ini files in: "/opt/homebrew/etc/php/8.4/conf.d         "
Additional .ini files parsed:      (none)
```

Output is not a tty:

```
$ make -j$(nproc) &> /dev/null && env PHP_INI_SCAN_DIR="/opt/homebrew/etc/php/8.4/conf.d         " PHPRC="/opt/homebrew/etc/php/8.4" ./sapi/cli/php --ini | tee
Configuration File (php.ini) Path: /usr/local/lib
Loaded Configuration File:         /opt/homebrew/etc/php/8.4/php.ini
Scan for additional .ini files in: /opt/homebrew/etc/php/8.4/conf.d
Additional .ini files parsed:      (none)
```