### PR TITLE
tree-wide: Do not manually check for `NULL` before calling `free()`

### DIFF
--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -1208,9 +1208,7 @@ static void zend_redo_pass_two(zend_op_array *op_array)
 		efree(op_array->literals);
 		op_array->literals = (zval*)(((char*)op_array->opcodes) + ZEND_MM_ALIGNED_SIZE_EX(sizeof(zend_op) * op_array->last, 16));
 	} else {
-		if (op_array->literals) {
-			efree(op_array->literals);
-		}
+		efree(op_array->literals);
 		op_array->literals = NULL;
 	}
 #endif
@@ -1318,9 +1316,7 @@ static void zend_redo_pass_two_ex(zend_op_array *op_array, zend_ssa *ssa)
 		efree(op_array->literals);
 		op_array->literals = (zval*)(((char*)op_array->opcodes) + ZEND_MM_ALIGNED_SIZE_EX(sizeof(zend_op) * op_array->last, 16));
 	} else {
-		if (op_array->literals) {
-			efree(op_array->literals);
-		}
+		efree(op_array->literals);
 		op_array->literals = NULL;
 	}
 #endif

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -790,10 +790,8 @@ static void compiler_globals_dtor(zend_compiler_globals *compiler_globals) /* {{
 		compiler_globals->map_ptr_base = ZEND_MAP_PTR_BIASED_BASE(NULL);
 		compiler_globals->map_ptr_size = 0;
 	}
-	if (compiler_globals->internal_run_time_cache) {
-		pefree(compiler_globals->internal_run_time_cache, 1);
-		compiler_globals->internal_run_time_cache = NULL;
-	}
+	pefree(compiler_globals->internal_run_time_cache, 1);
+	compiler_globals->internal_run_time_cache = NULL;
 }
 /* }}} */
 
@@ -1124,14 +1122,10 @@ zend_result zend_post_startup(void) /* {{{ */
 	compiler_globals->function_table = NULL;
 	free(compiler_globals->class_table);
 	compiler_globals->class_table = NULL;
-	if (compiler_globals->map_ptr_real_base) {
-		free(compiler_globals->map_ptr_real_base);
-	}
+	free(compiler_globals->map_ptr_real_base);
 	compiler_globals->map_ptr_real_base = NULL;
 	compiler_globals->map_ptr_base = ZEND_MAP_PTR_BIASED_BASE(NULL);
-	if (compiler_globals->internal_run_time_cache) {
-		pefree(compiler_globals->internal_run_time_cache, 1);
-	}
+	pefree(compiler_globals->internal_run_time_cache, 1);
 	compiler_globals->internal_run_time_cache = NULL;
 	if ((script_encoding_list = (zend_encoding **)compiler_globals->script_encoding_list)) {
 		compiler_globals_ctor(compiler_globals);
@@ -1215,10 +1209,8 @@ void zend_shutdown(void) /* {{{ */
 		CG(script_encoding_list) = NULL;
 		CG(script_encoding_list_size) = 0;
 	}
-	if (CG(internal_run_time_cache)) {
-		pefree(CG(internal_run_time_cache), 1);
-		CG(internal_run_time_cache) = NULL;
-	}
+	pefree(CG(internal_run_time_cache), 1);
+	CG(internal_run_time_cache) = NULL;
 #endif
 	zend_map_ptr_static_last = 0;
 	zend_map_ptr_static_size = 0;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1116,8 +1116,9 @@ static zend_result zend_parse_arg(uint32_t arg_num, zval *arg, va_list *va, cons
 			} else {
 				zend_argument_type_error(arg_num, "must be of type %s, %s given", expected_type, zend_zval_value_name(arg));
 			}
-		} else if (error) {
+		} else {
 			efree(error);
+		
 		}
 
 		return FAILURE;
@@ -4090,9 +4091,7 @@ get_function_via_handler:
 					if ((fcc->function_handler->common.fn_flags & ZEND_ACC_PRIVATE)
 					 || (!zend_check_protected(zend_get_function_root_class(fcc->function_handler), scope))) {
 						if (error) {
-							if (*error) {
-								efree(*error);
-							}
+							efree(*error);
 							zend_spprintf(error, 0, "cannot access %s method %s::%s()", zend_visibility_string(fcc->function_handler->common.fn_flags), ZSTR_VAL(fcc->calling_scope->name), ZSTR_VAL(fcc->function_handler->common.function_name));
 						}
 						retval = 0;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -349,10 +349,8 @@ void zend_oparray_context_begin(zend_oparray_context *prev_context, zend_op_arra
 
 void zend_oparray_context_end(zend_oparray_context *prev_context) /* {{{ */
 {
-	if (CG(context).brk_cont_array) {
-		efree(CG(context).brk_cont_array);
-		CG(context).brk_cont_array = NULL;
-	}
+	efree(CG(context).brk_cont_array);
+	CG(context).brk_cont_array = NULL;
 	if (CG(context).labels) {
 		zend_hash_destroy(CG(context).labels);
 		FREE_HASHTABLE(CG(context).labels);

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -472,10 +472,8 @@ static zend_always_inline void gc_remove_from_roots(gc_root_buffer *root)
 
 static void root_buffer_dtor(zend_gc_globals *gc_globals)
 {
-	if (gc_globals->buf) {
-		free(gc_globals->buf);
-		gc_globals->buf = NULL;
-	}
+	free(gc_globals->buf);
+	gc_globals->buf = NULL;
 }
 
 static void gc_globals_ctor_ex(zend_gc_globals *gc_globals)

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -512,18 +512,12 @@ ZEND_API void destroy_zend_class(zval *zv)
 				} ZEND_HASH_FOREACH_END();
 				zend_hash_destroy(&ce->constants_table);
 			}
-			if (ce->iterator_funcs_ptr) {
-				free(ce->iterator_funcs_ptr);
-			}
-			if (ce->arrayaccess_funcs_ptr) {
-				free(ce->arrayaccess_funcs_ptr);
-			}
+			free(ce->iterator_funcs_ptr);
+			free(ce->arrayaccess_funcs_ptr);
 			if (ce->num_interfaces > 0) {
 				free(ce->interfaces);
 			}
-			if (ce->properties_info_table) {
-				free(ce->properties_info_table);
-			}
+			free(ce->properties_info_table);
 			if (ce->attributes) {
 				zend_hash_release(ce->attributes);
 			}
@@ -613,12 +607,8 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 	if (op_array->attributes) {
 		zend_hash_release(op_array->attributes);
 	}
-	if (op_array->live_range) {
-		efree(op_array->live_range);
-	}
-	if (op_array->try_catch_array) {
-		efree(op_array->try_catch_array);
-	}
+	efree(op_array->live_range);
+	efree(op_array->try_catch_array);
 	if (zend_extension_flags & ZEND_EXTENSIONS_HAVE_OP_ARRAY_DTOR) {
 		if (op_array->fn_flags & ZEND_ACC_DONE_PASS_TWO) {
 			zend_llist_apply_with_argument(&zend_extensions, (llist_apply_with_arg_func_t) zend_extension_op_array_dtor_handler, op_array);

--- a/Zend/zend_ptr_stack.c
+++ b/Zend/zend_ptr_stack.c
@@ -71,9 +71,7 @@ ZEND_API void zend_ptr_stack_n_pop(zend_ptr_stack *stack, int count, ...)
 
 ZEND_API void zend_ptr_stack_destroy(zend_ptr_stack *stack)
 {
-	if (stack->elements) {
-		pefree(stack->elements, stack->persistent);
-	}
+	pefree(stack->elements, stack->persistent);
 }
 
 

--- a/Zend/zend_smart_string.h
+++ b/Zend/zend_smart_string.h
@@ -66,10 +66,8 @@ static zend_always_inline size_t smart_string_alloc(smart_string *str, size_t le
 }
 
 static zend_always_inline void smart_string_free_ex(smart_string *str, bool persistent) {
-	if (str->c) {
-		pefree(str->c, persistent);
-		str->c = NULL;
-	}
+	pefree(str->c, persistent);
+	str->c = NULL;
 	str->a = str->len = 0;
 }
 

--- a/Zend/zend_stack.c
+++ b/Zend/zend_stack.c
@@ -77,10 +77,8 @@ ZEND_API bool zend_stack_is_empty(const zend_stack *stack)
 
 ZEND_API void zend_stack_destroy(zend_stack *stack)
 {
-	if (stack->elements) {
-		efree(stack->elements);
-		stack->elements = NULL;
-	}
+	efree(stack->elements);
+	stack->elements = NULL;
 }
 
 
@@ -151,10 +149,8 @@ ZEND_API void zend_stack_clean(zend_stack *stack, void (*func)(void *), bool fre
 		}
 	}
 	if (free_elements) {
-		if (stack->elements) {
-			efree(stack->elements);
-			stack->elements = NULL;
-		}
+		efree(stack->elements);
+		stack->elements = NULL;
 		stack->top = stack->max = 0;
 	}
 }

--- a/Zend/zend_stream.c
+++ b/Zend/zend_stream.c
@@ -235,10 +235,8 @@ static void zend_file_handle_dtor(zend_file_handle *fh) /* {{{ */
 		zend_string_release_ex(fh->opened_path, 0);
 		fh->opened_path = NULL;
 	}
-	if (fh->buf) {
-		efree(fh->buf);
-		fh->buf = NULL;
-	}
+	efree(fh->buf);
+	fh->buf = NULL;
 	if (fh->filename) {
 		zend_string_release(fh->filename);
 		fh->filename = NULL;

--- a/ext/calendar/calendar.c
+++ b/ext/calendar/calendar.c
@@ -474,12 +474,8 @@ PHP_FUNCTION(jdtojewish)
 
 		RETVAL_NEW_STR(zend_strpprintf(0, "%s %s %s", heb_number_to_chars(day, fl, &dayp), JEWISH_HEB_MONTH_NAME(year)[month], heb_number_to_chars(year, fl, &yearp)));
 
-		if (dayp) {
-			efree(dayp);
-		}
-		if (yearp) {
-			efree(yearp);
-		}
+		efree(dayp);
+		efree(yearp);
 	}
 }
 /* }}} */

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -240,9 +240,7 @@ static void function_dtor(zval *zv)
 	zend_internal_function *f = (zend_internal_function*)Z_PTR_P(zv);
 
 	zend_string_release_ex(f->function_name, 0);
-	if (f->arg_info) {
-		efree(f->arg_info);
-	}
+	efree(f->arg_info);
 	efree(f);
 }
 

--- a/ext/com_dotnet/com_persist.c
+++ b/ext/com_dotnet/com_persist.c
@@ -392,9 +392,7 @@ CPH_METHOD(SaveToFile)
 			}
 		}
 
