### PR TITLE
Emit EXT_STMT after each pipe stage, and attach the TMP var that holds the intermediary result

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -420,6 +420,14 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				}
 				break;
 
+			case ZEND_EXT_STMT:
+				if (opline->op1_type & (IS_TMP_VAR|IS_VAR)) {
+					/* Variable will be deleted later by FREE, so we can't optimize it */
+					Tsource[VAR_NUM(opline->op1.var)] = NULL;
+					break;
+				}
+				break;
+
 			case ZEND_CASE:
 			case ZEND_CASE_STRICT:
 			case ZEND_COPY_TMP:

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -821,7 +821,8 @@ static void zend_do_free(znode *op1) /* {{{ */
 		} else {
 			while (opline >= CG(active_op_array)->opcodes) {
 				if ((opline->opcode == ZEND_FETCH_LIST_R ||
-				     opline->opcode == ZEND_FETCH_LIST_W) &&
+				     opline->opcode == ZEND_FETCH_LIST_W ||
+				     opline->opcode == ZEND_EXT_STMT) &&
 				    opline->op1_type == IS_VAR &&
 				    opline->op1.var == op1->u.op.var) {
 					zend_emit_op(NULL, ZEND_FREE, op1, NULL);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -903,7 +903,8 @@ static bool keeps_op1_alive(zend_op *opline) {
 	 || opline->opcode == ZEND_MATCH_ERROR
 	 || opline->opcode == ZEND_FETCH_LIST_R
 	 || opline->opcode == ZEND_FETCH_LIST_W
-	 || opline->opcode == ZEND_COPY_TMP) {
+	 || opline->opcode == ZEND_COPY_TMP
+	 || opline->opcode == ZEND_EXT_STMT) {
 		return 1;
 	}
 	ZEND_ASSERT(opline->opcode != ZEND_FE_FETCH_R


### PR DESCRIPTION
The following script:

```
<?php
function testPipes()
{
	$result = "Hello World"
		|> htmlentities(...)
		|> strtolower(...)
		|> str_split(...)
		|> fn($x) => array_map(strtoupper(...), $x)
		|> fn($x) => array_filter($x, fn($v) => $v != 'O');
	return $result;
}

$result = testPipes();
var_dump($result);
```

Creates the following opcodes for the `testPipes()` function (without this patch):

```
line      #* E I O op                               fetch          ext  return  operands
-----------------------------------------------------------------------------------------
    5     0  E >   EXT_STMT                                                     
          1        INIT_FCALL                                                   'htmlentities'
    4     2        SEND_VAL                                                     'Hello+World'
    5     3        DO_ICALL                                             $2      
    4     4        QM_ASSIGN                                            ~3      $2
    6     5        INIT_FCALL                                                   'strtolower'
    4     6        SEND_VAL                                                     ~3
    6     7        DO_ICALL                                             $4      
    4     8        QM_ASSIGN                                            ~5      $4
    7     9        INIT_FCALL                                                   'str_split'
    4    10        SEND_VAL                                                     ~5
    7    11        DO_ICALL                                             $6      
    4    12        QM_ASSIGN                                            ~7      $6
    8    13        DECLARE_LAMBDA_FUNCTION                              ~8      [0]
         14        BIND_LEXICAL                                                 ~8, !1
    9    15        INIT_DYNAMIC_CALL                                            ~8
    4    16        SEND_VAL_EX                                                  ~7
    9    17        DO_FCALL                                          0  $9      
    4    18        ASSIGN                                                       !0, $9
   10    19        EXT_STMT                                                     
         20      > RETURN                                                       !0
   11    21*       EXT_STMT                                                     
         22*     > RETURN                                                       null
```

If users set a breakpoint on line `4 $result = "Hello World"`, then Xdebug realises this and moves it to line `5`. This is because Xdebug only breaks on `EXT_STMT` lines, and is clever enough to adjust the breakpoint.

However, if you then would use "step over" then it would immediately go to line 10, as that's where the next `EXT_STMT` op is created. This means it is not possible to inspect the intermediary values being passed from pipe element to pipe element.

This patch changes the opcode generation to add additional `EXT_STMT` opcodes in between each state:

```
line      #* E I O op                               fetch          ext  return  operands
-----------------------------------------------------------------------------------------
    5     0  E >   EXT_STMT                                                     
          1        INIT_FCALL                                                   'htmlentities'
    4     2        SEND_VAL                                                     'Hello+World'
    5     3        DO_ICALL                                             $2      
          4        EXT_STMT                                                     $2
          5        QM_ASSIGN                                            ~3      $2
    6     6        INIT_FCALL                                                   'strtolower'
    5     7        SEND_VAL                                                     ~3
    6     8        DO_ICALL                                             $4      
          9        EXT_STMT                                                     $4
         10        QM_ASSIGN                                            ~5      $4
    7    11        INIT_FCALL                                                   'str_split'
    6    12        SEND_VAL                                                     ~5
    7    13        DO_ICALL                                             $6      
         14        EXT_STMT                                                     $6
         15        QM_ASSIGN                                            ~7      $6
    8    16        DECLARE_LAMBDA_FUNCTION                              ~8      [0]
         17        BIND_LEXICAL                                                 ~8, !1
    9    18        INIT_DYNAMIC_CALL                                            ~8
    7    19        SEND_VAL_EX                                                  ~7
    9    20        DO_FCALL                                          0  $9      
    4    21        EXT_STMT                                                     $9
         22        ASSIGN                                                       !0, $9
   10    23        EXT_STMT                                                     
         24      > RETURN                                                       !0
   11    25*       EXT_STMT                                                     
         26*     > RETURN                                                       null
```

The `EXT_STMT` in op 4, 9, 14, and 21 are new, and also have as their `op1` value the intermediate pipe value.
This allows Xdebug to break here, and [show the contents of this hinted variable](https://github.com/xdebug/xdebug/commit/b6cb3f3e760c886214bfaf9ec7da3844b3c591be).

This however does not work (yet) for the closure wrapped stages as these are handled differently. Ideally they all have a similar `DECLARE_LAMBDA_FUNCTION/BIND_LEXICAL/INIT_DYNAMIC_CALL` set, but instead PHP creates nested closures instead:

```
function name:  {closure:testPipes():8}
compiled vars:  !0 = $x, !1 = $v
line      #* E I O op                               fetch          ext  return  operands
-----------------------------------------------------------------------------------------
    8     0  E >   RECV                                                 !0      
          1        BIND_STATIC                                                  !1
          2        EXT_STMT                                                     
          3        INIT_FCALL                                                   'array_map'
          4        INIT_FCALL                                                   'strtoupper'
          5        CALLABLE_CONVERT                                     ~2      
          6        SEND_VAL                                                     ~2
          7        SEND_VAR                                                     !0
          8        DO_ICALL                                             $3      
          9        QM_ASSIGN                                            ~4      $3
    9    10        DECLARE_LAMBDA_FUNCTION                              ~5      [0]
         11        BIND_LEXICAL                                                 ~5, !1
         12        INIT_DYNAMIC_CALL                                            ~5
    8    13        SEND_VAL_EX                                                  ~4
    9    14        DO_FCALL                                          0  $6      
         15        EXT_STMT                                                     $6
         16      > RETURN                                                       $6
         17*       EXT_STMT                                                     
         18*     > RETURN                                                       null

function name:  {closure:{closure:testPipes():8}:9}
compiled vars:  !0 = $x, !1 = $v
line      #* E I O op                               fetch          ext  return  operands
-----------------------------------------------------------------------------------------
          0  E >   RECV                                                 !0      
          1        BIND_STATIC                                                  !1
          2        EXT_STMT                                                     
          3        INIT_FCALL                                                   'array_filter'
          4        SEND_VAR                                                     !0
          5        DECLARE_LAMBDA_FUNCTION                              ~2      [0]
          6        SEND_VAL                                                     ~2
          7        DO_ICALL                                             $3      
          8      > RETURN                                                       $3
          9*       EXT_STMT                                                     
         10*     > RETURN                                                       null
```

I can currently work around this by [*always* breaking upon the return of a user-land closure](https://github.com/xdebug/xdebug/commit/10df586829d09a047922bed5b57411af55033338), but this is not ideal. Instead, I would like to have an EXT_STMT in the *original* function just like in between `htmlentities`/`strtolower`/`str_split`).