### PR TITLE
[RFC] Deprecate ReflectionClass::getConstant() for missing constants

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4855,6 +4855,11 @@ ZEND_METHOD(ReflectionClass, getConstant)
 		}
 	} ZEND_HASH_FOREACH_END();
 	if ((c = zend_hash_find_ptr(constants_table, name)) == NULL) {
+		zend_error(
+			E_DEPRECATED,
+			"ReflectionClass::getConstant() for a non-existent constant is deprecated, "
+				"use ReflectionClass::hasConstant() to check if the constant exists"
+		);
 		RETURN_FALSE;
 	}
 	ZVAL_COPY_OR_DUP(return_value, &c->value);

--- a/ext/reflection/tests/022.phpt
+++ b/ext/reflection/tests/022.phpt
@@ -9,6 +9,8 @@ $class = new ReflectionClass("Foo");
 var_dump($class->getConstant("c1"));
 var_dump($class->getConstant("c2"));
 ?>
---EXPECT--
+--EXPECTF--
 int(1)
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)

--- a/ext/reflection/tests/ReflectionClass_getConstant_basic.phpt
+++ b/ext/reflection/tests/ReflectionClass_getConstant_basic.phpt
@@ -23,19 +23,31 @@ foreach($classes as $class) {
     var_dump($rc->getConstant('doesnotexist'));
 }
 ?>
---EXPECT--
+--EXPECTF--
 Reflecting on class C:
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on class D:
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on class E:
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on class F:
 string(12) "hello from F"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on class X:
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)

--- a/ext/reflection/tests/ReflectionClass_getConstant_error.phpt
+++ b/ext/reflection/tests/ReflectionClass_getConstant_error.phpt
@@ -12,8 +12,14 @@ var_dump($rc->getConstant(1));
 var_dump($rc->getConstant(1.5));
 var_dump($rc->getConstant(true));
 ?>
---EXPECT--
+--EXPECTF--
 Check invalid params:
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)

--- a/ext/reflection/tests/ReflectionObject_getConstant_basic.phpt
+++ b/ext/reflection/tests/ReflectionObject_getConstant_basic.phpt
@@ -23,19 +23,31 @@ foreach($classes as $class) {
     var_dump($rc->getConstant('doesNotexist'));
 }
 ?>
---EXPECT--
+--EXPECTF--
 Reflecting on instance of class C: 
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on instance of class D: 
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on instance of class E: 
 string(12) "hello from C"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on instance of class F: 
 string(12) "hello from F"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Reflecting on instance of class X: 
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)

--- a/ext/reflection/tests/bug38653.phpt
+++ b/ext/reflection/tests/bug38653.phpt
@@ -20,9 +20,11 @@ var_dump($foo->getConstant("no such const"));
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
 int(10)
 string(0) ""
 string(4) "test"
+
+Deprecated: ReflectionClass::getConstant() for a non-existent constant is deprecated, use ReflectionClass::hasConstant() to check if the constant exists in %s on line %d
 bool(false)
 Done


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_5