### PR TITLE
ext/pdo_sqlite: PDO::sqliteCreateCollection return type strenghtening.

### DIFF
--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -385,14 +385,14 @@ static int php_sqlite_collation_callback(void *context, int string1_len, const v
 			zend_type_error("%s(): Return value of the collation callback must be of type int, %s returned",
 				ZSTR_VAL(func_name), zend_zval_value_name(&retval));
 			zend_string_release(func_name);
-			zval_ptr_dtor(&retval);
-			return FAILURE;
+			ret = FAILURE;
 		}
 		if (Z_LVAL(retval) > 0) {
 			ret = 1;
 		} else if (Z_LVAL(retval) < 0) {
 			ret = -1;
 		}
+		zval_ptr_dtor(&retval);
 	}
 
 	return ret;

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
@@ -24,6 +24,13 @@ foreach ($result as $row) {
   echo $row['name'] . "\n";
 }
 
+$db->sqliteCreateCollation('MYCOLLATEBAD', function($a, $b) { return $a; });
+
+try {
+	$db->query('SELECT name FROM test_pdo_sqlite_createcollation ORDER BY name COLLATE MYCOLLATEBAD');
+} catch (\TypeError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
 ?>
 --EXPECT--
 1
@@ -32,3 +39,4 @@ foreach ($result as $row) {
 1
 10
 2
+PDO::query(): Return value of the collation callback must be of type int, string returned


### PR DESCRIPTION
Is supposed to be Pdo_Sqlite::createCollation alias but behavior differs in regard of return type checks.