### PR TITLE
Fix GH-18639: Internal class aliases can break preloading + JIT

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4628,8 +4628,16 @@ ZEND_EXT_API int zend_jit_script(zend_script *script)
 	 || JIT_G(trigger) == ZEND_JIT_ON_HOT_TRACE) {
 		zend_class_entry *ce;
 		zend_op_array *op_array;
+		zval *zv;
 
-		ZEND_HASH_MAP_FOREACH_PTR(&script->class_table, ce) {
+		ZEND_HASH_MAP_FOREACH_VAL(&script->class_table, zv) {
+			if (Z_TYPE_P(zv) == IS_ALIAS_PTR) {
+				continue;
+			}
+
+			ce = Z_PTR_P(zv);
+			ZEND_ASSERT(ce->type == ZEND_USER_CLASS);
+
 			ZEND_HASH_MAP_FOREACH_PTR(&ce->function_table, op_array) {
 				if (!ZEND_FUNC_INFO(op_array)) {
 					void *jit_extension = zend_shared_alloc_get_xlat_entry(op_array->opcodes);

--- a/ext/opcache/tests/gh18639.phpt
+++ b/ext/opcache/tests/gh18639.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-18639 (Internal class aliases can break preloading + JIT)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1255
+opcache.jit_buffer_size=16M
+opcache.preload={PWD}/preload_gh18567.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+echo "ok\n";
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
ZEND_FUNC_INFO() can not be used on internal CE's. If preloading makes a CE that's an alias of an internal class, the invalid access happens when setting the FUNC_INFO.

While we could check the class type to be of user code, we can just skip aliases altogether anyway which may be faster.