### PR TITLE
uri: Do not copy the normalized URI when cloning RFC 3986 URIs

### DIFF
--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -348,7 +348,7 @@ ZEND_ATTRIBUTE_NONNULL static void *php_uri_parser_rfc3986_clone(void *uri)
 	php_uri_parser_rfc3986_uris *new_uriparser_uris = uriparser_create_uris();
 	copy_uri(&new_uriparser_uris->uri, &uriparser_uris->uri);
 	/* Do not copy the normalized URI: The expected action after cloning is
-	 * modifying the cloned URL (which will invalidate the cached normalized
+	 * modifying the cloned URI (which will invalidate the cached normalized
 	 * URI). */
 
 	return new_uriparser_uris;


### PR DESCRIPTION
The with-ers are not yet implemented for RFC 3986, the argument in the comment however makes sense and the implementation did not match the comment.