### PR TITLE
ensure no blacklist configured in test

### DIFF
--- a/ext/opcache/tests/zzz_basic_logging.phpt
+++ b/ext/opcache/tests/zzz_basic_logging.phpt
@@ -13,6 +13,7 @@ opcache.log_verbosity_level=4
 opcache.huge_code_pages=0
 opcache.preload=
 opcache.interned_strings_buffer=8
+opcache.blacklist_filename=
 --EXTENSIONS--
 opcache
 --SKIPIF--


### PR DESCRIPTION
When running build with previous version installed and configured

```
TEST FAILURE: ../ext/opcache/tests/zzz_basic_logging.diff --
001+ Thu Jul 31 06:45:26 2025 (266802): Debug Loading blacklist file:  '/etc/opt/remi/php85/php.d/opcache-default.blacklist'
     %s Message Cached script '%sbasic_logging%s'
     Foo Bar
     %s Debug Restart Scheduled! Reason: user

```