### PR TITLE
Fix --with-openssl-legacy-provider build failure

### DIFF
--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -26,6 +26,10 @@
 /* Common */
 #include <time.h>
 
+#if PHP_OPENSSL_API_VERSION >= 0x30000 && defined(LOAD_OPENSSL_LEGACY_PROVIDER)
+#include <openssl/provider.h>
+#endif
+
 #if (defined(PHP_WIN32) && defined(_MSC_VER))
 #define timezone _timezone	/* timezone is called _timezone in LibC */
 #endif


### PR DESCRIPTION
--with-openssl-legacy-provider works ok on the 8.4 branch but needs this include on the master branch to build. It looks like it was just missed in the work on https://github.com/php/php-src/pull/16918