### PR TITLE
Use <winsock2.h> instead of legacy <winsock.h>

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -26,7 +26,7 @@
 #ifndef PHP_WIN32
 #include <netinet/tcp.h>
 #else
-#include <winsock.h>
+#include <winsock2.h>
 #endif
 
 

--- a/ext/sockets/config.w32
+++ b/ext/sockets/config.w32
@@ -4,8 +4,7 @@ ARG_ENABLE("sockets", "SOCKETS support", "no");
 
 if (PHP_SOCKETS != "no") {
 	if (CHECK_LIB("ws2_32.lib", "sockets", PHP_SOCKETS)
-	&& CHECK_LIB("Iphlpapi.lib", "sockets", PHP_SOCKETS)
-	&& CHECK_HEADER_ADD_INCLUDE("winsock.h", "CFLAGS_SOCKETS")) {
+	&& CHECK_LIB("Iphlpapi.lib", "sockets", PHP_SOCKETS)) {
 		EXTENSION('sockets', 'sockets.c multicast.c conversions.c sockaddr_conv.c sendrecvmsg.c', PHP_SOCKETS_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_SOCKETS', 1, "Define to 1 if the PHP extension 'sockets' is available.");
 		PHP_INSTALL_HEADERS("ext/sockets", "php_sockets.h windows_common.h");


### PR DESCRIPTION
This also omits defining unused HAVE_WINSOCK_H macro when building ext/sockets.

I'm not sure if I've missed anything here but `<winsock.h>` sounds kind of bad reading all the docs out there as it is part of the legacy Winsock 1.1.