### PR TITLE
mbstring: move mb_internal_encoding to INI section

### DIFF
--- a/ext/mbstring/tests/bug54494.phpt
+++ b/ext/mbstring/tests/bug54494.phpt
@@ -2,11 +2,10 @@
 Bug #54494: mb_substr() mishandles UTF-32LE and UCS-2LE
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-//declare(encoding = 'UTF-8');
-mb_internal_encoding('UTF-8');
 
 header('Content-Type: text/plain; charset=UTF-32LE');
 

--- a/ext/mbstring/tests/bug65045.phpt
+++ b/ext/mbstring/tests/bug65045.phpt
@@ -2,10 +2,10 @@
 Bug #65045: mb_convert_encoding breaks well-formed character
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $str = "\xF0\xA4\xAD".  "\xF0\xA4\xAD\xA2"."\xF0\xA4\xAD\xA2";
 $str2 = "\xF0\xA4\xAD\xA2"."\xF0\xA4\xAD\xA2"."\xF0\xA4\xAD";

--- a/ext/mbstring/tests/bug79441.phpt
+++ b/ext/mbstring/tests/bug79441.phpt
@@ -2,10 +2,11 @@
 Bug #79441 Segfault in mb_chr() if internal encoding is unsupported
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-7
 --FILE--
 <?php
 
