### PR TITLE
phar: Fix more alias memory leaks

### DIFF
--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -314,6 +314,7 @@ foundit:
 	entry.fp_type = PHAR_FP;
 	entry.is_persistent = mydata->is_persistent;
 #define PHAR_ZIP_FAIL(errmsg) \
+			efree(actual_alias); \
 			zend_hash_destroy(&mydata->manifest); \
 			HT_INVALIDATE(&mydata->manifest); \
 			zend_hash_destroy(&mydata->mounted_dirs); \
@@ -619,7 +620,6 @@ foundit:
 				}
 
 				if (!entry.uncompressed_filesize) {
-					efree(actual_alias);
 					php_stream_filter_remove(filter, 1);
 					pefree(entry.filename, entry.is_persistent);
 					PHAR_ZIP_FAIL("unable to read in alias, truncated");
@@ -653,7 +653,6 @@ foundit:
 				}
 
 				if (!entry.uncompressed_filesize) {
-					efree(actual_alias);
 					php_stream_filter_remove(filter, 1);
 					pefree(entry.filename, entry.is_persistent);
 					PHAR_ZIP_FAIL("unable to read in alias, truncated");
@@ -677,7 +676,6 @@ foundit:
 				}
 
 				if (!entry.uncompressed_filesize) {
-					efree(actual_alias);
 					pefree(entry.filename, entry.is_persistent);
 					PHAR_ZIP_FAIL("unable to read in alias, truncated");
 				}


### PR DESCRIPTION
Every exit path after a certain point can leak this actual_alias, so let's just move it to the exit macro.