-		if (olefilename) {
-			efree(olefilename);
-		}
+		efree(olefilename);
 
 		if (FAILED(res)) {
 			php_com_throw_exception(res, NULL);

--- a/ext/com_dotnet/com_variant.c
+++ b/ext/com_dotnet/com_variant.c
@@ -270,9 +270,7 @@ PHP_COM_DOTNET_API zend_result php_com_zval_from_variant(zval *z, VARIANT *v, in
 			php_com_wrap_variant(z, v, codepage);
 	}
 
-	if (olestring) {
-		efree(olestring);
-	}
+	efree(olestring);
 
 	if (ret == FAILURE) {
 		php_error_docref(NULL, E_WARNING, "variant->zval: conversion from 0x%x ret=%d", V_VT(v), ret);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -410,9 +410,7 @@ static void _php_date_tzinfo_dtor(zval *zv) /* {{{ */
 /* {{{ PHP_RINIT_FUNCTION */
 PHP_RINIT_FUNCTION(date)
 {
-	if (DATEG(timezone)) {
-		efree(DATEG(timezone));
-	}
+	efree(DATEG(timezone));
 	DATEG(timezone) = NULL;
 	DATEG(tzcache) = NULL;
 	DATEG(last_errors) = NULL;
@@ -424,9 +422,7 @@ PHP_RINIT_FUNCTION(date)
 /* {{{ PHP_RSHUTDOWN_FUNCTION */
 PHP_RSHUTDOWN_FUNCTION(date)
 {
-	if (DATEG(timezone)) {
-		efree(DATEG(timezone));
-	}
+	efree(DATEG(timezone));
 	DATEG(timezone) = NULL;
 
 	return SUCCESS;

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -258,12 +258,8 @@ DBA_NEXTKEY_FUNC(db4)
 			key = zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 		}
 		if (info->flags & DBA_PERSISTENT) {
-			if (gkey.data) {
-				free(gkey.data);
-			}
-			if (gval.data) {
-				free(gval.data);
-			}
+			free(gkey.data);
+			free(gval.data);
 		}
 	}
 

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -46,9 +46,7 @@ DBA_CLOSE_FUNC(flatfile)
 {
 	flatfile *dba = info->dbf;
 
-	if (dba->nextkey.dptr) {
-		efree(dba->nextkey.dptr);
-	}
+	efree(dba->nextkey.dptr);
 	pefree(dba, info->flags&DBA_PERSISTENT);
 }
 
@@ -127,9 +125,7 @@ DBA_FIRSTKEY_FUNC(flatfile)
 {
 	flatfile *dba = info->dbf;
 
-	if (dba->nextkey.dptr) {
-		efree(dba->nextkey.dptr);
-	}
+	efree(dba->nextkey.dptr);
 	dba->nextkey = flatfile_firstkey(dba);
 	if (dba->nextkey.dptr) {
 		return zend_string_init(dba->nextkey.dptr, dba->nextkey.dsize, /* persistent */ false);
@@ -145,9 +141,7 @@ DBA_NEXTKEY_FUNC(flatfile)
 		return NULL;
 	}
 
-	if (dba->nextkey.dptr) {
-		efree(dba->nextkey.dptr);
-	}
+	efree(dba->nextkey.dptr);
 	dba->nextkey = flatfile_nextkey(dba);
 	if (dba->nextkey.dptr) {
 		return zend_string_init(dba->nextkey.dptr, dba->nextkey.dsize, /* persistent */ false);

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -140,9 +140,7 @@ DBA_FIRSTKEY_FUNC(gdbm)
 	datum gkey;
 	zend_string *key = NULL;
 
-	if (dba->nextkey.dptr) {
-		free(dba->nextkey.dptr);
-	}
+	free(dba->nextkey.dptr);
 
 	gkey = gdbm_firstkey(dba->dbf);
 	if (gkey.dptr) {

--- a/ext/dba/libinifile/inifile.c
+++ b/ext/dba/libinifile/inifile.c
@@ -47,12 +47,8 @@ const char *inifile_version(void)
 /* {{{ inifile_free_key */
 void inifile_key_free(key_type *key)
 {
-	if (key->group) {
-		efree(key->group);
-	}
-	if (key->name) {
-		efree(key->name);
-	}
+	efree(key->group);
+	efree(key->name);
 	memset(key, 0, sizeof(key_type));
 }
 /* }}} */
@@ -60,9 +56,7 @@ void inifile_key_free(key_type *key)
 /* {{{ inifile_free_val */
 void inifile_val_free(val_type *val)
 {
-	if (val->value) {
-		efree(val->value);
-	}
+	efree(val->value);
 	memset(val, 0, sizeof(val_type));
 }
 /* }}} */
@@ -193,9 +187,7 @@ static int inifile_read(inifile *dba, line_type *ln) {
 					if (!ln->key.group) {
 						ln->key.group = estrdup("");
 					}
-					if (ln->key.name) {
-						efree(ln->key.name);
-					}
+					efree(ln->key.name);
 					ln->key.name = etrim(fline);
 					ln->val.value = etrim(pos+1);
 					ln->pos = php_stream_tell(dba->fp);

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -601,9 +601,7 @@ apprentice_unmap(struct magic_map *map)
 		if (map->p == NULL) {
 			int j;
 			for (j = 0; j < MAGIC_SETS; j++) {
-				if (map->magic[j]) {
-					efree(map->magic[j]);
-				}
+				efree(map->magic[j]);
 			}
 		} else {
 			efree(map->p);
@@ -3328,9 +3326,7 @@ internal_loaded:
 		for (i = 0; i < MAGIC_SETS; i++)
 			byteswap(map->magic[i], map->nmagic[i]);
 
-	if (dbname) {
-		efree(dbname);
-	}
+	efree(dbname);
 	return map;
 
 error:
@@ -3338,9 +3334,7 @@ error:
 		php_stream_close(stream);
 	}
 	apprentice_unmap(map);
-	if (dbname) {
-		efree(dbname);
-	}
+	efree(dbname);
 	return NULL;
 }
 

--- a/ext/fileinfo/libmagic/funcs.c
+++ b/ext/fileinfo/libmagic/funcs.c
@@ -527,10 +527,8 @@ file_reset(struct magic_set *ms, int checkloaded)
 		return -1;
 	}
 	file_clearbuf(ms);
-	if (ms->o.pbuf) {
-		efree(ms->o.pbuf);
-		ms->o.pbuf = NULL;
-	}
+	efree(ms->o.pbuf);
+	ms->o.pbuf = NULL;
 	ms->event_flags &= ~EVENT_HAD_ERR;
 	ms->error = -1;
 	return 0;

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -184,14 +184,10 @@ void ftp_gc(ftpbuf_t *ftp)
 	if (ftp == NULL) {
 		return;
 	}
-	if (ftp->pwd) {
-		efree(ftp->pwd);
-		ftp->pwd = NULL;
-	}
-	if (ftp->syst) {
-		efree(ftp->syst);
-		ftp->syst = NULL;
-	}
+	efree(ftp->pwd);
+	ftp->pwd = NULL;
+	efree(ftp->syst);
+	ftp->syst = NULL;
 }
 
 bool ftp_quit(ftpbuf_t *ftp)
@@ -207,10 +203,8 @@ bool ftp_quit(ftpbuf_t *ftp)
 		return false;
 	}
 
-	if (ftp->pwd) {
-		efree(ftp->pwd);
-		ftp->pwd = NULL;
-	}
+	efree(ftp->pwd);
+	ftp->pwd = NULL;
 
 	return true;
 }
@@ -497,10 +491,8 @@ bool ftp_chdir(ftpbuf_t *ftp, const char *dir, const size_t dir_len)
 		return false;
 	}
 
-	if (ftp->pwd) {
-		efree(ftp->pwd);
-		ftp->pwd = NULL;
-	}
+	efree(ftp->pwd);
+	ftp->pwd = NULL;
 
 	if (!ftp_putcmd(ftp, "CWD", sizeof("CWD")-1, dir, dir_len)) {
 		return false;
@@ -517,10 +509,8 @@ bool ftp_cdup(ftpbuf_t *ftp)
 		return false;
 	}
 
-	if (ftp->pwd) {
-		efree(ftp->pwd);
-		ftp->pwd = NULL;
-	}
+	efree(ftp->pwd);
+	ftp->pwd = NULL;
 
 	if (!ftp_putcmd(ftp, "CDUP", sizeof("CDUP")-1, NULL, (size_t) 0)) {
 		return false;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -246,9 +246,7 @@ static void php_gd_font_object_free(zend_object *zobj)
 	php_gd_font_object *obj = php_gd_font_object_from_zend_object(zobj);
 
 	if (obj->font) {
-		if (obj->font->data) {
-			efree(obj->font->data);
-		}
+		efree(obj->font->data);
 		efree(obj->font);
 		obj->font = NULL;
 	}

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -1380,10 +1380,8 @@ static zend_object* php_hashcontext_create(zend_class_entry *ce) {
 static void php_hashcontext_dtor(zend_object *obj) {
 	php_hashcontext_object *hash = php_hashcontext_from_object(obj);
 
-	if (hash->context) {
-		efree(hash->context);
-		hash->context = NULL;
-	}
+	efree(hash->context);
+	hash->context = NULL;
 
 	if (hash->key) {
 		ZEND_SECURE_ZERO(hash->key, hash->ops->block_size);

--- a/ext/intl/collator/collator_compare.c
+++ b/ext/intl/collator/collator_compare.c
@@ -72,9 +72,7 @@ PHP_FUNCTION( collator_compare )
 		/* Set error messages. */
 		intl_errors_set_custom_msg( COLLATOR_ERROR_P( co ),
 			"Error converting first argument to UTF-16", 0 );
-		if (ustr1) {
-			efree( ustr1 );
-		}
+		efree( ustr1 );
 		RETURN_FALSE;
 	}
 
@@ -88,12 +86,8 @@ PHP_FUNCTION( collator_compare )
 		/* Set error messages. */
 		intl_errors_set_custom_msg( COLLATOR_ERROR_P( co ),
 			"Error converting second argument to UTF-16", 0 );
-		if (ustr1) {
-			efree( ustr1 );
-		}
-		if (ustr2) {
-			efree( ustr2 );
-		}
+		efree( ustr1 );
+		efree( ustr2 );
 		RETURN_FALSE;
 	}
 

--- a/ext/intl/dateformat/dateformat_attr.c
+++ b/ext/intl/dateformat/dateformat_attr.c
@@ -126,9 +126,7 @@ PHP_FUNCTION( datefmt_set_pattern )
 
 	udat_applyPattern(DATE_FORMAT_OBJECT(dfo), (UBool)is_pattern_localized, svalue, slength);
 
-	if (svalue) {
-		efree(svalue);
-	}
+	efree(svalue);
 	INTL_METHOD_CHECK_STATUS(dfo, "Error setting symbol value");
 
 	RETURN_TRUE;

--- a/ext/intl/dateformat/dateformat_class.c
+++ b/ext/intl/dateformat/dateformat_class.c
@@ -35,9 +35,7 @@ void IntlDateFormatter_object_free( zend_object *object )
 
 	zend_object_std_dtor( &dfo->zo );
 
-	if (dfo->requested_locale) {
-		efree( dfo->requested_locale );
-	}
+	efree( dfo->requested_locale );
 
 	dateformat_data_free( &dfo->datef_data );
 }

--- a/ext/intl/dateformat/dateformat_parse.c
+++ b/ext/intl/dateformat/dateformat_parse.c
@@ -45,16 +45,12 @@ static void internal_parse_to_timestamp(IntlDateFormatter_object *dfo, char* tex
 	if (UNEXPECTED(update_calendar)) {
 		UCalendar *parsed_calendar = (UCalendar *)udat_getCalendar(DATE_FORMAT_OBJECT(dfo));
 		udat_parseCalendar(DATE_FORMAT_OBJECT(dfo), parsed_calendar, text_utf16, text_utf16_len, parse_pos, &INTL_DATA_ERROR_CODE(dfo));
-		if (text_utf16) {
-			efree(text_utf16);
-		}
+		efree(text_utf16);
 		INTL_METHOD_CHECK_STATUS( dfo, "Calendar parsing failed" );
 		timestamp = ucal_getMillis( parsed_calendar, &INTL_DATA_ERROR_CODE(dfo));
 	} else {
 		timestamp = udat_parse(DATE_FORMAT_OBJECT(dfo), text_utf16, text_utf16_len, parse_pos, &INTL_DATA_ERROR_CODE(dfo));
-		if (text_utf16) {
-			efree(text_utf16);
-		}
+		efree(text_utf16);
 	}
 
 	INTL_METHOD_CHECK_STATUS( dfo, "Date parsing failed" );
@@ -99,9 +95,7 @@ static void internal_parse_to_localtime(IntlDateFormatter_object *dfo, char* tex
 	parsed_calendar = (UCalendar *)udat_getCalendar(DATE_FORMAT_OBJECT(dfo));
 	udat_parseCalendar( DATE_FORMAT_OBJECT(dfo), parsed_calendar, text_utf16, text_utf16_len, parse_pos, &INTL_DATA_ERROR_CODE(dfo));
 
-	if (text_utf16) {
-		efree(text_utf16);
-	}
+	efree(text_utf16);
 
 	INTL_METHOD_CHECK_STATUS( dfo, "Date parsing failed" );
 

--- a/ext/intl/formatter/formatter_attr.c
+++ b/ext/intl/formatter/formatter_attr.c
@@ -200,9 +200,7 @@ PHP_FUNCTION( numfmt_set_text_attribute )
 
 	/* Actually set new attribute value. */
 	unum_setTextAttribute(FORMATTER_OBJECT(nfo), attribute, svalue, slength, &INTL_DATA_ERROR_CODE(nfo));
-	if (svalue) {
-		efree(svalue);
-	}
+	efree(svalue);
 	INTL_METHOD_CHECK_STATUS( nfo, "Error setting text attribute" );
 
 	RETURN_TRUE;
@@ -281,9 +279,7 @@ PHP_FUNCTION( numfmt_set_symbol )
 
 	/* Actually set the symbol. */
 	unum_setSymbol(FORMATTER_OBJECT(nfo), symbol, svalue, slength, &INTL_DATA_ERROR_CODE(nfo));
-	if (svalue) {
-		efree(svalue);
-	}
+	efree(svalue);
 	INTL_METHOD_CHECK_STATUS( nfo, "Error setting symbol value" );
 
 	RETURN_TRUE;
@@ -349,9 +345,7 @@ PHP_FUNCTION( numfmt_set_pattern )
 	INTL_METHOD_CHECK_STATUS( nfo, "Error converting pattern to UTF-16" );
 
 	unum_applyPattern(FORMATTER_OBJECT(nfo), 0, svalue, slength, &spattern_error, &INTL_DATA_ERROR_CODE(nfo));
-	if (svalue) {
-		efree(svalue);
-	}
+	efree(svalue);
 	if (U_FAILURE(INTL_DATA_ERROR_CODE(nfo))) {
 		char *msg;
 		spprintf(&msg, 0, "Error setting pattern value at line %d, offset %d", spattern_error.line, spattern_error.offset);

--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -173,9 +173,7 @@ PHP_FUNCTION( numfmt_format_currency )
 		INTL_METHOD_RETVAL_UTF8( nfo, formatted, formatted_len, ( formatted != format_buf ) );
 	}
 
-	if(scurrency) {
-		efree(scurrency);
-	}
+	efree(scurrency);
 }
 
 /* }}} */

--- a/ext/intl/formatter/formatter_parse.c
+++ b/ext/intl/formatter/formatter_parse.c
@@ -111,9 +111,7 @@ cleanup:
 	efree(oldlocale);
 #endif
 
-	if (sstr) {
-		efree(sstr);
-	}
+	efree(sstr);
 
 	INTL_METHOD_CHECK_STATUS( nfo, "Number parsing failed" );
 }
@@ -157,9 +155,7 @@ PHP_FUNCTION( numfmt_parse_currency )
 	if(zposition) {
 		ZEND_TRY_ASSIGN_REF_LONG(zposition, position);
 	}
-	if (sstr) {
-		efree(sstr);
-	}
+	efree(sstr);
 	INTL_METHOD_CHECK_STATUS( nfo, "Number parsing failed" );
 
 	/* Convert parsed currency to UTF-8 and pass it back to caller. */

--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -193,12 +193,8 @@ int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle,
 	}
 
 finish:
