### PR TITLE
Autotools, ext/gd: Ensure test program compiles without warnings

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -162,17 +162,22 @@ AC_CACHE_CHECK([for working gdImageCreateFrom$1 in libgd], [php_var],
 
 /* A custom gdErrorMethod */
 void exit1(int priority, const char *format, va_list args) {
+  (void)priority;
+  (void)format;
+  (void)args;
   _exit(1);
 }
 
 /* Override the default gd_error_method with one that
    actually causes the program to return an error. */
-int main(int argc, char** argv) {
+int main(void)
+{
   m4_if([$1],[Xpm],
   [char* f = "test.xpm"],
   [FILE* f = NULL]);
   gdSetErrorMethod(exit1);
   gdImagePtr p = gdImageCreateFrom$1(f);
+  (void)p;
   return 0;
 }])],
   [AS_VAR_SET([php_var], [yes])],


### PR DESCRIPTION
In case compiler is configured in some strict way it might emit warnings or even errors in the future if these aren't casted to void.
(I should recheck correct terminology which warning this is exactly and which flag can cause this, but this was issue in the past on some platforms already with some recent GCC versions).