### PR TITLE
Fix technically incorrect sizeof

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -227,7 +227,7 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 	for (n = 1; (sai = sai->ai_next) != NULL; n++)
 		;
 
-	*sal = safe_emalloc((n + 1), sizeof(*sal), 0);
+	*sal = safe_emalloc((n + 1), sizeof(**sal), 0);
 	sai = res;
 	sap = *sal;
 
@@ -266,7 +266,7 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 		in = *((struct in_addr *) host_info->h_addr);
 	}
 
-	*sal = safe_emalloc(2, sizeof(*sal), 0);
+	*sal = safe_emalloc(2, sizeof(**sal), 0);
 	sap = *sal;
 	*sap = emalloc(sizeof(struct sockaddr_in));
 	(*sap)->sa_family = AF_INET;


### PR DESCRIPTION
This doesn't actually matter because both `*sal` and `**sal` are pointer sized, but this makes analysers happy.
Fixes bug #68866.