### PR TITLE
Use dtor instead of free_obj for ZipArchive

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1004,8 +1004,10 @@ static void php_zip_cancel_callback_free(void *ptr)
 }
 #endif
 
-static void php_zip_object_free_storage(zend_object *object) /* {{{ */
+static void php_zip_object_dtor(zend_object *object) /* {{{ */
 {
+	zend_objects_destroy_object(object);
+
 	ze_zip_object * intern = php_zip_fetch_object(object);
 	int i;
 
@@ -1034,7 +1036,6 @@ static void php_zip_object_free_storage(zend_object *object) /* {{{ */
 #endif
 
 	intern->za = NULL;
-	zend_object_std_dtor(&intern->zo);
 
 	if (intern->filename) {
 		efree(intern->filename);
@@ -3119,7 +3120,7 @@ static PHP_MINIT_FUNCTION(zip)
 {
 	memcpy(&zip_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	zip_object_handlers.offset = XtOffsetOf(ze_zip_object, zo);
-	zip_object_handlers.free_obj = php_zip_object_free_storage;
+	zip_object_handlers.dtor_obj = php_zip_object_dtor;
 	zip_object_handlers.clone_obj = NULL;
 	zip_object_handlers.get_property_ptr_ptr = php_zip_get_property_ptr_ptr;
 

--- a/ext/zip/tests/ZipArchive_bailout.phpt
+++ b/ext/zip/tests/ZipArchive_bailout.phpt
@@ -1,0 +1,28 @@
+--TEST--
+ZipArchive destructor should be called on bailout
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+function &cb() {}
+
+$file = __DIR__ . '/gh18907.zip';
+$zip = new ZipArchive;
+$zip->open($file, ZIPARCHIVE::CREATE);
+$zip->registerCancelCallback(cb(...));
+$zip->addFromString('test', 'test');
+$fusion = $zip;
+
+?>
+--CLEAN--
+<?php
+$file = __DIR__ . '/gh18907.zip';
+@unlink($file);
+?>
+--EXPECTF--
+Notice: Only variable references should be returned by reference in %s on line %d
+
+Notice: Only variable references should be returned by reference in %s on line %d
+
+Notice: Only variable references should be returned by reference in %s on line %d


### PR DESCRIPTION
free_obj for objects referenced in the main symbol table may be called only once the executor has already shut down. php_zip_cancel_callback() may attempt to invoke a user callback, which will terminate the process because user code is not expected to be executed at this point. We solve this by using the dtor_obj handler instead, which is called earlier in the shutdown sequence.

Technically, this allows some shenanigans with escaping __destruct functions, but given destructors are useful, this may not be worth solving.

For reference:

```php
class MyZipArchive extends ZipArchive {
    public function __destruct() {
        global $leak;
        $leak = $this;
    }
}

new MyZipArchive;
$file = __DIR__ . '/gh18907.zip';
$leak->open($file, ZIPARCHIVE::CREATE);
$leak->addFromString('test', 'test');
```