### PR TITLE
streams: Re-add support for arbitrary metadata for stream notifier functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.5.0alpha3
 
+- Core:
+  . Fix support for non-userland stream notifiers. (timwolla)
+
 - Curl:
   . Add support for CURLINFO_CONN_ID in curl_getinfo() (thecaliskan)
   . Add support for CURLINFO_QUEUE_TIME_T in curl_getinfo() (thecaliskan)

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -23,6 +23,11 @@ PHP 8.5 INTERNALS UPGRADE NOTES
     the user side when requiring libphp.so, by using dlmopen with LM_ID_NEWLM
     instead of dlopen.
     RTLD_DEEPBIND is still enabled when the Apache SAPI is in use.
+  . The ptr field of the php_stream_notifier struct is now a void* instead
+    of a zval. If the zval was used to store IS_PTR values only, the
+    extra layer of indirection can be removed. In other cases a zval can
+    be heap-allocated and stored in the pointer as a minimal change to keep
+    compatibility.
 
 - Zend
   . Added zend_safe_assign_to_variable_noref() function to safely assign

--- a/main/streams/php_stream_context.h
+++ b/main/streams/php_stream_context.h
@@ -44,7 +44,7 @@ typedef struct _php_stream_notifier php_stream_notifier;
 struct _php_stream_notifier {
 	php_stream_notification_func func;
 	void (*dtor)(php_stream_notifier *notifier);
-	zend_fcall_info_cache *fcc;
+	void *ptr;
 	int mask;
 	size_t progress, progress_max; /* position for progress notification */
 };


### PR DESCRIPTION
Support for attaching arbitrary metadata for consumption by stream notifier functions got broken in php/php-src#19024 when the previous `zval ptr` got changed to `zend_fcall_info_cache *fcc`, making the data specific to the `user_space_stream_notifier`.

Fix this by changing the field to `void *ptr`, avoiding the indirection through a `zval`, but preserving the ability to store arbitrary data. If necessary to support different types than `IS_PTR`, extensions can heap-allocate a `zval` to store within `->ptr` as a minimal change to keep compatibility with PHP 8.4 or lower.