### PR TITLE
ext/tidy: using tidyParseString when available instead for tidy::pars…

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -63,6 +63,12 @@ if test "$PHP_TIDY" != "no"; then
     [],
     [-L$TIDY_LIBDIR])
 
+  PHP_CHECK_LIBRARY([$TIDY_LIB_NAME], [tidyParseString],
+    [AC_DEFINE([HAVE_TIDYPARSESTRING], [1],
+      [Define to 1 if Tidy library has the 'tidyParseString' function.])],
+    [],
+    [-L$TIDY_LIBDIR])
+
   PHP_ADD_LIBRARY_WITH_PATH([$TIDY_LIB_NAME],
     [$TIDY_LIBDIR],
     [TIDY_SHARED_LIBADD])

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -798,8 +798,6 @@ static zend_result _php_tidy_apply_config_array(TidyDoc doc, const HashTable *ht
 
 static zend_result php_tidy_parse_string(PHPTidyObj *obj, const char *string, uint32_t len, const char *enc)
 {
-	TidyBuffer buf;
-
 	if(enc) {
 		if (tidySetCharEncoding(obj->ptdoc->doc, enc) < 0) {
 			php_error_docref(NULL, E_WARNING, "Could not set encoding \"%s\"", enc);
@@ -809,9 +807,15 @@ static zend_result php_tidy_parse_string(PHPTidyObj *obj, const char *string, ui
 
 	obj->ptdoc->initialized = true;
 
+#ifdef HAVE_TIDYPARSESTRING
+	if (tidyParseString(obj->ptdoc->doc, string) < 0) {
+#else
+	TidyBuffer buf;
+
 	tidyBufInit(&buf);
 	tidyBufAttach(&buf, (byte *) string, len);
 	if (tidyParseBuffer(obj->ptdoc->doc, &buf) < 0) {
+#endif
 		php_error_docref(NULL, E_WARNING, "%s", obj->ptdoc->errbuf->bp);
 		return FAILURE;
 	}


### PR DESCRIPTION
…eString().