### PR TITLE
pdo: Fix scope for PDO mixins in pdo_hash_methods()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-19994 (openssl_get_cipher_methods inconsistent with fetching).
     (Jakub Zelenka)
 
+- PDO:
+  . Fixed bug GH-20095 (Incorrect class name in deprecation message for PDO
+    mixins). (timwolla)
+
 - Phar:
   . Fix potential buffer length truncation due to usage of type int instead
     of type size_t. (Girgias)

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1394,7 +1394,7 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 		func.type = ZEND_INTERNAL_FUNCTION;
 		func.handler = funcs->handler;
 		func.function_name = zend_string_init(funcs->fname, strlen(funcs->fname), dbh->is_persistent);
-		func.scope = dbh_obj->std.ce;
+		func.scope = pdo_dbh_ce;
 		func.prototype = NULL;
 		ZEND_MAP_PTR(func.run_time_cache) = rt_cache_size ? pecalloc(rt_cache_size, 1, dbh->is_persistent) : NULL;
 		func.T = ZEND_OBSERVER_ENABLED;

--- a/ext/pdo_sqlite/tests/gh20095.phpt
+++ b/ext/pdo_sqlite/tests/gh20095.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-20095: Incorrect class name in deprecation message for PDO mixins
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+
+class Foo extends PDO {
+	private function test() {
+		echo "foo";
+	}
+
+	public function register() {
+		$this->sqliteCreateFunction('my_test', [$this, "test"]);
+	}
+}
+
+$pdo = new Foo('sqlite::memory:');
+$pdo->register();
+$pdo->query("SELECT my_test()");
+
+?>
+--EXPECTF--
+Deprecated: Method PDO::sqliteCreateFunction() is deprecated since 8.5, use Pdo\Sqlite::createFunction() instead in %s on line %d
+foo


### PR DESCRIPTION
From what I see the incorrect scope is not observable in any other way. The mixin methods are completely invisible to Reflection and a SQLite function referring to a private method is still properly called as before.

Fixes php/php-src#20095.