### PR TITLE
gen_stub: Fix undefined variable warning

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -5313,6 +5313,8 @@ function generateGlobalConstantAttributeInitialization(
         $constInfos,
         "",
         static function (ConstInfo $constInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility) {
+            $code = "";
+
             if ($constInfo->attributes === []) {
                 return null;
             }


### PR DESCRIPTION
> PHP Warning:  Undefined variable $code in build/gen_stub.php on line 5322

Introduced in php/php-src#18735.