### PR TITLE
Use the same zend_arg_info struct for internal and user functions

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -49,6 +49,9 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     removed. Call zend_wrong_param_count(); followed by RETURN_THROWS();
     instead.
   . PHP_HAVE_STREAMS macro removed from <php.h>.
+  . zend_function.arg_info is now always a zend_arg_info*. Before, the arg_info
+    member was a zend_internal_arg_info on internal functions, unless the
+    ZEND_ACC_USER_ARG_INFO flag was set.
 
 ========================
 2. Build system changes

--- a/Zend/tests/closures/gh19653_3.phpt
+++ b/Zend/tests/closures/gh19653_3.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-19653 (Closure named argument unpacking between temporary closures can cause a crash) - temporary method variation
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+function usage1($f) {
+    $f(tmpMethodParamName: null);
+}
+
+usage1([new _ZendTestClass(), 'testTmpMethodWithArgInfo']);
+usage1(eval('return function (string $a, string $b): string { return $a.$b; };'));
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Unknown named parameter $tmpMethodParamName in %s:%d
+Stack trace:
+#0 %s(%d): usage1(Object(Closure))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/unified_arg_infos_001.phpt
+++ b/Zend/tests/unified_arg_infos_001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Declaring non persistent method with arg info
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$o = new _ZendTestClass();
+$o->testTmpMethodWithArgInfo(null);
+
+echo new ReflectionFunction($o->testTmpMethodWithArgInfo(...));
+
+?>
+--EXPECT--
+Closure [ <internal> public method testTmpMethodWithArgInfo ] {
+
+  - Parameters [2] {
+    Parameter #0 [ <optional> Foo|Bar|null $tmpMethodParamName = null ]
+    Parameter #1 [ <optional> string $tmpMethodParamWithStringDefaultValue = "tmpMethodParamWithStringDefaultValue" ]
+  }
+}

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -38,6 +38,8 @@
 #include "zend_call_stack.h"
 #include "zend_max_execution_timer.h"
 #include "zend_hrtime.h"
+#include "zend_enum.h"
+#include "zend_closures.h"
 #include "Optimizer/zend_optimizer.h"
 #include "php.h"
 #include "php_globals.h"
@@ -1054,6 +1056,7 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	ZVAL_UNDEF(&EG(last_fatal_error_backtrace));
 
 	zend_interned_strings_init();
+	zend_object_handlers_startup();
 	zend_startup_builtin_functions();
 	zend_register_standard_constants();
 	zend_register_auto_global(zend_string_init_interned("GLOBALS", sizeof("GLOBALS") - 1, 1), 1, php_auto_globals_create_globals);
@@ -1077,6 +1080,9 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	tsrm_set_new_thread_end_handler(zend_new_thread_end_handler);
 	tsrm_set_shutdown_handler(zend_interned_strings_dtor);
 #endif
+
+    zend_enum_startup();
+    zend_closure_startup();
 }
 /* }}} */
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -922,8 +922,12 @@ ZEND_API bool zend_is_iterable(const zval *iterable);
 
 ZEND_API bool zend_is_countable(const zval *countable);
 
+ZEND_API void zend_convert_internal_arg_info(zend_arg_info *new_arg_info,
+		const zend_internal_arg_info *arg_info, bool is_return_info,
+		bool permanent);
+
 ZEND_API zend_result zend_get_default_from_internal_arg_info(
-		zval *default_value_zval, const zend_internal_arg_info *arg_info);
+		zval *default_value_zval, const zend_arg_info *arg_info);
 
 END_EXTERN_C()
 

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -28,6 +28,7 @@ BEGIN_EXTERN_C()
 #define ZEND_CLOSURE_OBJECT(op_array) \
 	((zend_object*)((char*)(op_array) - sizeof(zend_object)))
 
