### PR TITLE
ext/mysqli: Get rid of calls to strcpy

### DIFF
--- a/ext/mysqli/mysqli_report.c
+++ b/ext/mysqli/mysqli_report.c
@@ -48,12 +48,12 @@ void php_mysqli_report_error(const char *sqlstate, int errorno, const char *erro
 
 /* {{{ void php_mysqli_report_index() */
 void php_mysqli_report_index(const char *query, unsigned int status) {
-	char index[15];
+	const char *index;
 
 	if (status & SERVER_QUERY_NO_GOOD_INDEX_USED) {
-		strcpy(index, "Bad index");
+		index = "Bad index";
 	} else if (status & SERVER_QUERY_NO_INDEX_USED) {
-		strcpy(index, "No index");
+		index = "No index";
 	} else {
 		return;
 	}


### PR DESCRIPTION
strcpy is a dangerous API that should be avoided.