### PR TITLE
uri: Improve return type of `uriparser_parse_uri_ex()`

### DIFF
--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -283,7 +283,7 @@ static uriparser_uris_t *uriparser_create_uris(void)
 	return uriparser_uris;
 }
 
-void *uriparser_parse_uri_ex(const char *uri_str, size_t uri_str_len, const uriparser_uris_t *uriparser_base_urls, bool silent)
+uriparser_uris_t *uriparser_parse_uri_ex(const char *uri_str, size_t uri_str_len, const uriparser_uris_t *uriparser_base_urls, bool silent)
 {
 	UriUriA uri = {0};
 

--- a/ext/uri/uri_parser_rfc3986.h
+++ b/ext/uri/uri_parser_rfc3986.h
@@ -30,6 +30,6 @@ typedef struct uriparser_uris_t {
 
 zend_result uriparser_read_userinfo(const uri_internal_t *internal_uri, uri_component_read_mode_t read_mode, zval *retval);
 
-void *uriparser_parse_uri_ex(const char *uri_str, size_t uri_str_len, const uriparser_uris_t *uriparser_base_url, bool silent);
+uriparser_uris_t *uriparser_parse_uri_ex(const char *uri_str, size_t uri_str_len, const uriparser_uris_t *uriparser_base_url, bool silent);
 
 #endif


### PR DESCRIPTION
This function is not intended to be called via a function pointer, so we don't need to deal with a generic `void*`.