### PR TITLE
ext/intl: better errors for IntlTimeZone::createTimeZoneIDEnumeration

### DIFF
--- a/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-IntlTimeZone::createTimeZoneIDEnumeration(): errors
+IntlTimeZone::createTimeZoneIDEnumeration() invalid zone type
 --EXTENSIONS--
 intl
 --FILE--
@@ -10,12 +10,7 @@ try {
 } catch (Throwable $e) {
 	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
 }
-try {
-	var_dump(IntlTimeZone::createTimeZoneIDEnumeration(IntlTimeZone::TYPE_ANY, '', PHP_INT_MAX));
-} catch (Throwable $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
-}
+
 ?>
 --EXPECT--
 ValueError: IntlTimeZone::createTimeZoneIDEnumeration(): Argument #1 ($type) must be one of IntlTimeZone::TYPE_ANY, IntlTimeZone::TYPE_CANONICAL, or IntlTimeZone::TYPE_CANONICAL_LOCATION
-ValueError: IntlTimeZone::createTimeZoneIDEnumeration(): Argument #1 ($type) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
+++ b/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error.phpt
@@ -4,10 +4,18 @@ IntlTimeZone::createTimeZoneIDEnumeration(): errors
 intl
 --FILE--
 <?php
-ini_set("intl.error_level", E_WARNING);
 
-var_dump(IntlTimeZone::createTimeZoneIDEnumeration(-1));
+try {
+	var_dump(IntlTimeZone::createTimeZoneIDEnumeration(-1));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+	var_dump(IntlTimeZone::createTimeZoneIDEnumeration(IntlTimeZone::TYPE_ANY, '', PHP_INT_MAX));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
---EXPECTF--
-Warning: IntlTimeZone::createTimeZoneIDEnumeration(): bad zone type in %s on line %d
-bool(false)
+--EXPECT--
+ValueError: IntlTimeZone::createTimeZoneIDEnumeration(): Argument #1 ($type) must be one of IntlTimeZone::TYPE_ANY, IntlTimeZone::TYPE_CANONICAL, or IntlTimeZone::TYPE_CANONICAL_LOCATION
+ValueError: IntlTimeZone::createTimeZoneIDEnumeration(): Argument #1 ($type) must be between -2147483648 and 2147483647

--- a/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error_64bit.phpt
+++ b/ext/intl/tests/timezone_createTimeZoneIDEnumeration_error_64bit.phpt
@@ -1,0 +1,17 @@
+--TEST--
+IntlTimeZone::createTimeZoneIDEnumeration() offset out of range
+--EXTENSIONS--
+intl
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--FILE--
+<?php
+
+try {
+	var_dump(IntlTimeZone::createTimeZoneIDEnumeration(IntlTimeZone::TYPE_ANY, '', PHP_INT_MAX));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+ValueError: IntlTimeZone::createTimeZoneIDEnumeration(): Argument #1 ($type) must be between -2147483648 and 2147483647

--- a/ext/intl/timezone/timezone_methods.cpp
+++ b/ext/intl/timezone/timezone_methods.cpp
@@ -229,17 +229,17 @@ U_CFUNC PHP_FUNCTION(intltz_create_time_zone_id_enumeration)
 
 	if (zoneType != UCAL_ZONE_TYPE_ANY && zoneType != UCAL_ZONE_TYPE_CANONICAL
 			&& zoneType != UCAL_ZONE_TYPE_CANONICAL_LOCATION) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "bad zone type");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must be one of IntlTimeZone::TYPE_ANY,"
+			" IntlTimeZone::TYPE_CANONICAL, or IntlTimeZone::TYPE_CANONICAL_LOCATION");
+		RETURN_THROWS();
 	}
 
 	if (!arg3isnull) {
-		if (UNEXPECTED(offset_arg < (zend_long)INT32_MIN || offset_arg > (zend_long)INT32_MAX)) {
-			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR,
-				"offset out of bounds");
-			RETURN_FALSE;
+		if (UNEXPECTED(ZEND_LONG_EXCEEDS_INT(offset_arg))) {
+			zend_argument_value_error(1, "must be between %d and %d", INT32_MIN, INT32_MAX);
+			RETURN_THROWS();
 		}
-		offset = (int32_t)offset_arg;
+		offset = static_cast<int32_t>(offset_arg);
 		offsetp = &offset;
 	} //else leave offsetp NULL
 


### PR DESCRIPTION
And convert those to ValueErrors directly as they are bugs