### PR TITLE
uri: Inline `parser` and `uri` into `uri_object_t`

### DIFF
--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -346,7 +346,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) PHPAPI void php_uri_instantiate_uri(
 	if (base_url_object != NULL) {
 		ZEND_ASSERT(base_url_object->std.ce == uri_object->std.ce);
 		const uri_internal_t *internal_base_url = &base_url_object->internal;
-		URI_ASSERT_INITIALIZATION(internal_base_url);
+		ZEND_ASSERT(internal_base_url->uri != NULL);
 		ZEND_ASSERT(internal_base_url->parser == uri_parser);
 		base_url = internal_base_url->uri;
 	}
@@ -532,7 +532,7 @@ static void rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAMETERS, php_uri_componen
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_read(internal_uri->uri, read_mode, return_value) == FAILURE)) {
 		zend_throw_error(NULL, "The userinfo component cannot be retrieved");
@@ -567,7 +567,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
 
 	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	zend_object *new_object = old_object->handlers->clone_obj(old_object);
 	if (new_object == NULL) {
@@ -579,7 +579,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
 	RETVAL_OBJ(new_object);
 
 	uri_internal_t *new_internal_uri = &uri_object_from_obj(new_object)->internal;
-	URI_ASSERT_INITIALIZATION(new_internal_uri);
+	ZEND_ASSERT(new_internal_uri->uri != NULL);
 
 	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_write(new_internal_uri->uri, &zv, NULL) == FAILURE)) {
 		RETURN_THROWS();
@@ -685,10 +685,10 @@ static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, uri_object_t *that_object, 
 {
 	uri_object_t *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	uri_internal_t *this_internal_uri = &this_object->internal;
-	URI_ASSERT_INITIALIZATION(this_internal_uri);
+	ZEND_ASSERT(this_internal_uri->uri != NULL);
 
 	uri_internal_t *that_internal_uri = &that_object->internal;
-	URI_ASSERT_INITIALIZATION(that_internal_uri);
+	ZEND_ASSERT(that_internal_uri->uri != NULL);
 
 	if (this_object->std.ce != that_object->std.ce &&
 		!instanceof_function(this_object->std.ce, that_object->std.ce) &&
@@ -744,7 +744,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, toRawString)
 
 	uri_object_t *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &this_object->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	zend_string *uri_str = internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
 	if (uri_str == NULL) {
@@ -761,7 +761,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, toString)
 
 	uri_object_t *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &this_object->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	zend_string *uri_str = internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, false);
 	if (uri_str == NULL) {
@@ -790,7 +790,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, __serialize)
 
 	uri_object_t *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &this_object->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	/* Serialize state: "uri" key in the first array */
 	zend_string *uri_str = internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
@@ -945,7 +945,7 @@ PHP_METHOD(Uri_WhatWg_Url, toUnicodeString)
 
 	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &uri_object_from_obj(this_object)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	RETURN_STR(internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_UNICODE, false));
 }
@@ -956,7 +956,7 @@ PHP_METHOD(Uri_WhatWg_Url, toAsciiString)
 
 	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &uri_object_from_obj(this_object)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	RETURN_STR(internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false));
 }
@@ -982,7 +982,7 @@ PHP_METHOD(Uri_WhatWg_Url, __serialize)
 
 	uri_object_t *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &this_object->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	/* Serialize state: "uri" key in the first array */
 	zend_string *uri_str = internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
@@ -1058,7 +1058,7 @@ PHPAPI zend_object *php_uri_object_handler_clone(zend_object *object)
 	uri_object_t *uri_object = uri_object_from_obj(object);
 	uri_internal_t *internal_uri = &uri_object_from_obj(object)->internal;
 
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	uri_object_t *new_uri_object = uri_object_from_obj(object->ce->create_object(object->ce));
 	ZEND_ASSERT(new_uri_object->internal.parser == internal_uri->parser);

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -531,7 +531,7 @@ static void rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAMETERS, php_uri_componen
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	uri_internal_t *internal_uri = Z_URI_INTERNAL_P(ZEND_THIS);
+	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_read(internal_uri->uri, read_mode, return_value) == FAILURE)) {
@@ -566,7 +566,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
 	}
 
 	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = Z_URI_INTERNAL_P(ZEND_THIS);
+	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	zend_object *new_object = old_object->handlers->clone_obj(old_object);
@@ -578,7 +578,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
 	 * case of an exception being thrown. */
 	RETVAL_OBJ(new_object);
 
