### PR TITLE
ext/tidy: throwing exception instead of warning for php calls.

### DIFF
--- a/ext/tidy/php_tidy.h
+++ b/ext/tidy/php_tidy.h
@@ -17,6 +17,7 @@
 #ifndef PHP_TIDY_H
 #define PHP_TIDY_H
 
+extern zend_class_entry *tidy_ce_exception;
 extern zend_module_entry tidy_module_entry;
 #define phpext_tidy_ptr &tidy_module_entry
 

--- a/ext/tidy/tests/parsing_inexistent_file.phpt
+++ b/ext/tidy/tests/parsing_inexistent_file.phpt
@@ -6,20 +6,26 @@ tidy
 <?php
 
 $tidy = new tidy;
-var_dump($tidy->parseFile("does_not_exist.html"));
 
-var_dump(tidy_parse_file("does_not_exist.html"));
+try {
+    $tidy->parseFile("does_not_exist.html");
+} catch (Throwable $e) {
+    echo $e::class . '::' . $e->getMessage(), PHP_EOL;
+}
+
+try {
+    tidy_parse_file("does_not_exist.html");
+} catch (Throwable $e) {
+    echo $e::class . '::' . $e->getMessage(), PHP_EOL;
+}
 
 try {
     $tidy = new tidy("does_not_exist.html");
-} catch (Exception $e) {
-    echo $e->getMessage(), "\n";
+} catch (Throwable $e) {
+    echo $e::class . '::' . $e->getMessage(), PHP_EOL;
 }
 ?>
---EXPECTF--
-Warning: tidy::parseFile(): Cannot load "does_not_exist.html" into memory in %s on line %d
-bool(false)
-
-Warning: tidy_parse_file(): Cannot load "does_not_exist.html" into memory in %s on line %d
-bool(false)
-Cannot load "does_not_exist.html" into memory
+--EXPECT--
+TidyException::Cannot load "does_not_exist.html" into memory
+TidyException::Cannot load "does_not_exist.html" into memory
+TidyException::Cannot load "does_not_exist.html" into memory

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -148,6 +148,8 @@ static zend_class_entry *tidy_ce_doc, *tidy_ce_node;
 static zend_object_handlers tidy_object_handlers_doc;
 static zend_object_handlers tidy_object_handlers_node;
 
+zend_class_entry *tidy_ce_exception;
+
 zend_module_entry tidy_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"tidy",
@@ -826,6 +828,9 @@ static PHP_MINIT_FUNCTION(tidy)
 	tidy_object_handlers_node.offset = tidy_object_handlers_doc.offset = XtOffsetOf(PHPTidyObj, std);
 	tidy_object_handlers_node.free_obj = tidy_object_handlers_doc.free_obj = tidy_object_free_storage;
 
+	tidy_ce_exception = register_class_TidyException(zend_ce_exception);
+	tidy_ce_exception->create_object = zend_ce_exception->create_object;
+
 	register_tidy_symbols(module_number);
 
 	php_output_handler_alias_register(ZEND_STRL("ob_tidyhandler"), php_tidy_output_handler_init);
@@ -1051,12 +1056,12 @@ PHP_FUNCTION(tidy_parse_file)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!(contents = php_tidy_file_to_mem(inputfile, use_include_path))) {
-		php_error_docref(NULL, E_WARNING, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
-		RETURN_FALSE;
+		zend_throw_error(tidy_ce_exception, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
+		RETURN_THROWS();
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(contents))) {
-		zend_string_release_ex(contents, 0);
+		zend_string_release_ex(contents, false);
 		zend_value_error("File content is too long");
 		RETURN_THROWS();
 	}
@@ -1327,11 +1332,9 @@ PHP_METHOD(tidy, __construct)
 		Z_PARAM_BOOL(use_include_path)
 	ZEND_PARSE_PARAMETERS_END();
 
-	obj = Z_TIDY_P(ZEND_THIS);
-
 	if (inputfile) {
 		if (!(contents = php_tidy_file_to_mem(inputfile, use_include_path))) {
-			zend_throw_error(zend_ce_exception, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
+			zend_throw_error(tidy_ce_exception, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
 			RETURN_THROWS();
 		}
 
@@ -1343,6 +1346,8 @@ PHP_METHOD(tidy, __construct)
 
 		zend_error_handling error_handling;
 		zend_replace_error_handling(EH_THROW, NULL, &error_handling);
+		obj = Z_TIDY_P(ZEND_THIS);
+
 		if (php_tidy_apply_config(obj->ptdoc->doc, options_str, options_ht, 2) != SUCCESS) {
 			zend_restore_error_handling(&error_handling);
 			zend_string_release_ex(contents, 0);
@@ -1373,11 +1378,9 @@ PHP_METHOD(tidy, parseFile)
 		Z_PARAM_BOOL(use_include_path)
 	ZEND_PARSE_PARAMETERS_END();
 
-	obj = Z_TIDY_P(ZEND_THIS);
-
 	if (!(contents = php_tidy_file_to_mem(inputfile, use_include_path))) {
-		php_error_docref(NULL, E_WARNING, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
-		RETURN_FALSE;
+		zend_throw_error(tidy_ce_exception, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
+		RETURN_THROWS();
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(contents))) {
@@ -1385,6 +1388,8 @@ PHP_METHOD(tidy, parseFile)
 		zend_value_error("File content is too long");
 		RETURN_THROWS();
 	}
+
+	obj = Z_TIDY_P(ZEND_THIS);
 
 	RETVAL_BOOL(php_tidy_apply_config(obj->ptdoc->doc, options_str, options_ht, 2) == SUCCESS
 				&& php_tidy_parse_string(obj, contents, enc) == SUCCESS);

--- a/ext/tidy/tidy.stub.php
+++ b/ext/tidy/tidy.stub.php
@@ -811,6 +811,10 @@ const TIDY_TAG_TRACK = UNKNOWN;
 const TIDY_TAG_VIDEO = UNKNOWN;
 # endif
 
+class TidyException extends Exception
+{
+}
+
 function tidy_parse_string(string $string, array|string|null $config = null, ?string $encoding = null): tidy|false {}
 
 function tidy_get_error_buffer(tidy $tidy): string|false {}

--- a/ext/tidy/tidy_arginfo.h
+++ b/ext/tidy/tidy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e6561410a63658f76011c1ddcecdd1e68757f0a */
+ * Stub hash: 447cc8da5a34139184478956bb5e1a3eb01a866d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_tidy_parse_string, 0, 1, tidy, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
@@ -465,6 +465,16 @@ static void register_tidy_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("TIDY_TAG_TRACK", TidyTag_TRACK, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("TIDY_TAG_VIDEO", TidyTag_VIDEO, CONST_PERSISTENT);
 #endif
+}
+
+static zend_class_entry *register_class_TidyException(zend_class_entry *class_entry_Exception)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "TidyException", NULL);
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+
+	return class_entry;
 }
 
 static zend_class_entry *register_class_tidy(void)


### PR DESCRIPTION
Also using less generic exception type while at it.