### PR TITLE
Remove dead code from openssl_spki_new() implementation

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -651,10 +651,6 @@ cleanup:
 	if (spki != NULL) {
 		NETSCAPE_SPKI_free(spki);
 	}
-
-	if (s && ZSTR_LEN(s) <= 0) {
-		RETVAL_FALSE;
-	}
 }
 /* }}} */
 


### PR DESCRIPTION
If s is not NULL, the length can't be <= 0 because we at least append `spkac` in the string, which is non-empty.
I noticed this condition because if it were actually possible to execute, then it would leak memory.