### PR TITLE
Fix stream wrapper stream_close() not being called on exception unwind

### DIFF
--- a/Zend/tests/exception_stream_wrapper.phpt
+++ b/Zend/tests/exception_stream_wrapper.phpt
@@ -29,4 +29,5 @@ try {
 stream_set_option
 stream_stat
 stream_read
+stream_close
 Message

--- a/Zend/tests/gh19525.phpt
+++ b/Zend/tests/gh19525.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-19525: Stream wrapper stream_close() not called on exception unwind
+--FILE--
+<?php
+
+class Loader {
+    public $context;
+
+    public function stream_open()  {
+        return true;
+    }
+    function stream_read() {}
+    function stream_eof() {}
+    function stream_flush() {}
+    function stream_close() {
+        echo __METHOD__, "\n";
+    }
+}
+
+function foo() {
+    stream_wrapper_register('Loader', 'Loader');
+    $fp = fopen('Loader://qqq.php', 'r');
+    throw new Exception();
+}
+foo();
+
+?>
+--EXPECTF--
+Loader::stream_close
+
+Fatal error: Uncaught Exception in %s:%d
+Stack trace:
+#0 %s(%d): foo()
+#1 {main}
+  thrown in %s on line %d

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -32,6 +32,7 @@
 # endif
 #endif
 #include "userspace_arginfo.h"
+#include "zend_exceptions.h"
 
 static int le_protocols;
 
@@ -680,7 +681,27 @@ static int php_userstreamop_close(php_stream *stream, int close_handle)
 	assert(us != NULL);
 
 	zend_string *func_name = ZSTR_INIT_LITERAL(USERSTREAM_CLOSE, false);
+
+	/* Reset currently thrown exception during call of close method. */
+	zend_object *old_exception = NULL;
+	const zend_op *old_opline_before_exception = NULL;
+	if (UNEXPECTED(EG(exception))) {
+		old_exception = EG(exception);
+		old_opline_before_exception = EG(opline_before_exception);
+		EG(exception) = NULL;
+	}
+
 	zend_call_method_if_exists(Z_OBJ(us->object), func_name, &retval, 0, NULL);
+
+	if (UNEXPECTED(old_exception)) {
+		EG(opline_before_exception) = old_opline_before_exception;
+		if (EG(exception)) {
+			zend_exception_set_previous(EG(exception), old_exception);
+		} else {
+			EG(exception) = old_exception;
+		}
+	}
+
 	zend_string_release_ex(func_name, false);
 
 	zval_ptr_dtor(&retval);


### PR DESCRIPTION
When EG(exception) is set, zend_call_function() will skip the call. Fix this anologously to zend_objects_destroy_object(), by backing up the exception and temporarily setting it to NULL.

Fixes GH-19525