### PR TITLE
Use C23 unreachable() when possible

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -109,7 +109,10 @@
 # define ZEND_ASSERT(c) ZEND_ASSUME(c)
 #endif
 
-#ifdef PHP_HAVE_BUILTIN_UNREACHABLE
+/* use C23 unreachable() from <stddef.h> if possible */
+#ifdef unreachable
+# define _ZEND_UNREACHABLE() unreachable()
+#elif defined(PHP_HAVE_BUILTIN_UNREACHABLE)
 # define _ZEND_UNREACHABLE() __builtin_unreachable()
 #else
 # define _ZEND_UNREACHABLE() ZEND_ASSUME(0)


### PR DESCRIPTION
This is a macro defined in stddef, which is already included in this header. Since this is a macro, we can just check for the define rather than add any additional build system checks.

Fixes GH-18975