### PR TITLE
Add allowed_classes_callback to unserialize()

### DIFF
--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -42,6 +42,8 @@ PHPAPI php_unserialize_data_t php_var_unserialize_init(void);
 PHPAPI void php_var_unserialize_destroy(php_unserialize_data_t d);
 PHPAPI HashTable *php_var_unserialize_get_allowed_classes(php_unserialize_data_t d);
 PHPAPI void php_var_unserialize_set_allowed_classes(php_unserialize_data_t d, HashTable *classes);
+PHPAPI zval *php_var_unserialize_get_allowed_classes_callback(php_unserialize_data_t d);
+PHPAPI void php_var_unserialize_set_allowed_classes_callback(php_unserialize_data_t d, zval *callback);
 PHPAPI void php_var_unserialize_set_max_depth(php_unserialize_data_t d, zend_long max_depth);
 PHPAPI zend_long php_var_unserialize_get_max_depth(php_unserialize_data_t d);
 PHPAPI void php_var_unserialize_set_cur_depth(php_unserialize_data_t d, zend_long cur_depth);

--- a/ext/standard/tests/serialize/__serialize_008.phpt
+++ b/ext/standard/tests/serialize/__serialize_008.phpt
@@ -1,0 +1,162 @@
+--TEST--
+unserialize allowed_classes_callback
+--FILE--
+<?php
+
+class TestClass {
+}
+
+class AnotherTestClass {
+}
+
+// Basic usage
+$serialized = serialize(
+    [
+        new TestClass(),
+        new TestClass(),
+    ]
+);
+
+$dummy = unserialize(
+    $serialized,
+    [
+        'allowed_classes_callback' => function ($className) {
+            var_dump($className);
+            return true;
+        }
+    ]
+);
+
+var_dump($dummy);
+
+
+// allowed_classes takes precedent to allowed_classes_callback, which is never called in this case
+$dummy = unserialize(
+    $serialized,
+    [
+        'allowed_classes' => ['TestClass'],
+        'allowed_classes_callback' => function ($className) {
+            var_dump($className);
+            return true;
+        }
+    ]
+);
+
+var_dump($dummy);
+
+
+// unserialize() blocked class
+$dummy = unserialize(
+    $serialized,
+    [
+        'allowed_classes_callback' => function ($className) {
+            return false;
+        }
+    ]
+);
+
+var_dump($dummy);
+
+// Nested unserialize() one is allowed, the second blocked
+$flip = false;
+$dummy = unserialize(
+    $serialized,
+    [
+        'allowed_classes_callback' => function ($className) use (&$flip) {
+            $serialized = serialize(
+                [
+                    new AnotherTestClass(),
+                ]
+            );
+
+            $dummy = unserialize(
+                $serialized,
+                [
+                    'allowed_classes_callback' => function ($className) use (&$flip) {
+                        echo 'Nested: ';
+                        var_dump($className);
+                        $flip = !$flip;
+                        return $flip;
+                    }
+                ]
+            );
+
+            echo 'Nested: ';
+            var_dump($dummy);
+            return true;
+        }
+    ]
+);
+
+var_dump($dummy);
+
+
+// throw from inside the callback
+try {
+    $dummy = unserialize(
+        $serialized,
+        [
+            'allowed_classes_callback' => function ($className) {
+                throw new RuntimeException('Better not unserialize this');
+            }
+        ]
+    );
+} catch (RuntimeException $e) {
+    var_dump($e->getMessage());
+}
+
+?>
+--EXPECT--
+string(9) "TestClass"
+string(9) "TestClass"
+array(2) {
+  [0]=>
+  object(TestClass)#1 (0) {
+  }
+  [1]=>
+  object(TestClass)#3 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(TestClass)#4 (0) {
+  }
+  [1]=>
+  object(TestClass)#5 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(__PHP_Incomplete_Class)#1 (1) {
+    ["__PHP_Incomplete_Class_Name"]=>
+    string(9) "TestClass"
+  }
+  [1]=>
+  object(__PHP_Incomplete_Class)#2 (1) {
+    ["__PHP_Incomplete_Class_Name"]=>
+    string(9) "TestClass"
+  }
+}
+Nested: string(16) "AnotherTestClass"
+Nested: array(1) {
+  [0]=>
+  object(AnotherTestClass)#3 (0) {
+  }
+}
+Nested: string(16) "AnotherTestClass"
+Nested: array(1) {
+  [0]=>
+  object(__PHP_Incomplete_Class)#6 (1) {
+    ["__PHP_Incomplete_Class_Name"]=>
+    string(16) "AnotherTestClass"
+  }
+}
+array(2) {
+  [0]=>
+  object(TestClass)#3 (0) {
+  }
+  [1]=>
+  object(TestClass)#6 (0) {
+  }
+}
+string(27) "Better not unserialize this"

