### PR TITLE
[RFC] Deprecate ReflectionProperty::getDefaultValue() without default

### DIFF
--- a/Zend/tests/property_hooks/cpp.phpt
+++ b/Zend/tests/property_hooks/cpp.phpt
@@ -24,11 +24,13 @@ var_dump($r->hasDefaultValue());
 var_dump($r->getDefaultValue());
 
 ?>
---EXPECT--
+--EXPECTF--
 Pre-test
 Setting
 Constructor
 Getting
 Setting
 bool(false)
+
+Deprecated: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, use ReflectionProperty::hasDefaultValue() to check if the default value exists in %s on line %d
 NULL

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6509,11 +6509,22 @@ ZEND_METHOD(ReflectionProperty, getDefaultValue)
 	prop_info = ref->prop;
 
 	if (prop_info == NULL) {
-		return; // throw exception?
+		// Dynamic property
+		zend_error(
+			E_DEPRECATED,
+			"ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, "
+				"use ReflectionProperty::hasDefaultValue() to check if the default value exists"
+		);
+		return;
 	}
 
 	prop = property_get_default(prop_info);
 	if (!prop || Z_ISUNDEF_P(prop)) {
+		zend_error(
+			E_DEPRECATED,
+			"ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, "
+				"use ReflectionProperty::hasDefaultValue() to check if the default value exists"
+		);
 		return;
 	}
 

--- a/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
@@ -60,15 +60,21 @@ $property = new ReflectionProperty($test, 'dynamic');
 var_dump($property->getDefaultValue());
 
 ?>
---EXPECT--
+--EXPECTF--
 NULL
 string(3) "baz"
 NULL
 int(1234)
+
+Deprecated: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, use ReflectionProperty::hasDefaultValue() to check if the default value exists in %s on line %d
 NULL
 int(1234)
+
+Deprecated: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, use ReflectionProperty::hasDefaultValue() to check if the default value exists in %s on line %d
 NULL
 NULL
 int(4)
 int(42)
+
+Deprecated: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, use ReflectionProperty::hasDefaultValue() to check if the default value exists in %s on line %d
 NULL


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_5