### PR TITLE
ext/standard: handle html entities empty string before processing

### DIFF
--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -1322,7 +1322,6 @@ static void php_html_entities(INTERNAL_FUNCTION_PARAMETERS, int all)
 
 	if (ZSTR_LEN(str) == 0) {
 		RETURN_EMPTY_STRING();
-		return;
 	}
 	replaced = php_escape_html_entities_ex(
 		(unsigned char*)ZSTR_VAL(str), ZSTR_LEN(str), all, (int) flags,


### PR DESCRIPTION
https://gist.github.com/xepozz/8a7cbb52dd2087634d2ddaa90a21acbe

### master
❯ ./sapi/cli/php test.php
Result: 0.12489318847656
Result: 0.025581121444702
Result: 0.024285078048706

### branch
❯ ./sapi/cli/php test.php
Result: 0.11230993270874
Result: 0.012480974197388
Result: 0.01120400428772

all the tests were made with local php build with enabled debug and so on

performance increases because of eliminating memory allocation, I hope memory usage is also reduced