### PR TITLE
uri: Call the proper `clone_obj` handler in `uri_write_component_ex()`

### DIFF
--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -979,7 +979,7 @@ static void uri_free_obj_handler(zend_object *object)
 	zend_object_std_dtor(&uri_object->std);
 }
 
-zend_object *uri_clone_obj_handler(zend_object *object)
+static zend_object *uri_clone_obj_handler(zend_object *object)
 {
 	uri_object_t *uri_object = uri_object_from_obj(object);
 	uri_internal_t *internal_uri = uri_internal_from_obj(object);

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -83,19 +83,22 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, uri_property_name_t proper
 
 static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, uri_property_name_t property_name, zval *property_zv)
 {
+	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
 	uri_internal_t *internal_uri = Z_URI_INTERNAL_P(ZEND_THIS);
 	URI_ASSERT_INITIALIZATION(internal_uri);
+
+	zend_object *new_object = old_object->handlers->clone_obj(old_object);
+	if (new_object == NULL) {
+		RETURN_THROWS();
+	}
 
 	const uri_property_handler_t *property_handler = uri_property_handler_from_internal_uri(internal_uri, property_name);
 	ZEND_ASSERT(property_handler != NULL);
 
-	zend_object *new_object = uri_clone_obj_handler(Z_OBJ_P(ZEND_THIS));
-	ZEND_ASSERT(new_object != NULL);
-
 	uri_internal_t *new_internal_uri = uri_internal_from_obj(new_object);
 	URI_ASSERT_INITIALIZATION(new_internal_uri);
 	if (UNEXPECTED(property_handler->write_func == NULL)) {
-		zend_readonly_property_modification_error_ex(ZSTR_VAL(Z_OBJ_P(ZEND_THIS)->ce->name),
+		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),
 			ZSTR_VAL(get_known_string_by_property_name(property_name)));
 		zend_object_release(new_object);
 		RETURN_THROWS();
@@ -110,7 +113,7 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, uri_property_na
 	}
 
 	ZEND_ASSERT(Z_ISUNDEF(errors));
-	RETVAL_OBJ(new_object);
+	RETURN_OBJ(new_object);
 }
 
 void uri_write_component_str(INTERNAL_FUNCTION_PARAMETERS, uri_property_name_t property_name)

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -92,6 +92,10 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, uri_property_na
 		RETURN_THROWS();
 	}
 
+	/* Assign the object early. The engine will take care of destruction in
+	 * case of an exception being thrown. */
+	RETVAL_OBJ(new_object);
+
 	const uri_property_handler_t *property_handler = uri_property_handler_from_internal_uri(internal_uri, property_name);
 	ZEND_ASSERT(property_handler != NULL);
 
@@ -100,7 +104,6 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, uri_property_na
 	if (UNEXPECTED(property_handler->write_func == NULL)) {
 		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),
 			ZSTR_VAL(get_known_string_by_property_name(property_name)));
-		zend_object_release(new_object);
 		RETURN_THROWS();
 	}
 
@@ -108,12 +111,10 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, uri_property_na
 	ZVAL_UNDEF(&errors);
 	if (UNEXPECTED(property_handler->write_func(new_internal_uri, property_zv, &errors) == FAILURE)) {
 		zval_ptr_dtor(&errors);
-		zend_object_release(new_object);
 		RETURN_THROWS();
 	}
 
 	ZEND_ASSERT(Z_ISUNDEF(errors));
-	RETURN_OBJ(new_object);
 }
 
 void uri_write_component_str(INTERNAL_FUNCTION_PARAMETERS, uri_property_name_t property_name)

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -27,7 +27,6 @@ extern zend_class_entry *uri_invalid_uri_exception_ce;
 extern zend_class_entry *uri_whatwg_invalid_url_exception_ce;
 extern zend_class_entry *uri_whatwg_url_validation_error_type_ce;
 extern zend_class_entry *uri_whatwg_url_validation_error_ce;
-extern zend_object *uri_clone_obj_handler(zend_object *object);
 
 typedef enum {
 	URI_RECOMPOSITION_RAW_ASCII,


### PR DESCRIPTION
Related to #19648.