### PR TITLE
Deprecate driver specific PDO methods

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1444,15 +1444,18 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 			}
 		}
 		if (new_name) {
-			zend_attribute *attr = zend_add_function_attribute(func_p,
-					ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+			uint32_t flags = dbh->is_persistent ? ZEND_ATTRIBUTE_PERSISTENT : 0;
+			zend_attribute *attr = zend_add_attribute(
+					&func_p->common.attributes,
+					ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED),
+					2, flags, 0, 0);
 
 			attr->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 			ZVAL_STR(&attr->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_5));
 
 			char *message;
 			size_t len = zend_spprintf(&message, 0, "use %s() instead", new_name);
-			zend_string *message_str = zend_string_init_interned(message, len, true);
+			zend_string *message_str = zend_string_init(message, len, dbh->is_persistent);
 			efree(message);
 
 			attr->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1340,7 +1340,7 @@ static void cls_method_pdtor(zval *el) /* {{{ */ {
 }
 /* }}} */
 
-/* We can not add #[Deprecated] attributes in @generate-function-entries stubs,
+/* We cannot add #[Deprecated] attributes in @generate-function-entries stubs,
  * and PDO drivers have no way to add them either, so we hard-code deprecation
  * info here and add the attribute manually in pdo_hash_methods() */
 struct driver_specific_method_deprecation {

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1318,6 +1318,9 @@ static void cls_method_dtor(zval *el) /* {{{ */ {
 	if (ZEND_MAP_PTR(func->common.run_time_cache)) {
 		efree(ZEND_MAP_PTR(func->common.run_time_cache));
 	}
+	if (func->common.attributes) {
+		zend_hash_release(func->common.attributes);
+	}
 	efree(func);
 }
 /* }}} */
@@ -1330,9 +1333,38 @@ static void cls_method_pdtor(zval *el) /* {{{ */ {
 	if (ZEND_MAP_PTR(func->common.run_time_cache)) {
 		pefree(ZEND_MAP_PTR(func->common.run_time_cache), 1);
 	}
+	if (func->common.attributes) {
+		zend_hash_release(func->common.attributes);
+	}
 	pefree(func, 1);
 }
 /* }}} */
+
+/* We can not add #[Deprecated] attributes in @generate-function-entries stubs,
+ * and PDO drivers have no way to add them either, so we hard-code deprecation
+ * info here and add the attribute manually in pdo_hash_methods() */
+struct driver_specific_method_deprecation {
+	const char *old_name;
+	const char *new_name;
+};
+
+/* Methods deprecated in https://wiki.php.net/rfc/deprecations_php_8_5
+ * "Deprecate driver specific PDO constants and methods" */
+static const struct driver_specific_method_deprecation driver_specific_method_deprecations[] = {
+	{"pgsqlCopyFromArray",      "Pdo\\Pgsql::copyFromArray"},
+	{"pgsqlCopyFromFile",       "Pdo\\Pgsql::copyFromFile"},
+	{"pgsqlCopyToArray",        "Pdo\\Pgsql::copyToArray"},
+	{"pgsqlCopyToFile",         "Pdo\\Pgsql::copyToFile"},
+	{"pgsqlGetNotify",          "Pdo\\Pgsql::getNotify"},
+	{"pgsqlGetPid",             "Pdo\\Pgsql::getPid"},
+	{"pgsqlLOBCreate",          "Pdo\\Pgsql::lobCreate"},
+	{"pgsqlLOBOpen",            "Pdo\\Pgsql::lobOpen"},
+	{"pgsqlLOBUnlink",          "Pdo\\Pgsql::lobUnlink"},
+	{"sqliteCreateAggregate",   "Pdo\\Sqlite::createAggregate"},
+	{"sqliteCreateCollation",   "Pdo\\Sqlite::createCollation"},
+	{"sqliteCreateFunction",    "Pdo\\Sqlite::createFunction"},
+	{NULL,                      NULL},
+};
 
 /* {{{ overloaded object handlers for PDO class */
 bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
@@ -1371,6 +1403,7 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 		} else {
 			func.fn_flags = ZEND_ACC_PUBLIC | ZEND_ACC_NEVER_CACHE;
 		}
