### PR TITLE
Use the default OpenSSL version for MacOS to match libs

### DIFF
--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -11,7 +11,7 @@ runs:
         set -x
         BREW_OPT="$(brew --prefix)"/opt
         export PATH="$BREW_OPT/bison/bin:$PATH"
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/openssl@1.1/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/openssl/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/curl/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/krb5/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BREW_OPT/libffi/lib/pkgconfig"


### PR DESCRIPTION
This seems like an issue that might be potentially causing issues like GH-12901. The problem is that libs like libcurl, libldap and others use the default OpenSSL version so this might result in linking issues.

The fact that OpenSSL 1.1.1 was actually good that we were able to have it in the pipeline but this is just not right setup so we should find another way how to test it at least in nightly.