### PR TITLE
Fix GH-19681 PHP_EXPAND_PATH broken with bash 5.3.0

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -64,7 +64,11 @@ AC_DEFUN([PHP_EXPAND_PATH],[
     changequote({,})
     ep_dir=`echo $1|$SED 's%/*[^/][^/]*/*$%%'`
     changequote([,])
-    ep_realdir=`(cd "$ep_dir" && pwd)`
+    if test -z $ep_dir ; then
+      ep_realdir=`(pwd)`
+    else
+      ep_realdir=`(cd "$ep_dir" && pwd)`
+    fi
     $2="$ep_realdir"/`basename "$1"`
   fi
 ])


### PR DESCRIPTION
With bash 5.3.0 `cd ""` (empty path) now outputs an error `sh: cd: null directory` and fails

