### PR TITLE
Set lineno of RECV[_INIT] ops to function start

### DIFF
--- a/Zend/tests/recv_lineno_001.phpt
+++ b/Zend/tests/recv_lineno_001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+RECV[_INIT] lineno is function start
+--FILE--
+<?php
+
+class Foo {
+    public function __construct(
+        public $x = FOO,
+    ) {}
+}
+
+new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Undefined constant "FOO" in %s:4
+Stack trace:
+#0 %s(9): Foo->__construct()
+#1 {main}
+  thrown in %s on line 4

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7639,7 +7639,7 @@ static bool zend_property_is_virtual(zend_class_entry *ce, zend_string *property
 	return is_virtual;
 }
 
-static void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fallback_return_type) /* {{{ */
+static void zend_compile_params(zend_ast_decl *func_decl_ast, zend_ast *ast, zend_ast *return_type_ast, uint32_t fallback_return_type) /* {{{ */
 {
 	zend_ast_list *list = zend_ast_get_list(ast);
 	uint32_t i;
@@ -7817,6 +7817,7 @@ static void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32
 		opline = zend_emit_op(NULL, opcode, NULL, &default_node);
 		SET_NODE(opline->result, &var_node);
 		opline->op1.num = i + 1;
+		opline->lineno = func_decl_ast->start_lineno;
 
 		uint32_t arg_info_flags = _ZEND_ARG_INFO_FLAGS(is_ref, is_variadic, /* is_tentative */ 0)
 			| (is_promoted ? _ZEND_IS_PROMOTED_BIT : 0);
@@ -8457,7 +8458,7 @@ static zend_op_array *zend_compile_func_decl_ex(
 		zend_stack_push(&CG(loop_var_stack), (void *) &dummy_var);
 	}
 
-	zend_compile_params(params_ast, return_type_ast,
+	zend_compile_params(decl, params_ast, return_type_ast,
 		is_method && zend_string_equals_literal(lcname, ZEND_TOSTRING_FUNC_NAME) ? IS_STRING : 0);
 	if (CG(active_op_array)->fn_flags & ZEND_ACC_GENERATOR) {
 		zend_mark_function_as_generator();


### PR DESCRIPTION
Restores behavior prior to GH-19100.

/cc @derickr. Although I would question whether this is actually better. I don't have strong opinions though.