### PR TITLE
Fix unhelpful error messages with multiple PHP CLI workers

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2721,14 +2721,16 @@ static zend_result php_cli_server_do_event_for_each_fd_callback(void *_params, p
 		struct sockaddr *sa = pemalloc(server->socklen, 1);
 		client_sock = accept(server->server_sock, sa, &socklen);
 		if (!ZEND_VALID_SOCKET(client_sock)) {
-			int err = php_socket_errno();
-			if (err != SOCK_EAGAIN && php_cli_server_log_level >= PHP_CLI_SERVER_LOG_ERROR) {
+			pefree(sa, 1);
+			if (php_socket_errno() == SOCK_EAGAIN) {
+				return SUCCESS;
+			}
+			if (php_cli_server_log_level >= PHP_CLI_SERVER_LOG_ERROR) {
 				char *errstr = php_socket_strerror(php_socket_errno(), NULL, 0);
 				php_cli_server_logf(PHP_CLI_SERVER_LOG_ERROR,
 					"Failed to accept a client (reason: %s)", errstr);
 				efree(errstr);
 			}
-			pefree(sa, 1);
 			return FAILURE;
 		}
 		if (SUCCESS != php_set_sock_blocking(client_sock, 0)) {


### PR DESCRIPTION
## Context

When the `PHP_CLI_SERVER_WORKERS` environment variable is set to >=2, the PHP error log contains a flood of error messages titled "Failed to poll event". It seems like more service workers also increase the number and likelyhood of these messages.

This has previously been reported to the Laravel project, where they filter out this message from their logs manually: https://github.com/laravel/framework/pull/52094

<details>
    <summary>Output log</summary>
<pre>$ PHP_CLI_SERVER_WORKERS=10 php -S localhost:8080 index.php
[117756] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117757] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117758] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117759] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117760] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117761] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117762] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117763] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117755] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117764] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117765] [Sat Sep  6 13:48:43 2025] PHP 8.4.12 Development Server (http://localhost:8080) started
[117755] [Sat Sep  6 13:48:47 2025] [::1]:43226 Accepted
[117755] [Sat Sep  6 13:48:47 2025] [::1]:43226 Closing
[117755] [Sat Sep  6 13:48:50 2025] [::1]:38070 Accepted
[117757] [Sat Sep  6 13:48:50 2025] Failed to poll event
[117760] [Sat Sep  6 13:48:50 2025] Failed to poll event
[117755] [Sat Sep  6 13:48:50 2025] [::1]:38070 Closing
[117759] [Sat Sep  6 13:48:51 2025] [::1]:38084 Accepted
[117759] [Sat Sep  6 13:48:51 2025] [::1]:38084 Closing
[117759] [Sat Sep  6 13:48:52 2025] Failed to poll event
[117760] [Sat Sep  6 13:48:52 2025] Failed to poll event
[117757] [Sat Sep  6 13:48:52 2025] Failed to poll event
[117755] [Sat Sep  6 13:48:52 2025] [::1]:38092 Accepted
[117755] [Sat Sep  6 13:48:52 2025] [::1]:38092 Closing
[117757] [Sat Sep  6 13:48:53 2025] Failed to poll event
[117759] [Sat Sep  6 13:48:53 2025] Failed to poll event
[117763] [Sat Sep  6 13:48:53 2025] [::1]:38102 Accepted
[117763] [Sat Sep  6 13:48:53 2025] [::1]:38102 Closing
[117763] [Sat Sep  6 13:48:55 2025] Failed to poll event
[117759] [Sat Sep  6 13:48:55 2025] [::1]:38116 Accepted
[117757] [Sat Sep  6 13:48:55 2025] Failed to poll event
[117759] [Sat Sep  6 13:48:55 2025] [::1]:38116 Closing
[117759] [Sat Sep  6 13:48:56 2025] Failed to poll event
[117755] [Sat Sep  6 13:48:56 2025] Failed to poll event
[117763] [Sat Sep  6 13:48:56 2025] Failed to poll event
[117757] [Sat Sep  6 13:48:56 2025] [::1]:38118 Accepted
[117757] [Sat Sep  6 13:48:56 2025] [::1]:38118 Closing
</pre>
</details>

## My diagnosis

I think this happens because multiple workers will (correctly) poll on the same set of shared file descriptors. As the workers get notified that a file descriptor is ready, they race to accept. However, only the first worker will succeed, while others receive an `EAGAIN` error.

## My solution

My solution simply considers a socket callback getting an `EAGAIN` error as that callback succeeding. I think this is fine, because I assume that the only way the `accept` call would return this error code is because the request is already being handled by another worker. It is possible that this assumption is incorrect, in which case a different solution would be required.

It would also be possible to simply remove or downgrade the "Failed to poll event" as _real_ connection errors already get logged [here](https://github.com/php/php-src/blob/366a5a2b37cb1c490ce35117711c1804168ca08f/sapi/cli/php_cli_server.c#L2716).
