### PR TITLE
zend_long: Remove `ZEND_LTOA()`

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -29,8 +29,9 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . CHECK_ZVAL_NULL_PATH() and CHECK_NULL_PATH() have been removed, use
     zend_str_has_nul_byte(Z_STR_P(...)) and zend_char_has_nul_byte()
     respectively.
-  . ZEND_LTOA() has been removed, as it was unsafe. Directly use
-    ZEND_LONG_FMT with a function from the printf family.
+  . ZEND_LTOA() (and ZEND_LTOA_BUF_LEN) has been removed, as it was
+    unsafe. Directly use ZEND_LONG_FMT with a function from the
+    printf family.
 
 ========================
 2. Build system changes

--- a/Zend/zend_long.h
+++ b/Zend/zend_long.h
@@ -51,9 +51,6 @@ typedef int32_t zend_off_t;
 #endif
 
 
-/* Conversion macros. */
-#define ZEND_LTOA_BUF_LEN 65
-
 #ifdef ZEND_ENABLE_ZVAL_LONG64
 # define ZEND_LONG_FMT "%" PRId64
 # define ZEND_ULONG_FMT "%" PRIu64

--- a/ext/standard/hrtime.c
+++ b/ext/standard/hrtime.c
@@ -31,9 +31,9 @@
 	} while (0)
 #endif
 #define PHP_RETURN_HRTIME(t) do { \
-	char _a[ZEND_LTOA_BUF_LEN]; \
+	char _a[65]; \
 	double _d; \
-	HRTIME_U64A(t, _a, ZEND_LTOA_BUF_LEN); \
+	HRTIME_U64A(t, _a, sizeof(_a)); \
 	_d = zend_strtod(_a, NULL); \
 	RETURN_DOUBLE(_d); \
 	} while (0)


### PR DESCRIPTION
This macro is unsafe when the given buffer is too small, since `snprintf()` returns the *required* length of the string if it would fit. Thus unconditionally writing a NUL there might result in a out-of-bounds write.