### PR TITLE
Update pcre2lib from 10.45 to 10.46

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ PHP                                                                        NEWS
 - Opcache:
   . Fixed bug GH-19486 (Incorrect opline after deoptimization). (Arnaud)
 
+- PCRE:
+  . Upgraded to pcre2lib from 10.45 to 10.46. (nielsdos)
+
 - Session:
   . Fix RC violation of session SID constant deprecation attribute. (ilutov)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -780,7 +780,7 @@ PHP 8.5 UPGRADE NOTES
     RFC: https://wiki.php.net/rfc/url_parsing_api
 
 - PCRE:
-  . Upgraded pcre2lib from 10.44 to 10.45.
+  . Upgraded pcre2lib from 10.44 to 10.46.
 
 - PDO_Sqlite:
   . Increased minimum release version support from 3.7.7 to 3.7.17.

--- a/ext/pcre/pcre2lib/pcre2.h
+++ b/ext/pcre/pcre2lib/pcre2.h
@@ -42,9 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
 /* The current PCRE version information. */
 
 #define PCRE2_MAJOR           10
-#define PCRE2_MINOR           45
+#define PCRE2_MINOR           46
 #define PCRE2_PRERELEASE      
-#define PCRE2_DATE            2025-02-05
+#define PCRE2_DATE            2025-08-27
 
 /* When an application links to a PCRE DLL in Windows, the symbols that are
 imported have to be identified as such. When building PCRE2, the appropriate

--- a/ext/pcre/pcre2lib/pcre2_match.c
+++ b/ext/pcre/pcre2lib/pcre2_match.c
@@ -5824,6 +5824,9 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               assert_accept_frame->offset_top * sizeof(PCRE2_SIZE));
         Foffset_top = assert_accept_frame->offset_top;
         Fmark = assert_accept_frame->mark;
+        mb->end_subject = Lsaved_end_subject;
+        mb->true_end_subject = mb->end_subject + Ltrue_end_extra;
+        mb->moptions = Lsaved_moptions;
         break;
         }
 


### PR DESCRIPTION
There is a new release of pcre2lib to address a security issue [1]. It only affects version 10.45.
Only the master branch has version 10.45.

[1] https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.46