### PR TITLE
Fix GH-20319: Prevent ASSIGN_OP / ASSIGN_DIM_OP lvalue from being invalidated during assignment

### DIFF
--- a/Zend/tests/gh20319-001.phpt
+++ b/Zend/tests/gh20319-001.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-20319 001: ASSIGN_OP: Ref lvalue may be released by __toString()
+--ENV--
+LEN=10
+--FILE--
+<?php
+
+$b = &$c;
+var_dump($b .= new class {
+    function __toString() {
+        unset($GLOBALS['b'], $GLOBALS['c']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+});
+
+var_dump(isset($b));
+
+$b = &$c;
+$b .= new class {
+    function __toString() {
+        unset($GLOBALS['b'], $GLOBALS['c']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+};
+
+var_dump(isset($b));
+
+?>
+--EXPECT--
+string(10) "dddddddddd"
+bool(false)
+bool(false)

--- a/Zend/tests/gh20319-002.phpt
+++ b/Zend/tests/gh20319-002.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-20319 002: ASSIGN_OP: var-var ref lvalue may be released by __toString()
+--ENV--
+LEN=10
+--FILE--
+<?php
+
+$b = &$c;
+$v = 'b';
+var_dump($$v .= new class {
+    function __toString() {
+        unset($GLOBALS['b'], $GLOBALS['c']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+});
+
+var_dump(isset($b));
+
+$b = &$c;
+$$v .= new class {
+    function __toString() {
+        unset($GLOBALS['b'], $GLOBALS['c']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+};
+
+var_dump(isset($b));
+
+?>
+--EXPECT--
+string(10) "dddddddddd"
+bool(false)
+bool(false)

--- a/Zend/tests/gh20319-003.phpt
+++ b/Zend/tests/gh20319-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-20319 003: ASSIGN_DIM_OP: Array lvalue may be released by __toString()
+--ENV--
+LEN=10
+--FILE--
+<?php
+
+$b = ['test'];
+
+var_dump($b[0] .= new class {
+    function __toString() {
+        unset($GLOBALS['b']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+});
+
+var_dump(isset($b));
+
+unset($b);
+
+$b = ['test'];
+
+$b[0] .= new class {
+    function __toString() {
+        unset($GLOBALS['b']);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+};
+
+var_dump(isset($b));
+
+?>
+--EXPECT--
+string(14) "testdddddddddd"
+bool(false)
+bool(false)

--- a/Zend/tests/gh20319-004.phpt
+++ b/Zend/tests/gh20319-004.phpt
@@ -1,0 +1,41 @@
+--TEST--
+GH-20319 004: ASSIGN_DIM_OP: Array dim lvalue may be released by __toString()
+--FILE--
+<?php
+
+$t = 'test';
+$b = [&$t];
+
+var_dump($b[0] .= new class {
+    function __toString() {
+        global $b;
+        unset($b[0]);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+});
+
+var_dump($b);
+
+unset($b);
+unset($t);
+
+$t = 'test';
+$b = [&$t];
+
+$b[0] .= new class {
+    function __toString() {
+        global $b;
+        unset($b[0]);
+        return str_repeat('d', (int)getenv('LEN'));
+    }
+};
+
+var_dump($b);
+
+?>
+--EXPECT--
+string(4) "test"
+array(0) {
+}
+array(0) {
+}

--- a/Zend/tests/gh20319-005.phpt
+++ b/Zend/tests/gh20319-005.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-20319 005: ASSIGN_OP: var-var slot may be invalidated by __toString()
+--ENV--
+LEN=10
+--FILE--
+<?php
+
+$v = 'b';
+
+$$v = 'test';
+var_dump($$v .= new class {
+    function __toString() {
+        for ($i = 0; $i < 128; $i++) {
+            $GLOBALS['_' . $i] = 0;
+        }
+        return str_repeat('a', (int)getenv('LEN'));
+    }
+});
+
+$$v = 'test';
+$$v .= new class {
+    function __toString() {
+        for ($i = 128; $i < 512; $i++) {
+            $GLOBALS['_' . $i] = 0;
+        }
+        return str_repeat('a', (int)getenv('LEN'));
+    }
+};
+
+var_dump($$v);
+
+?>
+--EXPECT--
+string(14) "testaaaaaaaaaa"
+string(14) "testaaaaaaaaaa"

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1188,6 +1188,9 @@ ZEND_VM_C_LABEL(assign_dim_op_new_array):
 
 		value = get_op_data_zval_ptr_r((opline+1)->op1_type, (opline+1)->op1);
 
+		/* Prevents array from being released or updated during binary_op */
+		GC_ADDREF(ht);
+
 		do {
 			if (OP2_TYPE != IS_UNUSED && UNEXPECTED(Z_ISREF_P(var_ptr))) {
 				zend_reference *ref = Z_REF_P(var_ptr);
@@ -1203,6 +1206,9 @@ ZEND_VM_C_LABEL(assign_dim_op_new_array):
 		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 			ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 		}
+
+		GC_DTOR(ht);
+
 		FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
 	} else {
 		if (EXPECTED(Z_ISREF_P(container))) {
@@ -1264,22 +1270,44 @@ ZEND_VM_HANDLER(26, ZEND_ASSIGN_OP, VAR|CV, CONST|TMPVAR|CV, OP)
 	value = GET_OP2_ZVAL_PTR(BP_VAR_R);
 	var_ptr = GET_OP1_ZVAL_PTR_PTR(BP_VAR_RW);
 
-	do {
-		if (UNEXPECTED(Z_TYPE_P(var_ptr) == IS_REFERENCE)) {
-			zend_reference *ref = Z_REF_P(var_ptr);
-			var_ptr = Z_REFVAL_P(var_ptr);
-			if (UNEXPECTED(ZEND_REF_HAS_TYPE_SOURCES(ref))) {
-				zend_binary_assign_op_typed_ref(ref, value OPLINE_CC EXECUTE_DATA_CC);
-				break;
+	if (UNEXPECTED(Z_TYPE_P(var_ptr) == IS_REFERENCE)) {
+ZEND_VM_C_LABEL(assign_op_ref):;
+		zend_reference *ref = Z_REF_P(var_ptr);
+		GC_ADDREF(ref);
+
+		var_ptr = Z_REFVAL_P(var_ptr);
+		if (UNEXPECTED(ZEND_REF_HAS_TYPE_SOURCES(ref))) {
+			zend_binary_assign_op_typed_ref(ref, value OPLINE_CC EXECUTE_DATA_CC);
+		} else {
+			zend_binary_op(var_ptr, var_ptr, value OPLINE_CC);
+		}
+
+		if (UNEXPECTED(GC_DELREF(ref) == 0)) {
+			if (RETURN_VALUE_USED(opline)) {
+				ZVAL_COPY_VALUE(EX_VAR(opline->result.var), var_ptr);
+			} else {
+				zval_ptr_dtor(var_ptr);
 			}
+			efree_size(ref, sizeof(zend_reference));
+			ZEND_VM_C_GOTO(assign_op_end);
+		}
+	} else {
+		if (OP1_TYPE == IS_VAR) {
+			ZEND_ASSERT(Z_TYPE_P(EX_VAR(opline->op1.num)) == IS_INDIRECT);
+			/* op1 is a var-var, var_ptr is a symbol table slot which may be
+			 * invalidated by the binary operation. Turn it into a ref so we
+			 * control the lifetime of the zval slot. */
+			ZVAL_MAKE_REF(var_ptr);
+			ZEND_VM_C_GOTO(assign_op_ref);
 		}
 		zend_binary_op(var_ptr, var_ptr, value OPLINE_CC);
-	} while (0);
+	}
 
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), var_ptr);
 	}
 
+ZEND_VM_C_LABEL(assign_op_end):
 	FREE_OP2();
 	FREE_OP1();
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();


### PR DESCRIPTION
In ASSIGN_DIM_OP, side effects of coercion may release the array or make the dimension pointer invalid (by reallocating the array). Increasing the array's refcount around the binary op is enough to prevent both issues.

In ASSIGN_OP, if the variable is a reference, side effects may release it. If the variable is a var-var slot, it may be invalidated if the symbol table is resized. In the former case, increase the refcount around the binary op. In the latter, turn the slot into a reference so we can apply the same fix.

Fixes: GH-20319
Related: GH-15938