### PR TITLE
ext/intl: wrap DateTimeZone constructor exception in an IntlException

### DIFF
--- a/ext/intl/tests/calendar_toDateTime_error.phpt
+++ b/ext/intl/tests/calendar_toDateTime_error.phpt
@@ -9,31 +9,43 @@ $cal = new IntlGregorianCalendar("Etc/Unknown");
 try {
 	var_dump($cal->toDateTime());
 } catch (Throwable $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    $previous = $e->getPrevious();
+    echo '    ', $previous::class, ': ', $previous->getMessage(), PHP_EOL;
 }
 
 try {
     var_dump(intlcal_to_date_time($cal));
 } catch (Throwable $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    $previous = $e->getPrevious();
+    echo '    ', $previous::class, ': ', $previous->getMessage(), PHP_EOL;
 }
 
 $cal = IntlCalendar::createInstance("Etc/Unknown");
 try {
     var_dump($cal->toDateTime());
 } catch (Throwable $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    $previous = $e->getPrevious();
+    echo '    ', $previous::class, ': ', $previous->getMessage(), PHP_EOL;
 }
 
 try {
     var_dump(intlcal_to_date_time($cal));
 } catch (Throwable $e) {
-	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    $previous = $e->getPrevious();
+    echo '    ', $previous::class, ': ', $previous->getMessage(), PHP_EOL;
 }
 
 ?>
 --EXPECT--
-DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
-DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
-DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
-DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
+IntlException: DateTimeZone constructor threw exception
+    DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
+IntlException: DateTimeZone constructor threw exception
+    DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
+IntlException: DateTimeZone constructor threw exception
+    DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)
+IntlException: DateTimeZone constructor threw exception
+    DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)

--- a/ext/intl/tests/timezone_toDateTimeZone_error.phpt
+++ b/ext/intl/tests/timezone_toDateTimeZone_error.phpt
@@ -4,17 +4,18 @@ IntlTimeZone::toDateTimeZone(): errors
 intl
 --FILE--
 <?php
-ini_set("intl.error_level", E_WARNING);
 
 $tz = IntlTimeZone::createTimeZone('Etc/Unknown');
 
 try {
     var_dump($tz->toDateTimeZone());
-} catch (Exception $e) {
-    var_dump($e->getMessage());
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    $previous = $e->getPrevious();
+    echo '    ', $previous::class, ': ', $previous->getMessage(), PHP_EOL;
 }
 
 ?>
---EXPECTF--
-Warning: IntlTimeZone::toDateTimeZone(): DateTimeZone constructor threw exception in %s on line %d
-string(66) "DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)"
+--EXPECT--
+IntlException: DateTimeZone constructor threw exception
+    DateInvalidTimeZoneException: DateTimeZone::__construct(): Unknown or bad timezone (Etc/Unknown)


### PR DESCRIPTION
The motivation is two fold:
- Userland code that deals with ext/intl can be expected to handle IntlException but not necessarily ext/date exceptions
- This removes the possibility of superfluous warnings being emitted by ext/intl when an exception has already been thrown