### PR TITLE
socket: properly expose TCP keepalive constants

### DIFF
--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -643,11 +643,15 @@ const TCP_KEEPALIVE = UNKNOWN;
  * @cvalue TCP_KEEPIDLE
  */
 const TCP_KEEPIDLE = UNKNOWN;
+#endif
+#ifdef TCP_KEEPINTVL
 /**
  * @var int
  * @cvalue TCP_KEEPINTVL
  */
 const TCP_KEEPINTVL = UNKNOWN;
+#endif
+#ifdef TCP_KEEPCNT
 /**
  * @var int
  * @cvalue TCP_KEEPCNT

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b1baf47dce2fb08faa5616068238ea078d1609b */
+ * Stub hash: f754368e28f6e45bf3a63a403e49f5659c29d2c6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -544,7 +544,11 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(TCP_KEEPIDLE)
 	REGISTER_LONG_CONSTANT("TCP_KEEPIDLE", TCP_KEEPIDLE, CONST_PERSISTENT);
+#endif
+#if defined(TCP_KEEPINTVL)
 	REGISTER_LONG_CONSTANT("TCP_KEEPINTVL", TCP_KEEPINTVL, CONST_PERSISTENT);
+#endif
+#if defined(TCP_KEEPCNT)
 	REGISTER_LONG_CONSTANT("TCP_KEEPCNT", TCP_KEEPCNT, CONST_PERSISTENT);
 #endif
 #if defined(TCP_FUNCTION_BLK)

--- a/ext/sockets/tests/socket_tcp_keepalive.phpt
+++ b/ext/sockets/tests/socket_tcp_keepalive.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Test SO_KEEPALIVE and TCP keepalive constants
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+if (!defined('TCP_KEEPIDLE') && !defined('TCP_KEEPALIVE')) {
+    die('skip TCP_KEEPIDLE/TCP_KEEPALIVE not available');
+}
+if (!defined('TCP_KEEPINTVL')) {
+    die('skip TCP_KEEPINTVL not available');
+}
+if (!defined('TCP_KEEPCNT')) {
+    die('skip TCP_KEEPCNT not available');
+}
+?>
+--FILE--
+<?php
+$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+if (!$socket) {
+    die("socket failed");
+}
+
+socket_set_option($socket, SOL_SOCKET, SO_KEEPALIVE, 1);
+$keepalive = socket_get_option($socket, SOL_SOCKET, SO_KEEPALIVE);
+echo "SO_KEEPALIVE: " . ($keepalive ? "enabled" : "disabled") . "\n";
+
+if (defined('TCP_KEEPIDLE')) {
+    socket_set_option($socket, SOL_TCP, TCP_KEEPIDLE, 60);
+    $idle = socket_get_option($socket, SOL_TCP, TCP_KEEPIDLE);
+    echo "TCP_KEEPIDLE: $idle\n";
+} else {
+    socket_set_option($socket, SOL_TCP, TCP_KEEPALIVE, 60);
+    $idle = socket_get_option($socket, SOL_TCP, TCP_KEEPALIVE);
+    echo "TCP_KEEPIDLE: $idle\n";
+}
+
+socket_set_option($socket, SOL_TCP, TCP_KEEPINTVL, 10);
+$intvl = socket_get_option($socket, SOL_TCP, TCP_KEEPINTVL);
+echo "TCP_KEEPINTVL: $intvl\n";
+
+socket_set_option($socket, SOL_TCP, TCP_KEEPCNT, 5);
+$cnt = socket_get_option($socket, SOL_TCP, TCP_KEEPCNT);
+echo "TCP_KEEPCNT: $cnt\n";
+
+socket_close($socket);
+?>
+--EXPECT--
+SO_KEEPALIVE: enabled
+TCP_KEEPIDLE: 60
+TCP_KEEPINTVL: 10
+TCP_KEEPCNT: 5


### PR DESCRIPTION
This doesn't seems to be correctly exposed for MacOS where TCP_KEEPALIVE, TCP_KEEPINTVL and TCP_KEEPCNT are available