### PR TITLE
Adding split as an alias for explode

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2351,7 +2351,10 @@ function wordwrap(string $string, int $width = 75, string $break = "\n", bool $c
  */
 function explode(string $separator, string $string, int $limit = PHP_INT_MAX): array {}
 
-/** @alias explode */
+/**
+ * @return array<int, string>
+ * @alias explode
+ */
 function split(string $separator, string $string, int $limit = PHP_INT_MAX): array {}
 
 /**

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2351,6 +2351,9 @@ function wordwrap(string $string, int $width = 75, string $break = "\n", bool $c
  */
 function explode(string $separator, string $string, int $limit = PHP_INT_MAX): array {}
 
+/** @alias explode */
+function split(string $separator, string $string, int $limit = PHP_INT_MAX): array {}
+
 /**
  * @compile-time-eval
  * @frameless-function {"arity": 1}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -854,6 +854,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_explode, 0, 2, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "PHP_INT_MAX")
 ZEND_END_ARG_INFO()
 
+#define arginfo_split arginfo_explode
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_implode, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, separator, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, array, IS_ARRAY, 1, "null")
@@ -3127,6 +3129,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("ltrim", zif_ltrim, arginfo_ltrim, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("wordwrap", zif_wordwrap, arginfo_wordwrap, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("explode", zif_explode, arginfo_explode, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
+	ZEND_RAW_FENTRY("split", zif_explode, arginfo_split, 0, NULL, NULL)
 	ZEND_RAW_FENTRY("implode", zif_implode, arginfo_implode, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_implode, NULL)
 	ZEND_RAW_FENTRY("join", zif_implode, arginfo_join, 0, NULL, NULL)
 	ZEND_FE(strtok, arginfo_strtok)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b451d298e78813d84a5cdf8f6aeb1aef52828083 */
+ * Stub hash: 37e777cecf17f3ad016c038edfc8c4590226e62e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: deb4ea96dd130d8a0174678095c30a61e118bd60 */
+ * Stub hash: b451d298e78813d84a5cdf8f6aeb1aef52828083 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)


### PR DESCRIPTION
We have `join` as an alias for `implode` so I think it makes sense to have `split` as an alias to `explode`