+		func.fn_flags |= ZEND_ACC_DEPRECATED;
 		func.doc_comment = NULL;
 		if (funcs->arg_info) {
 			zend_internal_function_info *info = (zend_internal_function_info*)funcs->arg_info;
@@ -1399,8 +1432,33 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 		namelen = strlen(funcs->fname);
 		lc_name = emalloc(namelen+1);
 		zend_str_tolower_copy(lc_name, funcs->fname, namelen);
-		zend_hash_str_add_mem(dbh->cls_methods[kind], lc_name, namelen, &func, sizeof(func));
+		zend_function *func_p = zend_hash_str_add_mem(dbh->cls_methods[kind], lc_name, namelen, &func, sizeof(func));
 		efree(lc_name);
+
+		const char *new_name = NULL;
+		for (const struct driver_specific_method_deprecation *d = driver_specific_method_deprecations;
+				d->old_name; d++) {
+			if (strcmp(d->old_name, funcs->fname) == 0) {
+				new_name = d->new_name;
+				break;
+			}
+		}
+		if (new_name) {
+			zend_attribute *attr = zend_add_function_attribute(func_p,
+					ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+
+			attr->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+			ZVAL_STR(&attr->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_5));
+
+			char *message;
+			size_t len = zend_spprintf(&message, 0, "use %s() instead", new_name);
+			zend_string *message_str = zend_string_init_interned(message, len, true);
+			efree(message);
+
+			attr->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+			ZVAL_STR(&attr->args[1].value, message_str);
+		}
+
 		funcs++;
 	}
 

--- a/ext/pdo_pgsql/tests/bug68199.phpt
+++ b/ext/pdo_pgsql/tests/bug68199.phpt
@@ -80,26 +80,41 @@ var_dump($notify[2]);
 var_dump($db->pgsqlGetNotify());
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::pgsqlGetPid() is deprecated since 8.5, use Pdo\Pgsql::getPid() instead in %s on line %d
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(3)
 string(16) "channel_bug68199"
 bool(true)
 string(7) "payload"
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(3)
 string(16) "channel_bug68199"
 bool(true)
 string(7) "payload"
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(3)
 string(16) "channel_bug68199"
 bool(true)
 string(7) "payload"
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(3)
 string(16) "channel_bug68199"
 bool(true)
 string(7) "payload"
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(6)
 string(16) "channel_bug68199"
 bool(true)
@@ -107,4 +122,6 @@ string(7) "payload"
 string(16) "channel_bug68199"
 bool(true)
 string(7) "payload"
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)

--- a/ext/pdo_pgsql/tests/copy_from.phpt
+++ b/ext/pdo_pgsql/tests/copy_from.phpt
@@ -134,6 +134,8 @@ $db->query('DROP TABLE IF EXISTS test_copy_from CASCADE');
 --EXPECTF--
 Preparing test file and array for CopyFrom tests
 Testing pgsqlCopyFromArray() with default parameters
+
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -178,6 +180,8 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromArray() with different field separator and not null indicator
+
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -222,6 +226,8 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromArray() with only selected fields
+
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -266,8 +272,12 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromArray() with error
+
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 Exception: SQLSTATE[42P01]: Undefined table: 7 %s:  %stest_error%s
 Testing pgsqlCopyFromFile() with default parameters
