### PR TITLE
Fix GH-20011: Array of SoapVar of unknown type causes crash

### DIFF
--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -3584,6 +3584,11 @@ static encodePtr get_array_type(xmlNodePtr node, zval *array, smart_str *type)
 				soap_error0(E_ERROR,  "Encoding: SoapVar has no 'enc_type' property");
 			}
 			cur_type = Z_LVAL_P(ztype);
+			if (cur_type == UNKNOWN_TYPE) {
+				/* Mimic guess_xml_convert() where we use the type of the data.
+				 * UNDEFs are handled transparently as it will error out upon encoding the data. */
+				cur_type = Z_TYPE_P(Z_VAR_ENC_VALUE_P(tmp));
+			}
 
 			zval *zstype = Z_VAR_ENC_STYPE_P(tmp);
 			if (Z_TYPE_P(zstype) == IS_STRING) {

--- a/ext/soap/tests/bugs/gh20011.phpt
+++ b/ext/soap/tests/bugs/gh20011.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-20011 (Array of SoapVar of unknown type causes crash)
+--EXTENSIONS--
+soap
+--FILE--
+<?php
+class TestSoapClient extends SoapClient {
+    public function __doRequest($request, $location, $action, $version, $one_way = false): ?string {
+        die($request);
+    }
+}
+
+$array = [new SoapVar('test string', NULL)];
+
+$client = new TestSoapClient(NULL, ['location' => 'test://', 'uri' => 'http://soapinterop.org/']);
+$client->echoStringArray($array);
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringArray><param0 SOAP-ENC:arrayType="xsd:string[1]" xsi:type="SOAP-ENC:Array"><item xsi:type="xsd:string">test string</item></param0></ns1:echoStringArray></SOAP-ENV:Body></SOAP-ENV:Envelope>


### PR DESCRIPTION
We "guess" the type in this case, consistent with what a SoapVar would do outside of an array.