### PR TITLE
Fix GH-13204: glob() fails if square bracket is in current directory

### DIFF
--- a/ext/standard/tests/file/gh13204.phpt
+++ b/ext/standard/tests/file/gh13204.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-13204 (glob() fails if square bracket is in current directory)
+--FILE--
+<?php
+chdir(__DIR__ . '/gh13204[brackets]/');
+var_dump(glob('./*'));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(11) "./empty.txt"
+}


### PR DESCRIPTION
The problem is not limited to square brackets, but to every meta character. The solution is to override the glob functions for handling paths with the VCWD ones in PHP. If that is not available, use the old but limited workaround.