### PR TITLE
main/streams/transports.c: remove useless cast

### DIFF
--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -130,7 +130,7 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 	}
 
 	stream = (factory)(protocol, n,
-			(char*)name, namelen, persistent_id, options, flags, timeout,
+			name, namelen, persistent_id, options, flags, timeout,
 			context STREAMS_REL_CC);
 
 	if (stream) {


### PR DESCRIPTION
The function pointer type declaration requires name to be a const char*