### PR TITLE
[Windows build] Remove redundant flags definitions

### DIFF
--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -285,12 +285,6 @@ if (TARGET_ARCH == 'x64') {
 }
 
 ADD_FLAG("CFLAGS_BD_ZEND", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-if (VS_TOOLSET && VCVERS >= 1914) {
-	ADD_FLAG("CFLAGS_BD_ZEND", "/d2FuncCache1");
-}
-
-/* XXX inspect this for other toolsets */
-//AC_DEFINE('ZEND_DVAL_TO_LVAL_CAST_OK', 1);
 
 ADD_SOURCES("main", "main.c snprintf.c spprintf.c getopt.c fopen_wrappers.c \
 	php_ini_builder.c php_glob.c \
@@ -299,9 +293,6 @@ ADD_SOURCES("main", "main.c snprintf.c spprintf.c getopt.c fopen_wrappers.c \
 	php_open_temporary_file.c output.c internal_functions.c \
 	php_syslog.c php_odbc_utils.c safe_bcmp.c");
 ADD_FLAG("CFLAGS_BD_MAIN", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-if (VS_TOOLSET && VCVERS >= 1914) {
-	ADD_FLAG("CFLAGS_BD_MAIN", "/d2FuncCache1");
-}
 
 AC_DEFINE('HAVE_STRNLEN', 1);
 
@@ -310,9 +301,6 @@ AC_DEFINE('ZEND_CHECK_STACK_LIMIT', 1)
 ADD_SOURCES("main/streams", "streams.c cast.c memory.c filter.c plain_wrapper.c \
 	userspace.c transports.c xp_socket.c mmap.c glob_wrapper.c");
 ADD_FLAG("CFLAGS_BD_MAIN_STREAMS", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-if (VS_TOOLSET && VCVERS >= 1914) {
-	ADD_FLAG("CFLAGS_BD_MAIN_STREAMS", "/d2FuncCache1");
-}
 
 ADD_SOURCES("win32", "dllmain.c readdir.c \
 	registry.c select.c sendmail.c time.c winutil.c wsyslog.c globals.c \
@@ -320,9 +308,6 @@ ADD_SOURCES("win32", "dllmain.c readdir.c \
 	fnmatch.c sockets.c console.c signal.c");
 
 ADD_FLAG("CFLAGS_BD_WIN32", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-if (VS_TOOLSET && VCVERS >= 1914) {
-	ADD_FLAG("CFLAGS_BD_WIN32", "/d2FuncCache1");
-}
 
 PHP_INSTALL_HEADERS("", "Zend/ TSRM/ main/ main/streams/ win32/");
 PHP_INSTALL_HEADERS("Zend/Optimizer", "zend_call_graph.h zend_cfg.h zend_dfg.h zend_dump.h zend_func_info.h zend_inference.h zend_optimizer.h zend_ssa.h zend_worklist.h");


### PR DESCRIPTION
The /d2FuncCache1 compile option is already added by toolset_setup_common_cflags() in confutils.js to all targets.

ZEND_DVAL_TO_LVAL_CAST_OK was removed in
3725717de18fd60a679a02210b3ed14517972524.