### PR TITLE
Remove redundant `PARSER_MODE()` call

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1641,7 +1641,7 @@ OPTIONAL_WHITESPACE_OR_COMMENTS ({WHITESPACE}|{MULTI_LINE_COMMENT}|{SINGLE_LINE_
 <ST_IN_SCRIPTING>"("{TABS_AND_SPACES}("integer"){TABS_AND_SPACES}")" {
 	if (PARSER_MODE()) {
 		zend_error(E_DEPRECATED, "Non-canonical cast (integer) is deprecated, use the (int) cast instead");
-		if (PARSER_MODE() && EG(exception)) {
+		if (EG(exception)) {
 			RETURN_TOKEN(T_ERROR);
 		}
 	}
@@ -1655,7 +1655,7 @@ OPTIONAL_WHITESPACE_OR_COMMENTS ({WHITESPACE}|{MULTI_LINE_COMMENT}|{SINGLE_LINE_
 <ST_IN_SCRIPTING>"("{TABS_AND_SPACES}("double"){TABS_AND_SPACES}")" {
 	if (PARSER_MODE()) {
 		zend_error(E_DEPRECATED, "Non-canonical cast (double) is deprecated, use the (float) cast instead");
-		if (PARSER_MODE() && EG(exception)) {
+		if (EG(exception)) {
 			RETURN_TOKEN(T_ERROR);
 		}
 	}
@@ -1677,7 +1677,7 @@ OPTIONAL_WHITESPACE_OR_COMMENTS ({WHITESPACE}|{MULTI_LINE_COMMENT}|{SINGLE_LINE_
 <ST_IN_SCRIPTING>"("{TABS_AND_SPACES}("binary"){TABS_AND_SPACES}")" {
 	if (PARSER_MODE()) {
 		zend_error(E_DEPRECATED, "Non-canonical cast (binary) is deprecated, use the (string) cast instead");
-		if (PARSER_MODE() && EG(exception)) {
+		if (EG(exception)) {
 			RETURN_TOKEN(T_ERROR);
 		}
 	}
@@ -1699,7 +1699,7 @@ OPTIONAL_WHITESPACE_OR_COMMENTS ({WHITESPACE}|{MULTI_LINE_COMMENT}|{SINGLE_LINE_
 <ST_IN_SCRIPTING>"("{TABS_AND_SPACES}("boolean"){TABS_AND_SPACES}")" {
 	if (PARSER_MODE()) {
 		zend_error(E_DEPRECATED, "Non-canonical cast (boolean) is deprecated, use the (bool) cast instead");
-		if (PARSER_MODE() && EG(exception)) {
+		if (EG(exception)) {
 			RETURN_TOKEN(T_ERROR);
 		}
 	}


### PR DESCRIPTION
Ref. https://github.com/php/php-src/pull/19547#discussion_r2294249059

In all cases, the check `PARSER_MODE()` is already made 2 lines above.