### PR TITLE
Fix #81724: openssl_cms_encrypt only allows specific ciphers

### DIFF
--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -574,7 +574,7 @@ function openssl_pkcs7_read(string $data, &$certificates): bool {}
 function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): bool {}
 
 /** @param OpenSSLCertificate|array|string $certificate */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): bool {}
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, string|int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): bool {}
 
 /**
  * @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $private_key

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 03e511abb97901a4a8268276b809b3cf7afbfa29 */
+ * Stub hash: 0e6a5f1a5f23602bafd5b7fdb10525c19a9476fc */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
@@ -219,7 +219,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_cms_encrypt, 0, 4, _IS_B
 	ZEND_ARG_TYPE_INFO(0, headers, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_LONG, 0, "OPENSSL_ENCODING_SMIME")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cipher_algo, IS_LONG, 0, "OPENSSL_CIPHER_AES_128_CBC")
+	ZEND_ARG_TYPE_MASK(0, cipher_algo, MAY_BE_STRING|MAY_BE_LONG, "OPENSSL_CIPHER_AES_128_CBC")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_cms_sign, 0, 5, _IS_BOOL, 0)

--- a/ext/openssl/tests/openssl_cms_encrypt_auth_env.phpt
+++ b/ext/openssl/tests/openssl_cms_encrypt_auth_env.phpt
@@ -1,0 +1,34 @@
+--TEST--
+openssl_cms_encrypt() auth enveloped data tests
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (OPENSSL_VERSION_NUMBER < 0x30000000) die('skip For OpenSSL >= 3.0');
+?>
+--FILE--
+<?php
+$infile = __DIR__ . "/plain.txt";
+$outfile = __DIR__ . "/openssl_cms_encrypt_auth_env.out1";
+$outfile2 = __DIR__ . "/openssl_cms_encrypt_auth_env.out2";
+$single_cert = "file://" . __DIR__ . "/cert.crt";
+$privkey = "file://" . __DIR__ . "/private_rsa_1024.key";
+$headers = array("test@test", "testing openssl_cms_encrypt()");
+$cipher = "AES-128-GCM";
+
+var_dump(openssl_cms_encrypt($infile, $outfile, $single_cert, $headers, cipher_algo: $cipher));
+var_dump(openssl_cms_encrypt($infile, $outfile, openssl_x509_read($single_cert), $headers, cipher_algo: $cipher));
+var_dump(openssl_cms_decrypt($outfile, $outfile2, $single_cert, $privkey));
+readfile($outfile2);
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/openssl_cms_encrypt_auth_env.out1");
+@unlink(__DIR__ . "/openssl_cms_encrypt_auth_env.out2");
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+Now is the winter of our discontent.

--- a/ext/openssl/tests/openssl_cms_encrypt_basic.phpt
+++ b/ext/openssl/tests/openssl_cms_encrypt_basic.phpt
@@ -5,13 +5,9 @@ openssl
 --FILE--
 <?php
 $infile = __DIR__ . "/plain.txt";
-$outfile = tempnam(sys_get_temp_dir(), "cms_enc_basic");
-if ($outfile === false)
-    die("failed to get a temporary filename!");
-$outfile2 = $outfile . ".out";
-$outfile3 = tempnam(sys_get_temp_dir(), "cms_enc_basic");
-if ($outfile3 === false)
-    die("failed to get a temporary filename!");
+$outfile = __DIR__ . "/openssl_cms_encrypt_basic.out1";
+$outfile2 = __DIR__ . "/openssl_cms_encrypt_basic.out2";
+$outfile3 = __DIR__ . "/openssl_cms_encrypt_basic.out3";
 $single_cert = "file://" . __DIR__ . "/cert.crt";
 $privkey = "file://" . __DIR__ . "/private_rsa_1024.key";
 $wrongkey = "file://" . __DIR__ . "/private_rsa_2048.key";
@@ -27,7 +23,7 @@ var_dump(openssl_cms_encrypt($infile, $outfile, $single_cert, $headers, cipher_a
 var_dump(openssl_cms_encrypt($infile, $outfile, openssl_x509_read($single_cert), $headers, cipher_algo: $cipher));
 var_dump(openssl_cms_decrypt($outfile, $outfile2, $single_cert, $privkey));
 readfile($outfile2);
-var_dump(openssl_cms_encrypt($infile, $outfile, $single_cert, $assoc_headers, cipher_algo: $cipher));
+var_dump(openssl_cms_encrypt($infile, $outfile, $single_cert, $assoc_headers, cipher_algo: "AES-128-CBC"));
 var_dump(openssl_cms_encrypt($infile, $outfile, $single_cert, $empty_headers, cipher_algo: $cipher));
 var_dump(openssl_cms_encrypt($wrong, $outfile, $single_cert, $headers, cipher_algo: $cipher));
 var_dump(openssl_cms_encrypt($empty, $outfile, $single_cert, $headers, cipher_algo: $cipher));
@@ -40,11 +36,9 @@ var_dump(openssl_cms_encrypt($infile, $outfile3, $single_cert, $headers, flags: 
 
 if (file_exists($outfile)) {
     echo "true\n";
-    unlink($outfile);
 }
 if (file_exists($outfile2)) {
     echo "true\n";
-    unlink($outfile2);
 }
 
 if (file_exists($outfile3)) {
@@ -53,8 +47,13 @@ if (file_exists($outfile3)) {
         echo "true\n";
     }
     unset($content); 
-    unlink($outfile3);
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/openssl_cms_encrypt_basic.out1");
+@unlink(__DIR__ . "/openssl_cms_encrypt_basic.out2");
+@unlink(__DIR__ . "/openssl_cms_encrypt_basic.out3");
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
The allows cipher_algo to be specified as a string. It means the not only predefined ID ciphers are available which means that also auth enveloped data can be created using AES GCM.

I also added the AES GCM test and refactored the basic tests as it was a bit messy in terms of clean up.