### PR TITLE
Fix not thread safe xmlSchemaParse calls in ZTS builds by calling xmlSchemaInitTypes during MINIT

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -39,6 +39,7 @@
 #ifdef LIBXML_SCHEMAS_ENABLED
 #include <libxml/relaxng.h>
 #include <libxml/xmlschemas.h>
+#include <libxml/xmlschemastypes.h>
 #endif
 
 #include "php_libxml.h"
@@ -933,7 +934,11 @@ PHP_LIBXML_API void php_libxml_initialize(void)
 	if (!_php_libxml_initialized) {
 		/* we should be the only one's to ever init!! */
 		ZEND_IGNORE_LEAKS_BEGIN();
+
 		xmlInitParser();
+#ifdef LIBXML_SCHEMAS_ENABLED
+		xmlSchemaInitTypes();
+#endif
 		ZEND_IGNORE_LEAKS_END();
 
 		_php_libxml_default_entity_loader = xmlGetExternalEntityLoader();


### PR DESCRIPTION
See: https://gitlab.gnome.org/GNOME/libxml2/-/issues/930

I was getting a segfault in a ZTS build with:

```
💣 Program crashed: Bad pointer dereference at 0x0000000000000038

Thread 40 "php-13" crashed:

 0 0x00000001a71a0614 xmlSchemaInitTypes + 1536 in libxml2.2.dylib
 1 0x00000001a7182fb8 xmlSchemaParse + 32 in libxml2.2.dylib
 2 _dom_document_schema_validate + 328 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/ext/dom/document.c:1787:9

  1785│                 (xmlSchemaValidityWarningFunc) php_libxml_error_handler,
  1786│                 parser);
  1787│         sptr = xmlSchemaParse(parser);                                                                                                                                        
      │         ▲
  1788│         xmlSchemaFreeParserCtxt(parser);
  1789│         PHP_LIBXML_RESTORE_GLOBALS(new_parser_ctxt);

 3 execute_ex + 132 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:57068:7

  57066│                 if (UNEXPECTED(!OPLINE)) {
  57067│ #else
  57068│                 if (UNEXPECTED((ret = ((opcode_handler_t)OPLINE->handler)(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU)) != 0)) {                                                       
       │       ▲
  57069│ #endif
  57070│ #endif

 4 ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER + 520 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:2052:4

  2050│                         LOAD_OPLINE();
  2051│                         ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
  2052│                         zend_execute_ex(call);                                                                                                                                
      │    ▲
  2053│                 }
  2054│         } else {

 5 execute_ex + 132 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:57068:7
 6 ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER + 520 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:2052:4
 7 execute_ex + 132 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:57068:7
 8 ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER + 520 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:2052:4
 9 execute_ex + 132 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:57068:7
10 zend_call_function + 1428 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_execute_API.c:961:3

   959│                 zend_init_func_execute_data(call, &func->op_array, fci->retval);
   960│                 ZEND_OBSERVER_FCALL_BEGIN(call);
   961│                 zend_execute_ex(call);                                                                                                                                        
      │   ▲
   962│                 EG(jit_trace_num) = orig_jit_trace_num;
   963│         } else {

11 0x00000001013bedc0 zif_frankenphp_handle_request + 900 in frankenphp
12 ZEND_DO_ICALL_SPEC_OBSERVER_HANDLER + 136 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:1400:2

  1398│ 
  1399│         zend_observer_fcall_begin(call);
  1400│         fbc->internal_function.handler(call, ret);                                                                                                                            
      │  ▲
  1401│ 
  1402│ #if ZEND_DEBUG

13 execute_ex + 132 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:57068:7
14 zend_execute.cold.1 + 344 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:61665:2

  61663│         i_init_code_execute_data(execute_data, op_array, return_value);
  61664│         ZEND_OBSERVER_FCALL_BEGIN(execute_data);
  61665│         zend_execute_ex(execute_data);                                                                                                                                       
       │  ▲
  61666│         /* Observer end handlers are called from ZEND_RETURN */
  61667│         zend_vm_stack_free_call_frame(execute_data);

15 zend_execute + 76 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend_vm_execute.h:61648:48

  61646│         }
  61647│ 
  61648│         object_or_called_scope = zend_get_this_object(EG(current_execute_data));                                                                                             
       │                                                ▲
  61649│         if (EXPECTED(!object_or_called_scope)) {
  61650│                 object_or_called_scope = zend_get_called_scope(EG(current_execute_data));

16 zend_execute_scripts + 208 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/Zend/zend.c:1895:4

  1893│                 }
  1894│                 if (op_array) {
  1895│                         zend_execute(op_array, retval);                                                                                                                       
      │    ▲
  1896│                         zend_exception_restore();
  1897│                         if (UNEXPECTED(EG(exception))) {

17 php_execute_script + 540 in libphp.dylib at /Users/spencermalone/Projects/php-src-php-8.3.25/main/main.c:2529:13

  2527│                 }
  2528│ 
  2529│                 retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 3, prepend_file_p, primary_file, append_file_p) == SUCCESS);                                               
      │             ▲
  2530│         } zend_end_try();
  2531│
```

Upon digging in, it looks like xmlSchemaParse is only thread safe if you call `xmlSchemaInitTypes` pre-threading / during init. I left out any call to `xmlSchemaCleanupTypes` due to https://github.com/php/php-src/commit/8742276eb3905eb97a585417000c7b8df85006d4, which would "normally" take care of this kind of thing, and as far as I can tell we haven't been calling cleanup in any way forever, so I'm trying to minimize changes here. If y'all think it's necessary I'm happy to adjust.

Locally, I haven't seen it crop up post-fix, but pre-fix it was occurring ~1/5th of the time when I was replicating by having https://github.com/php/frankenphp run phpunit in multiple threads.

Lemme know if I'm missing anything in making a PR here or if you want anything more rigorous than this.