### PR TITLE
zend_objects: Remove unnecessary refcounting when calling `__clone()`

### DIFF
--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -264,7 +264,6 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 	}
 
 	if (has_clone_method) {
-		GC_ADDREF(new_object);
 		zend_call_known_instance_method_with_0_params(new_object->ce->clone, new_object, NULL);
 
 		if (ZEND_CLASS_HAS_READONLY_PROPS(new_object->ce)) {
@@ -274,8 +273,6 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 				Z_PROP_FLAG_P(prop) &= ~IS_PROP_REINITABLE;
 			}
 		}
-
-		OBJ_RELEASE(new_object);
 	}
 }
 


### PR DESCRIPTION
Found as part of the clone-with review in php/php-src#18747.

------

Specifically: https://github.com/php/php-src/pull/18747/files#r2209484855