### PR TITLE
Fix GH-18640: heap-use-after-free ext/soap/php_encoding.c:299:32 in soap_check_zval_ref

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1936,6 +1936,10 @@ static xmlNodePtr to_xml_object(encodeTypePtr type, zval *data, int style, xmlNo
 				sdlAttributePtr attr;
 				zval *zattr, rv;
 
+				HashTable **ref_map = &SOAP_GLOBAL(ref_map);
+				HashTable *old_ref_map = *ref_map;
+				*ref_map = NULL;
+
 				ZEND_HASH_FOREACH_PTR(sdlType->attributes, attr) {
 					if (attr->name) {
 						zattr = get_zval_property(data, attr->name, &rv);
@@ -1965,6 +1969,8 @@ static xmlNodePtr to_xml_object(encodeTypePtr type, zval *data, int style, xmlNo
 						}
 					}
 				} ZEND_HASH_FOREACH_END();
+
+				*ref_map = old_ref_map;
 			}
 		}
 		if (style == SOAP_ENCODED) {
@@ -3034,6 +3040,11 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 	ret = xmlNewNode(NULL, BAD_CAST("BOGUS"));
 	xmlAddChild(parent, ret);
 	FIND_ZVAL_NULL(data, ret, style);
+
+	HashTable **ref_map = &SOAP_GLOBAL(ref_map);
+	HashTable *old_ref_map = *ref_map;
+	*ref_map = NULL;
+
 	if (Z_TYPE_P(data) == IS_ARRAY) {
 		zval *tmp;
 		smart_str list = {0};
@@ -3108,6 +3119,7 @@ static xmlNodePtr to_xml_list(encodeTypePtr enc, zval *data, int style, xmlNodeP
 			zval_ptr_dtor_str(&tmp);
 		}
 	}
+	*ref_map = old_ref_map;
 	return ret;
 }
 

--- a/ext/soap/tests/bugs/gh18640.phpt
+++ b/ext/soap/tests/bugs/gh18640.phpt
@@ -1,0 +1,42 @@
+--TEST---
+GH-18640 (heap-use-after-free ext/soap/php_encoding.c:299:32 in soap_check_zval_ref)
+--EXTENSIONS--
+soap
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$wsdl = __DIR__."/bug35142.wsdl";
+
+class TestSoapClient extends SoapClient {
+    function __doRequest($request, $location, $action, $version, $one_way = 0): ?string {
+        var_dump($request);
+        return '';
+    }
+}
+
+$soapClient = new TestSoapClient($wsdl, ['trace' => 1, 'classmap' => ['logOnEvent' => 'LogOnEvent', 'events' => 'IVREvents']]);
+$timestamp = new LogOnEvent(); // Bogus!
+$logOffEvents[] = new LogOffEvent($timestamp);
+$logOffEvents[] = new LogOffEvent($timestamp);
+$ivrEvents = new IVREvents($logOffEvents);
+$result = $soapClient->PostEvents($ivrEvents);
+
+class LogOffEvent {
+    function __construct(public $timestamp) {
+        $this->timestamp = $timestamp;
+    }
+}
+
+class LogOnEvent {
+}
+
+class IVREvents {
+    function __construct(public $logOffEvent) {
+    }
+}
+?>
+--EXPECT--
+string(359) "<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://testurl/Events" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://testurl/Message"><SOAP-ENV:Body><ns2:ivrEvents><ns2:logOffEvent/><ns2:logOffEvent/></ns2:ivrEvents></SOAP-ENV:Body></SOAP-ENV:Envelope>
+"


### PR DESCRIPTION
For attributes, relying on the ref_map doesn't make sense the first place as you can't really refer to attributes from attributes. The code therefore assumes that the node is unique, which is broken.