### PR TITLE
Deref property after FETCH_OBJ_R with REG destination

### DIFF
--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -1965,8 +1965,13 @@ static zval* ZEND_FASTCALL zend_jit_fetch_obj_r_slow_ex(zend_object *zobj)
 	void **cache_slot = CACHE_ADDR(opline->extended_value & ~ZEND_FETCH_OBJ_FLAGS);
 
 	retval = zobj->handlers->read_property(zobj, name, BP_VAR_R, cache_slot, result);
-	if (retval == result && UNEXPECTED(Z_ISREF_P(retval))) {
-		zend_unwrap_reference(retval);
+	if (UNEXPECTED(Z_ISREF_P(retval))) {
+		if (retval == result) {
+			zend_unwrap_reference(retval);
+		} else {
+			retval = Z_REFVAL_P(retval);
+		}
+		ZEND_ASSERT(!Z_REFCOUNTED_P(retval));
 	}
 	return retval;
 }

--- a/ext/opcache/tests/jit/gh19831_001.phpt
+++ b/ext/opcache/tests/jit/gh19831_001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-19831 001: fetch obj slow R REG + reference
+--CREDITS--
+dktapps
+--ENV--
+RT_COND=1
+--INI--
+opcache.jit=1203
+--FILE--
+<?php
+
+if (getenv('RT_COND')) {
+    class Base {
+    }
+}
+
+// Class is not linked
+class Test extends Base {
+	public int $layers = 1;
+
+	public function getLayers(): int {
+        // Prop info is not known, but res_addr is REG
+		return $this->layers;
+	}
+}
+
+$t = new Test();
+$a = &$t->layers;
+var_dump($t->getLayers());
+
+?>
+--EXPECT--
+int(1)

--- a/ext/opcache/tests/jit/gh19831_002.phpt
+++ b/ext/opcache/tests/jit/gh19831_002.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-19831 002: fetch obj slow R REG + __get + reference
+--CREDITS--
+dktapps
+--ENV--
+RT_COND=1
+--INI--
+opcache.jit=1203
+--FILE--
+<?php
+
+if (getenv('RT_COND')) {
+    class Base {
+    }
+}
+
+// Class is not linked
+class Test extends Base {
+	public int $layers = 1;
+
+    public function &__get($name) {
+        global $a;
+        $a = 1;
+        return $a;
+    }
+
+	public function getLayers(): int {
+        // Prop info is not known, but res_addr is REG
+		return $this->layers;
+	}
+}
+
+$t = new Test();
+unset($t->layers);
+var_dump($t->getLayers());
+
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
Possible fix for GH-19831.

`zend_jit_fetch_obj_r_slow_ex` doesn't deref the property.

Tracing JIT is unaffected due to type guards.

I believe that other variants of `zend_jit_fetch_obj_*_slow_ex` can not be used used in function JIT.