### PR TITLE
Zend: remove zend_delete_global_variable() API

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -44,6 +44,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The zend_get_call_trampoline_func() API now takes the __call or
     __callStatic zend_function* instead of a CE and a boolean argument.
   . The zend_set_hash_symbol() API has been removed.
+  . The zend_delete_global_variable() API has been removed.
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -884,8 +884,6 @@ ZEND_API zend_result zend_call_method_if_exists(
 		zend_object *object, zend_string *method_name, zval *retval,
 		uint32_t param_count, zval *params);
 
-ZEND_API zend_result zend_delete_global_variable(zend_string *name);
-
 ZEND_API zend_array *zend_rebuild_symbol_table(void);
 ZEND_API void zend_attach_symbol_table(zend_execute_data *execute_data);
 ZEND_API void zend_detach_symbol_table(zend_execute_data *execute_data);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1805,12 +1805,6 @@ zend_class_entry *zend_fetch_class_by_name(zend_string *class_name, zend_string 
 }
 /* }}} */
 
-ZEND_API zend_result zend_delete_global_variable(zend_string *name) /* {{{ */
-{
-	return zend_hash_del_ind(&EG(symbol_table), name);
-}
-/* }}} */
-
 ZEND_API zend_array *zend_rebuild_symbol_table(void) /* {{{ */
 {
 	zend_execute_data *ex;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -255,7 +255,7 @@ static void php_session_track_init(void)
 	zval session_vars;
 	zend_string *var_name = ZSTR_INIT_LITERAL("_SESSION", 0);
 	/* Unconditionally destroy existing array -- possible dirty data */
-	zend_delete_global_variable(var_name);
+	zend_hash_del_ind(&EG(symbol_table), var_name);
 
 	if (!Z_ISUNDEF(PS(http_session_vars))) {
 		zval_ptr_dtor(&PS(http_session_vars));


### PR DESCRIPTION
Only ext/session had one use of this that is easily replaceable, and a SourceGraph search returns 0 results.

Similar to #20413