### PR TITLE
Upgrade Alpine in nightly job

### DIFF
--- a/.github/actions/apk/action.yml
+++ b/.github/actions/apk/action.yml
@@ -7,6 +7,9 @@ runs:
         set -x
 
         OPCACHE_TLS_TESTS_DEPS="clang gcc binutils-gold lld"
+        # compiler-rt provides libclang_rt.asan-x86_64.a for clang20
+        # https://pkgs.alpinelinux.org/contents?file=libclang_rt.asan-x86_64.a&path=&name=&branch=v3.22
+        ASAN_DEPS="clang20 compiler-rt"
 
         apk update -q
         apk add \
@@ -52,8 +55,9 @@ runs:
             net-snmp-dev \
             openldap-dev \
             unixodbc-dev \
-            postgresql14-dev \
+            postgresql-dev \
             tzdata \
             musl-locales \
             musl-locales-lang \
-            $OPCACHE_TLS_TESTS_DEPS
+            $OPCACHE_TLS_TESTS_DEPS \
+            $ASAN_DEPS

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,7 +95,7 @@ jobs:
     name: ALPINE_X64_ASAN_UBSAN_DEBUG_ZTS
     runs-on: ubuntu-24.04
     container:
-      image: 'alpine:3.22.1'
+      image: 'alpine:3.22'
     steps:
       - name: git checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,9 +93,9 @@ jobs:
   ALPINE:
     if: inputs.run_alpine
     name: ALPINE_X64_ASAN_UBSAN_DEBUG_ZTS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: 'alpine:3.20.1'
+      image: 'alpine:3.22.1'
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -103,11 +103,6 @@ jobs:
           ref: ${{ inputs.branch }}
       - name: apk
         uses: ./.github/actions/apk
-      - name: LLVM 17 (ASAN-only)
-        # libclang_rt.asan-x86_64.a is provided by compiler-rt, and only for clang17:
-        # https://pkgs.alpinelinux.org/contents?file=libclang_rt.asan-x86_64.a&path=&name=&branch=v3.20
-        run: |
-          apk add clang17 compiler-rt
       - name: System info
         run: |
           echo "::group::Show host CPU info"
@@ -122,8 +117,8 @@ jobs:
           configurationParameters: >-
             CFLAGS="-fsanitize=undefined,address -fno-sanitize=function -DZEND_TRACK_ARENA_ALLOC"
             LDFLAGS="-fsanitize=undefined,address -fno-sanitize=function"
-            CC=clang-17
-            CXX=clang++-17
+            CC=clang-20
+            CXX=clang++-20
             --enable-debug
             --enable-zts
           skipSlow: true # FIXME: This should likely include slow extensions


### PR DESCRIPTION
Alpine 3.22 provides Clang 20, so this allows to test the tailcall VM.

The PR targets 8.4 because `.github/actions/apk/action.yml` does not exit in earlier branches, but this should be merged on 8.1.

Tested the change in https://github.com/arnaud-lb/php-src/actions/runs/18219748031/job/51876936398