### PR TITLE
Fix empty_fcall_info C++ missing-field-initializers warning

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -696,8 +696,8 @@ ZEND_API zend_result _call_user_function_impl(zval *object, zval *function_name,
 # define empty_fcall_info (zend_fcall_info) {0}
 # define empty_fcall_info_cache (zend_fcall_info_cache) {0}
 #else
-# define empty_fcall_info zend_fcall_info {0}
-# define empty_fcall_info_cache zend_fcall_info_cache {0}
+# define empty_fcall_info zend_fcall_info {}
+# define empty_fcall_info_cache zend_fcall_info_cache {}
 #endif
 
 /** Build zend_call_info/cache from a zval*


### PR DESCRIPTION
This [commit ](https://github.com/php/php-src/commit/16c4c066f4d395e4e7bcac4be94e40bbabe4ff9c)introduced the following change:

```
#ifndef __cplusplus
# define empty_fcall_info (zend_fcall_info) {0}
# define empty_fcall_info_cache (zend_fcall_info_cache) {0}
#else
# define empty_fcall_info zend_fcall_info {0}
# define empty_fcall_info_cache zend_fcall_info_cache {0}
#endif
```
When it comes to C++ it generates a `-Wmissing-field-initializers` [warning](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-field-initializers), which is different to C, where this option does not warn about the universal zero initializer ‘{ 0 }’.

To sort this issue out while still maintaining the expected (compiler) behaviour the empty { } initializer should be employed instead:
```
#ifndef __cplusplus
# define empty_fcall_info (zend_fcall_info) {0}
# define empty_fcall_info_cache (zend_fcall_info_cache) {0}
#else
# define empty_fcall_info zend_fcall_info {}
# define empty_fcall_info_cache zend_fcall_info_cache {}
#endif
```

This is particularly important since `-Wmissing-field-initializers` is included in `-Wextra`, which, coupled with `-Werror` precludes a successful C++ extension build.
