### PR TITLE
uri: Fix header guard constant name for `uri_parser_*.h`

### DIFF
--- a/ext/uri/uri_parser_rfc3986.h
+++ b/ext/uri/uri_parser_rfc3986.h
@@ -14,8 +14,8 @@
    +----------------------------------------------------------------------+
 */
 
-#ifndef PHP_URIPARSER_H
-#define PHP_URIPARSER_H
+#ifndef PHP_URI_PARSER_RFC3986_H
+#define PHP_URI_PARSER_RFC3986_H
 
 #include <uriparser/Uri.h>
 #include "php_uri_common.h"

--- a/ext/uri/uri_parser_whatwg.h
+++ b/ext/uri/uri_parser_whatwg.h
@@ -14,8 +14,8 @@
    +----------------------------------------------------------------------+
 */
 
-#ifndef PHP_LEXBOR_H
-#define PHP_LEXBOR_H
+#ifndef PHP_URI_PARSER_WHATWG_H
+#define PHP_URI_PARSER_WHATWG_H
 
 #include "php_uri_common.h"
 #include "lexbor/url/url.h"


### PR DESCRIPTION
Introduced in php/php-src#19530.