### PR TITLE
Zend: remove zend_set_hash_symbol() API

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -43,6 +43,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     pointer.
   . The zend_get_call_trampoline_func() API now takes the __call or
     __callStatic zend_function* instead of a CE and a boolean argument.
+  . The zend_set_hash_symbol() API has been removed.
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3611,29 +3611,6 @@ ZEND_API zend_result zend_register_class_alias_ex(const char *name, size_t name_
 }
 /* }}} */
 
-// TODO num_symbol_tables as unsigned int?
-ZEND_API zend_result zend_set_hash_symbol(zval *symbol, const char *name, size_t name_length, bool is_ref, int num_symbol_tables, ...) /* {{{ */
-{
-	HashTable *symbol_table;
-	va_list symbol_table_list;
-
-	if (num_symbol_tables <= 0) return FAILURE;
-
-	if (is_ref) {
-		ZVAL_MAKE_REF(symbol);
-	}
-
-	va_start(symbol_table_list, num_symbol_tables);
-	while (num_symbol_tables-- > 0) {
-		symbol_table = va_arg(symbol_table_list, HashTable *);
-		zend_hash_str_update(symbol_table, name, name_length, symbol);
-		Z_TRY_ADDREF_P(symbol);
-	}
-	va_end(symbol_table_list);
-	return SUCCESS;
-}
-/* }}} */
-
 /* Disabled functions support */
 
 static void zend_disable_function(const char *function_name, size_t function_name_length)

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -884,8 +884,6 @@ ZEND_API zend_result zend_call_method_if_exists(
 		zend_object *object, zend_string *method_name, zval *retval,
 		uint32_t param_count, zval *params);
 
-ZEND_API zend_result zend_set_hash_symbol(zval *symbol, const char *name, size_t name_length, bool is_ref, int num_symbol_tables, ...);
-
 ZEND_API zend_result zend_delete_global_variable(zend_string *name);
 
 ZEND_API zend_array *zend_rebuild_symbol_table(void);


### PR DESCRIPTION
This is unused both within php-src and a SourceGraph search returned 0 results