### PR TITLE
avoid false failure for long path

### DIFF
--- a/sapi/fpm/tests/socket-uds-too-long-filename-start.phpt
+++ b/sapi/fpm/tests/socket-uds-too-long-filename-start.phpt
@@ -40,11 +40,7 @@ $tester->expectLogPattern(
 
 $files = glob($socketFilePrefix . '*');
 
-if ($files === []) {
-    echo 'Socket files were not found.' . PHP_EOL;
-}
-
-if ($socketFile === $files[0]) {
+if (isset($files[0]) && $socketFile === $files[0]) {
     // this means the socket file path length is not an issue (anymore). Might be not long enough
     echo 'Socket file is the same as configured.' . PHP_EOL;
 }


### PR DESCRIPTION
With very long path, socket path may be truncated before `$socketFilePrefix,`

In which case, test is failing with `Socket files were not found` message

This is a false failure, as the log contains the expected message:

`[01-Jul-2025 05:38:07] WARNING: [pool fpm_pool] cannot bind to UNIX socket '/builddir/build/BUILD/php85-php-8.5.0_DEV.20250630-build/php-src-c9249e2d3aa401bda5d9a3071e86e0594807ed00/sapi/fpm/tests/socket-file-fpm-unix-socket-too-long-filename-but-starts-anyway-0000-0000-0000-0000-0000-0000-0000-0000-0000-0000-0000.sock' as path is too long (found length: 244, maximal length: 108), trying cut socket path instead '/builddir/build/BUILD/php85-php-8.5.0_DEV.20250630-build/php-src-c9249e2d3aa401bda5d9a3071e86e0594807ed00/s'
`

So only report about `Socket file is the same as configured` (failed test because path not truncated)

Also avoid the `Warning: Undefined array key 0 in .../sapi/fpm/tests/socket-uds-too-long-filename-start.php on line 41`

