### PR TITLE
Small change SIMD codes

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -65,9 +65,7 @@
 
 #include "rare_cp_bitvec.h"
 
-#ifdef __SSE2__
-#include <emmintrin.h>
-#endif
+#include "zend_simd.h"
 
 #ifdef __SSE3__
 #include <immintrin.h>
@@ -1749,7 +1747,7 @@ PHP_FUNCTION(mb_str_split)
 	}
 }
 
-#ifdef __SSE2__
+#ifdef XSSE2
 /* Thanks to StackOverflow user 'Paul R' (https://stackoverflow.com/users/253056/paul-r)
  * From: https://stackoverflow.com/questions/36998538/fastest-way-to-horizontally-sum-sse-unsigned-byte-vector
  * Takes a 128-bit XMM register, treats each byte as an 8-bit integer, and sums up all
@@ -1780,7 +1778,7 @@ static size_t mb_fast_strlen_utf8(unsigned char *p, size_t len)
 {
 	unsigned char *e = p + len;
 
-#ifdef __SSE2__
+#ifdef XSSE2
 	if (len >= sizeof(__m128i)) {
 		e -= sizeof(__m128i);
 
@@ -4919,7 +4917,7 @@ MBSTRING_API bool php_mb_check_encoding(const char *input, size_t length, const 
 static bool mb_fast_check_utf8_default(zend_string *str)
 {
 	unsigned char *p = (unsigned char*)ZSTR_VAL(str);
-# ifdef __SSE2__
+# ifdef XSSE2
 	/* `e` points 1 byte past the last full 16-byte block of string content
 	 * Note that we include the terminating null byte which is included in each zend_string
 	 * as part of the content to check; this ensures that multi-byte characters which are

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -67,11 +67,6 @@
 
 #include "zend_simd.h"
 
-#ifdef __SSE3__
-#include <immintrin.h>
-#include <pmmintrin.h>
-#endif
-
 /* }}} */
 
 /* {{{ prototypes */

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -27,10 +27,7 @@
 #include "zend_shared_alloc.h"
 #include "zend_observer.h"
 
-#ifdef __SSE2__
-/* For SSE2 adler32 */
-#include <immintrin.h>
-#endif
+#include "zend_simd.h"
 
 typedef int (*id_function_t)(void *, void *);
 typedef void (*unique_copy_ctor_func_t)(void *pElement);
@@ -466,7 +463,7 @@ static zend_always_inline void adler32_do16_loop(unsigned char *buf, unsigned ch
 	unsigned int s1 = *s1_out;
 	unsigned int s2 = *s2_out;
 
-#ifdef __SSE2__
+#ifdef XSSE2
 	const __m128i zero = _mm_setzero_si128();
 
 	__m128i accumulate_s2 = zero;


### PR DESCRIPTION
That convert the SSE2 API to NEON using `zend_simd.h`, enabling the use of SIMD in a NEON environment.