### PR TITLE
Fix stale nInternalPosition on rehashing

### DIFF
--- a/Zend/tests/gh19280.phpt
+++ b/Zend/tests/gh19280.phpt
@@ -1,0 +1,81 @@
+--TEST--
+GH-19280: Stale nInternalPosition on rehashing
+--FILE--
+<?php
+
+function rehash_packed() {
+    $a = range(0, 63);
+    for ($i = 0; $i <= 47; $i++) {
+        next($a);
+    }
+    for ($i = 16; $i < 62; $i++) {
+        unset($a[$i]);
+    }
+    var_dump(key($a));
+    $a[64] = 64;
+    var_dump(key($a));
+}
+
+function rehash_packed_iterated() {
+    $a = range(0, 63);
+    for ($i = 0; $i <= 47; $i++) {
+        next($a);
+    }
+    for ($i = 16; $i < 62; $i++) {
+        unset($a[$i]);
+    }
+    var_dump(key($a));
+    foreach ($a as &$_) {
+        $a[64] = 64;
+        break;
+    }
+    var_dump(key($a));
+}
+
+function rehash_string() {
+    $a = [];
+    for ($i = 0; $i < 64; $i++) {
+        $a[md5($i)] = $i;
+    }
+    for ($i = 0; $i <= 47; $i++) {
+        next($a);
+    }
+    for ($i = 16; $i < 62; $i++) {
+        unset($a[md5($i)]);
+    }
+    var_dump(key($a));
+    $a[md5(64)] = 64;
+    var_dump(key($a));
+}
+
+function rehash_int() {
+    $a = [];
+    for ($i = 63; $i >= 0; $i--) {
+        $a[$i] = $i;
+    }
+    for ($i = 0; $i <= 47; $i++) {
+        next($a);
+    }
+    for ($i = 48; $i >= 2; $i--) {
+        unset($a[$i]);
+    }
+    var_dump(key($a));
+    $a[64] = 64;
+    var_dump(key($a));
+}
+
+rehash_packed();
+rehash_packed_iterated();
+rehash_string();
+rehash_int();
+
+?>
+--EXPECT--
+int(62)
+int(62)
+int(62)
+int(62)
+string(32) "44f683a84163b3523afe57c2e008bc8c"
+string(32) "44f683a84163b3523afe57c2e008bc8c"
+int(1)
+int(1)

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1379,7 +1379,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 							q->key = p->key;
 							Z_NEXT(q->val) = HT_HASH(ht, nIndex);
 							HT_HASH(ht, nIndex) = HT_IDX_TO_HASH(j);
-							if (UNEXPECTED(ht->nInternalPointer == i)) {
+							if (UNEXPECTED(ht->nInternalPointer > j && ht->nInternalPointer <= i)) {
 								ht->nInternalPointer = j;
 							}
 							q++;
@@ -1398,7 +1398,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht)
 							q->key = p->key;
 							Z_NEXT(q->val) = HT_HASH(ht, nIndex);
 							HT_HASH(ht, nIndex) = HT_IDX_TO_HASH(j);
-							if (UNEXPECTED(ht->nInternalPointer == i)) {
+							if (UNEXPECTED(ht->nInternalPointer > j && ht->nInternalPointer <= i)) {
 								ht->nInternalPointer = j;
 							}
 							if (UNEXPECTED(i >= iter_pos)) {


### PR DESCRIPTION
Since GH-13188 we're no longer immediately updating iterator positions when deleting array elements. zend_hash_rehash() needs to adapt accordingly by adjusting nInternalPosition for IS_UNDEF elements. This is already the case for array iterators.

Fixes GH-19280