### PR TITLE
Get rid of redundant SOAP globals

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -3456,7 +3456,7 @@ xmlNsPtr encode_add_ns(xmlNodePtr node, const char* ns)
 	if (xmlns == NULL) {
 		xmlChar* prefix;
 
-		if ((prefix = zend_hash_str_find_ptr(&SOAP_GLOBAL(defEncNs), (char*)ns, strlen(ns))) != NULL) {
+		if ((prefix = zend_hash_str_find_ptr(&php_soap_defEncNs, (char*)ns, strlen(ns))) != NULL) {
 			xmlns = xmlNewNs(node->doc->children, BAD_CAST(ns), prefix);
 		} else {
 			smart_str prefix = {0};
@@ -3531,7 +3531,7 @@ encodePtr get_conversion(int encode)
 {
 	encodePtr enc;
 
-	if ((enc = zend_hash_index_find_ptr(&SOAP_GLOBAL(defEncIndex), encode)) == NULL) {
+	if ((enc = zend_hash_index_find_ptr(&php_soap_defEncIndex, encode)) == NULL) {
 		soap_error0(E_ERROR,  "Encoding: Cannot find encoding");
 		return NULL;
 	} else {

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -177,7 +177,7 @@ encodePtr get_encoder_ex(sdlPtr sdl, const char *nscat, size_t len)
 {
 	encodePtr enc;
 
-	if ((enc = zend_hash_str_find_ptr(&SOAP_GLOBAL(defEnc), nscat, len)) != NULL) {
+	if ((enc = zend_hash_str_find_ptr(&php_soap_defEnc, nscat, len)) != NULL) {
 		return enc;
 	} else if (sdl && sdl->encoders && (enc = zend_hash_str_find_ptr(sdl->encoders, nscat, len)) != NULL) {
 		return enc;

--- a/ext/soap/php_soap.h
+++ b/ext/soap/php_soap.h
@@ -151,9 +151,6 @@ struct _soapService {
 
 
 ZEND_BEGIN_MODULE_GLOBALS(soap)
-	HashTable  defEncNs;     /* mapping of default namespaces to prefixes */
-	HashTable  defEnc;
-	HashTable  defEncIndex;
 	HashTable *typemap;
 	int        cur_uniq_ns;
 	int        soap_version;
@@ -194,6 +191,8 @@ extern zend_class_entry* soap_class_entry;
 extern zend_class_entry* soap_var_class_entry;
 extern zend_class_entry* soap_url_class_entry;
 extern zend_class_entry* soap_sdl_class_entry;
+
+extern HashTable php_soap_defEncNs, php_soap_defEnc, php_soap_defEncIndex;
 
 void add_soap_fault(zval *obj, char *fault_code, char *fault_string, char *fault_actor, zval *fault_detail);
 


### PR DESCRIPTION
The copy doesn't make sense, remove it.