### PR TITLE
chore: dump ast within error when reach undefined state

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -11608,6 +11608,12 @@ static void zend_compile_expr_inner(znode *result, zend_ast *ast) /* {{{ */
 			zend_compile_match(result, ast);
 			return;
 		default:
+			zend_error(
+					E_ERROR,
+					"Unknown AST node kind %d. Expression: \"%s\".",
+					ast->kind,
+					ZSTR_VAL(zend_ast_export("", ast, ""))
+			);
 			ZEND_ASSERT(0 /* not supported */);
 	}
 }


### PR DESCRIPTION
It helps me when I reach the default case to understand what was it.

I think it may help others as well.