### PR TITLE
zend_memrchr using standard preprocessor id for x86 instead.

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -215,7 +215,7 @@ zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const 
 
 static zend_always_inline const void *zend_memrchr(const void *s, int c, size_t n)
 {
-#if defined(HAVE_MEMRCHR) && !defined(i386)
+#if defined(HAVE_MEMRCHR) && !defined(__i386__)
 	/* On x86 memrchr() doesn't use SSE/AVX, so inlined version is faster */
 	return (const void*)memrchr(s, c, n);
 #else


### PR DESCRIPTION
Might be intentional, but otherwise `__i386__` is the standard.