### PR TITLE
Avoid hardcoding the offset for ErrorException specific properties

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -36,7 +36,6 @@
 #define ZEND_EXCEPTION_LINE_OFF 4
 #define ZEND_EXCEPTION_TRACE_OFF 5
 #define ZEND_EXCEPTION_PREVIOUS_OFF 6
-#define ZEND_EXCEPTION_SEVERITY_OFF 7
 
 ZEND_API zend_class_entry *zend_ce_throwable;
 ZEND_API zend_class_entry *zend_ce_exception;
@@ -415,7 +414,7 @@ ZEND_METHOD(ErrorException, __construct)
 	}
 
 	ZVAL_LONG(&tmp, severity);
-	zend_update_property_num_checked(NULL, Z_OBJ_P(object), ZEND_EXCEPTION_SEVERITY_OFF, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
+	zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
 	if (UNEXPECTED(EG(exception))) {
 		RETURN_THROWS();
 	}


### PR DESCRIPTION
While I consider it fine to hardcode offsets for parent-less classes, doing it on inherited classes prohibits adding additional properties via extensions. In this specific case, an added property to Exception will cause "new ErrorException" to crash.

_Technically_, it's possible to work around this issue via a fake hooked property, to bypass the offset-access.
But that's quite hacky, and it would be much simpler to just not do that type of optimization on properties defined on child classes.