### PR TITLE
Drop FIXME in pcntl_signal_dispatch()

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1356,7 +1356,6 @@ void pcntl_signal_dispatch(void)
 	while (queue) {
 		if ((handle = zend_hash_index_find(&PCNTL_G(php_signal_table), queue->signo)) != NULL) {
 			if (Z_TYPE_P(handle) != IS_LONG) {
-				ZVAL_NULL(&retval);
 				ZVAL_LONG(&params[0], queue->signo);
 #ifdef HAVE_STRUCT_SIGINFO_T
 				array_init(&params[1]);
@@ -1366,7 +1365,6 @@ void pcntl_signal_dispatch(void)
 #endif
 
 				/* Call php signal handler - Note that we do not report errors, and we ignore the return value */
-				/* FIXME: this is probably broken when multiple signals are handled in this while loop (retval) */
 				call_user_function(NULL, NULL, handle, &retval, 2, params);
 				zval_ptr_dtor(&retval);
 #ifdef HAVE_STRUCT_SIGINFO_T


### PR DESCRIPTION
This comment used to be true when the zvals were heap allocated and the destruction must be done properly. However, it _is_ done properly nowadays by calling zval_ptr_dtor(). Furthermore, since call_user_function() always initializes the return value with UNDEF, we can remove the ZVAL_NULL() line.