### PR TITLE
Fix missing empty string checks in ext/enchant

### DIFF
--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -529,6 +529,11 @@ PHP_FUNCTION(enchant_broker_dict_exists)
 
 	PHP_ENCHANT_GET_BROKER;
 
+	if (taglen == 0) {
+		zend_argument_must_not_be_empty_error(2);
+		RETURN_THROWS();
+	}
+
 	RETURN_BOOL(enchant_broker_dict_exists(pbroker->pbroker, tag));
 }
 /* }}} */
@@ -553,6 +558,16 @@ PHP_FUNCTION(enchant_broker_set_ordering)
 	}
 
 	PHP_ENCHANT_GET_BROKER;
+
+	if (ptaglen == 0) {
+		zend_argument_must_not_be_empty_error(2);
+		RETURN_THROWS();
+	}
+
+	if (porderinglen == 0) {
+		zend_argument_must_not_be_empty_error(3);
+		RETURN_THROWS();
+	}
 
 	enchant_broker_set_ordering(pbroker->pbroker, ptag, pordering);
 	RETURN_TRUE;

--- a/ext/enchant/tests/broker_dict_exists_empty.phpt
+++ b/ext/enchant/tests/broker_dict_exists_empty.phpt
@@ -1,0 +1,17 @@
+--TEST--
+enchant_broker_dict_exists() function - empty tag
+--EXTENSIONS--
+enchant
+--FILE--
+<?php
+$broker = enchant_broker_init();
+try {
+    enchant_broker_dict_exists($broker, '');
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+echo "Done\n";
+?>
+--EXPECT--
+enchant_broker_dict_exists(): Argument #2 ($tag) must not be empty
+Done

--- a/ext/enchant/tests/broker_set_ordering_empty.phpt
+++ b/ext/enchant/tests/broker_set_ordering_empty.phpt
@@ -1,0 +1,23 @@
+--TEST--
+enchant_broker_set_ordering() function - empty tag
+--EXTENSIONS--
+enchant
+--FILE--
+<?php
+$broker = enchant_broker_init();
+try {
+    enchant_broker_set_ordering($broker, '', '');
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    enchant_broker_set_ordering($broker, '*', '');
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+echo "Done\n";
+?>
+--EXPECT--
+enchant_broker_set_ordering(): Argument #2 ($tag) must not be empty
+enchant_broker_set_ordering(): Argument #3 ($ordering) must not be empty
+Done


### PR DESCRIPTION
The library requires the tags to be non-empty, and also requires the ordering to be non-empty. For the tags, otherwise, assertion failures can be observed.