### PR TITLE
Intl: Remove unumberrangeformatter.h include in IntlNumberRangeFormatter

### DIFF
--- a/ext/intl/rangeformatter/rangeformatter_class.cpp
+++ b/ext/intl/rangeformatter/rangeformatter_class.cpp
@@ -20,7 +20,6 @@ extern "C" {
 
 #if U_ICU_VERSION_MAJOR_NUM >= 63
 #include <unicode/numberrangeformatter.h>
-#include <unicode/unumberrangeformatter.h>
 #include <unicode/numberformatter.h>
 #include <unicode/unistr.h>
 #include "../intl_convertcpp.h"


### PR DESCRIPTION
Since we don't use it in the class implementation and it's causing a build failure on systems with ICU 67, this PR removes the include.

The problem is that IntlNumberRangeFormatter should work with ICU 63 and up, however, the C equivalent is available from ICU 68.

see https://github.com/php/php-src/pull/19232#issuecomment-3341110312

Tested with this container on ICU 67.1: https://gist.github.com/BogdanUngureanu/943f8ffdf8dfc84123aa9c53bc995a7a