### PR TITLE
Fix #20262: SORT_REGULAR transitivity violation with mixed numeric/non-numeric strings

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -305,6 +305,20 @@ static zend_always_inline int php_array_data_compare_unstable_i(Bucket *f, Bucke
 			return -1;
 		}
 	}
+
+	zval *lhs = &f->val;
+	ZVAL_DEREF(lhs);
+	if (Z_TYPE_P(lhs) == IS_STRING && Z_TYPE_P(rhs) == IS_STRING) {
+		bool lhs_is_numeric = is_numeric_string(Z_STRVAL_P(lhs), Z_STRLEN_P(lhs), NULL, NULL, false);
+		bool rhs_is_numeric = is_numeric_string(Z_STRVAL_P(rhs), Z_STRLEN_P(rhs), NULL, NULL, false);
+
+		if (lhs_is_numeric != rhs_is_numeric) {
+			/* One is numeric, one is not. For transitivity, we order:
+			 * non-numeric < numeric (to maintain common expectations). */
+			return lhs_is_numeric ? 1 : -1;
+		}
+	}
+
 	return result;
 }
 /* }}} */

--- a/ext/standard/tests/array/gh20262.phpt
+++ b/ext/standard/tests/array/gh20262.phpt
@@ -1,0 +1,99 @@
+--TEST--
+GH-20262: array_unique() with SORT_REGULAR fails to identify duplicates with mixed numeric/alphanumeric strings
+--FILE--
+<?php
+// Original bug report: array_unique() with SORT_REGULAR doesn't properly
+// identify duplicates when array contains mixed numeric and alphanumeric strings
+$units = ['5', '10', '5', '3A', '5', '5'];
+$unique = array_unique($units, SORT_REGULAR);
+
+echo "Input array:\n";
+var_dump($units);
+
+echo "\nResult of array_unique():\n";
+var_dump($unique);
+
+echo "\nExpected: 3 unique values ('5', '10', '3A')\n";
+echo "Actual count: " . count($unique) . "\n";
+
+// Additional test: verify sort() groups equal values correctly
+$arr = ['5', '10', '5', '3A', '5', '5'];
+sort($arr);
+
+echo "\nSorted array (equal values should be grouped):\n";
+var_dump($arr);
+
+// Verify '5' values are consecutive
+$positions = [];
+foreach ($arr as $idx => $val) {
+    if ($val === '5') {
+        $positions[] = $idx;
+    }
+}
+
+$consecutive = true;
+for ($i = 0; $i < count($positions) - 1; $i++) {
+    if ($positions[$i] + 1 !== $positions[$i + 1]) {
+        $consecutive = false;
+        break;
+    }
+}
+
+echo "\nAll '5' values grouped together: " . ($consecutive ? "yes" : "no") . "\n";
+
+// Verify <=> operator behavior is NOT changed
+echo "\nComparison operator behavior (unchanged):\n";
+echo '"5" <=> "3A" = ' . ('5' <=> '3A') . " (lexicographic)\n";
+echo '"10" <=> "3A" = ' . ('10' <=> '3A') . " (lexicographic)\n";
+?>
+--EXPECT--
+Input array:
+array(6) {
+  [0]=>
+  string(1) "5"
+  [1]=>
+  string(2) "10"
+  [2]=>
+  string(1) "5"
+  [3]=>
+  string(2) "3A"
+  [4]=>
+  string(1) "5"
+  [5]=>
+  string(1) "5"
+}
+
+Result of array_unique():
+array(3) {
+  [0]=>
+  string(1) "5"
+  [1]=>
+  string(2) "10"
+  [3]=>
+  string(2) "3A"
+}
+
+Expected: 3 unique values ('5', '10', '3A')
+Actual count: 3
+
+Sorted array (equal values should be grouped):
+array(6) {
+  [0]=>
+  string(2) "3A"
+  [1]=>
+  string(1) "5"
+  [2]=>
+  string(1) "5"
+  [3]=>
+  string(1) "5"
+  [4]=>
+  string(1) "5"
+  [5]=>
+  string(2) "10"
+}
+
+All '5' values grouped together: yes
+
+Comparison operator behavior (unchanged):
+"5" <=> "3A" = 1 (lexicographic)
+"10" <=> "3A" = -1 (lexicographic)


### PR DESCRIPTION
### Problem
`array_unique()` with `SORT_REGULAR` was missing duplicates, and `sort()` was incorrectly ordering equal values due to a transitivity violation in string comparison.

When comparing numeric strings (like `'5'`, `'10'`) with non-numeric strings (like `'3A'`), the comparison function fell back to lexicographic comparison, which violated transitivity:
- `'5' < '10'` (numeric: 5 < 10)
- `'10' < '3A'` (lexicographic: '1' < '3')  
- `'5' > '3A'` (lexicographic: '5' > '3')  **Violates transitivity**

This caused equal values to not be grouped together in sorted arrays.

### Solution
Fixed `php_array_data_compare_unstable_i()` in `ext/standard/array.c` to consistently order non-numeric strings before numeric strings when one is numeric and one is not, ensuring transitivity for all SORT_REGULAR operations.

**Important:** This fix does _not_ change the behavior of comparison operators like `<=>`, maintaining backward compatibility. The fix only affects sorting and array operations with SORT_REGULAR, similar to how enum comparison is handled specially for sorting. This fix also does _not_ correct the underlying issue as it affects object and nested arrays.

### Test Updates Required
The following tests need their expected output updated to reflect the new transitive sort order:
- `ext/standard/tests/array/sort/array_multisort_basic1.phpt`
- `ext/standard/tests/array/sort/array_multisort_variation5.phpt`
- `ext/standard/tests/array/sort/array_multisort_variation6.phpt`

Tests marked as "(OK to fail as result is unpredictable)" (arsort_variation11, asort_variation11, sort_variation11, rsort_variation11) should maybe still be updated for consistency.