### PR TITLE
curl: Remove incorrect string release

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1369,7 +1369,6 @@ static inline CURLcode add_simple_field(struct HttpPost **first, struct HttpPost
 	part = curl_mime_addpart(mime);
 	if (part == NULL) {
 		zend_tmp_string_release(tmp_postval);
-		zend_string_release_ex(string_key, 0);
 		return CURLE_OUT_OF_MEMORY;
 	}
 	if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK


### PR DESCRIPTION
The string is owned by the caller, and the caller releases it.