### PR TITLE
Fix #19307: PGO builds of shared ext-intl are broken

### DIFF
--- a/ext/intl/idn/idn.cpp
+++ b/ext/intl/idn/idn.cpp
@@ -20,8 +20,9 @@
 #include <config.h>
 #endif
 
-#include <php.h>
-
+extern "C" {
+#include "../php_intl.h"
+}
 #include <unicode/uidna.h>
 #include <unicode/ustring.h>
 


### PR DESCRIPTION
We resolve the name mangling issue by including the right header file inside an `extern "C"` declaration.