### PR TITLE
ROR the callable_convert_cache key for better hash distribution

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9719,7 +9719,9 @@ ZEND_VM_HANDLER(202, ZEND_CALLABLE_CONVERT, UNUSED, UNUSED, NUM|CACHE_SLOT)
 		if (closure) {
 			ZVAL_OBJ_COPY(EX_VAR(opline->result.var), closure);
 		} else {
-			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), (zend_ulong)(uintptr_t)call->func);
+			zend_ulong key = (zend_ulong)(uintptr_t)call->func;
+			key = (key >> 3) | (key << ((sizeof(key) * 8) - 3));
+			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), key);
 			if (Z_TYPE_P(closure_zv) == IS_NULL) {
 				zend_closure_from_frame(closure_zv, call);
 			}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -39092,7 +39092,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_CALLABLE_CONV
 		if (closure) {
 			ZVAL_OBJ_COPY(EX_VAR(opline->result.var), closure);
 		} else {
-			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), (zend_ulong)(uintptr_t)call->func);
+			zend_ulong key = (zend_ulong)(uintptr_t)call->func;
+			key = (key >> 3) | (key << ((sizeof(key) * 8) - 3));
+			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), key);
 			if (Z_TYPE_P(closure_zv) == IS_NULL) {
 				zend_closure_from_frame(closure_zv, call);
 			}
@@ -94329,7 +94331,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_CALLABLE_CONVERT_S
 		if (closure) {
 			ZVAL_OBJ_COPY(EX_VAR(opline->result.var), closure);
 		} else {
-			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), (zend_ulong)(uintptr_t)call->func);
+			zend_ulong key = (zend_ulong)(uintptr_t)call->func;
+			key = (key >> 3) | (key << ((sizeof(key) * 8) - 3));
+			zval *closure_zv = zend_hash_index_lookup(&EG(callable_convert_cache), key);
 			if (Z_TYPE_P(closure_zv) == IS_NULL) {
 				zend_closure_from_frame(closure_zv, call);
 			}


### PR DESCRIPTION
The bottom 3 bits are zeros due to alignment, to get better key distributions we should ROR the 3 bottom bits.
This results in a single extra instruction on x86 or arm64, which is negligible for the benefit we get.