### PR TITLE
Fix "Constant already defined" warning with repeated inclusion of file with __halt_compiler()

### DIFF
--- a/Zend/tests/constants/gh18850.inc
+++ b/Zend/tests/constants/gh18850.inc
@@ -1,0 +1,5 @@
+<?php
+
+var_dump(__COMPILER_HALT_OFFSET__);
+
+__halt_compiler();

--- a/Zend/tests/constants/gh18850.phpt
+++ b/Zend/tests/constants/gh18850.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-18850: Repeated inclusion of file with __halt_compiler() triggers "Constant already defined" warning
+--FILE--
+<?php
+
+require __DIR__ . '/gh18850.inc';
+require __DIR__ . '/gh18850.inc';
+
+?>
+--EXPECT--
+int(62)
+int(62)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9752,7 +9752,11 @@ static void zend_compile_halt_compiler(zend_ast *ast) /* {{{ */
 	name = zend_mangle_property_name(const_name, sizeof(const_name) - 1,
 		ZSTR_VAL(filename), ZSTR_LEN(filename), 0);
 
-	zend_register_long_constant(ZSTR_VAL(name), ZSTR_LEN(name), offset, 0, 0);
+	/* Avoid repeated declaration of the __COMPILER_HALT_OFFSET__ constant in
+	 * case this file was already included. */
+	if (!zend_hash_find(EG(zend_constants), name)) {
+		zend_register_long_constant(ZSTR_VAL(name), ZSTR_LEN(name), offset, 0, 0);
+	}
 	zend_string_release_ex(name, 0);
 }
 /* }}} */

--- a/ext/phar/tests/bug77432.phpt
+++ b/ext/phar/tests/bug77432.phpt
@@ -38,8 +38,6 @@ include("phar://" . $filename);
 --- Include 1 ---
 hello world
 --- Include 2 ---
-
-Warning: Constant  already defined in %s on line %d
 hello world
 --- After unlink ---
 


### PR DESCRIPTION
Fixes GH-18850