### PR TITLE
Fix assertion failure in ReflectionProperty::skipLazyInitialization after failed LazyProxy initialization

### DIFF
--- a/Zend/tests/lazy_objects/gh20174.phpt
+++ b/Zend/tests/lazy_objects/gh20174.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-20174: Assertion failure in ReflectionProperty::skipLazyInitialization after failed LazyProxy skipLazyInitialization
+--CREDITS--
+vi3tL0u1s
+--FILE--
+<?php
+
+class C {
+    public $b;
+    public $c;
+}
+
+$reflector = new ReflectionClass(C::class);
+
+$obj = $reflector->newLazyProxy(function ($obj) {
+    $obj->b = 4;
+    throw new Exception();
+});
+
+try {
+    $reflector->initializeLazyObject($obj);
+} catch (Exception $e) {
+    $reflector->getProperty('b')->skipLazyInitialization($obj);
+}
+
+var_dump($obj);
+
+?>
+--EXPECTF--
+lazy proxy object(C)#%d (1) {
+  ["b"]=>
+  NULL
+}

--- a/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes.phpt
+++ b/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes.phpt
@@ -46,7 +46,6 @@ $obj = $reflector->newLazyProxy(function ($obj) {
     throw new Exception('initializer exception');
 });
 
-// Initializer effects on the proxy are not reverted
 test('Proxy', $obj);
 
 --EXPECTF--
@@ -63,12 +62,10 @@ Is lazy: 1
 # Proxy:
 string(11) "initializer"
 initializer exception
-lazy proxy object(C)#%d (3) {
-  ["a"]=>
-  int(3)
+lazy proxy object(C)#%d (1) {
   ["b"]=>
-  int(4)
+  uninitialized(int)
   ["c"]=>
-  int(5)
+  int(0)
 }
 Is lazy: 1

--- a/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_dyn_props.phpt
+++ b/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_dyn_props.phpt
@@ -49,7 +49,6 @@ $obj = $reflector->newLazyProxy(function ($obj) {
     throw new Exception('initializer exception');
 });
 
-// Initializer effects on the proxy are not reverted
 test('Proxy', $obj);
 
 --EXPECTF--
@@ -66,14 +65,10 @@ Is lazy: 1
 # Proxy:
 string(11) "initializer"
 initializer exception
-lazy proxy object(C)#%d (4) {
-  ["a"]=>
-  int(3)
+lazy proxy object(C)#%d (1) {
   ["b"]=>
-  int(4)
+  uninitialized(int)
   ["c"]=>
-  int(5)
-  ["d"]=>
-  int(6)
+  int(0)
 }
 Is lazy: 1

--- a/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_dyn_props_and_ht.phpt
+++ b/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_dyn_props_and_ht.phpt
@@ -52,7 +52,6 @@ $obj = $reflector->newLazyProxy(function ($obj) {
     throw new Exception('initializer exception');
 });
 
-// Initializer effects on the proxy are not reverted
 test('Proxy', $obj);
 
 --EXPECTF--
@@ -73,14 +72,10 @@ array(0) {
 }
 string(11) "initializer"
 initializer exception
-lazy proxy object(C)#%d (4) {
-  ["a"]=>
-  int(3)
+lazy proxy object(C)#%d (1) {
   ["b"]=>
-  int(4)
+  uninitialized(int)
   ["c"]=>
-  int(5)
-  ["d"]=>
-  int(6)
+  int(0)
 }
 Is lazy: 1

--- a/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_props_ht.phpt
+++ b/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_props_ht.phpt
@@ -49,7 +49,6 @@ $obj = $reflector->newLazyProxy(function ($obj) {
     throw new Exception('initializer exception');
 });
 
-// Initializer effects on the proxy are not reverted
 test('Proxy', $obj);
 
 --EXPECTF--
@@ -74,12 +73,10 @@ array(1) {
 }
 string(11) "initializer"
 initializer exception
-lazy proxy object(C)#%d (3) {
-  ["a"]=>
-  int(3)
+lazy proxy object(C)#%d (1) {
   ["b"]=>
-  int(4)
+  uninitialized(int)
   ["c"]=>
-  int(5)
+  int(0)
 }
 Is lazy: 1

--- a/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_props_ht_ref.phpt
+++ b/Zend/tests/lazy_objects/init_exception_reverts_initializer_changes_props_ht_ref.phpt
@@ -55,7 +55,6 @@ $obj = $reflector->newLazyProxy(function ($obj) {
     throw new Exception('initializer exception');
 });
 
-// Initializer effects on the proxy are not reverted
 test('Proxy', $obj);
 
 --EXPECTF--
@@ -83,13 +82,11 @@ array(1) {
 }
 string(11) "initializer"
 initializer exception
-lazy proxy object(C)#%d (3) {
-  ["a"]=>
-  int(3)
+lazy proxy object(C)#%d (1) {
   ["b"]=>
-  int(4)
+  uninitialized(int)
   ["c"]=>
