### PR TITLE
gen_stub: Update to PHP-Parser 5.6.1

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -6056,7 +6056,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "5.6.0";
+    $version = "5.6.1";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);


### PR DESCRIPTION
This fixes a PHP 8.5 Deprecation:

> Deprecated: Method SplObjectStorage::attach() is deprecated since 8.5, use
> method SplObjectStorage::offsetSet() instead in
> php-src/build/PHP-Parser-5.6.0/lib/PhpParser/Parser/Php7.php on line 2692