### PR TITLE
Fix GET_SHELL_CB macro for static builds 

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -739,12 +739,7 @@ typedef cli_shell_callbacks_t *(__cdecl *get_cli_shell_callbacks)(void);
 	} while(0)
 
 #else
-/*
 #ifdef COMPILE_DL_READLINE
-This dlsym() is always used as even the CGI SAPI is linked against "CLI"-only
-extensions. If that is being changed dlsym() should only be used when building
-this extension sharedto offer compatibility.
-*/
 #define GET_SHELL_CB(cb) \
 	do { \
 		(cb) = NULL; \
@@ -754,9 +749,9 @@ this extension sharedto offer compatibility.
 			(cb) = get_callbacks(); \
 		} \
 	} while(0)
-/*#else
+#else
 #define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()
-#endif*/
+#endif
 #endif
 
 PHP_MINIT_FUNCTION(cli_readline)


### PR DESCRIPTION
Restore conditional compilation for GET_SHELL_CB macro to support static builds.

This PR fixes the interactive shell `-a` not running with musl-static binaries.

EDIT: Oh, I didn't realize this issue only applies to CLI. For other SAPIs, should we use NULL or dlsym directly?