### PR TITLE
Fix leak when path is too long in ZipArchive::extractTo()

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -218,6 +218,7 @@ static int php_zip_extract_file(struct zip * za, char *dest, const char *file, s
 		return 0;
 	} else if (len > MAXPATHLEN) {
 		php_error_docref(NULL, E_WARNING, "Full extraction path exceed MAXPATHLEN (%i)", MAXPATHLEN);
+		efree(fullpath);
 		efree(file_dirname_fullpath);
 		zend_string_release_ex(file_basename, 0);
 		CWD_STATE_FREE(new_state.cwd);


### PR DESCRIPTION
I did not find an easy way to trigger this branch without also triggering some other error conditions earlier.