+void zend_closure_startup(void);
 void zend_register_closure_ce(void);
 void zend_closure_bind_var(zval *closure_zv, zend_string *var_name, zval *var);
 void zend_closure_bind_var_ex(zval *closure_zv, uint32_t offset, zval *val);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -592,7 +592,7 @@ typedef struct _zend_internal_function {
 	zend_function *prototype;
 	uint32_t num_args;
 	uint32_t required_num_args;
-	zend_internal_arg_info *arg_info;
+	zend_arg_info *arg_info;
 	HashTable *attributes;
 	ZEND_MAP_PTR_DEF(void **, run_time_cache);
 	zend_string *doc_comment;
@@ -976,7 +976,8 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void);
 		} \
 	} while (0)
 
-void zend_free_internal_arg_info(zend_internal_function *function);
+ZEND_API void zend_free_internal_arg_info(zend_internal_function *function,
+		bool permanent);
 ZEND_API void destroy_zend_function(zend_function *function);
 ZEND_API void zend_function_dtor(zval *zv);
 ZEND_API void destroy_zend_class(zval *zv);

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -36,6 +36,10 @@ ZEND_API zend_class_entry *zend_ce_unit_enum;
 ZEND_API zend_class_entry *zend_ce_backed_enum;
 ZEND_API zend_object_handlers zend_enum_object_handlers;
 
+static zend_arg_info zarginfo_class_UnitEnum_cases[sizeof(arginfo_class_UnitEnum_cases)/sizeof(zend_internal_arg_info)];
+static zend_arg_info zarginfo_class_BackedEnum_from[sizeof(arginfo_class_BackedEnum_from)/sizeof(zend_internal_arg_info)];
+static zend_arg_info zarginfo_class_BackedEnum_tryFrom[sizeof(arginfo_class_BackedEnum_tryFrom)/sizeof(zend_internal_arg_info)];
+
 zend_object *zend_enum_new(zval *result, zend_class_entry *ce, zend_string *case_name, zval *backing_value_zv)
 {
 	zend_object *zobj = zend_objects_new(ce);
@@ -446,7 +450,7 @@ void zend_enum_register_funcs(zend_class_entry *ce)
 	cases_function->function_name = ZSTR_KNOWN(ZEND_STR_CASES);
 	cases_function->fn_flags = fn_flags;
 	cases_function->doc_comment = NULL;
-	cases_function->arg_info = (zend_internal_arg_info *) (arginfo_class_UnitEnum_cases + 1);
+	cases_function->arg_info = zarginfo_class_UnitEnum_cases + 1;
 	zend_enum_register_func(ce, ZEND_STR_CASES, cases_function);
 
 	if (ce->enum_backing_type != IS_UNDEF) {
@@ -457,7 +461,7 @@ void zend_enum_register_funcs(zend_class_entry *ce)
 		from_function->doc_comment = NULL;
 		from_function->num_args = 1;
 		from_function->required_num_args = 1;
-		from_function->arg_info = (zend_internal_arg_info *) (arginfo_class_BackedEnum_from + 1);
+		from_function->arg_info = zarginfo_class_BackedEnum_from + 1;
 		zend_enum_register_func(ce, ZEND_STR_FROM, from_function);
 
 		zend_internal_function *try_from_function = zend_arena_calloc(&CG(arena), sizeof(zend_internal_function), 1);
@@ -467,7 +471,7 @@ void zend_enum_register_funcs(zend_class_entry *ce)
 		try_from_function->doc_comment = NULL;
 		try_from_function->num_args = 1;
 		try_from_function->required_num_args = 1;
-		try_from_function->arg_info = (zend_internal_arg_info *) (arginfo_class_BackedEnum_tryFrom + 1);
+		try_from_function->arg_info = zarginfo_class_BackedEnum_tryFrom + 1;
 		zend_enum_register_func(ce, ZEND_STR_TRYFROM_LOWERCASE, try_from_function);
 	}
 }
