### PR TITLE
Verify bundled sources using CI - Opcache JIT IR

### DIFF
--- a/.github/scripts/download-bundled/jit-ir.sh
+++ b/.github/scripts/download-bundled/jit-ir.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -ex
+cd "$(dirname "$0")/../../.."
+
+tmp_dir=/tmp/php-src-download-bundled/jit-ir
+rm -rf "$tmp_dir"
+
+revision=a098f9ed6c2f1c2852d6c0921283212aafb4afed
+
+git clone --depth 1 --revision="$revision" https://github.com/dstogov/ir.git "$tmp_dir"
+
+rm -rf ext/opcache/jit/ir
+cp -R "$tmp_dir" ext/opcache/jit/ir
+
+cd ext/opcache/jit/ir
+
+# remove unneeded files
+rm -r .git
+rm -r .github
+rm -r bench
+rm -r examples
+rm -r tests
+rm -r tools
+rm README.md
+rm TODO
+rm ir.g
+rm ir_cpuinfo.c
+rm ir_emit_c.c
+rm ir_emit_llvm.c
+rm ir_load.c
+rm ir_load_llvm.c
+rm ir_main.c
+rm ir_mem2ssa.c
+
+# add extra files
+git restore README

--- a/.github/workflows/verify-bundled-files.yml
+++ b/.github/workflows/verify-bundled-files.yml
@@ -5,6 +5,7 @@ on:
     paths: &paths
       - '.github/scripts/download-bundled/**'
       - 'Zend/asm/**'
+      - 'ext/opcache/jit/ir/**'
       - 'ext/pcre/pcre2lib/**'
       - 'ext/uri/uriparser/**'
   pull_request:
@@ -34,6 +35,9 @@ jobs:
             'boost-context':
               - '.github/scripts/download-bundled/boost-context.*'
               - 'Zend/asm/**'
+            'jit-ir':
+              - '.github/scripts/download-bundled/jit-ir.*'
+              - 'ext/opcache/jit/ir/**'
             pcre2:
               - '.github/scripts/download-bundled/pcre2.*'
               - 'ext/pcre/pcre2lib/**'
@@ -49,6 +53,15 @@ jobs:
           echo "::endgroup::"
           echo "::group::Verify files"
           .github/scripts/test-directory-unchanged.sh Zend/asm
+          echo "::endgroup::"
+      - name: 'JIT IR'
+        if: ${{ !cancelled() && (steps.changes.outputs.jit-ir == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        run: |
+          echo "::group::Download"
+          .github/scripts/download-bundled/jit-ir.sh
+          echo "::endgroup::"
+          echo "::group::Verify files"
+          .github/scripts/test-directory-unchanged.sh 'ext/opcache/jit/ir'
           echo "::endgroup::"
       - name: PCRE2
         if: ${{ !cancelled() && (steps.changes.outputs.pcre2 == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}


### PR DESCRIPTION
initial PR of #19802

The new CI asserts all bundled files are up-to-date and the CI code also provides trusted documentation of how the bundled deps were added.

On push/PR the CI is run only if the bundled files were changed.