### PR TITLE
Expose os, compiler, arch in `php -v`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1412,16 +1412,6 @@ AC_ARG_VAR([PHP_UNAME],
 AS_VAR_IF([PHP_UNAME],, [PHP_UNAME=$(uname -a | xargs)])
 AC_DEFINE_UNQUOTED([PHP_UNAME], ["$PHP_UNAME"], [The 'uname -a' output.])
 
-AC_ARG_VAR([PHP_UNAME_S],
-  [Operating system name (defaults to the 'uname -s' output)])
-AS_VAR_IF([PHP_UNAME_S],, [PHP_UNAME_S=$(uname -s | xargs)])
-AC_DEFINE_UNQUOTED([PHP_UNAME_S], ["$PHP_UNAME_S"], [The 'uname -s' output.])
-
-AC_ARG_VAR([PHP_UNAME_R],
-  [Operating system version (defaults to the 'uname -r' output)])
-AS_VAR_IF([PHP_UNAME_R],, [PHP_UNAME_R=$(uname -r | xargs)])
-AC_DEFINE_UNQUOTED([PHP_UNAME_R], ["$PHP_UNAME_R"], [The 'uname -r' output.])
-
 PHP_OS=$(uname | xargs)
 AC_DEFINE_UNQUOTED([PHP_OS], ["$PHP_OS"], [The 'uname' output.])
 
@@ -1446,6 +1436,11 @@ AC_ARG_VAR([PHP_BUILD_ARCH], [The build architecture])
 AS_VAR_IF([PHP_BUILD_ARCH],,,
   [AC_DEFINE_UNQUOTED([PHP_BUILD_ARCH], ["$PHP_BUILD_ARCH"],
     [The build architecture.])])
+
+AC_ARG_VAR([PHP_BUILD_OS], [The build OS])
+AS_VAR_IF([PHP_BUILD_OS],,,
+  [AC_DEFINE_UNQUOTED([PHP_BUILD_OS], ["$PHP_BUILD_OS"],
+    [The build OS.])])
 
 PHP_SUBST([PHP_FASTCGI_OBJS])
 PHP_SUBST([PHP_SAPI_OBJS])

--- a/configure.ac
+++ b/configure.ac
@@ -1412,6 +1412,16 @@ AC_ARG_VAR([PHP_UNAME],
 AS_VAR_IF([PHP_UNAME],, [PHP_UNAME=$(uname -a | xargs)])
 AC_DEFINE_UNQUOTED([PHP_UNAME], ["$PHP_UNAME"], [The 'uname -a' output.])
 
+AC_ARG_VAR([PHP_UNAME_S],
+  [Operating system name (defaults to the 'uname -s' output)])
+AS_VAR_IF([PHP_UNAME_S],, [PHP_UNAME_S=$(uname -s | xargs)])
+AC_DEFINE_UNQUOTED([PHP_UNAME_S], ["$PHP_UNAME_S"], [The 'uname -s' output.])
+
+AC_ARG_VAR([PHP_UNAME_R],
+  [Operating system version (defaults to the 'uname -r' output)])
+AS_VAR_IF([PHP_UNAME_R],, [PHP_UNAME_R=$(uname -r | xargs)])
+AC_DEFINE_UNQUOTED([PHP_UNAME_R], ["$PHP_UNAME_R"], [The 'uname -r' output.])
+
 PHP_OS=$(uname | xargs)
 AC_DEFINE_UNQUOTED([PHP_OS], ["$PHP_OS"], [The 'uname' output.])
 

--- a/main/main.c
+++ b/main/main.c
@@ -121,26 +121,36 @@ ZEND_ATTRIBUTE_CONST PHPAPI const char *php_build_provider(void)
 
 PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 {
+	zend_string *os = php_get_uname('s');
+	zend_string *os_version = php_get_uname('r');
+
 	smart_string version_info = {0};
 	smart_string_append_printf(&version_info,
-		"PHP %s (%s) (built: %s) (%s)\n",
+		"PHP %s (%s) (built: %s) (%s) (%s %s%s)\n",
 		PHP_VERSION, sapi_module->name, php_build_date,
 #ifdef ZTS
 		"ZTS"
 #else
 		"NTS"
 #endif
-#ifdef PHP_BUILD_COMPILER
-		" " PHP_BUILD_COMPILER
-#endif
-#ifdef PHP_BUILD_ARCH
-		" " PHP_BUILD_ARCH
-#endif
 #if ZEND_DEBUG
 		" DEBUG"
 #endif
 #ifdef HAVE_GCOV
 		" GCOV"
+#endif
+#ifdef PHP_BUILD_ARCH
+		" " PHP_BUILD_ARCH
+#else
+		" Unknown arch"
+#endif
+		,
+		ZSTR_VAL(os),
+		ZSTR_VAL(os_version),
+#ifdef PHP_BUILD_COMPILER
+		" " PHP_BUILD_COMPILER
+#else
+		" Unknown compiler"
 #endif
 	);
 	smart_string_appends(&version_info, "Copyright (c) The PHP Group\n");
@@ -149,6 +159,9 @@ PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 	}
 	smart_string_appends(&version_info, get_zend_version());
 	smart_string_0(&version_info);
+
+	zend_string_free(os);
+	zend_string_free(os_version);
 
 	return version_info.c;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -121,12 +121,9 @@ ZEND_ATTRIBUTE_CONST PHPAPI const char *php_build_provider(void)
 
 PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 {
-	zend_string *os = php_get_uname('s');
-	zend_string *os_version = php_get_uname('r');
-
 	smart_string version_info = {0};
 	smart_string_append_printf(&version_info,
-		"PHP %s (%s) (built: %s) (%s) (%s %s%s)\n",
+		"PHP %s (%s) (built: %s) (%s)\n",
 		PHP_VERSION, sapi_module->name, php_build_date,
 #ifdef ZTS
 		"ZTS"
@@ -144,24 +141,22 @@ PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 #else
 		" Unknown arch"
 #endif
-		,
-		ZSTR_VAL(os),
-		ZSTR_VAL(os_version),
-#ifdef PHP_BUILD_COMPILER
-		" " PHP_BUILD_COMPILER
-#else
-		" Unknown compiler"
-#endif
 	);
 	smart_string_appends(&version_info, "Copyright (c) The PHP Group\n");
-	if (php_build_provider()) {
-		smart_string_append_printf(&version_info, "Built by %s\n", php_build_provider());
-	}
+	smart_string_append_printf(&version_info, "Built %s\n",
+#ifdef PHP_BUILD_PROVIDER
+		"by " PHP_BUILD_PROVIDER
+#else
+		"on " PHP_UNAME_S " " PHP_UNAME_R
+#endif
+#ifdef PHP_BUILD_COMPILER
+		" (" PHP_BUILD_COMPILER ")"
+#else
+		""
+#endif
+	);
 	smart_string_appends(&version_info, get_zend_version());
 	smart_string_0(&version_info);
-
-	zend_string_free(os);
-	zend_string_free(os_version);
 
 	return version_info.c;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -138,23 +138,18 @@ PHPAPI char *php_get_version(sapi_module_struct *sapi_module)
 #endif
 #ifdef PHP_BUILD_ARCH
 		" " PHP_BUILD_ARCH
-#else
-		" Unknown arch"
+#endif
+#ifdef PHP_BUILD_OS
+		" " PHP_BUILD_OS
+#endif
+#ifdef PHP_BUILD_COMPILER
+		" " PHP_BUILD_COMPILER
 #endif
 	);
 	smart_string_appends(&version_info, "Copyright (c) The PHP Group\n");
-	smart_string_append_printf(&version_info, "Built %s\n",
-#ifdef PHP_BUILD_PROVIDER
-		"by " PHP_BUILD_PROVIDER
-#else
-		"on " PHP_UNAME_S " " PHP_UNAME_R
-#endif
-#ifdef PHP_BUILD_COMPILER
-		" (" PHP_BUILD_COMPILER ")"
-#else
-		""
-#endif
-	);
+	if (php_build_provider()) {
+		smart_string_append_printf(&version_info, "Built by %s\n", php_build_provider());
+	}
 	smart_string_appends(&version_info, get_zend_version());
 	smart_string_0(&version_info);
 

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -89,6 +89,26 @@ PHPAPI bool php_tsrm_startup(void);
 #define PHP_OS_STR PHP_OS
 #endif
 
+#ifndef PHP_BUILD_COMPILER
+# if defined(__clang__)
+/* __VERSION__ contains the compiler name */
+#  define PHP_BUILD_COMPILER __VERSION__
+# elif defined(__GNUC__)
+/* __VERSION__ does not contain the compiler name */
+#  define PHP_BUILD_COMPILER "GCC " __VERSION__
+# endif
+#endif
+
+#ifndef PHP_BUILD_ARCH
+# if defined(__x86_64__)
+#  define PHP_BUILD_ARCH "x86_64"
+# elif defined(__i386__)
+#  define PHP_BUILD_ARCH "x86"
+# elif defined(__aarch64__)
+#  define PHP_BUILD_ARCH "aarch64"
+# endif
+#endif
+
 END_EXTERN_C()
 
 #endif

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -110,6 +110,24 @@ PHPAPI bool php_tsrm_startup(void);
 # endif
 #endif
 
+#ifndef PHP_BUILD_OS
+# if defined(PHP_WIN32)
+#  define PHP_BUILD_OS "WINNT"
+# elif defined(__APPLE__)
+#  define PHP_BUILD_OS "Darwin"
+# elif defined(__linux__)
+#  define PHP_BUILD_OS "Linux"
+# elif defined(__FreeBSD__)
+#  define PHP_BUILD_OS "FreeBSD"
+# elif defined(__NetBSD__)
+#  define PHP_BUILD_OS "NetBSD"
+# elif defined(__OpenBSD__)
+#  define PHP_BUILD_OS "OpenBSD"
+#elif defined(__sun__)
+#  define PHP_BUILD_OS "Solaris"
+# endif
+#endif
+
 END_EXTERN_C()
 
 #endif

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -89,13 +89,14 @@ PHPAPI bool php_tsrm_startup(void);
 #define PHP_OS_STR PHP_OS
 #endif
 
+#define _PHP_STRINGIFY(s) #s
+#define PHP_STRINGIFY(s) _PHP_STRINGIFY(s)
+
 #ifndef PHP_BUILD_COMPILER
 # if defined(__clang__)
-/* __VERSION__ contains the compiler name */
-#  define PHP_BUILD_COMPILER __VERSION__
+#  define PHP_BUILD_COMPILER "Clang " PHP_STRINGIFY(__clang_major__)
 # elif defined(__GNUC__)
-/* __VERSION__ does not contain the compiler name */
-#  define PHP_BUILD_COMPILER "GCC " __VERSION__
+#  define PHP_BUILD_COMPILER "GCC " PHP_STRINGIFY(__GNUC__)
 # endif
 #endif
 

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -101,7 +101,7 @@ PHPAPI bool php_tsrm_startup(void);
 
 #ifndef PHP_BUILD_ARCH
 # if defined(__x86_64__)
-#  define PHP_BUILD_ARCH "x86_64"
+#  define PHP_BUILD_ARCH "x64"
 # elif defined(__i386__)
 #  define PHP_BUILD_ARCH "x86"
 # elif defined(__aarch64__)

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -133,6 +133,8 @@ extension_module_ptrs = "";
 	var oss = wmiservice.ExecQuery("Select * from Win32_OperatingSystem");
 	var os = oss.ItemIndex(0);
 	AC_DEFINE("PHP_BUILD_SYSTEM", os.Caption + " [" + os.Version + "]", "The system that PHP was built on.");
+	AC_DEFINE("PHP_UNAME_S", os.Caption, "The system name that PHP was built on.");
+	AC_DEFINE("PHP_UNAME_R", os.Version, "The system version that PHP was built on.");
 	var build_provider = WshShell.Environment("Process").Item("PHP_BUILD_PROVIDER");
 	if (build_provider) {
 		AC_DEFINE("PHP_BUILD_PROVIDER", build_provider, "The PHP build provider information.");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -133,8 +133,6 @@ extension_module_ptrs = "";
 	var oss = wmiservice.ExecQuery("Select * from Win32_OperatingSystem");
 	var os = oss.ItemIndex(0);
 	AC_DEFINE("PHP_BUILD_SYSTEM", os.Caption + " [" + os.Version + "]", "The system that PHP was built on.");
-	AC_DEFINE("PHP_UNAME_S", os.Caption, "The system name that PHP was built on.");
-	AC_DEFINE("PHP_UNAME_R", os.Version, "The system version that PHP was built on.");
 	var build_provider = WshShell.Environment("Process").Item("PHP_BUILD_PROVIDER");
 	if (build_provider) {
 		AC_DEFINE("PHP_BUILD_PROVIDER", build_provider, "The PHP build provider information.");


### PR DESCRIPTION
See https://github.com/php/php-src/issues/19256

The bug system requires the output of `php -v` when reporting bugs. Exposing more information in `php -v` can be useful.

`PHP_BUILD_COMPILER` and `PHP_BUILD_ARCH` are always defined in Windows build, or when defined in the environment during the build (https://github.com/php/php-src/pull/5834). In other cases I determine these from compiler macros.

Output examples: https://github.com/php/php-src/pull/19328#issuecomment-3150510431

<details>
  <summary>Outdated examples</summary>

```
PHP 8.5.0-dev (cli) (built: Jul 31 2025 11:18:32) (NTS DEBUG x86_64) (Linux 6.15.8-200.fc42.x86_64 Clang 20.1.8 (Fedora 20.1.8-1.fc42))
Copyright (c) The PHP Group
Zend Engine v4.5.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.0-dev, Copyright (c), by Zend Technologies
```

```
PHP 8.5.0-dev (cli) (built: Jul 31 2025 11:29:06) (ZTS DEBUG x64) (Windows NT 10.0 Visual C++ 2022)
Copyright (c) The PHP Group
Zend Engine v4.5.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.0-dev, Copyright (c), by Zend Technologies
```
</details>