### PR TITLE
zend_hrtime: Check posix clock once and prefer CLOCK_MONOTONIC_RAW

### DIFF
--- a/Zend/zend_hrtime.c
+++ b/Zend/zend_hrtime.c
@@ -27,6 +27,8 @@
 # include <time.h>
 # include <string.h>
 
+ZEND_API clockid_t zend_hrtime_posix_clock_id = CLOCK_MONOTONIC;
+
 #elif ZEND_HRTIME_PLATFORM_WINDOWS
 
 # define WIN32_LEAN_AND_MEAN
@@ -65,6 +67,25 @@ void zend_startup_hrtime(void)
 #elif ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE
 
 	mach_timebase_info(&zend_hrtime_timerlib_info);
+
+#elif ZEND_HRTIME_PLATFORM_POSIX
+
+	struct timespec ts;
+
+#ifdef CLOCK_MONOTONIC_RAW
+	if (EXPECTED(0 == clock_gettime(CLOCK_MONOTONIC_RAW, &ts))) {
+		zend_hrtime_posix_clock_id = CLOCK_MONOTONIC_RAW;
+		return;
+	}
+#endif
+
+	if (EXPECTED(0 == clock_gettime(zend_hrtime_posix_clock_id, &ts))) {
+		return;
+	}
+
+	// zend_error mechanism is not initialized at that point
+	fprintf(stderr, "No working CLOCK_MONOTONIC* found, this should never happen\n");
+	abort();
 
 #endif
 }

--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -72,6 +72,10 @@ ZEND_API extern double zend_hrtime_timer_scale;
 # include <string.h>
 ZEND_API extern mach_timebase_info_data_t zend_hrtime_timerlib_info;
 
+#elif ZEND_HRTIME_PLATFORM_POSIX
+
+ZEND_API extern clockid_t zend_hrtime_posix_clock_id;
+
 #endif
 
 #define ZEND_NANO_IN_SEC UINT64_C(1000000000)
@@ -92,10 +96,8 @@ static zend_always_inline zend_hrtime_t zend_hrtime(void)
 	return (zend_hrtime_t)mach_absolute_time() * zend_hrtime_timerlib_info.numer / zend_hrtime_timerlib_info.denom;
 #elif ZEND_HRTIME_PLATFORM_POSIX
 	struct timespec ts = { .tv_sec = 0, .tv_nsec = 0 };
-	if (EXPECTED(0 == clock_gettime(CLOCK_MONOTONIC, &ts))) {
-		return ((zend_hrtime_t) ts.tv_sec * (zend_hrtime_t)ZEND_NANO_IN_SEC) + ts.tv_nsec;
-	}
-	return 0;
+	clock_gettime(zend_hrtime_posix_clock_id, &ts);
+	return ((zend_hrtime_t) ts.tv_sec * (zend_hrtime_t)ZEND_NANO_IN_SEC) + ts.tv_nsec;
 #elif ZEND_HRTIME_PLATFORM_HPUX
 	return (zend_hrtime_t) gethrtime();
 #elif  ZEND_HRTIME_PLATFORM_AIX


### PR DESCRIPTION
Part of https://github.com/php/php-src/issues/19210.

This will test the support of the monotonic timer only once at startup.

Additionally it will prefer `CLOCK_MONOTONiC_RAW` (if available) to not be affected by the incremental adjustments performed by [adjtime(3)](https://man7.org/linux/man-pages/man3/adjtime.3.html) and NTP.

