### PR TITLE
ext/standard: Deprecate passing null to readdir(), rewinddir(), and closedir()

### DIFF
--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -160,6 +160,8 @@ PHP_FUNCTION(dir)
 static php_stream* php_dir_get_directory_stream_from_user_arg(php_stream *dir_stream)
 {
 	if (dir_stream == NULL) {
+		php_error_docref(NULL, E_DEPRECATED,
+			"Passing null is deprecated, instead the last opened directory stream should be provided");
 		if (UNEXPECTED(DIRG(default_dir) == NULL)) {
 			zend_type_error("No resource supplied");
 			return NULL;

--- a/ext/standard/tests/dir/closedir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/closedir_basic-win32-mb.phpt
@@ -44,6 +44,8 @@ rmdir($dir_path);
 *** Testing closedir() : basic functionality ***
 
 -- Call closedir() with no arguments: --
+
+Deprecated: closedir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 NULL
 -- Check Directory Handle: --
 resource(%d) of type (Unknown)

--- a/ext/standard/tests/dir/closedir_basic.phpt
+++ b/ext/standard/tests/dir/closedir_basic.phpt
@@ -38,6 +38,8 @@ rmdir($dir_path);
 *** Testing closedir() : basic functionality ***
 
 -- Call closedir() with no arguments: --
+
+Deprecated: closedir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 NULL
 -- Check Directory Handle: --
 resource(%d) of type (Unknown)

--- a/ext/standard/tests/dir/closedir_without_arg.phpt
+++ b/ext/standard/tests/dir/closedir_without_arg.phpt
@@ -8,5 +8,6 @@ try {
     echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: closedir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 No resource supplied

--- a/ext/standard/tests/dir/readdir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/readdir_basic-win32-mb.phpt
@@ -65,6 +65,18 @@ string(9) "file3.tmp"
 
 -- Call readdir() without $path argument --
 resource(%d) of type (stream)
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 string(1) "."
 string(2) ".."
 string(9) "file1.tmp"

--- a/ext/standard/tests/dir/readdir_basic.phpt
+++ b/ext/standard/tests/dir/readdir_basic.phpt
@@ -59,6 +59,18 @@ string(9) "file3.tmp"
 
 -- Call readdir() without $path argument --
 resource(%d) of type (stream)
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 string(1) "."
 string(2) ".."
 string(9) "file1.tmp"

--- a/ext/standard/tests/dir/readdir_variation6-win32-mb.phpt
+++ b/ext/standard/tests/dir/readdir_variation6-win32-mb.phpt
@@ -61,7 +61,7 @@ closedir();
 $dir_path = __DIR__ . "/私はガラスを食べられますreaddir_variation6";
 rmdir($dir_path);
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing readdir() : usage variations ***
 
 -- Reading Directory Contents with Previous Handle --
@@ -72,8 +72,22 @@ string(59) "私はガラスを食べられますreaddir_variation62.tmp"
 string(59) "私はガラスを食べられますreaddir_variation63.tmp"
 
 -- Reading Directory Contents with Current Handle (no arguments supplied) --
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 string(1) "."
 string(2) ".."
 string(59) "私はガラスを食べられますreaddir_variation61.tmp"
 string(59) "私はガラスを食べられますreaddir_variation62.tmp"
 string(59) "私はガラスを食べられますreaddir_variation63.tmp"
+
+Deprecated: closedir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d

--- a/ext/standard/tests/dir/readdir_variation6.phpt
+++ b/ext/standard/tests/dir/readdir_variation6.phpt
@@ -55,7 +55,7 @@ closedir();
 $dir_path = __DIR__ . "/readdir_variation6";
 rmdir($dir_path);
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing readdir() : usage variations ***
 
 -- Reading Directory Contents with Previous Handle --
@@ -66,8 +66,22 @@ string(23) "readdir_variation62.tmp"
 string(23) "readdir_variation63.tmp"
 
 -- Reading Directory Contents with Current Handle (no arguments supplied) --
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 string(1) "."
 string(2) ".."
 string(23) "readdir_variation61.tmp"
 string(23) "readdir_variation62.tmp"
 string(23) "readdir_variation63.tmp"
+
+Deprecated: closedir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d

--- a/ext/standard/tests/dir/rewinddir_basic-win32-mb.phpt
+++ b/ext/standard/tests/dir/rewinddir_basic-win32-mb.phpt
@@ -82,6 +82,14 @@ NULL
 bool(true)
 
 -- Read and rewind second directory (no argument supplied) --
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 array(3) {
   [0]=>
   string(1) "."
@@ -90,5 +98,9 @@ array(3) {
   [2]=>
   string(45) "私はガラスを食べられますfile2.tmp"
 }
+
+Deprecated: rewinddir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 NULL
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 bool(true)

--- a/ext/standard/tests/dir/rewinddir_basic.phpt
+++ b/ext/standard/tests/dir/rewinddir_basic.phpt
@@ -76,6 +76,14 @@ NULL
 bool(true)
 
 -- Read and rewind second directory (no argument supplied) --
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 array(3) {
   [0]=>
   string(1) "."
@@ -84,5 +92,9 @@ array(3) {
   [2]=>
   string(9) "file2.tmp"
 }
+
+Deprecated: rewinddir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 NULL
+
+Deprecated: readdir(): Passing null is deprecated, instead the last opened directory stream should be provided in %s on line %d
 bool(true)


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_null_to_readdir_rewinddir_and_closedir