### PR TITLE
Autoconf: Move getlogin check for HAVE_GETLOGIN to ext/posix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -540,7 +540,6 @@ AC_CHECK_FUNCS(m4_normalize([
   getgrnam_r
   gethostname
   getloadavg
-  getlogin
   getprotobyname
   getprotobynumber
   getpwnam_r

--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -17,6 +17,7 @@ if test "$PHP_POSIX" = "yes"; then
     eaccess
     getgrgid_r
     getgroups
+    getlogin
     getpgid
     getrlimit
     getsid


### PR DESCRIPTION
This check is related only to ext/posix so it's more clear to have it defined when ext/posix is enabled.