### PR TITLE
Fix ext/enchant test SKIPIFs

### DIFF
--- a/ext/enchant/tests/broker_dict_exists.phpt
+++ b/ext/enchant/tests/broker_dict_exists.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/broker_free.phpt
+++ b/ext/enchant/tests/broker_free.phpt
@@ -4,10 +4,6 @@ enchant_broker_free() function
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_free_01.phpt
+++ b/ext/enchant/tests/broker_free_01.phpt
@@ -4,10 +4,6 @@
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_free_02.phpt
+++ b/ext/enchant/tests/broker_free_02.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if(!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/broker_free_dict.phpt
+++ b/ext/enchant/tests/broker_free_dict.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if(!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/broker_get_error.phpt
+++ b/ext/enchant/tests/broker_get_error.phpt
@@ -4,10 +4,6 @@ enchant_broker_get_error() function
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_init.phpt
+++ b/ext/enchant/tests/broker_init.phpt
@@ -4,10 +4,6 @@ enchant_broker_init() function
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
- ?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_request_dict.phpt
+++ b/ext/enchant/tests/broker_request_dict.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/broker_request_dict_01.phpt
+++ b/ext/enchant/tests/broker_request_dict_01.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/broker_request_dict_error_on_empty_tag.phpt
+++ b/ext/enchant/tests/broker_request_dict_error_on_empty_tag.phpt
@@ -2,10 +2,6 @@
 enchant_broker_request_dict() must throw ValueError on empty tag
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_request_pwl_dict.phpt
+++ b/ext/enchant/tests/broker_request_pwl_dict.phpt
@@ -4,10 +4,6 @@ resource enchant_broker_request_pwl_dict(resource $broker, string $filename); fu
 marcosptf - <marcosptf@yahoo.com.br>
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if(!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/broker_set_ordering.phpt
+++ b/ext/enchant/tests/broker_set_ordering.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/bug53070.phpt
+++ b/ext/enchant/tests/bug53070.phpt
@@ -4,7 +4,6 @@ Bug #53070 (enchant_broker_get_path crashes if no path is set)
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
 --FILE--

--- a/ext/enchant/tests/dict_add_to_personal.phpt
+++ b/ext/enchant/tests/dict_add_to_personal.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_add_to_session.phpt
+++ b/ext/enchant/tests/dict_add_to_session.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_check.phpt
+++ b/ext/enchant/tests/dict_check.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_describe.phpt
+++ b/ext/enchant/tests/dict_describe.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_get_error.phpt
+++ b/ext/enchant/tests/dict_get_error.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_is_in_session.phpt
+++ b/ext/enchant/tests/dict_is_in_session.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_quick_check.phpt
+++ b/ext/enchant/tests/dict_quick_check.phpt
@@ -7,8 +7,7 @@ enchant
 --SKIPIF--
 <?php
 if (getenv('SKIP_ASAN')) die('xleak Known libenchant memory leak');
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 
 $tag = 'en_US';
 $r = enchant_broker_init();

--- a/ext/enchant/tests/dict_quick_check_01.phpt
+++ b/ext/enchant/tests/dict_quick_check_01.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_store_replacement.phpt
+++ b/ext/enchant/tests/dict_store_replacement.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/dict_suggest.phpt
+++ b/ext/enchant/tests/dict_suggest.phpt
@@ -6,8 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php

--- a/ext/enchant/tests/enchant_broker_set_dict_path.phpt
+++ b/ext/enchant/tests/enchant_broker_set_dict_path.phpt
@@ -7,8 +7,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 if (defined("LIBENCHANT_VERSION") && version_compare(LIBENCHANT_VERSION, "2", ">")) die('skip libenchant v1 only');
 ?>
 --FILE--

--- a/ext/enchant/tests/invalidobj.phpt
+++ b/ext/enchant/tests/invalidobj.phpt
@@ -2,10 +2,6 @@
 invalid object raise exception() function
 --EXTENSIONS--
 enchant
---SKIPIF--
-<?php
-if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
-?>
 --FILE--
 <?php
 $broker = enchant_broker_init();

--- a/ext/enchant/tests/null_bytes.phpt
+++ b/ext/enchant/tests/null_bytes.phpt
@@ -4,8 +4,7 @@ null bytes
 enchant
 --SKIPIF--
 <?php
-$broker = enchant_broker_init();
-if (!enchant_broker_list_dicts($broker)) die("skip No broker dicts installed");
+if (!enchant_broker_list_dicts(enchant_broker_init())) {die("skip no dictionary installed on this machine! \n");}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
The "resource"/object check makes no sense, and the is_array() check doesn't achieve anything. Drop the former, and replace the latter with a ! check.
Discovered while working on GH-18729.