### PR TITLE
tree-wide: Remove stacktraces from tests testing throwing clones

### DIFF
--- a/Zend/tests/generators/clone.phpt
+++ b/Zend/tests/generators/clone.phpt
@@ -7,12 +7,14 @@ function gen() {
     yield;
 }
 
-$gen = gen();
-clone $gen;
+
+try {
+    $gen = gen();
+    clone $gen;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class Generator in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class Generator

--- a/ext/dom/tests/modern/token_list/clone.phpt
+++ b/ext/dom/tests/modern/token_list/clone.phpt
@@ -7,11 +7,12 @@ dom
 
 $dom = DOM\XMLDocument::createFromString('<root class="a b c"><child/></root>');
 $element = $dom->documentElement;
-clone $element->classList;
+try {
+  clone $element->classList;
+} catch (Throwable $e) {
+  echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class Dom\TokenList in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class Dom\TokenList

--- a/ext/gd/tests/gdimage_prevent_cloning.phpt
+++ b/ext/gd/tests/gdimage_prevent_cloning.phpt
@@ -5,12 +5,13 @@ gd
 --FILE--
 <?php
 
+try {
     $img_src = imagecreatetruecolor(32, 32);
     $img_dst = clone $img_src;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class GdImage in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class GdImage

--- a/ext/mysqli/tests/mysqli_driver_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_driver_unclonable.phpt
@@ -4,12 +4,14 @@ Trying to clone mysqli_driver object
 mysqli
 --FILE--
 <?php
+
+try {
     $driver = new mysqli_driver;
     $driver_clone = clone $driver;
-    print "done!";
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class mysqli_driver in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class mysqli_driver

--- a/ext/mysqli/tests/mysqli_result_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_result_unclonable.phpt
@@ -17,11 +17,11 @@ require_once 'skipifconnectfailure.inc';
     if (!($res = mysqli_query($link, "SELECT 'good' AS morning")))
         printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    $res_clone = clone $res;
-    print "done!";
+    try {
+        $res_clone = clone $res;
+    } catch (Throwable $e) {
+        echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+    }
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class mysqli_result in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class mysqli_result

--- a/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_unclonable.phpt
@@ -17,12 +17,11 @@ require_once 'skipifconnectfailure.inc';
     if (!$stmt = mysqli_stmt_init($link))
         printf("[002] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    /* no, still bails out */
-    $stmt_clone = clone $stmt;
-    print "done!";
+    try {
+        $stmt_clone = clone $stmt;
+    } catch (Throwable $e) {
+        echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+    }
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class mysqli_stmt in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class mysqli_stmt

--- a/ext/mysqli/tests/mysqli_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_unclonable.phpt
@@ -14,13 +14,12 @@ require_once 'skipifconnectfailure.inc';
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
             $host, $user, $db, $port, $socket);
 
-    $link_clone = clone $link;
-    mysqli_close($link);
+    try {
+        $link_clone = clone $link;
+    } catch (Throwable $e) {
+        echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+    }
 
-    print "done!";
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class mysqli in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class mysqli

--- a/ext/pdo/tests/bug_77849.phpt
+++ b/ext/pdo/tests/bug_77849.phpt
@@ -15,10 +15,11 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.dirname(__FILE_
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 
 $db = PDOTest::factory();
-$db2 = clone $db;
+try {
+    $db2 = clone $db;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class PDO in %s
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class PDO

--- a/ext/pdo/tests/bug_77849_2.phpt
+++ b/ext/pdo/tests/bug_77849_2.phpt
@@ -4,13 +4,14 @@ PDO Common: Bug #77849 (inconsistent state of cloned statament object)
 pdo
 --FILE--
 <?php
-$stmt = new PDOStatement();
 
-clone $stmt;
+try {
+    $stmt = new PDOStatement();
+    clone $stmt;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class PDOStatement in %s:4
-Stack trace:
-#0 {main}
-  thrown in %s on line 4
-
+--EXPECT--
+Error: Trying to clone an uncloneable object of class PDOStatement

--- a/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
+++ b/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
@@ -6,10 +6,11 @@ TestFest PHP|Tek
 --FILE--
 <?php
 $rc = new ReflectionClass("stdClass");
-$rc2 = clone($rc);
+try {
+  $rc2 = clone($rc);
+} catch (Throwable $e) {
+  echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class ReflectionClass in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class ReflectionClass

--- a/ext/reflection/tests/ReflectionClass_isCloneable_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_isCloneable_001.phpt
@@ -49,10 +49,14 @@ $obj = new ReflectionClass('xmlwriter');
 var_dump($obj->isCloneable());
 $obj = new ReflectionObject(new XMLWriter);
 var_dump($obj->isCloneable());
-$h = clone new xmlwriter;
+try {
+    $h = clone new xmlwriter;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 User class
 bool(true)
 bool(true)
@@ -68,8 +72,4 @@ bool(true)
 Internal class - XMLWriter
 bool(false)
 bool(false)
-
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class XMLWriter in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+Error: Trying to clone an uncloneable object of class XMLWriter

--- a/ext/xml/tests/bug78563.phpt
+++ b/ext/xml/tests/bug78563.phpt
@@ -5,13 +5,13 @@ xml
 --FILE--
 <?php
 
-$parser = xml_parser_create();
-clone $parser;
+try {
+    $parser = xml_parser_create();
+    clone $parser;
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
 ?>
-===DONE===
---EXPECTF--
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class XMLParser in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Trying to clone an uncloneable object of class XMLParser

--- a/ext/xmlreader/tests/bug51936.phpt
+++ b/ext/xmlreader/tests/bug51936.phpt
@@ -4,20 +4,19 @@ Bug #51936 (Crash with clone XMLReader)
 xmlreader
 --FILE--
 <?php
-echo "Test\n";
 
 $xmlreader = new XMLReader();
 $xmlreader->xml("<a><b/></a>");
 
 $xmlreader->next();
-$xmlreader2 = clone $xmlreader;
-$xmlreader2->next();
-?>
-Done
---EXPECTF--
-Test
 
-Fatal error: Uncaught Error: Trying to clone an uncloneable object of class XMLReader in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+try {
+    $xmlreader2 = clone $xmlreader;
+    $xmlreader2->next();
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Error: Trying to clone an uncloneable object of class XMLReader

--- a/tests/classes/factory_and_singleton_007.phpt
+++ b/tests/classes/factory_and_singleton_007.phpt
@@ -8,14 +8,13 @@ class test {
   }
 }
 
-$obj = new test;
-$clone = clone $obj;
-$obj = NULL;
+try {
+  $obj = new test;
+  $clone = clone $obj;
+} catch (Throwable $e) {
+  echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
-echo "Done\n";
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Call to protected test::__clone() from global scope in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Call to protected test::__clone() from global scope

--- a/tests/classes/factory_and_singleton_008.phpt
+++ b/tests/classes/factory_and_singleton_008.phpt
@@ -8,14 +8,13 @@ class test {
   }
 }
 
-$obj = new test;
-$clone = clone $obj;
-$obj = NULL;
+try {
+  $obj = new test;
+  $clone = clone $obj;
+} catch (Throwable $e) {
+  echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+}
 
-echo "Done\n";
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Call to private test::__clone() from global scope in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+--EXPECT--
+Error: Call to private test::__clone() from global scope


### PR DESCRIPTION
This is in preparation for the possible future transformation of `clone` into a function call, but also meaningful on its own, since the purpose of the tests is not to test the stack trace generation, but rather that an exception was thrown. It also cleans up some unreachable code in the tests.

-----------------

This change was spun out of #18747.