### PR TITLE
zend_vm_gen: Track line numbers on a per-file basis

### DIFF
--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -563,10 +563,10 @@ function out($f, $s) {
 function out_line($f) {
     global $line_nos, $executor_file;
 
-    $line_no = $line_nos[(int)$f] ??= 1;
+    $line_nos[(int)$f] ??= 1;
+    $line_nos[(int)$f]++;
 
-    fputs($f,"#line ".($line_no+1)." \"".$executor_file."\"\n");
-    ++$line_no;
+    fputs($f,"#line ".$line_nos[(int)$f]." \"".$executor_file."\"\n");
 }
 
 function is_hot_helper($name) {


### PR DESCRIPTION
php/php-src#19789 fixed the line number references for `zend_vm_def.h`, when generating with line number information some of them are also specific to `zend_vm_execute.h` and thus should reference that file instead with the correct line numbers.

The line number tracking was broken, because it was tracked in a single global variable, instead of being tracked on a per-file basis. Fix this by making the line numbers an array indexed by the resource ID and consistently using the `out()` functions to write into the files.