### PR TITLE
Fix race condition in zend_runtime_jit(), zend_jit_hot_func()

### DIFF
--- a/Zend/Optimizer/zend_func_info.h
+++ b/Zend/Optimizer/zend_func_info.h
@@ -39,7 +39,7 @@
 #define ZEND_FUNC_JIT_ON_PROF_REQUEST      (1<<14) /* used by JIT */
 #define ZEND_FUNC_JIT_ON_HOT_COUNTERS      (1<<15) /* used by JIT */
 #define ZEND_FUNC_JIT_ON_HOT_TRACE         (1<<16) /* used by JIT */
-
+#define ZEND_FUNC_JITED                    (1<<17) /* used by JIT */
 
 typedef struct _zend_func_info zend_func_info;
 typedef struct _zend_call_info zend_call_info;


### PR DESCRIPTION
Fixes GH-19889.

`zend_runtime_jit()` prevents concurrent compilation with `zend_shared_alloc_lock()`, but this doesn't prevent blocked threads from trying to compile the function again after they acquire the lock.

In the case of GH-19889, one of the function entries is compiled with `zend_jit_handler()`, which fails when the op handler has been replaced by a JIT'ed handler.

This can be produced with this script:

``` php
function f(int $a, int ...$b) {
    // RECV $a
    // RECV_VARIADIC $b: second entry, compiled with zend_jit_handler()
    // RETURN $b
    return $b;
}

$f = 'f';
var_dump($f(1,2));
```

Fix by marking compiled functions with a new flag `ZEND_FUNC_JITED`, and skipping compilation of marked functions. The same fix is applied to `zend_jit_hot_func()`.