### PR TITLE
Use release_ex consistently in php_strtr_array_ex()

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2972,7 +2972,7 @@ static void php_strtr_array_ex(zval *return_value, zend_string *input, HashTable
 				len = ZSTR_LEN(key_used);
 				if (UNEXPECTED(len > slen)) {
 					/* skip long patterns */
-					zend_string_release(key_used);
+					zend_string_release_ex(key_used, false);
 					continue;
 				}
 				if (len > maxlen) {


### PR DESCRIPTION
Reduces code size from 2056 -> 2006 on x86-64 with GCC 15.2.1.