### PR TITLE
Fix memory leak on php_odbc_fetch_hash() failure

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1370,6 +1370,7 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 				if (rc == SQL_ERROR) {
 					odbc_sql_error(result->conn_ptr, result->stmt, "SQLGetData");
 					efree(buf);
+					zval_ptr_dtor(return_value);
 					RETURN_FALSE;
 				}
 


### PR DESCRIPTION
The array is initialized but not freed.
Note that this codepath is untested in CI and I'm not sure how to test this.