### PR TITLE
Fix OSS-Fuzz #427814452

### DIFF
--- a/Zend/tests/pipe_operator/gh18965.phpt
+++ b/Zend/tests/pipe_operator/gh18965.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-18965: ASSERT_CHECK avoids pipe lhs free
+--INI--
+zend.assertions=0
+--FILE--
+<?php
+namespace Foo;
+range(0, 10) |> assert(...);
+echo "No leak\n";
+?>
+--EXPECT--
+No leak

--- a/Zend/tests/pipe_operator/oss_fuzz_427814452.phpt
+++ b/Zend/tests/pipe_operator/oss_fuzz_427814452.phpt
@@ -1,0 +1,26 @@
+--TEST--
+OSS-Fuzz #427814452
+--FILE--
+<?php
+
+try {
+    false |> assert(...);
+} catch (\AssertionError $e) {
+    echo $e::class, ": '", $e->getMessage(), "'\n";
+}
+try {
+    0 |> "assert"(...);
+} catch (\AssertionError $e) {
+    echo $e::class, ": '", $e->getMessage(), "'\n";
+}
+try {
+    false |> ("a"."ssert")(...);
+} catch (\AssertionError $e) {
+    echo $e::class, ": '", $e->getMessage(), "'\n";
+}
+
+?>
+--EXPECT--
+AssertionError: ''
+AssertionError: ''
+AssertionError: ''

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -4356,7 +4356,10 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 		}
 		opline->result.num = zend_alloc_cache_slot();
 
-		if (args->children == 1) {
+		/* Skip adding a message on piped assert(...) calls, hence the ZEND_AST_ZNODE check.
+		 * We don't have access to the original AST anyway, so we would either need to duplicate
+		 * this logic in pipe compilation or store the AST. Neither seems worth the complexity. */
+		if (args->children == 1 && args->child[0]->kind != ZEND_AST_ZNODE) {
 			/* add "assert(condition) as assertion message */
 			zend_ast *arg = zend_ast_create_zval_from_str(
 				zend_ast_export("assert(", args->child[0], ")"));

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6426,18 +6426,18 @@ static bool can_match_use_jumptable(zend_ast_list *arms) {
 	return 1;
 }
 
-static bool zend_is_deopt_pipe_name(zend_ast *ast)
+static bool zend_is_pipe_optimizable_callable_name(zend_ast *ast)
 {
-	if (ast->kind != ZEND_AST_ZVAL || Z_TYPE_P(zend_ast_get_zval(ast)) != IS_STRING) {
-		return false;
+	if (ast->kind == ZEND_AST_ZVAL && Z_TYPE_P(zend_ast_get_zval(ast)) == IS_STRING) {
+		/* Assert compilation adds a message operand, but this is incompatible with the
+		 * pipe optimization that uses a temporary znode for the reference elimination.
+		 * Therefore, disable the optimization for assert.
+		 * Note that "assert" as a name is always treated as fully qualified. */
+		zend_string *str = zend_ast_get_str(ast);
+		return !zend_string_equals_literal_ci(str, "assert");
 	}
 
-	/* Assert compilation adds a message operand, but this is incompatible with the
-	 * pipe optimization that uses a temporary znode for the reference elimination.
-	 * Therefore, disable the optimization for assert.
-	 * Note that "assert" as a name is always treated as fully qualified. */
-	zend_string *str = zend_ast_get_str(ast);
-	return zend_string_equals_literal_ci(str, "assert");
+	return true;
 }
 
 static void zend_compile_pipe(znode *result, zend_ast *ast)
@@ -6468,7 +6468,7 @@ static void zend_compile_pipe(znode *result, zend_ast *ast)
 	/* Turn $foo |> bar(...) into bar($foo). */
 	if (callable_ast->kind == ZEND_AST_CALL
 		&& callable_ast->child[1]->kind == ZEND_AST_CALLABLE_CONVERT
-		&& !zend_is_deopt_pipe_name(callable_ast->child[0])) {
+		&& zend_is_pipe_optimizable_callable_name(callable_ast->child[0])) {
 		fcall_ast = zend_ast_create(ZEND_AST_CALL,
 				callable_ast->child[0], arg_list_ast);
 	/* Turn $foo |> bar::baz(...) into bar::baz($foo). */


### PR DESCRIPTION
Pipe compilation uses a temporary znode with QM_ASSIGN to remove references. Assert compilation wants to look at the operand AST and convert it to a string. However the original AST is lost due to the temporary znode. To solve this we either have to handle this specially in pipe compilation [1], or store the AST anyway somehow. Special casing this either way is not worth the complexity in my opinion, especially as it looks like a dynamic call anyway due to the FCC syntax. (Dynamic calls also don't have the assertion message added during compilation)

[1] Prototype (incomplete) at
    https://gist.github.com/nielsdos/50dc71718639c3af05db84a4dea6eb71
    shows this is not worthwhile in my opinion.