### PR TITLE
Use hasThis() where appropriate

### DIFF
--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -104,7 +104,7 @@ PHP_FUNCTION( numfmt_format )
 			INTL_METHOD_CHECK_STATUS( nfo, "Number formatting failed" );
 			break;
 		case FORMAT_TYPE_CURRENCY:
-			if (getThis()) {
+			if (hasThis()) {
 				const char *space;
 				const char *class_name = get_active_class_name(&space);
 				zend_argument_value_error(2, "cannot be NumberFormatter::TYPE_CURRENCY constant, "

--- a/ext/intl/formatter/formatter_parse.c
+++ b/ext/intl/formatter/formatter_parse.c
@@ -86,7 +86,7 @@ PHP_FUNCTION( numfmt_parse )
 			RETVAL_DOUBLE(val_double);
 			break;
 		case FORMAT_TYPE_CURRENCY:
-			if (getThis()) {
+			if (hasThis()) {
 				const char *space;
 				const char *class_name = get_active_class_name(&space);
 				zend_argument_value_error(2, "cannot be NumberFormatter::TYPE_CURRENCY constant, "

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -327,7 +327,7 @@ PHP_FUNCTION(mysqli_data_seek)
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
 
 	if (mysqli_result_is_unbuffered(result)) {
-		if (getThis()) {
+		if (hasThis()) {
 			zend_throw_error(NULL, "mysqli_result::data_seek() cannot be used in MYSQLI_USE_RESULT mode");
 		} else {
 			zend_throw_error(NULL, "mysqli_data_seek() cannot be used in MYSQLI_USE_RESULT mode");
@@ -855,7 +855,7 @@ PHP_FUNCTION(mysqli_free_result)
 /* {{{ Get MySQL client info */
 PHP_FUNCTION(mysqli_get_client_info)
 {
-	if (getThis()) {
+	if (hasThis()) {
 		if (zend_parse_parameters_none() == FAILURE) {
 			RETURN_THROWS();
 		}


### PR DESCRIPTION
This macro was introduced to solve false compilers warning about the getThis() condition not making sense for the address-taken part of the ternary.