### PR TITLE
GitHub: Remove ext/phar/php_phar.h

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -469,7 +469,6 @@
       - 'ext/pdo/php_pdo.h'
       - 'ext/pdo/php_pdo_driver.h'
       - 'ext/pdo/php_pdo_error.h'
-      - 'ext/phar/php_phar.h'
       - 'ext/random/php_random.h'
       - 'ext/random/php_random_csprng.h'
       - 'ext/random/php_random_uint128.h'


### PR DESCRIPTION
This header is not installed anymore and not intended to be used as a public header.
Related to: d7bdf902e5b88189037883d462e422838bd9be55