### PR TITLE
Fix missing strnlen symbol on Solaris 10

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -149,6 +149,7 @@ AC_CHECK_FUNCS(m4_normalize([
   pthread_get_stackaddr_np
   pthread_getattr_np
   pthread_stackseg_np
+  strnlen
 ]))
 
 AC_CHECK_DECL([clock_gettime_nsec_np],

--- a/configure.ac
+++ b/configure.ac
@@ -577,7 +577,6 @@ AC_CHECK_FUNCS(m4_normalize([
   statvfs
   std_syslog
   strcasecmp
-  strnlen
   strptime
   strtok_r
   symlink

--- a/main/php_glob.c
+++ b/main/php_glob.c
@@ -266,7 +266,7 @@ PHPAPI int php_glob(const char *pattern, int flags, int (*errfunc)(const char *,
 	pglob->gl_errfunc = errfunc;
 	pglob->gl_matchc = 0;
 
-	if (strnlen(pattern, PATH_MAX) == PATH_MAX)
+	if (zend_strnlen(pattern, PATH_MAX) == PATH_MAX)
 		return(PHP_GLOB_NOMATCH);
 
 	if (pglob->gl_offs >= SSIZE_MAX || pglob->gl_pathc >= SSIZE_MAX ||


### PR DESCRIPTION
- On Solaris, strnlen was implemented on Solaris 11.
- In Autotools, strnlen can be also checked in Zend scope as HAVE_STRNLEN is used only there.