### PR TITLE
Remove unnecessary semicolon in match rule

### DIFF
--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -727,7 +727,7 @@ case_separator:
 
 match:
 		T_MATCH '(' expr ')' '{' match_arm_list '}'
-			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); };
+			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); }
 ;
 
 match_arm_list:


### PR DESCRIPTION
```
match:
    T_MATCH '(' expr ')' '{' match_arm_list '}'
      { $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); };
      { $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); };
                                                       ^ unnecessary semicolon
;
^ semicolon is here
```