### PR TITLE
Fix GH-14082: Segmentation fault on unknown address 0x600000000018 in ext/opcache/jit/zend_jit.c

### DIFF
--- a/ext/opcache/tests/jit/gh14082.phpt
+++ b/ext/opcache/tests/jit/gh14082.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-14082 (Segmentation fault on unknown address 0x600000000018 in ext/opcache/jit/zend_jit.c)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=1235
+opcache.jit_buffer_size=16M
+opcache.preload={PWD}/preload_gh14082.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+Foo::test();
+echo "ok\n";
+?>
+--EXPECT--
+int(1)
+int(1)
+ok

--- a/ext/opcache/tests/jit/preload_gh14082.inc
+++ b/ext/opcache/tests/jit/preload_gh14082.inc
@@ -1,0 +1,9 @@
+<?php
+class Foo {
+    public static function test() {
+        static $i = 0;
+        var_dump(++$i);
+    }
+}
+
+Foo::test();


### PR DESCRIPTION
During persisting, the JIT may trigger and fill in the call graph. The call graph info is allocated on the arena which will be gone after preloading. To prevent invalid accesses during normal requests, the arena data should be cleared. This has to be done after all scripts have been persisted because shared op arrays between scripts can change the call graph.