### PR TITLE
Deprecate `report_memleaks` and `register_argc_argv` INI directives

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@ PHP                                                                        NEWS
     (timwolla)
   . Returning null from __debugInfo() has been deprecated. (DanielEScherzer)
   . Support #[\Override] on properties. (Jiří Pudil)
+  . The report_memleaks and register_argc_argv INI directives have been
+    deprecated. (alexandre-daubois)
 
 - Curl:
   . The curl_close() function has been deprecated. (DanielEScherzer)

--- a/UPGRADING
+++ b/UPGRADING
@@ -337,6 +337,7 @@ PHP 8.5 UPGRADE NOTES
   . Returning null from __debugInfo() has been deprecated.
     Return an empty array instead.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_debuginfo_returning_null
+  . The report_memleaks and register_argc_argv INI directives have been deprecated.
 
 - Curl:
   . The curl_close() function has been deprecated, as CurlHandle objects are

--- a/main/main.c
+++ b/main/main.c
@@ -2397,6 +2397,8 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 				"Directive '%s' is deprecated",
 				{
 					"allow_url_include",
+					"report_memleaks",
+					"register_argc_argv",
 					NULL
 				}
 			},

--- a/php.ini-development
+++ b/php.ini-development
@@ -537,6 +537,7 @@ ignore_repeated_errors = Off
 ; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
+; DEPRECATED: This INI setting is deprecated and will be removed in PHP 9.0.
 ; If this parameter is set to Off, then memory leaks will not be shown (on
 ; stdout or in the log). This is only effective in a debug compile, and if
 ; error reporting includes E_WARNING in the allowed list
@@ -670,6 +671,8 @@ variables_order = "GPCS"
 ; https://php.net/request-order
 request_order = "GP"
 
+; DEPRECATED: This INI setting is deprecated and will be hardcoded to Off in
+; no-CLI SAPI and On in CLI SAPI on PHP 9.0.
 ; This directive determines whether PHP registers $argv & $argc each time it
 ; runs. $argv contains an array of all the arguments passed to PHP when a script
 ; is invoked. $argc contains an integer representing the number of arguments

--- a/php.ini-production
+++ b/php.ini-production
@@ -539,6 +539,7 @@ ignore_repeated_errors = Off
 ; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
+; DEPRECATED: This INI setting is deprecated and will be removed in PHP 9.0.
 ; If this parameter is set to Off, then memory leaks will not be shown (on
 ; stdout or in the log). This is only effective in a debug compile, and if
 ; error reporting includes E_WARNING in the allowed list
@@ -672,6 +673,8 @@ variables_order = "GPCS"
 ; https://php.net/request-order
 request_order = "GP"
 
+; DEPRECATED: This INI setting is deprecated and will be hardcoded to Off in
+; no-CLI SAPI and On in CLI SAPI on PHP 9.0.
 ; This directive determines whether PHP registers $argv & $argc each time it
 ; runs. $argv contains an array of all the arguments passed to PHP when a script
 ; is invoked. $argc contains an integer representing the number of arguments

--- a/tests/basic/ini_directive_deprecated.phpt
+++ b/tests/basic/ini_directive_deprecated.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Deprecated INI directive report_memleaks/register_argc_argv warning
+--INI--
+register_argc_argv=1
+report_memleaks=1
+--FILE--
+<?php
+echo "Testing deprecated report_memleaks INI directive.\n";
+?>
+--EXPECT--
+Deprecated: Directive 'report_memleaks' is deprecated in Unknown on line 0
+
+Deprecated: Directive 'register_argc_argv' is deprecated in Unknown on line 0
+Testing deprecated report_memleaks INI directive.


### PR DESCRIPTION
Part of #19468