### PR TITLE
.gdbinit: Fix executor_globals locating in release builds

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -10,7 +10,7 @@ document set_ts
 end
 
 define ____executor_globals
-	if basic_functions_module.zts
+	if !$_isvoid(&_tsrm_ls_cache)
 		set $tsrm_ls = _tsrm_ls_cache
 		set $eg = ((zend_executor_globals*) (*((void ***) $tsrm_ls))[executor_globals_id-1])
 		set $cg = ((zend_compiler_globals*) (*((void ***) $tsrm_ls))[compiler_globals_id-1])


### PR DESCRIPTION
Apparently `basic_functions_module` may get optimised away in release builds. The alternative condition I provided seems to work, but I will note I haven't tested this on NTS.