### PR TITLE
Throw ValueError when 1 is provided to the second argument of `log()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -148,6 +148,8 @@ PHP                                                                        NEWS
   . Add enum SortDirection. (timwolla)
   . pathinfo() raises a ValueError with an invalid $flags argument.
     (David Carlier)
+  . Passing 1 or negative base to log() now throws a ValueError.
+    (alexandre-daubois)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/UPGRADING
+++ b/UPGRADING
@@ -132,6 +132,8 @@ PHP 8.6 UPGRADE NOTES
     constants).
 
 - Standard:
+  . log() now raises a ValueError when the base argument is 1 or less
+    than or equal to 0. Previously, base 1 silently returned NAN.
   . pathinfo() now raises a ValueError when an invalid $flag argument
     value is passed.
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -721,12 +721,8 @@ PHP_FUNCTION(log)
 		RETURN_DOUBLE(log10(num));
 	}
 
-	if (base == 1.0) {
-		RETURN_DOUBLE(ZEND_NAN);
-	}
-
-	if (base <= 0.0) {
-		zend_argument_value_error(2, "must be greater than 0");
+	if (base <= 0.0 || base == 1.0) {
+		zend_argument_value_error(2, "must not be 1 or less than or equal to 0");
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/tests/math/log_error.phpt
+++ b/ext/standard/tests/math/log_error.phpt
@@ -9,6 +9,13 @@ try {
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
+
+try {
+    log(36, 1);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 ?>
 --EXPECT--
-log(): Argument #2 ($base) must be greater than 0
+log(): Argument #2 ($base) must not be 1 or less than or equal to 0
+log(): Argument #2 ($base) must not be 1 or less than or equal to 0


### PR DESCRIPTION
This helps with early error detection and explicit intent, instead of having a potential NaN propagating.

https://wiki.php.net/rfc/deprecations_php_8_6#providing_invalid_values_to_log_second_argument