### PR TITLE
Simplify callers of zval_try_get_long()

### DIFF
--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -160,9 +160,7 @@ PHP_FUNCTION(curl_share_init_persistent)
 	}
 
 	ZEND_HASH_FOREACH_VAL(share_opts, zval *entry) {
-		ZVAL_DEREF(entry);
-
-		bool failed = false;
+		bool failed;
 		zend_ulong option = zval_try_get_long(entry, &failed);
 
 		if (failed) {

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3037,13 +3037,11 @@ static int php_zip_cancel_callback(zip_t *arch, void *ptr)
 		/* Cancel if an exception has been thrown */
 		return -1;
 	}
-	bool failed = false;
-	zval *cb_retval_ptr = &cb_retval;
-	ZVAL_DEREF(cb_retval_ptr);
-	zend_long retval = zval_try_get_long(cb_retval_ptr, &failed);
+	bool failed;
+	zend_long retval = zval_try_get_long(&cb_retval, &failed);
 	if (failed) {
 		zend_type_error("Return value of callback provided to ZipArchive::registerCancelCallback()"
-			" must be of type int, %s returned", zend_zval_value_name(cb_retval_ptr));
+			" must be of type int, %s returned", zend_zval_value_name(&cb_retval));
 		zval_ptr_dtor(&cb_retval);
 		return -1;
 	}


### PR DESCRIPTION
Since 2b383848 references are handled properly by the Zend API, so we can simplify the callers by removing reference handling from there.