### PR TITLE
Fix GH-19406: Redeclaring a protected constant in a child class should work

### DIFF
--- a/Zend/tests/property_protected_redeclare_access.phpt
+++ b/Zend/tests/property_protected_redeclare_access.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Protected property access with redeclared properties in child classes
+--FILE--
+<?php
+
+class B1 {
+    protected $c = 1;
+}
+
+class C1_1 extends B1 {
+    function f(B1 $x) {
+        return $x->c;
+    }
+}
+
+class C2_1 extends B1 {
+    protected $c = 2;
+}
+
+echo "Instance properties: ";
+var_dump((new C1_1)->f(new C2_1));
+
+class B2 {
+    protected static $c = 1;
+}
+
+class C1_2 extends B2 {
+    function f(B2 $x) {
+        return $x::$c;
+    }
+}
+
+class C2_2 extends B2 {
+    protected static $c = 2;
+}
+
+echo "Static properties: ";
+var_dump((new C1_2)->f(new C2_2));
+
+class B3 {
+    protected const c = 1;
+}
+
+class C1_3 extends B3 {
+    function f(B3 $x) {
+        return $x::c;
+    }
+}
+
+class C2_3 extends B3 {
+    protected const c = 2;
+}
+
+echo "Constants: ";
+var_dump((new C1_3)->f(new C2_3));
+
+?>
+--EXPECT--
+Instance properties: int(2)
+Static properties: int(2)
+Constants: int(2)

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -239,7 +239,20 @@ ZEND_API bool zend_verify_const_access(zend_class_constant *c, zend_class_entry 
 		return (c->ce == scope);
 	} else {
 		ZEND_ASSERT(ZEND_CLASS_CONST_FLAGS(c) & ZEND_ACC_PROTECTED);
-		return zend_check_protected(c->ce, scope);
+		
+		if (zend_check_protected(c->ce, scope)) {
+			return 1;
+		}
+
+		const zend_class_entry *current_ce = c->ce;
+		while (current_ce->parent) {
+			if (zend_check_protected(current_ce->parent, scope)) {
+				return 1;
+			}
+			current_ce = current_ce->parent;
+		}
+		
+		return 0;
 	}
 }
 /* }}} */


### PR DESCRIPTION
Fix #19406

The PR only focuses on constants, the other failing cases seem to be fixed already. I targeted 8.4 because of what's been mentioned in the issue.