### PR TITLE
ext/posix: posix_kill() process_id range check.

### DIFF
--- a/ext/posix/tests/posix_kill_pidoverflow.phpt
+++ b/ext/posix/tests/posix_kill_pidoverflow.phpt
@@ -1,0 +1,24 @@
+--TEST--
+posix_kill() with large pid
+--EXTENSIONS--
+posix
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--FILE--
+<?php
+// with pid overflow, it ends up being -1 which means all permissible processes are affected
+try {
+	posix_kill(PHP_INT_MAX, SIGTERM);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+	posix_kill(PHP_INT_MIN, SIGTERM);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECTF--
+posix_kill(): Argument #1 ($process_id) must be between %i and %d
+posix_kill(): Argument #1 ($process_id) must be between %i and %d

--- a/ext/posix/tests/posix_setpgid_error.phpt
+++ b/ext/posix/tests/posix_setpgid_error.phpt
@@ -1,0 +1,22 @@
+--TEST--
+posix_setpgid() with wrong pid values
+--EXTENSIONS--
+posix
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--FILE--
+<?php
+try {
+	posix_setpgid(PHP_INT_MAX, 1);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+try {
+	posix_setpgid(-2, 1);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECTF--
+posix_setpgid(): Argument #1 ($process_id) must be between 0 and %d
+posix_setpgid(): Argument #1 ($process_id) must be between 0 and %d


### PR DESCRIPTION
pid_t is, for the most part, represented by a signed int, by overflowing it, we end up being in the -1 case which affect all accessible processes.