### PR TITLE
CI: update `push.yml` `ignore-paths` to use YAML anchors aliases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: Push
 on:
   push:
-    paths-ignore:
+    paths-ignore: &ignore_paths
       - docs/**
       - NEWS
       - UPGRADING
@@ -18,16 +18,7 @@ on:
       - PHP-8.4
       - master
   pull_request:
-    paths-ignore:
-      - docs/**
-      - NEWS
-      - UPGRADING
-      - UPGRADING.INTERNALS
-      - '**/README.*'
-      - CONTRIBUTING.md
-      - CODING_STANDARDS.md
-      - .cirrus.yml
-      - .circleci/**
+    paths-ignore: *ignore_paths
     branches:
       - '**'
   workflow_dispatch: ~


### PR DESCRIPTION
GitHub Actions now supports YAML anchors and aliases[^1], so the workflows can use them to avoid repeating lists.

[^1]: https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases