### PR TITLE
fix: check priv_key_bits only for relevant private key types

### DIFF
--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -1437,15 +1437,14 @@ static const char *php_openssl_get_evp_pkey_name(int key_type) {
 
 EVP_PKEY *php_openssl_generate_private_key(struct php_x509_request * req)
 {
-	if (req->priv_key_bits < MIN_KEY_LENGTH) {
-		php_error_docref(NULL, E_WARNING, "Private key length must be at least %d bits, configured to %d",
-			MIN_KEY_LENGTH, req->priv_key_bits);
-		return NULL;
-	}
-
 	int type = php_openssl_get_evp_pkey_type(req->priv_key_type);
 	if (type < 0) {
 		php_error_docref(NULL, E_WARNING, "Unsupported private key type");
+		return NULL;
+	}
+	if ((type == EVP_PKEY_RSA || type == EVP_PKEY_DSA || type == EVP_PKEY_DH) && req->priv_key_bits < MIN_KEY_LENGTH) {
+		php_error_docref(NULL, E_WARNING, "Private key length must be at least %d bits, configured to %d",
+			MIN_KEY_LENGTH, req->priv_key_bits);
 		return NULL;
 	}
 	const char *name = php_openssl_get_evp_pkey_name(req->priv_key_type);

--- a/ext/openssl/tests/openssl_key_type_bits_enforcement.phpt
+++ b/ext/openssl/tests/openssl_key_type_bits_enforcement.phpt
@@ -1,0 +1,59 @@
+--TEST--
+openssl: test key type and bit length enforcement in php_openssl_generate_private_key
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!defined("OPENSSL_KEYTYPE_RSA")) die("skip RSA disabled");
+if (!defined("OPENSSL_KEYTYPE_DSA")) die("skip DSA disabled");
+if (!defined("OPENSSL_KEYTYPE_DH")) die("skip DH disabled");
+if (!defined("OPENSSL_KEYTYPE_EC")) die("skip EC disabled");
+?>
+--FILE--
+<?php
+function test_key($type, $bits = null) {
+    $args = [];
+    switch ($type) {
+        case OPENSSL_KEYTYPE_RSA:
+            $args['private_key_type'] = OPENSSL_KEYTYPE_RSA;
+            if ($bits !== null) $args['private_key_bits'] = $bits;
+            break;
+        case OPENSSL_KEYTYPE_DSA:
+            $args['private_key_type'] = OPENSSL_KEYTYPE_DSA;
+            if ($bits !== null) $args['private_key_bits'] = $bits;
+            break;
+        case OPENSSL_KEYTYPE_DH:
+            $args['private_key_type'] = OPENSSL_KEYTYPE_DH;
+            if ($bits !== null) $args['private_key_bits'] = $bits;
+            break;
+        case OPENSSL_KEYTYPE_EC:
+            $args['curve_name'] = 'prime256v1';
+            $args['private_key_type'] = OPENSSL_KEYTYPE_EC;
+            break;
+    }
+    $key = @openssl_pkey_new($args);
+    var_dump($key !== false);
+}
+
+// Should fail: RSA, DSA, DH with bits < MIN_KEY_LENGTH
+foreach ([OPENSSL_KEYTYPE_RSA, OPENSSL_KEYTYPE_DSA, OPENSSL_KEYTYPE_DH] as $type) {
+    test_key($type, 256); // too short
+}
+// Should succeed: RSA, DSA, DH with bits >= MIN_KEY_LENGTH
+foreach ([OPENSSL_KEYTYPE_RSA, OPENSSL_KEYTYPE_DSA, OPENSSL_KEYTYPE_DH] as $type) {
+    test_key($type, 2048); // valid
+}
+// Should succeed: EC with curve only
+ test_key(OPENSSL_KEYTYPE_EC);
+// Should succeed: EC with bits too low
+ test_key(OPENSSL_KEYTYPE_EC, 256);
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
# Description

`php_openssl_generate_private_key` currently applies the `MIN_KEY_LENGTH` (384 bits) check across all key types, including EC (Elliptic Curve) keys. However, for EC key generation, the `private_key_bits` parameter is not relevant—the security of EC keys is determined by the selected curve, not the bit length. As a result, applying this check to EC keys can cause developer confusion. For reference, see related discussions:
- [Laravel Notification Channels Issue #213](https://github.com/laravel-notification-channels/webpush/issues/213)
- [Stack Overflow: Why can't I use key lengths <384bit for EC in PHP OpenSSL?](https://stackoverflow.com/questions/62430373/why-cant-i-use-key-lengths-384bit-for-ec-in-php-openssl)

# Solution

This PR updates `php_openssl_generate_private_key` to enforce the `MIN_KEY_LENGTH` check only for key types where the `priv_key_bits` parameter is meaningful—specifically RSA, DSA, and DH keys.

# Additional Notes

- As a side note, the current `MIN_KEY_LENGTH` of 384 bits for RSA, DSA, and DH keys is not considered secure by modern standards. Ideally, this minimum should be raised (e.g., to 2048 bits for RSA), or the check reconsidered entirely.
- Regarding branch targets: The contribution guide suggests targeting the `PHP-8.3` branch for bug fixes (as this is the lowest actively supported version). However, for extension changes, this branch lacks the involved source files. Please advise if a different branch is preferred for this PR.