### PR TITLE
Fix GH-15496: Fix accessing NULL pointer on output handler stack

### DIFF
--- a/ext/standard/tests/gh15496_original_reproducer.phpt
+++ b/ext/standard/tests/gh15496_original_reproducer.phpt
@@ -1,0 +1,54 @@
+--TEST--
+GH-15496: Session handler ob_start crash
+--FILE--
+<?php
+class MySessionHandler implements SessionHandlerInterface
+{
+    public function open ($save_path, $session_name): bool
+    {
+        return true;
+    }
+
+    public function close(): bool
+    {
+      return true;
+    }
+
+    public function read($id): string
+    {
+        return '';
+    }
+
+    public function write($id, $sess_data): bool
+    {
+        ob_start(function () {});
+
+        return true;
+    }
+
+    public function destroy($id): bool
+    {
+        return true;
+    }
+
+    public function gc($maxlifetime): int
+    {
+        return 0;
+    }
+}
+
+session_set_save_handler(new MySessionHandler());
+session_start();
+
+ob_start(function() {
+    var_dump($b);
+});
+
+while (1) {
+    $a[] = 1;
+}
+?>
+--EXPECTF--
+Fatal error: {closure%A}(): Cannot use output buffering in output buffering display handlers in %s on line %d
+
+Notice: ob_start(): Failed to create buffer in %s on line %d

--- a/main/output.c
+++ b/main/output.c
@@ -257,7 +257,7 @@ PHPAPI int php_output_flush(void)
 	if (OG(active) && (OG(active)->flags & PHP_OUTPUT_HANDLER_FLUSHABLE)) {
 		php_output_context_init(&context, PHP_OUTPUT_HANDLER_FLUSH);
 		php_output_handler_op(OG(active), &context);
-		if (context.out.data && context.out.used) {
+		if (context.out.data && context.out.used && OG(flags) & PHP_OUTPUT_ACTIVATED) {
 			zend_stack_del_top(&OG(handlers));
 			php_output_write(context.out.data, context.out.used);
 			zend_stack_push(&OG(handlers), &OG(active));
@@ -536,6 +536,9 @@ PHPAPI int php_output_handler_start(php_output_handler *handler)
 	php_output_handler_conflict_check_t conflict;
 
 	if (php_output_lock_error(PHP_OUTPUT_HANDLER_START) || !handler) {
+		return FAILURE;
+	}
+	if (!(OG(flags) & PHP_OUTPUT_ACTIVATED)) {
 		return FAILURE;
 	}
 	if (NULL != (conflict = zend_hash_find_ptr(&php_output_handler_conflicts, handler->name))) {


### PR DESCRIPTION
Fix #15496

This PR prevents `zend_stack_push()` from being called when the `PHP_OUTPUT_ACTIVATED` flag is cleared by `php_output_deactivate()`. The new test case also crashes on branch PHP-8.3 and is passing with this fix.