### PR TITLE
ext/standard/tests/file/bug81145.phpt: unlink file before exit

### DIFF
--- a/ext/standard/tests/file/bug81145.phpt
+++ b/ext/standard/tests/file/bug81145.phpt
@@ -9,8 +9,8 @@ if (PHP_OS_FAMILY !== "Windows") {
     $src = __DIR__ . "/bug81145_src.bin";
     define('SIZE_4G', 0x100000000);
     exec("fallocate -l " . (SIZE_4G-0x100) . " " . escapeshellarg($src), $output, $status);
-    if ($status !== 0) die("skip fallocate() not supported");
     @unlink(__DIR__ . "/bug81145_src.bin");
+    if ($status !== 0) die("skip fallocate() not supported");
 }
 ?>
 --CONFLICTS--


### PR DESCRIPTION
If the test is skipped, the `--SKIPIF--` section exits (via `die()`) without removing the "bug81145_src.bin" file that gets created, and because the test was skipped the `--CLEAN--` section is not run, leaving the .bin file behind.

Adjust the `--SKIPIF--` section to remove the .bin file before exiting.