### PR TITLE
Fix ZEND_NONSTRING attribute for data_file.c

### DIFF
--- a/ext/fileinfo/create_data_file.php
+++ b/ext/fileinfo/create_data_file.php
@@ -39,7 +39,7 @@
     $chunks = str_split($dta, CHUNK_SIZE);
     $chunks[count($chunks) - 1] = str_pad($chunks[count($chunks) - 1], CHUNK_SIZE, chr(0));
 
-    echo 'const unsigned char php_magic_database[' . count($chunks) . '][' . CHUNK_SIZE . "] = {\n";
+    echo 'const unsigned char php_magic_database[' . count($chunks) . '][' . CHUNK_SIZE . "] ZEND_NONSTRING = {\n";
     foreach ($chunks as $chunk) {
         echo '"' . strtr($chunk, $map) . '",' . "\n";
     }

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -184,7 +184,7 @@ file_private struct {
 	{ NULL, 0, NULL }
 };
 
-#if __has_attribute(nonstring)
+#if __has_attribute(nonstring) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 15
 # define ZEND_NONSTRING __attribute__((nonstring))
 #else
 # define ZEND_NONSTRING


### PR DESCRIPTION
This broke in CI but not on my local machine because of the different compiler version. This is because there was an issue in GCC [1] that caused the attribute to not properly work on multidimensional arrays. This has since been fixed in GCC 15.
Therefore, we guard the attribute with a version check.

[1] https://gcc.gnu.org/cgit/gcc/commit/?id=afb46540d3921e96c4cd7ba8fa2c8b0901759455