### PR TITLE
ext/gd: Make TGA always available

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -192,7 +192,6 @@ AC_DEFUN([PHP_GD_CHECK_VERSION],[
   PHP_GD_CHECK_FORMAT([Jpeg], [AC_DEFINE([HAVE_GD_JPG], [1])])
   PHP_GD_CHECK_FORMAT([Xpm],  [AC_DEFINE([HAVE_GD_XPM], [1])])
   PHP_GD_CHECK_FORMAT([Bmp],  [AC_DEFINE([HAVE_GD_BMP], [1])])
-  PHP_GD_CHECK_FORMAT([Tga],  [AC_DEFINE([HAVE_GD_TGA], [1])])
   PHP_CHECK_LIBRARY([gd], [gdFontCacheShutdown],
     [AC_DEFINE([HAVE_GD_FREETYPE], [1])],
     [],
@@ -265,8 +264,6 @@ dnl These are always available with bundled library
       [Define to 1 if gd extension has PNG support.])
     AC_DEFINE([HAVE_GD_BMP], [1],
       [Define to 1 if gd extension has BMP support.])
-    AC_DEFINE([HAVE_GD_TGA], [1],
-      [Define to 1 if gd extension has TGA support.])
 
 dnl Various checks for GD features
     PHP_SETUP_ZLIB([GD_SHARED_LIBADD])

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -62,7 +62,6 @@ if (PHP_GD != "no") {
 		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Define to 1 if gd extension uses GD library bundled in PHP.");
 		AC_DEFINE('HAVE_GD_PNG', 1, "Define to 1 if gd extension has PNG support.");
 		AC_DEFINE('HAVE_GD_BMP', 1, "Define to 1 if gd extension has BMP support.");
-		AC_DEFINE('HAVE_GD_TGA', 1, "Define to 1 if gd extension has TGA support.");
 		AC_DEFINE('HAVE_LIBPNG', 1, "Define to 1 if you have the libpng library.");
 		AC_DEFINE('HAVE_LIBJPEG', 1, "Define to 1 if you have the libjpeg library.");
 		AC_DEFINE('HAVE_GD_JPG', 1, "Define to 1 if gd extension has JPEG support.");

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -449,9 +449,7 @@ PHP_MINFO_FUNCTION(gd)
 #ifdef HAVE_GD_AVIF
 	php_info_print_table_row(2, "AVIF Support", "enabled");
 #endif
-#ifdef HAVE_GD_TGA
 	php_info_print_table_row(2, "TGA Read Support", "enabled");
-#endif
 	php_info_print_table_end();
 	DISPLAY_INI_ENTRIES();
 }
@@ -506,11 +504,7 @@ PHP_FUNCTION(gd_info)
 #else
 	add_assoc_bool(return_value, "AVIF Support", 0);
 #endif
-#ifdef HAVE_GD_TGA
 	add_assoc_bool(return_value, "TGA Read Support", 1);
-#else
-	add_assoc_bool(return_value, "TGA Read Support", 0);
-#endif
 #ifdef USE_GD_JISX0208
 	add_assoc_bool(return_value, "JIS-mapped Japanese Font Support", 1);
 #else
@@ -1338,9 +1332,7 @@ PHP_FUNCTION(imagetypes)
 #ifdef HAVE_GD_BMP
 	ret |= PHP_IMG_BMP;
 #endif
-#ifdef HAVE_GD_TGA
 	ret |= PHP_IMG_TGA;
-#endif
 #ifdef HAVE_GD_AVIF
 	ret |= PHP_IMG_AVIF;
 #endif
@@ -1733,14 +1725,12 @@ PHP_FUNCTION(imagecreatefrombmp)
 /* }}} */
 #endif
 
-#ifdef HAVE_GD_TGA
 /* {{{ Create a new image from TGA file or URL */
 PHP_FUNCTION(imagecreatefromtga)
 {
 	_php_image_create_from(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_GDIMG_TYPE_TGA, "TGA", gdImageCreateFromTga, gdImageCreateFromTgaCtx);
 }
 /* }}} */
-#endif
 
 /* {{{ _php_image_output */
 static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type, const char *tn)

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -594,9 +594,7 @@ function imagecreatefromgd2part(string $filename, int $x, int $y, int $width, in
 function imagecreatefrombmp(string $filename): GdImage|false {}
 #endif
 
-#ifdef HAVE_GD_TGA
 function imagecreatefromtga(string $filename): GdImage|false {}
-#endif
 
 function imagexbm(GdImage $image, ?string $filename, ?int $foreground_color = null): bool {}
 

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 94822f6472750c646fc138f383278ca692b39d27 */
+ * Stub hash: 763dbec5f5a6eddce8fb3dae8d6c43def7e41f05 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -197,11 +197,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagecreatefrombmp, 0, 1, Gd
 ZEND_END_ARG_INFO()
 #endif
 
-#if defined(HAVE_GD_TGA)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagecreatefromtga, 0, 1, GdImage, MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_imagecreatefromtga arginfo_imagecreatefromgif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagexbm, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
@@ -622,9 +618,7 @@ ZEND_FUNCTION(imagecreatefromgd2part);
 #if defined(HAVE_GD_BMP)
 ZEND_FUNCTION(imagecreatefrombmp);
 #endif
-#if defined(HAVE_GD_TGA)
 ZEND_FUNCTION(imagecreatefromtga);
-#endif
 ZEND_FUNCTION(imagexbm);
 #if defined(HAVE_GD_AVIF)
 ZEND_FUNCTION(imageavif);
@@ -758,9 +752,7 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_GD_BMP)
 	ZEND_FE(imagecreatefrombmp, arginfo_imagecreatefrombmp)
 #endif
-#if defined(HAVE_GD_TGA)
 	ZEND_FE(imagecreatefromtga, arginfo_imagecreatefromtga)
-#endif
 	ZEND_FE(imagexbm, arginfo_imagexbm)
 #if defined(HAVE_GD_AVIF)
 	ZEND_FE(imageavif, arginfo_imageavif)

--- a/ext/gd/tests/imagecreatefromtga_basic.phpt
+++ b/ext/gd/tests/imagecreatefromtga_basic.phpt
@@ -4,7 +4,6 @@ imagecreatefromtga() - basic functionality
 gd
 --SKIPIF--
 <?php
-if (!(imagetypes() & IMG_TGA)) die('skip TGA support required');
 if (!(imagetypes() & IMG_PNG)) {
     die("skip No PNG support");
 }

--- a/ext/gd/tests/imagecreatefromtga_variation.phpt
+++ b/ext/gd/tests/imagecreatefromtga_variation.phpt
@@ -4,7 +4,6 @@ imagecreatefromtga() - RLE file reading
 gd
 --SKIPIF--
 <?php
-if (!(imagetypes() & IMG_TGA)) die('skip TGA support required');
 if (!(imagetypes() & IMG_PNG)) {
     die("skip No PNG support");
 }


### PR DESCRIPTION
- When building with bundled libgd, it has support for TGA
- When building with external libgd, at least 2.1.0 is required, which has TGA support.