### PR TITLE
Use MYSQL_TYPE constants instead of FIELD_TYPE

### DIFF
--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -753,7 +753,7 @@ static char *type_to_name_native(int type) /* {{{ */
 #if MYSQL_VERSION_ID >= 90000 && !defined(MARIADB_BASE_VERSION) /* TODO: mysqlnd support (added in 8.4 via a1ab846231aeff49c0441a30ebd44463fc7825b1) */
 		PDO_MYSQL_NATIVE_TYPE_NAME(VECTOR)
 #endif
-#if MYSQL_VERSION_ID >= 80000 || defined(PDO_USE_MYSQLND)
+#if MYSQL_VERSION_ID >= 50708 || defined(PDO_USE_MYSQLND)
 		PDO_MYSQL_NATIVE_TYPE_NAME(JSON)
 #endif
 		PDO_MYSQL_NATIVE_TYPE_NAME(TIME)


### PR DESCRIPTION
The FIELD_TYPE constants are for BC. The JSON/VECTOR types are not
defined in FIELD_TYPE for libmysqlclient.
MYSQL_TYPE is available since MYSQL 5.0.0, so switch to that.

Since MYSQL_TYPEs are enums and not defines, we need version checks
instead.
JSON was added in mysql 8.0.0 in mysql/mysql-server@c24045514581
VECTOR was added in mysql 9.0.0 in mysql/mysql-server@8cd51511de7d

Replaces GH-20245.
