### PR TITLE
Fix _pdo_pgsql_trim_message bad access

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -40,7 +40,7 @@ static char * _pdo_pgsql_trim_message(const char *message, int persistent)
 {
 	size_t i = strlen(message);
 	char *tmp;
-	if (i == 0) {
+	if (UNEXPECTED(i == 0)) {
 		tmp = pemalloc(1, persistent);
 		tmp[0] = '\0';
 		return tmp;


### PR DESCRIPTION
when input `const char *message` is empty string, the following line will access bad address