### PR TITLE
str_(starts|ends)_with variadic needle

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3834,3 +3834,4 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): bo
 
 function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): bool {}
 #endif
+//

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2443,10 +2443,10 @@ function str_contains(string $haystack, string $needle): bool {}
  * @compile-time-eval
  * @frameless-function {"arity": 2}
  */
-function str_starts_with(string $haystack, string $needle): bool {}
+function str_starts_with(string $haystack, string ...$needle): bool {}
 
 /** @compile-time-eval */
-function str_ends_with(string $haystack, string $needle): bool {}
+function str_ends_with(string $haystack, string ...$needle): bool {}
 
 /**
  * @compile-time-eval

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1068329ac705806034a06a8a01bf3d81c3c71e24 */
+ * Stub hash: 260f73232c43ba0c74d03b554413581c9c4bc516 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dfd7d2cfd31312f7f6c5074c10cab54e9d1fbccc */
+ * Stub hash: 1068329ac705806034a06a8a01bf3d81c3c71e24 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -918,9 +918,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_contains, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, needle, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_str_starts_with arginfo_str_contains
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_starts_with, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, haystack, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, needle, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_str_ends_with arginfo_str_contains
+#define arginfo_str_ends_with arginfo_str_starts_with
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_chunk_split, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)

--- a/ext/standard/tests/strings/str_ends_with.phpt
+++ b/ext/standard/tests/strings/str_ends_with.phpt
@@ -2,6 +2,7 @@
 str_ends_with() function - unit tests for str_ends_with()
 --FILE--
 <?php
+declare(strict_types=1);
 $testStr = "beginningMiddleEnd";
 var_dump(str_ends_with($testStr, "End"));
 var_dump(str_ends_with($testStr, "end"));
@@ -20,6 +21,24 @@ var_dump(str_ends_with("a\x00b", "d\x00b"));
 var_dump(str_ends_with("a\x00b", "a\x00z"));
 var_dump(str_ends_with("a", "\x00a"));
 var_dump(str_ends_with("a", "a\x00"));
+// now test varargs
+if (!str_ends_with("foo", "a", "o")) {
+    throw new \Exception("str does not end with o");
+}
+try {
+    if (!str_ends_with("foo1", "a", "o", 1, "x")) {
+        throw new \Exception("str does not end with 1");
+    }
+    throw new \Exception("int(1) did not trigger TypeError");
+} catch (\TypeError $e) {
+    // Expected TypeError due to int(1) + strict_types
+}
+if (!str_ends_with("foo1", "a", "o", "1", "x")) {
+    throw new \Exception("str does not end with 1");
+}
+if (str_ends_with("", "a", "o")) {
+    throw new \Exception("Empty string ends with something");
+}
 ?>
 --EXPECT--
 bool(true)

--- a/ext/standard/tests/strings/str_starts_with.phpt
+++ b/ext/standard/tests/strings/str_starts_with.phpt
@@ -2,6 +2,7 @@
 str_starts_with() function - unit tests for str_starts_with()
 --FILE--
 <?php
+declare(strict_types=1);
 $testStr = "beginningMiddleEnd";
 var_dump(str_starts_with($testStr, "beginning"));
 var_dump(str_starts_with($testStr, "Beginning"));
@@ -20,6 +21,24 @@ var_dump(str_starts_with("a\x00b", "a\x00d"));
 var_dump(str_starts_with("a\x00b", "z\x00b"));
 var_dump(str_starts_with("a", "a\x00"));
 var_dump(str_starts_with("a", "\x00a"));
+// now test varargs
+if (!str_starts_with("foo", "a", "f")) {
+    throw new \Exception("str does not start with f");
+}
+try {
+    if (!str_starts_with("1foo", "a", "f", 1, "x")) {
+        throw new \Exception("str does not start with 1");
+    }
+    throw new \Exception("int(1) did not trigger TypeError");
+} catch (\TypeError $e) {
+    // Expected TypeError due to int(1) + strict_types
+}
+if (!str_starts_with("1foo", "a", "f", "1", "x")) {
+    throw new \Exception("str does not start with 1");
+}
+if (str_starts_with("", "a", "f")) {
+    throw new \Exception("Empty string starts with something");
+}
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
make str_starts_with and str_ends_with variadic:
```php
str_starts_with(string $haystack, string ...$needle): bool
str_ends_with(string $haystack, string ...$needle): bool
```
a simple example could be
```php
if (str_starts_with($url, "http://", "https://")) {
// url
}
if (str_ends_with($filename, ".pdf", ".doc", ".docx")) {
 // document
}
if(str_starts_with($str, ...$arr){
//
}
```
which seems easier than
```php
if (str_starts_with($url, "http://") || str_starts_with($url, "https://")) {
    // url
}
if (str_ends_with($filename, ".pdf") || str_ends_with($filename, ".doc") || str_ends_with($filename, ".docx")) {
    // document
}
$found = false;
foreach ($arr as $needle) {
    if (str_starts_with($str, $needle)) {
        $found = true;
        break;
    }
}
if ($found) {
    //
}
```

inspired by Python's `str.startswith()` which supports python-tuples like `if str.startswith(("foo","bar")): ...`
