### PR TITLE
ext/intl: Do not register IntlNumberRangeFormatter on ICU 62 or lower

### DIFF
--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -190,9 +190,10 @@ PHP_MINIT_FUNCTION( intl )
 	/* Register 'ListFormatter' PHP class */
 	listformatter_register_class(  );
 
+#if U_ICU_VERSION_MAJOR_NUM >= 63
 	/* Register 'NumberRangeFormatter' PHP class */
 	rangeformatter_register_class( );
-
+#endif
 	/* Register 'Normalizer' PHP class */
 	normalizer_register_Normalizer_class(  );
 

--- a/ext/intl/rangeformatter/rangeformatter_class.cpp
+++ b/ext/intl/rangeformatter/rangeformatter_class.cpp
@@ -23,7 +23,6 @@ extern "C" {
 #include <unicode/numberformatter.h>
 #include <unicode/unistr.h>
 #include "../intl_convertcpp.h"
-#endif
 
 extern "C" {
     #include "../intl_error.h"
@@ -34,14 +33,12 @@ extern "C" {
     #include "intl_convert.h"
 }
 
-#if U_ICU_VERSION_MAJOR_NUM >= 63
 using icu::number::NumberRangeFormatter;
 using icu::number::NumberFormatter;
 using icu::number::UnlocalizedNumberFormatter;
 using icu::number::LocalizedNumberRangeFormatter;
 using icu::UnicodeString;
 using icu::MeasureUnit;
-#endif
 
 static zend_object_handlers rangeformatter_handlers;
 zend_class_entry *class_entry_IntlNumberRangeFormatter;
@@ -71,10 +68,6 @@ U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, __construct)
 
 U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, createFromSkeleton)
 {
-#if U_ICU_VERSION_MAJOR_NUM < 63
-    zend_throw_error(NULL, "IntlNumberRangeFormatter is not available in ICU 62 and earlier");
-    RETURN_THROWS();
-#else
     char* skeleton;
     char* locale;
     size_t locale_len;
@@ -145,15 +138,10 @@ U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, createFromSkeleton)
     RANGEFORMATTER_OBJECT(php_intl_numberrangeformatter_fetch_object(obj)) = nrf;
 
     RETURN_OBJ(obj);
-#endif
 }
 
 U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, format)
 {
-#if U_ICU_VERSION_MAJOR_NUM < 63
-    zend_throw_error(NULL, "IntlNumberRangeFormatter is not available in ICU 62 and earlier");
-    RETURN_THROWS();
-#else
     zval *start;
     zval *end;
 
@@ -191,7 +179,6 @@ U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, format)
     INTL_G(error_level) = old_error_level;
 
     RETVAL_NEW_STR(ret);
-#endif
 }
 
 U_CFUNC PHP_METHOD(IntlNumberRangeFormatter, getErrorCode)
@@ -236,3 +223,4 @@ void rangeformatter_register_class(void)
     rangeformatter_handlers.free_obj = IntlNumberRangeFormatter_object_free;
     rangeformatter_handlers.clone_obj = NULL;
 }
+#endif

--- a/ext/intl/rangeformatter/rangeformatter_class.h
+++ b/ext/intl/rangeformatter/rangeformatter_class.h
@@ -15,7 +15,6 @@
 #ifndef RANGEFORMATTER_CLASS_H
 #define RANGEFORMATTER_CLASS_H
 
-#if U_ICU_VERSION_MAJOR_NUM >= 63
 #include <unicode/numberrangeformatter.h>
 
 #ifdef __cplusplus
@@ -23,18 +22,13 @@ using icu::number::LocalizedNumberRangeFormatter;
 #else
 typedef void LocalizedNumberRangeFormatter;
 #endif
-#endif // U_ICU_VERSION_MAJOR_NUM >= 63
 
 typedef struct {
     // error handling
     intl_error      error;
 
     // formatter handling
-#if U_ICU_VERSION_MAJOR_NUM >= 63
     LocalizedNumberRangeFormatter*  unumrf;
-#else
-    void*  unumrf;
-#endif
 } rangeformatter_data;
 
 typedef struct {

--- a/ext/intl/tests/rangeformatter/rangeformatter_icu63_compatibility.phpt
+++ b/ext/intl/tests/rangeformatter/rangeformatter_icu63_compatibility.phpt
@@ -23,4 +23,4 @@ try {
 }
 ?>
 --EXPECT--
-IntlNumberRangeFormatter is not available in ICU 62 and earlier
+Class "IntlNumberRangeFormatter" not found


### PR DESCRIPTION
Instead of throwing an exception when ICU is 62 or earlier, we are now not registering the class at all.

[Discussed in the initial](https://github.com/php/php-src/pull/19232#issuecomment-3342090526) PR.

This can be tested with this [container](https://gist.github.com/BogdanUngureanu/26976b10454b5dcb388fe2adacb1d40c) that loads ICU 62.2

PS: the build on ICU 62 will fail due to an unrelated issue. I'll open a separate PR that will fix that as well.