### PR TITLE
Remove outdated comment

### DIFF
--- a/ext/pdo_sqlite/sqlite_statement.c
+++ b/ext/pdo_sqlite/sqlite_statement.c
@@ -335,7 +335,6 @@ static int pdo_sqlite_stmt_col_meta(pdo_stmt_t *stmt, zend_long colno, zval *ret
 
 		case SQLITE_BLOB:
 			add_next_index_string(&flags, "blob");
-			/* TODO Check this is correct */
 			ZEND_FALLTHROUGH;
 		case SQLITE_TEXT:
 			add_assoc_str(return_value, "native_type", ZSTR_KNOWN(ZEND_STR_STRING));


### PR DESCRIPTION
Yes this is correct, the blob is returned as a string so it needs to be put that way into the return value.