### PR TITLE
Fix IntlNumberRangeFormatter to build on <= ICU 67

### DIFF
--- a/ext/intl/rangeformatter/rangeformatter_class.cpp
+++ b/ext/intl/rangeformatter/rangeformatter_class.cpp
@@ -20,7 +20,9 @@ extern "C" {
 
 #if U_ICU_VERSION_MAJOR_NUM >= 63
 #include <unicode/numberrangeformatter.h>
+#if U_ICU_VERSION_MAJOR_NUM >= 68
 #include <unicode/unumberrangeformatter.h>
+#endif
 #include <unicode/numberformatter.h>
 #include <unicode/unistr.h>
 #include "../intl_convertcpp.h"


### PR DESCRIPTION
Follow up for #19232 

C API `unicode/unumberrangeformatter.h` was added in [ICU 68](https://icu.unicode.org/download/68). 
This PR fixes the build for icu 67 and older to load the header only for ICU 68 and above.