### PR TITLE
Make cloning DOM node lists, maps, and collections fail

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -45,6 +45,11 @@ PHP 8.5 UPGRADE NOTES
     change, but should more closely match user expectations, demonstrated by
     GH-15753 and GH-16198.
 
+- DOM:
+  . Cloning a DOMNamedNodeMap, DOMNodeList, Dom\NamedNodeMap, Dom\NodeList,
+    Dom\HTMLCollection, and Dom\DtdNamedNodeMap. This never actually resulted
+    in a working object, so the impact should actually be zero.
+
 - FileInfo:
   . finfo_file() and finfo::file() now throws a ValueError instead of a
     TypeError when $filename contains nul bytes.

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -806,6 +806,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_nnodemap_object_handlers.free_obj = dom_nnodemap_objects_free_storage;
 	dom_nnodemap_object_handlers.read_dimension = dom_nodemap_read_dimension;
 	dom_nnodemap_object_handlers.has_dimension = dom_nodemap_has_dimension;
+	dom_nnodemap_object_handlers.clone_obj = NULL;
 
 	memcpy(&dom_nodelist_object_handlers, &dom_nnodemap_object_handlers, sizeof(zend_object_handlers));
 	dom_nodelist_object_handlers.read_dimension = dom_nodelist_read_dimension;
@@ -823,7 +824,6 @@ PHP_MINIT_FUNCTION(dom)
 	dom_html_collection_object_handlers.read_dimension = dom_html_collection_read_dimension;
 	dom_html_collection_object_handlers.has_dimension = dom_html_collection_has_dimension;
 	dom_html_collection_object_handlers.get_gc = dom_html_collection_get_gc;
-	dom_html_collection_object_handlers.clone_obj = NULL;
 
 	memcpy(&dom_object_namespace_node_handlers, &dom_object_handlers, sizeof(zend_object_handlers));
 	dom_object_namespace_node_handlers.offset = XtOffsetOf(dom_object_namespace_node, dom.std);

--- a/ext/dom/tests/clone_list_map_collection.phpt
+++ b/ext/dom/tests/clone_list_map_collection.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Cloning node lists, maps, and collections should fail
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$dom = new DOMDocument;
+$dom->loadXML('<root a="1"><a/></root>');
+try {
+    clone $dom->documentElement->attributes;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    clone $dom->documentElement->childNodes;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$dom = Dom\XMLDocument::createFromString('<!DOCTYPE root [<!ENTITY foo "">]><root a="1"><a/></root>');
+try {
+    clone $dom->documentElement->attributes;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    clone $dom->documentElement->childNodes;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    clone $dom->documentElement->children;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    clone $dom->doctype->entities;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Trying to clone an uncloneable object of class DOMNamedNodeMap
+Trying to clone an uncloneable object of class DOMNodeList
+Trying to clone an uncloneable object of class Dom\NamedNodeMap
+Trying to clone an uncloneable object of class Dom\NodeList
+Trying to clone an uncloneable object of class Dom\HTMLCollection
+Trying to clone an uncloneable object of class Dom\DtdNamedNodeMap


### PR DESCRIPTION
This never worked and creates a broken object,
and on master can cause a crash with foreach.
It makes no sense to fix a behaviour that never worked, block it instead.