### PR TITLE
random: Use ZVAL_EMPTY_ARRAY() for members in serialization

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -324,8 +324,7 @@ PHP_METHOD(Random_Engine_Mt19937, __serialize)
 	array_init(return_value);
 
 	/* members */
-	ZVAL_ARR(&t, zend_std_get_properties(&engine->std));
-	Z_TRY_ADDREF(t);
+	ZVAL_EMPTY_ARRAY(&t);
 	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &t);
 
 	/* state */


### PR DESCRIPTION
Follow-up for GH-20369.