### PR TITLE
zend_compile: Optimize arguments for ZEND_NEW

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -103,6 +103,8 @@ PHP 8.6 UPGRADE NOTES
   . `printf()` using only `%s` and `%d` will be compiled into the equivalent
     string interpolation, avoiding the overhead of a function call and repeatedly
     parsing the format string.
+  . Arguments are now passed more efficiently to known constructors (e.g. when
+    using new self()).
 
 - JSON:
   . Improve performance of encoding arrays and objects.

--- a/ext/opcache/tests/named_parameter_new.phpt
+++ b/ext/opcache/tests/named_parameter_new.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Named Parameters are optimized for known constructors
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+--SKIPIF--
+<?php
+    if(substr(PHP_OS, 0, 3) == 'WIN') die("skip on windows: Internal classes cannot be optimized");
+?>
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+final class MyClass
+{
+	private function __construct(
+		private \Random\Engine $foo,
+		private int $bar = 0,
+	) {}
+
+	public static function new(int $bar): self
+	{
+		$engine = new \Random\Engine\Xoshiro256StarStar(seed: 123);
+		return new self(foo: $engine, bar: $bar);
+	}
+}
+
+MyClass::new(bar: 1);
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=4, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 INIT_STATIC_METHOD_CALL 1 string("MyClass") string("new")
+0001 SEND_VAL int(1) 1
+0002 DO_UCALL
+0003 RETURN int(1)
+
+MyClass::__construct:
+     ; (lines=7, args=2, vars=2, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 CV0($foo) = RECV 1
+0001 CV1($bar) = RECV_INIT 2 int(0)
+0002 ASSIGN_OBJ THIS string("foo")
+0003 OP_DATA CV0($foo)
+0004 ASSIGN_OBJ THIS string("bar")
+0005 OP_DATA CV1($bar)
+0006 RETURN null
+
+MyClass::new:
+     ; (lines=10, args=1, vars=2, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 CV0($bar) = RECV 1
+0001 V2 = NEW 1 string("Random\\Engine\\Xoshiro256StarStar")
+0002 SEND_VAL int(123) 1
+0003 DO_FCALL
+0004 CV1($engine) = QM_ASSIGN V2
+0005 V2 = NEW 2 (self) (exception)
+0006 SEND_VAR CV1($engine) 1
+0007 SEND_VAR CV0($bar) 2
+0008 DO_FCALL
+0009 RETURN V2
+LIVE RANGES:
+     2: 0002 - 0004 (new)
+     2: 0006 - 0009 (new)

--- a/ext/opcache/tests/opt/gh18107_1.phpt
+++ b/ext/opcache/tests/opt/gh18107_1.phpt
@@ -30,12 +30,12 @@ $_main:
 0000 T1 = ISSET_ISEMPTY_CV (isset) CV0($badvar)
 0001 JMPNZ T1 0006
 0002 V3 = NEW 1 string("Exception")
-0003 SEND_VAL_EX string("Should happen") 1
+0003 SEND_VAL%S string("Should happen") 1
 0004 DO_FCALL
 0005 THROW V3
 0006 JMP 0006
 0007 V6 = NEW 1 string("Exception")
-0008 SEND_VAL_EX string("Should not happen") 1
+0008 SEND_VAL%S string("Should not happen") 1
 0009 DO_FCALL
 0010 THROW V6
 0011 FAST_RET T5

--- a/ext/opcache/tests/opt/gh18107_2.phpt
+++ b/ext/opcache/tests/opt/gh18107_2.phpt
@@ -33,7 +33,7 @@ $_main:
 0000 T2 = ISSET_ISEMPTY_CV (isset) CV0($badvar)
 0001 JMPNZ T2 0008
 0002 V4 = NEW 1 string("Exception")
-0003 SEND_VAL_EX string("Should happen") 1
+0003 SEND_VAL%S string("Should happen") 1
 0004 DO_FCALL
 0005 THROW V4
 0006 CV1($e) = CATCH string("Throwable")
@@ -41,7 +41,7 @@ $_main:
 0008 T6 = FAST_CALL 0010
 0009 JMP 0015
 0010 V7 = NEW 1 string("Exception")
-0011 SEND_VAL_EX string("Should not happen") 1
+0011 SEND_VAL%S string("Should not happen") 1
 0012 DO_FCALL
 0013 THROW V7
 0014 FAST_RET T6


### PR DESCRIPTION
Apply the optimization for static method calls to `new` calls, since `new` is effectively a static method for all intents and purposes.

For:

    <?php

    final class MyClass
    {
    	private function __construct(
    		private \Random\Engine $foo,
    		private int $bar = 0,
    	) {}

    	public static function new(int $bar): self
    	{
    		$engine = new \Random\Engine\Xoshiro256StarStar(seed: 123);
    		return new self(foo: $engine, bar: $bar);
    	}
    }

    for ($i = 0; $i < 3_000_000; $i++) {
    	MyClass::new($i);
    }

This is ~1.13 faster for a gcc 13.3 release build on a Intel(R) Core(TM) i7-1365U.

    Benchmark 1: /tmp/bench/php.old /tmp/bench/test6.php
      Time (mean ± σ):     409.5 ms ±   1.9 ms    [User: 406.6 ms, System: 2.2 ms]
      Range (min … max):   407.4 ms … 414.0 ms    10 runs

    Benchmark 2: /tmp/bench/php.new /tmp/bench/test6.php
      Time (mean ± σ):     360.9 ms ±   1.7 ms    [User: 358.5 ms, System: 2.2 ms]
      Range (min … max):   359.2 ms … 365.0 ms    10 runs

    Summary
      /tmp/bench/php.new /tmp/bench/test6.php ran
        1.13 ± 0.01 times faster than /tmp/bench/php.old /tmp/bench/test6.php