### PR TITLE
Zend: Implement __unserialize() for Exception/Error

### DIFF
--- a/Zend/tests/exceptions/exception_error_serialization.phpt
+++ b/Zend/tests/exceptions/exception_error_serialization.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Check exception Error can round trip serialization
+--FILE--
+<?php
+
+$e1 = new Error("1", 25, null);
+$e2 = new Error("2", 42, $e1);
+
+$s = serialize($e2);
+
+$e = unserialize($s);
+
+var_dump($e->getMessage() === $e2->getMessage());
+var_dump($e->getCode() === $e2->getCode());
+var_dump($e->getFile() === $e2->getFile());
+var_dump($e->getLine() === $e2->getLine());
+var_dump($e->getTrace() === $e2->getTrace());
+var_dump($e->getPrevious()::class === $e2->getPrevious()::class);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/Zend/tests/exceptions/exception_serialization.phpt
+++ b/Zend/tests/exceptions/exception_serialization.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Check exceptions can round trip serialization
+--FILE--
+<?php
+
+$e1 = new Exception("1", 25, null);
+$e2 = new Exception("2", 42, $e1);
+
+$s = serialize($e2);
+
+$e = unserialize($s);
+
+var_dump($e->getMessage() === $e2->getMessage());
+var_dump($e->getCode() === $e2->getCode());
+var_dump($e->getFile() === $e2->getFile());
+var_dump($e->getLine() === $e2->getLine());
+var_dump($e->getTrace() === $e2->getTrace());
+var_dump($e->getPrevious()::class === $e2->getPrevious()::class);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/Zend/tests/serialize/bug70121.phpt
+++ b/Zend/tests/serialize/bug70121.phpt
@@ -8,6 +8,7 @@ OK
 --EXPECTF--
 Fatal error: Uncaught TypeError: Cannot assign stdClass to property Exception::$previous of type ?Throwable in %s:%d
 Stack trace:
-#0 %s(%d): unserialize('O:12:"DateInter...')
-#1 {main}
+#0 [internal function]: Exception->__unserialize(Array)
+#1 %s(%d): unserialize('O:12:"DateInter...')
+#2 {main}
   thrown in %s on line %d

--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -47,6 +47,8 @@ class Exception implements Throwable
     /** @tentative-return-type */
     public function __wakeup(): void {}
 
+    public function __unserialize(array $data): void {}
+
     final public function getMessage(): string {}
 
     /** @return int */
@@ -110,6 +112,11 @@ class Error implements Throwable
      * @implementation-alias Exception::__wakeup
      */
     public function __wakeup(): void {}
+
+    /**
+     * @implementation-alias Exception::__unserialize
+     */
+    public function __unserialize(array $data): void {}
 
     /** @implementation-alias Exception::getMessage */
     final public function getMessage(): string {}

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ba1562ca8fe2fe48c40bc52d10545aa989afd86c */
+ * Stub hash: e412ae81454288565daae5ffaf9cc3941b6edbb7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -30,6 +30,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Exception___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Exception___wakeup, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Exception___unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Exception_getMessage arginfo_class_Throwable_getMessage
@@ -65,6 +69,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Error___wakeup arginfo_class_Exception___wakeup
 
+#define arginfo_class_Error___unserialize arginfo_class_Exception___unserialize
+
 #define arginfo_class_Error_getMessage arginfo_class_Throwable_getMessage
 
 #define arginfo_class_Error_getCode arginfo_class_Throwable_getCode
@@ -84,6 +90,7 @@ ZEND_END_ARG_INFO()
 ZEND_METHOD(Exception, __clone);
 ZEND_METHOD(Exception, __construct);
 ZEND_METHOD(Exception, __wakeup);
+ZEND_METHOD(Exception, __unserialize);
 ZEND_METHOD(Exception, getMessage);
 ZEND_METHOD(Exception, getCode);
 ZEND_METHOD(Exception, getFile);
