### PR TITLE
Fix GH-19701: Serialize/deserialize loses some data

### DIFF
--- a/ext/standard/tests/serialize/gh19701.phpt
+++ b/ext/standard/tests/serialize/gh19701.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-19701 (Serialize/deserialize loses some data)
+--CREDITS--
+cuchac
+DanielEScherzer
+--FILE--
+<?php
+
+class Item {
+    public $children = [];
+    public $parent = null;
+
+    public function __sleep() {
+        return ["children", "parent"];
+    }
+}
+
+$baseProduct = new Item();
+
+$child = new Item();
+$child->parent = $baseProduct;
+$baseProduct->children = [ $child ];
+
+$data = [clone $baseProduct, $baseProduct];
+
+echo serialize($data), "\n";
+
+?>
+--EXPECT--
+a:2:{i:0;O:4:"Item":2:{s:8:"children";a:1:{i:0;O:4:"Item":2:{s:8:"children";a:0:{}s:6:"parent";O:4:"Item":2:{s:8:"children";a:1:{i:0;r:4;}s:6:"parent";N;}}}s:6:"parent";N;}i:1;r:6;}

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -951,18 +951,11 @@ static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable
 			/* we should still add element even if it's not OK,
 			 * since we already wrote the length of the array before */
 			if (Z_TYPE_P(data) == IS_ARRAY) {
-				if (UNEXPECTED(Z_IS_RECURSIVE_P(data))
-					|| UNEXPECTED(Z_TYPE_P(struc) == IS_ARRAY && Z_ARR_P(data) == Z_ARR_P(struc))) {
+				if (UNEXPECTED(Z_TYPE_P(struc) == IS_ARRAY && Z_ARR_P(data) == Z_ARR_P(struc))) {
 					php_add_var_hash(var_hash, struc, in_rcn_array);
 					smart_str_appendl(buf, "N;", 2);
 				} else {
-					if (Z_REFCOUNTED_P(data)) {
-						Z_PROTECT_RECURSION_P(data);
-					}
 					php_var_serialize_intern(buf, data, var_hash, in_rcn_array, false);
-					if (Z_REFCOUNTED_P(data)) {
-						Z_UNPROTECT_RECURSION_P(data);
-					}
 				}
 			} else {
 				php_var_serialize_intern(buf, data, var_hash, in_rcn_array, false);


### PR DESCRIPTION
See GH-19701 for discussion.
This now restores the (correct) serialization output from versions PHP 7.4.1 and below.