### PR TITLE
Fix OSS-Fuzz #447521098

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2183,7 +2183,14 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 
 			/* See GH-17246: we disable GC so that user code cannot be executed during the optimizer run. */
 			bool orig_gc_state = gc_enable(false);
-			persistent_script = cache_script_in_shared_memory(persistent_script, key, &from_shared_memory);
+			zend_try {
+				persistent_script = cache_script_in_shared_memory(persistent_script, key, &from_shared_memory);
+			} zend_catch {
+				SHM_PROTECT();
+				HANDLE_UNBLOCK_INTERRUPTIONS();
+				zend_free_recorded_errors();
+				zend_bailout();
+			} zend_end_try();
 			gc_enable(orig_gc_state);
 		}
 


### PR DESCRIPTION
There are exit points (via bailout) in this function that do not free the recorded errors. This can cause issues when an error is emitted during shutdown as ZendMM will have shut down already but the pointer is still pointing to ZendMM memory.

This became visible after 7b3e68ff690fd36a8c733c598f75fb648f6e35e1

We also need to backport part of this patch to handle signal unblocking and opcache memory protection, otherwise we get issues (and errors about depth level in zend_signals).