### PR TITLE
Improve performance of intval('+0b...', 2) and intval('0b...', 2)

### DIFF
--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -173,14 +173,17 @@ PHP_FUNCTION(intval)
 			}
 
 			if (strval[offset] == '0' && (strval[offset + 1] == 'b' || strval[offset + 1] == 'B')) {
+				if (strval[0] != '-') {
+					/* Either "+0b", or "0b" */
+					RETURN_LONG(ZEND_STRTOL(strval + 2 + offset, NULL, 2));
+				}
+
 				char *tmpval;
 				strlen -= 2; /* Removing "0b" */
 				tmpval = emalloc(strlen + 1);
 
-				/* Place the unary symbol at pos 0 if there was one */
-				if (offset) {
-					tmpval[0] = strval[0];
-				}
+				/* Place the unary symbol at pos 0 */
+				tmpval[0] = '-';
 
 				/* Copy the data from after "0b" to the end of the buffer */
 				memcpy(tmpval + offset, strval + offset + 2, strlen - offset);


### PR DESCRIPTION
For this benchmark:
```php
<?php

for ($i = 0; $i < 10000000; $i++) {
    intval('+0b11111111111100000000', 2);
}
```

On an i7-4790:
```
Benchmark 1: ./sapi/cli/php x.php
  Time (mean ± σ):     527.3 ms ±   8.1 ms    [User: 523.5 ms, System: 2.4 ms]
  Range (min … max):   515.4 ms … 545.1 ms    10 runs

Benchmark 2: ./sapi/cli/php_old x.php
  Time (mean ± σ):     629.3 ms ±   6.0 ms    [User: 625.9 ms, System: 1.8 ms]
  Range (min … max):   622.8 ms … 643.2 ms    10 runs

Summary
  ./sapi/cli/php x.php ran
    1.19 ± 0.02 times faster than ./sapi/cli/php_old x.php
```

On an i7-1185G7:
```
Benchmark 1: ./sapi/cli/php x.php
  Time (mean ± σ):     429.6 ms ±   7.2 ms    [User: 427.5 ms, System: 1.6 ms]
  Range (min … max):   423.0 ms … 449.0 ms    10 runs
 
Benchmark 2: ./sapi/cli/php_old x.php
  Time (mean ± σ):     486.0 ms ±  10.7 ms    [User: 479.2 ms, System: 2.3 ms]
  Range (min … max):   476.4 ms … 507.3 ms    10 runs
 
Summary
  ./sapi/cli/php x.php ran
    1.13 ± 0.03 times faster than ./sapi/cli/php_old x.php
```