### PR TITLE
Fix use-of-uninitialized-value in zend_get_arg_offset_by_name()

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5094,10 +5094,10 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 	}
 
 	if (fbc->common.fn_flags & ZEND_ACC_VARIADIC) {
-		if (!(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO)
-		 && (fbc->type == ZEND_INTERNAL_FUNCTION
-		  || !fbc->op_array.refcount
-		  || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE))) {
+		if ((fbc->type == ZEND_USER_FUNCTION
+		  && (!fbc->op_array.refcount || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE)))
+		 || (fbc->type == ZEND_INTERNAL_FUNCTION
+		  && !(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO))) {
 			*cache_slot = unique_id;
 			*(uintptr_t *)(cache_slot + 1) = fbc->common.num_args;
 		}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5094,7 +5094,10 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 	}
 
 	if (fbc->common.fn_flags & ZEND_ACC_VARIADIC) {
-		if (fbc->type == ZEND_INTERNAL_FUNCTION || !fbc->op_array.refcount || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+		if (!(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO)
+		 && (fbc->type == ZEND_INTERNAL_FUNCTION
+		  || !fbc->op_array.refcount
+		  || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE))) {
 			*cache_slot = unique_id;
 			*(uintptr_t *)(cache_slot + 1) = fbc->common.num_args;
 		}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -5072,9 +5072,9 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 	if (EXPECTED(fbc->type == ZEND_USER_FUNCTION)
 			|| EXPECTED(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
 		for (uint32_t i = 0; i < num_args; i++) {
-			zend_arg_info *arg_info = &fbc->op_array.arg_info[i];
+			zend_arg_info *arg_info = &fbc->common.arg_info[i];
 			if (zend_string_equals(arg_name, arg_info->name)) {
-				if (!fbc->op_array.refcount || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+				if (fbc->type == ZEND_USER_FUNCTION && (!fbc->op_array.refcount || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE))) {
 					*cache_slot = unique_id;
 					*(uintptr_t *)(cache_slot + 1) = i;
 				}


### PR DESCRIPTION
Don't access fbc->op_array.refcount on internal function. Don't attempt to cache ZEND_ACC_USER_ARG_INFO at all, which is only used in zend_get_closure_invoke_method(). This may reuse arg_info from a temporary closure, and hence caching would also be unsafe.

See https://github.com/php/php-src/actions/runs/17751635609/job/50447500518.
Introduced in https://github.com/php/php-src/pull/19654.