### PR TITLE
Fix GH-19397: mb_list_encodings() can cause crashes on shutdown

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1165,8 +1165,10 @@ PHP_RSHUTDOWN_FUNCTION(mbstring)
 	MBSTRG(outconv_state) = 0;
 
 	if (MBSTRG(all_encodings_list)) {
-		GC_DELREF(MBSTRG(all_encodings_list));
-		zend_array_destroy(MBSTRG(all_encodings_list));
+		if (GC_DELREF(MBSTRG(all_encodings_list)) == 0) {
+			/* must be *array* destroy to remove from GC root buffer and free the hashtable itself */
+			zend_array_destroy(MBSTRG(all_encodings_list));
+		}
 		MBSTRG(all_encodings_list) = NULL;
 	}
 

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1165,10 +1165,8 @@ PHP_RSHUTDOWN_FUNCTION(mbstring)
 	MBSTRG(outconv_state) = 0;
 
 	if (MBSTRG(all_encodings_list)) {
-		if (GC_DELREF(MBSTRG(all_encodings_list)) == 0) {
-			/* must be *array* destroy to remove from GC root buffer and free the hashtable itself */
-			zend_array_destroy(MBSTRG(all_encodings_list));
-		}
+		/* must be *array* release to remove from GC root buffer and free the hashtable itself */
+		zend_array_release(MBSTRG(all_encodings_list));
 		MBSTRG(all_encodings_list) = NULL;
 	}
 

--- a/ext/mbstring/tests/gh19397.phpt
+++ b/ext/mbstring/tests/gh19397.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-19397 (mb_list_encodings() can cause crashes on shutdown)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+$doNotDeleteThisVariableAssignment = mb_list_encodings();
+var_dump(count($doNotDeleteThisVariableAssignment) > 0);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
The request shutdown does not necessarily hold the last reference, if there is still a CV that refers to the array.