### PR TITLE
Fix build if --with-openssl-legacy-provider set

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -53,11 +53,6 @@
 #include <openssl/ssl.h>
 #include <openssl/pkcs12.h>
 #include <openssl/cms.h>
-#if PHP_OPENSSL_API_VERSION >= 0x30000
-#include <openssl/core_names.h>
-#include <openssl/param_build.h>
-#include <openssl/provider.h>
-#endif
 
 ZEND_DECLARE_MODULE_GLOBALS(openssl)
 

--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -473,23 +473,8 @@ zend_result php_openssl_write_rand_file(const char * file, int egdsocket, int se
 	return SUCCESS;
 }
 
-void php_openssl_backend_init(void)
+void php_openssl_backend_init_common(void)
 {
-#ifdef LIBRESSL_VERSION_NUMBER
-	OPENSSL_config(NULL);
-	SSL_library_init();
-	OpenSSL_add_all_ciphers();
-	OpenSSL_add_all_digests();
-	OpenSSL_add_all_algorithms();
-	SSL_load_error_strings();
-#else
-#if PHP_OPENSSL_API_VERSION >= 0x30000 && defined(LOAD_OPENSSL_LEGACY_PROVIDER)
-	OSSL_PROVIDER_load(NULL, "legacy");
-	OSSL_PROVIDER_load(NULL, "default");
-#endif
-	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
-#endif
-
 	/* Determine default SSL configuration file */
 	char *config_filename = getenv("OPENSSL_CONF");
 	if (config_filename == NULL) {

--- a/ext/openssl/openssl_backend_v1.c
+++ b/ext/openssl/openssl_backend_v1.c
@@ -27,6 +27,22 @@
 #include <openssl/engine.h>
 #endif
 
+void php_openssl_backend_init(void)
+{
+#ifdef LIBRESSL_VERSION_NUMBER
+	OPENSSL_config(NULL);
+	SSL_library_init();
+	OpenSSL_add_all_ciphers();
+	OpenSSL_add_all_digests();
+	OpenSSL_add_all_algorithms();
+	SSL_load_error_strings();
+#else
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
+
+	php_openssl_backend_init_common();
+}
+
 void php_openssl_backend_shutdown(void)
 {
 #ifdef LIBRESSL_VERSION_NUMBER

--- a/ext/openssl/openssl_backend_v3.c
+++ b/ext/openssl/openssl_backend_v3.c
@@ -24,6 +24,18 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(openssl)
 
+void php_openssl_backend_init(void)
+{
+#if PHP_OPENSSL_API_VERSION >= 0x30000 && defined(LOAD_OPENSSL_LEGACY_PROVIDER)
+	OSSL_PROVIDER_load(NULL, "legacy");
+	OSSL_PROVIDER_load(NULL, "default");
+#endif
+
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+	php_openssl_backend_init_common();
+}
+
 void php_openssl_backend_shutdown(void)
 {
 	(void) 0;


### PR DESCRIPTION
This fixes and improves the backend initialization which was failing when `--with-openssl-legacy-provider` set