### PR TITLE
Add a 1-char fastpath to `implode()`

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1026,7 +1026,11 @@ PHPAPI void php_implode(const zend_string *glue, HashTable *pieces, zval *return
 		}
 
 		cptr -= ZSTR_LEN(glue);
-		memcpy(cptr, ZSTR_VAL(glue), ZSTR_LEN(glue));
+		if (ZSTR_LEN(glue) == 1) {
+			*cptr = ZSTR_VAL(glue)[0];
+		} else {
+			memcpy(cptr, ZSTR_VAL(glue), ZSTR_LEN(glue));
+		}
 	}
 
 	free_alloca(strings, use_heap);


### PR DESCRIPTION
I think it's worth adding a 1 char fast path for `implode()`. A quick search on Github reveals the following stats:

- Implode usage with one char glue: `/implode\(\s*["'][^"']{1}["']\s*,\s*/ language:PHP` reveals 1.4 million occurrences
- Implode usage with 2+ char glue: `/implode\(\s*["'][^"']{2,}["']\s*,\s*/ language:PHP` reveals 1.1 million occurrences

Here is the benchmark code:

<details>
<summary>Benchmark code</summary>

```php
<?php

function run_implode_benchmark_round($round) {
    echo "=== Round $round ===\n";
    
    $iterations = 100000;
    
    $test_cases = [
        'small_comma' => [array_fill(0, 10, 'test'), ',', $iterations],
        'medium_comma' => [array_fill(0, 100, 'item'), ',', $iterations],
        'large_comma' => [array_fill(0, 1000, 'data'), ',', $iterations / 10],
        'xlarge_comma' => [array_fill(0, 10000, 'item'), ',', $iterations / 100],
        'small_multi' => [array_fill(0, 10, 'test'), ' -> ', $iterations],
        'medium_multi' => [array_fill(0, 100, 'item'), ' => ', $iterations],
        'large_multi' => [array_fill(0, 1000, 'data'), ' === ', $iterations / 10],
        'xlarge_multi' => [array_fill(0, 10000, 'item'), ' -> ', $iterations / 100],
    ];
    
    $results = [];
    
    foreach ($test_cases as $name => [$array, $glue, $iter]) {
        $start = hrtime(true);
        for ($i = 0; $i < $iter; $i++) {
            implode($glue, $array);
        }
        $end = hrtime(true);
        
        $nanoseconds = $end - $start;
        $milliseconds = $nanoseconds / 1e6;
        
        $results[$name] = $milliseconds;
        
        echo sprintf("%-15s: %8.2f ms\n", $name, $milliseconds);
    }
    
    echo "\n";
    return $results;
}

function calculate_implode_stats($all_results) {
    $test_names = array_keys($all_results[0]);
    
    foreach ($test_names as $test) {
        $times = [];
        foreach ($all_results as $round_results) {
            $times[] = $round_results[$test];
        }
        
        $avg = array_sum($times) / count($times);
        $min = min($times);
        $max = max($times);

        echo sprintf("%-15s: avg=%7.2f ms  min=%7.2f ms  max=%7.2f ms\n",
            $test, $avg, $min, $max);
    }
}

$all_results = [];
for ($round = 1; $round <= 5; $round++) {
    $all_results[] = run_implode_benchmark_round($round);
}

calculate_implode_stats($all_results);
```
</details>

```
Master
======

small_comma    : avg=   6.86 ms  min=   4.96 ms  max=  12.85 ms
medium_comma   : avg=  39.36 ms  min=  35.80 ms  max=  50.58 ms
large_comma    : avg=  36.09 ms  min=  34.84 ms  max=  37.03 ms
xlarge_comma   : avg=  35.58 ms  min=  34.70 ms  max=  37.17 ms
small_multi    : avg=   6.06 ms  min=   5.70 ms  max=   6.77 ms
medium_multi   : avg=  42.97 ms  min=  42.22 ms  max=  44.19 ms
large_multi    : avg=  44.99 ms  min=  44.25 ms  max=  46.07 ms
xlarge_multi   : avg=  42.90 ms  min=  42.03 ms  max=  44.20 ms

Branch
======

small_comma    : avg=   5.29 ms  min=   3.96 ms  max=  10.38 ms
medium_comma   : avg=  28.99 ms  min=  25.84 ms  max=  40.40 ms
large_comma    : avg=  26.38 ms  min=  25.45 ms  max=  28.98 ms
xlarge_comma   : avg=  25.57 ms  min=  25.18 ms  max=  25.78 ms
small_multi    : avg=   5.77 ms  min=   5.62 ms  max=   5.93 ms
medium_multi   : avg=  41.83 ms  min=  41.60 ms  max=  42.51 ms
large_multi    : avg=  46.73 ms  min=  43.49 ms  max=  50.49 ms
xlarge_multi   : avg=  41.27 ms  min=  41.10 ms  max=  41.72 ms
```

No change for multi char glue, but a nice improved performance for single char glue especially one big arrays.