### PR TITLE
Use consistent type for h on call zend_hash_index_*

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1215,7 +1215,7 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 					ALLOC_HASHTABLE(CG(unlinked_uses));
 					zend_hash_init(CG(unlinked_uses), 0, NULL, NULL, 0);
 				}
-				zend_hash_index_add_empty_element(CG(unlinked_uses), (zend_long)(uintptr_t)ce);
+				zend_hash_index_add_empty_element(CG(unlinked_uses), (zend_ulong)(uintptr_t)ce);
 				return ce;
 			}
 			return NULL;

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -179,7 +179,7 @@ static void zend_generator_remove_child(zend_generator_node *node, zend_generato
 		node->child.single = NULL;
 	} else {
 		HashTable *ht = node->child.ht;
-		zend_hash_index_del(ht, (zend_ulong) child);
+		zend_hash_index_del(ht, (zend_ulong)(uintptr_t) child);
 		if (node->children == 2) {
 			zend_generator *other_child;
 			ZEND_HASH_FOREACH_PTR(ht, other_child) {
@@ -537,7 +537,7 @@ static void zend_generator_add_child(zend_generator *generator, zend_generator *
 			node->child.ht = ht;
 		}
 
-		zend_hash_index_add_new_ptr(node->child.ht, (zend_ulong) child, child);
+		zend_hash_index_add_new_ptr(node->child.ht, (zend_ulong)(uintptr_t) child, child);
 	}
 
 	++node->children;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3314,7 +3314,7 @@ static void check_unrecoverable_load_failure(const zend_class_entry *ce) {
 	 * a dependence on the inheritance hierarchy of this specific class. Instead we fall back to
 	 * a fatal error, as would happen if we did not allow exceptions in the first place. */
 	if (CG(unlinked_uses)
-			&& zend_hash_index_del(CG(unlinked_uses), (zend_long)(uintptr_t)ce) == SUCCESS) {
+			&& zend_hash_index_del(CG(unlinked_uses), (zend_ulong)(uintptr_t)ce) == SUCCESS) {
 		zend_exception_uncaught_error(
 			"During inheritance of %s with variance dependencies", ZSTR_VAL(ce->name));
 	}
@@ -3599,7 +3599,7 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 		}
 
 		if (CG(unlinked_uses)) {
-			zend_hash_index_del(CG(unlinked_uses), (zend_long)(uintptr_t) ce);
+			zend_hash_index_del(CG(unlinked_uses), (zend_ulong)(uintptr_t) ce);
 		}
 
 		orig_linking_class = CG(current_linking_class);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -68187,7 +68187,7 @@ static void init_opcode_serialiser(void)
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;
-		zend_hash_index_add(zend_handlers_table, (zend_long)(uintptr_t)zend_opcode_handlers[i], &tmp);
+		zend_hash_index_add(zend_handlers_table, (zend_ulong)(uintptr_t)zend_opcode_handlers[i], &tmp);
 	}
 }
 
@@ -68198,7 +68198,7 @@ ZEND_API void ZEND_FASTCALL zend_serialize_opcode_handler(zend_op *op)
 	if (!zend_handlers_table) {
 		init_opcode_serialiser();
 	}
-	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
+	zv = zend_hash_index_find(zend_handlers_table, (zend_ulong)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
 	op->handler = (const void *)(uintptr_t)Z_LVAL_P(zv);
 }
