### PR TITLE
Improve accuracy of ext_stmt emits during pipe operations

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6534,9 +6534,9 @@ static void zend_compile_pipe(znode *result, zend_ast *ast)
 			callable_ast, arg_list_ast);
 	}
 
+	zend_do_extended_stmt(&operand_result);
+
 	zend_compile_expr(result, fcall_ast);
-	CG(zend_lineno) = fcall_ast->lineno;
-	zend_do_extended_stmt(result);
 }
 
 static void zend_compile_match(znode *result, zend_ast *ast)


### PR DESCRIPTION
We need to emit the EXT_STMT opcode before we compile the call, so that we attach the line number of where the right-hand pipe operator starts.

We also do not need to reset the line number any more.

The following code shows where the EXT_STMTs are now introduced.

```
<?php
/* EXT_STMT */ $myString = "<Hello World>";
$result = /* EXT_STMT */ $myString

    |> /* EXT_STMT(!0:$myString) */ \htmlentities(...)

    |>
		/* EXT_STMT($4) */ \str_split(...)

    |> /* EXT_STMT($6) */ (fn($x) => array_map(strtoupper(...), $x))

    |> /* EXT_STMT($9) */ (fn($x) => join( ', ', $x));

/* EXT_STMT */ echo $result, /* EXT_STMT */ "\n";
```