+
+Deprecated: Method PDO::pgsqlCopyFromFile() is deprecated since 8.5, use Pdo\Pgsql::copyFromFile() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -312,6 +322,8 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromFile() with different field separator and not null indicator
+
+Deprecated: Method PDO::pgsqlCopyFromFile() is deprecated since 8.5, use Pdo\Pgsql::copyFromFile() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -356,6 +368,8 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromFile() with only selected fields
+
+Deprecated: Method PDO::pgsqlCopyFromFile() is deprecated since 8.5, use Pdo\Pgsql::copyFromFile() instead in %s on line %d
 bool(true)
 array(6) {
   ["a"]=>
@@ -400,6 +414,10 @@ array(6) {
   NULL
 }
 Testing pgsqlCopyFromFile() with error
+
+Deprecated: Method PDO::pgsqlCopyFromFile() is deprecated since 8.5, use Pdo\Pgsql::copyFromFile() instead in %s on line %d
 Exception: SQLSTATE[42P01]: Undefined table: 7 %s:  %stest_error%s
 Testing pgsqlCopyFromFile() with non existing file
+
+Deprecated: Method PDO::pgsqlCopyFromFile() is deprecated since 8.5, use Pdo\Pgsql::copyFromFile() instead in %s on line %d
 Exception: SQLSTATE[HY000]: General error: 7 Unable to open the file

--- a/ext/pdo_pgsql/tests/copy_from_generator.phpt
+++ b/ext/pdo_pgsql/tests/copy_from_generator.phpt
@@ -41,7 +41,8 @@ require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->query('DROP TABLE IF EXISTS test_copy_from_generator CASCADE');
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 array (
   0 => 1,
   1 => 1,

--- a/ext/pdo_pgsql/tests/copy_from_iterator.phpt
+++ b/ext/pdo_pgsql/tests/copy_from_iterator.phpt
@@ -61,8 +61,11 @@ require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->query('DROP TABLE IF EXISTS test_copy_from_traversable CASCADE');
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 PDO::pgsqlCopyFromArray(): Argument #2 ($rows) must be of type Traversable|array, stdClass given
+
+Deprecated: Method PDO::pgsqlCopyFromArray() is deprecated since 8.5, use Pdo\Pgsql::copyFromArray() instead in %s on line %d
 array (
   0 => 1,
   1 => 1,

--- a/ext/pdo_pgsql/tests/copy_to.phpt
+++ b/ext/pdo_pgsql/tests/copy_to.phpt
@@ -87,6 +87,8 @@ $db->exec('DROP TABLE test_copy_to');
 --EXPECTF--
 Preparing test table for CopyTo tests
 Testing pgsqlCopyToArray() with default parameters
+
+Deprecated: Method PDO::pgsqlCopyToArray() is deprecated since 8.5, use Pdo\Pgsql::copyToArray() instead in %s on line %d
 array(3) {
   [0]=>
   string(19) "0	test insert 0	\N
@@ -99,6 +101,8 @@ array(3) {
 "
 }
 Testing pgsqlCopyToArray() with different field separator and not null indicator
+
+Deprecated: Method PDO::pgsqlCopyToArray() is deprecated since 8.5, use Pdo\Pgsql::copyToArray() instead in %s on line %d
 array(3) {
   [0]=>
   string(21) "0;test insert 0;NULL
@@ -111,6 +115,8 @@ array(3) {
 "
 }
 Testing pgsqlCopyToArray() with only selected fields
+
+Deprecated: Method PDO::pgsqlCopyToArray() is deprecated since 8.5, use Pdo\Pgsql::copyToArray() instead in %s on line %d
 array(3) {
   [0]=>
   string(7) "0;NULL
@@ -123,23 +129,35 @@ array(3) {
 "
 }
 Testing pgsqlCopyToArray() with error
+
+Deprecated: Method PDO::pgsqlCopyToArray() is deprecated since 8.5, use Pdo\Pgsql::copyToArray() instead in %s on line %d
 Exception: SQLSTATE[42P01]: Undefined table: 7 %s:  %stest_error%s
 Testing pgsqlCopyToFile() with default parameters
+
+Deprecated: Method PDO::pgsqlCopyToFile() is deprecated since 8.5, use Pdo\Pgsql::copyToFile() instead in %s on line %d
 bool(true)
 0	test insert 0	\N
 1	test insert 1	\N
 2	test insert 2	\N
 Testing pgsqlCopyToFile() with different field separator and not null indicator
+
+Deprecated: Method PDO::pgsqlCopyToFile() is deprecated since 8.5, use Pdo\Pgsql::copyToFile() instead in %s on line %d
 bool(true)
 0;test insert 0;NULL
 1;test insert 1;NULL
 2;test insert 2;NULL
 Testing pgsqlCopyToFile() with only selected fields
+
+Deprecated: Method PDO::pgsqlCopyToFile() is deprecated since 8.5, use Pdo\Pgsql::copyToFile() instead in %s on line %d
 bool(true)
 0;NULL
 1;NULL
 2;NULL
 Testing pgsqlCopyToFile() with error
+
+Deprecated: Method PDO::pgsqlCopyToFile() is deprecated since 8.5, use Pdo\Pgsql::copyToFile() instead in %s on line %d
 Exception: SQLSTATE[42P01]: Undefined table: 7 %s:  %stest_error%s
 Testing pgsqlCopyToFile() to unwritable file
+
+Deprecated: Method PDO::pgsqlCopyToFile() is deprecated since 8.5, use Pdo\Pgsql::copyToFile() instead in %s on line %d
 Exception: SQLSTATE[HY000]: General error: 7 Unable to open the file for writing

--- a/ext/pdo_pgsql/tests/getnotify.phpt
+++ b/ext/pdo_pgsql/tests/getnotify.phpt
@@ -84,29 +84,50 @@ var_dump($diff < 1 || abs(1 - abs($diff)) < .05);
 var_dump(count($notify));
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::pgsqlGetPid() is deprecated since 8.5, use Pdo\Pgsql::getPid() instead in %s on line %d
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(2)
 string(17) "channel_getnotify"
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(2)
 string(17) "channel_getnotify"
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(2)
 string(17) "channel_getnotify"
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(2)
 string(17) "channel_getnotify"
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 int(4)
 string(17) "channel_getnotify"
 bool(true)
 string(17) "channel_getnotify"
 bool(true)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(true)
 bool(false)
+
+Deprecated: Method PDO::pgsqlGetNotify() is deprecated since 8.5, use Pdo\Pgsql::getNotify() instead in %s on line %d
 bool(true)
 int(2)

--- a/ext/pdo_pgsql/tests/gh9411.phpt
+++ b/ext/pdo_pgsql/tests/gh9411.phpt
@@ -34,9 +34,18 @@ var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
 var_dump(fgets($lob));
 ?>
 --EXPECTF--
+Deprecated: Method PDO::pgsqlLOBCreate() is deprecated since 8.5, use Pdo\Pgsql::lobCreate() instead in %s on line %d
+
+Deprecated: Method PDO::pgsqlLOBOpen() is deprecated since 8.5, use Pdo\Pgsql::lobOpen() instead in %s on line %d
 resource(%d) of type (stream)
 resource(%d) of type (Unknown)
+
+Deprecated: Method PDO::pgsqlLOBCreate() is deprecated since 8.5, use Pdo\Pgsql::lobCreate() instead in %s on line %d
+
+Deprecated: Method PDO::pgsqlLOBOpen() is deprecated since 8.5, use Pdo\Pgsql::lobOpen() instead in %s on line %d
 resource(%d) of type (stream)
 resource(%d) of type (Unknown)
+
+Deprecated: Method PDO::pgsqlLOBOpen() is deprecated since 8.5, use Pdo\Pgsql::lobOpen() instead in %s on line %d
 resource(%d) of type (stream)
 string(4) "test"

--- a/ext/pdo_pgsql/tests/large_objects.phpt
+++ b/ext/pdo_pgsql/tests/large_objects.phpt
@@ -83,7 +83,10 @@ require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->exec('DROP TABLE test_large_objects');
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::pgsqlLOBCreate() is deprecated since 8.5, use Pdo\Pgsql::lobCreate() instead in %s on line %d
+
+Deprecated: Method PDO::pgsqlLOBOpen() is deprecated since 8.5, use Pdo\Pgsql::lobOpen() instead in %s on line %d
 Fetching:
 int(1)
 string(11) "Hello dude
@@ -97,3 +100,5 @@ Fetching NO bind:
 int(1)
 bool(true)
 Fetched!
+
+Deprecated: Method PDO::pgsqlLOBUnlink() is deprecated since 8.5, use Pdo\Pgsql::lobUnlink() instead in %s on line %d

--- a/ext/pdo_sqlite/tests/bug60104.phpt
+++ b/ext/pdo_sqlite/tests/bug60104.phpt
@@ -15,5 +15,8 @@ setUp();
 setUp();
 echo "done";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
 done

--- a/ext/pdo_sqlite/tests/bug70221.phpt
+++ b/ext/pdo_sqlite/tests/bug70221.phpt
@@ -16,5 +16,6 @@ unset($db);
 $dbfile = __DIR__ . '/test.sqlite';
 unlink($dbfile);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
 Everything is fine, no exceptions here

--- a/ext/pdo_sqlite/tests/gc.phpt
+++ b/ext/pdo_sqlite/tests/gc.phpt
@@ -18,5 +18,10 @@ $obj->a->sqliteCreateCollation('col', function() use ($obj) {});
 
 ?>
 ===DONE===
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateCollation() is deprecated since 8.5, use Pdo\Sqlite::createCollation() instead in %s on line %d
 ===DONE===

--- a/ext/pdo_sqlite/tests/gh13998.phpt
+++ b/ext/pdo_sqlite/tests/gh13998.phpt
@@ -21,5 +21,6 @@ try {
     echo 'done!';
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
 done!

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
@@ -19,7 +19,8 @@ foreach ($db->query('SELECT testing(name) FROM test_pdo_sqlite_createaggregate')
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
 array(2) {
   ["testing(name)"]=>
   string(2) "12"

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate_002.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate_002.phpt
@@ -19,6 +19,9 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
 PDO::sqliteCreateAggregate(): Argument #2 ($step) must be a valid callback, function "a" not found or invalid function name
+
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
 PDO::sqliteCreateAggregate(): Argument #3 ($finalize) must be a valid callback, function "" not found or invalid function name

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
@@ -32,11 +32,14 @@ try {
 	echo $e->getMessage(), PHP_EOL;
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateCollation() is deprecated since 8.5, use Pdo\Sqlite::createCollation() instead in %s on line %d
 1
 2
 10
 1
 10
 2
+
+Deprecated: Method PDO::sqliteCreateCollation() is deprecated since 8.5, use Pdo\Sqlite::createCollation() instead in %s on line %d
 PDO::query(): Return value of the collation callback must be of type int, string returned

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
@@ -20,7 +20,8 @@ foreach ($db->query('SELECT testing(name) FROM test_pdo_sqlite_createfunction') 
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
 array(2) {
   ["testing(name)"]=>
   string(3) "php"

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_002.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_002.phpt
@@ -17,5 +17,6 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
 PDO::sqliteCreateFunction(): Argument #2 ($callback) must be a valid callback, function "bar" not found or invalid function name

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
@@ -24,7 +24,8 @@ foreach ($db->query('SELECT testing(name) FROM test_pdo_sqlite_createfunction_wi
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
 array(2) {
   ["testing(name)"]=>
   string(3) "php"

--- a/ext/pdo_sqlite/tests/php_8.5_deprecations.phpt
+++ b/ext/pdo_sqlite/tests/php_8.5_deprecations.phpt
@@ -15,6 +15,16 @@ var_dump(
      PDO::SQLITE_OPEN_CREATE,
 );
 
+$pdo = new PDO("sqlite::memory:");
+$pdo->sqliteCreateFunction('test1', function(){});
+$pdo->sqliteCreateAggregate('test2', function(){}, function(){});
+$pdo->sqliteCreateCollation('test3', function(){});
+
+$pdo = new PDO("sqlite::memory:", options: [PDO::ATTR_PERSISTENT => true]);
+$pdo->sqliteCreateFunction('test1', function(){});
+$pdo->sqliteCreateAggregate('test2', function(){}, function(){});
+$pdo->sqliteCreateCollation('test3', function(){});
+
 ?>
 --EXPECTF--
 Deprecated: Constant PDO::SQLITE_ATTR_EXTENDED_RESULT_CODES is deprecated since 8.5, use Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES instead in %s on line %d
@@ -37,3 +47,15 @@ int(2048)
 int(1)
 int(2)
 int(4)
+
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateCollation() is deprecated since 8.5, use Pdo\Sqlite::createCollation() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateAggregate() is deprecated since 8.5, use Pdo\Sqlite::createAggregate() instead in %s on line %d
+
+Deprecated: Method PDO::sqliteCreateCollation() is deprecated since 8.5, use Pdo\Sqlite::createCollation() instead in %s on line %d

--- a/ext/zend_test/tests/observer_sqlite_create_function.phpt
+++ b/ext/zend_test/tests/observer_sqlite_create_function.phpt
@@ -30,6 +30,11 @@ echo 'Done' . PHP_EOL;
   <!-- init PDO::__construct() -->
   <PDO::__construct>
   </PDO::__construct>
+  <!-- init Deprecated::__construct() -->
+  <Deprecated::__construct>
+  </Deprecated::__construct>
+
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
   <!-- init PDO::sqliteCreateFunction() -->
   <PDO::sqliteCreateFunction>
   </PDO::sqliteCreateFunction>


### PR DESCRIPTION
This implements the "Deprecate driver specific PDO methods" part of https://wiki.php.net/rfc/deprecations_php_8_5.

Constants were handled in https://github.com/php/php-src/pull/19526.