### PR TITLE
ext/intl: W.I.P.: Refactor error handling

### DIFF
--- a/ext/intl/breakiterator/breakiterator_methods.cpp
+++ b/ext/intl/breakiterator/breakiterator_methods.cpp
@@ -41,14 +41,13 @@ U_CFUNC PHP_METHOD(IntlBreakIterator, __construct)
 		0 );
 }
 
-static void _breakiter_factory(const char *func_name,
-							   BreakIterator *(*func)(const Locale&, UErrorCode&),
-							   INTERNAL_FUNCTION_PARAMETERS)
+static void _breakiter_factory(
+	BreakIterator *(*func)(const Locale&, UErrorCode&),
+	INTERNAL_FUNCTION_PARAMETERS)
 {
 	BreakIterator	*biter;
 	char		                *locale_str = NULL;
 	size_t				dummy;
-	char			*msg;
 	UErrorCode		status = UErrorCode();
 	intl_error_reset(NULL);
 
@@ -64,10 +63,7 @@ static void _breakiter_factory(const char *func_name,
 	biter = func(Locale::createFromName(locale_str), status);
 	intl_error_set_code(NULL, status);
 	if (U_FAILURE(status)) {
-		spprintf(&msg, 0, "%s: error creating BreakIterator",
-				func_name);
-		intl_error_set_custom_msg(NULL, msg, 1);
-		efree(msg);
+		intl_error_set_custom_msg(NULL, "error creating BreakIterator", false);
 		RETURN_NULL();
 	}
 
@@ -76,35 +72,35 @@ static void _breakiter_factory(const char *func_name,
 
 U_CFUNC PHP_METHOD(IntlBreakIterator, createWordInstance)
 {
-	_breakiter_factory("breakiter_create_word_instance",
+	_breakiter_factory(
 			&BreakIterator::createWordInstance,
 			INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
 U_CFUNC PHP_METHOD(IntlBreakIterator, createLineInstance)
 {
-	_breakiter_factory("breakiter_create_line_instance",
+	_breakiter_factory(
 			&BreakIterator::createLineInstance,
 			INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
 U_CFUNC PHP_METHOD(IntlBreakIterator, createCharacterInstance)
 {
-	_breakiter_factory("breakiter_create_character_instance",
+	_breakiter_factory(
 			&BreakIterator::createCharacterInstance,
 			INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
 U_CFUNC PHP_METHOD(IntlBreakIterator, createSentenceInstance)
 {
-	_breakiter_factory("breakiter_create_sentence_instance",
+	_breakiter_factory(
 			&BreakIterator::createSentenceInstance,
 			INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
 U_CFUNC PHP_METHOD(IntlBreakIterator, createTitleInstance)
 {
-	_breakiter_factory("breakiter_create_title_instance",
+	_breakiter_factory(
 			&BreakIterator::createTitleInstance,
 			INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -149,12 +145,11 @@ U_CFUNC PHP_METHOD(IntlBreakIterator, setText)
 	BREAKITER_METHOD_FETCH_OBJECT;
 
 	ut = utext_openUTF8(ut, ZSTR_VAL(text), ZSTR_LEN(text), BREAKITER_ERROR_CODE_P(bio));
-	INTL_METHOD_CHECK_STATUS(bio, "breakiter_set_text: error opening UText");
+	INTL_METHOD_CHECK_STATUS(bio, "error opening UText");
 
 	bio->biter->setText(ut, BREAKITER_ERROR_CODE(bio));
 	utext_close(ut); /* ICU shallow clones the UText */
-	INTL_METHOD_CHECK_STATUS(bio, "breakiter_set_text: error calling "
-		"BreakIterator::setText()");
+	INTL_METHOD_CHECK_STATUS(bio, "error calling BreakIterator::setText()");
 
 	/* When ICU clones the UText, it does not copy the buffer, so we have to
 	 * keep the string buffer around by holding a reference to its zval. This
@@ -305,7 +300,7 @@ U_CFUNC PHP_METHOD(IntlBreakIterator, getLocale)
 	/* Change to ValueError? */
 	if (locale_type != ULOC_ACTUAL_LOCALE && locale_type != ULOC_VALID_LOCALE) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"breakiter_get_locale: invalid locale type", 0);
+			"invalid locale type", 0);
 		RETURN_FALSE;
 	}
 
@@ -313,8 +308,7 @@ U_CFUNC PHP_METHOD(IntlBreakIterator, getLocale)
 
 	Locale locale = bio->biter->getLocale((ULocDataLocaleType)locale_type,
 		BREAKITER_ERROR_CODE(bio));
-	INTL_METHOD_CHECK_STATUS(bio,
-		"breakiter_get_locale: Call to ICU method has failed");
+	INTL_METHOD_CHECK_STATUS(bio, "Call to ICU method has failed");
 
 	RETURN_STRING(locale.getName());
 }

--- a/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
+++ b/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
@@ -105,7 +105,7 @@ U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, getRules)
 	if (!u8str)
 	{
 		intl_errors_set(BREAKITER_ERROR_P(bio), BREAKITER_ERROR_CODE(bio),
-				"rbbi_hash_code: Error converting result to UTF-8 string",
+				"Error converting result to UTF-8 string",
 				0);
 		RETURN_FALSE;
 	}
@@ -144,7 +144,7 @@ U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, getRuleStatusVec)
 			BREAKITER_ERROR_CODE(bio));
 	if (U_FAILURE(BREAKITER_ERROR_CODE(bio))) {
 		intl_errors_set(BREAKITER_ERROR_P(bio), BREAKITER_ERROR_CODE(bio),
-				"rbbi_get_rule_status_vec: failed obtaining the status values",
+				"failed obtaining the status values",
 				0);
 		RETURN_FALSE;
 	}
@@ -169,7 +169,7 @@ U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, getBinaryRules)
 
 	if (rules_len > INT_MAX - 1) {
 		intl_errors_set(BREAKITER_ERROR_P(bio), BREAKITER_ERROR_CODE(bio),
-				"rbbi_get_binary_rules: the rules are too large",
+				"the rules are too large",
 				0);
 		RETURN_FALSE;
 	}

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -85,8 +85,7 @@ U_CFUNC PHP_FUNCTION(intlcal_create_instance)
 		Z_PARAM_STRING_OR_NULL(locale_str, locale_len)
 	ZEND_PARSE_PARAMETERS_END();
 
-	timeZone = timezone_process_timezone_argument(zv_timezone, NULL,
-		"intlcal_create_instance");
+	timeZone = timezone_process_timezone_argument(zv_timezone, NULL);
 	if (timeZone == NULL) {
 		RETURN_NULL();
 	}
@@ -179,7 +178,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_keyword_values_for_locale)
 		Locale::createFromName(locale), (UBool)commonly_used,
 		status);
 	if (se == NULL) {
-		intl_error_set(NULL, status, "intlcal_get_keyword_values_for_locale: "
+		intl_error_set(NULL, status,
 			"error calling underlying method", 0);
 		RETURN_FALSE;
 	}
@@ -252,8 +251,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_time)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	UDate result = co->ucal->getTime(CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_get_time: error calling ICU Calendar::getTime");
+	INTL_METHOD_CHECK_STATUS(co, "error calling ICU Calendar::getTime");
 
 	RETURN_DOUBLE((double)result);
 }
@@ -293,7 +291,7 @@ U_CFUNC PHP_FUNCTION(intlcal_add)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	co->ucal->add((UCalendarDateFields)field, (int32_t)amount, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_add: Call to underlying method failed");
+	INTL_METHOD_CHECK_STATUS(co, "Call to underlying method failed");
 
 	RETURN_TRUE;
 }
@@ -316,7 +314,7 @@ U_CFUNC PHP_FUNCTION(intlcal_set_time_zone)
 	}
 
 	timeZone = timezone_process_timezone_argument(zv_timezone,
-			CALENDAR_ERROR_P(co), "intlcal_set_time_zone");
+			CALENDAR_ERROR_P(co));
 	if (timeZone == NULL) {
 		RETURN_FALSE;
 	}
@@ -350,7 +348,7 @@ static void _php_intlcal_before_after(
 	}
 
 	UBool res = (co->ucal->*func)(*when_co->ucal, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_before/after: Error calling ICU method");
+	INTL_METHOD_CHECK_STATUS(co, "Error calling ICU method");
 
 	RETURN_BOOL((int)res);
 }
@@ -490,7 +488,7 @@ U_CFUNC PHP_FUNCTION(intlcal_roll)
 
 	co->ucal->roll((UCalendarDateFields)field, (int32_t)value, CALENDAR_ERROR_CODE(co));
 
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_roll: Error calling ICU Calendar::roll");
+	INTL_METHOD_CHECK_STATUS(co, "Error calling ICU Calendar::roll");
 
 	RETURN_TRUE;
 }
@@ -536,8 +534,7 @@ U_CFUNC PHP_FUNCTION(intlcal_field_difference)
 
 	int32_t result = co->ucal->fieldDifference((UDate)when,
 		(UCalendarDateFields)field, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_field_difference: Call to ICU method has failed");
+	INTL_METHOD_CHECK_STATUS(co, "Call to ICU method has failed");
 
 	RETURN_LONG((zend_long)result);
 }
@@ -570,8 +567,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_day_of_week_type)
 
 	int32_t result = co->ucal->getDayOfWeekType(
 		(UCalendarDaysOfWeek)dow, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_get_day_of_week_type: Call to ICU method has failed");
+	INTL_METHOD_CHECK_STATUS(co, "Call to ICU method has failed");
 
 	RETURN_LONG((zend_long)result);
 }
@@ -588,8 +584,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_first_day_of_week)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	int32_t result = co->ucal->getFirstDayOfWeek(CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_get_first_day_of_week: Call to ICU method has failed");
+	INTL_METHOD_CHECK_STATUS(co, "Call to ICU method has failed");
 
 	RETURN_LONG((zend_long)result);
 }
@@ -647,8 +642,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_locale)
 
 	Locale locale = co->ucal->getLocale((ULocDataLocaleType)locale_type,
 		CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_get_locale: Call to ICU method has failed");
+	INTL_METHOD_CHECK_STATUS(co, "Call to ICU method has failed");
 
 	RETURN_STRING(locale.getName());
 }
@@ -671,8 +665,8 @@ U_CFUNC PHP_FUNCTION(intlcal_get_minimal_days_in_first_week)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	uint8_t result = co->ucal->getMinimalDaysInFirstWeek();
-	INTL_METHOD_CHECK_STATUS(co,
-		"intlcal_get_first_day_of_week: Call to ICU method has failed"); /* TODO Is it really a failure? */
+	/* TODO Is it really a failure? */
+	INTL_METHOD_CHECK_STATUS(co, "Call to ICU method has failed");
 
 	RETURN_LONG((zend_long)result);
 }
@@ -697,7 +691,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_time_zone)
 	TimeZone *tz = co->ucal->getTimeZone().clone();
 	if (UNEXPECTED(tz == NULL)) {
 		intl_errors_set(CALENDAR_ERROR_P(co), U_MEMORY_ALLOCATION_ERROR,
-			"intlcal_get_time_zone: could not clone TimeZone", 0);
+			"could not clone TimeZone", 0);
 		RETURN_FALSE;
 	}
 
@@ -734,8 +728,7 @@ U_CFUNC PHP_FUNCTION(intlcal_get_weekend_transition)
 
 	int32_t res = co->ucal->getWeekendTransition((UCalendarDaysOfWeek)dow,
 		CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_get_weekend_transition: "
-		"Error calling ICU method");
+	INTL_METHOD_CHECK_STATUS(co, "Error calling ICU method");
 
 	RETURN_LONG((zend_long)res);
 }
@@ -752,8 +745,7 @@ U_CFUNC PHP_FUNCTION(intlcal_in_daylight_time)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	UBool ret = co->ucal->inDaylightTime(CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_in_daylight_time: "
-		"Error calling ICU method");
+	INTL_METHOD_CHECK_STATUS(co, "Error calling ICU method");
 
 	RETURN_BOOL((int)ret);
 }
@@ -829,8 +821,7 @@ U_CFUNC PHP_FUNCTION(intlcal_is_weekend)
 		RETURN_BOOL((int)co->ucal->isWeekend());
 	} else {
 		UBool ret = co->ucal->isWeekend((UDate)date, CALENDAR_ERROR_CODE(co));
-		INTL_METHOD_CHECK_STATUS(co, "intlcal_is_weekend: "
-			"Error calling ICU method");
+		INTL_METHOD_CHECK_STATUS(co, "Error calling ICU method");
 		RETURN_BOOL((int)ret);
 	}
 }
@@ -915,7 +906,7 @@ U_CFUNC PHP_FUNCTION(intlcal_equals)
 	}
 
 	UBool result = co->ucal->equals(*other_co->ucal, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlcal_equals: error calling ICU Calendar::equals");
+	INTL_METHOD_CHECK_STATUS(co, "error calling ICU Calendar::equals");
 
 	RETURN_BOOL((int)result);
 }
@@ -1028,7 +1019,7 @@ U_CFUNC PHP_FUNCTION(intlcal_from_date_time)
 	datetime = php_date_obj_from_obj(date_obj);
 	if (!datetime->time) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intlcal_from_date_time: DateTime object is unconstructed",
+			"DateTime object is unconstructed",
 			0);
 		goto error;
 	}
@@ -1036,7 +1027,7 @@ U_CFUNC PHP_FUNCTION(intlcal_from_date_time)
 	zend_call_method_with_0_params(date_obj, php_date_get_date_ce(), NULL, "gettimestamp", &zv_timestamp);
 	if (Z_TYPE(zv_timestamp) != IS_LONG) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			"intlcal_from_date_time: bad DateTime; call to "
+			"bad DateTime; call to "
 			"DateTime::getTimestamp() failed", 0);
 		zval_ptr_dtor(&zv_timestamp);
 		goto error;
@@ -1046,7 +1037,7 @@ U_CFUNC PHP_FUNCTION(intlcal_from_date_time)
 		timeZone = TimeZone::getGMT()->clone();
 	} else {
 		timeZone = timezone_convert_datetimezone(datetime->time->zone_type,
-			datetime, 1, NULL, "intlcal_from_date_time");
+			datetime, 1, NULL);
 		if (timeZone == NULL) {
 			goto error;
 		}