--- a/ext/standard/tests/serialize/__serialize_009.phpt
+++ b/ext/standard/tests/serialize/__serialize_009.phpt
@@ -1,0 +1,31 @@
+--TEST--
+unserialize allowed_classes_callback blocking unserialize
+--FILE--
+<?php
+
+class TestClass {
+}
+
+$serialized = serialize(
+    [
+        new TestClass(),
+        new TestClass(),
+    ]
+);
+
+$dummy = unserialize(
+    $serialized,
+    [
+        'allowed_classes_callback' => function ($className) {
+            return 0;
+        }
+    ]
+);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: "allowed_classes_callback" must return bool, int given in %s__serialize_009.php:%d
+Stack trace:
+#0 %s__serialize_009.php(%s): unserialize('a:2:{i:0;O:9:"T...', Array)
+#1 {main}
+  thrown in %s__serialize_009.php on line %d

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1381,7 +1381,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 {
 	const unsigned char *p;
 	php_unserialize_data_t var_hash;
-	zval *retval;
+	zval *retval, *prev_class_callback;
 	HashTable *class_hash = NULL, *prev_class_hash;
 	zend_long prev_max_depth, prev_cur_depth;
 
@@ -1393,10 +1393,11 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 	PHP_VAR_UNSERIALIZE_INIT(var_hash);
 
 	prev_class_hash = php_var_unserialize_get_allowed_classes(var_hash);
+	prev_class_callback = php_var_unserialize_get_allowed_classes_callback(var_hash);
 	prev_max_depth = php_var_unserialize_get_max_depth(var_hash);
 	prev_cur_depth = php_var_unserialize_get_cur_depth(var_hash);
 	if (options != NULL) {
-		zval *classes, *max_depth;
+		zval *classes, *classes_callback, *max_depth;
 
 		classes = zend_hash_str_find_deref(options, "allowed_classes", sizeof("allowed_classes")-1);
 		if (classes && Z_TYPE_P(classes) != IS_ARRAY && Z_TYPE_P(classes) != IS_TRUE && Z_TYPE_P(classes) != IS_FALSE) {
@@ -1434,6 +1435,13 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 			} ZEND_HASH_FOREACH_END();
 		}
 		php_var_unserialize_set_allowed_classes(var_hash, class_hash);
+
+		classes_callback = zend_hash_str_find_deref(options, "allowed_classes_callback", sizeof("allowed_classes_callback")-1);
+		if (classes_callback && !zend_is_callable(classes_callback, IS_CALLABLE_SUPPRESS_DEPRECATIONS, NULL)) {
+			zend_type_error("%s(): Option \"allowed_classes_callback\" must be a valid callback", function_name);
+			goto cleanup;
+		}
+		php_var_unserialize_set_allowed_classes_callback(var_hash, classes_callback);
 
 		max_depth = zend_hash_str_find_deref(options, "max_depth", sizeof("max_depth") - 1);
 		if (max_depth) {
@@ -1490,6 +1498,7 @@ cleanup:
 
 	/* Reset to previous options in case this is a nested call */
 	php_var_unserialize_set_allowed_classes(var_hash, prev_class_hash);
+	php_var_unserialize_set_allowed_classes_callback(var_hash, prev_class_callback);
 	php_var_unserialize_set_max_depth(var_hash, prev_max_depth);
 	php_var_unserialize_set_cur_depth(var_hash, prev_cur_depth);
 	PHP_VAR_UNSERIALIZE_DESTROY(var_hash);


### PR DESCRIPTION
I want to propose an added `allowed_classes_callback` option to `unserialize()`

The class name as parsed from the serialized string is passed as a parameter to the callback, it should return a boolean. `true` would allow the class, `false` would block it the same way 'allowed_classes' would, using `__PHP_Incomplete_Class`.

The callback will be triggered **after** `allowed_classes` is evaluated (if present).

This callback would solve a few problems where `allowed_classes` is not sufficient:

- It would allow for an `is_subclass_of()` check where for example an interface can be added to classes that are safe to get unserialized.

-  It would allow for better ways to fail, I think the `__PHP_Incomplete_Class` situation is kinda yucky. Since this is a callable the developer could just find another solution, for example throwing an exception, do a `trigger_error()` or `exit()`.

- This would also allow for fixing legacy applications where it is not exactly clear what is being unserialized. The callable would return a true value but a `E_USER_DEPRECATION` is triggered. This way data can be collected about what classes to allow. Providing a non-disrupting way to secure unserialize calls. This is especially helpful in very generic unserialize usages like caches.

- This would make the `unserialize_callback_func` ini setting redundant for many use-cases, as any custom autoloading routine could also be executed in this `allowed_classes_callback`.

Feedback is very much appreciated.