### PR TITLE
Zend: Fix anonymous closure names

### DIFF
--- a/Zend/tests/closures/closure_016.phpt
+++ b/Zend/tests/closures/closure_016.phpt
@@ -42,9 +42,9 @@ Foo::__invoke
 bool(true)
 Foo::__invoke
 bool(true)
-Closure::__invoke
+{closure:foo():9}
 bool(true)
-Closure::__invoke
+{closure:foo():9}
 bool(true)
 Closure::__invoke
 bool(true)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4160,13 +4160,10 @@ try_again:
 			if (ce == zend_ce_closure) {
 				const zend_function *fn = zend_get_closure_method_def(Z_OBJ_P(callable));
 
-				if (fn->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) {
-					if (fn->common.scope) {
-						return zend_create_member_string(fn->common.scope->name, fn->common.function_name);
-					} else {
-						return zend_string_copy(fn->common.function_name);
-					}
+				if (fn->common.fn_flags & ZEND_ACC_FAKE_CLOSURE && fn->common.scope) {
+					return zend_create_member_string(fn->common.scope->name, fn->common.function_name);
 				}
+				return zend_string_copy(fn->common.function_name);
 			}
 
 			return zend_string_concat2(

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4160,7 +4160,7 @@ try_again:
 			if (ce == zend_ce_closure) {
 				const zend_function *fn = zend_get_closure_method_def(Z_OBJ_P(callable));
 
-				if (fn->common.fn_flags & ZEND_ACC_FAKE_CLOSURE && fn->common.scope) {
+				if ((fn->common.fn_flags & ZEND_ACC_FAKE_CLOSURE) && fn->common.scope) {
 					return zend_create_member_string(fn->common.scope->name, fn->common.function_name);
 				}
 				return zend_string_copy(fn->common.function_name);

--- a/tests/output/ob_013.phpt
+++ b/tests/output/ob_013.phpt
@@ -57,11 +57,11 @@ Array
     [5] => E::f
     [6] => E::g
     [7] => E::__invoke
-    [8] => Closure::__invoke
+    [8] => {closure:%s:%d}
 )
 Array
 (
-    [name] => Closure::__invoke
+    [name] => {closure:%s:%d}
     [type] => 1
     [flags] => 20593
     [level] => 8
@@ -161,7 +161,7 @@ Array
 
     [8] => Array
         (
-            [name] => Closure::__invoke
+            [name] => {closure:%s:%d}
             [type] => 1
             [flags] => 20593
             [level] => 8


### PR DESCRIPTION
Noticed this when looking at the test output of https://github.com/php/php-src/pull/18932 where the anonymous functions had a name of `Closure::_invoke` instead of the better names that @TimWolla introduced.

@DanielEScherzer can you pull this patch for the PR to see what the test messages are?