### PR TITLE
Fix Alpine build

### DIFF
--- a/main/php_glob.h
+++ b/main/php_glob.h
@@ -111,11 +111,6 @@
 #else
 
 #include "php.h"
-
-#ifndef PHP_WIN32
-# include <sys/cdefs.h>
-#endif
-
 #include "Zend/zend_stream.h"
 
 typedef struct {


### PR DESCRIPTION
We're not allowed to include the sys/cdefs.h header on alpine, but it seems we don't even need this in the first place. So drop it.