### PR TITLE
gen_stub: Add support for generation C `#include` statements

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -5377,7 +5377,7 @@ function generateCodeWithConditions(
             continue;
         }
 
-        if ($info->cond && $info->cond !== $parentCond) {
+        if ($info->cond !== null && $info->cond !== $parentCond) {
             if ($openCondition !== null
                 && $info->cond !== $openCondition
             ) {

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1343,6 +1343,14 @@ class VersionFlags {
     }
 }
 
+class IncludeInfo {
+    public function __construct(
+        public readonly string $include,
+        public readonly ?string $cond,
+    ) {
+    }
+}
+
 class FuncInfo {
 
     /**
@@ -4296,6 +4304,8 @@ class FileInfo {
     private array $funcInfos = [];
     /** @var ClassInfo[] */
     public array $classInfos = [];
+    /** @var IncludeInfo[] */
+    public array $includeInfos = [];
     private bool $generateFunctionEntries = false;
     private string $declarationPrefix = "";
     private bool $generateClassEntries = false;
@@ -4440,6 +4450,16 @@ class FileInfo {
         $conds = [];
         foreach ($stmts as $stmt) {
             $cond = self::handlePreprocessorConditions($conds, $stmt);
+
+            if ($stmt instanceof Stmt\Declare_) {
+                foreach ($stmt->declares as $declare) {
+                    if ($declare->key->name !== 'c_include') {
+                        throw new Exception("Unexpected declare {$declare->key->name}");
+                    }
+                    $this->includeInfos[] = new IncludeInfo((string)EvaluatedValue::createFromExpression($declare->value, null, null, [])->value, $cond);
+                }
+                continue;
+            }
 
             if ($stmt instanceof Stmt\Nop) {
                 continue;
@@ -4664,6 +4684,11 @@ class FileInfo {
         string $stubHash
     ): array {
         $headerDependencies = new HeaderDependencies();
+
+        foreach ($this->includeInfos as $includeInfo) {
+            $headerDependencies->add($includeInfo->include, $includeInfo->cond);
+        }
+
         $code = "";
 
         $generatedFuncInfos = [];

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -6,6 +6,13 @@
  * @generate-legacy-arginfo 70000
  * @undocumentable
  */
+
+#if 1
+declare(
+    c_include='test_stub_cvalue.h'
+);
+#endif
+
 namespace {
     require "Zend/zend_attributes.stub.php";
 
@@ -17,6 +24,12 @@ namespace {
 
     /** @var string */
     const ZEND_CONSTANT_A = "global";
+
+    /**
+     * @var string
+     * @cvalue ZEND_TEST_STUB_CVALUE_A
+     */
+    const ZEND_TEST_STUB_CVALUE_A = UNKNOWN;
 
     /**
      * @var int

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,7 +1,10 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
+ * Stub hash: 2954e482259ba13b5b27c8652f388fb5e1b5dcb5
  * Has decl header: yes */
 
+#if 1
+#include "test_stub_cvalue.h"
+#endif
 #include "zend_attributes.h"
 #include "zend_constants.h"
 #if (PHP_VERSION_ID >= 80100)
@@ -866,6 +869,7 @@ static void register_test_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("ZEND_TEST_DEPRECATED", 42, CONST_PERSISTENT | CONST_DEPRECATED);
 	REGISTER_STRING_CONSTANT("ZEND_CONSTANT_A", "global", CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("ZEND_TEST_STUB_CVALUE_A", ZEND_TEST_STUB_CVALUE_A, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("ZEND_TEST_ATTRIBUTED_CONSTANT", 42, CONST_PERSISTENT | CONST_DEPRECATED);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZendSubNS\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT);

--- a/ext/zend_test/test_decl.h
+++ b/ext/zend_test/test_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636 */
+ * Stub hash: 2954e482259ba13b5b27c8652f388fb5e1b5dcb5 */
 
-#ifndef ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H
-#define ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H
+#ifndef ZEND_TEST_DECL_2954e482259ba13b5b27c8652f388fb5e1b5dcb5_H
+#define ZEND_TEST_DECL_2954e482259ba13b5b27c8652f388fb5e1b5dcb5_H
 
 typedef enum zend_enum_ZendTestUnitEnum {
 	ZEND_ENUM_ZendTestUnitEnum_Foo = 1,
@@ -27,4 +27,4 @@ typedef enum zend_enum_ZendTestEnumWithInterface {
 	ZEND_ENUM_ZendTestEnumWithInterface_Bar = 2,
 } zend_enum_ZendTestEnumWithInterface;
 
-#endif /* ZEND_TEST_DECL_4d728e740122add9d4c91f5c1abb5f5017690636_H */
+#endif /* ZEND_TEST_DECL_2954e482259ba13b5b27c8652f388fb5e1b5dcb5_H */

--- a/ext/zend_test/test_legacy_arginfo.h
+++ b/ext/zend_test/test_legacy_arginfo.h
@@ -1,7 +1,10 @@
 /* This is a generated file, edit test.stub.php instead.
- * Stub hash: 4d728e740122add9d4c91f5c1abb5f5017690636
+ * Stub hash: 2954e482259ba13b5b27c8652f388fb5e1b5dcb5
  * Has decl header: yes */
 
+#if 1
+#include "test_stub_cvalue.h"
+#endif
 #include "zend_constants.h"
 #if (PHP_VERSION_ID >= 80100)
 #include "zend_enum.h"
@@ -754,6 +757,7 @@ static void register_test_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("ZEND_TEST_DEPRECATED", 42, CONST_PERSISTENT | CONST_CS);
 	REGISTER_STRING_CONSTANT("ZEND_CONSTANT_A", "global", CONST_PERSISTENT | CONST_CS);
+	REGISTER_STRING_CONSTANT("ZEND_TEST_STUB_CVALUE_A", ZEND_TEST_STUB_CVALUE_A, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("ZEND_TEST_ATTRIBUTED_CONSTANT", 42, CONST_PERSISTENT | CONST_CS);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT | CONST_CS);
 	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZendSubNS\\ZEND_CONSTANT_A", "namespaced", CONST_PERSISTENT | CONST_CS);

--- a/ext/zend_test/test_stub_cvalue.h
+++ b/ext/zend_test/test_stub_cvalue.h
@@ -1,0 +1,18 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright © The PHP Group and Contributors.                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to the Modified BSD License that is      |
+  | bundled with this package in the file LICENSE, and is available      |
+  | through the World Wide Web at <https://www.php.net/license/>.        |
+  |                                                                      |
+  | SPDX-License-Identifier: BSD-3-Clause                                |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_TEST_STUB_CVALUE_H
+#define ZEND_TEST_STUB_CVALUE_H
+
+#define ZEND_TEST_STUB_CVALUE_A "my_value"
+
+#endif

--- a/ext/zend_test/tests/gh11423.phpt
+++ b/ext/zend_test/tests/gh11423.phpt
@@ -13,11 +13,13 @@ var_dump(get_defined_constants(true)["user"]);
 
 ?>
 --EXPECT--
-array(5) {
+array(6) {
   ["ZEND_TEST_DEPRECATED"]=>
   int(42)
   ["ZEND_CONSTANT_A"]=>
   string(6) "global"
+  ["ZEND_TEST_STUB_CVALUE_A"]=>
+  string(8) "my_value"
   ["ZEND_TEST_ATTRIBUTED_CONSTANT"]=>
   int(42)
   ["ZendTestNS2\ZEND_CONSTANT_A"]=>

--- a/ext/zend_test/tests/test_stub_cvalue.phpt
+++ b/ext/zend_test/tests/test_stub_cvalue.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Verify that declare(c_include='...') works in stubs
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(ZEND_TEST_STUB_CVALUE_A);
+
+?>
+--EXPECT--
+string(8) "my_value"


### PR DESCRIPTION
This is useful to include the necessary files for a constant’s `@cvalue` from within the arginfo itself.