### PR TITLE
zend_API: Do not overwrite `readonly` properties in `object_properties_load()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-19681 (PHP_EXPAND_PATH broken with bash 5.3.0). (Remi)
   . Fixed bug GH-19720 (Assertion failure when error handler throws when
     accessing a deprecated constant). (nielsdos)
+  . Fixed bug GH-19765 (object_properties_load() bypasses readonly property
+    checks). (timwolla)
 
 - CLI:
   . Fixed bug GH-19461 (Improve error message on listening error with IPv6

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1701,6 +1701,14 @@ ZEND_API void object_properties_load(zend_object *object, HashTable *properties)
 				property_info &&
 				(property_info->flags & ZEND_ACC_STATIC) == 0) {
 				zval *slot = OBJ_PROP(object, property_info->offset);
+				if (UNEXPECTED((property_info->flags & ZEND_ACC_READONLY) && !Z_ISUNDEF_P(slot))) {
+					if (Z_PROP_FLAG_P(slot) & IS_PROP_REINITABLE) {
+						Z_PROP_FLAG_P(slot) &= ~IS_PROP_REINITABLE;
+					} else {
+						zend_readonly_property_modification_error(property_info);
+						return;
+					}
+				}
 				zval_ptr_dtor(slot);
 				ZVAL_COPY_VALUE(slot, prop);
 				zval_add_ref(slot);

--- a/ext/random/tests/03_randomizer/gh_19765_unserialize.phpt
+++ b/ext/random/tests/03_randomizer/gh_19765_unserialize.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-19765: object_properties_load() bypasses readonly property checks
+--FILE--
+<?php
+
+use Random\Engine\Mt19937;
+use Random\Engine\PcgOneseq128XslRr64;
+use Random\Randomizer;
+
+try {
+    $r = new Randomizer(new Mt19937());
+    $r->__unserialize([['engine' => new PcgOneseq128XslRr64()]]);
+} catch (Exception $error) {
+    echo $error->getMessage() . "\n";
+}
+var_dump($r->engine::class);
+
+?>
+--EXPECT--
+Invalid serialization data for Random\Randomizer object
+string(21) "Random\Engine\Mt19937"

--- a/ext/random/tests/03_randomizer/gh_9186_unserialize.phpt
+++ b/ext/random/tests/03_randomizer/gh_9186_unserialize.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Fix GH-9186 @strict-properties can be bypassed using unserialization
+GH-9186: @strict-properties can be bypassed using unserialization
 --FILE--
 <?php
 


### PR DESCRIPTION
Fixes php/php-src#19765.