### PR TITLE
Fix PHP_BUILD_CRT input in the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,9 @@ on:
       windows_version:
         required: true
         type: string
+      vs_crt_version:
+        required: true
+        type: string
       skip_laravel:
         required: true
         type: boolean
@@ -1034,7 +1037,7 @@ jobs:
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: ${{ inputs.windows_version == '2022' && 'vs17' || 'vs16' }}
+      PHP_BUILD_CRT: ${{ inputs.vs_crt_version }}
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
       INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -60,6 +60,7 @@ jobs:
         (((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9) && '24.04')
         || '22.04' }}
       windows_version: '2022'
+      vs_crt_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) && 'vs17') || 'vs16' }}
       skip_laravel: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
       skip_symfony: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
       skip_wordpress: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}


### PR DESCRIPTION
We are now using windows-2022 for all supported PHP versions, so the `PHP_BUILD_CRT` version should be correctly based on the PHP version.