### PR TITLE
pgsql: Fix memory leak when object init fails

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1875,6 +1875,7 @@ static void php_pgsql_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, zend_long result_
 		ZVAL_COPY_VALUE(&dataset, return_value);
 		zend_result obj_initialized = object_init_ex(return_value, ce);
 		if (UNEXPECTED(obj_initialized == FAILURE)) {
+			zval_ptr_dtor(&dataset);
 			RETURN_THROWS();
 		}
 		if (!ce->default_properties_count && !ce->__set) {


### PR DESCRIPTION
The return value is already overwritten by this point so we do have to clean up the old return value (i.e. dataset) after all.