### PR TITLE
Fix Nightly workflow Symfony assertion (ir_ra.c:326: ir_fix_live_range: Assertion `ival && p->start == old_start' failed)

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -14642,6 +14642,13 @@ static int zend_jit_assign_obj(zend_jit_ctx         *jit,
 	ir_ref slow_inputs = IR_UNUSED;
 	uint32_t res_info = RES_INFO();
 
+	if (Z_MODE(val_addr) == IS_REG
+	 && Z_LOAD(val_addr)
+	 && jit->ra[Z_SSA_VAR(val_addr)].ref == IR_NULL) {
+		/* Force load */
+		zend_jit_use_reg(jit, val_addr);
+	}
+
 	if (val_addr != val_def_addr && val_def_addr) {
 		if (!zend_jit_update_regs(jit, (opline+1)->op1.var, val_addr, val_def_addr, val_info)) {
 			return 0;


### PR DESCRIPTION
The problem occurred because the usage of SSA variable wasn't dominated by its definition.
PHP-JIT decided to use register for variable `#5`, but loaded the value to register (`d_66`) too late.

```
---- TRACE 3662 TSSA start (side trace 3479/8) {closure:Symfony\Component\Cache\Adapter\AbstractTagAwareAdapter::__construct():66}() /home/dmitry/php/community_tests/symfony/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php:76
     ;#1.CV1($value) [rc1, rcn, array of [any, ref]]
     ;#3.CV3($item) [rc1, rcn, object]
     ;#5.X5 [!long]
0018 ASSIGN_OBJ #3.CV3($item) [rc1, rcn, object] -> #9.CV3($item) [rc1, rcn, object] string("value") ; op1(object of class Symfony\Component\Cache\CacheItem) op3(int) val(null)
0019 ;OP_DATA #5.T5 [!long]
	 ...
---- TRACE 3662 TSSA stop (return)
---- TRACE 3662 Live Ranges "{closure:Symfony\Component\Cache\Adapter\AbstractTagAwareAdapter::__construct():66}"
#5.X5 last_use load

TRACE-3662${closure:Symfony\Component\Cache\Adapter\AbstractTagAwareAdapter::__construct():66}$76: ; after folding
{
    ...
	l_62 = IF(l_61, d_61);
	l_63 = IF_TRUE(l_62, 1);
	uintptr_t d_64, l_64 = RLOAD(l_63, 14);
	uintptr_t d_65 = ADD(d_64, c_9);
	int64_t d_66, l_66 = LOAD(l_64, d_65);                     # LOAD(T5)
	l_67 = STORE(l_66, d_64, c_21);                            # EX(opline) = ?
	l_68 = CALL/4(l_67, c_22, d_53, d_61, d_65, c_1);          # zend_jit_assign_to_typed_prop()
	l_70 = END(l_68);
	l_71 = IF_FALSE(l_62);
	bool d_72 = EQ(d_55, c_23);
	l_73 = IF(l_71, d_72);
	l_74 = IF_TRUE(l_73);
	uintptr_t d_75, l_75 = LOAD(l_74, d_53);
	uintptr_t d_76 = ADD(d_75, c_24);
	uintptr_t d_77, l_77 = LOAD(l_75, d_76);
	l_78 = IF(l_77, d_77);
	l_79 = IF_TRUE(l_78, 1);
	uintptr_t d_80, l_80 = RLOAD(l_79, 14);
	l_81 = STORE(l_80, d_80, c_21);                           
	uintptr_t d_82 = ADD(d_80, c_9);
	l_83 = STORE(l_81, d_82, d_66);                            # SPILL_STORE(T5)
	uintptr_t d_84, l_84 = CALL/2(l_83, c_25, d_75, d_82);     # zend_jit_assign_tmp_to_typed_ref()
	...
```

Fix just moves the load at start of jit code for ASSIGN_OBJ.

It seems like SPILL_STORE code is useless, because we perform STORE into the same location as previous LOAD.