### PR TITLE
Fix access to uninitialized vars in preload_load()

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4345,15 +4345,6 @@ static void preload_load(void)
 		}
 	}
 
-	if (EG(zend_constants)) {
-		EG(persistent_constants_count) = EG(zend_constants)->nNumUsed;
-	}
-	if (EG(function_table)) {
-		EG(persistent_functions_count) = EG(function_table)->nNumUsed;
-	}
-	if (EG(class_table)) {
-		EG(persistent_classes_count)   = EG(class_table)->nNumUsed;
-	}
 	if (CG(map_ptr_last) != ZCSG(map_ptr_last)) {
 		size_t old_map_ptr_last = CG(map_ptr_last);
 		CG(map_ptr_last) = ZCSG(map_ptr_last);
@@ -4588,6 +4579,12 @@ static zend_result accel_preload(const char *config, bool in_child)
 		HANDLE_UNBLOCK_INTERRUPTIONS();
 
 		preload_load();
+
+		/* Update persistent counts, as shutdown will discard anything past
+		 * that, and these tables are aliases to global ones at this point. */
+		EG(persistent_functions_count) = EG(function_table)->nNumUsed;
+		EG(persistent_classes_count)   = EG(class_table)->nNumUsed;
+		EG(persistent_constants_count) = EG(zend_constants)->nNumUsed;
 
 		/* Store individual scripts with unlinked classes */
 		HANDLE_BLOCK_INTERRUPTIONS();


### PR DESCRIPTION
Found while looking at GH-20051.

`preload_load()` accesses `EG(function_table)` and `EG(class_table)`, but these may be uninitialized at this point. For instance, when preloading is done in a sub-process, these variables are uninitialized when the parent calls `preload_load()`.

The update of `EG(persistent_constants_count)`, `EG(persistent_functions_count)`, `EG(persistent_classes_count)` is only necessary when `preload_load()` is invoked in `accel_preload()`, and preloading doesn't forks, because in this case, shutdown will truncate global symbol tables after the preloading request.