### PR TITLE
Skip php_cli_server_pdeathsig.phpt if pgrep is missing

### DIFF
--- a/sapi/cli/tests/php_cli_server_pdeathsig.phpt
+++ b/sapi/cli/tests/php_cli_server_pdeathsig.phpt
@@ -9,6 +9,7 @@ if (!(str_contains(PHP_OS, 'Linux') || str_contains(PHP_OS, 'FreeBSD'))) {
     die('skip PDEATHSIG is only supported on Linux and FreeBSD');
 }
 if (@file_exists('/.dockerenv')) die("skip Broken in Docker");
+if (!shell_exec("which pgrep")) die("skip Missing pgrep command");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Fixes GH-19911