### PR TITLE
README: Fix non-existent `iconv` in macOS instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo dnf install re2c bison autoconf make libtool ccache libxml2-devel sqlite-de
 On MacOS, you can install these using `brew`:
 
 ```shell
-brew install autoconf bison re2c iconv libxml2 sqlite
+brew install autoconf bison re2c libiconv libxml2 sqlite
 ```
 
 or with `MacPorts`:

--- a/build/php.m4
+++ b/build/php.m4
@@ -1796,7 +1796,17 @@ AC_DEFUN([PHP_SETUP_ICONV], [
 
   dnl Check external libs for iconv funcs.
   AS_VAR_IF([found_iconv], [no], [
-    for i in $PHP_ICONV /usr/local /usr; do
+
+  dnl Find /opt/homebrew/opt/libiconv on macOS
+  dnl See: https://github.com/php/php-src/pull/19475
+    php_brew_prefix=no
+    AC_CHECK_PROG([BREW], [brew], [brew])
+    if test -n "$BREW"; then
+      AC_MSG_CHECKING([for homebrew prefix])
+      php_brew_prefix=$($BREW --prefix 2> /dev/null)
+    fi
+
+    for i in $PHP_ICONV $php_brew_prefix/opt/libiconv /usr/local /usr; do
       if test -r $i/include/gnu-libiconv/iconv.h; then
         ICONV_DIR=$i
         ICONV_INCLUDE_DIR=$i/include/gnu-libiconv


### PR DESCRIPTION
Follows-up 22e444c5c7 (GH-18670). There is currently no formula called "iconv" at https://brew.sh/ or https://github.com/Homebrew/homebrew-core/.

```
$ brew install iconv
Warning: No available formula with the name "iconv". Did you mean icon or cconv?
```

There is one called `libiconv`, however.

https://formulae.brew.sh/formula/libiconv