### PR TITLE
Fix GH-19989: PHP 8.5 FPM access log lines also go to STDERR

### DIFF
--- a/sapi/fpm/fpm/zlog.c
+++ b/sapi/fpm/fpm/zlog.c
@@ -466,7 +466,7 @@ static ssize_t zlog_stream_buf_flush(struct zlog_stream *stream) /* {{{ */
 	}
 #endif
 
-	if (external_logger != NULL) {
+	if (stream->use_external_logger) {
 		external_logger(stream->flags & ZLOG_LEVEL_MASK,
 				stream->buf.data + stream->prefix_len, stream->len - stream->prefix_len);
 	}
@@ -539,9 +539,11 @@ static inline void zlog_stream_init_internal(
 	stream->fd = fd > -1 ? fd : STDERR_FILENO;
 	stream->buf_init_size = capacity;
 	if (flags & ZLOG_ACCESS_LOG) {
+		stream->use_external_logger = 0;
 		stream->use_buffer = 1;
 		stream->use_stderr = fd < 0;
 	} else {
+		stream->use_external_logger = external_logger != NULL;
 		stream->use_buffer = zlog_buffering || external_logger != NULL || stream->use_syslog;
 		stream->use_stderr = fd < 0 ||
 				(

--- a/sapi/fpm/fpm/zlog.h
+++ b/sapi/fpm/fpm/zlog.h
@@ -77,6 +77,7 @@ struct zlog_stream {
 	unsigned int decorate:1;
 	unsigned int is_stdout:1;
 	unsigned int over_limit:1;
+	unsigned int use_external_logger:1;
 	int fd;
 	int line;
 	int child_pid;

--- a/sapi/fpm/tests/gh19989-access-log-fcgi-stderr.phpt
+++ b/sapi/fpm/tests/gh19989-access-log-fcgi-stderr.phpt
@@ -1,0 +1,47 @@
+--TEST--
+FPM: GH-19989 - Access log going to fcgi error stream
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$src = <<<EOT
+<?php
+echo "OK";
+EOT;
+
+$cfg = <<<EOT
+[global]
+error_log = {{RFILE:LOG:ERR}}
+pid = {{RFILE:PID}}
+[unconfined]
+listen = {{ADDR}}
+access.log = {{RFILE:LOG:ACC}}
+access.format = "'%m %r%Q%q' %s"
+pm = static
+pm.max_children = 2
+EOT;
+
+$prefix = __DIR__;
+$tester = new FPM\Tester($cfg, $src);
+$tester->start(['--prefix', $prefix]);
+$tester->expectLogStartNotices();
+$response = $tester->request()->expectBody('OK');
+$response->expectNoError();
+$tester->expectAccessLog("'GET /gh19989-access-log-fcgi-stderr.src.php' 200");
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+$tester->checkAccessLog();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
This was due to not omitting logging using external_log