### PR TITLE
Fix GH-19688: Remove pattern overflow in zip addGlob()

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1786,7 +1786,7 @@ static void php_zip_add_from_pattern(INTERNAL_FUNCTION_PARAMETERS, int type) /* 
 					basename = php_basename(Z_STRVAL_P(zval_file), Z_STRLEN_P(zval_file), NULL, 0);
 					file_stripped = ZSTR_VAL(basename);
 					file_stripped_len = ZSTR_LEN(basename);
-				} else if (opts.remove_path && !memcmp(Z_STRVAL_P(zval_file), opts.remove_path, opts.remove_path_len)) {
+				} else if (opts.remove_path && Z_STRLEN_P(zval_file) > opts.remove_path_len && !memcmp(Z_STRVAL_P(zval_file), opts.remove_path, opts.remove_path_len)) {
 					if (IS_SLASH(Z_STRVAL_P(zval_file)[opts.remove_path_len])) {
 						file_stripped = Z_STRVAL_P(zval_file) + opts.remove_path_len + 1;
 						file_stripped_len = Z_STRLEN_P(zval_file) - opts.remove_path_len - 1;

--- a/ext/zip/tests/gh19688.phpt
+++ b/ext/zip/tests/gh19688.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-19688 (Remove pattern overflow in zip addGlob())
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+$dir = __DIR__ . '/';
+$testfile = $dir . '001.phpt';
+$zip = new ZipArchive();
+$filename = $dir . '/gh19688.zip';
+$zip->open($filename, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$options = array('remove_path' => $dir . 'a very long string here that will overrun');
+$zip->addGlob($testfile, 0, $options);
+var_dump($zip->getNameIndex(0));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__  . '/gh19688.zip');
+?>
+--EXPECTF--
+string(%d) "%s001.phpt"


### PR DESCRIPTION
memcmp() can overread the filename if the filename is shorter than the pattern.