### PR TITLE
Automatically skip tty tests if not on tty

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -651,6 +651,10 @@ function main(): void
         }
     }
 
+    if (!stream_isatty(STDIN) || !stream_isatty(STDOUT) || !stream_isatty(STDERR)) {
+        $environment['SKIP_IO_CAPTURE_TESTS'] = '1';
+    }
+
     if ($selected_tests && count($test_files) === 0) {
         echo "No tests found.\n";
         return;


### PR DESCRIPTION
Without this, one can trivially run into test failures by not connecting all tty pipes to the run-tests.php process, or by running it inside a bash script. E.g. this will cause test failures:

```
$ php run-tests.php tests/output 2> /dev/null
```

See GH-19975