### PR TITLE
Fix uaf for nested finally with repeated return type check

### DIFF
--- a/Zend/tests/oss_fuzz_438780145.phpt
+++ b/Zend/tests/oss_fuzz_438780145.phpt
@@ -1,0 +1,27 @@
+--TEST--
+OSS-Fuzz #438780145: Nested finally with repeated return type check may uaf
+--FILE--
+<?php
+
+function &test(): int {
+    $x = 0;
+    try {
+        return $x;
+    } finally {
+        try {
+            return $x;
+        } finally {
+            $x = "";
+        }
+    }
+}
+
+test();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: test(): Return value must be of type int, string returned in %s:%d
+Stack trace:
+#0 %s(%d): test()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -8473,6 +8473,10 @@ ZEND_VM_HANDLER(159, ZEND_DISCARD_EXCEPTION, ANY, ANY)
 		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[Z_OPLINE_NUM_P(fast_call)].op2.var);
 
 		zval_ptr_dtor(return_value);
+		/* Clear return value in case we hit both DISCARD_EXCEPTION and
+		 * zend_dispatch_try_catch_finally_helper, which will free the return
+		 * value again. See OSS-Fuzz #438780145. */
+		ZVAL_NULL(return_value);
 	}
 
 	/* cleanup delayed exception */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3343,6 +3343,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DISCARD_EXCEPTION_SPEC_HANDLER
 		zval *return_value = EX_VAR(EX(func)->op_array.opcodes[Z_OPLINE_NUM_P(fast_call)].op2.var);
 
 		zval_ptr_dtor(return_value);
+		/* Clear return value in case we hit both DISCARD_EXCEPTION and
+		 * zend_dispatch_try_catch_finally_helper, which will free the return
+		 * value again. See OSS-Fuzz #438780145. */
+		ZVAL_NULL(return_value);
 	}
 
 	/* cleanup delayed exception */


### PR DESCRIPTION
Fixes OSS-Fuzz #438780145

Introduced by https://github.com/php/php-src/pull/19172. A bit unfortunate that this is necessary. I'm open to suggestions.