### PR TITLE
Fix GH-19752: Phar decompression with invalid extension can cause UAF

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2324,7 +2324,11 @@ no_copy:
 			if (phar->fp) {
 				php_stream_close(phar->fp);
 			}
-			efree(phar->fname);
+			if (phar->fname != source->fname) {
+				/* Depending on when phar_rename_archive() errors, the new filename
+				 * may have already been assigned or it may still be the old one. */
+				efree(phar->fname);
+			}
 			efree(phar);
 		}
 		return NULL;

--- a/ext/phar/tests/gh19752.phpt
+++ b/ext/phar/tests/gh19752.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-19752 (Phar decompression with invalid extension can cause UAF)
+--FILE--
+<?php
+$phar = new PharData(__DIR__.'/gh19752.1');
+try {
+    $phar->decompress("*");
+} catch (BadMethodCallException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+data phar converted from "%sgh19752.1" has invalid extension *


### PR DESCRIPTION
The rename code can error out prior to the reassignment of the filename, which is why the test causes a crash.
The rename code can also error out at a later point, which means it will have already assigned the new filename. We detect in which case we are in and act accordingly.