### PR TITLE
Use st_blksize and st_blocks members conditionally

### DIFF
--- a/ext/phar/func_interceptors.c
+++ b/ext/phar/func_interceptors.c
@@ -637,8 +637,10 @@ statme_baby:
 			if (data) {
 				sb.st_ino = data->inode;
 			}
-#ifndef PHP_WIN32
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
 			sb.st_blksize = -1;
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
 			sb.st_blocks = -1;
 #endif
 			phar_fancy_stat(&sb, type, return_value);

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -527,8 +527,10 @@ void phar_dostat(phar_archive_data *phar, phar_entry_info *data, php_stream_stat
 	if (!is_temp_dir) {
 		ssb->sb.st_ino = data->inode;
 	}
-#ifndef PHP_WIN32
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
 	ssb->sb.st_blksize = -1;
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
 	ssb->sb.st_blocks = -1;
 #endif
 }

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -872,7 +872,7 @@ mdtm_error:
 	ssb->sb.st_rdev = -1;
 #ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
 	ssb->sb.st_blksize = 4096;				/* Guess since FTP won't expose this information */
-#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
+#if defined(HAVE_STRUCT_STAT_ST_BLOCKS) && defined(HAVE_STRUCT_STAT_ST_BLKSIZE)
 	ssb->sb.st_blocks = (int)((4095 + ssb->sb.st_size) / ssb->sb.st_blksize); /* emulate ceil */
 #endif
 #endif

--- a/ext/zip/zip_stream.c
+++ b/ext/zip/zip_stream.c
@@ -184,8 +184,10 @@ static int php_zip_ops_stat(php_stream *stream, php_stream_statbuf *ssb) /* {{{ 
 		ssb->sb.st_ctime = sb.mtime;
 		ssb->sb.st_nlink = 1;
 		ssb->sb.st_rdev = -1;
-#ifndef PHP_WIN32
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
 		ssb->sb.st_blksize = -1;
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
 		ssb->sb.st_blocks = -1;
 #endif
 		ssb->sb.st_ino = -1;

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -213,8 +213,10 @@ static int php_stream_memory_stat(php_stream *stream, php_stream_statbuf *ssb) /
 	/* generate unique inode number for alias/filename, so no phars will conflict */
 	ssb->sb.st_ino = 0;
 
-#ifndef PHP_WIN32
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
 	ssb->sb.st_blksize = -1;
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_BLOCKS
 	ssb->sb.st_blocks = -1;
 #endif
 


### PR DESCRIPTION
Instead of filtering Windows specifically, the preprocessor macros HAVE_STRUCT_STAT_ST_BLKSIZE and HAVE_STRUCT_STAT_ST_BLOCKS can be used.

These members are mostly present on all POSIX-based systems except on Windows these days but this syncs the usage style across the code base.

Additionally, in ext/standard/ftp_fopen_wrapper.c to set ssb->sb.st_blocks, also ssb->sb.st_blksize is added in the condition.