### PR TITLE
Improve bug60602.phpt portability

### DIFF
--- a/ext/standard/tests/streams/bug60602.phpt
+++ b/ext/standard/tests/streams/bug60602.phpt
@@ -9,7 +9,7 @@ $descs = array(
     2 => array('pipe', 'w'), // strerr
 );
 
-$environment = array('test' => array(1, 2, 3));
+$environment = array('test' => array(1, 2, 3), 'PATH' => getenv('PATH'));
 
 $cmd = (substr(PHP_OS, 0, 3) == 'WIN') ? 'dir' : 'ls';
 $p = proc_open($cmd, $descs, $pipes, '.', $environment);


### PR DESCRIPTION
On NixOS we need to inherit the PATH variable so we can actually resolve the location of ls.