### PR TITLE
ci: update macos runner from 13 to 14 for old branches

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,7 +113,7 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
According to the Github announcement:

> The macOS 13 hosted runner image is closing down, following our [N-1 OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This process will begin September 1, 2025, and the image will be fully retired on November 14, 2025. We recommend updating workflows to use macos-14 or macos-15.

https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/

PHP 8.1 active support end 31 Dec 2025, so the macos13 will be removed before the end of support.

Macos-14 in GH actions is arm based image.