### PR TITLE
Add soap_globals->lang_en NULL initialization (SIGSEGV)

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -453,6 +453,7 @@ static void php_soap_init_globals(zend_soap_globals *soap_globals)
 	soap_globals->soap_version = SOAP_1_1;
 	soap_globals->mem_cache = NULL;
 	soap_globals->ref_map = NULL;
+	soap_globals->lang_en = NULL;
 }
 
 PHP_MSHUTDOWN_FUNCTION(soap)
@@ -3001,7 +3002,9 @@ static void set_soap_fault(zval *obj, const char *fault_code_ns, const char *fau
 	if (name != NULL) {
 		ZVAL_STR_COPY(Z_FAULT_NAME_P(obj), name);
 	}
-	ZVAL_STR_COPY(Z_FAULT_LANG_P(obj), lang);
+	if (lang != NULL) {
+		ZVAL_STR_COPY(Z_FAULT_LANG_P(obj), lang);
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
The following code:

```php
$sClient = new SoapClient("test-nulloptions-simple.wsdl");
```

Resulted in this output:
```
Thread 3 "httpd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff19fe640 (LWP 469560)]
0x00007ffff67bbeb7 in set_soap_fault (obj=obj@entry=0x7ffff19f9a80, fault_code_ns=fault_code_ns@entry=0x0, fault_code=<optimized out>, fault_string=fault_string@entry=0x7fffd846b0d8 "SOAP-ERROR: Parsing WSDL: Couldn't load from 'test-nulloptions-simple.wsdl' : failed to load external entity \"test-nulloptions-simple.wsdl\"\n", fault_actor=fault_actor@entry=0x0, fault_detail=fault_detail@entry=0x0, name=<optimized out>, lang=<optimized out>) at /php-src-php-8.5.0beta2/ext/soap/soap.c:3006
3006		ZVAL_STR_COPY(Z_FAULT_LANG_P(obj), lang);
(gdb) bt
#0  0x00007ffff67bbeb7 in set_soap_fault (obj=obj@entry=0x7ffff19f9a80, fault_code_ns=fault_code_ns@entry=0x0, fault_code=<optimized out>, 
    fault_string=fault_string@entry=0x7fffd846b0d8 "SOAP-ERROR: Parsing WSDL: Couldn't load from 'test-nulloptions-simple.wsdl' : failed to load external entity \"test-nulloptions-simple.wsdl\"\n", 
    fault_actor=fault_actor@entry=0x0, fault_detail=fault_detail@entry=0x0, name=<optimized out>, lang=<optimized out>)
    at /php-src-php-8.5.0beta2/ext/soap/soap.c:3006
#1  0x00007ffff67bc4ae in add_soap_fault_ex (fault=fault@entry=0x7ffff19f9a80, obj=0x7fffe40506f0, fault_code=<optimized out>, 
    fault_string=fault_string@entry=0x7fffd846b0d8 "SOAP-ERROR: Parsing WSDL: Couldn't load from 'test-nulloptions-simple.wsdl' : failed to load external entity \"test-nulloptions-simple.wsdl\"\n", 
    fault_actor=fault_actor@entry=0x0, fault_detail=fault_detail@entry=0x0, lang=0x24) at /php-src-php-8.5.0beta2/ext/soap/soap.c:2924
#2  0x00007ffff63b8c3f in add_soap_fault_ex_en (fault_actor=0x0, fault_detail=0x0, 
    fault_string=0x7fffd846b0d8 "SOAP-ERROR: Parsing WSDL: Couldn't load from 'test-nulloptions-simple.wsdl' : failed to load external entity \"test-nulloptions-simple.wsdl\"\n", 
    fault_code=<optimized out>, obj=<optimized out>, fault=0x7ffff19f9a80) at /php-src-php-8.5.0beta2/ext/soap/soap.c:2940
#3  soap_real_error_handler (error_num=1, error_filename=0x7fffd8469100, error_lineno=3, message=0x7fffd846b0c0) at /php-src-php-8.5.0beta2/ext/soap/soap.c:1884
#4  0x00007ffff63f2d16 in zend_error_zstr_at (orig_type=orig_type@entry=1, error_filename=error_filename@entry=0x7fffd8469100, error_lineno=error_lineno@entry=3, message=message@entry=0x7fffd846b0c0)
    at /php-src-php-8.5.0beta2/Zend/zend.c:1542
#5  0x00007ffff63f3117 in zend_error_va_list (orig_type=orig_type@entry=1, error_filename=0x7fffd8469100, error_lineno=3, 
    format=format@entry=0x7ffff76f17f8 "SOAP-ERROR: Parsing WSDL: Couldn't load from '%s' : %s", args=args@entry=0x7ffff19f9d00)
    at /php-src-php-8.5.0beta2/Zend/zend.c:1635
#6  0x00007ffff63f3305 in zend_error (type=type@entry=1, format=format@entry=0x7ffff76f17f8 "SOAP-ERROR: Parsing WSDL: Couldn't load from '%s' : %s")
    at /php-src-php-8.5.0beta2/Zend/zend.c:1705
#7  0x00007ffff63b82a8 in load_wsdl_ex (struri=0x7fffd8458130 "test-nulloptions-simple.wsdl", ctx=0x7ffff19f9f30, include=<optimized out>, this_ptr=<optimized out>)
    at /php-src-php-8.5.0beta2/ext/soap/php_sdl.c:321
#8  0x00007ffff67b7b99 in load_wsdl (struri=0x7fffd8458130 "test-nulloptions-simple.wsdl", this_ptr=<optimized out>)
    at /php-src-php-8.5.0beta2/ext/soap/php_sdl.c:714
#9  0x00007ffff67b907b in get_sdl (this_ptr=this_ptr@entry=0x7fffd84140d0, uri=<optimized out>, cache_wsdl=<optimized out>, cache_wsdl@entry=1)
    at /php-src-php-8.5.0beta2/ext/soap/php_sdl.c:3313
#10 0x00007ffff67c5c2c in zim_SoapClient___construct (execute_data=0x7fffd84140b0, return_value=<optimized out>) at /php-src-php-8.5.0beta2/ext/soap/soap.c:2202
#11 0x00007ffff69ebbc5 in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER () at /php-src-php-8.5.0beta2/Zend/zend_vm_execute.h:1994
#12 execute_ex (ex=0x7ffff76f283c) at /php-src-php-8.5.0beta2/Zend/zend_vm_execute.h:48187
#13 0x00007ffff69df319 in zend_execute (op_array=op_array@entry=0x7fffd847b000, return_value=return_value@entry=0x0)
    at /php-src-php-8.5.0beta2/Zend/zend_vm_execute.h:119146
#14 0x00007ffff6a4c512 in zend_execute_script (type=type@entry=8, retval=retval@entry=0x0, file_handle=file_handle@entry=0x7ffff19fda50)
    at /php-src-php-8.5.0beta2/Zend/zend.c:1977
#15 0x00007ffff68d8ce3 in php_execute_script_ex (primary_file=<optimized out>, retval=<optimized out>) at /php-src-php-8.5.0beta2/main/main.c:2608
#16 0x00007ffff6a4e588 in php_handler (r=<optimized out>) at /php-src-php-8.5.0beta2/sapi/apache2handler/sapi_apache2.c:718
#17 0x00005555555b7c78 in ap_run_handler (r=r@entry=0x7fffe4002c20) at config.c:169
#18 0x00005555555b8276 in ap_invoke_handler (r=r@entry=0x7fffe4002c20) at config.c:443
#19 0x00005555555cf8b8 in ap_process_async_request (r=r@entry=0x7fffe4002c20) at http_request.c:452
#20 0x00005555555cb953 in ap_process_http_async_connection (c=0x7fff70000f90) at http_core.c:155
#21 ap_process_http_connection (c=0x7fff70000f90) at http_core.c:246
#22 0x00005555555c1cc8 in ap_run_process_connection (c=c@entry=0x7fff70000f90) at connection.c:42
#23 0x00005555555dc42f in process_socket (thd=thd@entry=0x555555a28098, p=<optimized out>, sock=0x7fff70000ce0, cs=<optimized out>, my_child_num=my_child_num@entry=0, my_thread_num=my_thread_num@entry=0)
    at event.c:1098
#24 0x00005555555dd26b in worker_thread (thd=0x555555a28098, dummy=<optimized out>) at event.c:2252
#25 0x00007ffff7c94ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#26 0x00007ffff7d26850 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

```

PHP is compiled with `--with-apxs2=/httpd-2.4.65/bin/apxs` and run with via `httpd-2.4.65`.

The proposed changes are as follows:
- At minimum, initialize `soap_globals->lang_en` to `NULL` in `php_soap_init_globals`, and guard its use by checking for `NULL` in `set_soap_fault`.

- Whether it should also be initialized in `PHP_RINIT_FUNCTION` as `SOAP_GLOBAL(lang_en) = zend_string_init_interned(ZEND_STRL("en"), true);` should be decided separately.

This PR solves the following issue: https://github.com/php/php-src/issues/19773

For reference: https://github.com/php/php-src/issues/19226