### PR TITLE
Remove ZEND_ACC_USE_GUARDS from hooks

### DIFF
--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2983,7 +2983,6 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 						hooks[j] = new_fn;
 					}
 				}
-				ce->ce_flags |= ZEND_ACC_USE_GUARDS;
 			}
 		} ZEND_HASH_FOREACH_END();
 	}


### PR DESCRIPTION
This is no longer necessary since the hooks amendments removed guards for recursion.