### PR TITLE
Fix GH-19685: Reject out-of-range blocks/work values in bzip2.compress filter

### DIFF
--- a/ext/bz2/bz2_filter.c
+++ b/ext/bz2/bz2_filter.c
@@ -440,6 +440,7 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 					zend_long blocks = zval_get_long(tmpzval);
 					if (blocks < 1 || blocks > 9) {
 						php_error_docref(NULL, E_WARNING, "Invalid parameter given for number of blocks to allocate (" ZEND_LONG_FMT ")", blocks);
+						goto cleanup;
 					} else {
 						blockSize100k = (int) blocks;
 					}
@@ -450,6 +451,7 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 					zend_long work = zval_get_long(tmpzval);
 					if (work < 0 || work > 250) {
 						php_error_docref(NULL, E_WARNING, "Invalid parameter given for work factor (" ZEND_LONG_FMT ")", work);
+						goto cleanup;
 					} else {
 						workFactor = (int) work;
 					}
@@ -470,13 +472,16 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 
 	if (status != BZ_OK) {
 		/* Unspecified (probably strm) error, let stream-filter error do its own whining */
-		pefree(data->strm.next_in, persistent);
-		pefree(data->strm.next_out, persistent);
-		pefree(data, persistent);
-		return NULL;
+		goto cleanup;
 	}
 
 	return php_stream_filter_alloc(fops, data, persistent, PSFS_SEEKABLE_START);
+
+cleanup:
+	pefree(data->strm.next_in, persistent);
+	pefree(data->strm.next_out, persistent);
+	pefree(data, persistent);
+	return NULL;
 }
 
 const php_stream_filter_factory php_bz2_filter_factory = {

--- a/ext/bz2/tests/bug72447.phpt
+++ b/ext/bz2/tests/bug72447.phpt
@@ -17,3 +17,5 @@ unlink('testfile');
 ?>
 --EXPECTF--
 Warning: stream_filter_append(): Invalid parameter given for number of blocks to allocate (0) in %s%ebug72447.php on line %d
+
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s%ebug72447.php on line %d

--- a/ext/bz2/tests/bz2_filter_invalid_params.phpt
+++ b/ext/bz2/tests/bz2_filter_invalid_params.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-19685: bzip2.compress filter with invalid parameters should fail gracefully
+--EXTENSIONS--
+bz2
+--FILE--
+<?php
+$stream = fopen('php://memory', 'w+');
+
+// too low
+$filter = stream_filter_append($stream, 'bzip2.compress', STREAM_FILTER_WRITE, array('blocks' => 0));
+var_dump($filter);
+
+// too high
+$filter = stream_filter_append($stream, 'bzip2.compress', STREAM_FILTER_WRITE, array('blocks' => 10));
+var_dump($filter);
+
+// too low work
+$filter = stream_filter_append($stream, 'bzip2.compress', STREAM_FILTER_WRITE, array('work' => -1));
+var_dump($filter);
+
+// too high work
+$filter = stream_filter_append($stream, 'bzip2.compress', STREAM_FILTER_WRITE, array('work' => 251));
+var_dump($filter);
+
+fclose($stream);
+?>
+--EXPECTF--
+Warning: stream_filter_append(): Invalid parameter given for number of blocks to allocate (0) in %s on line %d
+
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s on line %d
+bool(false)
+
+Warning: stream_filter_append(): Invalid parameter given for number of blocks to allocate (10) in %s on line %d
+
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s on line %d
+bool(false)
+
+Warning: stream_filter_append(): Invalid parameter given for work factor (-1) in %s on line %d
+
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s on line %d
+bool(false)
+
+Warning: stream_filter_append(): Invalid parameter given for work factor (251) in %s on line %d
+
+Warning: stream_filter_append(): Unable to create or locate filter "bzip2.compress" in %s on line %d
+bool(false)


### PR DESCRIPTION
Fix #19685 

When `blocks` or `work` have invalid values, it currently let the function execution continue. Instead, we should free some resources and return null to avoid the segfault.