### PR TITLE
Fix JIT stack setup on aarch64/clang

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -2733,7 +2733,15 @@ static void zend_jit_init_ctx(zend_jit_ctx *jit, uint32_t flags)
 			/* Stack must be 16 byte aligned */
 			/* TODO: select stack size ??? */
 #if ZEND_VM_KIND == ZEND_VM_KIND_TAILCALL
+# if defined(IR_TARGET_AARCH64)
+			/* Must save LR */
+			jit->ctx.flags |= IR_USE_FRAME_POINTER;
+			/* Same as HYBRID VM */
+			jit->ctx.fixed_stack_frame_size = sizeof(void*) * 4; /* 4 spill slots (8 bytes) or 8 spill slots (4 bytes) */
+# else
+			/* Same as HYBRID VM, plus 1 slot for re-alignment (caller pushes return address, frame is not aligned on entry) */
 			jit->ctx.fixed_stack_frame_size = sizeof(void*) * 5; /* 5 spill slots (8 bytes) or 10 spill slots (4 bytes) */
+# endif
 #elif defined(IR_TARGET_AARCH64)
 			jit->ctx.flags |= IR_USE_FRAME_POINTER;
 			jit->ctx.fixed_stack_frame_size = sizeof(void*) * 16; /* 10 saved registers and 6 spill slots (8 bytes) */


### PR DESCRIPTION
Fixes GH-19601.

On aarch64 we must set `IR_USE_FRAME_POINTER` to ensure that LR/x30 is saved. Also, `fixed_stack_frame_size` must be `n*16`, not `n*16+8` like on x86. This was properly handled before, but this broke due to this change, which I failed to test on aarch64: https://github.com/php/php-src/blob/fc467dcb6474cafdbb2fa32c8e876f78dca00bd1/ext/opcache/jit/zend_jit_ir.c#L2735-L2736