### PR TITLE
Fix GH-18743: Incompatibility in Inline TLS Assembly on Alpine 3.22

### DIFF
--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -2910,7 +2910,7 @@ static int zend_jit_setup(void)
 
 		__asm__(
 			"leaq _tsrm_ls_cache@tlsgd(%%rip), %0\n"
-			: "=a" (ti));
+			: "=D" (ti));
 		tsrm_tls_offset = ti[1];
 		tsrm_tls_index = ti[0] * 8;
 #elif defined(__FreeBSD__)
@@ -2918,7 +2918,7 @@ static int zend_jit_setup(void)
 
 		__asm__(
 			"leaq _tsrm_ls_cache@tlsgd(%%rip), %0\n"
-			: "=a" (ti));
+			: "=D" (ti));
 		tsrm_tls_offset = ti[1];
 		/* Index is offset by 1 on FreeBSD (https://github.com/freebsd/freebsd-src/blob/bf56e8b9c8639ac4447d223b83cdc128107cc3cd/libexec/rtld-elf/rtld.c#L5260) */
 		tsrm_tls_index = (ti[0] + 1) * 8;
@@ -2927,7 +2927,7 @@ static int zend_jit_setup(void)
 
 		__asm__(
 			"leaq _tsrm_ls_cache@tlsgd(%%rip), %0\n"
-			: "=a" (ti));
+			: "=D" (ti));
 		tsrm_tls_offset = ti[1];
 		tsrm_tls_index = ti[0] * 16;
 #endif


### PR DESCRIPTION
GAS started checking the relocation for tlsgd: it must use the %rdi register. However, the inline assembly now uses %rax instead. This causes a build failure. Fix it by changing the "=a" output register to "=D". Source: https://github.com/bminor/binutils-gdb/blob/ec181e1710e37007a8d95c284609bfaa5868d086/gas/config/tc-i386.c#L6793

gottpoff is unaffected.