### PR TITLE
Fix master branch check in find-target-branch.bat

### DIFF
--- a/.github/scripts/windows/find-target-branch.bat
+++ b/.github/scripts/windows/find-target-branch.bat
@@ -3,6 +3,6 @@
 for /f "usebackq tokens=3" %%i in (`findstr PHP_MAJOR_VERSION main\php_version.h`) do set BRANCH=%%i
 for /f "usebackq tokens=3" %%i in (`findstr PHP_MINOR_VERSION main\php_version.h`) do set BRANCH=%BRANCH%.%%i
 
-if /i "%BRANCH%" equ "8.3" (
+if /i "%BRANCH%" equ "8.5" (
 	set BRANCH=master
 )


### PR DESCRIPTION
This PR is to fix checking the branch in `find-target-branch.bat` for all the supported branches.