### PR TITLE
zend_portability: Remove `EMPTY_SWITCH_DEFAULT_CASE()`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -86,6 +86,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The unused ZEND_AST_PARENT_PROPERTY_HOOK_CALL has been removed.
   . ZEND_AST_METHOD_REFERENCE has been renamed to
     ZEND_AST_TRAIT_METHOD_REFERENCE.
+  . The EMPTY_SWITCH_DEFAULT_CASE() macro has been removed. Use
+    default: ZEND_UNREACHABLE(); instead.
 
 ========================
 2. Build system changes

--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -1596,7 +1596,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 				case ZEND_SHORT_CIRCUITING_CHAIN_EMPTY:
 					ZVAL_TRUE(&zv);
 					break;
-				EMPTY_SWITCH_DEFAULT_CASE()
+				default: ZEND_UNREACHABLE();
 			}
 			SET_RESULT(result, &zv);
 			break;

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -1063,7 +1063,7 @@ static bool zend_inference_calc_binary_op_range(
 		case ZEND_BW_XOR:
 			// TODO
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return 0;
 }
@@ -2350,7 +2350,7 @@ static uint32_t binary_op_result_type(
 			/* TODO: +MAY_BE_OBJECT ??? */
 			tmp = MAY_BE_STRING | MAY_BE_RC1 | MAY_BE_RCN;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return tmp;
 }
@@ -3708,7 +3708,7 @@ static zend_always_inline zend_result _zend_update_type_info(
 							case ZEND_FREE:
 								/* This may happen if the using opcode is DCEd.  */
 								break;
-							EMPTY_SWITCH_DEFAULT_CASE()
+							default: ZEND_UNREACHABLE();
 						}
 						j = zend_ssa_next_use(ssa->ops, ssa_op->result_def, j);
 						if (j >= 0) {
@@ -5294,10 +5294,10 @@ ZEND_API bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op
 					return (t1 & MAY_BE_OBJECT);
 				case IS_OBJECT:
 					return 0;
-				EMPTY_SWITCH_DEFAULT_CASE()
+				default: ZEND_UNREACHABLE();
 			}
 			/* GCC is getting confused here for the Wimplicit-fallthrough warning with
-			 * EMPTY_SWITCH_DEFAULT_CASE() macro */
+			 * default: ZEND_UNREACHABLE(); macro */
 			return 0;
 		case ZEND_ARRAY_KEY_EXISTS:
 			if ((t2 & MAY_BE_ANY) != MAY_BE_ARRAY) {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -126,7 +126,7 @@ ZEND_API const char *zend_get_type_by_const(int type) /* {{{ */
 			return "mixed";
 		case _IS_NUMBER:
 			return "int|float";
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -262,7 +262,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_error(int error_code,
 		case ZPP_ERROR_FAILURE:
 			ZEND_ASSERT(EG(exception) && "Should have produced an error already");
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -814,7 +814,7 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 					case IS_OBJECT:
 						zend_cast_zval_to_object(result, &op1, IS_VAR);
 						break;
-					EMPTY_SWITCH_DEFAULT_CASE();
+					default: ZEND_UNREACHABLE();
 				}
 				zval_ptr_dtor_nogc(&op1);
 				if (UNEXPECTED(EG(exception))) {
@@ -1240,7 +1240,7 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 
 					break;
 				}
-				EMPTY_SWITCH_DEFAULT_CASE()
+				default: ZEND_UNREACHABLE();
 			}
 
 			zend_create_fake_closure(result, fptr, fptr->common.scope, called_scope, NULL);
