### PR TITLE
zend_vm_gen: Fix line numbers for `--with-lines`

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -989,6 +989,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_STATIC
 	prop = zend_fetch_static_property_address(&prop_info, opline->extended_value, BP_VAR_W, 0 OPLINE_CC EXECUTE_DATA_CC);
 	if (UNEXPECTED(!prop)) {
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -997,6 +998,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_STATIC
 
 	if (ZEND_TYPE_IS_SET(prop_info->type)) {
 		value = zend_assign_to_typed_prop(prop_info, prop, value, &garbage EXECUTE_DATA_CC);
+
 
 	} else {
 		value = zend_assign_to_variable_ex(prop, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
@@ -1100,6 +1102,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_STATIC
 	prop = zend_fetch_static_property_address(&prop_info, opline->extended_value, BP_VAR_W, 0 OPLINE_CC EXECUTE_DATA_CC);
 	if (UNEXPECTED(!prop)) {
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -1108,6 +1111,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_STATIC
 
 	if (ZEND_TYPE_IS_SET(prop_info->type)) {
 		value = zend_assign_to_typed_prop(prop_info, prop, value, &garbage EXECUTE_DATA_CC);
+
 
 	} else {
 		value = zend_assign_to_variable_ex(prop, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
@@ -1343,6 +1347,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 	ret = 0 ? EX_VAR(opline->result.var) : &retval;
 	ZVAL_NULL(ret);
 
+
 	fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -1357,6 +1362,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		zend_verify_internal_func_info(call->func, ret);
 	}
 #endif
+
 
 	ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -1407,6 +1413,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 	ret = 1 ? EX_VAR(opline->result.var) : &retval;
 	ZVAL_NULL(ret);
 
+
 	fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -1421,6 +1428,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		zend_verify_internal_func_info(call->func, ret);
 	}
 #endif
+
 
 	ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -1536,6 +1544,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 	LOAD_OPLINE_EX();
 
 
+
+
 	ZEND_VM_ENTER_EX();
 }
 
@@ -1558,6 +1568,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 	LOAD_OPLINE_EX();
+
+
 
 
 	ZEND_VM_ENTER_EX();
@@ -1630,6 +1642,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		LOAD_OPLINE_EX();
 
 
+
+
 		ZEND_VM_ENTER_EX();
 	} else {
 		ZEND_ASSERT(fbc->type == ZEND_INTERNAL_FUNCTION);
@@ -1647,6 +1661,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -1661,6 +1676,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -1739,6 +1755,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		LOAD_OPLINE_EX();
 
 
+
+
 		ZEND_VM_ENTER_EX();
 	} else {
 		ZEND_ASSERT(fbc->type == ZEND_INTERNAL_FUNCTION);
@@ -1756,6 +1774,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -1770,6 +1789,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -1964,9 +1984,12 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
@@ -1989,6 +2012,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -2008,6 +2032,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -2089,9 +2114,12 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
@@ -2114,6 +2142,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -2133,6 +2162,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_D
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -3597,9 +3627,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CALL_TRAMPOLI
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			if (execute_data) {
@@ -3625,6 +3658,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CALL_TRAMPOLI
 
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -3644,6 +3678,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CALL_TRAMPOLI
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		EG(current_execute_data) = call->prev_execute_data;
 
@@ -4065,6 +4100,7 @@ try_function_name:
 
 	if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 
+
 		if (UNEXPECTED(EG(exception))) {
 			if (call) {
 				 if (call->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
@@ -4444,6 +4480,7 @@ try_function_name:
 
 	if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 
+
 		if (UNEXPECTED(EG(exception))) {
 			if (call) {
 				 if (call->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
@@ -4499,6 +4536,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -4528,6 +4566,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ECHO_SPEC_CON
 		}
 		zend_string_release_ex(str, 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -4626,6 +4665,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline++;
@@ -4661,6 +4701,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline = OP_JMP_ADDR(opline, opline->op2);
@@ -4677,8 +4718,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = RT_CONSTANT(opline, opline->op1);
 	return_value = EX(return_value);
+
 
 	if (IS_CONST == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -4742,6 +4785,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 			}
 		}
 	}
+
+
+
 
 
 
@@ -4832,9 +4878,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR)) ||
@@ -4844,6 +4892,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 
 			retval_ptr = RT_CONSTANT(opline, opline->op1);
 			if (!return_value) {
+
 
 			} else {
 				if (IS_CONST == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -4869,6 +4918,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					ZVAL_NEW_REF(return_value, retval_ptr);
 				} else {
 
+
 				}
 				break;
 			}
@@ -4883,7 +4933,10 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			ZVAL_REF(return_value, Z_REF_P(retval_ptr));
 		}
 
+
 	} while (0);
+
+
 
 
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
@@ -4991,6 +5044,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GENERATOR_RET
 		}
 	}
 
+
 	EG(current_execute_data) = EX(prev_execute_data);
 
 	/* Close the generator to free up resources */
@@ -5071,6 +5125,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			}
 			zend_throw_error(NULL, "Can only throw objects");
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -5079,6 +5134,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	Z_TRY_ADDREF_P(value);
 	zend_throw_exception_object(value);
 	zend_exception_restore();
+
 
 	HANDLE_EXCEPTION();
 }
@@ -5151,6 +5207,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_USER_SPE
 		ZVAL_COPY(param, arg);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -5174,6 +5231,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -5213,6 +5271,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -5224,6 +5283,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -5234,12 +5294,14 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -5277,6 +5339,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -5287,6 +5350,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				zend_cast_zval_to_object(result, expr, IS_CONST);
 			}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -5301,6 +5365,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 	inc_filename = RT_CONSTANT(opline, opline->op1);
 	new_op_array = zend_include_or_eval(inc_filename, opline->extended_value);
 	if (UNEXPECTED(EG(exception) != NULL)) {
+
 
 		if (new_op_array != ZEND_FAKE_OP_ARRAY && new_op_array != NULL) {
 			destroy_op_array(new_op_array);
@@ -5351,7 +5416,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
 
 			ZEND_VM_ENTER();
 		} else {
@@ -5366,10 +5433,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			zend_rethrow_exception(execute_data);
 
+
 			UNDEF_RESULT();
 			HANDLE_EXCEPTION();
 		}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -5473,6 +5542,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CONST != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -5481,6 +5551,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -5506,14 +5577,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 0 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -5527,6 +5601,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -5568,6 +5643,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CONST != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -5577,6 +5653,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -5604,14 +5681,17 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 1 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -5625,6 +5705,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -5651,6 +5732,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 
 	if (UNEXPECTED(EG(exception))) {
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -5672,6 +5754,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		}
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -5729,6 +5812,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			if ((IS_CONST == IS_CV || IS_CONST == IS_VAR) && Z_TYPE_P(val) == IS_REFERENCE) {
 				val = Z_REFVAL_P(val);
 				if (Z_TYPE_P(val) <= IS_NULL) {
+
 
 					break;
 				}
@@ -5847,6 +5931,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_FROM_SP
 	if (UNEXPECTED(generator->flags & ZEND_GENERATOR_FORCED_CLOSE)) {
 		zend_throw_error(NULL, "Cannot use \"yield from\" in a force-closed generator");
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -5859,12 +5944,14 @@ yield_from_try_again:
 		}
 		Z_FE_POS(generator->values) = 0;
 
+
 	} else if (IS_CONST != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
 			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
 
 			Z_ADDREF_P(val);
+
 
 			if (UNEXPECTED(new_gen->execute_data == NULL)) {
 				zend_throw_error(NULL, "Generator passed to yield from was aborted without proper return and is unable to continue");
@@ -5888,6 +5975,7 @@ yield_from_try_again:
 			}
 		} else {
 			zend_object_iterator *iter = ce->get_iterator(ce, val, 0);
+
 
 			if (UNEXPECTED(!iter) || UNEXPECTED(EG(exception))) {
 				if (!EG(exception)) {
@@ -5914,6 +6002,7 @@ yield_from_try_again:
 		goto yield_from_try_again;
 	} else {
 		zend_throw_error(NULL, "Can use \"yield from\" only with arrays and Traversables");
+
 
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
@@ -5955,6 +6044,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
 				ZVAL_LONG(EX_VAR(opline->result.var), Z_STRLEN_P(value));
 
+
 				ZEND_VM_NEXT_OPCODE();
 			}
 		}
@@ -5994,6 +6084,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 		} while (0);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6026,6 +6117,7 @@ type_check_resource:
 	}
 	if (IS_CONST & (IS_TMP_VAR|IS_VAR)) {
 		SAVE_OPLINE();
+
 
 		ZEND_VM_SMART_BRANCH(result, 1);
 	} else {
@@ -6263,6 +6355,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6344,6 +6438,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6359,6 +6455,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -6372,6 +6470,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -6594,6 +6694,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6662,6 +6764,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6697,6 +6801,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -6708,6 +6814,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -6818,6 +6926,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -6895,6 +7005,8 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -7018,6 +7130,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -7046,6 +7160,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_R_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_LIST_r(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -7172,6 +7287,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -7206,10 +7323,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -7244,6 +7364,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -7252,6 +7373,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -7278,6 +7401,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CONST & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -7300,6 +7424,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -7348,6 +7473,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -7357,6 +7483,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -7390,6 +7517,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -7405,6 +7533,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -7416,6 +7545,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -7485,6 +7615,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 		 * to make sure we don't increase VM size too much. */
 		if (!(IS_CONST & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 
+
 			HANDLE_EXCEPTION();
 		}
 
@@ -7507,6 +7638,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 			call_info |= ZEND_CALL_RELEASE_THIS | ZEND_CALL_HAS_THIS;
 		}
 
+
 		if ((IS_CONST & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 			if (call_info & ZEND_CALL_CLOSURE) {
 				zend_object_release(ZEND_CLOSURE_OBJECT(func));
@@ -7522,6 +7654,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 	} else {
 		zend_type_error("%s(): Argument #1 ($callback) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
 		efree(error);
+
 
 		HANDLE_EXCEPTION();
 	}
@@ -7545,6 +7678,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		uint32_t arg_num;
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -7573,6 +7707,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_VAL_EX_S
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -7624,6 +7759,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -7632,6 +7768,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -7650,12 +7787,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -7670,12 +7809,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -7694,6 +7835,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -7704,12 +7846,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -7722,11 +7866,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -7745,6 +7891,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
@@ -7817,6 +7964,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -7900,6 +8048,7 @@ num_index_prop:
 			if (IS_CONST & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -7923,6 +8072,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -7975,6 +8126,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -8005,6 +8158,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -8047,6 +8202,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DECLARE_CONST
 			zval_ptr_dtor_nogc(&c.value);
 
 
+
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -8056,6 +8213,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DECLARE_CONST
 
 	if (zend_register_constant(&c) == NULL) {
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -8078,6 +8237,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DECLARE_ATTRI
 			zval_ptr_dtor_nogc(&c.value);
 
 
+
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -8089,6 +8250,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DECLARE_ATTRI
 	if (registered == NULL) {
 
 
+
+
 		/* two opcodes used, second one is the data with attributes */
 		ZEND_VM_NEXT_OPCODE_EX(1, 2);
 	}
@@ -8096,6 +8259,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DECLARE_ATTRI
 	HashTable *attributes = Z_PTR_P(get_op_data_zval_ptr_r((opline+1)->op1_type, (opline+1)->op1));
 	ZEND_ASSERT(attributes != NULL);
 	zend_constant_add_attributes(registered, attributes);
+
+
 
 
 	/* two opcodes used, second one is the data with attributes */
@@ -8159,6 +8324,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -8173,6 +8339,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -8193,6 +8360,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -8350,9 +8518,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			} else if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
 				result = zend_hash_index_find(ht, Z_LVAL_P(op1));
+
 
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
@@ -8378,6 +8548,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		}
@@ -8387,10 +8558,12 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			ZVAL_STR(&key_tmp, key);
 			if (zend_compare(op1, &key_tmp) == 0) {
 
+
 				ZEND_VM_SMART_BRANCH(1, 1);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
+
 
 	ZEND_VM_SMART_BRANCH(0, 1);
 }
@@ -9138,6 +9311,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR|IS_CV) OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -9145,6 +9319,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CONST & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -9165,6 +9340,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -9172,6 +9348,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9186,6 +9363,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_CONS
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9199,6 +9377,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_CONS
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -9276,6 +9455,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_C
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
+
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -9290,6 +9470,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -9327,6 +9508,7 @@ fetch_dim_r_slow:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -9339,6 +9521,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9448,6 +9631,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -9526,6 +9711,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9647,6 +9833,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9801,6 +9988,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -9836,11 +10024,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -9883,6 +10073,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -10180,6 +10371,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
 
+
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
 		if (IS_CONST == IS_TMP_VAR) {
@@ -10359,6 +10551,7 @@ num_index_prop:
 isset_dim_obj_exit:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -10409,6 +10602,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -10441,6 +10635,7 @@ array_key_exists_array:
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -10502,6 +10697,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -10516,6 +10712,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -10589,6 +10786,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV_
 		if (UNEXPECTED(!name)) {
 			if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
 
+
 			}
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
@@ -10650,6 +10848,7 @@ fetch_this:
 	}
 
 	if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
+
 
 	}
 
@@ -10737,6 +10936,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -10746,6 +10946,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -10779,6 +10980,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -10794,6 +10996,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -10805,6 +11008,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -10931,6 +11135,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -10958,6 +11163,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_VAL_EX_S
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -10995,6 +11201,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -11105,6 +11312,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
 
+
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
 		if (IS_CONST == IS_TMP_VAR) {
@@ -11177,6 +11385,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -11231,6 +11440,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_VAR_SPE
 		name = zval_try_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -11241,6 +11451,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_VAR_SPE
 	if (IS_CONST != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -11269,6 +11480,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 	if (IS_CONST != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	if (!value) {
 		result = (opline->extended_value & ZEND_ISEMPTY);
@@ -11347,6 +11559,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -11361,6 +11574,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -11381,6 +11595,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -11472,6 +11687,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 
 	ZVAL_LONG(EX_VAR(opline->result.var), count);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -11514,6 +11730,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 			break;
 		}
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -11532,6 +11749,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	} else {
 		ZVAL_STRING(EX_VAR(opline->result.var), "unknown type");
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -11680,6 +11898,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_CONS
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -11692,6 +11912,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_CONS
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -11770,6 +11992,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_C
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -11783,6 +12007,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -11820,6 +12046,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -11831,6 +12059,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -11941,6 +12171,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -12018,6 +12250,8 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -12141,6 +12375,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -12169,6 +12405,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_R_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_LIST_r(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -12295,6 +12532,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -12329,10 +12568,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -12367,6 +12609,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -12375,6 +12618,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -12401,6 +12646,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CONST & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -12423,6 +12669,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -12471,6 +12718,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -12480,6 +12728,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -12513,6 +12762,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -12528,6 +12778,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -12539,6 +12790,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -12608,6 +12860,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 		 * to make sure we don't increase VM size too much. */
 		if (!(IS_CV & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 
+
 			HANDLE_EXCEPTION();
 		}
 
@@ -12630,6 +12883,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 			call_info |= ZEND_CALL_RELEASE_THIS | ZEND_CALL_HAS_THIS;
 		}
 
+
 		if ((IS_CV & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 			if (call_info & ZEND_CALL_CLOSURE) {
 				zend_object_release(ZEND_CLOSURE_OBJECT(func));
@@ -12645,6 +12899,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_USER_CAL
 	} else {
 		zend_type_error("%s(): Argument #1 ($callback) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
 		efree(error);
+
 
 		HANDLE_EXCEPTION();
 	}
@@ -12671,6 +12926,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
@@ -12743,6 +12999,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -12826,6 +13083,7 @@ num_index_prop:
 			if (IS_CONST & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -12849,6 +13107,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -12901,6 +13161,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -12931,6 +13193,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -12993,6 +13257,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -13007,6 +13272,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -13027,6 +13293,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CO
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -13616,6 +13883,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_R_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_LIST_r(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -13985,6 +14253,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_NONE(result, 0);
 }
 
@@ -13997,6 +14266,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_JMPZ(result, 0);
 }
@@ -14011,6 +14281,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_JMPNZ(result, 0);
 }
 
@@ -14023,6 +14294,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_NONE(result, 0);
 }
@@ -14037,6 +14309,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_JMPZ(result, 0);
 }
 
@@ -14049,6 +14322,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_JMPNZ(result, 0);
 }
@@ -15135,6 +15409,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_R_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_LIST_r(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -15553,6 +15828,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			ZEND_VM_ENTER();
@@ -15849,6 +16125,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_TMPV
 	div_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -15862,6 +16139,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_TMPV
 	op2 = RT_CONSTANT(opline, opline->op2);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -15938,6 +16216,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_T
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -16302,6 +16581,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -16315,6 +16595,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_XOR_SPEC
 	op2 = RT_CONSTANT(opline, opline->op2);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -16350,6 +16631,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -16362,6 +16644,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -16453,6 +16736,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -16530,6 +16815,7 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -16651,6 +16937,7 @@ fetch_obj_is_copy:
 	} while (0);
 
 fetch_obj_is_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -16778,6 +17065,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 	} while (0);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -16817,6 +17105,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 
+
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -16850,6 +17139,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -16858,6 +17148,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
 
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 				HANDLE_EXCEPTION();
@@ -16884,6 +17175,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -16906,6 +17198,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -17005,6 +17298,7 @@ case_double:
 		if (EXPECTED(Z_TYPE_P(op2) == IS_STRING)) {
 			bool result = zend_fast_equal_strings(Z_STR_P(op1), Z_STR_P(op2));
 
+
 			if (result) {
 				goto case_true;
 			} else {
@@ -17066,6 +17360,7 @@ num_index_prop:
 			if ((IS_TMP_VAR|IS_VAR) & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -17089,6 +17384,7 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -17140,6 +17436,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 
 isset_object_finish:
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -17171,6 +17468,7 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -17944,6 +18242,8 @@ fetch_obj_r_fast_copy:
 						EX(opline) = hook->op_array.opcodes;
 #endif
 						LOAD_OPLINE_EX();
+
+
 
 
 						ZEND_VM_ENTER_EX();
@@ -19111,6 +19411,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_TMPV
 	div_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -19124,6 +19425,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_TMPV
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -19201,6 +19503,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_T
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -19215,6 +19518,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -19250,6 +19554,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, IS_CV OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -19262,6 +19567,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -19353,6 +19659,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -19430,6 +19738,7 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -19551,6 +19860,7 @@ fetch_obj_is_copy:
 	} while (0);
 
 fetch_obj_is_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -19678,6 +19988,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 	} while (0);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -19717,6 +20028,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 
+
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -19750,6 +20062,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -19758,6 +20071,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
 
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 				HANDLE_EXCEPTION();
@@ -19784,6 +20098,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -19806,6 +20121,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -19877,6 +20193,7 @@ case_double:
 		if (EXPECTED(Z_TYPE_P(op2) == IS_STRING)) {
 			bool result = zend_fast_equal_strings(Z_STR_P(op1), Z_STR_P(op2));
 
+
 			if (result) {
 				goto case_true;
 			} else {
@@ -19938,6 +20255,7 @@ num_index_prop:
 			if ((IS_TMP_VAR|IS_VAR) & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -19961,6 +20279,7 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -20012,6 +20331,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 
 isset_object_finish:
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -20044,6 +20364,7 @@ array_key_exists_array:
 		result = 0;
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -20054,8 +20375,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_TMP_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -20122,6 +20445,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 
 
 
+
+
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -20131,9 +20457,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR)) ||
@@ -20186,6 +20514,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 	} while (0);
 
 
+
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -20224,6 +20554,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GENERATOR_RET
 			ZVAL_COPY_VALUE(&generator->retval, retval);
 		}
 	}
+
 
 	EG(current_execute_data) = EX(prev_execute_data);
 
@@ -20288,6 +20619,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CAST_SPEC_TMP
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -20319,6 +20651,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_TMP_VAR != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -20327,6 +20660,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -20352,10 +20686,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -20415,6 +20751,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_TMP_VAR != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -20424,6 +20761,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -20451,10 +20789,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -20670,6 +21010,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = fast_is_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -20683,6 +21024,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CASE_STRICT_S
 	op1 = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -20698,6 +21040,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -20767,6 +21110,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_ADD_SPEC
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}
@@ -20801,6 +21145,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_END_SPEC
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				for (i = 0; i <= opline->extended_value; i++) {
@@ -20957,6 +21302,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -21061,6 +21407,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -21080,6 +21427,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -21502,6 +21850,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -21855,6 +22204,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -21959,6 +22309,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -21978,6 +22329,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -22034,6 +22386,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CASE_STRICT_S
 	op1 = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -22103,6 +22456,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_ADD_SPEC
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}
@@ -22137,6 +22491,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_END_SPEC
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				for (i = 0; i <= opline->extended_value; i++) {
@@ -22256,6 +22611,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -22360,6 +22716,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -22379,6 +22736,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_TM
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -22680,8 +23038,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -22748,6 +23108,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 
 
 
+
+
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -22757,9 +23120,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR)) ||
@@ -22812,6 +23177,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 	} while (0);
 
 
+
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -22850,6 +23217,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GENERATOR_RET
 			ZVAL_COPY_VALUE(&generator->retval, retval);
 		}
 	}
