### PR TITLE
Fix OpenSSL fetching of alias ciphers

### DIFF
--- a/ext/openssl/openssl_backend_v3.c
+++ b/ext/openssl/openssl_backend_v3.c
@@ -769,6 +769,12 @@ static const char *php_openssl_cipher_names[] = {
 
 const EVP_CIPHER *php_openssl_get_evp_cipher_by_name(const char *name)
 {
+	const EVP_CIPHER *cp = (const EVP_CIPHER *) OBJ_NAME_get(name, OBJ_NAME_TYPE_CIPHER_METH);
+
+	if (cp != NULL) {
+		return cp;
+	}
+
 	return EVP_CIPHER_fetch(PHP_OPENSSL_LIBCTX, name, PHP_OPENSSL_PROPQ);
 }
 

--- a/ext/openssl/tests/openssl_encrypt_cbc.phpt
+++ b/ext/openssl/tests/openssl_encrypt_cbc.phpt
@@ -1,0 +1,12 @@
+--TEST--
+openssl_encrypt() CBC and its alias
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+var_dump(bin2hex(openssl_encrypt('data', 'AES-128-CBC', 'foo', 0, '0123456789abcdef')));
+var_dump(bin2hex(openssl_encrypt('data', 'aes128', 'foo', 0, '0123456789abcdef')));
+?>
+--EXPECTF--
+string(48) "7a654459353452676f6c6b6a446b75455a6c4c6b4f513d3d"
+string(48) "7a654459353452676f6c6b6a446b75455a6c4c6b4f513d3d"


### PR DESCRIPTION
This does not seem like an issue as the aliases seem to be already fetched most of the time. But there might be cases when it could be failing like it was failing for MD in GH-19369.

It should be noted that the test does not fail without this change but it seems useful anyway so it is added as part of this change. I actually have not found the case where alias is not fetched for cipher but there might be some.