### PR TITLE
ext/standard/string.c: don't use `STR_EMPTY_ALLOC()`

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2404,7 +2404,7 @@ PHP_FUNCTION(substr_replace)
 			if (repl_idx < repl_ht->nNumUsed) {
 				repl_str = zval_get_tmp_string(tmp_repl, &tmp_repl_str);
 			} else {
-				repl_str = STR_EMPTY_ALLOC();
+				repl_str = ZSTR_EMPTY_ALLOC();
 			}
 		}
 


### PR DESCRIPTION
This was the only remaining use of a compatibility alias from 10 years ago; replace with `ZSTR_EMPTY_ALLOC()`.