### PR TITLE
[WIP]Make the FTP extension coroutine-enabled

### DIFF
--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -14,6 +14,7 @@ PHP_ARG_WITH([openssl-dir],
 if test "$PHP_FTP" = "yes"; then
   AC_DEFINE(HAVE_FTP,1,[Whether you want FTP support])
   PHP_NEW_EXTENSION(ftp, php_ftp.c ftp.c, $ext_shared)
+  PHP_INSTALL_HEADERS([ext/ftp], [php_ftp.h])
 
   dnl Empty variable means 'no'
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no

--- a/ext/ftp/config.w32
+++ b/ext/ftp/config.w32
@@ -5,6 +5,7 @@ ARG_ENABLE("ftp", "ftp support", "no");
 if (PHP_FTP != "no") {
 
 	EXTENSION("ftp", "php_ftp.c ftp.c");
+	PHP_INSTALL_HEADERS("ext/ftp/", "php_ftp.h");
 
 	var ret = SETUP_OPENSSL("ftp", PHP_FTP);
 

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -20,6 +20,7 @@
 #endif
 
 #include "php.h"
+#include "php_ftp.h"
 
 #include <stdio.h>
 #include <ctype.h>
@@ -1467,7 +1468,7 @@ static int my_poll(php_socket_t fd, int events, int timeout) {
 
 	while (true) {
 		zend_hrtime_t start_ns = zend_hrtime();
-		n = php_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
+		n = php_ftp_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
 
 		if (n == -1 && php_socket_errno() == EINTR) {
 			zend_hrtime_t delta_ns = zend_hrtime() - start_ns;

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -38,6 +38,7 @@
 
 static zend_class_entry *php_ftp_ce = NULL;
 static zend_object_handlers ftp_object_handlers;
+PHP_FTP_API int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
 
 zend_module_entry php_ftp_module_entry = {
 	STANDARD_MODULE_HEADER_EX,
@@ -120,7 +121,7 @@ PHP_MINIT_FUNCTION(ftp)
 	ftp_object_handlers.clone_obj = NULL;
 
 	register_ftp_symbols(module_number);
-
+	php_ftp_pollfd_for_ms = php_pollfd_for_ms;
 	return SUCCESS;
 }
 

--- a/ext/ftp/php_ftp.h
+++ b/ext/ftp/php_ftp.h
@@ -22,6 +22,7 @@ extern zend_module_entry php_ftp_module_entry;
 #define phpext_ftp_ptr &php_ftp_module_entry
 
 #include "php_version.h"
+#include "php_network.h"
 #define PHP_FTP_VERSION PHP_VERSION
 
 #define PHP_FTP_OPT_TIMEOUT_SEC	0
@@ -31,5 +32,17 @@ extern zend_module_entry php_ftp_module_entry;
 
 PHP_MINIT_FUNCTION(ftp);
 PHP_MINFO_FUNCTION(ftp);
+
+#ifdef PHP_WIN32
+#define PHP_FTP_API __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define PHP_FTP_API __attribute__ ((visibility("default")))
+#else
+#define PHP_FTP_API
+#endif
+
+/* expose this interface to enable coroutine support for FTP in other extensions
+ */
+PHP_FTP_API extern int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
 
 #endif


### PR DESCRIPTION
Hello everyone, I plan to add coroutine support for FTP in Swoole. However, in the current FTP implementation, the use of `poll` is hardcoded, which lacks flexibility and makes it impossible to coroutine-enable FTP in Swoole. Therefore, I have made the following modifications to the `my_poll` function in `ftp.c`:

1. Replaced the direct call to `php_pollfd_for_ms` with a function pointer named `php_ftp_pollfd_for_ms`.  
2. During the extension initialization phase, the pointer is set to point to the original `php_pollfd_for_ms` implementation by default, ensuring the existing synchronous logic remains unaffected.  
3. When running in a coroutine environment, this function pointer can be replaced with a coroutine-compatible polling function (such as a non-blocking version based on an event loop), thereby achieving non-blocking FTP socket operations for the main thread.  

This modification does not affect the original FTP logic and introduces no syntactic changes.  

With this change, I can easily assign a value to `php_ftp_pollfd_for_ms` in my own extension, enabling coroutine support for FTP without any disruptive intrusions into the FTP code.  

swoole pr：https://github.com/swoole/swoole-src/pull/5899
