### PR TITLE
mail: fix exit code handling of sendmail cmd

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -25,6 +25,10 @@
 #include "ext/date/php_date.h"
 #include "zend_smart_str.h"
 
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+
 #ifdef HAVE_SYSEXITS_H
 # include <sysexits.h>
 #endif
@@ -417,6 +421,7 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
 #endif
 	FILE *sendmail;
 	int ret;
+	int wstatus;
 	char *sendmail_path = INI_STR("sendmail_path");
 	char *sendmail_cmd = NULL;
 	char *mail_log = INI_STR("mail.log");
@@ -557,6 +562,7 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
 			fprintf(sendmail, "%s%s", hdr, line_sep);
 		}
 		fprintf(sendmail, "%s%s%s", line_sep, message, line_sep);
+#ifdef PHP_WIN32
 		ret = pclose(sendmail);
 
 #if PHP_SIGCHILD
@@ -564,17 +570,33 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
 			signal(SIGCHLD, sig_handler);
 		}
 #endif
-
-#ifdef PHP_WIN32
-		if (ret == -1)
 #else
+		wstatus = pclose(sendmail);
+#if PHP_SIGCHILD
+		if (sig_handler) {
+			signal(SIGCHLD, sig_handler);
+		}
+#endif
+		/* Determine the wait(2) exit status */
+		if (wstatus == -1) {
+			MAIL_RET(0);
+		} else if (WIFSIGNALED(wstatus)) {
+			MAIL_RET(0);
+		} else {
+			if (WIFEXITED(wstatus)) {
+				ret = WEXITSTATUS(wstatus);
+			} else {
+				MAIL_RET(0);
+			}
+		}
+#endif
+
 #if defined(EX_TEMPFAIL)
 		if ((ret != EX_OK)&&(ret != EX_TEMPFAIL))
 #elif defined(EX_OK)
 		if (ret != EX_OK)
 #else
 		if (ret != 0)
-#endif
 #endif
 		{
 			MAIL_RET(0);

--- a/ext/standard/tests/mail/mail_variation3.phpt
+++ b/ext/standard/tests/mail/mail_variation3.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test mail() function : variation sendmail temp fail
+--INI--
+sendmail_path=exit 75
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == "WIN")
+    die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+echo "*** Testing mail() : variation ***\n";
+
+// Initialise all required variables
+$to = 'user@example.com';
+$subject = 'Test Subject';
+$message = 'A Message';
+var_dump(mail($to, $subject, $message));
+?>
+--EXPECT--
+*** Testing mail() : variation ***
+bool(true)

--- a/ext/standard/tests/mail/mail_variation4.phpt
+++ b/ext/standard/tests/mail/mail_variation4.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test mail() function : variation sigterm
+--INI--
+sendmail_path="kill \$\$"
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == "WIN")
+    die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+echo "*** Testing mail() : variation ***\n";
+
+// Initialise all required variables
+$to = 'user@example.com';
+$subject = 'Test Subject';
+$message = 'A Message';
+var_dump(mail($to, $subject, $message));
+?>
+--EXPECT--
+*** Testing mail() : variation ***
+bool(false)

--- a/ext/standard/tests/mail/mail_variation5.phpt
+++ b/ext/standard/tests/mail/mail_variation5.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test mail() function : variation non-zero exit
+--INI--
+sendmail_path="exit 123"
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == "WIN")
+    die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+echo "*** Testing mail() : variation ***\n";
+
+// Initialise all required variables
+$to = 'user@example.com';
+$subject = 'Test Subject';
+$message = 'A Message';
+var_dump(mail($to, $subject, $message));
+?>
+--EXPECT--
+*** Testing mail() : variation ***
+bool(false)


### PR DESCRIPTION
Prior to this commit the return code of the pclose function was assumed to be the exit code of the process. However, the returned value as specified in wait(2) is a bit packed integer and must be interpreted with the provided macros. After this commit we use the macros to obtain the status code and also add some logging on failure.

For WIN32 we only check if the return value is non-zero, which should solve, #43327