@@ -1961,7 +1961,7 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, const zval *zv, int p
 		case IS_CONSTANT_AST:
 			zend_ast_export_ex(str, Z_ASTVAL_P(zv), priority, indent);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -2396,7 +2396,7 @@ simple_list:
 				case T_PROPERTY_C: APPEND_STR("__PROPERTY__");
 				case T_NS_C:     APPEND_STR("__NAMESPACE__");
 				case T_CLASS_C:  APPEND_STR("__CLASS__");
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_TYPE:
@@ -2405,7 +2405,7 @@ simple_list:
 				case IS_CALLABLE: APPEND_STR("callable");
 				case IS_STATIC:   APPEND_STR("static");
 				case IS_MIXED:    APPEND_STR("mixed");
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_PLACEHOLDER_ARG:
@@ -2439,7 +2439,7 @@ simple_list:
 				case IS_STRING:    PREFIX_OP("(string)", 240, 241);
 				case IS_ARRAY:     PREFIX_OP("(array)",  240, 241);
 				case IS_OBJECT:    PREFIX_OP("(object)", 240, 241);
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_CAST_VOID:
@@ -2473,14 +2473,14 @@ simple_list:
 				case ZEND_REQUIRE_ONCE: FUNC_OP("require_once");
 				case ZEND_REQUIRE:      FUNC_OP("require");
 				case ZEND_EVAL:         FUNC_OP("eval");
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_UNARY_OP:
 			switch (ast->attr) {
 				case ZEND_BW_NOT:   PREFIX_OP("~", 240, 241);
 				case ZEND_BOOL_NOT: PREFIX_OP("!", 240, 241);
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_PRE_INC:
@@ -2575,7 +2575,7 @@ simple_list:
 					case ZEND_FETCH_CLASS_PARENT:
 						smart_str_append(str, ZSTR_KNOWN(ZEND_STR_PARENT));
 						break;
-					EMPTY_SWITCH_DEFAULT_CASE()
+					default: ZEND_UNREACHABLE();
 				}
 			} else {
 				zend_ast_export_ns_name(str, ast->child[0], 0, indent);
@@ -2598,7 +2598,7 @@ simple_list:
 				case ZEND_BW_AND: BINARY_OP(" &= ",  90, 91, 90);
 				case ZEND_BW_XOR: BINARY_OP(" ^= ",  90, 91, 90);
 				case ZEND_POW:    BINARY_OP(" **= ", 90, 91, 90);
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_ASSIGN_COALESCE: BINARY_OP(" \?\?= ", 90, 91, 90);
@@ -2624,7 +2624,7 @@ simple_list:
 				case ZEND_POW:                 BINARY_OP(" ** ",  250, 251, 250);
 				case ZEND_BOOL_XOR:            BINARY_OP(" xor ",  40,  40,  41);
 				case ZEND_SPACESHIP:           BINARY_OP(" <=> ", 180, 181, 181);
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
 		case ZEND_AST_GREATER:                 BINARY_OP(" > ",   180, 181, 181);
@@ -2976,7 +2976,7 @@ simple_list:
 			zend_ast_export_indent(str, indent);
 			smart_str_appendc(str, '}');
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	return;
 
@@ -3073,7 +3073,7 @@ zend_ast * ZEND_FASTCALL zend_ast_with_attributes(zend_ast *ast, zend_ast *attr)
 		 * zend_compile_const_decl() checks the kind of the list elements. */
 		ast = zend_ast_list_add(ast, attr);
 		break;
-	EMPTY_SWITCH_DEFAULT_CASE()
+	default: ZEND_UNREACHABLE();
 	}
 
 	return ast;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -891,7 +891,7 @@ static const char *zend_modifier_token_to_string(uint32_t token)
 			return "protected(set)";
 		case T_PRIVATE_SET:
 			return "private(set)";
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -1834,7 +1834,7 @@ static bool zend_try_compile_const_expr_resolve_class_name(zval *zv, zend_ast *c
 		case ZEND_FETCH_CLASS_DEFAULT:
 			ZVAL_STR(zv, zend_resolve_class_name_ast(class_ast));
 			return 1;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -2281,7 +2281,7 @@ static void zend_adjust_for_fetch_type(zend_op *opline, znode *result, uint32_t 
 		case BP_VAR_UNSET:
 			opline->opcode += 5 * factor;
 			return;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -2444,7 +2444,7 @@ static inline void zend_update_jump_target(uint32_t opnum_jump, uint32_t opnum_t
 		case ZEND_JMP_FRAMELESS:
 			opline->op2.opline_num = opnum_target;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -3594,7 +3594,7 @@ static void zend_compile_assign(znode *result, zend_ast *ast, bool stmt, uint32_
 				result->op_type = IS_UNUSED;
 			}
 			return;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -3750,7 +3750,7 @@ static void zend_compile_compound_assign(znode *result, zend_ast *ast) /* {{{ */
 			opline = zend_emit_op_data(&expr_node);
 			opline->extended_value = cache_slot;
 			return;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -5012,7 +5012,7 @@ static zend_result zend_compile_func_sprintf(znode *result, zend_ast_list *args)
 				case 'd':
 					zend_emit_op_tmp(&elements[placeholder_count], ZEND_CAST, &elements[placeholder_count], NULL)->extended_value = IS_LONG;
 					break;
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 
 			if (rope_elements == 0) {
@@ -5329,7 +5329,7 @@ static const char *zend_get_cstring_from_property_hook_kind(zend_property_hook_k
 			return "get";
 		case ZEND_PROPERTY_HOOK_SET:
 			return "set";
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -5879,7 +5879,7 @@ static void zend_compile_unset(const zend_ast *ast) /* {{{ */
 			opline = zend_compile_static_prop(NULL, var_ast, BP_VAR_UNSET, false, false);
 			opline->opcode = ZEND_UNSET_STATIC_PROP;
 			return;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -9465,7 +9465,7 @@ static void zend_compile_use_trait(const zend_ast *ast) /* {{{ */
 			case ZEND_AST_TRAIT_ALIAS:
 				zend_compile_trait_alias(adaptation_ast);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 	}
 }
@@ -9837,7 +9837,7 @@ static HashTable *zend_get_import_ht(uint32_t type) /* {{{ */
 				zend_hash_init(FC(imports_const), 8, NULL, str_dtor, 0);
 			}
 			return FC(imports_const);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return NULL;
@@ -9853,7 +9853,7 @@ static char *zend_get_use_type_str(uint32_t type) /* {{{ */
 			return " function";
 		case ZEND_SYMBOL_CONST:
 			return " const";
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return " unknown";
@@ -10219,7 +10219,7 @@ static bool zend_try_ct_eval_magic_const(zval *zv, const zend_ast *ast) /* {{{ *
 				ZVAL_EMPTY_STRING(zv);
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 1;
@@ -10961,7 +10961,7 @@ static void zend_compile_assign_coalesce(znode *result, zend_ast *ast) /* {{{ */
 			zend_emit_op_data(&default_node);
 			assign_node = var_node_w;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	opline = zend_emit_op_tmp(NULL, ZEND_QM_ASSIGN, &assign_node, NULL);
@@ -11181,7 +11181,7 @@ static void zend_compile_isset_or_empty(znode *result, const zend_ast *ast) /* {
 			opline = zend_compile_static_prop(result, var_ast, BP_VAR_IS, false, false);
 			opline->opcode = ZEND_ISSET_ISEMPTY_STATIC_PROP;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	result->op_type = opline->result_type = IS_TMP_VAR;
@@ -11697,7 +11697,7 @@ static void zend_compile_const_expr_class_name(zend_ast **ast_ptr) /* {{{ */
 		case ZEND_FETCH_CLASS_STATIC:
 			zend_error_noreturn(E_COMPILE_ERROR,
 				"static::class cannot be used for compile-time class name resolution");
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -11805,7 +11805,7 @@ static void zend_compile_const_expr_fcc(zend_ast **ast_ptr)
 		case ZEND_AST_STATIC_CALL:
 			args_ast = &(*ast_ptr)->child[2];
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	if ((*args_ast)->kind != ZEND_AST_CALLABLE_CONVERT) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Constant expression contains invalid operations");
@@ -11843,7 +11843,7 @@ static void zend_compile_const_expr_fcc(zend_ast **ast_ptr)
 			}
 			break;
 		}
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -430,7 +430,7 @@ static zend_always_inline uint32_t zend_visibility_to_set_visibility(uint32_t vi
 			return ZEND_ACC_PROTECTED_SET;
 		case ZEND_ACC_PRIVATE:
 			return ZEND_ACC_PRIVATE_SET;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1789,10 +1789,10 @@ ZEND_API ZEND_COLD void zend_wrong_string_offset_error(void)
 				case ZEND_FETCH_DIM_INCDEC:
 					msg = "Cannot increment/decrement string offsets";
 					break;
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_ASSERT(msg != NULL);
 	zend_throw_error(NULL, "%s", msg);
@@ -3500,7 +3500,7 @@ static zend_never_inline bool zend_handle_fetch_obj_flags(
 				ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(ptr), prop_info);
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return 1;
 }
