### PR TITLE
Fix GH-19476: pipe operator fails to correctly handle returning by reference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-18850 (Repeated inclusion of file with __halt_compiler()
     triggers "Constant already defined" warning). (ilutov)
+  . Fixed bug GH-19476 (pipe operator fails to correctly handle returning
+    by reference). (alexandre-daubois)
 
 - ODBC:
   . Remove ODBCVER and assume ODBC 3.5. (Calvin Buckley)

--- a/Zend/tests/pipe_operator_reference_context.phpt
+++ b/Zend/tests/pipe_operator_reference_context.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Fix GH-19476: Pipe operator with function returning by reference
+--FILE--
+<?php
+
+function &get_ref($_): string {
+    static $a = "original";
+
+    $a .= " ".$_;
+
+    return $a;
+}
+
+function &test_pipe_ref(): string {
+    return "input" |> get_ref(...);
+}
+
+$ref = &test_pipe_ref();
+echo "Before: " . $ref . "\n";
+$ref = "changed";
+echo "After: " . test_pipe_ref() . "\n";
+
+?>
+--EXPECT--
+Before: original input
+After: changed input

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2726,7 +2726,8 @@ static inline bool zend_is_call(zend_ast *ast) /* {{{ */
 	return ast->kind == ZEND_AST_CALL
 		|| ast->kind == ZEND_AST_METHOD_CALL
 		|| ast->kind == ZEND_AST_NULLSAFE_METHOD_CALL
-		|| ast->kind == ZEND_AST_STATIC_CALL;
+		|| ast->kind == ZEND_AST_STATIC_CALL
+		|| ast->kind == ZEND_AST_PIPE;
 }
 /* }}} */
 


### PR DESCRIPTION
Fix #19476

Modifying the compiler to add the pipe AST node to the cases of `zend_is_call()` seems to work well.