### PR TITLE
pgsql: Fix memory leak when first string conversion fails

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1057,15 +1057,13 @@ PHP_FUNCTION(pg_query)
 
 static void _php_pgsql_free_params(char **params, int num_params)
 {
-	if (num_params > 0) {
-		int i;
-		for (i = 0; i < num_params; i++) {
-			if (params[i]) {
-				efree(params[i]);
-			}
+	int i;
+	for (i = 0; i < num_params; i++) {
+		if (params[i]) {
+			efree(params[i]);
 		}
-		efree(params);
 	}
+	efree(params);
 }
 
 /* Execute a query */


### PR DESCRIPTION
If the first string conversion fails, then i==0, but memory was still allocated for `params`. However, we skip freeing `params` when i==0.