### PR TITLE
Fix OSS-Fuzz #428983568 and #428760800

### DIFF
--- a/Zend/tests/zend_ini/oss_fuzz_428983568.phpt
+++ b/Zend/tests/zend_ini/oss_fuzz_428983568.phpt
@@ -1,0 +1,14 @@
+--TEST--
+OSS-Fuzz #428983568
+--FILE--
+<?php
+$ini = <<<INI
+[\${zz:-x
+
+INI;
+var_dump(parse_ini_string($ini));
+?>
+--EXPECTF--
+Warning: syntax error, unexpected end of file, expecting '}' in Unknown on line 1
+ in %s on line %d
+bool(false)

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -353,7 +353,7 @@ static void normalize_value(zval *zv)
 %left '|' '&' '^'
 %precedence '~' '!'
 
-%destructor { zval_ini_dtor(&$$); } TC_RAW TC_CONSTANT TC_NUMBER TC_STRING TC_WHITESPACE TC_LABEL TC_OFFSET TC_VARNAME BOOL_TRUE BOOL_FALSE NULL_NULL cfg_var_ref constant_literal constant_string encapsed_list expr option_offset section_string_or_value string_or_value var_string_list var_string_list_section
+%destructor { zval_ini_dtor(&$$); } TC_RAW TC_CONSTANT TC_NUMBER TC_STRING TC_WHITESPACE TC_LABEL TC_OFFSET TC_VARNAME BOOL_TRUE BOOL_FALSE NULL_NULL cfg_var_ref constant_literal constant_string encapsed_list expr fallback option_offset section_string_or_value string_or_value var_string_list var_string_list_section
 
 %%
 


### PR DESCRIPTION
Both these issues have the same root cause, their reproducer is extremely similar so I don't duplicate the test.

If the parser invokes the lexer, and the lexer fails, it could've allocated a string which must be freed when the parser backs up. The `%destructor` list is responsible for this but did not have an entry for `fallback` yet. Solve the issue by adding such an entry.