### PR TITLE
[RFC] Deprecate returning null from __debugInfo()

### DIFF
--- a/Zend/tests/debug_info/debug_info.phpt
+++ b/Zend/tests/debug_info/debug_info.phpt
@@ -36,5 +36,7 @@ object(Foo)#%d (3) {
   ["c":"Foo":private]=>
   int(3)
 }
+
+Deprecated: Returning null from Bar::__debugInfo() is deprecated in %s on line %d
 object(Bar)#%d (0) {
 }

--- a/Zend/tests/debug_info/debug_info.phpt
+++ b/Zend/tests/debug_info/debug_info.phpt
@@ -37,6 +37,6 @@ object(Foo)#%d (3) {
   int(3)
 }
 
-Deprecated: Returning null from Bar::__debugInfo() is deprecated in %s on line %d
+Deprecated: Returning null from Bar::__debugInfo() is deprecated, return an empty array instead in %s on line %d
 object(Bar)#%d (0) {
 }

--- a/Zend/tests/debug_info/recursion_return_null.phpt
+++ b/Zend/tests/debug_info/recursion_return_null.phpt
@@ -24,7 +24,7 @@ var_dump($f);
 --EXPECTF--
 in handler
 
-Deprecated: Returning null from Foo::__debugInfo() is deprecated in %s on line %d
+Deprecated: Returning null from Foo::__debugInfo() is deprecated, return an empty array instead in %s on line %d
 object(Foo)#3 (0) {
 }
 object(Foo)#2 (0) {

--- a/Zend/tests/debug_info/recursion_return_null.phpt
+++ b/Zend/tests/debug_info/recursion_return_null.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Testing __debugInfo() magic method
+--FILE--
+<?php
+
+set_error_handler(
+    static function () {
+        echo "in handler\n";
+        $f = new Foo();
+        var_dump($f);
+    }
+);
+
+class Foo {
+  public function __debugInfo() {
+    return null;
+  }
+}
+
+$f = new Foo;
+var_dump($f);
+
+?>
+--EXPECTF--
+in handler
+
+Deprecated: Returning null from Foo::__debugInfo() is deprecated in %s on line %d
+object(Foo)#3 (0) {
+}
+object(Foo)#2 (0) {
+}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -223,6 +223,8 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 			return Z_ARRVAL(retval);
 		}
 	} else if (Z_TYPE(retval) == IS_NULL) {
+		zend_error(E_DEPRECATED, "Returning null from %s::__debugInfo() is deprecated",
+			ZSTR_VAL(ce->name));
 		*is_temp = 1;
 		ht = zend_new_array(0);
 		return ht;

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -223,7 +223,7 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 			return Z_ARRVAL(retval);
 		}
 	} else if (Z_TYPE(retval) == IS_NULL) {
-		zend_error(E_DEPRECATED, "Returning null from %s::__debugInfo() is deprecated",
+		zend_error(E_DEPRECATED, "Returning null from %s::__debugInfo() is deprecated, return an empty array instead",
 			ZSTR_VAL(ce->name));
 		*is_temp = 1;
 		ht = zend_new_array(0);


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_5