### PR TITLE
Use color scheme styling for error pages of (builtin) webserver

### DIFF
--- a/ext/standard/css.c
+++ b/ext/standard/css.c
@@ -17,7 +17,11 @@
 #include "php.h"
 #include "info.h"
 
-PHPAPI ZEND_COLD void php_info_print_css(void) /* {{{ */
+/* {{{ void php_info_print_css(void)
+ * Perhaps duplicate changes in ext/standard/css.c
+ *                            , sapi/cli/php_cli_server.c
+ */
+PHPAPI ZEND_COLD void php_info_print_css(void)
 {
 	PUTS("body {background-color: #fff; color: #222; font-family: sans-serif;}\n");
 	PUTS("pre {margin: 0; font-family: monospace;}\n");

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -240,26 +240,46 @@ ZEND_DECLARE_MODULE_GLOBALS(cli_server)
  * copied from ext/standard/info.c
  */
 static const char php_cli_server_css[] = "<style>" \
+										":root{" \
+										"--c-black:#000000;" \
+										"--c-dark-grey:#333333;" \
+										"--c-lavender-misty:#E2E4EF;" \
+										"--c-blue-bell:#9999CC;" \
+										"--c-white:#FCFCFC;" \
+										"--php-background:light-dark(" \
+										"var(--c-white),var(--c-dark-grey)" \
+										");" \
+										"--php-code-background:var(--c-lavender-misty);" \
+										"--php-code-foreground:var(--c-black);" \
+										"--php-foreground:light-dark(" \
+										"var(--c-dark-grey),var(--c-lavender-misty)" \
+										");" \
+										"--php-heading-background:var(--c-blue-bell);" \
+										"--php-heading-foreground:var(--c-black);" \
+										"color-scheme:light dark;" \
+										"}" \
 										"body{" \
-										"background-color:#fcfcfc;" \
-										"color:#333333;" \
+										"background-color:var(--php-background);" \
+										"color:var(--php-foreground);" \
 										"margin:0;" \
 										"padding:0;" \
 										"}" \
 										"h1{" \
 										"font-size:1.5em;" \
 										"font-weight:normal;" \
-										"background-color:#9999cc;" \
+										"background-color:var(--php-heading-background);" \
+										"color:var(--php-heading-foreground);" \
 										"min-height:2em;" \
 										"line-height:2em;" \
-										"border-bottom:1px inset black;" \
+										"border-bottom:1px inset var(--php-black);" \
 										"margin:0;" \
 										"}" \
 										"h1,p{" \
 										"padding-left:10px;" \
 										"}" \
 										"code.url{" \
-										"background-color:#eeeeee;" \
+										"background-color:var(--php-code-background);" \
+										"color:var(--php-code-foreground);" \
 										"font-family:monospace;" \
 										"padding:0 2px;" \
 										"}" \

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -237,7 +237,8 @@ static void php_cli_server_log_response(php_cli_server_client *client, int statu
 ZEND_DECLARE_MODULE_GLOBALS(cli_server)
 
 /* {{{ static char php_cli_server_css[]
- * copied from ext/standard/info.c
+ * Perhaps duplicate changes in ext/standard/css.c
+ *                            , sapi/cli/php_cli_server.c
  */
 static const char php_cli_server_css[] = "<style>" \
 										":root{" \

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -239,12 +239,31 @@ ZEND_DECLARE_MODULE_GLOBALS(cli_server)
 /* {{{ static char php_cli_server_css[]
  * copied from ext/standard/info.c
  */
-static const char php_cli_server_css[] = "<style>\n" \
-										"body { background-color: #fcfcfc; color: #333333; margin: 0; padding:0; }\n" \
-										"h1 { font-size: 1.5em; font-weight: normal; background-color: #9999cc; min-height:2em; line-height:2em; border-bottom: 1px inset black; margin: 0; }\n" \
-										"h1, p { padding-left: 10px; }\n" \
-										"code.url { background-color: #eeeeee; font-family:monospace; padding:0 2px;}\n" \
-										"</style>\n";
+static const char php_cli_server_css[] = "<style>" \
+										"body{" \
+										"background-color:#fcfcfc;" \
+										"color:#333333;" \
+										"margin:0;" \
+										"padding:0;" \
+										"}" \
+										"h1{" \
+										"font-size:1.5em;" \
+										"font-weight:normal;" \
+										"background-color:#9999cc;" \
+										"min-height:2em;" \
+										"line-height:2em;" \
+										"border-bottom:1px inset black;" \
+										"margin:0;" \
+										"}" \
+										"h1,p{" \
+										"padding-left:10px;" \
+										"}" \
+										"code.url{" \
+										"background-color:#eeeeee;" \
+										"font-family:monospace;" \
+										"padding:0 2px;" \
+										"}" \
+										"</style>";
 /* }}} */
 
 #ifdef PHP_WIN32

--- a/sapi/cli/tests/php_cli_server_013.phpt
+++ b/sapi/cli/tests/php_cli_server_013.phpt
@@ -131,8 +131,7 @@ X-Powered-By: PHP/%s
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
 
-<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>404 Not Found</title><style>AAA</style>
-</head><body><h1>Not Found</h1><p>The requested resource <code class="url">/</code> was not found on this server.</p></body></html>
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>404 Not Found</title><style>AAA</style></head><body><h1>Not Found</h1><p>The requested resource <code class="url">/</code> was not found on this server.</p></body></html>
 HTTP/1.1 404 Not Found
 Host: %s
 Date: %s
@@ -141,8 +140,7 @@ X-Powered-By: PHP/%s
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
 
-<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>404 Not Found</title><style>AAA</style>
-</head><body><h1>Not Found</h1><p>The requested resource <code class="url">/main/style.css</code> was not found on this server.</p></body></html>
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>404 Not Found</title><style>AAA</style></head><body><h1>Not Found</h1><p>The requested resource <code class="url">/main/style.css</code> was not found on this server.</p></body></html>
 HTTP/1.1 404 Not Found
 Host: %s
 Date: %s
@@ -161,8 +159,7 @@ Content-Type: text/html; charset=UTF-8
 Content-Length: %d
 Allow: GET, HEAD, POST
 
-<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style>
-</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style></head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
 HTTP/1.1 405 Method Not Allowed
 Host: %s
 Date: %s
@@ -172,8 +169,7 @@ Content-Type: text/html; charset=UTF-8
 Content-Length: %d
 Allow: GET, HEAD, POST
 
-<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style>
-</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style></head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
 HTTP/1.1 405 Method Not Allowed
 Host: %s
 Date: %s
@@ -183,5 +179,4 @@ Content-Type: text/html; charset=UTF-8
 Content-Length: %d
 Allow: GET, HEAD, POST
 
-<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style>
-</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>405 Method Not Allowed</title><style>AAA</style></head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>


### PR DESCRIPTION
This request asks to
increase support for `prefer-color-scheme: dark`
by accordingly adding styles to the error pages generated by the builtin webserver.

This seems to be in line with earlier changes,
such as taking larger screens into account (as mentioned in #17956),
and complementing the contrast improvement for the phpinfo page (#8893).

In contrast to earlier changes,
i have removed new lines from the styles used on the error pages,
as that seems to be more in line with the rest of the output.

Another contrast with earlier changes, is
using the css function `light-dark`[^2] instead of the `prefers-color-scheme` used for the phpinfo page.

Aside from that, i have attempted to look for appropriate names for colors and separated the color definitions from the definitions that use them to assign a value to a selector. My hope is that such an approach might ease a future change to a rather consistent coloring scheme within php creations. There seems to be some work done on this, as some styling was moved from `ext/standard/info.c` to `ext/standard/css.c`.

On the matter of preferred color schemes, i would like to point out that defaulting to emitting less light to screen viewers seems preferable to bombarding them with light. In other words, it seems to me that being 'lost in the dark' is preferable to being 'blinded by the light'. Hopefully this will be picked up 'en masse' and lead to a default of screens emitting less radiation when a piece of software displays its initial screen.

## TL;DR:
> Remember Manfred Mann [^1]

[^1]: As is (hopefully widely) known, Manfred Mann's Earth Band was 'blinded by the light'.
  In short, my question to everyone working with web pages, is to remember that such a thing can happen.
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark