### PR TITLE
Fix Randomizer::__serialize() wrt INDIRECTs

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -468,8 +468,7 @@ PHP_METHOD(Random_Randomizer, __serialize)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
-	ZVAL_ARR(&t, zend_std_get_properties(&randomizer->std));
-	Z_TRY_ADDREF(t);
+	ZVAL_ARR(&t, zend_array_dup(zend_std_get_properties(&randomizer->std)));
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &t);
 }
 /* }}} */

--- a/ext/random/tests/03_randomizer/methods/__serialize_indirects.phpt
+++ b/ext/random/tests/03_randomizer/methods/__serialize_indirects.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Random: Engine: __serialize() must not expose INDIRECTs
+--FILE--
+<?php
+
+$randomizer = new Random\Randomizer(null);
+var_dump($randomizer->__serialize());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(1) {
+    ["engine"]=>
+    object(Random\Engine\Secure)#2 (0) {
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to GH-20102.
INDIRECTs must never get exposed to userland. The simple solution is to duplicate the properties array.