### PR TITLE
ext/pdo_sqlite: createCollation memory leaks fix.

### DIFF
--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -352,6 +352,8 @@ static int php_sqlite_collation_callback(void *context, int string1_len, const v
 			zend_type_error("%s(): Return value of the callback must be of type int, %s returned",
 				ZSTR_VAL(func_name), zend_zval_value_name(&retval));
 			zend_string_release(func_name);
+			zval_ptr_dtor(&zargs[0]);
+			zval_ptr_dtor(&zargs[1]);
 			zval_ptr_dtor(&retval);
 			return FAILURE;
 		}

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation_wrong_callback.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation_wrong_callback.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Pdo\Sqlite::createCollation() memory leaks on wrong callback return type
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$db = new Pdo\Sqlite('sqlite::memory:');
+
+$db->exec("CREATE TABLE test (c string)");
+$db->exec("INSERT INTO test VALUES('youwontseeme')");
+$db->exec("INSERT INTO test VALUES('neither')");
+$db->createCollation('NAT', function($a, $b): string { return $a . $b; });
+
+try {
+    $db->query("SELECT c FROM test ORDER BY c COLLATE NAT");
+} catch (\TypeError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+PDO::query(): Return value of the callback must be of type int, string returned


### PR DESCRIPTION
coming from callback arguments when its return type is incorrect.