### PR TITLE
Deprecate returning non-string values from a user output handler

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -258,6 +258,12 @@ PHP 8.5 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
+- Core:
+  . Returning a non-string from a user output handler is deprecated. The
+    deprecation warning will bypass user output handlers to ensure it is
+    visible.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
+
 - Hash:
   . The MHASH_* constants have been deprecated.  These have been overlooked
     when the mhash*() function family has been deprecated per

--- a/tests/output/bug60768.phpt
+++ b/tests/output/bug60768.phpt
@@ -5,7 +5,7 @@ Bug #60768 Output buffer not discarded
 
 global $storage;
 
-ob_start(function($buffer) use (&$storage) { $storage .= $buffer; }, 20);
+ob_start(function($buffer) use (&$storage) { $storage .= $buffer; return ''; }, 20);
 
 echo str_repeat("0", 20); // fill in the buffer
 

--- a/tests/output/ob_start_basic_002.phpt
+++ b/tests/output/ob_start_basic_002.phpt
@@ -35,19 +35,23 @@ foreach ($callbacks as $callback) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 --> Use callback 'return_empty_string':
 
 
 --> Use callback 'return_false':
 My output.
+Deprecated: ob_end_flush(): Returning a non-string result from user output handler return_false is deprecated in %s on line %d
+
 
 --> Use callback 'return_null':
 
 
+
+Deprecated: ob_end_flush(): Returning a non-string result from user output handler return_null is deprecated in %s on line %d
 --> Use callback 'return_string':
 I stole your output.
 
 --> Use callback 'return_zero':
 0
-
+Deprecated: ob_end_flush(): Returning a non-string result from user output handler return_zero is deprecated in %s on line %d


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_4