### PR TITLE
gen_stub: Update PHP-Parser to 5.6.0

### DIFF
--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -8,7 +8,7 @@ class stdClass
 }
 
 /** @refcount 1 */
-function _clone(object $object, array $withProperties = []): object {}
+function clone(object $object, array $withProperties = []): object {}
 
 function exit(string|int $status = 0): never {}
 

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0be87bb6b55e100c022e70aa6f3b17001725784f */
+ * Stub hash: 9b49f527064695c812cd204d9efc63c13681d942 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_clone, 0, 1, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -959,9 +959,6 @@ class FunctionName implements FunctionOrMethodName {
     private /* readonly */ Name $name;
 
     public function __construct(Name $name) {
-        if ($name->name === '_clone') {
-            $name = new Name('clone', $name->getAttributes());
-        }
         $this->name = $name;
     }
 
@@ -6059,7 +6056,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "5.5.0";
+    $version = "5.6.0";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);


### PR DESCRIPTION
Includes support for declaring functions named `clone`, so update the stub file here `clone` is declared to remove the `_clone` workaround.