### PR TITLE
fpm: Improve the error message when FPM is running as root

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -859,7 +859,7 @@ static int fpm_conf_process_all_pools(void)
 
 		/* alert if user is not set; only if we are root and fpm is not running with --allow-to-run-as-root */
 		if (!wp->config->user && !geteuid() && !fpm_globals.run_as_root) {
-			zlog(ZLOG_ALERT, "[pool %s] user has not been defined", wp->config->name);
+			zlog(ZLOG_ALERT, "[pool %s] 'user' directive has not been specified when running as a root without --allow-to-run-as-root", wp->config->name);
 			return -1;
 		}
 

--- a/sapi/fpm/tests/proc-user-not-set-when-root.phpt
+++ b/sapi/fpm/tests/proc-user-not-set-when-root.phpt
@@ -1,0 +1,51 @@
+--TEST--
+FPM: Process user setting unset when running as root
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die("skip not for Windows");
+}
+require_once "tester.inc";
+
+if (!FPM\Tester::findExecutable()) {
+    die("skip php-fpm binary not found");
+}
+
+FPM\Tester::skipIfNotRoot();
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+ping.path = /ping
+ping.response = pong
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogAlert(
+    "'user' directive has not been specified when running as a root without --allow-to-run-as-root",
+    'unconfined'
+);
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/proc-user-not-set-when-root.phpt
+++ b/sapi/fpm/tests/proc-user-not-set-when-root.phpt
@@ -2,15 +2,7 @@
 FPM: Process user setting unset when running as root
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die("skip not for Windows");
-}
-require_once "tester.inc";
-
-if (!FPM\Tester::findExecutable()) {
-    die("skip php-fpm binary not found");
-}
-
+include "skipif.inc";
 FPM\Tester::skipIfNotRoot();
 ?>
 --FILE--
@@ -33,7 +25,9 @@ pm.max_spare_servers = 3
 EOT;
 
 $tester = new FPM\Tester($cfg);
-$tester->start();
+$tester->start(envVars: [
+    'TEST_FPM_RUN_AS_ROOT' => 0,
+]);
 $tester->expectLogAlert(
     "'user' directive has not been specified when running as a root without --allow-to-run-as-root",
     'unconfined'

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -540,7 +540,7 @@ class Tester
             $cmd[] = '-d' . $iniEntryName . '=' . $iniEntryValue;
         }
 
-        if (getenv('TEST_FPM_RUN_AS_ROOT')) {
+        if ($envVars['TEST_FPM_RUN_AS_ROOT'] ?? getenv('TEST_FPM_RUN_AS_ROOT')) {
             $cmd[] = '--allow-to-run-as-root';
         }
         $cmd = array_merge($cmd, $extraArgs);


### PR DESCRIPTION
The error messages in `fpm_conf_process_all_pools()` all deserve some clean-up, but this one was particularly bad, since it didn't explain the issue at all.