### PR TITLE
Drop LIBXML_HTML_ENABLED checks

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2040,8 +2040,6 @@ PHP_METHOD(DOMDocument, relaxNGValidateSource)
 
 #endif
 
-#ifdef LIBXML_HTML_ENABLED
-
 static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 {
 	char *source;
@@ -2233,8 +2231,6 @@ PHP_METHOD(DOMDocument, saveHTML)
 
 }
 /* }}} end dom_document_save_html */
-
-#endif  /* defined(LIBXML_HTML_ENABLED) */
 
 /* {{{ Register extended class used to create base node type */
 static void dom_document_register_node_class(INTERNAL_FUNCTION_PARAMETERS, bool modern)

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1369,9 +1369,7 @@ PHP_MINFO_FUNCTION(dom)
 	php_info_print_table_row(2, "DOM/XML", "enabled");
 	php_info_print_table_row(2, "DOM/XML API Version", DOM_API_VERSION);
 	php_info_print_table_row(2, "libxml Version", LIBXML_DOTTED_VERSION);
-#ifdef LIBXML_HTML_ENABLED
 	php_info_print_table_row(2, "HTML Support", "enabled");
-#endif
 #ifdef LIBXML_XPATH_ENABLED
 	php_info_print_table_row(2, "XPath Support", "enabled");
 #endif
@@ -2709,20 +2707,10 @@ xmlChar *php_dom_libxml_fix_file_path(xmlChar *path)
 
 xmlDocPtr php_dom_create_html_doc(void)
 {
-#ifdef LIBXML_HTML_ENABLED
 	xmlDocPtr lxml_doc = htmlNewDocNoDtD(NULL, NULL);
 	if (EXPECTED(lxml_doc)) {
 		lxml_doc->dict = xmlDictCreate();
 	}
-#else
-	/* If HTML support is not enabled, then htmlNewDocNoDtD() is not available.
-	 * This code mimics the behaviour. */
-	xmlDocPtr lxml_doc = xmlNewDoc((const xmlChar *) "1.0");
-	if (EXPECTED(lxml_doc)) {
-		lxml_doc->type = XML_HTML_DOCUMENT_NODE;
-		lxml_doc->dict = xmlDictCreate();
-	}
-#endif
 	return lxml_doc;
 }
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -34,10 +34,8 @@ extern zend_module_entry dom_module_entry;
 #include <libxml/xinclude.h>
 #include <libxml/hash.h>
 #include <libxml/c14n.h>
-#ifdef LIBXML_HTML_ENABLED
 #include <libxml/HTMLparser.h>
 #include <libxml/HTMLtree.h>
-#endif
 #ifdef LIBXML_XPATH_ENABLED
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1013,7 +1013,6 @@ namespace
         /** @tentative-return-type */
         public function save(string $filename, int $options = 0): int|false {}
 
-#ifdef LIBXML_HTML_ENABLED
         /** @tentative-return-type */
         public function loadHTML(string $source, int $options = 0): bool {}
 
@@ -1025,7 +1024,6 @@ namespace
 
         /** @tentative-return-type */
         public function saveHTMLFile(string $filename): int|false {}
-#endif
 
         /** @tentative-return-type */
         public function saveXML(?DOMNode $node = null, int $options = 0): string|false {}

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 757889c0ca89cc8e9905ba465e0621fe89b6e716 */
+ * Stub hash: e3495cb89e4466d9102abb10bf6461989b7c8ba9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dom_import_simplexml, 0, 1, DOMAttr|DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -404,16 +404,9 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_save
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-#if defined(LIBXML_HTML_ENABLED)
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadHTML, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-ZEND_END_ARG_INFO()
+#define arginfo_class_DOMDocument_loadHTML arginfo_class_DOMDocument_loadXML
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadHTMLFile, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-ZEND_END_ARG_INFO()
+#define arginfo_class_DOMDocument_loadHTMLFile arginfo_class_DOMDocument_load
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_saveHTML, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, node, DOMNode, 1, "null")
@@ -422,7 +415,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_saveHTMLFile, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_saveXML, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, node, DOMNode, 1, "null")
@@ -1228,12 +1220,10 @@ ZEND_METHOD(DOMDocument, loadXML);
 ZEND_METHOD(DOMDocument, normalizeDocument);
 ZEND_METHOD(DOMDocument, registerNodeClass);
 ZEND_METHOD(DOMDocument, save);
-#if defined(LIBXML_HTML_ENABLED)
 ZEND_METHOD(DOMDocument, loadHTML);
 ZEND_METHOD(DOMDocument, loadHTMLFile);
 ZEND_METHOD(DOMDocument, saveHTML);
 ZEND_METHOD(DOMDocument, saveHTMLFile);
-#endif
 ZEND_METHOD(DOMDocument, saveXML);
 #if defined(LIBXML_SCHEMAS_ENABLED)
 ZEND_METHOD(DOMDocument, schemaValidate);
@@ -1496,12 +1486,10 @@ static const zend_function_entry class_DOMDocument_methods[] = {
 	ZEND_ME(DOMDocument, normalizeDocument, arginfo_class_DOMDocument_normalizeDocument, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMDocument, registerNodeClass, arginfo_class_DOMDocument_registerNodeClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMDocument, save, arginfo_class_DOMDocument_save, ZEND_ACC_PUBLIC)
-#if defined(LIBXML_HTML_ENABLED)
 	ZEND_ME(DOMDocument, loadHTML, arginfo_class_DOMDocument_loadHTML, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMDocument, loadHTMLFile, arginfo_class_DOMDocument_loadHTMLFile, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMDocument, saveHTML, arginfo_class_DOMDocument_saveHTML, ZEND_ACC_PUBLIC)
 	ZEND_ME(DOMDocument, saveHTMLFile, arginfo_class_DOMDocument_saveHTMLFile, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_ME(DOMDocument, saveXML, arginfo_class_DOMDocument_saveXML, ZEND_ACC_PUBLIC)
 #if defined(LIBXML_SCHEMAS_ENABLED)
 	ZEND_ME(DOMDocument, schemaValidate, arginfo_class_DOMDocument_schemaValidate, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
It is possible to build libxml without HTML support, which would mean that PHP does not support the saveHtml() features and HTML parsing in general. It also adds some maintenance complexity. I'm not aware of any distro that does this and it shows: this has been broken since stubs have been introduced. So we can just drop it as clearly no one cares about this or we would've known about it already. It also simplifies downstream code because they can now rely on the HTML functionality to always be available.