-mb_internal_encoding("utf-7");
 try {
     mb_chr(0xd800);
 } catch (\ValueError $e) {

--- a/ext/mbstring/tests/gh7902.phpt
+++ b/ext/mbstring/tests/gh7902.phpt
@@ -8,9 +8,9 @@ if (str_contains(getcwd(), " ")) die("skip sendmail_path ini with spaces");
 ?>
 --INI--
 sendmail_path={MAIL:{PWD}/gh7902.eml}
+internal_encoding=UTF-8
 --FILE--
 <?php
-mb_internal_encoding("UTF-8");
 mb_language("uni");
 $to = "omittedvalidaddress@example.com";
 $subject = "test mail";

--- a/ext/mbstring/tests/gh8086.phpt
+++ b/ext/mbstring/tests/gh8086.phpt
@@ -3,11 +3,11 @@ GH-8086 (mb_send_mail() function not working correctly in PHP 8.x)
 --EXTENSIONS--
 mbstring
 --INI--
+internal_encoding=UTF-8
 sendmail_path={MAIL:{PWD}/gh8086.eml}
 mail.mixed_lf_and_crlf=on
 --FILE--
 <?php
-mb_internal_encoding("UTF-8");
 mb_language("uni");
 $to = "omittedvalidaddress@example.com";
 $subject = "test mail";

--- a/ext/mbstring/tests/mb_decode_mimeheader_basic.phpt
+++ b/ext/mbstring/tests/mb_decode_mimeheader_basic.phpt
@@ -2,10 +2,11 @@
 Test mb_decode_mimeheader() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 echo "*** Testing mb_decode_mimeheader() : basic functionality ***\n";
-mb_internal_encoding('utf-8');
 
 //the following encoded-words are identical and are UTF-8 Japanese.
 $a = "=?UTF-8?b?5pel5pys6Kqe44OG44Kt44K544OI44Gn44GZ44CC?=";

--- a/ext/mbstring/tests/mb_decode_mimeheader_variation2.phpt
+++ b/ext/mbstring/tests/mb_decode_mimeheader_variation2.phpt
@@ -2,10 +2,11 @@
 Test mb_decode_mimeheader() function : variation
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 echo "*** Testing mb_decode_mimeheader() : variation ***\n";
-mb_internal_encoding('utf-8');
 
 //all the following are identical, we will convert to utf-8
 

--- a/ext/mbstring/tests/mb_decode_mimeheader_variation3.phpt
+++ b/ext/mbstring/tests/mb_decode_mimeheader_variation3.phpt
@@ -2,10 +2,11 @@
 Test mb_decode_mimeheader() function : variation
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=iso-8859-7
 --FILE--
 <?php
 echo "*** Testing mb_decode_mimeheader() : variation ***\n";
-mb_internal_encoding('iso-8859-7');
 
 //greek in UTF-8 to be converted to iso-8859-7
 $encoded_word = "=?UTF-8?B?zrHOss6zzrTOtc62zrfOuM65zrrOu868zr3Ovs6/z4DPgc+Dz4TPhc+Gz4fPiM+J?=";

--- a/ext/mbstring/tests/mb_encode_mimeheader_indent.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_indent.phpt
@@ -2,6 +2,8 @@
 Test mb_encode_mimeheader() function : basic functionality, indent
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 /* (string $str [, string $charset [, string $transfer_encoding [, string $linefeed [, int $indent]]]])
@@ -14,8 +16,6 @@ mbstring
  */
 
 echo "*** Testing mb_encode_mimeheader() : indent ***\n";
-
-mb_internal_encoding('utf-8');
 
 // Initialise function arguments not being substituted
 $str = base64_decode('zpHPhc+Ez4wgzrXOr869zrHOuSDOtc67zrvOt869zrnOus+MIM66zrXOr868zrXOvc6/LiAwMTIzNDU2Nzg5Lg==');

--- a/ext/mbstring/tests/mb_encode_mimeheader_variation6.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_variation6.phpt
@@ -2,6 +2,8 @@
 Test mb_encode_mimeheader() function : usage variations - Pass different strings to $linefeed arg
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 /* (string $str [, string $charset [, string $transfer_encoding [, string $linefeed [, int $indent]]]])
@@ -14,8 +16,6 @@ mbstring
  */
 
 echo "*** Testing mb_encode_mimeheader() : usage variations ***\n";
-
-mb_internal_encoding('utf-8');
 
 $linefeeds = array("\r\n",
                    "\n",

--- a/ext/mbstring/tests/mb_ereg_match_basic.phpt
+++ b/ext/mbstring/tests/mb_ereg_match_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_ereg_match() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --SKIPIF--
 <?php
 function_exists('mb_ereg_match') or die("skip mb_ereg_match() is not available in this build");
@@ -12,7 +14,6 @@ function_exists('mb_ereg_match') or die("skip mb_ereg_match() is not available i
  * Test basic functionality of mb_ereg_match
  */
 
-mb_internal_encoding('UTF-8');
 mb_regex_encoding('UTF-8');
 
 echo "*** Testing mb_ereg_match() : basic functionality ***\n";

--- a/ext/mbstring/tests/mb_ereg_replace_basic.phpt
+++ b/ext/mbstring/tests/mb_ereg_replace_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_ereg_replace() function : basic
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --SKIPIF--
 <?php
 function_exists('mb_ereg_replace') or die("skip mb_ereg_replace() is not available in this build");
@@ -14,7 +16,6 @@ function_exists('mb_ereg_replace') or die("skip mb_ereg_replace() is not availab
 
 echo "*** Testing mb_ereg_replace() : basic functionality ***\n";
 
-mb_internal_encoding('UTF-8');
 mb_regex_encoding('UTF-8');
 
 $string_ascii = 'abc def';

--- a/ext/mbstring/tests/mb_output_handler_pattern-01.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-01.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (1)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/html");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-02.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-02.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (2)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/plain");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-03.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-03.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (3)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: application/xhtml+xml");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-04.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-04.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (4)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: application/octet-stream");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-05.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-05.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (5)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 ob_start();
 ob_start('mb_output_handler');
 echo "テスト";

--- a/ext/mbstring/tests/mb_output_handler_pattern-06.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-06.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (6)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/html");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-07.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-07.phpt
@@ -4,9 +4,9 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes (7)
 mbstring
 --INI--
 mbstring.http_output_conv_mimetypes=html
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/html");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-08.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-08.phpt
@@ -3,10 +3,10 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes (8)
 --EXTENSIONS--
 mbstring
 --INI--
+output_encoding=EUC-JP
 mbstring.http_output_conv_mimetypes=html
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/plain");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-09.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-09.phpt
@@ -4,9 +4,9 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes (9)
 mbstring
 --INI--
 mbstring.http_output_conv_mimetypes=html
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: application/xhtml+xml");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-10.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-10.phpt
@@ -3,10 +3,10 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes (10)
 --EXTENSIONS--
 mbstring
 --INI--
+output_encoding=EUC-JP
 mbstring.http_output_conv_mimetypes=html
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: application/octet-stream");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_pattern-11.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-11.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (11)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 ob_start();
 ob_start('mb_output_handler');
 echo "テスト";

--- a/ext/mbstring/tests/mb_output_handler_pattern-12.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pattern-12.phpt
@@ -2,9 +2,10 @@
 mb_output_handler() and mbstring.http_output_conv_mimetypes (12)
 --EXTENSIONS--
 mbstring
+--INI--
+output_encoding=EUC-JP
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 header("Content-Type: text/html");
 ob_start();
 ob_start('mb_output_handler');

--- a/ext/mbstring/tests/mb_output_handler_runtime_ini_alteration-01.phpt
+++ b/ext/mbstring/tests/mb_output_handler_runtime_ini_alteration-01.phpt
@@ -4,10 +4,10 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes alteration in runtim
 mbstring
 --INI--
 internal_encoding=UTF-8
+output_encoding=EUC-JP
 mbstring.http_output_conv_mimetypes=plain
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 ini_set('mbstring.http_output_conv_mimetypes', 'text');
 header("Content-Type: text/html");
 ob_start();

--- a/ext/mbstring/tests/mb_output_handler_runtime_ini_alteration-02.phpt
+++ b/ext/mbstring/tests/mb_output_handler_runtime_ini_alteration-02.phpt
@@ -4,10 +4,10 @@ mb_output_handler() and mbstring.http_output_conv_mimetypes alteration in runtim
 mbstring
 --INI--
 internal_encoding=UTF-8
+output_encoding=EUC-JP
 mbstring.http_output_conv_mimetypes=html
 --FILE--
 <?php
-mb_http_output("EUC-JP");
 ini_set('mbstring.http_output_conv_mimetypes', 'application');
 header("Content-Type: text/html");
 ob_start();

--- a/ext/mbstring/tests/mb_parse_str_error.phpt
+++ b/ext/mbstring/tests/mb_parse_str_error.phpt
@@ -2,9 +2,10 @@
 mb_parse_str() error handling
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-mb_internal_encoding('UTF-8');
 
 $queries = array(
   "\x80\x80\x80",

--- a/ext/mbstring/tests/mb_parse_str_multi.phpt
+++ b/ext/mbstring/tests/mb_parse_str_multi.phpt
@@ -3,13 +3,13 @@ mb_parse_str() with multiple candidate encodings
 --EXTENSIONS--
 mbstring
 --INI--
+internal_encoding=UTF-8
 mbstring.http_input=UTF-8,SJIS,EUC-JP,ISO-8859-1,ISO-2022-JP
 --FILE--
 <?php
 // The encoding of the input strings will be guessed, from the list specified
 // via mbstring.http_input
 // All of them will be converted to UTF-8
-mb_internal_encoding('UTF-8');
 
 $queries = array(
   // UTF-8

--- a/ext/mbstring/tests/mb_stripos_basic.phpt
+++ b/ext/mbstring/tests/mb_stripos_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_stripos() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_stripos() : basic functionality***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii strings
 $ascii_haystacks = array(

--- a/ext/mbstring/tests/mb_stripos_basic2.phpt
+++ b/ext/mbstring/tests/mb_stripos_basic2.phpt
@@ -1,16 +1,13 @@
 --TEST--
-Test mb_stripos() function : basic functionality
+Test mb_stripos() function : basic functionality with ASCII and multibyte characters
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-/*
- * Test basic functionality of mb_stripos with ASCII and multibyte characters
- */
 
 echo "*** Testing mb_stripos() : basic functionality***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii strings
 $ascii_haystacks = array(

--- a/ext/mbstring/tests/mb_stripos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_stripos_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_stripos() function :  with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_stripos_invalid_offset.phpt
+++ b/ext/mbstring/tests/mb_stripos_invalid_offset.phpt
@@ -2,12 +2,13 @@
 mb_stripos() with invalid offsets
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 
 ini_set('include_path','.');
 include_once('common.inc');
-mb_internal_encoding('UTF-8') or print("mb_internal_encoding() failed\n");
 
 // Test string
 $string = '0123この文字列は日本語です。UTF-8を使っています。0123日本語は面倒臭い。';

--- a/ext/mbstring/tests/mb_stripos_variation5_Bug45923.phpt
+++ b/ext/mbstring/tests/mb_stripos_variation5_Bug45923.phpt
@@ -2,6 +2,8 @@
 Test mb_stripos() function : usage variations - Pass different integers as $offset argument
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  * The character length of $string_ascii and $string_mb is the same,
  * and the needle appears at the same positions in both strings
  */
-
-mb_internal_encoding('UTF-8');
 
 echo "*** Testing mb_stripos() : usage variations ***\n";
 

--- a/ext/mbstring/tests/mb_stristr_basic.phpt
+++ b/ext/mbstring/tests/mb_stristr_basic.phpt
@@ -2,11 +2,11 @@
 Test mb_stristr() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_stristr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abcdef';
 $needle_ascii_upper = "BCD";

--- a/ext/mbstring/tests/mb_stristr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_stristr_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_stristr() function : with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_stristr_variation5.phpt
+++ b/ext/mbstring/tests/mb_stristr_variation5.phpt
@@ -2,11 +2,11 @@
 Test mb_stristr() function : usage variation - multiple needles
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_stristr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii mixed case, multiple needles
 $string_ascii = 'abcDef zBcDyx';

--- a/ext/mbstring/tests/mb_strpos_basic.phpt
+++ b/ext/mbstring/tests/mb_strpos_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_strpos() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_strpos() : basic functionality***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 //Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strpos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strpos_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_strpos() function : with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strpos_invalid_offset.phpt
+++ b/ext/mbstring/tests/mb_strpos_invalid_offset.phpt
@@ -2,12 +2,13 @@
 mb_strpos() with invalid offsets
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 
 ini_set('include_path','.');
 include_once('common.inc');
-mb_internal_encoding('UTF-8') or print("mb_internal_encoding() failed\n");
 
 // Test string
 $string = '0123この文字列は日本語です。UTF-8を使っています。0123日本語は面倒臭い。';

--- a/ext/mbstring/tests/mb_strpos_variation5.phpt
+++ b/ext/mbstring/tests/mb_strpos_variation5.phpt
@@ -2,6 +2,8 @@
 Test mb_strpos() function : usage variations - Pass different integers as $offset argument
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  * The character length of $string_ascii and $string_mb is the same,
  * and the needle appears at the same positions in both strings
  */
-
-mb_internal_encoding('UTF-8');
 
 echo "*** Testing mb_strpos() : usage variations ***\n";
 

--- a/ext/mbstring/tests/mb_strrchr_basic.phpt
+++ b/ext/mbstring/tests/mb_strrchr_basic.phpt
@@ -2,11 +2,11 @@
 Test mb_strrchr() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strrchr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 //Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrchr_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_strrchr() function : with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strrchr_variation5.phpt
+++ b/ext/mbstring/tests/mb_strrchr_variation5.phpt
@@ -2,11 +2,11 @@
 Test mb_strrchr() function : variation - multiple needles
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strrchr() : variation ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //with repeated needles
 $string_ascii = 'abcdef zbcdyx';

--- a/ext/mbstring/tests/mb_strrchr_variation6.phpt
+++ b/ext/mbstring/tests/mb_strrchr_variation6.phpt
@@ -2,11 +2,11 @@
 Test mb_strrchr() function : variation - case sensitivity
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strrchr() : variation ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii
 $string_ascii = 'abcdef';

--- a/ext/mbstring/tests/mb_strrichr_basic.phpt
+++ b/ext/mbstring/tests/mb_strrichr_basic.phpt
@@ -2,11 +2,11 @@
 Test mb_strrichr() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strrichr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abcdef';
 $needle_ascii_upper = "BCD";

--- a/ext/mbstring/tests/mb_strrichr_variation5.phpt
+++ b/ext/mbstring/tests/mb_strrichr_variation5.phpt
@@ -2,11 +2,11 @@
 Test mb_strrichr() function : usage variation - multiple needles
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strrichr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii mixed case, multiple needles
 $string_ascii = 'abcDef zBcDyx';

--- a/ext/mbstring/tests/mb_strripos_basic.phpt
+++ b/ext/mbstring/tests/mb_strripos_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_strripos() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_strripos() : basic functionality***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii strings
 $ascii_haystacks = array(

--- a/ext/mbstring/tests/mb_strripos_basic2.phpt
+++ b/ext/mbstring/tests/mb_strripos_basic2.phpt
@@ -2,6 +2,8 @@
 Test mb_strripos() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_strripos() : basic functionality***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii strings
 $ascii_haystacks = array(

--- a/ext/mbstring/tests/mb_strripos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strripos_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_strripos() function : with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strripos_variation5_Bug45923.phpt
+++ b/ext/mbstring/tests/mb_strripos_variation5_Bug45923.phpt
@@ -2,6 +2,8 @@
 Test mb_strripos() function : usage variations - Pass different integers as $offset argument
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  * The character length of $string_ascii and $string_mb is the same,
  * and the needle appears at the same positions in both strings
  */
-
-mb_internal_encoding('UTF-8');
 
 echo "*** Testing mb_strripos() : usage variations ***\n";
 

--- a/ext/mbstring/tests/mb_strrpos_basic.phpt
+++ b/ext/mbstring/tests/mb_strrpos_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_strrpos() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_strrpos() : basic ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'This is an English string. 0123456789.';
 //Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strrpos_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_strrpos() function :  with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strstr_basic.phpt
+++ b/ext/mbstring/tests/mb_strstr_basic.phpt
@@ -2,11 +2,11 @@
 Test mb_strstr() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strstr() : basic functionality ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 //Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strstr_empty_needle.phpt
+++ b/ext/mbstring/tests/mb_strstr_empty_needle.phpt
@@ -2,10 +2,10 @@
 Test mb_strstr() function : with empty needle
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = 'abc def';
 // Japanese string in UTF-8

--- a/ext/mbstring/tests/mb_strstr_variation5.phpt
+++ b/ext/mbstring/tests/mb_strstr_variation5.phpt
@@ -2,11 +2,11 @@
 Test mb_strstr() function : variation - multiple needles
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strstr() : variation ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //with repeated needles
 $string_ascii = 'abcdef zbcdyx';

--- a/ext/mbstring/tests/mb_strstr_variation6.phpt
+++ b/ext/mbstring/tests/mb_strstr_variation6.phpt
@@ -2,11 +2,11 @@
 Test mb_strstr() function : variation - case sensitivity
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 echo "*** Testing mb_strstr() : variation ***\n";
-
-mb_internal_encoding('UTF-8');
 
 //ascii
 $string_ascii = 'abcdef';

--- a/ext/mbstring/tests/mb_strtoupper_basic.phpt
+++ b/ext/mbstring/tests/mb_strtoupper_basic.phpt
@@ -2,6 +2,8 @@
 Test mb_strtoupper() function : basic functionality
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 /*
@@ -10,7 +12,6 @@ mbstring
 
 echo "*** Testing mb_strtoupper() : basic functionality ***\n";
 
-mb_internal_encoding('utf-8');
 $ascii_lower = 'abcdefghijklmnopqrstuvwxyz';
 $ascii_upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 $greek_lower = base64_decode('zrHOss6zzrTOtc62zrfOuM65zrrOu868zr3Ovs6/z4DPgc+Dz4TPhc+Gz4fPiM+J');

--- a/ext/mbstring/tests/mb_substitute_character_variation_strict_types.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_variation_strict_types.phpt
@@ -2,6 +2,8 @@
 Test mb_substitute_character() function : usage variation
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=utf-8
 --FILE--
 <?php
 declare(strict_types=1);
@@ -93,7 +95,6 @@ $inputs = array(
 
 // loop through each element of the array for substchar
 
-mb_internal_encoding('utf-8');
 foreach($inputs as $key =>$value) {
       echo "--$key--\n";
       try {

--- a/ext/mbstring/tests/mb_substr_basic.phpt
+++ b/ext/mbstring/tests/mb_substr_basic.phpt
@@ -1,15 +1,11 @@
 --TEST--
-Test mb_substr() function : basic functionality
+Test mb_substr() function : basic functionality with ASCII characters and multibyte strings.
 --EXTENSIONS--
 mbstring
 --INI--
 internal_encoding=ISO-8859-1
 --FILE--
 <?php
-/*
- * Test Basic Functionality of mb_substr with ASCII characters and multibyte strings.
- */
-
 echo "*** Testing mb_substr() : basic functionality ***\n";
 
 $string_ascii = 'ABCDEF';

--- a/ext/mbstring/tests/mb_substr_count.phpt
+++ b/ext/mbstring/tests/mb_substr_count.phpt
@@ -4,9 +4,9 @@ mb_substr_count()
 mbstring
 --INI--
 output_handler=
+internal_encoding=EUC-JP
 --FILE--
 <?php
-    mb_internal_encoding("EUC-JP");
 
     print "== Empty needle should raise an error ==\n";
     try {

--- a/ext/mbstring/tests/mb_substr_count_basic.phpt
+++ b/ext/mbstring/tests/mb_substr_count_basic.phpt
@@ -4,9 +4,6 @@ Test mb_substr_count() function : basic functionality
 mbstring
 --FILE--
 <?php
-/*
- * Test Basic functionality of mb_substr_count
- */
 
 echo "*** Testing mb_substr_count() : basic functionality ***\n";
 

--- a/ext/mbstring/tests/mb_substr_count_error2.phpt
+++ b/ext/mbstring/tests/mb_substr_count_error2.phpt
@@ -4,9 +4,6 @@ Test mb_substr_count() function : error conditions - pass unknown encoding
 mbstring
 --FILE--
 <?php
-/*
- * Test behaviour of mb_substr_count() function when passed an unknown encoding
- */
 
 echo "*** Testing mb_substr_count() : error conditions ***\n";
 

--- a/ext/mbstring/tests/mb_substr_variation4.phpt
+++ b/ext/mbstring/tests/mb_substr_variation4.phpt
@@ -2,6 +2,8 @@
 Test mb_substr() function : usage variations - pass different integers to $start arg
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_substr() : usage variations ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = '+Is an English string'; //21 chars
 

--- a/ext/mbstring/tests/mb_substr_variation5.phpt
+++ b/ext/mbstring/tests/mb_substr_variation5.phpt
@@ -2,6 +2,8 @@
 Test mb_substr() function : usage variations - pass different integers to $length arg
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_substr() : usage variations ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = '+Is an English string'; //21 chars
 

--- a/ext/mbstring/tests/mb_substr_variation6.phpt
+++ b/ext/mbstring/tests/mb_substr_variation6.phpt
@@ -2,6 +2,8 @@
 Test mb_substr() function : usage variations - pass different integers to $start arg
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_substr() : usage variations ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = '+Is an English string'; //21 chars
 

--- a/ext/mbstring/tests/mb_substr_variation7.phpt
+++ b/ext/mbstring/tests/mb_substr_variation7.phpt
@@ -2,6 +2,8 @@
 Test mb_substr() function : usage variations - pass different integers to $length arg
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
 /*
@@ -9,8 +11,6 @@ mbstring
  */
 
 echo "*** Testing mb_substr() : usage variations ***\n";
-
-mb_internal_encoding('UTF-8');
 
 $string_ascii = '+Is an English string'; //21 chars
 

--- a/ext/mbstring/tests/mb_trim.phpt
+++ b/ext/mbstring/tests/mb_trim.phpt
@@ -2,9 +2,10 @@
 mb_trim() function tests
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-mb_internal_encoding("UTF-8");
 
 echo "== Copy from trim ==\n";
 var_dump('ABC' ===  mb_trim('ABC'));

--- a/ext/mbstring/tests/mb_ucfirst_lcfirst.phpt
+++ b/ext/mbstring/tests/mb_ucfirst_lcfirst.phpt
@@ -2,9 +2,10 @@
 mb_ucfirst(), mb_lcfirst functions tests
 --EXTENSIONS--
 mbstring
+--INI--
+internal_encoding=UTF-8
 --FILE--
 <?php
-mb_internal_encoding("UTF-8");
 
 function test_ascii_mb_ucfirst() {
 	for ($i = 0; $i < 128; $i++) {

--- a/ext/standard/tests/strings/htmlentities06.phpt
+++ b/ext/standard/tests/strings/htmlentities06.phpt
@@ -7,7 +7,6 @@ internal_encoding=ISO-8859-15
 mbstring
 --FILE--
 <?php
-    mb_internal_encoding('ISO-8859-15');
     print mb_internal_encoding()."\n";
     var_dump(htmlentities("\xbc\xbd\xbe", ENT_QUOTES, ''));
 ?>

--- a/ext/standard/tests/strings/htmlentities07.phpt
+++ b/ext/standard/tests/strings/htmlentities07.phpt
@@ -7,7 +7,6 @@ internal_encoding=ISO-8859-1
 mbstring
 --FILE--
 <?php
-    mb_internal_encoding('ISO-8859-1');
     print mb_internal_encoding()."\n";
     var_dump(htmlentities("\xe4\xf6\xfc", ENT_QUOTES, ''));
 ?>

--- a/ext/standard/tests/strings/htmlentities08.phpt
+++ b/ext/standard/tests/strings/htmlentities08.phpt
@@ -7,7 +7,6 @@ internal_encoding=EUC-JP
 mbstring
 --FILE--
 <?php
-    mb_internal_encoding('EUC-JP');
     print mb_internal_encoding()."\n";
     var_dump(htmlentities("\xa1\xa2\xa1\xa3\xa1\xa4", ENT_QUOTES, ''));
 ?>

--- a/ext/standard/tests/strings/htmlentities09.phpt
+++ b/ext/standard/tests/strings/htmlentities09.phpt
@@ -7,7 +7,6 @@ internal_encoding=Shift_JIS
 mbstring
 --FILE--
 <?php
-    mb_internal_encoding('Shift_JIS');
     print mb_internal_encoding()."\n";
     var_dump(bin2hex(htmlentities("\x81\x41\x81\x42\x81\x43", ENT_QUOTES, '')));
 ?>


### PR DESCRIPTION
Moves the usage of `mb_internal_encoding()` to INI section for the tests not testing the encoding/function itself, but the other mbstring/iconv functions. 

I'm aware of other tests where `mb_internal_encoding()` is still used to change encoding, but I want to tackle it in another PR.