### PR TITLE
mail: fix exit code handling of sendmail cmd

### DIFF
--- a/ext/standard/tests/mail/gh10990.phpt
+++ b/ext/standard/tests/mail/gh10990.phpt
@@ -13,5 +13,6 @@ $from = 'test@example.com';
 $headers = ['From' => &$from];
 var_dump(mail('test@example.com', 'Test', 'Test', $headers));
 ?>
---EXPECT--
+--EXPECTF--
+Warning: mail(): Sendmail exited with non-zero exit code 127 in %sgh10990.php on line %d
 bool(false)

--- a/ext/standard/tests/mail/mail_basic5.phpt
+++ b/ext/standard/tests/mail/mail_basic5.phpt
@@ -20,7 +20,9 @@ $message = 'A Message';
 echo "-- failure --\n";
 var_dump( mail($to, $subject, $message) );
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing mail() : basic functionality ***
 -- failure --
+
+Warning: mail(): Sendmail exited with non-zero exit code 1 in %smail_basic5.php on line %d
 bool(false)

--- a/ext/standard/tests/mail/mail_variation3.phpt
+++ b/ext/standard/tests/mail/mail_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Test mail() function : variation invalid program for sendmail
+Test mail() function : variation sendmail temp fail
 --INI--
-sendmail_path=rubbish 2>/dev/null
+sendmail_path=exit 75
 --SKIPIF--
 <?php
 if(substr(PHP_OS, 0, 3) == "WIN")
@@ -17,8 +17,6 @@ $subject = 'Test Subject';
 $message = 'A Message';
 var_dump( mail($to, $subject, $message) );
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing mail() : variation ***
-
-Warning: mail(): Sendmail exited with non-zero exit code 127 in %smail_variation1.php on line %d
-bool(false)
+bool(true)

--- a/ext/standard/tests/mail/mail_variation4.phpt
+++ b/ext/standard/tests/mail/mail_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Test mail() function : variation invalid program for sendmail
+Test mail() function : variation sigkill
 --INI--
-sendmail_path=rubbish 2>/dev/null
+sendmail_path="kill \$\$"
 --SKIPIF--
 <?php
 if(substr(PHP_OS, 0, 3) == "WIN")
@@ -20,5 +20,5 @@ var_dump( mail($to, $subject, $message) );
 --EXPECTF--
 *** Testing mail() : variation ***
 
-Warning: mail(): Sendmail exited with non-zero exit code 127 in %smail_variation1.php on line %d
+Warning: mail(): Sendmail killed by signal 15 (Terminated) in %smail_variation4.php on line %d
 bool(false)


### PR DESCRIPTION
Prior to this commit the return code of the pclose function was assumed to be the exit code of the process. However, the returned value as specified in wait(2) is a bit packed integer and must be interpreted with the provided macros. After this commit we use the macros to obtain the status code and also add some logging on failure.

For WIN32 we only check if the return value is non-zero, which should solve, #43327