### PR TITLE
ext/bcmath: use vector in compare

### DIFF
--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -92,6 +92,38 @@ bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool us
 	const char *n1ptr = n1->n_value;
 	const char *n2ptr = n2->n_value;
 
+	while (count >= sizeof(BC_VECTOR)) {
+		BC_VECTOR n1bytes;
+		BC_VECTOR n2bytes;
+		memcpy(&n1bytes, n1ptr, sizeof(BC_VECTOR));
+		memcpy(&n2bytes, n2ptr, sizeof(BC_VECTOR));
+
+		if (n1bytes != n2bytes) {
+#if BC_LITTLE_ENDIAN
+			n1bytes = BC_BSWAP(n1bytes);
+			n2bytes = BC_BSWAP(n2bytes);
+#endif
+			if (n1bytes > n2bytes) {
+				/* Magnitude of n1 > n2. */
+				if (!use_sign || n1->n_sign == PLUS) {
+					return BCMATH_LEFT_GREATER;
+				} else {
+					return BCMATH_RIGHT_GREATER;
+				}
+			} else {
+				/* Magnitude of n1 < n2. */
+				if (!use_sign || n1->n_sign == PLUS) {
+					return BCMATH_RIGHT_GREATER;
+				} else {
+					return BCMATH_LEFT_GREATER;
+				}
+			}
+		}
+		count -= sizeof(BC_VECTOR);
+		n1ptr += sizeof(BC_VECTOR);
+		n2ptr += sizeof(BC_VECTOR);
+	}
+
 	while ((count > 0) && (*n1ptr == *n2ptr)) {
 		n1ptr++;
 		n2ptr++;

--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -39,6 +39,25 @@
    than N2 and +1 if N1 is greater than N2.  If USE_SIGN is false, just
    compare the magnitudes. */
 
+static inline bcmath_compare_result bc_compare_get_result_val(bool left_abs_greater, bool use_sign, sign left_sign)
+{
+	if (left_abs_greater) {
+		/* Magnitude of left > right. */
+		if (!use_sign || left_sign == PLUS) {
+			return BCMATH_LEFT_GREATER;
+		} else {
+			return BCMATH_RIGHT_GREATER;
+		}
+	} else {
+		/* Magnitude of left < right. */
+		if (!use_sign || left_sign == PLUS) {
+			return BCMATH_RIGHT_GREATER;
+		} else {
+			return BCMATH_LEFT_GREATER;
+		}
+	}
+}
+
 bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool use_sign)
 {
 	/* First, compare signs. */
@@ -66,21 +85,7 @@ bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool us
 
 	/* Now compare the magnitude. */
 	if (n1->n_len != n2->n_len) {
-		if (n1->n_len > n2->n_len) {
-			/* Magnitude of n1 > n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_LEFT_GREATER;
-			} else {
-				return BCMATH_RIGHT_GREATER;
-			}
-		} else {
-			/* Magnitude of n1 < n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_RIGHT_GREATER;
-			} else {
-				return BCMATH_LEFT_GREATER;
-			}
-		}
+		return bc_compare_get_result_val(n1->n_len > n2->n_len, use_sign, n1->n_sign);
 	}
 
 	size_t n1_scale = MIN(n1->n_scale, scale);
@@ -103,21 +108,7 @@ bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool us
 			n1bytes = BC_BSWAP(n1bytes);
 			n2bytes = BC_BSWAP(n2bytes);
 #endif
-			if (n1bytes > n2bytes) {
-				/* Magnitude of n1 > n2. */
-				if (!use_sign || n1->n_sign == PLUS) {
-					return BCMATH_LEFT_GREATER;
-				} else {
-					return BCMATH_RIGHT_GREATER;
-				}
-			} else {
-				/* Magnitude of n1 < n2. */
-				if (!use_sign || n1->n_sign == PLUS) {
-					return BCMATH_RIGHT_GREATER;
-				} else {
-					return BCMATH_LEFT_GREATER;
-				}
-			}
+			return bc_compare_get_result_val(n1bytes > n2bytes, use_sign, n1->n_sign);
 		}
 		count -= sizeof(BC_VECTOR);
 		n1ptr += sizeof(BC_VECTOR);
@@ -131,21 +122,7 @@ bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool us
 	}
 
 	if (count != 0) {
-		if (*n1ptr > *n2ptr) {
-			/* Magnitude of n1 > n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_LEFT_GREATER;
-			} else {
-				return BCMATH_RIGHT_GREATER;
-			}
-		} else {
-			/* Magnitude of n1 < n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_RIGHT_GREATER;
-			} else {
-				return BCMATH_LEFT_GREATER;
-			}
-		}
+		return bc_compare_get_result_val(*n1ptr > *n2ptr, use_sign, n1->n_sign);
 	}
 
 	/* They are equal up to the last part of the equal part of the fraction. */


### PR DESCRIPTION
# Benchmark

Since https://github.com/php/php-src/pull/18871 had a few issues, I've reopened the PR with this version, which is more balanced and stable.

### Small value 1
```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1', '2', 0);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/0_2.php
  Time (mean ± σ):     265.4 ms ±  13.8 ms    [User: 259.1 ms, System: 3.9 ms]
  Range (min … max):   250.9 ms … 290.7 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/0_2.php
  Time (mean ± σ):     259.7 ms ±   8.4 ms    [User: 253.3 ms, System: 3.9 ms]
  Range (min … max):   247.1 ms … 270.0 ms    11 runs
 
Summary
  '/master/sapi/cli/php /mount/bc/cmp/0_2.php' ran
    1.02 ± 0.06 times faster than '/php-dev2/sapi/cli/php /mount/bc/cmp/0_2.php'
```

### Small value 2
```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.2345', '1.23456', 5);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/0.php
  Time (mean ± σ):     439.0 ms ±   2.6 ms    [User: 433.7 ms, System: 2.9 ms]
  Range (min … max):   434.4 ms … 444.2 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/0.php
  Time (mean ± σ):     443.4 ms ±   5.5 ms    [User: 437.4 ms, System: 3.5 ms]
  Range (min … max):   434.0 ms … 452.2 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/0.php' ran
    1.01 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/cmp/0.php'
```

### Middle value 1

```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.234567890123', '1.234567890123', 15);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/1.php
  Time (mean ± σ):     475.9 ms ±   1.7 ms    [User: 469.5 ms, System: 3.9 ms]
  Range (min … max):   472.0 ms … 477.4 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/1.php
  Time (mean ± σ):     489.9 ms ±   4.3 ms    [User: 483.9 ms, System: 3.5 ms]
  Range (min … max):   485.0 ms … 497.7 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/1.php' ran
    1.03 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/cmp/1.php'
```

### Middle value 2

```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.23456789012345678901234567890123456789012345678901234567890123456789', '1.23456789012345678901234567890123456789012345678901234567890123456789', 40);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/2.php
  Time (mean ± σ):     492.9 ms ±   3.0 ms    [User: 486.2 ms, System: 4.3 ms]
  Range (min … max):   487.9 ms … 498.1 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/2.php
  Time (mean ± σ):     590.1 ms ±   2.9 ms    [User: 584.2 ms, System: 3.4 ms]
  Range (min … max):   585.6 ms … 593.9 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/2.php' ran
    1.20 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/cmp/2.php'
```

### Large value

```
for ($i = 0; $i < 100000; $i++) {
    bccomp(str_repeat('1234567890', 3000), str_repeat('1234567890', 3000), 0);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/3.php
  Time (mean ± σ):     571.7 ms ±  22.2 ms    [User: 566.5 ms, System: 2.8 ms]
  Range (min … max):   561.6 ms … 634.5 ms    10 runs

Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/3.php
  Time (mean ± σ):      1.322 s ±  0.002 s    [User: 1.316 s, System: 0.004 s]
  Range (min … max):    1.319 s …  1.326 s    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/3.php' ran
    2.31 ± 0.09 times faster than '/master/sapi/cli/php /mount/bc/cmp/3.php'
```