### PR TITLE
Upgrade nightly macOS version to macos 15

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,9 @@ on:
       libmysqlclient_with_mysqli:
         required: true
         type: boolean
+      macos_arm64_version:
+        required: true
+        type: string
       run_alpine:
         required: true
         type: boolean
@@ -366,11 +369,11 @@ jobs:
       matrix:
         debug: [true, false]
         zts: [true, false]
-        os: ['13', '14']
+        arch: ['X64', 'ARM64']
         exclude:
-          - os: ${{ !inputs.run_macos_arm64 && '14' || '*never*' }}
-    name: "MACOS_${{ matrix.os == '13' && 'X64' || 'ARM64' }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: macos-${{ matrix.os }}
+          - arch: ${{ !inputs.run_macos_arm64 && 'ARM64' || '*never*' }}
+    name: "MACOS_${{ matrix.arch }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
+    runs-on: macos-${{ matrix.arch == 'X64' && '15-intel' || inputs.macos_arm64_version }}
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -393,7 +396,7 @@ jobs:
       - name: Test
         uses: ./.github/actions/test-macos
       - name: Test Tracing JIT
-        if: matrix.os != '14' || !matrix.zts
+        if: matrix.arch == 'X64' || !matrix.zts
         uses: ./.github/actions/test-macos
         with:
           jitType: tracing
@@ -405,7 +408,7 @@ jobs:
           runTestsParameters: >-
             -d opcache.enable_cli=1
       - name: Test Function JIT
-        if: matrix.os != '14' || !matrix.zts
+        if: matrix.arch == 'X64' || !matrix.zts
         uses: ./.github/actions/test-macos
         with:
           jitType: function

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -52,6 +52,7 @@ jobs:
       branch: ${{ matrix.branch.ref }}
       community_verify_type_inference: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       libmysqlclient_with_mysqli: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1) }}
+      macos_arm64_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9) && '15' || '14' }}
       run_alpine: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       run_linux_ppc64: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}
       run_macos_arm64: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9 }}


### PR DESCRIPTION
This PR upgrades macOS version in the nightly workflow as `macos-13` has been deprecated and will be discontinued soon. The next x86_64 macOS version they have added in macOS 15.
(https://github.com/actions/runner-images/issues/13046)
So, we can upgrade to.
  - macOS 15 (`macos-15-intel`) for all x86_64 runs.
  - macOS 15 for 8.5 and master. we can keep macOS 14 for 8.1 to 8.4 for arm64.
  
Issues Identified on macOS 15.
  - [X] JIT TLS changes in macos 15 causes segfaults. (Fixed in https://github.com/php/php-src/pull/20121)
  - [x] Test `ext/ctype/tests/lc_ctype_inheritance.phpt` fails on macOS 15 as it inherits LC_CTYPE into the thread locale. We can skip the test on macos 15 as the issue is a due to a change by Apple as discussed in #19828.
  - [x] 8.1 does not build on macos 15 with this error (no_caller_saved_registers function calls memcmp (Zend/zend_string.c:389). [Logs ](https://github.com/shivammathur/php-src/actions/runs/18394026495/job/52409827839#step:5:25). We can backport 6339938c7e289cb5a1c0bf8f37d96537301d5477 in `PHP-8.1` ([patch](https://github.com/shivammathur/php-src/commit/54f8a2a4388143f9a80d466a7f8bc2211bc9bdb4)), but I'm not sure as the branch is now for security-fixes only.