### PR TITLE
phar: Change hacky check into an assertion

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -595,13 +595,9 @@ zend_result phar_metadata_tracker_unserialize_or_copy(phar_metadata_tracker *tra
 	const bool has_unserialize_options = unserialize_options != NULL && zend_hash_num_elements(unserialize_options) > 0;
 	/* It should be impossible to create a zval in a persistent phar/entry. */
 	ZEND_ASSERT(!persistent || Z_ISUNDEF(tracker->val));
+	ZEND_ASSERT(!EG(exception));
 
 	if (Z_ISUNDEF(tracker->val) || has_unserialize_options) {
-		if (EG(exception)) {
-			/* Because other parts of the phar code haven't been updated to check for exceptions after doing something that may throw,
-			 * check for exceptions before potentially serializing/unserializing instead. */
-			return FAILURE;
-		}
 		/* Persistent phars should always be unserialized. */
 		const char *start;
 		/* Assert it should not be possible to create raw data in a persistent phar (i.e. from cache_list) */


### PR DESCRIPTION
phar_metadata_tracker_unserialize_or_copy() is only ever preceded by phar_metadata_tracker_has_data() which won't throw. This check is quite hacky and it should always be the responsibility of the caller to avoid calling this, even the comment acknowledges this is a hack.