### PR TITLE
Test support for libpcre2 10.47

### DIFF
--- a/ext/pcre/tests/grep2.phpt
+++ b/ext/pcre/tests/grep2.phpt
@@ -21,7 +21,7 @@ var_dump(preg_last_error() == PREG_RECURSION_LIMIT_ERROR);
 
 ?>
 --EXPECTF--
-Warning: preg_grep(): Compilation failed: quantifier does not follow a repeatable item at offset 0 in %sgrep2.php on line %d
+Warning: preg_grep(): Compilation failed: quantifier does not follow a repeatable item at offset %r(0|1)%r in %sgrep2.php on line %d
 bool(false)
 array(3) {
   [5]=>

--- a/ext/pcre/tests/pcre_extra.phpt
+++ b/ext/pcre/tests/pcre_extra.phpt
@@ -8,8 +8,8 @@ var_dump(preg_match('/\y/X', '\y'));
 
 ?>
 --EXPECTF--
-Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 3
+Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset %r(1|2)%r in %spcre_extra.php on line 3
 bool(false)
 
-Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset 1 in %spcre_extra.php on line 4
+Warning: preg_match(): Compilation failed: unrecognized character follows \ at offset %r(1|2)%r in %spcre_extra.php on line 4
 bool(false)

--- a/ext/pcre/tests/split.phpt
+++ b/ext/pcre/tests/split.phpt
@@ -16,7 +16,7 @@ var_dump(preg_split('/\d*/', 'ab2c3u', -1, PREG_SPLIT_NO_EMPTY));
 
 ?>
 --EXPECTF--
-Warning: preg_split(): Compilation failed: quantifier does not follow a repeatable item at offset 0 in %ssplit.php on line %d
+Warning: preg_split(): Compilation failed: quantifier does not follow a repeatable item at offset %r(0|1)%r in %ssplit.php on line %d
 bool(false)
 array(3) {
   [0]=>


### PR DESCRIPTION
In the latest version of libpcre2, the offsets appearing in some "compilation failed" warnings have increased by one due to https://github.com/PCRE2Project/pcre2/pull/756. This is causing spurious test failures, so in this commit we replace the hard-coded offsets by `%d` to match any integer.

An example failure:

```
---- EXPECTED OUTPUT
Warning: preg_grep(): Compilation failed: quantifier does not follow a repeatable item at offset 0 in %sgrep2.php on line %d
...
---- ACTUAL OUTPUT
Warning: preg_grep(): Compilation failed: quantifier does not follow a repeatable item at offset 1 in /var/tmp/portage/dev-lang/php-8.4.13/work/php-8.4.13/ext/pcre/tests/grep2.php on line 3
```

This was originally reported as https://bugs.gentoo.org/965018