### PR TITLE
Fix misplaced endif in apprentice_sort()

### DIFF
--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -328,8 +328,8 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 @@ -1151,6 +1075,7 @@
  			file_mdump(ma->mp);
  			file_mdump(mb->mp);
- 			return 0;
 +#endif
+ 			return 0;
  		}
  		return x > 0 ? -1 : 1;
  	}

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -1074,8 +1074,8 @@ apprentice_sort(const void *a, const void *b)
 			    ma->mp->desc);
 			file_mdump(ma->mp);
 			file_mdump(mb->mp);
-			return 0;
 #endif
+			return 0;
 		}
 		return x > 0 ? -1 : 1;
 	}


### PR DESCRIPTION
We shouldn't warn for BC, but still should return the right value.