### PR TITLE
Check unchecked error-prone calls in ext/ssl

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ PHP                                                                        NEWS
 
 - OpenSSL:
   . Fix a bunch of memory leaks and crashes on edge cases. (ndossche)
+  . Fixed bug GH-18988 (Check various unchecked error-prone OpenSSL function
+    return values). (alexandre-daubois)
 
 - SPL:
   . Fixed bug GH-21499 (RecursiveArrayIterator getChildren UAF after parent

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1303,7 +1303,6 @@ PHP_MINIT_FUNCTION(openssl)
 #endif
 	if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
 		php_error_docref(NULL, E_WARNING, "Failed to initialize OpenSSL");
-		return FAILURE;
 	}
 #endif
 
@@ -2330,10 +2329,7 @@ static STACK_OF(X509) *php_openssl_load_all_certs_from_file(
 	while (sk_X509_INFO_num(sk)) {
 		xi=sk_X509_INFO_shift(sk);
 		if (xi->x509 != NULL) {
-			if (sk_X509_push(stack,xi->x509) == 0) {
-				php_openssl_store_errors();
-				X509_free(xi->x509);
-			}
+			sk_X509_push(stack,xi->x509);
 			xi->x509=NULL;
 		}
 		X509_INFO_free(xi);

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1851,9 +1851,8 @@ static zend_result php_openssl_setup_crypto(php_stream *stream,
 			php_error_docref(NULL, E_WARNING, "Supplied session stream must be an SSL enabled stream");
 		} else if (((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle == NULL) {
 			php_error_docref(NULL, E_WARNING, "Supplied SSL session stream is not initialized");
-		} else if (SSL_copy_session_id(sslsock->ssl_handle, ((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle) != 1) {
-			php_openssl_store_errors();
-			php_error_docref(NULL, E_WARNING, "Failed to copy SSL session");
+		} else {
+			SSL_copy_session_id(sslsock->ssl_handle, ((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle);
 		}
 	}
 


### PR DESCRIPTION
Fix #18988

Some calls are not findable, or their errors are deliberately ignored (for example `NCONF_get_number`).