### PR TITLE
mbstring: Avoid pointless refcounted copy

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2788,7 +2788,7 @@ try_again:
 			case IS_FALSE:
 			case IS_LONG:
 			case IS_DOUBLE:
-				ZVAL_COPY(&entry_tmp, entry);
+				ZVAL_COPY_VALUE(&entry_tmp, entry);
 				break;
 			case IS_ARRAY:
 				chash = php_mb_convert_encoding_recursive(


### PR DESCRIPTION
These scalars can use the ZVAL_COPY_VALUE variant instead of ZVAL_COPY because they don't need refcounting.