### PR TITLE
Fix failed assertion with throwing __toString in binary const expr

### DIFF
--- a/Zend/tests/oss_fuzz_434346548.phpt
+++ b/Zend/tests/oss_fuzz_434346548.phpt
@@ -1,0 +1,22 @@
+--TEST--
+OSS-Fuzz #434346548: Failed assertion with throwing __toString in binary const expr
+--FILE--
+<?php
+
+class Foo {
+    function __toString() {}
+}
+
+function test($y = new Foo() < "") {
+    var_dump();
+}
+
+try {
+    test();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Foo::__toString(): Return value must be of type string, none returned

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -548,9 +548,10 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 				ret = FAILURE;
 			} else {
 				binary_op_type op = get_binary_op(ast->attr);
-				ret = op(result, &op1, &op2);
+				op(result, &op1, &op2);
 				zval_ptr_dtor_nogc(&op1);
 				zval_ptr_dtor_nogc(&op2);
+				ret = EG(exception) ? FAILURE : SUCCESS;
 			}
 			break;
 		case ZEND_AST_GREATER:


### PR DESCRIPTION
Solve this with the same pattern as ZEND_AST_GREATER[_EQUAL].

Fixes oss-fuzz #434346548