### PR TITLE
Fix GH-19197: session build fails on system with memcpy as macro.

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1246,7 +1246,7 @@ static inline void last_modified(void)
 		}
 
 #define LAST_MODIFIED "Last-Modified: "
-		memcpy(buf, ZEND_STRL(LAST_MODIFIED));
+		memcpy(buf, LAST_MODIFIED, sizeof(LAST_MODIFIED) - 1);
 		strcpy_gmt(buf + sizeof(LAST_MODIFIED) - 1, &sb.st_mtime);
 		ADD_HEADER(buf);
 	}
@@ -1261,7 +1261,7 @@ CACHE_LIMITER_FUNC(public)
 
 	gettimeofday(&tv, NULL);
 	now = tv.tv_sec + PS(cache_expire) * 60;
-	memcpy(buf, ZEND_STRL(EXPIRES));
+	memcpy(buf, EXPIRES, sizeof(EXPIRES) - 1);
 	strcpy_gmt(buf + sizeof(EXPIRES) - 1, &now);
 	ADD_HEADER(buf);
 


### PR DESCRIPTION
Thus ZEND_STRL macro does not expand as expected so going back to not using it like lower branches.