### PR TITLE
Fix GH-19369: openssl_sign() - support for alias digest algs broken

### DIFF
--- a/ext/openssl/openssl_backend_v3.c
+++ b/ext/openssl/openssl_backend_v3.c
@@ -713,6 +713,12 @@ zend_string *php_openssl_dh_compute_key(EVP_PKEY *pkey, char *pub_str, size_t pu
 
 const EVP_MD *php_openssl_get_evp_md_by_name(const char *name)
 {
+	const EVP_MD *dp = (const EVP_MD *) OBJ_NAME_get(name, OBJ_NAME_TYPE_MD_METH);
+
+	if (dp != NULL) {
+		return dp;
+	}
+
 	return EVP_MD_fetch(PHP_OPENSSL_LIBCTX, name, PHP_OPENSSL_PROPQ);
 }
 

--- a/ext/openssl/tests/gh19369.phpt
+++ b/ext/openssl/tests/gh19369.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-19369: openssl_sign with alias algorithms
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!in_array('sha256WithRSAEncryption', openssl_get_md_methods(true))) {
+    die('skip sha256WithRSAEncryption alias not present');
+}
+?>
+--FILE--
+<?php
+$digests             = openssl_get_md_methods();
+$digests_and_aliases = openssl_get_md_methods(true);
+$digest_aliases      = array_diff($digests_and_aliases, $digests);
+
+$data = "Testing openssl_sign() with alias algorithm";
+$privkey = "file://" . __DIR__ . "/private_rsa_1024.key";
+
+var_dump(openssl_sign($data, $sign, $privkey, 'sha256WithRSAEncryption'));
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
This was due to difference in `EVP_get_digestbyname` and pure `EVP_MD_fetch` that does not consider aliases.