### PR TITLE
ext/date: Remove implicit bool type coercions in tests

### DIFF
--- a/ext/date/tests/bug33536.phpt
+++ b/ext/date/tests/bug33536.phpt
@@ -4,10 +4,6 @@ Bug #33456 (strtotime defaults to now even on non time string)
 <?php
 date_default_timezone_set("GMT");
 var_dump(strtotime("monkey"));
-print date("Y-m-d", strtotime("monkey")) ."\n";
-print date("Y-m-d", false) ."\n";
 ?>
 --EXPECT--
 bool(false)
-1970-01-01
-1970-01-01

--- a/ext/date/tests/bug44780.phpt
+++ b/ext/date/tests/bug44780.phpt
@@ -2,8 +2,8 @@
 Bug #44780 (some time zone offsets not recognized by timezone_name_from_abbr)
 --FILE--
 <?php
-var_dump( timezone_name_from_abbr("", 5.5*3600, false) );
-var_dump( timezone_name_from_abbr("", 28800, false) );
+var_dump( timezone_name_from_abbr("", 5.5*3600, 0) );
+var_dump( timezone_name_from_abbr("", 28800, 0) );
 ?>
 --EXPECT--
 string(12) "Asia/Kolkata"

--- a/ext/date/tests/date_sun_info_003.phpt
+++ b/ext/date/tests/date_sun_info_003.phpt
@@ -5,38 +5,43 @@ edgarsandi - <edgar.r.sandi@gmail.com>
 --FILE--
 <?php
 date_default_timezone_set('America/Sao_Paulo');
-$sun_info = date_sun_info(strtotime("2015-01-12 00:00:00 UTC"), 89.00, 1.00);
-foreach ($sun_info as $key => $elem ) {
-    echo "$key: " . date("H:i:s", $elem) . "\n";
+
+function print_sun_info(string $date) {
+    echo $date, "\n";
+    $sun_info = date_sun_info(strtotime($date), 89.00, 1.00);
+    foreach ($sun_info as $key => $elem ) {
+        echo "$key: " . match ($elem) {
+            true => 'always',
+            false => 'never',
+            default => date("H:i:s", $elem),
+        } . "\n";
+    }
 }
 
+print_sun_info("2015-01-12 00:00:00 UTC");
 echo "\n";
+print_sun_info("2015-09-12 00:00:00 UTC");
 
-$sun_info = date_sun_info(strtotime("2015-09-12 00:00:00 UTC"), 89.00, 1.00);
-foreach ($sun_info as $key => $elem ) {
-    echo "$key: " . date("H:i:s", $elem) . "\n";
-}
-
-echo "Done\n";
 ?>
 --EXPECT--
-sunrise: 21:00:00
-sunset: 21:00:00
+2015-01-12 00:00:00 UTC
+sunrise: never
+sunset: never
 transit: 10:03:48
-civil_twilight_begin: 21:00:00
-civil_twilight_end: 21:00:00
-nautical_twilight_begin: 21:00:00
-nautical_twilight_end: 21:00:00
-astronomical_twilight_begin: 21:00:00
-astronomical_twilight_end: 21:00:00
+civil_twilight_begin: never
+civil_twilight_end: never
+nautical_twilight_begin: never
+nautical_twilight_end: never
+astronomical_twilight_begin: never
+astronomical_twilight_end: never
 
-sunrise: 21:00:01
-sunset: 21:00:01
+2015-09-12 00:00:00 UTC
+sunrise: always
+sunset: always
 transit: 08:52:44
-civil_twilight_begin: 21:00:01
-civil_twilight_end: 21:00:01
-nautical_twilight_begin: 21:00:01
-nautical_twilight_end: 21:00:01
-astronomical_twilight_begin: 21:00:01
-astronomical_twilight_end: 21:00:01
-Done
+civil_twilight_begin: always
+civil_twilight_end: always
+nautical_twilight_begin: always
+nautical_twilight_end: always
+astronomical_twilight_begin: always
+astronomical_twilight_end: always


### PR DESCRIPTION
The regression tests are relatively straight forward, but for `ext/date/tests/date_sun_info_003.phpt` it seems like the type coercion was hiding a bug within the test, and I'm not sure if the way I changed it is accurate.

Found while working on #18879 