### PR TITLE
mbstring: deprecate mb_internal_encoding() and mb_http_output()

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -24,6 +24,7 @@
 #include "php.h"
 #include "php_ini.h"
 #include "php_variables.h"
+#include "zend_attributes.h"
 #include "mbstring.h"
 #include "ext/standard/php_string.h"
 #include "ext/standard/php_mail.h"

--- a/ext/mbstring/mbstring.stub.php
+++ b/ext/mbstring/mbstring.stub.php
@@ -55,6 +55,7 @@ const MB_CASE_FOLD_SIMPLE = UNKNOWN;
 function mb_language(?string $language = null): string|bool {}
 
 /** @refcount 1 */
+ #[\Deprecated(since: '8.5', message: 'use internal_encoding INI settings instead')]
 function mb_internal_encoding(?string $encoding = null): string|bool {}
 
 /**
@@ -64,6 +65,7 @@ function mb_internal_encoding(?string $encoding = null): string|bool {}
 function mb_http_input(?string $type = null): array|string|false {}
 
 /** @refcount 1 */
+#[\Deprecated(since: '8.5', message: 'use output_encoding INI settings instead')]
 function mb_http_output(?string $encoding = null): string|bool {}
 
 /**

--- a/ext/mbstring/mbstring_arginfo.h
+++ b/ext/mbstring/mbstring_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 03c07f68bea7d7b96e6dc11f180f45663b859ed3 */
+ * Stub hash: 65f39a3821d61adec378cf6ae28dfe8cd9e8ec2d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_language, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, language, IS_STRING, 1, "null")
@@ -364,9 +364,9 @@ ZEND_FUNCTION(mb_regex_set_options);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mb_language, arginfo_mb_language)
-	ZEND_FE(mb_internal_encoding, arginfo_mb_internal_encoding)
+	ZEND_RAW_FENTRY("mb_internal_encoding", zif_mb_internal_encoding, arginfo_mb_internal_encoding, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(mb_http_input, arginfo_mb_http_input)
-	ZEND_FE(mb_http_output, arginfo_mb_http_output)
+	ZEND_RAW_FENTRY("mb_http_output", zif_mb_http_output, arginfo_mb_http_output, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(mb_detect_order, arginfo_mb_detect_order)
 	ZEND_FE(mb_substitute_character, arginfo_mb_substitute_character)
 	ZEND_FE(mb_preferred_mime_name, arginfo_mb_preferred_mime_name)
@@ -446,4 +446,19 @@ static void register_mbstring_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("MB_CASE_LOWER_SIMPLE", PHP_UNICODE_CASE_LOWER_SIMPLE, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("MB_CASE_TITLE_SIMPLE", PHP_UNICODE_CASE_TITLE_SIMPLE, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("MB_CASE_FOLD_SIMPLE", PHP_UNICODE_CASE_FOLD_SIMPLE, CONST_PERSISTENT);
+
+
+	zend_attribute *attribute_Deprecated_func_mb_internal_encoding_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mb_internal_encoding", sizeof("mb_internal_encoding") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	ZVAL_STR(&attribute_Deprecated_func_mb_internal_encoding_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_5));
+	attribute_Deprecated_func_mb_internal_encoding_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_mb_internal_encoding_0_arg1_str = zend_string_init("use internal_encoding INI settings instead", strlen("use internal_encoding INI settings instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mb_internal_encoding_0->args[1].value, attribute_Deprecated_func_mb_internal_encoding_0_arg1_str);
+	attribute_Deprecated_func_mb_internal_encoding_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_mb_http_output_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mb_http_output", sizeof("mb_http_output") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
+	ZVAL_STR(&attribute_Deprecated_func_mb_http_output_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_5));
+	attribute_Deprecated_func_mb_http_output_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zend_string *attribute_Deprecated_func_mb_http_output_0_arg1_str = zend_string_init("use output_encoding INI settings instead", strlen("use output_encoding INI settings instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mb_http_output_0->args[1].value, attribute_Deprecated_func_mb_http_output_0_arg1_str);
+	attribute_Deprecated_func_mb_http_output_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 }

--- a/ext/mbstring/tests/bug45239.phpt
+++ b/ext/mbstring/tests/bug45239.phpt
@@ -12,5 +12,6 @@ mb_internal_encoding("utf-8");
 mb_parse_str("a=%fc", $dummy);
 var_dump(mb_http_input());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"

--- a/ext/mbstring/tests/bug48697.phpt
+++ b/ext/mbstring/tests/bug48697.phpt
@@ -18,8 +18,22 @@ var_dump(mb_internal_encoding());
 ?>
 --EXPECTF--
 Deprecated: ini_set(): Use of mbstring.internal_encoding is deprecated in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-15"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"

--- a/ext/mbstring/tests/bug69079.phpt
+++ b/ext/mbstring/tests/bug69079.phpt
@@ -2,6 +2,8 @@
 Bug #69079 (enhancement for mb_substitute_character)
 --EXTENSIONS--
 mbstring
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 

--- a/ext/mbstring/tests/bug69086.phpt
+++ b/ext/mbstring/tests/bug69086.phpt
@@ -2,6 +2,8 @@
 Request #69086 (enhancement for mb_convert_encoding)
 --EXTENSIONS--
 mbstring
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 mb_substitute_character(0xfffd);

--- a/ext/mbstring/tests/casefold.phpt
+++ b/ext/mbstring/tests/casefold.phpt
@@ -12,7 +12,8 @@ output_handler=
     print mb_strtoupper( "הכן\n" );
     print mb_convert_case( "הכן\n", MB_CASE_TITLE );
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 abcdefghijklmnopqrstuvwxyz
 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ִֻֿ

--- a/ext/mbstring/tests/casemapping.phpt
+++ b/ext/mbstring/tests/casemapping.phpt
@@ -65,7 +65,7 @@ echo mb_convert_case("ΚΑΛΗΣΠΕΡΑ ΣΑΣ", MB_CASE_LOWER, "UTF-8"), "\n";
 echo mb_convert_case("ΚΑΛΗΣΠΕΡΑ ΣΑΣ", MB_CASE_LOWER_SIMPLE, "UTF-8"), "\n";
 
 ?>
---EXPECT--
+--EXPECTF--
 String: ß
 Lower: ß
 Lower Simple: ß
@@ -96,6 +96,8 @@ Title Simple: İ
 Fold: i̇
 Fold Simple: İ
 
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 69
 69
 69

--- a/ext/mbstring/tests/gh13815.phpt
+++ b/ext/mbstring/tests/gh13815.phpt
@@ -13,8 +13,10 @@ $strSjis = mb_convert_encoding($strUtf8, 'Shift_JIS', 'UTF-8');
 var_dump(mb_strlen(mb_trim($strSjis)));
 var_dump(mb_strlen(mb_trim($strSjis, encoding: 'Shift_JIS')));
 ?>
---EXPECT--
+--EXPECTF--
 int(1)
 int(1)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 int(1)
 int(1)

--- a/ext/mbstring/tests/gh9535.phpt
+++ b/ext/mbstring/tests/gh9535.phpt
@@ -2,6 +2,8 @@
 GH-9535 (mb_strcut(): The behavior of mb_strcut in mbstring has been changed in PHP8.1)
 --EXTENSIONS--
 mbstring
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 $encodings = [

--- a/ext/mbstring/tests/gh9535b.phpt
+++ b/ext/mbstring/tests/gh9535b.phpt
@@ -2,6 +2,8 @@
 Test output of mb_strcut for text encodings which use escape sequences
 --EXTENSIONS--
 mbstring
+--INI--
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 

--- a/ext/mbstring/tests/ini_language.phpt
+++ b/ext/mbstring/tests/ini_language.phpt
@@ -10,6 +10,8 @@ mbstring.language=Japanese
 var_dump(ini_get('internal_encoding'));
 var_dump(mb_internal_encoding());
 ?>
---EXPECT--
+--EXPECTF--
 string(9) "Shift_JIS"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "SJIS"

--- a/ext/mbstring/tests/internal_encoding.phpt
+++ b/ext/mbstring/tests/internal_encoding.phpt
@@ -46,23 +46,38 @@ var_dump(mb_strlen("\xc3\xb6"));
 
 ?>
 --EXPECTF--
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-1"
 int(2)
 
 Deprecated: ini_set(): Use of mbstring.internal_encoding is deprecated in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 int(1)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 int(1)
 
 Deprecated: ini_set(): Use of mbstring.internal_encoding is deprecated in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-2"
 int(2)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 int(1)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 int(1)
 
 Deprecated: ini_set(): Use of mbstring.internal_encoding is deprecated in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-3"
 int(2)

--- a/ext/mbstring/tests/mb_chr.phpt
+++ b/ext/mbstring/tests/mb_chr.phpt
@@ -46,7 +46,7 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 bool(true)
@@ -56,4 +56,6 @@ mb_chr(): Argument #2 ($encoding) must be a valid encoding, "pass" given
 mb_chr() does not support the "JIS" encoding
 mb_chr() does not support the "CP50222" encoding
 mb_chr() does not support the "UTF-7" encoding
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 mb_chr() does not support the "UTF-7" encoding

--- a/ext/mbstring/tests/mb_decode_mimeheader_variation4.phpt
+++ b/ext/mbstring/tests/mb_decode_mimeheader_variation4.phpt
@@ -8,89 +8,89 @@ mbstring
 // We convert runs of whitespace, including CR, LF, tab, and space, to a single space...
 // but ONLY when that run of whitespace does not occur right in the middle between two
 // valid MIME encoded words
-mb_internal_encoding('UCS-2');
+ini_set('internal_encoding', 'UCS-2');
 var_dump(bin2hex(mb_decode_mimeheader("2,\rGCG\xb3GS")));
 
 // We DO convert a run of whitespace to a single space at the very beginning of the input string,
 // as long as it is followed by a non-whitespace character
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("\n8i")));
 
 // But not if it is just a CR or LF at the end of the string
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("\r")));
 
 // Not if it is a run of whitespace going right up to the end of the string
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("\n ")));
 
 // Handle = which doesn't initiate a valid encoded word
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader(",\x13@=,")));
 
 // Encoded word which should not be accepted
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?I?B??=")));
 
 // Encoded word with invalid charset name, and input string ends with whitespace
 // The old implementation of mb_decode_mimeheader would get 'stuck' on the invalid encoding name
 // and could never get out of that state; it would not even try to interpret any other encoded words
 // up to the end of the input string
