### PR TITLE
Remove mentions of PHP 9.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,8 +58,7 @@ PHP                                                                        NEWS
   . Fixed bug GH-19476 (pipe operator fails to correctly handle returning
     by reference). (alexandre-daubois)
   . The report_memleaks INI directive has been deprecated. (alexandre-daubois)
-  . Constant redeclaration is deprecated and this behavior will trigger an
-    error in PHP 9. (alexandre-daubois)
+  . Constant redeclaration has been deprecated. (alexandre-daubois)
   . Fixed OSS-Fuzz #439125710 (Pipe cannot be used in write context).
     (nielsdos)
   . Added support for configuring the URI parser for the FTP/FTPS as well as

--- a/UPGRADING
+++ b/UPGRADING
@@ -360,8 +360,7 @@ PHP 8.5 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_debuginfo_returning_null
   . The report_memleaks INI directive has been deprecated.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_report_memleaks_ini_directive
-  . Constant redeclaration is deprecated and that behavior will trigger an
-    error in PHP 9.
+  . Constant redeclaration has been deprecated.
     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_constant_redeclaration
   . Enacted the follow-up phase of the "Path to Saner Increment/Decrement
     operators" RFC, meaning that incrementing non-numeric strings is now


### PR DESCRIPTION
PHP 9.0 is actually never mentioned in deprecation entries so existing one recently merged should be removed?

Spotted in https://github.com/php/php-src/pull/19510#discussion_r2281692335