### PR TITLE
enable openssl-argon2 by default

### DIFF
--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -19,9 +19,9 @@ PHP_ARG_WITH([openssl-legacy-provider],
 
 PHP_ARG_WITH([openssl-argon2],
   [whether to enable argon2 password hashing (requires OpenSSL >= 3.2)],
-  [AS_HELP_STRING([--with-openssl-argon2],
-    [OPENSSL: Enable argon2 password hashing])],
-  [no],
+  [AS_HELP_STRING([--without-openssl-argon2],
+    [OPENSSL: Disable argon2 password hashing])],
+  [yes],
   [no])
 
 if test "$PHP_OPENSSL" != "no"; then
@@ -48,11 +48,13 @@ if test "$PHP_OPENSSL" != "no"; then
       [Define to 1 to load the OpenSSL legacy algorithm provider in addition to
       the default provider.])])
 
-  AS_VAR_IF([PHP_OPENSSL_ARGON2], [no],, [
+  dnl Implicit default is yes; only error if explicitly set and unavailable
+  AS_IF([test "$PHP_OPENSSL_ARGON2" != "no"], [
     PHP_CHECK_LIBRARY([crypto], [OSSL_set_max_threads],
       [AC_DEFINE([HAVE_OPENSSL_ARGON2], [1],
         [Define to 1 to enable OpenSSL argon2 password hashing.])],
-      [AC_MSG_ERROR([argon2 hashing requires OpenSSL 3.2])],
+      [AS_IF([test "x$with_openssl_argon2" = "xyes"],
+        [AC_MSG_ERROR([argon2 hashing requires OpenSSL 3.2])])],
       [$OPENSSL_LIBS])
   ])
 fi


### PR DESCRIPTION
Motivation here is that "libargon2" has seen very little maintenance over the years, as it was mostly a reference implementation for the password hashing contest, while OpenSSL is actively developed.

OpenSSL 3.2 is widely supported and means that "libargon2" support could be dropped in the long term. Note that if the value was not explicitly enabled, it will silently disable in case openssl >= 3.2 cannot be found. In case it was explicitly passed with `--with-openssl-argon2`, it will fail like it did before.

One thing I'm not sure about is what will happen when --with-password-argon2 and --with-openssl-argon2 are passed. I suspect the "libargon2" implementation will be used, but I'm not sure if it's sensible to change that.

Since this does not affect userland, I haven't created an RFC. I'm generally open to votes on whether this should or shouldn't be done.