-	if (uhaystack) {
-		efree( uhaystack );
-	}
-	if (uneedle) {
-		efree( uneedle );
-	}
+	efree( uhaystack );
+	efree( uneedle );
 	if (bi) {
 		ubrk_close (bi);
 	}

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -430,9 +430,7 @@ static zend_string* get_icu_value_internal( const char* loc_name , char* tag_nam
 			if( tag_value ){
 				zend_string_release_ex( tag_value, 0 );
 			}
-			if( mod_loc_name ){
-				efree( mod_loc_name);
-			}
+			efree( mod_loc_name);
 			return NULL;
 		}
 	} while( buflen > tag_value_len );
@@ -443,17 +441,13 @@ static zend_string* get_icu_value_internal( const char* loc_name , char* tag_nam
 		if( tag_value ){
 			zend_string_release_ex( tag_value, 0 );
 		}
-		if( mod_loc_name ){
-			efree( mod_loc_name);
-		}
+		efree( mod_loc_name);
 		return NULL;
 	} else {
 		*result = 1;
 	}
 
-	if( mod_loc_name ){
-		efree( mod_loc_name);
-	}
+	efree( mod_loc_name);
 
 	tag_value->len = strlen(tag_value->val);
 	return tag_value;
@@ -1078,9 +1072,7 @@ static int add_array_entry(const char* loc_name, zval* hash_arr, char* key_name)
 			int cnt = 0;
 			/* Tokenize on the "_" or "-"  */
 			token = php_strtok_r( key_value->val , DELIMITER ,&last_ptr);
-			if( cur_key_name ){
-				efree( cur_key_name);
-			}
+			efree( cur_key_name);
 			/* Over-allocates a few bytes for the integer so we don't have to reallocate. */
 			size_t cur_key_name_size = (sizeof("-2147483648") - 1) + strlen(key_name) + 1;
 			cur_key_name = emalloc(cur_key_name_size);
@@ -1108,9 +1100,7 @@ static int add_array_entry(const char* loc_name, zval* hash_arr, char* key_name)
 		}
 	}
 
-	if( cur_key_name ){
-		efree( cur_key_name);
-	}
+	efree( cur_key_name);
 	/*if( key_name != LOC_PRIVATE_TAG && key_value){*/
 	return cur_result;
 }
@@ -1398,9 +1388,7 @@ static void array_cleanup( char* arr[] , int arr_size)
 {
 	int i=0;
 	for( i=0; i< arr_size; i++ ){
-		if( arr[i*2] ){
-			efree( arr[i*2]);
-		}
+		efree( arr[i*2]);
 	}
 	efree(arr);
 }

--- a/ext/intl/msgformat/msgformat_attr.c
+++ b/ext/intl/msgformat/msgformat_attr.c
@@ -77,9 +77,7 @@ PHP_FUNCTION( msgfmt_set_pattern )
 #endif
 
 	umsg_applyPattern(MSG_FORMAT_OBJECT(mfo), spattern, spattern_len, &spattern_error, &INTL_DATA_ERROR_CODE(mfo));
-	if (spattern) {
-		efree(spattern);
-	}
+	efree(spattern);
 	if (U_FAILURE(INTL_DATA_ERROR_CODE(mfo))) {
 		char *msg;
 		spprintf(&msg, 0, "Error setting symbol value at line %d, offset %d", spattern_error.line, spattern_error.offset);
@@ -88,9 +86,7 @@ PHP_FUNCTION( msgfmt_set_pattern )
 		RETURN_FALSE;
 	}
 
-	if(mfo->mf_data.orig_format) {
-		efree(mfo->mf_data.orig_format);
-	}
+	efree(mfo->mf_data.orig_format);
 	mfo->mf_data.orig_format = estrndup(value, value_len);
 	mfo->mf_data.orig_format_len = value_len;
 	/* invalidate cached format types */

--- a/ext/intl/msgformat/msgformat_data.c
+++ b/ext/intl/msgformat/msgformat_data.c
@@ -48,10 +48,8 @@ void msgformat_data_free(msgformat_data* mf_data)
 	if (mf_data->umsgf)
 		umsg_close(mf_data->umsgf);
 
-	if (mf_data->orig_format) {
-		efree(mf_data->orig_format);
-		mf_data->orig_format = NULL;
-	}
+	efree(mf_data->orig_format);
+	mf_data->orig_format = NULL;
 
 	if (mf_data->arg_types) {
 		zend_hash_destroy(mf_data->arg_types);

--- a/ext/intl/msgformat/msgformat_format.c
+++ b/ext/intl/msgformat/msgformat_format.c
@@ -37,9 +37,7 @@ static void msgfmt_do_format(MessageFormatter_object *mfo, zval *args, zval *ret
 	umsg_format_helper(mfo, Z_ARRVAL_P(args), &formatted, &formatted_len);
 
 	if (U_FAILURE(INTL_DATA_ERROR_CODE(mfo))) {
-		if (formatted) {
-			efree(formatted);
-		}
+		efree(formatted);
 		RETURN_FALSE;
 	} else {
 		INTL_METHOD_RETVAL_UTF8(mfo, formatted, formatted_len, 1);

--- a/ext/intl/msgformat/msgformat_parse.c
+++ b/ext/intl/msgformat/msgformat_parse.c
@@ -37,9 +37,7 @@ static void msgfmt_do_parse(MessageFormatter_object *mfo, char *source, size_t s
 	INTL_METHOD_CHECK_STATUS(mfo, "Converting parse string failed");
 
 	umsg_parse_helper(MSG_FORMAT_OBJECT(mfo), &count, &fargs, usource, usrc_len, &INTL_DATA_ERROR_CODE(mfo));
-	if (usource) {
-		efree(usource);
-	}
+	efree(usource);
 	INTL_METHOD_CHECK_STATUS(mfo, "Parsing failed");
 
 	array_init_size(return_value, count);

--- a/ext/intl/normalizer/normalizer_normalize.c
+++ b/ext/intl/normalizer/normalizer_normalize.c
@@ -131,9 +131,7 @@ PHP_FUNCTION( normalizer_normalize )
 
 		/* Set error messages. */
 		intl_error_set_custom_msg( NULL, "Error converting input string to UTF-16", 0 );
-		if (uinput) {
-			efree( uinput );
-		}
+		efree( uinput );
 		RETURN_FALSE;
 	}
 
@@ -249,9 +247,7 @@ PHP_FUNCTION( normalizer_is_normalized )
 
 		/* Set error messages. */
 		intl_error_set_custom_msg( NULL, "Error converting string to UTF-16.", 0 );
-		if (uinput) {
-			efree( uinput );
-		}
+		efree( uinput );
 		RETURN_FALSE;
 	}
 

--- a/ext/intl/resourcebundle/resourcebundle_iterator.c
+++ b/ext/intl/resourcebundle/resourcebundle_iterator.c
@@ -56,10 +56,8 @@ static void resourcebundle_iterator_invalidate( zend_object_iterator *iter )
 		zval_ptr_dtor( &iterator->current );
 		ZVAL_UNDEF(&iterator->current);
 	}
-	if (iterator->currentkey) {
-		efree( iterator->currentkey );
-		iterator->currentkey = NULL;
-	}
+	efree( iterator->currentkey );
+	iterator->currentkey = NULL;
 }
 /* }}} */
 

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -56,9 +56,7 @@ static int create_transliterator( char *str_id, size_t str_id_len, zend_long dir
 	/* Open ICU Transliterator. */
 	utrans = utrans_openU( ustr_id, ustr_id_len, (UTransDirection ) direction,
 		NULL, -1, &parse_error, TRANSLITERATOR_ERROR_CODE_P( to ) );
-	if (ustr_id) {
-		efree( ustr_id );
-	}
+	efree( ustr_id );
 
 	if( U_FAILURE( TRANSLITERATOR_ERROR_CODE( to ) ) )
 	{

--- a/ext/mbstring/libmbfl/mbfl/mbfl_memory_device.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_memory_device.c
@@ -56,9 +56,7 @@ void mbfl_memory_device_realloc(mbfl_memory_device *device, size_t initsz, size_
 
 void mbfl_memory_device_clear(mbfl_memory_device *device)
 {
-	if (device->buffer) {
-		efree(device->buffer);
-	}
+	efree(device->buffer);
 	device->buffer = NULL;
 	device->length = device->pos = 0;
 }
@@ -149,9 +147,7 @@ void mbfl_wchar_device_init(mbfl_wchar_device *device)
 
 void mbfl_wchar_device_clear(mbfl_wchar_device *device)
 {
-	if (device->buffer) {
-		efree(device->buffer);
-	}
+	efree(device->buffer);
 	device->buffer = NULL;
 	device->length = device->pos = 0;
 }

--- a/ext/mbstring/libmbfl/mbfl/mbfl_string.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_string.c
@@ -45,8 +45,6 @@ void mbfl_string_init(mbfl_string *string)
 
 void mbfl_string_clear(mbfl_string *string)
 {
-	if (string->val) {
-		efree(string->val);
-	}
+	efree(string->val);
 	mbfl_string_init_set(string, NULL); /* Poison it so any attempt to reuse will fail hard */
 }

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1128,9 +1128,7 @@ static void _php_mb_regex_ereg_replace_exec(INTERNAL_FUNCTION_PARAMETERS, OnigOp
 		onig_region_free(regs, 0);
 	}
 
-	if (description) {
-		efree(description);
-	}
+	efree(description);
 	if (regs != NULL) {
 		onig_region_free(regs, 1);
 	}

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -123,9 +123,7 @@ void php_clear_stmt_bind(MY_STMT *stmt)
 	  mysqlnd keeps track of the binding and has freed its
 	  structures in stmt_close() above
 	*/
-	if (stmt->query) {
-		efree(stmt->query);
-	}
+	efree(stmt->query);
 	efree(stmt);
 }
 /* }}} */
@@ -149,9 +147,7 @@ static void mysqli_objects_free_storage(zend_object	*object)
 	mysqli_object 	*intern = php_mysqli_fetch_object(object);
 	MYSQLI_RESOURCE	*my_res = (MYSQLI_RESOURCE *)intern->ptr;
 
-	if (my_res) {
-		efree(my_res);
-	}
+	efree(my_res);
 	zend_object_std_dtor(&intern->zo);
 }
 /* }}} */
@@ -571,9 +567,7 @@ PHP_RSHUTDOWN_FUNCTION(mysqli)
 {
 	/* check persistent connections, move used to free */
 
-	if (MyG(error_msg)) {
-		efree(MyG(error_msg));
-	}
+	efree(MyG(error_msg));
 
 	return SUCCESS;
 }

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -34,9 +34,7 @@
 static void php_mysqli_set_error(zend_long mysql_errno, char *mysql_err)
 {
 	MyG(error_no) = mysql_errno;
-	if (MyG(error_msg)) {
-		efree(MyG(error_msg));
-	}
+	efree(MyG(error_msg));
 	if(mysql_err && *mysql_err) {
 		MyG(error_msg) = estrdup(mysql_err);
 	} else {
@@ -240,25 +238,11 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, bool is_real_connect, b
 		/* if we're here, this means previous conn was ssl, repopulate settings */
 		mysql_ssl_set(mysql->mysql, ssl_key, ssl_cert, ssl_ca, ssl_capath, ssl_cipher);
 
-		if (ssl_key) {
-		    efree(ssl_key);
-		}
-
-		if (ssl_cert) {
-		    efree(ssl_cert);
-		}
-
-		if (ssl_ca) {
-		    efree(ssl_ca);
-		}
-
-		if (ssl_capath) {
-		    efree(ssl_capath);
-		}
-
-		if (ssl_cipher) {
-		    efree(ssl_cipher);
-		}
+		efree(ssl_key);
+		efree(ssl_cert);
+		efree(ssl_ca);
+		efree(ssl_capath);
+		efree(ssl_cipher);
 	}
 	if (mysqlnd_connect(mysql->mysql, hostname, username, passwd, passwd_len, dbname, dbname_len,
 						port, socket, flags, MYSQLND_CLIENT_NO_FLAG) == NULL)
@@ -801,15 +785,9 @@ PHP_FUNCTION(mysqli_poll)
 		mysqlnd_zval_array_from_mysqlnd_array(new_e_array, e_array);
 	}
 
-	if (new_dont_poll_array) {
-		efree(new_dont_poll_array);
-	}
-	if (new_r_array) {
-		efree(new_r_array);
-	}
-	if (new_e_array) {
-		efree(new_e_array);
-	}
+	efree(new_dont_poll_array);
+	efree(new_r_array);
+	efree(new_e_array);
 	if (ret == PASS) {
 		RETURN_LONG(desc_num);
 	} else {

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -504,18 +504,14 @@ static
 void php_mysqlnd_greet_free_mem(void * _packet)
 {
 	MYSQLND_PACKET_GREET *p= (MYSQLND_PACKET_GREET *) _packet;
-	if (p->server_version) {
-		efree(p->server_version);
-		p->server_version = NULL;
-	}
+	efree(p->server_version);
+	p->server_version = NULL;
 	if (p->authentication_plugin_data.s && p->authentication_plugin_data.s != p->intern_auth_plugin_data) {
 		efree(p->authentication_plugin_data.s);
 		p->authentication_plugin_data.s = NULL;
 	}
-	if (p->auth_protocol) {
-		efree(p->auth_protocol);
-		p->auth_protocol = NULL;
-	}
+	efree(p->auth_protocol);
+	p->auth_protocol = NULL;
 }
 /* }}} */
 

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -242,9 +242,7 @@ static void odbc_result_free(odbc_result *res)
 
 	if (res->values) {
 		for (int i = 0; i < res->numcols; i++) {
-			if (res->values[i].value) {
-				efree(res->values[i].value);
-			}
+			efree(res->values[i].value);
 		}
 		efree(res->values);
 		res->values = NULL;
@@ -263,10 +261,8 @@ static void odbc_result_free(odbc_result *res)
 		 */
 		res->stmt = NULL;
 	}
-	if (res->param_info) {
-		efree(res->param_info);
-		res->param_info = NULL;
-	}
+	efree(res->param_info);
+	res->param_info = NULL;
 
 	HashTable *results = &res->conn_ptr->results;
 	res->conn_ptr = NULL;
@@ -1504,9 +1500,7 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 			}
 		}
 	}
