### PR TITLE
curl: re-enable setopt ssl test on MacOS

### DIFF
--- a/ext/curl/tests/curl_setopt_ssl.phpt
+++ b/ext/curl/tests/curl_setopt_ssl.phpt
@@ -8,7 +8,6 @@ if (!function_exists("proc_open")) die("skip no proc_open");
 exec('openssl version', $out, $code);
 if ($code > 0) die("skip couldn't locate openssl binary");
 if (PHP_OS_FAMILY === 'Windows') die('skip not for Windows');
-if (PHP_OS_FAMILY === 'Darwin') die('skip Fails intermittently on macOS');
 if (PHP_OS === 'FreeBSD') die('skip proc_open seems to be stuck on FreeBSD');
 $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x074700) {


### PR DESCRIPTION
The MacOS CI no longer have messed up OpenSSL version so this tries to re-enable previously disabled setopt test.