### PR TITLE
Fix memory leak on failure in phar_convert_to_other()

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2229,6 +2229,12 @@ static zend_object *phar_convert_to_other(phar_archive_data *source, int convert
 	PHAR_G(last_phar) = NULL;
 	PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
 
+	php_stream *tmp_fp = php_stream_fopen_tmpfile();
+	if (tmp_fp == NULL) {
+		zend_throw_exception_ex(phar_ce_PharException, 0, "unable to create temporary file");
+		return NULL;
+	}
+
 	phar = (phar_archive_data *) ecalloc(1, sizeof(phar_archive_data));
 	/* set whole-archive compression and type from parameter */
 	phar->flags = flags;
@@ -2253,11 +2259,7 @@ static zend_object *phar_convert_to_other(phar_archive_data *source, int convert
 	zend_hash_init(&phar->virtual_dirs, sizeof(char *),
 		zend_get_hash_value, NULL, 0);
 
-	phar->fp = php_stream_fopen_tmpfile();
-	if (phar->fp == NULL) {
-		zend_throw_exception_ex(phar_ce_PharException, 0, "unable to create temporary file");
-		return NULL;
-	}
+	phar->fp = tmp_fp;
 	phar->fname = source->fname;
 	phar->fname_len = source->fname_len;
 	phar->is_temporary_alias = source->is_temporary_alias;


### PR DESCRIPTION
Discovered by coincidence while looking at https://github.com/php/php-src/issues/19752