### PR TITLE
Properly handle __debugInfo() returning an array reference

### DIFF
--- a/Zend/tests/__debugInfo_reference.phpt
+++ b/Zend/tests/__debugInfo_reference.phpt
@@ -1,0 +1,22 @@
+--TEST--
+__debugInfo with reference return
+--FILE--
+<?php
+
+class Test {
+    private $tmp = ['x' => 1];
+
+    public function &__debugInfo(): array
+    {
+        return $this->tmp;
+    }
+}
+
+var_dump(new Test);
+
+?>
+--EXPECT--
+object(Test)#1 (1) {
+  ["x"]=>
+  int(1)
+}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -174,6 +174,9 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 	}
 
 	zend_call_known_instance_method_with_0_params(ce->__debugInfo, object, &retval);
+	if (UNEXPECTED(Z_ISREF(retval))) {
+		zend_unwrap_reference(&retval);
+	}
 	if (Z_TYPE(retval) == IS_ARRAY) {
 		if (!Z_REFCOUNTED(retval)) {
 			*is_temp = 1;


### PR DESCRIPTION
Currently, this fails because the type is IS_REFERENCE instead of IS_ARRAY, but this could be confusing because a function return value is normally dereferenced automatically in a lot of cases.