### PR TITLE
release-process: update some confusing parts

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -162,7 +162,10 @@ slightly different steps. We'll call attention where the steps differ.
 4. Using your local-only release branch, bump the version numbers in
    `main/php_version.h`, `Zend/zend.h`, `configure.ac`, and possibly
    `NEWS`.
-
+  
+   The date for NEWS should be the date of the announcement (Thursday),
+   *not* the date of the tagging (Tuesday).
+  
    For examples, see [Update versions for PHP 8.1.0beta3][] (for a pre-GA
    example) or [Update versions for PHP 8.1.6RC1][] along with
    [Update NEWS for PHP 8.1.6RC1][] (for a post-GA example).
@@ -249,6 +252,9 @@ slightly different steps. We'll call attention where the steps differ.
    git add -p
    git commit --gpg-sign=YOURKEYID -m "[ci skip] Update NEWS for PHP X.Y.Z alpha2"
    ```
+
+   The NEWS is updated at the *start* of the cycle for the next tag, e.g.
+   [Update NEWS for PHP 8.2.0 alpha2][] was sent as part of tagging 8.2.0 alpha **1**.
 
    🔷 **For post-GA releases only,** switch back to the *version branch* for
    your release (e.g., `PHP-8.2`) and bump the version numbers in
@@ -365,6 +371,10 @@ slightly different steps. We'll call attention where the steps differ.
 
    Follow the documentation in the file for editing the QA release information.
 
+   > 🚨 **Attention** \
+   > **For pre-GA releases only,** don't commit yet, because you need to add an
+   > announcement with the release. After updating `$QA_RELEASES`, skip to step 2 below.
+
    Add, commit, and push your changes, when finished.
 
    ```shell
@@ -408,6 +418,15 @@ slightly different steps. We'll call attention where the steps differ.
    text slightly to indicate progression through the pre-release cycle. For
    example, here are all the news posts for the pre-GA releases of PHP 8.1.0:
 
+   > 💬 **Hint** \
+   > If you are going to base your language on one of these old announcements,
+   > remember that
+   > * `qa.php.net` has been replaced with https://www.php.net/release-candidates.php
+   > * `bugs.php.net` has been replaced with GitHub issues, use
+   >    `https://github.com/php/php-src/issues/new?template=bug_report.yml`
+   >   to link directly to the form for creating a new bug report.
+   > * Since 8.4 there have only been 4 release candidates for PHP X.Y.0, rather than 6.
+
    * [Announce 8.1.0alpha1](https://github.com/php/web-php/commit/57b9675c8d8550493289fa1fba77427c93cdd472)
    * [Announce 8.1.0alpha2](https://github.com/php/web-php/commit/cec044fc0763f5cfa77d0e79479f8b6279023570)
    * [Announce 8.1.0alpha3](https://github.com/php/web-php/commit/5c480765f444a3fddfd575e01fe0be3fcfdde05b)
@@ -431,7 +450,7 @@ slightly different steps. We'll call attention where the steps differ.
    > When a version is in its post-GA phase, we do not post news entries for
    > non-stable releases.
 
-3. Wait for the web and qa sites to update with the new information before
+3. Wait for the php site to update with the new information before
    sending announcements. This could take up to an hour.
 
 4. Send *separate* announcement emails to:
@@ -720,10 +739,10 @@ slightly different steps. We'll call attention where the steps differ.
 
    The array probably contains information about the RC released two weeks ago
    in preparation for the current release. Since the current release is now GA,
-   it's time to remove the RC build from the QA website.
+   it's time to remove the RC build from the release candidates page.
 
    It is sufficient to set the `number` property for the release to `0` to
-   stop displaying the RC build on the QA website. You may also remove the
+   stop displaying the RC build on the release candidates page. You may also remove the
    sha256 hashes for the RC tarballs, but it's not necessary.
 
 9. Review all the changes in `web-php`, commit, and push them.


### PR DESCRIPTION
Update based on my training with Pierrick
* dates should correspond to when releases are released, not tagged
* qa.php.net is no longer used
* bugs.php.net is no longer used
* multiple commits to web-php can be combined