### PR TITLE
Fix arginfo/zpp violations when LIBXML_SCHEMAS_ENABLED is not available

### DIFF
--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -468,12 +468,7 @@ static void php_xmlreader_no_arg_string(INTERNAL_FUNCTION_PARAMETERS, xmlreader_
 
 /* {{{ php_xmlreader_set_relaxng_schema */
 static void php_xmlreader_set_relaxng_schema(INTERNAL_FUNCTION_PARAMETERS, int type) {
-#ifdef LIBXML_SCHEMAS_ENABLED
-	zval *id;
 	size_t source_len = 0;
-	int retval = -1;
-	xmlreader_object *intern;
-	xmlRelaxNGPtr schema = NULL;
 	char *source;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p!", &source, &source_len) == FAILURE) {
@@ -484,11 +479,13 @@ static void php_xmlreader_set_relaxng_schema(INTERNAL_FUNCTION_PARAMETERS, int t
 		zend_argument_value_error(1, "cannot be empty");
 		RETURN_THROWS();
 	}
-
-	id = ZEND_THIS;
-
-	intern = Z_XMLREADER_P(id);
+	
+#ifdef LIBXML_SCHEMAS_ENABLED
+	xmlreader_object *intern = Z_XMLREADER_P(ZEND_THIS);
 	if (intern->ptr) {
+		int retval = -1;
+		xmlRelaxNGPtr schema = NULL;
+
 		if (source) {
 			schema =  _xmlreader_get_relaxNG(source, source_len, type, NULL, NULL);
 			if (schema) {
@@ -926,11 +923,7 @@ PHP_METHOD(XMLReader, readString)
 /* {{{ Use W3C XSD schema to validate the document as it is processed. Activation is only possible before the first Read(). */
 PHP_METHOD(XMLReader, setSchema)
 {
-#ifdef LIBXML_SCHEMAS_ENABLED
-	zval *id;
 	size_t source_len = 0;
-	int retval = -1;
-	xmlreader_object *intern;
 	char *source;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "p!", &source, &source_len) == FAILURE) {
@@ -941,13 +934,12 @@ PHP_METHOD(XMLReader, setSchema)
 		zend_argument_value_error(1, "cannot be empty");
 		RETURN_THROWS();
 	}
-
-	id = ZEND_THIS;
-
-	intern = Z_XMLREADER_P(id);
+	
+#ifdef LIBXML_SCHEMAS_ENABLED
+	xmlreader_object *intern = Z_XMLREADER_P(ZEND_THIS);
 	if (intern && intern->ptr) {
 		PHP_LIBXML_SANITIZE_GLOBALS(schema);
-		retval = xmlTextReaderSchemaValidate(intern->ptr, source);
+		int retval = xmlTextReaderSchemaValidate(intern->ptr, source);
 		PHP_LIBXML_RESTORE_GLOBALS(schema);
 
 		if (retval == 0) {


### PR DESCRIPTION
To do this, we move the macro check and therefore we also have to move some variable declarations to avoid compiler warnings.