### PR TITLE
fixes on mysqli, openssl, readline tests

### DIFF
--- a/ext/mysqli/tests/bug77956.phpt
+++ b/ext/mysqli/tests/bug77956.phpt
@@ -56,6 +56,6 @@ if (!$link->query('DROP TABLE IF EXISTS test')) {
 $link->close();
 unlink('bug77956.data');
 ?>
---EXPECT--
-[006] [2000] LOAD DATA LOCAL INFILE is forbidden, check related settings like mysqli.allow_local_infile|mysqli.local_infile_directory or PDO::MYSQL_ATTR_LOCAL_INFILE|PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY
+--EXPECTF--
+[006] [%d] LOAD DATA LOCAL INFILE is forbidden, check related settings like mysqli.allow_local_infile|mysqli.local_infile_directory or PDO::MYSQL_ATTR_LOCAL_INFILE|PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY
 done

--- a/ext/mysqli/tests/mysqli_fetch_assoc_no_alias_utf8.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc_no_alias_utf8.phpt
@@ -9,13 +9,13 @@ mysqli
     if (!$link = @mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
-    if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE 'UTF8'"))
+    if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE '%UTF8%'"))
         die("skip Cannot run SHOW CHARACTER SET to check charsets");
 
     if (!$tmp = mysqli_fetch_assoc($res))
         die("skip Looks like UTF8 is not available on the server");
 
-    if (strtolower($tmp['Charset']) !== 'utf8')
+    if (strtolower($tmp['Charset']) !== 'utf8' && strtolower($tmp['Charset']) !== 'utf8mb3')
         die("skip Not sure if UTF8 is available, canceling the test");
 
     mysqli_free_result($res);

--- a/ext/openssl/tests/bug70438.phpt
+++ b/ext/openssl/tests/bug70438.phpt
@@ -4,7 +4,8 @@ Request #70438: Add IV parameter for openssl_seal and openssl_open
 openssl
 --SKIPIF--
 <?php
-if (!in_array('AES-128-CBC', openssl_get_cipher_methods(true))) {
+if (!in_array('AES-128-CBC', openssl_get_cipher_methods(true)) &&
+    !in_array('aes-128-cbc', openssl_get_cipher_methods(true))) {
     print "skip";
 }
 ?>

--- a/ext/openssl/tests/bug74402.phpt
+++ b/ext/openssl/tests/bug74402.phpt
@@ -4,7 +4,8 @@ Bug #74402 (segfault on random_bytes, bin3hex, openssl_seal)
 openssl
 --SKIPIF--
 <?php
-if (!in_array('AES256', openssl_get_cipher_methods(true))) print "skip";
+if (!in_array('AES256', openssl_get_cipher_methods(true)) && 
+    !in_array('aes256', openssl_get_cipher_methods(true))) print "skip";
 ?>
 --FILE--
 <?php

--- a/ext/readline/tests/readline_read_history_error_001.phpt
+++ b/ext/readline/tests/readline_read_history_error_001.phpt
@@ -5,7 +5,7 @@ Pedro Manoel Evangelista <pedro.evangelista at gmail dot com>
 --EXTENSIONS--
 readline
 --SKIPIF--
-<?php if (!READLINE_LIB != "libedit") die('skip READLINE_LIB != "libedit"'); ?>
+<?php if (READLINE_LIB != "libedit") die('skip READLINE_LIB != "libedit"'); ?>
 --FILE--
 <?php
 var_dump(readline_read_history('nofile'));


### PR DESCRIPTION
### 1. ext\mysqli\tests\bug77956.phpt
The returned error number is 2068, tested on Windows MySQL 5.7.22 and Windows MySQL 8.0.34.

### 2. ext\mysqli\tests\mysqli_fetch_assoc_no_alias_utf8.phpt
MySQL 8.0 has changed 'utf-8' to 'utfmb3'. See [The utf8 Character Set](https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8.html).

### 3. ext\openssl\tests\bug70438.phpt
openssl_get_cipher_methods() returns cipher method names in lower cases. Tested on Windows openssl 3.2.0 and Linux openssl 1.1.1. But openssl_seal() supports case insensitive cipher method name, so the FILE section can leave unchanged.

### 4. ext\openssl\tests\bug74402.phpt
The same as the former one.

### 5. ext\readline\tests\readline_read_history_error_001.phpt
Typo.
