### PR TITLE
Disable opcache if no SHM backend is available

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3274,7 +3274,7 @@ static zend_result accel_post_startup(void)
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - probably not enough shared memory.");
 				return SUCCESS;
 			case NO_SHM_BACKEND:
-				zend_accel_error(ACCEL_LOG_INFO, "Opcode Caching is disabled (No available SHM backend)");
+				zend_accel_error(ACCEL_LOG_INFO, "Opcode Caching is disabled: No available SHM backend. Set opcache.enable=0 to hide this message.");
 				zps_startup_failure("No available SHM backend", NULL, accelerator_remove_cb);
 				/* Do not abort PHP startup */
 				return SUCCESS;

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3273,6 +3273,12 @@ static zend_result accel_post_startup(void)
 				accel_startup_ok = false;
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - probably not enough shared memory.");
 				return SUCCESS;
+			case NO_SHM_BACKEND:
+				zend_accel_error(ACCEL_LOG_INFO, "Opcode Caching is disabled (No available SHM backend)");
+				zps_startup_failure("No available SHM backend", NULL, accelerator_remove_cb);
+				/* Do not abort PHP startup */
+				return SUCCESS;
+
 			case SUCCESSFULLY_REATTACHED:
 #ifdef HAVE_JIT
 				reattached = true;

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -345,9 +345,9 @@ PHP_ADD_EXTENSION_DEP(opcache, date)
 PHP_ADD_EXTENSION_DEP(opcache, pcre)
 
 if test "$php_cv_shm_ipc" != "yes" && test "$php_cv_shm_mmap_posix" != "yes" && test "$php_cv_shm_mmap_anon" != "yes"; then
-  AC_MSG_FAILURE(m4_text_wrap([
+  AC_MSG_WARN(m4_text_wrap([
     No supported shared memory caching support was found when configuring
-    opcache.
+    opcache. Opcache will be disabled.
   ]))
 fi
 

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -229,6 +229,9 @@ int zend_shared_alloc_startup(size_t requested_size, size_t reserved_size)
 
 	if (!g_shared_alloc_handler) {
 		/* try memory handlers in order */
+		if (handler_table->name == NULL) {
+			return NO_SHM_BACKEND;
+		}
 		for (he = handler_table; he->name; he++) {
 			res = zend_shared_alloc_try(he, requested_size, &ZSMMG(shared_segments), &ZSMMG(shared_segments_count), &error_in);
 			if (res) {

--- a/ext/opcache/zend_shared_alloc.h
+++ b/ext/opcache/zend_shared_alloc.h
@@ -72,6 +72,7 @@
 #define SUCCESSFULLY_REATTACHED 4
 #define ALLOC_FAIL_MAPPING      8
 #define ALLOC_FALLBACK          9
+#define NO_SHM_BACKEND          10
 
 typedef struct _zend_shared_segment {
     size_t  size;


### PR DESCRIPTION
Currently, `./configure` fails when no SHM backend is available (we support a wide range of systems with mmap(MAP_ANONYMOUS), shmget(), shm_open(), but some non-standard systems may not have any of these). Additionally, even after bypassing the configure check, Opcache emits a fatal error if no SHM backend is available.

Changes in this PR:
 - Make the configure check non-fatal (a warning is printed)
 - At runtime, disable opacche if no backend is available, in the same way we disable opcache by default on CLI

cc @krakjoe @derickr 