### PR TITLE
Fix RC assertion in fpm when php_admin_value setting fails

### DIFF
--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -41,6 +41,8 @@ static int fpm_php_zend_ini_alter_master(char *name, int name_length, char *new_
 			ini_entry->modifiable = mode;
 		}
 	} else {
+		/* The string wasn't installed and won't be shared, it's safe to drop. */
+		GC_MAKE_PERSISTENT_LOCAL(duplicate);
 		zend_string_release_ex(duplicate, 1);
 	}
 

--- a/sapi/fpm/tests/php_admin_value-failure.phpt
+++ b/sapi/fpm/tests/php_admin_value-failure.phpt
@@ -1,0 +1,48 @@
+--TEST--
+RC violation on failed php_admin_value
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[precision]=-2
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(ini_get('precision'));
+EOT;
+
+$ini = <<<EOT
+precision=14
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->setUserIni($ini);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody(['string(2) "14"']);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
The value is temporarily duplicated. While the value is allocated persistently, it will be freed if the ini value can't be set. This is safe, given the value has not actually been stored.

Exposed by GH-19619

See https://github.com/php/php-src/actions/runs/17390733646/job/49364059680.