### PR TITLE
fix: Allow variadic syntax in PHPDoc parameter annotation in `gen_stub.php`

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3323,7 +3323,7 @@ class DocCommentTag {
         $matches = [];
 
         if ($this->name === "param") {
-            preg_match('/^\s*([\w\|\\\\\[\]<>, ]+)\s*([{(]|(\.\.\.)?\$\w+).*$/', $value, $matches);
+            preg_match('/^\s*([\w\|\\\\\[\]<>, ]+)\s*(?:[{(]|(\.\.\.)?\$\w+).*$/', $value, $matches);
         } elseif ($this->name === "return" || $this->name === "var") {
             preg_match('/^\s*([\w\|\\\\\[\]<>, ]+)/', $value, $matches);
         }


### PR DESCRIPTION
This PR changes the `gen_stub.php` script to allow PHPDoc parameter annotations to have proper variadic syntax.
The according regExes are adjusted to allow additional `...` right in front of the parameter name. See linked issue for more information.

Closes https://github.com/php/php-src/issues/20277