### PR TITLE
Fix GH-18897: printf: empty precision is interpreted as precision 6, not as precision 0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -263,6 +263,8 @@ PHP                                                                        NEWS
     (nielsdos)
   . Fixed exit code handling of sendmail cmd and added warnings.
     (Jesse Hathaway)
+  . Fixed bug GH-18897 (printf: empty precision is interpreted as precision 6,
+    not as precision 0). (nielsdos)
 
 - Streams:
   . Fixed bug GH-16889 (stream_select() timeout useless for pipes on Windows).

--- a/UPGRADING
+++ b/UPGRADING
@@ -116,6 +116,11 @@ PHP 8.5 UPGRADE NOTES
   . SplFileObject::fwrite's parameter $length is now nullable. The default
     value changed from 0 to null.
 
+- Standard:
+  . Using a printf-family function with a formatter that did not specify the
+    precision previously incorrectly reset the precision instead of treating
+    it as a precision of 0. See GH-18897.
+
 ========================================
 2. New Features
 ========================================

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -591,6 +591,7 @@ php_formatted_print(char *format, size_t format_len, zval *args, int argc, int n
 						expprec = 1;
 					} else {
 						precision = 0;
+						adjusting |= ADJ_PRECISION;
 					}
 				} else {
 					precision = 0;

--- a/ext/standard/tests/strings/gh18897.phpt
+++ b/ext/standard/tests/strings/gh18897.phpt
@@ -1,0 +1,10 @@
+--TEST--
+GH-18897 (printf: empty precision is interpreted as precision 6, not as precision 0)
+--FILE--
+<?php
+printf("%.f\n", 3.1415926535);
+printf("%.0f\n", 3.1415926535);
+?>
+--EXPECT--
+3
+3


### PR DESCRIPTION
Like in other languages, and especially C where printf originates from, a missing precision should be treated as a 0 precision. Because the ADJ_PRECISION flag was not set, the double formatting code resetted the precision to the default float precision of 6.

Targeting master because of the behavioural BC break.