### PR TITLE
Fix GH-17687: initializer-string for array of ... warnings

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -737,6 +737,12 @@ extern "C++" {
 # define ZEND_INDIRECT_RETURN
 #endif
 
+#if __has_attribute(nonstring)
+# define ZEND_NONSTRING __attribute__((nonstring))
+#else
+# define ZEND_NONSTRING
+#endif
+
 #define __ZEND_DO_PRAGMA(x) _Pragma(#x)
 #define _ZEND_DO_PRAGMA(x) __ZEND_DO_PRAGMA(x)
 #if defined(__clang__)

--- a/ext/pdo/pdo_sqlstate.c
+++ b/ext/pdo/pdo_sqlstate.c
@@ -25,7 +25,7 @@
 #include "php_pdo_driver.h"
 
 struct pdo_sqlstate_info {
-	const char state[5];
+	const char state[5] ZEND_NONSTRING;
 	const char *desc;
 };
 

--- a/ext/standard/crypt_sha256.c
+++ b/ext/standard/crypt_sha256.c
@@ -318,7 +318,7 @@ static const char sha256_rounds_prefix[] = "rounds=";
 #define ROUNDS_MAX 999999999
 
 /* Table with characters for base64 transformation.  */
-static const char b64t[64] =
+static const char b64t[64] ZEND_NONSTRING =
 "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 char * php_sha256_crypt_r(const char *key, const char *salt, char *buffer, int buflen)

--- a/ext/standard/crypt_sha512.c
+++ b/ext/standard/crypt_sha512.c
@@ -351,7 +351,7 @@ static const char sha512_rounds_prefix[] = "rounds=";
 #define ROUNDS_MAX 999999999
 
 /* Table with characters for base64 transformation.  */
-static const char b64t[64] =
+static const char b64t[64] ZEND_NONSTRING =
 "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 


### PR DESCRIPTION
Starting with gcc 15 the warning `-Wunterminated-string-initialization` is enabled by default. We make now use of the `nonstring` attribute to silence the warning for the cases where this is intended. This is targeted to 8.3 because of the people who compile with -Werror.

Upon merging up I'll handle ext/fileinfo too.
Lexbor should get fixed upstream.