### PR TITLE
Stream filter seeking

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -153,6 +153,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-21221 (Prevent closing of innerstream of php://temp stream).
     (ilutov)
   . Improved stream_socket_server() bind failure error reporting. (ilutov)
+  . Fixed bug #49874 (ftell() and fseek() inconsistency when using stream
+    filters). (Jakub Zelenka)
 
 - Zip:
   . Fixed ZipArchive callback being called after executor has shut down.

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -74,6 +74,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     longer is a pointer, but a directly embedded HashTable struct.
   . Added a C23_ENUM() helper macro to define forward-compatible fixed-size
     enums.
+  . Extended php_stream_filter_ops with seek method.
 
 ========================
 2. Build system changes

--- a/ext/bz2/tests/bz2_filter_seek_compress.phpt
+++ b/ext/bz2/tests/bz2_filter_seek_compress.phpt
@@ -1,0 +1,55 @@
+--TEST--
+bzip2.compress filter with seek to start
+--EXTENSIONS--
+bz2
+--FILE--
+<?php
+$file = __DIR__ . '/bz2_filter_seek_compress.bz2';
+
+$text1 = 'Short text.';
+$text2 = 'This is a much longer text that will completely overwrite the previous compressed data in the file.';
+
+$fp = fopen($file, 'w+');
+stream_filter_append($fp, 'bzip2.compress', STREAM_FILTER_WRITE);
+
+fwrite($fp, $text1);
+fflush($fp);
+
+$size1 = ftell($fp);
+echo "Size after first write: $size1\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fwrite($fp, $text2);
+fflush($fp);
+
+$size2 = ftell($fp);
+echo "Size after second write: $size2\n";
+echo "Second write is larger: " . ($size2 > $size1 ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'bzip2.decompress', STREAM_FILTER_READ);
+$content = stream_get_contents($fp);
+fclose($fp);
+
+echo "Decompressed content matches text2: " . ($content === $text2 ? "YES" : "NO") . "\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bz2_filter_seek_compress.bz2');
+?>
+--EXPECTF--
+Size after first write: 40
+Seek to start: SUCCESS
+Size after second write: 98
+Second write is larger: YES
+
+Warning: fseek(): Stream filter bzip2.compress is seekable only to start position in %s on line %d
+Seek to middle: FAILURE
+Decompressed content matches text2: YES

