### PR TITLE
zend_inheritance: Improve placement of return-by-ref `&` in zend_get_function_declaration()

### DIFF
--- a/Zend/tests/inheritance/argument_restriction_001.phpt
+++ b/Zend/tests/inheritance/argument_restriction_001.phpt
@@ -13,4 +13,4 @@ class Sub extends Base {
 }
 ?>
 --EXPECTF--
-Fatal error: Declaration of & Sub::test() must be compatible with & Base::test($foo, array $bar, $option = null, $extra = 'llllllllll...') in %s on line %d
+Fatal error: Declaration of Sub::&test() must be compatible with Base::&test($foo, array $bar, $option = null, $extra = 'llllllllll...') in %s on line %d

--- a/Zend/tests/objects/objects_005.phpt
+++ b/Zend/tests/objects/objects_005.phpt
@@ -19,4 +19,4 @@ class test3 extends test {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of test3::foo() must be compatible with & test::foo() in %s on line %d
+Fatal error: Declaration of test3::foo() must be compatible with test::&foo() in %s on line %d

--- a/Zend/tests/property_hooks/get_by_ref_implemented_by_val.phpt
+++ b/Zend/tests/property_hooks/get_by_ref_implemented_by_val.phpt
@@ -15,4 +15,4 @@ class A implements I {
 
 ?>
 --EXPECTF--
-Fatal error: Declaration of A::$prop::get() must be compatible with & I::$prop::get() in %s on line %d
+Fatal error: Declaration of A::$prop::get() must be compatible with I::&$prop::get() in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -915,10 +915,6 @@ static ZEND_COLD zend_string *zend_get_function_declaration(
 {
 	smart_str str = {0};
 
-	if (fptr->op_array.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
-		smart_str_appends(&str, "& ");
-	}
-
 	if (fptr->common.scope) {
 		if (fptr->common.scope->ce_flags & ZEND_ACC_ANON_CLASS) {
 			/* cut off on NULL byte ... class@anonymous */
@@ -927,6 +923,10 @@ static ZEND_COLD zend_string *zend_get_function_declaration(
 			smart_str_appendl(&str, ZSTR_VAL(fptr->common.scope->name), ZSTR_LEN(fptr->common.scope->name));
 		}
 		smart_str_appends(&str, "::");
+	}
+
+	if (fptr->op_array.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
+		smart_str_appendc(&str, '&');
 	}
 
 	smart_str_append(&str, fptr->common.function_name);


### PR DESCRIPTION
The space after `&` looked super odd. Remove it and put the `&` right before the function name (after the class name), matching the actual syntax for declaring a by-ref return.