### PR TITLE
Fix error return check of EVP_CIPHER_CTX_ctrl()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7547,7 +7547,7 @@ static int php_openssl_cipher_init(const EVP_CIPHER *cipher_type,
 		return FAILURE;
 	}
 	if (mode->set_tag_length_always || (enc && mode->set_tag_length_when_encrypting)) {
-		if (!EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, NULL)) {
+		if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, NULL) != 1) {
 			php_error_docref(NULL, E_WARNING, "Setting tag length for AEAD cipher failed");
 			return FAILURE;
 		}
@@ -7555,7 +7555,7 @@ static int php_openssl_cipher_init(const EVP_CIPHER *cipher_type,
 	if (!enc && tag && tag_len > 0) {
 		if (!mode->is_aead) {
 			php_error_docref(NULL, E_WARNING, "The tag cannot be used because the cipher algorithm does not support AEAD");
-		} else if (!EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, (unsigned char *) tag)) {
+		} else if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, (unsigned char *) tag) != 1) {
 			php_error_docref(NULL, E_WARNING, "Setting tag for AEAD cipher decryption failed");
 			return FAILURE;
 		}

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7475,7 +7475,7 @@ static int php_openssl_validate_iv(const char **piv, size_t *piv_len, size_t iv_
 	char *iv_new;
 
 	if (mode->is_aead) {
-		if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_ivlen_flag, *piv_len, NULL) != 1) {
+		if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_ivlen_flag, *piv_len, NULL) <= 0) {
 			php_error_docref(NULL, E_WARNING, "Setting of IV length for AEAD mode failed");
 			return FAILURE;
 		}
@@ -7547,7 +7547,7 @@ static int php_openssl_cipher_init(const EVP_CIPHER *cipher_type,
 		return FAILURE;
 	}
 	if (mode->set_tag_length_always || (enc && mode->set_tag_length_when_encrypting)) {
-		if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, NULL) != 1) {
+		if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, NULL) <= 0) {
 			php_error_docref(NULL, E_WARNING, "Setting tag length for AEAD cipher failed");
 			return FAILURE;
 		}
@@ -7555,7 +7555,7 @@ static int php_openssl_cipher_init(const EVP_CIPHER *cipher_type,
 	if (!enc && tag && tag_len > 0) {
 		if (!mode->is_aead) {
 			php_error_docref(NULL, E_WARNING, "The tag cannot be used because the cipher algorithm does not support AEAD");
-		} else if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, (unsigned char *) tag) != 1) {
+		} else if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode->aead_set_tag_flag, tag_len, (unsigned char *) tag) <= 0) {
 			php_error_docref(NULL, E_WARNING, "Setting tag for AEAD cipher decryption failed");
 			return FAILURE;
 		}
@@ -7693,7 +7693,7 @@ PHP_OPENSSL_API zend_string* php_openssl_encrypt(
 		if (mode.is_aead && tag) {
 			zend_string *tag_str = zend_string_alloc(tag_len, 0);
 
-			if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode.aead_get_tag_flag, tag_len, ZSTR_VAL(tag_str)) == 1) {
+			if (EVP_CIPHER_CTX_ctrl(cipher_ctx, mode.aead_get_tag_flag, tag_len, ZSTR_VAL(tag_str)) > 0) {
 				ZSTR_VAL(tag_str)[tag_len] = '\0';
 				ZSTR_LEN(tag_str) = tag_len;
 				ZEND_TRY_ASSIGN_REF_NEW_STR(tag, tag_str);


### PR DESCRIPTION
OpenSSL can return -1 on error [1, 2], and OpenBSD's docs confirm this [3]. Existing checks check for 1 for the success value, so do the same.

[1] https://github.com/openssl/openssl/blob/b3161bd9a9329be3d6bf6b29a06835e2721898bb/crypto/evp/evp_enc.c#L1530-L1531
[2] https://github.com/openssl/openssl/blob/b3161bd9a9329be3d6bf6b29a06835e2721898bb/crypto/evp/evp_enc.c#L1611
[3] https://man.openbsd.org/EVP_CIPHER_CTX_ctrl.3

---

This is the first batch of potentially a few of these fixes. https://github.com/php/php-src/issues/18986 prompted me to dig up my old analyzer and re-run it with the combined codebases of PHP and OpenSSL to check for inconsistencies.