### PR TITLE
Fix unused variable in pdo_sqlite_stmt_set_attribute()

### DIFF
--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -418,8 +418,6 @@ static int pdo_sqlite_stmt_get_attribute(pdo_stmt_t *stmt, zend_long attr, zval 
 
 static int pdo_sqlite_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zval *zval)
 {
-	pdo_sqlite_stmt *S = (pdo_sqlite_stmt*)stmt->driver_data;
-
 	switch (attr) {
         case PDO_SQLITE_ATTR_EXPLAIN_STATEMENT:
 #if SQLITE_VERSION_NUMBER >= 3041000
@@ -434,6 +432,8 @@ static int pdo_sqlite_stmt_set_attribute(pdo_stmt_t *stmt, zend_long attr, zval 
                     zend_value_error("explain mode must be one of the Pdo\\Sqlite::EXPLAIN_MODE_* constants");
                     return 0;
                 }
+
+                pdo_sqlite_stmt *S = (pdo_sqlite_stmt*)stmt->driver_data;
                 if (sqlite3_stmt_explain(S->stmt, (int)Z_LVAL_P(zval)) != SQLITE_OK) {
                     return 0;
                 }


### PR DESCRIPTION
The indentation is also wrong (using spaces instead of tabs), but this should be fixed in a separate commit.

See https://github.com/php/php-src/actions/runs/15647022368/job/44086182043