### PR TITLE
Fix error recording with file cache only

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1964,6 +1964,9 @@ static zend_op_array *file_cache_compile_file(zend_file_handle *file_handle, int
 		return zend_accel_load_script(persistent_script, from_memory);
 	}
 
+	zend_emit_recorded_errors();
+	zend_free_recorded_errors();
+
 	return op_array;
 }
 


### PR DESCRIPTION
Introduced by GH-18541.

This path is hit when compilation fails with a compile error, rather than bailout. If a non-fatal error is recorded, it will not be emitted nor freed. Handle accordingly.

See https://github.com/php/php-src/actions/runs/16557975646/job/46822407223.