### PR TITLE
Add HAVE_MEMMOVE to ext/pcre

### DIFF
--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -99,7 +99,14 @@ else
     [PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -Wno-implicit-fallthrough"],,
     [-Werror])
 
-  PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  PHP_PCRE_CFLAGS=m4_normalize(["
+    $PHP_PCRE_CFLAGS
+    -DHAVE_CONFIG_H
+    -DHAVE_MEMMOVE
+    -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1
+    -I@ext_srcdir@/pcre2lib
+  "])
+
   AC_DEFINE([HAVE_BUNDLED_PCRE], [1],
     [Define to 1 if PHP uses the bundled PCRE library.])
   AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8])


### PR DESCRIPTION
The pcre2 library still needs HAVE_MEMMOVE defined to use the system (C99 standard) memmove() function, otherwise emulation is used. On Windows, this is already enabled.

I think emulation sounds worse than using system in this case, so probably should be added. But someone who understands this better should confirm.