### PR TITLE
Fix misleading errors in printf()

### DIFF
--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -530,7 +530,7 @@ php_formatted_print(char *format, size_t format_len, zval *args, int argc, int n
 						goto fail;
 					}
 					if (Z_LVAL_P(tmp) < 0 || Z_LVAL_P(tmp) > INT_MAX) {
-						zend_value_error("Width must be greater than zero and less than %d", INT_MAX);
+						zend_value_error("Width must be between 0 and %d", INT_MAX);
 						goto fail;
 					}
 					width = Z_LVAL_P(tmp);
@@ -538,7 +538,7 @@ php_formatted_print(char *format, size_t format_len, zval *args, int argc, int n
 				} else if (isdigit((int)*format)) {
 					PRINTF_DEBUG(("sprintf: getting width\n"));
 					if ((width = php_sprintf_getnumber(&format, &format_len)) < 0) {
-						zend_value_error("Width must be greater than zero and less than %d", INT_MAX);
+						zend_value_error("Width must be between 0 and %d", INT_MAX);
 						goto fail;
 					}
 					adjusting |= ADJ_WIDTH;
@@ -582,7 +582,7 @@ php_formatted_print(char *format, size_t format_len, zval *args, int argc, int n
 						expprec = 1;
 					} else if (isdigit((int)*format)) {
 						if ((precision = php_sprintf_getnumber(&format, &format_len)) < 0) {
-							zend_value_error("Precision must be greater than zero and less than %d", INT_MAX);
+							zend_value_error("Precision must be between 0 and %d", INT_MAX);
 							goto fail;
 						}
 						adjusting |= ADJ_PRECISION;

--- a/ext/standard/tests/strings/sprintf_star.phpt
+++ b/ext/standard/tests/strings/sprintf_star.phpt
@@ -62,6 +62,18 @@ try {
     echo $e->getMessage(), "\n";
 }
 
+try {
+    printf("%9999999999999999999999.f\n", $f);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    printf("%.9999999999999999999999f\n", $f);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
 --EXPECT--
 float(1.2345678901234567)
@@ -95,4 +107,6 @@ foo
 Precision must be an integer
 Precision must be between -1 and 2147483647
 Precision -1 is only supported for %g, %G, %h and %H
-Width must be greater than zero and less than 2147483647
+Width must be between 0 and 2147483647
+Width must be between 0 and 2147483647
+Precision must be between 0 and 2147483647


### PR DESCRIPTION
The precision and with _can_ be zero.