### PR TITLE
Zend: Convert certain fields to uint32_t

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -1125,7 +1125,7 @@ static void assemble_code_blocks(zend_cfg *cfg, zend_op_array *op_array, zend_op
 
 	/* adjust exception jump targets & remove unused try_catch_array entries */
 	if (op_array->last_try_catch) {
-		int i, j;
+		uint32_t i, j;
 		uint32_t *map;
 		ALLOCA_FLAG(use_heap);
 
@@ -1165,7 +1165,7 @@ static void assemble_code_blocks(zend_cfg *cfg, zend_op_array *op_array, zend_op
 				while (opline < end) {
 					if (opline->opcode == ZEND_FAST_RET &&
 					    opline->op2.num != (uint32_t)-1 &&
-					    opline->op2.num < (uint32_t)j) {
+					    opline->op2.num < j) {
 						opline->op2.num = map[opline->op2.num];
 					}
 					opline++;

--- a/Zend/Optimizer/compact_literals.c
+++ b/Zend/Optimizer/compact_literals.c
@@ -110,7 +110,7 @@ static zend_string *create_str_cache_key(zval *literal, uint8_t num_related)
 void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 {
 	zend_op *opline, *end;
-	int i, j, n, *map;
+	int n, *map;
 	uint32_t cache_size;
 	zval zv, *pos;
 	literal_info *info;
@@ -124,6 +124,7 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 	int *const_slot, *class_slot, *func_slot, *bind_var_slot, *property_slot, *method_slot, *jmp_slot;
 
 	if (op_array->last_literal) {
+		uint32_t j;
 		info = (literal_info*)zend_arena_calloc(&ctx->arena, op_array->last_literal, sizeof(literal_info));
 
 	    /* Mark literals of specific types */
@@ -258,9 +259,9 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 					op_array->function_name ? op_array->function_name->val : "main");
 			fprintf(stderr, "Literals table size %d\n", op_array->last_literal);
 
-			for (int i = 0; i < op_array->last_literal; i++) {
+			for (uint32_t i = 0; i < op_array->last_literal; i++) {
 				zend_string *str = zval_get_string(op_array->literals + i);
-				fprintf(stderr, "Literal %d, val (%zu):%s\n", i, ZSTR_LEN(str), ZSTR_VAL(str));
+				fprintf(stderr, "Literal %" PRIu32 ", val (%zu):%s\n", i, ZSTR_LEN(str), ZSTR_VAL(str));
 				zend_string_release(str);
 			}
 			fflush(stderr);
@@ -272,7 +273,7 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 		zend_hash_init(&hash, op_array->last_literal, NULL, NULL, 0);
 		map = (int*)zend_arena_alloc(&ctx->arena, op_array->last_literal * sizeof(int));
 		memset(map, 0, op_array->last_literal * sizeof(int));
-		for (i = 0; i < op_array->last_literal; i++) {
+		for (uint32_t i = 0; i < op_array->last_literal; i++) {
 			if (!info[i].num_related) {
 				/* unset literal */
 				zval_ptr_dtor_nogc(&op_array->literals[i]);
@@ -770,9 +771,9 @@ void zend_optimizer_compact_literals(zend_op_array *op_array, zend_optimizer_ctx
 		{
 			fprintf(stderr, "Optimized literals table size %d\n", op_array->last_literal);
 
-			for (int i = 0; i < op_array->last_literal; i++) {
+			for (uint32_t i = 0; i < op_array->last_literal; i++) {
 				zend_string *str = zval_get_string(op_array->literals + i);
-				fprintf(stderr, "Literal %d, val (%zu):%s\n", i, ZSTR_LEN(str), ZSTR_VAL(str));
+				fprintf(stderr, "Literal %" PRIu32 ", val (%zu):%s\n", i, ZSTR_LEN(str), ZSTR_VAL(str));
 				zend_string_release(str);
 			}
 			fflush(stderr);

--- a/Zend/Optimizer/dfa_pass.c
+++ b/Zend/Optimizer/dfa_pass.c
@@ -226,7 +226,7 @@ static void zend_ssa_remove_nops(zend_op_array *op_array, zend_ssa *ssa, zend_op
 		}
 
 		/* update try/catch array */
-		for (j = 0; j < op_array->last_try_catch; j++) {
+		for (uint32_t j = 0; j < op_array->last_try_catch; j++) {
 			op_array->try_catch_array[j].try_op -= shiftlist[op_array->try_catch_array[j].try_op];
 			op_array->try_catch_array[j].catch_op -= shiftlist[op_array->try_catch_array[j].catch_op];
 			if (op_array->try_catch_array[j].finally_op) {

--- a/Zend/Optimizer/nop_removal.c
+++ b/Zend/Optimizer/nop_removal.c
@@ -34,7 +34,6 @@ void zend_optimizer_nop_removal(zend_op_array *op_array, zend_optimizer_ctx *ctx
 {
 	zend_op *end, *opline;
 	uint32_t new_count, i, shift;
-	int j;
 	uint32_t *shiftlist;
 	ALLOCA_FLAG(use_heap);
 
@@ -81,7 +80,7 @@ void zend_optimizer_nop_removal(zend_op_array *op_array, zend_optimizer_ctx *ctx
 		}
 
 		/* update try/catch array */
-		for (j = 0; j < op_array->last_try_catch; j++) {
+		for (uint32_t j = 0; j < op_array->last_try_catch; j++) {
 			op_array->try_catch_array[j].try_op -= shiftlist[op_array->try_catch_array[j].try_op];
 			op_array->try_catch_array[j].catch_op -= shiftlist[op_array->try_catch_array[j].catch_op];
 			if (op_array->try_catch_array[j].finally_op) {

--- a/Zend/Optimizer/zend_cfg.c
+++ b/Zend/Optimizer/zend_cfg.c
@@ -274,7 +274,6 @@ ZEND_API void zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, 
 {
 	uint32_t flags = 0;
 	uint32_t i;
-	int j;
 	uint32_t *block_map;
 	zend_function *fn;
 	int blocks_count = 0;
@@ -449,7 +448,7 @@ ZEND_API void zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, 
 	}
 
 	if (op_array->last_try_catch) {
-		for (j = 0; j < op_array->last_try_catch; j++) {
+		for (uint32_t j = 0; j < op_array->last_try_catch; j++) {
 			BB_START(op_array->try_catch_array[j].try_op);
 			if (op_array->try_catch_array[j].catch_op) {
 				BB_START(op_array->try_catch_array[j].catch_op);
@@ -494,7 +493,7 @@ ZEND_API void zend_build_cfg(zend_arena **arena, const zend_op_array *op_array, 
 	blocks_count++;
 
 	/* Build CFG, Step 3: Calculate successors */
-	for (j = 0; j < blocks_count; j++) {
+	for (int j = 0; j < blocks_count; j++) {
 		zend_basic_block *block = &blocks[j];
 		zend_op *opline;
 		if (block->len == 0) {

--- a/Zend/Optimizer/zend_dump.c
+++ b/Zend/Optimizer/zend_dump.c
@@ -1056,7 +1056,7 @@ ZEND_API void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_fl
 		}
 		if (op_array->last_live_range && (dump_flags & ZEND_DUMP_LIVE_RANGES)) {
 			fprintf(stderr, "LIVE RANGES:\n");
-			for (int i = 0; i < op_array->last_live_range; i++) {
+			for (uint32_t i = 0; i < op_array->last_live_range; i++) {
 				fprintf(stderr,
 					"     %u: %04u - %04u ",
 					EX_VAR_TO_NUM(op_array->live_range[i].var & ~ZEND_LIVE_MASK),
@@ -1116,7 +1116,7 @@ ZEND_API void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_fl
 		}
 		if (op_array->last_live_range && (dump_flags & ZEND_DUMP_LIVE_RANGES)) {
 			fprintf(stderr, "LIVE RANGES:\n");
-			for (int i = 0; i < op_array->last_live_range; i++) {
+			for (uint32_t i = 0; i < op_array->last_live_range; i++) {
 				fprintf(stderr,
 					"     %u: %04u - %04u ",
 					EX_VAR_TO_NUM(op_array->live_range[i].var & ~ZEND_LIVE_MASK),

--- a/Zend/Optimizer/zend_dump.c
+++ b/Zend/Optimizer/zend_dump.c
@@ -1083,7 +1083,7 @@ ZEND_API void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_fl
 		}
 		if (op_array->last_try_catch) {
 			fprintf(stderr, "EXCEPTION TABLE:\n");
-			for (int i = 0; i < op_array->last_try_catch; i++) {
+			for (uint32_t i = 0; i < op_array->last_try_catch; i++) {
 				fprintf(stderr, "        BB%u",
 					cfg->map[op_array->try_catch_array[i].try_op]);
 				if (op_array->try_catch_array[i].catch_op) {
@@ -1143,7 +1143,7 @@ ZEND_API void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_fl
 		}
 		if (op_array->last_try_catch) {
 			fprintf(stderr, "EXCEPTION TABLE:\n");
-			for (int i = 0; i < op_array->last_try_catch; i++) {
+			for (uint32_t i = 0; i < op_array->last_try_catch; i++) {
 				fprintf(stderr,
 					"     %04u",
 					op_array->try_catch_array[i].try_op);

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -210,9 +210,9 @@ void zend_optimizer_convert_to_free_op1(zend_op_array *op_array, zend_op *opline
 	}
 }
 
-int zend_optimizer_add_literal(zend_op_array *op_array, const zval *zv)
+uint32_t zend_optimizer_add_literal(zend_op_array *op_array, const zval *zv)
 {
-	int i = op_array->last_literal;
+	uint32_t i = op_array->last_literal;
 	op_array->last_literal++;
 	op_array->literals = (zval*)erealloc(op_array->literals, op_array->last_literal * sizeof(zval));
 	ZVAL_COPY_VALUE(&op_array->literals[i], zv);
@@ -220,7 +220,7 @@ int zend_optimizer_add_literal(zend_op_array *op_array, const zval *zv)
 	return i;
 }
 
-static inline int zend_optimizer_add_literal_string(zend_op_array *op_array, zend_string *str) {
+static inline uint32_t zend_optimizer_add_literal_string(zend_op_array *op_array, zend_string *str) {
 	zval zv;
 	ZVAL_STR(&zv, str);
 	zend_string_hash_val(str);

--- a/Zend/Optimizer/zend_optimizer_internal.h
+++ b/Zend/Optimizer/zend_optimizer_internal.h
@@ -79,7 +79,7 @@ static inline bool zend_optimizer_is_loop_var_free(const zend_op *opline) {
 }
 
 void zend_optimizer_convert_to_free_op1(zend_op_array *op_array, zend_op *opline);
-int  zend_optimizer_add_literal(zend_op_array *op_array, const zval *zv);
+uint32_t zend_optimizer_add_literal(zend_op_array *op_array, const zval *zv);
 bool zend_optimizer_get_persistent_constant(zend_string *name, zval *result, int copy);
 void zend_optimizer_collect_constant(zend_optimizer_ctx *ctx, zval *name, zval* value);
 bool zend_optimizer_get_collected_constant(HashTable *constants, zval *name, zval* value);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -536,7 +536,7 @@ static zend_always_inline uint32_t get_temporary_variable(void) /* {{{ */
 }
 /* }}} */
 
-static int lookup_cv(zend_string *name) /* {{{ */{
+static uint32_t lookup_cv(zend_string *name) /* {{{ */{
 	zend_op_array *op_array = CG(active_op_array);
 	int i = 0;
 	zend_ulong hash_value = zend_string_hash_val(name);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5886,7 +5886,7 @@ static void zend_compile_break_continue(zend_ast *ast) /* {{{ */
 void zend_resolve_goto_label(zend_op_array *op_array, zend_op *opline) /* {{{ */
 {
 	zend_label *dest;
-	int current, remove_oplines = opline->op1.num;
+	int remove_oplines = opline->op1.num;
 	zval *label;
 	uint32_t opnum = opline - op_array->opcodes;
 
@@ -5903,7 +5903,7 @@ void zend_resolve_goto_label(zend_op_array *op_array, zend_op *opline) /* {{{ */
 	zval_ptr_dtor_str(label);
 	ZVAL_NULL(label);
 
-	current = opline->extended_value;
+	uint32_t current = opline->extended_value;
 	for (; current != dest->brk_cont; current = CG(context).brk_cont_array[current].parent) {
 		if (current == -1) {
 			CG(in_compilation) = 1;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -588,7 +588,7 @@ static inline void zend_insert_literal(zend_op_array *op_array, zval *zv, int li
 static int zend_add_literal(zval *zv) /* {{{ */
 {
 	zend_op_array *op_array = CG(active_op_array);
-	int i = op_array->last_literal;
+	uint32_t i = op_array->last_literal;
 	op_array->last_literal++;
 	if (i >= CG(context).literals_size) {
 		while (i >= CG(context).literals_size) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -542,7 +542,7 @@ struct _zend_op_array {
 	uint32_t *refcount;
 
 	uint32_t last_live_range;
-	int last_try_catch;
+	uint32_t last_try_catch;
 	zend_live_range *live_range;
 	zend_try_catch_element *try_catch_array;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -197,7 +197,7 @@ typedef struct _zend_oparray_context {
 	struct _zend_oparray_context *prev;
 	zend_op_array *op_array;
 	uint32_t   opcodes_size;
-	int        vars_size;
+	uint32_t   vars_size;
 	int        literals_size;
 	uint32_t   fast_call_var;
 	uint32_t   try_catch_offset;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -541,7 +541,7 @@ struct _zend_op_array {
 
 	uint32_t *refcount;
 
-	int last_live_range;
+	uint32_t last_live_range;
 	int last_try_catch;
 	zend_live_range *live_range;
 	zend_try_catch_element *try_catch_array;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -198,7 +198,7 @@ typedef struct _zend_oparray_context {
 	zend_op_array *op_array;
 	uint32_t   opcodes_size;
 	uint32_t   vars_size;
-	int        literals_size;
+	uint32_t   literals_size;
 	uint32_t   fast_call_var;
 	uint32_t   try_catch_offset;
 	int        current_brk_cont;
@@ -550,7 +550,7 @@ struct _zend_op_array {
 	uint32_t line_start;
 	uint32_t line_end;
 
-	int last_literal;
+	uint32_t last_literal;
 	uint32_t num_dynamic_func_defs;
 	zval *literals;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -530,9 +530,9 @@ struct _zend_op_array {
 	const zend_property_info *prop_info; /* The corresponding prop_info if this is a hook. */
 	/* END of common elements */
 
-	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
-	int last_var;       /* number of CV variables */
-	uint32_t last;      /* number of opcodes */
+	uint32_t cache_size; /* number of run_time_cache_slots * sizeof(void*) */
+	int last_var;        /* number of CV variables */
+	uint32_t last;       /* number of opcodes */
 
 	zend_op *opcodes;
 	ZEND_MAP_PTR_DEF(HashTable *, static_variables_ptr);

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -244,7 +244,6 @@ static void zend_generator_dtor_storage(zend_object *object) /* {{{ */
 	zend_generator *current_generator = zend_generator_get_current(generator);
 	zend_execute_data *ex = generator->execute_data;
 	uint32_t op_num, try_catch_offset;
-	int i;
 
 	/* If current_generator is running in a fiber, there are 2 cases to consider:
 	 *  - If generator is also marked with ZEND_GENERATOR_IN_FIBER, then the
@@ -289,7 +288,7 @@ static void zend_generator_dtor_storage(zend_object *object) /* {{{ */
 	try_catch_offset = -1;
 
 	/* Find the innermost try/catch that we are inside of. */
-	for (i = 0; i < ex->func->op_array.last_try_catch; i++) {
+	for (uint32_t i = 0; i < ex->func->op_array.last_try_catch; i++) {
 		zend_try_catch_element *try_catch = &ex->func->op_array.try_catch_array[i];
 		if (op_num < try_catch->try_op) {
 			break;

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -686,9 +686,7 @@ static void zend_extension_op_array_handler(zend_extension *extension, zend_op_a
 
 static void zend_check_finally_breakout(zend_op_array *op_array, uint32_t op_num, uint32_t dst_num)
 {
-	int i;
-
-	for (i = 0; i < op_array->last_try_catch; i++) {
+	for (uint32_t i = 0; i < op_array->last_try_catch; i++) {
 		if ((op_num < op_array->try_catch_array[i].finally_op ||
 					op_num >= op_array->try_catch_array[i].finally_end)
 				&& (dst_num >= op_array->try_catch_array[i].finally_op &&

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -8164,7 +8164,7 @@ ZEND_VM_HANDLER(149, ZEND_HANDLE_EXCEPTION, ANY, ANY)
 	}
 
 	uint32_t throw_op_num = throw_op - EX(func)->op_array.opcodes;
-	int i, current_try_catch_offset = -1;
+	uint32_t current_try_catch_offset = -1;
 
 	if ((throw_op->opcode == ZEND_FREE || throw_op->opcode == ZEND_FE_FREE)
 		&& throw_op->extended_value & ZEND_FREE_ON_RETURN) {
@@ -8175,7 +8175,7 @@ ZEND_VM_HANDLER(149, ZEND_HANDLE_EXCEPTION, ANY, ANY)
 		const zend_live_range *range = find_live_range(
 			&EX(func)->op_array, throw_op_num, throw_op->op1.var);
 		/* free op1 of the corresponding RETURN */
-		for (i = throw_op_num; i < range->end; i++) {
+		for (uint32_t i = throw_op_num; i < range->end; i++) {
 			if (EX(func)->op_array.opcodes[i].opcode == ZEND_FREE
 			 || EX(func)->op_array.opcodes[i].opcode == ZEND_FE_FREE) {
 				/* pass */
@@ -8191,7 +8191,7 @@ ZEND_VM_HANDLER(149, ZEND_HANDLE_EXCEPTION, ANY, ANY)
 	}
 
 	/* Find the innermost try/catch/finally the exception was thrown in */
-	for (i = 0; i < EX(func)->op_array.last_try_catch; i++) {
+	for (uint32_t i = 0; i < EX(func)->op_array.last_try_catch; i++) {
 		zend_try_catch_element *try_catch = &EX(func)->op_array.try_catch_array[i];
 		if (try_catch->try_op > throw_op_num) {
 			/* further blocks will not be relevant... */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3392,7 +3392,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_HANDLE_EXCEPT
 	}
 
 	uint32_t throw_op_num = throw_op - EX(func)->op_array.opcodes;
-	int i, current_try_catch_offset = -1;
+	uint32_t current_try_catch_offset = -1;
 
 	if ((throw_op->opcode == ZEND_FREE || throw_op->opcode == ZEND_FE_FREE)
 		&& throw_op->extended_value & ZEND_FREE_ON_RETURN) {
@@ -3403,7 +3403,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_HANDLE_EXCEPT
 		const zend_live_range *range = find_live_range(
 			&EX(func)->op_array, throw_op_num, throw_op->op1.var);
 		/* free op1 of the corresponding RETURN */
-		for (i = throw_op_num; i < range->end; i++) {
+		for (uint32_t i = throw_op_num; i < range->end; i++) {
 			if (EX(func)->op_array.opcodes[i].opcode == ZEND_FREE
 			 || EX(func)->op_array.opcodes[i].opcode == ZEND_FE_FREE) {
 				/* pass */
@@ -3419,7 +3419,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_HANDLE_EXCEPT
 	}
 
 	/* Find the innermost try/catch/finally the exception was thrown in */
-	for (i = 0; i < EX(func)->op_array.last_try_catch; i++) {
+	for (uint32_t i = 0; i < EX(func)->op_array.last_try_catch; i++) {
 		zend_try_catch_element *try_catch = &EX(func)->op_array.try_catch_array[i];
 		if (try_catch->try_op > throw_op_num) {
 			/* further blocks will not be relevant... */
@@ -58815,7 +58815,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_HANDLE_EXCEPTION_S
 	}
 
 	uint32_t throw_op_num = throw_op - EX(func)->op_array.opcodes;
-	int i, current_try_catch_offset = -1;
+	uint32_t current_try_catch_offset = -1;
 
 	if ((throw_op->opcode == ZEND_FREE || throw_op->opcode == ZEND_FE_FREE)
 		&& throw_op->extended_value & ZEND_FREE_ON_RETURN) {
@@ -58826,7 +58826,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_HANDLE_EXCEPTION_S
 		const zend_live_range *range = find_live_range(
 			&EX(func)->op_array, throw_op_num, throw_op->op1.var);
 		/* free op1 of the corresponding RETURN */
-		for (i = throw_op_num; i < range->end; i++) {
+		for (uint32_t i = throw_op_num; i < range->end; i++) {
 			if (EX(func)->op_array.opcodes[i].opcode == ZEND_FREE
 			 || EX(func)->op_array.opcodes[i].opcode == ZEND_FE_FREE) {
 				/* pass */
@@ -58842,7 +58842,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_HANDLE_EXCEPTION_S
 	}
 
 	/* Find the innermost try/catch/finally the exception was thrown in */
-	for (i = 0; i < EX(func)->op_array.last_try_catch; i++) {
+	for (uint32_t i = 0; i < EX(func)->op_array.last_try_catch; i++) {
 		zend_try_catch_element *try_catch = &EX(func)->op_array.try_catch_array[i];
 		if (try_catch->try_op > throw_op_num) {
 			/* further blocks will not be relevant... */

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -1268,13 +1268,12 @@ static void zend_jit_allocate_registers(zend_jit_ctx *ctx, const zend_op_array *
 					 && ssa->vars[i].definition >= 0
 					 && ssa->ops[op_num].result_def == i) {
 						const zend_live_range *range = op_array->live_range;
-						int j;
 
 						op_num++;
 						if (op_array->opcodes[op_num].opcode == ZEND_OP_DATA) {
 							op_num++;
 						}
-						for (j = 0; j < op_array->last_live_range; range++, j++) {
+						for (uint32_t j = 0; j < op_array->last_live_range; range++, j++) {
 							if (range->start > op_num) {
 								/* further blocks will not be relevant... */
 								break;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -6583,10 +6583,9 @@ done:
 								uint32_t var_num = opline->result.var;
 								uint32_t op_num = opline - op_array->opcodes;
 								const zend_live_range *range = op_array->live_range;
-								int j;
 
 								op_num += zend_jit_trace_op_len(opline);
-								for (j = 0; j < op_array->last_live_range; range++, j++) {
+								for (uint32_t j = 0; j < op_array->last_live_range; range++, j++) {
 									if (range->start > op_num) {
 										/* further blocks will not be relevant... */
 										break;

--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -307,7 +307,7 @@ PHPDBG_INFO(literal) /* {{{ */
 	bool in_executor = PHPDBG_G(in_execution) && EG(current_execute_data) && EG(current_execute_data)->func;
 	if (in_executor || PHPDBG_G(ops)) {
 		zend_op_array *ops = in_executor ? &EG(current_execute_data)->func->op_array : PHPDBG_G(ops);
-		int literal = 0, count = ops->last_literal - 1;
+		uint32_t literal = 0, count = ops->last_literal - 1;
 
 		if (ops->function_name) {
 			if (ops->scope) {

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -612,7 +612,7 @@ int phpdbg_is_auto_global(char *name, int len) {
 PHPDBG_API bool phpdbg_check_caught_ex(zend_execute_data *execute_data, zend_object *exception) {
 	const zend_op *op;
 	zend_op *cur;
-	uint32_t op_num, i;
+	uint32_t op_num;
 	zend_op_array *op_array = &execute_data->func->op_array;
 
 	if (execute_data->opline >= EG(exception_op) && execute_data->opline < EG(exception_op) + 3 && EG(opline_before_exception)) {
@@ -623,7 +623,7 @@ PHPDBG_API bool phpdbg_check_caught_ex(zend_execute_data *execute_data, zend_obj
 
 	op_num = op - op_array->opcodes;
 
-	for (i = 0; i < op_array->last_try_catch && op_array->try_catch_array[i].try_op <= op_num; i++) {
+	for (uint32_t i = 0; i < op_array->last_try_catch && op_array->try_catch_array[i].try_op <= op_num; i++) {
 		uint32_t catch = op_array->try_catch_array[i].catch_op, finally = op_array->try_catch_array[i].finally_op;
 		if (op_num <= catch || op_num <= finally) {
 			if (finally) {


### PR DESCRIPTION
These basically always assign to `uint32_t` or be used as such anyway, so might as well make them this type properly so we don't need to think about C's implicit sign conversion rules