### PR TITLE
uri: Always use `const` pointers when referring to `uri_parser_t`

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -612,7 +612,7 @@ zend_result php_filter_validate_url(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	int parser_name_set;
 	FETCH_STR_OPTION(parser_name, URL_OPTION_URI_PARSER_CLASS);
 
-	uri_parser_t *uri_parser = php_uri_get_parser(parser_name_set ? parser_name : NULL);
+	const uri_parser_t *uri_parser = php_uri_get_parser(parser_name_set ? parser_name : NULL);
 	if (uri_parser == NULL) {
 		zend_value_error("%s(): \"uri_parser_class\" option has invalid value", get_active_function_name());
 		RETURN_VALIDATION_FAILED

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2634,7 +2634,7 @@ static char *php_openssl_get_url_name(const char *resourcename,
 		return NULL;
 	}
 
-	uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ssl", context);
+	const uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ssl", context);
 	if (uri_parser == NULL) {
 		zend_value_error("%s(): Provided stream context has invalid value for the \"uri_parser_class\" option", get_active_function_name());
 		return NULL;

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -431,7 +431,7 @@ int make_http_soap_request(
 	}
 
 	if (location != NULL && ZSTR_VAL(location)[0] != '\000') {
-		uri_parser_t *uri_parser = php_uri_get_parser(uri_parser_class);
+		const uri_parser_t *uri_parser = php_uri_get_parser(uri_parser_class);
 		if (uri_parser == NULL) {
 			zend_argument_value_error(6, "must be a valid URI parser name");
 			return FALSE;
@@ -1148,7 +1148,7 @@ try_again:
 		char *loc;
 
 		if ((loc = get_http_header_value(ZSTR_VAL(http_headers), "Location:")) != NULL) {
-			uri_parser_t *uri_parser = php_uri_get_parser(uri_parser_class);
+			const uri_parser_t *uri_parser = php_uri_get_parser(uri_parser_class);
 			if (uri_parser == NULL) {
 				efree(loc);
 				zend_argument_value_error(6, "must be a valid URI parser name");

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -135,7 +135,7 @@ static php_stream *php_ftp_fopen_connect(php_stream_wrapper *wrapper, const char
 	char *transport;
 	int transport_len;
 
-	uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ftp", context);
+	const uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ftp", context);
 	if (uri_parser == NULL) {
 		zend_value_error("%s(): Provided stream context has invalid value for the \"uri_parser_class\" option", get_active_function_name());
 		return NULL;
@@ -956,7 +956,7 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 	int result;
 	char tmp_line[512];
 
-	uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ftp", context);
+	const uri_parser_t *uri_parser = php_stream_context_get_uri_parser("ftp", context);
 	if (uri_parser == NULL) {
 		zend_value_error("%s(): Provided stream context has invalid value for the \"uri_parser_class\" option", get_active_function_name());
 		return 0;

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -393,7 +393,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 		return NULL;
 	}
 
-	uri_parser_t *uri_parser = php_stream_context_get_uri_parser("http", context);
+	const uri_parser_t *uri_parser = php_stream_context_get_uri_parser("http", context);
 	if (uri_parser == NULL) {
 		zend_value_error("%s(): Provided stream context has invalid value for the \"uri_parser_class\" option", get_active_function_name());
 		return NULL;

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -52,7 +52,7 @@ static const zend_module_dep uri_deps[] = {
 
 static zend_array uri_parsers;
 
-static uri_parser_t *uri_parser_by_name(const char *uri_parser_name, size_t uri_parser_name_len)
+static const uri_parser_t *uri_parser_by_name(const char *uri_parser_name, size_t uri_parser_name_len)
 {
 	return zend_hash_str_find_ptr(&uri_parsers, uri_parser_name, uri_parser_name_len);
 }
@@ -107,7 +107,7 @@ static HashTable *uri_get_debug_properties(zend_object *object)
 	return result;
 }
 
-PHPAPI uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name)
+PHPAPI const uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name)
 {
 	if (uri_parser_name == NULL) {
 		return uri_parser_by_name(PHP_URI_PARSER_PHP_PARSE_URL, sizeof(PHP_URI_PARSER_PHP_PARSE_URL) - 1);

--- a/ext/uri/php_uri.h
+++ b/ext/uri/php_uri.h
@@ -47,7 +47,7 @@ PHPAPI zend_result php_uri_parser_register(const uri_parser_t *uri_parser);
  * @param uri_parser_name The URI parser name
  * @return The URI parser
  */
-PHPAPI uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name);
+PHPAPI const uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name);
 
 ZEND_ATTRIBUTE_NONNULL PHPAPI uri_internal_t *php_uri_parse(const uri_parser_t *uri_parser, const char *uri_str, size_t uri_str_len, bool silent);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -735,7 +735,7 @@ static ZEND_FUNCTION(zend_test_uri_parser)
 		Z_PARAM_STR(parser_name)
 	ZEND_PARSE_PARAMETERS_END();
 
-	uri_parser_t *parser = php_uri_get_parser(parser_name);
+	const uri_parser_t *parser = php_uri_get_parser(parser_name);
 	if (parser == NULL) {
 		zend_argument_value_error(1, "Unknown parser");
 		RETURN_THROWS();

--- a/main/streams/php_stream_context.h
+++ b/main/streams/php_stream_context.h
@@ -68,7 +68,7 @@ void php_stream_context_unset_option(php_stream_context *context,
 
 struct uri_parser_t;
 
-PHPAPI struct uri_parser_t *php_stream_context_get_uri_parser(const char *wrappername, php_stream_context *context);
+PHPAPI const struct uri_parser_t *php_stream_context_get_uri_parser(const char *wrappername, php_stream_context *context);
 PHPAPI php_stream_notifier *php_stream_notification_alloc(void);
 PHPAPI void php_stream_notification_free(php_stream_notifier *notifier);
 END_EXTERN_C()

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2458,7 +2458,7 @@ void php_stream_context_unset_option(php_stream_context *context,
 }
 /* }}} */
 
-PHPAPI struct uri_parser_t *php_stream_context_get_uri_parser(const char *wrappername, php_stream_context *context)
+PHPAPI const struct uri_parser_t *php_stream_context_get_uri_parser(const char *wrappername, php_stream_context *context)
 {
 	if (context == NULL) {
 		return php_uri_get_parser(NULL);


### PR DESCRIPTION
The actual parser definitions are all `const` and must never be modified. Make sure to always use `const` pointers.