### PR TITLE
fastcgi: using accept4 on connections accept when possible.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -525,6 +525,7 @@ dnl Checks for library functions.
 dnl ----------------------------------------------------------------------------
 
 AC_CHECK_FUNCS(m4_normalize([
+  accept4
   alphasort
   asctime_r
   asprintf

--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_ENABLE([sockets],
     [Enable sockets support])])
 
 if test "$PHP_SOCKETS" != "no"; then
-  AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname sockatmark accept4])
+  AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname sockatmark])
   AC_CHECK_HEADERS([sys/sockio.h linux/filter.h linux/if_packet.h linux/if_ether.h linux/udp.h])
   AC_DEFINE([HAVE_SOCKETS], [1],
     [Define to 1 if the PHP extension 'sockets' is available.])


### PR DESCRIPTION
saving 1/2 fcntl calls in the process and possibly safer than doing so in 1 operation (possible race condition in between accept/fcntl parts).