### PR TITLE
Allow empty statements before declare(strict_types)

### DIFF
--- a/Zend/tests/gh19719.phpt
+++ b/Zend/tests/gh19719.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-19719: Allow empty expressions before declare(strict_types)
+--FILE--
+<?php
+// e.g some comments
+?>
+<?php
+
+declare(strict_types=1);
+
+function takesInt(int $x) {}
+
+try {
+    takesInt('42');
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+takesInt(): Argument #1 ($x) must be of type int, string given, called in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7008,7 +7008,7 @@ static void zend_compile_declare(zend_ast *ast) /* {{{ */
 		} else if (zend_string_equals_literal_ci(name, "strict_types")) {
 			zval value_zv;
 
-			if (FAILURE == zend_is_first_statement(ast, /* allow_nop */ 0)) {
+			if (FAILURE == zend_is_first_statement(ast, /* allow_nop */ true)) {
 				zend_error_noreturn(E_COMPILE_ERROR, "strict_types declaration must be "
 					"the very first statement in the script");
 			}


### PR DESCRIPTION
Fixes GH-19719

Is this still ok for 8.5 or should we wait until 8.6/9.0 is branched next week?