### PR TITLE
Skip mysql tests on ppc64 runner

### DIFF
--- a/.github/actions/configure-gentoo/action.yml
+++ b/.github/actions/configure-gentoo/action.yml
@@ -19,8 +19,8 @@ runs:
           --with-libdir=lib64 \
           --enable-phpdbg \
           --enable-fpm \
-          --with-pdo-mysql=mysqlnd \
-          --with-mysqli=mysqlnd \
+          ${{ inputs.skipSlow == 'false' && '--with-mysqli=mysqlnd' || '' }} \
+          ${{ inputs.skipSlow == 'false' && '--with-pdo-mysql=mysqlnd' || '' }} \
           ${{ inputs.skipSlow == 'false' && '--with-pgsql' || '' }} \
           ${{ inputs.skipSlow == 'false' && '--with-pdo-pgsql' || '' }} \
           ${{ inputs.skipSlow == 'false' && '--with-pdo-sqlite' || '' }} \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
             CXX=clang++-17
             --enable-debug
             --enable-zts
-          skipSlow: false # FIXME: This should likely include slow extensions
+          skipSlow: true # FIXME: This should likely include slow extensions
       - name: make
         run: make -j$(/usr/bin/nproc) >/dev/null
       # Skip an install action for now


### PR DESCRIPTION
For whatever reason, mysql tests are apocalyptically slow on ppc64 (presumably -O0 ASAN makes this much worse).

skipSlow is enabled, which skips some other tests, consistent with the Alpine nightly job. Could reconsider enabling some of these even in skipSlow.