### PR TITLE
GH-19153: Validate `#[\Attribute]` targets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ PHP                                                                        NEWS
   . The socket_set_timeout() alias function has been deprecated. (timwolla)
   . Passing null to to readdir(), rewinddir(), and closedir() to use the last
     opened directory has been deprecated. (Girgias)
+  . Fixed bug GH-19153 (#[\Attribute] validation should error on
+    trait/interface/enum/abstract class). (DanielEScherzer)
 
 31 Jul 2025, PHP 8.5.0alpha4
 

--- a/Zend/tests/attributes/Attribute/Attribute_on_abstract.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_abstract.phpt
@@ -8,5 +8,5 @@ abstract class Demo {}
 
 echo "Done\n";
 ?>
---EXPECT--
-Done
+--EXPECTF--
+Fatal error: Cannot apply #[\Attribute] to abstract class Demo in %s on line %d

--- a/Zend/tests/attributes/Attribute/Attribute_on_abstract.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_abstract.phpt
@@ -1,0 +1,12 @@
+--TEST--
+#[Attribute] on an abstract class
+--FILE--
+<?php
+
+#[Attribute]
+abstract class Demo {}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/Attribute/Attribute_on_enum.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_enum.phpt
@@ -1,0 +1,12 @@
+--TEST--
+#[Attribute] on an enum
+--FILE--
+<?php
+
+#[Attribute]
+enum Demo {}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/Attribute/Attribute_on_enum.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_enum.phpt
@@ -8,5 +8,5 @@ enum Demo {}
 
 echo "Done\n";
 ?>
---EXPECT--
-Done
+--EXPECTF--
+Fatal error: Cannot apply #[\Attribute] to enum Demo in %s on line %d

--- a/Zend/tests/attributes/Attribute/Attribute_on_interface.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_interface.phpt
@@ -8,5 +8,5 @@ interface Demo {}
 
 echo "Done\n";
 ?>
---EXPECT--
-Done
+--EXPECTF--
+Fatal error: Cannot apply #[\Attribute] to interface Demo in %s on line %d

--- a/Zend/tests/attributes/Attribute/Attribute_on_interface.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_interface.phpt
@@ -1,0 +1,12 @@
+--TEST--
+#[Attribute] on an interface
+--FILE--
+<?php
+
+#[Attribute]
+interface Demo {}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/Attribute/Attribute_on_trait.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_trait.phpt
@@ -1,0 +1,12 @@
+--TEST--
+#[Attribute] on a trait
+--FILE--
+<?php
+
+#[Attribute]
+trait Demo {}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/Attribute/Attribute_on_trait.phpt
+++ b/Zend/tests/attributes/Attribute/Attribute_on_trait.phpt
@@ -8,5 +8,5 @@ trait Demo {}
 
 echo "Done\n";
 ?>
---EXPECT--
-Done
+--EXPECTF--
+Fatal error: Cannot apply #[\Attribute] to trait Demo in %s on line %d


### PR DESCRIPTION
Do not allow `#[\Attribute]` on traits, interfaces, enums, or abstract classes.