### PR TITLE
Fix Windows test for openssl-3.5 upgrade

### DIFF
--- a/ext/openssl/tests/check_default_conf_path.phpt
+++ b/ext/openssl/tests/check_default_conf_path.phpt
@@ -21,7 +21,7 @@ ob_end_clean();
 preg_match(",Openssl default config [^ ]* (.*),", $info, $m);
 
 if (isset($m[1])) {
-    var_dump(str_replace('\/', '\\', strtolower($m[1])));
+    var_dump(str_replace('\\/', '\\', strtolower($m[1])));
 } else {
     echo $info;
 }

--- a/ext/openssl/tests/check_default_conf_path.phpt
+++ b/ext/openssl/tests/check_default_conf_path.phpt
@@ -21,7 +21,7 @@ ob_end_clean();
 preg_match(",Openssl default config [^ ]* (.*),", $info, $m);
 
 if (isset($m[1])) {
-    var_dump(str_replace('/', '\\', strtolower($m[1])));
+    var_dump(str_replace('\/', '\\', strtolower($m[1])));
 } else {
     echo $info;
 }


### PR DESCRIPTION
After upgrading to openssl-3.5.2 on Windows, `X509_get_default_cert_area` has a trailing slash.