### PR TITLE
PoC simple generational GC

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -165,9 +165,14 @@ ZEND_FUNCTION(gc_mem_caches)
    Returns number of freed zvals */
 ZEND_FUNCTION(gc_collect_cycles)
 {
-	ZEND_PARSE_PARAMETERS_NONE();
+	bool full_gc = true;
 
-	RETURN_LONG(gc_collect_cycles());
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(full_gc);
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(gc_collect_cycles(full_gc));
 }
 /* }}} */
 
@@ -231,6 +236,9 @@ ZEND_FUNCTION(gc_status)
 	add_assoc_double_ex(return_value, "collector_time", sizeof("collector_time")-1, (double) status.collector_time / ZEND_NANO_IN_SEC);
 	add_assoc_double_ex(return_value, "destructor_time", sizeof("destructor_time")-1, (double) status.dtor_time / ZEND_NANO_IN_SEC);
 	add_assoc_double_ex(return_value, "free_time", sizeof("free_time")-1, (double) status.free_time / ZEND_NANO_IN_SEC);
+	add_assoc_double_ex(return_value, "mark_roots_time", sizeof("mark_roots_time")-1, (double) status.mark_roots_time / ZEND_NANO_IN_SEC);
+	add_assoc_double_ex(return_value, "scan_roots_time", sizeof("scan_roots_time")-1, (double) status.scan_roots_time / ZEND_NANO_IN_SEC);
+	add_assoc_double_ex(return_value, "collect_roots_time", sizeof("collect_roots_time")-1, (double) status.collect_roots_time / ZEND_NANO_IN_SEC);
 }
 /* }}} */
 

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -204,7 +204,7 @@ function zend_thread_id(): int {}
 
 function gc_mem_caches(): int {}
 
-function gc_collect_cycles(): int {}
+function gc_collect_cycles(bool $full_gc = true): int {}
 
 function gc_enabled(): bool {}
 

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9b49f527064695c812cd204d9efc63c13681d942 */
+ * Stub hash: b6f62a97c96110bb42479f6bfd07d0266c5b723d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_clone, 0, 1, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
@@ -221,7 +221,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_gc_mem_caches arginfo_func_num_args
 
-#define arginfo_gc_collect_cycles arginfo_func_num_args
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gc_collect_cycles, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, full_gc, _IS_BOOL, 0, "true")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gc_enabled, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -422,7 +422,7 @@ ZEND_API void zend_shutdown_executor_values(bool fast_shutdown)
 
 #if ZEND_DEBUG
 		if (!CG(unclean_shutdown)) {
-			gc_collect_cycles();
+			gc_collect_cycles(true);
 		}
 #endif
 	} else {

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -21,6 +21,7 @@
 #define ZEND_GC_H
 
 #include "zend_hrtime.h"
+#include "zend_types.h"
 
 #ifndef GC_BENCH
 # define GC_BENCH 0
@@ -41,9 +42,12 @@ typedef struct _zend_gc_status {
 	zend_hrtime_t collector_time;
 	zend_hrtime_t dtor_time;
 	zend_hrtime_t free_time;
+	zend_hrtime_t mark_roots_time;
+	zend_hrtime_t scan_roots_time;
+	zend_hrtime_t collect_roots_time;
 } zend_gc_status;
 
-ZEND_API extern int (*gc_collect_cycles)(void);
+ZEND_API extern int (*gc_collect_cycles)(bool force_full_gc);
 
 ZEND_API void ZEND_FASTCALL gc_possible_root(zend_refcounted *ref);
 ZEND_API void ZEND_FASTCALL gc_remove_from_buffer(zend_refcounted *ref);
@@ -61,7 +65,7 @@ void gc_bench_print(void);
 #endif
 
 /* The default implementation of the gc_collect_cycles callback. */
-ZEND_API int  zend_gc_collect_cycles(void);
+ZEND_API int  zend_gc_collect_cycles(bool force_full_gc);
 
 ZEND_API void zend_gc_get_status(zend_gc_status *status);
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -766,10 +766,10 @@ static zend_always_inline uint8_t zval_get_type(const zval* pz) {
 	} while (0)
 
 #define GC_TYPE_MASK				0x0000000f
-#define GC_FLAGS_MASK				0x000003f0
-#define GC_INFO_MASK				0xfffffc00
+#define GC_FLAGS_MASK				0x000007f0
+#define GC_INFO_MASK				0xfffff800
 #define GC_FLAGS_SHIFT				0
-#define GC_INFO_SHIFT				10
+#define GC_INFO_SHIFT				11
 
 static zend_always_inline uint8_t zval_gc_type(uint32_t gc_type_info) {
 	return (gc_type_info & GC_TYPE_MASK);
@@ -812,6 +812,7 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 #define GC_IMMUTABLE                (1<<6) /* can't be changed in place */
 #define GC_PERSISTENT               (1<<7) /* allocated using malloc */
 #define GC_PERSISTENT_LOCAL         (1<<8) /* persistent, but thread-local */
+#define GC_RESERVED_1               (1<<10)
 
 #define GC_NULL						(IS_NULL         | (GC_NOT_COLLECTABLE << GC_FLAGS_SHIFT))
 #define GC_STRING					(IS_STRING       | (GC_NOT_COLLECTABLE << GC_FLAGS_SHIFT))


### PR DESCRIPTION
This is a PoC of making the GC generational.

In some applications, there is an object that transitively references everything (e.g. the DI container or the UnitOfWork), and many objects transitively reference the root as well. As a result, most GC runs in these applications will end up scanning the entire application.

Based on that, a generational GC _should_ improve throughput to some degree.

Unlike a tracing GC, we don't need to keep track of created inter-generational references, so this turns out relatively simple.

 1. Nodes that are scanned but not collected during a run are marked as OLD
 2. There are two kinds of GC runs: Partial and full. Partial runs ignore OLD nodes during trial deletion and other steps.
 4. gc_possible_root() adds OLD nodes to a separate buffer that doesn't count towards the threshold
 5. At the end of a partial run, OLD roots are moved to a separate buffer. This buffer is appended to the roots before full runs.

This is enabled by setting the environment variable `FULL_GC_FREQ` to a non-zero value (e.g. 10 will run a full GC every 10 runs).

I've used the following script to test this PoC: https://gist.github.com/arnaud-lb/6bfb493f361e056979571941f1b85990. This simulates a typical Doctrine or Symfony application.

The benchmark runs 10-20% faster when the root object (the Tree class) is large, or it creates garbage often (keeping the threshold low). The benchmark runs slower when the root object is relatively small and does not create garbage often, as the non-gen GC will keep the threshold high in this case. This could be mitigated by improving how the threshold is adjusted in the gen GC.