### PR TITLE
Fix memory leak when providing an invalid locale to IntlDateFormatter

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -119,8 +119,8 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	locale = Locale::createFromName(final_locale);
 	/* get*Name accessors being set does not preclude being bogus */
 	if (locale.isBogus() || ((locale_len == 1 && locale_str[0] != 'C') || (locale_len > 1 && strlen(locale.getISO3Language()) == 0))) {
-        zend_argument_value_error(1, "\"%s\" is invalid", locale_str);
-		return FAILURE;
+		zend_argument_value_error(1, "\"%s\" is invalid", locale_str);
+		goto error;
 	}
 
 	/* process calendar */


### PR DESCRIPTION
Introduced in #19593 but only leaking from PHP 8.4.