### PR TITLE
Fix inconsistent behavior when zend-max-execution-timers is enabled

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1531,7 +1531,9 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 		return;
 	}
 #elif defined(ZEND_MAX_EXECUTION_TIMERS)
-	zend_max_execution_timer_settime(seconds);
+	if (seconds > 0) {
+		zend_max_execution_timer_settime(seconds);
+	}
 
 	if (reset_signals) {
 		sigset_t sigset;
@@ -1618,7 +1620,9 @@ void zend_unset_timeout(void) /* {{{ */
 		tq_timer = NULL;
 	}
 #elif ZEND_MAX_EXECUTION_TIMERS
-	zend_max_execution_timer_settime(0);
+	if (EG(timeout_seconds)) {
+		zend_max_execution_timer_settime(0);
+	}
 #elif defined(HAVE_SETITIMER)
 	if (EG(timeout_seconds)) {
 		struct itimerval no_timeout;


### PR DESCRIPTION
When `zend-max-execution-timers` is enabled, [this test case](https://github.com/php/php-src/blob/PHP-8.3/tests/lang/045.phpt) consistently fails.
This patch aligns its behavior with other types of timeout implementations.

 I'm unsure whether related code paths—such as [main.c#L2523](https://github.com/php/php-src/blob/96c0bc55bb6c1201a73782615b88407e37f4a3ef/main/main.c#L2523) and [php_cli_server.c#L2278](https://github.com/php/php-src/blob/96c0bc55bb6c1201a73782615b88407e37f4a3ef/sapi/cli/php_cli_server.c#L2278)—should also be updated.