+
 
 	EG(current_execute_data) = EX(prev_execute_data);
 
@@ -23587,6 +23955,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = fast_is_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -23600,6 +23969,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CASE_STRICT_S
 	op1 = _get_zval_ptr_var_deref(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -23615,6 +23985,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -23705,6 +24076,7 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -23808,6 +24180,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -23837,6 +24210,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OP_SPE
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -23902,6 +24276,7 @@ pre_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -23964,6 +24339,7 @@ post_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -23976,6 +24352,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -23991,6 +24368,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -24026,6 +24404,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_UNS
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_UNSET(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -24047,6 +24426,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -24063,6 +24443,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -24098,6 +24479,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -24122,6 +24504,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_W_
 	} else {
 		zend_fetch_dimension_address_W(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -24249,6 +24632,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -24269,10 +24653,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -24428,6 +24814,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -24582,6 +24969,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -24711,6 +25099,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -24731,10 +25120,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -24840,6 +25231,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -24847,11 +25239,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -24859,6 +25253,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -24881,12 +25276,14 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CONST != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -25041,6 +25438,7 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -25194,6 +25592,7 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -25298,6 +25697,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -25305,11 +25705,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -25317,6 +25719,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -25339,12 +25742,14 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CONST != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -25442,6 +25847,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -25480,6 +25886,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -25502,6 +25910,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -25511,6 +25920,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -25544,6 +25954,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -25559,6 +25970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -25570,6 +25982,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -25935,6 +26348,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -25943,6 +26357,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -25961,12 +26376,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -25981,12 +26398,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -26005,6 +26424,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -26015,12 +26435,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -26033,11 +26455,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -26128,6 +26552,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -26247,6 +26672,7 @@ num_index_dim:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -26290,6 +26716,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -26387,6 +26814,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_VA
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -27255,6 +27683,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -27274,6 +27703,7 @@ free_and_exit_assign_obj:
 	if (UNEXPECTED(RETURN_VALUE_USED(opline)) && value) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
+
 
 exit_assign_obj:
 	if (garbage) {
@@ -27717,6 +28147,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -27736,6 +28167,7 @@ free_and_exit_assign_obj:
 	if (UNEXPECTED(RETURN_VALUE_USED(opline)) && value) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
+
 
 exit_assign_obj:
 	if (garbage) {
@@ -27846,6 +28278,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -27853,11 +28286,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -27865,6 +28300,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -27886,6 +28322,7 @@ try_assign_dim_array:
 			zend_use_scalar_as_array();
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
+
 
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
@@ -28304,6 +28741,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -28311,11 +28749,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -28323,6 +28763,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -28344,6 +28785,7 @@ try_assign_dim_array:
 			zend_use_scalar_as_array();
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
+
 
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
@@ -28427,6 +28869,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -29280,6 +29723,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -29292,6 +29736,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -29307,6 +29752,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -29431,6 +29877,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -29438,11 +29885,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -29450,6 +29899,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -29472,12 +29922,14 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_UNUSED != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -29632,6 +30084,7 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -29785,6 +30238,7 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -29889,6 +30343,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -29896,11 +30351,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -29908,6 +30365,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -29930,12 +30388,14 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_UNUSED != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -29961,6 +30421,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -29970,6 +30431,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -30003,6 +30465,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -30018,6 +30481,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -30029,6 +30493,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -30726,6 +31191,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -30865,6 +31331,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_VA
 		}
 		ZVAL_COPY(&generator->key, key);
 
+
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
 		) {
@@ -30976,6 +31443,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CASE_STRICT_S
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -31065,6 +31533,7 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -31168,6 +31637,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -31197,6 +31667,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OP_SPE
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -31262,6 +31733,7 @@ pre_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -31324,6 +31796,7 @@ post_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -31336,6 +31809,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -31351,6 +31825,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -31386,6 +31861,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_UNS
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_UNSET(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -31407,6 +31883,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -31423,6 +31900,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -31458,6 +31936,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -31482,6 +31961,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_LIST_W_
 	} else {
 		zend_fetch_dimension_address_W(container, dim, IS_CV OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -31609,6 +32089,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -31629,10 +32110,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -31788,6 +32271,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -31942,6 +32426,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -32071,6 +32556,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -32091,10 +32577,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -32200,6 +32688,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -32207,11 +32696,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -32219,6 +32710,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -32241,12 +32733,14 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CV != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -32401,6 +32895,7 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -32554,6 +33049,7 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -32658,6 +33154,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -32665,11 +33162,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -32677,6 +33176,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -32699,12 +33199,14 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CV != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -32804,6 +33306,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_REF_SP
 		GC_DTOR(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -32839,6 +33342,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -32878,6 +33382,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -32900,6 +33406,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -32909,6 +33416,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -32942,6 +33450,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -32957,6 +33466,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -32968,6 +33478,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -33102,6 +33613,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -33220,6 +33732,7 @@ num_index_dim:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -33263,6 +33776,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -33360,6 +33874,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_VA
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -33557,6 +34072,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_UN
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -33568,6 +34084,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_UN
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -33578,12 +34095,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_UN
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -33603,11 +34122,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_N
 				zend_type_error("Cannot use \"::class\" on %s", zend_zval_value_name(op));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 		}
 
 		ZVAL_STR_COPY(EX_VAR(opline->result.var), Z_OBJCE_P(op)->name);
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -33738,6 +34259,8 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -33804,6 +34327,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -33864,6 +34389,8 @@ post_incdec_object:
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -33955,6 +34482,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -34034,6 +34563,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -34057,6 +34588,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -34073,6 +34605,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -34198,6 +34731,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -34228,6 +34763,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -34358,6 +34894,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -34378,10 +34915,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -34538,6 +35078,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -34692,6 +35234,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -34820,6 +35364,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -34840,10 +35385,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -34880,6 +35428,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, IS_CONST, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -34919,6 +35469,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 
 
 
+
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -34951,6 +35504,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_INIT_SPE
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[0] = zval_get_string_func(var);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
@@ -34997,6 +35551,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -35031,10 +35586,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -35069,6 +35627,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -35077,6 +35636,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -35103,6 +35664,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_UNUSED & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -35125,6 +35687,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -35173,6 +35736,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -35182,6 +35746,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -35215,6 +35780,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -35230,6 +35796,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -35241,6 +35808,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -35361,6 +35929,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -35369,6 +35938,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -35387,12 +35957,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -35407,12 +35979,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -35431,6 +36005,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -35441,12 +36016,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -35459,11 +36036,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_C
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -35531,6 +36110,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -35579,6 +36160,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 	}
 
 isset_object_finish:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -35641,6 +36224,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -35655,6 +36239,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -35675,6 +36260,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -35924,6 +36510,7 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -35991,6 +36578,7 @@ pre_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -36053,6 +36641,7 @@ post_incdec_object:
 	} while (0);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -36143,6 +36732,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -36221,6 +36812,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -36380,6 +36972,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -36541,6 +37134,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -36561,11 +37155,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -36721,6 +37317,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -36875,6 +37472,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -37003,6 +37601,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -37023,11 +37622,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -37063,6 +37664,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -37100,7 +37702,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 		zend_assign_to_property_reference(container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -37215,11 +37819,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -37262,6 +37868,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -37536,6 +38143,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -37585,6 +38193,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -37646,6 +38255,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -37660,6 +38270,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -37748,6 +38359,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -37769,6 +38381,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -37778,6 +38391,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -37811,6 +38425,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -37826,6 +38441,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -37837,6 +38453,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -38184,6 +38801,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -38198,6 +38816,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -38218,6 +38837,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -38319,6 +38939,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GET_CLASS_SPE
 			}
 			break;
 		}
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -38573,6 +39194,8 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -38639,6 +39262,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -38699,6 +39324,8 @@ post_incdec_object:
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -38790,6 +39417,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -38869,6 +39498,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -38887,6 +39518,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -38903,6 +39535,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -39028,6 +39661,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -39058,6 +39693,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -39188,6 +39824,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -39208,10 +39845,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -39368,6 +40008,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -39522,6 +40164,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -39650,6 +40294,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -39670,10 +40315,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -39710,6 +40358,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -39749,6 +40399,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 
 
 
+
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -39781,6 +40434,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ROPE_INIT_SPE
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[0] = zval_get_string_func(var);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
@@ -39827,6 +40481,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -39861,10 +40516,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -39899,6 +40557,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -39907,6 +40566,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -39933,6 +40594,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_UNUSED & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -39955,6 +40617,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -40003,6 +40666,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -40012,6 +40676,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -40045,6 +40710,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -40060,6 +40726,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -40071,6 +40738,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_STATIC_M
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -40181,6 +40849,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -40229,6 +40899,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 	}
 
 isset_object_finish:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -40291,6 +40963,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -40305,6 +40978,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -40325,6 +40999,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_UN
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -40374,6 +41049,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_NOT_SPEC
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -40407,6 +41083,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV 
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -40477,6 +41154,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV 
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -40544,6 +41222,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV 
 		increment_function(var_ptr);
 	} while (0);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -40591,6 +41270,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV 
 		decrement_function(var_ptr);
 	} while (0);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -40634,6 +41314,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ECHO_SPEC_CV_
 		}
 		zend_string_release_ex(str, 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -40732,6 +41413,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_JMPZ_EX_SPEC_
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline++;
@@ -40767,6 +41449,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_JMPNZ_EX_SPEC
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline = OP_JMP_ADDR(opline, opline->op2);
@@ -40783,8 +41466,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = EX_VAR(opline->op1.var);
 	return_value = EX(return_value);
+
 
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -40851,6 +41536,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_R
 
 
 
+
+
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -40860,9 +41548,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR)) ||
@@ -40872,6 +41562,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 
 			retval_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 			if (!return_value) {
+
 
 			} else {
 				if (IS_CV == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -40897,6 +41588,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 					ZVAL_NEW_REF(return_value, retval_ptr);
 				} else {
 
+
 				}
 				break;
 			}
