### PR TITLE
Fix GH-20329: Remove CE cache from non-interned file cache strings

### DIFF
--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -142,13 +142,6 @@ static int zend_file_cache_flock(int fd, int type)
 			} else { \
 				ZEND_ASSERT(IS_UNSERIALIZED(ptr)); \
 				(ptr) = (void*)((char*)(ptr) - (char*)script->mem); \
-				zend_string *__new_str = (zend_string*)((char*)buf + (uintptr_t)(ptr)); \
-				/* script->corrupted shows if the script in SHM or not */ \
-				if (EXPECTED(script->corrupted)) { \
-					GC_ADD_FLAGS(__new_str, IS_STR_INTERNED); \
-					GC_DEL_FLAGS(__new_str, IS_STR_PERMANENT); \
-				} \
-				GC_DEL_FLAGS(__new_str, IS_STR_CLASS_NAME_MAP_PTR); \
 			} \
 		} \
 	} while (0)
@@ -166,6 +159,7 @@ static int zend_file_cache_flock(int fd, int type)
 					GC_ADD_FLAGS(ptr, IS_STR_INTERNED); \
 					GC_DEL_FLAGS(ptr, IS_STR_PERMANENT); \
 				} \
+				GC_DEL_FLAGS(ptr, IS_STR_CLASS_NAME_MAP_PTR); \
 			} \
 		} \
 	} while (0)


### PR DESCRIPTION
Possible fix for GH-20329.

 * In `SERIALIZE_STR()`, ensure that we update the right copy of the string. `ptr` is an interior pointer to `script->mem`, which is SHM or a temporary serialization of the script. `buf` is the copy of `script->mem` that will be written to the file cache.
 * Remove the `IS_STR_CLASS_NAME_MAP_PTR` flag

NB: I'm wondering if the `if (script->corrupted)` branch is useful, as we update flags in the same way in `UNSERIALIZE_STR()`.