### PR TITLE
ext/mysqli: host_info() dumps with assert after failed reconnect

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.4.22
 
+- mysqli:
+  . Fixed failed assertion when accessing mysqli property after failed
+    reconnection. (Kamil Tekiela)
+
 
 07 May 2026, PHP 8.4.21
 

--- a/ext/mysqli/mysqli_prop.c
+++ b/ext/mysqli/mysqli_prop.c
@@ -35,15 +35,29 @@
 
 #define MYSQLI_GET_MYSQL(statusval) \
 MYSQL *p; \
-if (!obj->ptr || !(MY_MYSQL *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr) { \
-	if (!quiet) { \
-		zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(obj->zo.ce->name)); \
+{ \
+	MYSQLI_RESOURCE *my_res = obj->ptr; \
+	MY_MYSQL *my_mysql; \
+	if (!my_res || !(my_mysql = (MY_MYSQL *)my_res->ptr)) { \
+		if (!quiet) { \
+			zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(obj->zo.ce->name)); \
+		} \
+		return FAILURE; \
 	} \
-	return FAILURE; \
-} else { \
-	CHECK_STATUS(statusval, quiet);\
-	p = (MYSQL *)((MY_MYSQL *)((MYSQLI_RESOURCE *)(obj->ptr))->ptr)->mysql;\
-}
+	if (my_res->status < statusval ) { \
+		if (!quiet) { \
+			zend_throw_error(NULL, "Property access is not allowed yet"); \
+		} \
+		return FAILURE; \
+	} \
+	p = (MYSQL *)my_mysql->mysql;\
+	if (!p) { \
+		if (!quiet) { \
+			zend_throw_error(NULL, "%s object is not fully initialized", ZSTR_VAL(obj->zo.ce->name)); \
+		} \
+		return FAILURE; \
+	} \
+} \
 
 #define MYSQLI_GET_RESULT(statusval) \
 MYSQL_RES *p; \

--- a/ext/mysqli/tests/mysqli_incomplete_initialization2.phpt
+++ b/ext/mysqli/tests/mysqli_incomplete_initialization2.phpt
@@ -1,0 +1,38 @@
+--TEST--
+host_info() dumps with assert after failed reconnect
+--EXTENSIONS--
+mysqli
+--SKIPIF--
+<?php
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+include 'connect.inc';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_init();
+
+$mysqli->connect($host, $user, $passwd, $db, $port, $socket);
+
+echo 'Success... ' . $mysqli->host_info . "\n";
+
+try {
+    $mysqli->connect($host, $user, $passwd, $db.'wrong', $port, $socket);
+} catch (mysqli_sql_exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+}
+
+try {
+    echo $mysqli->host_info . "\n";
+} catch (Error $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+}
+
+print "done!";
+?>
+--EXPECTF--
+Success... %s via %s
+Error: Unknown database 'testwrong'
+Error: mysqli object is not fully initialized
+done!


### PR DESCRIPTION
This is a follow-up to https://github.com/php/php-src/commit/ce38d3a919c1363efbeb592d77df5f255f205419 For justification see the other commit. 