### PR TITLE
Fix GH-19998: ext/standard/tests/file/bug46347.phpt sometimes fails: …

### DIFF
--- a/ext/standard/tests/file/bug46347.phpt
+++ b/ext/standard/tests/file/bug46347.phpt
@@ -8,14 +8,14 @@ $str = <<< EOF
 part1.*.part2 = 1
 EOF;
 
-$file = __DIR__ . '/parse.ini';
+$file = __DIR__ . '/bug46347.ini';
 file_put_contents($file, $str);
 
 var_dump(parse_ini_file($file));
 ?>
 --CLEAN--
 <?php
-unlink(__DIR__.'/parse.ini');
+unlink(__DIR__.'/bug46347.ini');
 ?>
 --EXPECT--
 array(1) {


### PR DESCRIPTION
…racy in parallel

The same test file name is already used in parse_ini_file.phpt.