### PR TITLE
Fix UAF in tidy when tidySetErrorBuffer() fails

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -434,7 +434,7 @@ static zend_object *tidy_object_new(zend_class_entry *class_type, zend_object_ha
 				efree(intern->ptdoc->errbuf);
 				tidyRelease(intern->ptdoc->doc);
 				efree(intern->ptdoc);
-				efree(intern);
+				/* TODO: convert to exception */
 				php_error_docref(NULL, E_ERROR, "Could not set Tidy error buffer");
 			}
 


### PR DESCRIPTION
We should not free `intern` as its stored in the object store as well, so the object store will already free it, leading to a UAF when the object store tries to read the object's fields.