### PR TITLE
Fix pcntl_rfork() / pcntl_forkx() with zend-max-execution-timers

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1277,6 +1277,8 @@ PHP_FUNCTION(pcntl_rfork)
 		default:
 			php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
+	} else if (pid == 0) {
+		zend_max_execution_timer_init();
 	}
 
 	RETURN_LONG((zend_long) pid);
@@ -1320,6 +1322,8 @@ PHP_FUNCTION(pcntl_forkx)
 		default:
 			php_error_docref(NULL, E_WARNING, "Error %d", errno);
 		}
+	} else if (pid == 0) {
+		zend_max_execution_timer_init();
 	}
 
 	RETURN_LONG((zend_long) pid);


### PR DESCRIPTION
After calling `pcntl_rfork()` or `pcntl_forkx()`, the child process triggers a fatal error during shutdown, in ZTS builds with `--enable-zend-max-execution-timers`:

    Fatal error: Could not set timer: Invalid argument (22) in Unknown on line 0

Here I fix this issue by calling `zend_max_execution_timer_init();` in the child process, as we do in `pcntl_fork()`:

https://github.com/php/php-src/blob/c7c6a79bd0a46a8600cf60b7fd3338d3f58fe825/ext/pcntl/pcntl.c#L299-L300

https://github.com/php/php-src/blob/c7c6a79bd0a46a8600cf60b7fd3338d3f58fe825/Zend/zend_max_execution_timer.h#L25-L26

See also: #10141 