### PR TITLE
Fix PHP 8.5+ ZTS segfault on CentOS 7 by disabling IFUNC resolvers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,17 +522,46 @@ dnl Checks for sockaddr_storage and sockaddr.sa_len.
 AC_CHECK_TYPES([struct sockaddr_storage],,,[#include <sys/socket.h>])
 AC_CHECK_MEMBERS([struct sockaddr.sa_len],,,[#include <sys/socket.h>])
 
-dnl Checks for GCC function attributes on all systems except ones without glibc
-dnl Fix for these systems is already included in GCC 7, but not on GCC 6.
+dnl Check for GCC ifunc and target function attributes.
 dnl
-dnl At least some versions of FreeBSD seem to have buggy ifunc support, see
-dnl bug #77284. Conservatively don't use ifuncs on FreeBSD prior to version 12.
-AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*|*openbsd*], [true], [
-  if test "$(uname -s 2>/dev/null)" != "FreeBSD" || test "$(uname -U 2>/dev/null)" -ge 1200000; then
-    AX_GCC_FUNC_ATTRIBUTE([ifunc])
-    AX_GCC_FUNC_ATTRIBUTE([target])
-  fi
-])
+dnl These attributes are disabled on:
+dnl - Android, uclibc, musl, OpenBSD: No glibc or ifunc support issues (GCC 7+ should have fixes)
+dnl - FreeBSD < 12: Buggy ifunc support (see bug #77284)
+dnl - glibc <= 2.17 on x86_64: __builtin_cpu_* functions are unsafe in ifunc resolvers
+dnl   during dynamic linking (e.g., CentOS 7) and lead to segfaults. This issue does not
+dnl   affect arm64.
+AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*|*openbsd*], [],
+  [if test "$(uname -s 2>/dev/null)" != "FreeBSD" || test "$(uname -U 2>/dev/null)" -ge 1200000; then
+    AS_CASE([$host_cpu],
+      [x86_64*|amd64*|i?86*], [
+        AC_MSG_CHECKING([if glibc version supports safe ifunc resolvers])
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+          #include <stdio.h>
+        ]], [[
+          #ifdef __GLIBC__
+          #if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 17)
+          return 1;
+          #endif
+          #endif
+          return 0;
+        ]])],
+        [AC_MSG_RESULT([yes])
+         AX_GCC_FUNC_ATTRIBUTE([ifunc])
+         AX_GCC_FUNC_ATTRIBUTE([target])],
+        [AC_MSG_RESULT([no, glibc <= 2.17 detected])
+         AC_MSG_WARN([Disabling ifunc resolver checks due to old glibc version])],
+        [AC_MSG_RESULT([unknown, assuming yes])
+         AX_GCC_FUNC_ATTRIBUTE([ifunc])
+         AX_GCC_FUNC_ATTRIBUTE([target])])
+      ],
+      [*], [
+        dnl arm64 and other architectures are safe even with old glibc
+        AX_GCC_FUNC_ATTRIBUTE([ifunc])
+        AX_GCC_FUNC_ATTRIBUTE([target])
+      ]
+    )
+  fi]
+)
 
 dnl Check for __attribute__ ((__aligned__)) support in the compiler.
 PHP_CHECK_VARIABLE_ATTRIBUTE([aligned])


### PR DESCRIPTION
CentOS 7's glibc (`2.17`) `__builtin_cpu_init()` causes `IFUNC` resolvers to crash during dynamic linking when detecting AVX2 support on a ZTS build on Amd64 hardware.

This PR disables `IFUNC` on Amd64 hardware when a glibc version <= `2.17` is detected.

The stacktrace for the segfault looks like this when executing a freshly build `./sapi/cli/php`:

```
#0  0x0000555555972b5a in resolve_wchar_utf16be ()
#1  0x00007ffff7de6e6f in _dl_relocate_object () from /lib64/ld-linux-x86-64.so.2
#2  0x00007ffff7ddf99a in dl_main () from /lib64/ld-linux-x86-64.so.2
#3  0x00007ffff7df300e in _dl_sysdep_start () from /lib64/ld-linux-x86-64.so.2
#4  0x00007ffff7ddcbd1 in _dl_start () from /lib64/ld-linux-x86-64.so.2
#5  0x00007ffff7ddc148 in _start () from /lib64/ld-linux-x86-64.so.2
#6  0x0000000000000003 in ?? ()
#7  0x00007fffffffe287 in ?? ()
#8  0x00007fffffffe29a in ?? ()
#9  0x00007fffffffe29d in ?? ()
#10 0x0000000000000000 in ?? ()
```

This is even before PHP's `main()` function is called.

Arm64 is not affected because `zend_cpu_supports_avx2(void)` has an early return for Arm64:
https://github.com/php/php-src/blob/52e1c9f1107e1be19483d9f404d6a69c46c395c7/Zend/zend_cpuinfo.h#L200-L210

Why NTS is not affected: I have no idea 🫤 
Also: why this is not a problem on PHP 8.4 ZTS Amd64: no idea either
