### PR TITLE
uri: Remove useless layer of indirection in `php_uri_get_parser()`

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -338,7 +338,7 @@ static bool in_domain(const zend_string *host, const zend_string *domain)
 
 int make_http_soap_request(
 	zval *this_ptr, zend_string *buf, zend_string *location, char *soapaction,
-	int soap_version, const zend_string *uri_parser_class, zval *return_value
+	int soap_version, zend_string *uri_parser_class, zval *return_value
 ) {
 	zend_string *request;
 	smart_str soap_headers = {0};

--- a/ext/soap/php_http.h
+++ b/ext/soap/php_http.h
@@ -21,7 +21,7 @@
 
 int make_http_soap_request(
 	zval *this_ptr, zend_string *buf, zend_string *location, char *soapaction,
-	int soap_version, const zend_string *uri_parser_class, zval *return_value
+	int soap_version, zend_string *uri_parser_class, zval *return_value
 );
 
 int proxy_authentication(zval* this_ptr, smart_str* soap_headers);

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -50,11 +50,6 @@ static const zend_module_dep uri_deps[] = {
 
 static zend_array uri_parsers;
 
-static const uri_parser_t *uri_parser_by_name(const char *uri_parser_name, size_t uri_parser_name_len)
-{
-	return zend_hash_str_find_ptr(&uri_parsers, uri_parser_name, uri_parser_name_len);
-}
-
 static HashTable *uri_get_debug_properties(zend_object *object)
 {
 	uri_internal_t *internal_uri = uri_internal_from_obj(object);
@@ -105,13 +100,13 @@ static HashTable *uri_get_debug_properties(zend_object *object)
 	return result;
 }
 
-PHPAPI const uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name)
+PHPAPI const uri_parser_t *php_uri_get_parser(zend_string *uri_parser_name)
 {
 	if (uri_parser_name == NULL) {
-		return uri_parser_by_name(PHP_URI_PARSER_PHP_PARSE_URL, sizeof(PHP_URI_PARSER_PHP_PARSE_URL) - 1);
+		return zend_hash_str_find_ptr(&uri_parsers, PHP_URI_PARSER_PHP_PARSE_URL, sizeof(PHP_URI_PARSER_PHP_PARSE_URL) - 1);
 	}
 
-	return uri_parser_by_name(ZSTR_VAL(uri_parser_name), ZSTR_LEN(uri_parser_name));
+	return zend_hash_find_ptr(&uri_parsers, uri_parser_name);
 }
 
 ZEND_ATTRIBUTE_NONNULL PHPAPI uri_internal_t *php_uri_parse(const uri_parser_t *uri_parser, const char *uri_str, size_t uri_str_len, bool silent)

--- a/ext/uri/php_uri.h
+++ b/ext/uri/php_uri.h
@@ -47,7 +47,7 @@ PHPAPI zend_result php_uri_parser_register(const uri_parser_t *uri_parser);
  * @param uri_parser_name The URI parser name
  * @return The URI parser
  */
-PHPAPI const uri_parser_t *php_uri_get_parser(const zend_string *uri_parser_name);
+PHPAPI const uri_parser_t *php_uri_get_parser(zend_string *uri_parser_name);
 
 ZEND_ATTRIBUTE_NONNULL PHPAPI uri_internal_t *php_uri_parse(const uri_parser_t *uri_parser, const char *uri_str, size_t uri_str_len, bool silent);
 


### PR DESCRIPTION
By using the `zend_hash_*()` functions directly, we can benefit from the precalculated hash value in the given `zend_string *uri_parser_name`. We need to deconstify the parameter, since the function might calculate the hash, thus modifying the `zend_string*`.