### PR TITLE
Add missing checks for php_crc32_stream_bulk_update() in phar

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -2799,7 +2799,16 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 			return EOF;
 		}
 		newcrc32 = php_crc32_bulk_init();
-		php_crc32_stream_bulk_update(&newcrc32, file, entry->uncompressed_filesize);
+		if (php_crc32_stream_bulk_update(&newcrc32, file, entry->uncompressed_filesize) != SUCCESS) {
+			if (closeoldfile) {
+				php_stream_close(oldfile);
+			}
+			php_stream_close(newfile);
+			if (error) {
+				spprintf(error, 0, "unable to read file \"%s\" for crc32 while creating new phar \"%s\"", entry->filename, phar->fname);
+			}
+			return EOF;
+		}
 		entry->crc32 = php_crc32_bulk_end(newcrc32);
 		entry->is_crc_checked = 1;
 		if (!(entry->flags & PHAR_ENT_COMPRESSION_MASK)) {

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -937,7 +937,10 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		efp = phar_get_efp(entry, 0);
 		newcrc32 = php_crc32_bulk_init();
 
-		php_crc32_stream_bulk_update(&newcrc32, efp, entry->uncompressed_filesize);
+		if (php_crc32_stream_bulk_update(&newcrc32, efp, entry->uncompressed_filesize) != SUCCESS) {
+			spprintf(p->error, 0, "unable to read file \"%s\" for crc32 in zip-based phar \"%s\"", entry->filename, entry->phar->fname);
+			return ZEND_HASH_APPLY_STOP;
+		}
 
 		entry->crc32 = php_crc32_bulk_end(newcrc32);
 		PHAR_SET_32(central.uncompsize, entry->uncompressed_filesize);


### PR DESCRIPTION
Found with the help of my static analyzer ESSS