### PR TITLE
Resolve MSVC C4146 Warning in php_random_uint128.h

### DIFF
--- a/ext/random/php_random_uint128.h
+++ b/ext/random/php_random_uint128.h
@@ -81,7 +81,7 @@ static inline uint64_t php_random_pcgoneseq128xslrr64_rotr64(php_random_uint128_
 		v = (num.hi ^ num.lo),
 		s = num.hi >> 58U;
 
-	return (v >> s) | (v << ((-s) & 63));
+	return (v >> s) | (v << ((~s + 1) & 63));
 }
 # else
 typedef __uint128_t php_random_uint128_t;
@@ -121,7 +121,7 @@ static inline uint64_t php_random_pcgoneseq128xslrr64_rotr64(php_random_uint128_
 		v = ((uint64_t) (num >> 64U)) ^ (uint64_t) num,
 		s = num >> 122U;
 
-	return (v >> s) | (v << ((-s) & 63));
+	return (v >> s) | (v << ((~s + 1) & 63));
 }
 # endif
 


### PR DESCRIPTION
The following [code](https://github.com/php/php-src/blob/master/ext/random/php_random_uint128.h#L124) in `php_random_uint128.h` gives out MSVC's [C4146](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170) warning (`unary minus operator applied to unsigned type, result still unsigned`):
```c
static inline uint64_t php_random_pcgoneseq128xslrr64_rotr64(php_random_uint128_t num)
{
	const uint64_t
		v = ((uint64_t) (num >> 64U)) ^ (uint64_t) num,
		s = num >> 122U;

	return (v >> s) | (v << ((-s) & 63));
}
```

This PR resolves it with substituting `(-s)` with `(~s + 1)`