### PR TITLE
Free opened_path when opened_path_len >= MAXPATHLEN

### DIFF
--- a/main/php_open_temporary_file.c
+++ b/main/php_open_temporary_file.c
@@ -157,6 +157,7 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
 			free(cwdw);
 			free(pfxw);
 			efree(new_state.cwd);
+			free(opened_path);
 			return -1;
 		}
 		assert(strlen(opened_path) == opened_path_len);


### PR DESCRIPTION
when `opened_path_len >= MAXPATHLEN` opened_path wont be free'd