### PR TITLE
Zend: remove zval_dtor() compatibility macro

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -29,6 +29,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . CHECK_ZVAL_NULL_PATH() and CHECK_NULL_PATH() have been removed, use
     zend_str_has_nul_byte(Z_STR_P(...)) and zend_char_has_nul_byte()
     respectively.
+  . The zval_dtor() alias of zval_ptr_dtor_nogc() has been removed.
+    Call zval_ptr_dtor_nogc() directly instead.
 
 ========================
 2. Build system changes

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -81,9 +81,6 @@ ZEND_API void zval_ptr_dtor(zval *zval_ptr);
 ZEND_API void zval_ptr_safe_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
-/* Kept for compatibility */
-#define zval_dtor(zvalue) zval_ptr_dtor_nogc(zvalue)
-
 ZEND_API void zval_add_ref(zval *p);
 
 END_EXTERN_C()

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1052,7 +1052,7 @@ PHP_METHOD(PDOStatement, fetch)
 		array_init_size(return_value, 1);
 		bool success = pdo_do_key_pair_fetch(stmt, ori, off, Z_ARRVAL_P(return_value));
 		if (!success) {
-			zval_dtor(return_value);
+			zval_ptr_dtor_nogc(return_value);
 			PDO_HANDLE_STMT_ERR();
 			RETURN_FALSE;
 		}


### PR DESCRIPTION
This is an alias for zval_ptr_dtor_nogc().
I've seen people make mistakes against this and use zval_dtor() instead of zval_ptr_dtor(). The crucial detail here is that the former won't root possible GC cycles while the latter will.
We can avoid the confusion by just retiring this compatibility macro.