### PR TITLE
Remove non-existing INI directive detect_unicode

### DIFF
--- a/ext/phar/tests/zip/notphar.phpt
+++ b/ext/phar/tests/zip/notphar.phpt
@@ -4,7 +4,6 @@ Phar: a non-executable zip with no stub named .phar.zip
 phar
 --INI--
 phar.readonly=1
-detect_unicode=0
 zend.multibyte=0
 --FILE--
 <?php

--- a/pear/Makefile.frag
+++ b/pear/Makefile.frag
@@ -1,7 +1,7 @@
 peardir=$(PEAR_INSTALLDIR)
 
 # Skip all php.ini files altogether
-PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0
+PEAR_INSTALL_FLAGS = -n -dshort_open_tag=0 -dopen_basedir= -derror_reporting=1803 -dmemory_limit=-1
 
 WGET = `which wget 2>/dev/null`
 FETCH = `which fetch 2>/dev/null`


### PR DESCRIPTION
Unless I've missed something, I think there isn't any INI setting named "detect_unicode" anymore but there is this "zend.detect_unicode". Since setting detect_unicode to `off` doesn't do anything, this can be probably removed now. 

The `detect_unicode` was removed and `zend.detect_unicode` was added in PHP 5.4 (bbf3d43c1ee0ad53b03c3821cd630f0746d5e954).