### PR TITLE
ext/intl: Refactor IntlRuleBasedBreakIterator::__construct()

### DIFF
--- a/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
+++ b/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
@@ -32,17 +32,16 @@ static inline RuleBasedBreakIterator *fetch_rbbi(BreakIterator_object *bio) {
 	return (RuleBasedBreakIterator*)bio->biter;
 }
 
-static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, __construct)
 {
-	char		*rules;
-	size_t		rules_len;
-	bool	compiled	= false;
-	UErrorCode	status		= U_ZERO_ERROR;
+	zend_string *rules;
+	bool compiled = false;
+	UErrorCode status = U_ZERO_ERROR;
 	BREAKITER_METHOD_INIT_VARS;
 	object = ZEND_THIS;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_STRING(rules, rules_len)
+		Z_PARAM_STR(rules)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(compiled)
 	ZEND_PARSE_PARAMETERS_END();
@@ -53,20 +52,14 @@ static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS, zend_er
 		RETURN_THROWS();
 	}
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-	*error_handling_replaced = 1;
-
-	// instantiation of ICU object
 	RuleBasedBreakIterator *rbbi;
 
 	if (!compiled) {
 		UnicodeString	rulesStr;
 		UParseError		parseError = UParseError();
-		if (intl_stringFromChar(rulesStr, rules, rules_len, &status)
-				== FAILURE) {
+		if (intl_stringFromChar(rulesStr, ZSTR_VAL(rules), ZSTR_LEN(rules), &status) == FAILURE) {
 			zend_throw_exception(IntlException_ce_ptr,
-				"IntlRuleBasedBreakIterator::__construct(): "
-				"rules were not a valid UTF-8 string", 0);
+				"IntlRuleBasedBreakIterator::__construct(): rules were not a valid UTF-8 string", 0);
 			RETURN_THROWS();
 		}
 
@@ -84,29 +77,16 @@ static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS, zend_er
 			RETURN_THROWS();
 		}
 	} else { // compiled
-		rbbi = new RuleBasedBreakIterator((uint8_t*)rules, rules_len, status);
+		rbbi = new RuleBasedBreakIterator(reinterpret_cast<uint8_t *>(ZSTR_VAL(rules)), ZSTR_LEN(rules), status);
 		if (U_FAILURE(status)) {
 			zend_throw_exception(IntlException_ce_ptr,
-				"IntlRuleBasedBreakIterator::__construct(): "
-				"unable to create instance from compiled rules", 0);
+				"IntlRuleBasedBreakIterator::__construct(): unable to create instance from compiled rules", 0);
 			delete rbbi;
 			RETURN_THROWS();
 		}
 	}
 
-	breakiterator_object_create(return_value, rbbi, 0);
-}
-
-U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, __construct)
-{
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
-
-	return_value = ZEND_THIS;
-	_php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced);
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	breakiterator_object_create(object, rbbi, false);
 }
 
 U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, getRules)


### PR DESCRIPTION
There is no need to delegate this to a seperate function and overwrite the error handler to promote warnings