@@ -40911,7 +41603,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_RETURN_BY_REF
 			ZVAL_REF(return_value, Z_REF_P(retval_ptr));
 		}
 
+
 	} while (0);
+
+
 
 
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
@@ -40953,6 +41648,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GENERATOR_RET
 		}
 	}
 
+
 	EG(current_execute_data) = EX(prev_execute_data);
 
 	/* Close the generator to free up resources */
@@ -40986,6 +41682,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_THROW_SPEC_CV
 			}
 			zend_throw_error(NULL, "Can only throw objects");
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -40994,6 +41691,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_THROW_SPEC_CV
 	Z_TRY_ADDREF_P(value);
 	zend_throw_exception_object(value);
 	zend_exception_restore();
+
 
 	HANDLE_EXCEPTION();
 }
@@ -41014,6 +41712,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_USER_SPE
 	} else {
 		ZVAL_COPY(param, arg);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41038,6 +41737,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_SPEC_CV_
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -41077,6 +41777,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_CV
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -41088,6 +41789,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_CV
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -41098,12 +41800,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CLONE_SPEC_CV
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41141,6 +41845,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CAST_SPEC_CV_
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -41151,6 +41856,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CAST_SPEC_CV_
 				zend_cast_zval_to_object(result, expr, IS_CV);
 			}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41165,6 +41871,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 	inc_filename = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	new_op_array = zend_include_or_eval(inc_filename, opline->extended_value);
 	if (UNEXPECTED(EG(exception) != NULL)) {
+
 
 		if (new_op_array != ZEND_FAKE_OP_ARRAY && new_op_array != NULL) {
 			destroy_op_array(new_op_array);
@@ -41215,7 +41922,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
 
 			ZEND_VM_ENTER();
 		} else {
@@ -41230,10 +41939,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INCLUDE_OR_EV
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			zend_rethrow_exception(execute_data);
 
+
 			UNDEF_RESULT();
 			HANDLE_EXCEPTION();
 		}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -41254,6 +41965,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CV != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -41262,6 +41974,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -41287,14 +42000,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 0 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -41308,6 +42024,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_R_SP
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -41349,6 +42066,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CV != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -41358,6 +42076,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -41385,14 +42104,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 1 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -41406,6 +42128,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FE_RESET_RW_S
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -41432,6 +42155,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_JMP_SET_SPEC_
 
 	if (UNEXPECTED(EG(exception))) {
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -41453,6 +42177,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_JMP_SET_SPEC_
 		}
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -41510,6 +42235,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_J
 			if ((IS_CV == IS_CV || IS_CV == IS_VAR) && Z_TYPE_P(val) == IS_REFERENCE) {
 				val = Z_REFVAL_P(val);
 				if (Z_TYPE_P(val) <= IS_NULL) {
+
 
 					break;
 				}
@@ -41592,6 +42318,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_FROM_SP
 	if (UNEXPECTED(generator->flags & ZEND_GENERATOR_FORCED_CLOSE)) {
 		zend_throw_error(NULL, "Cannot use \"yield from\" in a force-closed generator");
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -41604,12 +42331,14 @@ yield_from_try_again:
 		}
 		Z_FE_POS(generator->values) = 0;
 
+
 	} else if (IS_CV != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
 			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
 
 			Z_ADDREF_P(val);
+
 
 			if (UNEXPECTED(new_gen->execute_data == NULL)) {
 				zend_throw_error(NULL, "Generator passed to yield from was aborted without proper return and is unable to continue");
@@ -41633,6 +42362,7 @@ yield_from_try_again:
 			}
 		} else {
 			zend_object_iterator *iter = ce->get_iterator(ce, val, 0);
+
 
 			if (UNEXPECTED(!iter) || UNEXPECTED(EG(exception))) {
 				if (!EG(exception)) {
@@ -41659,6 +42389,7 @@ yield_from_try_again:
 		goto yield_from_try_again;
 	} else {
 		zend_throw_error(NULL, "Can use \"yield from\" only with arrays and Traversables");
+
 
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
@@ -41700,6 +42431,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_C
 			if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
 				ZVAL_LONG(EX_VAR(opline->result.var), Z_STRLEN_P(value));
 
+
 				ZEND_VM_NEXT_OPCODE();
 			}
 		}
@@ -41739,6 +42471,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_STRLEN_SPEC_C
 		} while (0);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -41772,6 +42505,7 @@ type_check_resource:
 	if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 		SAVE_OPLINE();
 
+
 		ZEND_VM_SMART_BRANCH(result, 1);
 	} else {
 		ZEND_VM_SMART_BRANCH(result, 0);
@@ -41793,11 +42527,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_N
 				zend_type_error("Cannot use \"::class\" on %s", zend_zval_value_name(op));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 		}
 
 		ZVAL_STR_COPY(EX_VAR(opline->result.var), Z_OBJCE_P(op)->name);
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -42097,6 +42833,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_CV_C
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -42109,6 +42847,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_CV_C
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -42187,6 +42927,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_C
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -42203,6 +42945,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -42216,6 +42960,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -42580,6 +43326,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -42592,6 +43340,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_XOR_SPEC
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -42683,6 +43433,8 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -42787,6 +43539,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -42815,6 +43569,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OP_SPE
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -42881,6 +43637,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -42943,6 +43701,8 @@ post_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -42978,6 +43738,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -42989,6 +43751,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -43005,6 +43768,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -43019,6 +43783,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -43051,6 +43817,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_UNS
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_UNSET(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -43144,6 +43911,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -43223,6 +43992,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -43246,6 +44017,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -43262,6 +44034,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -43387,6 +44160,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -43417,6 +44192,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -43547,6 +44323,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -43567,10 +44344,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -43727,6 +44507,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -43881,6 +44663,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -44009,6 +44793,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -44029,10 +44814,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -44138,6 +44926,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -44145,11 +44934,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -44157,6 +44948,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -44179,6 +44971,7 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -44186,7 +44979,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -44339,7 +45134,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -44492,7 +45289,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -44596,6 +45395,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -44603,11 +45403,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -44615,6 +45417,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -44637,6 +45440,7 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -44644,7 +45448,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -44674,6 +45480,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 		value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -44702,6 +45509,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -44739,6 +45547,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	}
 
 
+
+
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -44773,6 +45583,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CONST, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
+
 
 
 
@@ -44902,6 +45715,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -44936,10 +45751,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -44974,6 +45792,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -44982,6 +45801,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -45008,6 +45829,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CV & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -45030,6 +45852,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_I
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -45071,6 +45894,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		uint32_t arg_num;
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -45119,6 +45943,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_REF_SPEC
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -45132,6 +45957,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_REF_SPEC
 		ZVAL_MAKE_REF_EX(varptr, 2);
 	}
 	ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -45147,6 +45973,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_VAR_EX_S
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -45168,6 +45995,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -45215,6 +46043,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -45287,6 +46116,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -45407,6 +46237,8 @@ num_index_dim:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -45449,6 +46281,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -45505,6 +46339,7 @@ num_index_prop:
 			if (IS_CV & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -45528,6 +46363,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -45580,6 +46417,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -45612,6 +46451,8 @@ array_key_exists_array:
 	}
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -45640,6 +46481,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -45656,6 +46498,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -45717,6 +46560,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -45731,6 +46575,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -45751,6 +46596,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -45886,9 +46732,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IN_ARRAY_SPEC
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			} else if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
 				result = zend_hash_index_find(ht, Z_LVAL_P(op1));
+
 
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
@@ -45914,6 +46762,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IN_ARRAY_SPEC
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		}
@@ -45923,10 +46772,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IN_ARRAY_SPEC
 			ZVAL_STR(&key_tmp, key);
 			if (zend_compare(op1, &key_tmp) == 0) {
 
+
 				ZEND_VM_SMART_BRANCH(1, 1);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
+
 
 	ZEND_VM_SMART_BRANCH(0, 1);
 }
