### PR TITLE
opcache: fix revalidation in long running CLI scripts

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -76,7 +76,12 @@ typedef int gid_t;
 #endif
 #include <fcntl.h>
 #include <signal.h>
+
+#ifndef PHP_WIN32
 #include <time.h>
+#else
+#include "win32/time.h"
+#endif
 
 #ifndef ZEND_WIN32
 # include <sys/types.h>
@@ -1164,33 +1169,31 @@ zend_result validate_timestamp_and_record(zend_persistent_script *persistent_scr
 		return SUCCESS; /* Don't check timestamps of preloaded scripts */
 	}
 
+	double revalidate_reference_time = 0.0;
+
 	if (ZCG(cli_mode)) {
+#if HAVE_GETTIMEOFDAY
 		struct timeval tp = {0};
 
-		//check current time as opposed to the "time of request"
-		if (gettimeofday(&tp, NULL) != 0) {
-			return SUCCESS;
-		}
-
-		double now = (double)(tp.tv_sec + tp.tv_usec / 1000000.00);
-
-		if (ZCG(accel_directives).revalidate_freq && persistent_script->dynamic_members.revalidate >= now) {
-			return SUCCESS;
-		} else if (do_validate_timestamps(persistent_script, file_handle) == FAILURE) {
-			return FAILURE;
+		if (UNEXPECTED(gettimeofday(&tp, NULL) != 0)) {
+			revalidate_reference_time = (double)time(NULL);
 		} else {
-			persistent_script->dynamic_members.revalidate = now + ZCG(accel_directives).revalidate_freq;
-			return SUCCESS;
+			revalidate_reference_time = (double)(tp.tv_sec + tp.tv_usec / 1000000.00);
 		}
+#else
+		revalidate_reference_time = (double)time(NULL);
+#endif
 	} else {
-		if (ZCG(accel_directives).revalidate_freq && persistent_script->dynamic_members.revalidate >= ZCG(request_time)) {
-			return SUCCESS;
-		} else if (do_validate_timestamps(persistent_script, file_handle) == FAILURE) {
-			return FAILURE;
-		} else {
-			persistent_script->dynamic_members.revalidate = ZCG(request_time) + ZCG(accel_directives).revalidate_freq;
-			return SUCCESS;
-		}
+		revalidate_reference_time = (double)ZCG(request_time);
+	}
+
+	if (ZCG(accel_directives).revalidate_freq && persistent_script->dynamic_members.revalidate >= revalidate_reference_time) {
+		return SUCCESS;
+	} else if (do_validate_timestamps(persistent_script, file_handle) == FAILURE) {
+		return FAILURE;
+	} else {
+		persistent_script->dynamic_members.revalidate = revalidate_reference_time + ZCG(accel_directives).revalidate_freq;
+		return SUCCESS;
 	}
 }
 

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -224,6 +224,7 @@ typedef struct _zend_accel_globals {
 	zend_persistent_script *cache_persistent_script;
 	/* preallocated buffer for keys */
 	zend_string            *key;
+	bool                    cli_mode;
 } zend_accel_globals;
 
 typedef struct _zend_string_table {

--- a/ext/opcache/tests/opcache_revalidation_in_cli.phpt
+++ b/ext/opcache/tests/opcache_revalidation_in_cli.phpt
@@ -16,7 +16,7 @@ file_put_contents($file, <<<PHP
 return 42;
 PHP);
 
-var_dump(opcache_invalidate($file));
+var_dump(opcache_invalidate($file, true));
 
 var_dump(include $file);
 

--- a/ext/opcache/tests/opcache_revalidation_in_cli.phpt
+++ b/ext/opcache/tests/opcache_revalidation_in_cli.phpt
@@ -1,0 +1,42 @@
+--TEST--
+opcache revalidation should work properly in CLI mode
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=1
+opcache.revalidate_freq=1
+--FILE--
+<?php
+$file = __DIR__ . DIRECTORY_SEPARATOR . pathinfo(__FILE__, PATHINFO_FILENAME) . '.inc';
+
+file_put_contents($file, <<<PHP
+<?php
+return 42;
+PHP);
+
+var_dump(opcache_invalidate($file));
+
+var_dump(include $file);
+
+file_put_contents($file, <<<PHP
+<?php
+return 1234;
+PHP);
+
+var_dump(include $file);
+
+sleep(2);
+touch($file);
+
+var_dump(include $file);
+
+@unlink($file);
+
+?>
+--EXPECT--
+bool(true)
+int(42)
+int(42)
+int(1234)


### PR DESCRIPTION
It looks like opcache was initially designed with short-lived requests in mind, so when checking if the file should be re-validated, the code uses 'request time' instead of 'now', where request time is calculated once on the script startup. Which basically means that in CLI this check will never succeed.

This PR containing the patch to fix this issue covered with a test that passes in this branch but not in PHP-8.3.
The issue itself is older, but I rebased the patch to PHP-8.3 as mentioned in CONTRIBUTING doc.

Not sure if I must fill the issue separately, but will be happy to do if needed.