### PR TITLE
[Fix] UTF-8 handling on macOS in php_replace_controlchars()

### DIFF
--- a/ext/standard/tests/url/url_utf8.phpt
+++ b/ext/standard/tests/url/url_utf8.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Uri: hostnames should be preserved in Unicode form
+--FILE--
+<?php
+
+$parsed = parse_url('http://ουτοπία.δπθ.gr/');
+var_dump($parsed['host']);
+?>
+--EXPECT--
+string(24) "ουτοπία.δπθ.gr"

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -18,6 +18,12 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
+#if defined(__APPLE__)
+#include <wchar.h>
+#endif
+#if defined(__APPLE__)
+#include <wctype.h>
+#endif
 
 #include "php.h"
 
@@ -58,6 +64,24 @@ static void parse_url_free_uri(void *uri)
 
 static void php_replace_controlchars(char *str, size_t len)
 {
+	#if defined(__APPLE__) 
+	{
+		ZEND_ASSERT(str != NULL);
+		wchar_t wbuf[len];
+		memset(wbuf, 0, sizeof(wbuf));
+		size_t wlen = mbstowcs(wbuf, str, len);
+
+		for (size_t i = 0; i < wlen; i++) {
+			if (iswcntrl(wbuf[i])) {
+				wbuf[i] = L'_';
+			}
+		}
+
+		wcstombs(str, wbuf, len);
+		return;
+	}
+	#endif
+	
 	unsigned char *s = (unsigned char *)str;
 	unsigned char *e = (unsigned char *)str + len;
 


### PR DESCRIPTION
Fix php_replace_controlchars() on macOS so UTF-8 characters in URLs are preserved.

Previously, non-ASCII characters in hosts were replaced with _ or became � due to improper handling of multibyte UTF-8 characters.

```php

<?php
$parsed = parse_url('http://ουτοπία.δπθ.gr/');
var_dump($parsed['host']);
?>
--EXPECT--
string(24) "ουτοπία.δπθ.gr"
``` 