### PR TITLE
Zend: introduce gcc strub attribute.

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -759,6 +759,14 @@ extern "C++" {
 # define ZEND_INDIRECT_RETURN
 #endif
 
+#if __has_attribute(strub)
+# define ZEND_STRUB __attribute__((strub))
+# define ZEND_STRUB_OPT(o) __attribute__((strub(o)))
+#else
+# define ZEND_STRUB
+# define ZEND_STRUB_OPT(o)
+#endif
+
 #define __ZEND_DO_PRAGMA(x) _Pragma(#x)
 #define _ZEND_DO_PRAGMA(x) __ZEND_DO_PRAGMA(x)
 #if defined(__clang__)

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -49,7 +49,7 @@ void php_password_algo_unregister(const char *ident) {
 static int php_password_salt_to64(const char *str, const size_t str_len, const size_t out_len, char *ret) /* {{{ */
 {
 	size_t pos = 0;
-	zend_string *buffer;
+	zend_string ZEND_STRUB *buffer;
 	if ((int) str_len < 0) {
 		return FAILURE;
 	}
@@ -76,7 +76,8 @@ static int php_password_salt_to64(const char *str, const size_t str_len, const s
 
 static zend_string* php_password_make_salt(size_t length) /* {{{ */
 {
-	zend_string *ret, *buffer;
+	zend_string *ret;
+	zend_string ZEND_STRUB *buffer;
 
 	if (length > (INT_MAX / 3)) {
 		zend_value_error("Length is too large to safely generate");


### PR DESCRIPTION
exists since gcc 14.x, allow to zero stack/pointer local variables,
 a call or a callable (function pointers).