### PR TITLE
Removed ZEND_SIZE_MAX as SIZE_MAX is available on windows already

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -62,20 +62,6 @@ typedef enum {
 
 typedef ZEND_RESULT_CODE zend_result;
 
-#ifdef ZEND_ENABLE_ZVAL_LONG64
-# ifdef ZEND_WIN32
-#  define ZEND_SIZE_MAX  _UI64_MAX
-# else
-#  define ZEND_SIZE_MAX  SIZE_MAX
-# endif
-#else
-# if defined(ZEND_WIN32)
-#  define ZEND_SIZE_MAX  _UI32_MAX
-# else
-#  define ZEND_SIZE_MAX SIZE_MAX
-# endif
-#endif
-
 #ifdef ZTS
 #define ZEND_TLS static TSRM_TLS
 #define ZEND_EXT_TLS TSRM_TLS

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -103,7 +103,7 @@ php_sprintf_appendstring(zend_string **buffer, size_t *pos, char *add,
 	if (req_size > ZSTR_LEN(*buffer)) {
 		size_t size = ZSTR_LEN(*buffer);
 		while (req_size > size) {
-			if (size > ZEND_SIZE_MAX/2) {
+			if (size > SIZE_MAX/2) {
 				zend_error_noreturn(E_ERROR, "Field width %zd is too long", req_size);
 			}
 			size <<= 1;


### PR DESCRIPTION
Also, `SIZE_MAX` is already used all over the place while `ZEND_SIZE_MAX` was used only once.