### PR TITLE
ext/gd: Make BMP always available

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -131,9 +131,7 @@ static const func_info_t func_infos[] = {
 	F1("imagecreatefromgd", MAY_BE_OBJECT|MAY_BE_FALSE),
 	F1("imagecreatefromgd2", MAY_BE_OBJECT|MAY_BE_FALSE),
 	F1("imagecreatefromgd2part", MAY_BE_OBJECT|MAY_BE_FALSE),
-#if defined(HAVE_GD_BMP)
 	F1("imagecreatefrombmp", MAY_BE_OBJECT|MAY_BE_FALSE),
-#endif
 	F1("imagecolorsforindex", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG),
 	F1("imagegetclip", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG),
 #if defined(HAVE_GD_FREETYPE)

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -65,6 +65,7 @@ AC_DEFUN([PHP_GD_PNG],[
   PHP_EVAL_LIBLINE([$PNG_LIBS], [GD_SHARED_LIBADD])
   PHP_EVAL_INCLINE([$PNG_CFLAGS])
   AC_DEFINE([HAVE_LIBPNG], [1], [Define to 1 if you have the libpng library.])
+  AC_DEFINE([HAVE_GD_PNG], [1], [Define to 1 if gd extension has PNG support.])
 ])
 
 AC_DEFUN([PHP_GD_AVIF], [
@@ -191,7 +192,6 @@ AC_DEFUN([PHP_GD_CHECK_VERSION],[
   PHP_GD_CHECK_FORMAT([Webp], [AC_DEFINE([HAVE_GD_WEBP], [1])])
   PHP_GD_CHECK_FORMAT([Jpeg], [AC_DEFINE([HAVE_GD_JPG], [1])])
   PHP_GD_CHECK_FORMAT([Xpm],  [AC_DEFINE([HAVE_GD_XPM], [1])])
-  PHP_GD_CHECK_FORMAT([Bmp],  [AC_DEFINE([HAVE_GD_BMP], [1])])
   PHP_CHECK_LIBRARY([gd], [gdFontCacheShutdown],
     [AC_DEFINE([HAVE_GD_FREETYPE], [1])],
     [],
@@ -257,13 +257,8 @@ if test "$PHP_GD" != "no"; then
       libgd/wbmp.c
     "])
 
-dnl These are always available with bundled library
     AC_DEFINE([HAVE_GD_BUNDLED], [1],
       [Define to 1 if gd extension uses GD library bundled in PHP.])
-    AC_DEFINE([HAVE_GD_PNG], [1],
-      [Define to 1 if gd extension has PNG support.])
-    AC_DEFINE([HAVE_GD_BMP], [1],
-      [Define to 1 if gd extension has BMP support.])
 
 dnl Various checks for GD features
     PHP_SETUP_ZLIB([GD_SHARED_LIBADD])

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -61,7 +61,6 @@ if (PHP_GD != "no") {
 			gd_crop.c gd_interpolation.c gd_matrix.c gd_bmp.c gd_tga.c", "gd");
 		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Define to 1 if gd extension uses GD library bundled in PHP.");
 		AC_DEFINE('HAVE_GD_PNG', 1, "Define to 1 if gd extension has PNG support.");
-		AC_DEFINE('HAVE_GD_BMP', 1, "Define to 1 if gd extension has BMP support.");
 		AC_DEFINE('HAVE_LIBPNG', 1, "Define to 1 if you have the libpng library.");
 		AC_DEFINE('HAVE_LIBJPEG', 1, "Define to 1 if you have the libjpeg library.");
 		AC_DEFINE('HAVE_GD_JPG', 1, "Define to 1 if gd extension has JPEG support.");

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -443,9 +443,7 @@ PHP_MINFO_FUNCTION(gd)
 #ifdef HAVE_GD_WEBP
 	php_info_print_table_row(2, "WebP Support", "enabled");
 #endif
-#ifdef HAVE_GD_BMP
 	php_info_print_table_row(2, "BMP Support", "enabled");
-#endif
 #ifdef HAVE_GD_AVIF
 	php_info_print_table_row(2, "AVIF Support", "enabled");
 #endif
@@ -494,11 +492,7 @@ PHP_FUNCTION(gd_info)
 #else
 	add_assoc_bool(return_value, "WebP Support", 0);
 #endif
-#ifdef HAVE_GD_BMP
 	add_assoc_bool(return_value, "BMP Support", 1);
-#else
-	add_assoc_bool(return_value, "BMP Support", 0);
-#endif
 #ifdef HAVE_GD_AVIF
 	add_assoc_bool(return_value, "AVIF Support", 1);
 #else
@@ -1329,9 +1323,7 @@ PHP_FUNCTION(imagetypes)
 #ifdef HAVE_GD_WEBP
 	ret |= PHP_IMG_WEBP;
 #endif
-#ifdef HAVE_GD_BMP
 	ret |= PHP_IMG_BMP;
-#endif
 	ret |= PHP_IMG_TGA;
 #ifdef HAVE_GD_AVIF
 	ret |= PHP_IMG_AVIF;
@@ -1716,14 +1708,12 @@ PHP_FUNCTION(imagecreatefromgd2part)
 }
 /* }}} */
 
-#ifdef HAVE_GD_BMP
 /* {{{ Create a new image from BMP file or URL */
 PHP_FUNCTION(imagecreatefrombmp)
 {
 	_php_image_create_from(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_GDIMG_TYPE_BMP, "BMP", gdImageCreateFromBmp, gdImageCreateFromBmpCtx);
 }
 /* }}} */
-#endif
 
 /* {{{ Create a new image from TGA file or URL */
 PHP_FUNCTION(imagecreatefromtga)
@@ -2117,7 +2107,6 @@ PHP_FUNCTION(imagegd2)
 }
 /* }}} */
 
-#ifdef HAVE_GD_BMP
 /* {{{ Output BMP image to browser or file */
 PHP_FUNCTION(imagebmp)
 {
@@ -2148,7 +2137,6 @@ PHP_FUNCTION(imagebmp)
 	RETURN_TRUE;
 }
 /* }}} */
-#endif
 
 /* {{{ Destroy an image - No effect as of PHP 8.0 */
 PHP_FUNCTION(imagedestroy)

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -589,10 +589,8 @@ function imagecreatefromgd2(string $filename): GdImage|false {}
 /** @refcount 1 */
 function imagecreatefromgd2part(string $filename, int $x, int $y, int $width, int $height): GdImage|false {}
 
-#ifdef HAVE_GD_BMP
 /** @refcount 1 */
 function imagecreatefrombmp(string $filename): GdImage|false {}
-#endif
 
 function imagecreatefromtga(string $filename): GdImage|false {}
 
@@ -628,10 +626,8 @@ function imagegd(GdImage $image, ?string $file = null): bool {}
 
 function imagegd2(GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): bool {}
 
-#ifdef HAVE_GD_BMP
 /** @param resource|string|null $file */
 function imagebmp(GdImage $image, $file = null, bool $compressed = true): bool {}
-#endif
 
 function imagedestroy(GdImage $image): true {}
 

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 763dbec5f5a6eddce8fb3dae8d6c43def7e41f05 */
+ * Stub hash: 3db75a07cd5dfda50f239bc8c3992cd6d1e7afcb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -191,11 +191,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagecreatefromgd2part, 0, 5
 	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_GD_BMP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagecreatefrombmp, 0, 1, GdImage, MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_imagecreatefrombmp arginfo_imagecreatefromgif
 
 #define arginfo_imagecreatefromtga arginfo_imagecreatefromgif
 
@@ -262,13 +258,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagegd2, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "IMG_GD2_RAW")
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_GD_BMP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagebmp, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, file, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, compressed, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagedestroy, 0, 1, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
@@ -615,9 +609,7 @@ ZEND_FUNCTION(imagecreatefromwbmp);
 ZEND_FUNCTION(imagecreatefromgd);
 ZEND_FUNCTION(imagecreatefromgd2);
 ZEND_FUNCTION(imagecreatefromgd2part);
-#if defined(HAVE_GD_BMP)
 ZEND_FUNCTION(imagecreatefrombmp);
-#endif
 ZEND_FUNCTION(imagecreatefromtga);
 ZEND_FUNCTION(imagexbm);
 #if defined(HAVE_GD_AVIF)
@@ -636,9 +628,7 @@ ZEND_FUNCTION(imagejpeg);
 ZEND_FUNCTION(imagewbmp);
 ZEND_FUNCTION(imagegd);
 ZEND_FUNCTION(imagegd2);
-#if defined(HAVE_GD_BMP)
 ZEND_FUNCTION(imagebmp);
-#endif
 ZEND_FUNCTION(imagedestroy);
 ZEND_FUNCTION(imagecolorallocate);
 ZEND_FUNCTION(imagepalettecopy);
@@ -749,9 +739,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imagecreatefromgd, arginfo_imagecreatefromgd)
 	ZEND_FE(imagecreatefromgd2, arginfo_imagecreatefromgd2)
 	ZEND_FE(imagecreatefromgd2part, arginfo_imagecreatefromgd2part)
-#if defined(HAVE_GD_BMP)
 	ZEND_FE(imagecreatefrombmp, arginfo_imagecreatefrombmp)
-#endif
 	ZEND_FE(imagecreatefromtga, arginfo_imagecreatefromtga)
 	ZEND_FE(imagexbm, arginfo_imagexbm)
 #if defined(HAVE_GD_AVIF)
@@ -770,9 +758,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imagewbmp, arginfo_imagewbmp)
 	ZEND_FE(imagegd, arginfo_imagegd)
 	ZEND_FE(imagegd2, arginfo_imagegd2)
-#if defined(HAVE_GD_BMP)
 	ZEND_FE(imagebmp, arginfo_imagebmp)
-#endif
 	ZEND_FE(imagedestroy, arginfo_imagedestroy)
 	ZEND_FE(imagecolorallocate, arginfo_imagecolorallocate)
 	ZEND_FE(imagepalettecopy, arginfo_imagepalettecopy)

--- a/ext/gd/tests/bug77391.phpt
+++ b/ext/gd/tests/bug77391.phpt
@@ -5,7 +5,6 @@ gd
 --SKIPIF--
 <?php
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.5', '<=')) die('skip upstream not yet fixed');
-if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
 ?>
 --FILE--
 <?php

--- a/ext/gd/tests/imagebmp_basic.phpt
+++ b/ext/gd/tests/imagebmp_basic.phpt
@@ -2,10 +2,6 @@
 imagebmp() - basic functionality
 --EXTENSIONS--
 gd
---SKIPIF--
-<?php
-if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
-?>
 --FILE--
 <?php
 // create an image

--- a/ext/gd/tests/imagecreatefrombmp_basic.phpt
+++ b/ext/gd/tests/imagecreatefrombmp_basic.phpt
@@ -4,7 +4,6 @@ imagecreatefrombmp() - basic functionality
 gd
 --SKIPIF--
 <?php
-if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
 if (!(imagetypes() & IMG_PNG)) {
     die("skip No PNG support");
 }

--- a/ext/gd/tests/imagecreatefromstring_bmp.phpt
+++ b/ext/gd/tests/imagecreatefromstring_bmp.phpt
@@ -4,7 +4,6 @@ imagecreatefromstring() - BMP format
 gd
 --SKIPIF--
 <?php
-if (!(imagetypes() & IMG_BMP)) die('skip BMP support required');
 if (!(imagetypes() & IMG_PNG)) {
     die("skip No PNG support");
 }


### PR DESCRIPTION
- When building with bundled libgd, it has support for BMP
- When building with external libgd, at least 2.1.0 is required, which has BMP support.
- The HAVE_GD_PNG moved to PHP_GD_PNG Autoconf macro as it is always
  required when building with bundled libgd.