### PR TITLE
Remove HAVE_PTRDIFF_T and SIZEOF_PTRDIFF_T

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -50,6 +50,9 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 2. Build system changes
 ========================
 
+- Abstract
+  . Preprocessor macro SIZEOF_PTRDIFF_T has been removed.
+
 - Windows build system changes
   . SAPI() and ADD_SOURCES() now suport the optional `duplicate_sources`
     parameter.  If truthy, no rules to build the object files are generated.
@@ -69,6 +72,7 @@ PHP 8.5 INTERNALS UPGRADE NOTES
   . Autoconf macro PHP_DEF_HAVE has been removed (use AC_DEFINE).
   . Autoconf macro PHP_OUTPUT has been removed (use AC_CONFIG_FILES).
   . Autoconf macro PHP_TEST_BUILD has been removed (use AC_* macros).
+  . Preprocessor macro HAVE_PTRDIFF_T has been removed.
 
 ========================
 3. Module changes

--- a/configure.ac
+++ b/configure.ac
@@ -454,7 +454,6 @@ AC_CHECK_TYPES([socklen_t], [], [], [
 dnl These are defined elsewhere than stdio.h.
 PHP_CHECK_SIZEOF([intmax_t], [0])
 PHP_CHECK_SIZEOF([ssize_t], [8])
-PHP_CHECK_SIZEOF([ptrdiff_t], [8])
 
 dnl Check stdint types (must be after header check).
 PHP_CHECK_STDINT_TYPES

--- a/ext/intl/collator/collator_sort.c
+++ b/ext/intl/collator/collator_sort.c
@@ -24,10 +24,6 @@
 #include "collator_convert.h"
 #include "intl_convert.h"
 
-#if !defined(HAVE_PTRDIFF_T) && !defined(_PTRDIFF_T_DEFINED)
-typedef zend_long ptrdiff_t;
-#endif
-
 /**
  * Declare 'index' which will point to sort key in sort key
  * buffer.

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -621,11 +621,7 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 					break;
 				case 't':
 					fmt++;
-#if SIZEOF_PTRDIFF_T
 					modifier = LM_PTRDIFF_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
 					break;
 				case 'p':
 				{
@@ -694,11 +690,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							i_num = (int64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							i_num = (int64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					/*
 					 * The rest also applies to other integer formats, so fall
@@ -737,11 +731,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 								i_num = (int64_t) va_arg(ap, intmax_t);
 								break;
 #endif
-#if SIZEOF_PTRDIFF_T
 							case LM_PTRDIFF_T:
 								i_num = (int64_t) va_arg(ap, ptrdiff_t);
 								break;
-#endif
 						}
 					}
 					s = ap_php_conv_10(i_num, (*fmt) == 'u', &is_negative,
@@ -783,11 +775,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					s = ap_php_conv_p2(ui_num, 3, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
 					FIX_PRECISION(adjust_precision, precision, s, s_len);
@@ -822,11 +812,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					s = ap_php_conv_p2(ui_num, 4, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
 					FIX_PRECISION(adjust_precision, precision, s, s_len);

--- a/main/snprintf.h
+++ b/main/snprintf.h
@@ -116,9 +116,7 @@ typedef enum {
 #if SIZEOF_INTMAX_T
 	LM_INTMAX_T,
 #endif
-#if SIZEOF_PTRDIFF_T
 	LM_PTRDIFF_T,
-#endif
 #if SIZEOF_LONG_LONG
 	LM_LONG_LONG,
 #endif

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -321,11 +321,7 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 					break;
 				case 't':
 					fmt++;
-#if SIZEOF_PTRDIFF_T
 					modifier = LM_PTRDIFF_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
 					break;
 				case 'p':
 				{
@@ -403,11 +399,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							i_num = (int64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							i_num = (int64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					/*
 					 * The rest also applies to other integer formats, so fall
@@ -446,11 +440,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 								i_num = (int64_t) va_arg(ap, intmax_t);
 								break;
 #endif
-#if SIZEOF_PTRDIFF_T
 							case LM_PTRDIFF_T:
 								i_num = (int64_t) va_arg(ap, ptrdiff_t);
 								break;
-#endif
 						}
 					}
 					s = ap_php_conv_10(i_num, (*fmt) == 'u', &is_negative,
@@ -491,11 +483,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					s = ap_php_conv_p2(ui_num, 3, *fmt,
 								&num_buf[NUM_BUF_SIZE], &s_len);
@@ -531,11 +521,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
 #endif
-#if SIZEOF_PTRDIFF_T
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
-#endif
 					}
 					s = ap_php_conv_p2(ui_num, 4, *fmt,
 								&num_buf[NUM_BUF_SIZE], &s_len);

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -84,10 +84,8 @@
 #define ssize_t SSIZE_T
 #ifdef _WIN64
 # define SIZEOF_SIZE_T 8
-# define SIZEOF_PTRDIFF_T 8
 #else
 # define SIZEOF_SIZE_T 4
-# define SIZEOF_PTRDIFF_T 4
 #endif
 #define SIZEOF_OFF_T 4
 #define HAVE_FNMATCH


### PR DESCRIPTION
If I'm not mistaken... The ptrdiff_t is a C89 standard type defined in `<stddef.h>` and widely available on current platforms. Using it conditionally as in these occurrences is not needed anymore.