### PR TITLE
uri: Fixes to uri serialization

### DIFF
--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -800,8 +800,7 @@ PHP_METHOD(Uri_Rfc3986_Uri, __serialize)
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
 
 	/* Serialize regular properties: second array */
-	ZVAL_ARR(&arr, uri_object->std.handlers->get_properties(&uri_object->std));
-	Z_TRY_ADDREF(arr);
+	ZVAL_EMPTY_ARRAY(&arr);
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
 }
 
@@ -840,7 +839,7 @@ static void uri_unserialize(INTERNAL_FUNCTION_PARAMETERS)
 		RETURN_THROWS();
 	}
 
-	zval *uri_zv = zend_hash_str_find_ind(Z_ARRVAL_P(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME));
+	zval *uri_zv = zend_hash_str_find(Z_ARRVAL_P(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME));
 	if (uri_zv == NULL || Z_TYPE_P(uri_zv) != IS_STRING) {
 		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
 		RETURN_THROWS();
@@ -990,8 +989,7 @@ PHP_METHOD(Uri_WhatWg_Url, __serialize)
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
 
 	/* Serialize regular properties: second array */
-	ZVAL_ARR(&arr, this_object->std.handlers->get_properties(&this_object->std));
-	Z_ADDREF(arr);
+	ZVAL_EMPTY_ARRAY(&arr);
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
 }
 


### PR DESCRIPTION
- Incoming data should never have an INDIRECT element, that would be a violation of the rules wrt the INDIRECT types. Therefore there was never a need to use the _ind variant of the hash table find.
- It doesn't matter now because there are no properties; but the get_properties handler cannot be used in the output of a __serialize call as that would expose INDIRECT elements. To prevent issues in the future, make it an empty array as a placeholder. If in the future properties are added, then this will hard fail instead of silently fail with INDIRECTs.