### PR TITLE
Make the FTP extension coroutine-enabled

### DIFF
--- a/ext/ftp/config.m4
+++ b/ext/ftp/config.m4
@@ -20,7 +20,7 @@ if test "$PHP_FTP" = "yes"; then
   AC_DEFINE([HAVE_FTP], [1],
     [Define to 1 if the PHP extension 'ftp' is available.])
   PHP_NEW_EXTENSION([ftp], [php_ftp.c ftp.c], [$ext_shared])
-
+  PHP_INSTALL_HEADERS([ext/ftp], [php_ftp.h])
   AS_VAR_IF([PHP_FTP_SSL], [no],, [
     PHP_SETUP_OPENSSL([FTP_SHARED_LIBADD])
     PHP_SUBST([FTP_SHARED_LIBADD])

--- a/ext/ftp/config.w32
+++ b/ext/ftp/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("ftp", "ftp support", "no");
 if (PHP_FTP != "no") {
 
 	EXTENSION("ftp", "php_ftp.c ftp.c");
-
+    PHP_INSTALL_HEADERS("ext/ftp/", "php_ftp.h");
 	var ret = SETUP_OPENSSL("ftp", PHP_FTP);
 
 	if (ret >= 2) {

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -20,6 +20,7 @@
 #endif
 
 #include "php.h"
+#include "php_ftp.h"
 
 #include <stdio.h>
 #include <ctype.h>
@@ -1378,7 +1379,7 @@ static int my_poll(php_socket_t fd, int events, int timeout) {
 
 	while (true) {
 		zend_hrtime_t start_ns = zend_hrtime();
-		n = php_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
+		n = php_ftp_pollfd_for_ms(fd, events, (int) (timeout_hr / 1000000));
 
 		if (n == -1 && php_socket_errno() == EINTR) {
 			zend_hrtime_t delta_ns = zend_hrtime() - start_ns;

--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -38,6 +38,7 @@
 
 static zend_class_entry *php_ftp_ce = NULL;
 static zend_object_handlers ftp_object_handlers;
+PHP_FTP_API int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
 
 zend_module_entry php_ftp_module_entry = {
 	STANDARD_MODULE_HEADER_EX,
@@ -109,6 +110,7 @@ PHP_MINIT_FUNCTION(ftp)
 	ftp_object_handlers.clone_obj = NULL;
 
 	register_ftp_symbols(module_number);
+	php_ftp_pollfd_for_ms = php_pollfd_for_ms;
 
 	return SUCCESS;
 }

--- a/ext/ftp/php_ftp.h
+++ b/ext/ftp/php_ftp.h
@@ -22,6 +22,7 @@ extern zend_module_entry php_ftp_module_entry;
 #define phpext_ftp_ptr &php_ftp_module_entry
 
 #include "php_version.h"
+#include "php_network.h"
 #define PHP_FTP_VERSION PHP_VERSION
 
 #define PHP_FTP_OPT_TIMEOUT_SEC	0
@@ -31,5 +32,17 @@ extern zend_module_entry php_ftp_module_entry;
 
 PHP_MINIT_FUNCTION(ftp);
 PHP_MINFO_FUNCTION(ftp);
+
+#ifdef PHP_WIN32
+#define PHP_FTP_API __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define PHP_FTP_API __attribute__ ((visibility("default")))
+#else
+#define PHP_FTP_API
+#endif
+
+/* expose this interface to enable coroutine support for FTP in other extensions
+ */
+PHP_FTP_API extern int(*php_ftp_pollfd_for_ms)(php_socket_t, int, int);
 
 #endif


### PR DESCRIPTION
Hello everyone,

In the issue [swoole/swoole-src#5890](https://github.com/swoole/swoole-src/issues/5890), a developer inquired about the possibility of enabling coroutine support for the FTP extension in a Swoole environment. After a thorough analysis of the PHP FTP extension source code, we identified that the current implementation of the `my_poll` function uses a hardcoded traditional `poll` mechanism to handle socket read/write events.

This synchronous I/O model lacks the flexibility of an underlying event-driven architecture, causing FTP operations to block the entire process and preventing effective collaboration with Swoole's coroutine scheduler. Specifically, when an FTP read/write operation is initiated, `my_poll` enters a blocking wait state, during which coroutine switching cannot occur, thereby breaking the concurrency of Swoole coroutines.

To resolve this issue, we have refactored the `my_poll` function in `ftp.c` with the following key modifications:

1. Replace `php_pollfd_for_ms` with a function pointer named `php_ftp_pollfd_for_ms` to achieve a pluggable architecture for the FTP socket polling mechanism.

2. During the extension initialization phase, this pointer defaults to pointing to the original php_pollfd_for_ms implementation, ensuring that existing synchronous logic remains unaffected.

3. In the Swoole extension, this function pointer can be replaced with a coroutine-supported polling function (such as a non-blocking version based on an event loop), thereby enabling non-blocking FTP socket operations in the main thread.

Through these improvements, the FTP extension can now deeply integrate with Swoole's coroutine runtime, enabling truly non-blocking, coroutine-friendly FTP client operations.

This modification does not affect the original FTP logic and introduces no syntactic changes.  

With this change, I can easily assign a value to `php_ftp_pollfd_for_ms` in my own extension, enabling coroutine support for FTP without any disruptive intrusions into the FTP code.  