### PR TITLE
Fix GH-18617: socket_import_file_descriptor return check.

### DIFF
--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1457,7 +1457,10 @@ void to_zval_read_fd_array(const char *data, zval *zv, res_context *ctx)
 			object_init_ex(&elem, socket_ce);
 			php_socket *sock = Z_SOCKET_P(&elem);
 
-			socket_import_file_descriptor(fd, sock);
+			if (!socket_import_file_descriptor(fd, sock)) {
+				do_to_zval_err(ctx, "error getting protocol descriptor %d: getsockopt() call failed with errno %d", fd, errno);
+				return;
+			}
 		} else {
 			php_stream *stream = php_stream_fopen_from_fd(fd, "rw", NULL);
 			php_stream_to_zval(stream, &elem);

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1459,6 +1459,7 @@ void to_zval_read_fd_array(const char *data, zval *zv, res_context *ctx)
 
 			if (!socket_import_file_descriptor(fd, sock)) {
 				do_to_zval_err(ctx, "error getting protocol descriptor %d: getsockopt() call failed with errno %d", fd, errno);
+				zval_ptr_dtor(&elem);
 				return;
 			}
 		} else {


### PR DESCRIPTION
to_zval_read_fd_array() helper when retrieving the socket protocol did not check it.