-	uri_internal_t *new_internal_uri = uri_internal_from_obj(new_object);
+	uri_internal_t *new_internal_uri = &uri_object_from_obj(new_object)->internal;
 	URI_ASSERT_INITIALIZATION(new_internal_uri);
 
 	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_write(new_internal_uri->uri, &zv, NULL) == FAILURE)) {
@@ -823,7 +823,7 @@ static void uri_unserialize(INTERNAL_FUNCTION_PARAMETERS)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_object *object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = uri_internal_from_obj(object);
+	uri_internal_t *internal_uri = &uri_object_from_obj(object)->internal;
 	if (internal_uri->uri != NULL) {
 		/* Intentionally throw two exceptions for proper chaining. */
 		zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(object->ce->name));
@@ -944,7 +944,7 @@ PHP_METHOD(Uri_WhatWg_Url, toUnicodeString)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = uri_internal_from_obj(this_object);
+	uri_internal_t *internal_uri = &uri_object_from_obj(this_object)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	RETURN_STR(internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_UNICODE, false));
@@ -955,7 +955,7 @@ PHP_METHOD(Uri_WhatWg_Url, toAsciiString)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = uri_internal_from_obj(this_object);
+	uri_internal_t *internal_uri = &uri_object_from_obj(this_object)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	RETURN_STR(internal_uri->parser->to_string(internal_uri->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false));
@@ -1056,7 +1056,7 @@ PHPAPI void php_uri_object_handler_free(zend_object *object)
 PHPAPI zend_object *php_uri_object_handler_clone(zend_object *object)
 {
 	uri_object_t *uri_object = uri_object_from_obj(object);
-	uri_internal_t *internal_uri = uri_internal_from_obj(object);
+	uri_internal_t *internal_uri = &uri_object_from_obj(object)->internal;
 
 	URI_ASSERT_INITIALIZATION(internal_uri);
 

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -59,11 +59,10 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 
 static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
 {
-	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
-	uri_object_t *internal_uri = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(internal_uri->uri != NULL);
+	uri_object_t *old_uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(old_uri_object->uri != NULL);
 
-	zend_object *new_object = old_object->handlers->clone_obj(old_object);
+	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
 	if (new_object == NULL) {
 		RETURN_THROWS();
 	}
@@ -72,19 +71,19 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_propert
 	 * case of an exception being thrown. */
 	RETVAL_OBJ(new_object);
 
-	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
+	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(old_uri_object->parser, property_name);
 
-	uri_object_t *new_internal_uri = uri_object_from_obj(new_object);
-	ZEND_ASSERT(new_internal_uri->uri != NULL);
+	uri_object_t *new_uri_object = uri_object_from_obj(new_object);
+	ZEND_ASSERT(new_uri_object->uri != NULL);
 	if (UNEXPECTED(property_handler->write == NULL)) {
-		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),
+		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_uri_object->std.ce->name),
 			ZSTR_VAL(get_known_string_by_property_name(property_name)));
 		RETURN_THROWS();
 	}
 
 	zval errors;
 	ZVAL_UNDEF(&errors);
