### PR TITLE
ext/xml: Suppress libxml deprecation for `_xmlParserCtxt.inState`

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -355,7 +355,9 @@ get_entity(void *user, const xmlChar *name)
 		if (ret == NULL)
 			ret = xmlGetDocEntity(parser->parser->myDoc, name);
 
+		ZEND_DIAGNOSTIC_IGNORED_START("-Wdeprecated-declarations")
 		if (ret == NULL || parser->parser->instate == XML_PARSER_CONTENT) {
+		ZEND_DIAGNOSTIC_IGNORED_END
 			if (ret == NULL || ret->etype == XML_INTERNAL_GENERAL_ENTITY || ret->etype == XML_INTERNAL_PARAMETER_ENTITY || ret->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
 				/* Predefined entities will expand unless no cdata handler is present */
 				if (parser->h_default && ! (ret && ret->etype == XML_INTERNAL_PREDEFINED_ENTITY && parser->h_cdata)) {


### PR DESCRIPTION
The FreeBSD build fails due to the deprecation and -Werror:

    2025-07-15T00:37:20.8390774Z /home/runner/work/php-src/php-src/ext/xml/compat.c:358:38: error: 'instate' is deprecated [-Werror,-Wdeprecated-declarations]
    2025-07-15T00:37:20.8392577Z   358 |                 if (ret == NULL || parser->parser->instate == XML_PARSER_CONTENT) {
    2025-07-15T00:37:20.8393184Z       |                                                    ^
    2025-07-15T00:37:20.8394006Z /usr/local/include/libxml2/libxml/parser.h:309:33: note: 'instate' has been explicitly marked deprecated here
    2025-07-15T00:37:20.8394903Z   309 |     xmlParserInputState instate XML_DEPRECATED_MEMBER;
    2025-07-15T00:37:20.8395413Z       |                                 ^
    2025-07-15T00:37:20.8396166Z /usr/local/include/libxml2/libxml/xmlexports.h:74:50: note: expanded from macro 'XML_DEPRECATED_MEMBER'
    2025-07-15T00:37:20.8397058Z    74 |     #define XML_DEPRECATED_MEMBER __attribute__((deprecated))
    2025-07-15T00:37:20.8397581Z       |                                                  ^
    2025-07-15T00:37:20.8425542Z 1 error generated.