### PR TITLE
Fix leak when creating cycle in hook

### DIFF
--- a/Zend/tests/gh18907.phpt
+++ b/Zend/tests/gh18907.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-18907: Leak when creating cycle inside hook
+--FILE--
+<?php
+
+class Foo {
+    public $prop {
+        get {
+            $this->prop = $this;
+            return 1;
+        }
+    }
+}
+
+function test() {
+    var_dump((new Foo)->prop);
+}
+
+/* Call twice to test the ZEND_IS_PROPERTY_HOOK_SIMPLE_GET() path. */
+test();
+test();
+
+?>
+--EXPECT--
+int(1)
+int(1)

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -719,7 +719,9 @@ static bool zend_call_get_hook(
 		return false;
 	}
 
+	GC_ADDREF(zobj);
 	zend_call_known_instance_method_with_0_params(get, zobj, rv);
+	OBJ_RELEASE(zobj);
 
 	return true;
 }


### PR DESCRIPTION
This is necessary because the VM frees operands with the nogc variants. We cannot just call gc_possible_root() because the object may no longer exist at that point.

Fixes GH-18907