### PR TITLE
ext: fix naming clash with libxml macro

### DIFF
--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -201,10 +201,10 @@ PHP_METHOD(DOMAttr, isId)
 
 bool dom_compare_value(const xmlAttr *attr, const xmlChar *value)
 {
-	bool free;
-	xmlChar *attr_value = php_libxml_attr_value(attr, &free);
+	bool should_free;
+	xmlChar *attr_value = php_libxml_attr_value(attr, &should_free);
 	bool result = xmlStrEqual(attr_value, value);
-	if (free) {
+	if (should_free) {
 		xmlFree(attr_value);
 	}
 	return result;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -2396,10 +2396,10 @@ void php_dom_get_content_into_zval(const xmlNode *nodep, zval *return_value, boo
 		}
 
 		case XML_ATTRIBUTE_NODE: {
-			bool free;
-			xmlChar *value = php_libxml_attr_value((const xmlAttr *) nodep, &free);
+			bool should_free;
+			xmlChar *value = php_libxml_attr_value((const xmlAttr *) nodep, &should_free);
 			RETVAL_STRING_FAST((const char *) value);
-			if (free) {
+			if (should_free) {
 				xmlFree(value);
 			}
 			return;

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1529,10 +1529,10 @@ static void sxe_add_registered_namespaces(php_sxe_object *sxe, xmlNodePtr node, 
 				/* Attributes in the xmlns namespace should be treated as namespace declarations too. */
 				if (attr->ns && xmlStrEqual(attr->ns->href, (const xmlChar *) "http://www.w3.org/2000/xmlns/")) {
 					const char *prefix = attr->ns->prefix ? (const char *) attr->name : "";
-					bool free;
-					xmlChar *href = php_libxml_attr_value(attr, &free);
+					bool should_free;
+					xmlChar *href = php_libxml_attr_value(attr, &should_free);
 					sxe_add_namespace_name_raw(return_value, prefix, (const char *) href);
-					if (free) {
+					if (should_free) {
 						xmlFree(href);
 					}
 				}


### PR DESCRIPTION
In the macOS 26 SDK, xmlFree is defined as a macro for free. This causes issues where a same-named variable is used. Renaming the variable to should_free resolves the issue.

See:

    $ grep -B4 -A2 -n "#define xmlFree(" "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.sdk/usr/include/libxml/globals.h"
    261-#if defined(LIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS)
    262-#define xmlMalloc(size) malloc(size)
    263-#define xmlMallocAtomic(size) malloc(size)
    264-#define xmlRealloc(ptr, size) realloc((ptr), (size))
    265:#define xmlFree(ptr) free(ptr)
    266-#define xmlMemStrdup(str) strdup(str)
    267-#endif

Fixes:

    In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/libxml/xmlIO.h:117,
                    from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/libxml/parser.h:813,
                    from /private/tmp/php-20250914-13349-uqsk5o/php-8.4.12/ext/dom/php_dom.h:29,
                    from /private/tmp/php-20250914-13349-uqsk5o/php-8.4.12/ext/dom/attr.c:26:
    /private/tmp/php-20250914-13349-uqsk5o/php-8.4.12/ext/dom/attr.c: In function 'dom_compare_value':
    /private/tmp/php-20250914-13349-uqsk5o/php-8.4.12/ext/dom/attr.c:208:17: error: called object 'free' is not a function or function pointer
      208 |                 xmlFree(attr_value);
          |                 ^~~~~~~
    /private/tmp/php-20250914-13349-uqsk5o/php-8.4.12/ext/dom/attr.c:204:14: note: declared here
      204 |         bool free;
          |              ^~~~
    make: *** [ext/dom/attr.lo] Error 1
