### PR TITLE
Fix deprecation warning for libxml SAX header

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -22,7 +22,6 @@
 #include "php.h"
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
-#include <libxml/SAX.h>
 #include <libxml/xmlsave.h>
 #ifdef LIBXML_SCHEMAS_ENABLED
 #include <libxml/relaxng.h>


### PR DESCRIPTION
This header is deprecated, but fortunately it isn't actually used.