### PR TITLE
Deprecate constant redeclaration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-19476 (pipe operator fails to correctly handle returning
     by reference). (alexandre-daubois)
   . The report_memleaks INI directive has been deprecated. (alexandre-daubois)
+  . Constant redeclaration is deprecated and this behavior will trigger an
+    error in PHP 9. (alexandre-daubois)
 
 - ODBC:
   . Remove ODBCVER and assume ODBC 3.5. (Calvin Buckley)

--- a/UPGRADING
+++ b/UPGRADING
@@ -346,6 +346,9 @@ PHP 8.5 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_debuginfo_returning_null
   . The report_memleaks INI directive has been deprecated.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_report_memleaks_ini_directive
+  . Constant redeclaration is deprecated and that behavior will trigger an
+    error in PHP 9.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_constant_redeclaration
 
 - Curl:
   . The curl_close() function has been deprecated, as CurlHandle objects are

--- a/Zend/tests/attributes/constants/constant_redefined_addition.phpt
+++ b/Zend/tests/attributes/constants/constant_redefined_addition.phpt
@@ -15,7 +15,7 @@ var_dump($reflection->getAttributes())
 
 ?>
 --EXPECTF--
-Warning: Constant MY_CONST already defined in %s on line %d
+Warning: Constant MY_CONST already defined, this will be an error in PHP 9 in %s on line %d
 No attributes
 array(0) {
 }

--- a/Zend/tests/attributes/constants/constant_redefined_change.phpt
+++ b/Zend/tests/attributes/constants/constant_redefined_change.phpt
@@ -16,7 +16,7 @@ var_dump($reflection->getAttributes())
 
 ?>
 --EXPECTF--
-Warning: Constant MY_CONST already defined in %s on line %d
+Warning: Constant MY_CONST already defined, this will be an error in PHP 9 in %s on line %d
 Has attributes (1)
 array(1) {
   [0]=>

--- a/Zend/tests/attributes/constants/constant_redefined_removal.phpt
+++ b/Zend/tests/attributes/constants/constant_redefined_removal.phpt
@@ -15,7 +15,7 @@ var_dump($reflection->getAttributes())
 
 ?>
 --EXPECTF--
-Warning: Constant MY_CONST already defined in %s on line %d
+Warning: Constant MY_CONST already defined, this will be an error in PHP 9 in %s on line %d
 Has attributes
 array(1) {
   [0]=>

--- a/Zend/tests/bug29890.phpt
+++ b/Zend/tests/bug29890.phpt
@@ -20,4 +20,4 @@ define("TEST",3);
 
 ?>
 --EXPECT--
-error :Constant TEST already defined
+error :Constant TEST already defined, this will be an error in PHP 9

--- a/Zend/tests/constants/008.phpt
+++ b/Zend/tests/constants/008.phpt
@@ -27,13 +27,13 @@ echo "Done\n";
 --EXPECTF--
 TypeError: define(): Argument #1 ($constant_name) must be of type string, array given
 
-Warning: Constant TRUE already defined in %s on line %d
+Warning: Constant TRUE already defined, this will be an error in PHP 9 in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 bool(true)
 
-Warning: Constant test const already defined in %s on line %d
+Warning: Constant test const already defined, this will be an error in PHP 9 in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/Zend/tests/constants/constants_001.phpt
+++ b/Zend/tests/constants/constants_001.phpt
@@ -17,7 +17,7 @@ var_dump(constant('1foo'));
 
 ?>
 --EXPECTF--
-Warning: Constant 1 already defined in %s on line %d
+Warning: Constant 1 already defined, this will be an error in PHP 9 in %s on line %d
 int(2)
 int(2)
 int(2)

--- a/Zend/tests/constants/constants_004.phpt
+++ b/Zend/tests/constants/constants_004.phpt
@@ -10,4 +10,4 @@ const foo = 2;
 
 ?>
 --EXPECTF--
-Warning: Constant foo\foo already defined in %s on line %d
+Warning: Constant foo\foo already defined, this will be an error in PHP 9 in %s on line %d

--- a/Zend/tests/constants/constants_008.phpt
+++ b/Zend/tests/constants/constants_008.phpt
@@ -13,5 +13,5 @@ if (defined('a')) {
 
 ?>
 --EXPECTF--
-Warning: Constant a already defined in %s on line %d
+Warning: Constant a already defined, this will be an error in PHP 9 in %s on line %d
 2

--- a/Zend/tests/constants/halt_compiler/bug53305.phpt
+++ b/Zend/tests/constants/halt_compiler/bug53305.phpt
@@ -14,6 +14,6 @@ var_dump(constant('__COMPILER_HALT_OFFSET__1'.chr(0)));
 
 ?>
 --EXPECTF--
-Warning: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Warning: Constant __COMPILER_HALT_OFFSET__ already defined, this will be an error in PHP 9 in %s on line %d
 int(1)
 int(4)

--- a/Zend/tests/constants/halt_compiler/halt_compiler3.phpt
+++ b/Zend/tests/constants/halt_compiler/halt_compiler3.phpt
@@ -5,4 +5,4 @@ __HALT_COMPILER(); bad define() of __COMPILER_HALT_OFFSET__ 1
 define ('__COMPILER_HALT_OFFSET__', 1);
 ?>
 --EXPECTF--
-Warning: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Warning: Constant __COMPILER_HALT_OFFSET__ already defined, this will be an error in PHP 9 in %s on line %d

--- a/Zend/tests/constants/halt_compiler/halt_compiler4.phpt
+++ b/Zend/tests/constants/halt_compiler/halt_compiler4.phpt
@@ -7,4 +7,4 @@ __HALT_COMPILER();
 ?>
 ==DONE==
 --EXPECTF--
-Warning: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Warning: Constant __COMPILER_HALT_OFFSET__ already defined, this will be an error in PHP 9 in %s on line %d

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -541,7 +541,7 @@ ZEND_API zend_constant *zend_register_constant(zend_constant *c)
 		|| (!persistent && zend_get_special_const(ZSTR_VAL(name), ZSTR_LEN(name)))
 		|| (ret = zend_hash_add_constant(EG(zend_constants), name, c)) == NULL
 	) {
-		zend_error(E_WARNING, "Constant %s already defined", ZSTR_VAL(name));
+		zend_error(E_WARNING, "Constant %s already defined, this will be an error in PHP 9", ZSTR_VAL(name));
 		zend_string_release(c->name);
 		if (c->filename) {
 			zend_string_release(c->filename);

--- a/ext/opcache/tests/bug71127.phpt
+++ b/ext/opcache/tests/bug71127.phpt
@@ -21,5 +21,5 @@ include($file);
 @unlink(__DIR__ . "/bug71127.inc");
 ?>
 --EXPECTF--
-Warning: Constant FOO already defined in %sbug71127.inc on line %d
+Warning: Constant FOO already defined, this will be an error in PHP 9 in %sbug71127.inc on line %d
 okey


### PR DESCRIPTION
The wording now warns that redeclaring a constant will be an error in PHP 9, instead of a simple warning.

Should we keep the existing message and append to it, or change it to something like "Redeclaring constant %s is deprecated, this will throw an error in PHP 9"? I'm not sure what's the policy with error messages in this repo. I would say that changing the message to something more explicit is better.

RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_constant_redeclaration

Part of #19468, cc @DanielEScherzer 