### PR TITLE
Fix test failures in engine_unsafe_empty_string.phpt

### DIFF
--- a/ext/random/tests/03_randomizer/engine_unsafe_empty_string.phpt
+++ b/ext/random/tests/03_randomizer/engine_unsafe_empty_string.phpt
@@ -11,7 +11,7 @@ final class EmptyStringEngine implements Engine
     public function generate(): string
     {
         // Create a non-interned empty string.
-        return preg_replace('/./', '', random_bytes(4));
+        return preg_replace('/./s', '', random_bytes(4));
     }
 }
 


### PR DESCRIPTION
`/./` matches all characters but newlines, so if `random_bytes` generates a string with newlines in it, the resulting string is not empty. Fix this by adding the `s` modifier.