### PR TITLE
fix iconv tests got skipped on windows

### DIFF
--- a/ext/iconv/tests/translit-failure.phpt
+++ b/ext/iconv/tests/translit-failure.phpt
@@ -4,7 +4,7 @@ Translit failure
 iconv
 --SKIPIF--
 <?php
-( ICONV_IMPL != "libiconv" ) and die("skip ICONV_IMPL != \"libiconv\"");
+( ICONV_IMPL != "libiconv" && ICONV_IMPL != "\"libiconv\"" ) and die("skip ICONV_IMPL != \"libiconv\"");
 ?>
 --INI--
 error_reporting=2039

--- a/ext/iconv/tests/translit-utf8.phpt
+++ b/ext/iconv/tests/translit-utf8.phpt
@@ -4,7 +4,7 @@ Translit UTF-8 quotes
 iconv
 --SKIPIF--
 <?php
-( ICONV_IMPL != "libiconv" ) and die("skip ICONV_IMPL != \"libiconv\"");
+( ICONV_IMPL != "libiconv" && ICONV_IMPL != "\"libiconv\"" ) and die("skip ICONV_IMPL != \"libiconv\"");
 ?>
 --INI--
 error_reporting=2047


### PR DESCRIPTION
On Windows(with php 8.4.7 NTS-x64), if you run `php -r "var_dump(ICONV_IMPL);"`, the result is like this:
```
string(10) ""libiconv""
```
So, the translit-failure.phpt and translit-utf8.phpt tests currently would be skipped on Windows.