### PR TITLE
Make the FTP extension coroutine-enabled

### DIFF
--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -14,7 +14,7 @@ PHP_ARG_WITH([openssl-dir],
 if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])
   PHP_NEW_EXTENSION(ftp, php_ftp.c ftp.c, $ext_shared)
-
+  PHP_INSTALL_HEADERS([ext/ftp], [php_ftp.h])
   dnl Empty variable means 'no'
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 

--- a/ext/ftp/config.w32
+++ b/ext/ftp/config.w32
@@ -5,6 +5,7 @@ ARG_ENABLE("ftp", "ftp support", "no");
 if (PHP_FTP != "no") {
 
 	EXTENSION("ftp", "php_ftp.c ftp.c");
+	PHP_INSTALL_HEADERS("ext/ftp/", "php_ftp.h");
 
 	var ret = SETUP_OPENSSL("ftp", PHP_FTP);
 

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -64,6 +64,8 @@
 # define ETIMEDOUT WSAETIMEDOUT
 #endif
 
+PHPAPI int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
+
 /* sends an ftp command, returns true on success, false on error.
  * it sends the string "cmd args\r\n" if args is non-null, or
  * "cmd\r\n" if args is null
@@ -1467,7 +1469,7 @@ static int my_poll(php_socket_t fd, int events, int timeout) {
 
 	while (true) {
 		zend_hrtime_t start_ns = zend_hrtime();
-		n = php_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
+		n = php_ftp_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
 
 		if (n == -1 && php_socket_errno() == EINTR) {
 			zend_hrtime_t delta_ns = zend_hrtime() - start_ns;

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -120,7 +120,7 @@ PHP_MINIT_FUNCTION(ftp)
 	ftp_object_handlers.clone_obj = NULL;
 
 	register_ftp_symbols(module_number);
-
+	php_ftp_pollfd_for_ms = php_pollfd_for_ms;
 	return SUCCESS;
 }
 

--- a/ext/ftp/php_ftp.h
+++ b/ext/ftp/php_ftp.h
@@ -22,6 +22,7 @@ extern zend_module_entry php_ftp_module_entry;
 #define phpext_ftp_ptr &php_ftp_module_entry
 
 #include "php_version.h"
+#include "php_network.h"
 #define PHP_FTP_VERSION PHP_VERSION
 
 #define PHP_FTP_OPT_TIMEOUT_SEC	0
@@ -31,5 +32,9 @@ extern zend_module_entry php_ftp_module_entry;
 
 PHP_MINIT_FUNCTION(ftp);
 PHP_MINFO_FUNCTION(ftp);
+
+/* expose this interface to enable coroutine support for FTP in other extensions
+ */
+PHPAPI extern int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
 
 #endif


### PR DESCRIPTION
Hello everyone, I would like to add coroutine support for the FTP extension in my own extension. This PR modifies the `my_poll` function in `ftp.c` with the following specific changes:

1. The originally directly called php_pollfd_for_ms has been replaced with a function pointer php_ftp_pollfd_for_ms.
2. During extension initialization, this pointer is by default set to the original php_pollfd_for_ms implementation to preserve the existing synchronous logic.
3. When running in a coroutine environment, this function pointer can be replaced with a coroutine-compatible polling function (e.g., a non-blocking version based on an event loop), enabling FTP socket operations without blocking the main thread.