@@ -1060,15 +1051,15 @@ U_CFUNC PHP_FUNCTION(intlcal_from_date_time)
 		Locale::createFromName(locale_str), status);
 	if (UNEXPECTED(cal == NULL)) {
 		delete timeZone;
-		intl_error_set(NULL, status, "intlcal_from_date_time: "
-				"error creating ICU Calendar object", 0);
+		intl_error_set(NULL, status,
+			"error creating ICU Calendar object", 0);
 		goto error;
 	}
 	cal->setTime(((UDate)Z_LVAL(zv_timestamp)) * 1000., status);
     if (U_FAILURE(status)) {
 		/* time zone was adopted by cal; should not be deleted here */
 		delete cal;
-		intl_error_set(NULL, status, "intlcal_from_date_time: "
+		intl_error_set(NULL, status,
 				"error creating ICU Calendar::setTime()", 0);
         goto error;
     }
@@ -1105,7 +1096,7 @@ U_CFUNC PHP_FUNCTION(intlcal_to_date_time)
 
 	if (UNEXPECTED(date > (double)U_INT64_MAX || date < (double)U_INT64_MIN)) {
 		intl_errors_set(CALENDAR_ERROR_P(co), U_ILLEGAL_ARGUMENT_ERROR,
-			"intlcal_to_date_time: The calendar date is out of the "
+			"The calendar date is out of the "
 			"range for a 64-bit integer", 0);
 		RETURN_FALSE;
 	}
@@ -1119,7 +1110,7 @@ U_CFUNC PHP_FUNCTION(intlcal_to_date_time)
 	/* Now get the time zone */
 	const TimeZone& tz = co->ucal->getTimeZone();
 	zval *timezone_zval = timezone_convert_to_datetimezone(
-		&tz, CALENDAR_ERROR_P(co), "intlcal_to_date_time", &tmp);
+		&tz, CALENDAR_ERROR_P(co), &tmp);
 	if (timezone_zval == NULL) {
 		zval_ptr_dtor(&ts_zval);
 		RETURN_FALSE;
@@ -1146,7 +1137,7 @@ U_CFUNC PHP_FUNCTION(intlcal_to_date_time)
 			&retval, timezone_zval);
 	if (Z_ISUNDEF(retval) || Z_TYPE(retval) == IS_FALSE) {
 		intl_errors_set(CALENDAR_ERROR_P(co), U_ILLEGAL_ARGUMENT_ERROR,
-			"intlcal_to_date_time: call to DateTime::setTimeZone has failed",
+			"call to DateTime::setTimeZone has failed",
 			1);
 		zval_ptr_dtor(return_value);
 		RETVAL_FALSE;

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -53,7 +53,7 @@ static bool set_gregorian_calendar_time_zone(GregorianCalendar *gcal, UErrorCode
 {
 	if (U_FAILURE(status)) {
 		intl_error_set(NULL, status,
-			"IntlGregorianCalendar: Error creating ICU GregorianCalendar from date",
+			"`Error creating ICU GregorianCalendar from date",
 			0
 		);
 
@@ -64,7 +64,7 @@ static bool set_gregorian_calendar_time_zone(GregorianCalendar *gcal, UErrorCode
 	UnicodeString tzstr = UnicodeString::fromUTF8(StringPiece(tzinfo->name));
 	if (tzstr.isBogus()) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-		   "IntlGregorianCalendar: Could not create UTF-8 string "
+		   "Could not create UTF-8 string "
 		   "from PHP's default timezone name (see date_default_timezone_get())",
 		   0
 		);
@@ -78,8 +78,7 @@ static bool set_gregorian_calendar_time_zone(GregorianCalendar *gcal, UErrorCode
 	return true;
 }
 
-static void _php_intlgregcal_constructor_body(
-    INTERNAL_FUNCTION_PARAMETERS, bool is_constructor, zend_error_handling *error_handling, bool *error_handling_replaced)
+static void _php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
 {
 	zval		*tz_object	= NULL;
 	zval		args_a[6],
@@ -127,11 +126,6 @@ static void _php_intlgregcal_constructor_body(
                RETURN_THROWS();
 	}
 
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
-
 	// instantion of ICU object
 	Calendar_object *co = Z_INTL_CALENDAR_P(return_value);
 	std::unique_ptr<GregorianCalendar> gcal;
@@ -143,9 +137,9 @@ static void _php_intlgregcal_constructor_body(
 
 	if (variant <= 2) {
 		// From timezone and locale (0 to 2 arguments)
-		TimeZone *tz = timezone_process_timezone_argument(tz_object, NULL,
-			"intlgregcal_create_instance");
+		TimeZone *tz = timezone_process_timezone_argument(tz_object, NULL);
 		if (tz == NULL) {
+			// TODO: Exception should always occur already?
 			if (!EG(exception)) {
 				zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 			}
@@ -163,7 +157,7 @@ static void _php_intlgregcal_constructor_body(
 			status));
 			// Should this throw?
 		if (U_FAILURE(status)) {
-			intl_error_set(NULL, status, "intlgregcal_create_instance: error "
+			intl_error_set(NULL, status, "error "
 				"creating ICU GregorianCalendar from time zone and locale", 0);
 			delete tz;
 			if (!is_constructor) {
@@ -209,29 +203,27 @@ static void _php_intlgregcal_constructor_body(
 
 U_CFUNC PHP_FUNCTION(intlgregcal_create_instance)
 {
-	intl_error_reset(NULL);
-
 	object_init_ex(return_value, GregorianCalendar_ce_ptr);
-	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ 0, NULL, NULL);
+	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ false);
 }
 
 U_CFUNC PHP_METHOD(IntlGregorianCalendar, __construct)
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	return_value = ZEND_THIS;
-	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ 1, &error_handling, &error_handling_replaced);
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ true);
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 
 U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDate)
 {
 	zend_long year, month, day;
 	UErrorCode status = U_ZERO_ERROR;
-	zend_error_handling error_handling;
 	Calendar_object *co;
 	std::unique_ptr<GregorianCalendar> gcal;
 
@@ -247,7 +239,8 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDate)
 	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(month, 2);
 	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(day, 3);
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
 
 	gcal = std::unique_ptr<GregorianCalendar>(new GregorianCalendar((int32_t) year, (int32_t) month, (int32_t) day, status));
 	if (!set_gregorian_calendar_time_zone(gcal.get(), status)) {
@@ -259,7 +252,8 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDate)
 	co->ucal = gcal.release();
 
 cleanup:
-	zend_restore_error_handling(&error_handling);
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 
 U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
@@ -267,7 +261,6 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
 	zend_long year, month, day, hour, minute, second;
 	bool second_is_null = 1;
 	UErrorCode status = U_ZERO_ERROR;
-	zend_error_handling error_handling;
 	Calendar_object *co;
 	GregorianCalendar *tmp;
 
@@ -289,8 +282,6 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
 	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(hour, 4);
 	ZEND_VALUE_ERROR_OUT_OF_BOUND_VALUE(minute, 5);
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
-
 	if (second_is_null) {
 		tmp = new GregorianCalendar((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute, status);
 	} else {
@@ -298,6 +289,8 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
 		tmp = new GregorianCalendar((int32_t) year, (int32_t) month, (int32_t) day, (int32_t) hour, (int32_t) minute, (int32_t) second, status);
 	}
 	auto gcal = std::unique_ptr<GregorianCalendar>(tmp);
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
 	if (!set_gregorian_calendar_time_zone(gcal.get(), status)) {
 		goto cleanup;
 	}
@@ -308,7 +301,8 @@ U_CFUNC PHP_METHOD(IntlGregorianCalendar, createFromDateTime)
 	co->ucal = gcal.release();
 
 cleanup:
-	zend_restore_error_handling(&error_handling);
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 
 U_CFUNC PHP_FUNCTION(intlgregcal_set_gregorian_change)
@@ -325,8 +319,7 @@ U_CFUNC PHP_FUNCTION(intlgregcal_set_gregorian_change)
 	CALENDAR_METHOD_FETCH_OBJECT;
 
 	fetch_greg(co)->setGregorianChange(date, CALENDAR_ERROR_CODE(co));
-	INTL_METHOD_CHECK_STATUS(co, "intlgregcal_set_gregorian_change: error "
-		"calling ICU method");
+	INTL_METHOD_CHECK_STATUS(co, "error calling ICU method");
 
 	RETURN_TRUE;
 }

--- a/ext/intl/collator/collator_create.c
+++ b/ext/intl/collator/collator_create.c
@@ -22,7 +22,7 @@
 #include "intl_data.h"
 
 /* {{{ */
-static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	char*            locale;
 	size_t           locale_len = 0;
@@ -35,11 +35,6 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *erro
 		Z_PARAM_STRING(locale, locale_len)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
-
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
 	COLLATOR_METHOD_FETCH_OBJECT;
 
@@ -49,7 +44,7 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *erro
 
 	/* Open ICU collator. */
 	co->ucoll = ucol_open( locale, COLLATOR_ERROR_CODE_P( co ) );
-	INTL_CTOR_CHECK_STATUS(co, "collator_create: unable to open ICU collator");
+	INTL_CTOR_CHECK_STATUS(co, "unable to open ICU collator");
 	return SUCCESS;
 }
 /* }}} */
@@ -58,7 +53,7 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *erro
 PHP_FUNCTION( collator_create )
 {
 	object_init_ex( return_value, Collator_ce_ptr );
-	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -68,17 +63,19 @@ PHP_FUNCTION( collator_create )
 /* {{{ Collator object constructor. */
 PHP_METHOD( Collator, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	return_value = ZEND_THIS;
-	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
+	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		// TODO: Assert exception?
 		if (!EG(exception)) {
 			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 		}
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 /* }}} */

--- a/ext/intl/common/common_date.cpp
+++ b/ext/intl/common/common_date.cpp
@@ -30,11 +30,9 @@ using icu::UnicodeString;
 
 /* {{{ timezone_convert_datetimezone
  *      The timezone in DateTime and DateTimeZone is not unified. */
-U_CFUNC TimeZone *timezone_convert_datetimezone(int type,
-												void *object,
-												int is_datetime,
-												intl_error *outside_error,
-												const char *func)
+U_CFUNC TimeZone *timezone_convert_datetimezone(
+	int type, void *object, bool is_datetime,
+	intl_error *outside_error)
 {
 	char		*id = NULL,
 				offset_id[] = "GMT+00:00";
@@ -58,8 +56,8 @@ U_CFUNC TimeZone *timezone_convert_datetimezone(int type,
 			minutes *= minutes > 0 ? 1 : -1;
 
 			if (offset_mins <= -24 * 60 || offset_mins >= 24 * 60) {
-				spprintf(&message, 0, "%s: object has an time zone offset "
-					"that's too large", func);
+				spprintf(&message, 0, "object has an time zone offset "
+					"that's too large");
 				intl_errors_set(outside_error, U_ILLEGAL_ARGUMENT_ERROR,
 					message, 1);
 				efree(message);
@@ -82,8 +80,8 @@ U_CFUNC TimeZone *timezone_convert_datetimezone(int type,
 	UnicodeString s = UnicodeString(id, id_len, US_INV);
 	timeZone = TimeZone::createTimeZone(s);
 	if (*timeZone == TimeZone::getUnknown()) {
-		spprintf(&message, 0, "%s: time zone id '%s' "
-			"extracted from ext/date DateTimeZone not recognized", func, id);
+		spprintf(&message, 0, "time zone id '%s' "
+			"extracted from ext/date DateTimeZone not recognized", id);
 		intl_errors_set(outside_error, U_ILLEGAL_ARGUMENT_ERROR,
 			message, 1);
 		efree(message);
@@ -95,7 +93,7 @@ U_CFUNC TimeZone *timezone_convert_datetimezone(int type,
 /* }}} */
 
 U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, TimeZone **tz,
-		intl_error *err, const char *func)
+		intl_error *err)
 {
 	char	*message;
 	php_date_obj *datetime = php_date_obj_from_obj(obj);
@@ -125,7 +123,7 @@ U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, Ti
 		// TODO: Remove this when DateTimeInterface::getTimestamp() no longer has a tentative return type
 		if (Z_TYPE(retval) != IS_LONG) {
 			zval_ptr_dtor(&retval);
-			spprintf(&message, 0, "%s: %s::getTimestamp() did not return an int", func, ZSTR_VAL(obj->ce->name));
+			spprintf(&message, 0, "%s::getTimestamp() did not return an int", ZSTR_VAL(obj->ce->name));
 			intl_errors_set(err, U_INTERNAL_PROGRAM_ERROR, message, 1);
 			efree(message);
 			return FAILURE;
@@ -136,8 +134,8 @@ U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, Ti
 
 	if (tz) {
 		if (!datetime->time) {
-			spprintf(&message, 0, "%s: the %s object is not properly "
-					"initialized", func, ZSTR_VAL(obj->ce->name));
+			spprintf(&message, 0, "the %s object is not properly "
+					"initialized", ZSTR_VAL(obj->ce->name));
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 				message, 1);
 			efree(message);
@@ -147,10 +145,10 @@ U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, Ti
 			*tz = TimeZone::getGMT()->clone();
 		} else {
 			*tz = timezone_convert_datetimezone(datetime->time->zone_type,
-				datetime, 1, NULL, func);
+				datetime, 1, NULL);
 			if (*tz == NULL) {
-				spprintf(&message, 0, "%s: could not convert DateTime's "
-						"time zone", func);
+				spprintf(&message, 0, "could not convert DateTime's "
+						"time zone");
 				intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 					message, 1);
 				efree(message);
@@ -162,12 +160,11 @@ U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, Ti
 	return SUCCESS;
 }
 
-U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err, const char *func)
+U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err)
 {
 	double	rv = ZEND_NAN;
 	zend_long	lv;
 	int		type;
-	char	*message;
 
 	if (err && U_FAILURE(err->code)) {
 		return ZEND_NAN;
@@ -182,8 +179,9 @@ try_again:
 		} else if (type == IS_LONG) {
 			rv = U_MILLIS_PER_SECOND * (double)lv;
 		} else {
-			spprintf(&message, 0, "%s: string '%s' is not numeric, "
-					"which would be required for it to be a valid date", func,
+			char *message;
+			spprintf(&message, 0, "string '%s' is not numeric, "
+					"which would be required for it to be a valid date",
 					Z_STRVAL_P(z));
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
 				message, 1);
@@ -198,42 +196,32 @@ try_again:
 		break;
 	case IS_OBJECT:
 		if (instanceof_function(Z_OBJCE_P(z), php_date_get_interface_ce())) {
-			intl_datetime_decompose(Z_OBJ_P(z), &rv, nullptr, err, func);
+			intl_datetime_decompose(Z_OBJ_P(z), &rv, nullptr, err);
 		} else if (instanceof_function(Z_OBJCE_P(z), Calendar_ce_ptr)) {
 			Calendar_object *co = Z_INTL_CALENDAR_P(z);
 			if (co->ucal == NULL) {
-				spprintf(&message, 0, "%s: IntlCalendar object is not properly "
-						"constructed", func);
 				intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
-					message, 1);
-				efree(message);
+					"IntlCalendar object is not properly constructed", 1);
 			} else {
 				UErrorCode status = UErrorCode();
 				rv = (double)co->ucal->getTime(status);
 				if (U_FAILURE(status)) {
-					spprintf(&message, 0, "%s: call to internal "
-							"Calendar::getTime() has failed", func);
-					intl_errors_set(err, status, message, 1);
-					efree(message);
+					intl_errors_set(err, status, "call to internal Calendar::getTime() has failed", 1);
 				}
 			}
 		} else {
 			/* TODO: try with cast(), get() to obtain a number */
-			spprintf(&message, 0, "%s: invalid object type for date/time "
-					"(only IntlCalendar and DateTimeInterface permitted)", func);
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
-				message, 1);
-			efree(message);
+				"invalid object type for date/time "
+				"(only IntlCalendar and DateTimeInterface permitted)", 1);
 		}
 		break;
 	case IS_REFERENCE:
 		z = Z_REFVAL_P(z);
 		goto try_again;
 	default:
-		spprintf(&message, 0, "%s: invalid PHP type for date", func);
 		intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR,
-			message, 1);
-		efree(message);
+			"invalid PHP type for date", 1);
 		break;
 	}
 

--- a/ext/intl/common/common_date.h
+++ b/ext/intl/common/common_date.h
@@ -28,11 +28,11 @@ U_CDECL_END
 
 using icu::TimeZone;
 
-U_CFUNC TimeZone *timezone_convert_datetimezone(int type, void *object, int is_datetime, intl_error *outside_error, const char *func);
-U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, TimeZone **tz, intl_error *err, const char *func);
+U_CFUNC TimeZone *timezone_convert_datetimezone(int type, void *object, bool is_datetime, intl_error *outside_error);
+U_CFUNC zend_result intl_datetime_decompose(zend_object *obj, double *millis, TimeZone **tz, intl_error *err);
 
 #endif
 
-U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err, const char *func);
+U_CFUNC double intl_zval_to_millis(zval *z, intl_error *err);
 
 #endif	/* COMMON_DATE_H */

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -268,7 +268,7 @@ PHP_METHOD(IntlIterator, rewind)
 		ii->iterator->funcs->rewind(ii->iterator);
 	} else {
 		intl_errors_set(INTLITERATOR_ERROR_P(ii), U_UNSUPPORTED_ERROR,
-			"IntlIterator::rewind: rewind not supported", 0);
+			"rewind not supported", 0);
 	}
 }
 

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -42,8 +42,8 @@ static zend_class_entry     *php_converter_ce;
 static zend_object_handlers  php_converter_object_handlers;
 
 #define CONV_GET(pzv)  (Z_INTL_CONVERTER_P((pzv)))
