### PR TITLE
ext/lexbor: use PHP_VERSION for extension version

### DIFF
--- a/ext/lexbor/php_lexbor.c
+++ b/ext/lexbor/php_lexbor.c
@@ -72,7 +72,7 @@ zend_module_entry lexbor_module_entry = {
 	NULL,                       /* per-request startup function */
 	NULL,                       /* per-request shutdown function */
 	PHP_MINFO(lexbor),          /* information function */
-	NULL,
+	PHP_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
 


### PR DESCRIPTION
To match most other bundled extensions, instead of having no version at all