### PR TITLE
Skip OpenSSL proxy test for bug #74796 on Windows

### DIFF
--- a/ext/openssl/tests/bug74796.phpt
+++ b/ext/openssl/tests/bug74796.phpt
@@ -5,6 +5,9 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists("proc_open")) die("skip no proc_open");
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die("skip not reliable on Windows due to proxy wait limitation");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
So the wait time did not help and the test is just not reliable on Windows. It would require changing how ServerClientTestCase works and adding some pipe between server and proxy. Currently the wait and notify works for the clients only. I will add a task for this but till then, the test needs to be skipped.