-	if (buf) {
-		efree(buf);
-	}
+	efree(buf);
 }
 /* }}} */
 
@@ -2489,9 +2483,7 @@ PHP_FUNCTION(odbc_next_result)
 
 	if (result->values) {
 		for(i = 0; i < result->numcols; i++) {
-			if (result->values[i].value) {
-				efree(result->values[i].value);
-			}
+			efree(result->values[i].value);
 		}
 		efree(result->values);
 		result->values = NULL;

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2980,9 +2980,7 @@ static void accel_globals_ctor(zend_accel_globals *accel_globals)
 static void accel_globals_dtor(zend_accel_globals *accel_globals)
 {
 	zend_string_free(accel_globals->key);
-	if (accel_globals->preloaded_internal_run_time_cache) {
-		pefree(accel_globals->preloaded_internal_run_time_cache, 1);
-	}
+	pefree(accel_globals->preloaded_internal_run_time_cache, 1);
 }
 
 #ifdef HAVE_HUGE_CODE_PAGES

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -9002,9 +9002,7 @@ static void zend_jit_trace_reset_caches(void)
 
 static void zend_jit_trace_free_caches(zend_jit_globals *jit_globals)
 {
-	if (jit_globals->exit_counters) {
-		free(jit_globals->exit_counters);
-	}
+	free(jit_globals->exit_counters);
 }
 
 static void zend_jit_trace_restart(void)

--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -307,9 +307,7 @@ static void zend_accel_blacklist_loadone(zend_blacklist *blacklist, char *filena
 		blacklist->pos++;
 	}
 	fclose(fp);
-	if (blacklist_path) {
-		free(blacklist_path);
-	}
+	free(blacklist_path);
 }
 
 void zend_accel_blacklist_load(zend_blacklist *blacklist, char *filename)

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -447,12 +447,8 @@ PHP_GINIT_FUNCTION(openssl)
 /* {{{ PHP_GSHUTDOWN_FUNCTION */
 PHP_GSHUTDOWN_FUNCTION(openssl)
 {
-	if (openssl_globals->errors) {
-		pefree(openssl_globals->errors, 1);
-	}
-	if (openssl_globals->errors_mark) {
-		pefree(openssl_globals->errors_mark, 1);
-	}
+	pefree(openssl_globals->errors, 1);
+	pefree(openssl_globals->errors_mark, 1);
 #if PHP_OPENSSL_API_VERSION >= 0x30000
 	php_openssl_backend_destroy_libctx(openssl_globals->libctx, openssl_globals->propq);
 #endif
@@ -4174,9 +4170,7 @@ clean_exit:
 		if (pkeys[i] != NULL) {
 			EVP_PKEY_free(pkeys[i]);
 		}
-		if (eks[i]) {
-			efree(eks[i]);
-		}
+		efree(eks[i]);
 	}
 	efree(eks);
 	efree(eksl);

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1678,10 +1678,8 @@ static zend_result php_openssl_setup_crypto(php_stream *stream,
 		SSL_CTX_free(sslsock->ctx);
 		sslsock->ctx = NULL;
 #ifdef HAVE_TLS_ALPN
-		if (sslsock->alpn_ctx.data) {
-			pefree(sslsock->alpn_ctx.data, php_stream_is_persistent(stream));
-			sslsock->alpn_ctx.data = NULL;
-		}
+		pefree(sslsock->alpn_ctx.data, php_stream_is_persistent(stream));
+		sslsock->alpn_ctx.data = NULL;
 #endif
 		return FAILURE;
 	} else {
@@ -2139,9 +2137,7 @@ static int php_openssl_sockop_close(php_stream *stream, int close_handle) /* {{{
 			sslsock->ctx = NULL;
 		}
 #ifdef HAVE_TLS_ALPN
-		if (sslsock->alpn_ctx.data) {
-			pefree(sslsock->alpn_ctx.data, php_stream_is_persistent(stream));
-		}
+		pefree(sslsock->alpn_ctx.data, php_stream_is_persistent(stream));
 #endif
 #ifdef PHP_WIN32
 		if (sslsock->s.socket == -1)
@@ -2178,13 +2174,8 @@ static int php_openssl_sockop_close(php_stream *stream, int close_handle) /* {{{
 		sslsock->sni_certs = NULL;
 	}
 
-	if (sslsock->url_name) {
-		pefree(sslsock->url_name, php_stream_is_persistent(stream));
-	}
-
-	if (sslsock->reneg) {
-		pefree(sslsock->reneg, php_stream_is_persistent(stream));
-	}
+	pefree(sslsock->url_name, php_stream_is_persistent(stream));
+	pefree(sslsock->reneg, php_stream_is_persistent(stream));
 
 	pefree(sslsock, php_stream_is_persistent(stream));
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -202,9 +202,7 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 
 	zend_string_release_ex(message, false);
 
-	if (supp) {
-		efree(supp);
-	}
+	efree(supp);
 }
 /* }}} */
 
@@ -1310,9 +1308,7 @@ static void cls_method_dtor(zval *el) /* {{{ */ {
 	if (func->common.function_name) {
 		zend_string_release_ex(func->common.function_name, 0);
 	}
-	if (ZEND_MAP_PTR(func->common.run_time_cache)) {
-		efree(ZEND_MAP_PTR(func->common.run_time_cache));
-	}
+	efree(ZEND_MAP_PTR(func->common.run_time_cache));
 	efree(func);
 }
 /* }}} */
@@ -1322,9 +1318,7 @@ static void cls_method_pdtor(zval *el) /* {{{ */ {
 	if (func->common.function_name) {
 		zend_string_release_ex(func->common.function_name, 1);
 	}
-	if (ZEND_MAP_PTR(func->common.run_time_cache)) {
-		pefree(ZEND_MAP_PTR(func->common.run_time_cache), 1);
-	}
+	pefree(ZEND_MAP_PTR(func->common.run_time_cache), 1);
 	pefree(func, 1);
 }
 /* }}} */
@@ -1485,12 +1479,8 @@ static void dbh_free(pdo_dbh_t *dbh, bool free_persistent)
 	if (dbh->data_source) {
 		pefree((char *)dbh->data_source, dbh->is_persistent);
 	}
-	if (dbh->username) {
-		pefree(dbh->username, dbh->is_persistent);
-	}
-	if (dbh->password) {
-		pefree(dbh->password, dbh->is_persistent);
-	}
+	pefree(dbh->username, dbh->is_persistent);
+	pefree(dbh->password, dbh->is_persistent);
 
 	if (dbh->persistent_id) {
 		pefree((char *)dbh->persistent_id, dbh->is_persistent);

--- a/ext/pdo_dblib/pdo_dblib.c
+++ b/ext/pdo_dblib/pdo_dblib.c
@@ -95,12 +95,8 @@ int pdo_dblib_error_handler(DBPROCESS *dbproc, int severity, int dberr,
 	einfo->oserr = oserr;
 	einfo->dberr = dberr;
 
-	if (einfo->oserrstr) {
-		efree(einfo->oserrstr);
-	}
-	if (einfo->dberrstr) {
-		efree(einfo->dberrstr);
-	}
+	efree(einfo->oserrstr);
+	efree(einfo->dberrstr);
 	if (oserrstr) {
 		einfo->oserrstr = estrdup(oserrstr);
 	} else {
@@ -134,9 +130,7 @@ int pdo_dblib_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate,
 			einfo = &DBLIB_G(err);
 		}
 
-		if (einfo->lastmsg) {
-			efree(einfo->lastmsg);
-		}
+		efree(einfo->lastmsg);
 
 		einfo->lastmsg = estrdup(msgtext);
 	}
@@ -150,18 +144,12 @@ void pdo_dblib_err_dtor(pdo_dblib_err *err)
 		return;
 	}
 
-	if (err->dberrstr) {
-		efree(err->dberrstr);
-		err->dberrstr = NULL;
-	}
-	if (err->lastmsg) {
-		efree(err->lastmsg);
-		err->lastmsg = NULL;
-	}
-	if (err->oserrstr) {
-		efree(err->oserrstr);
-		err->oserrstr = NULL;
-	}
+	efree(err->dberrstr);
+	err->dberrstr = NULL;
+	efree(err->lastmsg);
+	err->lastmsg = NULL;
+	efree(err->oserrstr);
+	err->oserrstr = NULL;
 }
 
 static PHP_GINIT_FUNCTION(dblib)
