### PR TITLE
phar: Drop buggy redundant Windows-only check

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -609,10 +609,8 @@ PHP_METHOD(Phar, webPhar)
 	fname_len = ZSTR_LEN(zend_file_name);
 
 #ifdef PHP_WIN32
-	if (memchr(fname, '\\', fname_len)) {
-		fname = estrndup(fname, fname_len);
-		phar_unixify_path_separators(fname, fname_len);
-	}
+	fname = estrndup(fname, fname_len);
+	phar_unixify_path_separators(fname, fname_len);
 #endif
 	basename = zend_memrchr(fname, '/', fname_len);
 


### PR DESCRIPTION
If the path contains '\\' the path is duplicated and unixified. In practice this is always true. And if it were not, we'd get a heap corruption as the cleanup code assumes it is.