### PR TITLE
Add wiki link and update build instructions for 8.5

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,6 +6,7 @@ repository available according to the release schedule.
 The release schedule for each version is published on the
 [PHP wiki](https://wiki.php.net):
 
+- [PHP 8.5](https://wiki.php.net/todo/php85)
 - [PHP 8.4](https://wiki.php.net/todo/php84)
 - [PHP 8.3](https://wiki.php.net/todo/php83)
 - [PHP 8.2](https://wiki.php.net/todo/php82)
@@ -219,7 +220,7 @@ slightly different steps. We'll call attention where the steps differ.
    # With ZTS
    make distclean || \
    ./buildconf --force \
-       && ./configure --enable-zts --disable-all --enable-debug --enable-opcache --enable-opcache-jit \
+       && ./configure --enable-option-checking=fatal --enable-zts --disable-all --enable-debug --enable-opcache-jit \
        && make -j$(nproc) \
        && make test TEST_PHP_ARGS="-q -j$(nproc)" \
        || ./sapi/cli/php -v
@@ -227,7 +228,7 @@ slightly different steps. We'll call attention where the steps differ.
    # Without ZTS
    make distclean || \
    ./buildconf --force \
-       && ./configure --disable-all --enable-debug --enable-opcache --enable-opcache-jit \
+       && ./configure --enable-option-checking=fatal --disable-all --enable-debug --enable-opcache-jit \
        && make -j$(nproc) \
        && make test TEST_PHP_ARGS="-q -j$(nproc)" \
        || ./sapi/cli/php -v


### PR DESCRIPTION
- Add 8.5 wiki link
- Remove `--enable-opcache` as it's always built into 8.5.
- Add `--enable-option-checking=fatal` to fail the configure if an undefined option was used to ensure the instructions are up to date

Tagging the 8.4 RM team in case they use this page still and it would be an issue for them. Happy to have two sections for the different PHP versions as well.

