### PR TITLE
Update re2c minimum versions in Windows checks and docs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -210,8 +210,8 @@ slightly different steps. We'll call attention where the steps differ.
    > Do *not* bump the API versions after RC1.
 
 5. Compile and run `make test`, with and without ZTS (Zend Thread Safety), using
-   the correct Bison and re2c versions, e.g., for PHP 7.4, Bison 3.0.0 and re2c
-   0.13.4 are required, as a minimum.
+   the correct Bison and re2c versions, e.g., for PHP 8.5, Bison 3.0.0 and re2c
+   1.0.3 are required, as a minimum.
 
    For example:
 
@@ -555,8 +555,8 @@ slightly different steps. We'll call attention where the steps differ.
    an example.
 
 6. Compile and run `make test`, with and without ZTS (Zend Thread Safety), using
-   the correct Bison and re2c versions, e.g., for PHP 7.4, Bison 3.0.0 and re2c
-   0.13.4 are required, as a minimum.
+   the correct Bison and re2c versions, e.g., for PHP 8.5, Bison 3.0.0 and re2c
+   1.0.3 are required, as a minimum.
 
    For example:
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -56,7 +56,7 @@ var WINVER = "0x0602"; /* 8/2012 */
 var MINBISON = "3.0.0";
 
 // There's a minimum requirement for re2c..
-var MINRE2C = "0.13.4";
+var MINRE2C = "1.0.3";
 
 /* Store the enabled extensions (summary + QA check) */
 var extensions_enabled = new Array();


### PR DESCRIPTION
This syncs the re2c minimum version requirement on Windows with the one specified in configure.ac.