### PR TITLE
uri: Do not overwrite `defaultMemoryManager`

### DIFF
--- a/ext/uri/php_uriparser.h
+++ b/ext/uri/php_uriparser.h
@@ -18,7 +18,6 @@
 #define PHP_URIPARSER_H
 
 #include <uriparser/Uri.h>
-#include "uriparser/src/UriMemory.h"
 #include "php_uri_common.h"
 
 extern const uri_handler_t uriparser_uri_handler;


### PR DESCRIPTION
The `defaultMemoryManager` is only available via a non-public header and is not supposed to be used by users of the library [1]. It also has a very generic name, further indicating that it is not supposed to be used.

Instead pass the memory manager explicitly, which is how the library is supposed to be used.

[1] https://github.com/uriparser/uriparser/issues/52#issuecomment-453853700