### PR TITLE
Mark test as ONLINE

### DIFF
--- a/sapi/cli/tests/php_cli_server_ipv4_error_message.phpt
+++ b/sapi/cli/tests/php_cli_server_ipv4_error_message.phpt
@@ -2,6 +2,9 @@
 IPv4 address error message formatting
 --SKIPIF--
 <?php
+if (getenv("SKIP_ONLINE_TESTS")) {
+    die("skip online test");
+}
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die("skip not for Windows");
 }


### PR DESCRIPTION
AS it fails offline, when no DNS available

```
001- string(%d) "[%s] Failed to listen on 192.168.1.999:8080 %s
001+ string(349) "[Tue Sep  9 13:57:30 2025] PHP Warning:  Unknown: php_network_getaddresses: getaddrinfo for 192.168.1.999 failed: Temporary failure in name resolution in Unknown on line 0
002+ [Tue Sep  9 13:57:30 2025] Failed to listen on 192.168.1.999:8080 (reason: php_network_getaddresses: getaddrinfo for 192.168.1.999 failed: Temporary failure in name resolution)

```