### PR TITLE
Fix unreachable code in URL output handler

### DIFF
--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -701,7 +701,7 @@ static inline void php_url_scanner_session_handler_impl(char *output, size_t out
 				len = UINT_MAX;
 		}
 		*handled_output_len = len;
-	} else if (ZSTR_LEN(url_state->url_app.s) == 0) {
+	} else {
 		url_adapt_state_ex_t *ctx = url_state;
 		if (ctx->buf.s && ZSTR_LEN(ctx->buf.s)) {
 			smart_str_append(&ctx->result, ctx->buf.s);
@@ -715,8 +715,6 @@ static inline void php_url_scanner_session_handler_impl(char *output, size_t out
 		} else {
 			*handled_output = estrndup(output, *handled_output_len = output_len);
 		}
-	} else {
-		*handled_output = NULL;
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes a logical issue in the URL output handler where the final `else` branch was unreachable due to redundant conditionals.

## Problem

The existing code had the following structure:
```c
if (ZSTR_LEN(url_state->url_app.s) != 0) {
    // handle non-empty case
} else if (ZSTR_LEN(url_state->url_app.s) == 0) {
    // handle empty case  
} else {
    // unreachable branch
    *handled_output = NULL;
}
```

Since `ZSTR_LEN()` returns a `size_t` (unsigned integer), the value can only be either "not equal to 0" or "equal to 0". The third `else` branch was unreachable, making the `*handled_output = NULL;` assignment dead code.