### PR TITLE
Fix GH-19817: Decode SCRIPT_FILENAME issue in php 8.5

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -341,7 +341,7 @@ PHP 8.5 UPGRADE NOTES
     default.
 
 - FPM:
-  . FPM with httpd ProxyPass decodes the full script path. Added
+  . FPM with httpd ProxyPass optionally decodes the full script path. Added
     fastcgi.script_path_encoded INI setting to prevent this new behavior.
   . FPM access log limit now respects log_limit value.
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -807,10 +807,10 @@ enable_dl = Off
 ;fastcgi.impersonate = 1
 
 ; Prevent decoding of SCRIPT_FILENAME when using Apache ProxyPass or
-; ProxyPassMatch. This should only be used if script file paths are already
-; stored in an encoded format on the file system.
-; Default is 0.
-;fastcgi.script_path_encoded = 1
+; ProxyPassMatch. This should be used if script file paths are not stored
+; in an encoded format on the file system.
+; Default is 1.
+;fastcgi.script_path_encoded = 0
 
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
 ; this feature.

--- a/php.ini-production
+++ b/php.ini-production
@@ -809,10 +809,10 @@ enable_dl = Off
 ;fastcgi.impersonate = 1
 
 ; Prevent decoding of SCRIPT_FILENAME when using Apache ProxyPass or
-; ProxyPassMatch. This should only be used if script file paths are already
-; stored in an encoded format on the file system.
-; Default is 0.
-;fastcgi.script_path_encoded = 1
+; ProxyPassMatch. This should be used if script file paths are not stored
+; in an encoded format on the file system.
+; Default is 1.
+;fastcgi.script_path_encoded = 0
 
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
 ; this feature.

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1435,7 +1435,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("cgi.nph",                     "0",  PHP_INI_ALL,    OnUpdateBool,   nph, php_cgi_globals_struct, php_cgi_globals)
 	STD_PHP_INI_BOOLEAN("cgi.fix_pathinfo",            "1",  PHP_INI_SYSTEM, OnUpdateBool,   fix_pathinfo, php_cgi_globals_struct, php_cgi_globals)
 	STD_PHP_INI_BOOLEAN("cgi.discard_path",            "0",  PHP_INI_SYSTEM, OnUpdateBool,   discard_path, php_cgi_globals_struct, php_cgi_globals)
-	STD_PHP_INI_BOOLEAN("fastcgi.script_path_encoded", "0",  PHP_INI_SYSTEM, OnUpdateBool,   fcgi_script_path_encoded, php_cgi_globals_struct, php_cgi_globals)
+	STD_PHP_INI_BOOLEAN("fastcgi.script_path_encoded", "1",  PHP_INI_SYSTEM, OnUpdateBool,   fcgi_script_path_encoded, php_cgi_globals_struct, php_cgi_globals)
 	STD_PHP_INI_BOOLEAN("fastcgi.logging",             "1",  PHP_INI_SYSTEM, OnUpdateBool,   fcgi_logging, php_cgi_globals_struct, php_cgi_globals)
 	STD_PHP_INI_ENTRY("fastcgi.error_header",          NULL, PHP_INI_SYSTEM, OnUpdateString, error_header, php_cgi_globals_struct, php_cgi_globals)
 	STD_PHP_INI_ENTRY("fpm.config",                    NULL, PHP_INI_SYSTEM, OnUpdateString, fpm_config, php_cgi_globals_struct, php_cgi_globals)
@@ -1448,7 +1448,7 @@ static void php_cgi_globals_ctor(php_cgi_globals_struct *php_cgi_globals)
 	php_cgi_globals->nph = 0;
 	php_cgi_globals->fix_pathinfo = 1;
 	php_cgi_globals->discard_path = 0;
-	php_cgi_globals->fcgi_script_path_encoded = 0;
+	php_cgi_globals->fcgi_script_path_encoded = 1;
 	php_cgi_globals->fcgi_logging = 1;
 	php_cgi_globals->fcgi_logging_request_started = false;
 	zend_hash_init(&php_cgi_globals->user_config_cache, 0, NULL, user_config_cache_entry_dtor, 1);

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-decoding.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-decoding.phpt
@@ -18,6 +18,7 @@ pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 php_admin_value[cgi.fix_pathinfo] = yes
+php_admin_value[fastcgi.script_path_encoded] = no
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-encoded.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sfp-encoded.phpt
@@ -1,5 +1,5 @@
 --TEST--
-FPM: FastCGI change for Apache ProxyPass SCRIPT_FILENAME decoding - fallback (GH-17645)
+FPM: FastCGI change for Apache ProxyPass SCRIPT_FILENAME decoding - default (GH-17645)
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--
@@ -18,7 +18,6 @@ pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 php_admin_value[cgi.fix_pathinfo] = yes
-php_admin_value[fastcgi.script_path_encoded] = yes
 EOT;
 
 $code = <<<EOT


### PR DESCRIPTION
This changes default for fastcgi.script_path_encoded INI to have default behavior without a BC break. There has been already issue about this in RC so it is very likely that it could have much bigger impact so it's better to be safe.