### PR TITLE
gen_stub: Add support for attributes on constants in stubs

### DIFF
--- a/Zend/tests/e_strict-deprecated.phpt
+++ b/Zend/tests/e_strict-deprecated.phpt
@@ -10,5 +10,5 @@ var_dump(E_STRICT);
 --EXPECTF--
 int(30719)
 
-Deprecated: Constant E_STRICT is deprecated in %s on line %d
+Deprecated: Constant E_STRICT is deprecated since 8.4, the error level was removed in %s on line %d
 int(2048)

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -21,6 +21,7 @@
 #define ZEND_ATTRIBUTES_H
 
 #include "zend_compile.h"
+#include "zend_constants.h"
 
 #define ZEND_ATTRIBUTE_TARGET_CLASS			(1<<0)
 #define ZEND_ATTRIBUTE_TARGET_FUNCTION		(1<<1)
@@ -123,6 +124,12 @@ static zend_always_inline zend_attribute *zend_add_property_attribute(zend_class
 static zend_always_inline zend_attribute *zend_add_class_constant_attribute(zend_class_entry *ce, zend_class_constant *c, zend_string *name, uint32_t argc)
 {
 	uint32_t flags = ce->type != ZEND_USER_CLASS ? ZEND_ATTRIBUTE_PERSISTENT : 0;
+	return zend_add_attribute(&c->attributes, name, argc, flags, 0, 0);
+}
+
+static zend_always_inline zend_attribute *zend_add_global_constant_attribute(zend_constant *c, zend_string *name, uint32_t argc)
+{
+	uint32_t flags = ZEND_CONSTANT_MODULE_NUMBER(c) == PHP_USER_CONSTANT ? 0 : ZEND_ATTRIBUTE_PERSISTENT;
 	return zend_add_attribute(&c->attributes, name, argc, flags, 0, 0);
 }
 

--- a/Zend/zend_constants.stub.php
+++ b/Zend/zend_constants.stub.php
@@ -71,9 +71,9 @@ const E_USER_NOTICE = UNKNOWN;
 /**
  * @var int
  * @cvalue E_STRICT
- * @deprecated
  * @todo Remove in PHP 9.0
  */
+#[\Deprecated(since: '8.4', message: 'the error level was removed')]
 const E_STRICT = UNKNOWN;
 
 /**

--- a/Zend/zend_constants_arginfo.h
+++ b/Zend/zend_constants_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 65be08c1bdace83ad1fa1175fc824262e07eac2a */
+ * Stub hash: 5e224893a5fb72b3f93249235c2a1634233ce505 */
 
 static void register_zend_constants_symbols(int module_number)
 {
@@ -26,4 +26,18 @@ static void register_zend_constants_symbols(int module_number)
 	REGISTER_BOOL_CONSTANT("TRUE", true, CONST_PERSISTENT);
 	REGISTER_BOOL_CONSTANT("FALSE", false, CONST_PERSISTENT);
 	REGISTER_NULL_CONSTANT("NULL", CONST_PERSISTENT);
+
+	zend_constant *const_E_STRICT = zend_hash_str_find_ptr(EG(zend_constants), "E_STRICT", sizeof("E_STRICT") - 1);
+
+	zend_attribute *attribute_Deprecated_const_E_STRICT_0 = zend_add_global_constant_attribute(const_E_STRICT, ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zval attribute_Deprecated_const_E_STRICT_0_arg0;
+	zend_string *attribute_Deprecated_const_E_STRICT_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_E_STRICT_0_arg0, attribute_Deprecated_const_E_STRICT_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_E_STRICT_0->args[0].value, &attribute_Deprecated_const_E_STRICT_0_arg0);
+	attribute_Deprecated_const_E_STRICT_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_const_E_STRICT_0_arg1;
+	zend_string *attribute_Deprecated_const_E_STRICT_0_arg1_str = zend_string_init("the error level was removed", strlen("the error level was removed"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_E_STRICT_0_arg1, attribute_Deprecated_const_E_STRICT_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_E_STRICT_0->args[1].value, &attribute_Deprecated_const_E_STRICT_0_arg1);
+	attribute_Deprecated_const_E_STRICT_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }

--- a/ext/reflection/tests/ReflectionConstant_getAttributes_internal.phpt
+++ b/ext/reflection/tests/ReflectionConstant_getAttributes_internal.phpt
@@ -1,0 +1,17 @@
+--TEST--
+ReflectionConstant::getAttributes() with attribute (internal constant)
+--FILE--
+<?php
+
+$reflectionConstant = new ReflectionConstant('E_STRICT');
+var_dump($reflectionConstant->getAttributes());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  object(ReflectionAttribute)#%d (1) {
+    ["name"]=>
+    string(10) "Deprecated"
+  }
+}

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -17,6 +17,12 @@ namespace {
     /** @var string */
     const ZEND_CONSTANT_A = "global";
 
+    /**
+     * @var int
+     */
+    #[\Deprecated(message: "use something else", since: "version 1.5")]
+    const ZEND_TEST_ATTRIBUTED_CONSTANT = 42;
+
     interface _ZendTestInterface
     {
         /** @var int */

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1fd4c80ed74efcc50698748b2afc89391ed69c72 */
+ * Stub hash: 37ac76dddea2da24d3275cccc748b8fea4c8d09c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -579,6 +579,7 @@ static void register_test_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("ZEND_TEST_DEPRECATED", 42, CONST_PERSISTENT | CONST_DEPRECATED);
 	REGISTER_STRING_CONSTANT("ZEND_CONSTANT_A", "global", CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("ZEND_TEST_ATTRIBUTED_CONSTANT", 42, CONST_PERSISTENT | CONST_DEPRECATED);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZendSubNS\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT);
 
@@ -635,6 +636,22 @@ static void register_test_symbols(int module_number)
 	ZVAL_STR(&attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0, attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0_str);
 	ZVAL_COPY_VALUE(&attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0->args[0].value, &attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0_arg0);
 	attribute_ZendTestAttributeWithArguments_func_zend_test_attribute_with_named_argument_0->args[0].name = zend_string_init_interned("arg", sizeof("arg") - 1, 1);
+
+#if (PHP_VERSION_ID >= 80500)
+	zend_constant *const_ZEND_TEST_ATTRIBUTED_CONSTANT = zend_hash_str_find_ptr(EG(zend_constants), "ZEND_TEST_ATTRIBUTED_CONSTANT", sizeof("ZEND_TEST_ATTRIBUTED_CONSTANT") - 1);
+
+	zend_attribute *attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0 = zend_add_global_constant_attribute(const_ZEND_TEST_ATTRIBUTED_CONSTANT, ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	zval attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg0;
+	zend_string *attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg0_str = zend_string_init("use something else", strlen("use something else"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg0, attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0->args[0].value, &attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg0);
+	attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+	zval attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg1;
+	zend_string *attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg1_str = zend_string_init("version 1.5", strlen("version 1.5"), 1);
+	ZVAL_STR(&attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg1, attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0->args[1].value, &attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0_arg1);
+	attribute_Deprecated_const_ZEND_TEST_ATTRIBUTED_CONSTANT_0->args[1].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+#endif
 }
 
 static zend_class_entry *register_class__ZendTestInterface(void)

--- a/ext/zend_test/tests/attribute-deprecated.phpt
+++ b/ext/zend_test/tests/attribute-deprecated.phpt
@@ -17,6 +17,12 @@ $reflection = new ReflectionClassConstant('_ZendTestClass', 'ZEND_TEST_DEPRECATE
 var_dump($reflection->getAttributes()[0]->newInstance());
 var_dump($reflection->isDeprecated());
 
+ZEND_TEST_ATTRIBUTED_CONSTANT;
+
+$reflection = new ReflectionConstant('ZEND_TEST_ATTRIBUTED_CONSTANT');
+var_dump($reflection->getAttributes()[0]->newInstance());
+var_dump($reflection->isDeprecated());
+
 ?>
 --EXPECTF--
 Deprecated: Function zend_test_deprecated() is deprecated in %s on line %d
@@ -36,5 +42,14 @@ object(Deprecated)#%d (2) {
   string(14) "custom message"
   ["since"]=>
   NULL
+}
+bool(true)
+
+Deprecated: Constant ZEND_TEST_ATTRIBUTED_CONSTANT is deprecated since version 1.5, use something else in %s on line %d
+object(Deprecated)#%d (2) {
+  ["message"]=>
+  string(18) "use something else"
+  ["since"]=>
+  string(11) "version 1.5"
 }
 bool(true)


### PR DESCRIPTION
Update to PHP-Parser 5.5.0 and add support for attributes on constants in stubs. For now, I have only migrated over E_STRICT, once the support is in place I'll do a larger migration of the existing deprecated constants.