### PR TITLE
standard: Simplify array_chunk()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -7080,8 +7080,6 @@ PHP_FUNCTION(array_chunk)
 		}
 		zval_add_ref(entry);
 
-		/* If reached the chunk size, add it to the result array, and reset the
-		 * pointer. */
 		if (++current == size) {
 			current = 0;
 		}


### PR DESCRIPTION
Shrinks the code size from 682 to 601 bytes on x86-64 with GCC 15.2.1. Does not make a difference in performance, at least on my i7-4790. I also tried specialising the pack logic like I did with str_split(), but that is a hit or miss in performance improvement depending on the length. It seems that the instruction cache is become too full, and the fact that add_next_index_zval() and zend_hash_next_index_insert() use the same code internally is beneficial.