### PR TITLE
.gdbinit: Fix printing of variable names in `print_cvs`

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -42,7 +42,7 @@ define print_cvs
 
 	printf "Compiled variables count: %d\n\n", $cv_count
 	while $cv_idx < $cv_count
-		printf "[%d] '%s'\n", $cv_idx, $cv[$cv_idx].val
+		printf "[%d] '$%s'\n", $cv_idx, $cv[$cv_idx].val@$cv[$cv_idx].len
 		set $zvalue = ((zval *) $cv_ex_ptr) + $callFrameSize + $cv_idx
 		printzv $zvalue
 		set $cv_idx = $cv_idx + 1


### PR DESCRIPTION
Previously only the first character of each variable was printed.