### PR TITLE
Fix CGI with auto_globals_jit=0

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -663,17 +663,11 @@ static void cgi_php_load_env_var(const char *var, unsigned int var_len, char *va
 
 static void cgi_php_import_environment_variables(zval *array_ptr)
 {
-	if (PG(variables_order) && (strchr(PG(variables_order),'E') || strchr(PG(variables_order),'e'))) {
-		if (Z_TYPE(PG(http_globals)[TRACK_VARS_ENV]) != IS_ARRAY) {
-			zend_is_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_ENV));
-		}
-
-		if (Z_TYPE(PG(http_globals)[TRACK_VARS_ENV]) == IS_ARRAY &&
-			Z_ARR_P(array_ptr) != Z_ARR(PG(http_globals)[TRACK_VARS_ENV])) {
-			zend_array_destroy(Z_ARR_P(array_ptr));
-			Z_ARR_P(array_ptr) = zend_array_dup(Z_ARR(PG(http_globals)[TRACK_VARS_ENV]));
-			return;
-		}
+	if (Z_TYPE(PG(http_globals)[TRACK_VARS_ENV]) == IS_ARRAY &&
+		Z_ARR_P(array_ptr) != Z_ARR(PG(http_globals)[TRACK_VARS_ENV])) {
+		zend_array_destroy(Z_ARR_P(array_ptr));
+		Z_ARR_P(array_ptr) = zend_array_dup(Z_ARR(PG(http_globals)[TRACK_VARS_ENV]));
+		return;
 	}
 
 	/* call php's original import as a catch-all */

--- a/sapi/cgi/tests/auto_globals_no_jit.phpt
+++ b/sapi/cgi/tests/auto_globals_no_jit.phpt
@@ -1,0 +1,17 @@
+--TEST--
+CGI with auto_globals_jit=0
+--INI--
+auto_globals_jit=0
+--CGI--
+--ENV--
+FOO=BAR
+--FILE--
+<?php
+var_dump($_SERVER['FOO']);
+var_dump($_ENV['FOO']);
+var_dump(getenv('FOO'));
+?>
+--EXPECT--
+string(3) "BAR"
+string(3) "BAR"
+string(3) "BAR"


### PR DESCRIPTION
There's no need to call zend_is_auto_global(), which will read the uninitialized armed field. If the env is not yet initialized, we'll fall back to php_php_import_environment_variables().

See https://github.com/php/php-src/actions/runs/17815318830/job/50647381504. Exposed by GH-19833.