### PR TITLE
Use custom OpenSSL libctx for NCONF

### DIFF
--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -297,12 +297,12 @@ int php_openssl_parse_config(struct php_x509_request * req, zval * optional_args
 
 	SET_OPTIONAL_STRING_ARG("config", req->config_filename, default_ssl_conf_filename);
 	SET_OPTIONAL_STRING_ARG("config_section_name", req->section_name, "req");
-	req->global_config = NCONF_new(NULL);
+	req->global_config = php_openssl_nconf_new();
 	if (!NCONF_load(req->global_config, default_ssl_conf_filename, NULL)) {
 		php_openssl_store_errors();
 	}
 
-	req->req_config = NCONF_new(NULL);
+	req->req_config = php_openssl_nconf_new();
 	if (!NCONF_load(req->req_config, req->config_filename, NULL)) {
 		return FAILURE;
 	}

--- a/ext/openssl/openssl_backend_v1.c
+++ b/ext/openssl/openssl_backend_v1.c
@@ -687,4 +687,9 @@ void php_openssl_get_cipher_methods(zval *return_value, bool aliases)
 		return_value);
 }
 
+CONF *php_openssl_nconf_new(void)
+{
+	return NCONF_new(NULL);
+}
+
 #endif

--- a/ext/openssl/openssl_backend_v3.c
+++ b/ext/openssl/openssl_backend_v3.c
@@ -826,4 +826,9 @@ void php_openssl_get_cipher_methods(zval *return_value, bool aliases)
 	zend_hash_sort(Z_ARRVAL_P(return_value), php_openssl_compare_func, 1);
 }
 
+CONF *php_openssl_nconf_new(void)
+{
+	return NCONF_new_ex(PHP_OPENSSL_LIBCTX, NULL);
+}
+
 #endif

--- a/ext/openssl/php_openssl_backend.h
+++ b/ext/openssl/php_openssl_backend.h
@@ -366,4 +366,6 @@ zend_result php_openssl_cipher_update(const EVP_CIPHER *cipher_type,
 
 const EVP_CIPHER *php_openssl_get_evp_cipher_by_name(const char *method);
 
+CONF *php_openssl_nconf_new(void);
+
 #endif


### PR DESCRIPTION
Another change to allow using libctx. This time for `php_openssl_parse_config`