### PR TITLE
Fix GH-19548: remove ZEND_ACC_OVERRIDE on property inheritance only if it's not part of shared memory

### DIFF
--- a/Zend/tests/property_hooks/gh19548.phpt
+++ b/Zend/tests/property_hooks/gh19548.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-19548: Segfault when using inherited properties and opcache
+--FILE--
+<?php
+
+interface I {
+    public mixed $i { get; }
+}
+class P {
+    public mixed $i;
+}
+
+class C extends P implements I {}
+
+echo "Test passed - no segmentation fault\n";
+
+?>
+--EXPECT--
+Test passed - no segmentation fault

--- a/Zend/tests/property_hooks/gh19548_002.phpt
+++ b/Zend/tests/property_hooks/gh19548_002.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-19548: Segfault when using inherited properties and opcache (multiple properties)
+--FILE--
+<?php
+
+interface I1 {
+    public mixed $a { get; }
+    public mixed $b { get; }
+}
+class P1 {
+    public mixed $a;
+    public mixed $b;
+}
+class C1 extends P1 implements I1 {}
+
+interface I2 {
+    public mixed $prop { get; }
+}
+class P2 {
+    public mixed $prop;
+}
+class Q2 extends P2 {}
+class C2 extends Q2 implements I2 {}
+
+echo "Multiple property test passed - no segmentation fault\n";
+
+?>
+--EXPECT--
+Multiple property test passed - no segmentation fault

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1564,7 +1564,9 @@ static void do_inherit_property(zend_property_info *parent_info, zend_string *ke
 						ZSTR_VAL(parent_info->ce->name));
 			}
 
-			child_info->flags &= ~ZEND_ACC_OVERRIDE;
+			if (child_info->ce == ce) {
+				child_info->flags &= ~ZEND_ACC_OVERRIDE;
+			}
 		}
 	} else {
 		zend_function **hooks = parent_info->hooks;


### PR DESCRIPTION
Fix #19548 