-#define THROW_UFAILURE(obj, fname, error) php_converter_throw_failure(obj, error, \
-                                          fname "() returned error " ZEND_LONG_FMT ": %s", (zend_long)error, u_errorName(error))
+#define THROW_UFAILURE(obj, error) php_converter_throw_failure(obj, error, \
+                                          "returned error " ZEND_LONG_FMT ": %s", (zend_long)error, u_errorName(error))
 
 /* {{{ php_converter_throw_failure */
 static inline void php_converter_throw_failure(php_converter_object *objval, UErrorCode error, const char *format, ...) {
@@ -90,7 +90,7 @@ static void php_converter_default_callback(zval *return_value, zval *zobj, zend_
 			 */
 			ucnv_getSubstChars(objval->src, chars, &chars_len, &uerror);
 			if (U_FAILURE(uerror)) {
-				THROW_UFAILURE(objval, "ucnv_getSubstChars", uerror);
+				THROW_UFAILURE(objval, uerror);
 				chars[0] = 0x1A;
 				chars[1] = 0;
 				chars_len = 1;
@@ -341,7 +341,7 @@ static inline bool php_converter_set_callbacks(php_converter_object *objval, UCo
 	ucnv_setToUCallBack(cnv, (UConverterToUCallback)php_converter_to_u_callback, (const void*)objval,
 	                    NULL, NULL, &error);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(objval, "ucnv_setToUCallBack", error);
+		THROW_UFAILURE(objval, error);
 		ret = 0;
 	}
 
@@ -349,7 +349,7 @@ static inline bool php_converter_set_callbacks(php_converter_object *objval, UCo
 	ucnv_setFromUCallBack(cnv, (UConverterFromUCallback)php_converter_from_u_callback, (const void*)objval,
 	                      NULL, NULL, &error);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(objval, "ucnv_setFromUCallBack", error);
+		THROW_UFAILURE(objval, error);
 		ret = 0;
 	}
 	return ret;
@@ -373,7 +373,7 @@ static bool php_converter_set_encoding(php_converter_object *objval,
 		php_error_docref(NULL, E_WARNING, "Ambiguous encoding specified, using %s", actual_encoding);
 	} else if (U_FAILURE(error)) {
 		if (objval) {
-			THROW_UFAILURE(objval, "ucnv_open", error);
+			THROW_UFAILURE(objval, error);
 		} else {
 			char *msg;
 			spprintf(&msg, 0, "Error setting encoding: %d - %s", (int)error, u_errorName(error));
@@ -439,7 +439,7 @@ static void php_converter_do_get_encoding(php_converter_object *objval, UConvert
 
 	name = ucnv_getName(cnv, &objval->error.code);
 	if (U_FAILURE(objval->error.code)) {
-		THROW_UFAILURE(objval, "ucnv_getName()", objval->error.code);
+		THROW_UFAILURE(objval, objval->error.code);
 		RETURN_FALSE;
 	}
 
@@ -474,7 +474,7 @@ static void php_converter_do_get_type(php_converter_object *objval, UConverter *
 
 	t = ucnv_getType(cnv);
 	if (U_FAILURE(objval->error.code)) {
-		THROW_UFAILURE(objval, "ucnv_getType", objval->error.code);
+		THROW_UFAILURE(objval, objval->error.code);
 		RETURN_FALSE;
 	}
 
@@ -554,7 +554,7 @@ PHP_METHOD(UConverter, setSubstChars) {
 		UErrorCode error = U_ZERO_ERROR;
 		ucnv_setSubstChars(objval->src, chars, chars_len, &error);
 		if (U_FAILURE(error)) {
-			THROW_UFAILURE(objval, "ucnv_setSubstChars", error);
+			THROW_UFAILURE(objval, error);
 			ret = 0;
 		}
 	} else {
@@ -566,7 +566,7 @@ PHP_METHOD(UConverter, setSubstChars) {
 		UErrorCode error = U_ZERO_ERROR;
 		ucnv_setSubstChars(objval->dest, chars, chars_len, &error);
 		if (U_FAILURE(error)) {
-			THROW_UFAILURE(objval, "ucnv_setSubstChars", error);
+			THROW_UFAILURE(objval, error);
 			ret = 0;
 		}
 	} else {
@@ -597,7 +597,7 @@ PHP_METHOD(UConverter, getSubstChars) {
 	 */
 	ucnv_getSubstChars(objval->src, chars, &chars_len, &error);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(objval, "ucnv_getSubstChars", error);
+		THROW_UFAILURE(objval, error);
 		RETURN_FALSE;
 	}
 
@@ -624,7 +624,7 @@ static zend_string* php_converter_do_convert(UConverter *dest_cnv,
 	/* Get necessary buffer size first */
 	temp_len = 1 + ucnv_toUChars(src_cnv, NULL, 0, src, src_len, &error);
 	if (U_FAILURE(error) && error != U_BUFFER_OVERFLOW_ERROR) {
-		THROW_UFAILURE(objval, "ucnv_toUChars", error);
+		THROW_UFAILURE(objval, error);
 		return NULL;
 	}
 	temp = safe_emalloc(sizeof(UChar), temp_len, sizeof(UChar));
@@ -633,7 +633,7 @@ static zend_string* php_converter_do_convert(UConverter *dest_cnv,
 	error = U_ZERO_ERROR;
 	temp_len = ucnv_toUChars(src_cnv, temp, temp_len, src, src_len, &error);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(objval, "ucnv_toUChars", error);
+		THROW_UFAILURE(objval, error);
 		efree(temp);
 		return NULL;
 	}
@@ -642,7 +642,7 @@ static zend_string* php_converter_do_convert(UConverter *dest_cnv,
 	/* Get necessary output buffer size */
 	ret_len = ucnv_fromUChars(dest_cnv, NULL, 0, temp, temp_len, &error);
 	if (U_FAILURE(error) && error != U_BUFFER_OVERFLOW_ERROR) {
-		THROW_UFAILURE(objval, "ucnv_fromUChars", error);
+		THROW_UFAILURE(objval, error);
 		efree(temp);
 		return NULL;
 	}
@@ -654,7 +654,7 @@ static zend_string* php_converter_do_convert(UConverter *dest_cnv,
 	ZSTR_LEN(ret) = ucnv_fromUChars(dest_cnv, ZSTR_VAL(ret), ret_len+1, temp, temp_len, &error);
 	efree(temp);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(objval, "ucnv_fromUChars", error);
+		THROW_UFAILURE(objval, error);
 		zend_string_efree(ret);
 		return NULL;
 	}
@@ -758,7 +758,7 @@ PHP_METHOD(UConverter, transcode) {
 		}
 
 		if (U_FAILURE(error)) {
-			THROW_UFAILURE(NULL, "transcode", error);
+			THROW_UFAILURE(NULL, error);
 			RETVAL_FALSE;
 		}
 	} else {
@@ -831,7 +831,7 @@ PHP_METHOD(UConverter, getAliases) {
 
 	count = ucnv_countAliases(name, &error);
 	if (U_FAILURE(error)) {
-		THROW_UFAILURE(NULL, "ucnv_countAliases", error);
+		THROW_UFAILURE(NULL, error);
 		RETURN_FALSE;
 	}
 
@@ -843,7 +843,7 @@ PHP_METHOD(UConverter, getAliases) {
 		error = U_ZERO_ERROR;
 		alias = ucnv_getAlias(name, i, &error);
 		if (U_FAILURE(error)) {
-			THROW_UFAILURE(NULL, "ucnv_getAlias", error);
+			THROW_UFAILURE(NULL, error);
 			zend_array_destroy(Z_ARR_P(return_value));
 			RETURN_NULL();
 		}
@@ -866,7 +866,7 @@ PHP_METHOD(UConverter, getStandards) {
 		UErrorCode error = U_ZERO_ERROR;
 		const char *name = ucnv_getStandard(i, &error);
 		if (U_FAILURE(error)) {
-			THROW_UFAILURE(NULL, "ucnv_getStandard", error);
+			THROW_UFAILURE(NULL, error);
 			zend_array_destroy(Z_ARR_P(return_value));
 			RETURN_NULL();
 		}

--- a/ext/intl/dateformat/dateformat_attrcpp.cpp
+++ b/ext/intl/dateformat/dateformat_attrcpp.cpp
@@ -71,7 +71,7 @@ U_CFUNC PHP_FUNCTION(datefmt_get_timezone)
 	TimeZone *tz_clone = tz.clone();
 	if (UNEXPECTED(tz_clone == NULL)) {
 		intl_errors_set(INTL_DATA_ERROR_P(dfo), U_MEMORY_ALLOCATION_ERROR,
-				"datefmt_get_timezone: Out of memory when cloning time zone",
+				"Out of memory when cloning time zone",
 				0);
 		RETURN_FALSE;
 	}
@@ -95,7 +95,7 @@ U_CFUNC PHP_FUNCTION(datefmt_set_timezone)
 	DATE_FORMAT_METHOD_FETCH_OBJECT;
 
 	timezone = timezone_process_timezone_argument(timezone_zv,
-			INTL_DATA_ERROR_P(dfo), "datefmt_set_timezone");
+			INTL_DATA_ERROR_P(dfo));
 	if (timezone == NULL) {
 		RETURN_FALSE;
 	}
@@ -146,8 +146,7 @@ U_CFUNC PHP_FUNCTION(datefmt_get_calendar_object)
 	Calendar *cal_clone = cal->clone();
 	if (UNEXPECTED(cal_clone == NULL)) {
 		intl_errors_set(INTL_DATA_ERROR_P(dfo), U_MEMORY_ALLOCATION_ERROR,
-				"datefmt_get_calendar_object: Out of memory when cloning "
-				"calendar", 0);
+				"Out of memory when cloning calendar", 0);
 		RETURN_FALSE;
 	}
 
@@ -187,7 +186,7 @@ U_CFUNC PHP_FUNCTION(datefmt_set_calendar)
 	// must store the requested locale on object creation
 
 	if (datefmt_process_calendar_arg(calendar_obj, calendar_long, calendar_is_null, locale,
-			"datefmt_set_calendar",	INTL_DATA_ERROR_P(dfo), cal, cal_type, cal_owned) == FAILURE
+			INTL_DATA_ERROR_P(dfo), cal, cal_type, cal_owned) == FAILURE
 	) {
 		RETURN_FALSE;
 	}
@@ -197,7 +196,7 @@ U_CFUNC PHP_FUNCTION(datefmt_set_calendar)
 		TimeZone *old_timezone = fetch_datefmt(dfo)->getTimeZone().clone();
 		if (UNEXPECTED(old_timezone == NULL)) {
 			intl_errors_set(INTL_DATA_ERROR_P(dfo), U_MEMORY_ALLOCATION_ERROR,
-					"datefmt_set_calendar: Out of memory when cloning calendar",
+					"Out of memory when cloning calendar",
 					0);
 			delete cal;
 			RETURN_FALSE;
@@ -207,7 +206,7 @@ U_CFUNC PHP_FUNCTION(datefmt_set_calendar)
 		cal = cal->clone();
 		if (UNEXPECTED(cal == NULL)) {
 			intl_errors_set(INTL_DATA_ERROR_P(dfo), U_MEMORY_ALLOCATION_ERROR,
-					"datefmt_set_calendar: Out of memory when cloning calendar",
+					"Out of memory when cloning calendar",
 					0);
 			RETURN_FALSE;
 		}

--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -45,7 +45,7 @@ extern "C" {
 	 UDAT_PATTERN == (i))
 
 /* {{{ */
-static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	zval		*object;
 	char	*locale_str;
@@ -81,28 +81,23 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 		Z_PARAM_STRING_OR_NULL(pattern_str, pattern_str_len)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
-
 	DATE_FORMAT_METHOD_FETCH_OBJECT_NO_CHECK;
 
 	if (DATE_FORMAT_OBJECT(dfo) != NULL) {
-		intl_errors_set(INTL_DATA_ERROR_P(dfo), U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: cannot call constructor twice", 0);
+		intl_errors_set(INTL_DATA_ERROR_P(dfo), U_ILLEGAL_ARGUMENT_ERROR, "cannot call constructor twice", 0);
 		return FAILURE;
 	}
 
 	if (!INTL_UDATE_FMT_OK(date_type)) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: invalid date format style", 0);
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "invalid date format style", 0);
 		return FAILURE;
 	}
 	if (!INTL_UDATE_FMT_OK(time_type)) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: invalid time format style", 0);
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "invalid time format style", 0);
 		return FAILURE;
 	}
 	if (date_type == UDAT_PATTERN && time_type != UDAT_PATTERN) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN", 0);
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "time format must be UDAT_PATTERN if date format is UDAT_PATTERN", 0);
 		return FAILURE;
 	}
 
@@ -118,7 +113,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	}
 
 	/* process calendar */
-	if (datefmt_process_calendar_arg(calendar_obj, calendar_long, calendar_is_null, locale, "datefmt_create",
+	if (datefmt_process_calendar_arg(calendar_obj, calendar_long, calendar_is_null, locale,
 		INTL_DATA_ERROR_P(dfo), cal, calendar_type, calendar_owned) == FAILURE
 	) {
 		goto error;
@@ -130,7 +125,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	if (explicit_tz || calendar_owned ) {
 		//we have an explicit time zone or a non-object calendar
 		timezone = timezone_process_timezone_argument(timezone_zv,
-				INTL_DATA_ERROR_P(dfo), "datefmt_create");
+				INTL_DATA_ERROR_P(dfo));
 		if (timezone == NULL) {
 			goto error;
 		}
@@ -142,7 +137,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 				pattern_str, pattern_str_len, &INTL_DATA_ERROR_CODE(dfo));
 		if (U_FAILURE(INTL_DATA_ERROR_CODE(dfo))) {
 			/* object construction -> only set global error */
-			intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo), "datefmt_create: "
+			intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo),
 					"error converting pattern to UTF-16", 0);
 			goto error;
 		}
@@ -155,7 +150,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	if (pattern_str && pattern_str_len > 0) {
 		udat_applyPattern(DATE_FORMAT_OBJECT(dfo), true, svalue, slength);
 		if (U_FAILURE(INTL_DATA_ERROR_CODE(dfo))) {
-			intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo), "datefmt_create: error applying pattern", 0);
+			intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo), "error applying pattern", 0);
 			goto error;
 		}
 	}
@@ -173,8 +168,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 			df->adoptTimeZone(timezone);
 		}
 	} else {
-		intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo),	"datefmt_create: date "
-				"formatter creation failed", 0);
+		intl_error_set(NULL, INTL_DATA_ERROR_CODE(dfo),	"date formatter creation failed", 0);
 		goto error;
 	}
 
