### PR TITLE
ext/tidy: Enable tidyOptGetCategory on Windows

### DIFF
--- a/ext/tidy/config.m4
+++ b/ext/tidy/config.m4
@@ -81,7 +81,8 @@ if test "$PHP_TIDY" != "no"; then
   ])
   AS_VAR_IF([php_ac_cv_have_tidyoptgetcategory], [yes],
     [AC_DEFINE([HAVE_TIDYOPTGETCATEGORY], [1],
-      [Define to 1 if tidyOptGetCategory is available.])])
+      [Define to 1 if Tidy library has the 'tidyOptGetCategory' function and
+      supports the 'TidyInternalCategory' enumeration.])])
 
   CPPFLAGS=$old_CPPFLAGS
 

--- a/ext/tidy/config.w32
+++ b/ext/tidy/config.w32
@@ -21,6 +21,7 @@ if (PHP_TIDY != "no") {
 		AC_DEFINE('HAVE_TIDY_H', 1, "Define to 1 if you have the <tidy.h> header file.")
 		AC_DEFINE('HAVE_TIDYOPTGETDOC', 1, "Define to 1 if Tidy library has the 'tidyOptGetDoc' function.")
 		AC_DEFINE('HAVE_TIDYRELEASEDATE', 1, "Define to 1 if Tidy library has the 'tidyReleaseDate' function.")
+		AC_DEFINE('HAVE_TIDYOPTGETCATEGORY', 1, "Define to 1 if Tidy library has the 'tidyOptGetCategory' function and supports the 'TidyInternalCategory' enumeration.")
 		ADD_FLAG('CFLAGS_TIDY', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 		if (!PHP_TIDY_SHARED) {
 			ADD_DEF_FILE("ext\\tidy\\php_tidy.def");


### PR DESCRIPTION
The tidy library on Windows has been updated to tidy-html5 5.6.0 which provides `tidyOptGetCategory()` function and has the `TidyInternalCategory` enumeration.

https://github.com/winlibs/libtidy