### PR TITLE
hash: Use zend_string_efree() where possible

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -411,7 +411,7 @@ static void php_hash_do_hash(
 
 		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
 		ZSTR_VAL(hex_digest)[2 * ops->digest_size] = 0;
-		zend_string_release_ex(digest, 0);
+		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
 	}
 }
@@ -568,7 +568,7 @@ static void php_hash_do_hash_hmac(
 
 		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), ops->digest_size);
 		ZSTR_VAL(hex_digest)[2 * ops->digest_size] = 0;
-		zend_string_release_ex(digest, 0);
+		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
 	}
 }
@@ -829,7 +829,7 @@ PHP_FUNCTION(hash_final)
 
 		php_hash_bin2hex(ZSTR_VAL(hex_digest), (unsigned char *) ZSTR_VAL(digest), digest_len);
 		ZSTR_VAL(hex_digest)[2 * digest_len] = 0;
-		zend_string_release_ex(digest, 0);
+		zend_string_efree(digest);
 		RETURN_NEW_STR(hex_digest);
 	}
 }

--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -542,7 +542,7 @@ static void php_hash_do_hash_hmac(
 		if (n < 0) {
 			efree(context);
 			efree(K);
-			zend_string_release(digest);
+			zend_string_efree(digest);
 			RETURN_FALSE;
 		}
 


### PR DESCRIPTION
Mainly motivated to reduce machine code bloat.