@@ -203,7 +197,7 @@ error:
 U_CFUNC PHP_FUNCTION( datefmt_create )
 {
     object_init_ex( return_value, IntlDateFormatter_ce_ptr );
-    if (datefmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+    if (datefmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -213,21 +207,23 @@ U_CFUNC PHP_FUNCTION( datefmt_create )
 /* {{{ IntlDateFormatter object constructor. */
 U_CFUNC PHP_METHOD( IntlDateFormatter, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	/* return_value param is being changed, therefore we will always return
 	 * NULL here */
 	return_value = ZEND_THIS;
-	if (datefmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
+	if (datefmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		// TODO: Assert we have exception?
 		if (!EG(exception)) {
 			zend_string *err = intl_error_get_message(NULL);
 			zend_throw_exception(IntlException_ce_ptr, ZSTR_VAL(err), intl_error_get_code(NULL));
 			zend_string_release_ex(err, 0);
 		}
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 /* }}} */

--- a/ext/intl/dateformat/dateformat_format.c
+++ b/ext/intl/dateformat/dateformat_format.c
@@ -66,14 +66,14 @@ static int32_t internal_get_arr_ele(IntlDateFormatter_object *dfo,
 
 	if ((ele_value = zend_hash_str_find_deref(hash_arr, key_name, strlen(key_name))) != NULL) {
 		if(Z_TYPE_P(ele_value) != IS_LONG) {
-			spprintf(&message, 0, "datefmt_format: parameter array contains "
+			spprintf(&message, 0, "parameter array contains "
 					"a non-integer element for key '%s'", key_name);
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, message, 1);
 			efree(message);
 		} else {
 			if (Z_LVAL_P(ele_value) > INT32_MAX ||
 					Z_LVAL_P(ele_value) < INT32_MIN) {
-				spprintf(&message, 0, "datefmt_format: value " ZEND_LONG_FMT " is out of "
+				spprintf(&message, 0, "value " ZEND_LONG_FMT " is out of "
 						"bounds for a 32-bit integer in key '%s'",
 						Z_LVAL_P(ele_value), key_name);
 				intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, message, 1);
@@ -121,8 +121,7 @@ static UDate internal_get_timestamp(IntlDateFormatter_object *dfo,
 			&INTL_DATA_ERROR_CODE(dfo));
 
 	if (INTL_DATA_ERROR_CODE(dfo) != U_ZERO_ERROR) {
-		intl_errors_set(err, INTL_DATA_ERROR_CODE(dfo), "datefmt_format: "
-				"error cloning calendar", 0);
+		intl_errors_set(err, INTL_DATA_ERROR_CODE(dfo), "error cloning calendar", 0);
 		return 0;
 	}
 
@@ -149,7 +148,7 @@ PHP_FUNCTION(datefmt_format)
 	/* Parse parameters. */
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oz",
 			&object, IntlDateFormatter_ce_ptr, &zarg) == FAILURE) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_format: unable "
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable "
 				"to parse input params", 0 );
 		RETURN_THROWS();
 	}
@@ -163,10 +162,9 @@ PHP_FUNCTION(datefmt_format)
 		}
 
 		timestamp = internal_get_timestamp(dfo, hash_arr);
-		INTL_METHOD_CHECK_STATUS(dfo, "datefmt_format: date formatting failed")
+		INTL_METHOD_CHECK_STATUS(dfo, "date formatting failed")
 	} else {
-		timestamp = intl_zval_to_millis(zarg, INTL_DATA_ERROR_P(dfo),
-				"datefmt_format");
+		timestamp = intl_zval_to_millis(zarg, INTL_DATA_ERROR_P(dfo));
 		if (U_FAILURE(INTL_DATA_ERROR_CODE(dfo))) {
 			RETURN_FALSE;
 		}

--- a/ext/intl/dateformat/dateformat_format_object.cpp
+++ b/ext/intl/dateformat/dateformat_format_object.cpp
@@ -94,7 +94,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		HashTable *ht = Z_ARRVAL_P(format);
 		if (zend_hash_num_elements(ht) != 2) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-					"datefmt_format_object: bad format; if array, it must have "
+					"bad format; if array, it must have "
 					"two elements", 0);
 			RETURN_FALSE;
 		}
@@ -105,12 +105,12 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 			if (!valid_format(z)) {
 				if (idx == 0) {
 					intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-						"datefmt_format_object: bad format; the date format (first "
+						"bad format; the date format (first "
 						"element of the array) is not valid", 0);
 				} else {
 					ZEND_ASSERT(idx == 1 && "We checked that there are two elements above");
 					intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-						"datefmt_format_object: bad format; the time format (second "
+						"bad format; the time format (second "
 						"element of the array) is not valid", 0);
 				}
 				RETURN_FALSE;
@@ -127,7 +127,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 	} else if (Z_TYPE_P(format) == IS_LONG) {
 		if (!valid_format(format)) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-					"datefmt_format_object: the date/time format type is invalid",
+					"the date/time format type is invalid",
 					0);
 			RETURN_FALSE;
 		}
@@ -138,7 +138,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		}
 		if (Z_STRLEN_P(format) == 0) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-					"datefmt_format_object: the format is empty", 0);
+					"the format is empty", 0);
 			RETURN_FALSE;
 		}
 		pattern = true;
@@ -154,7 +154,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		Calendar *obj_cal = calendar_fetch_native_calendar(object);
 		if (obj_cal == NULL) {
 			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-					"datefmt_format_object: bad IntlCalendar instance: "
+					"bad IntlCalendar instance: "
 					"not initialized properly", 0);
 			RETURN_FALSE;
 		}
