### PR TITLE
Fix GH-19250 (Invalid conftest for rl_pending_input)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,10 @@ PHP                                                                        NEWS
     return value check). (nielsdos, botovq)
   . Fix error return check of EVP_CIPHER_CTX_ctrl(). (nielsdos)
 
+- Readline:
+  . Fixed bug GH-19250 and bug #51360 (Invalid conftest for rl_pending_input).
+    (petk, nielsdos)
+
 - SOAP:
   . Fixed bug GH-18640 (heap-use-after-free ext/soap/php_encoding.c:299:32
     in soap_check_zval_ref). (nielsdos)

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -47,13 +47,6 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
     -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
   ])
 
-  PHP_CHECK_LIBRARY(readline, rl_pending_input,
-  [], [
-    AC_MSG_ERROR([invalid readline installation detected. Try --with-libedit instead.])
-  ], [
-    -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
-  ])
-
   PHP_CHECK_LIBRARY(readline, rl_callback_read_char,
   [
     AC_DEFINE(HAVE_RL_CALLBACK_READ_CHAR, 1, [ ])
@@ -74,6 +67,26 @@ if test "$PHP_READLINE" && test "$PHP_READLINE" != "no"; then
   ],[],[
     -L$READLINE_DIR/$PHP_LIBDIR $PHP_READLINE_LIBS
   ])
+
+  CFLAGS_SAVE=$CFLAGS
+  LDFLAGS_SAVE=$LDFLAGS
+  LIBS_SAVE=$LIBS
+  CFLAGS="$CFLAGS $INCLUDES"
+  LDFLAGS="$LDFLAGS -L$READLINE_DIR/$PHP_LIBDIR"
+  LIBS="$LIBS -lreadline"
+
+  dnl Sanity and minimum version check if readline library has variable
+  dnl rl_pending_input.
+  AC_CHECK_DECL([rl_pending_input],, [AC_MSG_FAILURE([
+      Invalid readline installation detected. Try --with-libedit instead.
+    ])], [
+      #include <stdio.h>
+      #include <readline/readline.h>
+    ])
+
+  CFLAGS=$CFLAGS_SAVE
+  LDFLAGS=$LDFLAGS_SAVE
+  LIBS=$LIBS_SAVE
 
   AC_DEFINE(HAVE_HISTORY_LIST, 1, [ ])
   AC_DEFINE(HAVE_LIBREADLINE, 1, [ ])


### PR DESCRIPTION
The 'rl_pending_input' is a variable in Readline library and checking it with PHP_CHECK_LIBRARY wouldn't find it on some systems.

Library check works on most systems but not on the mentioned AIX in the bug as it exports variables and functions differently whereas the linker couldn't resolve the variable as a function.

This should fix the build on systems where this caused issues, such as AIX.

The <readline/readline.h> is not self-contained header and needs to also have <stdio.h> included before to have FILE type available. This fixes the issue on unpatched default readline installations, such as macOS.

Checking this variable ensures that the found library is the correct library and also that it is of minimum version needed by current PHP code (https://bugs.php.net/48608).

The library check:

```c
| char rl_pending_input ();
| int main (void) {
|     return rl_pending_input ();
| }
```

The declaration check:

```c
| #include <stdio.h>
| #include <readline/readline.h>
| int main (void) {
| #ifndef rl_pending_input
| #ifdef __cplusplus
|     (void) rl_pending_input;
| #else
|     (void) rl_pending_input;
| #endif
| #endif
| ;
|     return 0;
| }
```

Closes https://bugs.php.net/51558