### PR TITLE
ext/zlib: Remove unused ZLIB_EXPORTS

### DIFF
--- a/ext/zlib/config.w32
+++ b/ext/zlib/config.w32
@@ -6,7 +6,7 @@ if (PHP_ZLIB == "yes") {
 	if (CHECK_LIB("zlib_a.lib;zlib.lib", "zlib", PHP_ZLIB) &&
 		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)) {
 
-		EXTENSION("zlib", "zlib.c zlib_fopen_wrapper.c zlib_filter.c", PHP_ZLIB_SHARED, "/D ZLIB_EXPORTS /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+		EXTENSION("zlib", "zlib.c zlib_fopen_wrapper.c zlib_filter.c", PHP_ZLIB_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_ZLIB", 1, "Define to 1 if the PHP extension 'zlib' is available.");
 
 		if (!PHP_ZLIB_SHARED) {


### PR DESCRIPTION
This macro was probably once used in zconf.h on Windows in some custom(ized) zlib versions. Current zlib versions don't use this macro anywhere - zlib.net, winlibs...