### PR TITLE
Shorten table identifiers in PDO tests to be compatible with Oracle DB 11g

### DIFF
--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch1.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch1.phpt
@@ -27,13 +27,13 @@ class Test {
     }
 }
 
-$db->exec('CREATE TABLE pdo_fetch_class_change_ctor_one(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_one VALUES(1, 'A', 'alpha')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_one VALUES(2, 'B', 'beta')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_one VALUES(3, 'C', 'gamma')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_one VALUES(4, 'D', 'delta')");
+$db->exec('CREATE TABLE pdo_fetch_class_change_ctor1(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor1 VALUES(1, 'A', 'alpha')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor1 VALUES(2, 'B', 'beta')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor1 VALUES(3, 'C', 'gamma')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor1 VALUES(4, 'D', 'delta')");
 
-$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor_one');
+$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor1');
 $stmt->setFetchMode(PDO::FETCH_CLASS, 'Test', [$stmt]);
 
 $stmt->execute();
@@ -44,12 +44,12 @@ var_dump($stmt->fetch());
 <?php
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor_one");
+PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor1");
 ?>
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor_one"
+  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor1"
 }
 object(Test)#%d (2) {
   ["val1"]=>

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch1.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch1.phpt
@@ -49,7 +49,7 @@ PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor1");
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor1"
+  string(51) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor1"
 }
 object(Test)#%d (2) {
   ["val1"]=>

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
@@ -27,14 +27,13 @@ class Test {
     }
 }
 
-// TODO Rename pdo_fetch_class_change_ctor_two table to pdo_fetch_class_change_ctor_two in PHP-8.4
-$db->exec('CREATE TABLE pdo_fetch_class_change_ctor_two(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(1, 'A', 'alpha')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(2, 'B', 'beta')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(3, 'C', 'gamma')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(4, 'D', 'delta')");
+$db->exec('CREATE TABLE pdo_fetch_class_change_ctor2(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor2 VALUES(1, 'A', 'alpha')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor2 VALUES(2, 'B', 'beta')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor2 VALUES(3, 'C', 'gamma')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor2 VALUES(4, 'D', 'delta')");
 
-$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor_two');
+$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor2');
 
 $stmt->execute();
 var_dump($stmt->fetchObject('Test', [$stmt]));
@@ -44,12 +43,12 @@ var_dump($stmt->fetchObject('Test', [$stmt]));
 <?php
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor_two");
+PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor2");
 ?>
 --EXPECTF--
 object(PDOStatement)#%s (1) {
   ["queryString"]=>
-  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor_two"
+  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor2"
 }
 object(Test)#%s (2) {
   ["val1"]=>

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
@@ -48,7 +48,7 @@ PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor2");
 --EXPECTF--
 object(PDOStatement)#%s (1) {
   ["queryString"]=>
-  string(54) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor2"
+  string(51) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor2"
 }
 object(Test)#%s (2) {
   ["val1"]=>

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch3.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch3.phpt
@@ -49,7 +49,7 @@ PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor3");
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(56) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor3"
+  string(51) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor3"
 }
 string(5) "alpha"
 string(5) "alpha"

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch3.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch3.phpt
@@ -27,13 +27,13 @@ class Test {
     }
 }
 
-$db->exec('CREATE TABLE pdo_fetch_class_change_ctor_three(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_three VALUES(1, 'A', 'alpha')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_three VALUES(2, 'B', 'beta')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_three VALUES(3, 'C', 'gamma')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_three VALUES(4, 'D', 'delta')");
+$db->exec('CREATE TABLE pdo_fetch_class_change_ctor3(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor3 VALUES(1, 'A', 'alpha')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor3 VALUES(2, 'B', 'beta')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor3 VALUES(3, 'C', 'gamma')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor3 VALUES(4, 'D', 'delta')");
 
-$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor_three');
+$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor3');
 $stmt->setFetchMode(PDO::FETCH_CLASS, 'Test', [$stmt]);
 
 $stmt->execute();
@@ -44,12 +44,12 @@ var_dump($stmt->fetchAll());
 <?php
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor_three");
+PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor3");
 ?>
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(56) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor_three"
+  string(56) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor3"
 }
 string(5) "alpha"
 string(5) "alpha"

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch4.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch4.phpt
@@ -48,7 +48,7 @@ PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor4");
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(55) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor4"
+  string(51) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor4"
 }
 string(5) "alpha"
 string(5) "alpha"

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch4.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch4.phpt
@@ -27,13 +27,13 @@ class Test {
     }
 }
 
-$db->exec('CREATE TABLE pdo_fetch_class_change_ctor_four(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_four VALUES(1, 'A', 'alpha')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_four VALUES(2, 'B', 'beta')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_four VALUES(3, 'C', 'gamma')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_four VALUES(4, 'D', 'delta')");
+$db->exec('CREATE TABLE pdo_fetch_class_change_ctor4(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor4 VALUES(1, 'A', 'alpha')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor4 VALUES(2, 'B', 'beta')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor4 VALUES(3, 'C', 'gamma')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor4 VALUES(4, 'D', 'delta')");
 
-$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor_four');
+$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor4');
 
 $stmt->execute();
 var_dump($stmt->fetchAll(PDO::FETCH_CLASS, 'Test', [$stmt]));
@@ -43,12 +43,12 @@ var_dump($stmt->fetchAll(PDO::FETCH_CLASS, 'Test', [$stmt]));
 <?php
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor_four");
+PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor4");
 ?>
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(55) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor_four"
+  string(55) "SELECT val1, val2 FROM pdo_fetch_class_change_ctor4"
 }
 string(5) "alpha"
 string(5) "alpha"

--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch5.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch5.phpt
@@ -22,13 +22,13 @@ class B {
     public function __construct() {}
 }
 
-$db->exec('CREATE TABLE pdo_fetch_class_change_ctor_five(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_five VALUES(1, 'A', 'alpha')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_five VALUES(2, 'B', 'beta')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_five VALUES(3, 'C', 'gamma')");
-$db->exec("INSERT INTO pdo_fetch_class_change_ctor_five VALUES(4, 'D', 'delta')");
+$db->exec('CREATE TABLE pdo_fetch_class_change_ctor5(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor5 VALUES(1, 'A', 'alpha')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor5 VALUES(2, 'B', 'beta')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor5 VALUES(3, 'C', 'gamma')");
+$db->exec("INSERT INTO pdo_fetch_class_change_ctor5 VALUES(4, 'D', 'delta')");
 
-$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor_five');
+$stmt = $db->prepare('SELECT val1, val2 FROM pdo_fetch_class_change_ctor5');
 $stmt->execute();
 
 function stuffingErrorHandler(int $errno, string $errstr, string $errfile, int $errline) {
@@ -45,7 +45,7 @@ var_dump($stmt->fetchAll(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE, 'B', [$stmt]));
 <?php
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor_five");
+PDOTest::dropTableIfExists($db, "pdo_fetch_class_change_ctor5");
 ?>
 --EXPECTF--
 PDOStatement::fetchAll(): The PDO::FETCH_SERIALIZE mode is deprecated


### PR DESCRIPTION
needed for https://github.com/php/pecl-database-pdo_oci/pull/16

docs https://stackoverflow.com/questions/3085562/ora-00972-identifier-is-too-long-alias-column-name#3085571