### PR TITLE
Fix GH-19570: unable to fseek in /dev/zero and /dev/null

### DIFF
--- a/ext/standard/tests/streams/gh19570.phpt
+++ b/ext/standard/tests/streams/gh19570.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-19570 (unable to fseek in /dev/zero and /dev/null)
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== "Linux") die("skip only for Linux");
+?>
+--FILE--
+<?php
+var_dump(fseek(fopen("/dev/zero", "rb"), 1*1024*1024, SEEK_SET));
+var_dump(fseek(fopen("/dev/null", "rb"), 1*1024*1024, SEEK_SET));
+?>
+--EXPECT--
+int(0)
+int(0)

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -43,6 +43,10 @@
 # include <limits.h>
 #endif
 
+#ifdef __linux__
+# include <sys/sysmacros.h>
+#endif
+
 #define php_stream_fopen_from_fd_int(fd, mode, persistent_id)	_php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_CC)
 #define php_stream_fopen_from_fd_int_rel(fd, mode, persistent_id)	 _php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_REL_CC)
 #define php_stream_fopen_from_file_int(file, mode)	_php_stream_fopen_from_file_int((file), (mode) STREAMS_CC)
@@ -255,7 +259,18 @@ PHPAPI php_stream *_php_stream_fopen_tmpfile(int dummy STREAMS_DC)
 static void detect_is_seekable(php_stdio_stream_data *self) {
 #if defined(S_ISFIFO) && defined(S_ISCHR)
 	if (self->fd >= 0 && do_fstat(self, 0) == 0) {
+#ifdef __linux__
+		if (S_ISCHR(self->sb.st_mode)) {
+			/* /dev/null & /dev/zero are exceptions, check their major/minor ID
+			 * https://www.kernel.org/doc/Documentation/admin-guide/devices.txt */
+			self->is_seekable = major(self->sb.st_rdev) == 1
+							&& (minor(self->sb.st_rdev) == 3 || minor(self->sb.st_rdev) == 5);
+		} else {
+			self->is_seekable = !S_ISFIFO(self->sb.st_mode);
+		}
+#else
 		self->is_seekable = !(S_ISFIFO(self->sb.st_mode) || S_ISCHR(self->sb.st_mode));
+#endif
 		self->is_pipe = S_ISFIFO(self->sb.st_mode);
 	}
 #elif defined(PHP_WIN32)


### PR DESCRIPTION
On Linux, these two character devices are exceptions in that they can be seeked. Check their major/minor device number.