@@ -45977,6 +46828,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -45984,6 +46836,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -46004,6 +46857,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -46011,6 +46865,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46032,6 +46887,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR|IS_CV) OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -46039,6 +46895,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -46059,6 +46916,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -46066,6 +46924,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46080,6 +46939,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_CV_T
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46093,6 +46953,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_CV_T
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -46169,6 +47030,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_C
 			op2 = ZVAL_UNDEFINED_OP2();
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
+
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -46533,6 +47395,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46546,6 +47409,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_XOR_SPEC
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -46638,6 +47502,7 @@ assign_op_object:
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -46742,6 +47607,7 @@ assign_dim_op_ret_null:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -46772,6 +47638,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OP_SPE
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46838,6 +47705,7 @@ pre_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -46901,6 +47769,7 @@ post_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -46935,6 +47804,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46978,6 +47848,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -47102,6 +47973,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -47180,6 +48053,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -47339,6 +48213,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -47500,6 +48375,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -47520,11 +48396,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -47680,6 +48558,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -47834,6 +48713,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -47962,6 +48842,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -47982,11 +48863,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -48091,6 +48974,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -48098,11 +48982,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -48110,6 +48996,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -48132,6 +49019,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -48140,6 +49028,7 @@ assign_dim_error:
 	if ((IS_TMP_VAR|IS_VAR) != IS_UNUSED) {
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -48294,6 +49183,7 @@ assign_dim_error:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
 
+
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -48447,6 +49337,7 @@ assign_dim_error:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
 
+
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -48549,6 +49440,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -48556,11 +49448,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -48568,6 +49462,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -48590,6 +49485,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -48598,6 +49494,7 @@ assign_dim_error:
 	if ((IS_TMP_VAR|IS_VAR) != IS_UNUSED) {
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -48632,6 +49529,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -48669,7 +49567,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 		zend_assign_to_property_reference(container, IS_CV, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -48796,6 +49696,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -48831,11 +49732,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -48878,6 +49781,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -48969,6 +49873,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -49162,6 +50067,7 @@ num_index_dim:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -49206,6 +50112,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 	} while (0);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -49286,6 +50193,7 @@ num_index_prop:
 isset_dim_obj_exit:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -49336,6 +50244,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -49368,6 +50277,7 @@ array_key_exists_array:
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -49429,6 +50339,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -49443,6 +50354,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -49503,6 +50415,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	op2 = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -49517,6 +50430,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -49545,6 +50459,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -49575,6 +50490,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 		value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -49591,6 +50507,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	op2 = _get_zval_ptr_var_deref(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -49605,6 +50522,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var_deref(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -49634,6 +50552,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 		value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -49662,6 +50581,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -49704,6 +50624,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_REF_SP
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -49732,6 +50653,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -49748,6 +50670,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -49849,6 +50772,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -49875,6 +50800,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV_
 		name = zval_try_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(!name)) {
 			if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
+
 
 			}
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
@@ -49938,6 +50864,7 @@ fetch_this:
 
 	if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
 
+
 	}
 
 	if (IS_CV != IS_CONST) {
@@ -49996,6 +50923,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -50010,6 +50938,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -50134,6 +51063,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -50141,11 +51071,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -50153,6 +51085,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -50175,6 +51108,7 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -50182,7 +51116,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -50335,7 +51271,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -50488,7 +51426,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -50592,6 +51532,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -50599,11 +51540,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -50611,6 +51554,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -50633,6 +51577,7 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -50640,7 +51585,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -50725,6 +51672,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -50772,6 +51720,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_REF_SPEC
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -50785,6 +51734,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_REF_SPEC
 		ZVAL_MAKE_REF_EX(varptr, 2);
 	}
 	ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -50800,6 +51750,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SEND_VAR_EX_S
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -50821,6 +51772,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -50866,6 +51818,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_S
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -50886,6 +51839,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -50933,6 +51887,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -51006,6 +51961,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -51078,6 +52034,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_VAR_SPE
 		name = zval_try_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -51088,6 +52045,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_VAR_SPE
 	if (IS_CV != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -51161,6 +52119,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 		zend_tmp_string_release(tmp_name);
 	}
 
+
 	if (!value) {
 		result = (opline->extended_value & ZEND_ISEMPTY);
 	} else {
@@ -51206,6 +52165,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -51222,6 +52182,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -51283,6 +52244,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -51297,6 +52259,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -51317,6 +52280,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -51443,6 +52407,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_COUNT_SPEC_CV
 
 	ZVAL_LONG(EX_VAR(opline->result.var), count);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -51500,6 +52465,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GET_CLASS_SPE
 			break;
 		}
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -51518,6 +52484,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_GET_TYPE_SPEC
 	} else {
 		ZVAL_STRING(EX_VAR(opline->result.var), "unknown type");
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -51555,6 +52522,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_DIV_SPEC_CV_C
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -51567,6 +52536,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_POW_SPEC_CV_C
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -51645,6 +52616,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CONCAT_SPEC_C
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -51661,6 +52634,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_IDENTICAL_
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -51674,6 +52649,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_IS_NOT_IDENTI
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -52038,6 +53015,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_SPACESHIP_SPE
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52050,6 +53029,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_BOOL_XOR_SPEC
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -52141,6 +53122,8 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -52245,6 +53228,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -52273,6 +53258,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OP_SPE
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -52339,6 +53326,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52401,6 +53390,8 @@ post_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52436,6 +53427,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52447,6 +53440,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_W_S
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -52463,6 +53457,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_RW_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -52477,6 +53472,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_IS_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -52509,6 +53506,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_DIM_UNS
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_UNSET(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -52602,6 +53600,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -52681,6 +53681,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52699,6 +53701,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_W_S
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -52715,6 +53718,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_RW_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -52840,6 +53844,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -52870,6 +53876,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_OBJ_UNS
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -53000,6 +54007,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -53020,10 +54028,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -53180,6 +54191,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -53334,6 +54347,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -53462,6 +54477,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -53482,10 +54498,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -53591,6 +54610,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -53598,11 +54618,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -53610,6 +54632,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -53632,6 +54655,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -53639,7 +54663,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -53792,7 +54818,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -53945,7 +54973,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -54049,6 +55079,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -54056,11 +55087,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -54068,6 +55101,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -54090,6 +55124,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -54097,7 +55132,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -54127,6 +55164,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 		value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -54155,6 +55193,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_SPEC_C
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -54196,6 +55235,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_REF_SP
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -54228,6 +55269,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -54264,6 +55307,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ASSIGN_OBJ_RE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
+
 
 
 
@@ -54393,6 +55439,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FAST_CONCAT_S
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -54427,10 +55475,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -54465,6 +55516,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -54473,6 +55525,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -54499,6 +55553,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CV & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -54521,6 +55576,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_INIT_METHOD_C
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -54565,6 +55621,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ADD_ARRAY_ELE
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -54637,6 +55694,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -54757,6 +55815,8 @@ num_index_dim:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -54799,6 +55859,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_UNSET_OBJ_SPE
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -54855,6 +55917,7 @@ num_index_prop:
 			if (IS_CV & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -54878,6 +55941,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -54930,6 +55995,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_ISSET_ISEMPTY
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -54960,6 +56027,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -55022,6 +56091,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -55036,6 +56106,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -55056,6 +56127,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_YIELD_SPEC_CV
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -55396,6 +56468,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_STATIC_PROP
 	prop = zend_fetch_static_property_address(&prop_info, opline->extended_value, BP_VAR_W, 0 OPLINE_CC EXECUTE_DATA_CC);
 	if (UNEXPECTED(!prop)) {
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -55404,6 +56477,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_STATIC_PROP
 
 	if (ZEND_TYPE_IS_SET(prop_info->type)) {
 		value = zend_assign_to_typed_prop(prop_info, prop, value, &garbage EXECUTE_DATA_CC);
+
 
 	} else {
 		value = zend_assign_to_variable_ex(prop, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
@@ -55507,6 +56581,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_STATIC_PROP
 	prop = zend_fetch_static_property_address(&prop_info, opline->extended_value, BP_VAR_W, 0 OPLINE_CC EXECUTE_DATA_CC);
 	if (UNEXPECTED(!prop)) {
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -55515,6 +56590,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_STATIC_PROP
 
 	if (ZEND_TYPE_IS_SET(prop_info->type)) {
 		value = zend_assign_to_typed_prop(prop_info, prop, value, &garbage EXECUTE_DATA_CC);
+
 
 	} else {
 		value = zend_assign_to_variable_ex(prop, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
@@ -55750,6 +56826,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_ICA
 	ret = 0 ? EX_VAR(opline->result.var) : &retval;
 	ZVAL_NULL(ret);
 
+
 	fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -55764,6 +56841,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_ICA
 		zend_verify_internal_func_info(call->func, ret);
 	}
 #endif
+
 
 	ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -55814,6 +56892,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_ICA
 	ret = 1 ? EX_VAR(opline->result.var) : &retval;
 	ZVAL_NULL(ret);
 
+
 	fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -55828,6 +56907,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_ICA
 		zend_verify_internal_func_info(call->func, ret);
 	}
 #endif
+
 
 	ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -55943,6 +57023,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_UCA
 	LOAD_OPLINE_EX();
 
 
+
+
 	ZEND_VM_ENTER_EX();
 }
 
@@ -55965,6 +57047,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_UCA
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 	LOAD_OPLINE_EX();
+
+
 
 
 	ZEND_VM_ENTER_EX();
@@ -56037,6 +57121,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		LOAD_OPLINE_EX();
 
 
+
+
 		ZEND_VM_ENTER_EX();
 	} else {
 		ZEND_ASSERT(fbc->type == ZEND_INTERNAL_FUNCTION);
@@ -56054,6 +57140,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -56068,6 +57155,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -56146,6 +57234,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		LOAD_OPLINE_EX();
 
 
+
+
 		ZEND_VM_ENTER_EX();
 	} else {
 		ZEND_ASSERT(fbc->type == ZEND_INTERNAL_FUNCTION);
@@ -56163,6 +57253,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		fbc->internal_function.handler(call, ret);
 
 #if ZEND_DEBUG
@@ -56177,6 +57268,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -56371,9 +57463,12 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
@@ -56396,6 +57491,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		ret = 0 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -56415,6 +57511,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -56496,9 +57593,12 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
@@ -56521,6 +57621,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 		ret = 1 ? EX_VAR(opline->result.var) : &retval;
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -56540,6 +57641,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DO_FCA
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		ZEND_VM_FCALL_INTERRUPT_CHECK(call);
 
@@ -57888,9 +58990,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CALL_TRAMPOLINE_SP
 			LOAD_OPLINE_EX();
 
 
+
+
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 
 			execute_data = EX(prev_execute_data);
 			if (execute_data) {
@@ -57916,6 +59021,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CALL_TRAMPOLINE_SP
 
 		ZVAL_NULL(ret);
 
+
 		if (!zend_execute_internal) {
 			/* saves one function call if zend_execute_internal is not used */
 			fbc->internal_function.handler(call, ret);
@@ -57935,6 +59041,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CALL_TRAMPOLINE_SP
 			zend_verify_internal_func_info(call->func, ret);
 		}
 #endif
+
 
 		EG(current_execute_data) = call->prev_execute_data;
 
@@ -58356,6 +59463,7 @@ try_function_name:
 
 	if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 
+
 		if (UNEXPECTED(EG(exception))) {
 			if (call) {
 				 if (call->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
@@ -58735,6 +59843,7 @@ try_function_name:
 
 	if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 
+
 		if (UNEXPECTED(EG(exception))) {
 			if (call) {
 				 if (call->func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
@@ -58790,6 +59899,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -58819,6 +59929,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ECHO_SPEC_CONST_TA
 		}
 		zend_string_release_ex(str, 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -58917,6 +60028,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMPZ_
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline++;
@@ -58952,6 +60064,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMPNZ
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline = OP_JMP_ADDR(opline, opline->op2);
@@ -58968,8 +60081,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = RT_CONSTANT(opline, opline->op1);
 	return_value = EX(return_value);
+
 
 	if (IS_CONST == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -59033,6 +60148,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 			}
 		}
 	}
+
+
+
 
 
 
@@ -59123,9 +60241,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETUR
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR)) ||
@@ -59135,6 +60255,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETUR
 
 			retval_ptr = RT_CONSTANT(opline, opline->op1);
 			if (!return_value) {
+
 
 			} else {
 				if (IS_CONST == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -59160,6 +60281,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETUR
 					ZVAL_NEW_REF(return_value, retval_ptr);
 				} else {
 
+
 				}
 				break;
 			}
@@ -59174,7 +60296,10 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETUR
 			ZVAL_REF(return_value, Z_REF_P(retval_ptr));
 		}
 
+
 	} while (0);
+
+
 
 
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
@@ -59282,6 +60407,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GENERATOR_RETURN_S
 		}
 	}
 
+
 	EG(current_execute_data) = EX(prev_execute_data);
 
 	/* Close the generator to free up resources */
@@ -59362,6 +60488,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_THROW
 			}
 			zend_throw_error(NULL, "Can only throw objects");
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -59370,6 +60497,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_THROW
 	Z_TRY_ADDREF_P(value);
 	zend_throw_exception_object(value);
 	zend_exception_restore();
+
 
 	HANDLE_EXCEPTION();
 }
@@ -59442,6 +60570,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_USER_SPEC_CON
 		ZVAL_COPY(param, arg);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -59465,6 +60594,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -59504,6 +60634,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -59515,6 +60646,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -59525,12 +60657,14 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -59568,6 +60702,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CAST_
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -59578,6 +60713,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CAST_
 				zend_cast_zval_to_object(result, expr, IS_CONST);
 			}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -59592,6 +60728,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 	inc_filename = RT_CONSTANT(opline, opline->op1);
 	new_op_array = zend_include_or_eval(inc_filename, opline->extended_value);
 	if (UNEXPECTED(EG(exception) != NULL)) {
+
 
 		if (new_op_array != ZEND_FAKE_OP_ARRAY && new_op_array != NULL) {
 			destroy_op_array(new_op_array);
@@ -59642,7 +60779,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
 
 			ZEND_VM_ENTER();
 		} else {
@@ -59657,10 +60796,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			zend_rethrow_exception(execute_data);
 
+
 			UNDEF_RESULT();
 			HANDLE_EXCEPTION();
 		}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -59764,6 +60905,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CO
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CONST != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -59772,6 +60914,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CO
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -59797,14 +60940,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CO
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 0 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -59818,6 +60964,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CO
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -59859,6 +61006,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RE
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CONST != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -59868,6 +61016,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RE
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -59895,14 +61044,17 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RE
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 1 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -59916,6 +61068,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RE
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -59942,6 +61095,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_S
 
 	if (UNEXPECTED(EG(exception))) {
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -59963,6 +61117,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_S
 		}
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -60020,6 +61175,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_N
 			if ((IS_CONST == IS_CV || IS_CONST == IS_VAR) && Z_TYPE_P(val) == IS_REFERENCE) {
 				val = Z_REFVAL_P(val);
 				if (Z_TYPE_P(val) <= IS_NULL) {
+
 
 					break;
 				}
@@ -60138,6 +61294,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_FROM_SPEC_CO
 	if (UNEXPECTED(generator->flags & ZEND_GENERATOR_FORCED_CLOSE)) {
 		zend_throw_error(NULL, "Cannot use \"yield from\" in a force-closed generator");
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -60150,12 +61307,14 @@ yield_from_try_again:
 		}
 		Z_FE_POS(generator->values) = 0;
 
+
 	} else if (IS_CONST != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
 			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
 
 			Z_ADDREF_P(val);
+
 
 			if (UNEXPECTED(new_gen->execute_data == NULL)) {
 				zend_throw_error(NULL, "Generator passed to yield from was aborted without proper return and is unable to continue");
@@ -60179,6 +61338,7 @@ yield_from_try_again:
 			}
 		} else {
 			zend_object_iterator *iter = ce->get_iterator(ce, val, 0);
+
 
 			if (UNEXPECTED(!iter) || UNEXPECTED(EG(exception))) {
 				if (!EG(exception)) {
@@ -60205,6 +61365,7 @@ yield_from_try_again:
 		goto yield_from_try_again;
 	} else {
 		zend_throw_error(NULL, "Can use \"yield from\" only with arrays and Traversables");
+
 
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
@@ -60246,6 +61407,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLE
 			if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
 				ZVAL_LONG(EX_VAR(opline->result.var), Z_STRLEN_P(value));
 
+
 				ZEND_VM_NEXT_OPCODE();
 			}
 		}
@@ -60285,6 +61447,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLE
 		} while (0);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60317,6 +61480,7 @@ type_check_resource:
 	}
 	if (IS_CONST & (IS_TMP_VAR|IS_VAR)) {
 		SAVE_OPLINE();
+
 
 		ZEND_VM_SMART_BRANCH(result, 1);
 	} else {
@@ -60554,6 +61718,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_S
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60635,6 +61801,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_S
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60650,6 +61818,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_ID
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -60663,6 +61833,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NO
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -60885,6 +62057,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACE
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60953,6 +62127,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60988,6 +62164,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -60999,6 +62177,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -61109,6 +62289,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -61186,6 +62368,8 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -61309,6 +62493,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -61337,6 +62523,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_R_SPEC_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_LIST_r(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -61463,6 +62650,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -61497,10 +62686,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -61535,6 +62727,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -61543,6 +62736,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -61569,6 +62764,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CONST & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -61591,6 +62787,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -61639,6 +62836,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -61648,6 +62846,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -61681,6 +62880,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -61696,6 +62896,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -61707,6 +62908,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -61776,6 +62978,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 		 * to make sure we don't increase VM size too much. */
 		if (!(IS_CONST & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 
+
 			HANDLE_EXCEPTION();
 		}
 
@@ -61798,6 +63001,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 			call_info |= ZEND_CALL_RELEASE_THIS | ZEND_CALL_HAS_THIS;
 		}
 
+
 		if ((IS_CONST & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 			if (call_info & ZEND_CALL_CLOSURE) {
 				zend_object_release(ZEND_CLOSURE_OBJECT(func));
@@ -61813,6 +63017,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 	} else {
 		zend_type_error("%s(): Argument #1 ($callback) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
 		efree(error);
+
 
 		HANDLE_EXCEPTION();
 	}
@@ -61836,6 +63041,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		uint32_t arg_num;
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -61864,6 +63070,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_VAL_EX_SPEC_C
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -61915,6 +63122,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -61923,6 +63131,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -61941,12 +63150,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -61961,12 +63172,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -61985,6 +63198,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -61995,12 +63209,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -62013,11 +63229,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -62036,6 +63254,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
@@ -62108,6 +63327,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -62191,6 +63411,7 @@ num_index_prop:
 			if (IS_CONST & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -62214,6 +63435,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -62266,6 +63489,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -62296,6 +63521,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -62338,6 +63565,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DECLARE_CONST_SPEC
 			zval_ptr_dtor_nogc(&c.value);
 
 
+
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -62347,6 +63576,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DECLARE_CONST_SPEC
 
 	if (zend_register_constant(&c) == NULL) {
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -62369,6 +63600,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DECLARE_ATTRIBUTED
 			zval_ptr_dtor_nogc(&c.value);
 
 
+
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -62380,6 +63613,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DECLARE_ATTRIBUTED
 	if (registered == NULL) {
 
 
+
+
 		/* two opcodes used, second one is the data with attributes */
 		ZEND_VM_NEXT_OPCODE_EX(1, 2);
 	}
@@ -62387,6 +63622,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DECLARE_ATTRIBUTED
 	HashTable *attributes = Z_PTR_P(get_op_data_zval_ptr_r((opline+1)->op1_type, (opline+1)->op1));
 	ZEND_ASSERT(attributes != NULL);
 	zend_constant_add_attributes(registered, attributes);
+
+
 
 
 	/* two opcodes used, second one is the data with attributes */
@@ -62450,6 +63687,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -62464,6 +63702,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -62484,6 +63723,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -62641,9 +63881,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_AR
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			} else if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
 				result = zend_hash_index_find(ht, Z_LVAL_P(op1));
+
 
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
@@ -62669,6 +63911,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_AR
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		}
@@ -62678,10 +63921,12 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_AR
 			ZVAL_STR(&key_tmp, key);
 			if (zend_compare(op1, &key_tmp) == 0) {
 
+
 				ZEND_VM_SMART_BRANCH(1, 1);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
+
 
 	ZEND_VM_SMART_BRANCH(0, 1);
 }
@@ -63429,6 +64674,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR|IS_CV) OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -63436,6 +64682,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CONST & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -63456,6 +64703,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -63463,6 +64711,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -63477,6 +64726,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_CONST_TMP
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -63490,6 +64740,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_CONST_TMP
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -63567,6 +64818,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_CONST_
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
+
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -63581,6 +64833,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_CON
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -63618,6 +64871,7 @@ fetch_dim_r_slow:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -63630,6 +64884,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -63739,6 +64994,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -63817,6 +65074,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -63938,6 +65196,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -64092,6 +65351,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_C
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -64127,11 +65387,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -64174,6 +65436,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -64471,6 +65734,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
 
+
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
 		if (IS_CONST == IS_TMP_VAR) {
@@ -64650,6 +65914,7 @@ num_index_prop:
 isset_dim_obj_exit:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -64700,6 +65965,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -64732,6 +65998,7 @@ array_key_exists_array:
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -64793,6 +66060,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_T
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -64807,6 +66075,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_T
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -64928,6 +66197,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -64937,6 +66207,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -64970,6 +66241,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -64985,6 +66257,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -64996,6 +66269,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -65122,6 +66396,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -65149,6 +66424,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_VAL_EX_SPEC_C
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -65186,6 +66462,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -65296,6 +66573,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
 
+
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
 		if (IS_CONST == IS_TMP_VAR) {
@@ -65368,6 +66646,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -65422,6 +66701,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_VAR_SPEC_CON
 		name = zval_try_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -65432,6 +66712,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_VAR_SPEC_CON
 	if (IS_CONST != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -65460,6 +66741,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_VAR_
 	if (IS_CONST != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	if (!value) {
 		result = (opline->extended_value & ZEND_ISEMPTY);
@@ -65538,6 +66820,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_U
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -65552,6 +66835,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_U
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -65572,6 +66856,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_U
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -65663,6 +66948,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_COUNT
 
 	ZVAL_LONG(EX_VAR(opline->result.var), count);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -65705,6 +66991,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GET_C
 			break;
 		}
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -65723,6 +67010,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GET_T
 	} else {
 		ZVAL_STRING(EX_VAR(opline->result.var), "unknown type");
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -65871,6 +67159,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_CONST_CV_
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -65883,6 +67173,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_CONST_CV_
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -65961,6 +67253,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_CONST_
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -65974,6 +67268,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_CON
 	op1 = RT_CONSTANT(opline, opline->op1);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -66011,6 +67307,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -66022,6 +67320,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -66132,6 +67432,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -66209,6 +67511,8 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -66332,6 +67636,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -66360,6 +67666,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_R_SPEC_
 	SAVE_OPLINE();
 	container = RT_CONSTANT(opline, opline->op1);
 	zend_fetch_dimension_address_LIST_r(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -66486,6 +67793,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_C
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -66520,10 +67829,13 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -66558,6 +67870,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -66566,6 +67879,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -66592,6 +67907,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CONST & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -66614,6 +67930,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -66662,6 +67979,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -66671,6 +67989,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_CONST == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -66704,6 +68023,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -66719,6 +68039,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -66730,6 +68051,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -66799,6 +68121,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 		 * to make sure we don't increase VM size too much. */
 		if (!(IS_CV & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 
+
 			HANDLE_EXCEPTION();
 		}
 
@@ -66821,6 +68144,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 			call_info |= ZEND_CALL_RELEASE_THIS | ZEND_CALL_HAS_THIS;
 		}
 
+
 		if ((IS_CV & (IS_TMP_VAR|IS_VAR)) && UNEXPECTED(EG(exception))) {
 			if (call_info & ZEND_CALL_CLOSURE) {
 				zend_object_release(ZEND_CLOSURE_OBJECT(func));
@@ -66836,6 +68160,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_USER_CALL_SPE
 	} else {
 		zend_type_error("%s(): Argument #1 ($callback) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
 		efree(error);
+
 
 		HANDLE_EXCEPTION();
 	}
@@ -66862,6 +68187,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = RT_CONSTANT(opline, opline->op1);
@@ -66934,6 +68260,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -67017,6 +68344,7 @@ num_index_prop:
 			if (IS_CONST & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -67040,6 +68368,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -67092,6 +68422,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -67122,6 +68454,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -67184,6 +68518,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = RT_CONSTANT(opline, opline->op1);
@@ -67198,6 +68533,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -67218,6 +68554,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CONST_C
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -67807,6 +69144,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_R_SPEC_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_LIST_r(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -68176,6 +69514,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_EMPTY
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_NONE(result, 0);
 }
 
@@ -68188,6 +69527,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_EMPTY
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_JMPZ(result, 0);
 }
@@ -68202,6 +69542,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_EMPTY
 	result = Z_TYPE_P(op1) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(op1)) == 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_JMPNZ(result, 0);
 }
 
@@ -68214,6 +69555,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_E
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_NONE(result, 0);
 }
@@ -68228,6 +69570,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_E
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
 
+
 	ZEND_VM_SMART_BRANCH_JMPZ(result, 0);
 }
 
@@ -68240,6 +69583,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_E
 	op1 = _get_zval_ptr_tmpvarcv(opline->op1_type, opline->op1, BP_VAR_R EXECUTE_DATA_CC);
 	result = Z_TYPE_P(op1) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(op1)) > 0;
 	FREE_OP(opline->op1_type, opline->op1.var);
+
 
 	ZEND_VM_SMART_BRANCH_JMPNZ(result, 0);
 }
@@ -69326,6 +70670,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_R_SPEC_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_LIST_r(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -69744,6 +71089,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			ZEND_VM_ENTER();
@@ -70040,6 +71386,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_TMPVAR_CO
 	div_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -70053,6 +71400,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_TMPVAR_CO
 	op2 = RT_CONSTANT(opline, opline->op2);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -70129,6 +71477,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_TMPVAR
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -70493,6 +71842,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_TMP
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -70506,6 +71856,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_XOR_SPEC_TMPV
 	op2 = RT_CONSTANT(opline, opline->op2);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -70541,6 +71892,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -70553,6 +71905,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -70644,6 +71997,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -70721,6 +72076,7 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -70842,6 +72198,7 @@ fetch_obj_is_copy:
 	} while (0);
 
 fetch_obj_is_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -70969,6 +72326,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_T
 	} while (0);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -71008,6 +72366,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 
+
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -71041,6 +72400,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -71049,6 +72409,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
 
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 				HANDLE_EXCEPTION();
@@ -71075,6 +72436,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -71097,6 +72459,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -71196,6 +72559,7 @@ case_double:
 		if (EXPECTED(Z_TYPE_P(op2) == IS_STRING)) {
 			bool result = zend_fast_equal_strings(Z_STR_P(op1), Z_STR_P(op2));
 
+
 			if (result) {
 				goto case_true;
 			} else {
@@ -71257,6 +72621,7 @@ num_index_prop:
 			if ((IS_TMP_VAR|IS_VAR) & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -71280,6 +72645,7 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -71331,6 +72697,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 
 isset_object_finish:
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -71362,6 +72729,7 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -72135,6 +73503,8 @@ fetch_obj_r_fast_copy:
 						EX(opline) = hook->op_array.opcodes;
 #endif
 						LOAD_OPLINE_EX();
+
+
 
 
 						ZEND_VM_ENTER_EX();
@@ -73202,6 +74572,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_TMPVAR_CV
 	div_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -73215,6 +74586,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_TMPVAR_CV
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -73292,6 +74664,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_TMPVAR
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -73306,6 +74679,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_TMP
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -73341,6 +74715,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, IS_CV OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -73353,6 +74728,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -73444,6 +74820,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -73521,6 +74899,7 @@ fetch_obj_r_copy:
 	} while (0);
 
 fetch_obj_r_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -73642,6 +75021,7 @@ fetch_obj_is_copy:
 	} while (0);
 
 fetch_obj_is_finish:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -73769,6 +75149,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_T
 	} while (0);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -73808,6 +75189,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 
+
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -73841,6 +75223,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -73849,6 +75232,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
 
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 				HANDLE_EXCEPTION();
@@ -73875,6 +75259,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -73897,6 +75282,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -73968,6 +75354,7 @@ case_double:
 		if (EXPECTED(Z_TYPE_P(op2) == IS_STRING)) {
 			bool result = zend_fast_equal_strings(Z_STR_P(op1), Z_STR_P(op2));
 
+
 			if (result) {
 				goto case_true;
 			} else {
@@ -74029,6 +75416,7 @@ num_index_prop:
 			if ((IS_TMP_VAR|IS_VAR) & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -74052,6 +75440,7 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -74103,6 +75492,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 
 isset_object_finish:
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -74135,6 +75525,7 @@ array_key_exists_array:
 		result = 0;
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -74145,8 +75536,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_TMP_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -74213,6 +75606,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 
 
 
+
+
+
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
 }
 
@@ -74222,9 +75618,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR)) ||
@@ -74277,6 +75675,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 	} while (0);
 
 
+
+
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
 }
 
@@ -74315,6 +75715,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GENERATOR_RETURN_S
 			ZVAL_COPY_VALUE(&generator->retval, retval);
 		}
 	}
+
 
 	EG(current_execute_data) = EX(prev_execute_data);
 
@@ -74379,6 +75780,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CAST_SPEC_TMP_TAIL
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -74410,6 +75812,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_TM
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_TMP_VAR != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -74418,6 +75821,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_TM
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -74443,10 +75847,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_TM
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -74506,6 +75912,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_T
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_TMP_VAR != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -74515,6 +75922,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_T
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -74542,10 +75950,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_T
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -74761,6 +76171,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	result = fast_is_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -74774,6 +76185,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CASE_STRICT_SPEC_T
 	op1 = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -74789,6 +76201,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -74858,6 +76271,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_ADD_SPEC_TMP_
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}
@@ -74892,6 +76306,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_END_SPEC_TMP_
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				for (i = 0; i <= opline->extended_value; i++) {
@@ -75048,6 +76463,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -75152,6 +76568,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_CON
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -75171,6 +76588,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_CON
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -75593,6 +77011,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_TMP
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -75946,6 +77365,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -76050,6 +77470,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_UNU
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -76069,6 +77490,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_UNU
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -76125,6 +77547,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CASE_STRICT_SPEC_T
 	op1 = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -76194,6 +77617,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_ADD_SPEC_TMP_
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}
@@ -76228,6 +77652,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_END_SPEC_TMP_
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[opline->extended_value] = zval_get_string_func(var);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				for (i = 0; i <= opline->extended_value; i++) {
@@ -76347,6 +77772,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -76451,6 +77877,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_CV_
 			} else if ((IS_TMP_VAR & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
 
+
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
 				if (IS_TMP_VAR == IS_CV) {
@@ -76470,6 +77897,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_TMP_CV_
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -76771,8 +78199,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -76839,6 +78269,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 
 
 
+
+
+
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
 }
 
@@ -76848,9 +78281,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR)) ||
@@ -76903,6 +78338,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 	} while (0);
 
 
+
+
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
 }
 
