### PR TITLE
Fix leak of accel_globals->key

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2964,9 +2964,7 @@ static void accel_globals_ctor(zend_accel_globals *accel_globals)
 
 static void accel_globals_dtor(zend_accel_globals *accel_globals)
 {
-#ifdef ZTS
 	zend_string_free(accel_globals->key);
-#endif
 	if (accel_globals->preloaded_internal_run_time_cache) {
 		pefree(accel_globals->preloaded_internal_run_time_cache, 1);
 	}


### PR DESCRIPTION
I don't know why this was guarded with ZTS, but it leaks on this test (and a few more):
`./sapi/cli/php ./run-tests.php -c . --show-diff sapi/phpdbg/tests/stdin_001.phpt`

The same issue exists on 8.3 but needs a bit of a different fix, which I'll do after this is approved.