-  int(5)
+  int(0)
 }
 Is lazy: 1
 

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -479,6 +479,24 @@ static zend_object *zend_lazy_object_init_proxy(zend_object *obj)
 	/* prevent reentrant initialization */
 	OBJ_EXTRA_FLAGS(obj) &= ~(IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY);
 
+	zval *properties_table_snapshot = NULL;
+
+	/* Snapshot dynamic properties */
+	HashTable *properties_snapshot = obj->properties;
+	if (properties_snapshot) {
+		GC_TRY_ADDREF(properties_snapshot);
+	}
+
+	/* Snapshot declared properties */
+	if (obj->ce->default_properties_count) {
+		zval *properties_table = obj->properties_table;
+		properties_table_snapshot = emalloc(sizeof(*properties_table_snapshot) * obj->ce->default_properties_count);
+
+		for (int i = 0; i < obj->ce->default_properties_count; i++) {
+			ZVAL_COPY_PROP(&properties_table_snapshot[i], &properties_table[i]);
+		}
+	}
+
 	/* Call factory */
 	zval retval;
 	int argc = 1;
@@ -492,33 +510,29 @@ static zend_object *zend_lazy_object_init_proxy(zend_object *obj)
 	zend_call_known_fcc(initializer, &retval, argc, &zobj, named_params);
 
 	if (UNEXPECTED(EG(exception))) {
-		OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY;
-		goto exit;
+		goto fail;
 	}
 
 	if (UNEXPECTED(Z_TYPE(retval) != IS_OBJECT)) {
-		OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY;
 		zend_type_error("Lazy proxy factory must return an instance of a class compatible with %s, %s returned",
 				ZSTR_VAL(obj->ce->name),
 				zend_zval_value_name(&retval));
 		zval_ptr_dtor(&retval);
-		goto exit;
+		goto fail;
 	}
 
 	if (UNEXPECTED(Z_TYPE(retval) != IS_OBJECT || !zend_lazy_object_compatible(Z_OBJ(retval), obj))) {
-		OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY;
 		zend_type_error("The real instance class %s is not compatible with the proxy class %s. The proxy must be a instance of the same class as the real instance, or a sub-class with no additional properties, and no overrides of the __destructor or __clone methods.",
 				zend_zval_value_name(&retval),
 				ZSTR_VAL(obj->ce->name));
 		zval_ptr_dtor(&retval);
-		goto exit;
+		goto fail;
 	}
 
 	if (UNEXPECTED(Z_OBJ(retval) == obj || zend_object_is_lazy(Z_OBJ(retval)))) {
-		OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY;
 		zend_throw_error(NULL, "Lazy proxy factory must return a non-lazy object");
 		zval_ptr_dtor(&retval);
-		goto exit;
+		goto fail;
 	}
 
 	zend_fcc_dtor(&info->u.initializer.fcc);
@@ -542,6 +556,21 @@ static zend_object *zend_lazy_object_init_proxy(zend_object *obj)
 		}
 	}
 
+	if (properties_table_snapshot) {
+		for (int i = 0; i < obj->ce->default_properties_count; i++) {
+			zval *p = &properties_table_snapshot[i];
+			/* Use zval_ptr_dtor directly here (not zend_object_dtor_property),
+			 * as any reference type_source will have already been deleted in
+			 * case the prop is not bound to this value anymore. */
+			i_zval_ptr_dtor(p);
+		}
+		efree(properties_table_snapshot);
+	}
+
+	if (properties_snapshot) {
+		zend_release_properties(properties_snapshot);
+	}
+
 	instance = Z_OBJ(retval);
 
 exit:
@@ -554,6 +583,11 @@ exit:
 	}
 
 	return instance;
+
+fail:
+	OBJ_EXTRA_FLAGS(obj) |= IS_OBJ_LAZY_UNINITIALIZED|IS_OBJ_LAZY_PROXY;
+	zend_lazy_object_revert_init(obj, properties_table_snapshot, properties_snapshot);
+	goto exit;
 }
 
 /* Initialize a lazy object. */


### PR DESCRIPTION
Fixes GH-20174

We don't expect the lazy proxy to be modified during initialization, but that's allowed. The modification may set a property, still marked LAZY, without removing the LAZY flag. This causes the assertion failure.

Both the [RFC](https://wiki.php.net/rfc/lazy-objects#common_behavior) and the [documentation](https://www.php.net/manual/en/language.oop5.lazy-objects.php#language.oop5.lazy-objects.initialization-sequence) specify that after an initialization failure, the state of the object is reset to its pre-initialization state:

>  If the initializer throws an exception, the object state is reverted to its pre-initialization state and the object is marked as lazy again. In other words, all effects on the object itself are reverted. Other side effects, such as effects on other objects, are not reverted. This prevents exposing a partially initialized instance in case of failure. 

This behavior would have prevented this issue, but it was not implemented for lazy proxies (only for ghosts).

Here I fix the issue by implementing the missing behavior.