### PR TITLE
ext/oci8: Decrease the reference count before calling `zend_list_close()`

### DIFF
--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -573,12 +573,8 @@ void php_oci_column_hash_dtor(zval *data)
 		zend_list_close(column->stmtid);
 	}
 
-	if (column->descid) {
-		if (GC_REFCOUNT(column->descid) == 1)
-			zend_list_close(column->descid);
-		else {
-			GC_DELREF(column->descid);
-		}
+	if (column->descid && !GC_DELREF(column->descid)) {
+		zend_list_close(column->descid);
 	}
 
 	if (column->data) {


### PR DESCRIPTION
fixes #18873

Since the resource will eventually be freed at the end of the script, this does not result in an actual memory leak, but this change fixes the issue of unnecessary memory usage growth.