### PR TITLE
PDO: Migrate maxlen of pdo_column_data from size_t to zend_long

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1590,7 +1590,7 @@ PHP_METHOD(PDOStatement, getColumnMeta)
 	/* add stock items */
 	col = &stmt->columns[colno];
 	add_assoc_str(return_value, "name", zend_string_copy(col->name));
-	add_assoc_long(return_value, "len", col->maxlen); /* FIXME: unsigned ? */
+	add_assoc_long(return_value, "len", col->maxlen);
 	add_assoc_long(return_value, "precision", col->precision);
 }
 /* }}} */

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -533,7 +533,7 @@ static inline pdo_dbh_object_t *php_pdo_dbh_fetch_object(zend_object *obj) {
 /* describes a column */
 struct pdo_column_data {
 	zend_string *name;
-	size_t maxlen;
+	zend_long maxlen;
 	zend_ulong precision;
 };
 

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -608,7 +608,8 @@ static int odbc_stmt_describe(pdo_stmt_t *stmt, int colno)
 	}
 	colsize = displaysize;
 
-	col->maxlen = S->cols[colno].datalen = colsize;
+	S->cols[colno].datalen = colsize;
+	col->maxlen = displaysize;
 	col->name = zend_string_init(S->cols[colno].colname, colnamelen, 0);
 	S->cols[colno].is_unicode = pdo_odbc_sqltype_is_unicode(S, S->cols[colno].coltype);
 

--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -251,7 +251,7 @@ static int pdo_sqlite_stmt_describe(pdo_stmt_t *stmt, int colno)
 
 	str = sqlite3_column_name(S->stmt, colno);
 	stmt->columns[colno].name = zend_string_init(str, strlen(str), 0);
-	stmt->columns[colno].maxlen = SIZE_MAX;
+	stmt->columns[colno].maxlen = -1;
 	stmt->columns[colno].precision = 0;
 
 	return 1;


### PR DESCRIPTION
This is returned in [PDOStatement::getColumnMeta](https://www.php.net/manual/en/pdostatement.getcolumnmeta.php) as `len` documented as "The length of this column. Normally -1 for types other than floating point decimals."

Also, It was as `FIXME` already.

* pgsql: `PQfsize`: returns the space allocated for this column in a database row, in other words the size of the server's internal representation of the data type. (Accordingly, it is not really very useful to clients.) A negative value indicates the data type is variable-length.
* dblib: `dbcollen`: The maximum length, in bytes, of the data for the particular column. If the column number is not in range, dbcollen returns -1.
* firebird: `XSQLVAR.sqllen` -> `ISC_SHORT` -> `signed short`: length of data area
* mysql: `MYSQL_FIELD.length`
  * `MYSQLND_FIELD.length` -> `zend_ulong`: Width of column (create length)
  * libmysql: `unsigned long length` :  Width of column (create length)

I noticed this during my work of [64bit integers on 32bit arch](https://github.com/php/php-src/pull/19079) where it would was failing: https://github.com/php/php-src/actions/runs/16311803646/job/46068812948#step:9:2782