### PR TITLE
Fix visibility on zend_signal_{deactivate,activate,init}

### DIFF
--- a/Zend/zend_signal.h
+++ b/Zend/zend_signal.h
@@ -86,12 +86,12 @@ END_EXTERN_C()
 # endif /* not ZTS */
 
 ZEND_API void zend_signal_handler_unblock(void);
-void zend_signal_activate(void);
-void zend_signal_deactivate(void);
+ZEND_API void zend_signal_activate(void);
+ZEND_API void zend_signal_deactivate(void);
 BEGIN_EXTERN_C()
 ZEND_API void zend_signal_startup(void);
 END_EXTERN_C()
-void zend_signal_init(void);
+ZEND_API void zend_signal_init(void);
 
 ZEND_API void zend_signal(int signo, void (*handler)(int));
 ZEND_API void zend_sigaction(int signo, const struct sigaction *act, struct sigaction *oldact);


### PR DESCRIPTION
missing visibility breaks linkage when ELF-style symbol visibility is supported but underlinking is not.