### PR TITLE
Fix GH-8978: MySQLi: SSL certificate verification fails (port doubled)

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -557,7 +557,13 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_scheme)(MYSQLND_CONN_DATA * conn, MYSQLND_
 		if (hostname.s[0] != '[' && mysqlnd_fast_is_ipv6_address(hostname.s)) {
 			transport.l = mnd_sprintf(&transport.s, 0, "tcp://[%s]:%u", hostname.s, port);
 		} else {
-			transport.l = mnd_sprintf(&transport.s, 0, "tcp://%s:%u", hostname.s, port);
+			/* Not ipv6, but could already contain a port number, in which case we should not add an extra port.
+			 * See GH-8978. In a port doubling scenario, the first port would be used so we do the same to keep BC. */
+			if (strchr(hostname.s, ':')) {
+				transport.l = mnd_sprintf(&transport.s, 0, "tcp://%s", hostname.s);
+			} else {
+				transport.l = mnd_sprintf(&transport.s, 0, "tcp://%s:%u", hostname.s, port);
+			}
 		}
 	}
 	DBG_INF_FMT("transport=%s", transport.s? transport.s:"OOM");


### PR DESCRIPTION
If there are 2 ports, only the first is used.
However, then the certificate checking fails. So we drop the second port if there is one.