### PR TITLE
Remove conditional checks for ssize_t type

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -72,11 +72,14 @@ PHP 8.5 INTERNALS UPGRADE NOTES
   . Autoconf macro PHP_AP_EXTRACT_VERSION has been removed.
   . Autoconf macro PHP_BUILD_THREAD_SAFE has been removed (set enable_zts
     manually).
+  . Autoconf macro PHP_CHECK_SIZEOF is obsolete (use AC_CHECK_SIZEOF).
   . Autoconf macro PHP_DEF_HAVE has been removed (use AC_DEFINE).
   . Autoconf macro PHP_OUTPUT has been removed (use AC_CONFIG_FILES).
   . Autoconf macro PHP_TEST_BUILD has been removed (use AC_* macros).
   . Preprocessor macro HAVE_PTRDIFF_T has been removed.
   . Preprocessor macro HAVE_INTMAX_T has been removed.
+  . Preprocessor macro HAVE_SSIZE_T has been removed.
+  . Preprocessor macro SIZEOF_SSIZE_T has been removed.
 
 ========================
 3. Module changes

--- a/build/php.m4
+++ b/build/php.m4
@@ -1014,7 +1014,9 @@ dnl _PHP_CHECK_SIZEOF(type, cross-value, extra-headers [, found-action [, not-fo
 dnl
 dnl Internal helper macro.
 dnl
-AC_DEFUN([_PHP_CHECK_SIZEOF], [
+AC_DEFUN([_PHP_CHECK_SIZEOF],
+[m4_warn([obsolete],
+  [The PHP_CHECK_SIZEOF macro is obsolete. Use AC_CHECK_SIZEOF.])
   php_cache_value=php_cv_sizeof_[]$1
   AC_CACHE_VAL(php_cv_sizeof_[]$1, [
     old_LIBS=$LIBS
@@ -1055,6 +1057,9 @@ ifelse([$5],[],,[else $5])
 
 dnl
 dnl PHP_CHECK_SIZEOF(type, cross-value, extra-headers)
+dnl
+dnl Checks the size of specified "type". This macro is obsolete as of PHP 8.5 in
+dnl favor of the AC_CHECK_SIZEOF.
 dnl
 AC_DEFUN([PHP_CHECK_SIZEOF], [
   AC_MSG_CHECKING([size of $1])

--- a/configure.ac
+++ b/configure.ac
@@ -451,9 +451,6 @@ AC_CHECK_TYPES([socklen_t], [], [], [
   #endif
 ])
 
-dnl These are defined elsewhere than stdio.h.
-PHP_CHECK_SIZEOF([ssize_t], [8])
-
 dnl Check stdint types (must be after header check).
 PHP_CHECK_STDINT_TYPES
 

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -709,11 +709,7 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 								i_num = (int64_t) va_arg(ap, long int);
 								break;
 							case LM_SIZE_T:
-#if SIZEOF_SSIZE_T
 								i_num = (int64_t) va_arg(ap, ssize_t);
-#else
-								i_num = (int64_t) va_arg(ap, size_t);
-#endif
 								break;
 #if SIZEOF_LONG_LONG
 							case LM_LONG_LONG:

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -418,11 +418,7 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 								i_num = (int64_t) va_arg(ap, long int);
 								break;
 							case LM_SIZE_T:
-#if SIZEOF_SSIZE_T
 								i_num = (int64_t) va_arg(ap, ssize_t);
-#else
-								i_num = (int64_t) va_arg(ap, size_t);
-#endif
 								break;
 #if SIZEOF_LONG_LONG
 							case LM_LONG_LONG:


### PR DESCRIPTION
The ssize_t type is already used unconditionally in php-src code everywhere except the main/s{n,p}printf.c files. On Windows ssize_t is available as an alias to the SSIZE_T defined in BaseTsd.h (available in affected files through the included windows.h in zend_config.w32.h).

This also makes the Autoconf macro PHP_CHECK_SIZEOF obsolete in favor of the AC_CHECK_SIZEOF, which is more convenient to check for types without the need to run the test program - omitting the cross-compilation issues. AC_CHECK_SIZEOF once didn't provide including additional headers (resolved in Autoconf versions after 2.13).