### PR TITLE
random: Fix error message formatting for `Randomizer::getFloat()`

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -196,7 +196,7 @@ PHP_METHOD(Random_Randomizer, getFloat)
 		RETVAL_DOUBLE(php_random_gammasection_open_open(randomizer->engine, min, max));
 
 		if (UNEXPECTED(isnan(Z_DVAL_P(return_value)))) {
-			zend_value_error("The given interval is empty, there are no floats between argument #1 ($min) and argument #2 ($max).");
+			zend_value_error("The given interval is empty, there are no floats between argument #1 ($min) and argument #2 ($max)");
 			RETURN_THROWS();
 		}
 

--- a/ext/random/tests/03_randomizer/methods/getFloat_error.phpt
+++ b/ext/random/tests/03_randomizer/methods/getFloat_error.phpt
@@ -127,4 +127,4 @@ Random\Randomizer::getFloat(): Argument #2 ($max) must be finite
 Random\Randomizer::getFloat(): Argument #2 ($max) must be greater than argument #1 ($min)
 Random\Randomizer::getFloat(): Argument #2 ($max) must be greater than argument #1 ($min)
 Random\Randomizer::getFloat(): Argument #2 ($max) must be greater than argument #1 ($min)
-The given interval is empty, there are no floats between argument #1 ($min) and argument #2 ($max).
+The given interval is empty, there are no floats between argument #1 ($min) and argument #2 ($max)


### PR DESCRIPTION
Error messages should not end with a `.`.