### PR TITLE
Fix ZEND_STATIC_ASSERT for -std=c++17

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -761,7 +761,9 @@ extern "C++" {
 /** @deprecated */
 #define ZEND_CGG_DIAGNOSTIC_IGNORED_END ZEND_DIAGNOSTIC_IGNORED_END
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
+#if defined(__cplusplus)
+# define ZEND_STATIC_ASSERT(c, m) static_assert((c), m)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
 # define ZEND_STATIC_ASSERT(c, m) _Static_assert((c), m)
 #else
 # define ZEND_STATIC_ASSERT(c, m)


### PR DESCRIPTION
Fixes: #19169