@@ -4220,7 +4220,7 @@ static zend_never_inline void zend_fetch_this_var(int type OPLINE_DC EXECUTE_DAT
 			ZVAL_UNDEF(result);
 			zend_throw_error(NULL, "Cannot unset $this");
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -5357,7 +5357,7 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval 
 				efree(eval_desc);
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	zend_tmp_string_release(tmp_inc_filename);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1764,7 +1764,7 @@ zend_class_entry *zend_fetch_class_with_scope(
 		case 0:
 			break;
 		/* Other fetch types are not supported by this function. */
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	ce = zend_lookup_class_ex(class_name, NULL, fetch_type);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -537,7 +537,7 @@ static inheritance_status zend_is_class_subtype_of_type(
 						return INHERITANCE_SUCCESS;
 					}
 					continue;
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 		}
 

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -57,7 +57,7 @@ static int get_int_val(zval *op) {
 			zend_string_free(Z_STR_P(op));
 			return val;
 		}
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -359,7 +359,7 @@ static zend_never_inline zend_result ZEND_FASTCALL _zendi_try_convert_scalar_to_
 		case IS_RESOURCE:
 		case IS_ARRAY:
 			return FAILURE;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -461,7 +461,7 @@ try_again:
 				goto try_again;
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -606,7 +606,7 @@ try_again:
 		case IS_REFERENCE:
 			zend_unwrap_reference(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -665,7 +665,7 @@ try_again:
 		case IS_REFERENCE:
 			zend_unwrap_reference(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -747,7 +747,7 @@ try_again:
 		case IS_REFERENCE:
 			zend_unwrap_reference(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -805,7 +805,7 @@ try_again:
 		case IS_REFERENCE:
 			zend_unwrap_reference(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -1014,7 +1014,7 @@ try_again:
 		case IS_REFERENCE:
 			op = Z_REFVAL_P(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return 0;
 }
@@ -1053,7 +1053,7 @@ try_again:
 		case IS_REFERENCE:
 			op = Z_REFVAL_P(op);
 			goto try_again;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return 0.0;
 }
@@ -1094,7 +1094,7 @@ try_again:
 			goto try_again;
 		case IS_STRING:
 			return zend_string_copy(Z_STR_P(op));
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return NULL;
 }
@@ -2784,7 +2784,7 @@ try_again:
 		case IS_ARRAY:
 			zend_type_error("Cannot increment %s", zend_zval_value_name(op1));
 			return FAILURE;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return SUCCESS;
 }
@@ -2891,7 +2891,7 @@ try_again:
 		case IS_ARRAY:
 			zend_type_error("Cannot decrement %s", zend_zval_value_name(op1));
 			return FAILURE;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return SUCCESS;

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -137,10 +137,6 @@
 # define ZEND_FALLTHROUGH ((void)0)
 #endif
 
-/* Only use this macro if you know for sure that all of the switches values
-   are covered by its case statements */
-#define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_UNREACHABLE(); break;
-
 #if defined(__GNUC__) && __GNUC__ >= 4
 # define ZEND_IGNORE_VALUE(x) (({ __typeof__ (x) __x = (x); (void) __x; }))
 #else

--- a/Zend/zend_smart_str.c
+++ b/Zend/zend_smart_str.c
@@ -229,7 +229,7 @@ ZEND_API void ZEND_FASTCALL smart_str_append_scalar(smart_str *dest, const zval 
 			smart_str_appendc(dest, '\'');
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -537,7 +537,7 @@ static zend_always_inline zend_ulong zend_inline_hash_func(const char *str, size
 		case 2: hash = ((hash << 5) + hash) + *str++; /* fallthrough... */
 		case 1: hash = ((hash << 5) + hash) + *str++; break;
 		case 0: break;
-EMPTY_SWITCH_DEFAULT_CASE()
+default: ZEND_UNREACHABLE();
 	}
 #endif
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9012,7 +9012,7 @@ ZEND_VM_HANDLER(157, ZEND_FETCH_CLASS_NAME, CV|TMP|UNUSED|CLASS_FETCH, ANY)
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -18232,7 +18232,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_N
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -32825,7 +32825,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_N
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -40825,7 +40825,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FETCH_CLASS_N
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -70738,7 +70738,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_NAME_S
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -85231,7 +85231,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_NAME_S
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }
@@ -93231,7 +93231,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FETCH_CLASS_NAME_S
 			}
 			ZVAL_STR_COPY(EX_VAR(opline->result.var), called_scope->name);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	ZEND_VM_NEXT_OPCODE();
 }

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -195,7 +195,7 @@ static void bc_pow_err(bc_raise_status status, uint32_t arg_num)
 				zend_argument_value_error(arg_num, "exponent is too large, the number of digits overflowed");
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -573,7 +573,7 @@ PHP_FUNCTION(bcpowmod)
 		case OK:
 			RETVAL_NEW_STR(bc_num2str_ex(result, scale));
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	cleanup: {
@@ -1306,7 +1306,7 @@ static zend_result bcmath_number_do_operation(uint8_t opcode, zval *ret_val, zva
 				goto fail;
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	if (Z_TYPE_P(op1) != IS_OBJECT) {
@@ -1492,7 +1492,7 @@ static void bcmath_number_calc_method(INTERNAL_FUNCTION_PARAMETERS, uint8_t opco
 				goto fail;
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	if (num_obj == NULL) {
@@ -1652,7 +1652,7 @@ PHP_METHOD(BcMath_Number, powmod)
 			goto cleanup;
 		case OK:
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	bc_rm_trailing_zeros(ret);

--- a/ext/bcmath/libbcmath/src/round.c
+++ b/ext/bcmath/libbcmath/src/round.c
@@ -194,7 +194,7 @@ size_t bc_round(bc_num num, zend_long precision, zend_enum_RoundingMode mode, bc
 			}
 			break;
 
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 up:

--- a/ext/bz2/bz2.c
+++ b/ext/bz2/bz2.c
@@ -402,7 +402,7 @@ unsupported_mode:
 					RETURN_FALSE;
 				}
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 
 		if (FAILURE == php_stream_cast(stream, PHP_STREAM_AS_FD, (void *) &fd, REPORT_ERRORS)) {

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2049,7 +2049,7 @@ static int date_object_compare_timezone(zval *tz1, zval *tz2) /* {{{ */
 			return strcmp(o1->tzi.z.abbr, o2->tzi.z.abbr) ? 1 : 0;
 		case TIMELIB_ZONETYPE_ID:
 			return strcmp(o1->tzi.tz->name, o2->tzi.tz->name) ? 1 : 0;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 } /* }}} */
 
@@ -2744,7 +2744,7 @@ PHP_METHOD(DateTime, createFromTimestamp)
 			}
 			break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	RETURN_OBJ(Z_OBJ(new_object));
@@ -2825,7 +2825,7 @@ PHP_METHOD(DateTimeImmutable, createFromTimestamp)
 			}
 			break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	RETURN_OBJ(Z_OBJ(new_object));
@@ -5969,7 +5969,7 @@ static int date_period_has_property(zend_object *object, zend_string *name, int 
 				return 0;
 			case ZEND_PROPERTY_EXISTS:
 				return 1;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -466,7 +466,7 @@ PHP_METHOD(DOMElement, setAttribute)
 					break;
 				case XML_NAMESPACE_DECL:
 					RETURN_FALSE;
-				EMPTY_SWITCH_DEFAULT_CASE();
+				default: ZEND_UNREACHABLE();
 			}
 		}
 
@@ -593,7 +593,7 @@ static bool dom_remove_attribute(xmlNodePtr thisp, xmlNodePtr attrp)
 
 			break;
 		}
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	return true;
 }