@@ -76941,6 +78378,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GENERATOR_RETURN_S
 			ZVAL_COPY_VALUE(&generator->retval, retval);
 		}
 	}
+
 
 	EG(current_execute_data) = EX(prev_execute_data);
 
@@ -77678,6 +79116,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	result = fast_is_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -77691,6 +79130,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CASE_STRICT_SPEC_V
 	op1 = _get_zval_ptr_var_deref(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_identical_function(op1, op2);
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -77706,6 +79146,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -77796,6 +79237,7 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -77899,6 +79341,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -77928,6 +79371,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OP_SPEC_VAR
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -77993,6 +79437,7 @@ pre_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -78055,6 +79500,7 @@ post_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -78067,6 +79513,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_V
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -78082,6 +79529,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -78117,6 +79565,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_UNSET_SP
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_UNSET(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -78138,6 +79587,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_V
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -78154,6 +79604,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -78189,6 +79640,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -78213,6 +79665,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_W_SPEC_
 	} else {
 		zend_fetch_dimension_address_W(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -78340,6 +79793,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -78360,10 +79814,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -78519,6 +79975,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -78673,6 +80130,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -78802,6 +80260,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -78822,10 +80281,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -78931,6 +80392,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -78938,11 +80400,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -78950,6 +80414,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -78972,12 +80437,14 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CONST != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -79132,6 +80599,7 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -79285,6 +80753,7 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -79389,6 +80858,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -79396,11 +80866,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -79408,6 +80880,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -79430,12 +80903,14 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CONST != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -79533,6 +81008,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
+
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -79571,6 +81047,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -79593,6 +81071,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -79602,6 +81081,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -79635,6 +81115,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -79650,6 +81131,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -79661,6 +81143,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -80026,6 +81509,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -80034,6 +81518,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -80052,12 +81537,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -80072,12 +81559,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -80096,6 +81585,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -80106,12 +81596,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -80124,11 +81616,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -80219,6 +81713,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -80338,6 +81833,7 @@ num_index_dim:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -80381,6 +81877,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_VAR
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -80478,6 +81975,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_VAR_CON
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -81346,6 +82844,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -81365,6 +82864,7 @@ free_and_exit_assign_obj:
 	if (UNEXPECTED(RETURN_VALUE_USED(opline)) && value) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
+
 
 exit_assign_obj:
 	if (garbage) {
@@ -81808,6 +83308,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -81827,6 +83328,7 @@ free_and_exit_assign_obj:
 	if (UNEXPECTED(RETURN_VALUE_USED(opline)) && value) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
+
 
 exit_assign_obj:
 	if (garbage) {
@@ -81937,6 +83439,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -81944,11 +83447,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -81956,6 +83461,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -81977,6 +83483,7 @@ try_assign_dim_array:
 			zend_use_scalar_as_array();
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
+
 
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
@@ -82395,6 +83902,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -82402,11 +83910,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -82414,6 +83924,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -82435,6 +83946,7 @@ try_assign_dim_array:
 			zend_use_scalar_as_array();
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
+
 
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
@@ -82518,6 +84030,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -83371,6 +84884,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -83383,6 +84897,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_V
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -83398,6 +84913,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -83522,6 +85038,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -83529,11 +85046,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -83541,6 +85060,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -83563,12 +85083,14 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_UNUSED != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -83723,6 +85245,7 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -83876,6 +85399,7 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -83980,6 +85504,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -83987,11 +85512,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -83999,6 +85526,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -84021,12 +85549,14 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_UNUSED != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -84052,6 +85582,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -84061,6 +85592,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -84094,6 +85626,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -84109,6 +85642,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -84120,6 +85654,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -84817,6 +86352,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -84956,6 +86492,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_VAR_UNU
 		}
 		ZVAL_COPY(&generator->key, key);
 
+
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
 		) {
@@ -85067,6 +86604,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CASE_STRICT_SPEC_V
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -85156,6 +86694,7 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -85259,6 +86798,7 @@ assign_dim_op_ret_null:
 		}
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -85288,6 +86828,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OP_SPEC_VAR
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -85353,6 +86894,7 @@ pre_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -85415,6 +86957,7 @@ post_incdec_object:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -85427,6 +86970,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_V
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_W(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -85442,6 +86986,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	SAVE_OPLINE();
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_RW(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -85477,6 +87022,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_UNSET_SP
 	container = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	zend_fetch_dimension_address_UNSET(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -85498,6 +87044,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_V
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -85514,6 +87061,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -85549,6 +87097,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_VAR, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_VAR == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -85573,6 +87122,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_LIST_W_SPEC_
 	} else {
 		zend_fetch_dimension_address_W(container, dim, IS_CV OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -85700,6 +87250,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -85720,10 +87271,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -85879,6 +87432,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -86033,6 +87587,7 @@ exit_assign_obj:
 		GC_DTOR_NO_REF(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -86162,6 +87717,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -86182,10 +87738,12 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_obj has two opcodes! */
@@ -86291,6 +87849,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -86298,11 +87857,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -86310,6 +87871,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -86332,12 +87894,14 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CV != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -86492,6 +88056,7 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -86645,6 +88210,7 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* assign_dim has two opcodes! */
@@ -86749,6 +88315,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -86756,11 +88323,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -86768,6 +88337,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -86790,12 +88360,14 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
 		}
 	}
 	if (IS_CV != IS_UNUSED) {
+
 
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -86895,6 +88467,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_REF_SPEC_VA
 		GC_DTOR(garbage);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -86930,6 +88503,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
+
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -86969,6 +88543,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -86991,6 +88567,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -87000,6 +88577,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_VAR == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -87033,6 +88611,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -87048,6 +88627,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -87059,6 +88639,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -87193,6 +88774,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -87311,6 +88893,7 @@ num_index_dim:
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -87354,6 +88937,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_VAR
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -87451,6 +89035,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_VAR_CV_
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -87648,6 +89233,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_UNUSED_
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -87659,6 +89245,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_UNUSED_
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -87669,12 +89256,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_UNUSED_
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -87694,11 +89283,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_NAME_S
 				zend_type_error("Cannot use \"::class\" on %s", zend_zval_value_name(op));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 		}
 
 		ZVAL_STR_COPY(EX_VAR(opline->result.var), Z_OBJCE_P(op)->name);
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -87829,6 +89420,8 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -87895,6 +89488,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -87955,6 +89550,8 @@ post_incdec_object:
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -88046,6 +89643,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -88125,6 +89724,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -88148,6 +89749,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_U
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -88164,6 +89766,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -88289,6 +89892,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -88319,6 +89924,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -88449,6 +90055,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -88469,10 +90076,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -88629,6 +90239,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -88783,6 +90395,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -88911,6 +90525,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -88931,10 +90546,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -88971,6 +90589,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, IS_CONST, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -89010,6 +90630,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 
 
 
+
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -89042,6 +90665,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_INIT_SPEC_UNU
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[0] = zval_get_string_func(var);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
@@ -89088,6 +90712,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -89122,10 +90747,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -89160,6 +90788,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -89168,6 +90797,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -89194,6 +90825,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_UNUSED & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -89216,6 +90848,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -89264,6 +90897,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CONST != IS_CONST) {
@@ -89273,6 +90907,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -89306,6 +90941,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -89321,6 +90957,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CONST == IS_CONST &&
@@ -89332,6 +90969,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CONST != IS_CONST) {
+
 
 		}
 	} else {
@@ -89452,6 +91090,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(ce == NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 				CACHE_PTR(opline->extended_value, ce);
@@ -89460,6 +91099,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			ce = zend_fetch_class(NULL, opline->op1.num);
 			if (UNEXPECTED(ce == NULL)) {
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -89478,12 +91118,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 			zend_invalid_class_constant_type_error(Z_TYPE_P(constant_zv));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 		constant_name = Z_STR_P(constant_zv);
 		/* Magic 'class' for constant OP2 is caught at compile-time */
 		if (IS_CONST != IS_CONST && UNEXPECTED(zend_string_equals_literal_ci(constant_name, "class"))) {
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), ce->name);
+
 
 			ZEND_VM_NEXT_OPCODE();
 		}
@@ -89498,12 +91140,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(ZEND_CLASS_CONST_FLAGS(c)), ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 
 			if (ce->ce_flags & ZEND_ACC_TRAIT) {
 				zend_throw_error(NULL, "Cannot access trait constant %s::%s directly", ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -89522,6 +91166,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (EG(exception)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
@@ -89532,12 +91177,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				if (UNEXPECTED(zend_update_class_constant(c, constant_name, c->ce) != SUCCESS)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -89550,11 +91197,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_CONSTA
 				ZSTR_VAL(ce->name), ZSTR_VAL(constant_name));
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
 
 	ZVAL_COPY_OR_DUP(EX_VAR(opline->result.var), value);
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -89622,6 +91271,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_UNU
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -89670,6 +91321,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 	}
 
 isset_object_finish:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -89732,6 +91385,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -89746,6 +91400,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -89766,6 +91421,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -90015,6 +91671,7 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -90082,6 +91739,7 @@ pre_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -90144,6 +91802,7 @@ post_incdec_object:
 	} while (0);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -90234,6 +91893,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -90312,6 +91973,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -90471,6 +92133,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -90632,6 +92295,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -90652,11 +92316,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -90812,6 +92478,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -90966,6 +92633,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -91094,6 +92762,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -91114,11 +92783,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -91154,6 +92825,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -91191,7 +92863,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 		zend_assign_to_property_reference(container, IS_UNUSED, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -91306,11 +92980,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -91353,6 +93029,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -91627,6 +93304,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_UNU
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -91676,6 +93354,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -91737,6 +93416,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -91751,6 +93431,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -91839,6 +93520,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -91860,6 +93542,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_UNUSED != IS_CONST) {
@@ -91869,6 +93552,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -91902,6 +93586,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -91917,6 +93602,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_UNUSED == IS_CONST &&
@@ -91928,6 +93614,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_UNUSED != IS_CONST) {
+
 
 		}
 	} else {
@@ -92275,6 +93962,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -92289,6 +93977,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -92309,6 +93998,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -92410,6 +94100,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GET_CLASS_SPEC_UNU
 			}
 			break;
 		}
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -92664,6 +94355,8 @@ assign_op_object:
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -92730,6 +94423,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -92790,6 +94485,8 @@ post_incdec_object:
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -92881,6 +94578,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -92960,6 +94659,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -92978,6 +94679,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_U
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -92994,6 +94696,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -93119,6 +94822,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -93149,6 +94854,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_UNUSED, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_UNUSED == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -93279,6 +94985,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -93299,10 +95006,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -93459,6 +95169,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -93613,6 +95325,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -93741,6 +95455,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -93761,10 +95476,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -93801,6 +95519,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_UNUSED, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -93840,6 +95560,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 
 
 
+
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -93872,6 +95595,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ROPE_INIT_SPEC_UNU
 				ZVAL_UNDEFINED_OP2();
 			}
 			rope[0] = zval_get_string_func(var);
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
@@ -93918,6 +95642,7 @@ try_class_name:
 		}
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -93952,10 +95677,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -93990,6 +95718,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -93998,6 +95727,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -94024,6 +95755,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_UNUSED & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -94046,6 +95778,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -94094,6 +95827,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			ce = zend_fetch_class_by_name(Z_STR_P(RT_CONSTANT(opline, opline->op1)), Z_STR_P(RT_CONSTANT(opline, opline->op1) + 1), ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_EXCEPTION);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				HANDLE_EXCEPTION();
 			}
 			if (IS_CV != IS_CONST) {
@@ -94103,6 +95837,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 	} else if (IS_UNUSED == IS_UNUSED) {
 		ce = zend_fetch_class(NULL, opline->op1.num);
 		if (UNEXPECTED(ce == NULL)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -94136,6 +95871,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 					}
 					zend_throw_error(NULL, "Method name must be a string");
 
+
 					HANDLE_EXCEPTION();
 				} while (0);
 			}
