### PR TITLE
Fix signed int overflow in scanner

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -911,7 +911,7 @@ ZEND_API void zend_multibyte_yyinput_again(zend_encoding_filter old_input_filter
 		ZVAL_STRINGL(zendlval, yytext, yyleng); \
 	}
 
-static zend_result zend_scan_escape_string(zval *zendlval, char *str, int len, char quote_type)
+static zend_result zend_scan_escape_string(zval *zendlval, char *str, size_t len, char quote_type)
 {
 	char *s, *t;
 	char *end;


### PR DESCRIPTION
The signed int length breaks scanning of string literals >=2GB. yyleng is still limited to unsigned int, i.e. 4GB, but we can't fix this without breaking the ABI.

Partially addresses GH-19542