### PR TITLE
feat: allow empty extension name, fixes #19812

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -200,11 +200,15 @@ static void php_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callback_t
 
 				/* PHP and Zend extensions are not added into configuration hash! */
 				if (!is_special_section && zend_string_equals_literal_ci(Z_STR_P(arg1), PHP_EXTENSION_TOKEN)) { /* load PHP extension */
-					extension_name = estrndup(Z_STRVAL_P(arg2), Z_STRLEN_P(arg2));
-					zend_llist_add_element(&extension_lists.functions, &extension_name);
+					if (Z_STRLEN_P(arg2) > 0) {
+						extension_name = estrndup(Z_STRVAL_P(arg2), Z_STRLEN_P(arg2));
+						zend_llist_add_element(&extension_lists.functions, &extension_name);
+					}
 				} else if (!is_special_section && zend_string_equals_literal_ci(Z_STR_P(arg1), ZEND_EXTENSION_TOKEN)) { /* load Zend extension */
-					extension_name = estrndup(Z_STRVAL_P(arg2), Z_STRLEN_P(arg2));
-					zend_llist_add_element(&extension_lists.engine, &extension_name);
+					if (Z_STRLEN_P(arg2) > 0) {
+						extension_name = estrndup(Z_STRVAL_P(arg2), Z_STRLEN_P(arg2));
+						zend_llist_add_element(&extension_lists.engine, &extension_name);
+					}
 
 				/* All other entries are added into either configuration_hash or active ini section array */
 				} else {

--- a/sapi/cli/tests/empty_extension_loading.phpt
+++ b/sapi/cli/tests/empty_extension_loading.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Empty extension loading should not generate warnings
+--FILE--
+<?php
+
+function testEmptyExtension($type, $value) {
+    $cmd = [
+        PHP_BINARY, '-n',
+        '-dextension_dir=' . ini_get('extension_dir'),
+        '-d' . $type . '=' . $value,
+        '-r', 'echo "OK\n";'
+    ];
+    $proc = proc_open($cmd, [['null'], ['pipe', 'w'], ['pipe', 'w']], $pipes);
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    proc_close($proc);
+    
+    if ($stderr) {
+        echo "STDERR: " . trim($stderr) . "\n";
+    }
+    echo trim($stdout) . "\n";
+}
+
+echo "Testing empty extension directive:\n";
+testEmptyExtension('extension', '');
+
+echo "Testing empty zend_extension directive:\n";
+testEmptyExtension('zend_extension', '');
+
+?>
+--EXPECT--
+Testing empty extension directive:
+OK
+Testing empty zend_extension directive:
+OK


### PR DESCRIPTION
Allows to load a PHP extension by a php.ini like:

```ini
extension=${PROFILER}
```

If PROFILER env is not there, it loads nothing. if there. it loads that extension


