### PR TITLE
ext/Intl: Fix build failure on ICU 62 caused by dateformat

### DIFF
--- a/ext/intl/dateformat/dateformat_format.cpp
+++ b/ext/intl/dateformat/dateformat_format.cpp
@@ -16,13 +16,13 @@
 #include <config.h>
 #endif
 
+#include <unicode/ustring.h>
+#include <unicode/ucal.h>
+
 extern "C" {
 #include "../php_intl.h"
 #include "../intl_convert.h"
 }
-
-#include <unicode/ustring.h>
-#include <unicode/ucal.h>
 
 #include "../common/common_date.h"
 #include "dateformat.h"


### PR DESCRIPTION
When trying to build PHP with [this](https://gist.github.com/BogdanUngureanu/26976b10454b5dcb388fe2adacb1d40c) Docker container (which installs ICU 62.2), I'm getting a build error.

This PR fixes this problem. I'm not sure if it's a problem only on my environment, but I opened a PR just in case.

```
10.70 In file included from /usr/local/include/unicode/timezone.h:43,
10.70                  from /app/ext/intl/dateformat/../common/common_date.h:30,
10.70                  from /app/ext/intl/dateformat/dateformat_format.cpp:27:
10.70 /usr/local/include/unicode/ures.h:264:28: error: expected constructor, destructor, or type conversion before '(' token
10.70   264 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUResourceBundlePointer, UResourceBundle, ures_close);
10.70       |                            ^
10.70 In file included from /usr/local/include/unicode/unum.h:26,
10.70                  from /usr/local/include/unicode/udat.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_data.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_class.h:22,
10.70                  from /app/ext/intl/dateformat/dateformat_format.cpp:29:
10.70 /usr/local/include/unicode/uformattable.h:107:28: error: expected constructor, destructor, or type conversion before '(' token
10.70   107 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattablePointer, UFormattable, ufmt_close);
10.70       |                            ^
10.70 In file included from /usr/local/include/unicode/unum.h:28,
10.70                  from /usr/local/include/unicode/udat.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_data.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_class.h:22,
10.70                  from /app/ext/intl/dateformat/dateformat_format.cpp:29:
10.70 /usr/local/include/unicode/ufieldpositer.h:81:28: error: expected constructor, destructor, or type conversion before '(' token
10.70    81 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUFieldPositionIteratorPointer, UFieldPositionIterator, ufieldpositer_close);
10.70       |                            ^
10.70 In file included from /usr/local/include/unicode/udat.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_data.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_class.h:22,
10.70                  from /app/ext/intl/dateformat/dateformat_format.cpp:29:
10.70 /usr/local/include/unicode/unum.h:456:28: error: expected constructor, destructor, or type conversion before '(' token
10.70   456 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberFormatPointer, UNumberFormat, unum_close);
10.70       |                            ^
10.70 In file included from /app/ext/intl/dateformat/dateformat_data.h:19,
10.70                  from /app/ext/intl/dateformat/dateformat_class.h:22,
10.70                  from /app/ext/intl/dateformat/dateformat_format.cpp:29:
10.70 /usr/local/include/unicode/udat.h:953:28: error: expected constructor, destructor, or type conversion before '(' token
10.70   953 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateFormatPointer, UDateFormat, udat_close);
10.70       |                            ^
10.72 make: *** [Makefile:1115: ext/intl/dateformat/dateformat_format.lo] Error 1
10.72 make: *** Waiting for unfinished jobs....
```