### PR TITLE
Fix Exception constructor optimization after https://github.com/php/php-src/pull/18442

### DIFF
--- a/Zend/tests/exceptions/exception_027.phpt
+++ b/Zend/tests/exceptions/exception_027.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Exception properties are overridden by property hooks
+--FILE--
+<?php
+class MyException extends Exception
+{
+    private bool $modified = false;
+
+    protected $code {
+        set($value) {
+            if ($this->modified) {
+                throw new Exception();
+            } else {
+                $this->modified = true;
+
+                $this->code = $value;
+            }
+        }
+    }
+}
+
+$e = new MyException("foo", 1, new Exception());
+
+try {
+    $e->__construct("bar", 2, null);
+} catch (Exception) {
+}
+
+var_dump($e->getMessage());
+var_dump($e->getCode());
+var_dump($e->getPrevious()::class);
+
+?>
+--EXPECTF--
+string(3) "bar"
+int(1)
+string(9) "Exception"

--- a/Zend/tests/exceptions/exception_028.phpt
+++ b/Zend/tests/exceptions/exception_028.phpt
@@ -1,0 +1,43 @@
+--TEST--
+ErrorException properties are overridden by property hooks
+--FILE--
+<?php
+class MyException extends ErrorException
+{
+    private bool $modified = false;
+
+    protected $code {
+        set($value) {
+            if ($this->modified) {
+                throw new Exception();
+            } else {
+                $this->modified = true;
+
+                $this->code = $value;
+            }
+        }
+    }
+}
+
+$e = new MyException("foo", 1, E_NOTICE, "file1", 1, new Exception());
+
+try {
+    $e->__construct("bar", 2, E_WARNING, "file2", 2, null);
+} catch (Exception) {
+}
+
+var_dump($e->getMessage());
+var_dump($e->getCode());
+var_dump($e->getSeverity());
+var_dump($e->getFile());
+var_dump($e->getLine());
+var_dump($e->getPrevious()::class);
+
+?>
+--EXPECTF--
+string(3) "bar"
+int(1)
+int(8)
+string(5) "file1"
+int(1)
+string(9) "Exception"


### PR DESCRIPTION
- Property hooks may now throw exceptions, that seem to be forgotten to be handled (?)
- The `$previous` and `$trace` properties are private, and they were not accessible from the constructor of a child class