### PR TITLE
ci: remove macos13 from night job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,9 +20,6 @@ on:
       run_linux_ppc64:
         required: true
         type: boolean
-      run_macos_arm64:
-        required: true
-        type: boolean
       run_freebsd_zts:
         required: true
         type: boolean
@@ -374,10 +371,8 @@ jobs:
       matrix:
         debug: [true, false]
         zts: [true, false]
-        os: ['13', '14']
-        exclude:
-          - os: ${{ !inputs.run_macos_arm64 && '14' || '*never*' }}
-    name: "MACOS_${{ matrix.os == '13' && 'X64' || 'ARM64' }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
+        os: ['14', '15']
+    name: "MACOS_ARM64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: macos-${{ matrix.os }}
     steps:
       - name: git checkout
@@ -401,7 +396,7 @@ jobs:
       - name: Test
         uses: ./.github/actions/test-macos
       - name: Test Tracing JIT
-        if: matrix.os != '14' || !matrix.zts
+        if: ${{  !matrix.zts }}
         uses: ./.github/actions/test-macos
         with:
           jitType: tracing
@@ -415,7 +410,7 @@ jobs:
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
       - name: Test Function JIT
-        if: matrix.os != '14' || !matrix.zts
+        if:  ${{ !matrix.zts }}
         uses: ./.github/actions/test-macos
         with:
           jitType: function

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -54,7 +54,6 @@ jobs:
       libmysqlclient_with_mysqli: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1) }}
       run_alpine: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       run_linux_ppc64: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
-      run_macos_arm64: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       run_freebsd_zts: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 3) || matrix.branch.version[0] >= 9 }}
       ubuntu_version: ${{
         (((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9) && '24.04')


### PR DESCRIPTION
Changes macos13 with macos15 in nightly job.

Maco13 will be removed in November from Github job. Creating this PR in advance so it may be merged in November.