### PR TITLE
Fix GH-20009: XMLReader leak on RelaxNG schema failure

### DIFF
--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -508,6 +508,7 @@ static void php_xmlreader_set_relaxng_schema(INTERNAL_FUNCTION_PARAMETERS, int t
 
 			RETURN_TRUE;
 		} else {
+			xmlRelaxNGFree(schema);
 			php_error_docref(NULL, E_WARNING, "Schema contains errors");
 			RETURN_FALSE;
 		}


### PR DESCRIPTION
I can't be bothered to figure out a concise offline test.