### PR TITLE
Fix GH-17346: PDOStatement::$queryString "readonly" is not properly implemented

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1931,6 +1931,7 @@ static zval *dbstmt_prop_write(zend_object *object, zend_string *name, zval *val
 			zend_throw_error(NULL, "Property queryString is read only");
 			return value;
 		}
+		cache_slot = NULL;
 	}
 	return zend_std_write_property(object, name, value, cache_slot);
 }

--- a/ext/pdo/tests/gh17346.phpt
+++ b/ext/pdo/tests/gh17346.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-17346 (PDOStatement::$queryString "readonly" is not properly implemented)
+--EXTENSIONS--
+pdo
+--SKIPIF--
+<?php
+$dir = getenv('REDIR_TEST_DIR');
+if (false != $dir) die('skip is driver independent');
+?>
+--FILE--
+<?php
+$stmt = new PDOStatement();
+try {
+    for ($i = 0; $i < 10; $i++) {
+        $stmt->queryString = (string) $i;
+    }
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($stmt);
+?>
+--EXPECTF--
+Property queryString is read only
+object(PDOStatement)#%d (1) {
+  ["queryString"]=>
+  string(1) "0"
+}


### PR DESCRIPTION
We shouldn't use a cache slot while writing as it would allow to bypass the custom "read only" behaviour. (Note that this is not a "real" readonly, it is more like a "writeonce")