-mb_internal_encoding('ISO-8859-7');
+ini_set('internal_encoding', 'ISO-8859-7');
 var_dump(bin2hex(mb_decode_mimeheader("=?=\x20?=?R\xb7=?=\x20?\x8b\x00====?===??=\xc5UC-R\xb7=?=\x20?=?=====?=\x20?======?======?=\x20?======?===??=\xc5UC-KR\xb7=?=\x20?=?===?==?\x0a")));
 
 // While the old implementation would generally trim off whitespace at the end of the input string,
 // but there was a bug whereby it would not do this when the whitespace character was the 100th
 // byte of an invalid charset name
-mb_internal_encoding('UCS-2');
+ini_set('internal_encoding', 'UCS-2');
 var_dump(bin2hex(mb_decode_mimeheader("=?\xc2\x86tf7,U\x01\x00`@\x00\x04|\xf1D\x18\x00\x00\x00v\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xff\x13f7,U&\x00S\x01\x00\x17,D\xcb\xcb\xcb\xcb\xcb\xcb\xcb\x01\x00\x00\x14\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\xcb\x00\x11\x00\x00\x00\x00\x00\x00\x0a")));
 
 // Empty encoded word
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?us?B?")));
 
 // Encoded word with just one invalid Base64 byte
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?us?B?-")));
 
 // Encoded word with an invalid Base64 byte followed by a valid Base64 byte
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?us?B?-s")));
 
 // Empty encoded word with a ? which looks like it should be terminator, but = is missing
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?us?B??")));
 
 // Encoded word with just one invalid Base64 byte, but this time properly terminated
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?us?B?\x00?=")));
 
 // Invalid encoded word, followed immediately by valid encoded word
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?=?hz?b?")));
 
 // Another example of invalid encoded word followed immediately by valid encoded word
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?==?hz?b?")));
 
 // Yet another example
