### PR TITLE
Fix GH-19706: dba stream resource mismanagement

### DIFF
--- a/ext/dba/tests/gh19706.phpt
+++ b/ext/dba/tests/gh19706.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-19706 (dba stream resource mismanagement)
+--EXTENSIONS--
+dba
+--FILE--
+<?php
+// Must be in the global scope such that it's part of the symbol table cleanup
+$db = dba_open(__DIR__ . '/gh19706.cdb', 'n', 'cdb_make');
+$db2 = $db;
+var_dump($db, $db2);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh19706.cdb');
+?>
+--EXPECT--
+object(Dba\Connection)#1 (0) {
+}
+object(Dba\Connection)#1 (0) {
+}


### PR DESCRIPTION
This regressed in 8.4 when dba started mixing objects and resources (streams).
The streams are first destroyed at a first step in shutdown, and in slow shutdown then the symbol table is destroyed which destroys the dba objects. The dba objects still use the streams but they have been destroyed already, causing a UAF. Using dtor_obj instead of free_obj would work around this but would cause issues like memory leaks because dtor_obj may be skipped while free_obj may not be. Instead, use the same solution as mysqlnd uses in that we fully manage the stream lifecycle ourselves. This also avoids users from meddling with the stream through get_resources().
This would be fixed 'automatically' in the future when we are using objects for everything.