### PR TITLE
Intl: Fix compile issues with ICU versions lower than 67

### DIFF
--- a/ext/intl/listformatter/listformatter.stub.php
+++ b/ext/intl/listformatter/listformatter.stub.php
@@ -8,8 +8,13 @@
  */
 final class IntlListFormatter {
 
+#if U_ICU_VERSION_MAJOR_NUM >= 67
      /** @cvalue ULISTFMT_TYPE_AND */
      public const int TYPE_AND = UNKNOWN;
+#else
+    /** @cvalue INTL_LISTFORMATTER_FALLBACK_TYPE_AND */
+    public const int TYPE_AND = UNKNOWN;
+#endif
     
 #if U_ICU_VERSION_MAJOR_NUM >= 67
     /** @cvalue ULISTFMT_TYPE_OR */
@@ -19,8 +24,13 @@ final class IntlListFormatter {
     public const int TYPE_UNITS = UNKNOWN;
 #endif
 
+#if U_ICU_VERSION_MAJOR_NUM >= 67
     /** @cvalue ULISTFMT_WIDTH_WIDE */
     public const int WIDTH_WIDE = UNKNOWN;
+#else
+    /** @cvalue INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE */
+    public const int WIDTH_WIDE = UNKNOWN;
+#endif
 
 #if U_ICU_VERSION_MAJOR_NUM >= 67
     /** @cvalue ULISTFMT_WIDTH_SHORT */

--- a/ext/intl/listformatter/listformatter_arginfo.h
+++ b/ext/intl/listformatter/listformatter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f64f4171cfe4f66f976b9350b0a0e22269301ce5 */
+ * Stub hash: cdbbdb55d1e53f422c5854460c3c6cc3d01360d7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlListFormatter___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -36,12 +36,22 @@ static zend_class_entry *register_class_IntlListFormatter(void)
 
 	INIT_CLASS_ENTRY(ce, "IntlListFormatter", class_IntlListFormatter_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+#if U_ICU_VERSION_MAJOR_NUM >= 67
 
 	zval const_TYPE_AND_value;
 	ZVAL_LONG(&const_TYPE_AND_value, ULISTFMT_TYPE_AND);
 	zend_string *const_TYPE_AND_name = zend_string_init_interned("TYPE_AND", sizeof("TYPE_AND") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_TYPE_AND_name, &const_TYPE_AND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_AND_name);
+#endif
+#if !(U_ICU_VERSION_MAJOR_NUM >= 67)
+
+	zval const_TYPE_AND_value;
+	ZVAL_LONG(&const_TYPE_AND_value, INTL_LISTFORMATTER_FALLBACK_TYPE_AND);
+	zend_string *const_TYPE_AND_name = zend_string_init_interned("TYPE_AND", sizeof("TYPE_AND") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_AND_name, &const_TYPE_AND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_TYPE_AND_name);
+#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 67
 
 	zval const_TYPE_OR_value;
@@ -58,12 +68,22 @@ static zend_class_entry *register_class_IntlListFormatter(void)
 	zend_declare_typed_class_constant(class_entry, const_TYPE_UNITS_name, &const_TYPE_UNITS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UNITS_name);
 #endif
+#if U_ICU_VERSION_MAJOR_NUM >= 67
 
 	zval const_WIDTH_WIDE_value;
 	ZVAL_LONG(&const_WIDTH_WIDE_value, ULISTFMT_WIDTH_WIDE);
 	zend_string *const_WIDTH_WIDE_name = zend_string_init_interned("WIDTH_WIDE", sizeof("WIDTH_WIDE") - 1, 1);
 	zend_declare_typed_class_constant(class_entry, const_WIDTH_WIDE_name, &const_WIDTH_WIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_WIDTH_WIDE_name);
+#endif
+#if !(U_ICU_VERSION_MAJOR_NUM >= 67)
+
+	zval const_WIDTH_WIDE_value;
+	ZVAL_LONG(&const_WIDTH_WIDE_value, INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE);
+	zend_string *const_WIDTH_WIDE_name = zend_string_init_interned("WIDTH_WIDE", sizeof("WIDTH_WIDE") - 1, 1);
+	zend_declare_typed_class_constant(class_entry, const_WIDTH_WIDE_name, &const_WIDTH_WIDE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(const_WIDTH_WIDE_name);
+#endif
 #if U_ICU_VERSION_MAJOR_NUM >= 67
 
 	zval const_WIDTH_SHORT_value;

--- a/ext/intl/listformatter/listformatter_class.c
+++ b/ext/intl/listformatter/listformatter_class.c
@@ -15,8 +15,8 @@
 #include "php.h"
 #include "php_intl.h"
 #include <unicode/ulistformatter.h>
-#include "listformatter_arginfo.h"
 #include "listformatter_class.h"
+#include "listformatter_arginfo.h"
 #include "intl_convert.h"
 
 static zend_object_handlers listformatter_handlers;
@@ -53,8 +53,13 @@ PHP_METHOD(IntlListFormatter, __construct)
     ListFormatter_object *obj = Z_INTL_LISTFORMATTER_P(ZEND_THIS);
     char* locale;
     size_t locale_len = 0;
-    zend_long type = ULISTFMT_TYPE_AND;
-    zend_long width = ULISTFMT_WIDTH_WIDE;
+    #if U_ICU_VERSION_MAJOR_NUM >= 67
+        zend_long type = ULISTFMT_TYPE_AND;
+        zend_long width = ULISTFMT_WIDTH_WIDE;
+    #else
+        zend_long type = INTL_LISTFORMATTER_FALLBACK_TYPE_AND;
+        zend_long width = INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE;
+    #endif
     ZEND_PARSE_PARAMETERS_START(1, 3)
         Z_PARAM_STRING(locale, locale_len)
         Z_PARAM_OPTIONAL
@@ -90,12 +95,12 @@ PHP_METHOD(IntlListFormatter, __construct)
 
         LISTFORMATTER_OBJECT(obj) = ulistfmt_openForType(locale, type, width, &status);
     #else
-        if (type != ULISTFMT_TYPE_AND) {
+        if (type != INTL_LISTFORMATTER_FALLBACK_TYPE_AND) {
             zend_argument_value_error(2, "contains an unsupported type. ICU 66 and below only support IntlListFormatter::TYPE_AND");
             RETURN_THROWS();
         }
 
-        if (width != ULISTFMT_WIDTH_WIDE) {
+        if (width != INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE) {
             zend_argument_value_error(3, "contains an unsupported width. ICU 66 and below only support IntlListFormatter::WIDTH_WIDE");
             RETURN_THROWS();
         }

--- a/ext/intl/listformatter/listformatter_class.h
+++ b/ext/intl/listformatter/listformatter_class.h
@@ -49,4 +49,7 @@ static inline ListFormatter_object *php_intl_listformatter_fetch_object(zend_obj
 void listformatter_register_class( void );
 extern zend_class_entry *ListFormatter_ce_ptr;
 
+#define INTL_LISTFORMATTER_FALLBACK_TYPE_AND 0
+#define INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE 0
+
 #endif // LISTFORMATTER_CLASS_H 


### PR DESCRIPTION
fixes https://github.com/php/php-src/issues/18860

~~It gets built, but I'm having some environment issues with setting up ICU 63, so I haven't actually run the tests to see if it's working.~~

When PHP intl is built with an older version of ICU (66 or older), we need a fallback for the AND and WIDE parameters. To solve this, I've added INTL_LISTFORMATTER_FALLBACK_TYPE_AND and INTL_LISTFORMATTER_FALLBACK_WIDTH_WIDE.

I've ran it locally with ICU 63 and the change works as expected (the tests pass). There's a failing test related to currencies, but it's unrelated to this change (some CLDR differences between versions).

cc @SjonHortensius 