-mb_internal_encoding('ASCII');
+ini_set('internal_encoding', 'ASCII');
 var_dump(bin2hex(mb_decode_mimeheader("=?,=?hz?b?")));
 
 // In PHP 8.0-8.1 this would cause a crash
-mb_internal_encoding('UUENCODE');
+ini_set('internal_encoding', 'UUENCODE');
 var_dump(bin2hex(mb_decode_mimeheader("")));
 
 // The conversion filter for SJIS-Mobile#SOFTBANK did not work correctly when it was
 // passed the last buffer of wchars without passing 'end' flag, then called one more
 // time with an empty buffer and 'end' flag to finish up
-mb_internal_encoding('SJIS-Mobile#SOFTBANK');
+ini_set('internal_encoding', 'SJIS-Mobile#SOFTBANK');
 var_dump(bin2hex(mb_decode_mimeheader("6")));
 
 // Same for SJIS-Mobile#KDDI and SJIS-Mobile#DOCOMO
-mb_internal_encoding('SJIS-Mobile#KDDI');
+ini_set('internal_encoding', 'SJIS-Mobile#SOFTBANK');
 var_dump(bin2hex(mb_decode_mimeheader("6")));
-mb_internal_encoding('SJIS-Mobile#DOCOMO');
+ini_set('internal_encoding', 'SJIS-Mobile#SOFTBANK');
 var_dump(bin2hex(mb_decode_mimeheader("6")));
 
 ?>

--- a/ext/mbstring/tests/mb_encode_mimeheader_basic.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_basic.phpt
@@ -24,7 +24,7 @@ foreach ($english as $lang => $input) {
     var_dump(mb_encode_mimeheader($input, 'UTF-8', 'Q'));
 }
 