-	if (UNEXPECTED(property_handler->write(new_internal_uri->uri, property_zv, &errors) == FAILURE)) {
+	if (UNEXPECTED(property_handler->write(new_uri_object->uri, property_zv, &errors) == FAILURE)) {
 		zval_ptr_dtor(&errors);
 		RETURN_THROWS();
 	}

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -46,7 +46,7 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
+	uri_object_t *internal_uri = Z_URI_OBJECT_P(ZEND_THIS);
 	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
@@ -60,7 +60,7 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
 {
 	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
+	uri_object_t *internal_uri = Z_URI_OBJECT_P(ZEND_THIS);
 	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	zend_object *new_object = old_object->handlers->clone_obj(old_object);
@@ -74,7 +74,7 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_propert
 
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
 
-	uri_internal_t *new_internal_uri = &uri_object_from_obj(new_object)->internal;
+	uri_object_t *new_internal_uri = uri_object_from_obj(new_object);
 	ZEND_ASSERT(new_internal_uri->uri != NULL);
 	if (UNEXPECTED(property_handler->write == NULL)) {
 		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -47,7 +47,7 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
 
@@ -61,7 +61,7 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_propert
 {
 	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
 	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
-	URI_ASSERT_INITIALIZATION(internal_uri);
+	ZEND_ASSERT(internal_uri->uri != NULL);
 
 	zend_object *new_object = old_object->handlers->clone_obj(old_object);
 	if (new_object == NULL) {
@@ -75,7 +75,7 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_propert
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
 
 	uri_internal_t *new_internal_uri = &uri_object_from_obj(new_object)->internal;
-	URI_ASSERT_INITIALIZATION(new_internal_uri);
+	ZEND_ASSERT(new_internal_uri->uri != NULL);
 	if (UNEXPECTED(property_handler->write == NULL)) {
 		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),
 			ZSTR_VAL(get_known_string_by_property_name(property_name)));

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -46,12 +46,12 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	uri_object_t *internal_uri = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(internal_uri->uri != NULL);
+	uri_object_t *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
 
-	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
+	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(uri_object->parser, property_name);
 
-	if (UNEXPECTED(property_handler->read(internal_uri->uri, component_read_mode, return_value) == FAILURE)) {
+	if (UNEXPECTED(property_handler->read(uri_object->uri, component_read_mode, return_value) == FAILURE)) {
 		zend_throw_exception_ex(uri_error_ce, 0, "The %s component cannot be retrieved", ZSTR_VAL(get_known_string_by_property_name(property_name)));
 		RETURN_THROWS();
 	}

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -46,7 +46,7 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	uri_internal_t *internal_uri = Z_URI_INTERNAL_P(ZEND_THIS);
+	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
@@ -60,7 +60,7 @@ void uri_read_component(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name prop
 static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
 {
 	zend_object *old_object = Z_OBJ_P(ZEND_THIS);
-	uri_internal_t *internal_uri = Z_URI_INTERNAL_P(ZEND_THIS);
+	uri_internal_t *internal_uri = &Z_URI_OBJECT_P(ZEND_THIS)->internal;
 	URI_ASSERT_INITIALIZATION(internal_uri);
 
 	zend_object *new_object = old_object->handlers->clone_obj(old_object);
@@ -74,7 +74,7 @@ static void uri_write_component_ex(INTERNAL_FUNCTION_PARAMETERS, php_uri_propert
 
 	const php_uri_property_handler *property_handler = php_uri_parser_property_handler_by_name(internal_uri->parser, property_name);
 
-	uri_internal_t *new_internal_uri = uri_internal_from_obj(new_object);
+	uri_internal_t *new_internal_uri = &uri_object_from_obj(new_object)->internal;
 	URI_ASSERT_INITIALIZATION(new_internal_uri);
 	if (UNEXPECTED(property_handler->write == NULL)) {
 		zend_readonly_property_modification_error_ex(ZSTR_VAL(old_object->ce->name),

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -151,12 +151,7 @@ static inline uri_object_t *uri_object_from_obj(zend_object *object) {
 	return (uri_object_t*)((char*)(object) - XtOffsetOf(uri_object_t, std));
 }
 
-static inline uri_internal_t *uri_internal_from_obj(zend_object *object) {
-	return &(uri_object_from_obj(object)->internal);
-}
-
 #define Z_URI_OBJECT_P(zv) uri_object_from_obj(Z_OBJ_P((zv)))
-#define Z_URI_INTERNAL_P(zv) uri_internal_from_obj(Z_OBJ_P((zv)))
 
 PHPAPI uri_object_t *php_uri_object_create(zend_class_entry *class_type, const php_uri_parser *parser);
 PHPAPI void php_uri_object_handler_free(zend_object *object);

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -143,7 +143,8 @@ typedef struct uri_internal_t {
 } uri_internal_t;
 
 typedef struct uri_object_t {
-	uri_internal_t internal;
+	const php_uri_parser *parser;
+	void *uri;
 	zend_object std;
 } uri_object_t;
 

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -190,8 +190,4 @@ void uri_write_component_str(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name
 void uri_write_component_str_or_null(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name);
 void uri_write_component_long_or_null(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name);
 
-#define URI_ASSERT_INITIALIZATION(internal_uri) do { \
-	ZEND_ASSERT(internal_uri != NULL && internal_uri->uri != NULL); \
-} while (0)
-
 #endif


### PR DESCRIPTION
<strike>This PR includes and depends on #19903 with the first 2 commits. The PRs are independent for better commit history after merging.</strike>

The purpose of this change is to improve readability of the code by avoiding:

- Having multiple local variables to refer to the same “object”.
- Avoiding the `.internal` member that does not provide a value-add when already dealing with URI objects and just adds needless verbosity.