### PR TITLE
Fix GH-20002: build on BSD with MSAN

### DIFF
--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -500,8 +500,11 @@ ZEND_API zend_string *zend_string_concat3(
 	return res;
 }
 
-/* strlcpy and strlcat are not intercepted by msan, so we need to do it ourselves. */
-#if __has_feature(memory_sanitizer)
+/* strlcpy and strlcat are not always intercepted by msan, so we need to do it
+ * ourselves.
+ * Apply a simple heuristic to tell if the platform needs it,
+ * see https://github.com/php/php-src/issues/20002 */
+#if __has_feature(memory_sanitizer) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__APPLE__)
 static size_t (*libc_strlcpy)(char *__restrict, const char *__restrict, size_t);
 size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t n)
 {


### PR DESCRIPTION
See #20002.

The `#if` to have instrumented versions of strlcpy and strlcat was too inclusive, and defined them even on *BSD that indeed have those already defined, resulting in "duplicate symbol" at linking.

We use a really simple heuristic here (OSes that are _used_ to have instrumented `strlcpy` and `strlcat` already defined in their msan library do not redefine them).