### PR TITLE
Mark enums and static fake closures as not collectable

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -866,6 +866,9 @@ ZEND_API void zend_create_fake_closure(zval *res, zend_function *func, zend_clas
 
 	closure = (zend_closure *)Z_OBJ_P(res);
 	closure->func.common.fn_flags |= ZEND_ACC_FAKE_CLOSURE;
+	if (Z_TYPE(closure->this_ptr) != IS_OBJECT) {
+		GC_ADD_FLAGS(&closure->std, GC_NOT_COLLECTABLE);
+	}
 }
 /* }}} */
 

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -39,6 +39,7 @@ ZEND_API zend_object_handlers zend_enum_object_handlers;
 zend_object *zend_enum_new(zval *result, zend_class_entry *ce, zend_string *case_name, zval *backing_value_zv)
 {
 	zend_object *zobj = zend_objects_new(ce);
+	GC_ADD_FLAGS(zobj, GC_NOT_COLLECTABLE);
 	ZVAL_OBJ(result, zobj);
 
 	zval *zname = OBJ_PROP_NUM(zobj, 0);


### PR DESCRIPTION
Simple synthetic benchmark:

```php
function foo() {}

$array = [];
for ($i = 0; $i < 10_000_000; $i++) {
    $array[] = foo(...);
}

foreach ($array as $foo) {}

echo json_encode(gc_status(), JSON_PRETTY_PRINT);
```

```
❯ php-old -d memory_limit=-1 test.php
{
    "running": false,
    "protected": false,
    "full": false,
    "runs": 44,
    "collected": 0,
    "threshold": 450001,
    "buffer_size": 524288,
    "roots": 100043,
    "application_time": 1.841229413,
    "collector_time": 0.203653695,
    "destructor_time": 0,
    "free_time": 0
}

❯ php-new -d memory_limit=-1 test.php
{
    "running": false,
    "protected": false,
    "full": false,
    "runs": 0,
    "collected": 0,
    "threshold": 10001,
    "buffer_size": 16384,
    "roots": 0,
    "application_time": 1.635467089,
    "collector_time": 0,
    "destructor_time": 0,
    "free_time": 0
}
```

There should be virtually no downside to this, so hopefully this is still good for 8.5?