### PR TITLE
Add digest algo param to OpenSSL public encrypt and private decrypt

### DIFF
--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -575,13 +575,13 @@ function openssl_private_encrypt(#[\SensitiveParameter] string $data, &$encrypte
  * @param string $decrypted_data
  * @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $private_key
  */
-function openssl_private_decrypt(string $data, #[\SensitiveParameter] &$decrypted_data, #[\SensitiveParameter] $private_key, int $padding = OPENSSL_PKCS1_PADDING): bool {}
+function openssl_private_decrypt(string $data, #[\SensitiveParameter] &$decrypted_data, #[\SensitiveParameter] $private_key, int $padding = OPENSSL_PKCS1_PADDING, ?string $digest_algo = null): bool {}
 
 /**
  * @param string $encrypted_data
  * @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $public_key
  */
-function openssl_public_encrypt(#[\SensitiveParameter] string $data, &$encrypted_data, $public_key, int $padding = OPENSSL_PKCS1_PADDING): bool {}
+function openssl_public_encrypt(#[\SensitiveParameter] string $data, &$encrypted_data, $public_key, int $padding = OPENSSL_PKCS1_PADDING, ?string $digest_algo = null): bool {}
 
 /**
  * @param string $decrypted_data

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a42bd7dec0a5e011983ce08b5e31cd8718247501 */
+ * Stub hash: 4186e01a05ec179f1f2196a2afd1860671f793d5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
@@ -258,6 +258,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_private_decrypt, 0, 3, _
 	ZEND_ARG_INFO(1, decrypted_data)
 	ZEND_ARG_INFO(0, private_key)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, padding, IS_LONG, 0, "OPENSSL_PKCS1_PADDING")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, digest_algo, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_public_encrypt, 0, 3, _IS_BOOL, 0)
@@ -265,6 +266,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_public_encrypt, 0, 3, _I
 	ZEND_ARG_INFO(1, encrypted_data)
 	ZEND_ARG_INFO(0, public_key)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, padding, IS_LONG, 0, "OPENSSL_PKCS1_PADDING")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, digest_algo, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_public_decrypt, 0, 3, _IS_BOOL, 0)

--- a/ext/openssl/tests/openssl_private_decrypt_digest.phpt
+++ b/ext/openssl/tests/openssl_private_decrypt_digest.phpt
@@ -1,0 +1,57 @@
+--TEST--
+openssl_private_decrypt() with digest algorithm tests
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$data = "Testing openssl_private_decrypt() with digest algorithms";
+$privkey = "file://" . __DIR__ . "/private_rsa_1024.key";
+$pubkey = "file://" . __DIR__ . "/public.key";
+
+openssl_public_encrypt($data, $encrypted_sha256, $pubkey, OPENSSL_PKCS1_OAEP_PADDING, "sha256");
+var_dump(openssl_private_decrypt($encrypted_sha256, $output_sha256, $privkey, OPENSSL_PKCS1_OAEP_PADDING, "sha256"));
+var_dump($output_sha256);
+
+openssl_public_encrypt($data, $encrypted_default, $pubkey, OPENSSL_PKCS1_OAEP_PADDING);
+var_dump(openssl_private_decrypt($encrypted_default, $output_default, $privkey, OPENSSL_PKCS1_OAEP_PADDING));
+var_dump($output_default);
+
+// Some distros (RHEL) explicitly disable SHA1 so this runs only if available
+if (in_array('sha1', openssl_get_md_methods())) {
+    openssl_public_encrypt($data, $encrypted_sha256, $pubkey, OPENSSL_PKCS1_OAEP_PADDING, "sha256");
+    var_dump(openssl_private_decrypt($encrypted_sha256, $output_mismatch, $privkey, OPENSSL_PKCS1_OAEP_PADDING, "sha1"));
+    var_dump($output_mismatch);
+} else {
+    var_dump(false);
+    var_dump(NULL);
+}
+
+var_dump(openssl_private_decrypt($encrypted_sha256, $output_invalid, $privkey, OPENSSL_PKCS1_OAEP_PADDING, "invalid_hash"));
+var_dump($output_invalid);
+
+// Test that "p" is used instead of "s" (it is not a ZPP test but flag selection test so do not remove)
+try {
+    var_dump(openssl_private_decrypt($encrypted_sha256, $output_invalid, $privkey, OPENSSL_PKCS1_OAEP_PADDING, "sha256\0extra"));
+    var_dump($output_invalid);
+} catch (\ValueError $e) {
+    var_dump($e->getMessage());
+}
+
+openssl_public_encrypt($data, $encrypted_pkcs1, $pubkey, OPENSSL_PKCS1_PADDING);
+var_dump(openssl_private_decrypt($encrypted_pkcs1, $output_pkcs1, $privkey, OPENSSL_PKCS1_PADDING, "sha256"));
+var_dump($output_pkcs1);
+?>
+--EXPECTF--
+bool(true)
+string(56) "Testing openssl_private_decrypt() with digest algorithms"
+bool(true)
+string(56) "Testing openssl_private_decrypt() with digest algorithms"
+bool(false)
+NULL
+
+Warning: openssl_private_decrypt(): Unknown digest algorithm: invalid_hash in %s on line %d
+bool(false)
+NULL
+string(85) "openssl_private_decrypt(): Argument #5 ($digest_algo) must not contain any null bytes"
+bool(true)
+string(56) "Testing openssl_private_decrypt() with digest algorithms"


### PR DESCRIPTION
Specifically, it is added to openssl_public_encrypt() and openssl_private_decrypt() functions. The purpose is to specify digest algorithm for OEAP padding. It currently defaults to SHA1 for some OpenSSL versions / builds which is not preferred for modern setup and causes problems in compatibility with web crypto.