### PR TITLE
Remove dynamic defs from property hooks after preload

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4132,6 +4132,24 @@ static void preload_link(void)
 				preload_remove_declares(op_array);
 			}
 		} ZEND_HASH_FOREACH_END();
+
+		if (ce->num_hooked_props > 0) {
+			zend_property_info *info;
+
+			ZEND_HASH_MAP_FOREACH_PTR(&ce->properties_info, info) {
+				if (info->hooks) {
+					for (uint32_t i = 0; i < ZEND_PROPERTY_HOOK_COUNT; i++) {
+						if (info->hooks[i]) {
+							op_array = &info->hooks[i]->op_array;
+							ZEND_ASSERT(op_array->type == ZEND_USER_FUNCTION);
+							if (!(op_array->fn_flags & ZEND_ACC_TRAIT_CLONE)) {
+								preload_remove_declares(op_array);
+							}
+						}
+					}
+				}
+			} ZEND_HASH_FOREACH_END();
+		}
 	} ZEND_HASH_FOREACH_END();
 }
 

--- a/ext/opcache/tests/preload_dynamic_def_removal.inc
+++ b/ext/opcache/tests/preload_dynamic_def_removal.inc
@@ -5,6 +5,15 @@ class Test {
             echo "dynamic\n";
         }
     }      
+
+    public int $hook {
+        get {
+            function dynamic_in_hook() {
+                echo "dynamic in hook\n";
+            }
+            return 1;
+        }
+    }
 }       
 
 function func() {
@@ -16,3 +25,4 @@ function func() {
 $test = new Test; 
 $test->method();
 func();
+$test->hook;

--- a/ext/opcache/tests/preload_dynamic_def_removal.phpt
+++ b/ext/opcache/tests/preload_dynamic_def_removal.phpt
@@ -15,7 +15,9 @@ if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows
 <?php
 dynamic();
 dynamic2();
+dynamic_in_hook();
 ?>
 --EXPECT--
 dynamic
 dynamic2
+dynamic in hook


### PR DESCRIPTION
Otherwise this hits an assertion failure in pass2 reversal and causes a subsequent crash.