### PR TITLE
uri: Fix handling of empty ports for uri_parser_rfc3986

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,6 +61,8 @@ PHP                                                                        NEWS
     the Uri\WhatWg\Url parser. (timwolla)
   . Reject out-of-range ports when using the Uri\Rfc3986\Uri parser.
     (timwolla)
+  . Return null instead of 0 for Uri\Rfc3986\Uri::getPort() when the
+    URI contains an empty port. (timwolla)
   . Clean up naming of internal API. (timwolla)
 
 28 Aug 2025, PHP 8.5.0beta2

--- a/ext/uri/tests/059.phpt
+++ b/ext/uri/tests/059.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test empty ports become null
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri = new \Uri\Rfc3986\Uri('https://example.com:');
+var_dump($uri, $uri->getPort());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\Uri)#%d (8) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+NULL

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -326,15 +326,14 @@ php_uri_parser_rfc3986_uris *php_uri_parser_rfc3986_parse_ex(const char *uri_str
 	/* Make the resulting URI independent of the 'uri_str'. */
 	uriMakeOwnerMmA(&uri, mm);
 
-	if (
-		has_text_range(&uri.portText)
-		&& port_str_to_zend_long_checked(uri.portText.first, get_text_range_length(&uri.portText)) == -1
-	) {
-		if (!silent) {
-			zend_throw_exception(uri_invalid_uri_exception_ce, "The port is out of range", 0);
-		}
+	if (has_text_range(&uri.portText) && get_text_range_length(&uri.portText) > 0) {
+		if (port_str_to_zend_long_checked(uri.portText.first, get_text_range_length(&uri.portText)) == -1) {
+			if (!silent) {
+				zend_throw_exception(uri_invalid_uri_exception_ce, "The port is out of range", 0);
+			}
 
-		goto fail;
+			goto fail;
+		}
 	}
 
 	php_uri_parser_rfc3986_uris *uriparser_uris = uriparser_create_uris();

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -212,7 +212,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_port_read(const
 {
 	const UriUriA *uriparser_uri = get_uri_for_reading(internal_uri->uri, read_mode);
 
-	if (has_text_range(&uriparser_uri->portText)) {
+	if (has_text_range(&uriparser_uri->portText) && get_text_range_length(&uriparser_uri->portText) > 0) {
 		ZVAL_LONG(retval, port_str_to_zend_long_checked(uriparser_uri->portText.first, get_text_range_length(&uriparser_uri->portText)));
 	} else {
 		ZVAL_NULL(retval);


### PR DESCRIPTION
This is currently leaking due to uriparser/uriparser#250, thus leaving on draft for now.