### PR TITLE
Remove HAVE_SQLITE3_{CLOSE_V2,ERRSTR}

### DIFF
--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -9,12 +9,6 @@ if test "$PHP_PDO_SQLITE" != "no"; then
 
   PHP_SETUP_SQLITE([PDO_SQLITE_SHARED_LIBADD])
 
-  PHP_CHECK_LIBRARY([sqlite3], [sqlite3_close_v2],
-    [AC_DEFINE([HAVE_SQLITE3_CLOSE_V2], [1],
-      [Define to 1 if SQLite library has the 'sqlite3_close_v2' function.])],
-    [],
-    [$PDO_SQLITE_SHARED_LIBADD])
-
   PHP_CHECK_LIBRARY([sqlite3], [sqlite3_column_table_name],
     [AC_DEFINE([HAVE_SQLITE3_COLUMN_TABLE_NAME], [1],
       [Define to 1 if SQLite library was compiled with the

--- a/ext/pdo_sqlite/config.w32
+++ b/ext/pdo_sqlite/config.w32
@@ -8,7 +8,6 @@ if (PHP_PDO_SQLITE != "no") {
 
 		ADD_EXTENSION_DEP('pdo_sqlite', 'pdo');
 		AC_DEFINE("HAVE_SQLITE3_COLUMN_TABLE_NAME", 1, "Define to 1 if SQLite library was compiled with the SQLITE_ENABLE_COLUMN_METADATA and has the 'sqlite3_column_table_name' function.");
-		AC_DEFINE("HAVE_SQLITE3_CLOSE_V2", 1, "Define to 1 if SQLite library has the 'sqlite3_close_v2' function.");
 		ADD_MAKEFILE_FRAGMENT();
 	} else {
 		WARNING("pdo_sqlite not enabled; libraries and/or headers not found");

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -159,11 +159,7 @@ static void sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 
 		pdo_sqlite_cleanup_callbacks(H);
 		if (H->db) {
-#ifdef HAVE_SQLITE3_CLOSE_V2
 			sqlite3_close_v2(H->db);
-#else
-			sqlite3_close(H->db);
-#endif
 			H->db = NULL;
 		}
 		if (einfo->errmsg) {

--- a/ext/sqlite3/config.w32
+++ b/ext/sqlite3/config.w32
@@ -7,7 +7,6 @@ if (PHP_SQLITE3 != "no") {
 		EXTENSION("sqlite3", "sqlite3.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
 		AC_DEFINE("HAVE_SQLITE3", 1, "Define to 1 if the PHP extension 'sqlite3' is available.");
-		AC_DEFINE("HAVE_SQLITE3_ERRSTR", 1, "Define to 1 if SQLite library has the 'sqlite3_errstr' function.");
 		AC_DEFINE("HAVE_SQLITE3_EXPANDED_SQL", 1, "Define to 1 if SQLite library has the 'sqlite3_expanded_sql' function.");
 	} else {
 		WARNING("sqlite3 not enabled; libraries and/or headers not found");

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -9,12 +9,6 @@ if test $PHP_SQLITE3 != "no"; then
   AC_DEFINE([HAVE_SQLITE3], [1],
     [Define to 1 if the PHP extension 'sqlite3' is available.])
 
-  PHP_CHECK_LIBRARY([sqlite3], [sqlite3_errstr],
-    [AC_DEFINE([HAVE_SQLITE3_ERRSTR], [1],
-      [Define to 1 if SQLite library has the 'sqlite3_errstr' function.])],
-    [],
-    [$SQLITE3_SHARED_LIBADD])
-
   PHP_CHECK_LIBRARY([sqlite3], [sqlite3_expanded_sql],
     [AC_DEFINE([HAVE_SQLITE3_EXPANDED_SQL], [1],
       [Define to 1 if SQLite library has the 'sqlite3_expanded_sql' function.])],

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -143,11 +143,7 @@ PHP_METHOD(SQLite3, open)
 	rc = sqlite3_open_v2(fullpath, &(db_obj->db), flags, NULL);
 	if (rc != SQLITE_OK) {
 		zend_throw_exception_ex(zend_ce_exception, 0, "Unable to open database: %s",
-#ifdef HAVE_SQLITE3_ERRSTR
-				db_obj->db ? sqlite3_errmsg(db_obj->db) : sqlite3_errstr(rc));
-#else
-				db_obj->db ? sqlite3_errmsg(db_obj->db) : "");
-#endif
+			db_obj->db ? sqlite3_errmsg(db_obj->db) : sqlite3_errstr(rc));
 		sqlite3_close(db_obj->db);
 		if (fullpath != filename) {
 			efree(fullpath);
@@ -1329,7 +1325,6 @@ PHP_METHOD(SQLite3, setAuthorizer)
 /* }}} */
 
 
-#if SQLITE_VERSION_NUMBER >= 3006011
 /* {{{ Backups the current database to another one. */
 PHP_METHOD(SQLite3, backup)
 {
@@ -1383,7 +1378,6 @@ PHP_METHOD(SQLite3, backup)
 	RETURN_TRUE;
 }
 /* }}} */
-#endif
 
 /* {{{ Returns the number of parameters within the prepared statement. */
 PHP_METHOD(SQLite3Stmt, paramCount)

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -199,10 +199,8 @@ class SQLite3
     public function loadExtension(string $name): bool {}
 #endif
 
-#if SQLITE_VERSION_NUMBER >= 3006011
     /** @tentative-return-type */
     public function backup(SQLite3 $destination, string $sourceDatabase = "main", string $destinationDatabase = "main"): bool {}
-#endif
 
     /** @tentative-return-type */
     public static function escapeString(string $string): string {}

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit sqlite3.stub.php instead.
- * Stub hash: da91c32c6070c808d6e1b01894b5f8beedda7b45 */
+ * Stub hash: 247f02e9b12b901b36bb863cf2a8e73b3d97a191 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -41,13 +41,11 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_loadExte
 ZEND_END_ARG_INFO()
 #endif
 
-#if SQLITE_VERSION_NUMBER >= 3006011
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_backup, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, destination, SQLite3, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, sourceDatabase, IS_STRING, 0, "\"main\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destinationDatabase, IS_STRING, 0, "\"main\"")
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SQLite3_escapeString, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
@@ -193,9 +191,7 @@ ZEND_METHOD(SQLite3, busyTimeout);
 #if !defined(SQLITE_OMIT_LOAD_EXTENSION)
 ZEND_METHOD(SQLite3, loadExtension);
 #endif
-#if SQLITE_VERSION_NUMBER >= 3006011
 ZEND_METHOD(SQLite3, backup);
-#endif
 ZEND_METHOD(SQLite3, escapeString);
 ZEND_METHOD(SQLite3, prepare);
 ZEND_METHOD(SQLite3, exec);
@@ -246,9 +242,7 @@ static const zend_function_entry class_SQLite3_methods[] = {
 #if !defined(SQLITE_OMIT_LOAD_EXTENSION)
 	ZEND_ME(SQLite3, loadExtension, arginfo_class_SQLite3_loadExtension, ZEND_ACC_PUBLIC)
 #endif
-#if SQLITE_VERSION_NUMBER >= 3006011
 	ZEND_ME(SQLite3, backup, arginfo_class_SQLite3_backup, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_ME(SQLite3, escapeString, arginfo_class_SQLite3_escapeString, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(SQLite3, prepare, arginfo_class_SQLite3_prepare, ZEND_ACC_PUBLIC)
 	ZEND_ME(SQLite3, exec, arginfo_class_SQLite3_exec, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
It would be kind of good to follow up on these minimum version bumps and clean the code on the way. I should recheck this a bit if everything is fine but these could be probably changed...

As of PHP 8.5 the minimum required SQLite library is 3.7.17, and this removes the following preprocessor macros checks:

- HAVE_SQLITE3_CLOSE_V2 (sqlite3_close_v2() function is available since SQLite 3.7.14.)
- HAVE_SQLITE3_ERRSTR (sqlite3_errstr() function is available since SQLite 3.7.15)
- SQLITE_VERSION_NUMBER should be now always greater than 3006011 (3.6.11).

Otherwise, tests fail when using SQLite 3.7.17 due to unconditional usage of SQLITE_DETERMINISTIC and similar... but this is for now not important.