@@ -68218,7 +68218,7 @@ ZEND_API const void* ZEND_FASTCALL zend_get_opcode_handler_func(const zend_op *o
 	if (!zend_handlers_table) {
 		init_opcode_serialiser();
 	}
-	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
+	zv = zend_hash_index_find(zend_handlers_table, (zend_ulong)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
 	return zend_opcode_handler_funcs[Z_LVAL_P(zv)];
 #else

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -113,7 +113,7 @@ static void init_opcode_serialiser(void)
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {
 		Z_LVAL(tmp) = i;
-		zend_hash_index_add(zend_handlers_table, (zend_long)(uintptr_t)zend_opcode_handlers[i], &tmp);
+		zend_hash_index_add(zend_handlers_table, (zend_ulong)(uintptr_t)zend_opcode_handlers[i], &tmp);
 	}
 }
 
@@ -124,7 +124,7 @@ ZEND_API void ZEND_FASTCALL zend_serialize_opcode_handler(zend_op *op)
 	if (!zend_handlers_table) {
 		init_opcode_serialiser();
 	}
-	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
+	zv = zend_hash_index_find(zend_handlers_table, (zend_ulong)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
 	op->handler = (const void *)(uintptr_t)Z_LVAL_P(zv);
 }
@@ -144,7 +144,7 @@ ZEND_API const void* ZEND_FASTCALL zend_get_opcode_handler_func(const zend_op *o
 	if (!zend_handlers_table) {
 		init_opcode_serialiser();
 	}
-	zv = zend_hash_index_find(zend_handlers_table, (zend_long)(uintptr_t)op->handler);
+	zv = zend_hash_index_find(zend_handlers_table, (zend_ulong)(uintptr_t)op->handler);
 	ZEND_ASSERT(zv != NULL);
 	return zend_opcode_handler_funcs[Z_LVAL_P(zv)];
 #else

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -107,15 +107,15 @@ static void zend_weakref_register(zend_object *object, void *payload) {
 	void *tagged_ptr = Z_PTR_P(zv);
 	if (ZEND_WEAKREF_GET_TAG(tagged_ptr) == ZEND_WEAKREF_TAG_HT) {
 		HashTable *ht = ZEND_WEAKREF_GET_PTR(tagged_ptr);
-		zend_hash_index_add_new_ptr(ht, (zend_ulong) payload, payload);
+		zend_hash_index_add_new_ptr(ht, (zend_ulong)(uintptr_t) payload, payload);
 		return;
 	}
 
 	/* Convert simple pointer to hashtable. */
 	HashTable *ht = emalloc(sizeof(HashTable));
 	zend_hash_init(ht, 0, NULL, NULL, 0);
-	zend_hash_index_add_new_ptr(ht, (zend_ulong) tagged_ptr, tagged_ptr);
-	zend_hash_index_add_new_ptr(ht, (zend_ulong) payload, payload);
+	zend_hash_index_add_new_ptr(ht, (zend_ulong)(uintptr_t) tagged_ptr, tagged_ptr);
+	zend_hash_index_add_new_ptr(ht, (zend_ulong)(uintptr_t) payload, payload);
 	/* Replace the single WeakMap or WeakReference entry in EG(weakrefs) with a HashTable with 2 entries in place. */
 	ZVAL_PTR(zv, ZEND_WEAKREF_ENCODE(ht, ZEND_WEAKREF_TAG_HT));
 }
@@ -144,11 +144,11 @@ static void zend_weakref_unregister(zend_object *object, void *payload, bool wea
 
 	HashTable *ht = ptr;
 #if ZEND_DEBUG
-	void *old_payload = zend_hash_index_find_ptr(ht, (zend_ulong) payload);
+	void *old_payload = zend_hash_index_find_ptr(ht, (zend_ulong)(uintptr_t) payload);
 	ZEND_ASSERT(old_payload && "Weakref not registered?");
 	ZEND_ASSERT(old_payload == payload);
 #endif
-	zend_hash_index_del(ht, (zend_ulong) payload);
+	zend_hash_index_del(ht, (zend_ulong)(uintptr_t) payload);
 	if (zend_hash_num_elements(ht) == 0) {
 		GC_DEL_FLAGS(object, IS_OBJ_WEAKLY_REFERENCED);
 		zend_hash_destroy(ht);

--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -413,7 +413,7 @@ U_CFUNC void umsg_format_helper(MessageFormatter_object *mfo,
 		   int32_t len = u_sprintf(temp, "%u", (uint32_t)num_index);
 		   key.append(temp, len);
 
-		   storedArgType = (Formattable::Type*)zend_hash_index_find_ptr(types, (zend_ulong)num_index);
+		   storedArgType = (Formattable::Type*)zend_hash_index_find_ptr(types, num_index);
 		} else { //string; assumed to be in UTF-8
 			intl_stringFromChar(key, ZSTR_VAL(str_index), ZSTR_LEN(str_index), &err.code);
 

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -278,7 +278,7 @@ static bool soap_check_zval_ref(zval *data, xmlNodePtr node) {
 		if (Z_TYPE_P(data) == IS_OBJECT) {
 			data = (zval*)Z_OBJ_P(data);
 		}
-		if ((node_ptr = zend_hash_index_find_ptr(SOAP_GLOBAL(ref_map), (zend_ulong)data)) != NULL) {
+		if ((node_ptr = zend_hash_index_find_ptr(SOAP_GLOBAL(ref_map), (zend_ulong)(uintptr_t)data)) != NULL) {
 			xmlAttrPtr attr = node_ptr->properties;
 			char *id;
 			smart_str prefix = {0};
@@ -324,7 +324,7 @@ static bool soap_check_zval_ref(zval *data, xmlNodePtr node) {
 			smart_str_free(&prefix);
 			return 1;
 		} else {
-			zend_hash_index_update_ptr(SOAP_GLOBAL(ref_map), (zend_ulong)data, node);
+			zend_hash_index_update_ptr(SOAP_GLOBAL(ref_map), (zend_ulong)(uintptr_t)data, node);
 		}
 	}
 	return 0;
@@ -335,7 +335,7 @@ static bool soap_check_xml_ref(zval *data, xmlNodePtr node)
 	zval *data_ptr;
 
 	if (SOAP_GLOBAL(ref_map)) {
-		if ((data_ptr = zend_hash_index_find(SOAP_GLOBAL(ref_map), (zend_ulong)node)) != NULL) {
+		if ((data_ptr = zend_hash_index_find(SOAP_GLOBAL(ref_map), (zend_ulong)(uintptr_t)node)) != NULL) {
 			if (!Z_REFCOUNTED_P(data) ||
 			    !Z_REFCOUNTED_P(data_ptr) ||
 			    Z_COUNTED_P(data) != Z_COUNTED_P(data_ptr)) {
@@ -351,7 +351,7 @@ static bool soap_check_xml_ref(zval *data, xmlNodePtr node)
 static void soap_add_xml_ref(zval *data, xmlNodePtr node)
 {
 	if (SOAP_GLOBAL(ref_map)) {
-		zend_hash_index_update(SOAP_GLOBAL(ref_map), (zend_ulong)node, data);
+		zend_hash_index_update(SOAP_GLOBAL(ref_map), (zend_ulong)(uintptr_t)node, data);
 	}
 }
 

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -805,7 +805,7 @@ PHPDBG_API void phpdbg_set_breakpoint_opcode(const char *name, size_t name_len) 
 
 PHPDBG_API void phpdbg_set_breakpoint_opline_ex(phpdbg_opline_ptr_t opline) /* {{{ */
 {
-	if (!zend_hash_index_exists(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong) opline)) {
+	if (!zend_hash_index_exists(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong)(uintptr_t) opline)) {
 		phpdbg_breakline_t new_break;
 
 		PHPDBG_G(flags) |= PHPDBG_HAS_OPLINE_BP;
@@ -814,7 +814,7 @@ PHPDBG_API void phpdbg_set_breakpoint_opline_ex(phpdbg_opline_ptr_t opline) /* {
 		new_break.opline = (zend_ulong) opline;
 		new_break.base = NULL;
 
-		zend_hash_index_update_mem(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong) opline, &new_break, sizeof(phpdbg_breakline_t));
+		zend_hash_index_update_mem(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong)(uintptr_t) opline, &new_break, sizeof(phpdbg_breakline_t));
 
 		phpdbg_notice("Breakpoint #%d added at #"ZEND_ULONG_FMT, new_break.id, new_break.opline);
 		PHPDBG_BREAK_MAPPING(new_break.id, &PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
@@ -1002,7 +1002,7 @@ static inline phpdbg_breakbase_t *phpdbg_find_breakpoint_opline(phpdbg_opline_pt
 {
 	phpdbg_breakline_t *brake;
 
-	if ((brake = zend_hash_index_find_ptr(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong) opline)) && brake->base) {
+	if ((brake = zend_hash_index_find_ptr(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong)(uintptr_t) opline)) && brake->base) {
 		return (phpdbg_breakbase_t *)brake->base;
 	}
 

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -591,7 +591,7 @@ int phpdbg_skip_line_helper(void) /* {{{ */ {
 		 || opline->opcode == ZEND_YIELD
 		 || opline->opcode == ZEND_YIELD_FROM
 		) {
-			zend_hash_index_update_ptr(&PHPDBG_G(seek), (zend_ulong) opline, (void *) opline);
+			zend_hash_index_update_ptr(&PHPDBG_G(seek), (zend_ulong)(uintptr_t) opline, (void *) opline);
 		}
 	} while (++opline < op_array->opcodes + op_array->last);
 
@@ -633,7 +633,7 @@ static void phpdbg_seek_to_end(void) /* {{{ */ {
 			case ZEND_GENERATOR_RETURN:
 			case ZEND_YIELD:
 			case ZEND_YIELD_FROM:
-				zend_hash_index_update_ptr(&PHPDBG_G(seek), (zend_ulong) opline, (void *) opline);
+				zend_hash_index_update_ptr(&PHPDBG_G(seek), (zend_ulong)(uintptr_t) opline, (void *) opline);
 		}
 	} while (++opline < op_array->opcodes + op_array->last);
 }
@@ -647,7 +647,7 @@ PHPDBG_COMMAND(finish) /* {{{ */
 	}
 
 	phpdbg_seek_to_end();
-	if (zend_hash_index_exists(&PHPDBG_G(seek), (zend_ulong) phpdbg_user_execute_data(EG(current_execute_data))->opline)) {
+	if (zend_hash_index_exists(&PHPDBG_G(seek), (zend_ulong)(uintptr_t) phpdbg_user_execute_data(EG(current_execute_data))->opline)) {
 		zend_hash_clean(&PHPDBG_G(seek));
 	} else {
 		PHPDBG_G(flags) |= PHPDBG_IN_FINISH;
@@ -664,7 +664,7 @@ PHPDBG_COMMAND(leave) /* {{{ */
 	}
 
 	phpdbg_seek_to_end();
-	if (zend_hash_index_exists(&PHPDBG_G(seek), (zend_ulong) phpdbg_user_execute_data(EG(current_execute_data))->opline)) {
+	if (zend_hash_index_exists(&PHPDBG_G(seek), (zend_ulong)(uintptr_t) phpdbg_user_execute_data(EG(current_execute_data))->opline)) {
 		zend_hash_clean(&PHPDBG_G(seek));
 		phpdbg_notice("Already at the end of the function");
 		return SUCCESS;

--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -301,7 +301,7 @@ int phpdbg_watchpoint_segfault_handler(siginfo_t *info, void *context) {
 	/* re-enable writing */
 	mprotect(page, phpdbg_pagesize, PROT_READ | PROT_WRITE);
 
-	zend_hash_index_add_empty_element(PHPDBG_G(watchlist_mem), (zend_ulong) page);
+	zend_hash_index_add_empty_element(PHPDBG_G(watchlist_mem), (zend_ulong)(uintptr_t) page);
 
 	return SUCCESS;
 }
@@ -317,7 +317,7 @@ void *phpdbg_watchpoint_userfaultfd_thread(void *phpdbg_globals_ptr) {
 	struct uffd_msg fault_msg = {0};
 	while (read(globals->watch_userfaultfd, &fault_msg, sizeof(fault_msg)) == sizeof(fault_msg)) {
 		void *page = phpdbg_get_page_boundary((char *)(uintptr_t) fault_msg.arg.pagefault.address);
-		zend_hash_index_add_empty_element(globals->watchlist_mem, (zend_ulong) page);
+		zend_hash_index_add_empty_element(globals->watchlist_mem, (zend_ulong)(uintptr_t) page);
 		struct uffdio_writeprotect unprotect = {
 			.mode = 0,
 			.range = {
@@ -394,8 +394,8 @@ void phpdbg_watch_backup_data(phpdbg_watchpoint_t *watch) {
 /* watch collisions are responsible for having only one watcher on a given refcounted/refval and having a mapping back to the parent zvals */
 void phpdbg_delete_watch_collision(phpdbg_watchpoint_t *watch) {
 	phpdbg_watch_collision *coll;
-	if ((coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref))) {
-		zend_hash_index_del(&coll->parents, (zend_ulong) watch);
+	if ((coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref))) {
+		zend_hash_index_del(&coll->parents, (zend_ulong)(uintptr_t) watch);
 		if (zend_hash_num_elements(&coll->parents) == 0) {
 			phpdbg_remove_watchpoint_btree(&coll->ref);
 			phpdbg_deactivate_watchpoint(&coll->ref);
@@ -411,7 +411,7 @@ void phpdbg_delete_watch_collision(phpdbg_watchpoint_t *watch) {
 				}
 			}
 
-			zend_hash_index_del(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref);
+			zend_hash_index_del(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref);
 			zend_hash_destroy(&coll->parents);
 			efree(coll);
 		}
@@ -433,7 +433,7 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 
 		watch->ref = Z_COUNTED_P(watch->addr.zv);
 
-		if (!(coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref))) {
+		if (!(coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref))) {
 			coll = emalloc(sizeof(*coll));
 			coll->ref.type = WATCH_ON_REFCOUNTED;
 			phpdbg_set_addr_watchpoint(Z_COUNTED_P(watch->addr.zv), sizeof(uint32_t), &coll->ref);
@@ -462,9 +462,9 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 			}
 
 			zend_hash_init(&coll->parents, 8, NULL, NULL, 0);
-			zend_hash_index_add_ptr(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref, coll);
+			zend_hash_index_add_ptr(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref, coll);
 		}
-		zend_hash_index_add_ptr(&coll->parents, (zend_long) watch, watch);
+		zend_hash_index_add_ptr(&coll->parents, (zend_ulong)(uintptr_t) watch, watch);
 	} else if (Z_TYPE_P(watch->addr.zv) == IS_INDIRECT) {
 		if ((zend_refcounted *) Z_INDIRECT_P(watch->addr.zv) == watch->ref) {
 			return;
@@ -476,7 +476,7 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 
 		watch->ref = (zend_refcounted *) Z_INDIRECT_P(watch->addr.zv);
 
-		if (!(coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref))) {
+		if (!(coll = zend_hash_index_find_ptr(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref))) {
 			coll = emalloc(sizeof(*coll));
 			phpdbg_set_zval_watchpoint(Z_INDIRECT_P(watch->addr.zv), &coll->ref);
 			coll->ref.coll = coll;
@@ -486,9 +486,9 @@ void phpdbg_update_watch_ref(phpdbg_watchpoint_t *watch) {
 			phpdbg_watch_backup_data(&coll->ref);
 
 			zend_hash_init(&coll->parents, 8, NULL, NULL, 0);
-			zend_hash_index_add_ptr(&PHPDBG_G(watch_collisions), (zend_ulong) watch->ref, coll);
+			zend_hash_index_add_ptr(&PHPDBG_G(watch_collisions), (zend_ulong)(uintptr_t) watch->ref, coll);
 		}
-		zend_hash_index_add_ptr(&coll->parents, (zend_long) watch, watch);
+		zend_hash_index_add_ptr(&coll->parents, (zend_ulong)(uintptr_t) watch, watch);
 	} else if (watch->ref) {
 		phpdbg_delete_watch_collision(watch);
 		watch->ref = NULL;
@@ -712,7 +712,7 @@ void phpdbg_queue_element_for_recreation(phpdbg_watch_element *element) {
 
 	if (!element->parent) {
 		/* HERE BE DRAGONS; i.e. we assume HashTable is directly allocated via emalloc() ... (which *should be* the case for every user-accessible array and symbol tables) */
-		zend_hash_index_add_empty_element(&PHPDBG_G(watch_free), (zend_ulong) element->parent_container);
+		zend_hash_index_add_empty_element(&PHPDBG_G(watch_free), (zend_ulong)(uintptr_t) element->parent_container);
 	}
 }
 
@@ -775,7 +775,7 @@ void phpdbg_dequeue_elements_for_recreation(void) {
 
 	ZEND_HASH_MAP_FOREACH_PTR(&PHPDBG_G(watch_recreation), element) {
 		ZEND_ASSERT(element->flags & (PHPDBG_WATCH_IMPLICIT | PHPDBG_WATCH_RECURSIVE_ROOT | PHPDBG_WATCH_SIMPLE));
-		if (element->parent || zend_hash_index_find(&PHPDBG_G(watch_free), (zend_ulong) element->parent_container)) {
+		if (element->parent || zend_hash_index_find(&PHPDBG_G(watch_free), (zend_ulong)(uintptr_t) element->parent_container)) {
 			zval _zv, *zv = &_zv;
 			if (element->parent) {
 				ZEND_ASSERT(element->parent->watch->type == WATCH_ON_ZVAL || element->parent->watch->type == WATCH_ON_BUCKET);
@@ -1233,7 +1233,7 @@ void phpdbg_watch_efree(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) {
 			}
 		}
 
-		zend_hash_index_del(&PHPDBG_G(watch_free), (zend_ulong) ptr);
+		zend_hash_index_del(&PHPDBG_G(watch_free), (zend_ulong)(uintptr_t) ptr);
 	}
 
 	if (PHPDBG_G(original_free_function)) {


### PR DESCRIPTION
`zend_hash_index_*` expects `zend_ulong` for the `h` argument but often this argument got casted to `zend_long` (instead of `zend_ulong`.

Additionally, most of the time, a pointer first got casted to `(uintptr_t)` before `(zend_ulong)` but sometimes a pointer got casted directly. I noticed this during my work of #19079 as it fails if the pointer size and `zend_ulong` differs.