@@ -1819,7 +1819,7 @@ PHP_METHOD(Dom_Element, insertAdjacentHTML)
 			/* Set context to this. */
 			context = thisp;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	/* 4. If context is not an Element or all of the following are true: (...) */
@@ -1858,7 +1858,7 @@ PHP_METHOD(Dom_Element, insertAdjacentHTML)
 		case ZEND_ENUM_Dom_AdjacentPosition_BeforeEnd:
 			php_dom_node_append(this_intern->document, fragment, thisp);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 err:

--- a/ext/dom/html5_parser.c
+++ b/ext/dom/html5_parser.c
@@ -462,7 +462,7 @@ static php_libxml_quirks_mode dom_translate_quirks_mode(lxb_dom_document_cmode_t
 		case LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS: return PHP_LIBXML_NO_QUIRKS;
 		case LXB_DOM_DOCUMENT_CMODE_LIMITED_QUIRKS: return PHP_LIBXML_LIMITED_QUIRKS;
 		case LXB_DOM_DOCUMENT_CMODE_QUIRKS: return PHP_LIBXML_QUIRKS;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/dom/inner_outer_html_mixin.c
+++ b/ext/dom/inner_outer_html_mixin.c
@@ -181,7 +181,7 @@ static lxb_dom_document_cmode_t dom_translate_quirks_mode(php_libxml_quirks_mode
 		case PHP_LIBXML_NO_QUIRKS: return LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS;
 		case PHP_LIBXML_LIMITED_QUIRKS: return LXB_DOM_DOCUMENT_CMODE_LIMITED_QUIRKS;
 		case PHP_LIBXML_QUIRKS: return LXB_DOM_DOCUMENT_CMODE_QUIRKS;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/dom/lexbor/selectors-adapted/selectors.c
+++ b/ext/dom/lexbor/selectors-adapted/selectors.c
@@ -1453,7 +1453,7 @@ lxb_selectors_match(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
 		case LXB_CSS_SELECTOR_TYPE_PSEUDO_ELEMENT_FUNCTION:
 			return false;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return false;
@@ -1635,7 +1635,7 @@ lxb_selectors_match_attribute_value(const lxb_css_selector_attribute_t *attr, bo
 
 			return lexbor_str_data_ncmp_contain(trg->data, trg->length,
 												src->data, src->length);
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return false;

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -138,7 +138,7 @@ zend_result dom_node_node_name_read(dom_object *obj, zval *retval)
 		case XML_TEXT_NODE:
 			ZVAL_STRING(retval, "#text");
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return SUCCESS;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1746,7 +1746,7 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type)
 				RETURN_THROWS();
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	/* quality must fit in an int */
@@ -1776,7 +1776,7 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type)
 				}
 				gdImageGd2(im, fp, quality, type);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 		fflush(fp);
 		fclose(fp);
@@ -1802,7 +1802,7 @@ static void _php_image_output(INTERNAL_FUNCTION_PARAMETERS, int image_type)
 				}
 				gdImageGd2(im, tmp, quality, type);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 
 		fseek(tmp, 0, SEEK_SET);

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -393,7 +393,7 @@ typeof_op_failure: ;
 		case ZEND_SR:
 			op_sigil = ">>";
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	zend_type_error("Unsupported operand types: %s %s %s", zend_zval_type_name(op1), op_sigil, zend_zval_type_name(op2));
 	return FAILURE;
