### PR TITLE
ext/gd: Fix comparison with result of php_stream_can_cast()

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1589,7 +1589,7 @@ static void _php_image_create_from(INTERNAL_FUNCTION_PARAMETERS, int image_type,
 		pefree(pstr, 1);
 		zend_string_release_ex(buff, 0);
 	}
-	else if (php_stream_can_cast(stream, PHP_STREAM_AS_STDIO)) {
+	else if (php_stream_can_cast(stream, PHP_STREAM_AS_STDIO) == SUCCESS) {
 		/* try and force the stream to be FILE* */
 		if (FAILURE == php_stream_cast(stream, PHP_STREAM_AS_STDIO | PHP_STREAM_CAST_TRY_HARD, (void **) &fp, REPORT_ERRORS)) {
 			goto out_err;


### PR DESCRIPTION
`php_stream_can_cast()` returns a `zend_result` and not a `bool`.

Found while working on #19106 