### PR TITLE
ext/intl: GregorianCalendar using C++ upcasting operator.

### DIFF
--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -71,7 +71,7 @@ U_CFUNC void calendar_object_construct(zval *object,
 
 	CALENDAR_METHOD_FETCH_OBJECT_NO_CHECK; //populate to from object
 	assert(co->ucal == NULL);
-	co->ucal = (Calendar*)calendar;
+	co->ucal = calendar;
 }
 
 /* {{{ clone handler for Calendar */

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -46,7 +46,7 @@ using icu::StringPiece;
 	}
 
 static inline GregorianCalendar *fetch_greg(Calendar_object *co) {
-	return (GregorianCalendar*)co->ucal;
+	return static_cast<GregorianCalendar *>(co->ucal);
 }
 
 static bool set_gregorian_calendar_time_zone(GregorianCalendar *gcal, UErrorCode status)


### PR DESCRIPTION
when fetching the internal ICU object also removing one useless cast.