### PR TITLE
ext/opcache: Log a warning when opcache lock file permissions could not be changed

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -115,7 +115,9 @@ void zend_shared_alloc_create_lock(char *lockfile_path)
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Unable to create opcache lock file in %s: %s (%d)", lockfile_path, strerror(errno), errno);
 	}
 
-	fchmod(lock_file, 0666);
+	if (fchmod(lock_file, 0666) == -1) {
+		zend_accel_error(ACCEL_LOG_WARNING, "Unable to change opcache lock file permissions in %s: %s (%d)", lockfile_path, strerror(errno), errno);
+	}
 
 	val = fcntl(lock_file, F_GETFD, 0);
 	val |= FD_CLOEXEC;


### PR DESCRIPTION
Commit 9ab79822418a54c4dff03eefdc036f200e05d1d8 fixed an issue where failing `mkstemp` would return `-1` which would result in an invalid call of `fchmod` and the clobbering of `errno`. But the `fchmod` call itself could also fail (e.g. SELinux policy), thus the return code should also be checked and a relevant warning logged.