### PR TITLE
uri: Reject out-of-range ports for uri_parser_rfc3986

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,8 @@ PHP                                                                        NEWS
     (timwolla)
   . Fixed double-free when assigning to $errors fails when using
     the Uri\WhatWg\Url parser. (timwolla)
+  . Reject out-of-range ports when using the Uri\Rfc3986\Uri parser.
+    (timwolla)
   . Clean up naming of internal API. (timwolla)
 
 28 Aug 2025, PHP 8.5.0beta2

--- a/ext/uri/tests/058.phpt
+++ b/ext/uri/tests/058.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test that out of range ports are rejected
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+try {
+    new \Uri\Rfc3986\Uri('https://example.com:987654321987654321987654321987654321');
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), PHP_EOL;
+} 
+
+?>
+--EXPECT--
+Uri\InvalidUriException: The port is out of range

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -190,11 +190,11 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_host_read(const
 	return SUCCESS;
 }
 
-ZEND_ATTRIBUTE_NONNULL static size_t str_to_int(const char *str, size_t len)
+ZEND_ATTRIBUTE_NONNULL static zend_ulong str_to_int(const char *str, size_t len)
 {
-	size_t result = 0;
+	zend_ulong result = 0;
 
-	for (size_t i = 0; i < len; ++i) {
+	for (zend_ulong i = 0; i < len; ++i) {
 		result = result * 10 + (str[i] - '0');
 	}
 
@@ -318,6 +318,20 @@ php_uri_parser_rfc3986_uris *php_uri_parser_rfc3986_parse_ex(const char *uri_str
 
 	/* Make the resulting URI independent of the 'uri_str'. */
 	uriMakeOwnerMmA(&uri, mm);
+
+	if (has_text_range(&uri.portText)) {
+		size_t port_length = get_text_range_length(&uri.portText);
+		if (
+			port_length > 5
+			|| str_to_int(uri.portText.first, port_length) > 65535
+		) {
+			if (!silent) {
+				zend_throw_exception(uri_invalid_uri_exception_ce, "The port is out of range", 0);
+			}
+
+			goto fail;
+		}
+	}
 
 	php_uri_parser_rfc3986_uris *uriparser_uris = uriparser_create_uris();
 	uriparser_uris->uri = uri;


### PR DESCRIPTION
RFC 3986 technically allows arbitrarily large integers as port numbers, but our implementation is unable to deal with that, since it expects the port to fit `zend_long`. In practice these port numbers are unusable, so we might as well reject them.