### PR TITLE
standard: Deprecate `socket_set_timeout()`

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3587,6 +3587,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): bool 
  * @param resource $stream
  * @alias stream_set_timeout
  */
+#[\Deprecated(since: '8.5', message: "use stream_set_timeout() instead")]
 function socket_set_timeout($stream, int $seconds, int $microseconds = 0): bool {}
 #endif
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dcc4e6865dac52b23534b6ef61c0d6be766af6b9 */
+ * Stub hash: deb4ea96dd130d8a0174678095c30a61e118bd60 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -3431,7 +3431,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(stream_set_chunk_size, arginfo_stream_set_chunk_size)
 #if (defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32))
 	ZEND_FE(stream_set_timeout, arginfo_stream_set_timeout)
-	ZEND_RAW_FENTRY("socket_set_timeout", zif_stream_set_timeout, arginfo_socket_set_timeout, 0, NULL, NULL)
+	ZEND_RAW_FENTRY("socket_set_timeout", zif_stream_set_timeout, arginfo_socket_set_timeout, ZEND_ACC_DEPRECATED, NULL, NULL)
 #endif
 	ZEND_RAW_FENTRY("gettype", zif_gettype, arginfo_gettype, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("get_debug_type", zif_get_debug_type, arginfo_get_debug_type, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
@@ -3922,6 +3922,15 @@ static void register_basic_functions_symbols(int module_number)
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_verify", sizeof("password_verify") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#if (defined(HAVE_SYS_TIME_H) || defined(PHP_WIN32))
+
+	zend_attribute *attribute_Deprecated_func_socket_set_timeout_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "socket_set_timeout", sizeof("socket_set_timeout") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	ZVAL_STR(&attribute_Deprecated_func_socket_set_timeout_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_5));
+	attribute_Deprecated_func_socket_set_timeout_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_socket_set_timeout_0_arg1_str = zend_string_init("use stream_set_timeout() instead", strlen("use stream_set_timeout() instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_socket_set_timeout_0->args[1].value, attribute_Deprecated_func_socket_set_timeout_0_arg1_str);
+	attribute_Deprecated_func_socket_set_timeout_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+#endif
 
 	zend_attribute *attribute_Deprecated_const_ASSERT_ACTIVE_0 = zend_add_global_constant_attribute(const_ASSERT_ACTIVE, ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
 	ZVAL_STR(&attribute_Deprecated_const_ASSERT_ACTIVE_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_3));

--- a/ext/standard/tests/file/fread_socket_variation1.phpt
+++ b/ext/standard/tests/file/fread_socket_variation1.phpt
@@ -12,7 +12,7 @@ for ($i=0; $i<100; $i++) {
   }
 }
 
-socket_set_timeout($server, 0, 1000);
+stream_set_timeout($server, 0, 1000);
 
 var_dump(fread($server, 1));
 

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
@@ -18,7 +18,7 @@ $socket = stream_socket_accept($server);
 var_dump(stream_get_meta_data($client));
 
 echo "\n\nSet a timeout on the client and attempt a read:\n";
-socket_set_timeout($client, 0, 1000);
+stream_set_timeout($client, 0, 1000);
 fread($client, 1);
 var_dump(stream_get_meta_data($client));
 


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_socket_set_timeout