### PR TITLE
Fix JIT TLS on MacOS 15

### DIFF
--- a/ext/opcache/jit/tls/zend_jit_tls_darwin.c
+++ b/ext/opcache/jit/tls/zend_jit_tls_darwin.c
@@ -23,8 +23,35 @@
 
 #include <stdint.h>
 #include <unistd.h>
+#include <mach-o/dyld.h>
 
 TSRMLS_CACHE_EXTERN();
+
+/* Thunk format used since dydl 1284 (approx. MacOS 15)
+ * https://github.com/apple-oss-distributions/dyld/blob/9307719dd8dc9b385daa412b03cfceb897b2b398/libdyld/ThreadLocalVariables.h#L146 */
+#if defined(__x86_64__) || defined(__aarch64__)
+struct TLV_Thunkv2
+{
+	void*        func;
+	uint32_t     key;
+	uint32_t     offset;
+};
+#else
+struct TLV_Thunkv2
+{
+	void*        func;
+	uint16_t     key;
+	uint16_t     offset;
+};
+#endif
+
+/* Thunk format used in earlier versions */
+struct TLV_Thunkv1
+{
+	void*       func;
+	size_t      key;
+	size_t      offset;
+};
 
 zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 	size_t *tcb_offset,
@@ -37,12 +64,26 @@ zend_result zend_jit_resolve_tsrm_ls_cache_offsets(
 	}
 
 #if defined(__x86_64__)
-	size_t *ti;
+	void *data;
 	__asm__ __volatile__(
 		"leaq __tsrm_ls_cache(%%rip),%0"
-		: "=r" (ti));
-	*module_offset = ti[2];
-	*module_index = ti[1] * 8;
+		: "=r" (data));
+
+	/* Detect dyld 1284: With dyld 1284, thunk->func will be _tlv_get_addr.
+	 * Unfortunately this symbol is private, but we can find it
+	 * as _tlv_bootstrap+8: https://github.com/apple-oss-distributions/dyld/blob/9307719dd8dc9b385daa412b03cfceb897b2b398/libdyld/threadLocalHelpers.s#L54
+	 * On earlier version, thunk->func will be tlv_get_addr, which is not
+	 * _tlv_bootstrap+8.
+	 */
+	if (((struct TLV_Thunkv2*)data)->func == (void*)((char*)_tlv_bootstrap + 8)) {
+		struct TLV_Thunkv2 *thunk = (struct TLV_Thunkv2*) data;
+		*module_offset = thunk->offset;
+		*module_index = (size_t)thunk->key * 8;
+	} else {
+		struct TLV_Thunkv1 *thunk = (struct TLV_Thunkv1*) data;
+		*module_offset = thunk->offset;
+		*module_index = thunk->key * 8;
+	}
 
 	return SUCCESS;
 #endif


### PR DESCRIPTION
Since approximately MacOS 15, the dynamic loader changes the format of the TLV thunk, breaking our resolution code.

Here we use the new format when we detect the new loader.

This is not a regression of the new TLS resolution code. This targets 8.5, but this needs to be backported to 8.3.

Some background: https://github.com/apple-oss-distributions/dyld/blob/9307719dd8dc9b385daa412b03cfceb897b2b398/libdyld/ThreadLocalVariables.h#L46. Since MacOS 15, the dynamic loader patches the data emitted by the compiler, so that its format changes from
```
struct Thunk {
    void *func;
    size_t module;
    size_t offset;
}
```
to
```
struct Thunk_v2 {
     void *func;
     uint32_t module;
     uint32_t offset;
     // other fields
}
```
which has the same size, but not the same layout.

Possible alternative fixes:
 * Disable JIT on MacOS+ZTS (it's already disabled on JIT+ZTS+Apple Silicon: https://github.com/php/php-src/pull/13396).
 * Update JIT so it uses the slower fallback on MacOS: https://github.com/php/php-src/blob/02e38fe22e01c059a185ca8ca09b7bbdb43e4490/ext/opcache/jit/zend_jit_ir.c#L519
 * Update JIT and IR so it calls `thunk->func(thunk)`, which has more ABI garantees that the current method, but will be slower

cc @shivammathur 