### PR TITLE
ext/pgsql: Fix #19484 by setting the notice processor to a no-op

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,10 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed bug GH-16649 (UAF during array_splice). (alexandre-daubois)
 
+- PGSQL:
+  . Fixed bug GH-19485 (potential use after free when using persistent pgsql
+    connections). (Mark Karpeles)
+
 28 Aug 2025, PHP 8.3.25
 
 - Core:

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -328,6 +328,10 @@ static void _close_pgsql_plink(zend_resource *rsrc)
 
 static void _php_pgsql_notice_handler(void *l, const char *message)
 {
+	if (l == NULL) {
+		/* This connection does not currently have a valid context, ignore this notice */
+		return;
+	}
 	if (PGG(ignore_notices)) {
 		return;
 	}
@@ -359,6 +363,9 @@ static int _rollback_transactions(zval *el)
 	}
 
 	link = (PGconn *) rsrc->ptr;
+
+	/* unset notice processor */
+	PQsetNoticeProcessor(link, _php_pgsql_notice_handler, NULL);
 
 	if (PQsetnonblocking(link, 0)) {
 		php_error_docref("ref.pgsql", E_NOTICE, "Cannot set connection to blocking mode");

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -364,8 +364,10 @@ static int _rollback_transactions(zval *el)
 
 	link = (PGconn *) rsrc->ptr;
 
-	/* unset notice processor */
-	PQsetNoticeProcessor(link, _php_pgsql_notice_handler, NULL);
+	/* unset notice processor if we initially did set it */
+	if (PQsetNoticeProcessor(link, NULL, NULL) == _php_pgsql_notice_handler) {
+		PQsetNoticeProcessor(link, _php_pgsql_notice_handler, NULL);
+	}
 
 	if (PQsetnonblocking(link, 0)) {
 		php_error_docref("ref.pgsql", E_NOTICE, "Cannot set connection to blocking mode");


### PR DESCRIPTION
Resolving a potential use after free of the pgsql connection object.

See https://github.com/php/php-src/issues/19484 for details.