### PR TITLE
Skip gh20122.phpt on pdo_mysql + libmysqlclient

### DIFF
--- a/ext/pdo_mysql/tests/gh20122.phpt
+++ b/ext/pdo_mysql/tests/gh20122.phpt
@@ -5,11 +5,8 @@ pdo
 pdo_mysql
 --SKIPIF--
 <?php
-require __DIR__ . '/config.inc';
-require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
-PDOTest::skip();
-
 require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::skip();
 if (!MySQLPDOTest::isPDOMySQLnd()) die('skip only for mysqlnd');
 ?>
 --FILE--


### PR DESCRIPTION
FIELD_TYPE_JSON is a mysqlnd only feature.

See https://github.com/php/php-src/actions/runs/18639444525/job/53135588528#step:6:91.