### PR TITLE
Fix GH-18901: integer overflow mb_split

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(mb_split)
 	size_t string_len;
 
 	int err;
-	zend_long count = -1;
+	zend_ulong count = -1; /* unsigned, it's a limit and we want to prevent signed overflow */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|l", &arg_pattern, &arg_pattern_len, &string, &string_len, &count) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/mbstring/tests/gh18901.phpt
+++ b/ext/mbstring/tests/gh18901.phpt
@@ -1,0 +1,54 @@
+--TEST--
+GH-18901 (integer overflow mb_split)
+--EXTENSIONS--
+mbstring
+--SKIPIF--
+<?php
+if (!function_exists('mb_split')) die('skip mb_split() not available');
+?>
+--FILE--
+<?php
+$vals = [PHP_INT_MIN, PHP_INT_MAX, -1, 0, 1];
+foreach ($vals as $val) {
+    var_dump(mb_split('\d', '123', $val));
+}
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(0) ""
+}
+array(4) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(0) ""
+}
+array(4) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(0) ""
+}
+array(1) {
+  [0]=>
+  string(3) "123"
+}
+array(1) {
+  [0]=>
+  string(3) "123"
+}


### PR DESCRIPTION
We prevent signed overflow by making the count unsigned. The actual interpretation of the count doesn't matter as it's just used to denote a limit.

The test output for some limit values looks strange though, so that may need extra investigation. However, that's orthogonal to this fix.
I.e. I think `((OnigUChar *)(string + beg) - chunk_pos))` needs to be `((OnigUChar *)(string + end) - chunk_pos))`