### PR TITLE
ext/intl: Use ZPP specifier for IntlTimeZone::createEnumeration()

### DIFF
--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -571,8 +571,7 @@ function intltz_count_equivalent_ids(string $timezoneId): int|false {}
 
 function intltz_create_default(): IntlTimeZone {}
 
-/** @param IntlTimeZone|string|int|float|null $countryOrRawOffset */
-function intltz_create_enumeration($countryOrRawOffset = null): IntlIterator|false {}
+function intltz_create_enumeration(string|int|null $countryOrRawOffset = null): IntlIterator|false {}
 
 function intltz_create_time_zone(string $timezoneId): ?IntlTimeZone {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0d5b028a1ab8f35e8ee1b51ce3141b6ef782af28 */
+ * Stub hash: bd78e0b6aec5c52b13f83e3c3cc7770c942d7c20 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -679,7 +679,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intltz_create_default, 0, 0, Intl
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_intltz_create_enumeration, 0, 0, IntlIterator, MAY_BE_FALSE)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, countryOrRawOffset, "null")
+	ZEND_ARG_TYPE_MASK(0, countryOrRawOffset, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intltz_create_time_zone, 0, 1, IntlTimeZone, 1)

--- a/ext/intl/tests/timezone_createEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createEnumeration_error.phpt
@@ -4,10 +4,12 @@ IntlTimeZone::createEnumeration(): errors
 intl
 --FILE--
 <?php
-ini_set("intl.error_level", E_WARNING);
 
-var_dump(IntlTimeZone::createEnumeration(array()));
+try {
+	var_dump(IntlTimeZone::createEnumeration([]));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
---EXPECTF--
-Warning: IntlTimeZone::createEnumeration(): invalid argument type in %s on line %d
-bool(false)
+--EXPECT--
+TypeError: IntlTimeZone::createEnumeration(): Argument #1 ($countryOrRawOffset) must be of type string|int|null, array given

--- a/ext/intl/tests/timezone_createEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createEnumeration_error.phpt
@@ -10,6 +10,13 @@ try {
 } catch (Throwable $e) {
 	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
+
+try {
+	var_dump(IntlTimeZone::createEnumeration(new stdClass()));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
 --EXPECT--
 TypeError: IntlTimeZone::createEnumeration(): Argument #1 ($countryOrRawOffset) must be of type string|int|null, array given
+TypeError: IntlTimeZone::createEnumeration(): Argument #1 ($countryOrRawOffset) must be of type string|int|null, stdClass given

--- a/ext/intl/timezone/timezone.stub.php
+++ b/ext/intl/timezone/timezone.stub.php
@@ -45,11 +45,10 @@ class IntlTimeZone
     public static function createDefault(): IntlTimeZone {}
 
     /**
-     * @param IntlTimeZone|string|int|float|null $countryOrRawOffset
      * @tentative-return-type
      * @alias intltz_create_enumeration
      */
-    public static function createEnumeration($countryOrRawOffset = null): IntlIterator|false {}
+    public static function createEnumeration(string|int|null $countryOrRawOffset = null): IntlIterator|false {}
 
     /**
      * @tentative-return-type

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6ffeea8491aa48c49879fa77bdb644d10d5c71bd */
+ * Stub hash: 22e652c6a05ade0a6fd3119e4742cd260ba27146 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlTimeZone___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -12,7 +12,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IntlTimeZone_crea
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_IntlTimeZone_createEnumeration, 0, 0, IntlIterator, MAY_BE_FALSE)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, countryOrRawOffset, "null")
+	ZEND_ARG_TYPE_MASK(0, countryOrRawOffset, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IntlTimeZone_createTimeZone, 0, 1, IntlTimeZone, 1)


### PR DESCRIPTION
The existing code is extremely convoluted, incorrectly documented, and does not follow the usual semantics