### PR TITLE
Fix out of tree build

### DIFF
--- a/ext/uri/config.m4
+++ b/ext/uri/config.m4
@@ -15,6 +15,6 @@ $URIPARSER_DIR/src/UriMemory.c $URIPARSER_DIR/src/UriNormalize.c $URIPARSER_DIR/
 $URIPARSER_DIR/src/UriParse.c $URIPARSER_DIR/src/UriParseBase.c $URIPARSER_DIR/src/UriQuery.c \
 $URIPARSER_DIR/src/UriRecompose.c $URIPARSER_DIR/src/UriResolve.c $URIPARSER_DIR/src/UriShorten.c"
 
-PHP_NEW_EXTENSION(uri, [php_uri.c $URIPARSER_SOURCES], [no],,[-I$ext_builddir/$URIPARSER_DIR/include -DURI_STATIC_BUILD -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+PHP_NEW_EXTENSION(uri, [php_uri.c $URIPARSER_SOURCES], [no],,[-I$ext_srcdir/$URIPARSER_DIR/include -DURI_STATIC_BUILD -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 PHP_ADD_EXTENSION_DEP(uri, lexbor)
 PHP_ADD_BUILD_DIR($ext_builddir/$URIPARSER_DIR/src $ext_builddir/$URIPARSER_DIR/include)


### PR DESCRIPTION
This fixes the following error when building out of the source tree:

```
ext/uri/uriparser/src/UriCompare.c:41:10: fatal error: uriparser/UriDefsConfig.h: No such file or directory
   41 | #include <uriparser/UriDefsConfig.h>
```

I add `$ext_srcdir/$URIPARSER_DIR/include` to the include path instead of `$ext_builddir/$URIPARSER_DIR/include`, so that files are searched in the source tree. The extension doesn't appear to generate include files in the build dir.