### PR TITLE
Bump `php-sdk-binary-tools` tag.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1042,7 +1042,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.5.0
       PHP_BUILD_CRT: ${{ inputs.vs_crt_version }}
       PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
       THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -231,7 +231,7 @@ jobs:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
-      PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
+      PHP_BUILD_SDK_BRANCH: php-sdk-2.5.0
       PHP_BUILD_CRT: vs17
       PLATFORM: x64
       THREAD_SAFE: "1"


### PR DESCRIPTION
This PR bumps the tag for [`php/php-sdk-binary-tools`](https://github.com/php/php-sdk-binary-tools) for `push` and `nightly` workflows to [`php-sdk-2.5.0`](https://github.com/php/php-sdk-binary-tools/releases/tag/php-sdk-2.5.0).