### PR TITLE
Fix GH-19461: Improve error message on listening error with IPv6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-19544 (GC treats ZEND_WEAKREF_TAG_MAP references as WeakMap
     references). (Arnaud, timwolla)
 
+- CLI:
+  . Fixed bug GH-19461 (Improve error message on listening error with IPv6
+    address). (alexandre-daubois)
+
 - OpenSSL:
   . Fixed bug GH-19245 (Success error message on TLS stream accept failure).
     (Jakub Zelenka)

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2572,7 +2572,11 @@ static zend_result php_cli_server_ctor(php_cli_server *server, const char *addr,
 
 	server_sock = php_network_listen_socket(host, &port, SOCK_STREAM, &server->address_family, &server->socklen, &errstr);
 	if (server_sock == SOCK_ERR) {
-		php_cli_server_logf(PHP_CLI_SERVER_LOG_ERROR, "Failed to listen on %s:%d (reason: %s)", host, port, errstr ? ZSTR_VAL(errstr) : "?");
+		if (strchr(host, ':')) {
+			php_cli_server_logf(PHP_CLI_SERVER_LOG_ERROR, "Failed to listen on [%s]:%d (reason: %s)", host, port, errstr ? ZSTR_VAL(errstr) : "?");
+		} else {
+			php_cli_server_logf(PHP_CLI_SERVER_LOG_ERROR, "Failed to listen on %s:%d (reason: %s)", host, port, errstr ? ZSTR_VAL(errstr) : "?");
+		}
 		if (errstr) {
 			zend_string_release_ex(errstr, 0);
 		}

--- a/sapi/cli/tests/php_cli_server_ipv4_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv4_error_message.phpt
@@ -1,0 +1,41 @@
+--TEST--
+IPv4 address error message formatting
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die("skip not for Windows");
+}
+?>
+--FILE--
+<?php
+
+$descriptorspec = array(
+    0 => array("pipe", "r"),
+    1 => array("pipe", "w"),  
+    2 => array("pipe", "w")
+);
+
+$process = proc_open(
+    PHP_BINARY . ' -S "192.168.1.999:8080"',
+    $descriptorspec,
+    $pipes
+);
+
+if (is_resource($process)) {
+    usleep(100000);
+    
+    $stderr = stream_get_contents($pipes[2]);
+    
+    fclose($pipes[0]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    
+    proc_terminate($process);
+    proc_close($process);
+
+    var_dump($stderr);
+}
+?>
+--EXPECTF--
+string(%d) "[%s] Failed to listen on 192.168.1.999:8080 %s
+"

--- a/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv6_error_message.phpt
@@ -1,0 +1,40 @@
+--TEST--
+IPv6 address error message formatting
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die("skip not for Windows");
+}
+?>
+--FILE--
+<?php
+$descriptorspec = array(
+    0 => array("pipe", "r"),
+    1 => array("pipe", "w"),  
+    2 => array("pipe", "w")
+);
+
+$process = proc_open(
+    PHP_BINARY . ' -S "[2001:db8::]:8080"',
+    $descriptorspec,
+    $pipes
+);
+
+if (is_resource($process)) {
+    usleep(100000);
+    
+    $stderr = stream_get_contents($pipes[2]);
+    
+    fclose($pipes[0]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    
+    proc_terminate($process);
+    proc_close($process);
+
+    var_dump($stderr);
+}
+?>
+--EXPECTF--
+string(%d) "[%s] Failed to listen on [2001:db8::]:8080 %s
+"


### PR DESCRIPTION
Fix #19461

The built-in server has no problem listening to an IPv6. However, it's true that the error message should contain brackets when using an IPv6.