### PR TITLE
Fix GH-20281: \Dom\Document::getElementById() is inconsistent after nodes are removed

### DIFF
--- a/ext/dom/html5_parser.c
+++ b/ext/dom/html5_parser.c
@@ -268,7 +268,10 @@ static lexbor_libxml2_bridge_status lexbor_libxml2_bridge_convert(
 
                 /* xmlIsID does some other stuff too that is irrelevant here. */
                 if (local_name_length == 2 && local_name[0] == 'i' && local_name[1] == 'd' && attr->node.ns == LXB_NS_HTML) {
-                    xmlAddID(NULL, lxml_doc, value, lxml_attr);
+                    if (xmlAddID(NULL, lxml_doc, value, lxml_attr) == 0) {
+                        /* If the ID already exists, the ID attribute still needs to be marked as an ID. */
+                        lxml_attr->atype = XML_ATTRIBUTE_ID;
+                    }
                 }
 
                 /* libxml2 doesn't support line numbers on this anyway, it derives them instead, so don't bother */

--- a/ext/dom/tests/modern/html/interactions/gh20281.phpt
+++ b/ext/dom/tests/modern/html/interactions/gh20281.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-20281 (\Dom\Document::getElementById() is inconsistent after nodes are removed)
+--EXTENSIONS--
+dom
+--CREDITS--
+cscott
+--FILE--
+<?php
+$d = \Dom\HTMLDocument::createFromString('<p id="a">b</p><p id="a">c</p>', LIBXML_NOERROR);
+$p = $d->getElementById('a');
+$p->remove();
+echo $d->getElementById('a')->textContent, "\n";
+?>
+--EXPECT--
+c


### PR DESCRIPTION
This worked for non-parsed elements already, but not for elements where xmlAddID() returns early due to the ID already existing. In that case what was missing is marking the attribute as an ID.