@@ -94151,6 +95887,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 				zend_undefined_method(ce, Z_STR_P(function_name));
 			}
 
+
 			HANDLE_EXCEPTION();
 		}
 		if (IS_CV == IS_CONST &&
@@ -94162,6 +95899,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_STATIC_METHOD
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (IS_CV != IS_CONST) {
+
 
 		}
 	} else {
@@ -94272,6 +96010,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_UNU
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -94320,6 +96060,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 	}
 
 isset_object_finish:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -94382,6 +96124,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = NULL;
@@ -94396,6 +96139,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -94416,6 +96160,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_UNUSED_
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -94465,6 +96210,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_NOT_SPEC_CV_T
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), !i_zend_is_true(val));
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 	ZEND_VM_NEXT_OPCODE();
@@ -94498,6 +96244,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV  zend
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -94568,6 +96315,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV  zend
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -94635,6 +96383,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV  zend
 		increment_function(var_ptr);
 	} while (0);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -94682,6 +96431,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV  zend
 		decrement_function(var_ptr);
 	} while (0);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -94725,6 +96475,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ECHO_SPEC_CV_TAILC
 		}
 		zend_string_release_ex(str, 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -94823,6 +96574,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMPZ_EX_SPEC_CV_TA
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline++;
@@ -94858,6 +96610,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMPNZ_EX_SPEC_CV_T
 	SAVE_OPLINE();
 	ret = i_zend_is_true(val);
 
+
 	if (ret) {
 		ZVAL_TRUE(EX_VAR(opline->result.var));
 		opline = OP_JMP_ADDR(opline, opline->op2);
@@ -94874,8 +96627,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = EX_VAR(opline->op1.var);
 	return_value = EX(return_value);
+
 
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -94942,6 +96697,9 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN
 
 
 
+
+
+
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
 }
 
@@ -94951,9 +96709,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	SAVE_OPLINE();
 
 	return_value = EX(return_value);
+
 
 	do {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR)) ||
@@ -94963,6 +96723,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 
 			retval_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 			if (!return_value) {
+
 
 			} else {
 				if (IS_CV == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -94988,6 +96749,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 					ZVAL_NEW_REF(return_value, retval_ptr);
 				} else {
 
+
 				}
 				break;
 			}
@@ -95002,7 +96764,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_RETURN_BY_REF_SPEC
 			ZVAL_REF(return_value, Z_REF_P(retval_ptr));
 		}
 
+
 	} while (0);
+
+
 
 
 	ZEND_VM_DISPATCH_TO_LEAVE_HELPER(zend_leave_helper_SPEC_TAILCALL);
@@ -95044,6 +96809,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GENERATOR_RETURN_S
 		}
 	}
 
+
 	EG(current_execute_data) = EX(prev_execute_data);
 
 	/* Close the generator to free up resources */
@@ -95077,6 +96843,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_THROW_SPEC_CV_TAIL
 			}
 			zend_throw_error(NULL, "Can only throw objects");
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -95085,6 +96852,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_THROW_SPEC_CV_TAIL
 	Z_TRY_ADDREF_P(value);
 	zend_throw_exception_object(value);
 	zend_exception_restore();
+
 
 	HANDLE_EXCEPTION();
 }
@@ -95105,6 +96873,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_USER_SPEC_CV_
 	} else {
 		ZVAL_COPY(param, arg);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -95129,6 +96898,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_SPEC_CV_TAILC
 	} else {
 		SAVE_OPLINE();
 		ZVAL_BOOL(EX_VAR(opline->result.var), i_zend_is_true(val));
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -95168,6 +96938,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_CV_TAIL
 			}
 			zend_type_error("clone(): Argument #1 ($object) must be of type object, %s given", zend_zval_value_name(obj));
 
+
 			HANDLE_EXCEPTION();
 		}
 	} while (0);
@@ -95179,6 +96950,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_CV_TAIL
 	if (UNEXPECTED(clone_call == NULL)) {
 		zend_throw_error(NULL, "Trying to clone an uncloneable object of class %s", ZSTR_VAL(ce->name));
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -95189,12 +96961,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CLONE_SPEC_CV_TAIL
 		if (!zend_check_method_accessible(clone, scope)) {
 			zend_bad_method_call(clone, clone->common.function_name, scope);
 
+
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
 		}
 	}
 
 	ZVAL_OBJ(EX_VAR(opline->result.var), clone_call(zobj));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -95232,6 +97006,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CAST_SPEC_CV_TAILC
 					if (Z_OPT_REFCOUNTED_P(result)) Z_ADDREF_P(result);
 				}
 
+
 				ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 			}
 
@@ -95242,6 +97017,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CAST_SPEC_CV_TAILC
 				zend_cast_zval_to_object(result, expr, IS_CV);
 			}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -95256,6 +97032,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 	inc_filename = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	new_op_array = zend_include_or_eval(inc_filename, opline->extended_value);
 	if (UNEXPECTED(EG(exception) != NULL)) {
+
 
 		if (new_op_array != ZEND_FAKE_OP_ARRAY && new_op_array != NULL) {
 			destroy_op_array(new_op_array);
@@ -95306,7 +97083,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 		call->prev_execute_data = execute_data;
 		i_init_code_execute_data(call, new_op_array, return_value);
 
+
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
 
 			ZEND_VM_ENTER();
 		} else {
@@ -95321,10 +97100,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INCLUDE_OR_EVAL_SP
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			zend_rethrow_exception(execute_data);
 
+
 			UNDEF_RESULT();
 			HANDLE_EXCEPTION();
 		}
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -95345,6 +97126,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CV
 		}
 		Z_FE_POS_P(result) = 0;
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CV != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		zend_object *zobj = Z_OBJ_P(array_ptr);
@@ -95353,6 +97135,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CV
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -95378,14 +97161,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CV
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(result) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(result) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 0 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -95399,6 +97185,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_R_SPEC_CV
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -95440,6 +97227,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_C
 		}
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(Z_ARRVAL_P(array_ptr), 0);
 