@@ -175,18 +163,12 @@ static PHP_GINIT_FUNCTION(dblib)
 
 PHP_RSHUTDOWN_FUNCTION(pdo_dblib)
 {
-	if (DBLIB_G(err).oserrstr) {
-		efree(DBLIB_G(err).oserrstr);
-		DBLIB_G(err).oserrstr = NULL;
-	}
-	if (DBLIB_G(err).dberrstr) {
-		efree(DBLIB_G(err).dberrstr);
-		DBLIB_G(err).dberrstr = NULL;
-	}
-	if (DBLIB_G(err).lastmsg) {
-		efree(DBLIB_G(err).lastmsg);
-		DBLIB_G(err).lastmsg = NULL;
-	}
+	efree(DBLIB_G(err).oserrstr);
+	DBLIB_G(err).oserrstr = NULL;
+	efree(DBLIB_G(err).dberrstr);
+	DBLIB_G(err).dberrstr = NULL;
+	efree(DBLIB_G(err).lastmsg);
+	DBLIB_G(err).lastmsg = NULL;
 	return SUCCESS;
 }
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -599,20 +599,12 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 		php_firebird_error(dbh);
 	}
 
-	if (H->date_format) {
-		pefree(H->date_format, dbh->is_persistent);
-	}
-	if (H->time_format) {
-		pefree(H->time_format, dbh->is_persistent);
-	}
-	if (H->timestamp_format) {
-		pefree(H->timestamp_format, dbh->is_persistent);
-	}
+	pefree(H->date_format, dbh->is_persistent);
+	pefree(H->time_format, dbh->is_persistent);
+	pefree(H->timestamp_format, dbh->is_persistent);
 
-	if (H->einfo.errmsg) {
-		pefree(H->einfo.errmsg, dbh->is_persistent);
-		H->einfo.errmsg = NULL;
-	}
+	pefree(H->einfo.errmsg, dbh->is_persistent);
+	H->einfo.errmsg = NULL;
 
 	pefree(H, dbh->is_persistent);
 }
@@ -1091,10 +1083,8 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 				if (UNEXPECTED(!str)) {
 					return false;
 				}
-				if (H->date_format) {
-					pefree(H->date_format, dbh->is_persistent);
-					H->date_format = NULL;
-				}
+				pefree(H->date_format, dbh->is_persistent);
+				H->date_format = NULL;
 				H->date_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
@@ -1106,10 +1096,8 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 				if (UNEXPECTED(!str)) {
 					return false;
 				}
-				if (H->time_format) {
-					pefree(H->time_format, dbh->is_persistent);
-					H->time_format = NULL;
-				}
+				pefree(H->time_format, dbh->is_persistent);
+				H->time_format = NULL;
 				H->time_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}
@@ -1121,10 +1109,8 @@ static bool pdo_firebird_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val
 				if (UNEXPECTED(!str)) {
 					return false;
 				}
-				if (H->timestamp_format) {
-					pefree(H->timestamp_format, dbh->is_persistent);
-					H->timestamp_format = NULL;
-				}
+				pefree(H->timestamp_format, dbh->is_persistent);
+				H->timestamp_format = NULL;
 				H->timestamp_format = pestrndup(ZSTR_VAL(str), ZSTR_LEN(str),dbh->is_persistent);
 				zend_string_release_ex(str, 0);
 			}

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -145,9 +145,7 @@ static void php_firebird_free_sqlda(XSQLDA const *sqlda) /* {{{ */
 	for (i = 0; i < sqlda->sqld; ++i) {
 		XSQLVAR const *var = &sqlda->sqlvar[i];
 
-		if (var->sqlind) {
-			efree(var->sqlind);
-		}
+		efree(var->sqlind);
 	}
 }
 /* }}} */
@@ -679,9 +677,7 @@ static int pdo_firebird_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param
 		case PDO_PARAM_EVT_ALLOC:
 			if (param->is_param) {
 				/* allocate the parameter */
-				if (var->sqlind) {
-					efree(var->sqlind);
-				}
+				efree(var->sqlind);
 				var->sqlind = (void*)emalloc(var->sqllen + 2*sizeof(short));
 				var->sqldata = &((char*)var->sqlind)[sizeof(short)];
 			}

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -66,10 +66,8 @@ int _pdo_mysql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int lin
 	einfo->file = file;
 	einfo->line = line;
 
-	if (einfo->errmsg) {
-		pefree(einfo->errmsg, dbh->is_persistent);
-		einfo->errmsg = NULL;
-	}
+	pefree(einfo->errmsg, dbh->is_persistent);
+	einfo->errmsg = NULL;
 
 	if (einfo->errcode) {
 		if (einfo->errcode == 2014) {
@@ -156,10 +154,8 @@ static void mysql_handle_closer(pdo_dbh_t *dbh)
 			mysql_close(H->server);
 			H->server = NULL;
 		}
-		if (H->einfo.errmsg) {
-			pefree(H->einfo.errmsg, dbh->is_persistent);
-			H->einfo.errmsg = NULL;
-		}
+		pefree(H->einfo.errmsg, dbh->is_persistent);
+		H->einfo.errmsg = NULL;
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -74,25 +74,17 @@ static int pdo_mysql_stmt_dtor(pdo_stmt_t *stmt) /* {{{ */
 	PDO_DBG_INF_FMT("stmt=%p", S->stmt);
 
 	pdo_mysql_free_result(S);
-	if (S->einfo.errmsg) {
-		pefree(S->einfo.errmsg, stmt->dbh->is_persistent);
-		S->einfo.errmsg = NULL;
-	}
+	pefree(S->einfo.errmsg, stmt->dbh->is_persistent);
+	S->einfo.errmsg = NULL;
 	if (S->stmt) {
 		mysql_stmt_close(S->stmt);
 		S->stmt = NULL;
 	}
 
 #ifndef PDO_USE_MYSQLND
-	if (S->params) {
-		efree(S->params);
-	}
-	if (S->in_null) {
-		efree(S->in_null);
-	}
-	if (S->in_length) {
-		efree(S->in_length);
-	}
+	efree(S->params);
+	efree(S->in_null);
+	efree(S->in_length);
 #endif
 
 	if (!S->done && php_pdo_stmt_valid_db_obj_handle(stmt)) {

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -122,9 +122,7 @@ static void free_cols(pdo_stmt_t *stmt, pdo_odbc_stmt *S)
 		int i;
 
 		for (i = 0; i < S->col_count; i++) {
-			if (S->cols[i].data) {
-				efree(S->cols[i].data);
-			}
+			efree(S->cols[i].data);
 		}
 		efree(S->cols);
 		S->cols = NULL;
@@ -145,9 +143,7 @@ static int odbc_stmt_dtor(pdo_stmt_t *stmt)
 	}
 
 	free_cols(stmt, S);
-	if (S->convbuf) {
-		efree(S->convbuf);
-	}
+	efree(S->convbuf);
 	efree(S);
 
 	return 1;
@@ -207,9 +203,7 @@ static int odbc_stmt_execute(pdo_stmt_t *stmt)
 					case PDO_ODBC_CONV_FAIL:
 						pdo_odbc_stmt_error("error converting input string");
 						SQLCloseCursor(S->stmt);
-						if (buf) {
-							efree(buf);
-						}
+						efree(buf);
 						return 0;
 				}
 				continue;
@@ -223,9 +217,7 @@ static int odbc_stmt_execute(pdo_stmt_t *stmt)
 				/* shouldn't happen either */
 				pdo_odbc_stmt_error("input LOB is no longer a stream");
 				SQLCloseCursor(S->stmt);
-				if (buf) {
-					efree(buf);
-				}
+				efree(buf);
 				return 0;
 			}
 
@@ -247,9 +239,7 @@ static int odbc_stmt_execute(pdo_stmt_t *stmt)
 		}
 	}
 
-	if (buf) {
-		efree(buf);
-	}
+	efree(buf);
 
 	switch (rc) {
 		case SQL_SUCCESS:
@@ -304,9 +294,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 
 			case PDO_PARAM_EVT_FREE:
 				P = param->driver_data;
-				if (P) {
-					efree(P);
-				}
+				efree(P);
 				break;
 
 			case PDO_PARAM_EVT_ALLOC:

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -76,10 +76,8 @@ int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const char *
 	einfo->file = file;
 	einfo->line = line;
 
-	if (einfo->errmsg) {
-		pefree(einfo->errmsg, dbh->is_persistent);
-		einfo->errmsg = NULL;
-	}
+	pefree(einfo->errmsg, dbh->is_persistent);
+	einfo->errmsg = NULL;
 
 	if (sqlstate == NULL || strlen(sqlstate) >= sizeof(pdo_error_type)) {
 		strcpy(*pdo_err, "HY000");
@@ -252,10 +250,8 @@ static void pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 			PQfinish(H->server);
 			H->server = NULL;
 		}
-		if (H->einfo.errmsg) {
-			pefree(H->einfo.errmsg, dbh->is_persistent);
-			H->einfo.errmsg = NULL;
-		}
+		pefree(H->einfo.errmsg, dbh->is_persistent);
+		H->einfo.errmsg = NULL;
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}
@@ -282,9 +278,7 @@ static bool pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *
 		PDO_CURSOR_FWDONLY) == PDO_CURSOR_SCROLL;
 
 	if (scrollable) {
-		if (S->cursor_name) {
-			efree(S->cursor_name);
-		}
+		efree(S->cursor_name);
 		spprintf(&S->cursor_name, 0, "pdo_crsr_%08x", ++H->stmt_counter);
 		emulate = 1;
 	} else if (driver_options) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -126,26 +126,16 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 
 	pgsql_stmt_finish(S, FIN_DISCARD|(server_obj_usable ? FIN_CLOSE|FIN_ABORT : 0));
 
-	if (S->stmt_name) {
-		efree(S->stmt_name);
-		S->stmt_name = NULL;
-	}
-	if (S->param_lengths) {
-		efree(S->param_lengths);
-		S->param_lengths = NULL;
-	}
-	if (S->param_values) {
-		efree(S->param_values);
-		S->param_values = NULL;
-	}
-	if (S->param_formats) {
-		efree(S->param_formats);
-		S->param_formats = NULL;
-	}
-	if (S->param_types) {
-		efree(S->param_types);
-		S->param_types = NULL;
-	}
+	efree(S->stmt_name);
+	S->stmt_name = NULL;
+	efree(S->param_lengths);
+	S->param_lengths = NULL;
+	efree(S->param_values);
+	S->param_values = NULL;
+	efree(S->param_formats);
+	S->param_formats = NULL;
+	efree(S->param_types);
+	S->param_types = NULL;
 	if (S->query) {
 		zend_string_release(S->query);
 		S->query = NULL;
@@ -166,10 +156,8 @@ static int pgsql_stmt_dtor(pdo_stmt_t *stmt)
 		S->cursor_name = NULL;
 	}
 
-	if(S->cols) {
-		efree(S->cols);
-		S->cols = NULL;
-	}
+	efree(S->cols);
+	S->cols = NULL;
 	efree(S);
 	stmt->driver_data = NULL;
 	return 1;
