### PR TITLE
Fix bzopen() stream mode validation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ PHP                                                                        NEWS
   . The __sleep() and __wakeup() magic methods have been deprecated. (Girgias)
   . Fixed hard_timeout with --enable-zend-max-execution-timers. (Appla)
 
+- Bz2:
+  . Fixed bug GH-19810 (Broken bzopen() stream mode validation). (ilutov)
+
 - Exif:
   . Fix OSS-Fuzz #442954659 (zero-size box in HEIF file causes infinite loop).
     (nielsdos)

--- a/ext/bz2/tests/gh19810.phpt
+++ b/ext/bz2/tests/gh19810.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-19810: bzopen() stream mode validation
+--EXTENSIONS--
+bz2
+--FILE--
+<?php
+var_dump(bzopen(STDERR, 'r'));
+?>
+--EXPECTF--
+Warning: bzopen(): Cannot read from a stream opened in write only mode in %s on line %d
+bool(false)


### PR DESCRIPTION
The previous conditions were unreadable and incorrect. Extract the primary mode first, then compare it to the allowed values.

Fixes GH-19810