### PR TITLE
Fix incorrect opline after deoptimization

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -17291,16 +17291,8 @@ static int zend_jit_trace_return(zend_jit_ctx *jit, bool original_handler, const
 			addr = ir_CAST_FC_FUNC(addr);
 #endif
 			ref = ir_CALL_2(IR_ADDR, addr, jit_FP(jit), jit_IP(jit));
-			if (opline &&
-			    (opline->opcode == ZEND_RETURN
-			  || opline->opcode == ZEND_RETURN_BY_REF
-			  || opline->opcode == ZEND_GENERATOR_RETURN
-			  || opline->opcode == ZEND_GENERATOR_CREATE
-			  || opline->opcode == ZEND_YIELD
-			  || opline->opcode == ZEND_YIELD_FROM)) {
-				zend_jit_vm_enter(jit, ref);
-				return 1;
-			}
+			zend_jit_vm_enter(jit, ref);
+			return 1;
 		}
 		zend_jit_vm_enter(jit, jit_IP(jit));
 	}

--- a/ext/opcache/tests/jit/gh19486.phpt
+++ b/ext/opcache/tests/jit/gh19486.phpt
@@ -1,5 +1,8 @@
 --TEST--
 GH-19486: incorrect opline after deoptimization
+--INI--
+opcache.jit_blacklist_root_trace=1
+opcache.jit_blacklist_side_trace=1
 --FILE--
 <?php
 
@@ -16,7 +19,7 @@ class GameMap
 
     public function floodFill(int $x, int $y, int $id): void
     {
-        if (($x < 0) or ($x >= 900) or ($y < 0) or ($y >= 400)) {
+        if (($x < 0) or ($x >= 50) or ($y < 0) or ($y >= 50)) {
             return;
         }
         if (isset($this->lakeID[$y][$x]) and ($this->lakeID[$y][$x] == $id)) {

--- a/ext/opcache/tests/jit/gh19486.phpt
+++ b/ext/opcache/tests/jit/gh19486.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-19486: incorrect opline after deoptimization
+--FILE--
+<?php
+
+(new GameMap())->getLakeArea(0, 0);
+
+class GameMap
+{
+    public $lakeID = [];
+
+    public function getLakeArea(int $x, int $y): int
+    {
+        $this->floodFill(0, 0, 0);
+    }
+
+    public function floodFill(int $x, int $y, int $id): void
+    {
+        if (($x < 0) or ($x >= 900) or ($y < 0) or ($y >= 400)) {
+            return;
+        }
+        if (isset($this->lakeID[$y][$x]) and ($this->lakeID[$y][$x] == $id)) {
+            return;
+        }
+        $this->lakeID[$y][$x] = $id;
+        $this->floodFill($x - 1, $y, $id);
+        $this->floodFill($x + 1, $y, $id);
+        $this->floodFill($x, $y - 1, $id);
+        $this->floodFill($x, $y + 1, $id);
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: GameMap::getLakeArea(): Return value must be of type int, none returned in %s:%d
+Stack trace:
+#0 %s(%d): GameMap->getLakeArea(0, 0)
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
Fixes GH-19486 introduced by https://github.com/php/php-src/commit/76d7c616bb8775520f18456b41121bf934cac391.

Blacklisted side traces (aka JIT'ed exits) may return the previous opline after calling the original op handler. As a result, the op handler is called again by the VM.

Fix this by always returning the opline returned by the original op handler.

Always use `zend_jit_vm_enter(jit, ref)` to signal the VM that it must reload `EG(current_execute_data)` as it may have changed during the execution of the trace.

This is consistent with non-JIT'ed exits: https://github.com/php/php-src/blob/0bf295944df7171acf47502d31dd7df8b9155d81/ext/opcache/jit/zend_jit_ir.c#L2488-L2489

And with the previous version of this code (`ir_RETURN(ref)` and `ir_RETURN(ir_CONST_I32(2))` have the same effect in this case) : https://github.com/php/php-src/blob/bc05bfe7c58a0df531e92cb43f3ea2e6332c3c68/ext/opcache/jit/zend_jit_ir.c#L17108-L17119

Analysis of the reproducer code in GH-19486:

The function floodFill() performs a deep recursion, exhausting the VM stack, causing a side exit in zend_jit_push_call_frame(). The JIT'ed code of this side exit mistakenly returns the previous opline to the VM, causing the same opline (INIT_FCALL) to be executed twice:

 * The first time, the stack is extended and the new call frame is marked with ZEND_CALL_ALLOCATED
 * The second time, we re-use the newly allocated stack, so the frame is not marked

The first frame never make it to the call stack. Returning from the second frame to its parent creates the inconsistency that causes the assertion failure (the frame doesn't have ZEND_CALL_ALLOCATED, so EG(vm_stack) is not freed and set to EG(vm_stack)->prev).