### PR TITLE
.github: Bust the nightly CI cache on Sunday instead of Monday

### DIFF
--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -49,8 +49,8 @@ function get_current_version(): array {
 
 $trigger = $argv[1] ?? 'schedule';
 $attempt = (int) ($argv[2] ?? 1);
-$monday = date('w', time()) === '1';
-$discard_cache = $monday
+$sunday = date('w', time()) === '0';
+$discard_cache = $sunday
     || ($trigger === 'schedule' && $attempt !== 1)
     || $trigger === 'workflow_dispatch';
 if ($discard_cache) {


### PR DESCRIPTION
The nightly matrix with an empty cache takes several hours to complete due to the amount of jobs. This will effectively block the entire CI for the php organization since there is an organization-wide limit of 20 jobs. Move the cache buster job to Sunday to make it less likely for folks to fight with the Nightly build for resources.