### PR TITLE
SimpleXML: Use RETURN_STRINGL_FAST() for key()

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2028,7 +2028,7 @@ PHP_METHOD(SimpleXMLElement, key)
 	}
 
 	curnode = intern->node->node;
-	RETURN_STRINGL((char*)curnode->name, xmlStrlen(curnode->name));
+	RETURN_STRINGL_FAST((char*)curnode->name, xmlStrlen(curnode->name));
 }
 /* }}} */
 


### PR DESCRIPTION
We do the same for getName() because names are often one char.