### PR TITLE
Optimizer/zend_dump: Fix printing of the exception table

### DIFF
--- a/Zend/Optimizer/zend_dump.c
+++ b/Zend/Optimizer/zend_dump.c
@@ -1164,7 +1164,7 @@ ZEND_API void zend_dump_op_array(const zend_op_array *op_array, uint32_t dump_fl
 				}
 				if (op_array->try_catch_array[i].finally_end) {
 					fprintf(stderr,
-						", %04u",
+						", %04u\n",
 						op_array->try_catch_array[i].finally_end);
 				} else {
 					fprintf(stderr, ", -\n");

--- a/ext/opcache/tests/opt/gh18107_1.phpt
+++ b/ext/opcache/tests/opt/gh18107_1.phpt
@@ -41,6 +41,7 @@ $_main:
 0011 FAST_RET T5
 EXCEPTION TABLE:
      0006, -, 0007, 0011
+
 Fatal error: Uncaught Exception: Should happen in %s:%d
 Stack trace:
 #0 {main}

--- a/ext/opcache/tests/opt/gh18107_2.phpt
+++ b/ext/opcache/tests/opt/gh18107_2.phpt
@@ -48,6 +48,7 @@ $_main:
 0015 RETURN int(1)
 EXCEPTION TABLE:
      0006, 0006, 0010, 0014
+
 Fatal error: Uncaught Exception: Should happen in %s:%d
 Stack trace:
 #0 {main}


### PR DESCRIPTION
A newline was missing for finally blocks.