### PR TITLE
ODBC fetch refactoring

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1312,8 +1312,8 @@ typedef enum php_odbc_fetch_result_type_t {
 	ODBC_OBJECT = 2,
 } php_odbc_fetch_result_type_t;
 
-/* {{{ php_odbc_fetch_hash */
-static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, bool return_array, php_odbc_fetch_result_type_t result_type)
+/* {{{ php_odbc_fetch */
+static void php_odbc_fetch(INTERNAL_FUNCTION_PARAMETERS, bool return_array, php_odbc_fetch_result_type_t result_type)
 {
 	int i;
 	odbc_result *result;
@@ -1493,7 +1493,7 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, bool return_array,
 /* {{{ Fetch a result row as an object */
 PHP_FUNCTION(odbc_fetch_object)
 {
-	php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAM_PASSTHRU, true, ODBC_OBJECT);
+	php_odbc_fetch(INTERNAL_FUNCTION_PARAM_PASSTHRU, true, ODBC_OBJECT);
 	if (Z_TYPE_P(return_value) == IS_ARRAY) {
 		object_and_properties_init(return_value, ZEND_STANDARD_CLASS_DEF_PTR, Z_ARRVAL_P(return_value));
 	}
@@ -1503,21 +1503,21 @@ PHP_FUNCTION(odbc_fetch_object)
 /* {{{ Fetch a result row as an associative array */
 PHP_FUNCTION(odbc_fetch_array)
 {
-	php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAM_PASSTHRU, true, ODBC_OBJECT);
+	php_odbc_fetch(INTERNAL_FUNCTION_PARAM_PASSTHRU, true, ODBC_OBJECT);
 }
 /* }}} */
 
 /* {{{ Fetch one result row into an array */
 PHP_FUNCTION(odbc_fetch_into)
 {
-	php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAM_PASSTHRU, false, ODBC_NUM);
+	php_odbc_fetch(INTERNAL_FUNCTION_PARAM_PASSTHRU, false, ODBC_NUM);
 }
 /* }}} */
 
 /* {{{ Fetch a row */
 PHP_FUNCTION(odbc_fetch_row)
 {
-	php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAM_PASSTHRU, false, ODBC_NONE);
+	php_odbc_fetch(INTERNAL_FUNCTION_PARAM_PASSTHRU, false, ODBC_NONE);
 }
 /* }}} */
 


### PR DESCRIPTION
* Merge `php_odbc_fetch_into` into `php_odbc_fetch_hash`.
  * The implementation was nearly identical, so refactor into a common implementation with some differences in how the result set array is returned.
  * `odbc_fetch_into` is kind of weird. I don't know if it'd be better to deprecate it and have a more "symmetrical" API  that works like `odbc_fetch_array`.
* Converts `php_odbc_fetch_hash` to use ZPP.
  * Opportunistic since I was there anyways.
* Convert `SQLExtendedFetch` calls to `SQLFetchScroll`
  * This is obsolete, should be like PDO_ODBC now. Fixes GH-19522.
* Convert result type constants to an enum
* Merge `php_odbc_fetch_row` into `php_odbc_fetch_hash`
  * Similar to `fetch_into`, though with special $row == 0/-1 deprecation (see GH-13910)