### PR TITLE
Fix build on Apple Clang 17+

### DIFF
--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -126,58 +126,86 @@ ZEND_API int zend_cpu_supports(zend_cpu_feature feature);
  * functions */
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse2(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("sse2");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse3(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("sse3");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_ssse3(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("ssse3");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse41(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("sse4.1");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse42(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("sse4.2");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_avx(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("avx");
+#endif
 }
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_avx2(void) {
+#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+	return 0;
+#else
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif
 	return __builtin_cpu_supports("avx2");
+#endif
 }
 
 #if PHP_HAVE_AVX512_SUPPORTS

--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -126,7 +126,7 @@ ZEND_API int zend_cpu_supports(zend_cpu_feature feature);
  * functions */
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse2(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -138,7 +138,7 @@ static inline int zend_cpu_supports_sse2(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse3(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -150,7 +150,7 @@ static inline int zend_cpu_supports_sse3(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_ssse3(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -162,7 +162,7 @@ static inline int zend_cpu_supports_ssse3(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse41(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -174,7 +174,7 @@ static inline int zend_cpu_supports_sse41(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_sse42(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -186,7 +186,7 @@ static inline int zend_cpu_supports_sse42(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_avx(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT
@@ -198,7 +198,7 @@ static inline int zend_cpu_supports_avx(void) {
 
 ZEND_NO_SANITIZE_ADDRESS
 static inline int zend_cpu_supports_avx2(void) {
-#if (defined(__APPLE__) && defined(__aarch64__) && defined(__clang_major__) && __clang_major__ >= 17)
+#ifdef __aarch64__
 	return 0;
 #else
 #if PHP_HAVE_BUILTIN_CPU_INIT


### PR DESCRIPTION
After upgrading my Xcode version to the one that includes Apple Clang 17.0.0, I got the following compilation errors:

```
In file included from php-src/ext/hash/hash_sha.c:20:
php-src/Zend/zend_cpuinfo.h:133:9: error: invalid cpu feature string for builtin [-Werror]
  133 |         return __builtin_cpu_supports("sse2");
      |                ^                      ~~~~~~
php-src/Zend/zend_cpuinfo.h:141:9: error: invalid cpu feature string for builtin [-Werror]
  141 |         return __builtin_cpu_supports("sse3");
      |                ^                      ~~~~~~
php-src/Zend/zend_cpuinfo.h:149:9: error: invalid cpu feature string for builtin [-Werror]
  149 |         return __builtin_cpu_supports("ssse3");
      |                ^                      ~~~~~~~
php-src/Zend/zend_cpuinfo.h:157:9: error: invalid cpu feature string for builtin [-Werror]
  157 |         return __builtin_cpu_supports("sse4.1");
      |                ^                      ~~~~~~~~
php-src/Zend/zend_cpuinfo.h:165:9: error: invalid cpu feature string for builtin [-Werror]
  165 |         return __builtin_cpu_supports("sse4.2");
      |                ^                      ~~~~~~~~
php-src/Zend/zend_cpuinfo.h:173:9: error: invalid cpu feature string for builtin [-Werror]
  173 |         return __builtin_cpu_supports("avx");
      |                ^                      ~~~~~
php-src/Zend/zend_cpuinfo.h:181:9: error: invalid cpu feature string for builtin [-Werror]
  181 |         return __builtin_cpu_supports("avx2");
```

In order to fix the errors, I added some preprocessor conditions that skip calling `__builtin_cpu_supports` with the unsupported features on an Apple ARM when using Apple Clang.

Alternatively, I could have used a configure script based approach (probably similarly to https://github.com/php/php-src/blob/a191e7a4b145afd86e5c5caddc66772d007c9c08/build/php.m4#L2458), but I didn't really know how to implement a similar check there... So at last I sticked with the original, maybe less elegant solution.