### PR TITLE
Fix incorrect anonymous class type name assertion

### DIFF
--- a/Zend/tests/gh19304.phpt
+++ b/Zend/tests/gh19304.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-19304: Incorrect anonymous class type name assertion
+--FILE--
+<?php
+
+$foo = new class {
+    public self $v;
+};
+
+try {
+    $foo->v = 0;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Cannot assign int to property class@anonymous::$v of type class@anonymous

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1393,7 +1393,6 @@ static zend_string *resolve_class_name(zend_string *name, zend_class_entry *scop
 	 * null byte here, to avoid larger parts of the type being omitted by printing code later. */
 	size_t len = strlen(ZSTR_VAL(name));
 	if (len != ZSTR_LEN(name)) {
-		ZEND_ASSERT(scope && "This should only happen with resolved types");
 		return zend_string_init(ZSTR_VAL(name), len, 0);
 	}
 	return zend_string_copy(name);


### PR DESCRIPTION
Since GH-17755 self and parent are compile-time resolved. We may now also encounter this type error at runtime outside of the class itself.

Fixes GH-19304