### PR TITLE
uri: Use `has_text_range()` in `php_uri_parser_rfc3986_scheme_read()`

### DIFF
--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -103,7 +103,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_scheme_read(con
 {
 	const UriUriA *uriparser_uri = get_uri_for_reading(internal_uri->uri, read_mode);
 
-	if (uriparser_uri->scheme.first != NULL && uriparser_uri->scheme.afterLast != NULL) {
+	if (has_text_range(&uriparser_uri->scheme)) {
 		ZVAL_STRINGL(retval, uriparser_uri->scheme.first, get_text_range_length(&uriparser_uri->scheme));
 	} else {
 		ZVAL_NULL(retval);


### PR DESCRIPTION
Unfortunately missed that one in 119382354107006b1f24462c964ff44b4f960c3b.