### PR TITLE
Allow by-ref assign to WeakMap even if object is not yet in the map

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Added first-class callable cache to share instances for the duration of the
     request. (ilutov)
+  . It is now possible to use reference assign on WeakMap without the key
+    needing to be present beforehand. (nielsdos)
 
 - Intl:
   . Added IntlNumberRangeFormatter class to format an interval of two numbers

--- a/UPGRADING
+++ b/UPGRADING
@@ -23,6 +23,10 @@ PHP 8.6 UPGRADE NOTES
 2. New Features
 ========================================
 
+- Core:
+  . It is now possible to use reference assign on WeakMap without the key
+    needing to be present beforehand.
+
 - Intl:
   . Added IntlNumberRangeFormatter class to format an interval of two numbers with a given skeleton, locale, IntlNumberRangeFormatter::COLLAPSE_AUTO, IntlNumberRangeFormatter::COLLAPSE_NONE, IntlNumberRangeFormatter::COLLAPSE_UNIT, IntlNumberRangeFormatter::COLLAPSE_ALL collapse and
     IntlNumberRangeFormatter::IDENTITY_FALLBACK_SINGLE_VALUE, IntlNumberRangeFormatter::IDENTITY_FALLBACK_APPROXIMATELY_OR_SINGLE_VALUE, IntlNumberRangeFormatter::IDENTITY_FALLBACK_APPROXIMATELY and

--- a/Zend/tests/weakrefs/weakmap_by_ref_dimension_assign.phpt
+++ b/Zend/tests/weakrefs/weakmap_by_ref_dimension_assign.phpt
@@ -1,0 +1,13 @@
+--TEST--
+By-ref assign of WeakMap dimension
+--FILE--
+<?php
+$obj = new stdClass;
+$map = new WeakMap;
+$int = 0;
+$map[$obj] =& $int;
+$int++;
+var_dump($map[$obj]);
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
Previously this failed as the read_dimension which is invoked by ref-assign does not contain the logic to add the key, so it was required to first write the value using a normal assignment and then thereafter use the reference assignment.
This solves it by adding the necessary logic to assign references directly.

This is a follow-up for https://github.com/php/php-src/pull/20078