### PR TITLE
Fit JIT variable not stored before YIELD

### DIFF
--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -944,7 +944,7 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *ex,
 #ifdef HAVE_GCC_GLOBAL_REGS
 		handler();
 		if (UNEXPECTED(opline == zend_jit_halt_op)) {
-			if (prev_opline->opcode == ZEND_YIELD) {
+			if (prev_opline->opcode == ZEND_YIELD || prev_opline->opcode == ZEND_YIELD_FROM) {
 				stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
 			} else {
 				stop = ZEND_JIT_TRACE_STOP_RETURN;
@@ -958,7 +958,7 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *ex,
 		rc = handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
 		if (rc != 0) {
 			if (rc < 0) {
-				if (opline->opcode == ZEND_YIELD) {
+				if (opline->opcode == ZEND_YIELD || opline->opcode == ZEND_YIELD_FROM) {
 					stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
 				} else {
 					stop = ZEND_JIT_TRACE_STOP_RETURN;

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -937,11 +937,18 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *ex,
 			break;
 		}
 
+#ifdef HAVE_GCC_GLOBAL_REGS
+		const zend_op *prev_opline = opline;
+#endif
 		handler = (zend_vm_opcode_handler_t)ZEND_OP_TRACE_INFO(opline, offset)->call_handler;
 #ifdef HAVE_GCC_GLOBAL_REGS
 		handler();
 		if (UNEXPECTED(opline == zend_jit_halt_op)) {
-			stop = ZEND_JIT_TRACE_STOP_RETURN;
+			if (prev_opline->opcode == ZEND_YIELD) {
+				stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
+			} else {
+				stop = ZEND_JIT_TRACE_STOP_RETURN;
+			}
 			opline = NULL;
 			halt = ZEND_JIT_TRACE_HALT;
 			break;
@@ -951,7 +958,11 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data  *ex,
 		rc = handler(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU);
 		if (rc != 0) {
 			if (rc < 0) {
-				stop = ZEND_JIT_TRACE_STOP_RETURN;
+				if (opline->opcode == ZEND_YIELD) {
+					stop = ZEND_JIT_TRACE_STOP_INTERPRETER;
+				} else {
+					stop = ZEND_JIT_TRACE_STOP_RETURN;
+				}
 				opline = NULL;
 				halt = ZEND_JIT_TRACE_HALT;
 				break;

--- a/ext/opcache/tests/jit/gh19493-001.phpt
+++ b/ext/opcache/tests/jit/gh19493-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-19493 001: Var not stored before YIELD
+--FILE--
+<?php
+
+function f() {
+    $offset = 0;
+    yield true;
+    for ($i = 0; $i < 100; $i++) {
+        $offset++;
+        if ($offset === 99) {
+            break;
+        }
+        yield true;
+    }
+    return $offset;
+}
+$gen = f();
+foreach ($gen as $v) {}
+var_dump($gen->getReturn());
+
+?>
+--EXPECT--
+int(99)

--- a/ext/opcache/tests/jit/gh19493-002.phpt
+++ b/ext/opcache/tests/jit/gh19493-002.phpt
@@ -1,17 +1,17 @@
 --TEST--
-GH-19493: Var not stored before YIELD
+GH-19493 002: Var not stored before YIELD_FROM
 --FILE--
 <?php
 
 function f() {
     $offset = 0;
-    yield true;
+    yield from [true];
     for ($i = 0; $i < 100; $i++) {
         $offset++;
         if ($offset === 99) {
             break;
         }
-        yield true;
+        yield from [true];
     }
     return $offset;
 }

--- a/ext/opcache/tests/jit/gh19493.phpt
+++ b/ext/opcache/tests/jit/gh19493.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-19493: Var not stored before YIELD
+--FILE--
+<?php
+
+function f() {
+    $offset = 0;
+    yield true;
+    for ($i = 0; $i < 100; $i++) {
+        $offset++;
+        if ($offset === 99) {
+            break;
+        }
+        yield true;
+    }
+    return $offset;
+}
+$gen = f();
+foreach ($gen as $v) {}
+var_dump($gen->getReturn());
+
+?>
+--EXPECT--
+int(99)


### PR DESCRIPTION
Fixes GH-19493.

JIT doesn't recognize that variables may be used after returning from a trace due to YIELD, so some effects may never be stored to memory.

YIELD ops terminate trace recordings with ZEND_JIT_TRACE_STOP_RETURN, and are handled mostly like RETURN. Here I change zend_jit_trace_execute() so that YIELD terminates recordings with ZEND_JIT_TRACE_STOP_INTERPRETER instead, to ensure that we recognize that variables may be used after returning from the trace due to YIELD.