@@ -369,9 +357,7 @@ static int pgsql_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *
 	if (stmt->supports_placeholders == PDO_PLACEHOLDER_NAMED && param->is_param) {
 		switch (event_type) {
 			case PDO_PARAM_EVT_FREE:
-				if (param->driver_data) {
-					efree(param->driver_data);
-				}
+				efree(param->driver_data);
 				break;
 
 			case PDO_PARAM_EVT_NORMALIZE:

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -39,9 +39,7 @@ int _pdo_sqlite_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int li
 	einfo->line = line;
 
 	if (einfo->errcode != SQLITE_OK) {
-		if (einfo->errmsg) {
-			pefree(einfo->errmsg, dbh->is_persistent);
-		}
+		pefree(einfo->errmsg, dbh->is_persistent);
 		einfo->errmsg = pestrdup((char*)sqlite3_errmsg(H->db), dbh->is_persistent);
 	} else { /* no error */
 		strncpy(*pdo_err, PDO_ERR_NONE, sizeof(*pdo_err));
@@ -166,10 +164,8 @@ static void sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 #endif
 			H->db = NULL;
 		}
-		if (einfo->errmsg) {
-			pefree(einfo->errmsg, dbh->is_persistent);
-			einfo->errmsg = NULL;
-		}
+		pefree(einfo->errmsg, dbh->is_persistent);
+		einfo->errmsg = NULL;
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1219,9 +1219,7 @@ static void _php_pgsql_free_params(char **params, int num_params)
 	if (num_params > 0) {
 		int i;
 		for (i = 0; i < num_params; i++) {
-			if (params[i]) {
-				efree(params[i]);
-			}
+			efree(params[i]);
 		}
 		efree(params);
 	}

--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -291,9 +291,7 @@ php_stream *phar_wrapper_open_dir(php_stream_wrapper *wrapper, const char *path,
 		return NULL;
 	}
 
-	if (error) {
-		efree(error);
-	}
+	efree(error);
 
 	if (zend_string_equals(resource->path, ZSTR_CHAR('/'))) {
 		/* root directory requested */

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -199,15 +199,10 @@ void phar_destroy_phar_data(phar_archive_data *phar) /* {{{ */
 		phar->alias = NULL;
 	}
 
-	if (phar->fname) {
-		pefree(phar->fname, phar->is_persistent);
-		phar->fname = NULL;
-	}
-
-	if (phar->signature) {
-		pefree(phar->signature, phar->is_persistent);
-		phar->signature = NULL;
-	}
+	pefree(phar->fname, phar->is_persistent);
+	phar->fname = NULL;
+	pefree(phar->signature, phar->is_persistent);
+	phar->signature = NULL;
 
 	if (HT_IS_INITIALIZED(&phar->manifest)) {
 		zend_hash_destroy(&phar->manifest);
@@ -1058,9 +1053,7 @@ static zend_result phar_parse_pharfile(php_stream *fp, char *fname, size_t fname
 		{
 			php_stream_close(fp);
 
-			if (signature) {
-				efree(signature);
-			}
+			efree(signature);
 
 			if (error) {
 				spprintf(error, 0, "cannot load phar \"%s\" with implicit alias \"%.*s\" under different alias \"%s\"", fname, tmp_len, buffer, alias);
@@ -3098,10 +3091,8 @@ void phar_flush_ex(phar_archive_data *phar, zend_string *user_stub, bool is_defa
 
 		php_stream_rewind(newfile);
 
-		if (phar->signature) {
-			efree(phar->signature);
-			phar->signature = NULL;
-		}
+		efree(phar->signature);
+		phar->signature = NULL;
 
 		switch(phar->sig_flags) {
 			default: {
@@ -3114,9 +3105,7 @@ void phar_flush_ex(phar_archive_data *phar, zend_string *user_stub, bool is_defa
 						spprintf(error, 0, "phar error: unable to write signature: %s", save);
 						efree(save);
 					}
-					if (digest) {
-						efree(digest);
-					}
+					efree(digest);
 					if (must_close_old_file) {
 						php_stream_close(oldfile);
 					}
@@ -3521,9 +3510,7 @@ PHP_RSHUTDOWN_FUNCTION(phar) /* {{{ */
 
 		PHAR_G(request_init) = 0;
 
-		if (PHAR_G(cwd)) {
-			efree(PHAR_G(cwd));
-		}
+		efree(PHAR_G(cwd));
 
 		PHAR_G(cwd) = NULL;
 		PHAR_G(cwd_len) = 0;

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1520,9 +1520,7 @@ phar_spl_fileinfo:
 		temp = expand_filepath(base, NULL);
 		if (!temp) {
 			zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Could not resolve file path");
-			if (save) {
-				efree(save);
-			}
+			efree(save);
 			return ZEND_HASH_APPLY_STOP;
 		}
 
@@ -1586,13 +1584,8 @@ phar_spl_fileinfo:
 	if (php_check_open_basedir(fname)) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Iterator %s returned a path \"%s\" that open_basedir prevents opening", ZSTR_VAL(ce->name), fname);
 
-		if (save) {
-			efree(save);
-		}
-
-		if (temp) {
-			efree(temp);
-		}
+		efree(save);
+		efree(temp);
 
 		return ZEND_HASH_APPLY_STOP;
 	}
@@ -1603,26 +1596,16 @@ phar_spl_fileinfo:
 	if (!fp) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Iterator %s returned a file that could not be opened \"%s\"", ZSTR_VAL(ce->name), fname);
 
-		if (save) {
-			efree(save);
-		}
-
-		if (temp) {
-			efree(temp);
-		}
+		efree(save);
+		efree(temp);
 
 		return ZEND_HASH_APPLY_STOP;
 	}
 after_open_fp:
 	if (str_key_len >= sizeof(".phar")-1 && !memcmp(str_key, ".phar", sizeof(".phar")-1)) {
 		/* silently skip any files that would be added to the magic .phar directory */
-		if (save) {
-			efree(save);
-		}
-
-		if (temp) {
-			efree(temp);
-		}
+		efree(save);
+		efree(temp);
 
 		if (opened) {
 			zend_string_release_ex(opened, 0);
@@ -1639,17 +1622,13 @@ after_open_fp:
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Entry %s cannot be created: %s", str_key, error);
 		efree(error);
 
-		if (save) {
-			efree(save);
-		}
+		efree(save);
 
 		if (opened) {
 			zend_string_release_ex(opened, 0);
 		}
 
-		if (temp) {
-			efree(temp);
-		}
+		efree(temp);
 
 		if (close_fp) {
 			php_stream_close(fp);
@@ -1658,9 +1637,7 @@ after_open_fp:
 		return ZEND_HASH_APPLY_STOP;
 
 	} else {
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 		/* convert to PHAR_UFP */
 		if (data->internal_file->fp_type == PHAR_MOD) {
 			php_stream_close(data->internal_file->fp);
@@ -1691,13 +1668,8 @@ after_open_fp:
 
 	add_assoc_str(p_obj->ret, str_key, opened);
 
-	if (save) {
-		efree(save);
-	}
-
-	if (temp) {
-		efree(temp);
-	}
+	efree(save);
+	efree(temp);
 
 	data->internal_file->compressed_filesize = data->internal_file->uncompressed_filesize = contents_len;
 	phar_entry_delref(data);
@@ -3654,9 +3626,7 @@ static void phar_add_file(phar_archive_data **pphar, zend_string *file_name, con
 		}
 		goto finish;
 	} else {
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 
 		if (!data->internal_file->is_dir) {
 			size_t contents_len = 0;
@@ -3727,9 +3697,7 @@ static void phar_mkdir(phar_archive_data **pphar, zend_string *dir_name)
 
 		return;
 	} else {
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 
 		/* check for copy on write */
 		if (data->phar != *pphar) {

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -202,9 +202,7 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 			php_url_free(resource);
 			return NULL;
 		}
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 		fpf = php_stream_alloc(&phar_ops, idata, NULL, mode);
 		php_url_free(resource);
 		efree(internal_file);
@@ -584,14 +582,10 @@ static int phar_wrapper_stat(php_stream_wrapper *wrapper, const char *url, int f
 	/* find the phar in our trusty global hash indexed by alias (host of phar://blah.phar/file.whatever) */
 	if (FAILURE == phar_get_archive(&phar, ZSTR_VAL(resource->host), ZSTR_LEN(resource->host), NULL, 0, &error)) {
 		php_url_free(resource);
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 		return FAILURE;
 	}
-	if (error) {
-		efree(error);
-	}
+	efree(error);
 	if (*internal_file == '\0') {
 		/* root directory requested */
 		phar_dostat(phar, NULL, ssb, 1);
@@ -711,9 +705,7 @@ static int phar_wrapper_unlink(php_stream_wrapper *wrapper, const char *url, int
 		php_url_free(resource);
 		return 0;
 	}
-	if (error) {
-		efree(error);
-	}
+	efree(error);
 	if (idata->internal_file->fp_refcount > 1) {
 		/* more than just our fp resource is open for this file */
 		php_stream_wrapper_log_error(wrapper, options, "phar error: \"%s\" in phar \"%s\", has open file pointers, cannot unlink", internal_file, ZSTR_VAL(resource->host));
@@ -750,9 +742,7 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 	}
 	if (SUCCESS != phar_get_archive(&pfrom, ZSTR_VAL(resource_from->host), ZSTR_LEN(resource_from->host), NULL, 0, &error)) {
 		pfrom = NULL;
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 	}
 	if (PHAR_G(readonly) && (!pfrom || !pfrom->is_data)) {
 		php_url_free(resource_from);
@@ -766,9 +756,7 @@ static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from
 		return 0;
 	}
 	if (SUCCESS != phar_get_archive(&pto, ZSTR_VAL(resource_to->host), ZSTR_LEN(resource_to->host), NULL, 0, &error)) {
-		if (error) {
-			efree(error);
-		}
+		efree(error);
 		pto = NULL;
 	}
 	if (PHAR_G(readonly) && (!pto || !pto->is_data)) {

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1830,10 +1830,8 @@ zend_result phar_create_signature(phar_archive_data *phar, php_stream *fp, char 
 
 	php_stream_rewind(fp);
 
-	if (phar->signature) {
-		efree(phar->signature);
-		phar->signature = NULL;
-	}
+	efree(phar->signature);
+	phar->signature = NULL;
 
 	switch(phar->sig_flags) {
 		case PHAR_SIG_SHA512: {

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -198,9 +198,7 @@ PHP_FUNCTION(readline_info)
 #else
 				char *tmp = strdup(Z_STRVAL_P(value));
 				if (tmp) {
-					if (rl_line_buffer) {
-						free(rl_line_buffer);
-					}
+					free(rl_line_buffer);
 					rl_line_buffer = tmp;
 				}
 #endif

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -147,11 +147,9 @@ static PHP_GINIT_FUNCTION(snmp)
 /* }}} */
 
 #define PHP_SNMP_SESSION_FREE(a) { \
-	if ((*session)->a) { \
-		efree((*session)->a); \
+	efree((*session)->a); \
 		(*session)->a = NULL; \
-	} \
-}
+	}
 
 static void snmp_session_free(php_snmp_session **session) /* {{{ */
 {
@@ -362,10 +360,8 @@ static void php_snmp_getvalue(struct variable_list *vars, zval *snmpval, int val
 		ZVAL_COPY(snmpval, &val);
 	}
 	zval_ptr_dtor(&val);
-
-	if (dbuf){ /* malloc was used to store value */
-		efree(dbuf);
-	}
+/* malloc was used to store value */
+	efree(dbuf);
 }
 /* }}} */
 
@@ -1138,9 +1134,7 @@ static bool snmp_session_set_contextEngineID(struct snmp_session *s, zend_string
 		return false;
 	}
 
-	if (s->contextEngineID) {
-		efree(s->contextEngineID);
-	}
+	efree(s->contextEngineID);
 
 	s->contextEngineID = ebuf;
 	s->contextEngineIDLen = eout_len;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2533,7 +2533,7 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr != NULL) {
 			enc = get_encoder(SOAP_GLOBAL(sdl), (char*)nsptr->href, type);
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 
 	} else if ((attr = get_soap_enc_attribute(data->properties,"itemType")) &&
 	    attr->children &&
@@ -2547,7 +2547,7 @@ static zval *to_zval_array(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr != NULL) {
 			enc = get_encoder(SOAP_GLOBAL(sdl), (char*)nsptr->href, type);
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 
 		if ((attr = get_soap_enc_attribute(data->properties,"arraySize")) &&
 		    attr->children && attr->children->content) {
@@ -2901,7 +2901,7 @@ static zval *guess_zval_convert(zval *ret, encodeTypePtr type, xmlNodePtr data)
 		if (nsptr) {
 			ZVAL_STRING(Z_VAR_ENC_NS_P(&soapvar), (char*)nsptr->href);
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 		ZVAL_COPY_VALUE(ret, &soapvar);
 	}
 	return ret;
@@ -3673,12 +3673,8 @@ static void delete_mapping(void *data)
 void delete_encoder(zval *zv)
 {
 	encodePtr t = Z_PTR_P(zv);
-	if (t->details.ns) {
-		efree(t->details.ns);
-	}
-	if (t->details.type_str) {
-		efree(t->details.type_str);
-	}
+	efree(t->details.ns);
+	efree(t->details.type_str);
 	if (t->details.map) {
 		delete_mapping(t->details.map);
 	}
@@ -3691,12 +3687,8 @@ void delete_encoder(zval *zv)
 void delete_encoder_persistent(zval *zv)
 {
 	encodePtr t = Z_PTR_P(zv);
-	if (t->details.ns) {
-		free(t->details.ns);
-	}
-	if (t->details.type_str) {
-		free(t->details.type_str);
-	}
+	free(t->details.ns);
+	free(t->details.type_str);
 	if (t->details.clark_notation) {
 		zend_string_release_ex(t->details.clark_notation, 1);
 	}

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -960,9 +960,7 @@ try_again:
 				tmp = strstr(tmp," ");
 				if (tmp != NULL) {
 					tmp++;
-					if (http_msg) {
-						efree(http_msg);
-					}
+					efree(http_msg);
 					http_msg = estrdup(tmp);
 				}
 				efree(http_version);
@@ -986,9 +984,7 @@ try_again:
 			zend_string_release_ex(http_headers, 0);
 		}
 		ZVAL_NULL(Z_CLIENT_USE_PROXY_P(this_ptr));
-		if (http_msg) {
-			efree(http_msg);
-		}
+		efree(http_msg);
 		smart_str_free(&soap_headers_z);
 		return true;
 	}
@@ -1120,9 +1116,7 @@ try_again:
 		zend_string_release_ex(http_headers, 0);
 		ZVAL_NULL(Z_CLIENT_USE_PROXY_P(this_ptr));
 		add_soap_fault(this_ptr, "HTTP", "Error Fetching http body, No Content-Length, connection closed or chunked data", NULL, NULL, SOAP_GLOBAL(lang_en));
-		if (http_msg) {
-			efree(http_msg);
-		}
+		efree(http_msg);
 		smart_str_free(&soap_headers_z);
 		return FALSE;
 	}
@@ -1311,9 +1305,7 @@ try_again:
 			efree(content_encoding);
 			zend_string_release_ex(http_headers, 0);
 			zend_string_release_ex(http_body, 0);
-			if (http_msg) {
-				efree(http_msg);
-			}
+			efree(http_msg);
 			add_soap_fault(this_ptr, "HTTP", "Unknown Content-Encoding", NULL, NULL, SOAP_GLOBAL(lang_en));
 			return FALSE;
 		}
@@ -1327,9 +1319,7 @@ try_again:
 			zend_string_release_ex(http_headers, 0);
 			zend_string_release_ex(http_body, 0);
 			add_soap_fault(this_ptr, "HTTP", "Can't uncompress compressed response", NULL, NULL, SOAP_GLOBAL(lang_en));
-			if (http_msg) {
-				efree(http_msg);
-			}
+			efree(http_msg);
 			return FALSE;
 		}
 		efree(content_encoding);
@@ -1366,9 +1356,7 @@ try_again:
 		}
 	}
 
-	if (http_msg) {
-		efree(http_msg);
-	}
+	efree(http_msg);
 
 	return TRUE;
 }

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -70,12 +70,8 @@ static encodePtr create_encoder(sdlPtr sdl, sdlTypePtr cur_type, const xmlChar *
 	smart_str_0(&nscat);
 	if ((enc_ptr = zend_hash_find_ptr(sdl->encoders, nscat.s)) != NULL) {
 		enc = enc_ptr;
-		if (enc->details.ns) {
-			efree(enc->details.ns);
-		}
-		if (enc->details.type_str) {
-			efree(enc->details.type_str);
-		}
+		efree(enc->details.ns);
+		efree(enc->details.type_str);
 		if (enc->details.clark_notation) {
 			zend_string_release_ex(enc->details.clark_notation, 0);
 		}
@@ -470,7 +466,7 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 			}
 			zend_hash_next_index_insert_ptr(cur_type->elements, newType);
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 	}
 
 	trav = listType->children;
@@ -566,7 +562,7 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 				}
 				zend_hash_next_index_insert_ptr(cur_type->elements, newType);
 			}
-			if (ns) {efree(ns);}
+			efree(ns);
 
 			start = next;
 		}
@@ -683,7 +679,7 @@ static int schema_restriction_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodeP
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 	} else if (!simpleType) {
 		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
@@ -788,7 +784,7 @@ static int schema_restriction_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNode
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: restriction has no 'base' attribute");
 	}
@@ -913,7 +909,7 @@ static int schema_extension_simpleContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
@@ -968,7 +964,7 @@ static int schema_extension_complexContent(sdlPtr sdl, xmlAttrPtr tns, xmlNodePt
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(type));
 		}
-		if (ns) {efree(ns);}
+		efree(ns);
 	} else {
 		soap_error0(E_ERROR, "Parsing Schema: extension has no 'base' attribute");
 	}
@@ -1133,7 +1129,7 @@ static int schema_group(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr groupType, sdlTyp
 			newModel->kind = XSD_CONTENT_GROUP_REF;
 			newModel->u.group_ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
 
-			if (ns) {efree(ns);}
+			efree(ns);
 		} else {
 			newModel = emalloc(sizeof(sdlContentModel));
 			newModel->kind = XSD_CONTENT_SEQUENCE; /* will be redefined */
@@ -1568,7 +1564,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 			smart_str_appends(&nscat, type);
 			newType->name = estrdup(type);
 			smart_str_0(&nscat);
-			if (ns) {efree(ns);}
+			efree(ns);
 			newType->ref = estrndup(ZSTR_VAL(nscat.s), ZSTR_LEN(nscat.s));
 			smart_str_free(&nscat);
 		} else {
@@ -1703,7 +1699,7 @@ static int schema_element(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr element, sdlTyp
 		if (nsptr != NULL) {
 			cur_type->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(cptype));
 		}
-		if (str_ns) {efree(str_ns);}
+		efree(str_ns);
 	}
 
 	trav = element->children;
@@ -1800,7 +1796,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			smart_str_appends(&key, attr_name);
 			smart_str_0(&key);
 			newAttr->ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
-			if (ns) {efree(ns);}
+			efree(ns);
 		} else {
 			xmlAttrPtr ns;
 
@@ -1851,7 +1847,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 		if (nsptr != NULL) {
 			newAttr->encode = get_create_encoder(sdl, cur_type, nsptr->href, BAD_CAST(cptype));
 		}
-		if (str_ns) {efree(str_ns);}
+		efree(str_ns);
 	}
 
 	attr = attrType->properties;
@@ -1906,7 +1902,7 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 				} else {
 					ext->val = estrdup((char*)attr->children->content);
 				}
-				if (ns) {efree(ns);}
+				efree(ns);
 
 				if (!newAttr->extraAttributes) {
 					newAttr->extraAttributes = emalloc(sizeof(HashTable));
@@ -2040,7 +2036,7 @@ static int schema_attributeGroup(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrGrou
 			smart_str_appends(&key, group_name);
 			smart_str_0(&key);
 			newAttr->ref = estrndup(ZSTR_VAL(key.s), ZSTR_LEN(key.s));
-			if (ns) {efree(ns);}
+			efree(ns);
 			smart_str_free(&key);
 
 			zend_hash_next_index_insert_ptr(cur_type->attributes, newAttr);
@@ -2412,18 +2408,10 @@ void delete_type(zval *zv)
 {
 	sdlTypePtr type = Z_PTR_P(zv);
 
-	if (type->name) {
-		efree(type->name);
-	}
-	if (type->namens) {
-		efree(type->namens);
-	}
-	if (type->def) {
-		efree(type->def);
-	}
-	if (type->fixed) {
-		efree(type->fixed);
-	}
+	efree(type->name);
+	efree(type->namens);
+	efree(type->def);
+	efree(type->fixed);
 	if (type->elements) {
 		zend_hash_destroy(type->elements);
 		efree(type->elements);
@@ -2461,18 +2449,10 @@ void delete_type(zval *zv)
 void delete_type_persistent(zval *zv)
 {
 	sdlTypePtr type = Z_PTR_P(zv);
-	if (type->name) {
-		free(type->name);
-	}
-	if (type->namens) {
-		free(type->namens);
-	}
-	if (type->def) {
-		free(type->def);
-	}
-	if (type->fixed) {
-		free(type->fixed);
-	}
+	free(type->name);
+	free(type->namens);
+	free(type->def);
+	free(type->fixed);
 	if (type->elements) {
 		zend_hash_destroy(type->elements);
 		free(type->elements);
@@ -2509,12 +2489,8 @@ void delete_extra_attribute(zval *zv)
 {
 	sdlExtraAttributePtr attr = Z_PTR_P(zv);
 
-	if (attr->ns) {
-		efree(attr->ns);
-	}
-	if (attr->val) {
-		efree(attr->val);
-	}
+	efree(attr->ns);
+	efree(attr->val);
 	efree(attr);
 }
 
@@ -2522,12 +2498,8 @@ void delete_extra_attribute_persistent(zval *zv)
 {
 	sdlExtraAttributePtr attr = Z_PTR_P(zv);
 
-	if (attr->ns) {
-		free(attr->ns);
-	}
-	if (attr->val) {
-		free(attr->val);
-	}
+	free(attr->ns);
+	free(attr->val);
 	free(attr);
 }
 
@@ -2535,21 +2507,11 @@ void delete_attribute(zval *zv)
 {
 	sdlAttributePtr attr = Z_PTR_P(zv);
 
-	if (attr->def) {
-		efree(attr->def);
-	}
-	if (attr->fixed) {
-		efree(attr->fixed);
-	}
-	if (attr->name) {
-		efree(attr->name);
-	}
-	if (attr->namens) {
-		efree(attr->namens);
-	}
-	if (attr->ref) {
-		efree(attr->ref);
-	}
+	efree(attr->def);
+	efree(attr->fixed);
+	efree(attr->name);
+	efree(attr->namens);
+	efree(attr->ref);
 	if (attr->extraAttributes) {
 		zend_hash_destroy(attr->extraAttributes);
 		efree(attr->extraAttributes);
@@ -2561,21 +2523,11 @@ void delete_attribute_persistent(zval *zv)
 {
 	sdlAttributePtr attr = Z_PTR_P(zv);
 
-	if (attr->def) {
-		free(attr->def);
-	}
-	if (attr->fixed) {
-		free(attr->fixed);
-	}
-	if (attr->name) {
-		free(attr->name);
-	}
-	if (attr->namens) {
-		free(attr->namens);
-	}
-	if (attr->ref) {
-		free(attr->ref);
-	}
+	free(attr->def);
+	free(attr->fixed);
+	free(attr->name);
+	free(attr->namens);
+	free(attr->ref);
 	if (attr->extraAttributes) {
 		zend_hash_destroy(attr->extraAttributes);
 		free(attr->extraAttributes);
@@ -2585,24 +2537,18 @@ void delete_attribute_persistent(zval *zv)
 
 void delete_restriction_var_int(sdlRestrictionIntPtr ptr)
 {
-	if (ptr) {
-		efree(ptr);
-	}
+	efree(ptr);
 }
 
 void delete_restriction_var_int_persistent(sdlRestrictionIntPtr ptr)
 {
-	if (ptr) {
-		free(ptr);
-	}
+	free(ptr);
 }
 
 void delete_restriction_var_char_int(sdlRestrictionCharPtr ptr)
 {
 	if (ptr) {
-		if (ptr->value) {
-			efree(ptr->value);
-		}
+		efree(ptr->value);
 		efree(ptr);
 	}
 }
@@ -2615,9 +2561,7 @@ void delete_restriction_var_char(zval *zv)
 void delete_restriction_var_char_persistent_int(sdlRestrictionCharPtr ptr)
 {
 	if (ptr) {
-		if (ptr->value) {
-			free(ptr->value);
-		}
+		free(ptr->value);
 		free(ptr);
 	}
 }

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -67,7 +67,7 @@ encodePtr get_encoder_from_prefix(sdlPtr sdl, xmlNodePtr node, const xmlChar *ty
 	} else {
 		enc = get_encoder_ex(sdl, (char*)type, xmlStrlen(type));
 	}
-	if (ns) {efree(ns);}
+	efree(ns);
 	return enc;
 }
 
@@ -1752,9 +1752,7 @@ static sdlPtr get_sdl_from_cache(const char *fn, const char *uri, size_t uri_len
 		}
 	}
 
-	if (functions) {
-		efree(functions);
-	}
+	efree(functions);
 	efree(bindings);
 	efree(encoders);
 	efree(types);
@@ -3107,12 +3105,8 @@ static void delete_psdl_int(sdl_cache_bucket *p)
 	sdlPtr tmp = p->sdl;
 
 	zend_hash_destroy(&tmp->functions);
-	if (tmp->source) {
-		free(tmp->source);
-	}
-	if (tmp->target_ns) {
-		free(tmp->target_ns);
-	}
+	free(tmp->source);
+	free(tmp->target_ns);
 	if (tmp->elements) {
 		zend_hash_destroy(tmp->elements);
 		free(tmp->elements);
@@ -3381,12 +3375,8 @@ void delete_sdl_impl(void *handle)
 	sdlPtr tmp = (sdlPtr)handle;
 
 	zend_hash_destroy(&tmp->functions);
-	if (tmp->source) {
-		efree(tmp->source);
-	}
-	if (tmp->target_ns) {
-		efree(tmp->target_ns);
-	}
+	efree(tmp->source);
+	efree(tmp->target_ns);
 	if (tmp->elements) {
 		zend_hash_destroy(tmp->elements);
 		efree(tmp->elements);
@@ -3425,18 +3415,12 @@ static void delete_binding_ex(zval *zv, bool persistent)
 {
 	sdlBindingPtr binding = Z_PTR_P(zv);
 
-	if (binding->location) {
-		pefree(binding->location, persistent);
-	}
-	if (binding->name) {
-		pefree(binding->name, persistent);
-	}
+	pefree(binding->location, persistent);
+	pefree(binding->name, persistent);
 
 	if (binding->bindingType == BINDING_SOAP) {
 		sdlSoapBindingPtr soapBind = binding->bindingAttributes;
-		if (soapBind) {
-			pefree(soapBind, persistent);
-		}
+		pefree(soapBind, persistent);
 	}
 	pefree(binding, persistent);
 }
@@ -3453,9 +3437,7 @@ static void delete_binding_persistent(zval *zv)
 
 static void delete_sdl_soap_binding_function_body(sdlSoapBindingFunctionBody body, bool persistent)
 {
-	if (body.ns) {
-		pefree(body.ns, persistent);
-	}
+	pefree(body.ns, persistent);
 	if (body.headers) {
 		zend_hash_destroy(body.headers);
 		pefree(body.headers, persistent);
@@ -3466,15 +3448,9 @@ static void delete_function_ex(zval *zv, bool persistent)
 {
 	sdlFunctionPtr function = Z_PTR_P(zv);
 
-	if (function->functionName) {
-		pefree(function->functionName, persistent);
-	}
-	if (function->requestName) {
-		pefree(function->requestName, persistent);
-	}
-	if (function->responseName) {
-		pefree(function->responseName, persistent);
-	}
+	pefree(function->functionName, persistent);
+	pefree(function->requestName, persistent);
+	pefree(function->responseName, persistent);
 	if (function->requestParameters) {
 		zend_hash_destroy(function->requestParameters);
 		pefree(function->requestParameters, persistent);
@@ -3491,9 +3467,7 @@ static void delete_function_ex(zval *zv, bool persistent)
 	if (function->bindingAttributes &&
 	    function->binding && function->binding->bindingType == BINDING_SOAP) {
 		sdlSoapBindingFunctionPtr soapFunction = function->bindingAttributes;
-		if (soapFunction->soapAction) {
-			pefree(soapFunction->soapAction, persistent);
-		}
+		pefree(soapFunction->soapAction, persistent);
 		delete_sdl_soap_binding_function_body(soapFunction->input, persistent);
 		delete_sdl_soap_binding_function_body(soapFunction->output, persistent);
 		pefree(soapFunction, persistent);
@@ -3514,9 +3488,7 @@ static void delete_function_persistent(zval *zv)
 static void delete_parameter_ex(zval *zv, bool persistent)
 {
 	sdlParamPtr param = Z_PTR_P(zv);
-	if (param->paramName) {
-		pefree(param->paramName, persistent);
-	}
+	pefree(param->paramName, persistent);
 	pefree(param, persistent);
 }
 
@@ -3532,12 +3504,8 @@ static void delete_parameter_persistent(zval *zv)
 
 static void delete_header_int_ex(sdlSoapBindingFunctionHeaderPtr hdr, bool persistent)
 {
-	if (hdr->name) {
-		pefree(hdr->name, persistent);
-	}
-	if (hdr->ns) {
-		pefree(hdr->ns, persistent);
-	}
+	pefree(hdr->name, persistent);
+	pefree(hdr->ns, persistent);
 	if (hdr->headerfaults) {
 		zend_hash_destroy(hdr->headerfaults);
 		pefree(hdr->headerfaults, persistent);
@@ -3565,9 +3533,7 @@ static void delete_header_persistent(zval *zv)
 static void delete_fault_ex(zval *zv, bool persistent)
 {
 	sdlFaultPtr fault = Z_PTR_P(zv);
-	if (fault->name) {
-		pefree(fault->name, persistent);
-	}
+	pefree(fault->name, persistent);
 	if (fault->details) {
 		zend_hash_destroy(fault->details);
 		pefree(fault->details, persistent);
@@ -3575,9 +3541,7 @@ static void delete_fault_ex(zval *zv, bool persistent)
 	if (fault->bindingAttributes) {
 		sdlSoapBindingFunctionFaultPtr binding = (sdlSoapBindingFunctionFaultPtr)fault->bindingAttributes;
 
-		if (binding->ns) {
-			pefree(binding->ns, persistent);
-		}
+		pefree(binding->ns, persistent);
 		pefree(fault->bindingAttributes, persistent);
 	}
 	pefree(fault, persistent);

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4633,12 +4633,8 @@ static void delete_service(soapServicePtr service) /* {{{ */
 
 	delete_argv(&service->soap_class);
 
-	if (service->actor) {
-		efree(service->actor);
-	}
-	if (service->uri) {
-		efree(service->uri);
-	}
+	efree(service->actor);
+	efree(service->uri);
 	if (service->sdl) {
 		delete_sdl(service->sdl);
 	}

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -401,9 +401,7 @@ char *sockets_strerror(int error) /* {{{ */
 		buf = hstrerror(error);
 #else
 		{
-			if (SOCKETS_G(strerror_buf)) {
-				efree(SOCKETS_G(strerror_buf));
-			}
+			efree(SOCKETS_G(strerror_buf));
 
 			spprintf(&(SOCKETS_G(strerror_buf)), 0, "Host lookup error %d", error);
 			buf = SOCKETS_G(strerror_buf);
@@ -418,9 +416,7 @@ char *sockets_strerror(int error) /* {{{ */
 		buf = NULL;
 
 		if (tmp[0]) {
-			if (SOCKETS_G(strerror_buf)) {
-				efree(SOCKETS_G(strerror_buf));
-			}
+			efree(SOCKETS_G(strerror_buf));
 
 			SOCKETS_G(strerror_buf) = estrdup(tmp);
 			free(tmp);

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -96,9 +96,7 @@ static void php_sqlite3_error(php_sqlite3_db_object *db_obj, int errcode, const 
 		php_error_docref(NULL, E_WARNING, "%s", message);
 	}
 
-	if (message) {
-		efree(message);
-	}
+	efree(message);
 }
 /* }}} */
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -847,9 +847,7 @@ static void free_argv(char **argv, int argc)
 
 	if (argv) {
 		for (i = 0; i < argc; i++) {
-			if (argv[i]) {
-				efree(argv[i]);
-			}
+			efree(argv[i]);
 		}
 		efree(argv);
 	}

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -186,9 +186,7 @@ done:
 		signal(SIGCHLD, sig_handler);
 	}
 #endif
-	if (d) {
-		efree(d);
-	}
+	efree(d);
 	return pclose_return;
 err:
 	pclose_return = -1;

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -134,9 +134,7 @@ static void file_globals_ctor(php_file_globals *file_globals_p)
 static void file_globals_dtor(php_file_globals *file_globals_p)
 {
 #if defined(HAVE_GETHOSTBYNAME_R)
-	if (file_globals_p->tmp_host_buf) {
-		free(file_globals_p->tmp_host_buf);
-	}
+	free(file_globals_p->tmp_host_buf);
 #endif
 }
 

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -1142,9 +1142,7 @@ out:
 
 	smart_str_free(&req_buf);
 
-	if (http_header_line) {
-		efree(http_header_line);
-	}
+	efree(http_header_line);
 
 	if (header_info.location != NULL) {
 		efree(header_info.location);

--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -221,9 +221,7 @@ static struct gfxinfo *php_handle_swc(php_stream * stream)
 			 memcpy(b, buf, len);
 		}
 
-		if (buf) {
-			efree(buf);
-		}
+		efree(buf);
 	}
 
 	if (!status) {
@@ -1030,9 +1028,7 @@ static int php_get_xbm(php_stream *stream, struct gfxinfo **result)
 		efree(fline);
 		efree(iname);
 	}
-	if (fline) {
-		efree(fline);
-	}
+	efree(fline);
 
 	if (width && height) {
 		if (result) {

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -225,13 +225,9 @@ static php_process_env _php_array_to_envp(zval *environment)
 static void _php_free_envp(php_process_env env)
 {
 #ifndef PHP_WIN32
-	if (env.envarray) {
-		efree(env.envarray);
-	}
+	efree(env.envarray);
 #endif
-	if (env.envp) {
-		efree(env.envp);
-	}
+	efree(env.envp);
 }
 /* }}} */
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5403,12 +5403,8 @@ finish:
 		*rp = '\0';
 	}
 	efree((void *)buf);
-	if (tbuf) {
-		efree(tbuf);
-	}
-	if (allow_free) {
-		efree(allow_free);
-	}
+	efree(tbuf);
+	efree(allow_free);
 
 	return (size_t)(rp - rbuf);
 }

--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -42,10 +42,8 @@ PHP_MINIT_FUNCTION(syslog)
 PHP_RSHUTDOWN_FUNCTION(syslog)
 {
 	php_closelog();
-	if (BG(syslog_device)) {
-		free(BG(syslog_device));
-		BG(syslog_device) = NULL;
-	}
+	free(BG(syslog_device));
+	BG(syslog_device) = NULL;
 	return SUCCESS;
 }
 
@@ -83,10 +81,8 @@ PHP_FUNCTION(closelog)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	php_closelog();
-	if (BG(syslog_device)) {
-		free(BG(syslog_device));
-		BG(syslog_device)=NULL;
-	}
+	free(BG(syslog_device));
+	BG(syslog_device)=NULL;
 	RETURN_TRUE;
 }
 /* }}} */

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1204,9 +1204,7 @@ again:
 						}
 						smart_str_appendl(buf, "N;", 2);
 					}
-					if (serialized_data) {
-						efree(serialized_data);
-					}
+					efree(serialized_data);
 					return;
 				}
 

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -379,9 +379,7 @@ static void xml_parser_free_obj(zend_object *object)
 		zend_fcc_dtor(&parser->endNamespaceDeclHandler);
 		parser->endNamespaceDeclHandler.function_handler = NULL;
 	}
-	if (parser->baseURI) {
-		efree(parser->baseURI);
-	}
+	efree(parser->baseURI);
 	if (parser->object) {
 		OBJ_RELEASE(parser->object);
 	}

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1036,9 +1036,7 @@ static void php_zip_object_free_storage(zend_object *object) /* {{{ */
 	intern->za = NULL;
 	zend_object_std_dtor(&intern->zo);
 
-	if (intern->filename) {
-		efree(intern->filename);
-	}
+	efree(intern->filename);
 }
 /* }}} */
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -73,9 +73,7 @@ static void inflate_context_free_obj(zend_object *object)
 {
 	php_zlib_context *intern = inflate_context_from_obj(object);
 
-	if (intern->inflateDict) {
-		efree(intern->inflateDict);
-	}
+	efree(intern->inflateDict);
 	inflateEnd(&intern->Z);
 
 	zend_object_std_dtor(&intern->std);
@@ -326,9 +324,7 @@ static void php_zlib_output_handler_context_dtor(void *opaq)
 	php_zlib_context *ctx = (php_zlib_context *) opaq;
 
 	if (ctx) {
-		if (ctx->buffer.data) {
-			efree(ctx->buffer.data);
-		}
+		efree(ctx->buffer.data);
 		efree(ctx);
 	}
 }
@@ -455,9 +451,7 @@ static inline int php_zlib_inflate_rounds(z_stream *Z, size_t max, char **buf, s
 		*buf = buffer.data;
 		*len = buffer.used;
 	} else {
-		if (buffer.data) {
-			efree(buffer.data);
-		}
+		efree(buffer.data);
 		/* HACK: See zlib/examples/zpipe.c inf() function for explanation. */
 		/* This works as long as this function is not used for streaming. Required to catch very short invalid data. */
 		status = (status == Z_OK) ? Z_DATA_ERROR : status;


### PR DESCRIPTION
Changes performed with Coccinelle:

    @@
    expression e;
    @@

    - if (e) { efree(e);
    - }

    @@
    expression e;
    @@

    - if (e) { efree(e); e = NULL;
    - }

    @@
    expression e;
    @@

    - if (e) { free(e);
    - }

    @@
    expression e;
    @@

    - if (e) { free(e); e = NULL;
    - }

    @@
    expression e, e2;
    @@

    - if (e) { pefree(e, e2);
    - }

    @@
    expression e, e2;
    @@

    - if (e) { pefree(e, e2); e = NULL;
    - }