### PR TITLE
Fix missing new Foo(...) error in constant expressions

### DIFF
--- a/Zend/tests/gh20113.phpt
+++ b/Zend/tests/gh20113.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-20113: First-class callable constructor in constant AST
+--FILE--
+<?php
+const C = new \stdClass(...);
+?>
+--EXPECTF--
+Fatal error: Cannot create Closure for new expression in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -11468,6 +11468,11 @@ static void zend_compile_const_expr_new(zend_ast **ast_ptr)
 {
 	zend_ast *class_ast = (*ast_ptr)->child[0];
 	zend_compile_const_expr_class_reference(class_ast);
+
+	zend_ast *args_ast = (*ast_ptr)->child[1];
+	if (args_ast->kind == ZEND_AST_CALLABLE_CONVERT) {
+		zend_error_noreturn(E_COMPILE_ERROR, "Cannot create Closure for new expression");
+	}
 }
 
 static void zend_compile_const_expr_closure(zend_ast **ast_ptr)


### PR DESCRIPTION
Though first-class callables are now supported in constant expressions, they remain unsupported for the new expression.

Fixes GH-20113