+
 		ZEND_VM_NEXT_OPCODE();
 	} else if (IS_CV != IS_CONST && EXPECTED(Z_TYPE_P(array_ptr) == IS_OBJECT)) {
 		if (!Z_OBJCE_P(array_ptr)->get_iterator) {
@@ -95449,6 +97237,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_C
 				zobj = zend_lazy_object_init(zobj);
 				if (UNEXPECTED(EG(exception))) {
 					UNDEF_RESULT();
+
 
 					HANDLE_EXCEPTION();
 				}
@@ -95476,14 +97265,17 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_C
 			if (zend_hash_num_elements(properties) == 0) {
 				Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t) -1;
 
+
 				ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 			}
 
 			Z_FE_ITER_P(EX_VAR(opline->result.var)) = zend_hash_iterator_add(properties, 0);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
 			bool is_empty = zend_fe_reset_iterator(array_ptr, 1 OPLINE_CC EXECUTE_DATA_CC);
+
 
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
@@ -95497,6 +97289,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FE_RESET_RW_SPEC_C
 		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_value_name(array_ptr));
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
+
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
 	}
@@ -95523,6 +97316,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_SET_SPEC_CV_TA
 
 	if (UNEXPECTED(EG(exception))) {
 
+
 		ZVAL_UNDEF(EX_VAR(opline->result.var));
 		HANDLE_EXCEPTION();
 	}
@@ -95544,6 +97338,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_SET_SPEC_CV_TA
 		}
 		ZEND_VM_JMP_EX(OP_JMP_ADDR(opline, opline->op2), 0);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -95601,6 +97396,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_JMP_NU
 			if ((IS_CV == IS_CV || IS_CV == IS_VAR) && Z_TYPE_P(val) == IS_REFERENCE) {
 				val = Z_REFVAL_P(val);
 				if (Z_TYPE_P(val) <= IS_NULL) {
+
 
 					break;
 				}
@@ -95683,6 +97479,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_FROM_SPEC_CV
 	if (UNEXPECTED(generator->flags & ZEND_GENERATOR_FORCED_CLOSE)) {
 		zend_throw_error(NULL, "Cannot use \"yield from\" in a force-closed generator");
 
+
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
 	}
@@ -95695,12 +97492,14 @@ yield_from_try_again:
 		}
 		Z_FE_POS(generator->values) = 0;
 
+
 	} else if (IS_CV != IS_CONST && Z_TYPE_P(val) == IS_OBJECT && Z_OBJCE_P(val)->get_iterator) {
 		zend_class_entry *ce = Z_OBJCE_P(val);
 		if (ce == zend_ce_generator) {
 			zend_generator *new_gen = (zend_generator *) Z_OBJ_P(val);
 
 			Z_ADDREF_P(val);
+
 
 			if (UNEXPECTED(new_gen->execute_data == NULL)) {
 				zend_throw_error(NULL, "Generator passed to yield from was aborted without proper return and is unable to continue");
@@ -95724,6 +97523,7 @@ yield_from_try_again:
 			}
 		} else {
 			zend_object_iterator *iter = ce->get_iterator(ce, val, 0);
+
 
 			if (UNEXPECTED(!iter) || UNEXPECTED(EG(exception))) {
 				if (!EG(exception)) {
@@ -95750,6 +97550,7 @@ yield_from_try_again:
 		goto yield_from_try_again;
 	} else {
 		zend_throw_error(NULL, "Can use \"yield from\" only with arrays and Traversables");
+
 
 		UNDEF_RESULT();
 		HANDLE_EXCEPTION();
@@ -95791,6 +97592,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_CV_TAI
 			if (EXPECTED(Z_TYPE_P(value) == IS_STRING)) {
 				ZVAL_LONG(EX_VAR(opline->result.var), Z_STRLEN_P(value));
 
+
 				ZEND_VM_NEXT_OPCODE();
 			}
 		}
@@ -95830,6 +97632,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_STRLEN_SPEC_CV_TAI
 		} while (0);
 	}
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -95863,6 +97666,7 @@ type_check_resource:
 	if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 		SAVE_OPLINE();
 
+
 		ZEND_VM_SMART_BRANCH(result, 1);
 	} else {
 		ZEND_VM_SMART_BRANCH(result, 0);
@@ -95884,11 +97688,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_NAME_S
 				zend_type_error("Cannot use \"::class\" on %s", zend_zval_value_name(op));
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 
+
 				HANDLE_EXCEPTION();
 			}
 		}
 
 		ZVAL_STR_COPY(EX_VAR(opline->result.var), Z_OBJCE_P(op)->name);
+
 
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
@@ -96188,6 +97994,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_CV_CONST_
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -96200,6 +98008,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_CV_CONST_
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -96278,6 +98088,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_CV_CON
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -96294,6 +98106,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -96307,6 +98121,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -96671,6 +98487,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_CV_
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -96683,6 +98501,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_XOR_SPEC_CV_C
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = RT_CONSTANT(opline, opline->op2);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -96774,6 +98594,8 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -96878,6 +98700,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -96906,6 +98730,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OP_SPEC_CV_
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -96972,6 +98798,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -97034,6 +98862,8 @@ post_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -97069,6 +98899,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -97080,6 +98912,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_C
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -97096,6 +98929,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -97110,6 +98944,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -97142,6 +98978,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_UNSET_SP
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_UNSET(container, RT_CONSTANT(opline, opline->op2), IS_CONST OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -97235,6 +99072,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -97314,6 +99153,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -97337,6 +99178,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_C
 		((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -97353,6 +99195,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -97478,6 +99321,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -97508,6 +99353,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	property = RT_CONSTANT(opline, opline->op2);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CONST, ((IS_CONST == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -97638,6 +99484,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -97658,10 +99505,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -97818,6 +99668,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -97972,6 +99824,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -98100,6 +99954,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(RT_CONSTANT(opline, opline->op2), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -98120,10 +99975,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -98229,6 +100087,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -98236,11 +100095,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -98248,6 +100109,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -98270,6 +100132,7 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -98277,7 +100140,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -98430,7 +100295,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -98583,7 +100450,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -98687,6 +100556,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -98694,11 +100564,13 @@ try_assign_dim_array:
 			if (IS_CONST == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = RT_CONSTANT(opline, opline->op2);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -98706,6 +100578,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = RT_CONSTANT(opline, opline->op2);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -98728,6 +100601,7 @@ try_assign_dim_array:
 			dim = RT_CONSTANT(opline, opline->op2);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -98735,7 +100609,9 @@ assign_dim_error:
 	}
 	if (IS_CONST != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -98765,6 +100641,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_CON
 		value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -98793,6 +100670,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_CON
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -98830,6 +100708,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	}
 
 
+
+
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -98864,6 +100744,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CONST, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
+
 
 
 
@@ -98993,6 +100876,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_C
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -99027,10 +100912,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -99065,6 +100953,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CONST != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -99073,6 +100962,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 					function_name = RT_CONSTANT(opline, opline->op2);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -99099,6 +100990,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CV & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -99121,6 +101013,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_M
 	}
 
 	if (IS_CONST != IS_CONST) {
+
 
 	}
 
@@ -99162,6 +101055,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		uint32_t arg_num;
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -99210,6 +101104,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_REF_SPEC_CV_C
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -99223,6 +101118,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_REF_SPEC_CV_C
 		ZVAL_MAKE_REF_EX(varptr, 2);
 	}
 	ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -99238,6 +101134,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_VAR_EX_SPEC_C
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -99259,6 +101156,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -99306,6 +101204,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -99378,6 +101277,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -99498,6 +101398,8 @@ num_index_dim:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -99540,6 +101442,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_CV_
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -99596,6 +101500,7 @@ num_index_prop:
 			if (IS_CV & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -99619,6 +101524,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -99671,6 +101578,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -99703,6 +101612,8 @@ array_key_exists_array:
 	}
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -99731,6 +101642,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -99747,6 +101659,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -99808,6 +101721,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CONS
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -99822,6 +101736,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CONS
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -99842,6 +101757,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CONS
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -99977,9 +101893,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_ARRAY_SPEC_CV_C
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			} else if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
 				result = zend_hash_index_find(ht, Z_LVAL_P(op1));
+
 
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
@@ -100005,6 +101923,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_ARRAY_SPEC_CV_C
 			if (EXPECTED(Z_TYPE_P(op1) == IS_STRING)) {
 				result = zend_hash_find(ht, Z_STR_P(op1));
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		}
@@ -100014,10 +101933,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IN_ARRAY_SPEC_CV_C
 			ZVAL_STR(&key_tmp, key);
 			if (zend_compare(op1, &key_tmp) == 0) {
 
+
 				ZEND_VM_SMART_BRANCH(1, 1);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
+
 
 	ZEND_VM_SMART_BRANCH(0, 1);
 }
@@ -100068,6 +101989,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, IS_CONST OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -100075,6 +101997,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -100095,6 +102018,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -100102,6 +102026,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -100123,6 +102048,7 @@ fetch_dim_r_index_array:
 			SAVE_OPLINE();
 			zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR|IS_CV) OPLINE_CC EXECUTE_DATA_CC);
 
+
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 		ht = Z_ARRVAL_P(container);
@@ -100130,6 +102056,7 @@ fetch_dim_r_index_array:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 		if (IS_CV & (IS_TMP_VAR|IS_VAR)) {
 			SAVE_OPLINE();
+
 
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		} else {
@@ -100150,6 +102077,7 @@ fetch_dim_r_index_slow:
 		}
 		zend_fetch_dimension_address_read_R_slow(container, dim OPLINE_CC EXECUTE_DATA_CC);
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 
@@ -100157,6 +102085,7 @@ fetch_dim_r_index_undef:
 	ZVAL_NULL(EX_VAR(opline->result.var));
 	SAVE_OPLINE();
 	zend_undefined_offset(offset);
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -100171,6 +102100,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_CV_TMPVAR
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -100184,6 +102114,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_CV_TMPVAR
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -100260,6 +102191,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_CV_TMP
 			op2 = ZVAL_UNDEFINED_OP2();
 		}
 		concat_function(EX_VAR(opline->result.var), op1, op2);
+
 
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -100624,6 +102556,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_CV_
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -100637,6 +102570,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_XOR_SPEC_CV_T
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -100729,6 +102663,7 @@ assign_op_object:
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -100833,6 +102768,7 @@ assign_dim_op_ret_null:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -100863,6 +102799,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OP_SPEC_CV_
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -100929,6 +102866,7 @@ pre_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -100992,6 +102930,7 @@ post_incdec_object:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -101026,6 +102965,7 @@ fetch_dim_r_slow:
 		zend_fetch_dimension_address_read_R(container, dim, (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -101069,6 +103009,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), (IS_TMP_VAR|IS_VAR) OPLINE_CC EXECUTE_DATA_CC);
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -101193,6 +103134,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -101271,6 +103214,7 @@ fetch_obj_r_copy:
 
 fetch_obj_r_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -101430,6 +103374,7 @@ fetch_obj_is_copy:
 
 fetch_obj_is_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -101591,6 +103536,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -101611,11 +103557,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -101771,6 +103719,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -101925,6 +103874,7 @@ exit_assign_obj:
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -102053,6 +104003,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -102073,11 +104024,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -102182,6 +104135,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -102189,11 +104143,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -102201,6 +104157,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -102223,6 +104180,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -102231,6 +104189,7 @@ assign_dim_error:
 	if ((IS_TMP_VAR|IS_VAR) != IS_UNUSED) {
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -102385,6 +104344,7 @@ assign_dim_error:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
 
+
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -102538,6 +104498,7 @@ assign_dim_error:
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
 
+
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -102640,6 +104601,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -102647,11 +104609,13 @@ try_assign_dim_array:
 			if ((IS_TMP_VAR|IS_VAR) == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -102659,6 +104623,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -102681,6 +104646,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -102689,6 +104655,7 @@ assign_dim_error:
 	if ((IS_TMP_VAR|IS_VAR) != IS_UNUSED) {
 		zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -102723,6 +104690,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -102760,7 +104728,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 		zend_assign_to_property_reference(container, IS_CV, property, (IS_TMP_VAR|IS_VAR), value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -102887,6 +104857,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_C
 		}
 	} while (0);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -102922,11 +104893,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 			HANDLE_EXCEPTION();
 		} while (0);
@@ -102969,6 +104942,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				}
 				zend_invalid_method_call(object, function_name);
 				zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 				HANDLE_EXCEPTION();
 			}
@@ -103060,6 +105034,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -103253,6 +105228,7 @@ num_index_dim:
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -103297,6 +105273,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_CV_
 	} while (0);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -103377,6 +105354,7 @@ num_index_prop:
 isset_dim_obj_exit:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -103427,6 +105405,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 isset_object_finish:
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -103459,6 +105438,7 @@ array_key_exists_array:
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -103520,6 +105500,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_TMPV
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -103534,6 +105515,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_TMPV
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -103594,6 +105576,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	op2 = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -103608,6 +105591,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -103636,6 +105620,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_TMP
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -103666,6 +105651,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_TMP
 		value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -103682,6 +105668,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	op2 = _get_zval_ptr_var_deref(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_identical_function(op1, op2);
 
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -103696,6 +105683,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_var_deref(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -103725,6 +105713,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_VAR
 		value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -103753,6 +105742,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_VAR
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -103795,6 +105785,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_REF_SPEC_CV
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -103823,6 +105814,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -103839,6 +105831,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -103940,6 +105933,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -103987,6 +105982,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_C
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -104001,6 +105997,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, NULL, IS_UNUSED OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -104125,6 +106122,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -104132,11 +106130,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -104144,6 +106144,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -104166,6 +106167,7 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -104173,7 +106175,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -104326,7 +106330,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -104479,7 +106485,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -104583,6 +106591,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -104590,11 +106599,13 @@ try_assign_dim_array:
 			if (IS_UNUSED == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = NULL;
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -104602,6 +106613,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = NULL;
+
 
 				UNDEF_RESULT();
 			} else {
@@ -104624,6 +106636,7 @@ try_assign_dim_array:
 			dim = NULL;
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -104631,7 +106644,9 @@ assign_dim_error:
 	}
 	if (IS_UNUSED != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -104716,6 +106731,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -104763,6 +106779,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_REF_SPEC_CV_U
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -104776,6 +106793,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_REF_SPEC_CV_U
 		ZVAL_MAKE_REF_EX(varptr, 2);
 	}
 	ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -104791,6 +106809,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_VAR_EX_SPEC_C
 		zend_string *arg_name = Z_STR_P(RT_CONSTANT(opline, opline->op2));
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
+
 
 			HANDLE_EXCEPTION();
 		}
@@ -104812,6 +106831,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -104857,6 +106877,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SEND_V
 		arg = zend_handle_named_arg(&EX(call), arg_name, &arg_num, CACHE_ADDR(opline->result.num));
 		if (UNEXPECTED(!arg)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	} else {
@@ -104877,6 +106898,7 @@ send_var_by_ref:
 			ZVAL_MAKE_REF_EX(varptr, 2);
 		}
 		ZVAL_REF(arg, Z_REF_P(varptr));
+
 
 		ZEND_VM_NEXT_OPCODE();
 	}
