### PR TITLE
uri: Use PHP_RINIT/SHUTDOWN_FUNCTION in uri_parser_whatwg

### DIFF
--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -1077,7 +1077,7 @@ static PHP_MSHUTDOWN_FUNCTION(uri)
 
 PHP_RINIT_FUNCTION(uri)
 {
-	if (lexbor_request_init() == FAILURE) {
+	if (PHP_RINIT(uri_parser_whatwg)(INIT_FUNC_ARGS_PASSTHRU) == FAILURE) {
 		return FAILURE;
 	}
 
@@ -1086,7 +1086,9 @@ PHP_RINIT_FUNCTION(uri)
 
 PHP_RSHUTDOWN_FUNCTION(uri)
 {
-	lexbor_request_shutdown();
+	if (PHP_RSHUTDOWN(uri_parser_whatwg)(INIT_FUNC_ARGS_PASSTHRU) == FAILURE) {
+		return FAILURE;
+	}
 
 	return SUCCESS;
 }

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -533,7 +533,7 @@ static zend_result lexbor_write_fragment(struct uri_internal_t *internal_uri, zv
 	return SUCCESS;
 }
 
-zend_result lexbor_request_init(void)
+PHP_RINIT_FUNCTION(uri_parser_whatwg)
 {
 	lexbor_mraw_t *mraw = lexbor_mraw_create();
 	lxb_status_t status = lexbor_mraw_init(mraw, LEXBOR_MRAW_BYTE_SIZE);
@@ -554,12 +554,14 @@ zend_result lexbor_request_init(void)
 	return SUCCESS;
 }
 
-void lexbor_request_shutdown(void)
+PHP_RSHUTDOWN_FUNCTION(uri_parser_whatwg)
 {
 	lxb_url_parser_memory_destroy(&lexbor_parser);
 	lxb_url_parser_destroy(&lexbor_parser, false);
 
 	lexbor_urls = 0;
+
+	return SUCCESS;
 }
 
 lxb_url_t *lexbor_parse_uri_ex(const char *uri_str, size_t uri_str_len, const lxb_url_t *lexbor_base_url, zval *errors, bool silent)

--- a/ext/uri/uri_parser_whatwg.h
+++ b/ext/uri/uri_parser_whatwg.h
@@ -24,7 +24,7 @@ extern const uri_parser_t lexbor_uri_parser;
 
 lxb_url_t *lexbor_parse_uri_ex(const char *uri_str, size_t uri_str_len, const lxb_url_t *lexbor_base_url, zval *errors, bool silent);
 
-zend_result lexbor_request_init(void);
-void lexbor_request_shutdown(void);
+PHP_RINIT_FUNCTION(uri_parser_whatwg);
+PHP_RSHUTDOWN_FUNCTION(uri_parser_whatwg);
 
 #endif


### PR DESCRIPTION
This improves discoverability of this kind of “lifecycle” helper function.