### PR TITLE
Zend: add const qualifiers for _zend_execute_data.func related uses

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1501,12 +1501,10 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 
 	/* Report about uncaught exception in case of fatal errors */
 	if (EG(exception)) {
-		zend_execute_data *ex;
-		const zend_op *opline;
-
 		if (type & E_FATAL_ERRORS) {
-			ex = EG(current_execute_data);
-			opline = NULL;
+			zend_execute_data *ex = EG(current_execute_data);
+			const zend_op *opline = NULL;
+
 			while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
 				ex = ex->prev_execute_data;
 			}

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -502,7 +502,7 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_class(zval *arg, zend_class_entry **p
 /* }}} */
 
 static ZEND_COLD bool zend_null_arg_deprecated(const char *fallback_type, uint32_t arg_num) {
-	zend_function *func = zend_active_function();
+	const zend_function *func = zend_active_function();
 	ZEND_ASSERT(arg_num > 0);
 	uint32_t arg_offset = arg_num - 1;
 	if (arg_offset >= func->common.num_args) {
@@ -510,7 +510,7 @@ static ZEND_COLD bool zend_null_arg_deprecated(const char *fallback_type, uint32
 		arg_offset = func->common.num_args;
 	}
 
-	zend_arg_info *arg_info = &func->common.arg_info[arg_offset];
+	const zend_arg_info *arg_info = &func->common.arg_info[arg_offset];
 	zend_string *func_name = get_active_function_or_method_name();
 	const char *arg_name = get_active_function_arg_name(arg_num);
 
@@ -1140,7 +1140,7 @@ ZEND_API zend_result zend_parse_parameter(int flags, uint32_t arg_num, zval *arg
 }
 
 static ZEND_COLD void zend_parse_parameters_debug_error(const char *msg) {
-	zend_function *active_function = EG(current_execute_data)->func;
+	const zend_function *active_function = EG(current_execute_data)->func;
 	const char *class_name = active_function->common.scope
 		? ZSTR_VAL(active_function->common.scope->name) : "";
 	zend_error_noreturn(E_CORE_ERROR, "%s%s%s(): %s",
@@ -3703,12 +3703,12 @@ ZEND_API void zend_disable_functions(const char *function_list) /* {{{ */
 }
 /* }}} */
 
-static zend_always_inline zend_class_entry *get_scope(zend_execute_data *frame)
+static zend_always_inline zend_class_entry *get_scope(const zend_execute_data *frame)
 {
 	return frame && frame->func ? frame->func->common.scope : NULL;
 }
 
-static bool zend_is_callable_check_class(zend_string *name, zend_class_entry *scope, zend_execute_data *frame, zend_fcall_info_cache *fcc, bool *strict_class, char **error, bool suppress_deprecation) /* {{{ */
+static bool zend_is_callable_check_class(zend_string *name, zend_class_entry *scope, const zend_execute_data *frame, zend_fcall_info_cache *fcc, bool *strict_class, char **error, bool suppress_deprecation) /* {{{ */
 {
 	bool ret = false;
 	zend_class_entry *ce;
@@ -3812,7 +3812,7 @@ ZEND_API void zend_release_fcall_info_cache(zend_fcall_info_cache *fcc) {
 	}
 }
 
-static zend_always_inline bool zend_is_callable_check_func(zval *callable, zend_execute_data *frame, zend_fcall_info_cache *fcc, bool strict_class, char **error, bool suppress_deprecation) /* {{{ */
+static zend_always_inline bool zend_is_callable_check_func(zval *callable, const zend_execute_data *frame, zend_fcall_info_cache *fcc, bool strict_class, char **error, bool suppress_deprecation) /* {{{ */
 {
 	zend_class_entry *ce_org = fcc->calling_scope;
 	bool retval = false;
@@ -4058,7 +4058,7 @@ get_function_via_handler:
 }
 /* }}} */
 
-ZEND_API zend_string *zend_get_callable_name_ex(zval *callable, zend_object *object) /* {{{ */
+ZEND_API zend_string *zend_get_callable_name_ex(zval *callable, const zend_object *object) /* {{{ */
 {
 try_again:
 	switch (Z_TYPE_P(callable)) {
@@ -4092,7 +4092,7 @@ try_again:
 		}
 		case IS_OBJECT:
 		{
-			zend_class_entry *ce = Z_OBJCE_P(callable);
+			const zend_class_entry *ce = Z_OBJCE_P(callable);
 
 			if (ce == zend_ce_closure) {
 				const zend_function *fn = zend_get_closure_method_def(Z_OBJ_P(callable));
@@ -4123,7 +4123,7 @@ ZEND_API zend_string *zend_get_callable_name(zval *callable) /* {{{ */
 /* }}} */
 
 ZEND_API bool zend_is_callable_at_frame(
-		zval *callable, zend_object *object, zend_execute_data *frame,
+		zval *callable, zend_object *object, const zend_execute_data *frame,
 		uint32_t check_flags, zend_fcall_info_cache *fcc, char **error) /* {{{ */
 {
 	bool ret;
@@ -4236,7 +4236,7 @@ check_func:
 ZEND_API bool zend_is_callable_ex(zval *callable, zend_object *object, uint32_t check_flags, zend_string **callable_name, zend_fcall_info_cache *fcc, char **error) /* {{{ */
 {
 	/* Determine callability at the first parent user frame. */
-	zend_execute_data *frame = EG(current_execute_data);
+	const zend_execute_data *frame = EG(current_execute_data);
 	while (frame && (!frame->func || !ZEND_USER_CODE(frame->func->type))) {
 		frame = frame->prev_execute_data;
 	}
@@ -5314,7 +5314,7 @@ static zend_string *try_parse_string(const char *str, size_t len, char quote) {
 }
 
 ZEND_API zend_result zend_get_default_from_internal_arg_info(
-		zval *default_value_zval, zend_internal_arg_info *arg_info)
+		zval *default_value_zval, const zend_internal_arg_info *arg_info)
 {
 	const char *default_value = arg_info->default_value;
 	if (!default_value) {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -413,10 +413,10 @@ ZEND_API ZEND_COLD void zend_wrong_property_read(zval *object, zval *property);
 #define IS_CALLABLE_SUPPRESS_DEPRECATIONS (1<<1)
 
 ZEND_API void zend_release_fcall_info_cache(zend_fcall_info_cache *fcc);
-ZEND_API zend_string *zend_get_callable_name_ex(zval *callable, zend_object *object);
+ZEND_API zend_string *zend_get_callable_name_ex(zval *callable, const zend_object *object);
 ZEND_API zend_string *zend_get_callable_name(zval *callable);
 ZEND_API bool zend_is_callable_at_frame(
-		zval *callable, zend_object *object, zend_execute_data *frame,
+		zval *callable, zend_object *object, const zend_execute_data *frame,
 		uint32_t check_flags, zend_fcall_info_cache *fcc, char **error);
 ZEND_API bool zend_is_callable_ex(zval *callable, zend_object *object, uint32_t check_flags, zend_string **callable_name, zend_fcall_info_cache *fcc, char **error);
 ZEND_API bool zend_is_callable(zval *callable, uint32_t check_flags, zend_string **callable_name);
@@ -900,7 +900,7 @@ ZEND_API zend_result zend_set_local_var_str(const char *name, size_t len, zval *
 
 static zend_always_inline zend_result zend_forbid_dynamic_call(void)
 {
-	zend_execute_data *ex = EG(current_execute_data);
+	const zend_execute_data *ex = EG(current_execute_data);
 	ZEND_ASSERT(ex != NULL && ex->func != NULL);
 
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_DYNAMIC) {
@@ -931,7 +931,7 @@ ZEND_API bool zend_is_iterable(const zval *iterable);
 ZEND_API bool zend_is_countable(const zval *countable);
 
 ZEND_API zend_result zend_get_default_from_internal_arg_info(
-		zval *default_value_zval, zend_internal_arg_info *arg_info);
+		zval *default_value_zval, const zend_internal_arg_info *arg_info);
 
 END_EXTERN_C()
 

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -875,7 +875,7 @@ ZEND_API void zend_create_fake_closure(zval *res, zend_function *func, zend_clas
 /* __call and __callStatic name the arguments "$arguments" in the docs. */
 static zend_internal_arg_info trampoline_arg_info[] = {ZEND_ARG_VARIADIC_TYPE_INFO(false, arguments, IS_MIXED, false)};
 
-void zend_closure_from_frame(zval *return_value, zend_execute_data *call) { /* {{{ */
+void zend_closure_from_frame(zval *return_value, const zend_execute_data *call) { /* {{{ */
 	zval instance;
 	zend_internal_function trampoline;
 	zend_function *mptr = call->func;

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -31,7 +31,7 @@ BEGIN_EXTERN_C()
 void zend_register_closure_ce(void);
 void zend_closure_bind_var(zval *closure_zv, zend_string *var_name, zval *var);
 void zend_closure_bind_var_ex(zval *closure_zv, uint32_t offset, zval *val);
-void zend_closure_from_frame(zval *closure_zv, zend_execute_data *frame);
+void zend_closure_from_frame(zval *closure_zv, const zend_execute_data *frame);
 
 extern ZEND_API zend_class_entry *zend_ce_closure;
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4346,7 +4346,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_fcall_interrupt(zend_execute_data *ca
  */
 static zend_never_inline void zend_copy_extra_args(EXECUTE_DATA_D)
 {
-	zend_op_array *op_array = &EX(func)->op_array;
+	const zend_op_array *op_array = &EX(func)->op_array;
 	uint32_t first_extra_arg = op_array->num_args;
 	uint32_t num_args = EX_NUM_ARGS();
 	zval *src;
@@ -4926,7 +4926,7 @@ static void cleanup_live_vars(zend_execute_data *execute_data, uint32_t op_num, 
 					zval_ptr_dtor_nogc(var);
 				} else if (kind == ZEND_LIVE_ROPE) {
 					zend_string **rope = (zend_string **)var;
-					zend_op *last = EX(func)->op_array.opcodes + op_num;
+					const zend_op *last = EX(func)->op_array.opcodes + op_num;
 					while ((last->opcode != ZEND_ROPE_ADD && last->opcode != ZEND_ROPE_INIT)
 							|| last->result.var != var_num) {
 						ZEND_ASSERT(last >= EX(func)->op_array.opcodes);
@@ -4982,7 +4982,7 @@ ZEND_API HashTable *zend_unfinished_execution_gc_ex(zend_execute_data *execute_d
 		return NULL;
 	}
 
-	zend_op_array *op_array = &EX(func)->op_array;
+	const zend_op_array *op_array = &EX(func)->op_array;
 
 	if (!(EX_CALL_INFO() & ZEND_CALL_HAS_SYMBOL_TABLE)) {
 		uint32_t i, num_cvs = EX(func)->op_array.last_var;
@@ -4993,7 +4993,7 @@ ZEND_API HashTable *zend_unfinished_execution_gc_ex(zend_execute_data *execute_d
 
 	if (EX_CALL_INFO() & ZEND_CALL_FREE_EXTRA_ARGS) {
 		zval *zv = EX_VAR_NUM(op_array->last_var + op_array->T);
-		zval *end = zv + (EX_NUM_ARGS() - op_array->num_args);
+		const zval *end = zv + (EX_NUM_ARGS() - op_array->num_args);
 		while (zv != end) {
 			zend_get_gc_buffer_add_zval(gc_buffer, zv++);
 		}
@@ -5462,7 +5462,7 @@ static zend_never_inline zend_result ZEND_FASTCALL zend_quick_check_constant(
 } /* }}} */
 
 static zend_always_inline uint32_t zend_get_arg_offset_by_name(
-		zend_function *fbc, zend_string *arg_name, void **cache_slot) {
+		const zend_function *fbc, const zend_string *arg_name, void **cache_slot) {
 	/* Due to closures, the `fbc` address isn't unique if the memory address is reused.
 	 * The argument info will be however and uniquely positions the arguments.
 	 * We do support NULL arg_info, so we have to distinguish that from an uninitialized cache slot. */
@@ -5477,7 +5477,7 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 	if (EXPECTED(fbc->type == ZEND_USER_FUNCTION)
 			|| EXPECTED(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
 		for (uint32_t i = 0; i < num_args; i++) {
-			zend_arg_info *arg_info = &fbc->common.arg_info[i];
+			const zend_arg_info *arg_info = &fbc->common.arg_info[i];
 			if (zend_string_equals(arg_name, arg_info->name)) {
 				if (fbc->type == ZEND_USER_FUNCTION && (!fbc->op_array.refcount || !(fbc->op_array.fn_flags & ZEND_ACC_CLOSURE))) {
 					*cache_slot = unique_id;
@@ -5489,7 +5489,7 @@ static zend_always_inline uint32_t zend_get_arg_offset_by_name(
 	} else {
 		ZEND_ASSERT(num_args == 0 || fbc->internal_function.arg_info);
 		for (uint32_t i = 0; i < num_args; i++) {
-			zend_internal_arg_info *arg_info = &fbc->internal_function.arg_info[i];
+			const zend_internal_arg_info *arg_info = &fbc->internal_function.arg_info[i];
 			size_t len = strlen(arg_info->name);
 			if (zend_string_equals_cstr(arg_name, arg_info->name, len)) {
 				*cache_slot = unique_id;
@@ -5517,7 +5517,7 @@ zval * ZEND_FASTCALL zend_handle_named_arg(
 		zend_execute_data **call_ptr, zend_string *arg_name,
 		uint32_t *arg_num_ptr, void **cache_slot) {
 	zend_execute_data *call = *call_ptr;
-	zend_function *fbc = call->func;
+	const zend_function *fbc = call->func;
 	uint32_t arg_offset = zend_get_arg_offset_by_name(fbc, arg_name, cache_slot);
 	if (UNEXPECTED(arg_offset == (uint32_t) -1)) {
 		zend_throw_error(NULL, "Unknown named parameter $%s", ZSTR_VAL(arg_name));
@@ -5603,7 +5603,7 @@ ZEND_API zend_result ZEND_FASTCALL zend_handle_undef_args(zend_execute_data *cal
 				continue;
 			}
 
-			zend_op *opline = &op_array->opcodes[i];
+			const zend_op *opline = &op_array->opcodes[i];
 			if (EXPECTED(opline->opcode == ZEND_RECV_INIT)) {
 				zval *default_value = RT_CONSTANT(opline, opline->op2);
 				if (Z_OPT_TYPE_P(default_value) == IS_CONSTANT_AST) {

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -453,11 +453,11 @@ ZEND_API const char *get_active_class_name(const char **space);
 ZEND_API const char *get_active_function_name(void);
 ZEND_API const char *get_active_function_arg_name(uint32_t arg_num);
 ZEND_API const char *get_function_arg_name(const zend_function *func, uint32_t arg_num);
-ZEND_API zend_function *zend_active_function_ex(const zend_execute_data *execute_data);
+ZEND_API const zend_function *zend_active_function_ex(const zend_execute_data *execute_data);
 
-static zend_always_inline zend_function *zend_active_function(void)
+static zend_always_inline const zend_function *zend_active_function(void)
 {
-	zend_function *func = EG(current_execute_data)->func;
+	const zend_function *func = EG(current_execute_data)->func;
 	if (ZEND_USER_CODE(func->type)) {
 		return zend_active_function_ex(EG(current_execute_data));
 	} else {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -601,9 +601,9 @@ ZEND_API const char *get_active_function_name(void) /* {{{ */
 }
 /* }}} */
 
-ZEND_API zend_function *zend_active_function_ex(const zend_execute_data *execute_data)
+ZEND_API const zend_function *zend_active_function_ex(const zend_execute_data *execute_data)
 {
-	zend_function *func = EX(func);
+	const zend_function *func = EX(func);
 
 	/* Resolve function if op is a frameless call. */
 	if (ZEND_USER_CODE(func->type)) {
@@ -717,7 +717,7 @@ ZEND_API uint32_t zend_get_executed_lineno(void) /* {{{ */
 
 ZEND_API zend_class_entry *zend_get_executed_scope(void) /* {{{ */
 {
-	zend_execute_data *ex = EG(current_execute_data);
+	const zend_execute_data *ex = EG(current_execute_data);
 
 	while (1) {
 		if (!ex) {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -680,7 +680,7 @@ static ZEND_FUNCTION(zend_parent_hook_set_trampoline);
 
 static bool zend_is_in_hook(const zend_property_info *prop_info)
 {
-	zend_execute_data *execute_data = EG(current_execute_data);
+	const zend_execute_data *execute_data = EG(current_execute_data);
 	if (!execute_data || !EX(func) || !EX(func)->common.prop_info) {
 		return false;
 	}
@@ -996,7 +996,7 @@ exit:
 /* }}} */
 
 static zend_always_inline bool property_uses_strict_types(void) {
-	zend_execute_data *execute_data = EG(current_execute_data);
+	const zend_execute_data *execute_data = EG(current_execute_data);
 	return execute_data
 		&& execute_data->func
 		&& ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data));

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -74,10 +74,10 @@ ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init);
 
 // Call during runtime, but only if you have used zend_observer_fcall_register.
 // You must not have more than one begin and one end handler active at the same time. Remove the old one first, if there is an existing one.
-ZEND_API void zend_observer_add_begin_handler(zend_function *function, zend_observer_fcall_begin_handler begin);
-ZEND_API bool zend_observer_remove_begin_handler(zend_function *function, zend_observer_fcall_begin_handler begin, zend_observer_fcall_begin_handler *next);
-ZEND_API void zend_observer_add_end_handler(zend_function *function, zend_observer_fcall_end_handler end);
-ZEND_API bool zend_observer_remove_end_handler(zend_function *function, zend_observer_fcall_end_handler end, zend_observer_fcall_end_handler *next);
+ZEND_API void zend_observer_add_begin_handler(const zend_function *function, zend_observer_fcall_begin_handler begin);
+ZEND_API bool zend_observer_remove_begin_handler(const zend_function *function, zend_observer_fcall_begin_handler begin, zend_observer_fcall_begin_handler *next);
+ZEND_API void zend_observer_add_end_handler(const zend_function *function, zend_observer_fcall_end_handler end);
+ZEND_API bool zend_observer_remove_end_handler(const zend_function *function, zend_observer_fcall_end_handler end, zend_observer_fcall_end_handler *next);
 
 ZEND_API void zend_observer_startup(void); // Called by engine before MINITs
 ZEND_API void zend_observer_post_startup(void); // Called by engine after MINITs
@@ -88,13 +88,13 @@ ZEND_API void ZEND_FASTCALL zend_observer_fcall_begin(zend_execute_data *execute
 /* prechecked: the call is actually observed. */
 ZEND_API void ZEND_FASTCALL zend_observer_fcall_begin_prechecked(zend_execute_data *execute_data, zend_observer_fcall_begin_handler *observer_data);
 
-static zend_always_inline bool zend_observer_handler_is_unobserved(zend_observer_fcall_begin_handler *handler) {
+static zend_always_inline bool zend_observer_handler_is_unobserved(const zend_observer_fcall_begin_handler *handler) {
 	return *handler == ZEND_OBSERVER_NONE_OBSERVED;
 }
 
 /* Initial check for observers has not happened yet or no observers are installed. */
-static zend_always_inline bool zend_observer_fcall_has_no_observers(zend_execute_data *execute_data, bool allow_generator, zend_observer_fcall_begin_handler **handler) {
-	zend_function *function = EX(func);
+static zend_always_inline bool zend_observer_fcall_has_no_observers(const zend_execute_data *execute_data, bool allow_generator, zend_observer_fcall_begin_handler **handler) {
+	const zend_function *function = EX(func);
 	void *ZEND_MAP_PTR(runtime_cache) = ZEND_MAP_PTR(function->common.run_time_cache);
 
 	if (function->common.fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE | (allow_generator ? 0 : ZEND_ACC_GENERATOR))) {


### PR DESCRIPTION
This is a bit all over the place, as I was trying to see if we could make the `func` field of `_zend_execute_data` constant.

We cannot mainly due to trampolines, closures, and symbol table shenanigans due to `$http_response_header`, but might as well merge the added `const` qualifiers in line with some of my other PRs.

Happy to split this into multiple PRs if needed.