### PR TITLE
ZPP: Reduce code bloat for Z_PARAM_STR

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -755,58 +755,58 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_number_or_str_slow(zval *arg, zval **
 	return true;
 }
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, zend_string **dest, uint32_t arg_num) /* {{{ */
+ZEND_API zend_string* ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, uint32_t arg_num) /* {{{ */
 {
 	if (EXPECTED(Z_TYPE_P(arg) < IS_STRING)) {
 		if (UNEXPECTED(Z_TYPE_P(arg) == IS_NULL) && !zend_null_arg_deprecated("string", arg_num)) {
-			return 0;
+			return NULL;
 		}
 		convert_to_string(arg);
-		*dest = Z_STR_P(arg);
+		return Z_STR_P(arg);
 	} else if (UNEXPECTED(Z_TYPE_P(arg) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(arg);
 		zval obj;
 		if (zobj->handlers->cast_object(zobj, &obj, IS_STRING) == SUCCESS) {
 			OBJ_RELEASE(zobj);
 			ZVAL_COPY_VALUE(arg, &obj);
-			*dest = Z_STR_P(arg);
-			return 1;
+			return Z_STR_P(arg);
 		}
-		return 0;
+		return NULL;
 	} else {
-		return 0;
+		return NULL;
 	}
-	return 1;
 }
 /* }}} */
 
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_slow(zval *arg, zend_string **dest, uint32_t arg_num) /* {{{ */
+ZEND_API zend_string* ZEND_FASTCALL zend_parse_arg_str_slow(zval *arg, uint32_t arg_num) /* {{{ */
 {
 	if (UNEXPECTED(ZEND_ARG_USES_STRICT_TYPES())) {
-		return 0;
+		return NULL;
 	}
-	return zend_parse_arg_str_weak(arg, dest, arg_num);
+	return zend_parse_arg_str_weak(arg, arg_num);
 }
 /* }}} */
 
-ZEND_API bool ZEND_FASTCALL zend_flf_parse_arg_str_slow(zval *arg, zend_string **dest, uint32_t arg_num)
+ZEND_API zend_string* ZEND_FASTCALL zend_flf_parse_arg_str_slow(zval *arg, uint32_t arg_num)
 {
 	if (UNEXPECTED(ZEND_FLF_ARG_USES_STRICT_TYPES())) {
-		return 0;
+		return NULL;
 	}
-	return zend_parse_arg_str_weak(arg, dest, arg_num);
+	return zend_parse_arg_str_weak(arg, arg_num);
 }
 
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_or_long_slow(zval *arg, zend_string **dest_str, zend_long *dest_long, uint32_t arg_num) /* {{{ */
 {
+	zend_string *str;
 	if (UNEXPECTED(ZEND_ARG_USES_STRICT_TYPES())) {
 		return 0;
 	}
 	if (zend_parse_arg_long_weak(arg, dest_long, arg_num)) {
 		*dest_str = NULL;
 		return 1;
-	} else if (zend_parse_arg_str_weak(arg, dest_str, arg_num)) {
+	} else if ((str = zend_parse_arg_str_weak(arg, arg_num)) != NULL) {
 		*dest_long = 0;
+		*dest_str = str;
 		return 1;
 	} else {
 		return 0;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -2183,14 +2183,14 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_long_slow(const zval *arg, zend_long 
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_long_weak(const zval *arg, zend_long *dest, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_double_slow(const zval *arg, double *dest, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_double_weak(const zval *arg, double *dest, uint32_t arg_num);
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_slow(zval *arg, zend_string **dest, uint32_t arg_num);
-ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, zend_string **dest, uint32_t arg_num);
+ZEND_API zend_string* ZEND_FASTCALL zend_parse_arg_str_slow(zval *arg, uint32_t arg_num);
+ZEND_API zend_string* ZEND_FASTCALL zend_parse_arg_str_weak(zval *arg, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_number_slow(zval *arg, zval **dest, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_number_or_str_slow(zval *arg, zval **dest, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_parse_arg_str_or_long_slow(zval *arg, zend_string **dest_str, zend_long *dest_long, uint32_t arg_num);
 
 ZEND_API bool ZEND_FASTCALL zend_flf_parse_arg_bool_slow(const zval *arg, bool *dest, uint32_t arg_num);
-ZEND_API bool ZEND_FASTCALL zend_flf_parse_arg_str_slow(zval *arg, zend_string **dest, uint32_t arg_num);
+ZEND_API zend_string* ZEND_FASTCALL zend_flf_parse_arg_str_slow(zval *arg, uint32_t arg_num);
 ZEND_API bool ZEND_FASTCALL zend_flf_parse_arg_long_slow(const zval *arg, zend_long *dest, uint32_t arg_num);
 
 static zend_always_inline bool zend_parse_arg_bool_ex(const zval *arg, bool *dest, bool *is_null, bool check_null, uint32_t arg_num, bool frameless)
@@ -2292,10 +2292,16 @@ static zend_always_inline bool zend_parse_arg_str_ex(zval *arg, zend_string **de
 	} else if (check_null && Z_TYPE_P(arg) == IS_NULL) {
 		*dest = NULL;
 	} else {
+		zend_string *str;
 		if (frameless) {
-			return zend_flf_parse_arg_str_slow(arg, dest, arg_num);
+			str = zend_flf_parse_arg_str_slow(arg, arg_num);
 		} else {
-			return zend_parse_arg_str_slow(arg, dest, arg_num);
+			str = zend_parse_arg_str_slow(arg, arg_num);
+		}
+		if (str) {
+			*dest = str;
+		} else {
+			return 0;
 		}
 	}
 	return 1;
@@ -2529,7 +2535,8 @@ static zend_always_inline bool zend_parse_arg_array_ht_or_str(
 		*dest_str = NULL;
 	} else {
 		*dest_ht = NULL;
-		return zend_parse_arg_str_slow(arg, dest_str, arg_num);
+		*dest_str = zend_parse_arg_str_slow(arg, arg_num);
+		return *dest_str != NULL;
 	}
 	return 1;
 }

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -734,7 +734,6 @@ static bool zend_verify_weak_scalar_type_hint(uint32_t type_mask, zval *arg)
 {
 	zend_long lval;
 	double dval;
-	zend_string *str;
 	bool bval;
 
 	/* Type preference order: int -> float -> string -> bool */
@@ -766,7 +765,7 @@ static bool zend_verify_weak_scalar_type_hint(uint32_t type_mask, zval *arg)
 		ZVAL_DOUBLE(arg, dval);
 		return 1;
 	}
-	if ((type_mask & MAY_BE_STRING) && zend_parse_arg_str_weak(arg, &str, 0)) {
+	if ((type_mask & MAY_BE_STRING) && zend_parse_arg_str_weak(arg, 0)) {
 		/* on success "arg" is converted to IS_STRING */
 		return 1;
 	}

--- a/Zend/zend_frameless_function.h
+++ b/Zend/zend_frameless_function.h
@@ -65,7 +65,7 @@
 		dest_ht = NULL; \
 		ZVAL_COPY(&str_tmp, arg ## arg_num); \
 		arg ## arg_num = &str_tmp; \
-		if (!zend_flf_parse_arg_str_slow(arg ## arg_num, &dest_str, arg_num)) { \
+		if (!(dest_str = zend_flf_parse_arg_str_slow(arg ## arg_num, arg_num))) { \
 			zend_wrong_parameter_type_error(arg_num, Z_EXPECTED_ARRAY_OR_STRING, arg ## arg_num); \
 			goto flf_clean; \
 		} \

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -8776,8 +8776,8 @@ ZEND_VM_COLD_CONST_HANDLER(121, ZEND_STRLEN, CONST|TMPVAR|CV, ANY)
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -8790,7 +8790,7 @@ ZEND_VM_COLD_CONST_HANDLER(121, ZEND_STRLEN, CONST|TMPVAR|CV, ANY)
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6060,8 +6060,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -6074,7 +6074,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -15989,8 +15989,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_T
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -16003,7 +16003,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_T
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -42477,8 +42477,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_C
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -42491,7 +42491,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_C
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -61483,8 +61483,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLE
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -61497,7 +61497,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLE
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -71310,8 +71310,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_TMPVAR
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -71324,7 +71324,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_TMPVAR
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;
@@ -97698,8 +97698,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_CV_TAI
 		strict = EX_USES_STRICT_TYPES();
 		do {
 			if (EXPECTED(!strict)) {
-				zend_string *str;
 				zval tmp;
+				zend_string *str;
 
 				if (UNEXPECTED(Z_TYPE_P(value) == IS_NULL)) {
 					zend_error(E_DEPRECATED,
@@ -97712,7 +97712,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_CV_TAI
 				}
 
 				ZVAL_COPY(&tmp, value);
-				if (zend_parse_arg_str_weak(&tmp, &str, 1)) {
+				if ((str = zend_parse_arg_str_weak(&tmp, 1)) != NULL) {
 					ZVAL_LONG(EX_VAR(opline->result.var), ZSTR_LEN(str));
 					zval_ptr_dtor(&tmp);
 					break;


### PR DESCRIPTION
This idea is based on @nielsdos previous PR to reduce code bloat: https://github.com/php/php-src/pull/18436 To do so we create a specialized function to handle parameters that only accept strings and not null such that we can assign the zend_string to the destination directly.


Will take the assembly of the `ext/zend_test` function `ZEND_FUNCTION(zend_test_is_string_marked_as_valid_utf8)` as an example:
Compiled in a release build and retrieved using:
```shell
./configure -C --disable-all --enable-zend_test --prefix=/path/to/custom/releases
make -jN
gdb sapi/cli/php
disassemble zif_zend_test_is_string_marked_as_valid_utf8
```

Prior to this commit (`master@98e0dbcefedeecf5e4d032e54df1aeebaa118754`)the ASM looks like:
```s
Address range 0x7344e0 to 0x73455a:
   0x00000000007344e0 <+0>:	push   %rbx
   0x00000000007344e1 <+1>:	sub    $0x20,%rsp
   0x00000000007344e5 <+5>:	mov    0x2c(%rdi),%r9d
   0x00000000007344e9 <+9>:	cmp    $0x1,%r9d
   0x00000000007344ed <+13>:	jne    0x41ab56 <zif_zend_test_is_string_marked_as_valid_utf8-3250570>
   0x00000000007344f3 <+19>:	mov    %rsi,%rcx
   0x00000000007344f6 <+22>:	cmpb   $0x6,0x58(%rdi)
   0x00000000007344fa <+26>:	jne    0x734520 <zif_zend_test_is_string_marked_as_valid_utf8+64>
   0x00000000007344fc <+28>:	mov    0x50(%rdi),%rax
   0x0000000000734500 <+32>:	testb  $0x2,0x5(%rax)
   0x0000000000734504 <+36>:	setne  %al
   0x0000000000734507 <+39>:	movzbl %al,%eax
   0x000000000073450a <+42>:	add    $0x2,%eax
   0x000000000073450d <+45>:	mov    %eax,0x8(%rcx)
   0x0000000000734510 <+48>:	add    $0x20,%rsp
   0x0000000000734514 <+52>:	pop    %rbx
   0x0000000000734515 <+53>:	ret
   0x0000000000734516 <+54>:	cs nopw 0x0(%rax,%rax,1)
   0x0000000000734520 <+64>:	mov    %rsi,0x8(%rsp)
   0x0000000000734525 <+69>:	lea    0x50(%rdi),%rbx
   0x0000000000734529 <+73>:	lea    0x18(%rsp),%rsi
   0x000000000073452e <+78>:	add    $0x50,%rdi
   0x0000000000734532 <+82>:	mov    $0x1,%edx
   0x0000000000734537 <+87>:	mov    %r9d,0x4(%rsp)
   0x000000000073453c <+92>:	call   0x7afd50 <zend_parse_arg_str_slow>
   0x0000000000734541 <+97>:	mov    0x4(%rsp),%r9d
   0x0000000000734546 <+102>:	test   %al,%al
   0x0000000000734548 <+104>:	je     0x41ab3a <zif_zend_test_is_string_marked_as_valid_utf8.cold>
   0x000000000073454e <+110>:	mov    0x18(%rsp),%rax
   0x0000000000734553 <+115>:	mov    0x8(%rsp),%rcx
   0x0000000000734558 <+120>:	jmp    0x734500 <zif_zend_test_is_string_marked_as_valid_utf8+32>
Address range 0x41ab3a to 0x41ab73:
   0x000000000041ab3a <-3250598>:	mov    $0x9,%edi
   0x000000000041ab3f <-3250593>:	mov    $0x4,%ecx
   0x000000000041ab44 <-3250588>:	mov    %rbx,%r8
   0x000000000041ab47 <-3250585>:	xor    %edx,%edx
   0x000000000041ab49 <-3250583>:	mov    %r9d,%esi
   0x000000000041ab4c <-3250580>:	call   0x41f549 <zend_wrong_parameter_error>
   0x000000000041ab51 <-3250575>:	jmp    0x734510 <zif_zend_test_is_string_marked_as_valid_utf8+48>
   0x000000000041ab56 <-3250570>:	mov    $0x1,%edi
   0x000000000041ab5b <-3250565>:	mov    $0x1,%esi
   0x000000000041ab60 <-3250560>:	xor    %ebx,%ebx
   0x000000000041ab62 <-3250558>:	call   0x41f017 <zend_wrong_parameters_count_error>
   0x000000000041ab67 <-3250553>:	xor    %r9d,%r9d
   0x000000000041ab6a <-3250550>:	mov    $0x1,%edi
   0x000000000041ab6f <-3250545>:	xor    %ecx,%ecx
   0x000000000041ab71 <-3250543>:	jmp    0x41ab44 <zif_zend_test_is_string_marked_as_valid_utf8-3250588>
```
Afterwards it looks like:
```s
Address range 0x7339d0 to 0x733a45:
   0x00000000007339d0 <+0>:	sub    $0x28,%rsp
   0x00000000007339d4 <+4>:	mov    0x2c(%rdi),%r9d
   0x00000000007339d8 <+8>:	cmp    $0x1,%r9d
   0x00000000007339dc <+12>:	jne    0x41acd4 <zif_zend_test_is_string_marked_as_valid_utf8-3247356>
   0x00000000007339e2 <+18>:	mov    %rsi,%rdx
   0x00000000007339e5 <+21>:	lea    0x50(%rdi),%r8
   0x00000000007339e9 <+25>:	cmpb   $0x6,0x58(%rdi)
   0x00000000007339ed <+29>:	jne    0x733a18 <zif_zend_test_is_string_marked_as_valid_utf8+72>
   0x00000000007339ef <+31>:	mov    0x50(%rdi),%rax
   0x00000000007339f3 <+35>:	test   %rax,%rax
   0x00000000007339f6 <+38>:	je     0x41acbc <zif_zend_test_is_string_marked_as_valid_utf8.cold>
   0x00000000007339fc <+44>:	testb  $0x2,0x5(%rax)
   0x0000000000733a00 <+48>:	setne  %al
   0x0000000000733a03 <+51>:	movzbl %al,%eax
   0x0000000000733a06 <+54>:	add    $0x2,%eax
   0x0000000000733a09 <+57>:	mov    %eax,0x8(%rdx)
   0x0000000000733a0c <+60>:	add    $0x28,%rsp
   0x0000000000733a10 <+64>:	ret
   0x0000000000733a11 <+65>:	nopl   0x0(%rax)
   0x0000000000733a18 <+72>:	mov    %rsi,0x18(%rsp)
   0x0000000000733a1d <+77>:	mov    %r8,%rdi
   0x0000000000733a20 <+80>:	mov    $0x1,%esi
   0x0000000000733a25 <+85>:	mov    %r9d,0x14(%rsp)
   0x0000000000733a2a <+90>:	mov    %r8,0x8(%rsp)
   0x0000000000733a2f <+95>:	call   0x7af240 <zend_parse_arg_str_slow>
   0x0000000000733a34 <+100>:	mov    0x18(%rsp),%rdx
   0x0000000000733a39 <+105>:	mov    0x14(%rsp),%r9d
   0x0000000000733a3e <+110>:	mov    0x8(%rsp),%r8
   0x0000000000733a43 <+115>:	jmp    0x7339f3 <zif_zend_test_is_string_marked_as_valid_utf8+35>
Address range 0x41acbc to 0x41acf2:
   0x000000000041acbc <-3247380>:	mov    $0x9,%edi
   0x000000000041acc1 <-3247375>:	mov    $0x4,%ecx
   0x000000000041acc6 <-3247370>:	xor    %edx,%edx
   0x000000000041acc8 <-3247368>:	mov    %r9d,%esi
   0x000000000041accb <-3247365>:	add    $0x28,%rsp
   0x000000000041accf <-3247361>:	jmp    0x41f6f4 <zend_wrong_parameter_error>
   0x000000000041acd4 <-3247356>:	mov    $0x1,%edi
   0x000000000041acd9 <-3247351>:	mov    $0x1,%esi
   0x000000000041acde <-3247346>:	call   0x41f1c2 <zend_wrong_parameters_count_error>
   0x000000000041ace3 <-3247341>:	mov    $0x1,%edi
   0x000000000041ace8 <-3247336>:	xor    %ecx,%ecx
   0x000000000041acea <-3247334>:	xor    %r8d,%r8d
   0x000000000041aced <-3247331>:	xor    %r9d,%r9d
   0x000000000041acf0 <-3247328>:	jmp    0x41acc6 <zif_zend_test_is_string_marked_as_valid_utf8-3247370>
```

For reference we have 772 usages of `Z_PARAM_STR` (found using `git grep -o "Z_PARAM_STR" | wc -l`)

This approach should also work for the "path" and "C string" version, and more generally for the pure HashTable and object FZPP specifier