### PR TITLE
Remove `report_memleaks` entry from php.ini-*

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -537,13 +537,6 @@ ignore_repeated_errors = Off
 ; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
-; Use of this INI entry is deprecated, it will be removed in PHP 9.0.
-; If this parameter is set to Off, then memory leaks will not be shown (on
-; stdout or in the log). This is only effective in a debug compile, and if
-; error reporting includes E_WARNING in the allowed list
-; https://php.net/report-memleaks
-;report_memleaks = On
-
 ; This setting is off by default.
 ;report_zend_debug = 0
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -539,13 +539,6 @@ ignore_repeated_errors = Off
 ; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
-; Use of this INI entry is deprecated, it will be removed in PHP 9.0.
-; If this parameter is set to Off, then memory leaks will not be shown (on
-; stdout or in the log). This is only effective in a debug compile, and if
-; error reporting includes E_WARNING in the allowed list
-; https://php.net/report-memleaks
-;report_memleaks = On
-
 ; This setting is off by default.
 ;report_zend_debug = 0
 


### PR DESCRIPTION
After https://github.com/php/php-src/pull/19481#discussion_r2277329438. This INI entry is deprecated and only useful for debug builds, Tim and Niels agree that it should be removed from these files. It's deprecated to turn this setting Off since https://github.com/php/php-src/pull/19481.