### PR TITLE
Fix bug #70951: Segmentation fault on invalid WSDL cache

### DIFF
--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -31,6 +31,12 @@
 # define O_BINARY 0
 #endif
 
+#ifdef WORDS_BIGENDIAN
+# define SOAP_BIG_ENDIAN 1
+#else
+# define SOAP_BIG_ENDIAN 0
+#endif
+
 static void delete_fault(zval *zv);
 static void delete_fault_persistent(zval *zv);
 static void delete_binding(zval *zv);
@@ -3188,9 +3194,13 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 		char *user = php_get_current_user();
 		size_t user_len = user ? strlen(user) + 1 : 0;
 
+		/* System architecture identification (see bug #70951) */
+		static const char ids[] = {SIZEOF_ZEND_LONG, SOAP_BIG_ENDIAN};
+
 		md5str[0] = '\0';
 		PHP_MD5Init(&md5_context);
 		PHP_MD5Update(&md5_context, (unsigned char*)uri, uri_len);
+		PHP_MD5Update(&md5_context, ids, sizeof(ids));
 		PHP_MD5Final(digest, &md5_context);
 		make_digest(md5str, digest);
 		key = emalloc(len+sizeof("/wsdl-")-1+user_len+2+sizeof(md5str));


### PR DESCRIPTION
We mix in the endianness and the zend_long size to make sure cache files can't be used on incompatible architectures.