### PR TITLE
Fix GH-19070: setlocale($type, NULL) should not be deprecated

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2555,8 +2555,8 @@ function nl2br(string $string, bool $use_xhtml = true): string {}
 function strip_tags(string $string, array|string|null $allowed_tags = null): string {}
 
 /**
- * @param array|string $locales
- * @param string $rest
+ * @param array|string|null $locales
+ * @param string|null $rest
  */
 function setlocale(int $category, $locales, ...$rest): string|false {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f8c3745d39ed21f29f46b47f15b6fd1178e55dbb */
+ * Stub hash: b9958c8f2f643e072ba7c6ee33ad238ea8dd702e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)

--- a/ext/standard/tests/strings/gh18823_weak.phpt
+++ b/ext/standard/tests/strings/gh18823_weak.phpt
@@ -27,6 +27,5 @@ try {
     echo $e->getMessage(), "\n";
 }
 ?>
---EXPECTF--
-Deprecated: setlocale(): Passing null to parameter #2 ($locales) of type string is deprecated in %s on line %d
+--EXPECT--
 no

--- a/ext/standard/tests/strings/gh19070.phpt
+++ b/ext/standard/tests/strings/gh19070.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-19070 (setlocale($type, NULL) should not be deprecated)
+--FILE--
+<?php
+var_dump(setlocale(LC_ALL, null));
+?>
+--EXPECTF--
+string(%d) "%s"


### PR DESCRIPTION
This restores the old behaviour.