### PR TITLE
Fix GH-16319: protect fiber backtrace with null filename from crashing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,8 +14,6 @@ PHP                                                                        NEWS
     array). (ilutov)
   . Fixed bug GH-19480 (error_log php.ini cannot be unset when open_basedir is
     configured). (nielsdos)
-  . Fixed bug GH-16319 (Prevent crash when displaying fiber backtrace with
-    a null filename). (alexandre-daubois)
 
 - Date:
   . Fixed GH-17159: "P" format for ::createFromFormat swallows string literals.

--- a/ext/zend_test/tests/observer_fiber_backtrace_crash.phpt
+++ b/ext/zend_test/tests/observer_fiber_backtrace_crash.phpt
@@ -5,6 +5,10 @@ zend_test
 --INI--
 zend_test.observer.enabled=1
 zend_test.observer.show_init_backtrace=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_opcode=0
+opcache.jit=0
 --FILE--
 <?php
 $fiber = new Fiber(function() {});
@@ -12,25 +16,33 @@ $fiber->start();
 echo "Test completed without crash\n";
 ?>
 --EXPECTF--
-<!-- init '%s' -->
+<!-- init %s -->
 <!--
     {main} %s
 -->
-<!-- init Fiber::__construct() -->
-<!--
-    Fiber::__construct()
-    {main} %s
--->
-<!-- init Fiber::start() -->
-<!--
-    Fiber::start()
-    {main} %s
--->
-<!-- init {closure}() -->
-<!--
-    {closure}()
-    {main} [no active file]
-    Fiber::start()
-    {main} %s
--->
+<file %s>
+  <!-- init Fiber::__construct() -->
+  <!--
+      Fiber::__construct()
+      {main} %s
+  -->
+  <Fiber::__construct>
+  </Fiber::__construct>
+  <!-- init Fiber::start() -->
+  <!--
+      Fiber::start()
+      {main} %s
+  -->
+  <Fiber::start>
+    <!-- init {closure}() -->
+    <!--
+        {closure}()
+        {main} [no active file]
+        Fiber::start()
+        {main} %s
+    -->
+    <{closure}>
+    </{closure}>
+  </Fiber::start>
 Test completed without crash
+</file %s>


### PR DESCRIPTION
Fix #16319

Used `[no active file]` as it's already used at many places.