### PR TITLE
fix PDO fixedly passes MYSQL_TYPE_LONG, causing values exceeding INT32 to overflow When using non-mysqlnd drivers, #19413

### DIFF
--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -519,7 +519,11 @@ static int pdo_mysql_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_da
 						PDO_DBG_RETURN(1);
 
 					case IS_LONG:
+#if SIZEOF_ZEND_LONG==8
 						b->buffer_type = MYSQL_TYPE_LONGLONG;
+#elif SIZEOF_ZEND_LONG==4
+						b->buffer_type = MYSQL_TYPE_LONG;
+#endif /* SIZEOF_LONG */
 						b->buffer = &Z_LVAL_P(parameter);
 						PDO_DBG_RETURN(1);
 


### PR DESCRIPTION
fix : PDO fixedly passes MYSQL_TYPE_LONG, causing values exceeding INT32 to overflow When using non-mysqlnd drivers, #19413


https://github.com/php/php-src/issues/19413