### PR TITLE
ext/spl: Deprecate passing spl_autoload_call() to spl_autoload_unregister()

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -582,6 +582,13 @@ PHP_FUNCTION(spl_autoload_unregister)
 
 	if (fcc.function_handler && zend_string_equals_literal(
 			fcc.function_handler->common.function_name, "spl_autoload_call")) {
+		php_error_docref(NULL, E_DEPRECATED,
+			"Using spl_autoload_call() as a callback for spl_autoload_unregister() is deprecated,"
+			" to remove all registered autoloaders, call spl_autoload_unregister()"
+			" for all values returned from spl_autoload_functions()");
+		if (UNEXPECTED(EG(exception))) {
+			RETURN_THROWS();
+		}
 		if (spl_autoload_functions) {
 			/* Don't destroy the hash table, as we might be iterating over it right now. */
 			zend_hash_clean(spl_autoload_functions);

--- a/ext/spl/tests/bug71204.phpt
+++ b/ext/spl/tests/bug71204.phpt
@@ -13,6 +13,8 @@ spl_autoload_register(function ($name) {
 new A();
 ?>
 --EXPECTF--
+Deprecated: spl_autoload_unregister(): Using spl_autoload_call() as a callback for spl_autoload_unregister() is deprecated, to remove all registered autoloaders, call spl_autoload_unregister() for all values returned from spl_autoload_functions() in %s on line %d
+
 Fatal error: Uncaught Error: Class "A" not found in %s:%d
 Stack trace:
 #0 {main}

--- a/ext/spl/tests/spl_autoload_002.phpt
+++ b/ext/spl/tests/spl_autoload_002.phpt
@@ -35,7 +35,7 @@ spl_autoload_unregister('spl_autoload');
 var_dump(spl_autoload_functions());
 
 ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
 array(1) {
@@ -56,6 +56,8 @@ array(2) {
   [1]=>
   string(16) "SplAutoloadTest2"
 }
+
+Deprecated: spl_autoload_unregister(): Using spl_autoload_call() as a callback for spl_autoload_unregister() is deprecated, to remove all registered autoloaders, call spl_autoload_unregister() for all values returned from spl_autoload_functions() in %s on line %d
 array(0) {
 }
 array(1) {

--- a/ext/spl/tests/spl_autoload_unregister_without_registrations.phpt
+++ b/ext/spl/tests/spl_autoload_unregister_without_registrations.phpt
@@ -5,6 +5,8 @@ spl_autoload_unregister("spl_autoload_call") without registrations
 var_dump(spl_autoload_unregister("spl_autoload_call"));
 ?>
 Done
---EXPECT--
+--EXPECTF--
+
+Deprecated: spl_autoload_unregister(): Using spl_autoload_call() as a callback for spl_autoload_unregister() is deprecated, to remove all registered autoloaders, call spl_autoload_unregister() for all values returned from spl_autoload_functions() in %s on line %d
 bool(true)
 Done


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_spl_autoload_call_to_spl_autoload_unregister