### PR TITLE
Fix handling of references in zval_try_get_long()

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -378,6 +378,7 @@ static zend_always_inline zend_result zendi_try_convert_scalar_to_number(zval *o
 static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(const zval *op, bool *failed) /* {{{ */
 {
 	*failed = 0;
+try_again:
 	switch (Z_TYPE_P(op)) {
 		case IS_NULL:
 		case IS_FALSE:
@@ -448,6 +449,14 @@ static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(const zval *
 		case IS_ARRAY:
 			*failed = 1;
 			return 0;
+		case IS_REFERENCE:
+			op = Z_REFVAL_P(op);
+			if (Z_TYPE_P(op) == IS_LONG) {
+				return Z_LVAL_P(op);
+			} else {
+				goto try_again;
+			}
+			break;
 		EMPTY_SWITCH_DEFAULT_CASE()
 	}
 }

--- a/ext/intl/dateformat/dateformat_parse.c
+++ b/ext/intl/dateformat/dateformat_parse.c
@@ -185,12 +185,10 @@ PHP_METHOD(IntlDateFormatter, parseToCalendar)
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
 	if (z_parse_pos) {
-		zval *z_parse_pos_tmp = z_parse_pos;
-		ZVAL_DEREF(z_parse_pos_tmp);
-		bool failed = false;
-		zend_long long_parse_pos = zval_try_get_long(z_parse_pos_tmp, &failed);
+		bool failed;
+		zend_long long_parse_pos = zval_try_get_long(z_parse_pos, &failed);
 		if (failed) {
-			zend_argument_type_error(2, "must be of type int, %s given", zend_zval_value_name(z_parse_pos_tmp));
+			zend_argument_type_error(2, "must be of type int, %s given", zend_zval_value_name(z_parse_pos));
 			RETURN_THROWS();
 		}
 		if (ZEND_LONG_INT_OVFL(long_parse_pos)) {

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3930,7 +3930,7 @@ static uint32_t *make_conversion_map(HashTable *target_hash, size_t *conversion_
 	uint32_t *mapelm = convmap;
 
 	ZEND_HASH_FOREACH_VAL(target_hash, hash_entry) {
-		bool failed = true;
+		bool failed;
 		zend_long tmp = zval_try_get_long(hash_entry, &failed);
 		if (failed) {
 			efree(convmap);

--- a/ext/mbstring/tests/mb_encode_numericentity_references.phpt
+++ b/ext/mbstring/tests/mb_encode_numericentity_references.phpt
@@ -1,0 +1,12 @@
+--TEST--
+mb_encode_numericentity() reference handling
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+$n = 0;
+$convmap = [&$n, 0x1FFFFF, 0, 0x10FFFF];
+var_dump(mb_encode_numericentity("", $convmap, "utf8"));
+?>
+--EXPECT--
+string(0) ""

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -874,8 +874,7 @@ static bool php_pcntl_set_user_signal_infos(
 
 	zval *user_signal_no;
 	ZEND_HASH_FOREACH_VAL(user_signals, user_signal_no) {
-		bool failed = true;
-		ZVAL_DEREF(user_signal_no);
+		bool failed;
 		zend_long tmp = zval_try_get_long(user_signal_no, &failed);
 
 		if (failed) {


### PR DESCRIPTION
This API can't handle references, yet everyone keeps forgetting that it can't and that you should DEREF upfront. Fix every type of this issue once and for all by moving the reference handling to this Zend API.