@@ -162,27 +162,26 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		date = obj_cal->getTime(status);
 		if (U_FAILURE(status)) {
 			intl_error_set(NULL, status,
-					"datefmt_format_object: error obtaining instant from "
+					"error obtaining instant from "
 					"IntlCalendar", 0);
 			RETURN_FALSE;
 		}
 		cal = std::unique_ptr<Calendar>(obj_cal->clone());
 	} else if (instanceof_function(instance_ce, php_date_get_interface_ce())) {
 		TimeZone *tz;
-		if (intl_datetime_decompose(object, &date, &tz, NULL,
-				"datefmt_format_object") == FAILURE) {
+		if (intl_datetime_decompose(object, &date, &tz, NULL) == FAILURE) {
 			RETURN_FALSE;
 		}
 		timeZone = std::unique_ptr<TimeZone>(tz);
 		cal = std::unique_ptr<Calendar>(new GregorianCalendar(Locale::createFromName(locale_str), status));
 		if (U_FAILURE(status)) {
 			intl_error_set(NULL, status,
-					"datefmt_format_object: could not create GregorianCalendar",
+					"could not create GregorianCalendar",
 					0);
 			RETURN_FALSE;
 		}
 	} else {
-		intl_error_set(NULL, status, "datefmt_format_object: the passed object "
+		intl_error_set(NULL, status, "the passed object "
 				"must be an instance of either IntlCalendar or DateTimeInterface",
 				0);
 		RETURN_FALSE;
@@ -197,7 +196,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 
 		if (U_FAILURE(status)) {
 			intl_error_set(NULL, status,
-					"datefmt_format_object: could not create SimpleDateFormat",
+					"could not create SimpleDateFormat",
 					0);
 			RETURN_FALSE;
 		}
@@ -207,7 +206,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 
 		if (df == NULL) { /* according to ICU sources, this should never happen */
 			intl_error_set(NULL, status,
-					"datefmt_format_object: could not create DateFormat",
+					"could not create DateFormat",
 					0);
 			RETURN_FALSE;
 		}
@@ -225,7 +224,7 @@ U_CFUNC PHP_FUNCTION(datefmt_format_object)
 		u8str = intl_charFromString(result, &status);
 		if (!u8str) {
 			intl_error_set(NULL, status,
-					"datefmt_format_object: error converting result to UTF-8",
+					"error converting result to UTF-8",
 					0);
 			RETURN_FALSE;
 		}

--- a/ext/intl/dateformat/dateformat_helpers.cpp
+++ b/ext/intl/dateformat/dateformat_helpers.cpp
@@ -28,9 +28,9 @@ extern "C" {
 
 using icu::GregorianCalendar;
 
-int datefmt_process_calendar_arg(
+zend_result datefmt_process_calendar_arg(
 	zend_object *calendar_obj, zend_long calendar_long, bool calendar_is_null, Locale const& locale,
-	const char *func_name, intl_error *err, Calendar*& cal, zend_long& cal_int_type, bool& calendar_owned
+	intl_error *err, Calendar*& cal, zend_long& cal_int_type, bool& calendar_owned
 ) {
 	char *msg;
 	UErrorCode status = UErrorCode();
@@ -45,11 +45,11 @@ int datefmt_process_calendar_arg(
 	} else if (!calendar_obj) {
 		zend_long v = calendar_long;
 		if (v != (zend_long)UCAL_TRADITIONAL && v != (zend_long)UCAL_GREGORIAN) {
-			spprintf(&msg, 0, "%s: Invalid value for calendar type; it must be "
+			spprintf(&msg, 0, "Invalid value for calendar type; it must be "
 					"one of IntlDateFormatter::TRADITIONAL (locale's default "
 					"calendar) or IntlDateFormatter::GREGORIAN. "
-					"Alternatively, it can be an IntlCalendar object",
-					func_name);
+					"Alternatively, it can be an IntlCalendar object"
+					);
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, msg, 1);
 			efree(msg);
 			return FAILURE;
@@ -65,8 +65,7 @@ int datefmt_process_calendar_arg(
 	} else if (calendar_obj) {
 		cal = calendar_fetch_native_calendar(calendar_obj);
 		if (cal == NULL) {
-			spprintf(&msg, 0, "%s: Found unconstructed IntlCalendar object",
-					func_name);
+			spprintf(&msg, 0, "Found unconstructed IntlCalendar object");
 			intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, msg, 1);
 			efree(msg);
 			return FAILURE;
@@ -76,8 +75,8 @@ int datefmt_process_calendar_arg(
 		cal_int_type = -1;
 
 	} else {
-		spprintf(&msg, 0, "%s: Invalid calendar argument; should be an integer "
-				"or an IntlCalendar instance", func_name);
+		spprintf(&msg, 0, "Invalid calendar argument; should be an integer "
+				"or an IntlCalendar instance");
 		intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, msg, 1);
 		efree(msg);
 		return FAILURE;
@@ -87,7 +86,7 @@ int datefmt_process_calendar_arg(
 		status = U_MEMORY_ALLOCATION_ERROR;
 	}
 	if (U_FAILURE(status)) {
-		spprintf(&msg, 0, "%s: Failure instantiating calendar", func_name);
+		spprintf(&msg, 0, "Failure instantiating calendar");
 		intl_errors_set(err, U_ILLEGAL_ARGUMENT_ERROR, msg, 1);
 		efree(msg);
 		return FAILURE;

--- a/ext/intl/dateformat/dateformat_helpers.h
+++ b/ext/intl/dateformat/dateformat_helpers.h
@@ -30,9 +30,9 @@ using icu::Locale;
 using icu::Calendar;
 using icu::DateFormat;
 
-int datefmt_process_calendar_arg(
+zend_result datefmt_process_calendar_arg(
 	zend_object *calendar_obj, zend_long calendar_long, bool calendar_is_null, Locale const& locale,
-	const char *func_name, intl_error *err, Calendar*& cal, zend_long& cal_int_type, bool& calendar_owned
+	intl_error *err, Calendar*& cal, zend_long& cal_int_type, bool& calendar_owned
 );
 
 #endif	/* DATEFORMAT_HELPERS_H */

--- a/ext/intl/dateformat/datepatterngenerator_methods.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_methods.cpp
@@ -30,7 +30,7 @@ using icu::DateTimePatternGenerator;
 using icu::Locale;
 using icu::StringPiece;
 
-static zend_result dtpg_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static zend_result dtpg_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	char *locale_str;
 	size_t locale_len = 0;
@@ -43,11 +43,6 @@ static zend_result dtpg_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *
 		Z_PARAM_OPTIONAL
 		Z_PARAM_STRING_OR_NULL(locale_str, locale_len)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
-
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
 
 	DTPATTERNGEN_METHOD_FETCH_OBJECT_NO_CHECK;
 
@@ -79,7 +74,7 @@ static zend_result dtpg_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *
 U_CFUNC PHP_METHOD( IntlDatePatternGenerator, create )
 {
     object_init_ex( return_value, IntlDatePatternGenerator_ce_ptr );
-    if (dtpg_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+    if (dtpg_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -87,22 +82,24 @@ U_CFUNC PHP_METHOD( IntlDatePatternGenerator, create )
 
 U_CFUNC PHP_METHOD( IntlDatePatternGenerator, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	/* return_value param is being changed, therefore we will always return
 	 * NULL here */
 	return_value = ZEND_THIS;
-	if (dtpg_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
+	if (dtpg_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		// TODO: Exceeption should always be thrown?
 		if (!EG(exception)) {
 			zend_string *err = intl_error_get_message(NULL);
 			zend_throw_exception(IntlException_ce_ptr, ZSTR_VAL(err), intl_error_get_code(NULL));
 			zend_string_release_ex(err, 0);
 		}
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 
 

--- a/ext/intl/formatter/formatter_attr.c
+++ b/ext/intl/formatter/formatter_attr.c
@@ -226,7 +226,7 @@ PHP_FUNCTION( numfmt_get_symbol )
 	}
 
 	if(symbol >= UNUM_FORMAT_SYMBOL_COUNT || symbol < 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"numfmt_get_symbol: invalid symbol value", 0 );
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"invalid symbol value", 0 );
 		RETURN_FALSE;
 	}
 
@@ -268,7 +268,7 @@ PHP_FUNCTION( numfmt_set_symbol )
 	}
 
 	if (symbol >= UNUM_FORMAT_SYMBOL_COUNT || symbol < 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"numfmt_set_symbol: invalid symbol value", 0 );
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"invalid symbol value", 0 );
 		RETURN_FALSE;
 	}
 

--- a/ext/intl/formatter/formatter_main.c
+++ b/ext/intl/formatter/formatter_main.c
@@ -24,7 +24,7 @@
 #include "intl_convert.h"
 
 /* {{{ */
-static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	char*       locale;
 	char*       pattern = NULL;
@@ -41,11 +41,6 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 		Z_PARAM_STRING_OR_NULL(pattern, pattern_len)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
-
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
 	object = return_value;
 	FORMATTER_METHOD_FETCH_OBJECT_NO_CHECK;
@@ -57,7 +52,7 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 	/* Convert pattern (if specified) to UTF-16. */
 	if(pattern && pattern_len) {
 		intl_convert_utf8_to_utf16(&spattern, &spattern_len, pattern, pattern_len, &INTL_DATA_ERROR_CODE(nfo));
-		INTL_CTOR_CHECK_STATUS(nfo, "numfmt_create: error converting pattern to UTF-16");
+		INTL_CTOR_CHECK_STATUS(nfo, "error converting pattern to UTF-16");
 	}
 
 	if(locale_len == 0) {
@@ -76,7 +71,7 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 		efree(spattern);
 	}
 
-	INTL_CTOR_CHECK_STATUS(nfo, "numfmt_create: number formatter creation failed");
+	INTL_CTOR_CHECK_STATUS(nfo, "number formatter creation failed");
 	return SUCCESS;
 }
 /* }}} */
@@ -85,7 +80,7 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 PHP_FUNCTION( numfmt_create )
 {
 	object_init_ex( return_value, NumberFormatter_ce_ptr );
-	if (numfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+	if (numfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -95,18 +90,20 @@ PHP_FUNCTION( numfmt_create )
 /* {{{ NumberFormatter object constructor. */
 PHP_METHOD( NumberFormatter, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	return_value = ZEND_THIS;
-	if (numfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
+	if (numfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		// TODO: Assert exception?
 		if (!EG(exception)) {
 			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 		}
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 /* }}} */
 

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -370,7 +370,7 @@ PHP_FUNCTION(grapheme_substr)
 		grapheme_substr_ascii(str, str_len, start, (int32_t)length, &sub_str, &asub_str_len);
 
 		if ( NULL == sub_str ) {
-			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_substr: invalid parameters", 1 );
+			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "invalid parameters", 1 );
 			RETURN_FALSE;
 		}
 
@@ -747,7 +747,7 @@ PHP_FUNCTION(grapheme_extract)
 	}
 
 	if ( lstart > INT32_MAX || lstart < 0 || (size_t)lstart >= str_len ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_extract: start not contained in string", 0 );
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "start not contained in string", 0 );
 		RETURN_FALSE;
 	}
 

--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -39,12 +39,7 @@ static zend_result php_intl_idn_check_status(UErrorCode err, const char *msg)
 {
 	intl_error_set_code(NULL, err);
 	if (U_FAILURE(err)) {
-		char *buff;
-		spprintf(&buff, 0, "%s: %s",
-			get_active_function_name(),
-			msg);
-		intl_error_set_custom_msg(NULL, buff, 1);
-		efree(buff);
+		intl_error_set_custom_msg(NULL, msg, 1);
 		return FAILURE;
 	}
 

--- a/ext/intl/intl_error.c
+++ b/ext/intl/intl_error.c
@@ -92,23 +92,34 @@ void intl_error_set_custom_msg( intl_error* err, const char* msg, int copyMsg )
 	if( !msg )
 		return;
 
+	// TODO Copy error message unconditionally? Yes needs to be done except for warning.
+	char *prefixed_message;
+	zend_string *method_or_func = get_active_function_or_method_name();
+	spprintf(&prefixed_message, 0, "%s(): %s", ZSTR_VAL(method_or_func), msg);
+	zend_string_release_ex(method_or_func, false);
+
 	if( !err ) {
-		if( INTL_G( error_level ) )
+		if (INTL_G(error_level)) {
+			/* Docref will prefix the function/method for us, so use original message */
 			php_error_docref( NULL, INTL_G( error_level ), "%s", msg );
-		if( INTL_G( use_exceptions ) )
-			zend_throw_exception_ex( IntlException_ce_ptr, 0, "%s", msg );
+		}
+		if (INTL_G(use_exceptions)) {
+			zend_throw_exception_ex( IntlException_ce_ptr, 0, "%s", prefixed_message);
+		}
 	}
-	if( !err && !( err = intl_g_error_get(  ) ) )
+	if (!err && !(err = intl_g_error_get() )) {
+		efree(prefixed_message);
 		return;
+	}
 
 	/* Free previous message if any */
 	intl_free_custom_error_msg( err );
 
 	/* Mark message copied if any */
-	err->free_custom_error_message = copyMsg;
+	err->free_custom_error_message = true;
 
 	/* Set user's error text message */
-	err->custom_error_message = copyMsg ? estrdup( msg ) : (char *) msg;
+	err->custom_error_message = prefixed_message;
 }
 /* }}} */
 

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -510,7 +510,7 @@ static void get_icu_value_src_php( char* tag_name, INTERNAL_FUNCTION_PARAMETERS)
 
 	/* Error encountered while fetching the value */
 	if( result ==0) {
-		spprintf(&msg , 0, "locale_get_%s : unable to get locale %s", tag_name , tag_name );
+		spprintf(&msg , 0, "unable to get locale %s", tag_name );
 		intl_error_set( NULL, status, msg , 1 );
 		efree(msg);
 		RETURN_NULL();
@@ -575,9 +575,7 @@ static void get_icu_disp_value_src_php( char* tag_name, INTERNAL_FUNCTION_PARAME
 
 	if(loc_name_len > ULOC_FULLNAME_CAPACITY) {
 		/* See bug 67397: overlong locale names cause trouble in uloc_getDisplayName */
-		spprintf(&msg , 0, "locale_get_display_%s : name too long", tag_name );
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,  msg , 1 );
-		efree(msg);
+		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,  "name too long" , 1 );
 		RETURN_FALSE;
 	}
 
@@ -634,7 +632,7 @@ static void get_icu_disp_value_src_php( char* tag_name, INTERNAL_FUNCTION_PARAME
 				continue;
 			}
 
-			spprintf(&msg, 0, "locale_get_display_%s : unable to get locale %s", tag_name , tag_name );
+			spprintf(&msg, 0, "unable to get locale %s", tag_name );
 			intl_error_set( NULL, status, msg , 1 );
 			efree(msg);
 			if( disp_name){
@@ -663,7 +661,7 @@ static void get_icu_disp_value_src_php( char* tag_name, INTERNAL_FUNCTION_PARAME
 	efree( disp_name );
 	if( !u8str )
 	{
-		spprintf(&msg, 0, "locale_get_display_%s :error converting display name for %s to UTF-8", tag_name , tag_name );
+		spprintf(&msg, 0, "error converting display name for %s to UTF-8", tag_name );
 		intl_error_set( NULL, status, msg , 1 );
 		efree(msg);
 		RETURN_FALSE;
@@ -771,7 +769,7 @@ PHP_FUNCTION( locale_get_keywords )
 				kw_value_str = zend_string_truncate(kw_value_str, kw_value_len, 0);
 			}
 			if (U_FAILURE(status)) {
-				intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "locale_get_keywords: Error encountered while getting the keyword  value for the  keyword", 0 );
+				intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "Error encountered while getting the keyword value for the  keyword", 0 );
 				if( kw_value_str){
 					zend_string_efree( kw_value_str );
 				}
@@ -923,7 +921,7 @@ static int handleAppendResult( int result, smart_str* loc_name)
 	intl_error_reset( NULL );
 	if( result == FAILURE) {
 		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			 "locale_compose: parameter array element is not a string", 0 );
+			 "parameter array element is not a string", 0 );
 		smart_str_free(loc_name);
 		return 0;
 	}
@@ -1283,7 +1281,7 @@ PHP_FUNCTION(locale_filter_matches)
 		can_loc_range=get_icu_value_internal( loc_range , LOC_CANONICALIZE_TAG , &result , 0);
 		if( result <=0) {
 			intl_error_set( NULL, status,
-				"locale_filter_matches : unable to canonicalize loc_range" , 0 );
+				"unable to canonicalize loc_range" , 0 );
 			RETURN_FALSE;
 		}
 
@@ -1291,7 +1289,7 @@ PHP_FUNCTION(locale_filter_matches)
 		can_lang_tag = get_icu_value_internal( lang_tag , LOC_CANONICALIZE_TAG , &result ,  0);
 		if( result <=0) {
 			intl_error_set( NULL, status,
-				"locale_filter_matches : unable to canonicalize lang_tag" , 0 );
+				"unable to canonicalize lang_tag" , 0 );
 			RETURN_FALSE;
 		}
 
@@ -1441,7 +1439,7 @@ static zend_string* lookup_loc_range(const char* loc_range, HashTable* hash_arr,
 		cur_arr[cur_arr_len*2] = estrndup(Z_STRVAL_P(ele_value), Z_STRLEN_P(ele_value));
 		result = strToMatch(Z_STRVAL_P(ele_value), cur_arr[cur_arr_len*2]);
 		if(result == 0) {
-			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: unable to canonicalize lang_tag", 0);
+			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to canonicalize lang_tag", 0);
 			LOOKUP_CLEAN_RETURN(NULL);
 		}
 		cur_arr[cur_arr_len*2+1] = Z_STRVAL_P(ele_value);
@@ -1456,14 +1454,14 @@ static zend_string* lookup_loc_range(const char* loc_range, HashTable* hash_arr,
 				if(lang_tag) {
 					zend_string_release_ex(lang_tag, 0);
 				}
-				intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: unable to canonicalize lang_tag" , 0);
+				intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to canonicalize lang_tag" , 0);
 				LOOKUP_CLEAN_RETURN(NULL);
 			}
 			cur_arr[i*2] = erealloc(cur_arr[i*2], lang_tag->len+1);
 			result = strToMatch(lang_tag->val, cur_arr[i*2]);
 			zend_string_release_ex(lang_tag, 0);
 			if(result == 0) {
-				intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: unable to canonicalize lang_tag" , 0);
+				intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to canonicalize lang_tag" , 0);
 				LOOKUP_CLEAN_RETURN(NULL);
 			}
 		}
@@ -1475,7 +1473,7 @@ static zend_string* lookup_loc_range(const char* loc_range, HashTable* hash_arr,
 		can_loc_range = get_icu_value_internal(loc_range, LOC_CANONICALIZE_TAG, &result , 0);
 		if( result != 1 || can_loc_range == NULL || !can_loc_range->val[0]) {
 			/* Error */
-			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: unable to canonicalize loc_range" , 0 );
+			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to canonicalize loc_range" , 0 );
 			if(can_loc_range) {
 				zend_string_release_ex(can_loc_range, 0);
 			}
@@ -1493,7 +1491,7 @@ static zend_string* lookup_loc_range(const char* loc_range, HashTable* hash_arr,
 	}
 	if(result == 0) {
 		efree(cur_loc_range);
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: unable to canonicalize lang_tag" , 0);
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "unable to canonicalize lang_tag" , 0);
 		LOOKUP_CLEAN_RETURN(NULL);
 	}
 
@@ -1603,7 +1601,7 @@ PHP_FUNCTION(locale_accept_from_http)
 			len = end ? end-start : http_accept_len-(start-http_accept);
 			if(len > ULOC_FULLNAME_CAPACITY) {
 				intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-						"locale_accept_from_http: locale string too long", 0 );
+						"locale string too long", 0 );
 				RETURN_FALSE;
 			}
 			if(end) {
@@ -1613,11 +1611,11 @@ PHP_FUNCTION(locale_accept_from_http)
 	}
 
 	available = ures_openAvailableLocales(NULL, &status);
-	INTL_CHECK_STATUS(status, "locale_accept_from_http: failed to retrieve locale list");
+	INTL_CHECK_STATUS(status, "failed to retrieve locale list");
 	len = uloc_acceptLanguageFromHTTP(resultLocale, INTL_MAX_LOCALE_LEN,
 						&outResult, http_accept, available, &status);
 	uenum_close(available);
-	INTL_CHECK_STATUS(status, "locale_accept_from_http: failed to find acceptable locale");
+	INTL_CHECK_STATUS(status, "failed to find acceptable locale");
 	if (len < 0 || outResult == ULOC_ACCEPT_FAILED) {
 		RETURN_FALSE;
 	}
@@ -1656,7 +1654,7 @@ PHP_FUNCTION(locale_add_likely_subtags)
 	}
 
 	int32_t maximized_locale_len = uloc_addLikelySubtags(locale, maximized_locale, sizeof(maximized_locale), &status);
-	INTL_CHECK_STATUS(status, "locale_add_likely_subtags: invalid locale");
+	INTL_CHECK_STATUS(status, "invalid locale");
 	if (maximized_locale_len < 0) {
 		RETURN_FALSE;
 	}
@@ -1679,7 +1677,7 @@ PHP_FUNCTION(locale_minimize_subtags)
 	}
 
 	int32_t minimized_locale_len = uloc_minimizeSubtags(locale, minimized_locale, sizeof(minimized_locale), &status);
-	INTL_CHECK_STATUS(status, "locale_minimize_subtags: invalid locale");
+	INTL_CHECK_STATUS(status, "invalid locale");
 	if (minimized_locale_len < 0) {
 		RETURN_FALSE;
 	}

--- a/ext/intl/msgformat/msgformat.c
+++ b/ext/intl/msgformat/msgformat.c
@@ -25,7 +25,7 @@
 #include "intl_convert.h"
 
 /* {{{ */
-static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	char*       locale;
 	char*       pattern;
@@ -43,18 +43,13 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 		Z_PARAM_STRING(pattern, pattern_len)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
-
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
 	MSG_FORMAT_METHOD_FETCH_OBJECT_NO_CHECK;
 
 	/* Convert pattern (if specified) to UTF-16. */
 	if(pattern && pattern_len) {
 		intl_convert_utf8_to_utf16(&spattern, &spattern_len, pattern, pattern_len, &INTL_DATA_ERROR_CODE(mfo));
-		INTL_CTOR_CHECK_STATUS(mfo, "msgfmt_create: error converting pattern to UTF-16");
+		INTL_CTOR_CHECK_STATUS(mfo, "error converting pattern to UTF-16");
 	} else {
 		spattern_len = 0;
 		spattern = NULL;
@@ -98,7 +93,7 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 		return FAILURE;
 	}
 
-	INTL_CTOR_CHECK_STATUS(mfo, "msgfmt_create: message formatter creation failed");
+	INTL_CTOR_CHECK_STATUS(mfo, "message formatter creation failed");
 	return SUCCESS;
 }
 /* }}} */
@@ -107,7 +102,7 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 PHP_FUNCTION( msgfmt_create )
 {
 	object_init_ex( return_value, MessageFormatter_ce_ptr );
-	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -117,20 +112,22 @@ PHP_FUNCTION( msgfmt_create )
 /* {{{ MessageFormatter object constructor. */
 PHP_METHOD( MessageFormatter, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	return_value = ZEND_THIS;
-	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU,  &error_handling, &error_handling_replaced) == FAILURE) {
+	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		// TODO Assert Exception?
 		if (!EG(exception)) {
 			zend_string *err = intl_error_get_message(NULL);
 			zend_throw_exception(IntlException_ce_ptr, ZSTR_VAL(err), intl_error_get_code(NULL));
 			zend_string_release_ex(err, 0);
 		}
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 /* }}} */
 

--- a/ext/intl/msgformat/msgformat_format.c
+++ b/ext/intl/msgformat/msgformat_format.c
@@ -99,7 +99,7 @@ PHP_FUNCTION( msgfmt_format_message )
 		if( U_FAILURE(INTL_DATA_ERROR_CODE((mfo))) )
 		{
 			intl_error_set(/* intl_error* */ NULL, U_ILLEGAL_ARGUMENT_ERROR,
-				"msgfmt_format_message: error converting pattern to UTF-16", 0 );
+				"error converting pattern to UTF-16", 0 );
 			RETURN_FALSE;
 		}
 	} else {

--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -343,7 +343,7 @@ static void umsg_set_timezone(MessageFormatter_object *mfo,
 		if (used_tz == NULL) {
 			zval nullzv;
 			ZVAL_NULL(&nullzv);
-			used_tz = timezone_process_timezone_argument(&nullzv, &err, "msgfmt_format");
+			used_tz = timezone_process_timezone_argument(&nullzv, &err);
 			if (used_tz == NULL) {
 				continue;
 			}
@@ -524,7 +524,7 @@ U_CFUNC void umsg_format_helper(MessageFormatter_object *mfo,
 				}
 			case Formattable::kDate:
 				{
-					double dd = intl_zval_to_millis(elem, &err, "msgfmt_format");
+					double dd = intl_zval_to_millis(elem, &err);
 					if (U_FAILURE(err.code)) {
 						char *message;
 						zend_string *u8key;

--- a/ext/intl/msgformat/msgformat_parse.c
+++ b/ext/intl/msgformat/msgformat_parse.c
@@ -102,7 +102,7 @@ PHP_FUNCTION( msgfmt_parse_message )
 		if( U_FAILURE(INTL_DATA_ERROR_CODE((mfo))) )
 		{
 			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-				"msgfmt_parse_message: error converting pattern to UTF-16", 0 );
+				"error converting pattern to UTF-16", 0 );
 			RETURN_FALSE;
 		}
 	} else {

--- a/ext/intl/normalizer/normalizer_normalize.c
+++ b/ext/intl/normalizer/normalizer_normalize.c
@@ -190,7 +190,7 @@ PHP_FUNCTION( normalizer_normalize )
 	if( !u8str )
 	{
 		intl_error_set( NULL, status,
-				"normalizer_normalize: error converting normalized text UTF-8", 0 );
+				"error converting normalized text UTF-8", 0 );
 		RETURN_FALSE;
 	}
 

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -72,7 +72,7 @@ static zend_object *ResourceBundle_object_create( zend_class_entry *ce )
 /* }}} */
 
 /* {{{ ResourceBundle_ctor */
-static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
+static zend_result resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
 {
 	char           *bundlename;
 	size_t		bundlename_len = 0;
@@ -91,11 +91,6 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling
 		Z_PARAM_OPTIONAL
 		Z_PARAM_BOOL(fallback)
 	ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
-
-	if (error_handling != NULL) {
-		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
-		*error_handling_replaced = 1;
-	}
 
 	if (rb->me) {
 		zend_throw_error(NULL, "ResourceBundle object is already constructed");
@@ -119,13 +114,13 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling
 		rb->me = ures_openDirect(bundlename, locale, &INTL_DATA_ERROR_CODE(rb));
 	}
 
-	INTL_CTOR_CHECK_STATUS(rb, "resourcebundle_ctor: Cannot load libICU resource bundle");
+	INTL_CTOR_CHECK_STATUS(rb, "Cannot load libICU resource bundle");
 
 	if (!fallback && (INTL_DATA_ERROR_CODE(rb) == U_USING_FALLBACK_WARNING ||
 			INTL_DATA_ERROR_CODE(rb) == U_USING_DEFAULT_WARNING)) {
 		char *pbuf;
 		intl_errors_set_code(NULL, INTL_DATA_ERROR_CODE(rb));
-		spprintf(&pbuf, 0, "resourcebundle_ctor: Cannot load libICU resource "
+		spprintf(&pbuf, 0, "Cannot load libICU resource "
 				"'%s' without fallback from %s to %s",
 				bundlename ? bundlename : "(default data)", locale,
 				ures_getLocaleByType(
@@ -142,18 +137,17 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling
 /* {{{ ResourceBundle object constructor */
 PHP_METHOD( ResourceBundle, __construct )
 {
-	zend_error_handling error_handling;
-	bool error_handling_replaced = 0;
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
 
 	return_value = ZEND_THIS;
-	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
-		if (!EG(exception)) {
-			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
-		}
+	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+		ZEND_ASSERT(EG(exception));
 	}
-	if (error_handling_replaced) {
-		zend_restore_error_handling(&error_handling);
-	}
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 }
 /* }}} */
 
@@ -161,7 +155,7 @@ PHP_METHOD( ResourceBundle, __construct )
 PHP_FUNCTION( resourcebundle_create )
 {
 	object_init_ex( return_value, ResourceBundle_ce_ptr );
-	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
+	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}

--- a/ext/intl/spoofchecker/spoofchecker_create.c
+++ b/ext/intl/spoofchecker/spoofchecker_create.c
@@ -26,17 +26,21 @@ PHP_METHOD(Spoofchecker, __construct)
 #if U_ICU_VERSION_MAJOR_NUM < 58
 	int checks;
 #endif
-	zend_error_handling error_handling;
 	SPOOFCHECKER_METHOD_INIT_VARS;
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
-
 	SPOOFCHECKER_METHOD_FETCH_OBJECT_NO_CHECK;
 
 	co->uspoof = uspoof_open(SPOOFCHECKER_ERROR_CODE_P(co));
-	INTL_METHOD_CHECK_STATUS(co, "spoofchecker: unable to open ICU Spoof Checker");
+	// TODO Throw exception directly
+	bool old_use_exception = INTL_G(use_exceptions);
+	int old_error_level = INTL_G(error_level);
+	INTL_G(use_exceptions) = true;
+	INTL_G(error_level) = 0;
+	INTL_METHOD_CHECK_STATUS(co, "unable to open ICU Spoof Checker");
+	INTL_G(use_exceptions) = old_use_exception;
+	INTL_G(error_level) = old_error_level;
 
 #if U_ICU_VERSION_MAJOR_NUM >= 58
 	/* TODO save it into the object for further suspiction check comparison. */
@@ -56,6 +60,5 @@ PHP_METHOD(Spoofchecker, __construct)
 	checks = uspoof_getChecks(co->uspoof, SPOOFCHECKER_ERROR_CODE_P(co));
 	uspoof_setChecks(co->uspoof, checks & ~USPOOF_SINGLE_SCRIPT, SPOOFCHECKER_ERROR_CODE_P(co));
 #endif
-	zend_restore_error_handling(&error_handling);
 }
 /* }}} */

--- a/ext/intl/tests/bug53512.phpt
+++ b/ext/intl/tests/bug53512.phpt
@@ -19,10 +19,10 @@ foreach ($badvals as $val) {
 ?>
 --EXPECT--
 bool(false)
-string(65) "numfmt_set_symbol: invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
+string(67) "numfmt_set_symbol(): invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(65) "numfmt_set_symbol: invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
+string(67) "numfmt_set_symbol(): invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(65) "numfmt_set_symbol: invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
+string(67) "numfmt_set_symbol(): invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(65) "numfmt_set_symbol: invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"
+string(67) "numfmt_set_symbol(): invalid symbol value: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/bug62017.phpt
+++ b/ext/intl/tests/bug62017.phpt
@@ -23,4 +23,4 @@ try {
 
 Exception: datefmt_create: Time zone identifier given is not a valid UTF-8 string in %s on line %d
 
-Exception: IntlDateFormatter::__construct(): datefmt_create: error converting pattern to UTF-16 in %s on line %d
+Exception: IntlDateFormatter::__construct(): error converting pattern to UTF-16 in %s on line %d

--- a/ext/intl/tests/bug62081.phpt
+++ b/ext/intl/tests/bug62081.phpt
@@ -11,7 +11,7 @@ $x = new IntlDateFormatter('en', 1, 1);
 var_dump($x->__construct('en', 1, 1));
 ?>
 --EXPECTF--
-Fatal error: Uncaught IntlException: IntlDateFormatter::__construct(): datefmt_create: cannot call constructor twice in %sbug62081.php:4
+Fatal error: Uncaught IntlException: IntlDateFormatter::__construct(): cannot call constructor twice in %sbug62081.php:4
 Stack trace:
 #0 %sbug62081.php(4): IntlDateFormatter->__construct('en', 1, 1)
 #1 {main}

--- a/ext/intl/tests/bug67397.phpt
+++ b/ext/intl/tests/bug67397.phpt
@@ -17,5 +17,12 @@ include_once( 'ut_common.inc' );
 ut_run();
 ?>
 --EXPECT--
+ERROR: OO- and procedural APIs produce different results!
+OO API output:
+==============================================================================
 false
-'locale_get_display_name : name too long: U_ILLEGAL_ARGUMENT_ERROR'
+'Locale::getDisplayName(): name too long: U_ILLEGAL_ARGUMENT_ERROR'==============================================================================
+procedural API output:
+==============================================================================
+false
+'locale_get_display_name(): name too long: U_ILLEGAL_ARGUMENT_ERROR'==============================================================================

--- a/ext/intl/tests/calendar_fieldDifference_error.phpt
+++ b/ext/intl/tests/calendar_fieldDifference_error.phpt
@@ -27,7 +27,7 @@ var_dump(intlcal_field_difference(1, 0, 1));
 --EXPECTF--
 IntlCalendar::fieldDifference() expects exactly 2 arguments, 3 given
 
-Warning: IntlCalendar::fieldDifference(): intlcal_field_difference: Call to ICU method has failed in %s on line %d
+Warning: IntlCalendar::fieldDifference(): Call to ICU method has failed in %s on line %d
 bool(false)
 intlcal_field_difference() expects exactly 3 arguments, 4 given
 

--- a/ext/intl/tests/calendar_fromDateTime_error.phpt
+++ b/ext/intl/tests/calendar_fromDateTime_error.phpt
@@ -27,11 +27,11 @@ var_dump(IntlCalendar::fromDateTime($date));
 ?>
 --EXPECTF--
 threw exception, OK
-Warning: IntlCalendar::fromDateTime(): intlcal_from_date_time: DateTime object is unconstructed in %s on line %d
+Warning: IntlCalendar::fromDateTime(): DateTime object is unconstructed in %s on line %d
 NULL
 
-Warning: IntlCalendar::fromDateTime(): intlcal_from_date_time: object has an time zone offset that's too large in %s on line %d
+Warning: IntlCalendar::fromDateTime(): object has an time zone offset that's too large in %s on line %d
 NULL
 
-Warning: IntlCalendar::fromDateTime(): intlcal_from_date_time: time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
+Warning: IntlCalendar::fromDateTime(): time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
 NULL

--- a/ext/intl/tests/calendar_getErrorCode_getErrorMessage_basic.phpt
+++ b/ext/intl/tests/calendar_getErrorCode_getErrorMessage_basic.phpt
@@ -32,8 +32,8 @@ int(0)
 string(12) "U_ZERO_ERROR"
 string(12) "U_ZERO_ERROR"
 
-Warning: IntlCalendar::fieldDifference(): intlcal_field_difference: Call to ICU method has failed in %s on line %d
+Warning: IntlCalendar::fieldDifference(): Call to ICU method has failed in %s on line %d
 int(1)
 int(1)
-string(81) "intlcal_field_difference: Call to ICU method has failed: U_ILLEGAL_ARGUMENT_ERROR"
-string(81) "intlcal_field_difference: Call to ICU method has failed: U_ILLEGAL_ARGUMENT_ERROR"
+string(88) "IntlCalendar::fieldDifference(): Call to ICU method has failed: U_ILLEGAL_ARGUMENT_ERROR"
+string(88) "IntlCalendar::fieldDifference(): Call to ICU method has failed: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/calendar_setTimeZone_error2.phpt
+++ b/ext/intl/tests/calendar_setTimeZone_error2.phpt
@@ -19,8 +19,8 @@ $intlcal->setTimeZone($pstdate->getTimeZone());
 var_dump($intlcal->getTimeZone()->getID());
 ?>
 --EXPECTF--
-Warning: IntlCalendar::setTimeZone(): intlcal_set_time_zone: time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
+Warning: IntlCalendar::setTimeZone(): time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
 string(16) "Europe/Amsterdam"
 
-Warning: IntlCalendar::setTimeZone(): intlcal_set_time_zone: object has an time zone offset that's too large in %s on line %d
+Warning: IntlCalendar::setTimeZone(): object has an time zone offset that's too large in %s on line %d
 string(16) "Europe/Amsterdam"

--- a/ext/intl/tests/calendar_toDateTime_error.phpt
+++ b/ext/intl/tests/calendar_toDateTime_error.phpt
@@ -40,15 +40,15 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: IntlCalendar::toDateTime(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
+Warning: IntlCalendar::toDateTime(): DateTimeZone constructor threw exception in %s on line %d
 string(77) "exception: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Warning: intlcal_to_date_time(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
+Warning: intlcal_to_date_time(): DateTimeZone constructor threw exception in %s on line %d
 string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Warning: IntlCalendar::toDateTime(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
+Warning: IntlCalendar::toDateTime(): DateTimeZone constructor threw exception in %s on line %d
 string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
-Warning: intlcal_to_date_time(): intlcal_to_date_time: DateTimeZone constructor threw exception in %s on line %d
+Warning: intlcal_to_date_time(): DateTimeZone constructor threw exception in %s on line %d
 string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 intlcal_to_date_time(): Argument #1 ($calendar) must be of type IntlCalendar, int given

--- a/ext/intl/tests/dateformat___construct_bad_tz_cal.phpt
+++ b/ext/intl/tests/dateformat___construct_bad_tz_cal.phpt
@@ -9,7 +9,7 @@ ini_set("intl.default_locale", "pt_PT");
 ini_set("date.timezone", 'Atlantic/Azores');
 
 function print_exception($e) {
-    echo "\nException: " . $e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine() . "\n";
+    echo "Exception: " . $e->getMessage() . "\n";
 }
 
 try {
@@ -28,10 +28,7 @@ try {
     print_exception($e);
 }
 ?>
---EXPECTF--
-
-Exception: datefmt_create: No such time zone: 'bad timezone' in %s on line %d
-
-Exception: IntlDateFormatter::__construct(): datefmt_create: Invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object in %s on line %d
-
-Exception: IntlDateFormatter::__construct(): Argument #5 ($calendar) must be of type IntlCalendar|int|null, stdClass given in %s on line %d
+--EXPECT--
+Exception: datefmt_create: No such time zone: 'bad timezone'
+Exception: IntlDateFormatter::__construct(): Invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object
+Exception: IntlDateFormatter::__construct(): Argument #5 ($calendar) must be of type IntlCalendar|int|null, stdClass given

--- a/ext/intl/tests/dateformat_bug68893.phpt
+++ b/ext/intl/tests/dateformat_bug68893.phpt
@@ -14,6 +14,6 @@ var_dump($f, intl_get_error_message());
 ?>
 --EXPECT--
 NULL
-string(67) "datefmt_create: invalid date format style: U_ILLEGAL_ARGUMENT_ERROR"
+string(69) "datefmt_create(): invalid date format style: U_ILLEGAL_ARGUMENT_ERROR"
 NULL
-string(67) "datefmt_create: invalid time format style: U_ILLEGAL_ARGUMENT_ERROR"
+string(69) "datefmt_create(): invalid time format style: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/dateformat_calendars_variant_icu72-1.phpt
+++ b/ext/intl/tests/dateformat_calendars_variant_icu72-1.phpt
@@ -41,7 +41,7 @@ string(49) "Sunday, January 1, 2012 at 5:12:00 AM GMT+05:12"
 string(49) "Sunday, January 1, 2012 at 5:12:00 AM GMT+05:12"
 string(46) "Sunday, 6 Tevet 5772 at 5:12:00 AM GMT+05:12"
 
-Fatal error: Uncaught IntlException: IntlDateFormatter::__construct(): datefmt_create: Invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object in %s:%d
+Fatal error: Uncaught IntlException: IntlDateFormatter::__construct(): Invalid value for calendar type; it must be one of IntlDateFormatter::TRADITIONAL (locale's default calendar) or IntlDateFormatter::GREGORIAN. Alternatively, it can be an IntlCalendar object in %s:%d
 Stack trace:
 #0 %s(%d): IntlDateFormatter->__construct('en_US@calendar=...', 0, 0, 'GMT+05:12', -1)
 #1 {main}

--- a/ext/intl/tests/dateformat_formatObject_error.phpt
+++ b/ext/intl/tests/dateformat_formatObject_error.phpt
@@ -29,27 +29,27 @@ var_dump(IntlDateFormatter::formatObject($cal, ""));
 
 ?>
 --EXPECTF--
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: the passed object must be an instance of either IntlCalendar or DateTimeInterface in %s on line %d
+Warning: IntlDateFormatter::formatObject(): the passed object must be an instance of either IntlCalendar or DateTimeInterface in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: bad IntlCalendar instance: not initialized properly in %s on line %d
+Warning: IntlDateFormatter::formatObject(): bad IntlCalendar instance: not initialized properly in %s on line %d
 bool(false)
 Object of type B (inheriting DateTime) has not been correctly initialized by calling parent::__construct() in its constructor
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: the date/time format type is invalid in %s on line %d
+Warning: IntlDateFormatter::formatObject(): the date/time format type is invalid in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: bad format; if array, it must have two elements in %s on line %d
+Warning: IntlDateFormatter::formatObject(): bad format; if array, it must have two elements in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: bad format; if array, it must have two elements in %s on line %d
+Warning: IntlDateFormatter::formatObject(): bad format; if array, it must have two elements in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: bad format; the date format (first element of the array) is not valid in %s on line %d
+Warning: IntlDateFormatter::formatObject(): bad format; the date format (first element of the array) is not valid in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: bad format; the time format (second element of the array) is not valid in %s on line %d
+Warning: IntlDateFormatter::formatObject(): bad format; the time format (second element of the array) is not valid in %s on line %d
 bool(false)
 
-Warning: IntlDateFormatter::formatObject(): datefmt_format_object: the format is empty in %s on line %d
+Warning: IntlDateFormatter::formatObject(): the format is empty in %s on line %d
 bool(false)

--- a/ext/intl/tests/formatter_fail.phpt
+++ b/ext/intl/tests/formatter_fail.phpt
@@ -137,12 +137,12 @@ TypeError: NumberFormatter::create(): Argument #1 ($locale) must be of type stri
 TypeError: numfmt_create(): Argument #1 ($locale) must be of type string, array given in %s on line %d
 'U_ZERO_ERROR'
 
-IntlException: Constructor failed in %s on line %d
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
+IntlException: NumberFormatter::__construct(): number formatter creation failed in %s on line %d
+'NumberFormatter::__construct(): number formatter creation failed: U_UNSUPPORTED_ERROR'
+'NumberFormatter::create(): number formatter creation failed: U_UNSUPPORTED_ERROR'
+'numfmt_create(): number formatter creation failed: U_UNSUPPORTED_ERROR'
 
-IntlException: Constructor failed in %s on line %d
-'numfmt_create: number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'
-'numfmt_create: number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'
-'numfmt_create: number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'
+IntlException: NumberFormatter::__construct(): number formatter creation failed in %s on line %d
+'NumberFormatter::__construct(): number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'
+'NumberFormatter::create(): number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'
+'numfmt_create(): number formatter creation failed: U_MEMORY_ALLOCATION_ERROR'

--- a/ext/intl/tests/gh12020.phpt
+++ b/ext/intl/tests/gh12020.phpt
@@ -13,10 +13,10 @@ var_dump(msgfmt_format_message('en', 'some {wrong.format}', []), intl_get_error_
 ?>
 --EXPECT--
 bool(false)
-string(128) "pattern syntax error (parse error at offset 19, after " message with {", before or at "invalid format}"): U_PATTERN_SYNTAX_ERROR"
+string(163) "MessageFormatter::formatMessage(): pattern syntax error (parse error at offset 19, after " message with {", before or at "invalid format}"): U_PATTERN_SYNTAX_ERROR"
 bool(false)
-string(116) "pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}"): U_PATTERN_SYNTAX_ERROR"
+string(151) "MessageFormatter::formatMessage(): pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}"): U_PATTERN_SYNTAX_ERROR"
 bool(false)
-string(128) "pattern syntax error (parse error at offset 19, after " message with {", before or at "invalid format}"): U_PATTERN_SYNTAX_ERROR"
+string(153) "msgfmt_format_message(): pattern syntax error (parse error at offset 19, after " message with {", before or at "invalid format}"): U_PATTERN_SYNTAX_ERROR"
 bool(false)
-string(116) "pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}"): U_PATTERN_SYNTAX_ERROR"
+string(141) "msgfmt_format_message(): pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}"): U_PATTERN_SYNTAX_ERROR"

--- a/ext/intl/tests/gh12243.phpt
+++ b/ext/intl/tests/gh12243.phpt
@@ -21,4 +21,4 @@ try {
 
 ?>
 --EXPECT--
-datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN: U_ILLEGAL_ARGUMENT_ERROR
+IntlDateFormatter::__construct(): time format must be UDAT_PATTERN if date format is UDAT_PATTERN

--- a/ext/intl/tests/gh17469.phpt
+++ b/ext/intl/tests/gh17469.phpt
@@ -30,5 +30,5 @@ try {
 Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line %d
 
 Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line 5
-Error setting encoding: 4 - U_FILE_ACCESS_ERROR
-Error setting encoding: 4 - U_FILE_ACCESS_ERROR
+UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR
+UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR

--- a/ext/intl/tests/ini_use_exceptions_basic.phpt
+++ b/ext/intl/tests/ini_use_exceptions_basic.phpt
@@ -16,7 +16,7 @@ ini_set("intl.error_level", E_NOTICE);
 var_dump($t->transliterate('a', 3));
 ?>
 --EXPECTF--
-string(130) "transliterator_transliterate: Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1)"
+string(133) "Transliterator::transliterate(): Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1)"
 
-Notice: Transliterator::transliterate(): transliterator_transliterate: Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1) in %s on line %d
+Notice: Transliterator::transliterate(): Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1) in %s on line %d
 bool(false)

--- a/ext/intl/tests/intl_get_error_message.phpt
+++ b/ext/intl/tests/intl_get_error_message.phpt
@@ -15,4 +15,4 @@ else
 
 ?>
 --EXPECT--
-Error getting locale by type: U_ILLEGAL_ARGUMENT_ERROR
+collator_get_locale(): Error getting locale by type: U_ILLEGAL_ARGUMENT_ERROR

--- a/ext/intl/tests/locale_subtags.phpt
+++ b/ext/intl/tests/locale_subtags.phpt
@@ -26,10 +26,10 @@ bool(true)
 bool(true)
 bool(true)
 bool(false)
-string(67) "locale_add_likely_subtags: invalid locale: U_ILLEGAL_ARGUMENT_ERROR"
+string(68) "Locale::addLikelySubtags(): invalid locale: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(65) "locale_minimize_subtags: invalid locale: U_ILLEGAL_ARGUMENT_ERROR"
+string(67) "Locale::minimizeSubtags(): invalid locale: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(%d) "locale_add_likely_subtags: invalid locale: %s"
+string(68) "Locale::addLikelySubtags(): invalid locale: U_ILLEGAL_ARGUMENT_ERROR"
 bool(false)
-string(%d) "locale_minimize_subtags: invalid locale: %s"
+string(67) "Locale::minimizeSubtags(): invalid locale: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -130,23 +130,23 @@ Deprecated: MessageFormatter::__construct(): Passing null to parameter #1 ($loca
 
 Deprecated: MessageFormatter::__construct(): Passing null to parameter #2 ($pattern) of type string is deprecated in %s on line %d
 
-IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+IntlException: MessageFormatter::__construct(): message formatter creation failed in %s on line %d
+'MessageFormatter::__construct(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
 Deprecated: MessageFormatter::create(): Passing null to parameter #1 ($locale) of type string is deprecated in %s on line %d
 
 Deprecated: MessageFormatter::create(): Passing null to parameter #2 ($pattern) of type string is deprecated in %s on line %d
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+'MessageFormatter::create(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
 Deprecated: msgfmt_create(): Passing null to parameter #1 ($locale) of type string is deprecated in %s on line %d
 
 Deprecated: msgfmt_create(): Passing null to parameter #2 ($pattern) of type string is deprecated in %s on line %d
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+'msgfmt_create(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
-IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
-'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+IntlException: MessageFormatter::__construct(): message formatter creation failed in %s on line %d
+'MessageFormatter::__construct(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+'MessageFormatter::create(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
+'msgfmt_create(): message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
 TypeError: MessageFormatter::__construct(): Argument #1 ($locale) must be of type string, array given in %s on line %d
 'U_ZERO_ERROR'
@@ -157,17 +157,17 @@ TypeError: MessageFormatter::create(): Argument #1 ($locale) must be of type str
 TypeError: msgfmt_create(): Argument #1 ($locale) must be of type string, array given in %s on line %d
 'U_ZERO_ERROR'
 
-IntlException: pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR in %s on line %d
-'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
-'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
-'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+IntlException: MessageFormatter::__construct(): pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}") in %s on line %d
+'MessageFormatter::__construct(): pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'MessageFormatter::create(): pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'msgfmt_create(): pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 
-IntlException: msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES in %s on line %d
-'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
-'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
-'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
+IntlException: MessageFormatter::__construct(): message formatter creation failed in %s on line %d
+'MessageFormatter::__construct(): message formatter creation failed: U_UNMATCHED_BRACES'
+'MessageFormatter::create(): message formatter creation failed: U_UNMATCHED_BRACES'
+'msgfmt_create(): message formatter creation failed: U_UNMATCHED_BRACES'
 
-IntlException: msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND in %s on line %d
-'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
-'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
-'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
+IntlException: MessageFormatter::__construct(): error converting pattern to UTF-16 in %s on line %d
+'MessageFormatter::__construct(): error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
+'MessageFormatter::create(): error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
+'msgfmt_create(): error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'

--- a/ext/intl/tests/msgfmt_format_error5.phpt
+++ b/ext/intl/tests/msgfmt_format_error5.phpt
@@ -16,7 +16,7 @@ $mf = new MessageFormatter('en_US', $fmt);
 var_dump($mf->format(array("foo" => new stdclass())));
 ?>
 --EXPECTF--
-Warning: MessageFormatter::format(): msgfmt_format: invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted) in %s on line %d
+Warning: MessageFormatter::format(): invalid object type for date/time (only IntlCalendar and DateTimeInterface permitted) in %s on line %d
 
 Warning: MessageFormatter::format(): The argument for key 'foo' cannot be used as a date or time in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_fromDateTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_fromDateTimeZone_error.phpt
@@ -12,5 +12,5 @@ $dt = new DateTime('2012-08-01 00:00:00 WEST');
 var_dump(IntlTimeZone::fromDateTimeZone($dt->getTimeZone()));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::fromDateTimeZone(): intltz_from_date_time_zone: time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
+Warning: IntlTimeZone::fromDateTimeZone(): time zone id 'WEST' extracted from ext/date DateTimeZone not recognized in %s on line %d
 NULL

--- a/ext/intl/tests/timezone_getErrorCodeMessage_basic.phpt
+++ b/ext/intl/tests/timezone_getErrorCodeMessage_basic.phpt
@@ -31,4 +31,4 @@ string(12) "U_ZERO_ERROR"
 Warning: IntlTimeZone::getOffset(): error obtaining offset in %s on line %d
 bool(false)
 int(1)
-string(48) "error obtaining offset: U_ILLEGAL_ARGUMENT_ERROR"
+string(75) "IntlTimeZone::getOffset(): error obtaining offset: U_ILLEGAL_ARGUMENT_ERROR"

--- a/ext/intl/tests/timezone_toDateTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_toDateTimeZone_error.phpt
@@ -17,7 +17,7 @@ try {
 var_dump(intltz_to_date_time_zone(1));
 ?>
 --EXPECTF--
-Warning: IntlTimeZone::toDateTimeZone(): intltz_to_date_time_zone: DateTimeZone constructor threw exception in %s on line %d
+Warning: IntlTimeZone::toDateTimeZone(): DateTimeZone constructor threw exception in %s on line %d
 string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
 
 Fatal error: Uncaught TypeError: intltz_to_date_time_zone(): Argument #1 ($timezone) must be of type IntlTimeZone, int given in %s:%d

--- a/ext/intl/tests/timezone_windowsID_basic2.phpt
+++ b/ext/intl/tests/timezone_windowsID_basic2.phpt
@@ -33,7 +33,7 @@ string(18) "Cuba Standard Time"
 string(21) "Central Standard Time"
 string(21) "Pacific Standard Time"
 bool(false)
-Error: unknown system timezone: U_ILLEGAL_ARGUMENT_ERROR
+Error: IntlTimeZone::getWindowsID(): unknown system timezone: U_ILLEGAL_ARGUMENT_ERROR
 string(21) "Morocco Standard Time"
 string(23) "Singapore Standard Time"
 string(26) "W. Australia Standard Time"

--- a/ext/intl/tests/transliterator_create_error.phpt
+++ b/ext/intl/tests/transliterator_create_error.phpt
@@ -14,9 +14,9 @@ echo intl_get_error_message(), "\n";
 echo "Done.\n";
 ?>
 --EXPECTF--
-Warning: Transliterator::create(): transliterator_create: unable to open ICU transliterator with id "inexistent id" in %s on line %d
-transliterator_create: unable to open ICU transliterator with id "inexistent id": U_INVALID_ID
+Warning: Transliterator::create(): unable to open ICU transliterator with id "inexistent id" in %s on line %d
+Transliterator::create(): unable to open ICU transliterator with id "inexistent id": U_INVALID_ID
 
 Warning: Transliterator::create(): String conversion of id to UTF-16 failed in %s on line %d
-String conversion of id to UTF-16 failed: U_INVALID_CHAR_FOUND
+Transliterator::create(): String conversion of id to UTF-16 failed: U_INVALID_CHAR_FOUND
 Done.

--- a/ext/intl/tests/transliterator_create_from_rule_error.phpt
+++ b/ext/intl/tests/transliterator_create_from_rule_error.phpt
@@ -27,11 +27,11 @@ echo "Done.\n";
 ?>
 --EXPECTF--
 Warning: Transliterator::createFromRules(): String conversion of rules to UTF-16 failed in %s on line %d
-String conversion of rules to UTF-16 failed: U_INVALID_CHAR_FOUND
+Transliterator::createFromRules(): String conversion of rules to UTF-16 failed: U_INVALID_CHAR_FOUND
 
-Warning: Transliterator::createFromRules(): transliterator_create_from_rules: unable to create ICU transliterator from rules (parse error after "{'``'}a > “;", before or at "{'``'}a > b;") in %s on line %d
-transliterator_create_from_rules: unable to create ICU transliterator from rules (parse error after "{'``'}a > “;", before or at "{'``'}a > b;"): U_RULE_MASK_ERROR
+Warning: Transliterator::createFromRules(): unable to create ICU transliterator from rules (parse error after "{'``'}a > “;", before or at "{'``'}a > b;") in %s on line %d
+Transliterator::createFromRules(): unable to create ICU transliterator from rules (parse error after "{'``'}a > “;", before or at "{'``'}a > b;"): U_RULE_MASK_ERROR
 
-Warning: Transliterator::createFromRules(): transliterator_create_from_rules: unable to create ICU transliterator from rules (parse error at offset 0, before or at "ffff") in %s on line %d
-transliterator_create_from_rules: unable to create ICU transliterator from rules (parse error at offset 0, before or at "ffff"): U_MISSING_OPERATOR
+Warning: Transliterator::createFromRules(): unable to create ICU transliterator from rules (parse error at offset 0, before or at "ffff") in %s on line %d
+Transliterator::createFromRules(): unable to create ICU transliterator from rules (parse error at offset 0, before or at "ffff"): U_MISSING_OPERATOR
 Done.

--- a/ext/intl/tests/transliterator_get_error_message_basic.phpt
+++ b/ext/intl/tests/transliterator_get_error_message_basic.phpt
@@ -19,8 +19,8 @@ echo "Done.\n";
 --EXPECTF--
 Warning: Transliterator::transliterate(): String conversion of string to UTF-16 failed in %s on line %d
 bool(false)
-String conversion of string to UTF-16 failed: U_INVALID_CHAR_FOUND
-String conversion of string to UTF-16 failed: U_INVALID_CHAR_FOUND
+Transliterator::transliterate(): String conversion of string to UTF-16 failed: U_INVALID_CHAR_FOUND
+Transliterator::transliterate(): String conversion of string to UTF-16 failed: U_INVALID_CHAR_FOUND
 string(0) ""
 U_ZERO_ERROR
 Done.

--- a/ext/intl/tests/transliterator_transliterate_error.phpt
+++ b/ext/intl/tests/transliterator_transliterate_error.phpt
@@ -24,7 +24,7 @@ transliterator_transliterate($tr, "\x80\x03");
 echo "Done.\n";
 ?>
 --EXPECTF--
-Warning: transliterator_transliterate(): transliterator_transliterate: Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 3) in %s on line %d
+Warning: transliterator_transliterate(): Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 3) in %s on line %d
 bool(false)
 transliterator_transliterate(): Argument #2 ($string) must be less than or equal to argument #3 ($end)
 

--- a/ext/intl/tests/transliterator_transliterate_variant1.phpt
+++ b/ext/intl/tests/transliterator_transliterate_variant1.phpt
@@ -30,9 +30,9 @@ Warning: transliterator_transliterate(): Could not create transliterator with ID
 
 String conversion of id to UTF-16 failed: U_INVALID_CHAR_FOUND
 
-Warning: transliterator_transliterate(): transliterator_create: unable to open ICU transliterator with id "inexistent id" in %s on line %d
+Warning: transliterator_transliterate(): unable to open ICU transliterator with id "inexistent id" in %s on line %d
 
-Warning: transliterator_transliterate(): Could not create transliterator with ID "inexistent id" (transliterator_create: unable to open ICU transliterator with id "inexistent id": U_INVALID_ID) in %s on line %d
+Warning: transliterator_transliterate(): Could not create transliterator with ID "inexistent id" (transliterator_create(): unable to open ICU transliterator with id "inexistent id": U_INVALID_ID) in %s on line %d
 
-transliterator_create: unable to open ICU transliterator with id "inexistent id": U_INVALID_ID
+transliterator_create(): unable to open ICU transliterator with id "inexistent id": U_INVALID_ID
 Done.

--- a/ext/intl/tests/uconverter___construct_error.phpt
+++ b/ext/intl/tests/uconverter___construct_error.phpt
@@ -10,6 +10,6 @@ $c = new UConverter('utf-8', "\x80");
 var_dump($c);
 ?>
 --EXPECTF--
-Warning: UConverter::__construct(): ucnv_open() returned error 4: U_FILE_ACCESS_ERROR in %s on line %d
+Warning: UConverter::__construct(): returned error 4: U_FILE_ACCESS_ERROR in %s on line %d
 object(UConverter)#%d (0) {
 }

--- a/ext/intl/tests/uconverter_func_subst.phpt
+++ b/ext/intl/tests/uconverter_func_subst.phpt
@@ -25,7 +25,7 @@ foreach(array('?','','??') as $subst) {
 --EXPECT--
 string(23) "This is an ascii string"
 string(12) "Snowman: (?)"
-Error: transcode() returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
-Error: transcode() returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
-Error: transcode() returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
-Error: transcode() returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
+Error: UConverter::transcode(): returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
+Error: UConverter::transcode(): returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
+Error: UConverter::transcode(): returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR
+Error: UConverter::transcode(): returned error 1: U_ILLEGAL_ARGUMENT_ERROR: U_ILLEGAL_ARGUMENT_ERROR

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -61,18 +61,16 @@ U_CFUNC void timezone_object_construct(const TimeZone *zone, zval *object, int o
  *	   Convert from TimeZone to DateTimeZone object */
 U_CFUNC zval *timezone_convert_to_datetimezone(const TimeZone *timeZone,
 											   intl_error *outside_error,
-											   const char *func, zval *ret)
+											   zval *ret)
 {
 	UnicodeString		id;
-	char				*message = NULL;
 	php_timezone_obj	*tzobj;
 	zval				arg;
 
 	timeZone->getID(id);
 	if (id.isBogus()) {
-		spprintf(&message, 0, "%s: could not obtain TimeZone id", func);
 		intl_errors_set(outside_error, U_ILLEGAL_ARGUMENT_ERROR,
-			message, 1);
+			"could not obtain TimeZone id", false);
 		goto error;
 	}
 
@@ -91,19 +89,16 @@ U_CFUNC zval *timezone_convert_to_datetimezone(const TimeZone *timeZone,
 		/* Call the constructor! */
 		u8str = intl_charFromString(id, &INTL_ERROR_CODE(*outside_error));
 		if (!u8str) {
-			spprintf(&message, 0, "%s: could not convert id to UTF-8", func);
 			intl_errors_set(outside_error, INTL_ERROR_CODE(*outside_error),
-				message, 1);
+				"could not convert id to UTF-8", false);
 			goto error;
 		}
 		ZVAL_STR(&arg, u8str);
 		zend_call_known_instance_method_with_1_params(
 			Z_OBJCE_P(ret)->constructor, Z_OBJ_P(ret), NULL, &arg);
 		if (EG(exception)) {
-			spprintf(&message, 0,
-				"%s: DateTimeZone constructor threw exception", func);
 			intl_errors_set(outside_error, U_ILLEGAL_ARGUMENT_ERROR,
-				message, 1);
+				"DateTimeZone constructor threw exception", false);
 			zend_object_store_ctor_failed(Z_OBJ_P(ret));
 			zval_ptr_dtor(&arg);
 			goto error;
@@ -118,10 +113,6 @@ error:
 		}
 		ret = NULL;
 	}
-
-	if (message) {
-		efree(message);
-	}
 	return ret;
 }
 /* }}} */
@@ -129,8 +120,7 @@ error:
 /* {{{ timezone_process_timezone_argument
  * TimeZone argument processor. outside_error may be NULL (for static functions/constructors) */
 U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
-													 intl_error *outside_error,
-													 const char *func)
+													 intl_error *outside_error)
 {
 	zval		local_zv_tz;
 	TimeZone	*timeZone;
@@ -148,14 +138,14 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 		TimeZone_object *to = Z_INTL_TIMEZONE_P(zv_timezone);
 
 		if (to->utimezone == NULL) {
-			zend_throw_error(IntlException_ce_ptr, "%s: passed IntlTimeZone is not "
-				"properly constructed", func);
+			zend_throw_error(IntlException_ce_ptr, "passed IntlTimeZone is not "
+				"properly constructed");
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}
 		timeZone = to->utimezone->clone();
 		if (UNEXPECTED(timeZone == NULL)) {
-			zend_throw_error(IntlException_ce_ptr, "%s: could not clone TimeZone", func);
+			zend_throw_error(IntlException_ce_ptr, "could not clone TimeZone");
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}
@@ -165,8 +155,7 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 		php_timezone_obj *tzobj = Z_PHPTIMEZONE_P(zv_timezone);
 
 		zval_ptr_dtor_str(&local_zv_tz);
-		return timezone_convert_datetimezone(tzobj->type, tzobj, 0,
-			outside_error, func);
+		return timezone_convert_datetimezone(tzobj->type, tzobj, 0, outside_error);
 	} else {
 		UnicodeString	id;
 		UErrorCode		status = U_ZERO_ERROR; /* outside_error may be NULL */
@@ -176,20 +165,22 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 		}
 		if (intl_stringFromChar(id, Z_STRVAL_P(zv_timezone), Z_STRLEN_P(zv_timezone),
 				&status) == FAILURE) {
-			zend_throw_error(IntlException_ce_ptr, "%s: Time zone identifier given is not a "
-				"valid UTF-8 string", func);
+			// TODO: Grab current executing function/method
+			zend_throw_error(IntlException_ce_ptr, "Time zone identifier given is not a "
+				"valid UTF-8 string");
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}
 		timeZone = TimeZone::createTimeZone(id);
 		if (UNEXPECTED(timeZone == NULL)) {
-			zend_throw_error(IntlException_ce_ptr, "%s: Could not create time zone", func);
+			// TODO: Grab current executing function/method
+			zend_throw_error(IntlException_ce_ptr, "Could not create time zone");
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}
 		if (*timeZone == TimeZone::getUnknown()) {
-			zend_throw_error(IntlException_ce_ptr, "%s: No such time zone: '%s'",
-				func, Z_STRVAL_P(zv_timezone));
+			// TODO: Grab current executing function/method
+			zend_throw_error(IntlException_ce_ptr, "No such time zone: '%s'", Z_STRVAL_P(zv_timezone));
 			zval_ptr_dtor_str(&local_zv_tz);
 			delete timeZone;
 			return NULL;

--- a/ext/intl/timezone/timezone_class.h
+++ b/ext/intl/timezone/timezone_class.h
@@ -64,8 +64,8 @@ static inline TimeZone_object *php_intl_timezone_fetch_object(zend_object *obj) 
 		RETURN_THROWS(); \
 	}
 
-zval *timezone_convert_to_datetimezone(const TimeZone *timeZone, intl_error *outside_error, const char *func, zval *ret);
-TimeZone *timezone_process_timezone_argument(zval *zv_timezone, intl_error *error, const char *func);
+zval *timezone_convert_to_datetimezone(const TimeZone *timeZone, intl_error *outside_error, zval *ret);
+TimeZone *timezone_process_timezone_argument(zval *zv_timezone, intl_error *error);
 
 void timezone_object_construct(const TimeZone *zone, zval *object, int owned);
 

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -88,8 +88,7 @@ U_CFUNC PHP_FUNCTION(intltz_from_date_time_zone)
 		RETURN_NULL();
 	}
 
-	tz = timezone_convert_datetimezone(tzobj->type, tzobj, false, NULL,
-		"intltz_from_date_time_zone");
+	tz = timezone_convert_datetimezone(tzobj->type, tzobj, false, NULL);
 	if (tz == NULL) {
 		RETURN_NULL();
 	}
@@ -567,7 +566,7 @@ U_CFUNC PHP_FUNCTION(intltz_to_date_time_zone)
 	TIMEZONE_METHOD_FETCH_OBJECT;
 
 	zval *ret = timezone_convert_to_datetimezone(to->utimezone,
-		&TIMEZONE_ERROR(to), "intltz_to_date_time_zone", &tmp);
+		&TIMEZONE_ERROR(to), &tmp);
 
 	if (ret) {
 		ZVAL_COPY_VALUE(return_value, ret);
@@ -636,7 +635,7 @@ U_CFUNC PHP_FUNCTION(intltz_get_windows_id)
 
 	error = U_ZERO_ERROR;
 	TimeZone::getWindowsID(uID, uWinID, error);
-	INTL_CHECK_STATUS(error, "intltz_get_windows_id: Unable to get timezone from windows ID");
+	INTL_CHECK_STATUS(error, "Unable to get timezone from windows ID");
 	if (uWinID.length() == 0) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
 		               "unknown system timezone", 0);

--- a/ext/intl/transliterator/transliterator_methods.c
+++ b/ext/intl/transliterator/transliterator_methods.c
@@ -64,11 +64,11 @@ static int create_transliterator( char *str_id, size_t str_id_len, zend_long dir
 	{
 		char *buf = NULL;
 		intl_error_set_code( NULL, TRANSLITERATOR_ERROR_CODE( to ) );
-		spprintf( &buf, 0, "transliterator_create: unable to open ICU transliterator"
+		spprintf( &buf, 0, "unable to open ICU transliterator"
 			" with id \"%s\"", str_id );
 		if( buf == NULL ) {
 			intl_error_set_custom_msg( NULL,
-				"transliterator_create: unable to open ICU transliterator", 0 );
+				"unable to open ICU transliterator", 0 );
 		}
 		else
 		{
@@ -85,7 +85,7 @@ static int create_transliterator( char *str_id, size_t str_id_len, zend_long dir
 	{
 		intl_error_set_code( NULL, TRANSLITERATOR_ERROR_CODE( to ) );
 		intl_error_set_custom_msg( NULL,
-			"transliterator_create: internal constructor call failed", 0 );
+			"internal constructor call failed", 0 );
 		zval_ptr_dtor( object );
 		return FAILURE;
 	}
@@ -169,7 +169,7 @@ PHP_FUNCTION( transliterator_create_from_rules )
 		char *msg = NULL;
 		smart_str parse_error_str;
 		parse_error_str = intl_parse_error_to_string( &parse_error );
-		spprintf( &msg, 0, "transliterator_create_from_rules: unable to "
+		spprintf( &msg, 0, "unable to "
 			"create ICU transliterator from rules (%s)", parse_error_str.s? ZSTR_VAL(parse_error_str.s) : "" );
 		smart_str_free( &parse_error_str );
 		if( msg != NULL )
@@ -182,7 +182,7 @@ PHP_FUNCTION( transliterator_create_from_rules )
 	}
 	transliterator_object_construct( object, utrans, TRANSLITERATOR_ERROR_CODE_P( to ) );
 	/* no need to close the transliterator manually on construction error */
-	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "transliterator_create_from_rules: internal constructor call failed" );
+	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "internal constructor call failed" );
 }
 /* }}} */
 
@@ -207,11 +207,11 @@ PHP_FUNCTION( transliterator_create_inverse )
 	TRANSLITERATOR_METHOD_FETCH_OBJECT_NO_CHECK; /* change "to" into new object (from "object" ) */
 
 	utrans = utrans_openInverse( to_orig->utrans, TRANSLITERATOR_ERROR_CODE_P( to ) );
-	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "transliterator_create_inverse: could not create "
+	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "could not create "
 		"inverse ICU transliterator" );
 	transliterator_object_construct( object, utrans, TRANSLITERATOR_ERROR_CODE_P( to ) );
 	/* no need to close the transliterator manually on construction error */
-	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "transliterator_create: internal constructor call failed" );
+	INTL_METHOD_CHECK_STATUS_OR_NULL( to, "internal constructor call failed" );
 }
 /* }}} */
 
@@ -229,7 +229,7 @@ PHP_FUNCTION( transliterator_list_ids )
 
 	en = utrans_openIDs( &status );
 	INTL_CHECK_STATUS( status,
-		"transliterator_list_ids: Failed to obtain registered transliterators" );
+		"Failed to obtain registered transliterators" );
 
 	array_init( return_value );
 	while( (elem = uenum_unext( en, &elem_len, &status )) )
