### PR TITLE
zend_hash: Assert that the `interned` parameter is not a lie

### DIFF
--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1628,6 +1628,7 @@ static zend_always_inline zval *_zend_hash_append_ex(HashTable *ht, zend_string 
 	Bucket *p = ht->arData + idx;
 
 	ZVAL_COPY_VALUE(&p->val, zv);
+	ZEND_ASSERT(!interned || ZSTR_IS_INTERNED(key));
 	if (!interned && !ZSTR_IS_INTERNED(key)) {
 		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
@@ -1654,6 +1655,7 @@ static zend_always_inline zval *_zend_hash_append_ptr_ex(HashTable *ht, zend_str
 	Bucket *p = ht->arData + idx;
 
 	ZVAL_PTR(&p->val, ptr);
+	ZEND_ASSERT(!interned || ZSTR_IS_INTERNED(key));
 	if (!interned && !ZSTR_IS_INTERNED(key)) {
 		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1621,15 +1621,15 @@ static zend_always_inline bool zend_array_is_list(const zend_array *array)
 }
 
 
-static zend_always_inline zval *_zend_hash_append_ex(HashTable *ht, zend_string *key, zval *zv, bool interned)
+static zend_always_inline zval *_zend_hash_append_ex(HashTable *ht, zend_string *key, zval *zv, bool key_guaranteed_interned)
 {
 	uint32_t idx = ht->nNumUsed++;
 	uint32_t nIndex;
 	Bucket *p = ht->arData + idx;
 
 	ZVAL_COPY_VALUE(&p->val, zv);
-	ZEND_ASSERT(!interned || ZSTR_IS_INTERNED(key));
-	if (!interned && !ZSTR_IS_INTERNED(key)) {
+	ZEND_ASSERT(!key_guaranteed_interned || ZSTR_IS_INTERNED(key));
+	if (!key_guaranteed_interned && !ZSTR_IS_INTERNED(key)) {
 		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
 		zend_string_hash_val(key);
@@ -1648,15 +1648,15 @@ static zend_always_inline zval *_zend_hash_append(HashTable *ht, zend_string *ke
 	return _zend_hash_append_ex(ht, key, zv, 0);
 }
 
-static zend_always_inline zval *_zend_hash_append_ptr_ex(HashTable *ht, zend_string *key, void *ptr, bool interned)
+static zend_always_inline zval *_zend_hash_append_ptr_ex(HashTable *ht, zend_string *key, void *ptr, bool key_guaranteed_interned)
 {
 	uint32_t idx = ht->nNumUsed++;
 	uint32_t nIndex;
 	Bucket *p = ht->arData + idx;
 
 	ZVAL_PTR(&p->val, ptr);
-	ZEND_ASSERT(!interned || ZSTR_IS_INTERNED(key));
-	if (!interned && !ZSTR_IS_INTERNED(key)) {
+	ZEND_ASSERT(!key_guaranteed_interned || ZSTR_IS_INTERNED(key));
+	if (!key_guaranteed_interned && !ZSTR_IS_INTERNED(key)) {
 		HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 		zend_string_addref(key);
 		zend_string_hash_val(key);


### PR DESCRIPTION
While investigating php/php-src#19842 I was wondering why non-interned string didn't cause troubles, until I realized it was the value instead of the key. Nevertheless it appears useful to check that the key is actually interned as claimed by the caller to prevent hard-to-find bugs.