### PR TITLE
Fix GH-19428: openssl_pkey_derive segfaults for DH with low key_length

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5200,11 +5200,19 @@ PHP_FUNCTION(openssl_pkey_get_details)
 }
 /* }}} */
 
-static zend_string *php_openssl_pkey_derive(EVP_PKEY *key, EVP_PKEY *peer_key, size_t key_size) {
+static zend_string *php_openssl_pkey_derive(EVP_PKEY *key, EVP_PKEY *peer_key, size_t requested_key_size) {
+	size_t key_size = requested_key_size;
 	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(key, NULL);
 	if (!ctx) {
 		return NULL;
 	}
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+	/* OpenSSL 1.1 does not respect key_size for DH, so force size discovery so it can be compared later. */
+	if (EVP_PKEY_base_id(key) == EVP_PKEY_DH && key_size != 0) {
+		key_size = 0;
+	}
+#endif
 
 	if (EVP_PKEY_derive_init(ctx) <= 0 ||
 			EVP_PKEY_derive_set_peer(ctx, peer_key) <= 0 ||
@@ -5213,6 +5221,14 @@ static zend_string *php_openssl_pkey_derive(EVP_PKEY *key, EVP_PKEY *peer_key, s
 		EVP_PKEY_CTX_free(ctx);
 		return NULL;
 	}
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+	/* Now compare the computed size for DH to mirror OpenSSL 3.0+ behavior. */
+	if (EVP_PKEY_base_id(key) == EVP_PKEY_DH && requested_key_size > 0 && requested_key_size < key_size) {
+		EVP_PKEY_CTX_free(ctx);
+		return NULL;
+	}
+#endif
 
 	zend_string *result = zend_string_alloc(key_size, 0);
 	if (EVP_PKEY_derive(ctx, (unsigned char *)ZSTR_VAL(result), &key_size) <= 0) {

--- a/ext/openssl/tests/gh19428.phpt
+++ b/ext/openssl/tests/gh19428.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-19428: openssl_pkey_derive() DH with low key_length
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+$priv = openssl_pkey_get_private("-----BEGIN PRIVATE KEY-----
+MIICJgIBADCCARcGCSqGSIb3DQEDATCCAQgCggEBAJLxRCaZ933uW+AXmabHFDDy
+upojBIRlbmQLJZfigDaSA1f9YOTsIv+WwVFTX/J1mtCyx9uBcz0Nt2kmVwxWuc2f
+VtCEMPsmLsVXX7xRUFLpyX1Y1IYGBVXQOoOvLWYQjpZgnx47Pkh1Ok1+smffztfC
+0DCNt4KorWrbsPcmqBejXHN79KvWFjZmXOksRiNu/Bn76RiqvofC4z8Ri3kHXQG2
+197JGZzzFXHadGC3xbkg8UxsNbYhVMKbm0iANfafUH7/hoS9UjAVQYtvwe7YNiW/
+HnyfVCrKwcc7sadd8Iphh+3lf5P1AhaQEAMytanrzq9RDXKBxuvpSJifRYasZYsC
+AQIEggEEAoIBAGwAYC2E81Y1U2Aox0U7u1+vBcbht/OO87tutMvc4NTLf6NLPHsW
+cPqBixs+3rSn4fADzAIvdLBmogjtiIZoB6qyHrllF/2xwTVGEeYaZIupQH3bMK2b
+6eUvnpuu4Ytksiz6VpXBBRMrIsj3frM+zUtnq8vKUr+TbjV2qyKR8l3eNDwzqz30
+dlbKh9kIhZafclHfRVfyp+fVSKPfgrRAcLUgAbsVjOjPeJ90xQ4DTMZ6vjiv6tHM
+hkSjJIcGhRtSBzVF/cT38GyCeTmiIA/dRz2d70lWrqDQCdp9ArijgnpjNKAAulSY
+CirnMsGZTDGmLOHg4xOZ5FEAzZI2sFNLlcw=
+-----END PRIVATE KEY-----
+");
+
+$pub = openssl_pkey_get_public("-----BEGIN PUBLIC KEY-----
+MIICJDCCARcGCSqGSIb3DQEDATCCAQgCggEBAJLxRCaZ933uW+AXmabHFDDyupoj
+BIRlbmQLJZfigDaSA1f9YOTsIv+WwVFTX/J1mtCyx9uBcz0Nt2kmVwxWuc2fVtCE
+MPsmLsVXX7xRUFLpyX1Y1IYGBVXQOoOvLWYQjpZgnx47Pkh1Ok1+smffztfC0DCN
+t4KorWrbsPcmqBejXHN79KvWFjZmXOksRiNu/Bn76RiqvofC4z8Ri3kHXQG2197J
+GZzzFXHadGC3xbkg8UxsNbYhVMKbm0iANfafUH7/hoS9UjAVQYtvwe7YNiW/Hnyf
+VCrKwcc7sadd8Iphh+3lf5P1AhaQEAMytanrzq9RDXKBxuvpSJifRYasZYsCAQID
+ggEFAAKCAQAiCSBpxvGgsTorxAWtcAlSmzAJnJxFgSPef0g7OjhESytnc8G2QYmx
+ovMt5KVergcitztWh08hZQUdAYm4rI+zMlAFDdN8LWwBT/mGKSzRkWeprd8E7mvy
+ucqC1YXCMqmIwPySvLQUB/Dl8kgau7BLAnIJm8VP+MVrn8g9gghD0qRCgPgtEaDV
+vocfgnOU43rhKnIgO0cHOKtw2qybSFB8QuZrYugq4j8Bwkrzh6rdMMeyMl/ej5Aj
+c0wamOzuBDtXt0T9+Fx3khHaowjCc7xJZRgZCxg43SbqMWJ9lUg94I7+LTX61Gyv
+dtlkbGbtoDOnxeNnN93gwQZngGYZYciu
+-----END PUBLIC KEY-----
+");
+
+var_dump(openssl_pkey_derive($pub, $priv, 10));
+
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
This happens only for OpenSSL 1.1.1 because key_length is ignored for DH. It means that the provided string is overwritten with longer buffer.