### PR TITLE
Fix GH-16993: Fix filter_var_array to warn when validation filters are incorrectly combined with FILTER_NULL_ON_FAILURE flag

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,10 @@ PHP                                                                        NEWS
 - FPM:
   . Fixed failed debug assertion when php_admin_value setting fails. (ilutov)
 
+- Filter:
+  . Fixed bug GH-16993 (filter_var_array with FILTER_VALIDATE_INT|FILTER_NULL_ON_FAILURE
+    should emit warning for invalid filter usage). (alexandre-daubois)
+
 - Opcache:
   . Fixed bug GH-19486 (Incorrect opline after deoptimization). (Arnaud)
   . Fixed bug GH-19601 (Wrong JIT stack setup on aarch64/clang). (Arnaud)

--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -627,6 +627,14 @@ static void php_filter_array_handler(zval *input, HashTable *op_ht, zend_long op
 				zval nval;
 				ZVAL_DEREF(tmp);
 				ZVAL_DUP(&nval, tmp);
+
+				if (Z_TYPE_P(arg_elm) != IS_ARRAY) {
+					zend_long filter_id = zval_get_long(arg_elm);
+					if (!PHP_FILTER_ID_EXISTS(filter_id)) {
+						php_error_docref(NULL, E_WARNING, "Unknown filter with ID " ZEND_LONG_FMT, filter_id);
+					}
+				}
+
 				php_filter_call(&nval, -1,
 					Z_TYPE_P(arg_elm) == IS_ARRAY ? Z_ARRVAL_P(arg_elm) : NULL,
 					Z_TYPE_P(arg_elm) == IS_ARRAY ? 0 : zval_get_long(arg_elm),

--- a/ext/filter/tests/039.phpt
+++ b/ext/filter/tests/039.phpt
@@ -125,12 +125,18 @@ array(1) {
   ["var_name"]=>
   NULL
 }
+
+Warning: filter_var_array(): Unknown filter with ID -1 in %s on line %d
 array(1) {
   ["var_name"]=>
   string(0) ""
 }
 -- (5)
+
+Warning: filter_var_array(): Unknown filter with ID -1 in %s on line %d
 filter_var_array(): Argument #2 ($options) cannot contain empty keys
+
+Warning: filter_var_array(): Unknown filter with ID 0 in %s on line %d
 filter_var_array(): Argument #2 ($options) cannot contain empty keys
 
 Warning: filter_var_array(): Unknown filter with ID -1 in %s on line %d

--- a/ext/filter/tests/gh16993.phpt
+++ b/ext/filter/tests/gh16993.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-16993: filter_var_array should emit warning for unknown filters
+--EXTENSIONS--
+filter
+--FILE--
+<?php
+$data = ['test' => '42'];
+
+$result = filter_var_array($data, ['test' => FILTER_VALIDATE_INT|FILTER_NULL_ON_FAILURE]);
+var_dump($result);
+
+$result = filter_var_array($data, ['test' => ['filter' => FILTER_VALIDATE_INT, 'flags' => FILTER_NULL_ON_FAILURE]]);
+var_dump($result);
+?>
+--EXPECTF--
+Warning: filter_var_array(): Unknown filter with ID 134217985 in %s on line %d
+array(1) {
+  ["test"]=>
+  string(2) "42"
+}
+array(1) {
+  ["test"]=>
+  int(42)
+}


### PR DESCRIPTION
Fix #16993