### PR TITLE
Introduce zend_vm_opcode_handler_t / zend_vm_opcode_handler_func_t

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -24,6 +24,7 @@
 #include "zend_types.h"
 #include "zend_map_ptr.h"
 #include "zend_alloc.h"
+#include "zend_vm_opcodes.h"
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -135,7 +136,7 @@ void zend_const_expr_to_zval(zval *result, zend_ast **ast_ptr, bool allow_dynami
 typedef int (*user_opcode_handler_t) (zend_execute_data *execute_data);
 
 struct _zend_op {
-	const void *handler;
+	zend_vm_opcode_handler_t handler;
 	znode_op op1;
 	znode_op op2;
 	znode_op result;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -321,10 +321,10 @@ static uint8_t zend_user_opcodes[256] = {0,
 #define SPEC_RULE_OBSERVER     0x02000000
 
 static const uint32_t *zend_spec_handlers;
-static const void * const *zend_opcode_handlers;
+static zend_vm_opcode_handler_t const *zend_opcode_handlers;
 static int zend_handlers_count;
 #if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
-static const void * const * zend_opcode_handler_funcs;
+static zend_vm_opcode_handler_func_t const * zend_opcode_handler_funcs;
 static zend_op hybrid_halt_op;
 #endif
 #if (ZEND_VM_KIND != ZEND_VM_KIND_HYBRID) || !ZEND_VM_SPEC
@@ -58665,7 +58665,7 @@ ZEND_API void execute_ex(zend_execute_data *ex)
 			(void*)&&ZEND_FE_FETCH_R_SIMPLE_SPEC_VAR_CV_RETVAL_USED_LABEL,
 			(void*)&&ZEND_NULL_LABEL
 		};
-		zend_opcode_handlers = (const void **) labels;
+		zend_opcode_handlers = (zend_vm_opcode_handler_t*) labels;
 		zend_handlers_count = sizeof(labels) / sizeof(void*);
 		memset(&hybrid_halt_op, 0, sizeof(hybrid_halt_op));
 		hybrid_halt_op.handler = (void*)&&HYBRID_HALT_LABEL;
@@ -64397,7 +64397,11 @@ ZEND_API void zend_execute(zend_op_array *op_array, zval *return_value)
 
 void zend_vm_init(void)
 {
-	static const void * const labels[] = {
+#if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
+	static zend_vm_opcode_handler_func_t const labels[] = {
+#else
+	static zend_vm_opcode_handler_t const labels[] = {
+#endif
 		ZEND_NOP_SPEC_HANDLER,
 		ZEND_ADD_SPEC_CONST_CONST_HANDLER,
 		ZEND_ADD_SPEC_CONST_TMPVARCV_HANDLER,
@@ -68199,7 +68203,7 @@ ZEND_API void ZEND_FASTCALL zend_serialize_opcode_handler(zend_op *op)
 	}
 	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
-	op->handler = (const void *)(uintptr_t)Z_LVAL_P(zv);
+	op->handler = (zend_vm_opcode_handler_t)(uintptr_t)Z_LVAL_P(zv);
 }
 
 ZEND_API void ZEND_FASTCALL zend_deserialize_opcode_handler(zend_op *op)

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -328,7 +328,7 @@ static zend_vm_opcode_handler_func_t const * zend_opcode_handler_funcs;
 static zend_op hybrid_halt_op;
 #endif
 #if (ZEND_VM_KIND != ZEND_VM_KIND_HYBRID) || !ZEND_VM_SPEC
-static const void *zend_vm_get_opcode_handler(uint8_t opcode, const zend_op* op);
+static zend_vm_opcode_handler_t zend_vm_get_opcode_handler(uint8_t opcode, const zend_op* op);
 #endif
 
 #if (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID)
@@ -58666,7 +58666,7 @@ ZEND_API void execute_ex(zend_execute_data *ex)
 			(void*)&&ZEND_NULL_LABEL
 		};
 		zend_opcode_handlers = (zend_vm_opcode_handler_t*) labels;
-		zend_handlers_count = sizeof(labels) / sizeof(void*);
+		zend_handlers_count = sizeof(labels) / sizeof(labels[0]);
 		memset(&hybrid_halt_op, 0, sizeof(hybrid_halt_op));
 		hybrid_halt_op.handler = (void*)&&HYBRID_HALT_LABEL;
 #ifdef ZEND_VM_HYBRID_JIT_RED_ZONE_SIZE
@@ -68161,7 +68161,7 @@ void zend_vm_init(void)
 	execute_ex(NULL);
 #else
 	zend_opcode_handlers = labels;
-	zend_handlers_count = sizeof(labels) / sizeof(void*);
+	zend_handlers_count = sizeof(labels) / sizeof(labels[0]);
 	zend_spec_handlers = specs;
 #endif
 	VM_TRACE_START();
@@ -68289,7 +68289,7 @@ static uint32_t ZEND_FASTCALL zend_vm_get_opcode_handler_idx(uint32_t spec, cons
 }
 
 #if (ZEND_VM_KIND != ZEND_VM_KIND_HYBRID) || !ZEND_VM_SPEC
-static const void *zend_vm_get_opcode_handler(uint8_t opcode, const zend_op* op)
+static zend_vm_opcode_handler_t zend_vm_get_opcode_handler(uint8_t opcode, const zend_op* op)
 {
 	return zend_opcode_handlers[zend_vm_get_opcode_handler_idx(zend_spec_handlers[opcode], op)];
 }

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -126,7 +126,7 @@ ZEND_API void ZEND_FASTCALL zend_serialize_opcode_handler(zend_op *op)
 	}
 	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
-	op->handler = (const void *)(uintptr_t)Z_LVAL_P(zv);
+	op->handler = (zend_vm_opcode_handler_t)(uintptr_t)Z_LVAL_P(zv);
 }
 
 ZEND_API void ZEND_FASTCALL zend_deserialize_opcode_handler(zend_op *op)

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -42,6 +42,17 @@
 # endif
 #endif
 
+#if ZEND_VM_KIND == ZEND_VM_KIND_HYBRID
+typedef const void* zend_vm_opcode_handler_t;
+typedef void (ZEND_FASTCALL *zend_vm_opcode_handler_func_t)(void);
+#elif ZEND_VM_KIND == ZEND_VM_KIND_CALL
+typedef const struct _zend_op *(ZEND_FASTCALL *zend_vm_opcode_handler_t)(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
+typedef const struct _zend_op *(ZEND_FASTCALL *zend_vm_opcode_handler_func_t)(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
+#else
+typedef const void* zend_vm_opcode_handler_t;
+typedef const void* zend_vm_opcode_handler_func_t;
+#endif
+
 #define ZEND_VM_OP_SPEC          0x00000001
 #define ZEND_VM_OP_CONST         0x00000002
 #define ZEND_VM_OP_TMPVAR        0x00000004

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -48,9 +48,12 @@ typedef void (ZEND_FASTCALL *zend_vm_opcode_handler_func_t)(void);
 #elif ZEND_VM_KIND == ZEND_VM_KIND_CALL
 typedef const struct _zend_op *(ZEND_FASTCALL *zend_vm_opcode_handler_t)(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
 typedef const struct _zend_op *(ZEND_FASTCALL *zend_vm_opcode_handler_func_t)(struct _zend_execute_data *execute_data, const struct _zend_op *opline);
-#else
+#elif ZEND_VM_KIND == ZEND_VM_KIND_SWITCH
+typedef int zend_vm_opcode_handler_t;
+#elif ZEND_VM_KIND == ZEND_VM_KIND_GOTO
 typedef const void* zend_vm_opcode_handler_t;
-typedef const void* zend_vm_opcode_handler_func_t;
+#else
+# error
 #endif
 
 #define ZEND_VM_OP_SPEC          0x00000001

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -26,6 +26,7 @@
 #include "Zend/zend_constants.h"
 #include "Zend/Optimizer/zend_func_info.h"
 #include "Zend/Optimizer/zend_call_graph.h"
+#include "zend_vm_opcodes.h"
 
 /* Address Encoding */
 typedef uintptr_t zend_jit_addr;
@@ -130,7 +131,7 @@ static zend_always_inline bool zend_jit_same_addr(zend_jit_addr addr1, zend_jit_
 typedef struct _zend_jit_op_array_extension {
 	zend_func_info func_info;
 	const zend_op_array *op_array;
-	const void *orig_handler;
+	zend_vm_opcode_handler_t orig_handler;
 } zend_jit_op_array_extension;
 
 /* Profiler */
@@ -169,7 +170,7 @@ typedef struct _zend_jit_op_array_hot_extension {
 	zend_func_info func_info;
 	const zend_op_array *op_array;
 	int16_t    *counter;
-	const void *orig_handlers[1];
+	zend_vm_opcode_handler_t orig_handlers[1];
 } zend_jit_op_array_hot_extension;
 
 #define zend_jit_op_array_hash(op_array) \
@@ -224,9 +225,6 @@ extern const zend_op *zend_jit_halt_op;
 	} while(0)
 # define ZEND_VM_ENTER_BIT 1ULL
 #endif
-
-/* VM handlers */
-typedef ZEND_OPCODE_HANDLER_RET (ZEND_FASTCALL *zend_vm_opcode_handler_t)(ZEND_OPCODE_HANDLER_ARGS);
 
 /* VM helpers */
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_leave_nested_func_helper(ZEND_OPCODE_HANDLER_ARGS_EX uint32_t call_info);
@@ -339,8 +337,8 @@ typedef enum _zend_jit_trace_stop {
 typedef union _zend_op_trace_info {
 	zend_op dummy; /* the size of this structure must be the same as zend_op */
 	struct {
-		const void *orig_handler;
-		const void *call_handler;
+		zend_vm_opcode_handler_t      orig_handler;
+		zend_vm_opcode_handler_func_t call_handler;
 		int16_t    *counter;
 		uint8_t     trace_flags;
 	};

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -3409,7 +3409,7 @@ static void zend_jit_trace_setup_ret_counter(const zend_op *opline, size_t offse
 			ZEND_JIT_COUNTER_NUM = (ZEND_JIT_COUNTER_NUM + 1) % ZEND_HOT_COUNTERS_COUNT;
 		}
 		ZEND_OP_TRACE_INFO(next_opline, offset)->trace_flags = ZEND_JIT_TRACE_START_RETURN;
-		next_opline->handler = (const void*)zend_jit_ret_trace_counter_handler;
+		next_opline->handler = zend_jit_ret_trace_counter_handler;
 	}
 }
 
@@ -4079,9 +4079,9 @@ static bool zend_jit_trace_may_throw(const zend_op       *opline,
 	return zend_may_throw_ex(opline, ssa_op, op_array, ssa, t1, t2);
 }
 
-static const void *zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t parent_trace, uint32_t exit_num)
+static zend_vm_opcode_handler_t zend_jit_trace(zend_jit_trace_rec *trace_buffer, uint32_t parent_trace, uint32_t exit_num)
 {
-	const void *handler = NULL;
+	zend_vm_opcode_handler_t handler = NULL;
 	zend_jit_ctx ctx;
 	zend_jit_ctx *jit = &ctx;
 	zend_jit_reg_var *ra = NULL;
@@ -7392,9 +7392,9 @@ static zend_string *zend_jit_trace_escape_name(uint32_t trace_num, uint32_t exit
 	return buf.s;
 }
 
-static const void *zend_jit_trace_exit_to_vm(uint32_t trace_num, uint32_t exit_num)
+static zend_vm_opcode_handler_t zend_jit_trace_exit_to_vm(uint32_t trace_num, uint32_t exit_num)
 {
-	const void *handler = NULL;
+	zend_vm_opcode_handler_t handler = NULL;
 	zend_jit_ctx ctx;
 	zend_string *name;
 	void *checkpoint;
@@ -7458,7 +7458,7 @@ jit_failure:
 static zend_jit_trace_stop zend_jit_compile_root_trace(zend_jit_trace_rec *trace_buffer, const zend_op *opline, size_t offset)
 {
 	zend_jit_trace_stop ret;
-	const void *handler;
+	zend_vm_opcode_handler_t handler;
 	uint8_t orig_trigger;
 	zend_jit_trace_info *t = NULL;
 	zend_jit_trace_exit_info exit_info[ZEND_JIT_TRACE_MAX_EXITS];
@@ -8832,11 +8832,11 @@ int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf 
 			zend_jit_unprotect();
 
 			if (ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_START_LOOP) {
-				((zend_op*)(t->opline))->handler = (const void*)zend_jit_loop_trace_counter_handler;
+				((zend_op*)(t->opline))->handler = zend_jit_loop_trace_counter_handler;
 			} else if (ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_START_ENTER) {
-				((zend_op*)(t->opline))->handler = (const void*)zend_jit_func_trace_counter_handler;
+				((zend_op*)(t->opline))->handler = zend_jit_func_trace_counter_handler;
 			} else if (ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_START_RETURN) {
-				((zend_op*)(t->opline))->handler = (const void*)zend_jit_ret_trace_counter_handler;
+				((zend_op*)(t->opline))->handler = zend_jit_ret_trace_counter_handler;
 			}
 			ZEND_OP_TRACE_INFO(t->opline, jit_extension->offset)->trace_flags &=
 				ZEND_JIT_TRACE_START_LOOP|ZEND_JIT_TRACE_START_ENTER|ZEND_JIT_TRACE_START_RETURN;
@@ -8889,9 +8889,9 @@ static int zend_jit_restart_hot_trace_counters(zend_op_array *op_array)
 		jit_extension->trace_info[i].trace_flags &=
 			ZEND_JIT_TRACE_START_LOOP | ZEND_JIT_TRACE_START_ENTER | ZEND_JIT_TRACE_UNSUPPORTED;
 		if (jit_extension->trace_info[i].trace_flags == ZEND_JIT_TRACE_START_LOOP) {
-			op_array->opcodes[i].handler = (const void*)zend_jit_loop_trace_counter_handler;
+			op_array->opcodes[i].handler = zend_jit_loop_trace_counter_handler;
 		} else if (jit_extension->trace_info[i].trace_flags == ZEND_JIT_TRACE_START_ENTER) {
-			op_array->opcodes[i].handler = (const void*)zend_jit_func_trace_counter_handler;
+			op_array->opcodes[i].handler = zend_jit_func_trace_counter_handler;
 		} else {
 			op_array->opcodes[i].handler = jit_extension->trace_info[i].orig_handler;
 		}
@@ -8917,7 +8917,7 @@ static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
 	jit_extension->offset = (char*)jit_extension->trace_info - (char*)op_array->opcodes;
 	for (i = 0; i < op_array->last; i++) {
 		jit_extension->trace_info[i].orig_handler = op_array->opcodes[i].handler;
-		jit_extension->trace_info[i].call_handler = zend_get_opcode_handler_func(&op_array->opcodes[i]);
+		jit_extension->trace_info[i].call_handler = (zend_vm_opcode_handler_func_t)zend_get_opcode_handler_func(&op_array->opcodes[i]);
 		jit_extension->trace_info[i].counter = NULL;
 		jit_extension->trace_info[i].trace_flags =
 			zend_jit_trace_supported(&op_array->opcodes[i]);
@@ -8939,7 +8939,7 @@ static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
 					/* loop header */
 					opline = op_array->opcodes + cfg.blocks[i].start;
 					if (!(ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags & ZEND_JIT_TRACE_UNSUPPORTED)) {
-						opline->handler = (const void*)zend_jit_loop_trace_counter_handler;
+						opline->handler = zend_jit_loop_trace_counter_handler;
 						if (!ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter) {
 							ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter =
 								&zend_jit_hot_counters[ZEND_JIT_COUNTER_NUM];
@@ -8964,7 +8964,7 @@ static int zend_jit_setup_hot_trace_counters(zend_op_array *op_array)
 
 		if (!ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->trace_flags) {
 			/* function entry */
-			opline->handler = (const void*)zend_jit_func_trace_counter_handler;
+			opline->handler = zend_jit_func_trace_counter_handler;
 			ZEND_OP_TRACE_INFO(opline, jit_extension->offset)->counter =
 				&zend_jit_hot_counters[ZEND_JIT_COUNTER_NUM];
 			ZEND_JIT_COUNTER_NUM = (ZEND_JIT_COUNTER_NUM + 1) % ZEND_HOT_COUNTERS_COUNT;


### PR DESCRIPTION
This reduces the chances of confusion between opcode handlers used by the VM, and opcode handler functions used for tracing or debugging. Depending on the VM, zend_vm_opcode_handler_t may not be a function. For instance in the HYBRID VM this is a label pointer.

Extracted from https://github.com/php/php-src/pull/18720.