### PR TITLE
ext/calendar: jewishtojd overflow on year argument.

### DIFF
--- a/ext/calendar/calendar.c
+++ b/ext/calendar/calendar.c
@@ -490,6 +490,11 @@ PHP_FUNCTION(jewishtojd)
 		RETURN_THROWS();
 	}
 
+	if (ZEND_LONG_EXCEEDS_INT(year)) {
+		zend_argument_value_error(3, "must be between %d and %d", INT_MIN, INT_MAX);
+		RETURN_THROWS();
+	}
+
 	RETURN_LONG(JewishToSdn(year, month, day));
 }
 /* }}} */

--- a/ext/calendar/jewish.c
+++ b/ext/calendar/jewish.c
@@ -714,7 +714,7 @@ zend_long JewishToSdn(
 	int yearLength;
 	int lengthOfAdarIAndII;
 
-	if (year <= 0 || day <= 0 || day > 30) {
+	if (year <= 0 || year >= 6000 || day <= 0 || day > 30) {
 		return (0);
 	}
 	switch (month) {

--- a/ext/calendar/tests/gh16234_2.phpt
+++ b/ext/calendar/tests/gh16234_2.phpt
@@ -4,8 +4,14 @@ GH-16234 jewishtojd overflow on year argument
 calendar
 --FILE--
 <?php
+try {
+	jewishtojd(10, 6, PHP_INT_MIN);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
 jewishtojd(10, 6, 2147483647);
 echo "DONE";
 ?>
---EXPECT--
+--EXPECTF--
+jewishtojd(): Argument #3 ($year) must be between %i and %d
 DONE

--- a/ext/calendar/tests/gh16234_2.phpt
+++ b/ext/calendar/tests/gh16234_2.phpt
@@ -4,14 +4,8 @@ GH-16234 jewishtojd overflow on year argument
 calendar
 --FILE--
 <?php
-try {
-	jewishtojd(10, 6, PHP_INT_MIN);
-} catch (\ValueError $e) {
-	echo $e->getMessage(), PHP_EOL;
-}
 jewishtojd(10, 6, 2147483647);
 echo "DONE";
 ?>
 --EXPECTF--
-jewishtojd(): Argument #3 ($year) must be between %i and %d
 DONE

--- a/ext/calendar/tests/gh16234_2.phpt
+++ b/ext/calendar/tests/gh16234_2.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-16234 jewishtojd overflow on year argument
+--EXTENSIONS--
+calendar
+--FILE--
+<?php
+jewishtojd(10, 6, 2147483647);
+echo "DONE";
+?>
+--EXPECT--
+DONE

--- a/ext/calendar/tests/gh16234_2_64.phpt
+++ b/ext/calendar/tests/gh16234_2_64.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-16234 jewishtojd overflow on year argument
+--EXTENSIONS--
+calendar
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE == 4) {
+        die("skip this test is for 64bit platform only");
+}
+?>
+--FILE--
+<?php
+try {
+	jewishtojd(10, 6, PHP_INT_MIN);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECTF--
+jewishtojd(): Argument #3 ($year) must be between %i and %d
+


### PR DESCRIPTION
Upper limit set to the 7th millenium (Messianic Age) in the jewish calendar,
 around 2239 year in the gregorian calendar.