### PR TITLE
Fix the distinction between missing and empty username/password for RFC3986 URIs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,9 @@ PHP                                                                        NEWS
   . Use the "includes credentials" rule of the WHATWG URL Standard to
     decide whether Uri\WhatWg\Url::getUsername() and ::getPassword()
     getters should return null or an empty string. (timwolla)
+  . Fixed the distinction between empty and missing query/fragment
+    components of Uri\Rfc3986\Uri.
+    (kocsismate)
 
 - Zip:
   . Fixed missing zend_release_fcall_info_cache on the following methods

--- a/ext/uri/tests/rfc3986/parsing/userinfo_success_empty.phpt
+++ b/ext/uri/tests/rfc3986/parsing/userinfo_success_empty.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test Uri\Rfc3986\Uri parsing - userinfo - empty
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://@example.com");
+
+var_dump($uri);
+var_dump($uri->toRawString());
+var_dump($uri->toString());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\Uri)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  string(0) ""
+  ["password"]=>
+  string(0) ""
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(20) "https://@example.com"
+string(20) "https://@example.com"

--- a/ext/uri/tests/rfc3986/parsing/userinfo_success_only_password.phpt
+++ b/ext/uri/tests/rfc3986/parsing/userinfo_success_only_password.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test Uri\Rfc3986\Uri parsing - userinfo - only password
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://:pass@example.com");
+
+var_dump($uri);
+var_dump($uri->toRawString());
+var_dump($uri->toString());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\Uri)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  string(0) ""
+  ["password"]=>
+  string(4) "pass"
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(25) "https://:pass@example.com"
+string(25) "https://:pass@example.com"

--- a/ext/uri/tests/rfc3986/parsing/userinfo_success_only_username.phpt
+++ b/ext/uri/tests/rfc3986/parsing/userinfo_success_only_username.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test Uri\Rfc3986\Uri parsing - userinfo - only username
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://user:@example.com");
+
+var_dump($uri);
+var_dump($uri->toRawString());
+var_dump($uri->toString());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\Uri)#%d (%d) {
+  ["scheme"]=>
+  string(5) "https"
+  ["username"]=>
+  string(4) "user"
+  ["password"]=>
+  string(0) ""
+  ["host"]=>
+  string(11) "example.com"
+  ["port"]=>
+  NULL
+  ["path"]=>
+  string(0) ""
+  ["query"]=>
+  NULL
+  ["fragment"]=>
+  NULL
+}
+string(25) "https://user:@example.com"
+string(25) "https://user:@example.com"

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -202,7 +202,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_username_read(v
 		} else if (c != NULL && c - uriparser_uri->userInfo.first > 0) {
 			ZVAL_STRINGL(retval, uriparser_uri->userInfo.first, c - uriparser_uri->userInfo.first);
 		} else {
-			ZVAL_NULL(retval);
+			ZVAL_EMPTY_STRING(retval);
 		}
 	} else {
 		ZVAL_NULL(retval);
@@ -221,7 +221,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_password_read(v
 		if (c != NULL && uriparser_uri->userInfo.afterLast - c - 1 > 0) {
 			ZVAL_STRINGL(retval, c + 1, uriparser_uri->userInfo.afterLast - c - 1);
 		} else {
-			ZVAL_NULL(retval);
+			ZVAL_EMPTY_STRING(retval);
 		}
 	} else {
 		ZVAL_NULL(retval);


### PR DESCRIPTION
The same way as https://github.com/php/php-src/pull/20303