### PR TITLE
Fix memory leak in zip when encountering empty glob result

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -668,7 +668,6 @@ int php_zip_glob(char *pattern, int pattern_len, zend_long flags, zval *return_v
 			   can be used for simple glob() calls without further error
 			   checking.
 			*/
-			array_init(return_value);
 			return 0;
 		}
 #endif
@@ -677,7 +676,6 @@ int php_zip_glob(char *pattern, int pattern_len, zend_long flags, zval *return_v
 
 	/* now catch the FreeBSD style of "no matches" */
 	if (!globbuf.gl_pathc || !globbuf.gl_pathv) {
-		array_init(return_value);
 		return 0;
 	}
 


### PR DESCRIPTION
The case of returning 0 is inconsistent in when it returns an empty array, furthermore the caller already returns an empty array. Because the caller overwrites the return value in these cases, it can cause a memory leak.

This is easier to trigger on master in some cases as different code paths are taken with the new bundled glob. On some platforms it is also triggerable on 8.3.