### PR TITLE
Leak in failed unserialize() with opcache

### DIFF
--- a/ext/standard/tests/serialize/oss_fuzz_433303828.phpt
+++ b/ext/standard/tests/serialize/oss_fuzz_433303828.phpt
@@ -1,0 +1,13 @@
+--TEST--
+OSS-Fuzz #433303828
+--FILE--
+<?php
+
+unserialize('O:2:"yy": ');
+unserialize('O:2:"yy":: ');
+
+?>
+--EXPECTF--
+Warning: unserialize(): Error at offset 9 of 10 bytes in %s on line %d
+
+Warning: unserialize(): Error at offset 10 of 11 bytes in %s on line %d

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -1310,10 +1310,12 @@ object ":" uiv ":" ["]	{
 	YYCURSOR = *p;
 
 	if (*(YYCURSOR) != ':') {
+		zend_string_release_ex(class_name, 0);
 		return 0;
 	}
 	if (*(YYCURSOR+1) != '{') {
 		*p = YYCURSOR+1;
+		zend_string_release_ex(class_name, 0);
 		return 0;
 	}
 


### PR DESCRIPTION
With opcache, zend_string_init_interned() will allocate non-interned strings at runtime because shm is locked. Hence, we need to make sure to actually free this string.