@@ -929,7 +929,7 @@ ZEND_FUNCTION(gmp_div_qr)
 		case GMP_ROUND_MINUSINF:
 			mpz_fdiv_qr(gmpnum_result1, gmpnum_result2, gmpnum_a, gmpnum_b);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/intl/formatter/formatter_format.cpp
+++ b/ext/intl/formatter/formatter_format.cpp
@@ -55,7 +55,7 @@ U_CFUNC PHP_FUNCTION( numfmt_format )
 			case IS_DOUBLE:
 				type = FORMAT_TYPE_DOUBLE;
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 	}
 

--- a/ext/intl/resourcebundle/resourcebundle.cpp
+++ b/ext/intl/resourcebundle/resourcebundle.cpp
@@ -74,7 +74,7 @@ U_CFUNC void resourcebundle_extract_value( zval *return_value, ResourceBundle_ob
 			source->child = NULL;
 			intl_errors_reset(INTL_DATA_ERROR_P(source));
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -2783,7 +2783,7 @@ PHP_FUNCTION(ldap_modify_batch)
 			case LDAP_MODIFY_BATCH_REPLACE:
 				ldap_operation = LDAP_MOD_REPLACE;
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 
 		/* fill in the basic info */

--- a/ext/mbstring/libmbfl/filters/mbfilter_cjk.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_cjk.c
@@ -279,7 +279,7 @@ retry:
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -1836,7 +1836,7 @@ static int mbfl_filt_conv_jis2004_wchar(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -2528,7 +2528,7 @@ retry:
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -4115,7 +4115,7 @@ static int mbfl_filt_conv_2022kr_wchar(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -9223,7 +9223,7 @@ static int mbfl_filt_conv_hz_wchar(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;

--- a/ext/mbstring/libmbfl/filters/mbfilter_utf7.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_utf7.c
@@ -260,7 +260,7 @@ int mbfl_filt_conv_utf7_wchar(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -368,7 +368,7 @@ int mbfl_filt_conv_wchar_utf7(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;

--- a/ext/mbstring/libmbfl/filters/mbfilter_utf7imap.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_utf7imap.c
@@ -282,7 +282,7 @@ int mbfl_filt_conv_utf7imap_wchar(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;
@@ -409,7 +409,7 @@ int mbfl_filt_conv_wchar_utf7imap(int c, mbfl_convert_filter *filter)
 		}
 		break;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	return 0;

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -5260,7 +5260,7 @@ finish_up_remaining_bytes:
 			}
 			break;
 
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 	}
 

--- a/ext/mbstring/php_unicode.c
+++ b/ext/mbstring/php_unicode.c
@@ -463,7 +463,7 @@ set_title_mode:
 			}
 			break;
 
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 
 		converted_end = p;

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -325,7 +325,7 @@ static int mysqli_object_has_property(zend_object *object, zend_string *name, in
 				}
 				break;
 			}
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 	} else {
 		has_property = zend_std_has_property(object, name, has_set_exists, cache_slot);

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -1411,7 +1411,7 @@ static bool zend_jit_supported_binary_op(uint8_t op, uint32_t op1_info, uint32_t
 			return (op1_info & MAY_BE_LONG) && (op2_info & MAY_BE_LONG);
 		case ZEND_CONCAT:
 			return (op1_info & MAY_BE_STRING) && (op2_info & MAY_BE_STRING);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -2285,7 +2285,7 @@ static zend_never_inline bool zend_handle_fetch_obj_flags(
 				}
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	return 1;
 }

--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -16082,7 +16082,7 @@ static int zend_jit_fetch_static_prop(zend_jit_ctx *jit, const zend_op *opline, 
 		case ZEND_FETCH_STATIC_PROP_UNSET:
 			fetch_type = BP_VAR_UNSET;
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	// JIT: result = CACHED_PTR(cache_slot + sizeof(void *));

--- a/ext/openssl/openssl_backend_common.c
+++ b/ext/openssl/openssl_backend_common.c
@@ -1520,7 +1520,7 @@ EVP_PKEY *php_openssl_generate_private_key(struct php_x509_request * req)
 		case EVP_PKEY_ED448:
 			break;
 #endif
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 		}
 
 		if (EVP_PKEY_paramgen(ctx, &params) <= 0) {

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -2495,7 +2495,7 @@ PHP_FUNCTION(preg_replace_callback_array)
 			case IS_NULL:
 				RETVAL_NULL();
 				goto error;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 
 		if (EG(exception)) {

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -148,7 +148,7 @@ bool pdo_stmt_describe_columns(pdo_stmt_t *stmt) /* {{{ */
 					stmt->columns[col].name = zend_string_toupper(orig_name);
 					zend_string_release(orig_name);
 					break;
-				EMPTY_SWITCH_DEFAULT_CASE()
+				default: ZEND_UNREACHABLE();
 			}
 		}
 
@@ -823,7 +823,7 @@ static bool do_fetch(pdo_stmt_t *stmt, zval *return_value, enum pdo_fetch_type h
 			 * However, if we fetch a group key we will have over allocated. */
 			fetch_function_params = safe_emalloc(sizeof(zval), stmt->column_count, 0);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	if (group_key) {
@@ -918,7 +918,7 @@ static bool do_fetch(pdo_stmt_t *stmt, zval *return_value, enum pdo_fetch_type h
 			case PDO_FETCH_FUNC:
 				ZVAL_COPY_VALUE(&fetch_function_params[fetch_function_param_num++], &val);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE();
+			default: ZEND_UNREACHABLE();
 		}
 	}
 

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -492,7 +492,7 @@ static int pdo_firebird_stmt_get_col(
 					break;
 				case SQL_DOUBLE:
 					break;
-				EMPTY_SWITCH_DEFAULT_CASE()
+				default: ZEND_UNREACHABLE();
 			}
 
 			if ((var->sqltype & ~1) == SQL_DOUBLE) {

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1013,7 +1013,7 @@ static void php_pgsql_get_link_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type
 			break;
 		}
 #endif
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	if (result) {
 		RETURN_STRING(result);
@@ -1578,7 +1578,7 @@ static void php_pgsql_get_result_info(INTERNAL_FUNCTION_PARAMETERS, int entry_ty
 		case PHP_PG_CMD_TUPLES:
 			RETVAL_LONG(atoi(PQcmdTuples(pgsql_result)));
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -1817,7 +1817,7 @@ static void php_pgsql_get_field_info(INTERNAL_FUNCTION_PARAMETERS, int entry_typ
 
 			oid = PQftype(pgsql_result, (int)field);
 			PGSQL_RETURN_OID(oid);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -2348,7 +2348,7 @@ static void php_pgsql_data_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type, bo
 		case PHP_PG_DATA_ISNULL:
 			RETVAL_LONG(PQgetisnull(pgsql_result, pgsql_row, field_offset));
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -3921,7 +3921,7 @@ static void php_pgsql_do_async(INTERNAL_FUNCTION_PARAMETERS, int entry_type)
 			PQfreeCancel(c);
 			break;
 		}
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 	if (PQsetnonblocking(pgsql, 0)) {
 		php_error_docref(NULL, E_NOTICE, "Cannot set connection to blocking mode");

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1516,7 +1516,7 @@ static void reflection_type_factory(zend_type type, zval *object, bool legacy_be
 		case NAMED_TYPE:
 			object_init_ex(object, reflection_named_type_ptr);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 
 	intern = Z_REFLECTION_P(object);
@@ -6669,7 +6669,7 @@ static zend_always_inline uint32_t set_visibility_to_visibility(uint32_t set_vis
 			return ZEND_ACC_PROTECTED;
 		case ZEND_ACC_PRIVATE_SET:
 			return ZEND_ACC_PRIVATE;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2818,7 +2818,7 @@ static uint8_t php_range_process_input(const zval *input, uint32_t arg_num, zend
 			*dval = 0.0;
 			return IS_STRING;
 		}
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -79,7 +79,7 @@ try_again:
 			scalar = zend_enum_fetch_case_value(Z_OBJ_P(scalar));
 			goto try_again;
 		/* All possible types are either handled here or previously */
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -152,7 +152,7 @@ static inline double php_round_helper(double integral, double value, double expo
 
 			return integral;
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	// FIXME: GCC bug, branch is considered reachable.
 	ZEND_UNREACHABLE();
@@ -261,7 +261,7 @@ PHP_FUNCTION(abs)
 			}
 		case IS_DOUBLE:
 			RETURN_DOUBLE(fabs(Z_DVAL_P(value)));
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -280,7 +280,7 @@ PHP_FUNCTION(ceil)
 			RETURN_DOUBLE(zval_get_double(value));
 		case IS_DOUBLE:
 			RETURN_DOUBLE(ceil(Z_DVAL_P(value)));
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -299,7 +299,7 @@ PHP_FUNCTION(floor)
 			RETURN_DOUBLE(zval_get_double(value));
 		case IS_DOUBLE:
 			RETURN_DOUBLE(floor(Z_DVAL_P(value)));
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -382,7 +382,7 @@ PHP_FUNCTION(round)
 		case IS_DOUBLE:
 			RETURN_DOUBLE(_php_math_round(zval_get_double(value), (int)places, (int)mode));
 
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */
@@ -1437,7 +1437,7 @@ PHP_FUNCTION(number_format)
 			}
 			RETURN_STR(_php_math_number_format_ex(Z_DVAL_P(num), dec_int, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
 
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 /* }}} */

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1024,7 +1024,7 @@ static zend_result redirect_proc_descriptor(descriptorspec_item *desc, int targe
 			case 0: redirect_to = GetStdHandle(STD_INPUT_HANDLE); break;
 			case 1: redirect_to = GetStdHandle(STD_OUTPUT_HANDLE); break;
 			case 2: redirect_to = GetStdHandle(STD_ERROR_HANDLE); break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 #endif
 	}

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -705,7 +705,7 @@ static void php_tidy_create_node(INTERNAL_FUNCTION_PARAMETERS, tidy_base_nodetyp
 			node = tidyGetBody(obj->ptdoc->doc);
 			break;
 
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	if (!node) {

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -38,7 +38,7 @@ static zend_string *get_known_string_by_property_name(php_uri_property_name prop
 			return ZSTR_KNOWN(ZEND_STR_QUERY);
 		case PHP_URI_PROPERTY_NAME_FRAGMENT:
 			return ZSTR_KNOWN(ZEND_STR_FRAGMENT);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -182,7 +182,7 @@ static inline const php_uri_property_handler *php_uri_parser_property_handler_by
 			return &parser->property_handler.query;
 		case PHP_URI_PROPERTY_NAME_FRAGMENT:
 			return &parser->property_handler.fragment;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/uri/uri_parser_php_parse_url.c
+++ b/ext/uri/uri_parser_php_parse_url.c
@@ -34,7 +34,7 @@ static zend_string *decode_component(zend_string *in, php_uri_component_read_mod
 
 		return out;
 	}
-	EMPTY_SWITCH_DEFAULT_CASE();
+	default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -103,7 +103,7 @@ ZEND_ATTRIBUTE_NONNULL static UriUriA *get_uri_for_reading(php_uri_parser_rfc398
 			ZEND_FALLTHROUGH;
 		case PHP_URI_COMPONENT_READ_MODE_NORMALIZED_UNICODE:
 			return get_normalized_uri(uriparser_uris);
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -196,7 +196,7 @@ static const char *fill_errors(zval *errors)
 				error_str = "FileInvalidWindowsDriveLetterHost";
 				ZVAL_FALSE(&failure);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 
 		zval error_type;
@@ -374,7 +374,7 @@ static zend_result php_uri_parser_whatwg_host_read(void *uri, php_uri_component_
 			case PHP_URI_COMPONENT_READ_MODE_RAW:
 				ZVAL_STRINGL(retval, (const char *) lexbor_uri->host.u.domain.data, lexbor_uri->host.u.domain.length);
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 	} else {
 		ZVAL_NULL(retval);
@@ -615,7 +615,7 @@ static zend_string *php_uri_parser_whatwg_to_string(void *uri, php_uri_recomposi
 		case PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII:
 			lxb_url_serialize(lexbor_uri, serialize_to_smart_str_callback, &uri_str, exclude_fragment);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return smart_str_extract(&uri_str);

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -102,7 +102,7 @@ static int xmlreader_property_reader(xmlreader_object *obj, xmlreader_prop_handl
 		case IS_LONG:
 			ZVAL_LONG(rv, retint);
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return SUCCESS;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -347,7 +347,7 @@ static ZEND_FUNCTION(zend_number_or_string)
 			RETURN_DOUBLE(Z_DVAL_P(input));
 		case IS_STRING:
 			RETURN_STR_COPY(Z_STR_P(input));
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 
@@ -371,7 +371,7 @@ static ZEND_FUNCTION(zend_number_or_string_or_null)
 			RETURN_DOUBLE(Z_DVAL_P(input));
 		case IS_STRING:
 			RETURN_STR_COPY(Z_STR_P(input));
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 }
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -925,7 +925,7 @@ PHP_FUNCTION(inflate_init)
 				efree(ctx->inflateDict);
 				ctx->inflateDict = NULL;
 				break;
-			EMPTY_SWITCH_DEFAULT_CASE()
+			default: ZEND_UNREACHABLE();
 		}
 	}
 }
@@ -1022,7 +1022,7 @@ PHP_FUNCTION(inflate_add)
 							zend_string_release_ex(out, 0);
 							php_error_docref(NULL, E_WARNING, "Dictionary does not match expected dictionary (incorrect adler32 hash)");
 							RETURN_FALSE;
-						EMPTY_SWITCH_DEFAULT_CASE()
+						default: ZEND_UNREACHABLE();
 					}
 					break;
 				} else {

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2648,7 +2648,7 @@ static zend_result php_cli_server_recv_event_read_request(php_cli_server *server
 		case 0:
 			php_cli_server_poller_add(&server->poller, POLLIN, client->sock);
 			return SUCCESS;
-		EMPTY_SWITCH_DEFAULT_CASE();
+		default: ZEND_UNREACHABLE();
 	}
 	/* Under ASAN the compiler somehow doesn't realise that the switch block always returns */
 	return FAILURE;

--- a/sapi/phpdbg/phpdbg_out.c
+++ b/sapi/phpdbg/phpdbg_out.c
@@ -109,7 +109,7 @@ int phpdbg_process_print(int fd, int type, const char *msg, int msglen) {
 				}
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	if (msgoutlen != FAILURE) {

--- a/sapi/phpdbg/phpdbg_win.c
+++ b/sapi/phpdbg/phpdbg_win.c
@@ -35,7 +35,7 @@ int phpdbg_exception_handler_win32(EXCEPTION_POINTERS *xp) {
 				return EXCEPTION_CONTINUE_EXECUTION;
 			}
 			break;
-		EMPTY_SWITCH_DEFAULT_CASE()
+		default: ZEND_UNREACHABLE();
 	}
 
 	return EXCEPTION_CONTINUE_SEARCH;


### PR DESCRIPTION
There are several issues with this macro:

- It is incorrectly named: It's not an empty default case. It's an unreachable default case.
- It is hiding control flow in its definition, which can be confusing for humans and tools (such as Coccinelle) alike, because it looks like it would be a statement that belongs to the "current" case rather than opening a new one.

Since this macro is exactly as long as explicitly spelling out its definition
(excluding the useless `break;`), it is not even making the code any more
succinct.
