### PR TITLE
Fix GH-18899: JIT function crash when emitting undefined variable warning and opline is not set yet

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -5981,6 +5981,7 @@ static int zend_jit_long_math_helper(zend_jit_ctx   *jit,
 			ir_IF_FALSE_cold(if_def);
 
 			// zend_error_unchecked(E_WARNING, "Undefined variable $%S", CV_DEF_OF(EX_VAR_TO_NUM(opline->op1.var)));
+			jit_SET_EX_OPLINE(jit, opline);
 			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_undefined_op_helper), ir_CONST_U32(opline->op1.var));
 
 			ref2 = jit_EG(uninitialized_zval);
@@ -5997,6 +5998,7 @@ static int zend_jit_long_math_helper(zend_jit_ctx   *jit,
 			ir_IF_FALSE_cold(if_def);
 
 			// zend_error_unchecked(E_WARNING, "Undefined variable $%S", CV_DEF_OF(EX_VAR_TO_NUM(opline->op2.var)));
+			jit_SET_EX_OPLINE(jit, opline);
 			ir_CALL_1(IR_VOID, ir_CONST_FC_FUNC(zend_jit_undefined_op_helper), ir_CONST_U32(opline->op2.var));
 
 			ref2 = jit_EG(uninitialized_zval);

--- a/ext/opcache/tests/jit/gh18899.phpt
+++ b/ext/opcache/tests/jit/gh18899.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-18899 (JIT function crash when emitting undefined variable warning and opline is not set yet)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1205
+opcache.jit_buffer_size=8M
+--FILE--
+<?php
+function ptr2str()
+{
+    for ($i=0; $i<8; $i++) {
+        $ptr >>= 8;
+    }
+}
+str_repeat("A",232).ptr2str();
+?>
+--EXPECTF--
+Warning: Undefined variable $ptr in %s on line %d


### PR DESCRIPTION
The crash happens because EX(opline) is attempted to be accessed but it's not set yet.


Backport will happen after this is merged.