### PR TITLE
Fix line assignment in zend_ast_create_va()

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -279,7 +279,7 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_va(
 	ast->attr = attr;
 	for (uint32_t i = 0; i < children; i++) {
 		ast->child[i] = va_arg(*va, zend_ast *);
-		if (lineno != (uint32_t)-1 && ast->child[i]) {
+		if (lineno == (uint32_t)-1 && ast->child[i]) {
 			lineno = zend_ast_get_lineno(ast->child[i]);
 		}
 	}


### PR DESCRIPTION
The intent here was to assign the first found line. Instead this always fell back to CG(zend_lineno).

Not sure if this line matters for anything in php-src, but the issue was observed in https://github.com/nikic/php-ast/issues/247.