### PR TITLE
Allow using fast destruction path when ASAN is in use

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -439,7 +439,7 @@ void shutdown_executor(void) /* {{{ */
 #if ZEND_DEBUG
 	bool fast_shutdown = 0;
 #elif defined(__SANITIZE_ADDRESS__)
-	char *force_fast_shutdown = getenv("ZEND_FORCE_FAST_SHUTDOWN");
+	char *force_fast_shutdown = getenv("ZEND_ASAN_FORCE_FAST_SHUTDOWN");
 	bool fast_shutdown = (
 		is_zend_mm()
 		|| (force_fast_shutdown && ZEND_ATOL(force_fast_shutdown))


### PR DESCRIPTION
Disabling the fast path when a custom allocator is in use hid the https://github.com/php/php-src/issues/18833 issue, and made it super hard to debug, this re-enables it if php is compiled with asan.