### PR TITLE
ext/bcmath: use `memcmp` for compare

### DIFF
--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -92,29 +92,24 @@ bcmath_compare_result _bc_do_compare(bc_num n1, bc_num n2, size_t scale, bool us
 	const char *n1ptr = n1->n_value;
 	const char *n2ptr = n2->n_value;
 
-	while ((count > 0) && (*n1ptr == *n2ptr)) {
-		n1ptr++;
-		n2ptr++;
-		count--;
-	}
-
-	if (count != 0) {
-		if (*n1ptr > *n2ptr) {
-			/* Magnitude of n1 > n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_LEFT_GREATER;
-			} else {
-				return BCMATH_RIGHT_GREATER;
-			}
+	int cmp_ret = memcmp(n1ptr, n2ptr, count);
+	if (cmp_ret > 0) {
+		/* Magnitude of n1 > n2. */
+		if (!use_sign || n1->n_sign == PLUS) {
+			return BCMATH_LEFT_GREATER;
 		} else {
-			/* Magnitude of n1 < n2. */
-			if (!use_sign || n1->n_sign == PLUS) {
-				return BCMATH_RIGHT_GREATER;
-			} else {
-				return BCMATH_LEFT_GREATER;
-			}
+			return BCMATH_RIGHT_GREATER;
+		}
+	} else if (cmp_ret < 0) {
+		/* Magnitude of n1 < n2. */
+		if (!use_sign || n1->n_sign == PLUS) {
+			return BCMATH_RIGHT_GREATER;
+		} else {
+			return BCMATH_LEFT_GREATER;
 		}
 	}
+	n1ptr += count;
+	n2ptr += count;
 
 	/* They are equal up to the last part of the equal part of the fraction. */
 	if (n1_scale != n2_scale) {


### PR DESCRIPTION
Since the version using `memcmp` was faster than the one using `BC_VECTOR`, I will go with `memcmp`.

# Benchmark

### Small value
```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.2345', '1.23456', 5);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/0.php
  Time (mean ± σ):     438.3 ms ±   5.8 ms    [User: 432.8 ms, System: 3.1 ms]
  Range (min … max):   433.1 ms … 453.0 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/0.php
  Time (mean ± σ):     444.9 ms ±   6.9 ms    [User: 437.3 ms, System: 5.1 ms]
  Range (min … max):   437.1 ms … 458.1 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/0.php' ran
    1.02 ± 0.02 times faster than '/master/sapi/cli/php /mount/bc/cmp/0.php'
```

### Middle value 1

```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.234567890123', '1.234567890123', 15);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/1.php
  Time (mean ± σ):     465.3 ms ±   2.9 ms    [User: 458.9 ms, System: 3.9 ms]
  Range (min … max):   459.9 ms … 470.3 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/1.php
  Time (mean ± σ):     489.6 ms ±   3.2 ms    [User: 483.2 ms, System: 4.1 ms]
  Range (min … max):   484.9 ms … 494.5 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/1.php' ran
    1.05 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/cmp/1.php'
```

### Middle value 2

```
for ($i = 0; $i < 10000000; $i++) {
    bccomp('1.23456789012345678901234567890123456789012345678901234567890123456789', '1.23456789012345678901234567890123456789012345678901234567890123456789', 40);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/2.php
  Time (mean ± σ):     484.1 ms ±   2.3 ms    [User: 478.2 ms, System: 3.6 ms]
  Range (min … max):   482.0 ms … 488.8 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/2.php
  Time (mean ± σ):     589.0 ms ±   3.2 ms    [User: 582.7 ms, System: 3.7 ms]
  Range (min … max):   585.1 ms … 594.4 ms    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/2.php' ran
    1.22 ± 0.01 times faster than '/master/sapi/cli/php /mount/bc/cmp/2.php'
```

### Large value

```
for ($i = 0; $i < 100000; $i++) {
    bccomp(str_repeat('1234567890', 3000), str_repeat('1234567890', 3000), 0);
}
```

```
Benchmark 1: /php-dev2/sapi/cli/php /mount/bc/cmp/3.php
  Time (mean ± σ):     480.3 ms ±   1.1 ms    [User: 474.4 ms, System: 3.5 ms]
  Range (min … max):   479.1 ms … 482.6 ms    10 runs
 
Benchmark 2: /master/sapi/cli/php /mount/bc/cmp/3.php
  Time (mean ± σ):      1.330 s ±  0.014 s    [User: 1.324 s, System: 0.003 s]
  Range (min … max):    1.319 s …  1.362 s    10 runs
 
Summary
  '/php-dev2/sapi/cli/php /mount/bc/cmp/3.php' ran
    2.77 ± 0.03 times faster than '/master/sapi/cli/php /mount/bc/cmp/3.php'
```