### PR TITLE
Remove incorrect call to zval_ptr_dtor() in user_wrapper_metadata()

### DIFF
--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -1223,7 +1223,6 @@ static int user_wrapper_metadata(php_stream_wrapper *wrapper, const char *url, i
 			break;
 		default:
 			php_error_docref(NULL, E_WARNING, "Unknown option %d for " USERSTREAM_METADATA, option);
-			zval_ptr_dtor(&args[2]);
 			return ret;
 	}
 


### PR DESCRIPTION
This one is not initialized. This is not hittable from userspace code because all locations within first-party php-src code have a valid `option` argument.