### PR TITLE
Remove incorrect uses of zval_ptr_dtor

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -850,8 +850,6 @@ PHP_FUNCTION(hash_copy)
 	RETVAL_OBJ(Z_OBJ_HANDLER_P(zhash, clone_obj)(Z_OBJ_P(zhash)));
 
 	if (php_hashcontext_from_object(Z_OBJ_P(return_value))->context == NULL) {
-		zval_ptr_dtor(return_value);
-
 		zend_throw_error(NULL, "Cannot copy hash");
 		RETURN_THROWS();
 	}

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -2511,7 +2511,6 @@ PHP_FUNCTION(socket_addrinfo_bind)
 			}
 		default:
 			close(php_sock->bsd_socket);
-			zval_ptr_dtor(return_value);
 			zend_argument_value_error(1, "must be one of AF_UNIX, AF_INET, or AF_INET6");
 			RETURN_THROWS();
 	}
@@ -2575,7 +2574,6 @@ PHP_FUNCTION(socket_addrinfo_connect)
 		default:
 			zend_argument_value_error(1, "socket type must be one of AF_UNIX, AF_INET, or AF_INET6");
 			close(php_sock->bsd_socket);
-			zval_ptr_dtor(return_value);
 			RETURN_THROWS();
 	}
 


### PR DESCRIPTION
zval_ptr_dtor followed by RETURN_THROWS is always wrong, unless the return value is overwritten in between. That's because the VM will already destroy the zval, leading to double destroying it.