### PR TITLE
Fix GH-17951: memory_limit ini value not being overwritten by max_memory_limit

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -346,7 +346,7 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 		}
 
 		zend_ini_entry *max_mem_limit_ini = zend_hash_str_find_ptr(EG(ini_directives), ZEND_STRL("max_memory_limit"));
-		entry->value = zend_string_copy(max_mem_limit_ini->value);
+		entry->value = zend_string_init(ZSTR_VAL(max_mem_limit_ini->value), ZSTR_LEN(max_mem_limit_ini->value), true);
 		PG(memory_limit) = PG(max_memory_limit);
 
 		return SUCCESS;

--- a/tests/basic/gh17951_runtime_change_6.phpt
+++ b/tests/basic/gh17951_runtime_change_6.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-17951 Runtime Change 6
+--INI--
+memory_limit=128M
+max_memory_limit=512M
+--FILE--
+<?php
+for($i = 0; $i < 3; $i++) {
+  ini_set('memory_limit', '1024M');
+  echo ini_get('memory_limit');
+}
+?>
+--EXPECTF--
+Warning: Failed to set memory_limit to 1073741824 bytes. Setting to max_memory_limit instead (currently: 536870912 bytes) in %s on line %d
+512M
+Warning: Failed to set memory_limit to 1073741824 bytes. Setting to max_memory_limit instead (currently: 536870912 bytes) in %s on line %d
+512M
+Warning: Failed to set memory_limit to 1073741824 bytes. Setting to max_memory_limit instead (currently: 536870912 bytes) in %s on line %d
+512M


### PR DESCRIPTION
Make sure to always duplicate max_memory_limit ini value. Otherwise the alter ini routine may assume the value hasn't been overwritten, resulting in the user-specified value being set after the on_modify handler has run.