### PR TITLE
dom: Remove unnecessary objmap ptr null checks

### DIFF
--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -35,10 +35,6 @@
 zend_long php_dom_get_namednodemap_length(dom_object *obj)
 {
 	dom_nnodemap_object *objmap = obj->ptr;
-	if (!objmap) {
-		return 0;
-	}
-
 	return objmap->handler->length(objmap);
 }
 

--- a/ext/dom/obj_map.c
+++ b/ext/dom/obj_map.c
@@ -294,9 +294,6 @@ static void dom_map_get_null_item(dom_nnodemap_object *map, zend_long index, zva
 zend_long php_dom_get_nodelist_length(dom_object *obj)
 {
 	dom_nnodemap_object *objmap = obj->ptr;
-	if (!objmap) {
-		return 0;
-	}
 
 	if (objmap->handler->use_cache) {
 		xmlNodePtr nodep = dom_object_get_node(objmap->baseobj);


### PR DESCRIPTION
This will be unnecessary once GH-19089 is merged because we always will have a valid objmap object.