### PR TITLE
Autotools: Update ax_check_compile_flag.m4 to serial 11

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -88,6 +88,7 @@ PHP 8.5 INTERNALS UPGRADE NOTES
   . PHP_ODBC_CFLAGS, PHP_ODBC_LFLAGS, PHP_ODBC_LIBS, PHP_ODBC_TYPE preprocessor
     macros defined by ext/odbc are now defined in php_config.h instead of the
     build-defs.h header.
+  . Autoconf macro AX_CHECK_COMPILE_FLAG updated to serial 11.
   . Autoconf macro PHP_AP_EXTRACT_VERSION has been removed.
   . Autoconf macro PHP_BUILD_THREAD_SAFE has been removed (set enable_zts
     manually).

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -192,28 +192,21 @@ AS_VAR_IF([GCC], [yes],
 
 dnl Check if compiler supports -Wno-clobbered (only GCC).
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered],
-  [CFLAGS="-Wno-clobbered $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-Wno-clobbered $CFLAGS"])
 dnl Check for support for implicit fallthrough level 1, also add after previous
 dnl CFLAGS as level 3 is enabled in -Wextra.
 AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough=1],
-  [CFLAGS="$CFLAGS -Wimplicit-fallthrough=1"],,
-  [-Werror])
+  [CFLAGS="$CFLAGS -Wimplicit-fallthrough=1"])
 AX_CHECK_COMPILE_FLAG([-Wduplicated-cond],
-  [CFLAGS="-Wduplicated-cond $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-Wduplicated-cond $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wlogical-op],
-  [CFLAGS="-Wlogical-op $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-Wlogical-op $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wformat-truncation],
-  [CFLAGS="-Wformat-truncation $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-Wformat-truncation $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes],
-  [CFLAGS="-Wstrict-prototypes $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-Wstrict-prototypes $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-fno-common],
-  [CFLAGS="-fno-common $CFLAGS"],,
-  [-Werror])
+  [CFLAGS="-fno-common $CFLAGS"])
 
 ZEND_CHECK_ALIGNMENT
 ZEND_CHECK_SIGNALS

--- a/build/ax_check_compile_flag.m4
+++ b/build/ax_check_compile_flag.m4
@@ -34,14 +34,24 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 11
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
 AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether the _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  if test x"m4_case(_AC_LANG,
+                     [C], [$GCC],
+                     [C++], [$GXX],
+                     [Fortran], [$GFC],
+                     [Fortran 77], [$G77],
+                     [Objective C], [$GOBJC],
+                     [Objective C++], [$GOBJCXX],
+                     [no])" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1 $add_gnu_werror"
   AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
     [AS_VAR_SET(CACHEVAR,[yes])],
     [AS_VAR_SET(CACHEVAR,[no])])

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -5,16 +5,14 @@ dnl Check for strtoll, atoll
 AC_CHECK_FUNCS([strtoll atoll])
 
 AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
-  [PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -Wno-implicit-fallthrough"],,
-  [-Werror])
+  [PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -Wno-implicit-fallthrough"])
 
 PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -DHAVE_TIMELIB_CONFIG_H=1"
 PHP_TIMELIB_CFLAGS="$PHP_DATE_CFLAGS"
 PHP_DATE_CFLAGS="$PHP_DATE_CFLAGS -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
 AX_CHECK_COMPILE_FLAG([-fwrapv],
-  [PHP_TIMELIB_CFLAGS="$PHP_TIMELIB_CFLAGS -fwrapv"],,
-  [-Werror])
+  [PHP_TIMELIB_CFLAGS="$PHP_TIMELIB_CFLAGS -fwrapv"])
 
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -23,8 +23,7 @@ AS_VAR_IF([ac_cv_c_bigendian_php], [yes], [
     SHA3_OPT_SRC="$SHA3_DIR/KeccakP-1600-inplace32BI.c"
     dnl Add -Wno-implicit-fallthrough flag as it happens on 32 bit builds
     AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
-      [PHP_HASH_CFLAGS="$PHP_HASH_CFLAGS -Wno-implicit-fallthrough"],,
-      [-Werror])
+      [PHP_HASH_CFLAGS="$PHP_HASH_CFLAGS -Wno-implicit-fallthrough"])
   ],[
     AC_MSG_RESULT([yes])
     SHA3_DIR="sha3/generic64lc"

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -96,8 +96,7 @@ else
   "])
 
   AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
-    [PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -Wno-implicit-fallthrough"],,
-    [-Werror])
+    [PHP_PCRE_CFLAGS="$PHP_PCRE_CFLAGS -Wno-implicit-fallthrough"])
 
   PHP_PCRE_CFLAGS=m4_normalize(["
     $PHP_PCRE_CFLAGS

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -19,8 +19,7 @@ if test "$PHP_SODIUM" != "no"; then
   AS_IF([test "$ac_cv_sizeof_long" -eq 4], [
     SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-type-limits"
     AX_CHECK_COMPILE_FLAG([-Wno-logical-op],
-      [SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op"],,
-      [-Werror])
+      [SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op"])
   ])
 
   PHP_NEW_EXTENSION([sodium],


### PR DESCRIPTION
```sh
wget -O build/ax_check_compile_flag.m4 \
  https://cgit.git.savannah.gnu.org/cgit/autoconf-archive.git/plain/m4/ax_check_compile_flag.m4
```

New version of AX_CHECK_COMPILE_FLAG macro now adds the -Werror flag automatically, if GNU-compatible compiler is detected.