### PR TITLE
Zend: Deprecate __sleep()

### DIFF
--- a/Zend/tests/enum/__sleep.phpt
+++ b/Zend/tests/enum/__sleep.phpt
@@ -13,4 +13,6 @@ enum Foo {
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Fatal error: Enum Foo cannot include magic method __sleep in %s on line %d

--- a/Zend/tests/lazy_objects/oss_fuzz_71446.phpt
+++ b/Zend/tests/lazy_objects/oss_fuzz_71446.phpt
@@ -20,3 +20,4 @@ $obj = $reflector->newLazyProxy(function() {
 serialize($obj);
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d

--- a/Zend/tests/lazy_objects/serialize___sleep.phpt
+++ b/Zend/tests/lazy_objects/serialize___sleep.phpt
@@ -36,6 +36,7 @@ try {
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Init on serialize and successful initialization
 string(27) "O:1:"C":1:{s:4:"%0C%0b";i:1;}"
 Init on serialize and failed initialization

--- a/Zend/tests/lazy_objects/serialize___sleep_initializes.phpt
+++ b/Zend/tests/lazy_objects/serialize___sleep_initializes.phpt
@@ -37,6 +37,7 @@ $obj = $reflector->newLazyProxy(function ($obj) {
 test('Proxy', $obj);
 
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 # Ghost:
 string(11) "initializer"
 string(24) "O:1:"C":1:{s:1:"a";i:1;}"

--- a/Zend/tests/lazy_objects/serialize___sleep_skip_flag.phpt
+++ b/Zend/tests/lazy_objects/serialize___sleep_skip_flag.phpt
@@ -35,6 +35,7 @@ $obj = $reflector->newLazyProxy(function ($obj) {
 test('Proxy', $obj);
 
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 # Ghost:
 string(12) "O:1:"C":0:{}"
 object(C)#%d (0) {

--- a/Zend/tests/lazy_objects/serialize___sleep_skip_flag_may_initialize.phpt
+++ b/Zend/tests/lazy_objects/serialize___sleep_skip_flag_may_initialize.phpt
@@ -38,6 +38,7 @@ $obj = $reflector->newLazyProxy(function ($obj) {
 test('Proxy', $obj);
 
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 # Ghost:
 string(11) "initializer"
 int(1)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9351,6 +9351,11 @@ static void zend_compile_class_decl(znode *result, zend_ast *ast, bool toplevel)
 		ce->ce_flags |= ZEND_ACC_TOP_LEVEL;
 	}
 
+	if (ce->__serialize == NULL && zend_hash_exists(&ce->function_table, ZSTR_KNOWN(ZEND_STR_SLEEP))) {
+		zend_error(E_DEPRECATED, "The __sleep() serialization magic method has been deprecated."
+			" Implement __serialize() instead (or in addition, if support for old PHP versions is necessary)");
+	}
+
 	/* We currently don't early-bind classes that implement interfaces or use traits */
 	if (!ce->num_interfaces && !ce->num_traits && !ce->num_hooked_prop_variance_checks
 #ifdef ZEND_OPCACHE_SHM_REATTACHMENT

--- a/ext/dom/tests/gh8996.phpt
+++ b/ext/dom/tests/gh8996.phpt
@@ -80,6 +80,7 @@ echo "Serialized:\n-----------\n$serialized\n-----------\nRestored:\n-----------
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 === __sleep and __wakeup ===
 string(144) "O:34:"SerializableDomDocumentSleepWakeup":1:{s:43:"%0SerializableDomDocumentSleepWakeup%0xmlData";s:39:"<?xml version="1.0"?>
 <tag>value</tag>

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
@@ -110,6 +110,8 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_stmt_fetch_class');
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Creating an object, serializing it and writing it to DB...
 myclass::singleton(Creating object)

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
@@ -107,6 +107,8 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_stmt_fetch_serialize');
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Creating an object, serializing it and writing it to DB...
 myclass::singleton(Creating object)

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
@@ -110,6 +110,8 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test_stmt_fetchserialize_fetch_class');
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Creating an object, serializing it and writing it to DB...
 myclass::singleton(Creating object)

--- a/ext/phar/tests/phar_metadata_write4.phpt
+++ b/ext/phar/tests/phar_metadata_write4.phpt
@@ -68,6 +68,7 @@ unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar.php');
 unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar.php.copy.php');
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 In __destruct 1
 string(1) "a"
 Loading metadata for 'a' without allowed_classes

--- a/ext/session/tests/bug53141.phpt
+++ b/ext/session/tests/bug53141.phpt
@@ -13,10 +13,10 @@ spl_autoload_register(function ($class) {
 
 class Foo
 {
-    function __sleep()
+    function __serialize()
     {
         new Bar;
-        return array();
+        return [];
     }
 }
 

--- a/ext/standard/tests/serialize/001.phpt
+++ b/ext/standard/tests/serialize/001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-serialize()/unserialize()/var_dump()
+serialize()/unserialize()/var_dump() using __sleep() and __wakeup()
 --INI--
 serialize_precision=100
 --FILE--
@@ -78,6 +78,7 @@ $a = unserialize($data);
 var_dump($a);
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 N;
 b:1;
 b:0;

--- a/ext/standard/tests/serialize/005.phpt
+++ b/ext/standard/tests/serialize/005.phpt
@@ -128,6 +128,10 @@ echo "===AutoNA===\n";
 var_dump(unserialize('O:22:"autoload_not_available":0:{}'));
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 ===O1===
 TestOld::__sleep()

--- a/ext/standard/tests/serialize/bug14293.phpt
+++ b/ext/standard/tests/serialize/bug14293.phpt
@@ -26,6 +26,7 @@ var_dump($t);
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 __sleep called
 
 Warning: serialize(): "b" returned as member variable from __sleep() but does not exist in %s on line %d

--- a/ext/standard/tests/serialize/bug21957.phpt
+++ b/ext/standard/tests/serialize/bug21957.phpt
@@ -28,7 +28,8 @@ echo $s . "\n";
 
 var_dump(unserialize($s));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 array(2) {
   ["one"]=>
   string(3) "ABC"

--- a/ext/standard/tests/serialize/bug35895.phpt
+++ b/ext/standard/tests/serialize/bug35895.phpt
@@ -21,4 +21,8 @@ serialize($obj);
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): "parents" returned as member variable from __sleep() but does not exist in %s on line %d

--- a/ext/standard/tests/serialize/bug64354_3.phpt
+++ b/ext/standard/tests/serialize/bug64354_3.phpt
@@ -26,5 +26,7 @@ try {
 }
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(6) "Failed"

--- a/ext/standard/tests/serialize/bug65806.phpt
+++ b/ext/standard/tests/serialize/bug65806.phpt
@@ -73,7 +73,8 @@ function check(myObjC $obj) {
     return 'successful';
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 SCRIPT START
 check successful
 start serialize/unserialize

--- a/ext/standard/tests/serialize/bug69210.phpt
+++ b/ext/standard/tests/serialize/bug69210.phpt
@@ -34,7 +34,10 @@ echo $si . "\n";
 var_dump(unserialize($ss));
 var_dump(unserialize($si));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 O:10:"testString":1:{s:1:"a";b:1;}
 O:11:"testInteger":1:{s:1:"a";b:1;}
 object(testString)#3 (1) {

--- a/ext/standard/tests/serialize/bug70172_2.phpt
+++ b/ext/standard/tests/serialize/bug70172_2.phpt
@@ -48,7 +48,7 @@ function ptr2str($ptr)
 }
 ?>
 --EXPECTF--
-Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 array(2) {
   [0]=>
   object(obj2)#%d (1) {

--- a/ext/standard/tests/serialize/bug71995.phpt
+++ b/ext/standard/tests/serialize/bug71995.phpt
@@ -18,6 +18,8 @@ var_dump($s);
 var_dump(unserialize($s));
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): "b" is returned from __sleep() multiple times in %s on line %d
 string(39) "O:1:"A":1:{s:1:"b";O:8:"stdClass":0:{}}"
 object(A)#%d (1) {

--- a/ext/standard/tests/serialize/bug73154.phpt
+++ b/ext/standard/tests/serialize/bug73154.phpt
@@ -12,5 +12,6 @@ class a {
 $s = 'a:1:{i:0;O:1:"a":1:{s:1:"a";R:2;}}';
 var_dump(serialize(unserialize($s)));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(22) "a:1:{i:0;O:1:"a":0:{}}"

--- a/ext/standard/tests/serialize/bug79526.phpt
+++ b/ext/standard/tests/serialize/bug79526.phpt
@@ -24,6 +24,10 @@ serialize(new B());
 ?>
 Done
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): A::__sleep() should return an array only containing the names of instance-variables to serialize in %s on line %d
 
 Warning: serialize(): B::__sleep() should return an array only containing the names of instance-variables to serialize in %s on line %d

--- a/ext/standard/tests/serialize/bug81163.phpt
+++ b/ext/standard/tests/serialize/bug81163.phpt
@@ -18,4 +18,6 @@ class bar extends foo
 serialize(new bar());
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): bar::__sleep() should return an array only containing the names of instance-variables to serialize in %s on line %d

--- a/ext/standard/tests/serialize/sleep_deprecation_promoted_exception.phpt
+++ b/ext/standard/tests/serialize/sleep_deprecation_promoted_exception.phpt
@@ -1,0 +1,24 @@
+--TEST--
+__sleep() deprecation promoted to exception
+--FILE--
+<?php
+
+set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+    throw new ErrorException($errstr);
+});
+
+try {
+eval(<<<'CODE'
+    class Test {
+        public function __sleep() {
+            return [];
+        }
+    }
+CODE);
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ErrorException: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary)

--- a/ext/standard/tests/serialize/sleep_deprecation_promoted_exception2.inc
+++ b/ext/standard/tests/serialize/sleep_deprecation_promoted_exception2.inc
@@ -1,0 +1,7 @@
+<?php
+
+class Test {
+    public function __sleep() {
+        return [];
+    }
+}

--- a/ext/standard/tests/serialize/sleep_deprecation_promoted_exception2.phpt
+++ b/ext/standard/tests/serialize/sleep_deprecation_promoted_exception2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+___sleep() deprecation promoted to exception
+--FILE--
+<?php
+
+set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+    throw new ErrorException($errstr);
+});
+
+try {
+    require __DIR__ . '/sleep_deprecation_promoted_exception2.inc';
+} catch (Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+ErrorException: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary)

--- a/ext/standard/tests/serialize/sleep_deref.phpt
+++ b/ext/standard/tests/serialize/sleep_deref.phpt
@@ -14,5 +14,6 @@ class Test {
 var_dump(serialize(new Test));
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(28) "O:4:"Test":1:{s:1:"x";i:42;}"

--- a/ext/standard/tests/serialize/sleep_mangled_name_clash.phpt
+++ b/ext/standard/tests/serialize/sleep_mangled_name_clash.phpt
@@ -12,5 +12,7 @@ $s = serialize(new Test);
 var_dump(str_replace("\0", '\0', $s));
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): "priv" is returned from __sleep() multiple times in %s on line %d
 string(37) "O:4:"Test":1:{s:10:"\0Test\0priv";N;}"

--- a/ext/standard/tests/serialize/sleep_undefined_declared_properties.phpt
+++ b/ext/standard/tests/serialize/sleep_undefined_declared_properties.phpt
@@ -21,6 +21,8 @@ var_dump(serialize(new Test));
 
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): "pub" returned as member variable from __sleep() but does not exist in %s on line %d
 
 Warning: serialize(): "prot" returned as member variable from __sleep() but does not exist in %s on line %d

--- a/ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
+++ b/ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
@@ -32,7 +32,8 @@ var_dump(unserialize(serialize($t)) == $t);
 
 var_dump($t);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(15) "O:4:"Test":0:{}"
 bool(true)
 bool(true)

--- a/tests/classes/bug26737.phpt
+++ b/tests/classes/bug26737.phpt
@@ -18,5 +18,7 @@ $data = serialize($foo);
 var_dump(str_replace("\0", '\0', $data));
 ?>
 --EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+
 Warning: serialize(): "no_such" returned as member variable from __sleep() but does not exist in %s on line %d
 string(114) "O:3:"foo":3:{s:12:"\0foo\0private";s:7:"private";s:12:"\0*\0protected";s:9:"protected";s:6:"public";s:6:"public";}"

--- a/tests/classes/private_members_serialization.phpt
+++ b/tests/classes/private_members_serialization.phpt
@@ -19,5 +19,6 @@ class bar extends foo
 
 var_dump(str_replace("\0", '\0', serialize(new bar())));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(114) "O:3:"bar":3:{s:12:"\0foo\0private";s:7:"private";s:12:"\0*\0protected";s:9:"protected";s:6:"public";s:6:"public";}"


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods

Split from #19435 as `__sleep()` has an extremely easy migration path.