### PR TITLE
Remove HAVE_INTMAX_T and SIZEOF_INTMAX_T

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -52,6 +52,7 @@ PHP 8.5 INTERNALS UPGRADE NOTES
 
 - Abstract
   . Preprocessor macro SIZEOF_PTRDIFF_T has been removed.
+  . Preprocessor macro SIZEOF_INTMAX_T has been removed.
 
 - Windows build system changes
   . SAPI() and ADD_SOURCES() now suport the optional `duplicate_sources`
@@ -73,6 +74,7 @@ PHP 8.5 INTERNALS UPGRADE NOTES
   . Autoconf macro PHP_OUTPUT has been removed (use AC_CONFIG_FILES).
   . Autoconf macro PHP_TEST_BUILD has been removed (use AC_* macros).
   . Preprocessor macro HAVE_PTRDIFF_T has been removed.
+  . Preprocessor macro HAVE_INTMAX_T has been removed.
 
 ========================
 3. Module changes

--- a/configure.ac
+++ b/configure.ac
@@ -452,7 +452,6 @@ AC_CHECK_TYPES([socklen_t], [], [], [
 ])
 
 dnl These are defined elsewhere than stdio.h.
-PHP_CHECK_SIZEOF([intmax_t], [0])
 PHP_CHECK_SIZEOF([ssize_t], [8])
 
 dnl Check stdint types (must be after header check).

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -613,11 +613,7 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 					break;
 				case 'j':
 					fmt++;
-#if SIZEOF_INTMAX_T
 					modifier = LM_INTMAX_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
 					break;
 				case 't':
 					fmt++;
@@ -685,11 +681,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							i_num = (int64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							i_num = (int64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							i_num = (int64_t) va_arg(ap, ptrdiff_t);
 							break;
@@ -726,11 +720,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 								i_num = (int64_t) va_arg(ap, long long int);
 								break;
 #endif
-#if SIZEOF_INTMAX_T
 							case LM_INTMAX_T:
 								i_num = (int64_t) va_arg(ap, intmax_t);
 								break;
-#endif
 							case LM_PTRDIFF_T:
 								i_num = (int64_t) va_arg(ap, ptrdiff_t);
 								break;
@@ -770,11 +762,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							ui_num = (uint64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
@@ -807,11 +797,9 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 							ui_num = (uint64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;

--- a/main/snprintf.h
+++ b/main/snprintf.h
@@ -113,9 +113,7 @@ END_EXTERN_C()
 
 typedef enum {
 	LM_STD = 0,
-#if SIZEOF_INTMAX_T
 	LM_INTMAX_T,
-#endif
 	LM_PTRDIFF_T,
 #if SIZEOF_LONG_LONG
 	LM_LONG_LONG,

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -313,11 +313,7 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 					break;
 				case 'j':
 					fmt++;
-#if SIZEOF_INTMAX_T
 					modifier = LM_INTMAX_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
 					break;
 				case 't':
 					fmt++;
@@ -394,11 +390,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							i_num = (int64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							i_num = (int64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							i_num = (int64_t) va_arg(ap, ptrdiff_t);
 							break;
@@ -435,11 +429,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 								i_num = (int64_t) va_arg(ap, long long int);
 								break;
 #endif
-#if SIZEOF_INTMAX_T
 							case LM_INTMAX_T:
 								i_num = (int64_t) va_arg(ap, intmax_t);
 								break;
-#endif
 							case LM_PTRDIFF_T:
 								i_num = (int64_t) va_arg(ap, ptrdiff_t);
 								break;
@@ -478,11 +470,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							ui_num = (uint64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;
@@ -516,11 +506,9 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 							ui_num = (uint64_t) va_arg(ap, unsigned long long int);
 							break;
 #endif
-#if SIZEOF_INTMAX_T
 						case LM_INTMAX_T:
 							ui_num = (uint64_t) va_arg(ap, uintmax_t);
 							break;
-#endif
 						case LM_PTRDIFF_T:
 							ui_num = (uint64_t) va_arg(ap, ptrdiff_t);
 							break;

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -78,9 +78,8 @@
 /* int and long are still 32bit in 64bit compiles */
 #define SIZEOF_INT 4
 #define SIZEOF_LONG 4
-/* MSVC.6/NET don't allow 'long long' or know 'intmax_t' */
+/* MSVC.6/NET don't allow 'long long' */
 #define SIZEOF_LONG_LONG 8 /* defined as __int64 */
-#define SIZEOF_INTMAX_T 0
 #define ssize_t SSIZE_T
 #ifdef _WIN64
 # define SIZEOF_SIZE_T 8


### PR DESCRIPTION
This is another simplification regarding some standard types availability - the intmax_t isn't used much in PHP except in few bundled files and there doesn't seem to be any build errors regarding it out there. So I think this is also fine to do already at this point.

The intmax_t is a C99 standard type defined in `<stdint.h>` and widely available on current platforms. On Windows they are available as of Visual Studio 2013. Using it conditionally as in these occurrences is not needed anymore.