### PR TITLE
Make parameter $column_key optional in array_column()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4666,10 +4666,10 @@ PHP_FUNCTION(array_column)
 	zend_long index_long = 0;
 	bool index_is_null = 1;
 
-	ZEND_PARSE_PARAMETERS_START(2, 3)
+	ZEND_PARSE_PARAMETERS_START(1, 3)
 		Z_PARAM_ARRAY_HT(input)
-		Z_PARAM_STR_OR_LONG_OR_NULL(column_str, column_long, column_is_null)
 		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_LONG_OR_NULL(column_str, column_long, column_is_null)
 		Z_PARAM_STR_OR_LONG_OR_NULL(index_str, index_long, index_is_null)
 	ZEND_PARSE_PARAMETERS_END();
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1737,7 +1737,7 @@ function array_count_values(array $array): array {}
  * @compile-time-eval
  * @refcount 1
  */
-function array_column(array $array, int|string|null $column_key, int|string|null $index_key = null): array {}
+function array_column(array $array, int|string|null $column_key = null, int|string|null $index_key = null): array {}
 
 /**
  * @compile-time-eval

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -247,9 +247,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_array_count_values arginfo_array_values
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_column, 0, 2, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_column, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_MASK(0, column_key, MAY_BE_LONG|MAY_BE_STRING|MAY_BE_NULL, NULL)
+	ZEND_ARG_TYPE_MASK(0, column_key, MAY_BE_LONG|MAY_BE_STRING|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_MASK(0, index_key, MAY_BE_LONG|MAY_BE_STRING|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/tests/array/array_column_skip_column_argument.phpt
+++ b/ext/standard/tests/array/array_column_skip_column_argument.phpt
@@ -1,0 +1,22 @@
+--TEST--
+parameter $column_key of array_column() is optional
+--FILE--
+<?php
+
+$array = [['a'], ['b']];
+var_dump(array_column($array, index_key: 0));
+
+?>
+--EXPECT--
+array(2) {
+  ["a"]=>
+  array(1) {
+    [0]=>
+    string(1) "a"
+  }
+  ["b"]=>
+  array(1) {
+    [0]=>
+    string(1) "b"
+  }
+}


### PR DESCRIPTION
Quite often in my code I reindex object collections via `array_column`. However, I have to explicitly pass `null` to `$column_key` instead of skipping it. Here's a change that makes possible this:

```diff
- array_column($objects, null, 'name');
+ array_column($objects, index_key: 'name');
```

Does it require a discussion in internals or an RFC?