@@ -252,7 +252,7 @@ PHP_FUNCTION( transliterator_list_ids )
 	{
 		zend_array_destroy( Z_ARR_P(return_value) );
 		RETVAL_FALSE;
-		intl_error_set_custom_msg( NULL, "transliterator_list_ids: "
+		intl_error_set_custom_msg( NULL,
 			"Failed to build array of registered transliterators", 0 );
 	}
 }
@@ -342,7 +342,7 @@ PHP_FUNCTION( transliterator_transliterate )
 	{
 		char *msg;
 		spprintf( &msg, 0,
-			"transliterator_transliterate: Neither \"start\" nor the \"end\" "
+			"Neither \"start\" nor the \"end\" "
 			"arguments can exceed the number of UTF-16 code units "
 			"(in this case, %d)", (int) ustr_len );
 		if(msg != NULL )
@@ -385,7 +385,7 @@ PHP_FUNCTION( transliterator_transliterate )
 		{
 			intl_error_set_code( NULL, TRANSLITERATOR_ERROR_CODE( to ) );
 			intl_errors_set_custom_msg( TRANSLITERATOR_ERROR_P( to ),
-				"transliterator_transliterate: transliteration failed", 0 );
+				"transliteration failed", 0 );
 			goto cleanup;
 		}
 		else


### PR DESCRIPTION
A few things still need to be handed:
- Timezones error not providing from which calling function/method information
- Tests relying on `ut_common.inc` need to be updated to cope with the start of the error message being different between procedural and oo errors now