### PR TITLE
Fix 'phpdbg --help' segfault on shutdown with USE_ZEND_ALLOC=0

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -179,12 +179,6 @@ static PHP_MSHUTDOWN_FUNCTION(phpdbg) /* {{{ */
 		phpdbg_notice("Script ended normally");
 	}
 
-	/* hack to restore mm_heap->use_custom_heap in order to receive memory leak info */
-	if (use_mm_wrappers) {
-		/* ASSUMING that mm_heap->use_custom_heap is the first element of the struct ... */
-		*(int *) zend_mm_get_heap() = 0;
-	}
-
 	if (PHPDBG_G(buffer)) {
 		free(PHPDBG_G(buffer));
 		PHPDBG_G(buffer) = NULL;


### PR DESCRIPTION
This hack not only breaks the handling of custom allocators, but also breaks if zend_alloc is compiled with USE_CUSTOM_MM. This hack is just no good, if you want leak information then use ASAN.