### PR TITLE
Remove redundant operations from zend_llist_clean()

### DIFF
--- a/Zend/zend_llist.c
+++ b/Zend/zend_llist.c
@@ -121,7 +121,6 @@ ZEND_API void zend_llist_destroy(zend_llist *l)
 ZEND_API void zend_llist_clean(zend_llist *l)
 {
 	zend_llist_destroy(l);
-	l->head = l->tail = NULL;
 }
 
 


### PR DESCRIPTION
This function calls zend_llist_destroy() which already sets the head and tail pointers since c732ab40.