--- a/ext/bz2/tests/bz2_filter_seek_decompress.phpt
+++ b/ext/bz2/tests/bz2_filter_seek_decompress.phpt
@@ -1,0 +1,43 @@
+--TEST--
+bzip2.decompress filter with seek to start
+--EXTENSIONS--
+bz2
+--FILE--
+<?php
+$file = __DIR__ . '/bz2_filter_seek_decompress.bz2';
+
+$text = 'I am the very model of a modern major general, I\'ve information vegetable, animal, and mineral.';
+
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'bzip2.compress', STREAM_FILTER_WRITE);
+fwrite($fp, $text);
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'bzip2.decompress', STREAM_FILTER_READ);
+
+$partial = fread($fp, 20);
+echo "First read (20 bytes): " . $partial . "\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$full = stream_get_contents($fp);
+echo "Content after seek matches: " . ($full === $text ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bz2_filter_seek_decompress.bz2');
+?>
+--EXPECTF--
+First read (20 bytes): I am the very model 
+Seek to start: SUCCESS
+Content after seek matches: YES
+
+Warning: fseek(): Stream filter bzip2.decompress is seekable only to start position in %s on line %d
+Seek to middle: FAILURE

--- a/ext/gd/tests/bug79945.phpt
+++ b/ext/gd/tests/bug79945.phpt
@@ -9,17 +9,17 @@ if (!(imagetypes() & IMG_PNG)) {
 }
 set_error_handler(function($errno, $errstr) {
     if (str_contains($errstr, 'Cannot cast a filtered stream on this system')) {
-        die('skip: fopencookie not support on this system');
+        die('skip: fopencookie not supported on this system');
     }
 });
-imagecreatefrompng('php://filter/read=convert.base64-encode/resource=' . __DIR__ . '/test.png');
+imagecreatefrompng('php://filter/read=string.rot13/resource=' . __DIR__ . '/test.png');
 restore_error_handler();
 ?>
 --FILE--
 <?php
-imagecreatefrompng('php://filter/read=convert.base64-encode/resource=' . __DIR__ . '/test.png');
+imagecreatefrompng('php://filter/read=string.rot13/resource=' . __DIR__ . '/test.png');
 ?>
 --CLEAN--
 --EXPECTF--
 
-Warning: imagecreatefrompng(): "php://filter/read=convert.base64-encode/resource=%s" is not a valid PNG file in %s on line %d
+Warning: imagecreatefrompng(): "php://filter/read=string.rot13/resource=%s" is not a valid PNG file in %s on line %d

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -2585,6 +2585,33 @@ static php_stream_filter_status_t php_iconv_stream_filter_do_filter(
 }
 /* }}} */
 
+/* {{{ php_iconv_stream_filter_seek */
+static zend_result php_iconv_stream_filter_seek(
+		php_stream *stream,
+		php_stream_filter *filter,
+		zend_off_t offset,
+		int whence)
+{
+	php_iconv_stream_filter *self = (php_iconv_stream_filter *)Z_PTR(filter->abstract);
+
+	/* Reset stub buffer */
+	self->stub_len = 0;
+
+	/* Reset iconv conversion state by closing and reopening the converter */
+	iconv_close(self->cd);
+
+	self->cd = iconv_open(self->to_charset, self->from_charset);
+	if ((iconv_t)-1 == self->cd) {
+		php_error_docref(NULL, E_WARNING,
+				"iconv stream filter (\"%s\"=>\"%s\"): failed to reset conversion state",
+				self->from_charset, self->to_charset);
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ php_iconv_stream_filter_cleanup */
 static void php_iconv_stream_filter_cleanup(php_stream_filter *filter)
 {
@@ -2595,12 +2622,13 @@ static void php_iconv_stream_filter_cleanup(php_stream_filter *filter)
 
 static const php_stream_filter_ops php_iconv_stream_filter_ops = {
 	php_iconv_stream_filter_do_filter,
+	php_iconv_stream_filter_seek,
 	php_iconv_stream_filter_cleanup,
 	"convert.iconv.*"
 };
 
 /* {{{ php_iconv_stream_filter_create */
-static php_stream_filter *php_iconv_stream_filter_factory_create(const char *name, zval *params, uint8_t persistent)
+static php_stream_filter *php_iconv_stream_filter_factory_create(const char *name, zval *params, bool persistent)
 {
 	php_iconv_stream_filter *inst;
 	const char *from_charset = NULL, *to_charset = NULL;
@@ -2632,7 +2660,8 @@ static php_stream_filter *php_iconv_stream_filter_factory_create(const char *nam
 		return NULL;
 	}
 
-	return php_stream_filter_alloc(&php_iconv_stream_filter_ops, inst, persistent);
+	return php_stream_filter_alloc(&php_iconv_stream_filter_ops, inst, persistent,
+			PSFS_SEEKABLE_START);
 }
 /* }}} */
 

--- a/ext/iconv/tests/iconv_stream_filter_seek.phpt
+++ b/ext/iconv/tests/iconv_stream_filter_seek.phpt
@@ -1,0 +1,43 @@
+--TEST--
+iconv stream filter with seek to start
+--EXTENSIONS--
+iconv
+--FILE--
+<?php
+$file = __DIR__ . '/iconv_stream_filter_seek.txt';
+
+$text = 'Hello, this is a test for iconv stream filter seeking functionality.';
+
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'convert.iconv.ISO-2022-JP/UTF-8');
+fwrite($fp, $text);
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'convert.iconv.UTF-8/ISO-2022-JP');
+
+$partial = fread($fp, 20);
+echo "First read (20 bytes): " . $partial . "\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$full = fread($fp, strlen($text));
+echo "Content after seek matches: " . ($full === $text ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/iconv_stream_filter_seek.txt');
+?>
+--EXPECTF--
+First read (20 bytes): Hello, this is a tes
+Seek to start: SUCCESS
+Content after seek matches: YES
+
+Warning: fseek(): Stream filter convert.iconv.* is seekable only to start position in %s on line %d
+Seek to middle: FAILURE

--- a/ext/standard/tests/filters/convert_filter_seek.phpt
+++ b/ext/standard/tests/filters/convert_filter_seek.phpt
@@ -1,0 +1,75 @@
+--TEST--
+convert filters (base64, quoted-printable) with seek to start only
+--FILE--
+<?php
+$file = __DIR__ . '/convert_filters_seek.txt';
+
+$text = 'Hello World! This is a test for convert filter seeking functionality.';
+
+echo "Testing convert.base64-encode/decode\n";
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'convert.base64-encode', STREAM_FILTER_WRITE);
+fwrite($fp, $text);
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'convert.base64-decode', STREAM_FILTER_READ);
+
+$partial = fread($fp, 20);
+echo "First read (20 bytes): $partial\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$full = fread($fp, strlen($text));
+echo "Content matches: " . ($full === $text ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+
+echo "\nTesting convert.quoted-printable-encode/decode\n";
+$text2 = "Line1\r\nLine2\r\nLine3";
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'convert.quoted-printable-encode', STREAM_FILTER_WRITE);
+fwrite($fp, $text2);
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'convert.quoted-printable-decode', STREAM_FILTER_READ);
+
+$partial = fread($fp, 10);
+echo "First read (10 bytes): " . bin2hex($partial) . "\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$full = fread($fp, strlen($text2));
+echo "Content matches: " . ($full === $text2 ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 20, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/convert_filters_seek.txt');
+?>
+--EXPECTF--
+Testing convert.base64-encode/decode
+First read (20 bytes): Hello World! This is
+Seek to start: SUCCESS
+Content matches: YES
+
+Warning: fseek(): Stream filter convert.* is seekable only to start position in %s on line %d
+Seek to middle: FAILURE
+
+Testing convert.quoted-printable-encode/decode
+First read (10 bytes): 4c696e65310d0a4c696e
+Seek to start: SUCCESS
+Content matches: YES
+
+Warning: fseek(): Stream filter convert.* is seekable only to start position in %s on line %d
+Seek to middle: FAILURE

--- a/ext/standard/tests/filters/php_user_filter_04.phpt
+++ b/ext/standard/tests/filters/php_user_filter_04.phpt
@@ -1,0 +1,28 @@
+--TEST--
+php_user_filter with invalid seek signature
+--FILE--
+<?php
+
+class InvalidSeekFilter extends php_user_filter
+{
+    public function filter($in, $out, &$consumed, bool $closing): int
+    {
+        return PSFS_PASS_ON;
+    }
+    
+    public function onCreate(): bool
+    {
+        return true;
+    }
+    
+    public function onClose(): void {}
+    
+    public function seek($offset): bool
+    {
+        return true;
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of InvalidSeekFilter::seek($offset): bool must be compatible with php_user_filter::seek(int $offset, int $whence): bool in %s on line %d

--- a/ext/standard/tests/filters/string_filters_seek.phpt
+++ b/ext/standard/tests/filters/string_filters_seek.phpt
@@ -1,0 +1,68 @@
+--TEST--
+string filters (rot13, toupper, tolower) with seek - fully seekable
+--FILE--
+<?php
+$file = __DIR__ . '/string_filters_seek.txt';
+
+$text = 'Hello World! This is a test for string filter seeking.';
+
+$filters = ['string.rot13', 'string.toupper', 'string.tolower'];
+$expected = [
+    'string.rot13' => 'Uryyb Jbeyq! Guvf vf n grfg sbe fgevat svygre frrxvat.',
+    'string.toupper' => 'HELLO WORLD! THIS IS A TEST FOR STRING FILTER SEEKING.',
+    'string.tolower' => 'hello world! this is a test for string filter seeking.'
+];
+
+foreach ($filters as $filter) {
+    echo "Testing filter: $filter\n";
+    
+    file_put_contents($file, $text);
+    
+    $fp = fopen($file, 'r');
+    stream_filter_append($fp, $filter, STREAM_FILTER_READ);
+    
+    $partial = fread($fp, 20);
+    echo "First read (20 bytes): $partial\n";
+    
+    $result = fseek($fp, 0, SEEK_SET);
+    echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+    
+    $full = fread($fp, strlen($text));
+    echo "Content matches: " . ($full === $expected[$filter] ? "YES" : "NO") . "\n";
+    
+    $result = fseek($fp, 13, SEEK_SET);
+    echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+    
+    $from_middle = fread($fp, 10);
+    $expected_middle = substr($expected[$filter], 13, 10);
+    echo "Read from middle matches: " . ($from_middle === $expected_middle ? "YES" : "NO") . "\n";
+    
+    fclose($fp);
+    echo "\n";
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/string_filters_seek.txt');
+?>
+--EXPECT--
+Testing filter: string.rot13
+First read (20 bytes): Uryyb Jbeyq! Guvf vf
+Seek to start: SUCCESS
+Content matches: YES
+Seek to middle: SUCCESS
+Read from middle matches: YES
+
+Testing filter: string.toupper
+First read (20 bytes): HELLO WORLD! THIS IS
+Seek to start: SUCCESS
+Content matches: YES
+Seek to middle: SUCCESS
+Read from middle matches: YES
+
+Testing filter: string.tolower
+First read (20 bytes): hello world! this is
+Seek to start: SUCCESS
+Content matches: YES
+Seek to middle: SUCCESS
+Read from middle matches: YES

--- a/ext/standard/tests/filters/user_filter_seek_01.phpt
+++ b/ext/standard/tests/filters/user_filter_seek_01.phpt
@@ -1,0 +1,81 @@
+--TEST--
+php_user_filter with seek method - always seekable (stateless filter)
+--FILE--
+<?php
+
+class RotateFilter extends php_user_filter
+{
+    private $rotation = 0;
+    
+    public function filter($in, $out, &$consumed, bool $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $rotated = '';
+            for ($i = 0; $i < strlen($bucket->data); $i++) {
+                $char = $bucket->data[$i];
+                if (ctype_alpha($char)) {
+                    $base = ctype_upper($char) ? ord('A') : ord('a');
+                    $rotated .= chr($base + (ord($char) - $base + $this->rotation) % 26);
+                } else {
+                    $rotated .= $char;
+                }
+            }
+            $bucket->data = $rotated;
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+        return PSFS_PASS_ON;
+    }
+    
+    public function onCreate(): bool
+    {
+        if (isset($this->params['rotation'])) {
+            $this->rotation = (int)$this->params['rotation'];
+        }
+        return true;
+    }
+    
+    public function onClose(): void {}
+    
+    public function seek(int $offset, int $whence): bool
+    {
+        // Stateless filter - always seekable to any position
+        return true;
+    }
+}
+
+stream_filter_register('test.rotate', 'RotateFilter');
+
+$file = __DIR__ . '/user_filter_seek_001.txt';
+$text = 'Hello World';
+
+file_put_contents($file, $text);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'test.rotate', STREAM_FILTER_READ, ['rotation' => 13]);
+
+$partial = fread($fp, 5);
+echo "First read: $partial\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$full = fread($fp, strlen($text));
+echo "Full content: $full\n";
+
+$result = fseek($fp, 6, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$from_middle = fread($fp, 5);
+echo "Read from middle: $from_middle\n";
+
+fclose($fp);
+unlink($file);
+
+?>
+--EXPECT--
+First read: Uryyb
+Seek to start: SUCCESS
+Full content: Uryyb Jbeyq
+Seek to middle: SUCCESS
+Read from middle: Jbeyq

--- a/ext/standard/tests/filters/user_filter_seek_02.phpt
+++ b/ext/standard/tests/filters/user_filter_seek_02.phpt
@@ -1,0 +1,75 @@
+--TEST--
+php_user_filter with seek method - stateful filter
+--FILE--
+<?php
+
+class CountingFilter extends php_user_filter
+{
+    private $count = 0;
+    
+    public function filter($in, $out, &$consumed, bool $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $modified = '';
+            for ($i = 0; $i < strlen($bucket->data); $i++) {
+                $modified .= $bucket->data[$i] . $this->count++;
+            }
+            $bucket->data = $modified;
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+        return PSFS_PASS_ON;
+    }
+    
+    public function onCreate(): bool
+    {
+        return true;
+    }
+    
+    public function onClose(): void {}
+    
+    public function seek(int $offset, int $whence): bool
+    {
+        if ($offset === 0 && $whence === SEEK_SET) {
+            $this->count = 0;
+            return true;
+        }
+        return false;
+    }
+}
+
+stream_filter_register('test.counting', 'CountingFilter');
+
+$file = __DIR__ . '/user_filter_seek_002.txt';
+$text = 'ABC';
+
+file_put_contents($file, $text);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'test.counting', STREAM_FILTER_READ);
+
+$first = fread($fp, 10);
+echo "First read: $first\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+$second = fread($fp, 10);
+echo "Second read after seek: $second\n";
+echo "Counts reset: " . ($first === $second ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 1, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+unlink($file);
+
+?>
+--EXPECTF--
+First read: A0B1C2
+Seek to start: SUCCESS
+Second read after seek: A0B1C2
+Counts reset: YES
+
+Warning: fseek(): Stream filter seeking for user-filter failed in %s on line %d
+Seek to middle: FAILURE

--- a/ext/standard/user_filters.stub.php
+++ b/ext/standard/user_filters.stub.php
@@ -50,6 +50,9 @@ class php_user_filter
     public function filter($in, $out, &$consumed, bool $closing): int {}
 
     /** @tentative-return-type */
+    public function seek(int $offset, int $whence): bool {}
+
+    /** @tentative-return-type */
     public function onCreate(): bool {}
 
     /** @tentative-return-type */

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -1,11 +1,16 @@
 /* This is a generated file, edit user_filters.stub.php instead.
- * Stub hash: 33264435fe01a2cc9aa21a4a087dbbf3c4007206 */
+ * Stub hash: 593afbcb51bb35207b93ac7556b92ac845043116 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_php_user_filter_filter, 0, 4, IS_LONG, 0)
 	ZEND_ARG_INFO(0, in)
 	ZEND_ARG_INFO(0, out)
 	ZEND_ARG_INFO(1, consumed)
 	ZEND_ARG_TYPE_INFO(0, closing, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_php_user_filter_seek, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, whence, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_php_user_filter_onCreate, 0, 0, _IS_BOOL, 0)
@@ -15,11 +20,13 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_php_user_filter_
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(php_user_filter, filter);
+ZEND_METHOD(php_user_filter, seek);
 ZEND_METHOD(php_user_filter, onCreate);
 ZEND_METHOD(php_user_filter, onClose);
 
 static const zend_function_entry class_php_user_filter_methods[] = {
 	ZEND_ME(php_user_filter, filter, arginfo_class_php_user_filter_filter, ZEND_ACC_PUBLIC)
+	ZEND_ME(php_user_filter, seek, arginfo_class_php_user_filter_seek, ZEND_ACC_PUBLIC)
 	ZEND_ME(php_user_filter, onCreate, arginfo_class_php_user_filter_onCreate, ZEND_ACC_PUBLIC)
 	ZEND_ME(php_user_filter, onClose, arginfo_class_php_user_filter_onClose, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/ext/zlib/tests/zlib_filter_seek_deflate.phpt
+++ b/ext/zlib/tests/zlib_filter_seek_deflate.phpt
@@ -1,0 +1,55 @@
+--TEST--
+zlib.deflate filter with seek to start
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+$file = __DIR__ . '/zlib_filter_seek_deflate.zlib';
+
+$text1 = 'Short text.';
+$text2 = 'This is a much longer text that will completely overwrite the previous compressed data in the file.';
+
+$fp = fopen($file, 'w+');
+stream_filter_append($fp, 'zlib.deflate', STREAM_FILTER_WRITE);
+
+fwrite($fp, $text1);
+fflush($fp);
+
+$size1 = ftell($fp);
+echo "Size after first write: $size1\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fwrite($fp, $text2);
+fflush($fp);
+
+$size2 = ftell($fp);
+echo "Size after second write: $size2\n";
+echo "Second write is larger: " . ($size2 > $size1 ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'zlib.inflate', STREAM_FILTER_READ);
+$content = stream_get_contents($fp);
+fclose($fp);
+
+echo "Decompressed content matches text2: " . ($content === $text2 ? "YES" : "NO") . "\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/zlib_filter_seek_deflate.zlib');
+?>
+--EXPECTF--
+Size after first write: %d
+Seek to start: SUCCESS
+Size after second write: %d
+Second write is larger: YES
+
+Warning: fseek(): Stream filter zlib.deflate is seekable only to start position in %s on line %d
+Seek to middle: FAILURE
+Decompressed content matches text2: YES

--- a/ext/zlib/tests/zlib_filter_seek_inflate.phpt
+++ b/ext/zlib/tests/zlib_filter_seek_inflate.phpt
@@ -1,0 +1,45 @@
+--TEST--
+zlib.inflate filter with seek to start
+--EXTENSIONS--
+zlib
+--FILE--
+<?php
+$file = __DIR__ . '/zlib_filter_seek_inflate.zlib';
+
+$text = 'I am the very model of a modern major general, I\'ve information vegetable, animal, and mineral.';
+
+$fp = fopen($file, 'w');
+stream_filter_append($fp, 'zlib.deflate', STREAM_FILTER_WRITE);
+fwrite($fp, $text);
+fclose($fp);
+
+$fp = fopen($file, 'r');
+stream_filter_append($fp, 'zlib.inflate', STREAM_FILTER_READ);
+
+$partial = fread($fp, 20);
+echo "First read (20 bytes): " . $partial . "\n";
+
+$result = fseek($fp, 0, SEEK_SET);
+echo "Seek to start: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+echo "Position after seek: " . ftell($fp) . "\n";
+
+$full = stream_get_contents($fp);
+echo "Content after seek matches: " . ($full === $text ? "YES" : "NO") . "\n";
+
+$result = fseek($fp, 50, SEEK_SET);
+echo "Seek to middle: " . ($result === 0 ? "SUCCESS" : "FAILURE") . "\n";
+
+fclose($fp);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/zlib_filter_seek_inflate.zlib');
+?>
+--EXPECTF--
+First read (20 bytes): I am the very model 
+Seek to start: SUCCESS
+Position after seek: 0
+Content after seek matches: YES
+
+Warning: fseek(): Stream filter zlib.inflate is seekable only to start position in %s on line %d
+Seek to middle: FAILURE

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -216,7 +216,7 @@ PHPAPI void php_stream_bucket_unlink(php_stream_bucket *bucket)
  * match. If that fails, we try "convert.charset.*", then "convert.*"
  * This means that we don't need to clog up the hashtable with a zillion
  * charsets (for example) but still be able to provide them all as filters */
-PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval *filterparams, uint8_t persistent)
+PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval *filterparams, bool persistent)
 {
 	HashTable *filter_hash = (FG(stream_filters) ? FG(stream_filters) : &stream_filters_hash);
 	const php_stream_filter_factory *factory = NULL;
@@ -260,7 +260,8 @@ PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval 
 	return filter;
 }
 
-PHPAPI php_stream_filter *_php_stream_filter_alloc(const php_stream_filter_ops *fops, void *abstract, uint8_t persistent STREAMS_DC)
+PHPAPI php_stream_filter *_php_stream_filter_alloc(const php_stream_filter_ops *fops,
+		void *abstract, bool persistent, php_stream_filter_seekable_t seekable STREAMS_DC)
 {
 	php_stream_filter *filter;
 
@@ -268,6 +269,7 @@ PHPAPI php_stream_filter *_php_stream_filter_alloc(const php_stream_filter_ops *
 	memset(filter, 0, sizeof(php_stream_filter));
 
 	filter->fops = fops;
+	filter->seekable = seekable;
 	Z_PTR(filter->abstract) = abstract;
 	filter->is_persistent = persistent;
 

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1362,6 +1362,52 @@ PHPAPI zend_off_t _php_stream_tell(const php_stream *stream)
 	return stream->position;
 }
 
+static bool php_stream_are_filters_seekable(php_stream_filter *filter, bool is_start_seeking)
+{
+	while (filter) {
+		if (filter->seekable == PSFS_SEEKABLE_NEVER) {
+			php_error_docref(NULL, E_WARNING, "Stream filter %s is never seekable", filter->fops->label);
+			return false;
+		}
+		if (!is_start_seeking && filter->seekable == PSFS_SEEKABLE_START) {
+			php_error_docref(NULL, E_WARNING, "Stream filter %s is seekable only to start position", filter->fops->label);
+			return false;
+		}
+		filter = filter->next;
+	}
+	return true;
+}
+
+static zend_result php_stream_filters_seek(php_stream *stream, php_stream_filter *filter,
+		bool is_start_seeking, zend_off_t offset, int whence)
+{
+	while (filter) {
+		if (((filter->seekable == PSFS_SEEKABLE_START && is_start_seeking) ||
+				filter->seekable == PSFS_SEEKABLE_CHECK) &&
+				filter->fops->seek(stream, filter, offset, whence) == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "Stream filter seeking for %s failed", filter->fops->label);
+			return FAILURE;
+		}
+		filter = filter->next;
+	}
+	return SUCCESS;
+}
+
+static zend_result php_stream_filters_seek_all(php_stream *stream, bool is_start_seeking,
+		zend_off_t offset, int whence)
+{
+	if (php_stream_filters_seek(stream, stream->writefilters.head, is_start_seeking, offset, whence) == FAILURE) {
+		return FAILURE;
+	}
+	if (php_stream_filters_seek(stream, stream->readfilters.head, is_start_seeking, offset, whence) == FAILURE) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+
+
 PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 {
 	if (stream->fclose_stdiocast == PHP_STREAM_FCLOSE_FOPENCOOKIE) {
@@ -1374,6 +1420,18 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 		}
 	}
 
+	bool is_start_seeking = whence == SEEK_SET && offset == 0;
+
+	if (stream->writefilters.head) {
+		_php_stream_flush(stream, 0);
+		if (!php_stream_are_filters_seekable(stream->writefilters.head, is_start_seeking)) {
+			return -1;
+		}
+	}
+	if (stream->readfilters.head && !php_stream_are_filters_seekable(stream->readfilters.head, is_start_seeking)) {
+		return -1;
+	}
+
 	/* handle the case where we are in the buffer */
 	if ((stream->flags & PHP_STREAM_FLAG_NO_BUFFER) == 0) {
 		switch(whence) {
@@ -1383,7 +1441,7 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 					stream->position += offset;
 					stream->eof = 0;
 					stream->fatal_error = 0;
-					return 0;
+					return php_stream_filters_seek_all(stream, is_start_seeking, offset, whence) == SUCCESS ? 0 : -1;
 				}
 				break;
 			case SEEK_SET:
@@ -1393,7 +1451,7 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 					stream->position = offset;
 					stream->eof = 0;
 					stream->fatal_error = 0;
-					return 0;
+					return php_stream_filters_seek_all(stream, is_start_seeking, offset, whence) == SUCCESS ? 0 : -1;
 				}
 				break;
 		}
@@ -1402,11 +1460,6 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 
 	if (stream->ops->seek && (stream->flags & PHP_STREAM_FLAG_NO_SEEK) == 0) {
 		int ret;
-
-		if (stream->writefilters.head) {
-			_php_stream_flush(stream, 0);
-		}
-
 		switch(whence) {
 			case SEEK_CUR:
 				ZEND_ASSERT(stream->position >= 0);
@@ -1433,7 +1486,7 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 			/* invalidate the buffer contents */
 			stream->readpos = stream->writepos = 0;
 
-			return ret;
+			return php_stream_filters_seek_all(stream, is_start_seeking, offset, whence) == SUCCESS ? ret : -1;
 		}
 		/* else the stream has decided that it can't support seeking after all;
 		 * fall through to attempt emulation */


### PR DESCRIPTION
Currently filter seeking does not work correctly for most streams. The idea is to extend API to allow seeking for some streams. There are couple of cases:
* filter is always seekable - e.g. `string.rot13`, `string.toupper`, `string.tolower`
* filter is seekable only when sought to start or when it re-run the data from the start (it means when there is some data buffered) - this is for pretty much all other filters that keep some state.
* user filters are seekable by default for BC reason but if new seek method is implemented, then it is called and based on the bool result the seeking either fails or succeed.

The seeking to zero is implemented by resetting the internal state.

Fixes https://bugs.php.net/bug.php?id=49874 