### PR TITLE
fix sizeof zend_function allocation/copy

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -175,11 +175,7 @@ ZEND_METHOD(Closure, call)
 		ZVAL_UNDEF(&fake_closure->this_ptr);
 		fake_closure->called_scope = NULL;
 		my_function = &fake_closure->func;
-		if (ZEND_USER_CODE(closure->func.type)) {
-			memcpy(my_function, &closure->func, sizeof(zend_op_array));
-		} else {
-			memcpy(my_function, &closure->func, sizeof(zend_internal_function));
-		}
+		memcpy(my_function, &closure->func, sizeof(zend_function));
 		/* use scope of passed object */
 		my_function->common.scope = newclass;
 		if (closure->func.type == ZEND_INTERNAL_FUNCTION) {
@@ -787,7 +783,7 @@ static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_en
 		}
 		ZEND_MAP_PTR_INIT(closure->func.op_array.run_time_cache, ptr);
 	} else {
-		memcpy(&closure->func, func, sizeof(zend_internal_function));
+		memcpy(&closure->func, func, sizeof(zend_function));
 		closure->func.common.fn_flags |= ZEND_ACC_CLOSURE;
 		/* wrap internal function handler to avoid memory leak */
 		if (UNEXPECTED(closure->func.internal_function.handler == zend_closure_internal_handler)) {

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -97,11 +97,11 @@ static zend_function *zend_duplicate_internal_function(zend_function *func, zend
 	zend_function *new_function;
 
 	if (UNEXPECTED(ce->type & ZEND_INTERNAL_CLASS)) {
-		new_function = pemalloc(sizeof(zend_internal_function), 1);
-		memcpy(new_function, func, sizeof(zend_internal_function));
+		new_function = pemalloc(sizeof(zend_function), 1);
+		memcpy(new_function, func, sizeof(zend_function));
 	} else {
-		new_function = zend_arena_alloc(&CG(arena), sizeof(zend_internal_function));
-		memcpy(new_function, func, sizeof(zend_internal_function));
+		new_function = zend_arena_alloc(&CG(arena), sizeof(zend_function));
+		memcpy(new_function, func, sizeof(zend_function));
 		new_function->common.fn_flags |= ZEND_ACC_ARENA_ALLOCATED;
 	}
 	if (EXPECTED(new_function->common.function_name)) {

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2182,7 +2182,7 @@ static zend_result zend_ffi_cdata_get_closure(zend_object *obj, zend_class_entry
 	if (EXPECTED(EG(trampoline).common.function_name == NULL)) {
 		func = &EG(trampoline);
 	} else {
-		func = ecalloc(1, sizeof(zend_internal_function));
+		func = ecalloc(1, sizeof(zend_function));
 	}
 	func->type = ZEND_INTERNAL_FUNCTION;
 	func->common.arg_flags[0] = 0;
@@ -2958,7 +2958,7 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 	if (EXPECTED(EG(trampoline).common.function_name == NULL)) {
 		func = &EG(trampoline);
 	} else {
-		func = ecalloc(1, sizeof(zend_internal_function));
+		func = ecalloc(1, sizeof(zend_function));
 	}
 	func->common.type = ZEND_INTERNAL_FUNCTION;
 	func->common.arg_flags[0] = 0;


### PR DESCRIPTION
During build I notice some warnings, example

```
/builddir/build/BUILD/php-8.3.28_RC1-build/php-8.3.28RC1/ext/ffi/ffi.c: In function 'zend_ffi_cdata_get_closure':
/builddir/build/BUILD/php-8.3.28_RC1-build/php-8.3.28RC1/ext/ffi/ffi.c:2185:22: warning: allocation of insufficient size '136' for type 'zend_function' {aka 'union _zend_function'} with size '240' [-Walloc-size]
 2185 |                 func = ecalloc(1, sizeof(zend_internal_function));
      |                      ^
/builddir/build/BUILD/php-8.3.28_RC1-build/php-8.3.28RC1/ext/ffi/ffi.c: In function 'zend_ffi_get_func':
/builddir/build/BUILD/php-8.3.28_RC1-build/php-8.3.28RC1/ext/ffi/ffi.c:2961:22: warning: allocation of insufficient size '136' for type 'zend_function' {aka 'union _zend_function'} with size '240' [-Walloc-size]
 2961 |                 func = ecalloc(1, sizeof(zend_internal_function));
      |                      ^

```

Trying to find everywhere where sizeof(zend_internal_function) is used for a zend_function

Expert eyes welcome as I probably miss something