### PR TITLE
remove safe_mode leftovers

### DIFF
--- a/ext/gd/php_gd.h
+++ b/ext/gd/php_gd.h
@@ -23,7 +23,6 @@
 
 #if defined(HAVE_LIBGD) || defined(HAVE_GD_BUNDLED)
 
-/* open_basedir and safe_mode checks */
 #define PHP_GD_CHECK_OPEN_BASEDIR(filename, errormsg)                       \
 	if (!filename || php_check_open_basedir(filename)) {      \
 		php_error_docref(NULL, E_WARNING, errormsg);      \

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -649,7 +649,7 @@ static PHP_INI_MH(OnUpdateSaveDir)
 	SESSION_CHECK_ACTIVE_STATE;
 	SESSION_CHECK_OUTPUT_STATE;
 
-	/* Only do the safemode/open_basedir check at runtime */
+	/* Only do the open_basedir check at runtime */
 	if (stage == PHP_INI_STAGE_RUNTIME || stage == PHP_INI_STAGE_HTACCESS) {
 		char *p;
 

--- a/main/fopen_wrappers.h
+++ b/main/fopen_wrappers.h
@@ -33,8 +33,6 @@ PHPAPI int php_check_specific_open_basedir(const char *basedir, const char *path
 /* OPENBASEDIR_CHECKPATH(filename) to ease merge between 6.x and 5.x */
 #define OPENBASEDIR_CHECKPATH(filename) php_check_open_basedir(filename)
 
-PHPAPI int php_check_safe_mode_include_dir(const char *path);
-
 PHPAPI zend_string *php_resolve_path(const char *filename, size_t filename_len, const char *path);
 
 PHPAPI FILE *php_fopen_with_path(const char *filename, const char *mode, const char *path, zend_string **opened_path);

--- a/main/main.c
+++ b/main/main.c
@@ -730,7 +730,7 @@ static PHP_INI_MH(OnUpdateOutputEncoding)
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnUpdateErrorLog)
 {
-	/* Only do the safemode/open_basedir check at runtime */
+	/* Only do the open_basedir check at runtime */
 	if ((stage == PHP_INI_STAGE_RUNTIME || stage == PHP_INI_STAGE_HTACCESS) &&
 			new_value && zend_string_equals_literal(new_value, "syslog")) {
 		if (PG(open_basedir) && php_check_open_basedir(ZSTR_VAL(new_value))) {
@@ -745,7 +745,7 @@ static PHP_INI_MH(OnUpdateErrorLog)
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnUpdateMailLog)
 {
-	/* Only do the safemode/open_basedir check at runtime */
+	/* Only do the open_basedir check at runtime */
 	if ((stage == PHP_INI_STAGE_RUNTIME || stage == PHP_INI_STAGE_HTACCESS) && new_value) {
 		if (PG(open_basedir) && php_check_open_basedir(ZSTR_VAL(new_value))) {
 			return FAILURE;


### PR DESCRIPTION
`safe_mode` ini directive was removed in PHP 5.4: https://github.com/php/php-src/commit/dd8e59da8f5aafd9d77a0f1f17e5e272d09f643f