### PR TITLE
php.ini templates: Group dynamic extension related settings

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -770,21 +770,9 @@ doc_root =
 ; https://php.net/user-dir
 user_dir =
 
-; Directory in which the loadable extensions (modules) reside.
-; https://php.net/extension-dir
-;extension_dir = "./"
-; On windows:
-;extension_dir = "ext"
-
 ; Directory where the temporary files should be placed.
 ; Defaults to the system default (see sys_get_temp_dir)
 ;sys_temp_dir = "/tmp"
-
-; Whether or not to enable the dl() function.  The dl() function does NOT work
-; properly in multithreaded servers, such as IIS or Zeus, and is automatically
-; disabled on them.
-; https://php.net/enable-dl
-enable_dl = Off
 
 ; cgi.force_redirect is necessary to provide security running PHP as a CGI under
 ; most web servers.  Left undefined, PHP turns this on by default.  You can
@@ -906,6 +894,18 @@ default_socket_timeout = 60
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Dynamic Extensions ;
 ;;;;;;;;;;;;;;;;;;;;;;
+
+; Whether or not to enable the dl() function.  The dl() function does NOT work
+; properly in multithreaded servers, such as IIS or Zeus, and is automatically
+; disabled on them.
+; https://php.net/enable-dl
+enable_dl = Off
+
+; Directory in which the loadable extensions (modules) reside.
+; https://php.net/extension-dir
+;extension_dir = "./"
+; On windows:
+;extension_dir = "ext"
 
 ; If you wish to have an extension loaded automatically, use the following
 ; syntax:

--- a/php.ini-production
+++ b/php.ini-production
@@ -772,21 +772,9 @@ doc_root =
 ; https://php.net/user-dir
 user_dir =
 
-; Directory in which the loadable extensions (modules) reside.
-; https://php.net/extension-dir
-;extension_dir = "./"
-; On windows:
-;extension_dir = "ext"
-
 ; Directory where the temporary files should be placed.
 ; Defaults to the system default (see sys_get_temp_dir)
 ;sys_temp_dir = "/tmp"
-
-; Whether or not to enable the dl() function.  The dl() function does NOT work
-; properly in multithreaded servers, such as IIS or Zeus, and is automatically
-; disabled on them.
-; https://php.net/enable-dl
-enable_dl = Off
 
 ; cgi.force_redirect is necessary to provide security running PHP as a CGI under
 ; most web servers.  Left undefined, PHP turns this on by default.  You can
@@ -908,6 +896,18 @@ default_socket_timeout = 60
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Dynamic Extensions ;
 ;;;;;;;;;;;;;;;;;;;;;;
+
+; Whether or not to enable the dl() function.  The dl() function does NOT work
+; properly in multithreaded servers, such as IIS or Zeus, and is automatically
+; disabled on them.
+; https://php.net/enable-dl
+enable_dl = Off
+
+; Directory in which the loadable extensions (modules) reside.
+; https://php.net/extension-dir
+;extension_dir = "./"
+; On windows:
+;extension_dir = "ext"
 
 ; If you wish to have an extension loaded automatically, use the following
 ; syntax:


### PR DESCRIPTION
Related #19499

Group the dynamic extension related settings. Specifically this moves the `extension_dir` setting right above the extension list, making it much easier to find even if you don't know it exists.

While I recognize that this does move the setting away from the "paths and directories" group, there's precedence for this with, for example `upload_tmp_dir` (and also paths under specific extension sections such as `[mail]` and `[session]`). 

I believe this move is an overall improvement for user experience as you most commonly need this setting when troubleshooting extension issues, and new users often don't know it exists.