@@ -104924,6 +106946,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -104997,6 +107020,7 @@ num_index:
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
 
+
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
 			zend_cannot_add_element();
@@ -105069,6 +107093,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_VAR_SPEC_CV_
 		name = zval_try_get_tmp_string(varname, &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			HANDLE_EXCEPTION();
 		}
 	}
@@ -105079,6 +107104,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_VAR_SPEC_CV_
 	if (IS_CV != IS_CONST) {
 		zend_tmp_string_release(tmp_name);
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -105152,6 +107178,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_VAR_
 		zend_tmp_string_release(tmp_name);
 	}
 
+
 	if (!value) {
 		result = (opline->extended_value & ZEND_ISEMPTY);
 	} else {
@@ -105197,6 +107224,7 @@ try_instanceof:
 			ce = zend_fetch_class(NULL, opline->op2.num);
 			if (UNEXPECTED(ce == NULL)) {
 
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -105213,6 +107241,7 @@ try_instanceof:
 		}
 		result = 0;
 	}
+
 
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
@@ -105274,6 +107303,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_UNUS
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -105288,6 +107318,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_UNUS
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -105308,6 +107339,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_UNUS
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -105434,6 +107466,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_COUNT_SPEC_CV_UNUS
 
 	ZVAL_LONG(EX_VAR(opline->result.var), count);
 
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -105491,6 +107524,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GET_CLASS_SPEC_CV_
 			break;
 		}
 
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -105509,6 +107543,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_GET_TYPE_SPEC_CV_U
 	} else {
 		ZVAL_STRING(EX_VAR(opline->result.var), "unknown type");
 	}
+
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -105546,6 +107581,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_DIV_SPEC_CV_CV_TAI
 	div_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -105558,6 +107595,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_POW_SPEC_CV_CV_TAI
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	pow_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -105636,6 +107675,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CONCAT_SPEC_CV_CV_
 		concat_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 }
@@ -105652,6 +107693,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_IDENTICAL_SPEC_
 	result = fast_is_identical_function(op1, op2);
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -105665,6 +107708,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_IS_NOT_IDENTICAL_S
 	op1 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_deref_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = fast_is_not_identical_function(op1, op2);
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -106029,6 +108074,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_SPACESHIP_SPEC_CV_
 	compare_function(EX_VAR(opline->result.var), op1, op2);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106041,6 +108088,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_BOOL_XOR_SPEC_CV_C
 	op1 = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 	op2 = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	boolean_xor_function(EX_VAR(opline->result.var), op1, op2);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -106132,6 +108181,8 @@ assign_op_object:
 	} while (0);
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -106236,6 +108287,8 @@ assign_dim_op_ret_null:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
 
@@ -106264,6 +108317,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OP_SPEC_CV_
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -106330,6 +108385,8 @@ pre_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106392,6 +108449,8 @@ post_incdec_object:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106427,6 +108486,8 @@ fetch_dim_r_slow:
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106438,6 +108499,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_W_SPEC_C
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_W(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -106454,6 +108516,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_RW_SPEC_
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_RW(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -106468,6 +108531,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_IS_SPEC_
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_read_IS(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -106500,6 +108565,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_DIM_UNSET_SP
 	SAVE_OPLINE();
 	container = EX_VAR(opline->op1.var);
 	zend_fetch_dimension_address_UNSET(container, EX_VAR(opline->op2.var), IS_CV OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -106593,6 +108659,8 @@ fetch_obj_r_fast_copy:
 						LOAD_OPLINE_EX();
 
 
+
+
 						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
@@ -106672,6 +108740,8 @@ fetch_obj_r_copy:
 fetch_obj_r_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106690,6 +108760,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_W_SPEC_C
 		((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS) : NULL),
 		BP_VAR_W, opline->extended_value, NULL OPLINE_CC EXECUTE_DATA_CC);
 
+
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
 	}
@@ -106706,6 +108777,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_RW_SPEC_
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_RW, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -106831,6 +108903,8 @@ fetch_obj_is_copy:
 fetch_obj_is_finish:
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -106861,6 +108935,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_OBJ_UNSET_SP
 	property = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	result = EX_VAR(opline->result.var);
 	zend_fetch_property_address(result, container, IS_CV, property, IS_CV, ((IS_CV == IS_CONST) ? CACHE_ADDR(opline->extended_value) : NULL), BP_VAR_UNSET, 0, NULL OPLINE_CC EXECUTE_DATA_CC);
+
 
 	if (IS_CV == IS_VAR) {
 		FREE_VAR_PTR_AND_EXTRACT_RESULT_IF_NECESSARY(opline->op1.var);
@@ -106991,6 +109066,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -107011,10 +109087,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -107171,6 +109250,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -107325,6 +109406,8 @@ exit_assign_obj:
 	}
 
 
+
+
 	/* assign_obj has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
 }
@@ -107453,6 +109536,7 @@ fast_assign_obj:
 		name = zval_try_get_tmp_string(_get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC), &tmp_name);
 		if (UNEXPECTED(!name)) {
 
+
 			UNDEF_RESULT();
 			goto exit_assign_obj;
 		}
@@ -107473,10 +109557,13 @@ free_and_exit_assign_obj:
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), value);
 	}
 
+
 exit_assign_obj:
 	if (garbage) {
 		GC_DTOR_NO_REF(garbage);
 	}
+
+
 
 
 	/* assign_obj has two opcodes! */
@@ -107582,6 +109669,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -107589,11 +109677,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = RT_CONSTANT((opline+1), (opline+1)->op1);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -107601,6 +109691,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -107623,6 +109714,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -107630,7 +109722,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -107783,7 +109877,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -107936,7 +110032,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -108040,6 +110138,7 @@ try_assign_dim_array:
 
 			zend_assign_to_object_dim(obj, dim, value OPLINE_CC EXECUTE_DATA_CC);
 
+
 			if (UNEXPECTED(GC_DELREF(obj) == 0)) {
 				zend_objects_store_del(obj);
 			}
@@ -108047,11 +110146,13 @@ try_assign_dim_array:
 			if (IS_CV == IS_UNUSED) {
 				zend_use_new_element_for_string();
 
+
 				UNDEF_RESULT();
 			} else {
 				dim = EX_VAR(opline->op2.var);
 				value = EX_VAR((opline+1)->op1.var);
 				zend_assign_to_string_offset(object_ptr, dim, value OPLINE_CC EXECUTE_DATA_CC);
+
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
@@ -108059,6 +110160,7 @@ try_assign_dim_array:
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
 				dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
+
 
 				UNDEF_RESULT();
 			} else {
@@ -108081,6 +110183,7 @@ try_assign_dim_array:
 			dim = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 assign_dim_error:
 
+
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -108088,7 +110191,9 @@ assign_dim_error:
 	}
 	if (IS_CV != IS_UNUSED) {
 
+
 	}
+
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);
@@ -108118,6 +110223,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_CV_
 		value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
 
+
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -108146,6 +110252,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_SPEC_CV_CV_
 	} else {
 		value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
+
 
 	/* zend_assign_to_variable() always takes care of op2, never free it! */
 
@@ -108187,6 +110294,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_REF_SPEC_CV
 	}
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -108219,6 +110328,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
 
 
 	zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
@@ -108255,6 +110366,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ASSIGN_OBJ_REF_SPE
 	} else {
 		zend_assign_to_property_reference(container, IS_CV, property, IS_CV, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	}
+
+
+
 
 
 
@@ -108384,6 +110498,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FAST_CONCAT_SPEC_C
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -108418,10 +110534,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				ZVAL_UNDEFINED_OP2();
 				if (UNEXPECTED(EG(exception) != NULL)) {
 
+
 					HANDLE_EXCEPTION();
 				}
 			}
 			zend_throw_error(NULL, "Method name must be a string");
+
+
 
 
 			HANDLE_EXCEPTION();
@@ -108456,6 +110575,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					if (UNEXPECTED(EG(exception) != NULL)) {
 						if (IS_CV != IS_CONST) {
 
+
 						}
 						HANDLE_EXCEPTION();
 					}
@@ -108464,6 +110584,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 					function_name = EX_VAR(opline->op2.var);
 				}
 				zend_invalid_method_call(object, function_name);
+
+
 
 
 				HANDLE_EXCEPTION();
@@ -108490,6 +110612,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 				zend_undefined_method(orig_obj->ce, Z_STR_P(function_name));
 			}
 
+
 			if ((IS_CV & (IS_VAR|IS_TMP_VAR)) && GC_DELREF(orig_obj) == 0) {
 				zend_objects_store_del(orig_obj);
 			}
@@ -108512,6 +110635,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_INIT_METHOD_CALL_S
 	}
 
 	if (IS_CV != IS_CONST) {
+
 
 	}
 
@@ -108556,6 +110680,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ADD_ARRAY_ELEMENT_
 		} else {
 			ZVAL_MAKE_REF_EX(expr_ptr, 2);
 		}
+
 
 	} else {
 		expr_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -108628,6 +110753,7 @@ num_index:
 			zend_illegal_array_offset_access(offset);
 			zval_ptr_dtor_nogc(expr_ptr);
 		}
+
 
 	} else {
 		if (!zend_hash_next_index_insert(Z_ARRVAL_P(EX_VAR(opline->result.var)), expr_ptr)) {
@@ -108748,6 +110874,8 @@ num_index_dim:
 	} while (0);
 
 
+
+
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
 
@@ -108790,6 +110918,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_UNSET_OBJ_SPEC_CV_
 			zend_tmp_string_release(tmp_name);
 		}
 	} while (0);
+
+
 
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
@@ -108846,6 +110976,7 @@ num_index_prop:
 			if (IS_CV & (IS_CONST|IS_CV)) {
 				/* avoid exception check */
 
+
 				ZEND_VM_SMART_BRANCH(result, 0);
 			}
 		} else {
@@ -108869,6 +111000,8 @@ num_index_prop:
 	}
 
 isset_dim_obj_exit:
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -108921,6 +111054,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_ISSET_ISEMPTY_PROP
 isset_object_finish:
 
 
+
+
 	ZEND_VM_SMART_BRANCH(result, 1);
 }
 
@@ -108951,6 +111086,8 @@ array_key_exists_array:
 		zend_array_key_exists_error(subject, key OPLINE_CC EXECUTE_DATA_CC);
 		result = 0;
 	}
+
+
 
 
 	ZEND_VM_SMART_BRANCH(result, 1);
@@ -109013,6 +111150,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CV_T
 					ZVAL_REF(&generator->value, Z_REF_P(value_ptr));
 				} while (0);
 
+
 			}
 		} else {
 			zval *value = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
@@ -109027,6 +111165,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CV_T
 				ZVAL_COPY_VALUE(&generator->value, value);
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && Z_ISREF_P(value)) {
 				ZVAL_COPY(&generator->value, Z_REFVAL_P(value));
+
 
 			} else {
 				ZVAL_COPY_VALUE(&generator->value, value);
@@ -109047,6 +111186,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_YIELD_SPEC_CV_CV_T
 			key = Z_REFVAL_P(key);
 		}
 		ZVAL_COPY(&generator->key, key);
+
 
 		if (Z_TYPE(generator->key) == IS_LONG
 		    && Z_LVAL(generator->key) > generator->largest_used_integer_key
@@ -109594,6 +111734,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV_EX  z
 		if (UNEXPECTED(!name)) {
 			if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
 
+
 			}
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
@@ -109655,6 +111796,7 @@ fetch_this:
 	}
 
 	if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
+
 
 	}
 
@@ -109796,6 +111938,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV_EX  z
 		if (UNEXPECTED(!name)) {
 			if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
 
+
 			}
 			ZVAL_UNDEF(EX_VAR(opline->result.var));
 			HANDLE_EXCEPTION();
@@ -109857,6 +112000,7 @@ fetch_this:
 	}
 
 	if (!(opline->extended_value & ZEND_FETCH_GLOBAL_LOCK)) {
+
 
 	}
 
@@ -113980,8 +116124,10 @@ zend_leave_helper_SPEC_LABEL:
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = RT_CONSTANT(opline, opline->op1);
 	return_value = EX(return_value);
+
 
 	if (IS_CONST == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -114045,6 +116191,9 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
+
+
 
 
 
@@ -116009,8 +118158,10 @@ zend_leave_helper_SPEC_LABEL:
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_TMP_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -116074,6 +118225,9 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
+
+
 
 
 
@@ -116373,8 +118527,10 @@ zend_leave_helper_SPEC_LABEL:
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 	return_value = EX(return_value);
+
 
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -116438,6 +118594,9 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
+
+
 
 
 
@@ -117787,8 +119946,10 @@ zend_leave_helper_SPEC_LABEL:
 	zval *retval_ptr;
 	zval *return_value;
 
+
 	retval_ptr = EX_VAR(opline->op1.var);
 	return_value = EX(return_value);
+
 
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_INFO_P(retval_ptr) == IS_UNDEF)) {
 		SAVE_OPLINE();
@@ -117852,6 +120013,9 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
+
+
 
 
 

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -919,10 +919,7 @@ function gen_code($f, $spec, $kind, $code, $op1, $op2, $name, $extra_spec=null) 
     }
 
     /* Remove unnecessary ';' */
-    $code = preg_replace('/^\s*;\s*$/m', '', $code);
-
-    /* Remove WS */
-    $code = preg_replace('/[ \t]+\n/m', "\n", $code);
+    $code = preg_replace('/^\s*;\s*$/m', "\n", $code);
 
     out($f, $code);
 }


### PR DESCRIPTION
The removal of empty lines and lines containing only semicolons moved the offsets around. Remove just the standalone semicolons without removing entire lines to keep both files in sync. This is also useful for IDE split view mode even when not enabling `--with-lines`.