### PR TITLE
Remove dead error checks for php_stream_filter_alloc()

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -2571,7 +2571,6 @@ static const php_stream_filter_ops php_iconv_stream_filter_ops = {
 /* {{{ php_iconv_stream_filter_create */
 static php_stream_filter *php_iconv_stream_filter_factory_create(const char *name, zval *params, uint8_t persistent)
 {
-	php_stream_filter *retval = NULL;
 	php_iconv_stream_filter *inst;
 	const char *from_charset = NULL, *to_charset = NULL;
 	size_t from_charset_len, to_charset_len;
@@ -2602,12 +2601,7 @@ static php_stream_filter *php_iconv_stream_filter_factory_create(const char *nam
 		return NULL;
 	}
 
-	if (NULL == (retval = php_stream_filter_alloc(&php_iconv_stream_filter_ops, inst, persistent))) {
-		php_iconv_stream_filter_dtor(inst);
-		pefree(inst, persistent);
-	}
-
-	return retval;
+	return php_stream_filter_alloc(&php_iconv_stream_filter_ops, inst, persistent);
 }
 /* }}} */
 

--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1557,7 +1557,6 @@ static const php_stream_filter_ops strfilter_convert_ops = {
 static php_stream_filter *strfilter_convert_create(const char *filtername, zval *filterparams, uint8_t persistent)
 {
 	php_convert_filter *inst;
-	php_stream_filter *retval = NULL;
 
 	char *dot;
 	int conv_mode = 0;
@@ -1587,16 +1586,11 @@ static php_stream_filter *strfilter_convert_create(const char *filtername, zval 
 	if (php_convert_filter_ctor(inst, conv_mode,
 		(filterparams != NULL ? Z_ARRVAL_P(filterparams) : NULL),
 		filtername, persistent) != SUCCESS) {
-		goto out;
-	}
-
-	retval = php_stream_filter_alloc(&strfilter_convert_ops, inst, persistent);
-out:
-	if (retval == NULL) {
 		pefree(inst, persistent);
+		return NULL;
 	}
 
-	return retval;
+	return php_stream_filter_alloc(&strfilter_convert_ops, inst, persistent);
 }
 
 static const php_stream_filter_factory strfilter_convert_factory = {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -283,10 +283,6 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 	}
 
 	filter = php_stream_filter_alloc(&userfilter_ops, NULL, 0);
-	if (filter == NULL) {
-		zval_ptr_dtor(&obj);
-		return NULL;
-	}
 
 	/* filtername */
 	add_property_string(&obj, "filtername", (char*)filtername);


### PR DESCRIPTION
php_stream_filter_alloc() can't fail, so simplify the code.