### PR TITLE
Fix GH-19780: InvalidUrlException should check $errors argument

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-19765 (object_properties_load() bypasses readonly property
     checks). (timwolla)
 
+- URI:
+  . Fixed bug GH-19780 (InvalidUrlException should check $errors argument).
+    (nielsdos)
+
 11 Sep 2025, PHP 8.5.0beta3
 
 - Core:

--- a/ext/uri/tests/gh19780.phpt
+++ b/ext/uri/tests/gh19780.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-19780 (InvalidUrlException should check $errors argument)
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+use Uri\WhatWg\InvalidUrlException;
+use Uri\WhatWg\UrlValidationError;
+use Uri\WhatWg\UrlValidationErrorType;
+
+try {
+    new InvalidUrlException('message', ['foo']);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    new InvalidUrlException('message', [
+        1 => new UrlValidationError('context', UrlValidationErrorType::HostMissing, true)
+    ]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Uri\WhatWg\InvalidUrlException::__construct(): Argument #2 ($errors) must be a list of Uri\WhatWg\UrlValidationError
+Uri\WhatWg\InvalidUrlException::__construct(): Argument #2 ($errors) must be a list of Uri\WhatWg\UrlValidationError


### PR DESCRIPTION
It makes sense to restrict the types used for $errors. This can also improve the types for static analysis tools as they can now rely on the array being a list of this class type.