### PR TITLE
exif: Fix possible memory leak when tag is empty

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -3253,6 +3253,7 @@ static bool exif_process_IFD_in_MAKERNOTE(image_info_type *ImageInfo, char * val
 
 #define REQUIRE_NON_EMPTY() do { \
 	if (byte_count == 0) { \
+		EFREE_IF(outside); \
 		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Process tag(x%04X=%s): Cannot be empty", tag, exif_get_tagname_debug(tag, tag_table)); \
 		return false; \
 	} \


### PR DESCRIPTION
When `!value_ptr` is handled, memory is allocated at line 3314. At later exit paths, `outside` (pointing to `value_ptr`) is freed, but not when exiting via the `REQUIRE_NON_EMPTY` macro.