### PR TITLE
Zend: fix undefined symbol 'execute_ex' on Windows ARM64 Issue#19064

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -55088,7 +55088,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NULL_HANDLER(ZEND_OPCODE_HANDL
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
 #endif
-#ifdef _WIN64
+#if defined(_WIN64) && defined(_M_X64)
 /* See save_xmm_x86_64_ms_masm.asm */
 void execute_ex_real(zend_execute_data *ex)
 #else

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -5,7 +5,7 @@
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
 #endif
-#ifdef _WIN64
+#if defined(_WIN64) && defined(_M_X64)
 /* See save_xmm_x86_64_ms_masm.asm */
 void {%EXECUTOR_NAME%}_ex_real(zend_execute_data *ex)
 #else

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -62,11 +62,6 @@ TODO:
 #include "gdhelpers.h"
 #include "gd_intern.h"
 
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
-# pragma optimize("t", on)
-# include <emmintrin.h>
-#endif
-
 #ifndef MIN
 #define MIN(a,b) ((a)<(b)?(a):(b))
 #endif

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -62,7 +62,7 @@ TODO:
 #include "gdhelpers.h"
 #include "gd_intern.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 # pragma optimize("t", on)
 # include <emmintrin.h>
 #endif


### PR DESCRIPTION
ext/gd: fix emmintrin.h not found on Windows ARM64. emmintrin.h is x86 specific.