### PR TITLE
Fix GH-19988: zend_string_init with NULL pointer in simplexml (UB)

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1661,7 +1661,7 @@ PHP_METHOD(SimpleXMLElement, getName)
 	node = php_sxe_get_first_node(sxe, node);
 	if (node) {
 		namelen = xmlStrlen(node->name);
-		RETURN_STRINGL((char*)node->name, namelen);
+		RETURN_STRINGL_FAST((const char *) node->name, namelen);
 	} else {
 		RETURN_EMPTY_STRING();
 	}

--- a/ext/xsl/tests/gh19988.phpt
+++ b/ext/xsl/tests/gh19988.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-19988 (zend_string_init with NULL pointer in simplexml (UB))
+--EXTENSIONS--
+simplexml
+xsl
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$sxe = simplexml_load_file(__DIR__ . '/53965/collection.xml');
+$processor = new XSLTProcessor;
+$dom = new DOMDocument;
+$dom->load(__DIR__ . '/53965/collection.xsl');
+$processor->importStylesheet($dom);
+$result = $processor->transformToDoc($sxe, SimpleXMLElement::class);
+var_dump($result->getName());
+?>
+--EXPECT--
+string(0) ""


### PR DESCRIPTION
Normally, simplexml cannot import document nodes,
but xsl allows to circumvent this.
A document does not have a name, so we return the empty string in that case.
While we could add an explicit check, we might as well switch the macro to a form that would be more optimal anyway as many tag names can be single characters.

The test was added in xsl because adding it in simplexml would break out-of-tree builds of simplexml.