### PR TITLE
[Fix] parse_url: don’t treat colon in path as port #19527

### DIFF
--- a/ext/standard/tests/url/gh12703.phpt
+++ b/ext/standard/tests/url/gh12703.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-12703 parse_url() return false on absolute path containing ':' and no query string.
+--FILE--
+<?php
+var_dump(
+    parse_url('/page:1'),
+    parse_url('/page:1', \PHP_URL_SCHEME),
+
+    // Working example for context.
+    parse_url('/page:1?foo=bar'),
+
+    // Examples from similar GH issue (7890)
+    parse_url('//www.examle.com/foo:65535/'),
+    parse_url('//www.examle.com:8080/foo:65535/'),
+);
+
+?>
+--EXPECT--
+array(1) {
+  ["path"]=>
+  string(7) "/page:1"
+}
+NULL
+array(2) {
+  ["path"]=>
+  string(7) "/page:1"
+  ["query"]=>
+  string(7) "foo=bar"
+}
+array(2) {
+  ["host"]=>
+  string(14) "www.examle.com"
+  ["path"]=>
+  string(11) "/foo:65535/"
+}
+array(3) {
+  ["host"]=>
+  string(14) "www.examle.com"
+  ["port"]=>
+  int(8080)
+  ["path"]=>
+  string(11) "/foo:65535/"
+}

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -181,7 +181,10 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 		p = e + 1;
 		pp = p;
 
+		const char *first_slash = memchr(s, '/', ue - s);
+
 		while (pp < ue && pp - p < 6 && isdigit(*pp)) {
+			if (first_slash && pp >= first_slash) break;
 			pp++;
 		}
 


### PR DESCRIPTION
Fix `parse_url()` to avoid treating a colon followed by digits inside the path as a port number.

**Before**:

```php
$url = '//www.example.com/ddd:65333/';
var_export(parse_url($url));
```

```bash
array (
  'host' => 'www.example.com',
  'port' => 65333,
  'path' => '/ddd:65333/',
)
```
**After**
```bash
array (
  'host' => 'www.example.com',
  'path' => '/ddd:65333/',
)
```