### PR TITLE
ext/gd/imagefilter: Improve wording of ArgCount error

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3605,7 +3605,7 @@ PHP_FUNCTION(imagefilter)
 	zval *tmp;
 
 	typedef void (*image_filter)(INTERNAL_FUNCTION_PARAMETERS);
-	zend_long filtertype;
+	zend_long filtertype = 0;
 	image_filter filters[] =
 	{
 		php_image_filter_negate ,
@@ -3623,9 +3623,9 @@ PHP_FUNCTION(imagefilter)
 		php_image_filter_scatter
 	};
 
-	if (ZEND_NUM_ARGS() < 2 || ZEND_NUM_ARGS() > IMAGE_FILTER_MAX_ARGS) {
-		WRONG_PARAM_COUNT;
-	} else if (zend_parse_parameters(2, "Ol", &tmp, gd_image_ce, &filtertype) == FAILURE) {
+	/* We need to do some initial ZPP parsing to be able to extract the filter value */
+	if (zend_parse_parameters(MIN(2, ZEND_NUM_ARGS()), "Ol*", &tmp, gd_image_ce, &filtertype) == FAILURE) {
+
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/tests/imagefilter_error1.phpt
+++ b/ext/gd/tests/imagefilter_error1.phpt
@@ -21,5 +21,5 @@ try {
 }
 ?>
 --EXPECT--
-Wrong parameter count for imagefilter()
+imagefilter() expects at least 2 arguments, 1 given
 imagefilter(): Argument #1 ($image) must be of type GdImage, int given


### PR DESCRIPTION
Extract GD changes from https://github.com/php/php-src/pull/20066

# Commits
## ext/gd/imagefilter: Add test case for manual ZPP

## ext/gd/imagefilter: Improve wording of ArgCount error

This is done by parsing this as 2 arguments with variadics that are never actually parsed