### PR TITLE
Remove redundant PCRE_STATIC definition

### DIFF
--- a/main/php_compat.h
+++ b/main/php_compat.h
@@ -393,8 +393,4 @@
 #define XML_NS 1
 #endif
 
-#ifdef PHP_EXPORTS
-#define PCRE_STATIC
-#endif
-
 #endif


### PR DESCRIPTION
Current minimum PCRE2 library in PHP is 10.30 (with bundled 10.45) and none of these versions use PCRE_STATIC macro anymore in favor of PCRE2_STATIC, which is defined in the generated config.w32.h on Windows.