### PR TITLE
Create str_icontains PHP function

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2441,6 +2441,11 @@ function str_contains(string $haystack, string $needle): bool {}
 
 /**
  * @compile-time-eval
+ */
+function str_icontains(string $haystack, string $needle): bool {}
+
+/**
+ * @compile-time-eval
  * @frameless-function {"arity": 2}
  */
 function str_starts_with(string $haystack, string $needle): bool {}

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1836,6 +1836,20 @@ flf_clean:
 	Z_FLF_PARAM_FREE_STR(2, needle_tmp);
 }
 
+/* {{{ Checks if a string contains another, case insensitive */
+PHP_FUNCTION(str_icontains)
+{
+	zend_string *haystack, *needle;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(haystack)
+		Z_PARAM_STR(needle)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_BOOL(php_memnistr(ZSTR_VAL(haystack), ZSTR_VAL(needle), ZSTR_LEN(needle), ZSTR_VAL(haystack) + ZSTR_LEN(haystack)));
+}
+/* }}} */
+
 /* {{{ Checks if haystack starts with needle */
 PHP_FUNCTION(str_starts_with)
 {

--- a/ext/standard/tests/strings/str_icontains.phpt
+++ b/ext/standard/tests/strings/str_icontains.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test str_icontains() function
+--FILE--
+<?php
+var_dump(str_icontains("test string", "test"));
+var_dump(str_icontains("test string", "string"));
+var_dump(str_icontains("test string", "strin"));
+var_dump(str_icontains("test string", "t s"));
+var_dump(str_icontains("test string", "g"));
+var_dump(str_icontains("te".chr(0)."st", chr(0)));
+var_dump(str_icontains("tEst", "test"));
+var_dump(str_icontains("teSt", "test"));
+var_dump(str_icontains("TEST", "test"));
+var_dump(str_icontains("test", "TEST"));
+var_dump(str_icontains("TESST", "TEST"));
+var_dump(str_icontains("", ""));
+var_dump(str_icontains("a", ""));
+var_dump(str_icontains("", "a"));
+var_dump(str_icontains("\\\\a", "\\a"));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
As a PHP developer of 20 years I'm somewhat accustomed to adding "i" into the function name when I'm after a case-insensitive version. Therefore, I found it a bit odd I couldn't do it with the new "str_contains" function, so have added a case-insensitive version. Tests added too.

Assume this would need a RFC to be accepted.