@@ -110,6 +117,7 @@ static const zend_function_entry class_Exception_methods[] = {
 	ZEND_ME(Exception, __clone, arginfo_class_Exception___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(Exception, __construct, arginfo_class_Exception___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(Exception, __wakeup, arginfo_class_Exception___wakeup, ZEND_ACC_PUBLIC)
+	ZEND_ME(Exception, __unserialize, arginfo_class_Exception___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Exception, getMessage, arginfo_class_Exception_getMessage, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(Exception, getCode, arginfo_class_Exception_getCode, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(Exception, getFile, arginfo_class_Exception_getFile, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -131,6 +139,7 @@ static const zend_function_entry class_Error_methods[] = {
 	ZEND_RAW_FENTRY("__clone", zim_Exception___clone, arginfo_class_Error___clone, ZEND_ACC_PRIVATE, NULL, NULL)
 	ZEND_RAW_FENTRY("__construct", zim_Exception___construct, arginfo_class_Error___construct, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("__wakeup", zim_Exception___wakeup, arginfo_class_Error___wakeup, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_RAW_FENTRY("__unserialize", zim_Exception___unserialize, arginfo_class_Error___unserialize, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getMessage", zim_Exception_getMessage, arginfo_class_Error_getMessage, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL, NULL, NULL)
 	ZEND_RAW_FENTRY("getCode", zim_Exception_getCode, arginfo_class_Error_getCode, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL, NULL, NULL)
 	ZEND_RAW_FENTRY("getFile", zim_Exception_getFile, arginfo_class_Error_getFile, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL, NULL, NULL)

--- a/ext/soap/tests/bugs/bug73452.phpt
+++ b/ext/soap/tests/bugs/bug73452.phpt
@@ -13,6 +13,7 @@ echo unserialize($data);
 --EXPECTF--
 Fatal error: Uncaught TypeError: Cannot assign %s to property SoapFault::$faultcode of type ?string in %s:%d
 Stack trace:
-#0 %sbug73452.php(4): unserialize('O:9:"SoapFault"...')
-#1 {main}
+#0 [internal function]: Exception->__unserialize(Array)
+#1 %s(4): unserialize('O:9:"SoapFault"...')
+#2 {main}
   thrown in %s on line %d

--- a/ext/standard/tests/serialize/bug69152.phpt
+++ b/ext/standard/tests/serialize/bug69152.phpt
@@ -2,15 +2,25 @@
 Bug #69152: Type Confusion Infoleak Vulnerability in unserialize()
 --FILE--
 <?php
-$x = unserialize('O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"ryat";}');
-echo $x;
-$x =  unserialize('O:4:"test":1:{s:27:"__PHP_Incomplete_Class_Name";R:1;}');
-$x->test();
+try {
+	$x = unserialize('O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"ryat";}');
+	var_dump($x);
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+	$x = unserialize('O:4:"test":1:{s:27:"__PHP_Incomplete_Class_Name";R:1;}');
+	var_dump($x);
+	$x->test();
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 
 ?>
---EXPECTF--
-Fatal error: Uncaught TypeError: Cannot assign string to property Exception::$trace of type array in %s:%d
-Stack trace:
-#0 %s(%d): unserialize('O:9:"exception"...')
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+TypeError: Cannot assign string to property Exception::$trace of type array
+object(__PHP_Incomplete_Class)#1 (1) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  *RECURSION*
+}
+Error: The script tried to call a method on an incomplete object. Please ensure that the class definition "unknown" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition

--- a/ext/standard/tests/serialize/bug69793.phpt
+++ b/ext/standard/tests/serialize/bug69793.phpt
@@ -2,13 +2,13 @@
 Bug #69793: Remotely triggerable stack exhaustion via recursive method calls
 --FILE--
 <?php
-$e = unserialize('O:9:"Exception":7:{s:17:"'."\0".'Exception'."\0".'string";s:1:"a";s:7:"'."\0".'*'."\0".'code";i:0;s:7:"'."\0".'*'."\0".'file";s:0:"";s:7:"'."\0".'*'."\0".'line";i:1337;s:16:"'."\0".'Exception'."\0".'trace";a:0:{}s:19:"'."\0".'Exception'."\0".'previous";i:10;s:10:"'."\0".'*'."\0".'message";N;}');
-
-var_dump($e."");
+try {
+	$e = unserialize('O:9:"Exception":7:{s:17:"'."\0".'Exception'."\0".'string";s:1:"a";s:7:"'."\0".'*'."\0".'code";i:0;s:7:"'."\0".'*'."\0".'file";s:0:"";s:7:"'."\0".'*'."\0".'line";i:1337;s:16:"'."\0".'Exception'."\0".'trace";a:0:{}s:19:"'."\0".'Exception'."\0".'previous";i:10;s:10:"'."\0".'*'."\0".'message";N;}');
+	var_dump($e);
+	var_dump($e."");
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
---EXPECTF--
-Fatal error: Uncaught TypeError: Cannot assign int to property Exception::$previous of type ?Throwable in %s:%d
-Stack trace:
-#0 %s(%d): unserialize('O:9:"Exception"...')
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+TypeError: Cannot assign null to property Exception::$message of type string

--- a/ext/standard/tests/serialize/bug70963.phpt
+++ b/ext/standard/tests/serialize/bug70963.phpt
@@ -2,12 +2,19 @@
 Bug #70963 (Unserialize shows UNKNOW in result)
 --FILE--
 <?php
-var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"test";}i:1;R:3;}'));
-var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"test";}i:1;r:3;}'));
+try {
+	var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"test";}i:1;R:3;}'));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+try {
+	var_dump(unserialize('a:2:{i:0;O:9:"exception":1:{s:16:"'."\0".'Exception'."\0".'trace";s:4:"test";}i:1;r:3;}'));
+} catch (Throwable $e) {
+	echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: Cannot assign string to property Exception::$trace of type array in %s:%d
-Stack trace:
-#0 %s(%d): unserialize('a:2:{i:0;O:9:"e...')
-#1 {main}
-  thrown in %s on line %d
+TypeError: Cannot assign string to property Exception::$trace of type array
+
+Warning: unserialize(): Error at offset 72 of 73 bytes in %s on line %d
+TypeError: Cannot assign string to property Exception::$trace of type array

--- a/sapi/cli/tests/005.phpt
+++ b/sapi/cli/tests/005.phpt
@@ -37,7 +37,7 @@ string(183) "Class [ <internal:Core> class stdClass ] {
 }
 
 "
-string(2232) "Class [ <internal:Core> class Exception implements Stringable, Throwable ] {
+string(2406) "Class [ <internal:Core> class Exception implements Stringable, Throwable ] {
 
   - Constants [0] {
   }
@@ -58,7 +58,7 @@ string(2232) "Class [ <internal:Core> class Exception implements Stringable, Thr
     Property [ private ?Throwable $previous = NULL ]
   }
 
-  - Methods [11] {
+  - Methods [12] {
     Method [ <internal:Core> private method __clone ] {
 
       - Parameters [0] {
@@ -80,6 +80,14 @@ string(2232) "Class [ <internal:Core> class Exception implements Stringable, Thr
       - Parameters [0] {
       }
       - Tentative return [ void ]
+    }
+
+    Method [ <internal:Core> public method __unserialize ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> array $data ]
+      }
+      - Return [ void ]
     }
 
     Method [ <internal:Core, prototype Throwable> final public method getMessage ] {


### PR DESCRIPTION
This makes the DOM classes the only classes that only have `__sleep()` magic methods, and `__wakeup()` methods without a corresponding `__unserialize()` magic method, as it is needed to allow serialization of child classes.