### PR TITLE
ext/intl: Deprecate intl.error_level INI setting

### DIFF
--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -98,10 +98,24 @@ const char *intl_locale_get_default( void )
 	return INTL_G(default_locale);
 }
 
+static PHP_INI_MH(OnUpdateErrorLevel)
+{
+	zend_long *p = (zend_long *) ZEND_INI_GET_ADDR();
+	*p = zend_ini_parse_quantity_warn(new_value, entry->name);
+	if (*p) {
+		php_error_docref("session.configuration", E_DEPRECATED,
+			"Using a value different than 0 for intl.error_level is deprecated,"
+			" as the intl.error_level INI setting is deprecated."
+			" Instead the intl.use_exceptions INI setting should be enabled to throw exceptions on errors"
+			" or intl_get_error_code()/intl_get_error_message() should be used to manually deal with errors");
+	}
+	return SUCCESS;
+}
+
 /* {{{ INI Settings */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY(LOCALE_INI_NAME, NULL, PHP_INI_ALL, OnUpdateStringUnempty, default_locale, zend_intl_globals, intl_globals)
-	STD_PHP_INI_ENTRY("intl.error_level", "0", PHP_INI_ALL, OnUpdateLong, error_level, zend_intl_globals, intl_globals)
+	STD_PHP_INI_ENTRY("intl.error_level", "0", PHP_INI_ALL, OnUpdateErrorLevel, error_level, zend_intl_globals, intl_globals)
 	STD_PHP_INI_BOOLEAN("intl.use_exceptions", "0", PHP_INI_ALL, OnUpdateBool, use_exceptions, zend_intl_globals, intl_globals)
 PHP_INI_END()
 /* }}} */

--- a/ext/intl/tests/gh17469.phpt
+++ b/ext/intl/tests/gh17469.phpt
@@ -28,9 +28,10 @@ try {
 }
 ?>
 --EXPECTF--
+Deprecated: ini_set(): Using a value different than 0 for intl.error_level is deprecated, as the intl.error_level INI setting is deprecated. Instead the intl.use_exceptions INI setting should be enabled to throw exceptions on errors or intl_get_error_code()/intl_get_error_message() should be used to manually deal with errors in %s on line %d
 
 Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line %d
 
-Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line 5
+Warning: UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR in %s on line %d
 UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR
 UConverter::transcode(): Error setting encoding: 4 - U_FILE_ACCESS_ERROR

--- a/ext/intl/tests/ini_use_exceptions_basic.phpt
+++ b/ext/intl/tests/ini_use_exceptions_basic.phpt
@@ -18,5 +18,7 @@ var_dump($t->transliterate('a', 3));
 --EXPECTF--
 string(133) "Transliterator::transliterate(): Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1)"
 
+Deprecated: ini_set(): Using a value different than 0 for intl.error_level is deprecated, as the intl.error_level INI setting is deprecated. Instead the intl.use_exceptions INI setting should be enabled to throw exceptions on errors or intl_get_error_code()/intl_get_error_message() should be used to manually deal with errors in %s on line %d
+
 Notice: Transliterator::transliterate(): Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 1) in %s on line %d
 bool(false)

--- a/ext/intl/tests/timezone_createTimeZoneIDEnumeration_variant2.phpt
+++ b/ext/intl/tests/timezone_createTimeZoneIDEnumeration_variant2.phpt
@@ -4,7 +4,6 @@ IntlTimeZone::createTimeZoneIDEnumeration(): variant without region
 intl
 --FILE--
 <?php
-ini_set("intl.error_level", E_WARNING);
 $enum = IntlTimeZone::createTimeZoneIDEnumeration(
     IntlTimeZone::TYPE_ANY);
 $countAny = count(iterator_to_array($enum));

--- a/php.ini-development
+++ b/php.ini-development
@@ -1021,8 +1021,12 @@ cli_server.color = On
 ; This directive allows you to produce PHP errors when some error
 ; happens within intl functions. The value is the level of the error produced.
 ; Default is 0, which does not produce any errors.
+; This directive is deprecated.
 ;intl.error_level = E_WARNING
-;intl.use_exceptions = 0
+; If enabled this directive indicates that when an error occurs within an
+; intl function a IntlException should be thrown.
+; Default is Off, which means errors need to be handled manually.
+;intl.use_exceptions = On
 
 [sqlite3]
 ; Directory pointing to SQLite3 extensions

--- a/php.ini-production
+++ b/php.ini-production
@@ -1023,8 +1023,12 @@ cli_server.color = On
 ; This directive allows you to produce PHP errors when some error
 ; happens within intl functions. The value is the level of the error produced.
 ; Default is 0, which does not produce any errors.
+; This directive is deprecated.
 ;intl.error_level = E_WARNING
-;intl.use_exceptions = 0
+; If enabled this directive indicates that when an error occurs within an
+; intl function a IntlException should be thrown.
+; Default is Off, which means errors need to be handled manually.
+;intl.use_exceptions = On
 
 [sqlite3]
 ; Directory pointing to SQLite3 extensions


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_intlerror_level_ini_setting