### PR TITLE
Fix getNamedItemNS() incorrect namespace check

### DIFF
--- a/ext/dom/obj_map.c
+++ b/ext/dom/obj_map.c
@@ -515,11 +515,11 @@ static xmlNodePtr dom_map_get_ns_named_item_prop(dom_nnodemap_object *map, const
 {
 	xmlNodePtr nodep = dom_object_get_node(map->baseobj);
 	if (nodep) {
-		if (php_dom_follow_spec_intern(map->baseobj)) {
-			return (xmlNodePtr) php_dom_get_attribute_node(nodep, BAD_CAST ZSTR_VAL(named), ZSTR_LEN(named));
+		if (ns) {
+			return (xmlNodePtr) xmlHasNsProp(nodep, BAD_CAST ZSTR_VAL(named), BAD_CAST ns);
 		} else {
-			if (ns) {
-				return (xmlNodePtr) xmlHasNsProp(nodep, BAD_CAST ZSTR_VAL(named), BAD_CAST ns);
+			if (php_dom_follow_spec_intern(map->baseobj)) {
+				return (xmlNodePtr) php_dom_get_attribute_node(nodep, BAD_CAST ZSTR_VAL(named), ZSTR_LEN(named));
 			} else {
 				return (xmlNodePtr) xmlHasProp(nodep, BAD_CAST ZSTR_VAL(named));
 			}

--- a/ext/dom/tests/modern/xml/attribute_getNamedItemNS_incorrect_ns_check.phpt
+++ b/ext/dom/tests/modern/xml/attribute_getNamedItemNS_incorrect_ns_check.phpt
@@ -1,0 +1,26 @@
+--TEST--
+getNamedItemNS() incorrect namespace check
+--EXTENSIONS--
+dom
+--CREDITS--
+veewee
+--FILE--
+<?php 
+
+$xml = Dom\XMLDocument::createFromString(<<<EOXML
+<?xml version="1.0" encoding="UTF-8"?>
+<note
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="note-nonamespace1.xsd http://localhost/note-nonamespace2.xsd"
+      xsi:schemaLocation="http://www.happy-helpers1.com note-namespace1.xsd http://www.happy-helpers2.com http://localhost/note-namespace2.xsd">
+</note>
+EOXML
+);
+$documentElement = $xml->documentElement;
+$attributes = $documentElement->attributes;
+$schemaLocation = $attributes->getNamedItemNS('http://www.w3.org/2001/XMLSchema-instance', 'schemaLocation');
+var_dump($schemaLocation->textContent);
+
+?>
+--EXPECT--
+string(116) "http://www.happy-helpers1.com note-namespace1.xsd http://www.happy-helpers2.com http://localhost/note-namespace2.xsd"


### PR DESCRIPTION
Accidentally introduced while refactoring iterator handling. The check ordering of namespace vs spec compliance was wrong.