@@ -632,4 +636,17 @@ ZEND_API zend_object *zend_enum_get_case(zend_class_entry *ce, zend_string *name
 ZEND_API zend_object *zend_enum_get_case_cstr(zend_class_entry *ce, const char *name) {
 	zend_class_constant *c = zend_hash_str_find_ptr(CE_CONSTANTS_TABLE(ce), name, strlen(name));
 	return zend_enum_case_from_class_constant(c);
+}
+
+void zend_enum_startup(void)
+{
+	for (size_t i = 0; i < sizeof(zarginfo_class_UnitEnum_cases)/sizeof(zend_arg_info); i++) {
+		zend_convert_internal_arg_info(&zarginfo_class_UnitEnum_cases[i], &arginfo_class_UnitEnum_cases[i], i == 0, true);
+	}
+	for (size_t i = 0; i < sizeof(zarginfo_class_BackedEnum_from)/sizeof(zend_arg_info); i++) {
+		zend_convert_internal_arg_info(&zarginfo_class_BackedEnum_from[i], &arginfo_class_BackedEnum_from[i], i == 0, true);
+	}
+	for (size_t i = 0; i < sizeof(zarginfo_class_BackedEnum_tryFrom)/sizeof(zend_arg_info); i++) {
+		zend_convert_internal_arg_info(&zarginfo_class_BackedEnum_tryFrom[i], &arginfo_class_BackedEnum_tryFrom[i], i == 0, true);
+	}
 }

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -30,6 +30,7 @@ extern ZEND_API zend_class_entry *zend_ce_unit_enum;
 extern ZEND_API zend_class_entry *zend_ce_backed_enum;
 extern ZEND_API zend_object_handlers zend_enum_object_handlers;
 
+void zend_enum_startup(void);
 void zend_register_enum_ce(void);
 void zend_enum_add_interfaces(zend_class_entry *ce);
 zend_result zend_enum_build_backed_enum_table(zend_class_entry *ce);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -652,11 +652,7 @@ ZEND_API const char *get_function_arg_name(const zend_function *func, uint32_t a
 		return NULL;
 	}
 
-	if (func->type == ZEND_USER_FUNCTION || (func->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
-		return ZSTR_VAL(func->common.arg_info[arg_num - 1].name);
-	} else {
-		return ((zend_internal_arg_info*) func->common.arg_info)[arg_num - 1].name;
-	}
+	return ZSTR_VAL(func->common.arg_info[arg_num - 1].name);
 }
 /* }}} */
 

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -953,18 +953,14 @@ static ZEND_COLD zend_string *zend_get_function_declaration(
 			}
 
 			smart_str_appendc(&str, '$');
-			if (fptr->type == ZEND_INTERNAL_FUNCTION) {
-				smart_str_appends(&str, ((zend_internal_arg_info*)arg_info)->name);
-			} else {
-				smart_str_appendl(&str, ZSTR_VAL(arg_info->name), ZSTR_LEN(arg_info->name));
-			}
+			smart_str_append(&str, arg_info->name);
 
 			if (i >= required && !ZEND_ARG_IS_VARIADIC(arg_info)) {
 				smart_str_appends(&str, " = ");
 
 				if (fptr->type == ZEND_INTERNAL_FUNCTION) {
-					if (((zend_internal_arg_info*)arg_info)->default_value) {
-						smart_str_appends(&str, ((zend_internal_arg_info*)arg_info)->default_value);
+					if (arg_info->default_value) {
+						smart_str_append(&str, arg_info->default_value);
 					} else {
 						smart_str_appends(&str, "<default>");
 					}

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -334,6 +334,8 @@ ZEND_API zend_function *zend_get_property_hook_trampoline(
 
 ZEND_API bool ZEND_FASTCALL zend_asymmetric_property_has_set_access(const zend_property_info *prop_info);
 
+void zend_object_handlers_startup(void);
+
 #define zend_release_properties(ht) do { \
 	if (ht) { \
 		zend_array_release(ht); \

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -663,8 +663,7 @@ static void accel_copy_permanent_strings(zend_new_interned_string_func_t new_int
 		if (Z_FUNC(p->val)->common.function_name) {
 			Z_FUNC(p->val)->common.function_name = new_interned_string(Z_FUNC(p->val)->common.function_name);
 		}
-		if (Z_FUNC(p->val)->common.arg_info &&
-		    (Z_FUNC(p->val)->common.fn_flags & (ZEND_ACC_HAS_RETURN_TYPE|ZEND_ACC_HAS_TYPE_HINTS))) {
+		if (Z_FUNC(p->val)->common.arg_info) {
 			uint32_t i;
 			uint32_t num_args = Z_FUNC(p->val)->common.num_args + 1;
 			zend_arg_info *arg_info = Z_FUNC(p->val)->common.arg_info - 1;
@@ -673,6 +672,12 @@ static void accel_copy_permanent_strings(zend_new_interned_string_func_t new_int
 				num_args++;
 			}
 			for (i = 0 ; i < num_args; i++) {
+				if (i > 0) {
+					arg_info[i].name = new_interned_string(arg_info[i].name);
+					if (arg_info[i].default_value) {
+						arg_info[i].default_value = new_interned_string(arg_info[i].default_value);
+					}
+				}
 				accel_copy_permanent_list_types(new_interned_string, arg_info[i].type);
 			}
 		}
@@ -713,6 +718,24 @@ static void accel_copy_permanent_strings(zend_new_interned_string_func_t new_int
 			}
 			if (Z_FUNC(q->val)->common.function_name) {
 				Z_FUNC(q->val)->common.function_name = new_interned_string(Z_FUNC(q->val)->common.function_name);
+			}
+			if (Z_FUNC(q->val)->common.scope == ce) {
+				uint32_t i;
+				uint32_t num_args = Z_FUNC(q->val)->common.num_args + 1;
+				zend_arg_info *arg_info = Z_FUNC(q->val)->common.arg_info - 1;
+
+				if (Z_FUNC(q->val)->common.fn_flags & ZEND_ACC_VARIADIC) {
+					num_args++;
+				}
+				for (i = 0 ; i < num_args; i++) {
+					if (i > 0) {
+						arg_info[i].name = new_interned_string(arg_info[i].name);
+						if (arg_info[i].default_value) {
+							arg_info[i].default_value = new_interned_string(arg_info[i].default_value);
+						}
+					}
+					accel_copy_permanent_list_types(new_interned_string, arg_info[i].type);
+				}
 			}
 		} ZEND_HASH_FOREACH_END();
 

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -493,7 +493,7 @@ static bool zend_jit_needs_arg_dtor(const zend_function *func, uint32_t arg_num,
 	 && func->type == ZEND_INTERNAL_FUNCTION
 	 && (func->internal_function.fn_flags & ZEND_ACC_HAS_TYPE_HINTS) != 0
 	 && arg_num < func->internal_function.num_args) {
-		const zend_internal_arg_info *arg_info = &func->internal_function.arg_info[arg_num];
+		const zend_arg_info *arg_info = &func->internal_function.arg_info[arg_num];
 
 		if (ZEND_ARG_SEND_MODE(arg_info) == ZEND_SEND_BY_VAL
 		 && ZEND_TYPE_IS_SET(arg_info->type)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -37,10 +37,12 @@
 #include "Zend/Optimizer/zend_optimizer.h"
 #include "Zend/zend_alloc.h"
 #include "test_arginfo.h"
+#include "tmp_methods_arginfo.h"
 #include "zend_call_stack.h"
 #include "zend_exceptions.h"
 #include "zend_mm_custom_handlers.h"
 #include "ext/uri/php_uri.h"
+#include "zend_observer.h"
 
 #if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 # include <libxml/globals.h>
@@ -1030,16 +1032,38 @@ static ZEND_FUNCTION(zend_test_log_err_debug)
 	php_log_err_with_severity(ZSTR_VAL(str), LOG_DEBUG);
 }
 
+typedef struct _zend_test_object {
+	zend_internal_function *tmp_method;
+	zend_object std;
+} zend_test_object;
+
 static zend_object *zend_test_class_new(zend_class_entry *class_type)
 {
-	zend_object *obj = zend_objects_new(class_type);
-	object_properties_init(obj, class_type);
-	obj->handlers = &zend_test_class_handlers;
-	return obj;
+	zend_test_object *intern = zend_object_alloc(sizeof(zend_test_object), class_type);
+	zend_object_std_init(&intern->std, class_type);
+	object_properties_init(&intern->std, class_type);
+	return &intern->std;
+}
+
+static void zend_test_class_free_obj(zend_object *object)
+{
+	zend_test_object *intern = (zend_test_object*)((char*)object - XtOffsetOf(zend_test_object, std));
+
+	if (intern->tmp_method) {
+		zend_internal_function *func = intern->tmp_method;
+		intern->tmp_method = NULL;
+		zend_string_release_ex(func->function_name, 0);
+		zend_free_internal_arg_info(func, false);
+		efree(func);
+	}
+
+	zend_object_std_dtor(object);
 }
 
 static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key)
 {
+	zend_test_object *intern = (zend_test_object*)((char*)(*object) - XtOffsetOf(zend_test_object, std));
+
 	if (zend_string_equals_literal_ci(name, "test")) {
 		zend_internal_function *fptr;
 
@@ -1057,6 +1081,41 @@ static zend_function *zend_test_class_method_get(zend_object **object, zend_stri
 		fptr->function_name = zend_string_copy(name);
 		fptr->handler = ZEND_FN(zend_test_func);
 		fptr->doc_comment = NULL;
+
+		return (zend_function*)fptr;
+	} else if (zend_string_equals_literal_ci(name, "testTmpMethodWithArgInfo")) {
+		if (intern->tmp_method) {
+			return (zend_function*)intern->tmp_method;
+		}
+
+		const zend_function_entry *entry = &class_ZendTestTmpMethods_methods[0];
+		zend_internal_function *fptr = emalloc(sizeof(zend_internal_function));
+		memset(fptr, 0, sizeof(zend_internal_function));
+		fptr->type = ZEND_INTERNAL_FUNCTION;
+		fptr->handler = entry->handler;
+		fptr->function_name = zend_string_init(entry->fname, strlen(entry->fname), false);
+		fptr->scope = intern->std.ce;
+		fptr->prototype = NULL;
+		fptr->T = ZEND_OBSERVER_ENABLED;
+		fptr->fn_flags = ZEND_ACC_PUBLIC | ZEND_ACC_NEVER_CACHE;
+
+		zend_internal_function_info *info = (zend_internal_function_info*)entry->arg_info;
+
+		uint32_t num_arg_info = 1 + entry->num_args;
+		zend_arg_info *arg_info = safe_emalloc(num_arg_info, sizeof(zend_arg_info), 0);
+		for (uint32_t i = 0; i < num_arg_info; i++) {
+			zend_convert_internal_arg_info(&arg_info[i], &entry->arg_info[i], i == 0, false);
+		}
+
+		fptr->arg_info = arg_info + 1;
+		fptr->num_args = entry->num_args;
+		if (info->required_num_args == (uint32_t)-1) {
+			fptr->required_num_args = entry->num_args;
+		} else {
+			fptr->required_num_args = info->required_num_args;
+		}
+
+		intern->tmp_method = fptr;
 
 		return (zend_function*)fptr;
 	}
@@ -1143,6 +1202,18 @@ static ZEND_METHOD(_ZendTestClass, variadicTest) {
 	}
 
 	object_init_ex(return_value, zend_get_called_scope(execute_data));
+}
+
+ZEND_METHOD(ZendTestTmpMethods, testTmpMethodWithArgInfo)
+{
+	zend_object *obj;
+	zend_string *str;
+
+	ZEND_PARSE_PARAMETERS_START(0, 2);
+		Z_PARAM_OPTIONAL;
+		Z_PARAM_OBJ_OR_NULL(obj);
+		Z_PARAM_STR(str);
+	ZEND_PARSE_PARAMETERS_END();
 }
 
 static ZEND_METHOD(_ZendTestChildClass, returnsThrowable)
@@ -1450,11 +1521,14 @@ PHP_MINIT_FUNCTION(zend_test)
 	register_ZendTestClass_dnf_property(zend_test_class);
 	zend_test_class->create_object = zend_test_class_new;
 	zend_test_class->get_static_method = zend_test_class_static_method_get;
+	zend_test_class->default_object_handlers = &zend_test_class_handlers;
 
 	zend_test_child_class = register_class__ZendTestChildClass(zend_test_class);
 
 	memcpy(&zend_test_class_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	zend_test_class_handlers.get_method = zend_test_class_method_get;
+	zend_test_class_handlers.free_obj = zend_test_class_free_obj;
+	zend_test_class_handlers.offset = XtOffsetOf(zend_test_object, std);
 
 	zend_test_gen_stub_flag_compatibility_test = register_class_ZendTestGenStubFlagCompatibilityTest();
 

--- a/ext/zend_test/tmp_methods.stub.php
+++ b/ext/zend_test/tmp_methods.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @generate-function-entries */
+
+/**
+ * These methods will be added to a class at runtime
+ * @undocumentable
+ */
+class ZendTestTmpMethods {
+    public function testTmpMethodWithArgInfo(Foo|Bar|null $tmpMethodParamName = null, string $tmpMethodParamWithStringDefaultValue = "tmpMethodParamWithStringDefaultValue"): void {}
+}

--- a/ext/zend_test/tmp_methods_arginfo.h
+++ b/ext/zend_test/tmp_methods_arginfo.h
@@ -1,0 +1,14 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 7fd99c0b5a1957cb3a8c08a74421a720475bb46d */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ZendTestTmpMethods_testTmpMethodWithArgInfo, 0, 0, IS_VOID, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, tmpMethodParamName, Foo|Bar, MAY_BE_NULL, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tmpMethodParamWithStringDefaultValue, IS_STRING, 0, "\"tmpMethodParamWithStringDefaultValue\"")
+ZEND_END_ARG_INFO()
+
+ZEND_METHOD(ZendTestTmpMethods, testTmpMethodWithArgInfo);
+
+static const zend_function_entry class_ZendTestTmpMethods_methods[] = {
+	ZEND_ME(ZendTestTmpMethods, testTmpMethodWithArgInfo, arginfo_class_ZendTestTmpMethods_testTmpMethodWithArgInfo, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};

--- a/sapi/phpdbg/phpdbg_frame.c
+++ b/sapi/phpdbg/phpdbg_frame.c
@@ -34,11 +34,7 @@ static inline void phpdbg_append_individual_arg(smart_str *s, uint32_t i, zend_f
 	}
 	if (i < func->common.num_args) {
 		if (arginfo) {
-			if (func->type == ZEND_INTERNAL_FUNCTION) {
-				arg_name = (char *) ((zend_internal_arg_info *) &arginfo[i])->name;
-			} else {
-				arg_name = ZSTR_VAL(arginfo[i].name);
-			}
+			arg_name = ZSTR_VAL(arginfo[i].name);
 		}
 		smart_str_appends(s, arg_name ? arg_name : "?");
 		smart_str_appendc(s, '=');
@@ -213,11 +209,7 @@ static void phpdbg_dump_prototype(zval *tmp) /* {{{ */
 				char *arg_name = NULL;
 
 				if (arginfo) {
-					if (func->type == ZEND_INTERNAL_FUNCTION) {
-						arg_name = (char *)((zend_internal_arg_info *)&arginfo[j])->name;
-					} else {
-						arg_name = ZSTR_VAL(arginfo[j].name);
-					}
+					arg_name = ZSTR_VAL(arginfo[j].name);
 				}
 
 				if (!is_variadic) {


### PR DESCRIPTION
Internal functions use `char*` strings to represent arg names and default values. This differs from user functions, which use zend strings.

Here I unify this by using the same struct, `zend_arg_info` in both function types.

This simplifies accesses to arg infos. Also, in the PFAs RFC this avoids converting internal arg infos at runtime when applying an internal function.