### PR TITLE
Fix GH-19994: openssl_get_cipher_methods inconsistent with fetching

### DIFF
--- a/ext/openssl/tests/gh19994.phpt
+++ b/ext/openssl/tests/gh19994.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-19994: openssl_get_cipher_methods inconsistent with fetched methods
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+$ciphers = openssl_get_cipher_methods();
+
+foreach ($ciphers as $cipher) {
+    if (openssl_cipher_iv_length($cipher) === false) {
+        var_dump($cipher);
+    }
+}
+
+?>
+--EXPECT--


### PR DESCRIPTION
This is fixed by libctx work so this just adds test to confirm it.

The actual fix is 2f5ef4d2b729227f5847dd36faba94ee430cd096 .

