### PR TITLE
Update m4 check for libpcre2 version

### DIFF
--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -14,7 +14,7 @@ PHP_ARG_WITH([pcre-jit],,
 
 if test "$PHP_EXTERNAL_PCRE" != "no"; then
 
-  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
+  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.42])
 
   PHP_EVAL_INCLINE($PCRE2_CFLAGS)
   PHP_EVAL_LIBLINE($PCRE2_LIBS)


### PR DESCRIPTION
The pcre extension automake configuration only requires libpcre2 10.30. PHP 8.2 requires 10.42 else on startup one would encounter:

  Warning: PHP Startup: ^(text/|application/xhtml\+xml) (offset=0): unrecognised
  compile-time option bit(s) in Unknown on line 0

Most people use the bundled libpcre2. When one uses a dynamically linked version of libpcre2, the pcre extension has an outdated version requirement:

  ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])

That was introduced by a5bc5aed71f7a15f14f33bb31b8e17bf5f327e2d (released with php 7.30) which came with libpcre2 10.30.

If one backports php 8.3 to an older version of Debian (Bullseye has 10.36), the compilation configuration checks pass but the PHP startup warning will appear.

The bundled version of libpcre2 has been updated several time and the version check was never kept in sync:

| PHP   | libpcre2 | commit
|-------|----------|-------
| 7.3.0 | 10.30    | a5bc5aed71f7a15f14f33bb31b8e17bf5f327e2d
| 7.3.0 | 10.31    | 703e0370905bc432aa26d71803b3081851e99230
| 7.4.0 | 10.32    | d918e0776b5168aed2707b0ca500589844f0faa8
| 7.4.0 | 10.33    | aa9433e9286801a6af6d4cee73d9a165a61e0e3b
| 8.0.0 | 10.34    | 52d07834df3ebd3720fd4f7d0a6eb11c52d33fb1
| 8.0.0 | 10.35    | b419f96c626d1f9cbbba42698e947e32a0af9c4f
| 8.1.0 | 10.37    | 5d4290088e7ce12a6919ee87899412c33f893695
| 8.1.1 | 10.39    | 6008a75f393ddc9a170fc1e6a9ec8a1556ea12cf
| 8.2.0 | 10.40    | 32cceb75bf5e42bebbf4d12bab4369924f1d6885
| 8.3.0 | 10.42    | c4e8f652c571ff60224807a3700951997e0abe8d
| 8.4.0 | 10.43    | ae5beff61b3bf4fd91b9aa1a6f33f434ec99f584
| 8.4.0 | 10.44    | d1f14a46095571b1b6363fa7f83c6a681d1d02de
| 8.5.x | 10.45    | e92848789acd8aa5cf32fedb519ba9378ac64e02

The requirement did not:
```
$ git grep libpcre {PHP-{7.4,8.0,8.1,8.2,8.3,8.4},master} ext/pcre/config0.m4
PHP-7.4:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
PHP-8.0:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
PHP-8.1:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
PHP-8.2:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
PHP-8.3:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
PHP-8.4:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
master:ext/pcre/config0.m4:  PKG_CHECK_MODULES([PCRE2], [libpcre2-8 >= 10.30])
```

Update the m4 macro libpre2-8 requirement from 1.30 to 10.42.

References:
* https://phabricator.wikimedia.org/T398245#11010808
* https://phabricator.wikimedia.org/T400693