### PR TITLE
Fix GH-19720: Assertion failure when error handler throws when accessing a deprecated constant

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1459,6 +1459,9 @@ ZEND_API zend_result zend_update_class_constant(zend_class_constant *c, const ze
 	zval_ptr_dtor(&c->value);
 	ZVAL_COPY_VALUE(&c->value, &tmp);
 
+	/* may not return SUCCESS in case of an exception,
+	 * should've returned FAILURE in zval_update_constant_ex! */
+	ZEND_ASSERT(!EG(exception));
 	return SUCCESS;
 }
 

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -536,6 +536,9 @@ failure:
 
 	if (!(flags & ZEND_FETCH_CLASS_SILENT) && (ZEND_CONSTANT_FLAGS(c) & CONST_DEPRECATED)) {
 		zend_error(E_DEPRECATED, "Constant %s is deprecated", name);
+		if (UNEXPECTED(EG(exception))) {
+			return NULL;
+		}
 	}
 	return &c->value;
 }

--- a/ext/zend_test/tests/gh19720.phpt
+++ b/ext/zend_test/tests/gh19720.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-19720 (Assertion failure when error handler throws when accessing a deprecated constant)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+class Test {
+    public const MyConst = [ZEND_TEST_DEPRECATED => 42];
+}
+
+set_error_handler(function ($_, $errstr) {
+    throw new Exception($errstr);
+});
+
+try {
+    var_dump(Test::MyConst);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Constant ZEND_TEST_DEPRECATED is deprecated


### PR DESCRIPTION
When deprecation causes an exception, we should return NULL instead of continuing.