### PR TITLE
Fix GH-18695: float numbers zero fraction is now preserved in zend_ast_export()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.3.23
 
+- Core:
+  . Fixed GH-18695 (zend_ast_export() - float number is not preserved).
+    (Oleg Efimov)
+
 - Date:
   . Fix leaks with multiple calls to DatePeriod iterator current(). (nielsdos)
 

--- a/Zend/tests/ast/ast_serialize_floats.phpt
+++ b/Zend/tests/ast/ast_serialize_floats.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Serialization of floats are correct
+--INI--
+zend.assertions=1
+--FILE--
+<?php
+try {
+    assert(!is_float(0.0));
+} catch (AssertionError $e) {
+    echo 'assert(): ', $e->getMessage(), ' failed', PHP_EOL;
+}
+try {
+    assert(!is_float(1.1));
+} catch (AssertionError $e) {
+    echo 'assert(): ', $e->getMessage(), ' failed', PHP_EOL;
+}
+try {
+    assert(!is_float(1234.5678));
+} catch (AssertionError $e) {
+    echo 'assert(): ', $e->getMessage(), ' failed', PHP_EOL;
+}
+?>
+--EXPECT--
+assert(): assert(!is_float(0.0)) failed
+assert(): assert(!is_float(1.1)) failed
+assert(): assert(!is_float(1234.5678)) failed

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1563,7 +1563,7 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priorit
 			break;
 		case IS_DOUBLE:
 			smart_str_append_double(
-				str, Z_DVAL_P(zv), (int) EG(precision), /* zero_fraction */ false);
+				str, Z_DVAL_P(zv), (int) EG(precision), /* zero_fraction */ true);
 			break;
 		case IS_STRING:
 			smart_str_appendc(str, '\'');


### PR DESCRIPTION
This fixes #18695.

After this patch, there are no more `smart_str_append_double()` calls with `zero_fraction=false`.
However I didn't remove it, as this is a part of public API for extensions as I understand.