### PR TITLE
Removed `ZEND_IS_XDIGIT()`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -43,6 +43,8 @@ PHP 8.5 INTERNALS UPGRADE NOTES
   . Added the zend_update_exception_properties() function for instantiating
     Exception child classes. It updates the $message, $code, and $previous
     properties.
+  . ZEND_IS_XDIGIT() macro was removed because it was unused and its name
+    did not match its actual behavior.
 
 ========================
 2. Build system changes

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -156,7 +156,6 @@ static zend_always_inline zend_long zend_dval_to_lval_safe(double d)
 }
 
 #define ZEND_IS_DIGIT(c) ((c) >= '0' && (c) <= '9')
-#define ZEND_IS_XDIGIT(c) (((c) >= 'A' && (c) <= 'F') || ((c) >= 'a' && (c) <= 'f'))
 
 static zend_always_inline uint8_t is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
 	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data)


### PR DESCRIPTION
This macro cannot correctly determine whether a string is a valid hexadecimal unless used together with `ZEND_IS_DIGIT()`.

In practice, it is not used anywhere within php-src, and its name does not reflect its actual behavior, so I propose removing it.