-mb_internal_encoding('utf-8');
+ini_set('internal_encoding', 'utf-8');
 
 foreach ($nonEnglish as $lang => $input) {
     echo "\nLanguage: $lang\n";

--- a/ext/mbstring/tests/mb_encode_mimeheader_basic2.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_basic2.phpt
@@ -22,7 +22,7 @@ $inputs = array('SJIS' => $sjis_string,
 foreach ($inputs as $lang => $input) {
     echo "\nLanguage: $lang\n";
     echo "-- Base 64: --\n";
-    mb_internal_encoding($lang);
+    ini_set('internal_encoding', $lang);
     $outEncoding = "UTF-8";
     var_dump(mb_encode_mimeheader($input, $outEncoding, 'B'));
     echo "-- Quoted-Printable --\n";

--- a/ext/mbstring/tests/mb_encode_mimeheader_basic3.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_basic3.phpt
@@ -22,7 +22,7 @@ $inputs = array('SJIS' => $sjis_string,
 foreach ($inputs as $lang => $input) {
     echo "\nLanguage: $lang\n";
     echo "-- Base 64: --\n";
-    mb_internal_encoding($lang);
+    ini_set('internal_encoding', $lang);
     $outEncoding = $lang;
     var_dump(mb_encode_mimeheader($input, $outEncoding, 'B'));
     echo "-- Quoted-Printable --\n";

--- a/ext/mbstring/tests/mb_http_output.phpt
+++ b/ext/mbstring/tests/mb_http_output.phpt
@@ -52,17 +52,41 @@ $enc = mb_http_output();
 print "$enc\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 OK_ASCII_SET
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 ASCII
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 OK_SJIS_SET
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 SJIS
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 OK_JIS_SET
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 JIS
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 OK_UTF-8_SET
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 UTF-8
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 OK_EUC-JP_SET
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 EUC-JP
 == INVALID PARAMETER ==
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 mb_http_output(): Argument #1 ($encoding) must be a valid encoding, "BAD_NAME" given
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 EUC-JP

--- a/ext/mbstring/tests/mb_internal_encoding.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding.phpt
@@ -41,13 +41,29 @@ $enc = mb_internal_encoding();
 print "$enc\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 OK_EUC-JP_SET
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 EUC-JP
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 OK_UTF-8_SET
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 UTF-8
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 OK_ASCII_SET
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 ASCII
 == INVALID PARAMETER ==
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 mb_internal_encoding(): Argument #1 ($encoding) must be a valid encoding, "BAD_NAME" given
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 ASCII

--- a/ext/mbstring/tests/mb_internal_encoding_basic.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_basic.phpt
@@ -21,7 +21,13 @@ echo "Done";
 ?>
 --EXPECTF--
 *** Testing mb_internal_encoding() : basic functionality ***
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(%d) "%s"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 Done

--- a/ext/mbstring/tests/mb_internal_encoding_basic2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_basic2.phpt
@@ -29,7 +29,7 @@ var_dump(mb_internal_encoding());    //check internal encoding is now set to UTF
 
 echo "Done";
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing mb_internal_encoding() : basic functionality ***
 string(0) ""
 string(10) "ISO-8859-1"
@@ -38,7 +38,13 @@ string(10) "ISO-8859-1"
 string(0) ""
 string(0) ""
 string(0) ""
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-1"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 Done

--- a/ext/mbstring/tests/mb_internal_encoding_error2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_error2.phpt
@@ -17,6 +17,8 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing mb_internal_encoding() : error conditions ***
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 mb_internal_encoding(): Argument #1 ($encoding) must be a valid encoding, "unknown-encoding" given

--- a/ext/mbstring/tests/mb_internal_encoding_ini_basic2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_ini_basic2.phpt
@@ -16,10 +16,16 @@ echo mb_internal_encoding()."\n";
 echo ini_get('mbstring.internal_encoding')."\n";
 
 ?>
---EXPECT--
+--EXPECTF--
 Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
 *** Testing INI mbstring.internal_encoding : basic functionality ***
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 ISO-8859-7
 ISO-8859-7
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 UTF-8
 ISO-8859-7

--- a/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
@@ -16,12 +16,18 @@ echo mb_internal_encoding()."\n";
 echo ini_get('mbstring.internal_encoding')."\n";
 
 ?>
---EXPECT--
+--EXPECTF--
 Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
 
 Warning: PHP Startup: Unknown encoding "BAD" in ini setting in Unknown on line 0
 *** Testing INI mbstring.internal_encoding: invalid encoding specified in INI ***
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 UTF-8
 BAD
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 UTF-8
 BAD

--- a/ext/mbstring/tests/mb_internal_encoding_variation2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_variation2.phpt
@@ -79,262 +79,574 @@ echo "Done";
 *** Testing mb_internal_encoding() : usage variations ***
 
 -- Iteration 1 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(%d) "%s"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UCS-4"
 
 -- Iteration 2 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UCS-4"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-4BE"
 
 -- Iteration 3 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-4BE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-4LE"
 
 -- Iteration 4 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-4LE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UCS-2"
 
 -- Iteration 5 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UCS-2"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-2BE"
 
 -- Iteration 6 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-2BE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-2LE"
 
 -- Iteration 7 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(7) "UCS-2LE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "UTF-32"
 
 -- Iteration 8 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "UTF-32"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-32BE"
 
 -- Iteration 9 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-32BE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-32LE"
 
 -- Iteration 10 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-32LE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "UTF-16"
 
 -- Iteration 11 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "UTF-16"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-16BE"
 
 -- Iteration 12 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-16BE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-16LE"
 
 -- Iteration 13 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "UTF-16LE"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-7"
 
 -- Iteration 14 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-7"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(9) "UTF7-IMAP"
 
 -- Iteration 15 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(9) "UTF7-IMAP"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
 
 -- Iteration 16 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "ASCII"
 
 -- Iteration 17 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "ASCII"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-JP"
 
 -- Iteration 18 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-JP"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "SJIS"
 
 -- Iteration 19 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "SJIS"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(9) "eucJP-win"
 
 -- Iteration 20 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(9) "eucJP-win"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "SJIS-win"
 
 -- Iteration 21 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(8) "SJIS-win"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-2022-JP"
 
 -- Iteration 22 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-2022-JP"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(3) "JIS"
 
 -- Iteration 23 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(3) "JIS"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-1"
 
 -- Iteration 24 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-1"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-2"
 
 -- Iteration 25 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-2"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-3"
 
 -- Iteration 26 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-3"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-4"
 
 -- Iteration 27 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-4"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-5"
 
 -- Iteration 28 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-5"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-6"
 
 -- Iteration 29 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-6"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-7"
 
 -- Iteration 30 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-7"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-8"
 
 -- Iteration 31 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-9"
 
 -- Iteration 32 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(10) "ISO-8859-9"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-10"
 
 -- Iteration 33 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-10"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-13"
 
 -- Iteration 34 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-13"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-14"
 
 -- Iteration 35 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-14"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-15"
 
 -- Iteration 36 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-8859-15"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "BASE64"
 
 -- Iteration 37 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "BASE64"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(13) "HTML-ENTITIES"
 
 -- Iteration 38 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(13) "HTML-ENTITIES"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "7bit"
 
 -- Iteration 39 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "7bit"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "8bit"
 
 -- Iteration 40 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(4) "8bit"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-CN"
 
 -- Iteration 41 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-CN"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP936"
 
 -- Iteration 42 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP936"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(2) "HZ"
 
 -- Iteration 43 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(2) "HZ"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-TW"
 
 -- Iteration 44 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-TW"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP950"
 
 -- Iteration 45 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP950"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "BIG-5"
 
 -- Iteration 46 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "BIG-5"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-KR"
 
 -- Iteration 47 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "EUC-KR"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(3) "UHC"
 
 -- Iteration 48 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(3) "UHC"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-2022-KR"
 
 -- Iteration 49 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(11) "ISO-2022-KR"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(12) "Windows-1251"
 
 -- Iteration 50 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(12) "Windows-1251"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(12) "Windows-1252"
 
 -- Iteration 51 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(12) "Windows-1252"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP866"
 
 -- Iteration 52 --
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "CP866"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 bool(true)
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(6) "KOI8-R"
 Done

--- a/ext/mbstring/tests/mb_ord.phpt
+++ b/ext/mbstring/tests/mb_ord.phpt
@@ -44,7 +44,7 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 
-mb_internal_encoding("utf-7");
+ini_set("internal_encoding", "utf-7");
 try {
     var_dump( mb_ord("\u{d800}") );
 } catch (\ValueError $e) {

--- a/ext/mbstring/tests/mb_output_handler_euc_jp.phpt
+++ b/ext/mbstring/tests/mb_output_handler_euc_jp.phpt
@@ -16,5 +16,6 @@ $output = ob_get_clean();
 var_dump( $output );
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 string(73) "テスト用日本語文字列。このモジュールはPHPにマルチバイト関数を提供します。"

--- a/ext/mbstring/tests/mb_output_handler_pass.phpt
+++ b/ext/mbstring/tests/mb_output_handler_pass.phpt
@@ -20,8 +20,14 @@ ob_start('mb_output_handler');
 mb_http_output("pass");
 var_dump("\xff");
 ?>
---EXPECT--
+--EXPECTF--
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 string(4) "pass"
 string(1) "ÿ"
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 string(1) "?"
+
+Deprecated: Function mb_http_output() is deprecated since 8.5, use output_encoding INI settings instead in %s on line %d
 string(1) "ÿ"

--- a/ext/mbstring/tests/mb_send_mail01.phpt
+++ b/ext/mbstring/tests/mb_send_mail01.phpt
@@ -21,7 +21,7 @@ readfile(__DIR__ . "/mb_send_mail01.eml");
 
 /* neutral (UTF-8) */
 if (mb_language("neutral")) {
-    mb_internal_encoding("UTF-8");
+    ini_set('internal_encoding', 'UTF-8');
     mb_send_mail($to, "test ".mb_language(), "test");
     readfile(__DIR__ . "/mb_send_mail01.eml");
 }

--- a/ext/mbstring/tests/mb_send_mail02.phpt
+++ b/ext/mbstring/tests/mb_send_mail02.phpt
@@ -21,7 +21,7 @@ readfile(__DIR__ . "/mb_send_mail02.eml");
 
 /* Japanese (EUC-JP) */
 if (mb_language("japanese")) {
-    mb_internal_encoding('EUC-JP');
+    ini_set('internal_encoding', 'EUC-JP');
     mb_send_mail($to, "テスト ".mb_language(), "テスト");
     readfile(__DIR__ . "/mb_send_mail02.eml");
 }

--- a/ext/mbstring/tests/mb_send_mail03.phpt
+++ b/ext/mbstring/tests/mb_send_mail03.phpt
@@ -21,7 +21,7 @@ readfile(__DIR__ . "/mb_send_mail03.eml");
 
 /* English (iso-8859-1) */
 if (mb_language("english")) {
-    mb_internal_encoding("ISO-8859-1");
+    ini_set('internal_encoding', 'ISO-8859-1');
     mb_send_mail($to, "test ".mb_language(), "test");
     readfile(__DIR__ . "/mb_send_mail03.eml");
 }

--- a/ext/mbstring/tests/mb_send_mail04.phpt
+++ b/ext/mbstring/tests/mb_send_mail04.phpt
@@ -21,7 +21,7 @@ readfile(__DIR__ . "/mb_send_mail04.eml");
 
 /* German (iso-8859-15) */
 if (mb_language("german")) {
-    mb_internal_encoding("ISO-8859-15");
+    ini_set('internal_encoding', 'ISO-8859-15');
     mb_send_mail($to, "Pr"."\xfc"."fung ".mb_language(), "Pr"."\xfc"."fung");
     readfile(__DIR__ . "/mb_send_mail04.eml");
 }

--- a/ext/mbstring/tests/mb_send_mail05.phpt
+++ b/ext/mbstring/tests/mb_send_mail05.phpt
@@ -7,7 +7,7 @@ mbstring
 if (!function_exists("mb_send_mail") || !mb_language("Simplified Chinese")) {
     die("skip mb_send_mail() not available");
 }
-if (!@mb_internal_encoding('GB2312')) {
+if (!@ini_set('internal_encoding','GB2312')) {
     die("skip GB2312 encoding is not available on this platform");
 }
 ?>
@@ -24,8 +24,8 @@ readfile(__DIR__ . "/mb_send_mail05.eml");
 
 /* Simplified Chinese (HK-GB-2312) */
 if (mb_language("simplified chinese")) {
-    mb_internal_encoding('GB2312');
-    mb_send_mail($to, "²âÑé ".mb_language(), "²âÑé");
+    ini_set('internal_encoding','GB2312');
+    mb_send_mail($to, "ï¿½ï¿½ï¿½ï¿½ ".mb_language(), "ï¿½ï¿½ï¿½ï¿½");
     readfile(__DIR__ . "/mb_send_mail05.eml");
 }
 ?>

--- a/ext/mbstring/tests/mb_send_mail06.phpt
+++ b/ext/mbstring/tests/mb_send_mail06.phpt
@@ -7,7 +7,7 @@ mbstring
 if (!function_exists("mb_send_mail") || !mb_language("Traditional Chinese")) {
     die("skip mb_send_mail() not available");
 }
-if (!@mb_internal_encoding('BIG5')) {
+if (!@ini_set('internal_encoding','BIG5')) {
     die("skip BIG5 encoding is not available on this platform");
 }
 ?>
@@ -24,8 +24,8 @@ readfile(__DIR__ . "/mb_send_mail06.eml");
 
 /* Traditional Chinese () */
 if (mb_language("traditional chinese")) {
-    mb_internal_encoding('BIG5');
-    mb_send_mail($to, "´úÅç ".mb_language(), "´úÅç");
+    ini_set('internal_encoding','BIG5');
+    mb_send_mail($to, "ï¿½ï¿½ï¿½ï¿½ ".mb_language(), "ï¿½ï¿½ï¿½ï¿½");
     readfile(__DIR__ . "/mb_send_mail06.eml");
 }
 ?>
@@ -47,4 +47,4 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=BIG5
 Content-Transfer-Encoding: 8bit
 
-´úÅç
+ï¿½ï¿½ï¿½ï¿½

--- a/ext/mbstring/tests/mb_send_mail07.phpt
+++ b/ext/mbstring/tests/mb_send_mail07.phpt
@@ -7,7 +7,7 @@ mbstring
 if (!function_exists("mb_send_mail") || !mb_language("Korean")) {
     die("skip mb_send_mail() not available");
 }
-if (!@mb_internal_encoding('ISO-2022-KR')) {
+if (!@ini_set('internal_encoding','ISO-2022-KR')) {
     die("skip ISO-2022-KR encoding is not available on this platform");
 }
 ?>
@@ -24,8 +24,8 @@ readfile(__DIR__ . "/mb_send_mail07.eml");
 
 /* Korean */
 if (mb_language("korean")) {
-    mb_internal_encoding('EUC-KR');
-    mb_send_mail($to, "�׽�Ʈ ".mb_language(), "�׽�Ʈ");
+    ini_set('internal_encoding','EUC-KR');
+    mb_send_mail($to, "�׽�Ʈ ".mb_language(), "�׽�Ʈ");
     readfile(__DIR__ . "/mb_send_mail07.eml");
 }
 

--- a/ext/mbstring/tests/mb_strcut_missing_boundary_check.phpt
+++ b/ext/mbstring/tests/mb_strcut_missing_boundary_check.phpt
@@ -4,19 +4,19 @@ mb_strcut() missing boundary check.
 mbstring
 --FILE--
 <?php
-mb_internal_encoding("UCS-4LE");
+ini_set('internal_coding',"UCS-4LE");
 var_dump(bin2hex(mb_strcut("\x61\x00\x00\x00\x62\x00\x00\x00\x63\x00\x00\x00", 0, 32)));
-mb_internal_encoding("UCS-4BE");
+ini_set('internal_coding',"UCS-4BE");
 var_dump(bin2hex(mb_strcut("\x00\x00\x00\x61\x00\x00\x00\x62\x00\x00\x00\x63", 0, 32)));
-mb_internal_encoding("UCS-2LE");
+ini_set('internal_coding',"UCS-2LE");
 var_dump(bin2hex(mb_strcut("\x61\x00\x62\x00\x63\x00", 0, 32)));
-mb_internal_encoding("UCS-2BE");
+ini_set('internal_coding',"UCS-2BE");
 var_dump(bin2hex(mb_strcut("\x00\x61\x00\x62\x00\x63", 0, 32)));
-mb_internal_encoding("UTF-16");
+ini_set('internal_coding',"UTF-16");
 var_dump(bin2hex(mb_strcut("\x00\x61\x00\x62\x00\x63", 0, 32)));
-mb_internal_encoding("UTF-8");
+ini_set('internal_coding',"UTF-8");
 var_dump(bin2hex(mb_strcut("abc", 0, 32)));
-mb_internal_encoding("ISO-8859-1");
+ini_set('internal_coding',"ISO-8859-1");
 var_dump(bin2hex(mb_strcut("abc", 0, 32)));
 ?>
 --EXPECT--

--- a/ext/mbstring/tests/mb_stripos.phpt
+++ b/ext/mbstring/tests/mb_stripos.phpt
@@ -16,7 +16,7 @@ $slen = mb_strlen($euc_jp, 'EUC-JP');
 echo "String len: $slen\n";
 
 // EUC-JP - With encoding parameter
-mb_internal_encoding('UTF-8') or print("mb_internal_encoding() failed\n");
+ini_set('internal_encoding', 'UTF-8');
 
 echo  "== POSITIVE OFFSET ==\n";
 
@@ -73,7 +73,7 @@ $r = mb_stripos($euc_jp, "\n",     0, 'EUC-JP');
 // EUC-JP - No encoding parameter
 echo "== NO ENCODING PARAMETER ==\n";
 
-mb_internal_encoding('EUC-JP')  or print("mb_internal_encoding() failed\n");
+ini_set('internal_encoding', 'EUC-JP');
 
 print  mb_stripos($euc_jp, "\xC6\xFC\xCB\xDC\xB8\xEC", 0) . "\n";
 print  mb_stripos($euc_jp, '0', 0) . "\n";
@@ -88,7 +88,7 @@ $r = mb_stripos($euc_jp, "\n", 0);
 // EUC-JP - No offset and encoding parameter
 echo "== NO OFFSET AND ENCODING PARAMETER ==\n";
 
-mb_internal_encoding('EUC-JP')  or print("mb_internal_encoding() failed\n");
+ini_set('internal_encoding', 'EUC-JP');
 
 print  mb_stripos($euc_jp, "\xC6\xFC\xCB\xDC\xB8\xEC") . "\n";
 print  mb_stripos($euc_jp, '0') . "\n";

--- a/ext/mbstring/tests/mb_strlen.phpt
+++ b/ext/mbstring/tests/mb_strlen.phpt
@@ -101,15 +101,19 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 == ASCII ==
 40
 40
 == EUC-JP ==
 43
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 72
 == SJIS ==
 43
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 72
 -- Testing illegal bytes 0x80,0xFD-FF --
 2
@@ -136,9 +140,13 @@ try {
 6
 == JIS ==
 43
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 90
 == UTF-8 ==
 43 codepoints
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 101 bytes
 23
 2300
@@ -147,4 +155,6 @@ try {
 2300
 2048
 == WRONG PARAMETERS ==
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 mb_strlen(): Argument #2 ($encoding) must be a valid encoding, "BAD_NAME" given

--- a/ext/mbstring/tests/mb_strpos.phpt
+++ b/ext/mbstring/tests/mb_strpos.phpt
@@ -104,8 +104,10 @@ var_dump(mb_strpos("abc\x80\x80", "\x80", 0, "UTF-8"));
 var_dump(mb_strpos("abc\xFF", "c\xFF", 0, "UTF-8"));
 
 ?>
---EXPECT--
+--EXPECTF--
 String len: 43
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 == POSITIVE OFFSET ==
 10
 0
@@ -125,6 +127,8 @@ String len: 43
 OK_STR
 OK_NEWLINE
 == NO ENCODING PARAMETER ==
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 10
 0
 3
@@ -132,6 +136,8 @@ OK_NEWLINE
 OK_STR
 OK_NEWLINE
 == NO OFFSET AND ENCODING PARAMETER ==
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 10
 0
 3

--- a/ext/mbstring/tests/mb_strstr.phpt
+++ b/ext/mbstring/tests/mb_strstr.phpt
@@ -17,7 +17,7 @@ var_dump(mb_strstr("あいうえおかきくけこ", "おかき", false));
 var_dump(mb_strstr("あいうえおかきくけこ", "おかき", true));
 var_dump(FROM_EUC_JP(mb_strstr(EUC_JP("あいうえおかきくけこ"), EUC_JP("おかき"), false, "EUC-JP")));
 var_dump(FROM_EUC_JP(mb_strstr(EUC_JP("あいうえおかきくけこ"), EUC_JP("おかき"), true, "EUC-JP")));
-mb_internal_encoding("EUC-JP");
+ini_set("internal_encoding", "EUC-JP");
 var_dump(FROM_EUC_JP(mb_strstr(EUC_JP("あいうえおかきくけこ"), EUC_JP("おかき"))));
 var_dump(FROM_EUC_JP(mb_strstr(EUC_JP("あいうえおかきくけこ"), EUC_JP("おかき"), false)));
 var_dump(FROM_EUC_JP(mb_strstr(EUC_JP("あいうえおかきくけこ"), EUC_JP("おかき"), true)));

--- a/ext/mbstring/tests/php_gr_jp_16242.phpt
+++ b/ext/mbstring/tests/php_gr_jp_16242.phpt
@@ -13,7 +13,9 @@ var_dump(ini_get('internal_encoding'));
 var_dump(mb_internal_encoding());
 
 ?>
---EXPECT--
+--EXPECTF--
 string(8) "Japanese"
 string(5) "UTF-8"
+
+Deprecated: Function mb_internal_encoding() is deprecated since 8.5, use internal_encoding INI settings instead in %s on line %d
 string(5) "UTF-8"

--- a/ext/standard/tests/strings/htmlentities05.phpt
+++ b/ext/standard/tests/strings/htmlentities05.phpt
@@ -7,11 +7,11 @@ internal_encoding=cp1252
 mbstring
 --FILE--
 <?php
-    print mb_internal_encoding()."\n";
+    print ini_get('internal_encoding')."\n";
     var_dump(htmlentities("\x82\x86\x99\x9f", ENT_QUOTES, ''));
     var_dump(htmlentities("\x80\xa2\xa3\xa4\xa5", ENT_QUOTES, ''));
 ?>
 --EXPECT--
-Windows-1252
+cp1252
 string(28) "&sbquo;&dagger;&trade;&Yuml;"
 string(32) "&euro;&cent;&pound;&curren;&yen;"

--- a/ext/standard/tests/strings/htmlentities06.phpt
+++ b/ext/standard/tests/strings/htmlentities06.phpt
@@ -7,7 +7,7 @@ internal_encoding=ISO-8859-15
 mbstring
 --FILE--
 <?php
-    print mb_internal_encoding()."\n";
+    print ini_get('internal_encoding')."\n";
     var_dump(htmlentities("\xbc\xbd\xbe", ENT_QUOTES, ''));
 ?>
 --EXPECT--

--- a/ext/standard/tests/strings/htmlentities07.phpt
+++ b/ext/standard/tests/strings/htmlentities07.phpt
@@ -7,7 +7,7 @@ internal_encoding=ISO-8859-1
 mbstring
 --FILE--
 <?php
-    print mb_internal_encoding()."\n";
+    print ini_get('internal_encoding')."\n";
     var_dump(htmlentities("\xe4\xf6\xfc", ENT_QUOTES, ''));
 ?>
 --EXPECT--

--- a/ext/standard/tests/strings/htmlentities08.phpt
+++ b/ext/standard/tests/strings/htmlentities08.phpt
@@ -7,7 +7,7 @@ internal_encoding=EUC-JP
 mbstring
 --FILE--
 <?php
-    print mb_internal_encoding()."\n";
+    print ini_get('internal_encoding')."\n";
     var_dump(htmlentities("\xa1\xa2\xa1\xa3\xa1\xa4", ENT_QUOTES, ''));
 ?>
 --EXPECTF--

--- a/ext/standard/tests/strings/htmlentities09.phpt
+++ b/ext/standard/tests/strings/htmlentities09.phpt
@@ -7,7 +7,7 @@ internal_encoding=Shift_JIS
 mbstring
 --FILE--
 <?php
-    print mb_internal_encoding()."\n";
+    print ini_set('internal_encoding')."\n";
     var_dump(bin2hex(htmlentities("\x81\x41\x81\x42\x81\x43", ENT_QUOTES, '')));
 ?>
 --EXPECTF--


### PR DESCRIPTION
Deprecation for `mb_internal_encoding()` and `mb_http_output()`,similarly as https://github.com/php/php-src/pull/19664