### PR TITLE
uri: Update to uriparser-0.9.9-59-gc3b4956

### DIFF
--- a/ext/uri/tests/rfc3986/modification/host_success_unset_existing.phpt
+++ b/ext/uri/tests/rfc3986/modification/host_success_unset_existing.phpt
@@ -18,6 +18,6 @@ var_dump($uri2->toString());
 --EXPECT--
 string(11) "example.com"
 NULL
-string(7) "https:/"
+string(6) "https:"
 NULL
-string(7) "https:/"
+string(6) "https:"

--- a/ext/uri/uriparser/include/uriparser/Uri.h
+++ b/ext/uri/uriparser/include/uriparser/Uri.h
@@ -45,47 +45,41 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include "UriDefsConfig.h"
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include "UriDefsConfig.h"
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "Uri.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "Uri.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "Uri.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "Uri.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_H_ANSI 1
-#  include "UriDefsAnsi.h"
-# else
-#  define URI_H_UNICODE 1
-#  include "UriDefsUnicode.h"
-# endif
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI) && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_H_ANSI 1
+#      include "UriDefsAnsi.h"
+#    else
+#      define URI_H_UNICODE 1
+#      include "UriDefsUnicode.h"
+#    endif
 
-
-
-#ifdef __cplusplus
+#    ifdef __cplusplus
 extern "C" {
-#endif
+#    endif
 
-
-
-#ifndef URI_DOXYGEN
-# include "UriBase.h"
-#endif
-
-
+#    ifndef URI_DOXYGEN
+#      include "UriBase.h"
+#    endif
 
 /**
  * Specifies a range of characters within a string.
@@ -99,11 +93,9 @@ extern "C" {
  * @since 0.3.0
  */
 typedef struct URI_TYPE(TextRangeStruct) {
-	const URI_CHAR * first; /**< Pointer to first character */
-	const URI_CHAR * afterLast; /**< Pointer to character after the last one still in */
+    const URI_CHAR * first; /**< Pointer to first character */
+    const URI_CHAR * afterLast; /**< Pointer to character after the last one still in */
 } URI_TYPE(TextRange); /**< @copydoc UriTextRangeStructA */
-
-
 
 /**
  * Represents a path segment within a %URI path.
@@ -114,13 +106,12 @@ typedef struct URI_TYPE(TextRangeStruct) {
  * @since 0.3.0
  */
 typedef struct URI_TYPE(PathSegmentStruct) {
-	URI_TYPE(TextRange) text; /**< Path segment name */
-	struct URI_TYPE(PathSegmentStruct) * next; /**< Pointer to the next path segment in the list, can be NULL if last already */
+    URI_TYPE(TextRange) text; /**< Path segment name */
+    struct URI_TYPE(PathSegmentStruct) * next; /**< Pointer to the next path segment in
+                                                  the list, can be NULL if last already */
 
-	void * reserved; /**< Reserved to the parser */
+    void * reserved; /**< Reserved to the parser */
 } URI_TYPE(PathSegment); /**< @copydoc UriPathSegmentStructA */
-
-
 
 /**
  * Holds structured host information.
@@ -132,16 +123,15 @@ typedef struct URI_TYPE(PathSegmentStruct) {
  * @since 0.3.0
  */
 typedef struct URI_TYPE(HostDataStruct) {
-	UriIp4 * ip4; /**< IPv4 address */
-	UriIp6 * ip6; /**< IPv6 address */
-	URI_TYPE(TextRange) ipFuture; /**< IPvFuture address
-		@note
-		With non-<c>NULL</c> members in UriUriStructA.hostData context,
-		this text range's pointers must be <em>identical</em> to those
-		of UriUriStructA.hostText at all times. */
+    UriIp4 * ip4; /**< IPv4 address */
+    UriIp6 * ip6; /**< IPv6 address */
+    URI_TYPE(TextRange)
+    ipFuture; /**< IPvFuture address
+@note
+With non-<c>NULL</c> members in UriUriStructA.hostData context,
+this text range's pointers must be <em>identical</em> to those
+of UriUriStructA.hostText at all times. */
 } URI_TYPE(HostData); /**< @copydoc UriHostDataStructA */
-
-
 
 /**
  * Represents an RFC 3986 %URI.
@@ -153,23 +143,22 @@ typedef struct URI_TYPE(HostDataStruct) {
  * @since 0.3.0
  */
 typedef struct URI_TYPE(UriStruct) {
-	URI_TYPE(TextRange) scheme; /**< Scheme (e.g. "http") */
-	URI_TYPE(TextRange) userInfo; /**< User info (e.g. "user:pass") */
-	URI_TYPE(TextRange) hostText; /**< Host text (set for all hosts, excluding square brackets) */
-	URI_TYPE(HostData) hostData; /**< Structured host type specific data */
-	URI_TYPE(TextRange) portText; /**< Port (e.g. "80") */
-	URI_TYPE(PathSegment) * pathHead; /**< Head of a linked list of path segments */
-	URI_TYPE(PathSegment) * pathTail; /**< Tail of the list behind pathHead */
-	URI_TYPE(TextRange) query; /**< Query without leading "?" */
-	URI_TYPE(TextRange) fragment; /**< Query without leading "#" */
-	UriBool absolutePath; /**< Absolute path flag, distincting "a" and "/a";
-								always <c>URI_FALSE</c> for URIs with host */
-	UriBool owner; /**< Memory owner flag */
+    URI_TYPE(TextRange) scheme; /**< Scheme (e.g. "http") */
+    URI_TYPE(TextRange) userInfo; /**< User info (e.g. "user:pass") */
+    URI_TYPE(TextRange)
+    hostText; /**< Host text (set for all hosts, excluding square brackets) */
+    URI_TYPE(HostData) hostData; /**< Structured host type specific data */
+    URI_TYPE(TextRange) portText; /**< Port (e.g. "80") */
+    URI_TYPE(PathSegment) * pathHead; /**< Head of a linked list of path segments */
+    URI_TYPE(PathSegment) * pathTail; /**< Tail of the list behind pathHead */
+    URI_TYPE(TextRange) query; /**< Query without leading "?" */
+    URI_TYPE(TextRange) fragment; /**< Query without leading "#" */
+    UriBool absolutePath; /**< Absolute path flag, distincting "a" and "/a"; always
+                             <c>URI_FALSE</c> for URIs with host */
+    UriBool owner; /**< Memory owner flag */
 
-	void * reserved; /**< Reserved to the parser */
+    void * reserved; /**< Reserved to the parser */
 } URI_TYPE(Uri); /**< @copydoc UriUriStructA */
-
-
 
 /**
  * Represents a state of the %URI parser.
@@ -181,14 +170,13 @@ typedef struct URI_TYPE(UriStruct) {
  * @since 0.3.0
  */
 typedef struct URI_TYPE(ParserStateStruct) {
-	URI_TYPE(Uri) * uri; /**< Plug in the %URI structure to be filled while parsing here */
-	int errorCode; /**< Code identifying the error which occurred */
-	const URI_CHAR * errorPos; /**< Pointer to position in case of a syntax error */
+    URI_TYPE(Uri)
+    *uri; /**< Plug in the %URI structure to be filled while parsing here */
+    int errorCode; /**< Code identifying the error which occurred */
+    const URI_CHAR * errorPos; /**< Pointer to position in case of a syntax error */
 
-	void * reserved; /**< Reserved to the parser */
+    void * reserved; /**< Reserved to the parser */
 } URI_TYPE(ParserState); /**< @copydoc UriParserStateStructA */
-
-
 
 /**
  * Represents a query element.
@@ -198,12 +186,12 @@ typedef struct URI_TYPE(ParserStateStruct) {
  * @since 0.7.0
  */
 typedef struct URI_TYPE(QueryListStruct) {
-	const URI_CHAR * key; /**< Key of the query element */
-	const URI_CHAR * value; /**< Value of the query element, can be NULL */
+    const URI_CHAR * key; /**< Key of the query element */
+    const URI_CHAR * value; /**< Value of the query element, can be NULL */
 
-	struct URI_TYPE(QueryListStruct) * next; /**< Pointer to the next key/value pair in the list, can be NULL if last already */
+    struct URI_TYPE(QueryListStruct) * next; /**< Pointer to the next key/value pair in
+                                                the list, can be NULL if last already */
 } URI_TYPE(QueryList); /**< @copydoc UriQueryListStructA */
-
 
 /**
  * Checks if a URI has the host component set.
@@ -214,8 +202,6 @@ typedef struct URI_TYPE(QueryListStruct) {
  * @since 0.9.9
  */
 URI_PUBLIC UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri);
-
-
 
 /**
  * Converts an IPv6 text representation into 16 bytes.
@@ -232,11 +218,8 @@ URI_PUBLIC UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri);
  * @see uriIsWellFormedHostIp6A
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(UriIp6 * output,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(UriIp6 * output, const URI_CHAR * first,
+                                           const URI_CHAR * afterLast);
 
 /**
  * Converts an IPv6 text representation into 16 bytes.
@@ -252,12 +235,9 @@ URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(UriIp6 * output,
  * @see uriIsWellFormedHostIp6MmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
+                                             const URI_CHAR * afterLast,
+                                             UriMemoryManager * memory);
 
 /**
  * Parses a RFC 3986 %URI.
@@ -265,7 +245,8 @@ URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output,
  *
  * @param state       <b>INOUT</b>: Parser state with set output %URI, must not be NULL
  * @param first       <b>IN</b>: Pointer to the first character to parse, must not be NULL
- * @param afterLast   <b>IN</b>: Pointer to the character after the last to parse, must not be NULL
+ * @param afterLast   <b>IN</b>: Pointer to the character after the last to parse, must
+ * not be NULL
  * @return            0 on success, error code otherwise
  *
  * @see uriParseUriA
@@ -273,12 +254,11 @@ URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output,
  * @see uriParseSingleUriExA
  * @see uriToStringA
  * @since 0.3.0
- * @deprecated Deprecated since 0.9.0, please migrate to uriParseSingleUriExA (with "Single").
+ * @deprecated Deprecated since 0.9.0, please migrate to uriParseSingleUriExA (with
+ * "Single").
  */
-URI_PUBLIC int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                                    const URI_CHAR * afterLast);
 
 /**
  * Parses a RFC 3986 %URI.
@@ -293,12 +273,10 @@ URI_PUBLIC int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state,
  * @see uriParseSingleUriExA
  * @see uriToStringA
  * @since 0.3.0
- * @deprecated Deprecated since 0.9.0, please migrate to uriParseSingleUriA (with "Single").
+ * @deprecated Deprecated since 0.9.0, please migrate to uriParseSingleUriA (with
+ * "Single").
  */
-URI_PUBLIC int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * text);
-
-
+URI_PUBLIC int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state, const URI_CHAR * text);
 
 /**
  * Parses a single RFC 3986 %URI.
@@ -317,10 +295,8 @@ URI_PUBLIC int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state,
  * @see uriToStringA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * text, const URI_CHAR ** errorPos);
-
-
+URI_PUBLIC int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri, const URI_CHAR * text,
+                                        const URI_CHAR ** errorPos);
 
 /**
  * Parses a single RFC 3986 %URI.
@@ -342,11 +318,9 @@ URI_PUBLIC int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri,
  * @see uriToStringA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		const URI_CHAR ** errorPos);
-
-
+URI_PUBLIC int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                          const URI_CHAR * afterLast,
+                                          const URI_CHAR ** errorPos);
 
 /**
  * Parses a single RFC 3986 %URI.
@@ -368,11 +342,10 @@ URI_PUBLIC int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri,
  * @see uriToStringA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		const URI_CHAR ** errorPos, UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                            const URI_CHAR * afterLast,
+                                            const URI_CHAR ** errorPos,
+                                            UriMemoryManager * memory);
 
 /**
  * Frees all memory associated with the members
@@ -381,8 +354,8 @@ URI_PUBLIC int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri,
  * Uses default libc-based memory manager.
  *
  * @remarks
- * Calling on an all-zeros structure (e.g. through <c>memset</c> or <c>calloc</c>) is safe.<br/>
- * Calling on an uninitialized structure is <em>not</em> safe.
+ * Calling on an all-zeros structure (e.g. through <c>memset</c> or <c>calloc</c>) is
+ * safe.<br/> Calling on an uninitialized structure is <em>not</em> safe.
  *
  * @param uri   <b>INOUT</b>: %URI structure whose members should be freed
  *
@@ -391,16 +364,14 @@ URI_PUBLIC int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri,
  */
 URI_PUBLIC void URI_FUNC(FreeUriMembers)(URI_TYPE(Uri) * uri);
 
-
-
 /**
  * Frees all memory associated with the members
  * of the %URI structure. Note that the structure
  * itself is not freed, only its members.
  *
  * @remarks
- * Calling on an all-zeros structure (e.g. through <c>memset</c> or <c>calloc</c>) is safe.<br/>
- * Calling on an uninitialized structure is <em>not</em> safe.
+ * Calling on an all-zeros structure (e.g. through <c>memset</c> or <c>calloc</c>) is
+ * safe.<br/> Calling on an uninitialized structure is <em>not</em> safe.
  *
  * @param uri     <b>INOUT</b>: %URI structure whose members should be freed
  * @param memory  <b>IN</b>: Memory manager to use, NULL for default libc
@@ -409,10 +380,7 @@ URI_PUBLIC void URI_FUNC(FreeUriMembers)(URI_TYPE(Uri) * uri);
  * @see uriFreeUriMembersA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(FreeUriMembersMm)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(FreeUriMembersMm)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 
 /**
  * Percent-encodes all but unreserved characters from the input string and
@@ -443,10 +411,8 @@ URI_PUBLIC int URI_FUNC(FreeUriMembersMm)(URI_TYPE(Uri) * uri,
  * @since 0.5.2
  */
 URI_PUBLIC URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst,
-		const URI_CHAR * inAfterLast, URI_CHAR * out,
-		UriBool spaceToPlus, UriBool normalizeBreaks);
-
-
+                                         const URI_CHAR * inAfterLast, URI_CHAR * out,
+                                         UriBool spaceToPlus, UriBool normalizeBreaks);
 
 /**
  * Percent-encodes all but unreserved characters from the input string and
@@ -476,9 +442,7 @@ URI_PUBLIC URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst,
  * @since 0.5.0
  */
 URI_PUBLIC URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
-		UriBool spaceToPlus, UriBool normalizeBreaks);
-
-
+                                       UriBool spaceToPlus, UriBool normalizeBreaks);
 
 /**
  * Unescapes percent-encoded groups in a given string.
@@ -497,10 +461,9 @@ URI_PUBLIC URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
  * @see uriEscapeExA
  * @since 0.5.0
  */
-URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout,
-		UriBool plusToSpace, UriBreakConversion breakConversion);
-
-
+URI_PUBLIC const URI_CHAR *
+    URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
+                                UriBreakConversion breakConversion);
 
 /**
  * Unescapes percent-encoded groups in a given string.
@@ -522,13 +485,11 @@ URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout,
  */
 URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlace)(URI_CHAR * inout);
 
-
-
 /**
  * Performs reference resolution as described in
- * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of RFC 3986</a>.
- * Uses default libc-based memory manager.
- * NOTE: On success you have to call uriFreeUriMembersA on \p absoluteDest manually later.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of
+ * RFC 3986</a>. Uses default libc-based memory manager. NOTE: On success you have to call
+ * uriFreeUriMembersA on \p absoluteDest manually later.
  *
  * @param absoluteDest     <b>OUT</b>: Result %URI
  * @param relativeSource   <b>IN</b>: Reference to resolve
@@ -542,16 +503,14 @@ URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlace)(URI_CHAR * inout);
  * @since 0.4.0
  */
 URI_PUBLIC int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absoluteDest,
-		const URI_TYPE(Uri) * relativeSource,
-		const URI_TYPE(Uri) * absoluteBase);
-
-
+                                    const URI_TYPE(Uri) * relativeSource,
+                                    const URI_TYPE(Uri) * absoluteBase);
 
 /**
  * Performs reference resolution as described in
- * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of RFC 3986</a>.
- * Uses default libc-based memory manager.
- * NOTE: On success you have to call uriFreeUriMembersA on \p absoluteDest manually later.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of
+ * RFC 3986</a>. Uses default libc-based memory manager. NOTE: On success you have to call
+ * uriFreeUriMembersA on \p absoluteDest manually later.
  *
  * @param absoluteDest     <b>OUT</b>: Result %URI
  * @param relativeSource   <b>IN</b>: Reference to resolve
@@ -565,16 +524,15 @@ URI_PUBLIC int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.8.1
  */
 URI_PUBLIC int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absoluteDest,
-		const URI_TYPE(Uri) * relativeSource,
-		const URI_TYPE(Uri) * absoluteBase,
-		UriResolutionOptions options);
-
-
+                                      const URI_TYPE(Uri) * relativeSource,
+                                      const URI_TYPE(Uri) * absoluteBase,
+                                      UriResolutionOptions options);
 
 /**
  * Performs reference resolution as described in
- * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of RFC 3986</a>.
- * NOTE: On success you have to call uriFreeUriMembersMmA on \p absoluteDest manually later.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2">section 5.2.2 of
+ * RFC 3986</a>. NOTE: On success you have to call uriFreeUriMembersMmA on \p absoluteDest
+ * manually later.
  *
  * @param absoluteDest     <b>OUT</b>: Result %URI
  * @param relativeSource   <b>IN</b>: Reference to resolve
@@ -590,11 +548,10 @@ URI_PUBLIC int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absoluteDest,
-		const URI_TYPE(Uri) * relativeSource,
-		const URI_TYPE(Uri) * absoluteBase,
-		UriResolutionOptions options, UriMemoryManager * memory);
-
-
+                                        const URI_TYPE(Uri) * relativeSource,
+                                        const URI_TYPE(Uri) * absoluteBase,
+                                        UriResolutionOptions options,
+                                        UriMemoryManager * memory);
 
 /**
  * Tries to make a relative %URI (a reference) from an
@@ -619,11 +576,9 @@ URI_PUBLIC int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * absoluteSource,
-		const URI_TYPE(Uri) * absoluteBase,
-		UriBool domainRootMode);
-
-
+                                       const URI_TYPE(Uri) * absoluteSource,
+                                       const URI_TYPE(Uri) * absoluteBase,
+                                       UriBool domainRootMode);
 
 /**
  * Tries to make a relative %URI (a reference) from an
@@ -648,11 +603,10 @@ URI_PUBLIC int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * absoluteSource,
-		const URI_TYPE(Uri) * absoluteBase,
-		UriBool domainRootMode, UriMemoryManager * memory);
-
-
+                                         const URI_TYPE(Uri) * absoluteSource,
+                                         const URI_TYPE(Uri) * absoluteBase,
+                                         UriBool domainRootMode,
+                                         UriMemoryManager * memory);
 
 /**
  * Checks two URIs for equivalence. Comparison is done
@@ -665,10 +619,7 @@ URI_PUBLIC int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest,
  *
  * @since 0.4.0
  */
-URI_PUBLIC UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a,
-		const URI_TYPE(Uri) * b);
-
-
+URI_PUBLIC UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a, const URI_TYPE(Uri) * b);
 
 /**
  * Calculates the number of characters needed to store the
@@ -676,38 +627,39 @@ URI_PUBLIC UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a,
  * terminator.
  *
  * @param uri             <b>IN</b>: %URI to measure
- * @param charsRequired   <b>OUT</b>: Length of the string representation in characters <b>excluding</b> terminator
+ * @param charsRequired   <b>OUT</b>: Length of the string representation in characters
+ * <b>excluding</b> terminator
  * @return                Error code or 0 on success
  *
  * @see uriToStringA
  * @since 0.5.0
  */
 URI_PUBLIC int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri,
-		int * charsRequired);
-
-
+                                               int * charsRequired);
 
 /**
  * Converts a %URI structure back to text as described in
- * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.3">section 5.3 of RFC 3986</a>.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5.3">section 5.3 of RFC
+ * 3986</a>.
  *
  * NOTE: Scheme-based normalization
- * (<a href="https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.3">section 6.2.3 of RFC 3986</a>)
- * is not applied and is considered a responsibility of the application using uriparser.
+ * (<a href="https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.3">section 6.2.3 of
+ * RFC 3986</a>) is not applied and is considered a responsibility of the application
+ * using uriparser.
  *
  * @param dest           <b>OUT</b>: Output destination
  * @param uri            <b>IN</b>: %URI to convert
- * @param maxChars       <b>IN</b>: Maximum number of characters to copy <b>including</b> terminator
- * @param charsWritten   <b>OUT</b>: Number of characters written, can be lower than maxChars even if the %URI is too long!
+ * @param maxChars       <b>IN</b>: Maximum number of characters to copy <b>including</b>
+ * terminator
+ * @param charsWritten   <b>OUT</b>: Number of characters written, can be lower than
+ * maxChars even if the %URI is too long!
  * @return               Error code or 0 on success
  *
  * @see uriToStringCharsRequiredA
  * @since 0.4.0
  */
 URI_PUBLIC int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-		int maxChars, int * charsWritten);
-
-
+                                  int maxChars, int * charsWritten);
 
 /**
  * Copies a %URI structure.
@@ -721,9 +673,8 @@ URI_PUBLIC int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
-		const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory);
-
-
+                                   const URI_TYPE(Uri) * sourceUri,
+                                   UriMemoryManager * memory);
 
 /**
  * Copies a %URI structure.
@@ -735,9 +686,8 @@ URI_PUBLIC int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
  * @see uriCopyUriMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri);
-
-
+URI_PUBLIC int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
+                                 const URI_TYPE(Uri) * sourceUri);
 
 /**
  * Determines the components of a %URI that are not normalized.
@@ -750,12 +700,10 @@ URI_PUBLIC int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * 
  * @see uriNormalizeSyntaxExMmA
  * @see uriNormalizeSyntaxMaskRequiredExA
  * @since 0.5.0
- * @deprecated Deprecated since 0.9.0, please migrate to uriNormalizeSyntaxMaskRequiredExA (with "Ex").
+ * @deprecated Deprecated since 0.9.0, please migrate to uriNormalizeSyntaxMaskRequiredExA
+ * (with "Ex").
  */
-URI_PUBLIC unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(
-		const URI_TYPE(Uri) * uri);
-
-
+URI_PUBLIC unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(const URI_TYPE(Uri) * uri);
 
 /**
  * Determines the components of a %URI that are not normalized.
@@ -770,10 +718,8 @@ URI_PUBLIC unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(
  * @see uriNormalizeSyntaxMaskRequiredA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(
-		const URI_TYPE(Uri) * uri, unsigned int * outMask);
-
-
+URI_PUBLIC int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
+                                                       unsigned int * outMask);
 
 /**
  * Normalizes a %URI using a normalization mask.
@@ -792,10 +738,7 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(
  * @see uriNormalizeSyntaxMaskRequiredA
  * @since 0.5.0
  */
-URI_PUBLIC int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri,
-		unsigned int mask);
-
-
+URI_PUBLIC int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri, unsigned int mask);
 
 /**
  * Normalizes a %URI using a normalization mask.
@@ -814,10 +757,8 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri,
  * @see uriNormalizeSyntaxMaskRequiredA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri,
-		unsigned int mask, UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri, unsigned int mask,
+                                             UriMemoryManager * memory);
 
 /**
  * Normalizes all components of a %URI.
@@ -835,8 +776,6 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri,
  * @since 0.5.0
  */
 URI_PUBLIC int URI_FUNC(NormalizeSyntax)(URI_TYPE(Uri) * uri);
-
-
 
 /**
  * Converts a Unix filename to a %URI string.
@@ -857,9 +796,7 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntax)(URI_TYPE(Uri) * uri);
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename,
-		URI_CHAR * uriString);
-
-
+                                                 URI_CHAR * uriString);
 
 /**
  * Converts a Windows filename to a %URI string.
@@ -880,9 +817,7 @@ URI_PUBLIC int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename,
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
-		URI_CHAR * uriString);
-
-
+                                                    URI_CHAR * uriString);
 
 /**
  * Extracts a Unix filename from a %URI string.
@@ -899,9 +834,7 @@ URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString,
-		URI_CHAR * filename);
-
-
+                                                 URI_CHAR * filename);
 
 /**
  * Extracts a Windows filename from a %URI string.
@@ -918,9 +851,7 @@ URI_PUBLIC int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString,
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
-		URI_CHAR * filename);
-
-
+                                                    URI_CHAR * filename);
 
 /**
  * Calculates the number of characters needed to store the
@@ -929,17 +860,16 @@ URI_PUBLIC int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
  * normalized to "%0D%0A".
  *
  * @param queryList         <b>IN</b>: Query list to measure
- * @param charsRequired     <b>OUT</b>: Length of the string representation in characters <b>excluding</b> terminator
+ * @param charsRequired     <b>OUT</b>: Length of the string representation in characters
+ * <b>excluding</b> terminator
  * @return                  Error code or 0 on success
  *
  * @see uriComposeQueryCharsRequiredExA
  * @see uriComposeQueryA
  * @since 0.7.0
  */
-URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(
-		const URI_TYPE(QueryList) * queryList, int * charsRequired);
-
-
+URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * queryList,
+                                                   int * charsRequired);
 
 /**
  * Calculates the number of characters needed to store the
@@ -947,7 +877,8 @@ URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(
  * terminator.
  *
  * @param queryList         <b>IN</b>: Query list to measure
- * @param charsRequired     <b>OUT</b>: Length of the string representation in characters <b>excluding</b> terminator
+ * @param charsRequired     <b>OUT</b>: Length of the string representation in characters
+ * <b>excluding</b> terminator
  * @param spaceToPlus       <b>IN</b>: Whether to convert ' ' to '+' or not
  * @param normalizeBreaks   <b>IN</b>: Whether to convert CR and LF to CR-LF or not.
  * @return                  Error code or 0 on success
@@ -956,11 +887,10 @@ URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(
  * @see uriComposeQueryExA
  * @since 0.7.0
  */
-URI_PUBLIC  int URI_FUNC(ComposeQueryCharsRequiredEx)(
-		const URI_TYPE(QueryList) * queryList,
-		int * charsRequired, UriBool spaceToPlus, UriBool normalizeBreaks);
-
-
+URI_PUBLIC int
+    URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
+                                          int * charsRequired, UriBool spaceToPlus,
+                                          UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -970,8 +900,10 @@ URI_PUBLIC  int URI_FUNC(ComposeQueryCharsRequiredEx)(
  *
  * @param dest              <b>OUT</b>: Output destination
  * @param queryList         <b>IN</b>: Query list to convert
- * @param maxChars          <b>IN</b>: Maximum number of characters to copy <b>including</b> terminator
- * @param charsWritten      <b>OUT</b>: Number of characters written, can be lower than maxChars even if the query list is too long!
+ * @param maxChars          <b>IN</b>: Maximum number of characters to copy
+ * <b>including</b> terminator
+ * @param charsWritten      <b>OUT</b>: Number of characters written, can be lower than
+ * maxChars even if the query list is too long!
  * @return                  Error code or 0 on success
  *
  * @see uriComposeQueryExA
@@ -985,9 +917,8 @@ URI_PUBLIC  int URI_FUNC(ComposeQueryCharsRequiredEx)(
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten);
-
-
+                                      const URI_TYPE(QueryList) * queryList, int maxChars,
+                                      int * charsWritten);
 
 /**
  * Converts a query list structure back to a query string.
@@ -995,8 +926,10 @@ URI_PUBLIC int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
  *
  * @param dest              <b>OUT</b>: Output destination
  * @param queryList         <b>IN</b>: Query list to convert
- * @param maxChars          <b>IN</b>: Maximum number of characters to copy <b>including</b> terminator
- * @param charsWritten      <b>OUT</b>: Number of characters written, can be lower than maxChars even if the query list is too long!
+ * @param maxChars          <b>IN</b>: Maximum number of characters to copy
+ * <b>including</b> terminator
+ * @param charsWritten      <b>OUT</b>: Number of characters written, can be lower than
+ * maxChars even if the query list is too long!
  * @param spaceToPlus       <b>IN</b>: Whether to convert ' ' to '+' or not
  * @param normalizeBreaks   <b>IN</b>: Whether to convert CR and LF to CR-LF or not.
  * @return                  Error code or 0 on success
@@ -1012,10 +945,9 @@ URI_PUBLIC int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten,
-		UriBool spaceToPlus, UriBool normalizeBreaks);
-
-
+                                        const URI_TYPE(QueryList) * queryList,
+                                        int maxChars, int * charsWritten,
+                                        UriBool spaceToPlus, UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -1038,9 +970,7 @@ URI_PUBLIC int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList);
-
-
+                                            const URI_TYPE(QueryList) * queryList);
 
 /**
  * Converts a query list structure back to a query string.
@@ -1063,10 +993,9 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList,
-		UriBool spaceToPlus, UriBool normalizeBreaks);
-
-
+                                              const URI_TYPE(QueryList) * queryList,
+                                              UriBool spaceToPlus,
+                                              UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -1089,11 +1018,10 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList,
-		UriBool spaceToPlus, UriBool normalizeBreaks,
-		UriMemoryManager * memory);
-
-
+                                                const URI_TYPE(QueryList) * queryList,
+                                                UriBool spaceToPlus,
+                                                UriBool normalizeBreaks,
+                                                UriMemoryManager * memory);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1113,10 +1041,9 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
  * @see uriFreeQueryListMmA
  * @since 0.7.0
  */
-URI_PUBLIC int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) ** dest,
-		int * itemCount, const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) * *dest, int * itemCount,
+                                            const URI_CHAR * first,
+                                            const URI_CHAR * afterLast);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1136,11 +1063,11 @@ URI_PUBLIC int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) ** dest,
  * @see uriFreeQueryListA
  * @since 0.7.0
  */
-URI_PUBLIC int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) ** dest,
-		int * itemCount, const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriBool plusToSpace, UriBreakConversion breakConversion);
-
-
+URI_PUBLIC int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) * *dest,
+                                              int * itemCount, const URI_CHAR * first,
+                                              const URI_CHAR * afterLast,
+                                              UriBool plusToSpace,
+                                              UriBreakConversion breakConversion);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1161,12 +1088,12 @@ URI_PUBLIC int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) ** dest,
  * @see uriFreeQueryListMmA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) ** dest,
-		int * itemCount, const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriBool plusToSpace, UriBreakConversion breakConversion,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest,
+                                                int * itemCount, const URI_CHAR * first,
+                                                const URI_CHAR * afterLast,
+                                                UriBool plusToSpace,
+                                                UriBreakConversion breakConversion,
+                                                UriMemoryManager * memory);
 
 /**
  * Frees all memory associated with the given query list.
@@ -1178,8 +1105,6 @@ URI_PUBLIC int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) ** dest,
  * @since 0.7.0
  */
 URI_PUBLIC void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList);
-
-
 
 /**
  * Frees all memory associated with the given query list.
@@ -1193,9 +1118,7 @@ URI_PUBLIC void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList);
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
-		UriMemoryManager * memory);
-
-
+                                         UriMemoryManager * memory);
 
 /**
  * Makes the %URI hold copies of strings so that it no longer depends
@@ -1212,8 +1135,6 @@ URI_PUBLIC int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
  */
 URI_PUBLIC int URI_FUNC(MakeOwner)(URI_TYPE(Uri) * uri);
 
-
-
 /**
  * Makes the %URI hold copies of strings so that it no longer depends
  * on the original %URI string.  If the %URI is already owner of copies,
@@ -1226,10 +1147,7 @@ URI_PUBLIC int URI_FUNC(MakeOwner)(URI_TYPE(Uri) * uri);
  * @see uriMakeOwnerA
  * @since 0.9.4
  */
-URI_PUBLIC int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri,
-                                     UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 
 /**
  * Determines if the given text range contains a well-formed fragment
@@ -1237,7 +1155,8 @@ URI_PUBLIC int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri,
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedHostIp4A
  * @see uriIsWellFormedHostIp6A
@@ -1252,9 +1171,8 @@ URI_PUBLIC int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri,
  * @see uriSetFragmentMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPv4 address
@@ -1262,7 +1180,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first, const 
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp6A
@@ -1277,9 +1196,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first, const 
  * @see uriSetHostIp4MmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPv6 address
@@ -1289,7 +1207,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first, const U
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error code
+ * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error
+ * code
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1307,8 +1226,6 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first, const U
  */
 int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * afterLast);
 
-
-
 /**
  * Determines if the given text range contains a well-formed IPv6 address
  * according to RFC 3986 or not.
@@ -1316,7 +1233,8 @@ int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * after
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
- * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error code
+ * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error
+ * code
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1330,9 +1248,8 @@ int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * after
  * @see uriIsWellFormedUserInfoA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-
-
+int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * afterLast,
+                                    UriMemoryManager * memory);
 
 /**
  * Determines if the given text range contains a well-formed IPvFuture address
@@ -1342,7 +1259,8 @@ int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * aft
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error code
+ * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error
+ * code
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1358,9 +1276,8 @@ int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * aft
  * @see uriSetHostIpFutureMmA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first,
+                                       const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPvFuture address
@@ -1369,7 +1286,8 @@ int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first, const URI_CHAR * 
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
- * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error code
+ * @return           <c>URI_SUCCESS</c> if non-<c>NULL</c> and well-formed, else an error
+ * code
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1385,9 +1303,9 @@ int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first, const URI_CHAR * 
  * @see uriSetHostIpFutureMmA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-
-
+int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
+                                         const URI_CHAR * afterLast,
+                                         UriMemoryManager * memory);
 
 /**
  * Determines if the given text range contains a well-formed registered host name
@@ -1395,7 +1313,8 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first, const URI_CHAR 
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1410,9 +1329,8 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first, const URI_CHAR 
  * @see uriSetHostRegNameMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
+                                                     const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed path
@@ -1420,8 +1338,10 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first, con
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @param hasHost    <b>IN</b>: Whether the target %URI has a non-<c>NULL</c> host set or not
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @param hasHost    <b>IN</b>: Whether the target %URI has a non-<c>NULL</c> host set or
+ * not
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1437,9 +1357,9 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first, con
  * @see uriSetPathMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_CHAR * afterLast, UriBool hasHost);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first,
+                                              const URI_CHAR * afterLast,
+                                              UriBool hasHost);
 
 /**
  * Determines if the given text range contains a well-formed port text
@@ -1447,7 +1367,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1462,9 +1383,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_
  * @see uriSetPortTextMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first,
+                                              const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed query
@@ -1472,7 +1392,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first, const URI_
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1487,8 +1408,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first, const URI_
  * @see uriSetQueryMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first,
+                                               const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed scheme
@@ -1496,7 +1417,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first, const URI
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1512,9 +1434,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first, const URI
  * @see uriSetSchemeMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first,
+                                                const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed user info
@@ -1522,7 +1443,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first, const UR
  *
  * @param first      <b>IN</b>: Pointer to first character
  * @param afterLast  <b>IN</b>: Pointer to character after the last one still in
- * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else <c>URI_FALSE</c>
+ * @return           <c>URI_TRUE</c> if non-<c>NULL</c> and well-formed, else
+ * <c>URI_FALSE</c>
  *
  * @see uriIsWellFormedFragmentA
  * @see uriIsWellFormedHostIp4A
@@ -1537,9 +1459,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first, const UR
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast);
 
 /**
  * Sets the fragment of the given %URI to the given value.
@@ -1557,7 +1478,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first, const 
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedFragmentA
@@ -1573,11 +1495,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first, const 
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast);
 
 /**
  * Sets the fragment of the given %URI to the given value.
@@ -1593,7 +1512,8 @@ URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -1610,12 +1530,9 @@ URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                       const URI_CHAR * afterLast,
+                                       UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1633,7 +1550,8 @@ URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedHostIp4A
@@ -1654,11 +1572,8 @@ URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1674,7 +1589,8 @@ URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -1696,12 +1612,9 @@ URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                       const URI_CHAR * afterLast,
+                                       UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1719,7 +1632,8 @@ URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedHostRegNameA
@@ -1735,11 +1649,8 @@ URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                        const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1755,7 +1666,8 @@ URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -1772,12 +1684,9 @@ URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                          const URI_CHAR * afterLast,
+                                          UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1795,7 +1704,8 @@ URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedHostIp4A
@@ -1811,11 +1721,8 @@ URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                    const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1831,7 +1738,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -1848,12 +1756,9 @@ URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                      const URI_CHAR * afterLast,
+                                      UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1871,7 +1776,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedHostIp6A
@@ -1887,11 +1793,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                    const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1907,7 +1810,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -1924,12 +1828,9 @@ URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                      const URI_CHAR * afterLast,
+                                      UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1947,7 +1848,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedHostIp4A
@@ -1963,11 +1865,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                         const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1983,7 +1882,8 @@ URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2000,12 +1900,9 @@ URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                           const URI_CHAR * afterLast,
+                                           UriMemoryManager * memory);
 
 /**
  * Sets the path of the given %URI to the given value.
@@ -2025,7 +1922,8 @@ URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedPathA
@@ -2042,11 +1940,8 @@ URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                 const URI_CHAR * afterLast);
 
 /**
  * Sets the path of the given %URI to the given value.
@@ -2066,7 +1961,8 @@ URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2084,12 +1980,8 @@ URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                   const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the port text of the given %URI to the given value.
@@ -2109,7 +2001,8 @@ URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedPortA
@@ -2125,11 +2018,8 @@ URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast);
 
 /**
  * Sets the port text of the given %URI to the given value.
@@ -2147,7 +2037,8 @@ URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2164,12 +2055,9 @@ URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                       const URI_CHAR * afterLast,
+                                       UriMemoryManager * memory);
 
 /**
  * Sets the query of the given %URI to the given value.
@@ -2187,7 +2075,8 @@ URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedQueryA
@@ -2203,11 +2092,8 @@ URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                  const URI_CHAR * afterLast);
 
 /**
  * Sets the query of the given %URI to the given value.
@@ -2223,7 +2109,8 @@ URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2240,12 +2127,9 @@ URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                    const URI_CHAR * afterLast,
+                                    UriMemoryManager * memory);
 
 /**
  * Sets the scheme of the given %URI to the given value.
@@ -2263,7 +2147,8 @@ URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedSchemeA
@@ -2279,11 +2164,8 @@ URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                   const URI_CHAR * afterLast);
 
 /**
  * Sets the scheme of the given %URI to the given value.
@@ -2299,7 +2181,8 @@ URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2316,12 +2199,9 @@ URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast,
+                                     UriMemoryManager * memory);
 
 /**
  * Sets the user info of the given %URI to the given value.
@@ -2341,7 +2221,8 @@ URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @return           Error code or 0 on success
  *
  * @see uriIsWellFormedUserInfoA
@@ -2357,11 +2238,8 @@ URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast);
-
-
+URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast);
 
 /**
  * Sets the user info of the given %URI to the given value.
@@ -2379,7 +2257,8 @@ URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri,
  *
  * @param uri        <b>INOUT</b>: %URI to modify
  * @param first      <b>IN</b>: Pointer to first character, can be <c>NULL</c>
- * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be <c>NULL</c>
+ * @param afterLast  <b>IN</b>: Pointer to character after the last one still in, can be
+ * <c>NULL</c>
  * @param memory     <b>IN</b>: Memory manager to use, <c>NULL</c> for default libc
  * @return           Error code or 0 on success
  *
@@ -2396,12 +2275,9 @@ URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+URI_PUBLIC int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                       const URI_CHAR * afterLast,
+                                       UriMemoryManager * memory);
 
 /**
  * Obtain the base runtime version of uriparser.
@@ -2425,13 +2301,9 @@ URI_PUBLIC int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri,
  */
 URI_PUBLIC const URI_CHAR * URI_FUNC(BaseRuntimeVersion)(void);
 
-
-
-#ifdef __cplusplus
+#    ifdef __cplusplus
 }
-#endif
+#    endif
 
-
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/include/uriparser/UriBase.h
+++ b/ext/uri/uriparser/include/uriparser/UriBase.h
@@ -43,152 +43,136 @@
  */
 
 #ifndef URI_BASE_H
-#define URI_BASE_H 1
-
-
+#  define URI_BASE_H 1
 
 /* Version helper macro */
-#define URI_ANSI_TO_UNICODE_HELPER(x)  L ## x
-#define URI_ANSI_TO_UNICODE(x)         URI_ANSI_TO_UNICODE_HELPER(x)
-
-
+#  define URI_ANSI_TO_UNICODE_HELPER(x) L##x
+#  define URI_ANSI_TO_UNICODE(x) URI_ANSI_TO_UNICODE_HELPER(x)
 
 /* Version */
-#define URI_VER_MAJOR           0
-#define URI_VER_MINOR           9
-#define URI_VER_RELEASE         9
-#define URI_VER_SUFFIX_ANSI     ""
-#define URI_VER_SUFFIX_UNICODE  URI_ANSI_TO_UNICODE(URI_VER_SUFFIX_ANSI)
-
-
+#  define URI_VER_MAJOR 0
+#  define URI_VER_MINOR 9
+#  define URI_VER_RELEASE 9
+#  define URI_VER_SUFFIX_ANSI ""
+#  define URI_VER_SUFFIX_UNICODE URI_ANSI_TO_UNICODE(URI_VER_SUFFIX_ANSI)
 
 /* More version helper macros */
-#define URI_INT_TO_ANSI_HELPER(x) #x
-#define URI_INT_TO_ANSI(x) URI_INT_TO_ANSI_HELPER(x)
+#  define URI_INT_TO_ANSI_HELPER(x) #x
+#  define URI_INT_TO_ANSI(x) URI_INT_TO_ANSI_HELPER(x)
 
-#define URI_INT_TO_UNICODE_HELPER(x) URI_ANSI_TO_UNICODE(#x)
-#define URI_INT_TO_UNICODE(x) URI_INT_TO_UNICODE_HELPER(x)
+#  define URI_INT_TO_UNICODE_HELPER(x) URI_ANSI_TO_UNICODE(#x)
+#  define URI_INT_TO_UNICODE(x) URI_INT_TO_UNICODE_HELPER(x)
 
-#define URI_VER_ANSI_HELPER(ma, mi, r, s) \
-	URI_INT_TO_ANSI(ma) "." \
-	URI_INT_TO_ANSI(mi) "." \
-	URI_INT_TO_ANSI(r) \
-	s
+#  define URI_VER_ANSI_HELPER(ma, mi, r, s) \
+      URI_INT_TO_ANSI(ma) "." URI_INT_TO_ANSI(mi) "." URI_INT_TO_ANSI(r) s
 
-#define URI_VER_UNICODE_HELPER(ma, mi, r, s) \
-	URI_INT_TO_UNICODE(ma) L"." \
-	URI_INT_TO_UNICODE(mi) L"." \
-	URI_INT_TO_UNICODE(r) \
-	s
-
-
+#  define URI_VER_UNICODE_HELPER(ma, mi, r, s) \
+      URI_INT_TO_UNICODE(ma) L"." URI_INT_TO_UNICODE(mi) L"." URI_INT_TO_UNICODE(r) s
 
 /* Full version strings */
-#define URI_VER_ANSI     URI_VER_ANSI_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_ANSI)
-#define URI_VER_UNICODE  URI_VER_UNICODE_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_UNICODE)
-
-
+#  define URI_VER_ANSI \
+      URI_VER_ANSI_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, \
+                          URI_VER_SUFFIX_ANSI)
+#  define URI_VER_UNICODE \
+      URI_VER_UNICODE_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, \
+                             URI_VER_SUFFIX_UNICODE)
 
 /* Unused parameter macro */
-#ifdef __GNUC__
-# define URI_UNUSED(x) unused_##x __attribute__((unused))
-#else
-# define URI_UNUSED(x) x
-#endif
-
-
+#  ifdef __GNUC__
+#    define URI_UNUSED(x) unused_##x __attribute__((unused))
+#  else
+#    define URI_UNUSED(x) x
+#  endif
 
 /* Import/export decorator */
-#if defined(_MSC_VER)
-# if defined(URI_STATIC_BUILD)
-#  define URI_PUBLIC
-# elif defined(URI_LIBRARY_BUILD)
-#  define URI_PUBLIC __declspec(dllexport)
-# else
-#  define URI_PUBLIC __declspec(dllimport)
-# endif
-#else
-# if ! defined(URI_LIBRARY_BUILD) || ! defined(URI_VISIBILITY)
-#  define URI_PUBLIC
-# else
-#  define URI_PUBLIC __attribute__ ((visibility("default")))
-# endif
-#endif
-
-
+#  if defined(_MSC_VER)
+#    if defined(URI_STATIC_BUILD)
+#      define URI_PUBLIC
+#    elif defined(URI_LIBRARY_BUILD)
+#      define URI_PUBLIC __declspec(dllexport)
+#    else
+#      define URI_PUBLIC __declspec(dllimport)
+#    endif
+#  else
+#    if !defined(URI_LIBRARY_BUILD) || !defined(URI_VISIBILITY)
+#      define URI_PUBLIC
+#    else
+#      define URI_PUBLIC __attribute__((visibility("default")))
+#    endif
+#  endif
 
 typedef int UriBool; /**< Boolean type */
 
-#define URI_TRUE     1
-#define URI_FALSE    0
-
-
+#  define URI_TRUE 1
+#  define URI_FALSE 0
 
 /* Shared errors */
-#define URI_SUCCESS                        0
-#define URI_ERROR_SYNTAX                   1 /* Parsed text violates expected format */
-#define URI_ERROR_NULL                     2 /* One of the params passed was NULL
-                                                although it mustn't be */
-#define URI_ERROR_MALLOC                   3 /* Requested memory could not be allocated */
-#define URI_ERROR_OUTPUT_TOO_LARGE         4 /* Some output is to large for the receiving buffer */
-#define URI_ERROR_NOT_IMPLEMENTED          8 /* The called function is not implemented yet */
-#define URI_ERROR_RANGE_INVALID            9 /* The parameters passed contained invalid ranges */
-#define URI_ERROR_MEMORY_MANAGER_INCOMPLETE  10 /* [>=0.9.0] The UriMemoryManager passed does not implement all needed functions */
-
+#  define URI_SUCCESS 0
+#  define URI_ERROR_SYNTAX 1 /* Parsed text violates expected format */
+#  define URI_ERROR_NULL \
+      2 /* One of the params passed was NULL although it mustn't be \
+         */
+#  define URI_ERROR_MALLOC 3 /* Requested memory could not be allocated */
+#  define URI_ERROR_OUTPUT_TOO_LARGE \
+      4 /* Some output is to large for the receiving buffer */
+#  define URI_ERROR_NOT_IMPLEMENTED 8 /* The called function is not implemented yet */
+#  define URI_ERROR_RANGE_INVALID 9 /* The parameters passed contained invalid ranges */
+#  define URI_ERROR_MEMORY_MANAGER_INCOMPLETE \
+      10 /* [>=0.9.0] The UriMemoryManager passed does not implement all needed \
+            functions */
 
 /* Errors specific to ToString */
-#define URI_ERROR_TOSTRING_TOO_LONG        URI_ERROR_OUTPUT_TOO_LARGE /* Deprecated, test for URI_ERROR_OUTPUT_TOO_LARGE instead */
+#  define URI_ERROR_TOSTRING_TOO_LONG \
+      URI_ERROR_OUTPUT_TOO_LARGE /* Deprecated, test for URI_ERROR_OUTPUT_TOO_LARGE \
+                                    instead */
 
 /* Errors specific to AddBaseUri */
-#define URI_ERROR_ADDBASE_REL_BASE         5 /* Given base is not absolute */
+#  define URI_ERROR_ADDBASE_REL_BASE 5 /* Given base is not absolute */
 
 /* Errors specific to RemoveBaseUri */
-#define URI_ERROR_REMOVEBASE_REL_BASE      6 /* Given base is not absolute */
-#define URI_ERROR_REMOVEBASE_REL_SOURCE    7 /* Given base is not absolute */
+#  define URI_ERROR_REMOVEBASE_REL_BASE 6 /* Given base is not absolute */
+#  define URI_ERROR_REMOVEBASE_REL_SOURCE 7 /* Given base is not absolute */
 
 /* Error specific to uriTestMemoryManager */
-#define URI_ERROR_MEMORY_MANAGER_FAULTY   11 /* [>=0.9.0] The UriMemoryManager given did not pass the test suite */
+#  define URI_ERROR_MEMORY_MANAGER_FAULTY \
+      11 /* [>=0.9.0] The UriMemoryManager given did not pass the test suite */
 
 /* Error specific to uriSetUserInfo */
-#define URI_ERROR_SETUSERINFO_HOST_NOT_SET 12 /* [>=0.9.9] The %URI given does not have the host set */
+#  define URI_ERROR_SETUSERINFO_HOST_NOT_SET \
+      12 /* [>=0.9.9] The %URI given does not have the host set */
 
 /* Error specific to uriSetPort */
-#define URI_ERROR_SETPORT_HOST_NOT_SET     13 /* [>=0.9.9] The %URI given does not have the host set */
+#  define URI_ERROR_SETPORT_HOST_NOT_SET \
+      13 /* [>=0.9.9] The %URI given does not have the host set */
 
 /* Error specific to uriSetHost* */
-#define URI_ERROR_SETHOST_USERINFO_SET     14 /* [>=0.9.9] The %URI given does have user info set */
-#define URI_ERROR_SETHOST_PORT_SET         15 /* [>=0.9.9] The %URI given does have a port set */
+#  define URI_ERROR_SETHOST_USERINFO_SET \
+      14 /* [>=0.9.9] The %URI given does have user info set */
+#  define URI_ERROR_SETHOST_PORT_SET \
+      15 /* [>=0.9.9] The %URI given does have a port set */
 
-
-
-#ifndef URI_DOXYGEN
-# include <stdio.h> /* For NULL, snprintf */
-# include <ctype.h> /* For wchar_t */
-# include <string.h> /* For strlen, memset, memcpy */
-# include <stdlib.h> /* For malloc */
-#endif /* URI_DOXYGEN */
-
-
+#  ifndef URI_DOXYGEN
+#    include <stdio.h> /* For NULL, snprintf */
+#    include <ctype.h> /* For wchar_t */
+#    include <string.h> /* For strlen, memset, memcpy */
+#    include <stdlib.h> /* For malloc */
+#  endif /* URI_DOXYGEN */
 
 /**
  * Holds an IPv4 address.
  */
 typedef struct UriIp4Struct {
-	unsigned char data[4]; /**< Each octet in one byte */
+    unsigned char data[4]; /**< Each octet in one byte */
 } UriIp4; /**< @copydoc UriIp4Struct */
-
-
 
 /**
  * Holds an IPv6 address.
  */
 typedef struct UriIp6Struct {
-	unsigned char data[16]; /**< Each quad in two bytes */
+    unsigned char data[16]; /**< Each quad in two bytes */
 } UriIp6; /**< @copydoc UriIp6Struct */
 
-
-struct UriMemoryManagerStruct;  /* forward declaration to break loop */
-
+struct UriMemoryManagerStruct; /* forward declaration to break loop */
 
 /**
  * Function signature that custom malloc(3) functions must conform to
@@ -216,7 +200,8 @@ typedef void * (*UriFuncRealloc)(struct UriMemoryManagerStruct *, void *, size_t
  *
  * @since 0.9.0
  */
-typedef void * (*UriFuncReallocarray)(struct UriMemoryManagerStruct *, void *, size_t, size_t);
+typedef void * (*UriFuncReallocarray)(struct UriMemoryManagerStruct *, void *, size_t,
+                                      size_t);
 
 /**
  * Function signature that custom free(3) functions must conform to
@@ -224,7 +209,6 @@ typedef void * (*UriFuncReallocarray)(struct UriMemoryManagerStruct *, void *, s
  * @since 0.9.0
  */
 typedef void (*UriFuncFree)(struct UriMemoryManagerStruct *, void *);
-
 
 /**
  * Class-like interface of custom memory managers
@@ -236,55 +220,57 @@ typedef void (*UriFuncFree)(struct UriMemoryManagerStruct *, void *);
  * @since 0.9.0
  */
 typedef struct UriMemoryManagerStruct {
-	UriFuncMalloc malloc; /**< Pointer to custom malloc(3) */
-	UriFuncCalloc calloc; /**< Pointer to custom calloc(3); to emulate using malloc and memset see uriEmulateCalloc */
-	UriFuncRealloc realloc; /**< Pointer to custom realloc(3) */
-	UriFuncReallocarray reallocarray; /**< Pointer to custom reallocarray(3); to emulate using realloc see uriEmulateReallocarray */
-	UriFuncFree free; /**< Pointer to custom free(3) */
-	void * userData; /**< Pointer to data that the other function members need access to */
+    UriFuncMalloc malloc; /**< Pointer to custom malloc(3) */
+    UriFuncCalloc calloc; /**< Pointer to custom calloc(3); to emulate using malloc and
+                             memset see uriEmulateCalloc */
+    UriFuncRealloc realloc; /**< Pointer to custom realloc(3) */
+    UriFuncReallocarray reallocarray; /**< Pointer to custom reallocarray(3); to emulate
+                                         using realloc see uriEmulateReallocarray */
+    UriFuncFree free; /**< Pointer to custom free(3) */
+    void *
+        userData; /**< Pointer to data that the other function members need access to */
 } UriMemoryManager; /**< @copydoc UriMemoryManagerStruct */
-
 
 /**
  * Specifies a line break conversion mode.
  */
 typedef enum UriBreakConversionEnum {
-	URI_BR_TO_LF, /**< Convert to Unix line breaks ("\\x0a") */
-	URI_BR_TO_CRLF, /**< Convert to Windows line breaks ("\\x0d\\x0a") */
-	URI_BR_TO_CR, /**< Convert to Macintosh line breaks ("\\x0d") */
-	URI_BR_TO_UNIX = URI_BR_TO_LF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_LF */
-	URI_BR_TO_WINDOWS = URI_BR_TO_CRLF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CRLF */
-	URI_BR_TO_MAC = URI_BR_TO_CR, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CR */
-	URI_BR_DONT_TOUCH /**< Copy line breaks unmodified */
+    URI_BR_TO_LF, /**< Convert to Unix line breaks ("\\x0a") */
+    URI_BR_TO_CRLF, /**< Convert to Windows line breaks ("\\x0d\\x0a") */
+    URI_BR_TO_CR, /**< Convert to Macintosh line breaks ("\\x0d") */
+    URI_BR_TO_UNIX = URI_BR_TO_LF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_LF */
+    URI_BR_TO_WINDOWS =
+        URI_BR_TO_CRLF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CRLF */
+    URI_BR_TO_MAC = URI_BR_TO_CR, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CR */
+    URI_BR_DONT_TOUCH /**< Copy line breaks unmodified */
 } UriBreakConversion; /**< @copydoc UriBreakConversionEnum */
-
-
 
 /**
  * Specifies which component of a %URI has to be normalized.
  */
 typedef enum UriNormalizationMaskEnum {
-	URI_NORMALIZED = 0, /**< Do not normalize anything */
-	URI_NORMALIZE_SCHEME = 1 << 0, /**< Normalize scheme (fix uppercase letters) */
-	URI_NORMALIZE_USER_INFO = 1 << 1, /**< Normalize user info (fix uppercase percent-encodings) */
-	URI_NORMALIZE_HOST = 1 << 2, /**< Normalize host (fix uppercase letters) */
-	URI_NORMALIZE_PATH = 1 << 3, /**< Normalize path (fix uppercase percent-encodings and redundant dot segments) */
-	URI_NORMALIZE_QUERY = 1 << 4, /**< Normalize query (fix uppercase percent-encodings) */
-	URI_NORMALIZE_FRAGMENT = 1 << 5, /**< Normalize fragment (fix uppercase percent-encodings) */
-	URI_NORMALIZE_PORT = 1 << 6 /**< Normalize port (drop leading zeros) @since 0.9.9 */
+    URI_NORMALIZED = 0, /**< Do not normalize anything */
+    URI_NORMALIZE_SCHEME = 1 << 0, /**< Normalize scheme (fix uppercase letters) */
+    URI_NORMALIZE_USER_INFO =
+        1 << 1, /**< Normalize user info (fix uppercase percent-encodings) */
+    URI_NORMALIZE_HOST = 1 << 2, /**< Normalize host (fix uppercase letters) */
+    URI_NORMALIZE_PATH = 1 << 3, /**< Normalize path (fix uppercase percent-encodings and
+                                    redundant dot segments) */
+    URI_NORMALIZE_QUERY =
+        1 << 4, /**< Normalize query (fix uppercase percent-encodings) */
+    URI_NORMALIZE_FRAGMENT =
+        1 << 5, /**< Normalize fragment (fix uppercase percent-encodings) */
+    URI_NORMALIZE_PORT = 1 << 6 /**< Normalize port (drop leading zeros) @since 0.9.9 */
 } UriNormalizationMask; /**< @copydoc UriNormalizationMaskEnum */
-
-
 
 /**
  * Specifies how to resolve %URI references.
  */
 typedef enum UriResolutionOptionsEnum {
-	URI_RESOLVE_STRICTLY = 0, /**< Full RFC conformance */
-	URI_RESOLVE_IDENTICAL_SCHEME_COMPAT = 1 << 0 /**< Treat %URI to resolve with identical scheme as having no scheme */
+    URI_RESOLVE_STRICTLY = 0, /**< Full RFC conformance */
+    URI_RESOLVE_IDENTICAL_SCHEME_COMPAT =
+        1 << 0 /**< Treat %URI to resolve with identical scheme as having no scheme */
 } UriResolutionOptions; /**< @copydoc UriResolutionOptionsEnum */
-
-
 
 /**
  * Wraps a memory manager backend that only provides <c>malloc(3)</c> and
@@ -322,9 +308,7 @@ typedef enum UriResolutionOptionsEnum {
  * @since 0.9.0
  */
 URI_PUBLIC int uriCompleteMemoryManager(UriMemoryManager * memory,
-		UriMemoryManager * backend);
-
-
+                                        UriMemoryManager * backend);
 
 /**
  * Offers emulation of calloc(3) based on memory-&gt;malloc and memset.
@@ -340,10 +324,7 @@ URI_PUBLIC int uriCompleteMemoryManager(UriMemoryManager * memory,
  * @see UriMemoryManager
  * @since 0.9.0
  */
-URI_PUBLIC void * uriEmulateCalloc(UriMemoryManager * memory,
-		size_t nmemb, size_t size);
-
-
+URI_PUBLIC void * uriEmulateCalloc(UriMemoryManager * memory, size_t nmemb, size_t size);
 
 /**
  * Offers emulation of reallocarray(3) based on memory-&gt;realloc.
@@ -360,10 +341,8 @@ URI_PUBLIC void * uriEmulateCalloc(UriMemoryManager * memory,
  * @see UriMemoryManager
  * @since 0.9.0
  */
-URI_PUBLIC void * uriEmulateReallocarray(UriMemoryManager * memory,
-		void * ptr, size_t nmemb, size_t size);
-
-
+URI_PUBLIC void * uriEmulateReallocarray(UriMemoryManager * memory, void * ptr,
+                                         size_t nmemb, size_t size);
 
 /**
  * Run multiple tests against a given memory manager.
@@ -392,8 +371,6 @@ URI_PUBLIC void * uriEmulateReallocarray(UriMemoryManager * memory,
  */
 URI_PUBLIC int uriTestMemoryManager(UriMemoryManager * memory);
 
-
-
 /**
  * Run multiple tests against a given memory manager.
  * For example, one test
@@ -419,8 +396,7 @@ URI_PUBLIC int uriTestMemoryManager(UriMemoryManager * memory);
  * @see uriTestMemoryManager
  * @since 0.9.10
  */
-URI_PUBLIC int uriTestMemoryManagerEx(UriMemoryManager * memory, UriBool challengeAlignment);
-
-
+URI_PUBLIC int uriTestMemoryManagerEx(UriMemoryManager * memory,
+                                      UriBool challengeAlignment);
 
 #endif /* URI_BASE_H */

--- a/ext/uri/uriparser/include/uriparser/UriDefsAnsi.h
+++ b/ext/uri/uriparser/include/uriparser/UriDefsAnsi.h
@@ -46,23 +46,17 @@
 /* Allow multi inclusion */
 #include "UriDefsConfig.h"
 
-
-
 #undef URI_CHAR
 #define URI_CHAR char
 
 #undef _UT
 #define _UT(x) x
 
-
-
 #undef URI_FUNC
 #define URI_FUNC(x) uri##x##A
 
 #undef URI_TYPE
 #define URI_TYPE(x) Uri##x##A
-
-
 
 #undef URI_STRLEN
 #define URI_STRLEN strlen
@@ -76,7 +70,7 @@
 /* TODO Remove on next source-compatibility break */
 #undef URI_SNPRINTF
 #if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32))
-# define URI_SNPRINTF _snprintf
+#  define URI_SNPRINTF _snprintf
 #else
-# define URI_SNPRINTF snprintf
+#  define URI_SNPRINTF snprintf
 #endif

--- a/ext/uri/uriparser/include/uriparser/UriDefsConfig.h
+++ b/ext/uri/uriparser/include/uriparser/UriDefsConfig.h
@@ -43,59 +43,51 @@
  */
 
 #ifndef URI_DEFS_CONFIG_H
-#define URI_DEFS_CONFIG_H 1
-
-
+#  define URI_DEFS_CONFIG_H 1
 
 /* Deny external overriding */
-#undef URI_ENABLE_ANSI      /* Internal for !URI_NO_ANSI */
-#undef URI_ENABLE_UNICODE   /* Internal for !URI_NO_UNICODE */
-
-
+#  undef URI_ENABLE_ANSI /* Internal for !URI_NO_ANSI */
+#  undef URI_ENABLE_UNICODE /* Internal for !URI_NO_UNICODE */
 
 /* Encoding */
-#ifdef URI_NO_ANSI
-# ifdef URI_NO_UNICODE
+#  ifdef URI_NO_ANSI
+#    ifdef URI_NO_UNICODE
 /* No encoding at all */
-#  error URI_NO_ANSI and URI_NO_UNICODE cannot go together.
-# else
+#      error URI_NO_ANSI and URI_NO_UNICODE cannot go together.
+#    else
 /* Wide strings only */
-#  define URI_ENABLE_UNICODE  1
-# endif
-#else
-# ifdef URI_NO_UNICODE
+#      define URI_ENABLE_UNICODE 1
+#    endif
+#  else
+#    ifdef URI_NO_UNICODE
 /* Narrow strings only */
-#  define URI_ENABLE_ANSI     1
-# else
+#      define URI_ENABLE_ANSI 1
+#    else
 /* Both narrow and wide strings */
-#  define URI_ENABLE_ANSI     1
-#  define URI_ENABLE_UNICODE  1
-# endif
-#endif
-
-
+#      define URI_ENABLE_ANSI 1
+#      define URI_ENABLE_UNICODE 1
+#    endif
+#  endif
 
 /* Function inlining, not ANSI/ISO C! */
-#if defined(URI_DOXYGEN)
-# define URI_INLINE
-#elif defined(__INTEL_COMPILER)
+#  if defined(URI_DOXYGEN)
+#    define URI_INLINE
+#  elif defined(__INTEL_COMPILER)
 /* Intel C/C++ */
 /* http://predef.sourceforge.net/precomp.html#sec20 */
 /* http://www.intel.com/support/performancetools/c/windows/sb/CS-007751.htm#2 */
-# define URI_INLINE __forceinline
-#elif defined(_MSC_VER)
+#    define URI_INLINE __forceinline
+#  elif defined(_MSC_VER)
 /* Microsoft Visual C++ */
 /* http://predef.sourceforge.net/precomp.html#sec32 */
 /* http://msdn2.microsoft.com/en-us/library/ms882281.aspx */
-# define URI_INLINE __forceinline
-#elif (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
+#    define URI_INLINE __forceinline
+#  elif (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
 /* C99, "inline" is a keyword */
-# define URI_INLINE inline
-#else
+#    define URI_INLINE inline
+#  else
 /* No inlining */
-# define URI_INLINE
-#endif
-
-
+#    define URI_INLINE
+#  endif
 
 #endif /* URI_DEFS_CONFIG_H */

--- a/ext/uri/uriparser/include/uriparser/UriDefsUnicode.h
+++ b/ext/uri/uriparser/include/uriparser/UriDefsUnicode.h
@@ -46,23 +46,17 @@
 /* Allow multi inclusion */
 #include "UriDefsConfig.h"
 
-
-
 #undef URI_CHAR
 #define URI_CHAR wchar_t
 
 #undef _UT
 #define _UT(x) L##x
 
-
-
 #undef URI_FUNC
 #define URI_FUNC(x) uri##x##W
 
 #undef URI_TYPE
 #define URI_TYPE(x) Uri##x##W
-
-
 
 #undef URI_STRLEN
 #define URI_STRLEN wcslen
@@ -76,7 +70,7 @@
 /* TODO Remove on next source-compatibility break */
 #undef URI_SNPRINTF
 #if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32))
-# define URI_SNPRINTF _snwprintf
+#  define URI_SNPRINTF _snwprintf
 #else
-# define URI_SNPRINTF swprintf
+#  define URI_SNPRINTF swprintf
 #endif

--- a/ext/uri/uriparser/include/uriparser/UriIp4.h
+++ b/ext/uri/uriparser/include/uriparser/UriIp4.h
@@ -44,48 +44,43 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include "UriDefsConfig.h"
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include "UriDefsConfig.h"
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriIp4.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriIp4.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "UriIp4.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "UriIp4.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_IP4_TWICE_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_IP4_TWICE_H_ANSI 1
-#  include "UriDefsAnsi.h"
-# else
-#  define URI_IP4_TWICE_H_UNICODE 1
-#  include "UriDefsUnicode.h"
-#  include <wchar.h>
-# endif
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI) \
+         && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_IP4_TWICE_H_ANSI 1
+#      include "UriDefsAnsi.h"
+#    else
+#      define URI_IP4_TWICE_H_UNICODE 1
+#      include "UriDefsUnicode.h"
+#      include <wchar.h>
+#    endif
 
-
-
-#ifdef __cplusplus
+#    ifdef __cplusplus
 extern "C" {
-#endif
+#    endif
 
-
-
-#ifndef URI_DOXYGEN
-# include "UriBase.h"
-#endif
-
-
+#    ifndef URI_DOXYGEN
+#      include "UriBase.h"
+#    endif
 
 /**
  * Converts an IPv4 text representation into four bytes.
@@ -99,15 +94,12 @@ extern "C" {
  * @see uriParseIpSixAddressMmA
  */
 URI_PUBLIC int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
+                                            const URI_CHAR * first,
+                                            const URI_CHAR * afterLast);
 
-
-
-#ifdef __cplusplus
+#    ifdef __cplusplus
 }
-#endif
+#    endif
 
-
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/src/UriCommon.c
+++ b/ext/uri/uriparser/src/UriCommon.c
@@ -41,668 +41,662 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriCommon.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriCommon.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriCommon.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriCommon.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#  endif
 
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-#endif
-
-
-
-#include <assert.h>
-
-
+#  include <assert.h>
 
 /*extern*/ const URI_CHAR * const URI_FUNC(SafeToPointTo) = _UT("X");
 /*extern*/ const URI_CHAR * const URI_FUNC(ConstPwd) = _UT(".");
 /*extern*/ const URI_CHAR * const URI_FUNC(ConstParent) = _UT("..");
 
-
-
 void URI_FUNC(ResetUri)(URI_TYPE(Uri) * uri) {
-	if (uri == NULL) {
-		return;
-	}
-	memset(uri, 0, sizeof(URI_TYPE(Uri)));
+    if (uri == NULL) {
+        return;
+    }
+    memset(uri, 0, sizeof(URI_TYPE(Uri)));
 }
-
-
 
 int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
+    assert(uri != NULL);
+    assert(memory != NULL);
 
-	if (uri->pathHead != NULL) {
-		URI_TYPE(PathSegment) * segWalk = uri->pathHead;
-		while (segWalk != NULL) {
-			URI_TYPE(PathSegment) * const next = segWalk->next;
-			if ((uri->owner == URI_TRUE) && (segWalk->text.first != segWalk->text.afterLast)) {
-				memory->free(memory, (URI_CHAR *)segWalk->text.first);
-			}
-			segWalk->text.first = NULL;
-			segWalk->text.afterLast = NULL;
-			segWalk->next = NULL;
-			memory->free(memory, segWalk);
-			segWalk = next;
-		}
-		uri->pathHead = NULL;
-		uri->pathTail = NULL;
-	}
+    if (uri->pathHead != NULL) {
+        URI_TYPE(PathSegment) * segWalk = uri->pathHead;
+        while (segWalk != NULL) {
+            URI_TYPE(PathSegment) * const next = segWalk->next;
+            if ((uri->owner == URI_TRUE)
+                && (segWalk->text.first != segWalk->text.afterLast)) {
+                memory->free(memory, (URI_CHAR *)segWalk->text.first);
+            }
+            segWalk->text.first = NULL;
+            segWalk->text.afterLast = NULL;
+            segWalk->next = NULL;
+            memory->free(memory, segWalk);
+            segWalk = next;
+        }
+        uri->pathHead = NULL;
+        uri->pathTail = NULL;
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 /* Compares two text ranges for equal text content */
-int URI_FUNC(CompareRange)(
-		const URI_TYPE(TextRange) * a,
-		const URI_TYPE(TextRange) * b) {
-	int diff;
+int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRange) * b) {
+    int diff;
 
-	/* NOTE: Both NULL means equal! */
-	if ((a == NULL) || (b == NULL)) {
-		return ((a == NULL) ? 0 : 1) - ((b == NULL) ? 0 : 1);
-	}
+    /* NOTE: Both NULL means equal! */
+    if ((a == NULL) || (b == NULL)) {
+        return ((a == NULL) ? 0 : 1) - ((b == NULL) ? 0 : 1);
+    }
 
-	/* NOTE: Both NULL means equal! */
-	if ((a->first == NULL) || (b->first == NULL)) {
-		return ((a->first == NULL) ? 0 : 1) - ((b->first == NULL) ? 0 : 1);
-	}
+    /* NOTE: Both NULL means equal! */
+    if ((a->first == NULL) || (b->first == NULL)) {
+        return ((a->first == NULL) ? 0 : 1) - ((b->first == NULL) ? 0 : 1);
+    }
 
-	diff = ((int)(a->afterLast - a->first) - (int)(b->afterLast - b->first));
-	if (diff > 0) {
-		return 1;
-	} else if (diff < 0) {
-		return -1;
-	}
+    diff = ((int)(a->afterLast - a->first) - (int)(b->afterLast - b->first));
+    if (diff > 0) {
+        return 1;
+    } else if (diff < 0) {
+        return -1;
+    }
 
-	diff = URI_STRNCMP(a->first, b->first, (a->afterLast - a->first));
+    diff = URI_STRNCMP(a->first, b->first, (a->afterLast - a->first));
 
-	if (diff > 0) {
-		return 1;
-	} else if (diff < 0) {
-		return -1;
-	}
+    if (diff > 0) {
+        return 1;
+    } else if (diff < 0) {
+        return -1;
+    }
 
-	return diff;
+    return diff;
 }
-
-
 
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
-	const int lenInChars = (int)(sourceRange->afterLast - sourceRange->first);
-	const int lenInBytes = lenInChars * sizeof(URI_CHAR);
-	URI_CHAR * dup = memory->malloc(memory, lenInBytes);
-	if (dup == NULL) {
-		return URI_FALSE;
-	}
-	memcpy(dup, sourceRange->first, lenInBytes);
-	destRange->first = dup;
-	destRange->afterLast = dup + lenInChars;
+                            const URI_TYPE(TextRange) * sourceRange,
+                            UriMemoryManager * memory) {
+    const int lenInChars = (int)(sourceRange->afterLast - sourceRange->first);
+    const int lenInBytes = lenInChars * sizeof(URI_CHAR);
+    URI_CHAR * dup = memory->malloc(memory, lenInBytes);
+    if (dup == NULL) {
+        return URI_FALSE;
+    }
+    memcpy(dup, sourceRange->first, lenInBytes);
+    destRange->first = dup;
+    destRange->afterLast = dup + lenInChars;
 
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
-
 
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
-	if (sourceRange->first == NULL) {
-		destRange->first = NULL;
-		destRange->afterLast = NULL;
-	} else if (sourceRange->first == sourceRange->afterLast) {
-		destRange->first = URI_FUNC(SafeToPointTo);
-		destRange->afterLast = URI_FUNC(SafeToPointTo);
-	} else {
-		return URI_FUNC(CopyRange)(destRange, sourceRange, memory);
-	}
+                                    const URI_TYPE(TextRange) * sourceRange,
+                                    UriMemoryManager * memory) {
+    if (sourceRange->first == NULL) {
+        destRange->first = NULL;
+        destRange->afterLast = NULL;
+    } else if (sourceRange->first == sourceRange->afterLast) {
+        destRange->first = URI_FUNC(SafeToPointTo);
+        destRange->afterLast = URI_FUNC(SafeToPointTo);
+    } else {
+        return URI_FUNC(CopyRange)(destRange, sourceRange, memory);
+    }
 
-	return URI_TRUE;
+    return URI_TRUE;
 }
 
+UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
+                                      UriBool pathOwned, UriMemoryManager * memory) {
+    URI_TYPE(PathSegment) * walker;
+    if ((uri == NULL) || (uri->pathHead == NULL)) {
+        return URI_TRUE;
+    }
 
+    walker = uri->pathHead;
+    walker->reserved = NULL; /* Prev pointer */
+    do {
+        UriBool removeSegment = URI_FALSE;
+        int len = (int)(walker->text.afterLast - walker->text.first);
+        switch (len) {
+        case 1:
+            if ((walker->text.first)[0] == _UT('.')) {
+                /* "." segment -> remove if not essential */
+                URI_TYPE(PathSegment) * const prev = walker->reserved;
+                URI_TYPE(PathSegment) * const nextBackup = walker->next;
 
-UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
-		UriBool relative, UriBool pathOwned, UriMemoryManager * memory) {
-	URI_TYPE(PathSegment) * walker;
-	if ((uri == NULL) || (uri->pathHead == NULL)) {
-		return URI_TRUE;
-	}
+                /*
+                 * Is this dot segment essential,
+                 * i.e. is there a chance of changing semantics by dropping this dot
+                 * segment?
+                 *
+                 * For example, changing "./http://foo" into "http://foo" would change
+                 * semantics and hence the dot segment is essential to that case and
+                 * cannot be removed.
+                 *
+                 * Other examples that would change semantics are:
+                 * - cutting "/.//" down to "//"
+                 * - cutting "scheme:/.//" down to "scheme://".
+                 */
+                removeSegment = URI_TRUE;
+                if ((walker == uri->pathHead) && (walker->next != NULL)) {
+                    /* Detect case "/.//" (with or without scheme) */
+                    if ((walker->next->text.first == walker->next->text.afterLast)
+                        && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
+                        removeSegment = URI_FALSE;
+                        /* Detect case "./withcolon:" */
+                    } else if (relative) {
+                        const URI_CHAR * ch = walker->next->text.first;
+                        for (; ch < walker->next->text.afterLast; ch++) {
+                            if (*ch == _UT(':')) {
+                                removeSegment = URI_FALSE;
+                                break;
+                            }
+                        }
+                    }
+                }
 
-	walker = uri->pathHead;
-	walker->reserved = NULL; /* Prev pointer */
-	do {
-		UriBool removeSegment = URI_FALSE;
-		int len = (int)(walker->text.afterLast - walker->text.first);
-		switch (len) {
-		case 1:
-			if ((walker->text.first)[0] == _UT('.')) {
-				/* "." segment -> remove if not essential */
-				URI_TYPE(PathSegment) * const prev = walker->reserved;
-				URI_TYPE(PathSegment) * const nextBackup = walker->next;
+                if (removeSegment) {
+                    /* .. then let's go remove that segment. */
+                    /* Last segment? */
+                    if (walker->next != NULL) {
+                        /* Not last segment, i.e. first or middle segment
+                         * OLD: (prev|NULL) <- walker <- next
+                         * NEW: (prev|NULL) <----------- next */
+                        walker->next->reserved = prev;
 
-				/*
-				 * Is this dot segment essential,
-				 * i.e. is there a chance of changing semantics by dropping this dot segment?
-				 *
-				 * For example, changing "./http://foo" into "http://foo" would change semantics
-				 * and hence the dot segment is essential to that case and cannot be removed.
-				 *
-				 * Other examples that would change semantics are:
-				 * - cutting "/.//" down to "//"
-				 * - cutting "scheme:/.//" down to "scheme://".
-				 */
-				removeSegment = URI_TRUE;
-				if ((walker == uri->pathHead) && (walker->next != NULL)) {
-					/* Detect case "/.//" (with or without scheme) */
-					if ((walker->next->text.first == walker->next->text.afterLast)
-							&& (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
-						removeSegment = URI_FALSE;
-					/* Detect case "./withcolon:" */
-					} else if (relative) {
-						const URI_CHAR * ch = walker->next->text.first;
-						for (; ch < walker->next->text.afterLast; ch++) {
-							if (*ch == _UT(':')) {
-								removeSegment = URI_FALSE;
-								break;
-							}
-						}
-					}
-				}
+                        if (prev == NULL) {
+                            /* First but not last segment
+                             * OLD: head -> walker -> next
+                             * NEW: head -----------> next */
+                            uri->pathHead = walker->next;
+                        } else {
+                            /* Middle segment
+                             * OLD: prev -> walker -> next
+                             * NEW: prev -----------> next */
+                            prev->next = walker->next;
+                        }
 
-				if (removeSegment) {
-					/* .. then let's go remove that segment. */
-					/* Last segment? */
-					if (walker->next != NULL) {
-						/* Not last segment, i.e. first or middle segment
-						 * OLD: (prev|NULL) <- walker <- next
-						 * NEW: (prev|NULL) <----------- next */
-						walker->next->reserved = prev;
+                        if (pathOwned && (walker->text.first != walker->text.afterLast)) {
+                            memory->free(memory, (URI_CHAR *)walker->text.first);
+                        }
+                        memory->free(memory, walker);
+                    } else {
+                        /* Last segment */
+                        if (pathOwned && (walker->text.first != walker->text.afterLast)) {
+                            memory->free(memory, (URI_CHAR *)walker->text.first);
+                        }
 
-						if (prev == NULL) {
-							/* First but not last segment
-							 * OLD: head -> walker -> next
-							 * NEW: head -----------> next */
-							uri->pathHead = walker->next;
-						} else {
-							/* Middle segment
-							 * OLD: prev -> walker -> next
-							 * NEW: prev -----------> next */
-							prev->next = walker->next;
-						}
+                        if (prev == NULL) {
+                            /* Last and first */
+                            if (URI_FUNC(HasHost)(uri)) {
+                                /* Replace "." with empty segment to represent trailing
+                                 * slash */
+                                walker->text.first = URI_FUNC(SafeToPointTo);
+                                walker->text.afterLast = URI_FUNC(SafeToPointTo);
+                            } else {
+                                memory->free(memory, walker);
 
-						if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-							memory->free(memory, (URI_CHAR *)walker->text.first);
-						}
-						memory->free(memory, walker);
-					} else {
-						/* Last segment */
-						if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-							memory->free(memory, (URI_CHAR *)walker->text.first);
-						}
+                                uri->pathHead = NULL;
+                                uri->pathTail = NULL;
+                            }
+                        } else {
+                            /* Last but not first, replace "." with empty segment to
+                             * represent trailing slash */
+                            walker->text.first = URI_FUNC(SafeToPointTo);
+                            walker->text.afterLast = URI_FUNC(SafeToPointTo);
+                        }
+                    }
 
-						if (prev == NULL) {
-							/* Last and first */
-							if (URI_FUNC(HasHost)(uri)) {
-								/* Replace "." with empty segment to represent trailing slash */
-								walker->text.first = URI_FUNC(SafeToPointTo);
-								walker->text.afterLast = URI_FUNC(SafeToPointTo);
-							} else {
-								memory->free(memory, walker);
+                    walker = nextBackup;
+                }
+            }
+            break;
 
-								uri->pathHead = NULL;
-								uri->pathTail = NULL;
-							}
-						} else {
-							/* Last but not first, replace "." with empty segment to represent trailing slash */
-							walker->text.first = URI_FUNC(SafeToPointTo);
-							walker->text.afterLast = URI_FUNC(SafeToPointTo);
-						}
-					}
+        case 2:
+            if (((walker->text.first)[0] == _UT('.'))
+                && ((walker->text.first)[1] == _UT('.'))) {
+                /* Path ".." -> remove this and the previous segment */
+                URI_TYPE(PathSegment) * const prev = walker->reserved;
+                URI_TYPE(PathSegment) * prevPrev;
+                URI_TYPE(PathSegment) * const nextBackup = walker->next;
 
-					walker = nextBackup;
-				}
-			}
-			break;
+                removeSegment = URI_TRUE;
+                if (relative) {
+                    if (prev == NULL) {
+                        /* We cannot remove traversal beyond because the
+                         * URI is relative and may be resolved later.
+                         * So we can simplify "a/../b/d" to "b/d" but
+                         * we cannot simplify "../b/d" (outside of reference resolution).
+                         */
+                        removeSegment = URI_FALSE;
+                    } else if ((prev != NULL)
+                               && ((prev->text.afterLast - prev->text.first) == 2)
+                               && ((prev->text.first)[0] == _UT('.'))
+                               && ((prev->text.first)[1] == _UT('.'))) {
+                        /* We need to protect against mis-simplifying "a/../../b" to
+                         * "a/b". */
+                        removeSegment = URI_FALSE;
+                    }
+                }
 
-		case 2:
-			if (((walker->text.first)[0] == _UT('.'))
-					&& ((walker->text.first)[1] == _UT('.'))) {
-				/* Path ".." -> remove this and the previous segment */
-				URI_TYPE(PathSegment) * const prev = walker->reserved;
-				URI_TYPE(PathSegment) * prevPrev;
-				URI_TYPE(PathSegment) * const nextBackup = walker->next;
+                if (removeSegment) {
+                    if (prev != NULL) {
+                        /* Not first segment */
+                        prevPrev = prev->reserved;
+                        if (prevPrev != NULL) {
+                            /* Not even prev is the first one
+                             * OLD: prevPrev -> prev -> walker -> (next|NULL)
+                             * NEW: prevPrev -------------------> (next|NULL) */
+                            prevPrev->next = walker->next;
+                            if (walker->next != NULL) {
+                                /* Update parent relationship as well
+                                 * OLD: prevPrev <- prev <- walker <- next
+                                 * NEW: prevPrev <------------------- next */
+                                walker->next->reserved = prevPrev;
+                            } else {
+                                /* Last segment -> insert "" segment to represent trailing
+                                 * slash, update tail */
+                                URI_TYPE(PathSegment) * const segment = memory->calloc(
+                                    memory, 1, sizeof(URI_TYPE(PathSegment)));
+                                if (segment == NULL) {
+                                    if (pathOwned
+                                        && (walker->text.first
+                                            != walker->text.afterLast)) {
+                                        memory->free(memory,
+                                                     (URI_CHAR *)walker->text.first);
+                                    }
+                                    memory->free(memory, walker);
 
-				removeSegment = URI_TRUE;
-				if (relative) {
-					if (prev == NULL) {
-						/* We cannot remove traversal beyond because the
-						 * URI is relative and may be resolved later.
-						 * So we can simplify "a/../b/d" to "b/d" but
-						 * we cannot simplify "../b/d" (outside of reference resolution). */
-						removeSegment = URI_FALSE;
-					} else if ((prev != NULL)
-							&& ((prev->text.afterLast - prev->text.first) == 2)
-							&& ((prev->text.first)[0] == _UT('.'))
-							&& ((prev->text.first)[1] == _UT('.'))) {
-						/* We need to protect against mis-simplifying "a/../../b" to "a/b". */
-						removeSegment = URI_FALSE;
-					}
-				}
+                                    if (pathOwned
+                                        && (prev->text.first != prev->text.afterLast)) {
+                                        memory->free(memory,
+                                                     (URI_CHAR *)prev->text.first);
+                                    }
+                                    memory->free(memory, prev);
 
-				if (removeSegment) {
-					if (prev != NULL) {
-						/* Not first segment */
-						prevPrev = prev->reserved;
-						if (prevPrev != NULL) {
-							/* Not even prev is the first one
-							 * OLD: prevPrev -> prev -> walker -> (next|NULL)
-							 * NEW: prevPrev -------------------> (next|NULL) */
-							prevPrev->next = walker->next;
-							if (walker->next != NULL) {
-								/* Update parent relationship as well
-								 * OLD: prevPrev <- prev <- walker <- next
-								 * NEW: prevPrev <------------------- next */
-								walker->next->reserved = prevPrev;
-							} else {
-								/* Last segment -> insert "" segment to represent trailing slash, update tail */
-								URI_TYPE(PathSegment) * const segment = memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
-								if (segment == NULL) {
-									if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-										memory->free(memory, (URI_CHAR *)walker->text.first);
-									}
-									memory->free(memory, walker);
+                                    return URI_FALSE; /* Raises malloc error */
+                                }
+                                segment->text.first = URI_FUNC(SafeToPointTo);
+                                segment->text.afterLast = URI_FUNC(SafeToPointTo);
+                                prevPrev->next = segment;
+                                uri->pathTail = segment;
+                            }
 
-									if (pathOwned && (prev->text.first != prev->text.afterLast)) {
-										memory->free(memory, (URI_CHAR *)prev->text.first);
-									}
-									memory->free(memory, prev);
+                            if (pathOwned
+                                && (walker->text.first != walker->text.afterLast)) {
+                                memory->free(memory, (URI_CHAR *)walker->text.first);
+                            }
+                            memory->free(memory, walker);
 
-									return URI_FALSE; /* Raises malloc error */
-								}
-								segment->text.first = URI_FUNC(SafeToPointTo);
-								segment->text.afterLast = URI_FUNC(SafeToPointTo);
-								prevPrev->next = segment;
-								uri->pathTail = segment;
-							}
+                            if (pathOwned && (prev->text.first != prev->text.afterLast)) {
+                                memory->free(memory, (URI_CHAR *)prev->text.first);
+                            }
+                            memory->free(memory, prev);
 
-							if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-								memory->free(memory, (URI_CHAR *)walker->text.first);
-							}
-							memory->free(memory, walker);
+                            walker = nextBackup;
+                        } else {
+                            /* Prev is the first segment */
+                            if (walker->next != NULL) {
+                                uri->pathHead = walker->next;
+                                walker->next->reserved = NULL;
 
-							if (pathOwned && (prev->text.first != prev->text.afterLast)) {
-								memory->free(memory, (URI_CHAR *)prev->text.first);
-							}
-							memory->free(memory, prev);
+                                if (pathOwned
+                                    && (walker->text.first != walker->text.afterLast)) {
+                                    memory->free(memory, (URI_CHAR *)walker->text.first);
+                                }
+                                memory->free(memory, walker);
+                            } else {
+                                /* Reuse segment for "" path segment to represent trailing
+                                 * slash, update tail */
+                                URI_TYPE(PathSegment) * const segment = walker;
+                                if (pathOwned
+                                    && (segment->text.first != segment->text.afterLast)) {
+                                    memory->free(memory, (URI_CHAR *)segment->text.first);
+                                }
+                                segment->text.first = URI_FUNC(SafeToPointTo);
+                                segment->text.afterLast = URI_FUNC(SafeToPointTo);
+                                uri->pathHead = segment;
+                                uri->pathTail = segment;
+                            }
 
-							walker = nextBackup;
-						} else {
-							/* Prev is the first segment */
-							if (walker->next != NULL) {
-								uri->pathHead = walker->next;
-								walker->next->reserved = NULL;
+                            if (pathOwned && (prev->text.first != prev->text.afterLast)) {
+                                memory->free(memory, (URI_CHAR *)prev->text.first);
+                            }
+                            memory->free(memory, prev);
 
-								if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-									memory->free(memory, (URI_CHAR *)walker->text.first);
-								}
-								memory->free(memory, walker);
-							} else {
-								/* Reuse segment for "" path segment to represent trailing slash, update tail */
-								URI_TYPE(PathSegment) * const segment = walker;
-								if (pathOwned && (segment->text.first != segment->text.afterLast)) {
-									memory->free(memory, (URI_CHAR *)segment->text.first);
-								}
-								segment->text.first = URI_FUNC(SafeToPointTo);
-								segment->text.afterLast = URI_FUNC(SafeToPointTo);
-								uri->pathHead = segment;
-								uri->pathTail = segment;
-							}
+                            walker = nextBackup;
+                        }
+                    } else {
+                        URI_TYPE(PathSegment) * const anotherNextBackup = walker->next;
+                        int freeWalker = URI_TRUE;
 
-							if (pathOwned && (prev->text.first != prev->text.afterLast)) {
-								memory->free(memory, (URI_CHAR *)prev->text.first);
-							}
-							memory->free(memory, prev);
+                        /* First segment */
+                        if (walker->next != NULL) {
+                            /* First segment of multiple -> update head
+                             * OLD: head -> walker -> next
+                             * NEW: head -----------> next */
+                            uri->pathHead = walker->next;
 
-							walker = nextBackup;
-						}
-					} else {
-						URI_TYPE(PathSegment) * const anotherNextBackup = walker->next;
-						int freeWalker = URI_TRUE;
+                            /* Update parent link as well
+                             * OLD: head <- walker <- next
+                             * NEW: head <----------- next */
+                            walker->next->reserved = NULL;
+                        } else {
+                            if (uri->absolutePath) {
+                                /* First and only segment -> update head
+                                 * OLD: head -> walker -> NULL
+                                 * NEW: head -----------> NULL */
+                                uri->pathHead = NULL;
 
-						/* First segment */
-						if (walker->next != NULL) {
-							/* First segment of multiple -> update head
-							 * OLD: head -> walker -> next
-							 * NEW: head -----------> next */
-							uri->pathHead = walker->next;
+                                /* Last segment -> update tail
+                                 * OLD: tail -> walker
+                                 * NEW: tail -> NULL */
+                                uri->pathTail = NULL;
+                            } else {
+                                /* Reuse segment for "" path segment to represent trailing
+                                 * slash, then update head and tail */
+                                if (pathOwned
+                                    && (walker->text.first != walker->text.afterLast)) {
+                                    memory->free(memory, (URI_CHAR *)walker->text.first);
+                                }
+                                walker->text.first = URI_FUNC(SafeToPointTo);
+                                walker->text.afterLast = URI_FUNC(SafeToPointTo);
+                                freeWalker = URI_FALSE;
+                            }
+                        }
 
-							/* Update parent link as well
-							 * OLD: head <- walker <- next
-							 * NEW: head <----------- next */
-							walker->next->reserved = NULL;
-						} else {
-							if (uri->absolutePath) {
-								/* First and only segment -> update head
-								 * OLD: head -> walker -> NULL
-								 * NEW: head -----------> NULL */
-								uri->pathHead = NULL;
+                        if (freeWalker) {
+                            if (pathOwned
+                                && (walker->text.first != walker->text.afterLast)) {
+                                memory->free(memory, (URI_CHAR *)walker->text.first);
+                            }
+                            memory->free(memory, walker);
+                        }
 
-								/* Last segment -> update tail
-								 * OLD: tail -> walker
-								 * NEW: tail -> NULL */
-								uri->pathTail = NULL;
-							} else {
-								/* Reuse segment for "" path segment to represent trailing slash,
-								 * then update head and tail */
-								if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-									memory->free(memory, (URI_CHAR *)walker->text.first);
-								}
-								walker->text.first = URI_FUNC(SafeToPointTo);
-								walker->text.afterLast = URI_FUNC(SafeToPointTo);
-								freeWalker = URI_FALSE;
-							}
-						}
+                        walker = anotherNextBackup;
+                    }
+                }
+            }
+            break;
+        } /* end of switch */
 
-						if (freeWalker) {
-							if (pathOwned && (walker->text.first != walker->text.afterLast)) {
-								memory->free(memory, (URI_CHAR *)walker->text.first);
-							}
-							memory->free(memory, walker);
-						}
+        if (!removeSegment) {
+            /* .. then let's move to the next element, and start again. */
+            if (walker->next != NULL) {
+                walker->next->reserved = walker;
+            } else {
+                /* Last segment -> update tail */
+                uri->pathTail = walker;
+            }
+            walker = walker->next;
+        }
+    } while (walker != NULL);
 
-						walker = anotherNextBackup;
-					}
-				}
-			}
-			break;
-		} /* end of switch */
-
-		if (!removeSegment) {
-			/* .. then let's move to the next element, and start again. */
-			if (walker->next != NULL) {
-				walker->next->reserved = walker;
-			} else {
-				/* Last segment -> update tail */
-				uri->pathTail = walker;
-			}
-			walker = walker->next;
-		}
-	} while (walker != NULL);
-
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
-
 
 /* Properly removes "." and ".." path segments */
 UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory) {
-	const UriBool ABSOLUTE = URI_FALSE;
-	if (uri == NULL) {
-		return URI_TRUE;
-	}
-	return URI_FUNC(RemoveDotSegmentsEx)(uri, ABSOLUTE, uri->owner, memory);
+                                            UriMemoryManager * memory) {
+    const UriBool ABSOLUTE = URI_FALSE;
+    if (uri == NULL) {
+        return URI_TRUE;
+    }
+    return URI_FUNC(RemoveDotSegmentsEx)(uri, ABSOLUTE, uri->owner, memory);
 }
-
-
 
 unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig) {
-	switch (hexdig) {
-	case _UT('0'):
-	case _UT('1'):
-	case _UT('2'):
-	case _UT('3'):
-	case _UT('4'):
-	case _UT('5'):
-	case _UT('6'):
-	case _UT('7'):
-	case _UT('8'):
-	case _UT('9'):
-		return (unsigned char)(9 + hexdig - _UT('9'));
+    switch (hexdig) {
+    case _UT('0'):
+    case _UT('1'):
+    case _UT('2'):
+    case _UT('3'):
+    case _UT('4'):
+    case _UT('5'):
+    case _UT('6'):
+    case _UT('7'):
+    case _UT('8'):
+    case _UT('9'):
+        return (unsigned char)(9 + hexdig - _UT('9'));
 
-	case _UT('a'):
-	case _UT('b'):
-	case _UT('c'):
-	case _UT('d'):
-	case _UT('e'):
-	case _UT('f'):
-		return (unsigned char)(15 + hexdig - _UT('f'));
+    case _UT('a'):
+    case _UT('b'):
+    case _UT('c'):
+    case _UT('d'):
+    case _UT('e'):
+    case _UT('f'):
+        return (unsigned char)(15 + hexdig - _UT('f'));
 
-	case _UT('A'):
-	case _UT('B'):
-	case _UT('C'):
-	case _UT('D'):
-	case _UT('E'):
-	case _UT('F'):
-		return (unsigned char)(15 + hexdig - _UT('F'));
+    case _UT('A'):
+    case _UT('B'):
+    case _UT('C'):
+    case _UT('D'):
+    case _UT('E'):
+    case _UT('F'):
+        return (unsigned char)(15 + hexdig - _UT('F'));
 
-	default:
-		return 0;
-	}
+    default:
+        return 0;
+    }
 }
-
-
 
 URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase) {
-	switch (value) {
-	case  0: return _UT('0');
-	case  1: return _UT('1');
-	case  2: return _UT('2');
-	case  3: return _UT('3');
-	case  4: return _UT('4');
-	case  5: return _UT('5');
-	case  6: return _UT('6');
-	case  7: return _UT('7');
-	case  8: return _UT('8');
-	case  9: return _UT('9');
+    switch (value) {
+    case 0:
+        return _UT('0');
+    case 1:
+        return _UT('1');
+    case 2:
+        return _UT('2');
+    case 3:
+        return _UT('3');
+    case 4:
+        return _UT('4');
+    case 5:
+        return _UT('5');
+    case 6:
+        return _UT('6');
+    case 7:
+        return _UT('7');
+    case 8:
+        return _UT('8');
+    case 9:
+        return _UT('9');
 
-	case 10: return (uppercase == URI_TRUE) ? _UT('A') : _UT('a');
-	case 11: return (uppercase == URI_TRUE) ? _UT('B') : _UT('b');
-	case 12: return (uppercase == URI_TRUE) ? _UT('C') : _UT('c');
-	case 13: return (uppercase == URI_TRUE) ? _UT('D') : _UT('d');
-	case 14: return (uppercase == URI_TRUE) ? _UT('E') : _UT('e');
-	default: return (uppercase == URI_TRUE) ? _UT('F') : _UT('f');
-	}
+    case 10:
+        return (uppercase == URI_TRUE) ? _UT('A') : _UT('a');
+    case 11:
+        return (uppercase == URI_TRUE) ? _UT('B') : _UT('b');
+    case 12:
+        return (uppercase == URI_TRUE) ? _UT('C') : _UT('c');
+    case 13:
+        return (uppercase == URI_TRUE) ? _UT('D') : _UT('d');
+    case 14:
+        return (uppercase == URI_TRUE) ? _UT('E') : _UT('e');
+    default:
+        return (uppercase == URI_TRUE) ? _UT('F') : _UT('f');
+    }
 }
-
-
 
 /* Checks if a URI has the host component set. */
 UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri) {
-	/* NOTE: .hostData.ipFuture.first is not being checked,   *
-	 *       because we do check .hostText.first and          *
-	 *       .hostData.ipFuture.first has to be identical to  *
-	 *       .hostText.first if set, and hence there is       *
-	 *       no more information to be gained.                */
-	return (uri != NULL)
-			&& ((uri->hostText.first != NULL)
-				|| (uri->hostData.ip4 != NULL)
-				|| (uri->hostData.ip6 != NULL)
-			);
+    /* NOTE: .hostData.ipFuture.first is not being checked,   *
+     *       because we do check .hostText.first and          *
+     *       .hostData.ipFuture.first has to be identical to  *
+     *       .hostText.first if set, and hence there is       *
+     *       no more information to be gained.                */
+    return (uri != NULL)
+           && ((uri->hostText.first != NULL) || (uri->hostData.ip4 != NULL)
+               || (uri->hostData.ip6 != NULL));
 }
-
-
 
 /* Copies the path segment list from one URI to another. */
-UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * source, UriMemoryManager * memory) {
-	if (source->pathHead == NULL) {
-		/* No path component */
-		dest->pathHead = NULL;
-		dest->pathTail = NULL;
-	} else {
-		/* Copy list but not the text contained */
-		URI_TYPE(PathSegment) * sourceWalker = source->pathHead;
-		URI_TYPE(PathSegment) * destPrev = NULL;
-		do {
-			URI_TYPE(PathSegment) * cur = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
-			if (cur == NULL) {
-				/* Fix broken list */
-				if (destPrev != NULL) {
-					destPrev->next = NULL;
-				}
-				return URI_FALSE; /* Raises malloc error */
-			}
+UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
+                           UriMemoryManager * memory) {
+    if (source->pathHead == NULL) {
+        /* No path component */
+        dest->pathHead = NULL;
+        dest->pathTail = NULL;
+    } else {
+        /* Copy list but not the text contained */
+        URI_TYPE(PathSegment) * sourceWalker = source->pathHead;
+        URI_TYPE(PathSegment) * destPrev = NULL;
+        do {
+            URI_TYPE(PathSegment) * cur =
+                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+            if (cur == NULL) {
+                /* Fix broken list */
+                if (destPrev != NULL) {
+                    destPrev->next = NULL;
+                }
+                return URI_FALSE; /* Raises malloc error */
+            }
 
-			/* From this functions usage we know that *
-			 * the dest URI cannot be uri->owner      */
-			cur->text = sourceWalker->text;
-			if (destPrev == NULL) {
-				/* First segment ever */
-				dest->pathHead = cur;
-			} else {
-				destPrev->next = cur;
-			}
-			destPrev = cur;
-			sourceWalker = sourceWalker->next;
-		} while (sourceWalker != NULL);
-		dest->pathTail = destPrev;
-		dest->pathTail->next = NULL;
-	}
+            /* From this functions usage we know that *
+             * the dest URI cannot be uri->owner      */
+            cur->text = sourceWalker->text;
+            if (destPrev == NULL) {
+                /* First segment ever */
+                dest->pathHead = cur;
+            } else {
+                destPrev->next = cur;
+            }
+            destPrev = cur;
+            sourceWalker = sourceWalker->next;
+        } while (sourceWalker != NULL);
+        dest->pathTail = destPrev;
+        dest->pathTail->next = NULL;
+    }
 
-	dest->absolutePath = source->absolutePath;
-	return URI_TRUE;
+    dest->absolutePath = source->absolutePath;
+    return URI_TRUE;
 }
-
-
 
 /* Copies the authority part of an URI over to another. */
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * source, UriMemoryManager * memory) {
-	/* From this functions usage we know that *
-	 * the dest URI cannot be uri->owner      */
-	
-	/* Copy userInfo */
-	dest->userInfo = source->userInfo;
+UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
+                                UriMemoryManager * memory) {
+    /* From this functions usage we know that *
+     * the dest URI cannot be uri->owner      */
 
-	/* Copy hostText */
-	dest->hostText = source->hostText;
+    /* Copy userInfo */
+    dest->userInfo = source->userInfo;
 
-	/* Copy hostData */
-	if (source->hostData.ip4 != NULL) {
-		dest->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
-		if (dest->hostData.ip4 == NULL) {
-			return URI_FALSE; /* Raises malloc error */
-		}
-		*(dest->hostData.ip4) = *(source->hostData.ip4);
-		dest->hostData.ip6 = NULL;
-		dest->hostData.ipFuture.first = NULL;
-		dest->hostData.ipFuture.afterLast = NULL;
-	} else if (source->hostData.ip6 != NULL) {
-		dest->hostData.ip4 = NULL;
-		dest->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
-		if (dest->hostData.ip6 == NULL) {
-			return URI_FALSE; /* Raises malloc error */
-		}
-		*(dest->hostData.ip6) = *(source->hostData.ip6);
-		dest->hostData.ipFuture.first = NULL;
-		dest->hostData.ipFuture.afterLast = NULL;
-	} else {
-		dest->hostData.ip4 = NULL;
-		dest->hostData.ip6 = NULL;
-		dest->hostData.ipFuture = source->hostData.ipFuture;
-	}
+    /* Copy hostText */
+    dest->hostText = source->hostText;
 
-	/* Copy portText */
-	dest->portText = source->portText;
+    /* Copy hostData */
+    if (source->hostData.ip4 != NULL) {
+        dest->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
+        if (dest->hostData.ip4 == NULL) {
+            return URI_FALSE; /* Raises malloc error */
+        }
+        *(dest->hostData.ip4) = *(source->hostData.ip4);
+        dest->hostData.ip6 = NULL;
+        dest->hostData.ipFuture.first = NULL;
+        dest->hostData.ipFuture.afterLast = NULL;
+    } else if (source->hostData.ip6 != NULL) {
+        dest->hostData.ip4 = NULL;
+        dest->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
+        if (dest->hostData.ip6 == NULL) {
+            return URI_FALSE; /* Raises malloc error */
+        }
+        *(dest->hostData.ip6) = *(source->hostData.ip6);
+        dest->hostData.ipFuture.first = NULL;
+        dest->hostData.ipFuture.afterLast = NULL;
+    } else {
+        dest->hostData.ip4 = NULL;
+        dest->hostData.ip6 = NULL;
+        dest->hostData.ipFuture = source->hostData.ipFuture;
+    }
 
-	return URI_TRUE;
+    /* Copy portText */
+    dest->portText = source->portText;
+
+    return URI_TRUE;
 }
 
+UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
+    URI_TYPE(PathSegment) * segment;
 
+    if (/* Case 1: absolute path, empty first segment */
+        (uri->absolutePath && (uri->pathHead != NULL)
+         && (uri->pathHead->text.afterLast == uri->pathHead->text.first))
 
-UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory) {
-	URI_TYPE(PathSegment) * segment;
+        /* Case 2: relative path, empty first and second segment */
+        || (!uri->absolutePath && (uri->pathHead != NULL) && (uri->pathHead->next != NULL)
+            && (uri->pathHead->text.afterLast == uri->pathHead->text.first)
+            && (uri->pathHead->next->text.afterLast
+                == uri->pathHead->next->text.first))) {
+        /* NOOP */
+    } else {
+        return URI_TRUE;
+    }
 
-	if (	/* Case 1: absolute path, empty first segment */
-			(uri->absolutePath
-			&& (uri->pathHead != NULL)
-			&& (uri->pathHead->text.afterLast == uri->pathHead->text.first))
+    segment = memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
+    if (segment == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
 
-			/* Case 2: relative path, empty first and second segment */
-			|| (!uri->absolutePath
-			&& (uri->pathHead != NULL)
-			&& (uri->pathHead->next != NULL)
-			&& (uri->pathHead->text.afterLast == uri->pathHead->text.first)
-			&& (uri->pathHead->next->text.afterLast == uri->pathHead->next->text.first))) {
-		/* NOOP */
-	} else {
-		return URI_TRUE;
-	}
-
-	segment = memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
-	if (segment == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-
-	/* Insert "." segment in front */
-	segment->next = uri->pathHead;
-	segment->text.first = URI_FUNC(ConstPwd);
-	segment->text.afterLast = URI_FUNC(ConstPwd) + 1;
-	uri->pathHead = segment;
-	return URI_TRUE;
+    /* Insert "." segment in front */
+    segment->next = uri->pathHead;
+    segment->text.first = URI_FUNC(ConstPwd);
+    segment->text.afterLast = URI_FUNC(ConstPwd) + 1;
+    uri->pathHead = segment;
+    return URI_TRUE;
 }
 
+static UriBool URI_FUNC(PrependNewDotSegment)(URI_TYPE(Uri) * uri,
+                                              UriMemoryManager * memory) {
+    assert(uri != NULL);
+    assert(memory != NULL);
 
+    URI_TYPE(PathSegment) * const segment =
+        memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
 
-static UriBool URI_FUNC(PrependNewDotSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
+    if (segment == NULL) {
+        return URI_FALSE; /* i.e. raise malloc error */
+    }
 
-	{
-		URI_TYPE(PathSegment) * const segment = memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
+    segment->next = uri->pathHead;
 
-		if (segment == NULL) {
-			return URI_FALSE;  /* i.e. raise malloc error */
-		}
+    URI_TYPE(TextRange) dotRange;
+    dotRange.first = URI_FUNC(ConstPwd);
+    dotRange.afterLast = URI_FUNC(ConstPwd) + 1;
 
-		segment->next = uri->pathHead;
+    if (uri->owner == URI_TRUE) {
+        if (URI_FUNC(CopyRange)(&(segment->text), &dotRange, memory) == URI_FALSE) {
+            memory->free(memory, segment);
+            return URI_FALSE; /* i.e. raise malloc error */
+        }
+    } else {
+        segment->text = dotRange; /* copies all members */
+    }
 
-		{
-			URI_TYPE(TextRange) dotRange;
-			dotRange.first = URI_FUNC(ConstPwd);
-			dotRange.afterLast = URI_FUNC(ConstPwd) + 1;
+    uri->pathHead = segment;
 
-			if (uri->owner == URI_TRUE) {
-				if (URI_FUNC(CopyRange)(&(segment->text), &dotRange, memory) == URI_FALSE) {
-					memory->free(memory, segment);
-					return URI_FALSE;  /* i.e. raise malloc error */
-				}
-			} else {
-				segment->text = dotRange;  /* copies all members */
-			}
-		}
-
-		uri->pathHead = segment;
-	}
-
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
-
 
 /* When dropping a scheme from a URI without a host and with a colon (":")
  * in the first path segment, a consecutive reparse would rightfully
@@ -721,43 +715,36 @@ static UriBool URI_FUNC(PrependNewDotSegment)(URI_TYPE(Uri) * uri, UriMemoryMana
  * Returns URI_TRUE for (a) nothing to do or (b) successful changes.
  * Returns URI_FALSE to signal out-of-memory.
  */
-UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
+UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
+    assert(uri != NULL);
+    assert(memory != NULL);
 
-	if ((uri->absolutePath == URI_TRUE)
-			|| (uri->pathHead == NULL)
-			|| (uri->scheme.first != NULL)
-			|| URI_FUNC(HasHost)(uri)) {
-		return URI_TRUE;  /* i.e. nothing to do */
-	}
+    if ((uri->absolutePath == URI_TRUE) || (uri->pathHead == NULL)
+        || (uri->scheme.first != NULL) || URI_FUNC(HasHost)(uri)) {
+        return URI_TRUE; /* i.e. nothing to do */
+    }
 
-	/* Check for troublesome first path segment containing a colon */
-	{
-		UriBool colonFound = URI_FALSE;
-		const URI_CHAR * walker = uri->pathHead->text.first;
+    /* Check for troublesome first path segment containing a colon */
+    UriBool colonFound = URI_FALSE;
+    const URI_CHAR * walker = uri->pathHead->text.first;
 
-		while (walker < uri->pathHead->text.afterLast) {
-			if (walker[0] == _UT(':')) {
-				colonFound = URI_TRUE;
-				break;
-			}
-			walker++;
-		}
+    while (walker < uri->pathHead->text.afterLast) {
+        if (walker[0] == _UT(':')) {
+            colonFound = URI_TRUE;
+            break;
+        }
+        walker++;
+    }
 
-		assert((walker == uri->pathHead->text.afterLast) || (colonFound == URI_TRUE));
+    assert((walker == uri->pathHead->text.afterLast) || (colonFound == URI_TRUE));
 
-		if (colonFound == URI_FALSE) {
-			return URI_TRUE;  /* i.e. nothing to do */
-		}
-	}
+    if (colonFound == URI_FALSE) {
+        return URI_TRUE; /* i.e. nothing to do */
+    }
 
-	/* Insert "." segment in front */
-	return URI_FUNC(PrependNewDotSegment)(uri, memory);
+    /* Insert "." segment in front */
+    return URI_FUNC(PrependNewDotSegment)(uri, memory);
 }
-
-
 
 /* When dropping a host from a URI without a scheme, an absolute path
  * and and empty first path segment, a consecutive reparse would rightfully
@@ -774,38 +761,30 @@ UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri,
  * Returns URI_FALSE to signal out-of-memory.
  */
 UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
+                                                     UriMemoryManager * memory) {
+    assert(uri != NULL);
+    assert(memory != NULL);
 
-	if ((URI_FUNC(HasHost)(uri) == URI_TRUE)
-			|| (uri->absolutePath == URI_FALSE)
-			|| (uri->pathHead == NULL)
-			|| (uri->pathHead == uri->pathTail)  /* i.e. no second slash */
-			|| (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
-		return URI_TRUE;  /* i.e. nothing to do */
-	}
+    if ((URI_FUNC(HasHost)(uri) == URI_TRUE) || (uri->absolutePath == URI_FALSE)
+        || (uri->pathHead == NULL)
+        || (uri->pathHead == uri->pathTail) /* i.e. no second slash */
+        || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
+        return URI_TRUE; /* i.e. nothing to do */
+    }
 
-	/* Insert "." segment in front */
-	return URI_FUNC(PrependNewDotSegment)(uri, memory);
+    /* Insert "." segment in front */
+    return URI_FUNC(PrependNewDotSegment)(uri, memory);
 }
 
-
-
-void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory) {
-	/* Fix path if only one empty segment */
-	if (!uri->absolutePath
-			&& !URI_FUNC(HasHost)(uri)
-			&& (uri->pathHead != NULL)
-			&& (uri->pathHead->next == NULL)
-			&& (uri->pathHead->text.first == uri->pathHead->text.afterLast)) {
-		memory->free(memory, uri->pathHead);
-		uri->pathHead = NULL;
-		uri->pathTail = NULL;
-	}
+void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
+    /* Fix path if only one empty segment */
+    if (!uri->absolutePath && !URI_FUNC(HasHost)(uri) && (uri->pathHead != NULL)
+        && (uri->pathHead->next == NULL)
+        && (uri->pathHead->text.first == uri->pathHead->text.afterLast)) {
+        memory->free(memory, uri->pathHead);
+        uri->pathHead = NULL;
+        uri->pathTail = NULL;
+    }
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriCommon.h
+++ b/ext/uri/uriparser/src/UriCommon.h
@@ -38,35 +38,34 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include <uriparser/UriDefsConfig.h>
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include <uriparser/UriDefsConfig.h>
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriCommon.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriCommon.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "UriCommon.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "UriCommon.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_COMMON_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_COMMON_H_ANSI 1
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  define URI_COMMON_H_UNICODE 1
-#  include <uriparser/UriDefsUnicode.h>
-# endif
-
-
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
+         && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_COMMON_H_ANSI 1
+#      include <uriparser/UriDefsAnsi.h>
+#    else
+#      define URI_COMMON_H_UNICODE 1
+#      include <uriparser/UriDefsUnicode.h>
+#    endif
 
 /* Used to point to from empty path segments.
  * X.first and X.afterLast must be the same non-NULL value then. */
@@ -74,40 +73,37 @@ extern const URI_CHAR * const URI_FUNC(SafeToPointTo);
 extern const URI_CHAR * const URI_FUNC(ConstPwd);
 extern const URI_CHAR * const URI_FUNC(ConstParent);
 
-
-
 void URI_FUNC(ResetUri)(URI_TYPE(Uri) * uri);
 
 int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 
-int URI_FUNC(CompareRange)(
-		const URI_TYPE(TextRange) * a,
-		const URI_TYPE(TextRange) * b);
+int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRange) * b);
 
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
+                            const URI_TYPE(TextRange) * sourceRange,
+                            UriMemoryManager * memory);
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
+                                    const URI_TYPE(TextRange) * sourceRange,
+                                    UriMemoryManager * memory);
 
 UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
-		UriBool relative, UriBool pathOwned, UriMemoryManager * memory);
+                                            UriMemoryManager * memory);
+UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
+                                      UriBool pathOwned, UriMemoryManager * memory);
 
 unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig);
 URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase);
 
 UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * source, UriMemoryManager * memory);
+                           UriMemoryManager * memory);
+UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
+                                UriMemoryManager * memory);
 
 UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
-UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
-void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
+UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri,
+                                                     UriMemoryManager * memory);
+void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/src/UriConfig.h
+++ b/ext/uri/uriparser/src/UriConfig.h
@@ -37,17 +37,13 @@
  */
 
 #if !defined(URI_CONFIG_H)
-# define URI_CONFIG_H 1
+#  define URI_CONFIG_H 1
 
-
-
-#define PACKAGE_VERSION "@PROJECT_VERSION@"
+#  define PACKAGE_VERSION "@PROJECT_VERSION@"
 
 /*
-#define HAVE_WPRINTF*
+#define HAVE_WPRINTF
 #define HAVE_REALLOCARRAY
 */
 
-
-
-#endif  /* !defined(URI_CONFIG_H) */
+#endif /* !defined(URI_CONFIG_H) */

--- a/ext/uri/uriparser/src/UriConfig.h.in
+++ b/ext/uri/uriparser/src/UriConfig.h.in
@@ -37,15 +37,11 @@
  */
 
 #if !defined(URI_CONFIG_H)
-# define URI_CONFIG_H 1
+#  define URI_CONFIG_H 1
 
-
-
-#define PACKAGE_VERSION "@PROJECT_VERSION@"
+#  define PACKAGE_VERSION "@PROJECT_VERSION@"
 
 #cmakedefine HAVE_WPRINTF
 #cmakedefine HAVE_REALLOCARRAY
 
-
-
-#endif  /* !defined(URI_CONFIG_H) */
+#endif /* !defined(URI_CONFIG_H) */

--- a/ext/uri/uriparser/src/UriCopy.c
+++ b/ext/uri/uriparser/src/UriCopy.c
@@ -48,192 +48,195 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriCopy.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriCopy.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriCopy.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriCopy.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-# include "UriNormalize.h"
-# include "UriCopy.h"
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#    include "UriNormalize.h"
+#    include "UriCopy.h"
+#  endif
 
 static void URI_FUNC(PreventLeakageAfterCopy)(URI_TYPE(Uri) * uri,
-		unsigned int revertMask, UriMemoryManager * memory) {
-	URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                                              unsigned int revertMask,
+                                              UriMemoryManager * memory) {
+    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
 
-	if (uri->hostData.ip4 != NULL) {
-		memory->free(memory, uri->hostData.ip4);
-		uri->hostData.ip4 = NULL;
-	} else if (uri->hostData.ip6 != NULL) {
-		memory->free(memory, uri->hostData.ip6);
-		uri->hostData.ip6 = NULL;
-	}
+    if (uri->hostData.ip4 != NULL) {
+        memory->free(memory, uri->hostData.ip4);
+        uri->hostData.ip4 = NULL;
+    } else if (uri->hostData.ip6 != NULL) {
+        memory->free(memory, uri->hostData.ip6);
+        uri->hostData.ip6 = NULL;
+    }
 
-	if (revertMask & URI_NORMALIZE_PORT) {
-		if (uri->portText.first != uri->portText.afterLast) {
-			memory->free(memory, (URI_CHAR *)uri->portText.first);
-		}
-		uri->portText.first = NULL;
-		uri->portText.afterLast = NULL;
-	}
+    if (revertMask & URI_NORMALIZE_PORT) {
+        if (uri->portText.first != uri->portText.afterLast) {
+            memory->free(memory, (URI_CHAR *)uri->portText.first);
+        }
+        uri->portText.first = NULL;
+        uri->portText.afterLast = NULL;
+    }
 }
 
+int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri,
+                        UriMemoryManager * memory) {
+    unsigned int revertMask = URI_NORMALIZED;
 
+    if (sourceUri == NULL || destUri == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
-		 const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory) {
-	unsigned int revertMask = URI_NORMALIZED;
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-	if (sourceUri == NULL || destUri == NULL) {
-		return URI_ERROR_NULL;
-	}
+    URI_FUNC(ResetUri)(destUri);
 
-	URI_CHECK_MEMORY_MANAGER(memory); /* may return */
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, memory)
+        == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	URI_FUNC(ResetUri)(destUri);
+    revertMask |= URI_NORMALIZE_SCHEME;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, memory) == URI_FALSE) {
-		return URI_ERROR_MALLOC;
-	}
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, memory)
+        == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	revertMask |= URI_NORMALIZE_SCHEME;
+    revertMask |= URI_NORMALIZE_USER_INFO;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, memory)
+        == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	revertMask |= URI_NORMALIZE_USER_INFO;
+    revertMask |= URI_NORMALIZE_HOST;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    if (sourceUri->hostData.ip4 == NULL) {
+        destUri->hostData.ip4 = NULL;
+    } else {
+        destUri->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
+        if (destUri->hostData.ip4 == NULL) {
+            URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+            return URI_ERROR_MALLOC;
+        }
+        *(destUri->hostData.ip4) = *(sourceUri->hostData.ip4);
+    }
 
-	revertMask |= URI_NORMALIZE_HOST;
+    if (sourceUri->hostData.ip6 == NULL) {
+        destUri->hostData.ip6 = NULL;
+    } else {
+        destUri->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
+        if (destUri->hostData.ip6 == NULL) {
+            URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+            return URI_ERROR_MALLOC;
+        }
+        *(destUri->hostData.ip6) = *(sourceUri->hostData.ip6);
+    }
 
-	if (sourceUri->hostData.ip4 == NULL) {
-		destUri->hostData.ip4 = NULL;
-	} else {
-		destUri->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
-		if (destUri->hostData.ip4 == NULL) {
-			URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-			return URI_ERROR_MALLOC;
-		}
-		*(destUri->hostData.ip4) = *(sourceUri->hostData.ip4);
-	}
+    if (sourceUri->hostData.ipFuture.first != NULL) {
+        destUri->hostData.ipFuture.first = destUri->hostText.first;
+        destUri->hostData.ipFuture.afterLast = destUri->hostText.afterLast;
+    } else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture,
+                                           &sourceUri->hostData.ipFuture, memory)
+               == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	if (sourceUri->hostData.ip6 == NULL) {
-		destUri->hostData.ip6 = NULL;
-	} else {
-		destUri->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
-		if (destUri->hostData.ip6 == NULL) {
-			URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-			return URI_ERROR_MALLOC;
-		}
-		*(destUri->hostData.ip6) = *(sourceUri->hostData.ip6);
-	}
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, memory)
+        == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	if (sourceUri->hostData.ipFuture.first != NULL) {
-		destUri->hostData.ipFuture.first = destUri->hostText.first;
-		destUri->hostData.ipFuture.afterLast = destUri->hostText.afterLast;
-	} else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    revertMask |= URI_NORMALIZE_PORT;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    destUri->pathHead = NULL;
+    destUri->pathTail = NULL;
 
-	revertMask |= URI_NORMALIZE_PORT;
+    if (sourceUri->pathHead != NULL) {
+        URI_TYPE(PathSegment) * sourceWalker = sourceUri->pathHead;
+        URI_TYPE(PathSegment) * destPrev = NULL;
 
-	destUri->pathHead = NULL;
-	destUri->pathTail = NULL;
+        while (sourceWalker != NULL) {
+            URI_TYPE(PathSegment) * destWalker =
+                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+            if (destWalker == NULL) {
+                URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+                return URI_ERROR_MALLOC;
+            }
 
-	if (sourceUri->pathHead != NULL) {
-		URI_TYPE(PathSegment) * sourceWalker = sourceUri->pathHead;
-		URI_TYPE(PathSegment) * destPrev = NULL;
+            destWalker->text.first = NULL;
+            destWalker->text.afterLast = NULL;
+            destWalker->next = NULL;
+            destWalker->reserved = NULL;
 
-		while (sourceWalker != NULL) {
-			URI_TYPE(PathSegment) * destWalker = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
-			if (destWalker == NULL) {
-				URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-				return URI_ERROR_MALLOC;
-			}
+            if (destUri->pathHead == NULL) {
+                destUri->pathHead = destWalker;
+                revertMask |= URI_NORMALIZE_PATH;
+            }
 
-			destWalker->text.first = NULL;
-			destWalker->text.afterLast = NULL;
-			destWalker->next = NULL;
-			destWalker->reserved = NULL;
+            if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text,
+                                            memory)
+                == URI_FALSE) {
+                URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+                return URI_ERROR_MALLOC;
+            }
 
-			if (destUri->pathHead == NULL) {
-				destUri->pathHead = destWalker;
-				revertMask |= URI_NORMALIZE_PATH;
-			}
+            if (destPrev != NULL) {
+                destPrev->next = destWalker;
+            }
 
-			if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text, memory) == URI_FALSE) {
-				URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-				return URI_ERROR_MALLOC;
-			}
+            destPrev = destWalker;
+            sourceWalker = sourceWalker->next;
 
-			if (destPrev != NULL) {
-				destPrev->next = destWalker;
-			}
+            destUri->pathTail = destWalker;
+        }
+    }
 
-			destPrev = destWalker;
-			sourceWalker = sourceWalker->next;
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, memory)
+        == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-			destUri->pathTail = destWalker;
-		}
-	}
+    revertMask |= URI_NORMALIZE_QUERY;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, memory)
+        == URI_FALSE) {
+        URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	revertMask |= URI_NORMALIZE_QUERY;
+    destUri->absolutePath = sourceUri->absolutePath;
+    destUri->owner = URI_TRUE;
+    destUri->reserved = NULL;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, memory) == URI_FALSE) {
-		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
-
-	destUri->absolutePath = sourceUri->absolutePath;
-	destUri->owner = URI_TRUE;
-	destUri->reserved = NULL;
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
-		const URI_TYPE(Uri) * sourceUri) {
-	return URI_FUNC(CopyUriMm)(destUri, sourceUri, NULL);
+int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri) {
+    return URI_FUNC(CopyUriMm)(destUri, sourceUri, NULL);
 }
 
 #endif

--- a/ext/uri/uriparser/src/UriCopy.h
+++ b/ext/uri/uriparser/src/UriCopy.h
@@ -39,40 +39,38 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include <uriparser/UriDefsConfig.h>
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include <uriparser/UriDefsConfig.h>
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriCopy.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriCopy.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "UriCopy.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "UriCopy.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_COPY_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_COPY_H_ANSI 1
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  define URI_COPY_H_UNICODE 1
-#  include <uriparser/UriDefsUnicode.h>
-# endif
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI) \
+         && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_COPY_H_ANSI 1
+#      include <uriparser/UriDefsAnsi.h>
+#    else
+#      define URI_COPY_H_UNICODE 1
+#      include <uriparser/UriDefsUnicode.h>
+#    endif
 
+int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri,
+                        UriMemoryManager * memory);
+int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri);
 
-
-int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
-		const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory);
-int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
-		const URI_TYPE(Uri) * sourceUri);
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/src/UriEscape.c
+++ b/ext/uri/uriparser/src/UriEscape.c
@@ -41,416 +41,399 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriEscape.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriEscape.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriEscape.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriEscape.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#  endif
 
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-#endif
-
-
-
-URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
-		UriBool spaceToPlus, UriBool normalizeBreaks) {
-	return URI_FUNC(EscapeEx)(in, NULL, out, spaceToPlus, normalizeBreaks);
+URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out, UriBool spaceToPlus,
+                            UriBool normalizeBreaks) {
+    return URI_FUNC(EscapeEx)(in, NULL, out, spaceToPlus, normalizeBreaks);
 }
 
+URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
+                              URI_CHAR * out, UriBool spaceToPlus,
+                              UriBool normalizeBreaks) {
+    const URI_CHAR * read = inFirst;
+    URI_CHAR * write = out;
+    UriBool prevWasCr = URI_FALSE;
+    if ((out == NULL) || (inFirst == out)) {
+        return NULL;
+    } else if (inFirst == NULL) {
+        if (out != NULL) {
+            out[0] = _UT('\0');
+        }
+        return out;
+    }
 
+    for (;;) {
+        if ((inAfterLast != NULL) && (read >= inAfterLast)) {
+            write[0] = _UT('\0');
+            return write;
+        }
 
-URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst,
-		const URI_CHAR * inAfterLast, URI_CHAR * out,
-		UriBool spaceToPlus, UriBool normalizeBreaks) {
-	const URI_CHAR * read = inFirst;
-	URI_CHAR * write = out;
-	UriBool prevWasCr = URI_FALSE;
-	if ((out == NULL) || (inFirst == out)) {
-		return NULL;
-	} else if (inFirst == NULL) {
-		if (out != NULL) {
-			out[0] = _UT('\0');
-		}
-		return out;
-	}
+        switch (read[0]) {
+        case _UT('\0'):
+            write[0] = _UT('\0');
+            return write;
 
-	for (;;) {
-		if ((inAfterLast != NULL) && (read >= inAfterLast)) {
-			write[0] = _UT('\0');
-			return write;
-		}
+        case _UT(' '):
+            if (spaceToPlus) {
+                write[0] = _UT('+');
+                write++;
+            } else {
+                write[0] = _UT('%');
+                write[1] = _UT('2');
+                write[2] = _UT('0');
+                write += 3;
+            }
+            prevWasCr = URI_FALSE;
+            break;
 
-		switch (read[0]) {
-		case _UT('\0'):
-			write[0] = _UT('\0');
-			return write;
+        case _UT('a'): /* ALPHA */
+        case _UT('A'):
+        case _UT('b'):
+        case _UT('B'):
+        case _UT('c'):
+        case _UT('C'):
+        case _UT('d'):
+        case _UT('D'):
+        case _UT('e'):
+        case _UT('E'):
+        case _UT('f'):
+        case _UT('F'):
+        case _UT('g'):
+        case _UT('G'):
+        case _UT('h'):
+        case _UT('H'):
+        case _UT('i'):
+        case _UT('I'):
+        case _UT('j'):
+        case _UT('J'):
+        case _UT('k'):
+        case _UT('K'):
+        case _UT('l'):
+        case _UT('L'):
+        case _UT('m'):
+        case _UT('M'):
+        case _UT('n'):
+        case _UT('N'):
+        case _UT('o'):
+        case _UT('O'):
+        case _UT('p'):
+        case _UT('P'):
+        case _UT('q'):
+        case _UT('Q'):
+        case _UT('r'):
+        case _UT('R'):
+        case _UT('s'):
+        case _UT('S'):
+        case _UT('t'):
+        case _UT('T'):
+        case _UT('u'):
+        case _UT('U'):
+        case _UT('v'):
+        case _UT('V'):
+        case _UT('w'):
+        case _UT('W'):
+        case _UT('x'):
+        case _UT('X'):
+        case _UT('y'):
+        case _UT('Y'):
+        case _UT('z'):
+        case _UT('Z'):
+        case _UT('0'): /* DIGIT */
+        case _UT('1'):
+        case _UT('2'):
+        case _UT('3'):
+        case _UT('4'):
+        case _UT('5'):
+        case _UT('6'):
+        case _UT('7'):
+        case _UT('8'):
+        case _UT('9'):
+        case _UT('-'): /* "-" / "." / "_" / "~" */
+        case _UT('.'):
+        case _UT('_'):
+        case _UT('~'):
+            /* Copy unmodified */
+            write[0] = read[0];
+            write++;
 
-		case _UT(' '):
-			if (spaceToPlus) {
-				write[0] = _UT('+');
-				write++;
-			} else {
-				write[0] = _UT('%');
-				write[1] = _UT('2');
-				write[2] = _UT('0');
-				write += 3;
-			}
-			prevWasCr = URI_FALSE;
-			break;
+            prevWasCr = URI_FALSE;
+            break;
 
-		case _UT('a'): /* ALPHA */
-		case _UT('A'):
-		case _UT('b'):
-		case _UT('B'):
-		case _UT('c'):
-		case _UT('C'):
-		case _UT('d'):
-		case _UT('D'):
-		case _UT('e'):
-		case _UT('E'):
-		case _UT('f'):
-		case _UT('F'):
-		case _UT('g'):
-		case _UT('G'):
-		case _UT('h'):
-		case _UT('H'):
-		case _UT('i'):
-		case _UT('I'):
-		case _UT('j'):
-		case _UT('J'):
-		case _UT('k'):
-		case _UT('K'):
-		case _UT('l'):
-		case _UT('L'):
-		case _UT('m'):
-		case _UT('M'):
-		case _UT('n'):
-		case _UT('N'):
-		case _UT('o'):
-		case _UT('O'):
-		case _UT('p'):
-		case _UT('P'):
-		case _UT('q'):
-		case _UT('Q'):
-		case _UT('r'):
-		case _UT('R'):
-		case _UT('s'):
-		case _UT('S'):
-		case _UT('t'):
-		case _UT('T'):
-		case _UT('u'):
-		case _UT('U'):
-		case _UT('v'):
-		case _UT('V'):
-		case _UT('w'):
-		case _UT('W'):
-		case _UT('x'):
-		case _UT('X'):
-		case _UT('y'):
-		case _UT('Y'):
-		case _UT('z'):
-		case _UT('Z'):
-		case _UT('0'): /* DIGIT */
-		case _UT('1'):
-		case _UT('2'):
-		case _UT('3'):
-		case _UT('4'):
-		case _UT('5'):
-		case _UT('6'):
-		case _UT('7'):
-		case _UT('8'):
-		case _UT('9'):
-		case _UT('-'): /* "-" / "." / "_" / "~" */
-		case _UT('.'):
-		case _UT('_'):
-		case _UT('~'):
-			/* Copy unmodified */
-			write[0] = read[0];
-			write++;
+        case _UT('\x0a'):
+            if (normalizeBreaks) {
+                if (!prevWasCr) {
+                    write[0] = _UT('%');
+                    write[1] = _UT('0');
+                    write[2] = _UT('D');
+                    write[3] = _UT('%');
+                    write[4] = _UT('0');
+                    write[5] = _UT('A');
+                    write += 6;
+                }
+            } else {
+                write[0] = _UT('%');
+                write[1] = _UT('0');
+                write[2] = _UT('A');
+                write += 3;
+            }
+            prevWasCr = URI_FALSE;
+            break;
 
-			prevWasCr = URI_FALSE;
-			break;
+        case _UT('\x0d'):
+            if (normalizeBreaks) {
+                write[0] = _UT('%');
+                write[1] = _UT('0');
+                write[2] = _UT('D');
+                write[3] = _UT('%');
+                write[4] = _UT('0');
+                write[5] = _UT('A');
+                write += 6;
+            } else {
+                write[0] = _UT('%');
+                write[1] = _UT('0');
+                write[2] = _UT('D');
+                write += 3;
+            }
+            prevWasCr = URI_TRUE;
+            break;
 
-		case _UT('\x0a'):
-			if (normalizeBreaks) {
-				if (!prevWasCr) {
-					write[0] = _UT('%');
-					write[1] = _UT('0');
-					write[2] = _UT('D');
-					write[3] = _UT('%');
-					write[4] = _UT('0');
-					write[5] = _UT('A');
-					write += 6;
-				}
-			} else {
-				write[0] = _UT('%');
-				write[1] = _UT('0');
-				write[2] = _UT('A');
-				write += 3;
-			}
-			prevWasCr = URI_FALSE;
-			break;
+        default:
+            /* Percent encode */
+            {
+                const unsigned char code = (unsigned char)read[0];
+                /* Uppercase recommended in (last sentence of) section 2.1   *
+                 * of RFC 3986:                                              *
+                 * https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 */
+                write[0] = _UT('%');
+                write[1] = URI_FUNC(HexToLetterEx)(code >> 4, URI_TRUE);
+                write[2] = URI_FUNC(HexToLetterEx)(code & 0x0f, URI_TRUE);
+                write += 3;
+            }
+            prevWasCr = URI_FALSE;
+            break;
+        }
 
-		case _UT('\x0d'):
-			if (normalizeBreaks) {
-				write[0] = _UT('%');
-				write[1] = _UT('0');
-				write[2] = _UT('D');
-				write[3] = _UT('%');
-				write[4] = _UT('0');
-				write[5] = _UT('A');
-				write += 6;
-			} else {
-				write[0] = _UT('%');
-				write[1] = _UT('0');
-				write[2] = _UT('D');
-				write += 3;
-			}
-			prevWasCr = URI_TRUE;
-			break;
-
-		default:
-			/* Percent encode */
-			{
-				const unsigned char code = (unsigned char)read[0];
-				/* Uppercase recommended in (last sentence of) section 2.1   *
-				 * of RFC 3986:                                              *
-				 * https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 */
-				write[0] = _UT('%');
-				write[1] = URI_FUNC(HexToLetterEx)(code >> 4, URI_TRUE);
-				write[2] = URI_FUNC(HexToLetterEx)(code & 0x0f, URI_TRUE);
-				write += 3;
-			}
-			prevWasCr = URI_FALSE;
-			break;
-		}
-
-		read++;
-	}
+        read++;
+    }
 }
-
-
 
 const URI_CHAR * URI_FUNC(UnescapeInPlace)(URI_CHAR * inout) {
-	return URI_FUNC(UnescapeInPlaceEx)(inout, URI_FALSE, URI_BR_DONT_TOUCH);
+    return URI_FUNC(UnescapeInPlaceEx)(inout, URI_FALSE, URI_BR_DONT_TOUCH);
 }
 
+const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
+                                             UriBreakConversion breakConversion) {
+    URI_CHAR * read = inout;
+    URI_CHAR * write = inout;
+    UriBool prevWasCr = URI_FALSE;
 
+    if (inout == NULL) {
+        return NULL;
+    }
 
-const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout,
-		UriBool plusToSpace, UriBreakConversion breakConversion) {
-	URI_CHAR * read = inout;
-	URI_CHAR * write = inout;
-	UriBool prevWasCr = URI_FALSE;
+    for (;;) {
+        switch (read[0]) {
+        case _UT('\0'):
+            if (read > write) {
+                write[0] = _UT('\0');
+            }
+            return write;
 
-	if (inout == NULL) {
-		return NULL;
-	}
+        case _UT('%'):
+            switch (read[1]) {
+            case _UT('0'):
+            case _UT('1'):
+            case _UT('2'):
+            case _UT('3'):
+            case _UT('4'):
+            case _UT('5'):
+            case _UT('6'):
+            case _UT('7'):
+            case _UT('8'):
+            case _UT('9'):
+            case _UT('a'):
+            case _UT('b'):
+            case _UT('c'):
+            case _UT('d'):
+            case _UT('e'):
+            case _UT('f'):
+            case _UT('A'):
+            case _UT('B'):
+            case _UT('C'):
+            case _UT('D'):
+            case _UT('E'):
+            case _UT('F'):
+                switch (read[2]) {
+                case _UT('0'):
+                case _UT('1'):
+                case _UT('2'):
+                case _UT('3'):
+                case _UT('4'):
+                case _UT('5'):
+                case _UT('6'):
+                case _UT('7'):
+                case _UT('8'):
+                case _UT('9'):
+                case _UT('a'):
+                case _UT('b'):
+                case _UT('c'):
+                case _UT('d'):
+                case _UT('e'):
+                case _UT('f'):
+                case _UT('A'):
+                case _UT('B'):
+                case _UT('C'):
+                case _UT('D'):
+                case _UT('E'):
+                case _UT('F'): {
+                    /* Percent group found */
+                    const unsigned char left = URI_FUNC(HexdigToInt)(read[1]);
+                    const unsigned char right = URI_FUNC(HexdigToInt)(read[2]);
+                    const int code = 16 * left + right;
+                    switch (code) {
+                    case 10:
+                        switch (breakConversion) {
+                        case URI_BR_TO_LF:
+                            if (!prevWasCr) {
+                                write[0] = (URI_CHAR)10;
+                                write++;
+                            }
+                            break;
 
-	for (;;) {
-		switch (read[0]) {
-		case _UT('\0'):
-			if (read > write) {
-				write[0] = _UT('\0');
-			}
-			return write;
+                        case URI_BR_TO_CRLF:
+                            if (!prevWasCr) {
+                                write[0] = (URI_CHAR)13;
+                                write[1] = (URI_CHAR)10;
+                                write += 2;
+                            }
+                            break;
 
-		case _UT('%'):
-			switch (read[1]) {
-			case _UT('0'):
-			case _UT('1'):
-			case _UT('2'):
-			case _UT('3'):
-			case _UT('4'):
-			case _UT('5'):
-			case _UT('6'):
-			case _UT('7'):
-			case _UT('8'):
-			case _UT('9'):
-			case _UT('a'):
-			case _UT('b'):
-			case _UT('c'):
-			case _UT('d'):
-			case _UT('e'):
-			case _UT('f'):
-			case _UT('A'):
-			case _UT('B'):
-			case _UT('C'):
-			case _UT('D'):
-			case _UT('E'):
-			case _UT('F'):
-				switch (read[2]) {
-				case _UT('0'):
-				case _UT('1'):
-				case _UT('2'):
-				case _UT('3'):
-				case _UT('4'):
-				case _UT('5'):
-				case _UT('6'):
-				case _UT('7'):
-				case _UT('8'):
-				case _UT('9'):
-				case _UT('a'):
-				case _UT('b'):
-				case _UT('c'):
-				case _UT('d'):
-				case _UT('e'):
-				case _UT('f'):
-				case _UT('A'):
-				case _UT('B'):
-				case _UT('C'):
-				case _UT('D'):
-				case _UT('E'):
-				case _UT('F'):
-					{
-						/* Percent group found */
-						const unsigned char left = URI_FUNC(HexdigToInt)(read[1]);
-						const unsigned char right = URI_FUNC(HexdigToInt)(read[2]);
-						const int code = 16 * left + right;
-						switch (code) {
-						case 10:
-							switch (breakConversion) {
-							case URI_BR_TO_LF:
-								if (!prevWasCr) {
-									write[0] = (URI_CHAR)10;
-									write++;
-								}
-								break;
+                        case URI_BR_TO_CR:
+                            if (!prevWasCr) {
+                                write[0] = (URI_CHAR)13;
+                                write++;
+                            }
+                            break;
 
-							case URI_BR_TO_CRLF:
-								if (!prevWasCr) {
-									write[0] = (URI_CHAR)13;
-									write[1] = (URI_CHAR)10;
-									write += 2;
-								}
-								break;
+                        case URI_BR_DONT_TOUCH:
+                        default:
+                            write[0] = (URI_CHAR)10;
+                            write++;
+                        }
+                        prevWasCr = URI_FALSE;
+                        break;
 
-							case URI_BR_TO_CR:
-								if (!prevWasCr) {
-									write[0] = (URI_CHAR)13;
-									write++;
-								}
-								break;
+                    case 13:
+                        switch (breakConversion) {
+                        case URI_BR_TO_LF:
+                            write[0] = (URI_CHAR)10;
+                            write++;
+                            break;
 
-							case URI_BR_DONT_TOUCH:
-							default:
-								write[0] = (URI_CHAR)10;
-								write++;
+                        case URI_BR_TO_CRLF:
+                            write[0] = (URI_CHAR)13;
+                            write[1] = (URI_CHAR)10;
+                            write += 2;
+                            break;
 
-							}
-							prevWasCr = URI_FALSE;
-							break;
+                        case URI_BR_TO_CR:
+                            write[0] = (URI_CHAR)13;
+                            write++;
+                            break;
 
-						case 13:
-							switch (breakConversion) {
-							case URI_BR_TO_LF:
-								write[0] = (URI_CHAR)10;
-								write++;
-								break;
+                        case URI_BR_DONT_TOUCH:
+                        default:
+                            write[0] = (URI_CHAR)13;
+                            write++;
+                        }
+                        prevWasCr = URI_TRUE;
+                        break;
 
-							case URI_BR_TO_CRLF:
-								write[0] = (URI_CHAR)13;
-								write[1] = (URI_CHAR)10;
-								write += 2;
-								break;
+                    default:
+                        write[0] = (URI_CHAR)(code);
+                        write++;
 
-							case URI_BR_TO_CR:
-								write[0] = (URI_CHAR)13;
-								write++;
-								break;
+                        prevWasCr = URI_FALSE;
+                    }
+                    read += 3;
+                } break;
 
-							case URI_BR_DONT_TOUCH:
-							default:
-								write[0] = (URI_CHAR)13;
-								write++;
+                default:
+                    /* Copy two chars unmodified and */
+                    /* look at this char again */
+                    if (read > write) {
+                        write[0] = read[0];
+                        write[1] = read[1];
+                    }
+                    read += 2;
+                    write += 2;
 
-							}
-							prevWasCr = URI_TRUE;
-							break;
+                    prevWasCr = URI_FALSE;
+                }
+                break;
 
-						default:
-							write[0] = (URI_CHAR)(code);
-							write++;
+            default:
+                /* Copy one char unmodified and */
+                /* look at this char again */
+                if (read > write) {
+                    write[0] = read[0];
+                }
+                read++;
+                write++;
 
-							prevWasCr = URI_FALSE;
+                prevWasCr = URI_FALSE;
+            }
+            break;
 
-						}
-						read += 3;
-					}
-					break;
+        case _UT('+'):
+            if (plusToSpace) {
+                /* Convert '+' to ' ' */
+                write[0] = _UT(' ');
+            } else {
+                /* Copy one char unmodified */
+                if (read > write) {
+                    write[0] = read[0];
+                }
+            }
+            read++;
+            write++;
 
-				default:
-					/* Copy two chars unmodified and */
-					/* look at this char again */
-					if (read > write) {
-						write[0] = read[0];
-						write[1] = read[1];
-					}
-					read += 2;
-					write += 2;
+            prevWasCr = URI_FALSE;
+            break;
 
-					prevWasCr = URI_FALSE;
-				}
-				break;
+        default:
+            /* Copy one char unmodified */
+            if (read > write) {
+                write[0] = read[0];
+            }
+            read++;
+            write++;
 
-			default:
-				/* Copy one char unmodified and */
-				/* look at this char again */
-				if (read > write) {
-					write[0] = read[0];
-				}
-				read++;
-				write++;
-
-				prevWasCr = URI_FALSE;
-			}
-			break;
-
-		case _UT('+'):
-			if (plusToSpace) {
-				/* Convert '+' to ' ' */
-				write[0] = _UT(' ');
-			} else {
-				/* Copy one char unmodified */
-				if (read > write) {
-					write[0] = read[0];
-				}
-			}
-			read++;
-			write++;
-
-			prevWasCr = URI_FALSE;
-			break;
-
-		default:
-			/* Copy one char unmodified */
-			if (read > write) {
-				write[0] = read[0];
-			}
-			read++;
-			write++;
-
-			prevWasCr = URI_FALSE;
-		}
-	}
+            prevWasCr = URI_FALSE;
+        }
+    }
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriFile.c
+++ b/ext/uri/uriparser/src/UriFile.c
@@ -41,202 +41,181 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriFile.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriFile.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriFile.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriFile.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#  endif
 
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-#endif
-
-
-
-#include <stdlib.h>  /* for size_t, avoiding stddef.h for older MSVCs */
-
-
+#  include <stdlib.h> /* for size_t, avoiding stddef.h for older MSVCs */
 
 static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
-		URI_CHAR * uriString, UriBool fromUnix) {
-	const URI_CHAR * input = filename;
-	const URI_CHAR * lastSep = input - 1;
-	UriBool firstSegment = URI_TRUE;
-	URI_CHAR * output = uriString;
-	UriBool absolute;
-	UriBool is_windows_network;
+                                                    URI_CHAR * uriString,
+                                                    UriBool fromUnix) {
+    const URI_CHAR * input = filename;
+    const URI_CHAR * lastSep = input - 1;
+    UriBool firstSegment = URI_TRUE;
+    URI_CHAR * output = uriString;
+    UriBool absolute;
+    UriBool is_windows_network;
 
-	if ((filename == NULL) || (uriString == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    if ((filename == NULL) || (uriString == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-	is_windows_network = (filename[0] == _UT('\\')) && (filename[1] == _UT('\\'));
-	absolute = fromUnix
-			? (filename[0] == _UT('/'))
-			: (((filename[0] != _UT('\0')) && (filename[1] == _UT(':')))
-				|| is_windows_network);
+    is_windows_network = (filename[0] == _UT('\\')) && (filename[1] == _UT('\\'));
+    absolute = fromUnix ? (filename[0] == _UT('/'))
+                        : (((filename[0] != _UT('\0')) && (filename[1] == _UT(':')))
+                           || is_windows_network);
 
-	if (absolute) {
-		const URI_CHAR * const prefix = fromUnix
-				? _UT("file://")
-				: is_windows_network
-					? _UT("file:")
-					: _UT("file:///");
-		const size_t prefixLen = URI_STRLEN(prefix);
+    if (absolute) {
+        const URI_CHAR * const prefix = fromUnix             ? _UT("file://")
+                                        : is_windows_network ? _UT("file:")
+                                                             : _UT("file:///");
+        const size_t prefixLen = URI_STRLEN(prefix);
 
-		/* Copy prefix */
-		memcpy(uriString, prefix, prefixLen * sizeof(URI_CHAR));
-		output += prefixLen;
-	}
+        /* Copy prefix */
+        memcpy(uriString, prefix, prefixLen * sizeof(URI_CHAR));
+        output += prefixLen;
+    }
 
-	/* Copy and escape on the fly */
-	for (;;) {
-		if ((input[0] == _UT('\0'))
-				|| (fromUnix && input[0] == _UT('/'))
-				|| (!fromUnix && input[0] == _UT('\\'))) {
-			/* Copy text after last separator */
-			if (lastSep + 1 < input) {
-				if (!fromUnix && absolute && (firstSegment == URI_TRUE)) {
-					/* Quick hack to not convert "C:" to "C%3A" */
-					const int charsToCopy = (int)(input - (lastSep + 1));
-					memcpy(output, lastSep + 1, charsToCopy * sizeof(URI_CHAR));
-					output += charsToCopy;
-				} else {
-					output = URI_FUNC(EscapeEx)(lastSep + 1, input, output,
-							URI_FALSE, URI_FALSE);
-				}
-			}
-			firstSegment = URI_FALSE;
-		}
+    /* Copy and escape on the fly */
+    for (;;) {
+        if ((input[0] == _UT('\0')) || (fromUnix && input[0] == _UT('/'))
+            || (!fromUnix && input[0] == _UT('\\'))) {
+            /* Copy text after last separator */
+            if (lastSep + 1 < input) {
+                if (!fromUnix && absolute && (firstSegment == URI_TRUE)) {
+                    /* Quick hack to not convert "C:" to "C%3A" */
+                    const int charsToCopy = (int)(input - (lastSep + 1));
+                    memcpy(output, lastSep + 1, charsToCopy * sizeof(URI_CHAR));
+                    output += charsToCopy;
+                } else {
+                    output = URI_FUNC(EscapeEx)(lastSep + 1, input, output, URI_FALSE,
+                                                URI_FALSE);
+                }
+            }
+            firstSegment = URI_FALSE;
+        }
 
-		if (input[0] == _UT('\0')) {
-			output[0] = _UT('\0');
-			break;
-		} else if (fromUnix && (input[0] == _UT('/'))) {
-			/* Copy separators unmodified */
-			output[0] = _UT('/');
-			output++;
-			lastSep = input;
-		} else if (!fromUnix && (input[0] == _UT('\\'))) {
-			/* Convert backslashes to forward slashes */
-			output[0] = _UT('/');
-			output++;
-			lastSep = input;
-		}
-		input++;
-	}
+        if (input[0] == _UT('\0')) {
+            output[0] = _UT('\0');
+            break;
+        } else if (fromUnix && (input[0] == _UT('/'))) {
+            /* Copy separators unmodified */
+            output[0] = _UT('/');
+            output++;
+            lastSep = input;
+        } else if (!fromUnix && (input[0] == _UT('\\'))) {
+            /* Convert backslashes to forward slashes */
+            output[0] = _UT('/');
+            output++;
+            lastSep = input;
+        }
+        input++;
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 static URI_INLINE int URI_FUNC(UriStringToFilename)(const URI_CHAR * uriString,
-		URI_CHAR * filename, UriBool toUnix) {
-	if ((uriString == NULL) || (filename == NULL)) {
-		return URI_ERROR_NULL;
-	}
+                                                    URI_CHAR * filename, UriBool toUnix) {
+    if ((uriString == NULL) || (filename == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-	{
-		const UriBool file_unknown_slashes =
-				URI_STRNCMP(uriString, _UT("file:"), URI_STRLEN(_UT("file:"))) == 0;
-		const UriBool file_one_or_more_slashes = file_unknown_slashes
-				&& (URI_STRNCMP(uriString, _UT("file:/"), URI_STRLEN(_UT("file:/"))) == 0);
-		const UriBool file_two_or_more_slashes = file_one_or_more_slashes
-				&& (URI_STRNCMP(uriString, _UT("file://"), URI_STRLEN(_UT("file://"))) == 0);
-		const UriBool file_three_or_more_slashes = file_two_or_more_slashes
-				&& (URI_STRNCMP(uriString, _UT("file:///"), URI_STRLEN(_UT("file:///"))) == 0);
+    const UriBool file_unknown_slashes =
+        URI_STRNCMP(uriString, _UT("file:"), URI_STRLEN(_UT("file:"))) == 0;
+    const UriBool file_one_or_more_slashes =
+        file_unknown_slashes
+        && (URI_STRNCMP(uriString, _UT("file:/"), URI_STRLEN(_UT("file:/"))) == 0);
+    const UriBool file_two_or_more_slashes =
+        file_one_or_more_slashes
+        && (URI_STRNCMP(uriString, _UT("file://"), URI_STRLEN(_UT("file://"))) == 0);
+    const UriBool file_three_or_more_slashes =
+        file_two_or_more_slashes
+        && (URI_STRNCMP(uriString, _UT("file:///"), URI_STRLEN(_UT("file:///"))) == 0);
 
-		const size_t charsToSkip = file_two_or_more_slashes
-				? file_three_or_more_slashes
-					? toUnix
-						/* file:///bin/bash */
-						? URI_STRLEN(_UT("file://"))
-						/* file:///E:/Documents%20and%20Settings */
-						: URI_STRLEN(_UT("file:///"))
-					/* file://Server01/Letter.txt */
-					: URI_STRLEN(_UT("file://"))
-				: ((file_one_or_more_slashes && toUnix)
-					/* file:/bin/bash */
-					/* https://tools.ietf.org/html/rfc8089#appendix-B */
-					? URI_STRLEN(_UT("file:"))
-					: ((! toUnix && file_unknown_slashes && ! file_one_or_more_slashes)
-						/* file:c:/path/to/file */
-						/* https://tools.ietf.org/html/rfc8089#appendix-E.2 */
-						? URI_STRLEN(_UT("file:"))
-						: 0));
-		const size_t charsToCopy = URI_STRLEN(uriString + charsToSkip) + 1;
+    const size_t charsToSkip =
+        file_two_or_more_slashes
+            ? file_three_or_more_slashes ? toUnix
+                                               /* file:///bin/bash */
+                                               ? URI_STRLEN(_UT("file://"))
+                                               /* file:///E:/Documents%20and%20Settings */
+                                               : URI_STRLEN(_UT("file:///"))
+                                         /* file://Server01/Letter.txt */
+                                         : URI_STRLEN(_UT("file://"))
+            : ((file_one_or_more_slashes && toUnix)
+                   /* file:/bin/bash */
+                   /* https://tools.ietf.org/html/rfc8089#appendix-B */
+                   ? URI_STRLEN(_UT("file:"))
+                   : ((!toUnix && file_unknown_slashes && !file_one_or_more_slashes)
+                          /* file:c:/path/to/file */
+                          /* https://tools.ietf.org/html/rfc8089#appendix-E.2 */
+                          ? URI_STRLEN(_UT("file:"))
+                          : 0));
+    const size_t charsToCopy = URI_STRLEN(uriString + charsToSkip) + 1;
 
-		const UriBool is_windows_network_with_authority =
-				(toUnix == URI_FALSE)
-				&& file_two_or_more_slashes
-				&& ! file_three_or_more_slashes;
+    const UriBool is_windows_network_with_authority =
+        (toUnix == URI_FALSE) && file_two_or_more_slashes && !file_three_or_more_slashes;
 
-		URI_CHAR * const unescape_target = is_windows_network_with_authority
-				? (filename + 2)
-				: filename;
+    URI_CHAR * const unescape_target =
+        is_windows_network_with_authority ? (filename + 2) : filename;
 
-		if (is_windows_network_with_authority) {
-			filename[0] = '\\';
-			filename[1] = '\\';
-		}
+    if (is_windows_network_with_authority) {
+        filename[0] = '\\';
+        filename[1] = '\\';
+    }
 
-		memcpy(unescape_target, uriString + charsToSkip, charsToCopy * sizeof(URI_CHAR));
-		URI_FUNC(UnescapeInPlaceEx)(filename, URI_FALSE, URI_BR_DONT_TOUCH);
-	}
+    memcpy(unescape_target, uriString + charsToSkip, charsToCopy * sizeof(URI_CHAR));
+    URI_FUNC(UnescapeInPlaceEx)(filename, URI_FALSE, URI_BR_DONT_TOUCH);
 
-	/* Convert forward slashes to backslashes */
-	if (!toUnix) {
-		URI_CHAR * walker = filename;
-		while (walker[0] != _UT('\0')) {
-			if (walker[0] == _UT('/')) {
-				walker[0] = _UT('\\');
-			}
-			walker++;
-		}
-	}
+    /* Convert forward slashes to backslashes */
+    if (!toUnix) {
+        URI_CHAR * walker = filename;
+        while (walker[0] != _UT('\0')) {
+            if (walker[0] == _UT('/')) {
+                walker[0] = _UT('\\');
+            }
+            walker++;
+        }
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename, URI_CHAR * uriString) {
-	return URI_FUNC(FilenameToUriString)(filename, uriString, URI_TRUE);
+    return URI_FUNC(FilenameToUriString)(filename, uriString, URI_TRUE);
 }
 
-
-
-int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename, URI_CHAR * uriString) {
-	return URI_FUNC(FilenameToUriString)(filename, uriString, URI_FALSE);
+int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
+                                         URI_CHAR * uriString) {
+    return URI_FUNC(FilenameToUriString)(filename, uriString, URI_FALSE);
 }
-
-
 
 int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString, URI_CHAR * filename) {
-	return URI_FUNC(UriStringToFilename)(uriString, filename, URI_TRUE);
+    return URI_FUNC(UriStringToFilename)(uriString, filename, URI_TRUE);
 }
 
-
-
-int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString, URI_CHAR * filename) {
-	return URI_FUNC(UriStringToFilename)(uriString, filename, URI_FALSE);
+int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
+                                         URI_CHAR * filename) {
+    return URI_FUNC(UriStringToFilename)(uriString, filename, URI_FALSE);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriIp4.c
+++ b/ext/uri/uriparser/src/UriIp4.c
@@ -47,96 +47,92 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriIp4.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriIp4.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriIp4.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriIp4.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/UriIp4.h>
-# include "UriIp4Base.h"
-# include <uriparser/UriBase.h>
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/UriIp4.h>
+#    include "UriIp4Base.h"
+#    include <uriparser/UriBase.h>
+#  endif
 
 /* Prototypes */
 static const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
+                                                const URI_CHAR * first,
+                                                const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
+                                                     const URI_CHAR * first,
+                                                     const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseDecOctetFour)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast);
-
-
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast);
 
 /*
  * [ipFourAddress]->[decOctet]<.>[decOctet]<.>[decOctet]<.>[decOctet]
  */
-int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	const URI_CHAR * after;
-	UriIp4Parser parser;
+int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput, const URI_CHAR * first,
+                                 const URI_CHAR * afterLast) {
+    const URI_CHAR * after;
+    UriIp4Parser parser;
 
-	/* Essential checks */
-	if ((octetOutput == NULL) || (first == NULL)
-			|| (afterLast <= first)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Essential checks */
+    if ((octetOutput == NULL) || (first == NULL) || (afterLast <= first)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	/* Reset parser */
-	parser.stackCount = 0;
+    /* Reset parser */
+    parser.stackCount = 0;
 
-	/* Octet #1 */
-	after = URI_FUNC(ParseDecOctet)(&parser, first, afterLast);
-	if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
-		return URI_ERROR_SYNTAX;
-	}
-	uriStackToOctet(&parser, octetOutput);
+    /* Octet #1 */
+    after = URI_FUNC(ParseDecOctet)(&parser, first, afterLast);
+    if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
+        return URI_ERROR_SYNTAX;
+    }
+    uriStackToOctet(&parser, octetOutput);
 
-	/* Octet #2 */
-	after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
-	if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
-		return URI_ERROR_SYNTAX;
-	}
-	uriStackToOctet(&parser, octetOutput + 1);
+    /* Octet #2 */
+    after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
+    if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
+        return URI_ERROR_SYNTAX;
+    }
+    uriStackToOctet(&parser, octetOutput + 1);
 
-	/* Octet #3 */
-	after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
-	if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
-		return URI_ERROR_SYNTAX;
-	}
-	uriStackToOctet(&parser, octetOutput + 2);
+    /* Octet #3 */
+    after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
+    if ((after == NULL) || (after >= afterLast) || (*after != _UT('.'))) {
+        return URI_ERROR_SYNTAX;
+    }
+    uriStackToOctet(&parser, octetOutput + 2);
 
-	/* Octet #4 */
-	after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
-	if (after != afterLast) {
-		return URI_ERROR_SYNTAX;
-	}
-	uriStackToOctet(&parser, octetOutput + 3);
+    /* Octet #4 */
+    after = URI_FUNC(ParseDecOctet)(&parser, after + 1, afterLast);
+    if (after != afterLast) {
+        return URI_ERROR_SYNTAX;
+    }
+    uriStackToOctet(&parser, octetOutput + 3);
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 /*
  * [decOctet]-><0>
@@ -151,71 +147,71 @@ int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput,
  * [decOctet]-><9>[decOctetThree]
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return NULL;
-	}
+                                                           const URI_CHAR * first,
+                                                           const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('0'):
-		uriPushToStack(parser, 0);
-		return first + 1;
+    switch (*first) {
+    case _UT('0'):
+        uriPushToStack(parser, 0);
+        return first + 1;
 
-	case _UT('1'):
-		uriPushToStack(parser, 1);
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetOne)(parser, first + 1, afterLast);
+    case _UT('1'):
+        uriPushToStack(parser, 1);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetOne)(parser, first + 1, afterLast);
 
-	case _UT('2'):
-		uriPushToStack(parser, 2);
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetTwo)(parser, first + 1, afterLast);
+    case _UT('2'):
+        uriPushToStack(parser, 2);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetTwo)(parser, first + 1, afterLast);
 
-	case _UT('3'):
-	case _UT('4'):
-	case _UT('5'):
-	case _UT('6'):
-	case _UT('7'):
-	case _UT('8'):
-	case _UT('9'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1, afterLast);
+    case _UT('3'):
+    case _UT('4'):
+    case _UT('5'):
+    case _UT('6'):
+    case _UT('7'):
+    case _UT('8'):
+    case _UT('9'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
+                                                              afterLast);
 
-	default:
-		return NULL;
-	}
+    default:
+        return NULL;
+    }
 }
-
-
 
 /*
  * [decOctetOne]-><NULL>
  * [decOctetOne]->[DIGIT][decOctetThree]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser, const URI_CHAR * first,
+                           const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('0'):
-	case _UT('1'):
-	case _UT('2'):
-	case _UT('3'):
-	case _UT('4'):
-	case _UT('5'):
-	case _UT('6'):
-	case _UT('7'):
-	case _UT('8'):
-	case _UT('9'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1, afterLast);
+    switch (*first) {
+    case _UT('0'):
+    case _UT('1'):
+    case _UT('2'):
+    case _UT('3'):
+    case _UT('4'):
+    case _UT('5'):
+    case _UT('6'):
+    case _UT('7'):
+    case _UT('8'):
+    case _UT('9'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
+                                                              afterLast);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [decOctetTwo]-><NULL>
@@ -229,70 +225,70 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetOne)(UriIp4Parser * par
  * [decOctetTwo]-><7>
  * [decOctetTwo]-><8>
  * [decOctetTwo]-><9>
-*/
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+ */
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser, const URI_CHAR * first,
+                           const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('0'):
-	case _UT('1'):
-	case _UT('2'):
-	case _UT('3'):
-	case _UT('4'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1, afterLast);
+    switch (*first) {
+    case _UT('0'):
+    case _UT('1'):
+    case _UT('2'):
+    case _UT('3'):
+    case _UT('4'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
+                                                              afterLast);
 
-	case _UT('5'):
-		uriPushToStack(parser, 5);
-		return (const URI_CHAR *)URI_FUNC(ParseDecOctetFour)(parser, first + 1, afterLast);
+    case _UT('5'):
+        uriPushToStack(parser, 5);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetFour)(parser, first + 1,
+                                                             afterLast);
 
-	case _UT('6'):
-	case _UT('7'):
-	case _UT('8'):
-	case _UT('9'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return first + 1;
+    case _UT('6'):
+    case _UT('7'):
+    case _UT('8'):
+    case _UT('9'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return first + 1;
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [decOctetThree]-><NULL>
  * [decOctetThree]->[DIGIT]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser, const URI_CHAR * first,
+                             const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('0'):
-	case _UT('1'):
-	case _UT('2'):
-	case _UT('3'):
-	case _UT('4'):
-	case _UT('5'):
-	case _UT('6'):
-	case _UT('7'):
-	case _UT('8'):
-	case _UT('9'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return first + 1;
+    switch (*first) {
+    case _UT('0'):
+    case _UT('1'):
+    case _UT('2'):
+    case _UT('3'):
+    case _UT('4'):
+    case _UT('5'):
+    case _UT('6'):
+    case _UT('7'):
+    case _UT('8'):
+    case _UT('9'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return first + 1;
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [decOctetFour]-><NULL>
@@ -303,27 +299,26 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetThree)(UriIp4Parser * p
  * [decOctetFour]-><4>
  * [decOctetFour]-><5>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetFour)(UriIp4Parser * parser,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseDecOctetFour)(UriIp4Parser * parser, const URI_CHAR * first,
+                            const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('0'):
-	case _UT('1'):
-	case _UT('2'):
-	case _UT('3'):
-	case _UT('4'):
-	case _UT('5'):
-		uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-		return first + 1;
+    switch (*first) {
+    case _UT('0'):
+    case _UT('1'):
+    case _UT('2'):
+    case _UT('3'):
+    case _UT('4'):
+    case _UT('5'):
+        uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
+        return first + 1;
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriIp4Base.c
+++ b/ext/uri/uriparser/src/UriIp4Base.c
@@ -43,54 +43,45 @@
  */
 
 #ifndef URI_DOXYGEN
-# include "UriIp4Base.h"
+#  include "UriIp4Base.h"
 #endif
 
-
-
 void uriStackToOctet(UriIp4Parser * parser, unsigned char * octet) {
-	switch (parser->stackCount) {
-	case 1:
-		*octet = parser->stackOne;
-		break;
+    switch (parser->stackCount) {
+    case 1:
+        *octet = parser->stackOne;
+        break;
 
-	case 2:
-		*octet = parser->stackOne * 10
-				+ parser->stackTwo;
-		break;
+    case 2:
+        *octet = parser->stackOne * 10 + parser->stackTwo;
+        break;
 
-	case 3:
-		*octet = parser->stackOne * 100
-				+ parser->stackTwo * 10
-				+ parser->stackThree;
-		break;
+    case 3:
+        *octet = parser->stackOne * 100 + parser->stackTwo * 10 + parser->stackThree;
+        break;
 
-	default:
-		;
-	}
-	parser->stackCount = 0;
+    default:;
+    }
+    parser->stackCount = 0;
 }
 
-
-
 void uriPushToStack(UriIp4Parser * parser, unsigned char digit) {
-	switch (parser->stackCount) {
-	case 0:
-		parser->stackOne = digit;
-		parser->stackCount = 1;
-		break;
+    switch (parser->stackCount) {
+    case 0:
+        parser->stackOne = digit;
+        parser->stackCount = 1;
+        break;
 
-	case 1:
-		parser->stackTwo = digit;
-		parser->stackCount = 2;
-		break;
+    case 1:
+        parser->stackTwo = digit;
+        parser->stackCount = 2;
+        break;
 
-	case 2:
-		parser->stackThree = digit;
-		parser->stackCount = 3;
-		break;
+    case 2:
+        parser->stackThree = digit;
+        parser->stackCount = 3;
+        break;
 
-	default:
-		;
-	}
+    default:;
+    }
 }

--- a/ext/uri/uriparser/src/UriIp4Base.h
+++ b/ext/uri/uriparser/src/UriIp4Base.h
@@ -38,22 +38,16 @@
  */
 
 #ifndef URI_IP4_BASE_H
-#define URI_IP4_BASE_H 1
-
-
+#  define URI_IP4_BASE_H 1
 
 typedef struct UriIp4ParserStruct {
-	unsigned char stackCount;
-	unsigned char stackOne;
-	unsigned char stackTwo;
-	unsigned char stackThree;
+    unsigned char stackCount;
+    unsigned char stackOne;
+    unsigned char stackTwo;
+    unsigned char stackThree;
 } UriIp4Parser;
-
-
 
 void uriPushToStack(UriIp4Parser * parser, unsigned char digit);
 void uriStackToOctet(UriIp4Parser * parser, unsigned char * octet);
-
-
 
 #endif /* URI_IP4_BASE_H */

--- a/ext/uri/uriparser/src/UriMemory.c
+++ b/ext/uri/uriparser/src/UriMemory.c
@@ -42,469 +42,423 @@
  * Holds memory manager implementation.
  */
 
-#include "UriConfig.h"  /* for HAVE_REALLOCARRAY */
+#include "UriConfig.h" /* for HAVE_REALLOCARRAY */
 
 #ifdef HAVE_REALLOCARRAY
-# ifndef _GNU_SOURCE
-#  define _GNU_SOURCE 1
-# endif
-# ifdef __NetBSD__
-#  define _OPENBSD_SOURCE 1
-# endif
+#  ifndef _GNU_SOURCE
+#    define _GNU_SOURCE 1
+#  endif
+#  ifdef __NetBSD__
+#    define _OPENBSD_SOURCE 1
+#  endif
 #endif
 
 #include <errno.h>
 #include <stdlib.h>
 
-
-
 #ifndef URI_DOXYGEN
-# include "UriMemory.h"
+#  include "UriMemory.h"
 #endif
 
-
-
-#define URI_MAX(a, b)         (((a) > (b)) ? (a) : (b))
+#define URI_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 /* NOTE: This intends to mimic MALLOC_ALIGNMENT of glibc */
-#define URI_MALLOC_ALIGNMENT  URI_MAX(2 * sizeof(size_t), sizeof(long double))
+#define URI_MALLOC_ALIGNMENT URI_MAX(2 * sizeof(size_t), sizeof(long double))
 
-#define URI_MALLOC_PADDING    (URI_MALLOC_ALIGNMENT - sizeof(size_t))
-
-
+#define URI_MALLOC_PADDING (URI_MALLOC_ALIGNMENT - sizeof(size_t))
 
 #define URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size) \
-		do { \
-			/* check for unsigned overflow */ \
-			if ((nmemb != 0) && (total_size / nmemb != size)) { \
-				errno = ENOMEM; \
-				return NULL; \
-			} \
-		} while (0)
+    do { \
+        /* check for unsigned overflow */ \
+        if ((nmemb != 0) && (total_size / nmemb != size)) { \
+            errno = ENOMEM; \
+            return NULL; \
+        } \
+    } while (0)
 
-
-
-static void * uriDefaultMalloc(UriMemoryManager * URI_UNUSED(memory),
-		size_t size) {
-	return malloc(size);
+static void * uriDefaultMalloc(UriMemoryManager * URI_UNUSED(memory), size_t size) {
+    return malloc(size);
 }
 
-
-
-static void * uriDefaultCalloc(UriMemoryManager * URI_UNUSED(memory),
-		size_t nmemb, size_t size) {
-	return calloc(nmemb, size);
+static void * uriDefaultCalloc(UriMemoryManager * URI_UNUSED(memory), size_t nmemb,
+                               size_t size) {
+    return calloc(nmemb, size);
 }
 
-
-
-static void * uriDefaultRealloc(UriMemoryManager * URI_UNUSED(memory),
-		void * ptr, size_t size) {
-	return realloc(ptr, size);
+static void * uriDefaultRealloc(UriMemoryManager * URI_UNUSED(memory), void * ptr,
+                                size_t size) {
+    return realloc(ptr, size);
 }
 
-
-
-static void * uriDefaultReallocarray(UriMemoryManager * URI_UNUSED(memory),
-		void * ptr, size_t nmemb, size_t size) {
+static void * uriDefaultReallocarray(UriMemoryManager * URI_UNUSED(memory), void * ptr,
+                                     size_t nmemb, size_t size) {
 #ifdef HAVE_REALLOCARRAY
-	return reallocarray(ptr, nmemb, size);
+    return reallocarray(ptr, nmemb, size);
 #else
-	const size_t total_size = nmemb * size;
+    const size_t total_size = nmemb * size;
 
-	URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size);  /* may return */
+    URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size); /* may return */
 
-	return realloc(ptr, total_size);
+    return realloc(ptr, total_size);
 #endif
 }
 
-
-
-static void uriDefaultFree(UriMemoryManager * URI_UNUSED(memory),
-		void * ptr) {
-	free(ptr);
+static void uriDefaultFree(UriMemoryManager * URI_UNUSED(memory), void * ptr) {
+    free(ptr);
 }
-
-
 
 UriBool uriMemoryManagerIsComplete(const UriMemoryManager * memory) {
-	return (memory
-			&& memory->malloc
-			&& memory->calloc
-			&& memory->realloc
-			&& memory->reallocarray
-			&& memory->free) ? URI_TRUE : URI_FALSE;
+    return (memory && memory->malloc && memory->calloc && memory->realloc
+            && memory->reallocarray && memory->free)
+               ? URI_TRUE
+               : URI_FALSE;
 }
-
-
 
 void * uriEmulateCalloc(UriMemoryManager * memory, size_t nmemb, size_t size) {
-	void * buffer;
-	const size_t total_size = nmemb * size;
+    void * buffer;
+    const size_t total_size = nmemb * size;
 
-	if (memory == NULL) {
-		errno = EINVAL;
-		return NULL;
-	}
+    if (memory == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
 
-	URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size);  /* may return */
+    URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size); /* may return */
 
-	buffer = memory->malloc(memory, total_size);
-	if (buffer == NULL) {
-		/* errno set by malloc */
-		return NULL;
-	}
-	memset(buffer, 0, total_size);
-	return buffer;
+    buffer = memory->malloc(memory, total_size);
+    if (buffer == NULL) {
+        /* errno set by malloc */
+        return NULL;
+    }
+    memset(buffer, 0, total_size);
+    return buffer;
 }
 
+void * uriEmulateReallocarray(UriMemoryManager * memory, void * ptr, size_t nmemb,
+                              size_t size) {
+    const size_t total_size = nmemb * size;
 
+    if (memory == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
 
-void * uriEmulateReallocarray(UriMemoryManager * memory,
-		void * ptr, size_t nmemb, size_t size) {
-	const size_t total_size = nmemb * size;
+    URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size); /* may return */
 
-	if (memory == NULL) {
-		errno = EINVAL;
-		return NULL;
-	}
-
-	URI_CHECK_ALLOC_OVERFLOW(total_size, nmemb, size);  /* may return */
-
-	return memory->realloc(memory, ptr, total_size);
+    return memory->realloc(memory, ptr, total_size);
 }
 
+static void * uriDecorateMalloc(UriMemoryManager * memory, size_t size) {
+    UriMemoryManager * backend;
+    const size_t extraBytes = sizeof(size_t) + URI_MALLOC_PADDING;
+    void * buffer;
 
+    if (memory == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
 
-static void * uriDecorateMalloc(UriMemoryManager * memory,
-		size_t size) {
-	UriMemoryManager * backend;
-	const size_t extraBytes = sizeof(size_t) + URI_MALLOC_PADDING;
-	void * buffer;
+    /* check for unsigned overflow */
+    if (size > ((size_t)-1) - extraBytes) {
+        errno = ENOMEM;
+        return NULL;
+    }
 
-	if (memory == NULL) {
-		errno = EINVAL;
-		return NULL;
-	}
+    backend = (UriMemoryManager *)memory->userData;
+    if (backend == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
 
-	/* check for unsigned overflow */
-	if (size > ((size_t)-1) - extraBytes) {
-		errno = ENOMEM;
-		return NULL;
-	}
+    buffer = backend->malloc(backend, extraBytes + size);
+    if (buffer == NULL) {
+        return NULL;
+    }
 
-	backend = (UriMemoryManager *)memory->userData;
-	if (backend == NULL) {
-		errno = EINVAL;
-		return NULL;
-	}
+    *(size_t *)buffer = size;
 
-	buffer = backend->malloc(backend, extraBytes + size);
-	if (buffer == NULL) {
-		return NULL;
-	}
-
-	*(size_t *)buffer = size;
-
-	return (char *)buffer + extraBytes;
+    return (char *)buffer + extraBytes;
 }
 
+static void * uriDecorateRealloc(UriMemoryManager * memory, void * ptr, size_t size) {
+    void * newBuffer;
+    size_t prevSize;
 
+    if (memory == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
 
-static void * uriDecorateRealloc(UriMemoryManager * memory,
-		void * ptr, size_t size) {
-	void * newBuffer;
-	size_t prevSize;
+    /* man realloc: "If ptr is NULL, then the call is equivalent to
+     * malloc(size), for *all* values of size" */
+    if (ptr == NULL) {
+        return memory->malloc(memory, size);
+    }
 
-	if (memory == NULL) {
-		errno = EINVAL;
-		return NULL;
-	}
+    /* man realloc: "If size is equal to zero, and ptr is *not* NULL,
+     * then the call is equivalent to free(ptr)." */
+    if (size == 0) {
+        memory->free(memory, ptr);
+        return NULL;
+    }
 
-	/* man realloc: "If ptr is NULL, then the call is equivalent to
-	 * malloc(size), for *all* values of size" */
-	if (ptr == NULL) {
-		return memory->malloc(memory, size);
-	}
+    prevSize = *((size_t *)((char *)ptr - sizeof(size_t) - URI_MALLOC_PADDING));
 
-	/* man realloc: "If size is equal to zero, and ptr is *not* NULL,
-	 * then the call is equivalent to free(ptr)." */
-	if (size == 0) {
-		memory->free(memory, ptr);
-		return NULL;
-	}
+    /* Anything to do? */
+    /* mull-ignore-next cxx_le_to_lt */
+    if (size <= prevSize) {
+        return ptr;
+    }
 
-	prevSize = *((size_t *)((char *)ptr - sizeof(size_t) - URI_MALLOC_PADDING));
+    newBuffer = memory->malloc(memory, size);
+    if (newBuffer == NULL) {
+        /* errno set by malloc */
+        return NULL;
+    }
 
-	/* Anything to do? */
-	if (size <= prevSize) {
-		return ptr;
-	}
+    memcpy(newBuffer, ptr, prevSize);
 
-	newBuffer = memory->malloc(memory, size);
-	if (newBuffer == NULL) {
-		/* errno set by malloc */
-		return NULL;
-	}
+    memory->free(memory, ptr);
 
-	memcpy(newBuffer, ptr, prevSize);
-
-	memory->free(memory, ptr);
-
-	return newBuffer;
+    return newBuffer;
 }
-
-
 
 static void uriDecorateFree(UriMemoryManager * memory, void * ptr) {
-	UriMemoryManager * backend;
+    UriMemoryManager * backend;
 
-	if ((ptr == NULL) || (memory == NULL)) {
-		return;
-	}
+    if ((ptr == NULL) || (memory == NULL)) {
+        return;
+    }
 
-	backend = (UriMemoryManager *)memory->userData;
-	if (backend == NULL) {
-		return;
-	}
+    backend = (UriMemoryManager *)memory->userData;
+    if (backend == NULL) {
+        return;
+    }
 
-	backend->free(backend, (char *)ptr - sizeof(size_t) - URI_MALLOC_PADDING);
+    backend->free(backend, (char *)ptr - sizeof(size_t) - URI_MALLOC_PADDING);
 }
 
+int uriCompleteMemoryManager(UriMemoryManager * memory, UriMemoryManager * backend) {
+    if ((memory == NULL) || (backend == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
+    if ((backend->malloc == NULL) || (backend->free == NULL)) {
+        return URI_ERROR_MEMORY_MANAGER_INCOMPLETE;
+    }
 
-int uriCompleteMemoryManager(UriMemoryManager * memory,
-		UriMemoryManager * backend) {
-	if ((memory == NULL) || (backend == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    memory->calloc = uriEmulateCalloc;
+    memory->reallocarray = uriEmulateReallocarray;
 
-	if ((backend->malloc == NULL) || (backend->free == NULL)) {
-		return URI_ERROR_MEMORY_MANAGER_INCOMPLETE;
-	}
+    memory->malloc = uriDecorateMalloc;
+    memory->realloc = uriDecorateRealloc;
+    memory->free = uriDecorateFree;
 
-	memory->calloc = uriEmulateCalloc;
-	memory->reallocarray = uriEmulateReallocarray;
+    memory->userData = backend;
 
-	memory->malloc = uriDecorateMalloc;
-	memory->realloc = uriDecorateRealloc;
-	memory->free = uriDecorateFree;
-
-	memory->userData = backend;
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
+/* mull-off */
 int uriTestMemoryManagerEx(UriMemoryManager * memory, UriBool challengeAlignment) {
-	const size_t mallocSize = 7;
-	const size_t callocNmemb = 3;
-	const size_t callocSize = 5;
-	const size_t callocTotalSize = callocNmemb * callocSize;
-	const size_t reallocSize = 11;
-	const size_t reallocarrayNmemb = 5;
-	const size_t reallocarraySize = 7;
-	const size_t reallocarrayTotal = reallocarrayNmemb * reallocarraySize;
-	size_t index;
-	char * buffer;
+    const size_t mallocSize = 7;
+    const size_t callocNmemb = 3;
+    const size_t callocSize = 5;
+    const size_t callocTotalSize = callocNmemb * callocSize;
+    const size_t reallocSize = 11;
+    const size_t reallocarrayNmemb = 5;
+    const size_t reallocarraySize = 7;
+    const size_t reallocarrayTotal = reallocarrayNmemb * reallocarraySize;
+    size_t index;
+    char * buffer;
 
-	if (memory == NULL) {
-		return URI_ERROR_NULL;
-	}
+    if (memory == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-	if (uriMemoryManagerIsComplete(memory) != URI_TRUE) {
-		return URI_ERROR_MEMORY_MANAGER_INCOMPLETE;
-	}
+    if (uriMemoryManagerIsComplete(memory) != URI_TRUE) {
+        return URI_ERROR_MEMORY_MANAGER_INCOMPLETE;
+    }
 
-	/* malloc + free*/
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xF1';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* malloc + free*/
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xF1';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* calloc + free */
-	buffer = memory->calloc(memory, callocNmemb, callocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	for (index = 0; index < callocTotalSize; index++) {  /* all zeros? */
-		if (buffer[index] != '\0') {
-			return URI_ERROR_MEMORY_MANAGER_FAULTY;
-		}
-	}
-	buffer[callocTotalSize - 1] = '\xF2';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* calloc + free */
+    buffer = memory->calloc(memory, callocNmemb, callocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    for (index = 0; index < callocTotalSize; index++) { /* all zeros? */
+        if (buffer[index] != '\0') {
+            return URI_ERROR_MEMORY_MANAGER_FAULTY;
+        }
+    }
+    buffer[callocTotalSize - 1] = '\xF2';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* malloc + realloc + free */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	for (index = 0; index < mallocSize; index++) {
-		buffer[index] = '\xF3';
-	}
-	buffer = memory->realloc(memory, buffer, reallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	for (index = 0; index < mallocSize; index++) {  /* previous content? */
-		if (buffer[index] != '\xF3') {
-			return URI_ERROR_MEMORY_MANAGER_FAULTY;
-		}
-	}
-	buffer[reallocSize - 1] = '\xF4';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* malloc + realloc + free */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    for (index = 0; index < mallocSize; index++) {
+        buffer[index] = '\xF3';
+    }
+    buffer = memory->realloc(memory, buffer, reallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    for (index = 0; index < mallocSize; index++) { /* previous content? */
+        if (buffer[index] != '\xF3') {
+            return URI_ERROR_MEMORY_MANAGER_FAULTY;
+        }
+    }
+    buffer[reallocSize - 1] = '\xF4';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* malloc + realloc ptr!=NULL size==0 (equals free) */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xF5';
-	memory->realloc(memory, buffer, 0);
-	buffer = NULL;
+    /* malloc + realloc ptr!=NULL size==0 (equals free) */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xF5';
+    memory->realloc(memory, buffer, 0);
+    buffer = NULL;
 
-	/* realloc ptr==NULL size!=0 (equals malloc) + free */
-	buffer = memory->realloc(memory, NULL, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xF6';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* realloc ptr==NULL size!=0 (equals malloc) + free */
+    buffer = memory->realloc(memory, NULL, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xF6';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* realloc ptr==NULL size==0 (equals malloc) + free */
-	buffer = memory->realloc(memory, NULL, 0);
-	if (buffer != NULL) {
-		memory->free(memory, buffer);
-		buffer = NULL;
-	}
+    /* realloc ptr==NULL size==0 (equals malloc) + free */
+    buffer = memory->realloc(memory, NULL, 0);
+    if (buffer != NULL) {
+        memory->free(memory, buffer);
+        buffer = NULL;
+    }
 
-	/* malloc + reallocarray + free */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	for (index = 0; index < mallocSize; index++) {
-		buffer[index] = '\xF7';
-	}
-	buffer = memory->reallocarray(memory, buffer, reallocarrayNmemb,
-			reallocarraySize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	for (index = 0; index < mallocSize; index++) {  /* previous content? */
-		if (buffer[index] != '\xF7') {
-			return URI_ERROR_MEMORY_MANAGER_FAULTY;
-		}
-	}
-	buffer[reallocarrayTotal - 1] = '\xF8';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* malloc + reallocarray + free */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    for (index = 0; index < mallocSize; index++) {
+        buffer[index] = '\xF7';
+    }
+    buffer = memory->reallocarray(memory, buffer, reallocarrayNmemb, reallocarraySize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    for (index = 0; index < mallocSize; index++) { /* previous content? */
+        if (buffer[index] != '\xF7') {
+            return URI_ERROR_MEMORY_MANAGER_FAULTY;
+        }
+    }
+    buffer[reallocarrayTotal - 1] = '\xF8';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* malloc + reallocarray ptr!=NULL nmemb==0 size!=0 (equals free) */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xF9';
-	memory->reallocarray(memory, buffer, 0, reallocarraySize);
-	buffer = NULL;
+    /* malloc + reallocarray ptr!=NULL nmemb==0 size!=0 (equals free) */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xF9';
+    memory->reallocarray(memory, buffer, 0, reallocarraySize);
+    buffer = NULL;
 
-	/* malloc + reallocarray ptr!=NULL nmemb!=0 size==0 (equals free) */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xFA';
-	memory->reallocarray(memory, buffer, reallocarrayNmemb, 0);
-	buffer = NULL;
+    /* malloc + reallocarray ptr!=NULL nmemb!=0 size==0 (equals free) */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xFA';
+    memory->reallocarray(memory, buffer, reallocarrayNmemb, 0);
+    buffer = NULL;
 
-	/* malloc + reallocarray ptr!=NULL nmemb==0 size==0 (equals free) */
-	buffer = memory->malloc(memory, mallocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[mallocSize - 1] = '\xFB';
-	memory->reallocarray(memory, buffer, 0, 0);
-	buffer = NULL;
+    /* malloc + reallocarray ptr!=NULL nmemb==0 size==0 (equals free) */
+    buffer = memory->malloc(memory, mallocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[mallocSize - 1] = '\xFB';
+    memory->reallocarray(memory, buffer, 0, 0);
+    buffer = NULL;
 
-	/* reallocarray ptr==NULL nmemb!=0 size!=0 (equals malloc) + free */
-	buffer = memory->reallocarray(memory, NULL, callocNmemb, callocSize);
-	if (buffer == NULL) {
-		return URI_ERROR_MEMORY_MANAGER_FAULTY;
-	}
-	buffer[callocTotalSize - 1] = '\xFC';
-	memory->free(memory, buffer);
-	buffer = NULL;
+    /* reallocarray ptr==NULL nmemb!=0 size!=0 (equals malloc) + free */
+    buffer = memory->reallocarray(memory, NULL, callocNmemb, callocSize);
+    if (buffer == NULL) {
+        return URI_ERROR_MEMORY_MANAGER_FAULTY;
+    }
+    buffer[callocTotalSize - 1] = '\xFC';
+    memory->free(memory, buffer);
+    buffer = NULL;
 
-	/* reallocarray ptr==NULL nmemb==0 size!=0 (equals malloc) + free */
-	buffer = memory->reallocarray(memory, NULL, 0, callocSize);
-	if (buffer != NULL) {
-		memory->free(memory, buffer);
-		buffer = NULL;
-	}
+    /* reallocarray ptr==NULL nmemb==0 size!=0 (equals malloc) + free */
+    buffer = memory->reallocarray(memory, NULL, 0, callocSize);
+    if (buffer != NULL) {
+        memory->free(memory, buffer);
+        buffer = NULL;
+    }
 
-	/* reallocarray ptr==NULL nmemb!=0 size==0 (equals malloc) + free */
-	buffer = memory->reallocarray(memory, NULL, callocNmemb, 0);
-	if (buffer != NULL) {
-		memory->free(memory, buffer);
-		buffer = NULL;
-	}
+    /* reallocarray ptr==NULL nmemb!=0 size==0 (equals malloc) + free */
+    buffer = memory->reallocarray(memory, NULL, callocNmemb, 0);
+    if (buffer != NULL) {
+        memory->free(memory, buffer);
+        buffer = NULL;
+    }
 
-	/* reallocarray ptr==NULL nmemb==0 size==0 (equals malloc) + free */
-	buffer = memory->reallocarray(memory, NULL, 0, 0);
-	if (buffer != NULL) {
-		memory->free(memory, buffer);
-		buffer = NULL;
-	}
+    /* reallocarray ptr==NULL nmemb==0 size==0 (equals malloc) + free */
+    buffer = memory->reallocarray(memory, NULL, 0, 0);
+    if (buffer != NULL) {
+        memory->free(memory, buffer);
+        buffer = NULL;
+    }
 
-	/* challenge pointer alignment */
-	if (challengeAlignment == URI_TRUE) {
-		long double * ptr = memory->malloc(memory, 4 * sizeof(long double));
-		if (ptr != NULL) {
-			ptr[0] = 0.0L;
-			ptr[1] = 1.1L;
-			ptr[2] = 2.2L;
-			ptr[3] = 3.3L;
+    /* challenge pointer alignment */
+    if (challengeAlignment == URI_TRUE) {
+        long double * ptr = memory->malloc(memory, 4 * sizeof(long double));
+        if (ptr != NULL) {
+            ptr[0] = 0.0L;
+            ptr[1] = 1.1L;
+            ptr[2] = 2.2L;
+            ptr[3] = 3.3L;
 
-			{
-				long double * const ptrNew = memory->realloc(memory, ptr, 8 * sizeof(long double));
-				if (ptrNew != NULL) {
-					ptr = ptrNew;
-					ptr[4] = 4.4L;
-					ptr[5] = 5.5L;
-					ptr[6] = 6.6L;
-					ptr[7] = 7.7L;
-				}
-			}
+            long double * const ptrNew =
+                memory->realloc(memory, ptr, 8 * sizeof(long double));
+            if (ptrNew != NULL) {
+                ptr = ptrNew;
+                ptr[4] = 4.4L;
+                ptr[5] = 5.5L;
+                ptr[6] = 6.6L;
+                ptr[7] = 7.7L;
+            }
 
-			memory->free(memory, ptr);
-		}
-	}
+            memory->free(memory, ptr);
+        }
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
+/* mull-on */
 
 int uriTestMemoryManager(UriMemoryManager * memory) {
-    return uriTestMemoryManagerEx(memory, /*challengeAlignment=*/ URI_FALSE);
+    return uriTestMemoryManagerEx(memory, /*challengeAlignment=*/URI_FALSE);
 }
 
-
-
 /*extern*/ UriMemoryManager defaultMemoryManager = {
-	uriDefaultMalloc,
-	uriDefaultCalloc,
-	uriDefaultRealloc,
-	uriDefaultReallocarray,
-	uriDefaultFree,
-	NULL  /* userData */
+    uriDefaultMalloc,       uriDefaultCalloc, uriDefaultRealloc,
+    uriDefaultReallocarray, uriDefaultFree,   NULL /* userData */
 };

--- a/ext/uri/uriparser/src/UriMemory.h
+++ b/ext/uri/uriparser/src/UriMemory.h
@@ -38,41 +38,31 @@
  */
 
 #ifndef URI_MEMORY_H
-#define URI_MEMORY_H 1
+#  define URI_MEMORY_H 1
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#  endif
 
+#  define URI_CHECK_MEMORY_MANAGER(memory) \
+      do { \
+          if (memory == NULL) { \
+              memory = &defaultMemoryManager; \
+          } else if (uriMemoryManagerIsComplete(memory) != URI_TRUE) { \
+              return URI_ERROR_MEMORY_MANAGER_INCOMPLETE; \
+          } \
+      } while (0)
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-#endif
-
-
-
-#define URI_CHECK_MEMORY_MANAGER(memory)  \
-	do { \
-		if (memory == NULL) { \
-			memory = &defaultMemoryManager; \
-		} else if (uriMemoryManagerIsComplete(memory) != URI_TRUE) { \
-			return URI_ERROR_MEMORY_MANAGER_INCOMPLETE; \
-		} \
-	} while (0)
-
-
-
-#ifdef __cplusplus
-# define URIPARSER_EXTERN extern "C"
-#else
-# define URIPARSER_EXTERN extern
-#endif
+#  ifdef __cplusplus
+#    define URIPARSER_EXTERN extern "C"
+#  else
+#    define URIPARSER_EXTERN extern
+#  endif
 
 URIPARSER_EXTERN UriMemoryManager defaultMemoryManager;
 
-#undef URIPARSER_EXTERN
-
-
+#  undef URIPARSER_EXTERN
 
 UriBool uriMemoryManagerIsComplete(const UriMemoryManager * memory);
-
-
 
 #endif /* URI_MEMORY_H */

--- a/ext/uri/uriparser/src/UriNormalize.c
+++ b/ext/uri/uriparser/src/UriNormalize.c
@@ -47,865 +47,818 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriNormalize.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriNormalize.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriNormalize.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriNormalize.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriNormalizeBase.h"
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriNormalizeBase.h"
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
-
-
-
-#include <assert.h>
-
-
+#  include <assert.h>
 
 static int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri, unsigned int inMask,
-		unsigned int * outMask, UriMemoryManager * memory);
+                                           unsigned int * outMask,
+                                           UriMemoryManager * memory);
 
-static UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask,
-		unsigned int maskTest, URI_TYPE(TextRange) * range,
-		UriMemoryManager * memory);
-static UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri,
-		unsigned int * revertMask, UriMemoryManager * memory);
+static UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask, unsigned int maskTest,
+                                        URI_TYPE(TextRange) * range,
+                                        UriMemoryManager * memory);
+static UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri, unsigned int * revertMask,
+                                         UriMemoryManager * memory);
 
 static void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * first,
-		const URI_CHAR ** afterLast);
+                                                const URI_CHAR ** afterLast);
 static UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** first,
-		const URI_CHAR ** afterLast, UriMemoryManager * memory);
-static void URI_FUNC(FixPercentEncodingEngine)(
-		const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
-		const URI_CHAR * outFirst, const URI_CHAR ** outAfterLast);
+                                                  const URI_CHAR ** afterLast,
+                                                  UriMemoryManager * memory);
+static void URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst,
+                                               const URI_CHAR * inAfterLast,
+                                               const URI_CHAR * outFirst,
+                                               const URI_CHAR ** outAfterLast);
 
 static UriBool URI_FUNC(ContainsUppercaseLetters)(const URI_CHAR * first,
-		const URI_CHAR * afterLast);
+                                                  const URI_CHAR * afterLast);
 static UriBool URI_FUNC(ContainsUglyPercentEncoding)(const URI_CHAR * first,
-		const URI_CHAR * afterLast);
+                                                     const URI_CHAR * afterLast);
 
 static void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
-		const URI_CHAR * afterLast);
+                                       const URI_CHAR * afterLast);
 static void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
-		const URI_CHAR * afterLast);
+                                                            const URI_CHAR * afterLast);
 static UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
-		const URI_CHAR ** afterLast, UriMemoryManager * memory);
+                                         const URI_CHAR ** afterLast,
+                                         UriMemoryManager * memory);
 
+void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri, unsigned int revertMask,
+                              UriMemoryManager * memory) {
+    if (revertMask & URI_NORMALIZE_SCHEME) {
+        /* NOTE: A scheme cannot be the empty string
+         *       so no need to compare .first with .afterLast, here. */
+        memory->free(memory, (URI_CHAR *)uri->scheme.first);
+        uri->scheme.first = NULL;
+        uri->scheme.afterLast = NULL;
+    }
 
+    if (revertMask & URI_NORMALIZE_USER_INFO) {
+        if (uri->userInfo.first != uri->userInfo.afterLast) {
+            memory->free(memory, (URI_CHAR *)uri->userInfo.first);
+        }
+        uri->userInfo.first = NULL;
+        uri->userInfo.afterLast = NULL;
+    }
 
-void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
-		unsigned int revertMask, UriMemoryManager * memory) {
-	if (revertMask & URI_NORMALIZE_SCHEME) {
-		/* NOTE: A scheme cannot be the empty string
-		 *       so no need to compare .first with .afterLast, here. */
-		memory->free(memory, (URI_CHAR *)uri->scheme.first);
-		uri->scheme.first = NULL;
-		uri->scheme.afterLast = NULL;
-	}
+    if (revertMask & URI_NORMALIZE_HOST) {
+        if (uri->hostData.ipFuture.first != NULL) {
+            /* IPvFuture */
+            /* NOTE: An IPvFuture address cannot be the empty string
+             *       so no need to compare .first with .afterLast, here. */
+            memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
+            uri->hostData.ipFuture.first = NULL;
+            uri->hostData.ipFuture.afterLast = NULL;
+            uri->hostText.first = NULL;
+            uri->hostText.afterLast = NULL;
+        } else if (uri->hostText.first != NULL) {
+            /* Regname */
+            if (uri->hostText.first != uri->hostText.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->hostText.first);
+            }
+            uri->hostText.first = NULL;
+            uri->hostText.afterLast = NULL;
+        }
+    }
 
-	if (revertMask & URI_NORMALIZE_USER_INFO) {
-		if (uri->userInfo.first != uri->userInfo.afterLast) {
-			memory->free(memory, (URI_CHAR *)uri->userInfo.first);
-		}
-		uri->userInfo.first = NULL;
-		uri->userInfo.afterLast = NULL;
-	}
+    /* NOTE: Port cannot happen! */
 
-	if (revertMask & URI_NORMALIZE_HOST) {
-		if (uri->hostData.ipFuture.first != NULL) {
-			/* IPvFuture */
-			/* NOTE: An IPvFuture address cannot be the empty string
-			 *       so no need to compare .first with .afterLast, here. */
-			memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
-			uri->hostData.ipFuture.first = NULL;
-			uri->hostData.ipFuture.afterLast = NULL;
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
-		} else if (uri->hostText.first != NULL) {
-			/* Regname */
-			if (uri->hostText.first != uri->hostText.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->hostText.first);
-			}
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
-		}
-	}
+    if (revertMask & URI_NORMALIZE_PATH) {
+        URI_TYPE(PathSegment) * walker = uri->pathHead;
+        while (walker != NULL) {
+            URI_TYPE(PathSegment) * const next = walker->next;
+            if (walker->text.afterLast > walker->text.first) {
+                memory->free(memory, (URI_CHAR *)walker->text.first);
+            }
+            memory->free(memory, walker);
+            walker = next;
+        }
+        uri->pathHead = NULL;
+        uri->pathTail = NULL;
+    }
 
-	/* NOTE: Port cannot happen! */
+    if (revertMask & URI_NORMALIZE_QUERY) {
+        if (uri->query.first != uri->query.afterLast) {
+            memory->free(memory, (URI_CHAR *)uri->query.first);
+        }
+        uri->query.first = NULL;
+        uri->query.afterLast = NULL;
+    }
 
-	if (revertMask & URI_NORMALIZE_PATH) {
-		URI_TYPE(PathSegment) * walker = uri->pathHead;
-		while (walker != NULL) {
-			URI_TYPE(PathSegment) * const next = walker->next;
-			if (walker->text.afterLast > walker->text.first) {
-				memory->free(memory, (URI_CHAR *)walker->text.first);
-			}
-			memory->free(memory, walker);
-			walker = next;
-		}
-		uri->pathHead = NULL;
-		uri->pathTail = NULL;
-	}
-
-	if (revertMask & URI_NORMALIZE_QUERY) {
-		if (uri->query.first != uri->query.afterLast) {
-			memory->free(memory, (URI_CHAR *)uri->query.first);
-		}
-		uri->query.first = NULL;
-		uri->query.afterLast = NULL;
-	}
-
-	if (revertMask & URI_NORMALIZE_FRAGMENT) {
-		if (uri->fragment.first != uri->fragment.afterLast) {
-			memory->free(memory, (URI_CHAR *)uri->fragment.first);
-		}
-		uri->fragment.first = NULL;
-		uri->fragment.afterLast = NULL;
-	}
+    if (revertMask & URI_NORMALIZE_FRAGMENT) {
+        if (uri->fragment.first != uri->fragment.afterLast) {
+            memory->free(memory, (URI_CHAR *)uri->fragment.first);
+        }
+        uri->fragment.first = NULL;
+        uri->fragment.afterLast = NULL;
+    }
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(ContainsUppercaseLetters)(const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
-		const URI_CHAR * i = first;
-		for (; i < afterLast; i++) {
-			/* 6.2.2.1 Case Normalization: uppercase letters in scheme or host */
-			if ((*i >= _UT('A')) && (*i <= _UT('Z'))) {
-				return URI_TRUE;
-			}
-		}
-	}
-	return URI_FALSE;
+                                                             const URI_CHAR * afterLast) {
+    if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
+        const URI_CHAR * i = first;
+        for (; i < afterLast; i++) {
+            /* 6.2.2.1 Case Normalization: uppercase letters in scheme or host */
+            if ((*i >= _UT('A')) && (*i <= _UT('Z'))) {
+                return URI_TRUE;
+            }
+        }
+    }
+    return URI_FALSE;
 }
 
-
-
-static URI_INLINE UriBool URI_FUNC(ContainsUglyPercentEncoding)(const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
-		const URI_CHAR * i = first;
-		for (; i + 2 < afterLast; i++) {
-			if (i[0] == _UT('%')) {
-				/* 6.2.2.1 Case Normalization: *
-				 * lowercase percent-encodings */
-				if (((i[1] >= _UT('a')) && (i[1] <= _UT('f')))
-						|| ((i[2] >= _UT('a')) && (i[2] <= _UT('f')))) {
-					return URI_TRUE;
-				} else {
-					/* 6.2.2.2 Percent-Encoding Normalization: *
-					 * percent-encoded unreserved characters   */
-					const unsigned char left = URI_FUNC(HexdigToInt)(i[1]);
-					const unsigned char right = URI_FUNC(HexdigToInt)(i[2]);
-					const int code = 16 * left + right;
-					if (uriIsUnreserved(code)) {
-						return URI_TRUE;
-					}
-				}
-			}
-		}
-	}
-	return URI_FALSE;
+static URI_INLINE UriBool URI_FUNC(ContainsUglyPercentEncoding)(
+    const URI_CHAR * first, const URI_CHAR * afterLast) {
+    if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
+        const URI_CHAR * i = first;
+        for (; i + 2 < afterLast; i++) {
+            if (i[0] == _UT('%')) {
+                /* 6.2.2.1 Case Normalization: *
+                 * lowercase percent-encodings */
+                if (((i[1] >= _UT('a')) && (i[1] <= _UT('f')))
+                    || ((i[2] >= _UT('a')) && (i[2] <= _UT('f')))) {
+                    return URI_TRUE;
+                } else {
+                    /* 6.2.2.2 Percent-Encoding Normalization: *
+                     * percent-encoded unreserved characters   */
+                    const unsigned char left = URI_FUNC(HexdigToInt)(i[1]);
+                    const unsigned char right = URI_FUNC(HexdigToInt)(i[2]);
+                    const int code = 16 * left + right;
+                    if (uriIsUnreserved(code)) {
+                        return URI_TRUE;
+                    }
+                }
+            }
+        }
+    }
+    return URI_FALSE;
 }
-
-
 
 static URI_INLINE void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
-		URI_CHAR * i = (URI_CHAR *)first;
-		const int lowerUpperDiff = (_UT('a') - _UT('A'));
-		for (; i < afterLast; i++) {
-			if ((*i >= _UT('A')) && (*i <=_UT('Z'))) {
-				*i = (URI_CHAR)(*i + lowerUpperDiff);
-			}
-		}
-	}
+                                                  const URI_CHAR * afterLast) {
+    if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
+        URI_CHAR * i = (URI_CHAR *)first;
+        const int lowerUpperDiff = (_UT('a') - _UT('A'));
+        for (; i < afterLast; i++) {
+            if ((*i >= _UT('A')) && (*i <= _UT('Z'))) {
+                *i = (URI_CHAR)(*i + lowerUpperDiff);
+            }
+        }
+    }
 }
 
-
-
-static URI_INLINE void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
-		URI_CHAR * i = (URI_CHAR *)first;
-		const int lowerUpperDiff = (_UT('a') - _UT('A'));
-		for (; i < afterLast; i++) {
-			if ((*i >= _UT('A')) && (*i <=_UT('Z'))) {
-				*i = (URI_CHAR)(*i + lowerUpperDiff);
-			} else if (*i == _UT('%')) {
-				if (i + 3 >= afterLast) {
-					return;
-				}
-				i += 2;
-			}
-		}
-	}
+static URI_INLINE void
+URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
+                                                const URI_CHAR * afterLast) {
+    if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
+        URI_CHAR * i = (URI_CHAR *)first;
+        const int lowerUpperDiff = (_UT('a') - _UT('A'));
+        for (; i < afterLast; i++) {
+            if ((*i >= _UT('A')) && (*i <= _UT('Z'))) {
+                *i = (URI_CHAR)(*i + lowerUpperDiff);
+            } else if (*i == _UT('%')) {
+                if (i + 3 >= afterLast) {
+                    return;
+                }
+                i += 2;
+            }
+        }
+    }
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
-		const URI_CHAR ** afterLast, UriMemoryManager * memory) {
-	int lenInChars;
-	const int lowerUpperDiff = (_UT('a') - _UT('A'));
-	URI_CHAR * buffer;
-	int i = 0;
+                                                    const URI_CHAR ** afterLast,
+                                                    UriMemoryManager * memory) {
+    int lenInChars;
+    const int lowerUpperDiff = (_UT('a') - _UT('A'));
+    URI_CHAR * buffer;
+    int i = 0;
 
-	if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
-			|| (*afterLast == NULL)) {
-		return URI_FALSE;
-	}
+    if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
+        || (*afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-	lenInChars = (int)(*afterLast - *first);
-	if (lenInChars == 0) {
-		return URI_TRUE;
-	} else if (lenInChars < 0) {
-		return URI_FALSE;
-	}
+    lenInChars = (int)(*afterLast - *first);
+    if (lenInChars == 0) {
+        return URI_TRUE;
+    } else if (lenInChars < 0) {
+        return URI_FALSE;
+    }
 
-	buffer = memory->malloc(memory, lenInChars * sizeof(URI_CHAR));
-	if (buffer == NULL) {
-		return URI_FALSE;
-	}
+    buffer = memory->malloc(memory, lenInChars * sizeof(URI_CHAR));
+    if (buffer == NULL) {
+        return URI_FALSE;
+    }
 
-	for (; i < lenInChars; i++) {
-		if (((*first)[i] >= _UT('A')) && ((*first)[i] <=_UT('Z'))) {
-			buffer[i] = (URI_CHAR)((*first)[i] + lowerUpperDiff);
-		} else {
-			buffer[i] = (*first)[i];
-		}
-	}
+    for (; i < lenInChars; i++) {
+        if (((*first)[i] >= _UT('A')) && ((*first)[i] <= _UT('Z'))) {
+            buffer[i] = (URI_CHAR)((*first)[i] + lowerUpperDiff);
+        } else {
+            buffer[i] = (*first)[i];
+        }
+    }
 
-	*first = buffer;
-	*afterLast = buffer + lenInChars;
-	return URI_TRUE;
+    *first = buffer;
+    *afterLast = buffer + lenInChars;
+    return URI_TRUE;
 }
-
-
 
 /* NOTE: Implementation must stay inplace-compatible */
-static URI_INLINE void URI_FUNC(FixPercentEncodingEngine)(
-		const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
-		const URI_CHAR * outFirst, const URI_CHAR ** outAfterLast) {
-	URI_CHAR * write = (URI_CHAR *)outFirst;
-	const int lenInChars = (int)(inAfterLast - inFirst);
-	int i = 0;
+static URI_INLINE void
+URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
+                                   const URI_CHAR * outFirst,
+                                   const URI_CHAR ** outAfterLast) {
+    URI_CHAR * write = (URI_CHAR *)outFirst;
+    const int lenInChars = (int)(inAfterLast - inFirst);
+    int i = 0;
 
-	/* All but last two */
-	for (; i + 2 < lenInChars; i++) {
-		if (inFirst[i] != _UT('%')) {
-			write[0] = inFirst[i];
-			write++;
-		} else {
-			/* 6.2.2.2 Percent-Encoding Normalization: *
-			 * percent-encoded unreserved characters   */
-			const URI_CHAR one = inFirst[i + 1];
-			const URI_CHAR two = inFirst[i + 2];
-			const unsigned char left = URI_FUNC(HexdigToInt)(one);
-			const unsigned char right = URI_FUNC(HexdigToInt)(two);
-			const int code = 16 * left + right;
-			if (uriIsUnreserved(code)) {
-				write[0] = (URI_CHAR)(code);
-				write++;
-			} else {
-				/* 6.2.2.1 Case Normalization: *
-				 * uppercase percent-encodings */
-				write[0] = _UT('%');
-				write[1] = URI_FUNC(HexToLetterEx)(left, URI_TRUE);
-				write[2] = URI_FUNC(HexToLetterEx)(right, URI_TRUE);
-				write += 3;
-			}
+    /* All but last two */
+    for (; i + 2 < lenInChars; i++) {
+        if (inFirst[i] != _UT('%')) {
+            write[0] = inFirst[i];
+            write++;
+        } else {
+            /* 6.2.2.2 Percent-Encoding Normalization: *
+             * percent-encoded unreserved characters   */
+            const URI_CHAR one = inFirst[i + 1];
+            const URI_CHAR two = inFirst[i + 2];
+            const unsigned char left = URI_FUNC(HexdigToInt)(one);
+            const unsigned char right = URI_FUNC(HexdigToInt)(two);
+            const int code = 16 * left + right;
+            if (uriIsUnreserved(code)) {
+                write[0] = (URI_CHAR)(code);
+                write++;
+            } else {
+                /* 6.2.2.1 Case Normalization: *
+                 * uppercase percent-encodings */
+                write[0] = _UT('%');
+                write[1] = URI_FUNC(HexToLetterEx)(left, URI_TRUE);
+                write[2] = URI_FUNC(HexToLetterEx)(right, URI_TRUE);
+                write += 3;
+            }
 
-			i += 2; /* For the two chars of the percent group we just ate */
-		}
-	}
+            i += 2; /* For the two chars of the percent group we just ate */
+        }
+    }
 
-	/* Last two */
-	for (; i < lenInChars; i++) {
-		write[0] = inFirst[i];
-		write++;
-	}
+    /* Last two */
+    for (; i < lenInChars; i++) {
+        write[0] = inFirst[i];
+        write++;
+    }
 
-	*outAfterLast = write;
+    *outAfterLast = write;
 }
-
-
 
 static URI_INLINE void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * first,
-		const URI_CHAR ** afterLast) {
-	/* Death checks */
-	if ((first == NULL) || (afterLast == NULL) || (*afterLast == NULL)) {
-		return;
-	}
+                                                           const URI_CHAR ** afterLast) {
+    /* Death checks */
+    if ((first == NULL) || (afterLast == NULL) || (*afterLast == NULL)) {
+        return;
+    }
 
-	/* Fix inplace */
-	URI_FUNC(FixPercentEncodingEngine)(first, *afterLast, first, afterLast);
+    /* Fix inplace */
+    URI_FUNC(FixPercentEncodingEngine)(first, *afterLast, first, afterLast);
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** first,
-		const URI_CHAR ** afterLast, UriMemoryManager * memory) {
-	int lenInChars;
-	URI_CHAR * buffer;
+                                                             const URI_CHAR ** afterLast,
+                                                             UriMemoryManager * memory) {
+    int lenInChars;
+    URI_CHAR * buffer;
 
-	/* Death checks */
-	if ((first == NULL) || (afterLast == NULL)
-			|| (*first == NULL) || (*afterLast == NULL)) {
-		return URI_FALSE;
-	}
+    /* Death checks */
+    if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
+        || (*afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-	/* Old text length */
-	lenInChars = (int)(*afterLast - *first);
-	if (lenInChars == 0) {
-		return URI_TRUE;
-	} else if (lenInChars < 0) {
-		return URI_FALSE;
-	}
+    /* Old text length */
+    lenInChars = (int)(*afterLast - *first);
+    if (lenInChars == 0) {
+        return URI_TRUE;
+    } else if (lenInChars < 0) {
+        return URI_FALSE;
+    }
 
-	/* New buffer */
-	buffer = memory->malloc(memory, lenInChars * sizeof(URI_CHAR));
-	if (buffer == NULL) {
-		return URI_FALSE;
-	}
+    /* New buffer */
+    buffer = memory->malloc(memory, lenInChars * sizeof(URI_CHAR));
+    if (buffer == NULL) {
+        return URI_FALSE;
+    }
 
-	/* Fix on copy */
-	URI_FUNC(FixPercentEncodingEngine)(*first, *afterLast, buffer, afterLast);
-	*first = buffer;
-	return URI_TRUE;
+    /* Fix on copy */
+    URI_FUNC(FixPercentEncodingEngine)(*first, *afterLast, buffer, afterLast);
+    *first = buffer;
+    return URI_TRUE;
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask,
-		unsigned int maskTest, URI_TYPE(TextRange) * range,
-		UriMemoryManager * memory) {
-	if (((*revertMask & maskTest) == 0)
-			&& (range->first != NULL)
-			&& (range->afterLast != NULL)
-			&& (range->afterLast > range->first)) {
-		if (URI_FUNC(CopyRange)(range, range, memory) == URI_FALSE) {
-			return URI_FALSE;
-		}
-		*revertMask |= maskTest;
-	}
-	return URI_TRUE;
+                                                   unsigned int maskTest,
+                                                   URI_TYPE(TextRange) * range,
+                                                   UriMemoryManager * memory) {
+    if (((*revertMask & maskTest) == 0) && (range->first != NULL)
+        && (range->afterLast != NULL) && (range->afterLast > range->first)) {
+        if (URI_FUNC(CopyRange)(range, range, memory) == URI_FALSE) {
+            return URI_FALSE;
+        }
+        *revertMask |= maskTest;
+    }
+    return URI_TRUE;
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri,
-		unsigned int * revertMask, UriMemoryManager * memory) {
-	URI_TYPE(PathSegment) * walker = uri->pathHead;
-	if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_SCHEME,
-				&(uri->scheme), memory)
-			|| !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_USER_INFO,
-				&(uri->userInfo), memory)
-			|| !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_QUERY,
-				&(uri->query), memory)
-			|| !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_FRAGMENT,
-				&(uri->fragment), memory)) {
-		return URI_FALSE; /* Raises malloc error */
-	}
+                                                    unsigned int * revertMask,
+                                                    UriMemoryManager * memory) {
+    URI_TYPE(PathSegment) * walker = uri->pathHead;
+    if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_SCHEME, &(uri->scheme),
+                                  memory)
+        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_USER_INFO,
+                                     &(uri->userInfo), memory)
+        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_QUERY, &(uri->query),
+                                     memory)
+        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_FRAGMENT, &(uri->fragment),
+                                     memory)) {
+        return URI_FALSE; /* Raises malloc error */
+    }
 
-	/* Host */
-	if ((*revertMask & URI_NORMALIZE_HOST) == 0) {
-		if (uri->hostData.ipFuture.first != NULL) {
-			/* IPvFuture */
-			if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
-					&(uri->hostData.ipFuture), memory)) {
-				return URI_FALSE; /* Raises malloc error */
-			}
-			uri->hostText.first = uri->hostData.ipFuture.first;
-			uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
-		} else if (uri->hostText.first != NULL) {
-			/* Regname */
-			if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
-					&(uri->hostText), memory)) {
-				return URI_FALSE; /* Raises malloc error */
-			}
-		}
-	}
+    /* Host */
+    if ((*revertMask & URI_NORMALIZE_HOST) == 0) {
+        if (uri->hostData.ipFuture.first != NULL) {
+            /* IPvFuture */
+            if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
+                                          &(uri->hostData.ipFuture), memory)) {
+                return URI_FALSE; /* Raises malloc error */
+            }
+            uri->hostText.first = uri->hostData.ipFuture.first;
+            uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
+        } else if (uri->hostText.first != NULL) {
+            /* Regname */
+            if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
+                                          &(uri->hostText), memory)) {
+                return URI_FALSE; /* Raises malloc error */
+            }
+        }
+    }
 
-	/* Path */
-	if ((*revertMask & URI_NORMALIZE_PATH) == 0) {
-		while (walker != NULL) {
-			if (!URI_FUNC(MakeRangeOwner)(revertMask, 0, &(walker->text), memory)) {
-				/* Free allocations done so far and kill path */
+    /* Path */
+    if ((*revertMask & URI_NORMALIZE_PATH) == 0) {
+        while (walker != NULL) {
+            if (!URI_FUNC(MakeRangeOwner)(revertMask, 0, &(walker->text), memory)) {
+                /* Free allocations done so far and kill path */
 
-				/* Kill path to one before walker (if any) */
-				URI_TYPE(PathSegment) * ranger = uri->pathHead;
-				while (ranger != walker) {
-					URI_TYPE(PathSegment) * const next = ranger->next;
-					if ((ranger->text.first != NULL)
-							&& (ranger->text.afterLast != NULL)
-							&& (ranger->text.afterLast > ranger->text.first)) {
-						memory->free(memory, (URI_CHAR *)ranger->text.first);
-					}
-					memory->free(memory, ranger);
-					ranger = next;
-				}
+                /* Kill path to one before walker (if any) */
+                URI_TYPE(PathSegment) * ranger = uri->pathHead;
+                while (ranger != walker) {
+                    URI_TYPE(PathSegment) * const next = ranger->next;
+                    if ((ranger->text.first != NULL) && (ranger->text.afterLast != NULL)
+                        && (ranger->text.afterLast > ranger->text.first)) {
+                        memory->free(memory, (URI_CHAR *)ranger->text.first);
+                    }
+                    memory->free(memory, ranger);
+                    ranger = next;
+                }
 
-				/* Kill path from walker */
-				while (walker != NULL) {
-					URI_TYPE(PathSegment) * const next = walker->next;
-					memory->free(memory, walker);
-					walker = next;
-				}
+                /* Kill path from walker */
+                while (walker != NULL) {
+                    URI_TYPE(PathSegment) * const next = walker->next;
+                    memory->free(memory, walker);
+                    walker = next;
+                }
 
-				uri->pathHead = NULL;
-				uri->pathTail = NULL;
-				return URI_FALSE; /* Raises malloc error */
-			}
-			walker = walker->next;
-		}
-		*revertMask |= URI_NORMALIZE_PATH;
-	}
+                uri->pathHead = NULL;
+                uri->pathTail = NULL;
+                return URI_FALSE; /* Raises malloc error */
+            }
+            walker = walker->next;
+        }
+        *revertMask |= URI_NORMALIZE_PATH;
+    }
 
-	/* Port text, must come last so we don't have to undo that one if it fails. *
-	 * Otherwise we would need and extra enum flag for it although the port      *
-	 * cannot go unnormalized...                                                */
-	if (!URI_FUNC(MakeRangeOwner)(revertMask, 0, &(uri->portText), memory)) {
-		return URI_FALSE; /* Raises malloc error */
-	}
+    /* Port text, must come last so we don't have to undo that one if it fails. *
+     * Otherwise we would need and extra enum flag for it although the port      *
+     * cannot go unnormalized...                                                */
+    if (!URI_FUNC(MakeRangeOwner)(revertMask, 0, &(uri->portText), memory)) {
+        return URI_FALSE; /* Raises malloc error */
+    }
 
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
-
 
 unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(const URI_TYPE(Uri) * uri) {
-	unsigned int outMask = URI_NORMALIZED;  /* for NULL uri */
-	URI_FUNC(NormalizeSyntaxMaskRequiredEx)(uri, &outMask);
-	return outMask;
+    unsigned int outMask = URI_NORMALIZED; /* for NULL uri */
+    URI_FUNC(NormalizeSyntaxMaskRequiredEx)(uri, &outMask);
+    return outMask;
 }
-
-
 
 int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
-		unsigned int * outMask) {
-	UriMemoryManager * const memory = NULL;  /* no use of memory manager */
+                                            unsigned int * outMask) {
+    UriMemoryManager * const memory = NULL; /* no use of memory manager */
 
-#if defined(__GNUC__) && ((__GNUC__ > 4) \
-		|| ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
-	/* Slower code that fixes a warning, not sure if this is a smart idea */
-	URI_TYPE(Uri) writeableClone;
-#endif
+#  if defined(__GNUC__) \
+      && ((__GNUC__ > 4) \
+          || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+    /* Slower code that fixes a warning, not sure if this is a smart idea */
+    URI_TYPE(Uri) writeableClone;
+#  endif
 
-	if ((uri == NULL) || (outMask == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    if ((uri == NULL) || (outMask == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-#if defined(__GNUC__) && ((__GNUC__ > 4) \
-		|| ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
-	/* Slower code that fixes a warning, not sure if this is a smart idea */
-	memcpy(&writeableClone, uri, 1 * sizeof(URI_TYPE(Uri)));
-	URI_FUNC(NormalizeSyntaxEngine)(&writeableClone, 0, outMask, memory);
-#else
-	URI_FUNC(NormalizeSyntaxEngine)((URI_TYPE(Uri) *)uri, 0, outMask, memory);
-#endif
-	return URI_SUCCESS;
+#  if defined(__GNUC__) \
+      && ((__GNUC__ > 4) \
+          || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+    /* Slower code that fixes a warning, not sure if this is a smart idea */
+    memcpy(&writeableClone, uri, 1 * sizeof(URI_TYPE(Uri)));
+    URI_FUNC(NormalizeSyntaxEngine)(&writeableClone, 0, outMask, memory);
+#  else
+    URI_FUNC(NormalizeSyntaxEngine)((URI_TYPE(Uri) *)uri, 0, outMask, memory);
+#  endif
+    return URI_SUCCESS;
 }
-
-
 
 int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri, unsigned int mask) {
-	return URI_FUNC(NormalizeSyntaxExMm)(uri, mask, NULL);
+    return URI_FUNC(NormalizeSyntaxExMm)(uri, mask, NULL);
 }
-
-
 
 int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri, unsigned int mask,
-		UriMemoryManager * memory) {
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
-	return URI_FUNC(NormalizeSyntaxEngine)(uri, mask, NULL, memory);
+                                  UriMemoryManager * memory) {
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
+    return URI_FUNC(NormalizeSyntaxEngine)(uri, mask, NULL, memory);
 }
-
-
 
 int URI_FUNC(NormalizeSyntax)(URI_TYPE(Uri) * uri) {
-	return URI_FUNC(NormalizeSyntaxEx)(uri, (unsigned int)-1);
+    return URI_FUNC(NormalizeSyntaxEx)(uri, (unsigned int)-1);
 }
 
+static const URI_CHAR * URI_FUNC(PastLeadingZeros)(const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast) {
+    assert(first != NULL);
+    assert(afterLast != NULL);
+    assert(first != afterLast);
 
-static const URI_CHAR * URI_FUNC(PastLeadingZeros)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	assert(first != NULL);
-	assert(afterLast != NULL);
-	assert(first != afterLast);
+    /* Find the first non-zero character */
+    const URI_CHAR * remainderFirst = first;
+    while ((remainderFirst < afterLast) && (remainderFirst[0] == _UT('0'))) {
+        remainderFirst++;
+    }
 
-	{	
-		/* Find the first non-zero character */
-		const URI_CHAR * remainderFirst = first;
-		while ((remainderFirst < afterLast) && (remainderFirst[0] == _UT('0'))) {
-			remainderFirst++;
-		}
+    /* Is the string /all/ zeros? */
+    if (remainderFirst == afterLast) {
+        /* Yes, and length is >=1 because we ruled out the empty string earlier;
+         * pull back onto rightmost zero */
+        assert(remainderFirst > first);
+        remainderFirst--;
+        assert(remainderFirst[0] == _UT('0'));
+    }
 
-		/* Is the string /all/ zeros? */
-		if (remainderFirst == afterLast) {
-			/* Yes, and length is >=1 because we ruled out the empty string earlier;
-			 * pull back onto rightmost zero */
-			assert(remainderFirst > first);
-			remainderFirst--;
-			assert(remainderFirst[0] == _UT('0'));
-		}
-
-		return remainderFirst;
-	}
+    return remainderFirst;
 }
 
+static void URI_FUNC(DropLeadingZerosInplace)(URI_CHAR * first,
+                                              const URI_CHAR ** afterLast) {
+    assert(first != NULL);
+    assert(afterLast != NULL);
+    assert(*afterLast != NULL);
 
+    if (first == *afterLast) {
+        return;
+    }
 
-static void URI_FUNC(DropLeadingZerosInplace)(URI_CHAR * first, const URI_CHAR ** afterLast) {
-	assert(first != NULL);
-	assert(afterLast != NULL);
-	assert(*afterLast != NULL);
+    const URI_CHAR * const remainderFirst = URI_FUNC(PastLeadingZeros)(first, *afterLast);
 
-	if (first == *afterLast) {
-		return;
-	}
-
-	{
-		const URI_CHAR * const remainderFirst = URI_FUNC(PastLeadingZeros)(first, *afterLast);
-
-		if (remainderFirst > first) {
-			const size_t remainderLen = *afterLast - remainderFirst;
-			memmove(first, remainderFirst, remainderLen * sizeof(URI_CHAR));
-			first[remainderLen] = _UT('\0');
-			*afterLast = first + remainderLen;
-		}
-	}
+    if (remainderFirst > first) {
+        const size_t remainderLen = *afterLast - remainderFirst;
+        memmove(first, remainderFirst, remainderLen * sizeof(URI_CHAR));
+        first[remainderLen] = _UT('\0');
+        *afterLast = first + remainderLen;
+    }
 }
 
+static void URI_FUNC(AdvancePastLeadingZeros)(const URI_CHAR ** first,
+                                              const URI_CHAR * afterLast) {
+    assert(first != NULL);
+    assert(*first != NULL);
+    assert(afterLast != NULL);
 
+    if (*first == afterLast) {
+        return;
+    }
 
-static void URI_FUNC(AdvancePastLeadingZeros)(
-		const URI_CHAR ** first, const URI_CHAR * afterLast) {
-	assert(first != NULL);
-	assert(*first != NULL);
-	assert(afterLast != NULL);
+    const URI_CHAR * const remainderFirst = URI_FUNC(PastLeadingZeros)(*first, afterLast);
 
-	if (*first == afterLast) {
-		return;
-	}
-
-	{
-		const URI_CHAR * const remainderFirst = URI_FUNC(PastLeadingZeros)(*first, afterLast);
-
-		/* Cut off leading zeros */
-		*first = remainderFirst;
-	}
+    /* Cut off leading zeros */
+    *first = remainderFirst;
 }
-
-
 
 static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
-		unsigned int inMask, unsigned int * outMask,
-		UriMemoryManager * memory) {
-	unsigned int revertMask = URI_NORMALIZED;
+                                                      unsigned int inMask,
+                                                      unsigned int * outMask,
+                                                      UriMemoryManager * memory) {
+    unsigned int revertMask = URI_NORMALIZED;
 
-	/* Not just doing inspection? -> memory manager required! */
-	if (outMask == NULL) {
-		assert(memory != NULL);
-	}
+    /* Not just doing inspection? -> memory manager required! */
+    if (outMask == NULL) {
+        assert(memory != NULL);
+    }
 
-	if (uri == NULL) {
-		if (outMask != NULL) {
-			*outMask = URI_NORMALIZED;
-			return URI_SUCCESS;
-		} else {
-			return URI_ERROR_NULL;
-		}
-	}
+    if (uri == NULL) {
+        if (outMask != NULL) {
+            *outMask = URI_NORMALIZED;
+            return URI_SUCCESS;
+        } else {
+            return URI_ERROR_NULL;
+        }
+    }
 
-	if (outMask != NULL) {
-		/* Reset mask */
-		*outMask = URI_NORMALIZED;
-	} else if (inMask == URI_NORMALIZED) {
-		/* Nothing to do */
-		return URI_SUCCESS;
-	}
+    if (outMask != NULL) {
+        /* Reset mask */
+        *outMask = URI_NORMALIZED;
+    } else if (inMask == URI_NORMALIZED) {
+        /* Nothing to do */
+        return URI_SUCCESS;
+    }
 
-	/* Scheme, host */
-	if (outMask != NULL) {
-		const UriBool normalizeScheme = URI_FUNC(ContainsUppercaseLetters)(
-				uri->scheme.first, uri->scheme.afterLast);
-		const UriBool normalizeHostCase = URI_FUNC(ContainsUppercaseLetters)(
-			uri->hostText.first, uri->hostText.afterLast);
-		if (normalizeScheme) {
-			*outMask |= URI_NORMALIZE_SCHEME;
-		}
+    /* Scheme, host */
+    if (outMask != NULL) {
+        const UriBool normalizeScheme =
+            URI_FUNC(ContainsUppercaseLetters)(uri->scheme.first, uri->scheme.afterLast);
+        const UriBool normalizeHostCase = URI_FUNC(ContainsUppercaseLetters)(
+            uri->hostText.first, uri->hostText.afterLast);
+        if (normalizeScheme) {
+            *outMask |= URI_NORMALIZE_SCHEME;
+        }
 
-		if (normalizeHostCase) {
-			*outMask |= URI_NORMALIZE_HOST;
-		} else {
-			const UriBool normalizeHostPrecent = URI_FUNC(ContainsUglyPercentEncoding)(
-					uri->hostText.first, uri->hostText.afterLast);
-			if (normalizeHostPrecent) {
-				*outMask |= URI_NORMALIZE_HOST;
-			}
-		}
-	} else {
-		/* Scheme */
-		if ((inMask & URI_NORMALIZE_SCHEME) && (uri->scheme.first != NULL)) {
-			if (uri->owner) {
-				URI_FUNC(LowercaseInplace)(uri->scheme.first, uri->scheme.afterLast);
-			} else {
-				if (!URI_FUNC(LowercaseMalloc)(&(uri->scheme.first), &(uri->scheme.afterLast), memory)) {
-					URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-					return URI_ERROR_MALLOC;
-				}
-				revertMask |= URI_NORMALIZE_SCHEME;
-			}
-		}
+        if (normalizeHostCase) {
+            *outMask |= URI_NORMALIZE_HOST;
+        } else {
+            const UriBool normalizeHostPrecent = URI_FUNC(ContainsUglyPercentEncoding)(
+                uri->hostText.first, uri->hostText.afterLast);
+            if (normalizeHostPrecent) {
+                *outMask |= URI_NORMALIZE_HOST;
+            }
+        }
+    } else {
+        /* Scheme */
+        if ((inMask & URI_NORMALIZE_SCHEME) && (uri->scheme.first != NULL)) {
+            if (uri->owner) {
+                URI_FUNC(LowercaseInplace)(uri->scheme.first, uri->scheme.afterLast);
+            } else {
+                if (!URI_FUNC(LowercaseMalloc)(&(uri->scheme.first),
+                                               &(uri->scheme.afterLast), memory)) {
+                    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                    return URI_ERROR_MALLOC;
+                }
+                revertMask |= URI_NORMALIZE_SCHEME;
+            }
+        }
 
-		/* Host */
-		if (inMask & URI_NORMALIZE_HOST) {
-			if (uri->hostData.ipFuture.first != NULL) {
-				/* IPvFuture */
-				if (uri->owner) {
-					URI_FUNC(LowercaseInplace)(uri->hostData.ipFuture.first,
-							uri->hostData.ipFuture.afterLast);
-				} else {
-					if (!URI_FUNC(LowercaseMalloc)(&(uri->hostData.ipFuture.first),
-							&(uri->hostData.ipFuture.afterLast), memory)) {
-						URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-						return URI_ERROR_MALLOC;
-					}
-					revertMask |= URI_NORMALIZE_HOST;
-				}
-				uri->hostText.first = uri->hostData.ipFuture.first;
-				uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
-			} else if ((uri->hostText.first != NULL)
-					&& (uri->hostData.ip4 == NULL)) {
-				/* Regname or IPv6 */
-				if (uri->owner) {
-					URI_FUNC(FixPercentEncodingInplace)(uri->hostText.first,
-							&(uri->hostText.afterLast));
-				} else {
-					if (!URI_FUNC(FixPercentEncodingMalloc)(
-							&(uri->hostText.first),
-							&(uri->hostText.afterLast),
-							memory)) {
-						URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-						return URI_ERROR_MALLOC;
-					}
-					revertMask |= URI_NORMALIZE_HOST;
-				}
+        /* Host */
+        if (inMask & URI_NORMALIZE_HOST) {
+            if (uri->hostData.ipFuture.first != NULL) {
+                /* IPvFuture */
+                if (uri->owner) {
+                    URI_FUNC(LowercaseInplace)(uri->hostData.ipFuture.first,
+                                               uri->hostData.ipFuture.afterLast);
+                } else {
+                    if (!URI_FUNC(LowercaseMalloc)(&(uri->hostData.ipFuture.first),
+                                                   &(uri->hostData.ipFuture.afterLast),
+                                                   memory)) {
+                        URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                        return URI_ERROR_MALLOC;
+                    }
+                    revertMask |= URI_NORMALIZE_HOST;
+                }
+                uri->hostText.first = uri->hostData.ipFuture.first;
+                uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
+            } else if ((uri->hostText.first != NULL) && (uri->hostData.ip4 == NULL)) {
+                /* Regname or IPv6 */
+                if (uri->owner) {
+                    URI_FUNC(FixPercentEncodingInplace)(uri->hostText.first,
+                                                        &(uri->hostText.afterLast));
+                } else {
+                    if (!URI_FUNC(FixPercentEncodingMalloc)(
+                            &(uri->hostText.first), &(uri->hostText.afterLast), memory)) {
+                        URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                        return URI_ERROR_MALLOC;
+                    }
+                    revertMask |= URI_NORMALIZE_HOST;
+                }
 
-				URI_FUNC(LowercaseInplaceExceptPercentEncoding)(uri->hostText.first,
-						uri->hostText.afterLast);
-			}
-		}
-	}
+                URI_FUNC(LowercaseInplaceExceptPercentEncoding)(uri->hostText.first,
+                                                                uri->hostText.afterLast);
+            }
+        }
+    }
 
-	/* Port */
-	if (outMask != NULL) {
-		/* Is there a port even? */
-		if (uri->portText.first != NULL) {
-			/* Determine whether the port is already normalized, i.e. either "", "0" or no leading zeros */
-			const size_t portLen = uri->portText.afterLast - uri->portText.first;
-			if ((portLen > 1) && (uri->portText.first[0] == _UT('0'))) {
-				*outMask |= URI_NORMALIZE_PORT;
-			}
-		}
-	} else {
-		/* Normalize the port, i.e. drop leading zeros (except for string "0") */
-		if ((inMask & URI_NORMALIZE_PORT) && (uri->portText.first != NULL)) {
-			if (uri->owner) {
-				URI_FUNC(DropLeadingZerosInplace)((URI_CHAR *)uri->portText.first, &(uri->portText.afterLast));
-			} else {
-				URI_FUNC(AdvancePastLeadingZeros)(&(uri->portText.first), uri->portText.afterLast);
-			}
-		}
-	}
+    /* Port */
+    if (outMask != NULL) {
+        /* Is there a port even? */
+        if (uri->portText.first != NULL) {
+            /* Determine whether the port is already normalized, i.e. either "", "0" or no
+             * leading zeros */
+            const size_t portLen = uri->portText.afterLast - uri->portText.first;
+            if ((portLen > 1) && (uri->portText.first[0] == _UT('0'))) {
+                *outMask |= URI_NORMALIZE_PORT;
+            }
+        }
+    } else {
+        /* Normalize the port, i.e. drop leading zeros (except for string "0") */
+        if ((inMask & URI_NORMALIZE_PORT) && (uri->portText.first != NULL)) {
+            if (uri->owner) {
+                URI_FUNC(DropLeadingZerosInplace)((URI_CHAR *)uri->portText.first,
+                                                  &(uri->portText.afterLast));
+            } else {
+                URI_FUNC(AdvancePastLeadingZeros)(&(uri->portText.first),
+                                                  uri->portText.afterLast);
+            }
+        }
+    }
 
-	/* User info */
-	if (outMask != NULL) {
-		const UriBool normalizeUserInfo = URI_FUNC(ContainsUglyPercentEncoding)(
-			uri->userInfo.first, uri->userInfo.afterLast);
-		if (normalizeUserInfo) {
-			*outMask |= URI_NORMALIZE_USER_INFO;
-		}
-	} else {
-		if ((inMask & URI_NORMALIZE_USER_INFO) && (uri->userInfo.first != NULL)) {
-			if (uri->owner) {
-				URI_FUNC(FixPercentEncodingInplace)(uri->userInfo.first, &(uri->userInfo.afterLast));
-			} else {
-				if (!URI_FUNC(FixPercentEncodingMalloc)(&(uri->userInfo.first),
-						&(uri->userInfo.afterLast), memory)) {
-					URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-					return URI_ERROR_MALLOC;
-				}
-				revertMask |= URI_NORMALIZE_USER_INFO;
-			}
-		}
-	}
+    /* User info */
+    if (outMask != NULL) {
+        const UriBool normalizeUserInfo = URI_FUNC(ContainsUglyPercentEncoding)(
+            uri->userInfo.first, uri->userInfo.afterLast);
+        if (normalizeUserInfo) {
+            *outMask |= URI_NORMALIZE_USER_INFO;
+        }
+    } else {
+        if ((inMask & URI_NORMALIZE_USER_INFO) && (uri->userInfo.first != NULL)) {
+            if (uri->owner) {
+                URI_FUNC(FixPercentEncodingInplace)(uri->userInfo.first,
+                                                    &(uri->userInfo.afterLast));
+            } else {
+                if (!URI_FUNC(FixPercentEncodingMalloc)(
+                        &(uri->userInfo.first), &(uri->userInfo.afterLast), memory)) {
+                    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                    return URI_ERROR_MALLOC;
+                }
+                revertMask |= URI_NORMALIZE_USER_INFO;
+            }
+        }
+    }
 
-	/* Path */
-	if (outMask != NULL) {
-		const URI_TYPE(PathSegment) * walker = uri->pathHead;
-		while (walker != NULL) {
-			const URI_CHAR * const first = walker->text.first;
-			const URI_CHAR * const afterLast = walker->text.afterLast;
-			if ((first != NULL)
-					&& (afterLast != NULL)
-					&& (afterLast > first)
-					&& (
-						(((afterLast - first) == 1)
-							&& (first[0] == _UT('.')))
-						||
-						(((afterLast - first) == 2)
-							&& (first[0] == _UT('.'))
-							&& (first[1] == _UT('.')))
-						||
-						URI_FUNC(ContainsUglyPercentEncoding)(first, afterLast)
-					)) {
-				*outMask |= URI_NORMALIZE_PATH;
-				break;
-			}
-			walker = walker->next;
-		}
-	} else if (inMask & URI_NORMALIZE_PATH) {
-		URI_TYPE(PathSegment) * walker;
-		const UriBool relative = ((uri->scheme.first == NULL)
-				&& !uri->absolutePath) ? URI_TRUE : URI_FALSE;
+    /* Path */
+    if (outMask != NULL) {
+        const URI_TYPE(PathSegment) * walker = uri->pathHead;
+        while (walker != NULL) {
+            const URI_CHAR * const first = walker->text.first;
+            const URI_CHAR * const afterLast = walker->text.afterLast;
+            if ((first != NULL) && (afterLast != NULL) && (afterLast > first)
+                && ((((afterLast - first) == 1) && (first[0] == _UT('.')))
+                    || (((afterLast - first) == 2) && (first[0] == _UT('.'))
+                        && (first[1] == _UT('.')))
+                    || URI_FUNC(ContainsUglyPercentEncoding)(first, afterLast))) {
+                *outMask |= URI_NORMALIZE_PATH;
+                break;
+            }
+            walker = walker->next;
+        }
+    } else if (inMask & URI_NORMALIZE_PATH) {
+        URI_TYPE(PathSegment) * walker;
+        const UriBool relative =
+            ((uri->scheme.first == NULL) && !uri->absolutePath) ? URI_TRUE : URI_FALSE;
 
-		/* Fix percent-encoding for each segment */
-		walker = uri->pathHead;
-		if (uri->owner) {
-			while (walker != NULL) {
-				URI_FUNC(FixPercentEncodingInplace)(walker->text.first, &(walker->text.afterLast));
-				walker = walker->next;
-			}
-		} else {
-			while (walker != NULL) {
-				if (!URI_FUNC(FixPercentEncodingMalloc)(&(walker->text.first),
-						&(walker->text.afterLast), memory)) {
-					URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-					return URI_ERROR_MALLOC;
-				}
-				walker = walker->next;
-			}
-			revertMask |= URI_NORMALIZE_PATH;
-		}
+        /* Fix percent-encoding for each segment */
+        walker = uri->pathHead;
+        if (uri->owner) {
+            while (walker != NULL) {
+                URI_FUNC(FixPercentEncodingInplace)(walker->text.first,
+                                                    &(walker->text.afterLast));
+                walker = walker->next;
+            }
+        } else {
+            while (walker != NULL) {
+                if (!URI_FUNC(FixPercentEncodingMalloc)(
+                        &(walker->text.first), &(walker->text.afterLast), memory)) {
+                    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                    return URI_ERROR_MALLOC;
+                }
+                walker = walker->next;
+            }
+            revertMask |= URI_NORMALIZE_PATH;
+        }
 
-		/* 6.2.2.3 Path Segment Normalization */
-		if (!URI_FUNC(RemoveDotSegmentsEx)(uri, relative,
-				(uri->owner == URI_TRUE)
-				|| ((revertMask & URI_NORMALIZE_PATH) != 0),
-				memory)) {
-			URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-			return URI_ERROR_MALLOC;
-		}
-		URI_FUNC(FixEmptyTrailSegment)(uri, memory);
-	}
+        /* 6.2.2.3 Path Segment Normalization */
+        if (!URI_FUNC(RemoveDotSegmentsEx)(
+                uri, relative,
+                (uri->owner == URI_TRUE) || ((revertMask & URI_NORMALIZE_PATH) != 0),
+                memory)) {
+            URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+            return URI_ERROR_MALLOC;
+        }
+        URI_FUNC(FixEmptyTrailSegment)(uri, memory);
+    }
 
-	/* Query, fragment */
-	if (outMask != NULL) {
-		const UriBool normalizeQuery = URI_FUNC(ContainsUglyPercentEncoding)(
-				uri->query.first, uri->query.afterLast);
-		const UriBool normalizeFragment = URI_FUNC(ContainsUglyPercentEncoding)(
-				uri->fragment.first, uri->fragment.afterLast);
-		if (normalizeQuery) {
-			*outMask |= URI_NORMALIZE_QUERY;
-		}
+    /* Query, fragment */
+    if (outMask != NULL) {
+        const UriBool normalizeQuery =
+            URI_FUNC(ContainsUglyPercentEncoding)(uri->query.first, uri->query.afterLast);
+        const UriBool normalizeFragment = URI_FUNC(ContainsUglyPercentEncoding)(
+            uri->fragment.first, uri->fragment.afterLast);
+        if (normalizeQuery) {
+            *outMask |= URI_NORMALIZE_QUERY;
+        }
 
-		if (normalizeFragment) {
-			*outMask |= URI_NORMALIZE_FRAGMENT;
-		}
-	} else {
-		/* Query */
-		if ((inMask & URI_NORMALIZE_QUERY) && (uri->query.first != NULL)) {
-			if (uri->owner) {
-				URI_FUNC(FixPercentEncodingInplace)(uri->query.first, &(uri->query.afterLast));
-			} else {
-				if (!URI_FUNC(FixPercentEncodingMalloc)(&(uri->query.first),
-						&(uri->query.afterLast), memory)) {
-					URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-					return URI_ERROR_MALLOC;
-				}
-				revertMask |= URI_NORMALIZE_QUERY;
-			}
-		}
+        if (normalizeFragment) {
+            *outMask |= URI_NORMALIZE_FRAGMENT;
+        }
+    } else {
+        /* Query */
+        if ((inMask & URI_NORMALIZE_QUERY) && (uri->query.first != NULL)) {
+            if (uri->owner) {
+                URI_FUNC(FixPercentEncodingInplace)(uri->query.first,
+                                                    &(uri->query.afterLast));
+            } else {
+                if (!URI_FUNC(FixPercentEncodingMalloc)(
+                        &(uri->query.first), &(uri->query.afterLast), memory)) {
+                    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                    return URI_ERROR_MALLOC;
+                }
+                revertMask |= URI_NORMALIZE_QUERY;
+            }
+        }
 
-		/* Fragment */
-		if ((inMask & URI_NORMALIZE_FRAGMENT) && (uri->fragment.first != NULL)) {
-			if (uri->owner) {
-				URI_FUNC(FixPercentEncodingInplace)(uri->fragment.first, &(uri->fragment.afterLast));
-			} else {
-				if (!URI_FUNC(FixPercentEncodingMalloc)(&(uri->fragment.first),
-						&(uri->fragment.afterLast), memory)) {
-					URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-					return URI_ERROR_MALLOC;
-				}
-				revertMask |= URI_NORMALIZE_FRAGMENT;
-			}
-		}
-	}
+        /* Fragment */
+        if ((inMask & URI_NORMALIZE_FRAGMENT) && (uri->fragment.first != NULL)) {
+            if (uri->owner) {
+                URI_FUNC(FixPercentEncodingInplace)(uri->fragment.first,
+                                                    &(uri->fragment.afterLast));
+            } else {
+                if (!URI_FUNC(FixPercentEncodingMalloc)(
+                        &(uri->fragment.first), &(uri->fragment.afterLast), memory)) {
+                    URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+                    return URI_ERROR_MALLOC;
+                }
+                revertMask |= URI_NORMALIZE_FRAGMENT;
+            }
+        }
+    }
 
-	/* Dup all not duped yet */
-	if ((outMask == NULL) && !uri->owner) {
-		if (!URI_FUNC(MakeOwnerEngine)(uri, &revertMask, memory)) {
-			URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-			return URI_ERROR_MALLOC;
-		}
-		uri->owner = URI_TRUE;
-	}
+    /* Dup all not duped yet */
+    if ((outMask == NULL) && !uri->owner) {
+        if (!URI_FUNC(MakeOwnerEngine)(uri, &revertMask, memory)) {
+            URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+            return URI_ERROR_MALLOC;
+        }
+        uri->owner = URI_TRUE;
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	unsigned int revertMask = URI_NORMALIZED;
+    unsigned int revertMask = URI_NORMALIZED;
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-	if (uri == NULL) {
-		return URI_ERROR_NULL;
-	}
+    if (uri == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-	if (uri->owner == URI_TRUE) {
-		return URI_SUCCESS;
-	}
+    if (uri->owner == URI_TRUE) {
+        return URI_SUCCESS;
+    }
 
-	if (! URI_FUNC(MakeOwnerEngine)(uri, &revertMask, memory)) {
-		URI_FUNC(PreventLeakage)(uri, revertMask, memory);
-		return URI_ERROR_MALLOC;
-	}
+    if (!URI_FUNC(MakeOwnerEngine)(uri, &revertMask, memory)) {
+        URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	uri->owner = URI_TRUE;
+    uri->owner = URI_TRUE;
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 int URI_FUNC(MakeOwner)(URI_TYPE(Uri) * uri) {
-	return URI_FUNC(MakeOwnerMm)(uri, NULL);
+    return URI_FUNC(MakeOwnerMm)(uri, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriNormalize.h
+++ b/ext/uri/uriparser/src/UriNormalize.h
@@ -39,38 +39,37 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include <uriparser/UriDefsConfig.h>
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include <uriparser/UriDefsConfig.h>
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriNormalize.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriNormalize.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "UriNormalize.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "UriNormalize.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_NORMALIZE_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_NORMALIZE_H_ANSI 1
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  define URI_NORMALIZE_H_UNICODE 1
-#  include <uriparser/UriDefsUnicode.h>
-# endif
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI) \
+         && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_NORMALIZE_H_ANSI 1
+#      include <uriparser/UriDefsAnsi.h>
+#    else
+#      define URI_NORMALIZE_H_UNICODE 1
+#      include <uriparser/UriDefsUnicode.h>
+#    endif
 
+void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri, unsigned int revertMask,
+                              UriMemoryManager * memory);
 
-
-void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
-		unsigned int revertMask, UriMemoryManager * memory);
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/src/UriNormalizeBase.c
+++ b/ext/uri/uriparser/src/UriNormalizeBase.c
@@ -38,82 +38,80 @@
  */
 
 #ifndef URI_DOXYGEN
-# include "UriNormalizeBase.h"
+#  include "UriNormalizeBase.h"
 #endif
 
-
-
 UriBool uriIsUnreserved(int code) {
-	switch (code) {
-	case L'a': /* ALPHA */
-	case L'A':
-	case L'b':
-	case L'B':
-	case L'c':
-	case L'C':
-	case L'd':
-	case L'D':
-	case L'e':
-	case L'E':
-	case L'f':
-	case L'F':
-	case L'g':
-	case L'G':
-	case L'h':
-	case L'H':
-	case L'i':
-	case L'I':
-	case L'j':
-	case L'J':
-	case L'k':
-	case L'K':
-	case L'l':
-	case L'L':
-	case L'm':
-	case L'M':
-	case L'n':
-	case L'N':
-	case L'o':
-	case L'O':
-	case L'p':
-	case L'P':
-	case L'q':
-	case L'Q':
-	case L'r':
-	case L'R':
-	case L's':
-	case L'S':
-	case L't':
-	case L'T':
-	case L'u':
-	case L'U':
-	case L'v':
-	case L'V':
-	case L'w':
-	case L'W':
-	case L'x':
-	case L'X':
-	case L'y':
-	case L'Y':
-	case L'z':
-	case L'Z':
-	case L'0': /* DIGIT */
-	case L'1':
-	case L'2':
-	case L'3':
-	case L'4':
-	case L'5':
-	case L'6':
-	case L'7':
-	case L'8':
-	case L'9':
-	case L'-': /* "-" / "." / "_" / "~" */
-	case L'.':
-	case L'_':
-	case L'~':
-		return URI_TRUE;
+    switch (code) {
+    case L'a': /* ALPHA */
+    case L'A':
+    case L'b':
+    case L'B':
+    case L'c':
+    case L'C':
+    case L'd':
+    case L'D':
+    case L'e':
+    case L'E':
+    case L'f':
+    case L'F':
+    case L'g':
+    case L'G':
+    case L'h':
+    case L'H':
+    case L'i':
+    case L'I':
+    case L'j':
+    case L'J':
+    case L'k':
+    case L'K':
+    case L'l':
+    case L'L':
+    case L'm':
+    case L'M':
+    case L'n':
+    case L'N':
+    case L'o':
+    case L'O':
+    case L'p':
+    case L'P':
+    case L'q':
+    case L'Q':
+    case L'r':
+    case L'R':
+    case L's':
+    case L'S':
+    case L't':
+    case L'T':
+    case L'u':
+    case L'U':
+    case L'v':
+    case L'V':
+    case L'w':
+    case L'W':
+    case L'x':
+    case L'X':
+    case L'y':
+    case L'Y':
+    case L'z':
+    case L'Z':
+    case L'0': /* DIGIT */
+    case L'1':
+    case L'2':
+    case L'3':
+    case L'4':
+    case L'5':
+    case L'6':
+    case L'7':
+    case L'8':
+    case L'9':
+    case L'-': /* "-" / "." / "_" / "~" */
+    case L'.':
+    case L'_':
+    case L'~':
+        return URI_TRUE;
 
-	default:
-		return URI_FALSE;
-	}
+    default:
+        return URI_FALSE;
+    }
 }

--- a/ext/uri/uriparser/src/UriNormalizeBase.h
+++ b/ext/uri/uriparser/src/UriNormalizeBase.h
@@ -38,16 +38,10 @@
  */
 
 #ifndef URI_NORMALIZE_BASE_H
-#define URI_NORMALIZE_BASE_H 1
+#  define URI_NORMALIZE_BASE_H 1
 
-
-
-#include <uriparser/UriBase.h>
-
-
+#  include <uriparser/UriBase.h>
 
 UriBool uriIsUnreserved(int code);
-
-
 
 #endif /* URI_NORMALIZE_BASE_H */

--- a/ext/uri/uriparser/src/UriParse.c
+++ b/ext/uri/uriparser/src/UriParse.c
@@ -47,337 +47,421 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriParse.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriParse.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriParse.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriParse.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include <uriparser/UriIp4.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#    include "UriParseBase.h"
+#  endif
 
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include <uriparser/UriIp4.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-# include "UriParseBase.h"
-#endif
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
+static const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState) * state,
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseHexZero)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState) * state,
+                                                const URI_CHAR * first,
+                                                const URI_CHAR * afterLast,
+                                                UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseIpFutLoop)(URI_TYPE(ParserState) * state,
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseIpFutStopGo)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) * state,
+                                              const URI_CHAR * first,
+                                              const URI_CHAR * afterLast,
+                                              UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast,
+                                               UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnHost2)(URI_TYPE(ParserState) * state,
+                                                const URI_CHAR * first,
+                                                const URI_CHAR * afterLast,
+                                                UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfo)(URI_TYPE(ParserState) * state,
+                                                       const URI_CHAR * first,
+                                                       const URI_CHAR * afterLast,
+                                                       UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(URI_TYPE(ParserState) * state,
+                                                       const URI_CHAR * first,
+                                                       const URI_CHAR * afterLast,
+                                                       UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state,
+                                                     const URI_CHAR * first,
+                                                     const URI_CHAR * afterLast,
+                                                     UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state,
+                                                          const URI_CHAR * first,
+                                                          const URI_CHAR * afterLast,
+                                                          UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state,
+                                             const URI_CHAR * first,
+                                             const URI_CHAR * afterLast,
+                                             UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state,
+                                                  const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast,
+                                                  UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePort)(URI_TYPE(ParserState) * state,
+                                            const URI_CHAR * first,
+                                            const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseQueryFrag)(URI_TYPE(ParserState) * state,
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseSegment)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast,
+                                               UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState) * state,
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
+                                                            const URI_CHAR * first,
+                                                            const URI_CHAR * afterLast,
+                                                            UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast,
+                                               UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state,
+                                                  const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast,
+                                                  UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory);
 
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-static const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseHexZero)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseIpFutLoop)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseIpFutStopGo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnHost2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePort)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseQueryFrag)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseSegment)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
-
-static UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state,
+                                        const URI_CHAR * first,
+                                        UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    UriMemoryManager * memory);
 static void URI_FUNC(OnExitPartHelperTwo)(URI_TYPE(ParserState) * state);
 
 static void URI_FUNC(ResetParserStateExceptUri)(URI_TYPE(ParserState) * state);
 
 static UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
+                                         const URI_CHAR * first,
+                                         const URI_CHAR * afterLast,
+                                         UriMemoryManager * memory);
 
-static void URI_FUNC(StopSyntax)(URI_TYPE(ParserState) * state, const URI_CHAR * errorPos, UriMemoryManager * memory);
-static void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state, UriMemoryManager * memory);
+static void URI_FUNC(StopSyntax)(URI_TYPE(ParserState) * state, const URI_CHAR * errorPos,
+                                 UriMemoryManager * memory);
+static void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state,
+                                 UriMemoryManager * memory);
 
-static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
+static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                                  const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 static URI_INLINE void URI_FUNC(StopSyntax)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * errorPos, UriMemoryManager * memory) {
-	URI_FUNC(FreeUriMembersMm)(state->uri, memory);
-	state->errorPos = errorPos;
-	state->errorCode = URI_ERROR_SYNTAX;
+                                            const URI_CHAR * errorPos,
+                                            UriMemoryManager * memory) {
+    URI_FUNC(FreeUriMembersMm)(state->uri, memory);
+    state->errorPos = errorPos;
+    state->errorCode = URI_ERROR_SYNTAX;
 }
 
-
-
-static URI_INLINE void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state, UriMemoryManager * memory) {
-	URI_FUNC(FreeUriMembersMm)(state->uri, memory);
-	state->errorPos = NULL;
-	state->errorCode = URI_ERROR_MALLOC;
+static URI_INLINE void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state,
+                                            UriMemoryManager * memory) {
+    URI_FUNC(FreeUriMembersMm)(state->uri, memory);
+    state->errorPos = NULL;
+    state->errorCode = URI_ERROR_MALLOC;
 }
-
-
 
 /*
  * [authority]-><[>[ipLit2][authorityTwo]
  * [authority]->[ownHostUserInfoNz]
  * [authority]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthority)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		/* "" regname host */
-		state->uri->hostText.first = URI_FUNC(SafeToPointTo);
-		state->uri->hostText.afterLast = URI_FUNC(SafeToPointTo);
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState) * state,
+                                                            const URI_CHAR * first,
+                                                            const URI_CHAR * afterLast,
+                                                            UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        /* "" regname host */
+        state->uri->hostText.first = URI_FUNC(SafeToPointTo);
+        state->uri->hostText.afterLast = URI_FUNC(SafeToPointTo);
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('['):
-		{
-			const URI_CHAR * const afterIpLit2
-					= URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
-			if (afterIpLit2 == NULL) {
-				return NULL;
-			}
-			state->uri->hostText.first = first + 1; /* HOST BEGIN */
-			return URI_FUNC(ParseAuthorityTwo)(state, afterIpLit2, afterLast);
-		}
+    switch (*first) {
+    case _UT('['): {
+        const URI_CHAR * const afterIpLit2 =
+            URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
+        if (afterIpLit2 == NULL) {
+            return NULL;
+        }
+        state->uri->hostText.first = first + 1; /* HOST BEGIN */
+        return URI_FUNC(ParseAuthorityTwo)(state, afterIpLit2, afterLast);
+    }
 
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		state->uri->userInfo.first = first; /* USERINFO BEGIN */
-		return URI_FUNC(ParseOwnHostUserInfoNz)(state, first, afterLast, memory);
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        state->uri->userInfo.first = first; /* USERINFO BEGIN */
+        return URI_FUNC(ParseOwnHostUserInfoNz)(state, first, afterLast, memory);
 
-	default:
-		/* "" regname host */
-		state->uri->hostText.first = URI_FUNC(SafeToPointTo);
-		state->uri->hostText.afterLast = URI_FUNC(SafeToPointTo);
-		return first;
-	}
+    default:
+        /* "" regname host */
+        state->uri->hostText.first = URI_FUNC(SafeToPointTo);
+        state->uri->hostText.afterLast = URI_FUNC(SafeToPointTo);
+        return first;
+    }
 }
-
-
 
 /*
  * [authorityTwo]-><:>[port]
  * [authorityTwo]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                            const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT(':'):
-		{
-			const URI_CHAR * const afterPort = URI_FUNC(ParsePort)(state, first + 1, afterLast);
-			if (afterPort == NULL) {
-				return NULL;
-			}
-			state->uri->portText.first = first + 1; /* PORT BEGIN */
-			state->uri->portText.afterLast = afterPort; /* PORT END */
-			return afterPort;
-		}
+    switch (*first) {
+    case _UT(':'): {
+        const URI_CHAR * const afterPort =
+            URI_FUNC(ParsePort)(state, first + 1, afterLast);
+        if (afterPort == NULL) {
+            return NULL;
+        }
+        state->uri->portText.first = first + 1; /* PORT BEGIN */
+        state->uri->portText.afterLast = afterPort; /* PORT END */
+        return afterPort;
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [hexZero]->[HEXDIG][hexZero]
  * [hexZero]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParseHexZero)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseHexZero)(URI_TYPE(ParserState) * state,
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case URI_SET_HEXDIG:
-		return URI_FUNC(ParseHexZero)(state, first + 1, afterLast);
+    switch (*first) {
+    case URI_SET_HEXDIG:
+        return URI_FUNC(ParseHexZero)(state, first + 1, afterLast);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [hierPart]->[pathRootless]
  * [hierPart]-></>[partHelperTwo]
  * [hierPart]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseHierPart)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState) * state,
+                                                           const URI_CHAR * first,
+                                                           const URI_CHAR * afterLast,
+                                                           UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return URI_FUNC(ParsePathRootless)(state, first, afterLast, memory);
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return URI_FUNC(ParsePathRootless)(state, first, afterLast, memory);
 
-	case _UT('/'):
-		return URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
+    case _UT('/'):
+        return URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [ipFutLoop]->[subDelims][ipFutStopGo]
@@ -385,500 +469,497 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseHierPart)(
  * [ipFutLoop]-><:>[ipFutStopGo]
  */
 static const URI_CHAR * URI_FUNC(ParseIpFutLoop)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return URI_FUNC(ParseIpFutStopGo)(state, first + 1, afterLast, memory);
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return URI_FUNC(ParseIpFutStopGo)(state, first + 1, afterLast, memory);
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
-
-
 
 /*
  * [ipFutStopGo]->[ipFutLoop]
  * [ipFutStopGo]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParseIpFutStopGo)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseIpFutStopGo)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return URI_FUNC(ParseIpFutLoop)(state, first, afterLast, memory);
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return URI_FUNC(ParseIpFutLoop)(state, first, afterLast, memory);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [ipFuture]-><v>[HEXDIG][hexZero]<.>[ipFutLoop]
  */
 static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+                                                const URI_CHAR * first,
+                                                const URI_CHAR * afterLast,
+                                                UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	/*
-	First character has already been
-	checked before entering this rule.
+    /*
+    First character has already been
+    checked before entering this rule.
 
-	switch (*first) {
-	case _UT('v'):
-	case _UT('V'):
-	*/
-		if (afterLast - first < 2) {
-			URI_FUNC(StopSyntax)(state, afterLast, memory);
-			return NULL;
-		}
+    switch (*first) {
+    case _UT('v'):
+    case _UT('V'):
+    */
+    if (afterLast - first < 2) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-		switch (first[1]) {
-		case URI_SET_HEXDIG:
-			{
-				const URI_CHAR * afterIpFutLoop;
-				const URI_CHAR * const afterHexZero
-						= URI_FUNC(ParseHexZero)(state, first + 2, afterLast);
-				if (afterHexZero == NULL) {
-					return NULL;
-				}
-				if (afterHexZero >= afterLast) {
-					URI_FUNC(StopSyntax)(state, afterLast, memory);
-					return NULL;
-				}
-				if (*afterHexZero != _UT('.')) {
-					URI_FUNC(StopSyntax)(state, afterHexZero, memory);
-					return NULL;
-				}
-				state->uri->hostText.first = first; /* HOST BEGIN */
-				state->uri->hostData.ipFuture.first = first; /* IPFUTURE BEGIN */
-				afterIpFutLoop = URI_FUNC(ParseIpFutLoop)(state, afterHexZero + 1, afterLast, memory);
-				if (afterIpFutLoop == NULL) {
-					return NULL;
-				}
-				state->uri->hostText.afterLast = afterIpFutLoop; /* HOST END */
-				state->uri->hostData.ipFuture.afterLast = afterIpFutLoop; /* IPFUTURE END */
-				return afterIpFutLoop;
-			}
+    switch (first[1]) {
+    case URI_SET_HEXDIG: {
+        const URI_CHAR * afterIpFutLoop;
+        const URI_CHAR * const afterHexZero =
+            URI_FUNC(ParseHexZero)(state, first + 2, afterLast);
+        if (afterHexZero == NULL) {
+            return NULL;
+        }
+        if (afterHexZero >= afterLast) {
+            URI_FUNC(StopSyntax)(state, afterLast, memory);
+            return NULL;
+        }
+        if (*afterHexZero != _UT('.')) {
+            URI_FUNC(StopSyntax)(state, afterHexZero, memory);
+            return NULL;
+        }
+        state->uri->hostText.first = first; /* HOST BEGIN */
+        state->uri->hostData.ipFuture.first = first; /* IPFUTURE BEGIN */
+        afterIpFutLoop =
+            URI_FUNC(ParseIpFutLoop)(state, afterHexZero + 1, afterLast, memory);
+        if (afterIpFutLoop == NULL) {
+            return NULL;
+        }
+        state->uri->hostText.afterLast = afterIpFutLoop; /* HOST END */
+        state->uri->hostData.ipFuture.afterLast = afterIpFutLoop; /* IPFUTURE END */
+        return afterIpFutLoop;
+    }
 
-		default:
-			URI_FUNC(StopSyntax)(state, first + 1, memory);
-			return NULL;
-		}
+    default:
+        URI_FUNC(StopSyntax)(state, first + 1, memory);
+        return NULL;
+    }
 
-	/*
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
-	*/
+    /*
+    default:
+            URI_FUNC(StopSyntax)(state, first, memory);
+            return NULL;
+    }
+    */
 }
-
-
 
 /*
  * [ipLit2]->[ipFuture]<]>
  * [ipLit2]->[IPv6address2]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	/* The leading "v" of IPvFuture is case-insensitive. */
-	case _UT('v'):
-	case _UT('V'):
-		{
-			const URI_CHAR * const afterIpFuture
-					= URI_FUNC(ParseIpFuture)(state, first, afterLast, memory);
-			if (afterIpFuture == NULL) {
-				return NULL;
-			}
-			if (afterIpFuture >= afterLast) {
-				URI_FUNC(StopSyntax)(state, afterLast, memory);
-				return NULL;
-			}
-			if (*afterIpFuture != _UT(']')) {
-				URI_FUNC(StopSyntax)(state, afterIpFuture, memory);
-				return NULL;
-			}
-			return afterIpFuture + 1;
-		}
+    switch (*first) {
+    /* The leading "v" of IPvFuture is case-insensitive. */
+    case _UT('v'):
+    case _UT('V'): {
+        const URI_CHAR * const afterIpFuture =
+            URI_FUNC(ParseIpFuture)(state, first, afterLast, memory);
+        if (afterIpFuture == NULL) {
+            return NULL;
+        }
+        if (afterIpFuture >= afterLast) {
+            URI_FUNC(StopSyntax)(state, afterLast, memory);
+            return NULL;
+        }
+        if (*afterIpFuture != _UT(']')) {
+            URI_FUNC(StopSyntax)(state, afterIpFuture, memory);
+            return NULL;
+        }
+        return afterIpFuture + 1;
+    }
 
-	case _UT(':'):
-	case _UT(']'):
-	case URI_SET_HEXDIG:
-		state->uri->hostData.ip6 = memory->malloc(memory, 1 * sizeof(UriIp6)); /* Freed when stopping on parse error */
-		if (state->uri->hostData.ip6 == NULL) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return URI_FUNC(ParseIPv6address2)(state, first, afterLast, memory);
+    case _UT(':'):
+    case _UT(']'):
+    case URI_SET_HEXDIG:
+        state->uri->hostData.ip6 = memory->malloc(
+            memory, 1 * sizeof(UriIp6)); /* Freed when stopping on parse error */
+        if (state->uri->hostData.ip6 == NULL) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParseIPv6address2)(state, first, afterLast, memory);
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
-
-
 
 /*
  * [IPv6address2]->..<]>
  */
-static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	int zipperEver = 0;
-	int quadsDone = 0;
-	int digitCount = 0;
-	unsigned char digitHistory[4];
-	int ip4OctetsDone = 0;
+static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory) {
+    int zipperEver = 0;
+    int quadsDone = 0;
+    int digitCount = 0;
+    unsigned char digitHistory[4];
+    int ip4OctetsDone = 0;
 
-	unsigned char quadsAfterZipper[14];
-	int quadsAfterZipperCount = 0;
+    unsigned char quadsAfterZipper[14];
+    int quadsAfterZipperCount = 0;
 
+    for (;;) {
+        if (first >= afterLast) {
+            URI_FUNC(StopSyntax)(state, afterLast, memory);
+            return NULL;
+        }
 
-	for (;;) {
-		if (first >= afterLast) {
-			URI_FUNC(StopSyntax)(state, afterLast, memory);
-			return NULL;
-		}
+        /* Inside IPv4 part? */
+        if (ip4OctetsDone > 0) {
+            /* Eat rest of IPv4 address */
+            for (;;) {
+                switch (*first) {
+                case URI_SET_DIGIT:
+                    if (digitCount == 4) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
+                    digitHistory[digitCount++] = (unsigned char)(9 + *first - _UT('9'));
+                    break;
 
-		/* Inside IPv4 part? */
-		if (ip4OctetsDone > 0) {
-			/* Eat rest of IPv4 address */
-			for (;;) {
-				switch (*first) {
-				case URI_SET_DIGIT:
-					if (digitCount == 4) {
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					}
-					digitHistory[digitCount++] = (unsigned char)(9 + *first - _UT('9'));
-					break;
+                case _UT('.'):
+                    if ((ip4OctetsDone == 4) /* NOTE! */
+                        || (digitCount == 0) || (digitCount == 4)) {
+                        /* Invalid digit or octet count */
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    } else if ((digitCount > 1) && (digitHistory[0] == 0)) {
+                        /* Leading zero */
+                        URI_FUNC(StopSyntax)(state, first - digitCount, memory);
+                        return NULL;
+                    } else if ((digitCount == 3)
+                               && (100 * digitHistory[0] + 10 * digitHistory[1]
+                                       + digitHistory[2]
+                                   > 255)) {
+                        /* Octet value too large */
+                        if (digitHistory[0] > 2) {
+                            URI_FUNC(StopSyntax)(state, first - 3, memory);
+                        } else if (digitHistory[1] > 5) {
+                            URI_FUNC(StopSyntax)(state, first - 2, memory);
+                        } else {
+                            URI_FUNC(StopSyntax)(state, first - 1, memory);
+                        }
+                        return NULL;
+                    }
 
-				case _UT('.'):
-					if ((ip4OctetsDone == 4) /* NOTE! */
-							|| (digitCount == 0)
-							|| (digitCount == 4)) {
-						/* Invalid digit or octet count */
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					} else if ((digitCount > 1)
-							&& (digitHistory[0] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
-						return NULL;
-					} else if ((digitCount == 3)
-							&& (100 * digitHistory[0]
-								+ 10 * digitHistory[1]
-								+ digitHistory[2] > 255)) {
-						/* Octet value too large */
-						if (digitHistory[0] > 2) {
-							URI_FUNC(StopSyntax)(state, first - 3, memory);
-						} else if (digitHistory[1] > 5) {
-							URI_FUNC(StopSyntax)(state, first - 2, memory);
-						} else {
-							URI_FUNC(StopSyntax)(state, first - 1, memory);
-						}
-						return NULL;
-					}
+                    /* Copy IPv4 octet */
+                    state->uri->hostData.ip6->data[16 - 4 + ip4OctetsDone] =
+                        uriGetOctetValue(digitHistory, digitCount);
+                    digitCount = 0;
+                    ip4OctetsDone++;
+                    break;
 
-					/* Copy IPv4 octet */
-					state->uri->hostData.ip6->data[16 - 4 + ip4OctetsDone] = uriGetOctetValue(digitHistory, digitCount);
-					digitCount = 0;
-					ip4OctetsDone++;
-					break;
+                case _UT(']'):
+                    if ((ip4OctetsDone != 3) /* NOTE! */
+                        || (digitCount == 0) || (digitCount == 4)) {
+                        /* Invalid digit or octet count */
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    } else if ((digitCount > 1) && (digitHistory[0] == 0)) {
+                        /* Leading zero */
+                        URI_FUNC(StopSyntax)(state, first - digitCount, memory);
+                        return NULL;
+                    } else if ((digitCount == 3)
+                               && (100 * digitHistory[0] + 10 * digitHistory[1]
+                                       + digitHistory[2]
+                                   > 255)) {
+                        /* Octet value too large */
+                        if (digitHistory[0] > 2) {
+                            URI_FUNC(StopSyntax)(state, first - 3, memory);
+                        } else if (digitHistory[1] > 5) {
+                            URI_FUNC(StopSyntax)(state, first - 2, memory);
+                        } else {
+                            URI_FUNC(StopSyntax)(state, first - 1, memory);
+                        }
+                        return NULL;
+                    }
 
-				case _UT(']'):
-					if ((ip4OctetsDone != 3) /* NOTE! */
-							|| (digitCount == 0)
-							|| (digitCount == 4)) {
-						/* Invalid digit or octet count */
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					} else if ((digitCount > 1)
-							&& (digitHistory[0] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
-						return NULL;
-					} else if ((digitCount == 3)
-							&& (100 * digitHistory[0]
-								+ 10 * digitHistory[1]
-								+ digitHistory[2] > 255)) {
-						/* Octet value too large */
-						if (digitHistory[0] > 2) {
-							URI_FUNC(StopSyntax)(state, first - 3, memory);
-						} else if (digitHistory[1] > 5) {
-							URI_FUNC(StopSyntax)(state, first - 2, memory);
-						} else {
-							URI_FUNC(StopSyntax)(state, first - 1, memory);
-						}
-						return NULL;
-					}
+                    state->uri->hostText.afterLast = first; /* HOST END */
 
-					state->uri->hostText.afterLast = first; /* HOST END */
+                    /* Copy missing quads right before IPv4 */
+                    memcpy(state->uri->hostData.ip6->data + 16 - 4
+                               - 2 * quadsAfterZipperCount,
+                           quadsAfterZipper, 2 * quadsAfterZipperCount);
 
-					/* Copy missing quads right before IPv4 */
-					memcpy(state->uri->hostData.ip6->data + 16 - 4 - 2 * quadsAfterZipperCount,
-								quadsAfterZipper, 2 * quadsAfterZipperCount);
+                    /* Copy last IPv4 octet */
+                    state->uri->hostData.ip6->data[16 - 4 + 3] =
+                        uriGetOctetValue(digitHistory, digitCount);
 
-					/* Copy last IPv4 octet */
-					state->uri->hostData.ip6->data[16 - 4 + 3] = uriGetOctetValue(digitHistory, digitCount);
+                    return first + 1;
 
-					return first + 1;
+                default:
+                    URI_FUNC(StopSyntax)(state, first, memory);
+                    return NULL;
+                }
+                first++;
 
-				default:
-					URI_FUNC(StopSyntax)(state, first, memory);
-					return NULL;
-				}
-				first++;
+                if (first >= afterLast) {
+                    URI_FUNC(StopSyntax)(state, afterLast, memory);
+                    return NULL;
+                }
+            }
+        } else {
+            /* Eat while no dot in sight */
+            int letterAmong = 0;
+            int walking = 1;
+            do {
+                switch (*first) {
+                case URI_SET_HEX_LETTER_LOWER:
+                    letterAmong = 1;
+                    if (digitCount == 4) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
+                    digitHistory[digitCount] = (unsigned char)(15 + *first - _UT('f'));
+                    digitCount++;
+                    break;
 
-				if (first >= afterLast) {
-					URI_FUNC(StopSyntax)(state, afterLast, memory);
-					return NULL;
-				}
-			}
-		} else {
-			/* Eat while no dot in sight */
-			int letterAmong = 0;
-			int walking = 1;
-			do {
-				switch (*first) {
-				case URI_SET_HEX_LETTER_LOWER:
-					letterAmong = 1;
-					if (digitCount == 4) {
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					}
-					digitHistory[digitCount] = (unsigned char)(15 + *first - _UT('f'));
-					digitCount++;
-					break;
+                case URI_SET_HEX_LETTER_UPPER:
+                    letterAmong = 1;
+                    if (digitCount == 4) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
+                    digitHistory[digitCount] = (unsigned char)(15 + *first - _UT('F'));
+                    digitCount++;
+                    break;
 
-				case URI_SET_HEX_LETTER_UPPER:
-					letterAmong = 1;
-					if (digitCount == 4) {
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					}
-					digitHistory[digitCount] = (unsigned char)(15 + *first - _UT('F'));
-					digitCount++;
-					break;
+                case URI_SET_DIGIT:
+                    if (digitCount == 4) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
+                    digitHistory[digitCount] = (unsigned char)(9 + *first - _UT('9'));
+                    digitCount++;
+                    break;
 
-				case URI_SET_DIGIT:
-					if (digitCount == 4) {
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					}
-					digitHistory[digitCount] = (unsigned char)(9 + *first - _UT('9'));
-					digitCount++;
-					break;
+                case _UT(':'): {
+                    int setZipper = 0;
 
-				case _UT(':'):
-					{
-						int setZipper = 0;
+                    if (digitCount > 0) {
+                        if (zipperEver) {
+                            uriWriteQuadToDoubleByte(digitHistory, digitCount,
+                                                     quadsAfterZipper
+                                                         + 2 * quadsAfterZipperCount);
+                            quadsAfterZipperCount++;
+                        } else {
+                            uriWriteQuadToDoubleByte(digitHistory, digitCount,
+                                                     state->uri->hostData.ip6->data
+                                                         + 2 * quadsDone);
+                        }
+                        quadsDone++;
+                        digitCount = 0;
+                    }
+                    letterAmong = 0;
 
-						if (digitCount > 0) {
-							if (zipperEver) {
-								uriWriteQuadToDoubleByte(digitHistory, digitCount, quadsAfterZipper + 2 * quadsAfterZipperCount);
-								quadsAfterZipperCount++;
-							} else {
-								uriWriteQuadToDoubleByte(digitHistory, digitCount, state->uri->hostData.ip6->data + 2 * quadsDone);
-							}
-							quadsDone++;
-							digitCount = 0;
-						}
-						letterAmong = 0;
+                    /* Too many quads? */
+                    if (quadsDone >= 8 - zipperEver) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
 
-						/* Too many quads? */
-						if (quadsDone >= 8 - zipperEver) {
-							URI_FUNC(StopSyntax)(state, first, memory);
-							return NULL;
-						}
+                    /* "::"? */
+                    if (afterLast - first < 2) {
+                        URI_FUNC(StopSyntax)(state, afterLast, memory);
+                        return NULL;
+                    }
+                    if (first[1] == _UT(':')) {
+                        const int resetOffset = 2 * (quadsDone + (digitCount > 0));
 
-						/* "::"? */
-						if (afterLast - first < 2) {
-							URI_FUNC(StopSyntax)(state, afterLast, memory);
-							return NULL;
-						}
-						if (first[1] == _UT(':')) {
-							const int resetOffset = 2 * (quadsDone + (digitCount > 0));
+                        first++;
+                        if (zipperEver) {
+                            URI_FUNC(StopSyntax)(state, first, memory);
+                            return NULL; /* "::.+::" */
+                        }
 
-							first++;
-							if (zipperEver) {
-								URI_FUNC(StopSyntax)(state, first, memory);
-								return NULL; /* "::.+::" */
-							}
+                        /* Zero everything after zipper */
+                        memset(state->uri->hostData.ip6->data + resetOffset, 0,
+                               16 - resetOffset);
+                        setZipper = 1;
 
-							/* Zero everything after zipper */
-							memset(state->uri->hostData.ip6->data + resetOffset, 0, 16 - resetOffset);
-							setZipper = 1;
+                        /* ":::+"? */
+                        if (afterLast - first < 2) {
+                            URI_FUNC(StopSyntax)(state, afterLast, memory);
+                            return NULL; /* No ']' yet */
+                        }
+                        if (first[1] == _UT(':')) {
+                            URI_FUNC(StopSyntax)(state, first + 1, memory);
+                            return NULL; /* ":::+ "*/
+                        }
+                    } else if (quadsDone == 0 || first[1] == _UT(']')) {
+                        /* Single leading or trailing ":" */
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
 
-							/* ":::+"? */
-							if (afterLast - first < 2) {
-								URI_FUNC(StopSyntax)(state, afterLast, memory);
-								return NULL; /* No ']' yet */
-							}
-							if (first[1] == _UT(':')) {
-								URI_FUNC(StopSyntax)(state, first + 1, memory);
-								return NULL; /* ":::+ "*/
-							}
-						} else if (quadsDone == 0 || first[1] == _UT(']')) {
-							/* Single leading or trailing ":" */
-							URI_FUNC(StopSyntax)(state, first, memory);
-							return NULL;
-						}
+                    if (setZipper) {
+                        zipperEver = 1;
+                    }
+                } break;
 
-						if (setZipper) {
-							zipperEver = 1;
-						}
-					}
-					break;
+                case _UT('.'):
+                    if ((quadsDone + zipperEver > 6) /* NOTE */
+                        || (!zipperEver && (quadsDone < 6)) || letterAmong
+                        || (digitCount == 0) || (digitCount == 4)) {
+                        /* Invalid octet before */
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    } else if ((digitCount > 1) && (digitHistory[0] == 0)) {
+                        /* Leading zero */
+                        URI_FUNC(StopSyntax)(state, first - digitCount, memory);
+                        return NULL;
+                    } else if ((digitCount == 3)
+                               && (100 * digitHistory[0] + 10 * digitHistory[1]
+                                       + digitHistory[2]
+                                   > 255)) {
+                        /* Octet value too large */
+                        if (digitHistory[0] > 2) {
+                            URI_FUNC(StopSyntax)(state, first - 3, memory);
+                        } else if (digitHistory[1] > 5) {
+                            URI_FUNC(StopSyntax)(state, first - 2, memory);
+                        } else {
+                            URI_FUNC(StopSyntax)(state, first - 1, memory);
+                        }
+                        return NULL;
+                    }
 
-				case _UT('.'):
-					if ((quadsDone + zipperEver > 6) /* NOTE */
-							|| (!zipperEver && (quadsDone < 6))
-							|| letterAmong
-							|| (digitCount == 0)
-							|| (digitCount == 4)) {
-						/* Invalid octet before */
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					} else if ((digitCount > 1)
-							&& (digitHistory[0] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
-						return NULL;
-					} else if ((digitCount == 3)
-							&& (100 * digitHistory[0]
-								+ 10 * digitHistory[1]
-								+ digitHistory[2] > 255)) {
-						/* Octet value too large */
-						if (digitHistory[0] > 2) {
-							URI_FUNC(StopSyntax)(state, first - 3, memory);
-						} else if (digitHistory[1] > 5) {
-							URI_FUNC(StopSyntax)(state, first - 2, memory);
-						} else {
-							URI_FUNC(StopSyntax)(state, first - 1, memory);
-						}
-						return NULL;
-					}
+                    /* Copy first IPv4 octet */
+                    state->uri->hostData.ip6->data[16 - 4] =
+                        uriGetOctetValue(digitHistory, digitCount);
+                    digitCount = 0;
 
-					/* Copy first IPv4 octet */
-					state->uri->hostData.ip6->data[16 - 4] = uriGetOctetValue(digitHistory, digitCount);
-					digitCount = 0;
+                    /* Switch over to IPv4 loop */
+                    ip4OctetsDone = 1;
+                    walking = 0;
+                    break;
 
-					/* Switch over to IPv4 loop */
-					ip4OctetsDone = 1;
-					walking = 0;
-					break;
+                case _UT(']'):
+                    /* Too little quads? */
+                    if (!zipperEver && !((quadsDone == 7) && (digitCount > 0))) {
+                        URI_FUNC(StopSyntax)(state, first, memory);
+                        return NULL;
+                    }
 
-				case _UT(']'):
-					/* Too little quads? */
-					if (!zipperEver && !((quadsDone == 7) && (digitCount > 0))) {
-						URI_FUNC(StopSyntax)(state, first, memory);
-						return NULL;
-					}
+                    if (digitCount > 0) {
+                        if (zipperEver) {
+                            /* Too many quads? */
+                            if (quadsDone >= 7) {
+                                URI_FUNC(StopSyntax)(state, first, memory);
+                                return NULL;
+                            }
+                            uriWriteQuadToDoubleByte(digitHistory, digitCount,
+                                                     quadsAfterZipper
+                                                         + 2 * quadsAfterZipperCount);
+                            quadsAfterZipperCount++;
+                        } else {
+                            uriWriteQuadToDoubleByte(digitHistory, digitCount,
+                                                     state->uri->hostData.ip6->data
+                                                         + 2 * quadsDone);
+                        }
+                        /*
+                        quadsDone++;
+                        digitCount = 0;
+                        */
+                    }
 
-					if (digitCount > 0) {
-						if (zipperEver) {
-							/* Too many quads? */
-							if (quadsDone >= 7) {
-								URI_FUNC(StopSyntax)(state, first, memory);
-								return NULL;
-							}
-							uriWriteQuadToDoubleByte(digitHistory, digitCount, quadsAfterZipper + 2 * quadsAfterZipperCount);
-							quadsAfterZipperCount++;
-						} else {
-							uriWriteQuadToDoubleByte(digitHistory, digitCount, state->uri->hostData.ip6->data + 2 * quadsDone);
-						}
-						/*
-						quadsDone++;
-						digitCount = 0;
-						*/
-					}
+                    /* Copy missing quads to the end */
+                    memcpy(state->uri->hostData.ip6->data + 16
+                               - 2 * quadsAfterZipperCount,
+                           quadsAfterZipper, 2 * quadsAfterZipperCount);
 
-					/* Copy missing quads to the end */
-					memcpy(state->uri->hostData.ip6->data + 16 - 2 * quadsAfterZipperCount,
-								quadsAfterZipper, 2 * quadsAfterZipperCount);
+                    state->uri->hostText.afterLast = first; /* HOST END */
+                    return first + 1; /* Fine */
 
-					state->uri->hostText.afterLast = first; /* HOST END */
-					return first + 1; /* Fine */
+                default:
+                    URI_FUNC(StopSyntax)(state, first, memory);
+                    return NULL;
+                }
+                first++;
 
-				default:
-					URI_FUNC(StopSyntax)(state, first, memory);
-					return NULL;
-				}
-				first++;
-
-				if (first >= afterLast) {
-					URI_FUNC(StopSyntax)(state, afterLast, memory);
-					return NULL; /* No ']' yet */
-				}
-			} while (walking);
-		}
-	}
+                if (first >= afterLast) {
+                    URI_FUNC(StopSyntax)(state, afterLast, memory);
+                    return NULL; /* No ']' yet */
+                }
+            } while (walking);
+        }
+    }
 }
-
-
 
 /*
  * [mustBeSegmentNzNc]->[pctEncoded][mustBeSegmentNzNc]
@@ -888,345 +969,341 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
  * [mustBeSegmentNzNc]-></>[segment][zeroMoreSlashSegs][uriTail]
  * [mustBeSegmentNzNc]-><@>[mustBeSegmentNzNc]
  */
-static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		state->uri->scheme.first = NULL; /* Not a scheme, reset */
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        state->uri->scheme.first = NULL; /* Not a scheme, reset */
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('%'):
-		{
-			const URI_CHAR * const afterPctEncoded
-					= URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
-			if (afterPctEncoded == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('%'): {
+        const URI_CHAR * const afterPctEncoded =
+            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+        if (afterPctEncoded == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast,
+                                                memory);
+    }
 
-	case _UT('@'):
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('+'):
-	case _UT('='):
-	case _UT('-'):
-	case _UT('.'):
-	case _UT('_'):
-	case _UT('~'):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
+    case _UT('@'):
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('+'):
+    case _UT('='):
+    case _UT('-'):
+    case _UT('.'):
+    case _UT('_'):
+    case _UT('~'):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
 
-	case _UT('/'):
-		{
-			const URI_CHAR * afterZeroMoreSlashSegs;
-			const URI_CHAR * afterSegment;
-			if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			state->uri->scheme.first = NULL; /* Not a scheme, reset */
-			afterSegment = URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
-			if (afterSegment == NULL) {
-				return NULL;
-			}
-			if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			afterZeroMoreSlashSegs
-					= URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
-			if (afterZeroMoreSlashSegs == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseUriTail)(state, afterZeroMoreSlashSegs, afterLast, memory);
-		}
+    case _UT('/'): {
+        const URI_CHAR * afterZeroMoreSlashSegs;
+        const URI_CHAR * afterSegment;
+        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        state->uri->scheme.first = NULL; /* Not a scheme, reset */
+        afterSegment = URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+        if (afterSegment == NULL) {
+            return NULL;
+        }
+        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        afterZeroMoreSlashSegs =
+            URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
+        if (afterZeroMoreSlashSegs == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseUriTail)(state, afterZeroMoreSlashSegs, afterLast, memory);
+    }
 
-	default:
-		if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		state->uri->scheme.first = NULL; /* Not a scheme, reset */
-		return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
-	}
+    default:
+        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        state->uri->scheme.first = NULL; /* Not a scheme, reset */
+        return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
+    }
 }
-
-
 
 /*
  * [ownHost]-><[>[ipLit2][authorityTwo]
  * [ownHost]->[ownHost2] // can take <NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHost)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		state->uri->hostText.afterLast = afterLast; /* HOST END */
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) * state,
+                                                          const URI_CHAR * first,
+                                                          const URI_CHAR * afterLast,
+                                                          UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        state->uri->hostText.afterLast = afterLast; /* HOST END */
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('['):
-		{
-			const URI_CHAR * const afterIpLit2
-					= URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
-			if (afterIpLit2 == NULL) {
-				return NULL;
-			}
-			state->uri->hostText.first = first + 1; /* HOST BEGIN */
-			return URI_FUNC(ParseAuthorityTwo)(state, afterIpLit2, afterLast);
-		}
+    switch (*first) {
+    case _UT('['): {
+        const URI_CHAR * const afterIpLit2 =
+            URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
+        if (afterIpLit2 == NULL) {
+            return NULL;
+        }
+        state->uri->hostText.first = first + 1; /* HOST BEGIN */
+        return URI_FUNC(ParseAuthorityTwo)(state, afterIpLit2, afterLast);
+    }
 
-	default:
-		return URI_FUNC(ParseOwnHost2)(state, first, afterLast, memory);
-	}
+    default:
+        return URI_FUNC(ParseOwnHost2)(state, first, afterLast, memory);
+    }
 }
 
+static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   UriMemoryManager * memory) {
+    state->uri->hostText.afterLast = first; /* HOST END */
 
-
-static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		UriMemoryManager * memory) {
-	state->uri->hostText.afterLast = first; /* HOST END */
-
-	/* Valid IPv4 or just a regname? */
-	state->uri->hostData.ip4 = memory->malloc(memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
-	if (state->uri->hostData.ip4 == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-			state->uri->hostText.first, state->uri->hostText.afterLast)) {
-		/* Not IPv4 */
-		memory->free(memory, state->uri->hostData.ip4);
-		state->uri->hostData.ip4 = NULL;
-	}
-	return URI_TRUE; /* Success */
+    /* Valid IPv4 or just a regname? */
+    state->uri->hostData.ip4 = memory->malloc(
+        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+    if (state->uri->hostData.ip4 == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
+                                     state->uri->hostText.first,
+                                     state->uri->hostText.afterLast)) {
+        /* Not IPv4 */
+        memory->free(memory, state->uri->hostData.ip4);
+        state->uri->hostData.ip4 = NULL;
+    }
+    return URI_TRUE; /* Success */
 }
-
-
 
 /*
  * [ownHost2]->[authorityTwo] // can take <NULL>
  * [ownHost2]->[pctSubUnres][ownHost2]
  */
-static const URI_CHAR * URI_FUNC(ParseOwnHost2)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		if (!URI_FUNC(OnExitOwnHost2)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseOwnHost2)(URI_TYPE(ParserState) * state,
+                                                const URI_CHAR * first,
+                                                const URI_CHAR * afterLast,
+                                                UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        if (!URI_FUNC(OnExitOwnHost2)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterPctSubUnres
-					= URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
-			if (afterPctSubUnres == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseOwnHost2)(state, afterPctSubUnres, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterPctSubUnres =
+            URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+        if (afterPctSubUnres == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseOwnHost2)(state, afterPctSubUnres, afterLast, memory);
+    }
 
-	default:
-		if (!URI_FUNC(OnExitOwnHost2)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return URI_FUNC(ParseAuthorityTwo)(state, first, afterLast);
-	}
+    default:
+        if (!URI_FUNC(OnExitOwnHost2)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParseAuthorityTwo)(state, first, afterLast);
+    }
 }
 
+static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) * state,
+                                                          const URI_CHAR * first,
+                                                          UriMemoryManager * memory) {
+    state->uri->hostText.first =
+        state->uri->userInfo.first; /* Host instead of userInfo, update */
+    state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
+    state->uri->hostText.afterLast = first; /* HOST END */
 
-
-static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		UriMemoryManager * memory) {
-	state->uri->hostText.first = state->uri->userInfo.first; /* Host instead of userInfo, update */
-	state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
-	state->uri->hostText.afterLast = first; /* HOST END */
-
-	/* Valid IPv4 or just a regname? */
-	state->uri->hostData.ip4 = memory->malloc(memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
-	if (state->uri->hostData.ip4 == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-			state->uri->hostText.first, state->uri->hostText.afterLast)) {
-		/* Not IPv4 */
-		memory->free(memory, state->uri->hostData.ip4);
-		state->uri->hostData.ip4 = NULL;
-	}
-	return URI_TRUE; /* Success */
+    /* Valid IPv4 or just a regname? */
+    state->uri->hostData.ip4 = memory->malloc(
+        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+    if (state->uri->hostData.ip4 == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
+                                     state->uri->hostText.first,
+                                     state->uri->hostText.afterLast)) {
+        /* Not IPv4 */
+        memory->free(memory, state->uri->hostData.ip4);
+        state->uri->hostData.ip4 = NULL;
+    }
+    return URI_TRUE; /* Success */
 }
-
-
 
 /*
  * [ownHostUserInfo]->[ownHostUserInfoNz]
  * [ownHostUserInfo]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHostUserInfo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		if (!URI_FUNC(OnExitOwnHostUserInfo)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseOwnHostUserInfo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                               const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        if (!URI_FUNC(OnExitOwnHostUserInfo)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return URI_FUNC(ParseOwnHostUserInfoNz)(state, first, afterLast, memory);
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return URI_FUNC(ParseOwnHostUserInfoNz)(state, first, afterLast, memory);
 
-	default:
-		if (!URI_FUNC(OnExitOwnHostUserInfo)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return first;
-	}
+    default:
+        if (!URI_FUNC(OnExitOwnHostUserInfo)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return first;
+    }
 }
-
-
 
 /*
  * [ownHostUserInfoNz]->[pctSubUnres][ownHostUserInfo]
  * [ownHostUserInfoNz]-><:>[ownPortUserInfo]
  * [ownHostUserInfoNz]-><@>[ownHost]
  */
-static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterPctSubUnres
-					= URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
-			if (afterPctSubUnres == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseOwnHostUserInfo)(state, afterPctSubUnres, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterPctSubUnres =
+            URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+        if (afterPctSubUnres == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseOwnHostUserInfo)(state, afterPctSubUnres, afterLast, memory);
+    }
 
-	case _UT(':'):
-		state->uri->hostText.afterLast = first; /* HOST END */
-		state->uri->portText.first = first + 1; /* PORT BEGIN */
-		return URI_FUNC(ParseOwnPortUserInfo)(state, first + 1, afterLast, memory);
+    case _UT(':'):
+        state->uri->hostText.afterLast = first; /* HOST END */
+        state->uri->portText.first = first + 1; /* PORT BEGIN */
+        return URI_FUNC(ParseOwnPortUserInfo)(state, first + 1, afterLast, memory);
 
-	case _UT('@'):
-		state->uri->userInfo.afterLast = first; /* USERINFO END */
-		state->uri->hostText.first = first + 1; /* HOST BEGIN */
-		return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
+    case _UT('@'):
+        state->uri->userInfo.afterLast = first; /* USERINFO END */
+        state->uri->hostText.first = first + 1; /* HOST BEGIN */
+        return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
 
+static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) * state,
+                                                          const URI_CHAR * first,
+                                                          UriMemoryManager * memory) {
+    state->uri->hostText.first =
+        state->uri->userInfo.first; /* Host instead of userInfo, update */
+    state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
+    state->uri->portText.afterLast = first; /* PORT END */
 
-
-static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		UriMemoryManager * memory) {
-	state->uri->hostText.first = state->uri->userInfo.first; /* Host instead of userInfo, update */
-	state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
-	state->uri->portText.afterLast = first; /* PORT END */
-
-	/* Valid IPv4 or just a regname? */
-	state->uri->hostData.ip4 = memory->malloc(memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
-	if (state->uri->hostData.ip4 == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-			state->uri->hostText.first, state->uri->hostText.afterLast)) {
-		/* Not IPv4 */
-		memory->free(memory, state->uri->hostData.ip4);
-		state->uri->hostData.ip4 = NULL;
-	}
-	return URI_TRUE; /* Success */
+    /* Valid IPv4 or just a regname? */
+    state->uri->hostData.ip4 = memory->malloc(
+        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+    if (state->uri->hostData.ip4 == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
+                                     state->uri->hostText.first,
+                                     state->uri->hostText.afterLast)) {
+        /* Not IPv4 */
+        memory->free(memory, state->uri->hostData.ip4);
+        state->uri->hostData.ip4 = NULL;
+    }
+    return URI_TRUE; /* Success */
 }
-
-
 
 /*
  * [ownPortUserInfo]->[ALPHA][ownUserInfo]
@@ -1241,280 +1318,267 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(
  * [ownPortUserInfo]-><@>[ownHost]
  * [ownPortUserInfo]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		if (!URI_FUNC(OnExitOwnPortUserInfo)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(URI_TYPE(ParserState) * state,
+                                                       const URI_CHAR * first,
+                                                       const URI_CHAR * afterLast,
+                                                       UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        if (!URI_FUNC(OnExitOwnPortUserInfo)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return afterLast;
+    }
 
-	switch (*first) {
-	/* begin sub-delims */
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('\''):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT('+'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('='):
-	/* end sub-delims */
-	/* begin unreserved (except alpha and digit) */
-	case _UT('-'):
-	case _UT('.'):
-	case _UT('_'):
-	case _UT('~'):
-	/* end unreserved (except alpha and digit) */
-	case _UT(':'):
-	case URI_SET_ALPHA:
-		state->uri->hostText.afterLast = NULL; /* Not a host, reset */
-		state->uri->portText.first = NULL; /* Not a port, reset */
-		return URI_FUNC(ParseOwnUserInfo)(state, first + 1, afterLast, memory);
+    switch (*first) {
+    /* begin sub-delims */
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('\''):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT('+'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('='):
+    /* end sub-delims */
+    /* begin unreserved (except alpha and digit) */
+    case _UT('-'):
+    case _UT('.'):
+    case _UT('_'):
+    case _UT('~'):
+    /* end unreserved (except alpha and digit) */
+    case _UT(':'):
+    case URI_SET_ALPHA:
+        state->uri->hostText.afterLast = NULL; /* Not a host, reset */
+        state->uri->portText.first = NULL; /* Not a port, reset */
+        return URI_FUNC(ParseOwnUserInfo)(state, first + 1, afterLast, memory);
 
-	case URI_SET_DIGIT:
-		return URI_FUNC(ParseOwnPortUserInfo)(state, first + 1, afterLast, memory);
+    case URI_SET_DIGIT:
+        return URI_FUNC(ParseOwnPortUserInfo)(state, first + 1, afterLast, memory);
 
-	case _UT('%'):
-		state->uri->portText.first = NULL; /* Not a port, reset */
-		{
-			const URI_CHAR * const afterPct
-					= URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
-			if (afterPct == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseOwnUserInfo)(state, afterPct, afterLast, memory);
-		}
+    case _UT('%'):
+        state->uri->portText.first = NULL; /* Not a port, reset */
+        const URI_CHAR * const afterPct =
+            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+        if (afterPct == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseOwnUserInfo)(state, afterPct, afterLast, memory);
 
-	case _UT('@'):
-		state->uri->hostText.afterLast = NULL; /* Not a host, reset */
-		state->uri->portText.first = NULL; /* Not a port, reset */
-		state->uri->userInfo.afterLast = first; /* USERINFO END */
-		state->uri->hostText.first = first + 1; /* HOST BEGIN */
-		return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
+    case _UT('@'):
+        state->uri->hostText.afterLast = NULL; /* Not a host, reset */
+        state->uri->portText.first = NULL; /* Not a port, reset */
+        state->uri->userInfo.afterLast = first; /* USERINFO END */
+        state->uri->hostText.first = first + 1; /* HOST BEGIN */
+        return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
 
-	default:
-		if (!URI_FUNC(OnExitOwnPortUserInfo)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return first;
-	}
+    default:
+        if (!URI_FUNC(OnExitOwnPortUserInfo)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return first;
+    }
 }
-
-
 
 /*
  * [ownUserInfo]->[pctSubUnres][ownUserInfo]
  * [ownUserInfo]-><:>[ownUserInfo]
  * [ownUserInfo]-><@>[ownHost]
  */
-static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterPctSubUnres
-					= URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
-			if (afterPctSubUnres == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseOwnUserInfo)(state, afterPctSubUnres, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterPctSubUnres =
+            URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+        if (afterPctSubUnres == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseOwnUserInfo)(state, afterPctSubUnres, afterLast, memory);
+    }
 
-	case _UT(':'):
-		return URI_FUNC(ParseOwnUserInfo)(state, first + 1, afterLast, memory);
+    case _UT(':'):
+        return URI_FUNC(ParseOwnUserInfo)(state, first + 1, afterLast, memory);
 
-	case _UT('@'):
-		/* SURE */
-		state->uri->userInfo.afterLast = first; /* USERINFO END */
-		state->uri->hostText.first = first + 1; /* HOST BEGIN */
-		return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
+    case _UT('@'):
+        /* SURE */
+        state->uri->userInfo.afterLast = first; /* USERINFO END */
+        state->uri->hostText.first = first + 1; /* HOST BEGIN */
+        return URI_FUNC(ParseOwnHost)(state, first + 1, afterLast, memory);
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
-
-
 
 static URI_INLINE void URI_FUNC(OnExitPartHelperTwo)(URI_TYPE(ParserState) * state) {
-	state->uri->absolutePath = URI_TRUE;
+    state->uri->absolutePath = URI_TRUE;
 }
-
-
 
 /*
  * [partHelperTwo]->[pathAbsNoLeadSlash] // can take <NULL>
  * [partHelperTwo]-></>[authority][pathAbsEmpty]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParsePartHelperTwo)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(OnExitPartHelperTwo)(state);
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                             const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(OnExitPartHelperTwo)(state);
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('/'):
-		{
-			const URI_CHAR * const afterAuthority
-					= URI_FUNC(ParseAuthority)(state, first + 1, afterLast, memory);
-			const URI_CHAR * afterPathAbsEmpty;
-			if (afterAuthority == NULL) {
-				return NULL;
-			}
-			afterPathAbsEmpty = URI_FUNC(ParsePathAbsEmpty)(state, afterAuthority, afterLast, memory);
+    switch (*first) {
+    case _UT('/'): {
+        const URI_CHAR * const afterAuthority =
+            URI_FUNC(ParseAuthority)(state, first + 1, afterLast, memory);
+        const URI_CHAR * afterPathAbsEmpty;
+        if (afterAuthority == NULL) {
+            return NULL;
+        }
+        afterPathAbsEmpty =
+            URI_FUNC(ParsePathAbsEmpty)(state, afterAuthority, afterLast, memory);
 
-			URI_FUNC(FixEmptyTrailSegment)(state->uri, memory);
+        URI_FUNC(FixEmptyTrailSegment)(state->uri, memory);
 
-			return afterPathAbsEmpty;
-		}
+        return afterPathAbsEmpty;
+    }
 
-	default:
-		URI_FUNC(OnExitPartHelperTwo)(state);
-		return URI_FUNC(ParsePathAbsNoLeadSlash)(state, first, afterLast, memory);
-	}
+    default:
+        URI_FUNC(OnExitPartHelperTwo)(state);
+        return URI_FUNC(ParsePathAbsNoLeadSlash)(state, first, afterLast, memory);
+    }
 }
-
-
 
 /*
  * [pathAbsEmpty]-></>[segment][pathAbsEmpty]
  * [pathAbsEmpty]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('/'):
-		{
-			const URI_CHAR * const afterSegment
-					= URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
-			if (afterSegment == NULL) {
-				return NULL;
-			}
-			if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			return URI_FUNC(ParsePathAbsEmpty)(state, afterSegment, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('/'): {
+        const URI_CHAR * const afterSegment =
+            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+        if (afterSegment == NULL) {
+            return NULL;
+        }
+        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParsePathAbsEmpty)(state, afterSegment, afterLast, memory);
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [pathAbsNoLeadSlash]->[segmentNz][zeroMoreSlashSegs]
  * [pathAbsNoLeadSlash]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParsePathAbsNoLeadSlash)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                                  const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterSegmentNz
-					= URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
-			if (afterSegmentNz == NULL) {
-				return NULL;
-			}
-			if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegmentNz, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterSegmentNz =
+            URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
+        if (afterSegmentNz == NULL) {
+            return NULL;
+        }
+        if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegmentNz, afterLast, memory);
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [pathRootless]->[segmentNz][zeroMoreSlashSegs]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParsePathRootless)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	const URI_CHAR * const afterSegmentNz
-			= URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
-	if (afterSegmentNz == NULL) {
-		return NULL;
-	} else {
-		if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz, memory)) { /* SEGMENT BOTH */
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-	}
-	return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegmentNz, afterLast, memory);
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    const URI_CHAR * const afterSegmentNz =
+        URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
+    if (afterSegmentNz == NULL) {
+        return NULL;
+    } else {
+        if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+    }
+    return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegmentNz, afterLast, memory);
 }
-
-
 
 /*
  * [pchar]->[pctEncoded]
@@ -1524,165 +1588,160 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParsePathRootless)(
  * [pchar]-><@>
  */
 static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+                                             const URI_CHAR * first,
+                                             const URI_CHAR * afterLast,
+                                             UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('%'):
-		return URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+    switch (*first) {
+    case _UT('%'):
+        return URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
 
-	case _UT(':'):
-	case _UT('@'):
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('+'):
-	case _UT('='):
-	case _UT('-'):
-	case _UT('.'):
-	case _UT('_'):
-	case _UT('~'):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return first + 1;
+    case _UT(':'):
+    case _UT('@'):
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('+'):
+    case _UT('='):
+    case _UT('-'):
+    case _UT('.'):
+    case _UT('_'):
+    case _UT('~'):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return first + 1;
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
-
-
 
 /*
  * [pctEncoded]-><%>[HEXDIG][HEXDIG]
  */
-static const URI_CHAR * URI_FUNC(ParsePctEncoded)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state,
+                                                  const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast,
+                                                  UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	/*
-	First character has already been
-	checked before entering this rule.
+    /*
+    First character has already been
+    checked before entering this rule.
 
-	switch (*first) {
-	case _UT('%'):
-	*/
-		if (afterLast - first < 2) {
-			URI_FUNC(StopSyntax)(state, afterLast, memory);
-			return NULL;
-		}
+    switch (*first) {
+    case _UT('%'):
+    */
+    if (afterLast - first < 2) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-		switch (first[1]) {
-		case URI_SET_HEXDIG:
-			if (afterLast - first < 3) {
-				URI_FUNC(StopSyntax)(state, afterLast, memory);
-				return NULL;
-			}
+    switch (first[1]) {
+    case URI_SET_HEXDIG:
+        if (afterLast - first < 3) {
+            URI_FUNC(StopSyntax)(state, afterLast, memory);
+            return NULL;
+        }
 
-			switch (first[2]) {
-			case URI_SET_HEXDIG:
-				return first + 3;
+        switch (first[2]) {
+        case URI_SET_HEXDIG:
+            return first + 3;
 
-			default:
-				URI_FUNC(StopSyntax)(state, first + 2, memory);
-				return NULL;
-			}
+        default:
+            URI_FUNC(StopSyntax)(state, first + 2, memory);
+            return NULL;
+        }
 
-		default:
-			URI_FUNC(StopSyntax)(state, first + 1, memory);
-			return NULL;
-		}
+    default:
+        URI_FUNC(StopSyntax)(state, first + 1, memory);
+        return NULL;
+    }
 
-	/*
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
-	*/
+    /*
+    default:
+            URI_FUNC(StopSyntax)(state, first, memory);
+            return NULL;
+    }
+    */
 }
-
-
 
 /*
  * [pctSubUnres]->[pctEncoded]
  * [pctSubUnres]->[subDelims]
  * [pctSubUnres]->[unreserved]
  */
-static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		URI_FUNC(StopSyntax)(state, afterLast, memory);
-		return NULL;
-	}
+static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state,
+                                                   const URI_CHAR * first,
+                                                   const URI_CHAR * afterLast,
+                                                   UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        URI_FUNC(StopSyntax)(state, afterLast, memory);
+        return NULL;
+    }
 
-	switch (*first) {
-	case _UT('%'):
-		return URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+    switch (*first) {
+    case _UT('%'):
+        return URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
 
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('+'):
-	case _UT('='):
-	case _UT('-'):
-	case _UT('.'):
-	case _UT('_'):
-	case _UT('~'):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		return first + 1;
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('+'):
+    case _UT('='):
+    case _UT('-'):
+    case _UT('.'):
+    case _UT('_'):
+    case _UT('~'):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA:
+        return first + 1;
 
-	default:
-		URI_FUNC(StopSyntax)(state, first, memory);
-		return NULL;
-	}
+    default:
+        URI_FUNC(StopSyntax)(state, first, memory);
+        return NULL;
+    }
 }
-
-
 
 /*
  * [port]->[DIGIT][port]
  * [port]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParsePort)(URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParsePort)(URI_TYPE(ParserState) * state,
+                                            const URI_CHAR * first,
+                                            const URI_CHAR * afterLast) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case URI_SET_DIGIT:
-		return URI_FUNC(ParsePort)(state, first + 1, afterLast);
+    switch (*first) {
+    case URI_SET_DIGIT:
+        return URI_FUNC(ParsePort)(state, first + 1, afterLast);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [queryFrag]->[pchar][queryFrag]
@@ -1691,129 +1750,121 @@ static const URI_CHAR * URI_FUNC(ParsePort)(URI_TYPE(ParserState) * state, const
  * [queryFrag]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseQueryFrag)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+                                                 const URI_CHAR * first,
+                                                 const URI_CHAR * afterLast,
+                                                 UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterPchar
-					= URI_FUNC(ParsePchar)(state, first, afterLast, memory);
-			if (afterPchar == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseQueryFrag)(state, afterPchar, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterPchar =
+            URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+        if (afterPchar == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseQueryFrag)(state, afterPchar, afterLast, memory);
+    }
 
-	case _UT('/'):
-	case _UT('?'):
-		return URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+    case _UT('/'):
+    case _UT('?'):
+        return URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [segment]->[pchar][segment]
  * [segment]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseSegment)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+                                               const URI_CHAR * first,
+                                               const URI_CHAR * afterLast,
+                                               UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('%'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('-'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT('.'):
-	case _UT(':'):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('\''):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('+'):
-	case _UT('='):
-	case URI_SET_DIGIT:
-	case URI_SET_ALPHA:
-		{
-			const URI_CHAR * const afterPchar
-					= URI_FUNC(ParsePchar)(state, first, afterLast, memory);
-			if (afterPchar == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('%'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('-'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT('.'):
+    case _UT(':'):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('\''):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('+'):
+    case _UT('='):
+    case URI_SET_DIGIT:
+    case URI_SET_ALPHA: {
+        const URI_CHAR * const afterPchar =
+            URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+        if (afterPchar == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [segmentNz]->[pchar][segment]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseSegmentNz)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	const URI_CHAR * const afterPchar
-			= URI_FUNC(ParsePchar)(state, first, afterLast, memory);
-	if (afterPchar == NULL) {
-		return NULL;
-	}
-	return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState) * state,
+                                                            const URI_CHAR * first,
+                                                            const URI_CHAR * afterLast,
+                                                            UriMemoryManager * memory) {
+    const URI_CHAR * const afterPchar =
+        URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+    if (afterPchar == NULL) {
+        return NULL;
+    }
+    return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		UriMemoryManager * memory) {
-	if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
-		return URI_FALSE; /* Raises malloc error*/
-	}
-	state->uri->scheme.first = NULL; /* Not a scheme, reset */
-	return URI_TRUE; /* Success */
+    URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory) {
+    if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
+                                   memory)) { /* SEGMENT BOTH */
+        return URI_FALSE; /* Raises malloc error*/
+    }
+    state->uri->scheme.first = NULL; /* Not a scheme, reset */
+    return URI_TRUE; /* Success */
 }
-
-
 
 /*
  * [segmentNzNcOrScheme2]->[ALPHA][segmentNzNcOrScheme2]
@@ -1839,96 +1890,95 @@ static URI_INLINE UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(
  * [segmentNzNcOrScheme2]-><'>[mustBeSegmentNzNc]
  * [segmentNzNcOrScheme2]-><->[segmentNzNcOrScheme2]
  */
-static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		if (!URI_FUNC(OnExitSegmentNzNcOrScheme2)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
+                                                            const URI_CHAR * first,
+                                                            const URI_CHAR * afterLast,
+                                                            UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        if (!URI_FUNC(OnExitSegmentNzNcOrScheme2)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('.'):
-	case _UT('+'):
-	case _UT('-'):
-	case URI_SET_ALPHA:
-	case URI_SET_DIGIT:
-		return URI_FUNC(ParseSegmentNzNcOrScheme2)(state, first + 1, afterLast, memory);
+    switch (*first) {
+    case _UT('.'):
+    case _UT('+'):
+    case _UT('-'):
+    case URI_SET_ALPHA:
+    case URI_SET_DIGIT:
+        return URI_FUNC(ParseSegmentNzNcOrScheme2)(state, first + 1, afterLast, memory);
 
-	case _UT('%'):
-		{
-			const URI_CHAR * const afterPctEncoded
-					= URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
-			if (afterPctEncoded == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast, memory);
-		}
+    case _UT('%'): {
+        const URI_CHAR * const afterPctEncoded =
+            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+        if (afterPctEncoded == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast,
+                                                memory);
+    }
 
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('@'):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('='):
-	case _UT('\''):
-		return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('@'):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('='):
+    case _UT('\''):
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
 
-	case _UT('/'):
-		{
-			const URI_CHAR * afterZeroMoreSlashSegs;
-			const URI_CHAR * const afterSegment
-					= URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
-			if (afterSegment == NULL) {
-				return NULL;
-			}
-			if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			state->uri->scheme.first = NULL; /* Not a scheme, reset */
-			if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			afterZeroMoreSlashSegs
-					= URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
-			if (afterZeroMoreSlashSegs == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseUriTail)(state, afterZeroMoreSlashSegs, afterLast, memory);
-		}
+    case _UT('/'): {
+        const URI_CHAR * afterZeroMoreSlashSegs;
+        const URI_CHAR * const afterSegment =
+            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+        if (afterSegment == NULL) {
+            return NULL;
+        }
+        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        state->uri->scheme.first = NULL; /* Not a scheme, reset */
+        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        afterZeroMoreSlashSegs =
+            URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
+        if (afterZeroMoreSlashSegs == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseUriTail)(state, afterZeroMoreSlashSegs, afterLast, memory);
+    }
 
-	case _UT(':'):
-		{
-			const URI_CHAR * const afterHierPart
-					= URI_FUNC(ParseHierPart)(state, first + 1, afterLast, memory);
-			state->uri->scheme.afterLast = first; /* SCHEME END */
-			if (afterHierPart == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseUriTail)(state, afterHierPart, afterLast, memory);
-		}
+    case _UT(':'): {
+        const URI_CHAR * const afterHierPart =
+            URI_FUNC(ParseHierPart)(state, first + 1, afterLast, memory);
+        state->uri->scheme.afterLast = first; /* SCHEME END */
+        if (afterHierPart == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseUriTail)(state, afterHierPart, afterLast, memory);
+    }
 
-	default:
-		if (!URI_FUNC(OnExitSegmentNzNcOrScheme2)(state, first, memory)) {
-			URI_FUNC(StopMalloc)(state, memory);
-			return NULL;
-		}
-		return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
-	}
+    default:
+        if (!URI_FUNC(OnExitSegmentNzNcOrScheme2)(state, first, memory)) {
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
+    }
 }
-
-
 
 /*
  * [uriReference]->[ALPHA][segmentNzNcOrScheme2]
@@ -1943,452 +1993,418 @@ static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(
  * [uriReference]-><~>[mustBeSegmentNzNc]
  * [uriReference]-><->[mustBeSegmentNzNc]
  */
-static const URI_CHAR * URI_FUNC(ParseUriReference)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case URI_SET_ALPHA:
-		state->uri->scheme.first = first; /* SCHEME BEGIN */
-		return URI_FUNC(ParseSegmentNzNcOrScheme2)(state, first + 1, afterLast, memory);
+    switch (*first) {
+    case URI_SET_ALPHA:
+        state->uri->scheme.first = first; /* SCHEME BEGIN */
+        return URI_FUNC(ParseSegmentNzNcOrScheme2)(state, first + 1, afterLast, memory);
 
-	case URI_SET_DIGIT:
-	case _UT('!'):
-	case _UT('$'):
-	case _UT('&'):
-	case _UT('('):
-	case _UT(')'):
-	case _UT('*'):
-	case _UT(','):
-	case _UT(';'):
-	case _UT('\''):
-	case _UT('+'):
-	case _UT('='):
-	case _UT('.'):
-	case _UT('_'):
-	case _UT('~'):
-	case _UT('-'):
-	case _UT('@'):
-		state->uri->scheme.first = first; /* SEGMENT BEGIN, ABUSE SCHEME POINTER */
-		return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
+    case URI_SET_DIGIT:
+    case _UT('!'):
+    case _UT('$'):
+    case _UT('&'):
+    case _UT('('):
+    case _UT(')'):
+    case _UT('*'):
+    case _UT(','):
+    case _UT(';'):
+    case _UT('\''):
+    case _UT('+'):
+    case _UT('='):
+    case _UT('.'):
+    case _UT('_'):
+    case _UT('~'):
+    case _UT('-'):
+    case _UT('@'):
+        state->uri->scheme.first = first; /* SEGMENT BEGIN, ABUSE SCHEME POINTER */
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, first + 1, afterLast, memory);
 
-	case _UT('%'):
-		{
-			const URI_CHAR * const afterPctEncoded
-					= URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
-			if (afterPctEncoded == NULL) {
-				return NULL;
-			}
-			state->uri->scheme.first = first; /* SEGMENT BEGIN, ABUSE SCHEME POINTER */
-			return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast, memory);
-		}
+    case _UT('%'): {
+        const URI_CHAR * const afterPctEncoded =
+            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+        if (afterPctEncoded == NULL) {
+            return NULL;
+        }
+        state->uri->scheme.first = first; /* SEGMENT BEGIN, ABUSE SCHEME POINTER */
+        return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast,
+                                                memory);
+    }
 
-	case _UT('/'):
-		{
-			const URI_CHAR * const afterPartHelperTwo
-					= URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
-			if (afterPartHelperTwo == NULL) {
-				return NULL;
-			}
-			return URI_FUNC(ParseUriTail)(state, afterPartHelperTwo, afterLast, memory);
-		}
+    case _UT('/'): {
+        const URI_CHAR * const afterPartHelperTwo =
+            URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
+        if (afterPartHelperTwo == NULL) {
+            return NULL;
+        }
+        return URI_FUNC(ParseUriTail)(state, afterPartHelperTwo, afterLast, memory);
+    }
 
-	default:
-		return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
-	}
+    default:
+        return URI_FUNC(ParseUriTail)(state, first, afterLast, memory);
+    }
 }
-
-
 
 /*
  * [uriTail]-><#>[queryFrag]
  * [uriTail]-><?>[queryFrag][uriTailTwo]
  * [uriTail]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) * state,
+                                                          const URI_CHAR * first,
+                                                          const URI_CHAR * afterLast,
+                                                          UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('#'):
-		{
-			const URI_CHAR * const afterQueryFrag = URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
-			if (afterQueryFrag == NULL) {
-				return NULL;
-			}
-			state->uri->fragment.first = first + 1; /* FRAGMENT BEGIN */
-			state->uri->fragment.afterLast = afterQueryFrag; /* FRAGMENT END */
-			return afterQueryFrag;
-		}
+    switch (*first) {
+    case _UT('#'): {
+        const URI_CHAR * const afterQueryFrag =
+            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+        if (afterQueryFrag == NULL) {
+            return NULL;
+        }
+        state->uri->fragment.first = first + 1; /* FRAGMENT BEGIN */
+        state->uri->fragment.afterLast = afterQueryFrag; /* FRAGMENT END */
+        return afterQueryFrag;
+    }
 
-	case _UT('?'):
-		{
-			const URI_CHAR * const afterQueryFrag
-					= URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
-			if (afterQueryFrag == NULL) {
-				return NULL;
-			}
-			state->uri->query.first = first + 1; /* QUERY BEGIN */
-			state->uri->query.afterLast = afterQueryFrag; /* QUERY END */
-			return URI_FUNC(ParseUriTailTwo)(state, afterQueryFrag, afterLast, memory);
-		}
+    case _UT('?'): {
+        const URI_CHAR * const afterQueryFrag =
+            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+        if (afterQueryFrag == NULL) {
+            return NULL;
+        }
+        state->uri->query.first = first + 1; /* QUERY BEGIN */
+        state->uri->query.afterLast = afterQueryFrag; /* QUERY END */
+        return URI_FUNC(ParseUriTailTwo)(state, afterQueryFrag, afterLast, memory);
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [uriTailTwo]-><#>[queryFrag]
  * [uriTailTwo]-><NULL>
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTailTwo)(
-		URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static URI_INLINE const URI_CHAR *
+URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                          const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('#'):
-		{
-			const URI_CHAR * const afterQueryFrag = URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
-			if (afterQueryFrag == NULL) {
-				return NULL;
-			}
-			state->uri->fragment.first = first + 1; /* FRAGMENT BEGIN */
-			state->uri->fragment.afterLast = afterQueryFrag; /* FRAGMENT END */
-			return afterQueryFrag;
-		}
+    switch (*first) {
+    case _UT('#'): {
+        const URI_CHAR * const afterQueryFrag =
+            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+        if (afterQueryFrag == NULL) {
+            return NULL;
+        }
+        state->uri->fragment.first = first + 1; /* FRAGMENT BEGIN */
+        state->uri->fragment.afterLast = afterQueryFrag; /* FRAGMENT END */
+        return afterQueryFrag;
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
-
-
 
 /*
  * [zeroMoreSlashSegs]-></>[segment][zeroMoreSlashSegs]
  * [zeroMoreSlashSegs]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if (first >= afterLast) {
-		return afterLast;
-	}
+static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(URI_TYPE(ParserState) * state,
+                                                         const URI_CHAR * first,
+                                                         const URI_CHAR * afterLast,
+                                                         UriMemoryManager * memory) {
+    if (first >= afterLast) {
+        return afterLast;
+    }
 
-	switch (*first) {
-	case _UT('/'):
-		{
-			const URI_CHAR * const afterSegment
-					= URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
-			if (afterSegment == NULL) {
-				return NULL;
-			}
-			if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
-				URI_FUNC(StopMalloc)(state, memory);
-				return NULL;
-			}
-			return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
-		}
+    switch (*first) {
+    case _UT('/'): {
+        const URI_CHAR * const afterSegment =
+            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+        if (afterSegment == NULL) {
+            return NULL;
+        }
+        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
+                                       memory)) { /* SEGMENT BOTH */
+            URI_FUNC(StopMalloc)(state, memory);
+            return NULL;
+        }
+        return URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
+    }
 
-	default:
-		return first;
-	}
+    default:
+        return first;
+    }
 }
 
-
-
-static URI_INLINE void URI_FUNC(ResetParserStateExceptUri)(URI_TYPE(ParserState) * state) {
-	URI_TYPE(Uri) * const uriBackup = state->uri;
-	memset(state, 0, sizeof(URI_TYPE(ParserState)));
-	state->uri = uriBackup;
+static URI_INLINE void URI_FUNC(ResetParserStateExceptUri)(URI_TYPE(ParserState)
+                                                           * state) {
+    URI_TYPE(Uri) * const uriBackup = state->uri;
+    memset(state, 0, sizeof(URI_TYPE(ParserState)));
+    state->uri = uriBackup;
 }
 
+static URI_INLINE UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * state,
+                                                    const URI_CHAR * first,
+                                                    const URI_CHAR * afterLast,
+                                                    UriMemoryManager * memory) {
+    URI_TYPE(PathSegment) * segment =
+        memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
+    if (segment == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    if (first == afterLast) {
+        segment->text.first = URI_FUNC(SafeToPointTo);
+        segment->text.afterLast = URI_FUNC(SafeToPointTo);
+    } else {
+        segment->text.first = first;
+        segment->text.afterLast = afterLast;
+    }
 
+    /* First segment ever? */
+    if (state->uri->pathHead == NULL) {
+        /* First segment ever, set head and tail */
+        state->uri->pathHead = segment;
+        state->uri->pathTail = segment;
+    } else {
+        /* Append, update tail */
+        state->uri->pathTail->next = segment;
+        state->uri->pathTail = segment;
+    }
 
-static URI_INLINE UriBool URI_FUNC(PushPathSegment)(
-		URI_TYPE(ParserState) * state, const URI_CHAR * first,
-		const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	URI_TYPE(PathSegment) * segment = memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
-	if (segment == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	if (first == afterLast) {
-		segment->text.first = URI_FUNC(SafeToPointTo);
-		segment->text.afterLast = URI_FUNC(SafeToPointTo);
-	} else {
-		segment->text.first = first;
-		segment->text.afterLast = afterLast;
-	}
-
-	/* First segment ever? */
-	if (state->uri->pathHead == NULL) {
-		/* First segment ever, set head and tail */
-		state->uri->pathHead = segment;
-		state->uri->pathTail = segment;
-	} else {
-		/* Append, update tail */
-		state->uri->pathTail->next = segment;
-		state->uri->pathTail = segment;
-	}
-
-	return URI_TRUE; /* Success */
+    return URI_TRUE; /* Success */
 }
 
-
-
-int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	return URI_FUNC(ParseUriExMm)(state, first, afterLast, NULL);
+int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                         const URI_CHAR * afterLast) {
+    return URI_FUNC(ParseUriExMm)(state, first, afterLast, NULL);
 }
 
+static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
+                                  const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    const URI_CHAR * afterUriReference;
+    URI_TYPE(Uri) * uri;
 
+    /* Check params */
+    if ((state == NULL) || (first == NULL) || (afterLast == NULL)) {
+        return URI_ERROR_NULL;
+    }
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	const URI_CHAR * afterUriReference;
-	URI_TYPE(Uri) * uri;
+    uri = state->uri;
 
-	/* Check params */
-	if ((state == NULL) || (first == NULL) || (afterLast == NULL)) {
-		return URI_ERROR_NULL;
-	}
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Init parser */
+    URI_FUNC(ResetParserStateExceptUri)(state);
+    URI_FUNC(ResetUri)(uri);
 
-	uri = state->uri;
-
-	/* Init parser */
-	URI_FUNC(ResetParserStateExceptUri)(state);
-	URI_FUNC(ResetUri)(uri);
-
-	/* Parse */
-	afterUriReference = URI_FUNC(ParseUriReference)(state, first, afterLast, memory);
-	if (afterUriReference == NULL) {
-		/* Waterproof errorPos <= afterLast */
-		if (state->errorPos && (state->errorPos > afterLast)) {
-			state->errorPos = afterLast;
-		}
-		return state->errorCode;
-	}
-	if (afterUriReference != afterLast) {
-		if (afterUriReference < afterLast) {
-			URI_FUNC(StopSyntax)(state, afterUriReference, memory);
-		} else {
-			URI_FUNC(StopSyntax)(state, afterLast, memory);
-		}
-		return state->errorCode;
-	}
-	return URI_SUCCESS;
+    /* Parse */
+    afterUriReference = URI_FUNC(ParseUriReference)(state, first, afterLast, memory);
+    if (afterUriReference == NULL) {
+        /* Waterproof errorPos <= afterLast */
+        if (state->errorPos && (state->errorPos > afterLast)) {
+            state->errorPos = afterLast;
+        }
+        return state->errorCode;
+    }
+    if (afterUriReference != afterLast) {
+        if (afterUriReference < afterLast) {
+            URI_FUNC(StopSyntax)(state, afterUriReference, memory);
+        } else {
+            URI_FUNC(StopSyntax)(state, afterLast, memory);
+        }
+        return state->errorCode;
+    }
+    return URI_SUCCESS;
 }
-
-
 
 int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state, const URI_CHAR * text) {
-	if ((state == NULL) || (text == NULL)) {
-		return URI_ERROR_NULL;
-	}
-	return URI_FUNC(ParseUriEx)(state, text, text + URI_STRLEN(text));
+    if ((state == NULL) || (text == NULL)) {
+        return URI_ERROR_NULL;
+    }
+    return URI_FUNC(ParseUriEx)(state, text, text + URI_STRLEN(text));
 }
-
-
 
 int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri, const URI_CHAR * text,
-		const URI_CHAR ** errorPos) {
-	return URI_FUNC(ParseSingleUriEx)(uri, text, NULL, errorPos);
+                             const URI_CHAR ** errorPos) {
+    return URI_FUNC(ParseSingleUriEx)(uri, text, NULL, errorPos);
 }
 
-
-
-int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		const URI_CHAR ** errorPos) {
+int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                               const URI_CHAR * afterLast, const URI_CHAR ** errorPos) {
     if ((afterLast == NULL) && (first != NULL)) {
-		afterLast = first + URI_STRLEN(first);
-	}
-	return URI_FUNC(ParseSingleUriExMm)(uri, first, afterLast, errorPos, NULL);
+        afterLast = first + URI_STRLEN(first);
+    }
+    return URI_FUNC(ParseSingleUriExMm)(uri, first, afterLast, errorPos, NULL);
 }
 
+int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                 const URI_CHAR * afterLast, const URI_CHAR ** errorPos,
+                                 UriMemoryManager * memory) {
+    URI_TYPE(ParserState) state;
+    int res;
 
+    /* Check params */
+    if ((uri == NULL) || (first == NULL) || (afterLast == NULL)) {
+        return URI_ERROR_NULL;
+    }
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		const URI_CHAR ** errorPos, UriMemoryManager * memory) {
-	URI_TYPE(ParserState) state;
-	int res;
+    state.uri = uri;
 
-	/* Check params */
-	if ((uri == NULL) || (first == NULL) || (afterLast == NULL)) {
-		return URI_ERROR_NULL;
-	}
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    res = URI_FUNC(ParseUriExMm)(&state, first, afterLast, memory);
 
-	state.uri = uri;
+    if (res != URI_SUCCESS) {
+        if (errorPos != NULL) {
+            *errorPos = state.errorPos;
+        }
+        URI_FUNC(FreeUriMembersMm)(uri, memory);
+    }
 
-	res = URI_FUNC(ParseUriExMm)(&state, first, afterLast, memory);
-
-	if (res != URI_SUCCESS) {
-		if (errorPos != NULL) {
-			*errorPos = state.errorPos;
-		}
-		URI_FUNC(FreeUriMembersMm)(uri, memory);
-	}
-
-	return res;
+    return res;
 }
-
-
 
 void URI_FUNC(FreeUriMembers)(URI_TYPE(Uri) * uri) {
-	URI_FUNC(FreeUriMembersMm)(uri, NULL);
+    URI_FUNC(FreeUriMembersMm)(uri, NULL);
 }
-
-
 
 int URI_FUNC(FreeUriMembersMm)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	if (uri == NULL) {
-		return URI_ERROR_NULL;
-	}
+    if (uri == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-	if (uri->owner) {
-		/* Scheme */
-		if (uri->scheme.first != NULL) {
-			if (uri->scheme.first != uri->scheme.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->scheme.first);
-			}
-			uri->scheme.first = NULL;
-			uri->scheme.afterLast = NULL;
-		}
+    if (uri->owner) {
+        /* Scheme */
+        if (uri->scheme.first != NULL) {
+            if (uri->scheme.first != uri->scheme.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->scheme.first);
+            }
+            uri->scheme.first = NULL;
+            uri->scheme.afterLast = NULL;
+        }
 
-		/* User info */
-		if (uri->userInfo.first != NULL) {
-			if (uri->userInfo.first != uri->userInfo.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->userInfo.first);
-			}
-			uri->userInfo.first = NULL;
-			uri->userInfo.afterLast = NULL;
-		}
+        /* User info */
+        if (uri->userInfo.first != NULL) {
+            if (uri->userInfo.first != uri->userInfo.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->userInfo.first);
+            }
+            uri->userInfo.first = NULL;
+            uri->userInfo.afterLast = NULL;
+        }
 
-		/* Host data - IPvFuture (may affect host text) */
-		if (uri->hostData.ipFuture.first != NULL) {
-			/* NOTE: .hostData.ipFuture holds the very same range pointers
-			 *       as .hostText; we must not free memory twice. */
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
+        /* Host data - IPvFuture (may affect host text) */
+        if (uri->hostData.ipFuture.first != NULL) {
+            /* NOTE: .hostData.ipFuture holds the very same range pointers
+             *       as .hostText; we must not free memory twice. */
+            uri->hostText.first = NULL;
+            uri->hostText.afterLast = NULL;
 
-			if (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
-			}
-			uri->hostData.ipFuture.first = NULL;
-			uri->hostData.ipFuture.afterLast = NULL;
-		}
+            if (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
+            }
+            uri->hostData.ipFuture.first = NULL;
+            uri->hostData.ipFuture.afterLast = NULL;
+        }
 
-		/* Host text (after IPvFuture, see above) */
-		if (uri->hostText.first != NULL) {
-			if (uri->hostText.first != uri->hostText.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->hostText.first);
-			}
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
-		}
-	}
+        /* Host text (after IPvFuture, see above) */
+        if (uri->hostText.first != NULL) {
+            if (uri->hostText.first != uri->hostText.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->hostText.first);
+            }
+            uri->hostText.first = NULL;
+            uri->hostText.afterLast = NULL;
+        }
+    }
 
-	/* Host data - IPv4 */
-	if (uri->hostData.ip4 != NULL) {
-		memory->free(memory, uri->hostData.ip4);
-		uri->hostData.ip4 = NULL;
-	}
+    /* Host data - IPv4 */
+    if (uri->hostData.ip4 != NULL) {
+        memory->free(memory, uri->hostData.ip4);
+        uri->hostData.ip4 = NULL;
+    }
 
-	/* Host data - IPv6 */
-	if (uri->hostData.ip6 != NULL) {
-		memory->free(memory, uri->hostData.ip6);
-		uri->hostData.ip6 = NULL;
-	}
+    /* Host data - IPv6 */
+    if (uri->hostData.ip6 != NULL) {
+        memory->free(memory, uri->hostData.ip6);
+        uri->hostData.ip6 = NULL;
+    }
 
-	/* Port text */
-	if (uri->owner && (uri->portText.first != NULL)) {
-		if (uri->portText.first != uri->portText.afterLast) {
-			memory->free(memory, (URI_CHAR *)uri->portText.first);
-		}
-		uri->portText.first = NULL;
-		uri->portText.afterLast = NULL;
-	}
+    /* Port text */
+    if (uri->owner && (uri->portText.first != NULL)) {
+        if (uri->portText.first != uri->portText.afterLast) {
+            memory->free(memory, (URI_CHAR *)uri->portText.first);
+        }
+        uri->portText.first = NULL;
+        uri->portText.afterLast = NULL;
+    }
 
-	/* Path */
-	URI_FUNC(FreeUriPath)(uri, memory);
+    /* Path */
+    URI_FUNC(FreeUriPath)(uri, memory);
 
-	if (uri->owner) {
-		/* Query */
-		if (uri->query.first != NULL) {
-			if (uri->query.first != uri->query.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->query.first);
-			}
-			uri->query.first = NULL;
-			uri->query.afterLast = NULL;
-		}
+    if (uri->owner) {
+        /* Query */
+        if (uri->query.first != NULL) {
+            if (uri->query.first != uri->query.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->query.first);
+            }
+            uri->query.first = NULL;
+            uri->query.afterLast = NULL;
+        }
 
-		/* Fragment */
-		if (uri->fragment.first != NULL) {
-			if (uri->fragment.first != uri->fragment.afterLast) {
-				memory->free(memory, (URI_CHAR *)uri->fragment.first);
-			}
-			uri->fragment.first = NULL;
-			uri->fragment.afterLast = NULL;
-		}
-	}
+        /* Fragment */
+        if (uri->fragment.first != NULL) {
+            if (uri->fragment.first != uri->fragment.afterLast) {
+                memory->free(memory, (URI_CHAR *)uri->fragment.first);
+            }
+            uri->fragment.first = NULL;
+            uri->fragment.afterLast = NULL;
+        }
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 UriBool URI_FUNC(_TESTING_ONLY_ParseIpSix)(const URI_CHAR * text) {
-	UriMemoryManager * const memory = &defaultMemoryManager;
-	URI_TYPE(Uri) uri;
-	URI_TYPE(ParserState) parser;
-	const URI_CHAR * const afterIpSix = text + URI_STRLEN(text);
-	const URI_CHAR * res;
+    UriMemoryManager * const memory = &defaultMemoryManager;
+    URI_TYPE(Uri) uri;
+    URI_TYPE(ParserState) parser;
+    const URI_CHAR * const afterIpSix = text + URI_STRLEN(text);
+    const URI_CHAR * res;
 
-	URI_FUNC(ResetUri)(&uri);
-	parser.uri = &uri;
-	URI_FUNC(ResetParserStateExceptUri)(&parser);
-	parser.uri->hostData.ip6 = memory->malloc(memory, 1 * sizeof(UriIp6));
-	res = URI_FUNC(ParseIPv6address2)(&parser, text, afterIpSix, memory);
-	URI_FUNC(FreeUriMembersMm)(&uri, memory);
-	return res == afterIpSix ? URI_TRUE : URI_FALSE;
+    URI_FUNC(ResetUri)(&uri);
+    parser.uri = &uri;
+    URI_FUNC(ResetParserStateExceptUri)(&parser);
+    parser.uri->hostData.ip6 = memory->malloc(memory, 1 * sizeof(UriIp6));
+    res = URI_FUNC(ParseIPv6address2)(&parser, text, afterIpSix, memory);
+    URI_FUNC(FreeUriMembersMm)(&uri, memory);
+    return res == afterIpSix ? URI_TRUE : URI_FALSE;
 }
-
-
 
 UriBool URI_FUNC(_TESTING_ONLY_ParseIpFour)(const URI_CHAR * text) {
-	unsigned char octets[4];
-	int res = URI_FUNC(ParseIpFourAddress)(octets, text, text + URI_STRLEN(text));
-	return (res == URI_SUCCESS) ? URI_TRUE : URI_FALSE;
+    unsigned char octets[4];
+    int res = URI_FUNC(ParseIpFourAddress)(octets, text, text + URI_STRLEN(text));
+    return (res == URI_SUCCESS) ? URI_TRUE : URI_FALSE;
 }
 
-
-
-#undef URI_SET_DIGIT
-#undef URI_SET_HEX_LETTER_UPPER
-#undef URI_SET_HEX_LETTER_LOWER
-#undef URI_SET_HEXDIG
-#undef URI_SET_ALPHA
-
-
+#  undef URI_SET_DIGIT
+#  undef URI_SET_HEX_LETTER_UPPER
+#  undef URI_SET_HEX_LETTER_LOWER
+#  undef URI_SET_HEXDIG
+#  undef URI_SET_ALPHA
 
 #endif

--- a/ext/uri/uriparser/src/UriParseBase.c
+++ b/ext/uri/uriparser/src/UriParseBase.c
@@ -38,53 +38,48 @@
  */
 
 #ifndef URI_DOXYGEN
-# include "UriParseBase.h"
+#  include "UriParseBase.h"
 #endif
 
+void uriWriteQuadToDoubleByte(const unsigned char * hexDigits, int digitCount,
+                              unsigned char * output) {
+    switch (digitCount) {
+    case 1:
+        /* 0x___? -> \x00 \x0? */
+        output[0] = 0;
+        output[1] = hexDigits[0];
+        break;
 
+    case 2:
+        /* 0x__?? -> \0xx \x?? */
+        output[0] = 0;
+        output[1] = 16 * hexDigits[0] + hexDigits[1];
+        break;
 
-void uriWriteQuadToDoubleByte(const unsigned char * hexDigits, int digitCount, unsigned char * output) {
-	switch (digitCount) {
-	case 1:
-		/* 0x___? -> \x00 \x0? */
-		output[0] = 0;
-		output[1] = hexDigits[0];
-		break;
+    case 3:
+        /* 0x_??? -> \0x? \x?? */
+        output[0] = hexDigits[0];
+        output[1] = 16 * hexDigits[1] + hexDigits[2];
+        break;
 
-	case 2:
-		/* 0x__?? -> \0xx \x?? */
-		output[0] = 0;
-		output[1] = 16 * hexDigits[0] + hexDigits[1];
-		break;
-
-	case 3:
-		/* 0x_??? -> \0x? \x?? */
-		output[0] = hexDigits[0];
-		output[1] = 16 * hexDigits[1] + hexDigits[2];
-		break;
-
-	case 4:
-		/* 0x???? -> \0?? \x?? */
-		output[0] = 16 * hexDigits[0] + hexDigits[1];
-		output[1] = 16 * hexDigits[2] + hexDigits[3];
-		break;
-
-	}
+    case 4:
+        /* 0x???? -> \0?? \x?? */
+        output[0] = 16 * hexDigits[0] + hexDigits[1];
+        output[1] = 16 * hexDigits[2] + hexDigits[3];
+        break;
+    }
 }
 
-
-
 unsigned char uriGetOctetValue(const unsigned char * digits, int digitCount) {
-	switch (digitCount) {
-	case 1:
-		return digits[0];
+    switch (digitCount) {
+    case 1:
+        return digits[0];
 
-	case 2:
-		return 10 * digits[0] + digits[1];
+    case 2:
+        return 10 * digits[0] + digits[1];
 
-	case 3:
-	default:
-		return 100 * digits[0] + 10 * digits[1] + digits[2];
-
-	}
+    case 3:
+    default:
+        return 100 * digits[0] + 10 * digits[1] + digits[2];
+    }
 }

--- a/ext/uri/uriparser/src/UriParseBase.h
+++ b/ext/uri/uriparser/src/UriParseBase.h
@@ -38,18 +38,12 @@
  */
 
 #ifndef URI_PARSE_BASE_H
-#define URI_PARSE_BASE_H 1
+#  define URI_PARSE_BASE_H 1
 
-
-
-#include <uriparser/UriBase.h>
-
-
+#  include <uriparser/UriBase.h>
 
 void uriWriteQuadToDoubleByte(const unsigned char * hexDigits, int digitCount,
-		unsigned char * output);
+                              unsigned char * output);
 unsigned char uriGetOctetValue(const unsigned char * digits, int digitCount);
-
-
 
 #endif /* URI_PARSE_BASE_H */

--- a/ext/uri/uriparser/src/UriQuery.c
+++ b/ext/uri/uriparser/src/UriQuery.c
@@ -41,465 +41,427 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriQuery.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriQuery.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriQuery.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriQuery.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
-
-
-
-#include <limits.h>
-#include <stddef.h> /* size_t */
-
-
+#  include <limits.h>
+#  include <stddef.h> /* size_t */
 
 static int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList,
-		int maxChars, int * charsWritten, int * charsRequired,
-		UriBool spaceToPlus, UriBool normalizeBreaks);
+                                        const URI_TYPE(QueryList) * queryList,
+                                        int maxChars, int * charsWritten,
+                                        int * charsRequired, UriBool spaceToPlus,
+                                        UriBool normalizeBreaks);
 
-static UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) ** prevNext,
-		int * itemCount, const URI_CHAR * keyFirst, const URI_CHAR * keyAfter,
-		const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
-		UriBool plusToSpace, UriBreakConversion breakConversion,
-		UriMemoryManager * memory);
-
-
+static UriBool URI_FUNC(AppendQueryItem)(
+    URI_TYPE(QueryList) * *prevNext, int * itemCount, const URI_CHAR * keyFirst,
+    const URI_CHAR * keyAfter, const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
+    UriBool plusToSpace, UriBreakConversion breakConversion, UriMemoryManager * memory);
 
 int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * queryList,
-		int * charsRequired) {
-	const UriBool spaceToPlus = URI_TRUE;
-	const UriBool normalizeBreaks = URI_TRUE;
+                                        int * charsRequired) {
+    const UriBool spaceToPlus = URI_TRUE;
+    const UriBool normalizeBreaks = URI_TRUE;
 
-	return URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, charsRequired,
-			spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, charsRequired, spaceToPlus,
+                                                 normalizeBreaks);
 }
-
-
 
 int URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
-		int * charsRequired, UriBool spaceToPlus, UriBool normalizeBreaks) {
-	if ((queryList == NULL) || (charsRequired == NULL)) {
-		return URI_ERROR_NULL;
-	}
+                                          int * charsRequired, UriBool spaceToPlus,
+                                          UriBool normalizeBreaks) {
+    if ((queryList == NULL) || (charsRequired == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-	return URI_FUNC(ComposeQueryEngine)(NULL, queryList, 0, NULL,
-			charsRequired, spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryEngine)(NULL, queryList, 0, NULL, charsRequired,
+                                        spaceToPlus, normalizeBreaks);
 }
 
+int URI_FUNC(ComposeQuery)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
+                           int maxChars, int * charsWritten) {
+    const UriBool spaceToPlus = URI_TRUE;
+    const UriBool normalizeBreaks = URI_TRUE;
 
-
-int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten) {
-	const UriBool spaceToPlus = URI_TRUE;
-	const UriBool normalizeBreaks = URI_TRUE;
-
-	return URI_FUNC(ComposeQueryEx)(dest, queryList, maxChars, charsWritten,
-			spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryEx)(dest, queryList, maxChars, charsWritten, spaceToPlus,
+                                    normalizeBreaks);
 }
 
+int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
+                             int maxChars, int * charsWritten, UriBool spaceToPlus,
+                             UriBool normalizeBreaks) {
+    if ((dest == NULL) || (queryList == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
+    if (maxChars < 1) {
+        return URI_ERROR_OUTPUT_TOO_LARGE;
+    }
 
-int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten,
-		UriBool spaceToPlus, UriBool normalizeBreaks) {
-	if ((dest == NULL) || (queryList == NULL)) {
-		return URI_ERROR_NULL;
-	}
-
-	if (maxChars < 1) {
-		return URI_ERROR_OUTPUT_TOO_LARGE;
-	}
-
-	return URI_FUNC(ComposeQueryEngine)(dest, queryList, maxChars,
-			charsWritten, NULL, spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryEngine)(dest, queryList, maxChars, charsWritten, NULL,
+                                        spaceToPlus, normalizeBreaks);
 }
-
-
 
 int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList) {
-	const UriBool spaceToPlus = URI_TRUE;
-	const UriBool normalizeBreaks = URI_TRUE;
+                                 const URI_TYPE(QueryList) * queryList) {
+    const UriBool spaceToPlus = URI_TRUE;
+    const UriBool normalizeBreaks = URI_TRUE;
 
-	return URI_FUNC(ComposeQueryMallocEx)(dest, queryList,
-			spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryMallocEx)(dest, queryList, spaceToPlus, normalizeBreaks);
 }
-
-
 
 int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList,
-		UriBool spaceToPlus, UriBool normalizeBreaks) {
-	return URI_FUNC(ComposeQueryMallocExMm)(dest, queryList, spaceToPlus,
-			normalizeBreaks, NULL);
+                                   const URI_TYPE(QueryList) * queryList,
+                                   UriBool spaceToPlus, UriBool normalizeBreaks) {
+    return URI_FUNC(ComposeQueryMallocExMm)(dest, queryList, spaceToPlus, normalizeBreaks,
+                                            NULL);
 }
-
-
 
 int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
-		const URI_TYPE(QueryList) * queryList,
-		UriBool spaceToPlus, UriBool normalizeBreaks,
-		UriMemoryManager * memory) {
-	int charsRequired;
-	int res;
-	URI_CHAR * queryString;
+                                     const URI_TYPE(QueryList) * queryList,
+                                     UriBool spaceToPlus, UriBool normalizeBreaks,
+                                     UriMemoryManager * memory) {
+    int charsRequired;
+    int res;
+    URI_CHAR * queryString;
 
-	if (dest == NULL) {
-		return URI_ERROR_NULL;
-	}
+    if (dest == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-	/* Calculate space */
-	res = URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, &charsRequired,
-			spaceToPlus, normalizeBreaks);
-	if (res != URI_SUCCESS) {
-		return res;
-	}
-	if (charsRequired == INT_MAX) {
-	    return URI_ERROR_MALLOC;
-	}
-	charsRequired++;
+    /* Calculate space */
+    res = URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, &charsRequired, spaceToPlus,
+                                                normalizeBreaks);
+    if (res != URI_SUCCESS) {
+        return res;
+    }
+    if (charsRequired == INT_MAX) {
+        return URI_ERROR_MALLOC;
+    }
+    charsRequired++;
 
-	/* Allocate space */
-	queryString = memory->calloc(memory, charsRequired, sizeof(URI_CHAR));
-	if (queryString == NULL) {
-		return URI_ERROR_MALLOC;
-	}
+    /* Allocate space */
+    queryString = memory->calloc(memory, charsRequired, sizeof(URI_CHAR));
+    if (queryString == NULL) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Put query in */
-	res = URI_FUNC(ComposeQueryEx)(queryString, queryList, charsRequired,
-			NULL, spaceToPlus, normalizeBreaks);
-	if (res != URI_SUCCESS) {
-		memory->free(memory, queryString);
-		return res;
-	}
+    /* Put query in */
+    res = URI_FUNC(ComposeQueryEx)(queryString, queryList, charsRequired, NULL,
+                                   spaceToPlus, normalizeBreaks);
+    if (res != URI_SUCCESS) {
+        memory->free(memory, queryString);
+        return res;
+    }
 
-	*dest = queryString;
-	return URI_SUCCESS;
+    *dest = queryString;
+    return URI_SUCCESS;
 }
 
+int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
+                                 int maxChars, int * charsWritten, int * charsRequired,
+                                 UriBool spaceToPlus, UriBool normalizeBreaks) {
+    UriBool firstItem = URI_TRUE;
+    int ampersandLen = 0; /* increased to 1 from second item on */
+    URI_CHAR * write = dest;
 
+    /* Subtract terminator */
+    if (dest == NULL) {
+        *charsRequired = 0;
+    } else {
+        maxChars--;
+    }
 
-int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
-		const URI_TYPE(QueryList) * queryList,
-		int maxChars, int * charsWritten, int * charsRequired,
-		UriBool spaceToPlus, UriBool normalizeBreaks) {
-	UriBool firstItem = URI_TRUE;
-	int ampersandLen = 0;  /* increased to 1 from second item on */
-	URI_CHAR * write = dest;
+    while (queryList != NULL) {
+        const URI_CHAR * const key = queryList->key;
+        const URI_CHAR * const value = queryList->value;
+        const int worstCase = (normalizeBreaks == URI_TRUE ? 6 : 3);
+        const size_t keyLen = (key == NULL) ? 0 : URI_STRLEN(key);
+        int keyRequiredChars;
+        const size_t valueLen = (value == NULL) ? 0 : URI_STRLEN(value);
+        int valueRequiredChars;
 
-	/* Subtract terminator */
-	if (dest == NULL) {
-		*charsRequired = 0;
-	} else {
-		maxChars--;
-	}
+        if ((keyLen >= (size_t)INT_MAX / worstCase)
+            || (valueLen >= (size_t)INT_MAX / worstCase)) {
+            return URI_ERROR_OUTPUT_TOO_LARGE;
+        }
+        keyRequiredChars = worstCase * (int)keyLen;
+        valueRequiredChars = worstCase * (int)valueLen;
 
-	while (queryList != NULL) {
-		const URI_CHAR * const key = queryList->key;
-		const URI_CHAR * const value = queryList->value;
-		const int worstCase = (normalizeBreaks == URI_TRUE ? 6 : 3);
-		const size_t keyLen = (key == NULL) ? 0 : URI_STRLEN(key);
-		int keyRequiredChars;
-		const size_t valueLen = (value == NULL) ? 0 : URI_STRLEN(value);
-		int valueRequiredChars;
+        if (dest == NULL) {
+            (*charsRequired) += ampersandLen + keyRequiredChars
+                                + ((value == NULL) ? 0 : 1 + valueRequiredChars);
 
-		if ((keyLen >= (size_t)INT_MAX / worstCase) || (valueLen >= (size_t)INT_MAX / worstCase)) {
-			return URI_ERROR_OUTPUT_TOO_LARGE;
-		}
-		keyRequiredChars = worstCase * (int)keyLen;
-		valueRequiredChars = worstCase * (int)valueLen;
+            if (firstItem == URI_TRUE) {
+                ampersandLen = 1;
+                firstItem = URI_FALSE;
+            }
+        } else {
+            if ((write - dest) + ampersandLen + keyRequiredChars > maxChars) {
+                return URI_ERROR_OUTPUT_TOO_LARGE;
+            }
 
-		if (dest == NULL) {
-			(*charsRequired) += ampersandLen + keyRequiredChars + ((value == NULL)
-						? 0
-						: 1 + valueRequiredChars);
+            /* Copy key */
+            if (firstItem == URI_TRUE) {
+                ampersandLen = 1;
+                firstItem = URI_FALSE;
+            } else {
+                write[0] = _UT('&');
+                write++;
+            }
+            write = URI_FUNC(EscapeEx)(key, key + keyLen, write, spaceToPlus,
+                                       normalizeBreaks);
 
-			if (firstItem == URI_TRUE) {
-				ampersandLen = 1;
-				firstItem = URI_FALSE;
-			}
-		} else {
-			if ((write - dest) + ampersandLen + keyRequiredChars > maxChars) {
-				return URI_ERROR_OUTPUT_TOO_LARGE;
-			}
+            if (value != NULL) {
+                if ((write - dest) + 1 + valueRequiredChars > maxChars) {
+                    return URI_ERROR_OUTPUT_TOO_LARGE;
+                }
 
-			/* Copy key */
-			if (firstItem == URI_TRUE) {
-				ampersandLen = 1;
-				firstItem = URI_FALSE;
-			} else {
-				write[0] = _UT('&');
-				write++;
-			}
-			write = URI_FUNC(EscapeEx)(key, key + keyLen,
-					write, spaceToPlus, normalizeBreaks);
+                /* Copy value */
+                write[0] = _UT('=');
+                write++;
+                write = URI_FUNC(EscapeEx)(value, value + valueLen, write, spaceToPlus,
+                                           normalizeBreaks);
+            }
+        }
 
-			if (value != NULL) {
-				if ((write - dest) + 1 + valueRequiredChars > maxChars) {
-					return URI_ERROR_OUTPUT_TOO_LARGE;
-				}
+        queryList = queryList->next;
+    }
 
-				/* Copy value */
-				write[0] = _UT('=');
-				write++;
-				write = URI_FUNC(EscapeEx)(value, value + valueLen,
-						write, spaceToPlus, normalizeBreaks);
-			}
-		}
+    if (dest != NULL) {
+        write[0] = _UT('\0');
+        if (charsWritten != NULL) {
+            *charsWritten = (int)(write - dest) + 1; /* .. for terminator */
+        }
+    }
 
-		queryList = queryList->next;
-	}
-
-	if (dest != NULL) {
-		write[0] = _UT('\0');
-		if (charsWritten != NULL) {
-			*charsWritten = (int)(write - dest) + 1; /* .. for terminator */
-		}
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
+UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCount,
+                                  const URI_CHAR * keyFirst, const URI_CHAR * keyAfter,
+                                  const URI_CHAR * valueFirst,
+                                  const URI_CHAR * valueAfter, UriBool plusToSpace,
+                                  UriBreakConversion breakConversion,
+                                  UriMemoryManager * memory) {
+    const int keyLen = (int)(keyAfter - keyFirst);
+    const int valueLen = (int)(valueAfter - valueFirst);
+    URI_CHAR * key;
+    URI_CHAR * value;
 
+    if ((prevNext == NULL) || (itemCount == NULL) || (keyFirst == NULL)
+        || (keyAfter == NULL) || (keyFirst > keyAfter) || (valueFirst > valueAfter)
+        || ((keyFirst == keyAfter) && (valueFirst == NULL) && (valueAfter == NULL))) {
+        return URI_TRUE;
+    }
 
-UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) ** prevNext,
-		int * itemCount, const URI_CHAR * keyFirst, const URI_CHAR * keyAfter,
-		const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
-		UriBool plusToSpace, UriBreakConversion breakConversion,
-		UriMemoryManager * memory) {
-	const int keyLen = (int)(keyAfter - keyFirst);
-	const int valueLen = (int)(valueAfter - valueFirst);
-	URI_CHAR * key;
-	URI_CHAR * value;
+    /* Append new empty item */
+    *prevNext = memory->malloc(memory, 1 * sizeof(URI_TYPE(QueryList)));
+    if (*prevNext == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    (*prevNext)->next = NULL;
 
-	if ((prevNext == NULL) || (itemCount == NULL)
-			|| (keyFirst == NULL) || (keyAfter == NULL)
-			|| (keyFirst > keyAfter) || (valueFirst > valueAfter)
-			|| ((keyFirst == keyAfter)
-				&& (valueFirst == NULL) && (valueAfter == NULL))) {
-		return URI_TRUE;
-	}
+    /* Fill key */
+    key = memory->malloc(memory, (keyLen + 1) * sizeof(URI_CHAR));
+    if (key == NULL) {
+        memory->free(memory, *prevNext);
+        *prevNext = NULL;
+        return URI_FALSE; /* Raises malloc error */
+    }
 
-	/* Append new empty item */
-	*prevNext = memory->malloc(memory, 1 * sizeof(URI_TYPE(QueryList)));
-	if (*prevNext == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	(*prevNext)->next = NULL;
+    key[keyLen] = _UT('\0');
+    if (keyLen > 0) {
+        /* Copy 1:1 */
+        memcpy(key, keyFirst, keyLen * sizeof(URI_CHAR));
 
+        /* Unescape */
+        URI_FUNC(UnescapeInPlaceEx)(key, plusToSpace, breakConversion);
+    }
+    (*prevNext)->key = key;
 
-	/* Fill key */
-	key = memory->malloc(memory, (keyLen + 1) * sizeof(URI_CHAR));
-	if (key == NULL) {
-		memory->free(memory, *prevNext);
-		*prevNext = NULL;
-		return URI_FALSE; /* Raises malloc error */
-	}
+    /* Fill value */
+    if (valueFirst != NULL) {
+        value = memory->malloc(memory, (valueLen + 1) * sizeof(URI_CHAR));
+        if (value == NULL) {
+            memory->free(memory, key);
+            memory->free(memory, *prevNext);
+            *prevNext = NULL;
+            return URI_FALSE; /* Raises malloc error */
+        }
 
-	key[keyLen] = _UT('\0');
-	if (keyLen > 0) {
-		/* Copy 1:1 */
-		memcpy(key, keyFirst, keyLen * sizeof(URI_CHAR));
+        value[valueLen] = _UT('\0');
+        if (valueLen > 0) {
+            /* Copy 1:1 */
+            memcpy(value, valueFirst, valueLen * sizeof(URI_CHAR));
 
-		/* Unescape */
-		URI_FUNC(UnescapeInPlaceEx)(key, plusToSpace, breakConversion);
-	}
-	(*prevNext)->key = key;
+            /* Unescape */
+            URI_FUNC(UnescapeInPlaceEx)(value, plusToSpace, breakConversion);
+        }
+        (*prevNext)->value = value;
+    } else {
+        value = NULL;
+    }
+    (*prevNext)->value = value;
 
-
-	/* Fill value */
-	if (valueFirst != NULL) {
-		value = memory->malloc(memory, (valueLen + 1) * sizeof(URI_CHAR));
-		if (value == NULL) {
-			memory->free(memory, key);
-			memory->free(memory, *prevNext);
-			*prevNext = NULL;
-			return URI_FALSE; /* Raises malloc error */
-		}
-
-		value[valueLen] = _UT('\0');
-		if (valueLen > 0) {
-			/* Copy 1:1 */
-			memcpy(value, valueFirst, valueLen * sizeof(URI_CHAR));
-
-			/* Unescape */
-			URI_FUNC(UnescapeInPlaceEx)(value, plusToSpace, breakConversion);
-		}
-		(*prevNext)->value = value;
-	} else {
-		value = NULL;
-	}
-	(*prevNext)->value = value;
-
-	(*itemCount)++;
-	return URI_TRUE;
+    (*itemCount)++;
+    return URI_TRUE;
 }
-
-
 
 void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList) {
-	URI_FUNC(FreeQueryListMm)(queryList, NULL);
+    URI_FUNC(FreeQueryListMm)(queryList, NULL);
 }
-
-
 
 int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
-		UriMemoryManager * memory) {
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
-	while (queryList != NULL) {
-		URI_TYPE(QueryList) * nextBackup = queryList->next;
-		memory->free(memory, (URI_CHAR *)queryList->key); /* const cast */
-		memory->free(memory, (URI_CHAR *)queryList->value); /* const cast */
-		memory->free(memory, queryList);
-		queryList = nextBackup;
-	}
-	return URI_SUCCESS;
+                              UriMemoryManager * memory) {
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
+    while (queryList != NULL) {
+        URI_TYPE(QueryList) * nextBackup = queryList->next;
+        memory->free(memory, (URI_CHAR *)queryList->key); /* const cast */
+        memory->free(memory, (URI_CHAR *)queryList->value); /* const cast */
+        memory->free(memory, queryList);
+        queryList = nextBackup;
+    }
+    return URI_SUCCESS;
 }
 
+int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) * *dest, int * itemCount,
+                                 const URI_CHAR * first, const URI_CHAR * afterLast) {
+    const UriBool plusToSpace = URI_TRUE;
+    const UriBreakConversion breakConversion = URI_BR_DONT_TOUCH;
 
-
-int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) ** dest, int * itemCount,
-		const URI_CHAR * first, const URI_CHAR * afterLast) {
-	const UriBool plusToSpace = URI_TRUE;
-	const UriBreakConversion breakConversion = URI_BR_DONT_TOUCH;
-
-	return URI_FUNC(DissectQueryMallocEx)(dest, itemCount, first, afterLast,
-			plusToSpace, breakConversion);
+    return URI_FUNC(DissectQueryMallocEx)(dest, itemCount, first, afterLast, plusToSpace,
+                                          breakConversion);
 }
 
-
-
-int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) ** dest, int * itemCount,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriBool plusToSpace, UriBreakConversion breakConversion) {
-	return URI_FUNC(DissectQueryMallocExMm)(dest, itemCount, first, afterLast,
-			plusToSpace, breakConversion, NULL);
+int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) * *dest, int * itemCount,
+                                   const URI_CHAR * first, const URI_CHAR * afterLast,
+                                   UriBool plusToSpace,
+                                   UriBreakConversion breakConversion) {
+    return URI_FUNC(DissectQueryMallocExMm)(dest, itemCount, first, afterLast,
+                                            plusToSpace, breakConversion, NULL);
 }
 
+int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest, int * itemCount,
+                                     const URI_CHAR * first, const URI_CHAR * afterLast,
+                                     UriBool plusToSpace,
+                                     UriBreakConversion breakConversion,
+                                     UriMemoryManager * memory) {
+    const URI_CHAR * walk = first;
+    const URI_CHAR * keyFirst = first;
+    const URI_CHAR * keyAfter = NULL;
+    const URI_CHAR * valueFirst = NULL;
+    const URI_CHAR * valueAfter = NULL;
+    URI_TYPE(QueryList) ** prevNext = dest;
+    int nullCounter;
+    int * itemsAppended = (itemCount == NULL) ? &nullCounter : itemCount;
 
+    if ((dest == NULL) || (first == NULL) || (afterLast == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) ** dest, int * itemCount,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriBool plusToSpace, UriBreakConversion breakConversion,
-		UriMemoryManager * memory) {
-	const URI_CHAR * walk = first;
-	const URI_CHAR * keyFirst = first;
-	const URI_CHAR * keyAfter = NULL;
-	const URI_CHAR * valueFirst = NULL;
-	const URI_CHAR * valueAfter = NULL;
-	URI_TYPE(QueryList) ** prevNext = dest;
-	int nullCounter;
-	int * itemsAppended = (itemCount == NULL) ? &nullCounter : itemCount;
+    if (first > afterLast) {
+        return URI_ERROR_RANGE_INVALID;
+    }
 
-	if ((dest == NULL) || (first == NULL) || (afterLast == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-	if (first > afterLast) {
-		return URI_ERROR_RANGE_INVALID;
-	}
+    *dest = NULL;
+    *itemsAppended = 0;
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Parse query string */
+    for (; walk < afterLast; walk++) {
+        switch (*walk) {
+        case _UT('&'):
+            if (valueFirst != NULL) {
+                valueAfter = walk;
+            } else {
+                keyAfter = walk;
+            }
 
-	*dest = NULL;
-	*itemsAppended = 0;
+            if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended, keyFirst, keyAfter,
+                                          valueFirst, valueAfter, plusToSpace,
+                                          breakConversion, memory)
+                == URI_FALSE) {
+                /* Free list we built */
+                *itemsAppended = 0;
+                URI_FUNC(FreeQueryListMm)(*dest, memory);
+                return URI_ERROR_MALLOC;
+            }
 
-	/* Parse query string */
-	for (; walk < afterLast; walk++) {
-		switch (*walk) {
-		case _UT('&'):
-			if (valueFirst != NULL) {
-				valueAfter = walk;
-			} else {
-				keyAfter = walk;
-			}
+            /* Make future items children of the current */
+            if ((prevNext != NULL) && (*prevNext != NULL)) {
+                prevNext = &((*prevNext)->next);
+            }
 
-			if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended,
-					keyFirst, keyAfter, valueFirst, valueAfter,
-					plusToSpace, breakConversion, memory)
-					== URI_FALSE) {
-				/* Free list we built */
-				*itemsAppended = 0;
-				URI_FUNC(FreeQueryListMm)(*dest, memory);
-				return URI_ERROR_MALLOC;
-			}
+            if (walk + 1 < afterLast) {
+                keyFirst = walk + 1;
+            } else {
+                keyFirst = NULL;
+            }
+            keyAfter = NULL;
+            valueFirst = NULL;
+            valueAfter = NULL;
+            break;
 
-			/* Make future items children of the current */
-			if ((prevNext != NULL) && (*prevNext != NULL)) {
-				prevNext = &((*prevNext)->next);
-			}
+        case _UT('='):
+            /* NOTE: WE treat the first '=' as a separator, */
+            /*       all following go into the value part   */
+            if (keyAfter == NULL) {
+                keyAfter = walk;
+                if (walk + 1 <= afterLast) {
+                    valueFirst = walk + 1;
+                    valueAfter = walk + 1;
+                }
+            }
+            break;
 
-			if (walk + 1 < afterLast) {
-				keyFirst = walk + 1;
-			} else {
-				keyFirst = NULL;
-			}
-			keyAfter = NULL;
-			valueFirst = NULL;
-			valueAfter = NULL;
-			break;
+        default:
+            break;
+        }
+    }
 
-		case _UT('='):
-			/* NOTE: WE treat the first '=' as a separator, */
-			/*       all following go into the value part   */
-			if (keyAfter == NULL) {
-				keyAfter = walk;
-				if (walk + 1 <= afterLast) {
-					valueFirst = walk + 1;
-					valueAfter = walk + 1;
-				}
-			}
-			break;
+    if (valueFirst != NULL) {
+        /* Must be key/value pair */
+        valueAfter = walk;
+    } else {
+        /* Must be key only */
+        keyAfter = walk;
+    }
 
-		default:
-			break;
-		}
-	}
+    if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended, keyFirst, keyAfter, valueFirst,
+                                  valueAfter, plusToSpace, breakConversion, memory)
+        == URI_FALSE) {
+        /* Free list we built */
+        *itemsAppended = 0;
+        URI_FUNC(FreeQueryListMm)(*dest, memory);
+        return URI_ERROR_MALLOC;
+    }
 
-	if (valueFirst != NULL) {
-		/* Must be key/value pair */
-		valueAfter = walk;
-	} else {
-		/* Must be key only */
-		keyAfter = walk;
-	}
-
-	if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended, keyFirst, keyAfter,
-			valueFirst, valueAfter, plusToSpace, breakConversion, memory)
-			== URI_FALSE) {
-		/* Free list we built */
-		*itemsAppended = 0;
-		URI_FUNC(FreeQueryListMm)(*dest, memory);
-		return URI_ERROR_MALLOC;
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriRecompose.c
+++ b/ext/uri/uriparser/src/UriRecompose.c
@@ -41,537 +41,564 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriRecompose.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriRecompose.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriRecompose.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriRecompose.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#  endif
 
 static int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-		int maxChars, int * charsWritten, int * charsRequired);
+                                    int maxChars, int * charsWritten,
+                                    int * charsRequired);
 
-
-
-int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri,
-		int * charsRequired) {
-	const int MAX_CHARS = ((unsigned int)-1) >> 1;
-	return URI_FUNC(ToStringEngine)(NULL, uri, MAX_CHARS, NULL, charsRequired);
+int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri, int * charsRequired) {
+    const int MAX_CHARS = ((unsigned int)-1) >> 1;
+    return URI_FUNC(ToStringEngine)(NULL, uri, MAX_CHARS, NULL, charsRequired);
 }
 
-
-
-int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-		int maxChars, int * charsWritten) {
-	return URI_FUNC(ToStringEngine)(dest, uri, maxChars, charsWritten, NULL);
+int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri, int maxChars,
+                       int * charsWritten) {
+    return URI_FUNC(ToStringEngine)(dest, uri, maxChars, charsWritten, NULL);
 }
 
+static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
+                                               int maxChars, int * charsWritten,
+                                               int * charsRequired) {
+    int written = 0;
+    if ((uri == NULL) || ((dest == NULL) && (charsRequired == NULL))) {
+        if (charsWritten != NULL) {
+            *charsWritten = 0;
+        }
+        return URI_ERROR_NULL;
+    }
 
+    if (maxChars < 1) {
+        if (charsWritten != NULL) {
+            *charsWritten = 0;
+        }
+        return URI_ERROR_TOSTRING_TOO_LONG;
+    }
+    maxChars--; /* So we don't have to subtract 1 for '\0' all the time */
 
-static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest,
-		const URI_TYPE(Uri) * uri, int maxChars, int * charsWritten,
-		int * charsRequired) {
-	int written = 0;
-	if ((uri == NULL) || ((dest == NULL) && (charsRequired == NULL))) {
-		if (charsWritten != NULL) {
-			*charsWritten = 0;
-		}
-		return URI_ERROR_NULL;
-	}
+    /* NOTE: The curly brackets here force deeper indent (and that's all) */
+    {
+        {
+            {
+                /* clang-format off */
+    /* [01/19] result = "" */
+                /* clang-format on */
+                if (dest != NULL) {
+                    dest[0] = _UT('\0');
+                } else {
+                    (*charsRequired) = 0;
+                }
+                /* clang-format off */
+    /* [02/19] if defined(scheme) then */
+                /* clang-format on */
+                if (uri->scheme.first != NULL) {
+                    /* clang-format off */
+    /* [03/19]     append scheme to result; */
+                    /* clang-format on */
+                    const int charsToWrite =
+                        (int)(uri->scheme.afterLast - uri->scheme.first);
+                    if (dest != NULL) {
+                        if (written + charsToWrite <= maxChars) {
+                            memcpy(dest + written, uri->scheme.first,
+                                   charsToWrite * sizeof(URI_CHAR));
+                            written += charsToWrite;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += charsToWrite;
+                    }
+                    /* clang-format off */
+    /* [04/19]     append ":" to result; */
+                    /* clang-format on */
+                    if (dest != NULL) {
+                        if (written + 1 <= maxChars) {
+                            memcpy(dest + written, _UT(":"), 1 * sizeof(URI_CHAR));
+                            written += 1;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += 1;
+                    }
+                    /* clang-format off */
+    /* [05/19] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [06/19] if defined(authority) then */
+                /* clang-format on */
+                if (URI_FUNC(HasHost)(uri)) {
+                    /* clang-format off */
+    /* [07/19]     append "//" to result; */
+                    /* clang-format on */
+                    if (dest != NULL) {
+                        if (written + 2 <= maxChars) {
+                            memcpy(dest + written, _UT("//"), 2 * sizeof(URI_CHAR));
+                            written += 2;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += 2;
+                    }
+                    /* clang-format off */
+    /* [08/19]     append authority to result; */
+                    /* clang-format on */
+                    /* UserInfo */
+                    if (uri->userInfo.first != NULL) {
+                        const int charsToWrite =
+                            (int)(uri->userInfo.afterLast - uri->userInfo.first);
+                        if (dest != NULL) {
+                            if (written + charsToWrite <= maxChars) {
+                                memcpy(dest + written, uri->userInfo.first,
+                                       charsToWrite * sizeof(URI_CHAR));
+                                written += charsToWrite;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
 
-	if (maxChars < 1) {
-		if (charsWritten != NULL) {
-			*charsWritten = 0;
-		}
-		return URI_ERROR_TOSTRING_TOO_LONG;
-	}
-	maxChars--; /* So we don't have to subtract 1 for '\0' all the time */
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT("@"), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += charsToWrite + 1;
+                        }
+                    }
 
-	/* [01/19]	result = "" */
-				if (dest != NULL) {
-					dest[0] = _UT('\0');
-				} else {
-					(*charsRequired) = 0;
-				}
-	/* [02/19]	if defined(scheme) then */
-				if (uri->scheme.first != NULL) {
-	/* [03/19]		append scheme to result; */
-					const int charsToWrite
-							= (int)(uri->scheme.afterLast - uri->scheme.first);
-					if (dest != NULL) {
-						if (written + charsToWrite <= maxChars) {
-							memcpy(dest + written, uri->scheme.first,
-									charsToWrite * sizeof(URI_CHAR));
-							written += charsToWrite;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += charsToWrite;
-					}
-	/* [04/19]		append ":" to result; */
-					if (dest != NULL) {
-						if (written + 1 <= maxChars) {
-							memcpy(dest + written, _UT(":"),
-									1 * sizeof(URI_CHAR));
-							written += 1;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += 1;
-					}
-	/* [05/19]	endif; */
-				}
-	/* [06/19]	if defined(authority) then */
-				if (URI_FUNC(HasHost)(uri)) {
-	/* [07/19]		append "//" to result; */
-					if (dest != NULL) {
-						if (written + 2 <= maxChars) {
-							memcpy(dest + written, _UT("//"),
-									2 * sizeof(URI_CHAR));
-							written += 2;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += 2;
-					}
-	/* [08/19]		append authority to result; */
-					/* UserInfo */
-					if (uri->userInfo.first != NULL) {
-						const int charsToWrite = (int)(uri->userInfo.afterLast - uri->userInfo.first);
-						if (dest != NULL) {
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->userInfo.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
+                    /* Host */
+                    if (uri->hostData.ip4 != NULL) {
+                        /* IPv4 */
+                        int i = 0;
+                        for (; i < 4; i++) {
+                            const unsigned char value = uri->hostData.ip4->data[i];
+                            const int charsToWrite =
+                                (value > 99) ? 3 : ((value > 9) ? 2 : 1);
+                            if (dest != NULL) {
+                                if (written + charsToWrite <= maxChars) {
+                                    URI_CHAR text[4];
+                                    if (value > 99) {
+                                        text[0] = _UT('0') + (value / 100);
+                                        text[1] = _UT('0') + ((value % 100) / 10);
+                                        text[2] = _UT('0') + (value % 10);
+                                    } else if (value > 9) {
+                                        text[0] = _UT('0') + (value / 10);
+                                        text[1] = _UT('0') + (value % 10);
+                                    } else {
+                                        text[0] = _UT('0') + value;
+                                    }
+                                    text[charsToWrite] = _UT('\0');
+                                    memcpy(dest + written, text,
+                                           charsToWrite * sizeof(URI_CHAR));
+                                    written += charsToWrite;
+                                } else {
+                                    dest[0] = _UT('\0');
+                                    if (charsWritten != NULL) {
+                                        *charsWritten = 0;
+                                    }
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+                                if (i < 3) {
+                                    if (written + 1 <= maxChars) {
+                                        memcpy(dest + written, _UT("."),
+                                               1 * sizeof(URI_CHAR));
+                                        written += 1;
+                                    } else {
+                                        dest[0] = _UT('\0');
+                                        if (charsWritten != NULL) {
+                                            *charsWritten = 0;
+                                        }
+                                        return URI_ERROR_TOSTRING_TOO_LONG;
+                                    }
+                                }
+                            } else {
+                                (*charsRequired) += charsToWrite + ((i == 3) ? 0 : 1);
+                            }
+                        }
+                    } else if (uri->hostData.ip6 != NULL) {
+                        /* IPv6 */
+                        int i = 0;
+                        if (dest != NULL) {
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT("["), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += 1;
+                        }
 
-							if (written + 1 <= maxChars) {
-								memcpy(dest + written, _UT("@"),
-										1 * sizeof(URI_CHAR));
-								written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += charsToWrite + 1;
-						}
-					}
+                        for (; i < 16; i++) {
+                            const unsigned char value = uri->hostData.ip6->data[i];
+                            if (dest != NULL) {
+                                if (written + 2 <= maxChars) {
+                                    URI_CHAR text[3];
+                                    text[0] =
+                                        URI_FUNC(HexToLetterEx)(value / 16, URI_FALSE);
+                                    text[1] =
+                                        URI_FUNC(HexToLetterEx)(value % 16, URI_FALSE);
+                                    text[2] = _UT('\0');
+                                    memcpy(dest + written, text, 2 * sizeof(URI_CHAR));
+                                    written += 2;
+                                } else {
+                                    dest[0] = _UT('\0');
+                                    if (charsWritten != NULL) {
+                                        *charsWritten = 0;
+                                    }
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+                            } else {
+                                (*charsRequired) += 2;
+                            }
+                            if (((i & 1) == 1) && (i < 15)) {
+                                if (dest != NULL) {
+                                    if (written + 1 <= maxChars) {
+                                        memcpy(dest + written, _UT(":"),
+                                               1 * sizeof(URI_CHAR));
+                                        written += 1;
+                                    } else {
+                                        dest[0] = _UT('\0');
+                                        if (charsWritten != NULL) {
+                                            *charsWritten = 0;
+                                        }
+                                        return URI_ERROR_TOSTRING_TOO_LONG;
+                                    }
+                                } else {
+                                    (*charsRequired) += 1;
+                                }
+                            }
+                        }
 
-					/* Host */
-					if (uri->hostData.ip4 != NULL) {
-						/* IPv4 */
-						int i = 0;
-						for (; i < 4; i++) {
-							const unsigned char value = uri->hostData.ip4->data[i];
-							const int charsToWrite = (value > 99) ? 3 : ((value > 9) ? 2 : 1);
-							if (dest != NULL) {
-								if (written + charsToWrite <= maxChars) {
-									URI_CHAR text[4];
-									if (value > 99) {
-										text[0] = _UT('0') + (value / 100);
-										text[1] = _UT('0') + ((value % 100) / 10);
-										text[2] = _UT('0') + (value % 10);
-									} else if (value > 9)  {
-										text[0] = _UT('0') + (value / 10);
-										text[1] = _UT('0') + (value % 10);
-									} else {
-										text[0] = _UT('0') + value;
-									}
-									text[charsToWrite] = _UT('\0');
-									memcpy(dest + written, text, charsToWrite * sizeof(URI_CHAR));
-									written += charsToWrite;
-								} else {
-									dest[0] = _UT('\0');
-									if (charsWritten != NULL) {
-										*charsWritten = 0;
-									}
-									return URI_ERROR_TOSTRING_TOO_LONG;
-								}
-								if (i < 3) {
-									if (written + 1 <= maxChars) {
-										memcpy(dest + written, _UT("."),
-												1 * sizeof(URI_CHAR));
-										written += 1;
-									} else {
-										dest[0] = _UT('\0');
-										if (charsWritten != NULL) {
-											*charsWritten = 0;
-										}
-										return URI_ERROR_TOSTRING_TOO_LONG;
-									}
-								}
-							} else {
-								(*charsRequired) += charsToWrite + ((i == 3) ? 0 : 1);
-							}
-						}
-					} else if (uri->hostData.ip6 != NULL) {
-						/* IPv6 */
-						int i = 0;
-						if (dest != NULL) {
-							if (written + 1 <= maxChars) {
-								memcpy(dest + written, _UT("["),
-										1 * sizeof(URI_CHAR));
-								written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += 1;
-						}
+                        if (dest != NULL) {
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT("]"), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += 1;
+                        }
+                    } else if (uri->hostData.ipFuture.first != NULL) {
+                        /* IPvFuture */
+                        const int charsToWrite = (int)(uri->hostData.ipFuture.afterLast
+                                                       - uri->hostData.ipFuture.first);
+                        if (dest != NULL) {
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT("["), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
 
-						for (; i < 16; i++) {
-							const unsigned char value = uri->hostData.ip6->data[i];
-							if (dest != NULL) {
-								if (written + 2 <= maxChars) {
-									URI_CHAR text[3];
-									text[0] = URI_FUNC(HexToLetterEx)(value / 16, URI_FALSE);
-									text[1] = URI_FUNC(HexToLetterEx)(value % 16, URI_FALSE);
-									text[2] = _UT('\0');
-									memcpy(dest + written, text, 2 * sizeof(URI_CHAR));
-									written += 2;
-								} else {
-									dest[0] = _UT('\0');
-									if (charsWritten != NULL) {
-										*charsWritten = 0;
-									}
-									return URI_ERROR_TOSTRING_TOO_LONG;
-								}
-							} else {
-								(*charsRequired) += 2;
-							}
-							if (((i & 1) == 1) && (i < 15)) {
-								if (dest != NULL) {
-									if (written + 1 <= maxChars) {
-										memcpy(dest + written, _UT(":"),
-												1 * sizeof(URI_CHAR));
-										written += 1;
-									} else {
-										dest[0] = _UT('\0');
-										if (charsWritten != NULL) {
-											*charsWritten = 0;
-										}
-										return URI_ERROR_TOSTRING_TOO_LONG;
-									}
-								} else {
-									(*charsRequired) += 1;
-								}
-							}
-						}
+                            if (written + charsToWrite <= maxChars) {
+                                memcpy(dest + written, uri->hostData.ipFuture.first,
+                                       charsToWrite * sizeof(URI_CHAR));
+                                written += charsToWrite;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
 
-						if (dest != NULL) {
-							if (written + 1 <= maxChars) {
-								memcpy(dest + written, _UT("]"),
-										1 * sizeof(URI_CHAR));
-								written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += 1;
-						}
-					} else if (uri->hostData.ipFuture.first != NULL) {
-						/* IPvFuture */
-						const int charsToWrite = (int)(uri->hostData.ipFuture.afterLast
-								- uri->hostData.ipFuture.first);
-						if (dest != NULL) {
-							if (written + 1 <= maxChars) {
-								memcpy(dest + written, _UT("["),
-										1 * sizeof(URI_CHAR));
-								written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT("]"), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += 1 + charsToWrite + 1;
+                        }
+                    } else if (uri->hostText.first != NULL) {
+                        /* Regname */
+                        const int charsToWrite =
+                            (int)(uri->hostText.afterLast - uri->hostText.first);
+                        if (dest != NULL) {
+                            if (written + charsToWrite <= maxChars) {
+                                memcpy(dest + written, uri->hostText.first,
+                                       charsToWrite * sizeof(URI_CHAR));
+                                written += charsToWrite;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += charsToWrite;
+                        }
+                    }
 
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->hostData.ipFuture.first, charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
+                    /* Port */
+                    if (uri->portText.first != NULL) {
+                        const int charsToWrite =
+                            (int)(uri->portText.afterLast - uri->portText.first);
+                        if (dest != NULL) {
+                            /* Leading ':' */
+                            if (written + 1 <= maxChars) {
+                                memcpy(dest + written, _UT(":"), 1 * sizeof(URI_CHAR));
+                                written += 1;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
 
-							if (written + 1 <= maxChars) {
-								memcpy(dest + written, _UT("]"),
-										1 * sizeof(URI_CHAR));
-								written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += 1 + charsToWrite + 1;
-						}
-					} else if (uri->hostText.first != NULL) {
-						/* Regname */
-						const int charsToWrite = (int)(uri->hostText.afterLast - uri->hostText.first);
-						if (dest != NULL) {
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->hostText.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += charsToWrite;
-						}
-					}
+                            /* Port number */
+                            if (written + charsToWrite <= maxChars) {
+                                memcpy(dest + written, uri->portText.first,
+                                       charsToWrite * sizeof(URI_CHAR));
+                                written += charsToWrite;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += 1 + charsToWrite;
+                        }
+                    }
+                    /* clang-format off */
+    /* [09/19] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [10/19] append path to result; */
+                /* clang-format on */
+                /* Slash needed here? */
+                if (uri->absolutePath
+                    || ((uri->pathHead != NULL) && URI_FUNC(HasHost)(uri))) {
+                    if (dest != NULL) {
+                        if (written + 1 <= maxChars) {
+                            memcpy(dest + written, _UT("/"), 1 * sizeof(URI_CHAR));
+                            written += 1;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += 1;
+                    }
+                }
 
-					/* Port */
-					if (uri->portText.first != NULL) {
-						const int charsToWrite = (int)(uri->portText.afterLast - uri->portText.first);
-						if (dest != NULL) {
-							/* Leading ':' */
-							if (written + 1 <= maxChars) {
-									memcpy(dest + written, _UT(":"),
-											1 * sizeof(URI_CHAR));
-									written += 1;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
+                if (uri->pathHead != NULL) {
+                    URI_TYPE(PathSegment) * walker = uri->pathHead;
+                    do {
+                        const int charsToWrite =
+                            (int)(walker->text.afterLast - walker->text.first);
+                        if (dest != NULL) {
+                            if (written + charsToWrite <= maxChars) {
+                                memcpy(dest + written, walker->text.first,
+                                       charsToWrite * sizeof(URI_CHAR));
+                                written += charsToWrite;
+                            } else {
+                                dest[0] = _UT('\0');
+                                if (charsWritten != NULL) {
+                                    *charsWritten = 0;
+                                }
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+                        } else {
+                            (*charsRequired) += charsToWrite;
+                        }
 
-							/* Port number */
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->portText.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += 1 + charsToWrite;
-						}
-					}
-	/* [09/19]	endif; */
-				}
-	/* [10/19]	append path to result; */
-				/* Slash needed here? */
-				if (uri->absolutePath || ((uri->pathHead != NULL)
-						&& URI_FUNC(HasHost)(uri))) {
-					if (dest != NULL) {
-						if (written + 1 <= maxChars) {
-							memcpy(dest + written, _UT("/"),
-									1 * sizeof(URI_CHAR));
-							written += 1;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += 1;
-					}
-				}
+                        /* Not last segment -> append slash */
+                        if (walker->next != NULL) {
+                            if (dest != NULL) {
+                                if (written + 1 <= maxChars) {
+                                    memcpy(dest + written, _UT("/"),
+                                           1 * sizeof(URI_CHAR));
+                                    written += 1;
+                                } else {
+                                    dest[0] = _UT('\0');
+                                    if (charsWritten != NULL) {
+                                        *charsWritten = 0;
+                                    }
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+                            } else {
+                                (*charsRequired) += 1;
+                            }
+                        }
 
-				if (uri->pathHead != NULL) {
-					URI_TYPE(PathSegment) * walker = uri->pathHead;
-					do {
-						const int charsToWrite = (int)(walker->text.afterLast - walker->text.first);
-						if (dest != NULL) {
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, walker->text.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += charsToWrite;
-						}
-
-						/* Not last segment -> append slash */
-						if (walker->next != NULL) {
-							if (dest != NULL) {
-								if (written + 1 <= maxChars) {
-									memcpy(dest + written, _UT("/"),
-											1 * sizeof(URI_CHAR));
-									written += 1;
-								} else {
-									dest[0] = _UT('\0');
-									if (charsWritten != NULL) {
-										*charsWritten = 0;
-									}
-									return URI_ERROR_TOSTRING_TOO_LONG;
-								}
-							} else {
-								(*charsRequired) += 1;
-							}
-						}
-
-						walker = walker->next;
-					} while (walker != NULL);
-				}
-	/* [11/19]	if defined(query) then */
-				if (uri->query.first != NULL) {
-	/* [12/19]		append "?" to result; */
-					if (dest != NULL) {
-						if (written + 1 <= maxChars) {
-							memcpy(dest + written, _UT("?"),
-									1 * sizeof(URI_CHAR));
-							written += 1;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += 1;
-					}
-	/* [13/19]		append query to result; */
-					{
-						const int charsToWrite
-								= (int)(uri->query.afterLast - uri->query.first);
-						if (dest != NULL) {
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->query.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += charsToWrite;
-						}
-					}
-	/* [14/19]	endif; */
-				}
-	/* [15/19]	if defined(fragment) then */
-				if (uri->fragment.first != NULL) {
-	/* [16/19]		append "#" to result; */
-					if (dest != NULL) {
-						if (written + 1 <= maxChars) {
-							memcpy(dest + written, _UT("#"),
-									1 * sizeof(URI_CHAR));
-							written += 1;
-						} else {
-							dest[0] = _UT('\0');
-							if (charsWritten != NULL) {
-								*charsWritten = 0;
-							}
-							return URI_ERROR_TOSTRING_TOO_LONG;
-						}
-					} else {
-						(*charsRequired) += 1;
-					}
-	/* [17/19]		append fragment to result; */
-					{
-						const int charsToWrite
-								= (int)(uri->fragment.afterLast - uri->fragment.first);
-						if (dest != NULL) {
-							if (written + charsToWrite <= maxChars) {
-								memcpy(dest + written, uri->fragment.first,
-										charsToWrite * sizeof(URI_CHAR));
-								written += charsToWrite;
-							} else {
-								dest[0] = _UT('\0');
-								if (charsWritten != NULL) {
-									*charsWritten = 0;
-								}
-								return URI_ERROR_TOSTRING_TOO_LONG;
-							}
-						} else {
-							(*charsRequired) += charsToWrite;
-						}
-					}
-	/* [18/19]	endif; */
-				}
-	/* [19/19]	return result; */
-				if (dest != NULL) {
-					dest[written++] = _UT('\0');
-					if (charsWritten != NULL) {
-						*charsWritten = written;
-					}
-				}
-				return URI_SUCCESS;
+                        walker = walker->next;
+                    } while (walker != NULL);
+                }
+                /* clang-format off */
+    /* [11/19] if defined(query) then */
+                /* clang-format on */
+                if (uri->query.first != NULL) {
+                    /* clang-format off */
+    /* [12/19]     append "?" to result; */
+                    /* clang-format on */
+                    if (dest != NULL) {
+                        if (written + 1 <= maxChars) {
+                            memcpy(dest + written, _UT("?"), 1 * sizeof(URI_CHAR));
+                            written += 1;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += 1;
+                    }
+                    /* clang-format off */
+    /* [13/19]     append query to result; */
+                    /* clang-format on */
+                    const int charsToWrite =
+                        (int)(uri->query.afterLast - uri->query.first);
+                    if (dest != NULL) {
+                        if (written + charsToWrite <= maxChars) {
+                            memcpy(dest + written, uri->query.first,
+                                   charsToWrite * sizeof(URI_CHAR));
+                            written += charsToWrite;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += charsToWrite;
+                    }
+                    /* clang-format off */
+    /* [14/19] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [15/19] if defined(fragment) then */
+                /* clang-format on */
+                if (uri->fragment.first != NULL) {
+                    /* clang-format off */
+    /* [16/19]     append "#" to result; */
+                    /* clang-format on */
+                    if (dest != NULL) {
+                        if (written + 1 <= maxChars) {
+                            memcpy(dest + written, _UT("#"), 1 * sizeof(URI_CHAR));
+                            written += 1;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += 1;
+                    }
+                    /* clang-format off */
+    /* [17/19]     append fragment to result; */
+                    /* clang-format on */
+                    const int charsToWrite =
+                        (int)(uri->fragment.afterLast - uri->fragment.first);
+                    if (dest != NULL) {
+                        if (written + charsToWrite <= maxChars) {
+                            memcpy(dest + written, uri->fragment.first,
+                                   charsToWrite * sizeof(URI_CHAR));
+                            written += charsToWrite;
+                        } else {
+                            dest[0] = _UT('\0');
+                            if (charsWritten != NULL) {
+                                *charsWritten = 0;
+                            }
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+                    } else {
+                        (*charsRequired) += charsToWrite;
+                    }
+                    /* clang-format off */
+    /* [18/19] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [19/19] return result; */
+                /* clang-format on */
+                if (dest != NULL) {
+                    dest[written++] = _UT('\0');
+                    if (charsWritten != NULL) {
+                        *charsWritten = written;
+                    }
+                }
+                return URI_SUCCESS;
+            }
+        }
+    }
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriResolve.c
+++ b/ext/uri/uriparser/src/UriResolve.c
@@ -41,289 +41,358 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriResolve.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriResolve.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriResolve.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriResolve.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
 /* Appends a relative URI to an absolute. The last path segment of
  * the absolute URI is replaced. */
 static URI_INLINE UriBool URI_FUNC(MergePath)(URI_TYPE(Uri) * absWork,
-		const URI_TYPE(Uri) * relAppend, UriMemoryManager * memory) {
-	URI_TYPE(PathSegment) * sourceWalker;
-	URI_TYPE(PathSegment) * destPrev;
-	if (relAppend->pathHead == NULL) {
-		return URI_TRUE;
-	}
+                                              const URI_TYPE(Uri) * relAppend,
+                                              UriMemoryManager * memory) {
+    URI_TYPE(PathSegment) * sourceWalker;
+    URI_TYPE(PathSegment) * destPrev;
+    if (relAppend->pathHead == NULL) {
+        return URI_TRUE;
+    }
 
-	/* Replace last segment ("" if trailing slash) with first of append chain */
-	if (absWork->pathHead == NULL) {
-		URI_TYPE(PathSegment) * const dup = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
-		if (dup == NULL) {
-			return URI_FALSE; /* Raises malloc error */
-		}
-		dup->next = NULL;
-		absWork->pathHead = dup;
-		absWork->pathTail = dup;
-	}
-	absWork->pathTail->text.first = relAppend->pathHead->text.first;
-	absWork->pathTail->text.afterLast = relAppend->pathHead->text.afterLast;
+    /* Replace last segment ("" if trailing slash) with first of append chain */
+    if (absWork->pathHead == NULL) {
+        URI_TYPE(PathSegment) * const dup =
+            memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+        if (dup == NULL) {
+            return URI_FALSE; /* Raises malloc error */
+        }
+        dup->next = NULL;
+        absWork->pathHead = dup;
+        absWork->pathTail = dup;
+    }
+    absWork->pathTail->text.first = relAppend->pathHead->text.first;
+    absWork->pathTail->text.afterLast = relAppend->pathHead->text.afterLast;
 
-	/* Append all the others */
-	sourceWalker = relAppend->pathHead->next;
-	if (sourceWalker == NULL) {
-		return URI_TRUE;
-	}
-	destPrev = absWork->pathTail;
+    /* Append all the others */
+    sourceWalker = relAppend->pathHead->next;
+    if (sourceWalker == NULL) {
+        return URI_TRUE;
+    }
+    destPrev = absWork->pathTail;
 
-	for (;;) {
-		URI_TYPE(PathSegment) * const dup = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
-		if (dup == NULL) {
-			destPrev->next = NULL;
-			absWork->pathTail = destPrev;
-			return URI_FALSE; /* Raises malloc error */
-		}
-		dup->text = sourceWalker->text;
-		destPrev->next = dup;
+    for (;;) {
+        URI_TYPE(PathSegment) * const dup =
+            memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+        if (dup == NULL) {
+            destPrev->next = NULL;
+            absWork->pathTail = destPrev;
+            return URI_FALSE; /* Raises malloc error */
+        }
+        dup->text = sourceWalker->text;
+        destPrev->next = dup;
 
-		if (sourceWalker->next == NULL) {
-			absWork->pathTail = dup;
-			absWork->pathTail->next = NULL;
-			break;
-		}
-		destPrev = dup;
-		sourceWalker = sourceWalker->next;
-	}
+        if (sourceWalker->next == NULL) {
+            absWork->pathTail = dup;
+            absWork->pathTail->next = NULL;
+            break;
+        }
+        destPrev = dup;
+        sourceWalker = sourceWalker->next;
+    }
 
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
 
 static int URI_FUNC(ResolveAbsolutePathFlag)(URI_TYPE(Uri) * absWork,
-		UriMemoryManager * memory) {
-	if (absWork == NULL) {
-		return URI_ERROR_NULL;
-	}
+                                             UriMemoryManager * memory) {
+    if (absWork == NULL) {
+        return URI_ERROR_NULL;
+    }
 
-	if (URI_FUNC(HasHost)(absWork) && absWork->absolutePath) {
-		/* Empty segment needed, instead? */
-		if (absWork->pathHead == NULL) {
-			URI_TYPE(PathSegment) * const segment = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
-			if (segment == NULL) {
-				return URI_ERROR_MALLOC;
-			}
-			segment->text.first = URI_FUNC(SafeToPointTo);
-			segment->text.afterLast = URI_FUNC(SafeToPointTo);
-			segment->next = NULL;
+    if (URI_FUNC(HasHost)(absWork) && absWork->absolutePath) {
+        /* Empty segment needed, instead? */
+        if (absWork->pathHead == NULL) {
+            URI_TYPE(PathSegment) * const segment =
+                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+            if (segment == NULL) {
+                return URI_ERROR_MALLOC;
+            }
+            segment->text.first = URI_FUNC(SafeToPointTo);
+            segment->text.afterLast = URI_FUNC(SafeToPointTo);
+            segment->next = NULL;
 
-			absWork->pathHead = segment;
-			absWork->pathTail = segment;
-		}
+            absWork->pathHead = segment;
+            absWork->pathTail = segment;
+        }
 
-		absWork->absolutePath = URI_FALSE;
-	}
+        absWork->absolutePath = URI_FALSE;
+    }
 
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
 
 static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
-		const URI_TYPE(Uri) * relSource,
-		const URI_TYPE(Uri) * absBase,
-		UriResolutionOptions options, UriMemoryManager * memory) {
-	UriBool relSourceHasScheme;
+                                    const URI_TYPE(Uri) * relSource,
+                                    const URI_TYPE(Uri) * absBase,
+                                    UriResolutionOptions options,
+                                    UriMemoryManager * memory) {
+    UriBool relSourceHasScheme;
 
-	if (absDest == NULL) {
-		return URI_ERROR_NULL;
-	}
-	URI_FUNC(ResetUri)(absDest);
+    if (absDest == NULL) {
+        return URI_ERROR_NULL;
+    }
+    URI_FUNC(ResetUri)(absDest);
 
-	if ((relSource == NULL) || (absBase == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    if ((relSource == NULL) || (absBase == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-	/* absBase absolute? */
-	if (absBase->scheme.first == NULL) {
-		return URI_ERROR_ADDBASE_REL_BASE;
-	}
+    /* absBase absolute? */
+    if (absBase->scheme.first == NULL) {
+        return URI_ERROR_ADDBASE_REL_BASE;
+    }
 
-	/* [00/32] 	-- A non-strict parser may ignore a scheme in the reference */
-	/* [00/32] 	-- if it is identical to the base URI's scheme. */
-	/* [00/32] 	if ((not strict) and (R.scheme == Base.scheme)) then */
-	relSourceHasScheme = (relSource->scheme.first != NULL) ? URI_TRUE : URI_FALSE;
-	if ((options & URI_RESOLVE_IDENTICAL_SCHEME_COMPAT)
-			&& (absBase->scheme.first != NULL)
-			&& (relSource->scheme.first != NULL)
-			&& (0 == URI_FUNC(CompareRange)(&(absBase->scheme), &(relSource->scheme)))) {
-	/* [00/32] 		undefine(R.scheme); */
-		relSourceHasScheme = URI_FALSE;
-	/* [00/32] 	endif; */
-	}
+    /* NOTE: The curly brackets here force deeper indent (and that's all) */
+    {
+        {
+            {
+                /* clang-format off */
+    /* [00/32] -- A non-strict parser may ignore a scheme in the reference */
+    /* [00/32] -- if it is identical to the base URI's scheme. */
+    /* [00/32] if ((not strict) and (R.scheme == Base.scheme)) then */
+                /* clang-format on */
+                relSourceHasScheme =
+                    (relSource->scheme.first != NULL) ? URI_TRUE : URI_FALSE;
+                if ((options & URI_RESOLVE_IDENTICAL_SCHEME_COMPAT)
+                    && (absBase->scheme.first != NULL)
+                    && (relSource->scheme.first != NULL)
+                    && (0
+                        == URI_FUNC(CompareRange)(&(absBase->scheme),
+                                                  &(relSource->scheme)))) {
+                    /* clang-format off */
+    /* [00/32]     undefine(R.scheme); */
+                    /* clang-format on */
+                    relSourceHasScheme = URI_FALSE;
+                    /* clang-format off */
+    /* [00/32] endif; */
+                    /* clang-format on */
+                }
 
-	/* [01/32]	if defined(R.scheme) then */
-				if (relSourceHasScheme) {
-	/* [02/32]		T.scheme = R.scheme; */
-					absDest->scheme = relSource->scheme;
-	/* [03/32]		T.authority = R.authority; */
-					if (!URI_FUNC(CopyAuthority)(absDest, relSource, memory)) {
-						return URI_ERROR_MALLOC;
-					}
-	/* [04/32]		T.path = remove_dot_segments(R.path); */
-					if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
-						return URI_ERROR_MALLOC;
-					}
-					if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
-						return URI_ERROR_MALLOC;
-					}
-	/* [05/32]		T.query = R.query; */
-					absDest->query = relSource->query;
-	/* [06/32]	else */
-				} else {
-	/* [07/32]		if defined(R.authority) then */
-					if (URI_FUNC(HasHost)(relSource)) {
-	/* [08/32]			T.authority = R.authority; */
-						if (!URI_FUNC(CopyAuthority)(absDest, relSource, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-	/* [09/32]			T.path = remove_dot_segments(R.path); */
-						if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-						if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-	/* [10/32]			T.query = R.query; */
-						absDest->query = relSource->query;
-	/* [11/32]		else */
-					} else {
-	/* [28/32]			T.authority = Base.authority; */
-						if (!URI_FUNC(CopyAuthority)(absDest, absBase, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-	/* [12/32]			if (R.path == "") then */
-						if (relSource->pathHead == NULL && !relSource->absolutePath) {
-	/* [13/32]				T.path = Base.path; */
-							if (!URI_FUNC(CopyPath)(absDest, absBase, memory)) {
-								return URI_ERROR_MALLOC;
-							}
-	/* [14/32]				if defined(R.query) then */
-							if (relSource->query.first != NULL) {
-	/* [15/32]					T.query = R.query; */
-								absDest->query = relSource->query;
-	/* [16/32]				else */
-							} else {
-	/* [17/32]					T.query = Base.query; */
-								absDest->query = absBase->query;
-	/* [18/32]				endif; */
-							}
-	/* [19/32]			else */
-						} else {
-	/* [20/32]				if (R.path starts-with "/") then */
-							if (relSource->absolutePath) {
-								int res;
-	/* [21/32]					T.path = remove_dot_segments(R.path); */
-								if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-								res = URI_FUNC(ResolveAbsolutePathFlag)(absDest, memory);
-								if (res != URI_SUCCESS) {
-									return res;
-								}
-								if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-	/* [22/32]				else */
-							} else {
-	/* [23/32]					T.path = merge(Base.path, R.path); */
-								if (!URI_FUNC(CopyPath)(absDest, absBase, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-								if (!URI_FUNC(MergePath)(absDest, relSource, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-	/* [24/32]					T.path = remove_dot_segments(T.path); */
-								if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
-									return URI_ERROR_MALLOC;
-								}
+                /* clang-format off */
+    /* [01/32] if defined(R.scheme) then */
+                /* clang-format on */
+                if (relSourceHasScheme) {
+                    /* clang-format off */
+    /* [02/32]     T.scheme = R.scheme; */
+                    /* clang-format on */
+                    absDest->scheme = relSource->scheme;
+                    /* clang-format off */
+    /* [03/32]     T.authority = R.authority; */
+                    /* clang-format on */
+                    if (!URI_FUNC(CopyAuthority)(absDest, relSource, memory)) {
+                        return URI_ERROR_MALLOC;
+                    }
+                    /* clang-format off */
+    /* [04/32]     T.path = remove_dot_segments(R.path); */
+                    /* clang-format on */
+                    if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
+                        return URI_ERROR_MALLOC;
+                    }
+                    if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
+                        return URI_ERROR_MALLOC;
+                    }
+                    /* clang-format off */
+    /* [05/32]     T.query = R.query; */
+                    /* clang-format on */
+                    absDest->query = relSource->query;
+                    /* clang-format off */
+    /* [06/32] else */
+                    /* clang-format on */
+                } else {
+                    /* clang-format off */
+    /* [07/32]     if defined(R.authority) then */
+                    /* clang-format on */
+                    if (URI_FUNC(HasHost)(relSource)) {
+                        /* clang-format off */
+    /* [08/32]         T.authority = R.authority; */
+                        /* clang-format on */
+                        if (!URI_FUNC(CopyAuthority)(absDest, relSource, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        /* clang-format off */
+    /* [09/32]         T.path = remove_dot_segments(R.path); */
+                        /* clang-format on */
+                        if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        /* clang-format off */
+    /* [10/32]         T.query = R.query; */
+                        /* clang-format on */
+                        absDest->query = relSource->query;
+                        /* clang-format off */
+    /* [11/32]     else */
+                        /* clang-format on */
+                    } else {
+                        /* clang-format off */
+    /* [28/32]         T.authority = Base.authority; */
+                        /* clang-format on */
+                        if (!URI_FUNC(CopyAuthority)(absDest, absBase, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        /* clang-format off */
+    /* [12/32]         if (R.path == "") then */
+                        /* clang-format on */
+                        if (relSource->pathHead == NULL && !relSource->absolutePath) {
+                            /* clang-format off */
+    /* [13/32]             T.path = Base.path; */
+                            /* clang-format on */
+                            if (!URI_FUNC(CopyPath)(absDest, absBase, memory)) {
+                                return URI_ERROR_MALLOC;
+                            }
+                            /* clang-format off */
+    /* [14/32]             if defined(R.query) then */
+                            /* clang-format on */
+                            if (relSource->query.first != NULL) {
+                                /* clang-format off */
+    /* [15/32]                 T.query = R.query; */
+                                /* clang-format on */
+                                absDest->query = relSource->query;
+                                /* clang-format off */
+    /* [16/32]             else */
+                                /* clang-format on */
+                            } else {
+                                /* clang-format off */
+    /* [17/32]                 T.query = Base.query; */
+                                /* clang-format on */
+                                absDest->query = absBase->query;
+                                /* clang-format off */
+    /* [18/32]             endif; */
+                                /* clang-format on */
+                            }
+                            /* clang-format off */
+    /* [19/32]         else */
+                            /* clang-format on */
+                        } else {
+                            /* clang-format off */
+    /* [20/32]             if (R.path starts-with "/") then */
+                            /* clang-format on */
+                            if (relSource->absolutePath) {
+                                int res;
+                                /* clang-format off */
+    /* [21/32]                 T.path = remove_dot_segments(R.path); */
+                                /* clang-format on */
+                                if (!URI_FUNC(CopyPath)(absDest, relSource, memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                res = URI_FUNC(ResolveAbsolutePathFlag)(absDest, memory);
+                                if (res != URI_SUCCESS) {
+                                    return res;
+                                }
+                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest,
+                                                                         memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                /* clang-format off */
+    /* [22/32]             else */
+                                /* clang-format on */
+                            } else {
+                                /* clang-format off */
+    /* [23/32]                 T.path = merge(Base.path, R.path); */
+                                /* clang-format on */
+                                if (!URI_FUNC(CopyPath)(absDest, absBase, memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                if (!URI_FUNC(MergePath)(absDest, relSource, memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                /* clang-format off */
+    /* [24/32]                 T.path = remove_dot_segments(T.path); */
+                                /* clang-format on */
+                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest,
+                                                                         memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
 
-								if (!URI_FUNC(FixAmbiguity)(absDest, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-	/* [25/32]				endif; */
-							}
-	/* [26/32]				T.query = R.query; */
-							absDest->query = relSource->query;
-	/* [27/32]			endif; */
-						}
-						URI_FUNC(FixEmptyTrailSegment)(absDest, memory);
-	/* [29/32]		endif; */
-					}
-	/* [30/32]		T.scheme = Base.scheme; */
-					absDest->scheme = absBase->scheme;
-	/* [31/32]	endif; */
-				}
-	/* [32/32]	T.fragment = R.fragment; */
-				absDest->fragment = relSource->fragment;
-
-	return URI_SUCCESS;
-
+                                if (!URI_FUNC(FixAmbiguity)(absDest, memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                /* clang-format off */
+    /* [25/32]             endif; */
+                            }
+    /* clang-format off */
+    /* [26/32]             T.query = R.query; */
+                            /* clang-format on */
+                            absDest->query = relSource->query;
+                            /* clang-format off */
+    /* [27/32]         endif; */
+                            /* clang-format on */
+                        }
+                        URI_FUNC(FixEmptyTrailSegment)(absDest, memory);
+                        /* clang-format off */
+    /* [29/32]     endif; */
+                        /* clang-format on */
+                    }
+                    /* clang-format off */
+    /* [30/32]     T.scheme = Base.scheme; */
+                    /* clang-format on */
+                    absDest->scheme = absBase->scheme;
+                    /* clang-format off */
+    /* [31/32] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [32/32] T.fragment = R.fragment; */
+                /* clang-format on */
+                absDest->fragment = relSource->fragment;
+            }
+        }
+    }
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absDest,
-		const URI_TYPE(Uri) * relSource, const URI_TYPE(Uri) * absBase) {
-	const UriResolutionOptions options = URI_RESOLVE_STRICTLY;
-	return URI_FUNC(AddBaseUriEx)(absDest, relSource, absBase, options);
+int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
+                         const URI_TYPE(Uri) * absBase) {
+    const UriResolutionOptions options = URI_RESOLVE_STRICTLY;
+    return URI_FUNC(AddBaseUriEx)(absDest, relSource, absBase, options);
 }
 
-
-
-int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absDest,
-		const URI_TYPE(Uri) * relSource, const URI_TYPE(Uri) * absBase,
-		UriResolutionOptions options) {
-	return URI_FUNC(AddBaseUriExMm)(absDest, relSource, absBase, options, NULL);
+int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
+                           const URI_TYPE(Uri) * absBase, UriResolutionOptions options) {
+    return URI_FUNC(AddBaseUriExMm)(absDest, relSource, absBase, options, NULL);
 }
 
+int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
+                             const URI_TYPE(Uri) * absBase, UriResolutionOptions options,
+                             UriMemoryManager * memory) {
+    int res;
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absDest,
-		const URI_TYPE(Uri) * relSource, const URI_TYPE(Uri) * absBase,
-		UriResolutionOptions options, UriMemoryManager * memory) {
-	int res;
-
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
-
-	res = URI_FUNC(AddBaseUriImpl)(absDest, relSource, absBase, options, memory);
-	if ((res != URI_SUCCESS) && (absDest != NULL)) {
-		URI_FUNC(FreeUriMembersMm)(absDest, memory);
-	}
-	return res;
+    res = URI_FUNC(AddBaseUriImpl)(absDest, relSource, absBase, options, memory);
+    if ((res != URI_SUCCESS) && (absDest != NULL)) {
+        URI_FUNC(FreeUriMembersMm)(absDest, memory);
+    }
+    return res;
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetFragment.c
+++ b/ext/uri/uriparser/src/UriSetFragment.c
@@ -40,267 +40,234 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetFragment.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetFragment.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetFragment.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetFragment.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
-#include <assert.h>
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
+#  define URI_SET_SUB_DELIMS \
+  _UT('!') : case _UT('$'): \
+  case _UT('&'): \
+  case _UT('\''): \
+  case _UT('('): \
+  case _UT(')'): \
+  case _UT('*'): \
+  case _UT('+'): \
+  case _UT(','): \
+  case _UT(';'): \
+  case _UT('=')
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
+#  define URI_SET_UNRESERVED \
+  URI_SET_ALPHA: \
+  case URI_SET_DIGIT: \
+  case _UT('-'): \
+  case _UT('.'): \
+  case _UT('_'): \
+  case _UT('~')
 
+UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
+                                       const URI_CHAR * afterLast) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
+    /* The related part of the grammar in RFC 3986 reads:
+     *
+     *   fragment      = *( pchar / "/" / "?" )
+     *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_UNRESERVED:
+            break;
 
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
+        /* pct-encoded */
+        case _UT('%'):
+            if (afterLast - first < 3) {
+                return URI_FALSE;
+            }
+            switch (first[1]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            switch (first[2]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            first += 2;
+            break;
 
+        case URI_SET_SUB_DELIMS:
+            break;
 
+        /* ":" / "@" and "/" / "?" */
+        case _UT(':'):
+        case _UT('@'):
+        case _UT('/'):
+        case _UT('?'):
+            break;
 
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
+        default:
+            return URI_FALSE;
+        }
 
-
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-#define URI_SET_SUB_DELIMS \
-	     _UT('!'): \
-	case _UT('$'): \
-	case _UT('&'): \
-	case _UT('\''): \
-	case _UT('('): \
-	case _UT(')'): \
-	case _UT('*'): \
-	case _UT('+'): \
-	case _UT(','): \
-	case _UT(';'): \
-	case _UT('=')
-
-
-
-#define URI_SET_UNRESERVED \
-	URI_SET_ALPHA: \
-	case URI_SET_DIGIT: \
-	case _UT('-'): \
-	case _UT('.'): \
-	case _UT('_'): \
-	case _UT('~')
-
-
-
-UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
-
-	/* The related part of the grammar in RFC 3986 reads:
-	 *
-	 *   fragment      = *( pchar / "/" / "?" )
-	 *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-	 */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_UNRESERVED:
-				break;
-
-			/* pct-encoded */
-			case _UT('%'):
-				if (afterLast - first < 3) {
-					return URI_FALSE;
-				}
-				switch (first[1]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				switch (first[2]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				first += 2;
-				break;
-
-			case URI_SET_SUB_DELIMS:
-				break;
-
-			/* ":" / "@" and "/" / "?" */
-			case _UT(':'):
-			case _UT('@'):
-			case _UT('/'):
-			case _UT('?'):
-				break;
-
-			default:
-				return URI_FALSE;
-		}
-
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
+int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    if ((first != NULL)
+        && (URI_FUNC(IsWellFormedFragment)(first, afterLast) == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Clear old value */
+    if ((uri->owner == URI_TRUE) && (uri->fragment.first != uri->fragment.afterLast)) {
+        memory->free(memory, (URI_CHAR *)uri->fragment.first);
+    }
+    uri->fragment.first = NULL;
+    uri->fragment.afterLast = NULL;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedFragment)(first, afterLast) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done? */
+    if (first == NULL) {
+        return URI_SUCCESS;
+    }
 
-	/* Clear old value */
-	if ((uri->owner == URI_TRUE) && (uri->fragment.first != uri->fragment.afterLast)) {
-		memory->free(memory, (URI_CHAR *)uri->fragment.first);
-	}
-	uri->fragment.first = NULL;
-	uri->fragment.afterLast = NULL;
+    assert(first != NULL);
 
-	/* Already done? */
-	if (first == NULL) {
-		return URI_SUCCESS;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+    /* Apply new value */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-	assert(uri->owner == URI_TRUE);
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->fragment, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Apply new value */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->fragment, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetFragmentMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                          const URI_CHAR * afterLast) {
+    return URI_FUNC(SetFragmentMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetHostBase.h
+++ b/ext/uri/uriparser/src/UriSetHostBase.h
@@ -37,9 +37,7 @@
  */
 
 #ifndef URI_SET_HOST_BASE_H
-#define URI_SET_HOST_BASE_H 1
-
-
+#  define URI_SET_HOST_BASE_H 1
 
 typedef enum UriHostTypeEnum {
     URI_HOST_TYPE_IP4,
@@ -47,7 +45,5 @@ typedef enum UriHostTypeEnum {
     URI_HOST_TYPE_IPFUTURE,
     URI_HOST_TYPE_REGNAME
 } UriHostType;
-
-
 
 #endif /* URI_SET_HOST_BASE_H */

--- a/ext/uri/uriparser/src/UriSetHostCommon.c
+++ b/ext/uri/uriparser/src/UriSetHostCommon.c
@@ -46,221 +46,203 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetHostCommon.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetHostCommon.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetHostCommon.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetHostCommon.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include <uriparser/UriIp4.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#    include "UriSetHostBase.h"
+#    include "UriSetHostCommon.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include <uriparser/UriIp4.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-# include "UriSetHostBase.h"
-# include "UriSetHostCommon.h"
-#endif
+int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
+                                const URI_CHAR * first, const URI_CHAR * afterLast,
+                                UriMemoryManager * memory) {
+    /* Superficial input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
+    /* The RFC 3986 grammar reads:
+     *   authority = [ userinfo "@" ] host [ ":" port ]
+     * So no user info or port without a host. */
+    if (first == NULL) {
+        if (uri->userInfo.first != NULL) {
+            return URI_ERROR_SETHOST_USERINFO_SET;
+        } else if (uri->portText.first != NULL) {
+            return URI_ERROR_SETHOST_PORT_SET;
+        }
+    }
 
-#include <assert.h>
+    /* Syntax-check the new value */
+    if (first != NULL) {
+        switch (hostType) {
+        case URI_HOST_TYPE_IP4:
+            if (URI_FUNC(IsWellFormedHostIp4)(first, afterLast) == URI_FALSE) {
+                return URI_ERROR_SYNTAX;
+            }
+            break;
+        case URI_HOST_TYPE_IP6: {
+            const int res = URI_FUNC(IsWellFormedHostIp6Mm)(first, afterLast, memory);
+            assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
+                   || (res == URI_ERROR_MALLOC));
+            if (res != URI_SUCCESS) {
+                return res;
+            }
+        } break;
+        case URI_HOST_TYPE_IPFUTURE: {
+            const int res =
+                URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, memory);
+            assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
+                   || (res == URI_ERROR_MALLOC));
+            if (res != URI_SUCCESS) {
+                return res;
+            }
+        } break;
+        case URI_HOST_TYPE_REGNAME:
+            if (URI_FUNC(IsWellFormedHostRegName)(first, afterLast) == URI_FALSE) {
+                return URI_ERROR_SYNTAX;
+            }
+            break;
+        default:
+            assert(0 && "Unsupported URI host type");
+        }
+    }
 
+    /* Clear old value */
+    const UriBool hadHostBefore = URI_FUNC(HasHost)(uri);
+    if (uri->hostData.ipFuture.first != NULL) {
+        /* NOTE: .hostData.ipFuture holds the very same range pointers
+         *       as .hostText; we must not free memory twice. */
+        uri->hostText.first = NULL;
+        uri->hostText.afterLast = NULL;
 
+        if ((uri->owner == URI_TRUE)
+            && (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast)) {
+            memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
+        }
+        uri->hostData.ipFuture.first = NULL;
+        uri->hostData.ipFuture.afterLast = NULL;
+    } else if (uri->hostText.first != NULL) {
+        if ((uri->owner == URI_TRUE)
+            && (uri->hostText.first != uri->hostText.afterLast)) {
+            memory->free(memory, (URI_CHAR *)uri->hostText.first);
+        }
+        uri->hostText.first = NULL;
+        uri->hostText.afterLast = NULL;
+    }
 
-int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri,
-		UriHostType hostType,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Superficial input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    if (uri->hostData.ip4 != NULL) {
+        memory->free(memory, uri->hostData.ip4);
+        uri->hostData.ip4 = NULL;
+    } else if (uri->hostData.ip6 != NULL) {
+        memory->free(memory, uri->hostData.ip6);
+        uri->hostData.ip6 = NULL;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Already done setting? */
+    if (first == NULL) {
+        /* Yes, but disambiguate as needed */
+        if (hadHostBefore == URI_TRUE) {
+            if (uri->pathHead != NULL) {
+                uri->absolutePath = URI_TRUE;
+            }
 
-	/* The RFC 3986 grammar reads:
-	 *   authority = [ userinfo "@" ] host [ ":" port ]
-	 * So no user info or port without a host. */
-	if (first == NULL) {
-		if (uri->userInfo.first != NULL) {
-			return URI_ERROR_SETHOST_USERINFO_SET;
-		} else if (uri->portText.first != NULL) {
-			return URI_ERROR_SETHOST_PORT_SET;
-		}
-	}
+            const UriBool success =
+                URI_FUNC(EnsureThatPathIsNotMistakenForHost)(uri, memory);
+            return (success == URI_TRUE) ? URI_SUCCESS : URI_ERROR_MALLOC;
+        }
 
-	/* Syntax-check the new value */
-	if (first != NULL) {
-		switch (hostType) {
-			case URI_HOST_TYPE_IP4:
-				if (URI_FUNC(IsWellFormedHostIp4)(first, afterLast) == URI_FALSE) {
-					return URI_ERROR_SYNTAX;
-				}
-				break;
-			case URI_HOST_TYPE_IP6:
-				{
-					const int res = URI_FUNC(IsWellFormedHostIp6Mm)(first, afterLast, memory);
-					assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX) || (res == URI_ERROR_MALLOC));
-					if (res != URI_SUCCESS) {
-						return res;
-					}
-				}
-				break;
-			case URI_HOST_TYPE_IPFUTURE:
-				{
-					const int res = URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, memory);
-					assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX) || (res == URI_ERROR_MALLOC));
-					if (res != URI_SUCCESS) {
-						return res;
-					}
-				}
-				break;
-			case URI_HOST_TYPE_REGNAME:
-				if (URI_FUNC(IsWellFormedHostRegName)(first, afterLast) == URI_FALSE) {
-					return URI_ERROR_SYNTAX;
-				}
-				break;
-			default:
-				assert(0 && "Unsupported URI host type");
-		}
-	}
+        return URI_SUCCESS;
+    }
 
-	{
-		/* Clear old value */
-		const UriBool hadHostBefore = URI_FUNC(HasHost)(uri);
-		if (uri->hostData.ipFuture.first != NULL) {
-			/* NOTE: .hostData.ipFuture holds the very same range pointers
-			 *       as .hostText; we must not free memory twice. */
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
+    assert(first != NULL);
 
-			if ((uri->owner == URI_TRUE) && (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast)) {
-				memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
-			}
-			uri->hostData.ipFuture.first = NULL;
-			uri->hostData.ipFuture.afterLast = NULL;
-		} else if (uri->hostText.first != NULL) {
-			if ((uri->owner == URI_TRUE) && (uri->hostText.first != uri->hostText.afterLast)) {
-				memory->free(memory, (URI_CHAR *)uri->hostText.first);
-			}
-			uri->hostText.first = NULL;
-			uri->hostText.afterLast = NULL;
-		}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-		if (uri->hostData.ip4 != NULL) {
-			memory->free(memory, uri->hostData.ip4);
-			uri->hostData.ip4 = NULL;
-		} else if (uri->hostData.ip6 != NULL) {
-			memory->free(memory, uri->hostData.ip6);
-			uri->hostData.ip6 = NULL;
-		}
+    assert(uri->owner == URI_TRUE);
 
-		/* Already done setting? */
-		if (first == NULL) {
-			/* Yes, but disambiguate as needed */
-			if (hadHostBefore == URI_TRUE) {
-				uri->absolutePath = URI_TRUE;
+    /* Apply new value; NOTE that .hostText is set for all four host types */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-				{
-					const UriBool success = URI_FUNC(EnsureThatPathIsNotMistakenForHost)(uri, memory);
-					return (success == URI_TRUE)
-							? URI_SUCCESS
-							: URI_ERROR_MALLOC;
-				}
-			}
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->hostText, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-			return URI_SUCCESS;
-		}
-	}
+    uri->absolutePath = URI_FALSE; /* always URI_FALSE for URIs with host  */
 
-	assert(first != NULL);
+    /* Fill .hostData as needed */
+    switch (hostType) {
+    case URI_HOST_TYPE_IP4: {
+        uri->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
+        if (uri->hostData.ip4 == NULL) {
+            return URI_ERROR_MALLOC;
+        }
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+        const int res =
+            URI_FUNC(ParseIpFourAddress)(uri->hostData.ip4->data, first, afterLast);
+#  if defined(NDEBUG)
+        (void)res; /* i.e. mark as unused */
+#  else
+        assert(res == URI_SUCCESS); /* because checked for well-formedness earlier */
+#  endif
+    } break;
+    case URI_HOST_TYPE_IP6: {
+        uri->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
+        if (uri->hostData.ip6 == NULL) {
+            return URI_ERROR_MALLOC;
+        }
 
-	assert(uri->owner == URI_TRUE);
+        const int res =
+            URI_FUNC(ParseIpSixAddressMm)(uri->hostData.ip6, first, afterLast, memory);
+        assert((res == URI_SUCCESS)
+               || (res == URI_ERROR_MALLOC)); /* because checked for
+                                                 well-formedness earlier */
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    } break;
+    case URI_HOST_TYPE_IPFUTURE:
+        uri->hostData.ipFuture.first = uri->hostText.first;
+        uri->hostData.ipFuture.afterLast = uri->hostText.afterLast;
+        break;
+    case URI_HOST_TYPE_REGNAME:
+        break;
+    default:
+        assert(0 && "Unsupported URI host type");
+    }
 
-	/* Apply new value; NOTE that .hostText is set for all four host types */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->hostText, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-
-		uri->absolutePath = URI_FALSE;  /* always URI_FALSE for URIs with host  */
-
-		/* Fill .hostData as needed */
-		switch (hostType) {
-			case URI_HOST_TYPE_IP4:
-				{
-					uri->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
-					if (uri->hostData.ip4 == NULL) {
-						return URI_ERROR_MALLOC;
-					}
-
-					{
-						const int res = URI_FUNC(ParseIpFourAddress)(uri->hostData.ip4->data, first, afterLast);
-#if defined(NDEBUG)
-						(void)res;  /* i.e. mark as unused */
-#else
-						assert(res == URI_SUCCESS);  /* because checked for well-formedness earlier */
-#endif
-					}
-				}
-				break;
-			case URI_HOST_TYPE_IP6:
-				{
-					uri->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
-					if (uri->hostData.ip6 == NULL) {
-						return URI_ERROR_MALLOC;
-					}
-
-					{
-						const int res = URI_FUNC(ParseIpSixAddressMm)(uri->hostData.ip6, first, afterLast, memory);
-						assert((res == URI_SUCCESS) || (res == URI_ERROR_MALLOC));  /* because checked for well-formedness earlier */
-						if (res != URI_SUCCESS) {
-							return res;
-						}
-					}
-				}
-				break;
-			case URI_HOST_TYPE_IPFUTURE:
-				uri->hostData.ipFuture.first = uri->hostText.first;
-				uri->hostData.ipFuture.afterLast = uri->hostText.afterLast;
-				break;
-			case URI_HOST_TYPE_REGNAME:
-				break;
-			default:
-				assert(0 && "Unsupported URI host type");
-		}
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetHostCommon.h
+++ b/ext/uri/uriparser/src/UriSetHostCommon.h
@@ -37,43 +37,38 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE)) \
-	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+    || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE)) \
+    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
-#include <uriparser/UriDefsConfig.h>
-#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+#  include <uriparser/UriDefsConfig.h>
+#  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetHostCommon.h"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetHostCommon.h"
-#  undef URI_PASS_UNICODE
-# endif
+#    ifdef URI_ENABLE_ANSI
+#      define URI_PASS_ANSI 1
+#      include "UriSetHostCommon.h"
+#      undef URI_PASS_ANSI
+#    endif
+#    ifdef URI_ENABLE_UNICODE
+#      define URI_PASS_UNICODE 1
+#      include "UriSetHostCommon.h"
+#      undef URI_PASS_UNICODE
+#    endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI) \
-	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_SET_HOST_COMMON_H_UNICODE) && defined(URI_ENABLE_UNICODE))
-# ifdef URI_PASS_ANSI
-#  define URI_SET_HOST_COMMON_H_ANSI 1
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  define URI_SET_HOST_COMMON_H_UNICODE 1
-#  include <uriparser/UriDefsUnicode.h>
-# endif
+#  elif (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI) \
+         && defined(URI_ENABLE_ANSI)) \
+      || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE) \
+          && defined(URI_ENABLE_UNICODE))
+#    ifdef URI_PASS_ANSI
+#      define URI_SET_HOST_COMMON_H_ANSI 1
+#      include <uriparser/UriDefsAnsi.h>
+#    else
+#      define URI_SET_HOST_COMMON_H_UNICODE 1
+#      include <uriparser/UriDefsUnicode.h>
+#    endif
 
+int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
+                                const URI_CHAR * first, const URI_CHAR * afterLast,
+                                UriMemoryManager * memory);
 
-
-int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri,
-		UriHostType hostType,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory);
-
-
-
-#endif
+#  endif
 #endif

--- a/ext/uri/uriparser/src/UriSetHostIp4.c
+++ b/ext/uri/uriparser/src/UriSetHostIp4.c
@@ -40,66 +40,52 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetHostIp4.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetHostIp4.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetHostIp4.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetHostIp4.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include <uriparser/UriIp4.h>
+#    include "UriMemory.h"
+#    include "UriSetHostBase.h"
+#    include "UriSetHostCommon.h"
+#  endif
 
+UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
+                                      const URI_CHAR * afterLast) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include <uriparser/UriIp4.h>
-# include "UriMemory.h"
-# include "UriSetHostBase.h"
-# include "UriSetHostCommon.h"
-#endif
-
-
-
-UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
-
-	{
-		unsigned char octetOutput[4];
-		return (URI_FUNC(ParseIpFourAddress)(octetOutput, first, afterLast) == URI_SUCCESS)
-				? URI_TRUE
-				: URI_FALSE;
-	}
+    unsigned char octetOutput[4];
+    return (URI_FUNC(ParseIpFourAddress)(octetOutput, first, afterLast) == URI_SUCCESS)
+               ? URI_TRUE
+               : URI_FALSE;
 }
 
-
-
-int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IP4, first, afterLast, memory);
+int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                           const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IP4, first, afterLast, memory);
 }
 
-
-
-int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetHostIp4Mm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                         const URI_CHAR * afterLast) {
+    return URI_FUNC(SetHostIp4Mm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetHostIpFuture.c
+++ b/ext/uri/uriparser/src/UriSetHostIpFuture.c
@@ -40,135 +40,118 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetHostIpFuture.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetHostIpFuture.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetHostIpFuture.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetHostIpFuture.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriMemory.h"
+#    include "UriSetHostBase.h"
+#    include "UriSetHostCommon.h"
+#  endif
 
+#  include <assert.h>
+#  include <string.h> /* for memcpy */
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriMemory.h"
-# include "UriSetHostBase.h"
-# include "UriSetHostCommon.h"
-#endif
+int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
+                                         const URI_CHAR * afterLast,
+                                         UriMemoryManager * memory) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
+    /* Are we dealing with potential IPv6 input? */
+    if (first < afterLast) {
+        switch (first[0]) {
+        case _UT('v'):
+        case _UT('V'):
+            break;
+        default:
+            return URI_ERROR_SYNTAX;
+        }
+    }
 
-#include <assert.h>
-#include <string.h>  /* for memcpy */
+    /* Are we dealing with IPvFuture input? */
+    /* Assemble "//[..]" input wrap for upcoming parse as a URI
+     * NOTE: If the input contains closing "]" on its own, the resulting
+     *       string will not be valid URI syntax, and hence there is
+     *       no risk of false positives from "bracket injection". */
+    const size_t inputLenChars = (afterLast - first);
+    const size_t MAX_SIZE_T = (size_t)-1;
 
+    /* Detect overflow */
+    if (MAX_SIZE_T - inputLenChars < 3 + 1 + 1) {
+        return URI_ERROR_MALLOC;
+    }
 
+    const size_t candidateLenChars = 3 + inputLenChars + 1;
 
-int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    /* Detect overflow */
+    if (MAX_SIZE_T / sizeof(URI_CHAR) < candidateLenChars + 1) {
+        return URI_ERROR_MALLOC;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    URI_CHAR * const candidate =
+        memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
 
-	/* Are we dealing with potential IPv6 input? */
-	if (first < afterLast) {
-		switch (first[0]) {
-			case _UT('v'):
-			case _UT('V'):
-				break;
-			default:
-				return URI_ERROR_SYNTAX;
-		}
-	}
+    if (candidate == NULL) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Are we dealing with IPvFuture input? */
-	{
-		/* Assemble "//[..]" input wrap for upcoming parse as a URI
-		 * NOTE: If the input contains closing "]" on its own, the resulting
-		 *       string will not be valid URI syntax, and hence there is
-		 *       no risk of false positives from "bracket injection". */
-		const size_t inputLenChars = (afterLast - first);
-		const size_t MAX_SIZE_T = (size_t)-1;
+    memcpy(candidate, _UT("//["), 3 * sizeof(URI_CHAR));
+    memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
+    memcpy(candidate + 3 + inputLenChars, _UT("]"),
+           2 * sizeof(URI_CHAR)); /* includes zero terminator */
 
-		/* Detect overflow */
-		if (MAX_SIZE_T - inputLenChars < 3 + 1 + 1) {
-		    return URI_ERROR_MALLOC;
-		}
+    /* Parse as an RFC 3986 URI */
+    URI_TYPE(Uri) uri;
+    const int res = URI_FUNC(ParseSingleUriExMm)(
+        &uri, candidate, candidate + candidateLenChars, NULL, memory);
 
-		{
-			const size_t candidateLenChars = 3 + inputLenChars + 1;
+    assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
+           || (res == URI_ERROR_MALLOC));
 
-			/* Detect overflow */
-			if (MAX_SIZE_T / sizeof(URI_CHAR) < candidateLenChars + 1) {
-				return URI_ERROR_MALLOC;
-			}
+    if (res == URI_SUCCESS) {
+        assert(uri.hostData.ipFuture.first != NULL);
+        URI_FUNC(FreeUriMembersMm)(&uri, memory);
+    }
 
-			{
-				URI_CHAR * const candidate = memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
+    memory->free(memory, candidate);
 
-				if (candidate == NULL) {
-					return URI_ERROR_MALLOC;
-				}
-
-				memcpy(candidate, _UT("//["), 3 * sizeof(URI_CHAR));
-				memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
-				memcpy(candidate + 3 + inputLenChars, _UT("]"), 2 * sizeof(URI_CHAR));  /* includes zero terminator */
-
-				/* Parse as an RFC 3986 URI */
-				{
-					URI_TYPE(Uri) uri;
-					const int res = URI_FUNC(ParseSingleUriExMm)(&uri, candidate, candidate + candidateLenChars, NULL, memory);
-
-					assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX) || (res == URI_ERROR_MALLOC));
-
-					if (res == URI_SUCCESS) {
-						assert(uri.hostData.ipFuture.first != NULL);
-						URI_FUNC(FreeUriMembersMm)(&uri, memory);
-					}
-
-					memory->free(memory, candidate);
-
-					return res;
-				}
-			}
-		}
-	}
+    return res;
 }
 
-
-
-int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	return URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, NULL);
+int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first,
+                                       const URI_CHAR * afterLast) {
+    return URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, NULL);
 }
 
-
-
-int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IPFUTURE, first, afterLast, memory);
+int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                                const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IPFUTURE, first, afterLast,
+                                       memory);
 }
 
-
-
-int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetHostIpFutureMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                              const URI_CHAR * afterLast) {
+    return URI_FUNC(SetHostIpFutureMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetHostRegName.c
+++ b/ext/uri/uriparser/src/UriSetHostRegName.c
@@ -40,207 +40,178 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetHostRegName.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetHostRegName.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetHostRegName.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetHostRegName.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriMemory.h"
+#    include "UriSetHostBase.h"
+#    include "UriSetHostCommon.h"
+#  endif
 
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriMemory.h"
-# include "UriSetHostBase.h"
-# include "UriSetHostCommon.h"
-#endif
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
+#  define URI_SET_SUB_DELIMS \
+  _UT('!') : case _UT('$'): \
+  case _UT('&'): \
+  case _UT('\''): \
+  case _UT('('): \
+  case _UT(')'): \
+  case _UT('*'): \
+  case _UT('+'): \
+  case _UT(','): \
+  case _UT(';'): \
+  case _UT('=')
 
+#  define URI_SET_UNRESERVED \
+  URI_SET_ALPHA: \
+  case URI_SET_DIGIT: \
+  case _UT('-'): \
+  case _UT('.'): \
+  case _UT('_'): \
+  case _UT('~')
 
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
+UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
+                                          const URI_CHAR * afterLast) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
+    /* reg-name = *( unreserved / pct-encoded / sub-delims ) */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_UNRESERVED:
+            break;
 
+        /* pct-encoded */
+        case _UT('%'):
+            if (afterLast - first < 3) {
+                return URI_FALSE;
+            }
+            switch (first[1]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            switch (first[2]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            first += 2;
+            break;
 
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
+        case URI_SET_SUB_DELIMS:
+            break;
 
+        default:
+            return URI_FALSE;
+        }
 
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-#define URI_SET_SUB_DELIMS \
-	     _UT('!'): \
-	case _UT('$'): \
-	case _UT('&'): \
-	case _UT('\''): \
-	case _UT('('): \
-	case _UT(')'): \
-	case _UT('*'): \
-	case _UT('+'): \
-	case _UT(','): \
-	case _UT(';'): \
-	case _UT('=')
-
-
-
-#define URI_SET_UNRESERVED \
-	URI_SET_ALPHA: \
-	case URI_SET_DIGIT: \
-	case _UT('-'): \
-	case _UT('.'): \
-	case _UT('_'): \
-	case _UT('~')
-
-
-
-UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
-
-	/* reg-name = *( unreserved / pct-encoded / sub-delims ) */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_UNRESERVED:
-				break;
-
-			/* pct-encoded */
-			case _UT('%'):
-				if (afterLast - first < 3) {
-					return URI_FALSE;
-				}
-				switch (first[1]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				switch (first[2]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				first += 2;
-				break;
-
-			case URI_SET_SUB_DELIMS:
-				break;
-
-			default:
-				return URI_FALSE;
-		}
-
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
-
-
-int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_REGNAME, first, afterLast, memory);
+int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                               const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_REGNAME, first, afterLast,
+                                       memory);
 }
 
-
-
-int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetHostRegNameMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                             const URI_CHAR * afterLast) {
+    return URI_FUNC(SetHostRegNameMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetPath.c
+++ b/ext/uri/uriparser/src/UriSetPath.c
@@ -40,456 +40,403 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetPath.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetPath.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetPath.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetPath.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
-#include <assert.h>
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
+#  define URI_SET_SUB_DELIMS \
+  _UT('!') : case _UT('$'): \
+  case _UT('&'): \
+  case _UT('\''): \
+  case _UT('('): \
+  case _UT(')'): \
+  case _UT('*'): \
+  case _UT('+'): \
+  case _UT(','): \
+  case _UT(';'): \
+  case _UT('=')
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
+#  define URI_SET_UNRESERVED \
+  URI_SET_ALPHA: \
+  case URI_SET_DIGIT: \
+  case _UT('-'): \
+  case _UT('.'): \
+  case _UT('_'): \
+  case _UT('~')
 
+UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_CHAR * afterLast,
+                                   UriBool hasHost) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
+    if ((hasHost == URI_TRUE) && ((first >= afterLast) || (first[0] != _UT('/')))) {
+        return URI_FALSE;
+    }
 
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
+    /* The related part of the grammar in RFC 3986 (section 3.3) reads:
+     *
+     *   path          = path-abempty    ; begins with "/" or is empty
+     *                 / path-absolute   ; begins with "/" but not "//"
+     *                 / path-noscheme   ; begins with a non-colon segment
+     *                 / path-rootless   ; begins with a segment
+     *                 / path-empty      ; zero characters
+     *
+     *   path-abempty  = *( "/" segment )
+     *   path-absolute = "/" [ segment-nz *( "/" segment ) ]
+     *   path-noscheme = segment-nz-nc *( "/" segment )
+     *   path-rootless = segment-nz *( "/" segment )
+     *   path-empty    = 0<pchar>
+     *
+     *   segment       = *pchar
+     *   segment-nz    = 1*pchar
+     *   segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+     *                 ; non-zero-length segment without any colon ":"
+     *
+     *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     *
+     * The check below simplifies this to ..
+     *
+     *   path          = *( unreserved / pct-encoded / sub-delims / ":" / "@" / "/" )
+     *
+     * .. and leaves the rest to pre-return removal of ambiguity
+     * from cases like "path1:/path2" and "//path1/path2" inside SetPath.
+     */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_UNRESERVED:
+            break;
 
+        /* pct-encoded */
+        case _UT('%'):
+            if (afterLast - first < 3) {
+                return URI_FALSE;
+            }
+            switch (first[1]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            switch (first[2]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            first += 2;
+            break;
 
+        case URI_SET_SUB_DELIMS:
+            break;
 
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
+        /* ":" / "@" and "/" */
+        case _UT(':'):
+        case _UT('@'):
+        case _UT('/'):
+            break;
 
+        default:
+            return URI_FALSE;
+        }
 
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-#define URI_SET_SUB_DELIMS \
-	     _UT('!'): \
-	case _UT('$'): \
-	case _UT('&'): \
-	case _UT('\''): \
-	case _UT('('): \
-	case _UT(')'): \
-	case _UT('*'): \
-	case _UT('+'): \
-	case _UT(','): \
-	case _UT(';'): \
-	case _UT('=')
-
-
-
-#define URI_SET_UNRESERVED \
-	URI_SET_ALPHA: \
-	case URI_SET_DIGIT: \
-	case _UT('-'): \
-	case _UT('.'): \
-	case _UT('_'): \
-	case _UT('~')
-
-
-
-UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_CHAR * afterLast, UriBool hasHost) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
-
-	if ((hasHost == URI_TRUE) && ((first >= afterLast) || (first[0] != _UT('/')))) {
-		return URI_FALSE;
-	}
-
-	/* The related part of the grammar in RFC 3986 (section 3.3) reads:
-	 *
-	 *   path          = path-abempty    ; begins with "/" or is empty
-	 *                 / path-absolute   ; begins with "/" but not "//"
-	 *                 / path-noscheme   ; begins with a non-colon segment
-	 *                 / path-rootless   ; begins with a segment
-	 *                 / path-empty      ; zero characters
-	 *
-	 *   path-abempty  = *( "/" segment )
-	 *   path-absolute = "/" [ segment-nz *( "/" segment ) ]
-	 *   path-noscheme = segment-nz-nc *( "/" segment )
-	 *   path-rootless = segment-nz *( "/" segment )
-	 *   path-empty    = 0<pchar>
-	 *
-	 *   segment       = *pchar
-	 *   segment-nz    = 1*pchar
-	 *   segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
-	 *                 ; non-zero-length segment without any colon ":"
-	 *
-	 *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-	 *
-	 * The check below simplifies this to ..
-	 *
-	 *   path          = *( unreserved / pct-encoded / sub-delims / ":" / "@" / "/" )
-	 *
-	 * .. and leaves the rest to pre-return removal of ambiguity
-	 * from cases like "path1:/path2" and "//path1/path2" inside SetPath.
-	 */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_UNRESERVED:
-				break;
-
-			/* pct-encoded */
-			case _UT('%'):
-				if (afterLast - first < 3) {
-					return URI_FALSE;
-				}
-				switch (first[1]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				switch (first[2]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				first += 2;
-				break;
-
-			case URI_SET_SUB_DELIMS:
-				break;
-
-			/* ":" / "@" and "/" */
-			case _UT(':'):
-			case _UT('@'):
-			case _UT('/'):
-				break;
-
-			default:
-				return URI_FALSE;
-		}
-
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
+static void URI_FUNC(DropEmptyFirstPathSegment)(URI_TYPE(Uri) * uri,
+                                                UriMemoryManager * memory) {
+    assert(uri != NULL);
+    assert(memory != NULL);
+    assert(uri->pathHead != NULL);
+    assert(uri->pathHead->text.first == uri->pathHead->text.afterLast);
 
+    URI_TYPE(PathSegment) * const originalHead = uri->pathHead;
 
-static void URI_FUNC(DropEmptyFirstPathSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
-	assert(uri->pathHead != NULL);
-	assert(uri->pathHead->text.first == uri->pathHead->text.afterLast);
+    uri->pathHead = uri->pathHead->next;
 
-	{
-		URI_TYPE(PathSegment) * const originalHead = uri->pathHead;
-
-		uri->pathHead = uri->pathHead->next;
-
-		originalHead->text.first = NULL;
-		originalHead->text.afterLast = NULL;
-		memory->free(memory, originalHead);
-	}
+    originalHead->text.first = NULL;
+    originalHead->text.afterLast = NULL;
+    memory->free(memory, originalHead);
 }
-
-
 
 /* URIs without a host encode a leading slash in the path as .absolutePath == URI_TRUE.
- * This function checks for a leading empty path segment (that would have the "visual effect"
- * of a leading slash during stringification) and transforms it into .absolutePath == URI_TRUE
- * instead, if present. */
-static void URI_FUNC(TransformEmptyLeadPathSegments)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
-	assert(uri != NULL);
-	assert(memory != NULL);
+ * This function checks for a leading empty path segment (that would have the "visual
+ * effect" of a leading slash during stringification) and transforms it into .absolutePath
+ * == URI_TRUE instead, if present. */
+static void URI_FUNC(TransformEmptyLeadPathSegments)(URI_TYPE(Uri) * uri,
+                                                     UriMemoryManager * memory) {
+    assert(uri != NULL);
+    assert(memory != NULL);
 
-	if ((URI_FUNC(HasHost)(uri) == URI_TRUE)
-			|| (uri->pathHead == NULL)
-			|| (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
-		return;  /* i.e. nothing to do */
-	}
+    if ((URI_FUNC(HasHost)(uri) == URI_TRUE) || (uri->pathHead == NULL)
+        || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
+        return; /* i.e. nothing to do */
+    }
 
-	assert(uri->absolutePath == URI_FALSE);
+    assert(uri->absolutePath == URI_FALSE);
 
-	URI_FUNC(DropEmptyFirstPathSegment)(uri, memory);
+    URI_FUNC(DropEmptyFirstPathSegment)(uri, memory);
 
-	uri->absolutePath = URI_TRUE;
+    uri->absolutePath = URI_TRUE;
 }
 
+static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri, const URI_CHAR * first,
+                                     const URI_CHAR * afterLast,
+                                     UriMemoryManager * memory) {
+    assert(destUri != NULL);
+    assert(first != NULL);
+    assert(afterLast != NULL);
+    assert(memory != NULL);
+    assert(destUri->pathHead == NULL); /* set by SetPathMm right before */
+    assert(destUri->pathTail == NULL); /* set by SetPathMm right before */
+    assert(destUri->absolutePath == URI_FALSE); /* set by SetPathMm right before */
 
+    /* Skip the leading slash from target URIs with a host (so that we can
+     * transfer the path 1:1 further down) */
+    if (URI_FUNC(HasHost)(destUri) == URI_TRUE) {
+        /* NOTE: This is because SetPathMm called IsWellFormedPath earlier: */
+        assert((afterLast - first >= 1) && (first[0] == _UT('/')));
+        first++;
+    } else if (first == afterLast) {
+        /* This avoids (1) all the expensive but unnecessary work below
+         * and also (2) mis-encoding as single empty path segment
+         * that would need (detection and) repair further down otherwise */
+        return URI_SUCCESS;
+    }
 
-static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	assert(destUri != NULL);
-	assert(first != NULL);
-	assert(afterLast != NULL);
-	assert(memory != NULL);
-	assert(destUri->pathHead == NULL);  /* set by SetPathMm right before */
-	assert(destUri->pathTail == NULL);  /* set by SetPathMm right before */
-	assert(destUri->absolutePath == URI_FALSE);  /* set by SetPathMm right before */
+    /* Assemble "///.." input wrap for upcoming parse as a URI */
+    const size_t inputLenChars = (afterLast - first);
+    const size_t MAX_SIZE_T = (size_t)-1;
 
-	/* Skip the leading slash from target URIs with a host (so that we can
-	 * transfer the path 1:1 further down) */
-	if (URI_FUNC(HasHost)(destUri) == URI_TRUE) {
-		/* NOTE: This is because SetPathMm called IsWellFormedPath earlier: */
-		assert((afterLast - first >= 1) && (first[0] == _UT('/')));
-		first++;
-	} else if (first == afterLast) {
-	    /* This avoids (1) all the expensive but unnecessary work below
-	     * and also (2) mis-encoding as single empty path segment
-	     * that would need (detection and) repair further down otherwise */
-	    return URI_SUCCESS;
-	}
+    /* Detect overflow */
+    if (MAX_SIZE_T - inputLenChars < 3 + 1) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Assemble "///.." input wrap for upcoming parse as a URI */
-	{
-		const size_t inputLenChars = (afterLast - first);
-		const size_t MAX_SIZE_T = (size_t)-1;
+    const size_t candidateLenChars = 3 + inputLenChars;
 
-		/* Detect overflow */
-		if (MAX_SIZE_T - inputLenChars < 3 + 1) {
-			return URI_ERROR_MALLOC;
-		}
+    /* Detect overflow */
+    if (MAX_SIZE_T / sizeof(URI_CHAR) < candidateLenChars + 1) {
+        return URI_ERROR_MALLOC;
+    }
 
-		{
-			const size_t candidateLenChars = 3 + inputLenChars;
+    URI_CHAR * const candidate =
+        memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
 
-			/* Detect overflow */
-			if (MAX_SIZE_T / sizeof(URI_CHAR) < candidateLenChars + 1) {
-				return URI_ERROR_MALLOC;
-			}
+    if (candidate == NULL) {
+        return URI_ERROR_MALLOC;
+    }
 
-			{
-				URI_CHAR * const candidate = memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
+    memcpy(candidate, _UT("///"), 3 * sizeof(URI_CHAR));
+    memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
+    candidate[3 + inputLenChars] = _UT('\0');
 
-				if (candidate == NULL) {
-					return URI_ERROR_MALLOC;
-				}
+    /* Parse as an RFC 3986 URI */
+    URI_TYPE(Uri) tempUri;
+    int res = URI_FUNC(ParseSingleUriExMm)(&tempUri, candidate,
+                                           candidate + candidateLenChars, NULL, memory);
+    assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
+           || (res == URI_ERROR_MALLOC));
+    if (res != URI_SUCCESS) {
+        memory->free(memory, candidate);
+        return res;
+    }
 
-				memcpy(candidate, _UT("///"), 3 * sizeof(URI_CHAR));
-				memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
-				candidate[3 + inputLenChars] = _UT('\0');
+    /* Nothing but path and host is supposed to be set by the parse, in
+     * particular not: */
+    assert(tempUri.query.first == NULL);
+    assert(tempUri.fragment.first == NULL);
 
-				/* Parse as an RFC 3986 URI */
-				{
-					URI_TYPE(Uri) tempUri;
-					const int res = URI_FUNC(ParseSingleUriExMm)(&tempUri,
-							candidate,
-							candidate + candidateLenChars,
-							NULL,
-							memory);
-					assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX) || (res == URI_ERROR_MALLOC));
-					if (res != URI_SUCCESS) {
-						memory->free(memory, candidate);
-						return res;
-					}
+    /* Ensure that the strings in the path segments are all owned by
+     * `tempUri` because we want to (1) rip out and keep the full path
+     * list further down and (2) be able to free the parsed string
+     * (`candidate`) also. */
+    res = URI_FUNC(MakeOwnerMm)(&tempUri, memory);
+    assert((res == URI_SUCCESS) || (res == URI_ERROR_MALLOC));
+    if (res != URI_SUCCESS) {
+        URI_FUNC(FreeUriMembersMm)(&tempUri, memory);
+        memory->free(memory, candidate);
+        return res;
+    }
+    assert(tempUri.owner == URI_TRUE);
 
-					/* Nothing but path and host is supposed to be set by the parse, in particular not: */
-					assert(tempUri.query.first == NULL);
-					assert(tempUri.fragment.first == NULL);
+    /* Move path to destination URI */
+    assert(tempUri.absolutePath == URI_FALSE); /* always URI_FALSE for URIs with host */
+    destUri->pathHead = tempUri.pathHead;
+    destUri->pathTail = tempUri.pathTail;
+    destUri->absolutePath = URI_FALSE;
 
-					/* Ensure that the strings in the path segments are all owned by `tempUri`
-					 * because we want to (1) rip out and keep the full path list further down
-					 * and (2) be able to free the parsed string (`candidate`) also. */
-					{
-						const int res = URI_FUNC(MakeOwnerMm)(&tempUri, memory);
-						assert((res == URI_SUCCESS) || (res == URI_ERROR_MALLOC));
-						if (res != URI_SUCCESS) {
-							URI_FUNC(FreeUriMembersMm)(&tempUri, memory);
-							memory->free(memory, candidate);
-							return res;
-						}
-						assert(tempUri.owner == URI_TRUE);
-					}
+    tempUri.pathHead = NULL;
+    tempUri.pathTail = NULL;
 
-					/* Move path to destination URI */
-					assert(tempUri.absolutePath == URI_FALSE);  /* always URI_FALSE for URIs with host */
-					destUri->pathHead = tempUri.pathHead;
-					destUri->pathTail = tempUri.pathTail;
-					destUri->absolutePath = URI_FALSE;
+    /* Free the rest of the temp URI */
+    URI_FUNC(FreeUriMembersMm)(&tempUri, memory);
+    memory->free(memory, candidate);
 
-					tempUri.pathHead = NULL;
-					tempUri.pathTail = NULL;
+    /* Restore use of .absolutePath as needed */
+    URI_FUNC(TransformEmptyLeadPathSegments)(destUri, memory);
 
-					/* Free the rest of the temp URI */
-					URI_FUNC(FreeUriMembersMm)(&tempUri, memory);
-					memory->free(memory, candidate);
+    /* Disambiguate as needed */
+    UriBool success = URI_FUNC(FixPathNoScheme)(destUri, memory);
+    if (success == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-					/* Restore use of .absolutePath as needed */
-					URI_FUNC(TransformEmptyLeadPathSegments)(destUri, memory);
+    success = URI_FUNC(EnsureThatPathIsNotMistakenForHost)(destUri, memory);
+    if (success == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-					/* Disambiguate as needed */
-					{
-						const UriBool success = URI_FUNC(FixPathNoScheme)(destUri, memory);
-						if (success == URI_FALSE) {
-							return URI_ERROR_MALLOC;
-						}
-					}
-					{
-						const UriBool success = URI_FUNC(EnsureThatPathIsNotMistakenForHost)(destUri, memory);
-						if (success == URI_FALSE) {
-							return URI_ERROR_MALLOC;
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
+int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                        const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    if ((first != NULL)
+        && (URI_FUNC(IsWellFormedPath)(first, afterLast, URI_FUNC(HasHost)(uri))
+            == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Clear old value */
+    int res = URI_FUNC(FreeUriPath)(uri, memory);
+    if (res != URI_SUCCESS) {
+        return res;
+    }
+    uri->absolutePath = URI_FALSE;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedPath)(first, afterLast, URI_FUNC(HasHost)(uri)) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done? */
+    if (first == NULL) {
+        return URI_SUCCESS;
+    }
 
-	/* Clear old value */
-	{
-		const int res = URI_FUNC(FreeUriPath)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-		uri->absolutePath = URI_FALSE;
-	}
+    assert(first != NULL);
 
-	/* Already done? */
-	if (first == NULL) {
-		return URI_SUCCESS;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
-
-	assert(uri->owner == URI_TRUE);
-
-	/* Apply new value */
-	{
-		const int res = URI_FUNC(InternalSetPath)(uri, first, afterLast, memory);
-		assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX) || (res == URI_ERROR_MALLOC));
-		return res;
-	}
+    /* Apply new value */
+    res = URI_FUNC(InternalSetPath)(uri, first, afterLast, memory);
+    assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
+           || (res == URI_ERROR_MALLOC));
+    return res;
 }
 
-
-
-int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetPathMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                      const URI_CHAR * afterLast) {
+    return URI_FUNC(SetPathMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetPort.c
+++ b/ext/uri/uriparser/src/UriSetPort.c
@@ -40,140 +40,120 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetPort.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetPort.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetPort.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetPort.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
-
-
-
-#include <assert.h>
-
-
-
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
-
-
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
 UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-	/* NOTE: Grammar reads "port = *DIGIT" which includes the empty string. */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_DIGIT:
-				break;
-			default:
-				return URI_FALSE;
-		}
-		first++;
-	}
-	return URI_TRUE;
+    /* NOTE: Grammar reads "port = *DIGIT" which includes the empty string. */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_DIGIT:
+            break;
+        default:
+            return URI_FALSE;
+        }
+        first++;
+    }
+    return URI_TRUE;
 }
 
+int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    /* The RFC 3986 grammar reads:
+     *   authority = [ userinfo "@" ] host [ ":" port ]
+     * So no port without a host. */
+    if ((first != NULL) && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
+        return URI_ERROR_SETPORT_HOST_NOT_SET;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    if ((first != NULL) && (URI_FUNC(IsWellFormedPort)(first, afterLast) == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	/* The RFC 3986 grammar reads:
-	 *   authority = [ userinfo "@" ] host [ ":" port ]
-	 * So no port without a host. */
-	if ((first != NULL) && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
-		return URI_ERROR_SETPORT_HOST_NOT_SET;
-	}
+    /* Clear old value */
+    if ((uri->owner == URI_TRUE) && (uri->portText.first != uri->portText.afterLast)) {
+        memory->free(memory, (URI_CHAR *)uri->portText.first);
+    }
+    uri->portText.first = NULL;
+    uri->portText.afterLast = NULL;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedPort)(first, afterLast) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done? */
+    if (first == NULL) {
+        return URI_SUCCESS;
+    }
 
-	/* Clear old value */
-	if ((uri->owner == URI_TRUE) && (uri->portText.first != uri->portText.afterLast)) {
-		memory->free(memory, (URI_CHAR *)uri->portText.first);
-	}
-	uri->portText.first = NULL;
-	uri->portText.afterLast = NULL;
+    assert(first != NULL);
 
-	/* Already done? */
-	if (first == NULL) {
-		return URI_SUCCESS;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+    /* Apply new value */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-	assert(uri->owner == URI_TRUE);
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->portText, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Apply new value */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->portText, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-	}
-	
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetPortTextMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                          const URI_CHAR * afterLast) {
+    return URI_FUNC(SetPortTextMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetQuery.c
+++ b/ext/uri/uriparser/src/UriSetQuery.c
@@ -40,267 +40,232 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetQuery.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetQuery.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetQuery.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetQuery.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
-#include <assert.h>
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
+#  define URI_SET_SUB_DELIMS \
+  _UT('!') : case _UT('$'): \
+  case _UT('&'): \
+  case _UT('\''): \
+  case _UT('('): \
+  case _UT(')'): \
+  case _UT('*'): \
+  case _UT('+'): \
+  case _UT(','): \
+  case _UT(';'): \
+  case _UT('=')
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
-
-
-        
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
-
-
-
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
-
-
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER	
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-#define URI_SET_SUB_DELIMS \
-	     _UT('!'): \
-	case _UT('$'): \
-	case _UT('&'): \
-	case _UT('\''): \
-	case _UT('('): \
-	case _UT(')'): \
-	case _UT('*'): \
-	case _UT('+'): \
-	case _UT(','): \
-	case _UT(';'): \
-	case _UT('=')
-
-
-
-#define URI_SET_UNRESERVED \
-	URI_SET_ALPHA: \
-	case URI_SET_DIGIT: \
-	case _UT('-'): \
-	case _UT('.'): \
-	case _UT('_'): \
-	case _UT('~')
-
-
+#  define URI_SET_UNRESERVED \
+  URI_SET_ALPHA: \
+  case URI_SET_DIGIT: \
+  case _UT('-'): \
+  case _UT('.'): \
+  case _UT('_'): \
+  case _UT('~')
 
 UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-	/* The related part of the grammar in RFC 3986 reads:
-	 * 
-	 *   query         = *( pchar / "/" / "?" )
-	 *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-	 */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_UNRESERVED:
-				break;
+    /* The related part of the grammar in RFC 3986 reads:
+     *
+     *   query         = *( pchar / "/" / "?" )
+     *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_UNRESERVED:
+            break;
 
-			/* pct-encoded */
-			case _UT('%'):
-				if (afterLast - first < 3) {
-					return URI_FALSE;
-				}
-				switch (first[1]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				switch (first[2]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				first += 2;
-				break;
+        /* pct-encoded */
+        case _UT('%'):
+            if (afterLast - first < 3) {
+                return URI_FALSE;
+            }
+            switch (first[1]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            switch (first[2]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            first += 2;
+            break;
 
-			case URI_SET_SUB_DELIMS:
-				break;
+        case URI_SET_SUB_DELIMS:
+            break;
 
-			/* ":" / "@" and "/" / "?" */
-			case _UT(':'):
-			case _UT('@'):
-			case _UT('/'):
-			case _UT('?'):
-				break;
+        /* ":" / "@" and "/" / "?" */
+        case _UT(':'):
+        case _UT('@'):
+        case _UT('/'):
+        case _UT('?'):
+            break;
 
-			default:
-				return URI_FALSE;
-		}
+        default:
+            return URI_FALSE;
+        }
 
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
+int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                         const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    if ((first != NULL) && (URI_FUNC(IsWellFormedQuery)(first, afterLast) == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Clear old value */
+    if ((uri->owner == URI_TRUE) && (uri->query.first != uri->query.afterLast)) {
+        memory->free(memory, (URI_CHAR *)uri->query.first);
+    }
+    uri->query.first = NULL;
+    uri->query.afterLast = NULL;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedQuery)(first, afterLast) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done? */
+    if (first == NULL) {
+        return URI_SUCCESS;
+    }
 
-	/* Clear old value */
-	if ((uri->owner == URI_TRUE) && (uri->query.first != uri->query.afterLast)) {
-		memory->free(memory, (URI_CHAR *)uri->query.first);
-	}
-	uri->query.first = NULL;
-	uri->query.afterLast = NULL;
+    assert(first != NULL);
 
-	/* Already done? */
-	if (first == NULL) {
-		return URI_SUCCESS;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+    /* Apply new value */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-	assert(uri->owner == URI_TRUE);
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->query, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Apply new value */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->query, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-	}
-	
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetQueryMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                       const URI_CHAR * afterLast) {
+    return URI_FUNC(SetQueryMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetScheme.c
+++ b/ext/uri/uriparser/src/UriSetScheme.c
@@ -40,233 +40,202 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetScheme.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetScheme.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetScheme.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetScheme.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
-#include <assert.h>
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
-
-
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
-
-
-
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
-
-
-
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
-
-
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
 UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-	/* The related part of the grammar in RFC 3986 reads:
-	 *
-	 *   scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-	 */
-	if (first >= afterLast) {
-		return URI_FALSE;
-	}
+    /* The related part of the grammar in RFC 3986 reads:
+     *
+     *   scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+     */
+    if (first >= afterLast) {
+        return URI_FALSE;
+    }
 
-	switch (first[0]) {
-		case URI_SET_ALPHA:
-			break;
+    switch (first[0]) {
+    case URI_SET_ALPHA:
+        break;
 
-		default:
-			return URI_FALSE;
-	}
+    default:
+        return URI_FALSE;
+    }
 
-	first++;
+    first++;
 
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_ALPHA:
-			case URI_SET_DIGIT:
-			case _UT('+'):
-			case _UT('-'):
-			case _UT('.'):
-				break;
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_ALPHA:
+        case URI_SET_DIGIT:
+        case _UT('+'):
+        case _UT('-'):
+        case _UT('.'):
+            break;
 
-			default:
-				return URI_FALSE;
-		}
+        default:
+            return URI_FALSE;
+        }
 
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
+int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                          const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    if ((first != NULL)
+        && (URI_FUNC(IsWellFormedScheme)(first, afterLast) == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    /* Clear old value */
+    if ((uri->owner == URI_TRUE) && (uri->scheme.first != uri->scheme.afterLast)) {
+        memory->free(memory, (URI_CHAR *)uri->scheme.first);
+    }
+    uri->scheme.first = NULL;
+    uri->scheme.afterLast = NULL;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedScheme)(first, afterLast) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done setting? */
+    if (first == NULL) {
+        /* Yes, but disambiguate as needed */
+        const UriBool success = URI_FUNC(FixPathNoScheme)(uri, memory);
+        return (success == URI_TRUE) ? URI_SUCCESS : URI_ERROR_MALLOC;
+    }
 
-	/* Clear old value */
-	if ((uri->owner == URI_TRUE) && (uri->scheme.first != uri->scheme.afterLast)) {
-		memory->free(memory, (URI_CHAR *)uri->scheme.first);
-	}
-	uri->scheme.first = NULL;
-	uri->scheme.afterLast = NULL;
+    assert(first != NULL);
 
-	/* Already done setting? */
-	if (first == NULL) {
-		/* Yes, but disambiguate as needed */
-		const UriBool success = URI_FUNC(FixPathNoScheme)(uri, memory);
-		return (success == URI_TRUE)
-				? URI_SUCCESS
-				: URI_ERROR_MALLOC;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+    /* Apply new value */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-	assert(uri->owner == URI_TRUE);
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->scheme, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Apply new value */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->scheme, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-	}
-
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetSchemeMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                        const URI_CHAR * afterLast) {
+    return URI_FUNC(SetSchemeMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriSetUserInfo.c
+++ b/ext/uri/uriparser/src/UriSetUserInfo.c
@@ -40,267 +40,234 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriSetUserInfo.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriSetUserInfo.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriSetUserInfo.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriSetUserInfo.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
+#  include <assert.h>
 
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
+#  define URI_SET_DIGIT \
+  _UT('0') : case _UT('1'): \
+  case _UT('2'): \
+  case _UT('3'): \
+  case _UT('4'): \
+  case _UT('5'): \
+  case _UT('6'): \
+  case _UT('7'): \
+  case _UT('8'): \
+  case _UT('9')
 
+#  define URI_SET_HEX_LETTER_UPPER \
+  _UT('A') : case _UT('B'): \
+  case _UT('C'): \
+  case _UT('D'): \
+  case _UT('E'): \
+  case _UT('F')
 
+#  define URI_SET_HEX_LETTER_LOWER \
+  _UT('a') : case _UT('b'): \
+  case _UT('c'): \
+  case _UT('d'): \
+  case _UT('e'): \
+  case _UT('f')
 
-#include <assert.h>
+#  define URI_SET_HEXDIG \
+  URI_SET_DIGIT: \
+  case URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER
 
+#  define URI_SET_ALPHA \
+  URI_SET_HEX_LETTER_UPPER: \
+  case URI_SET_HEX_LETTER_LOWER: \
+  case _UT('g'): \
+  case _UT('G'): \
+  case _UT('h'): \
+  case _UT('H'): \
+  case _UT('i'): \
+  case _UT('I'): \
+  case _UT('j'): \
+  case _UT('J'): \
+  case _UT('k'): \
+  case _UT('K'): \
+  case _UT('l'): \
+  case _UT('L'): \
+  case _UT('m'): \
+  case _UT('M'): \
+  case _UT('n'): \
+  case _UT('N'): \
+  case _UT('o'): \
+  case _UT('O'): \
+  case _UT('p'): \
+  case _UT('P'): \
+  case _UT('q'): \
+  case _UT('Q'): \
+  case _UT('r'): \
+  case _UT('R'): \
+  case _UT('s'): \
+  case _UT('S'): \
+  case _UT('t'): \
+  case _UT('T'): \
+  case _UT('u'): \
+  case _UT('U'): \
+  case _UT('v'): \
+  case _UT('V'): \
+  case _UT('w'): \
+  case _UT('W'): \
+  case _UT('x'): \
+  case _UT('X'): \
+  case _UT('y'): \
+  case _UT('Y'): \
+  case _UT('z'): \
+  case _UT('Z')
 
+#  define URI_SET_SUB_DELIMS \
+  _UT('!') : case _UT('$'): \
+  case _UT('&'): \
+  case _UT('\''): \
+  case _UT('('): \
+  case _UT(')'): \
+  case _UT('*'): \
+  case _UT('+'): \
+  case _UT(','): \
+  case _UT(';'): \
+  case _UT('=')
 
-#define URI_SET_DIGIT \
-	     _UT('0'): \
-	case _UT('1'): \
-	case _UT('2'): \
-	case _UT('3'): \
-	case _UT('4'): \
-	case _UT('5'): \
-	case _UT('6'): \
-	case _UT('7'): \
-	case _UT('8'): \
-	case _UT('9')
+#  define URI_SET_UNRESERVED \
+  URI_SET_ALPHA: \
+  case URI_SET_DIGIT: \
+  case _UT('-'): \
+  case _UT('.'): \
+  case _UT('_'): \
+  case _UT('~')
 
+UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
+                                       const URI_CHAR * afterLast) {
+    if ((first == NULL) || (afterLast == NULL)) {
+        return URI_FALSE;
+    }
 
-        
-#define URI_SET_HEX_LETTER_UPPER \
-	     _UT('A'): \
-	case _UT('B'): \
-	case _UT('C'): \
-	case _UT('D'): \
-	case _UT('E'): \
-	case _UT('F')
+    /* userinfo = *( unreserved / pct-encoded / sub-delims / ":" ) */
+    while (first < afterLast) {
+        switch (first[0]) {
+        case URI_SET_UNRESERVED:
+            break;
 
+        /* pct-encoded */
+        case _UT('%'):
+            if (afterLast - first < 3) {
+                return URI_FALSE;
+            }
+            switch (first[1]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            switch (first[2]) {
+            case URI_SET_HEXDIG:
+                break;
+            default:
+                return URI_FALSE;
+            }
+            first += 2;
+            break;
 
+        case URI_SET_SUB_DELIMS:
+            break;
 
-#define URI_SET_HEX_LETTER_LOWER \
-	     _UT('a'): \
-	case _UT('b'): \
-	case _UT('c'): \
-	case _UT('d'): \
-	case _UT('e'): \
-	case _UT('f')
+        /* ":" */
+        case _UT(':'):
+            break;
 
+        default:
+            return URI_FALSE;
+        }
 
-
-#define URI_SET_HEXDIG \
-	URI_SET_DIGIT: \
-	case URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER	
-
-
-
-#define URI_SET_ALPHA \
-	URI_SET_HEX_LETTER_UPPER: \
-	case URI_SET_HEX_LETTER_LOWER: \
-	case _UT('g'): \
-	case _UT('G'): \
-	case _UT('h'): \
-	case _UT('H'): \
-	case _UT('i'): \
-	case _UT('I'): \
-	case _UT('j'): \
-	case _UT('J'): \
-	case _UT('k'): \
-	case _UT('K'): \
-	case _UT('l'): \
-	case _UT('L'): \
-	case _UT('m'): \
-	case _UT('M'): \
-	case _UT('n'): \
-	case _UT('N'): \
-	case _UT('o'): \
-	case _UT('O'): \
-	case _UT('p'): \
-	case _UT('P'): \
-	case _UT('q'): \
-	case _UT('Q'): \
-	case _UT('r'): \
-	case _UT('R'): \
-	case _UT('s'): \
-	case _UT('S'): \
-	case _UT('t'): \
-	case _UT('T'): \
-	case _UT('u'): \
-	case _UT('U'): \
-	case _UT('v'): \
-	case _UT('V'): \
-	case _UT('w'): \
-	case _UT('W'): \
-	case _UT('x'): \
-	case _UT('X'): \
-	case _UT('y'): \
-	case _UT('Y'): \
-	case _UT('z'): \
-	case _UT('Z')
-
-
-
-#define URI_SET_SUB_DELIMS \
-	     _UT('!'): \
-	case _UT('$'): \
-	case _UT('&'): \
-	case _UT('\''): \
-	case _UT('('): \
-	case _UT(')'): \
-	case _UT('*'): \
-	case _UT('+'): \
-	case _UT(','): \
-	case _UT(';'): \
-	case _UT('=')
-
-
-
-#define URI_SET_UNRESERVED \
-	URI_SET_ALPHA: \
-	case URI_SET_DIGIT: \
-	case _UT('-'): \
-	case _UT('.'): \
-	case _UT('_'): \
-	case _UT('~')
-
-
-
-UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first, const URI_CHAR * afterLast) {
-	if ((first == NULL) || (afterLast == NULL)) {
-		return URI_FALSE;
-	}
-
-	/* userinfo = *( unreserved / pct-encoded / sub-delims / ":" ) */
-	while (first < afterLast) {
-		switch (first[0]) {
-			case URI_SET_UNRESERVED:
-				break;
-
-			/* pct-encoded */
-			case _UT('%'):
-				if (afterLast - first < 3) {
-					return URI_FALSE;
-				}
-				switch (first[1]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				switch (first[2]) {
-					case URI_SET_HEXDIG:
-						break;
-					default:
-						return URI_FALSE;
-				}
-				first += 2;
-				break;
-
-			case URI_SET_SUB_DELIMS:
-				break;
-
-			/* ":" */
-			case _UT(':'):
-				break;
-
-			default:
-				return URI_FALSE;
-		}
-
-		first++;
-	}
-	return URI_TRUE;
+        first++;
+    }
+    return URI_TRUE;
 }
 
+int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    /* Input validation (before making any changes) */
+    if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
+        return URI_ERROR_NULL;
+    }
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Input validation (before making any changes) */
-	if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
-		return URI_ERROR_NULL;
-	}
+    /* The RFC 3986 grammar reads:
+     *   authority = [ userinfo "@" ] host [ ":" port ]
+     * So no user info without a host. */
+    if ((first != NULL) && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
+        return URI_ERROR_SETUSERINFO_HOST_NOT_SET;
+    }
 
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
+    if ((first != NULL)
+        && (URI_FUNC(IsWellFormedUserInfo)(first, afterLast) == URI_FALSE)) {
+        return URI_ERROR_SYNTAX;
+    }
 
-	/* The RFC 3986 grammar reads:
-	 *   authority = [ userinfo "@" ] host [ ":" port ]
-	 * So no user info without a host. */
-	if ((first != NULL) && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
-		return URI_ERROR_SETUSERINFO_HOST_NOT_SET;
-	}
+    /* Clear old value */
+    if ((uri->owner == URI_TRUE) && (uri->userInfo.first != uri->userInfo.afterLast)) {
+        memory->free(memory, (URI_CHAR *)uri->userInfo.first);
+    }
+    uri->userInfo.first = NULL;
+    uri->userInfo.afterLast = NULL;
 
-	if ((first != NULL) && (URI_FUNC(IsWellFormedUserInfo)(first, afterLast) == URI_FALSE)) {
-		return URI_ERROR_SYNTAX;
-	}
+    /* Already done? */
+    if (first == NULL) {
+        return URI_SUCCESS;
+    }
 
-	/* Clear old value */
-	if ((uri->owner == URI_TRUE) && (uri->userInfo.first != uri->userInfo.afterLast)) {
-		memory->free(memory, (URI_CHAR *)uri->userInfo.first);
-	}
-	uri->userInfo.first = NULL;
-	uri->userInfo.afterLast = NULL;
+    assert(first != NULL);
 
-	/* Already done? */
-	if (first == NULL) {
-		return URI_SUCCESS;
-	}
+    /* Ensure owned */
+    if (uri->owner == URI_FALSE) {
+        const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
+        if (res != URI_SUCCESS) {
+            return res;
+        }
+    }
 
-	assert(first != NULL);
+    assert(uri->owner == URI_TRUE);
 
-	/* Ensure owned */
-	if (uri->owner == URI_FALSE) {
-		const int res = URI_FUNC(MakeOwnerMm)(uri, memory);
-		if (res != URI_SUCCESS) {
-			return res;
-		}
-	}
+    /* Apply new value */
+    URI_TYPE(TextRange) sourceRange;
+    sourceRange.first = first;
+    sourceRange.afterLast = afterLast;
 
-	assert(uri->owner == URI_TRUE);
+    if (URI_FUNC(CopyRangeAsNeeded)(&uri->userInfo, &sourceRange, memory) == URI_FALSE) {
+        return URI_ERROR_MALLOC;
+    }
 
-	/* Apply new value */
-	{
-		URI_TYPE(TextRange) sourceRange;
-		sourceRange.first = first;
-		sourceRange.afterLast = afterLast;
-
-		if (URI_FUNC(CopyRangeAsNeeded)(&uri->userInfo, &sourceRange, memory) == URI_FALSE) {
-			return URI_ERROR_MALLOC;
-		}
-	}
-	
-	return URI_SUCCESS;
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first,
-		const URI_CHAR * afterLast) {
-	return URI_FUNC(SetUserInfoMm)(uri, first, afterLast, NULL);
+int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
+                          const URI_CHAR * afterLast) {
+    return URI_FUNC(SetUserInfoMm)(uri, first, afterLast, NULL);
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriShorten.c
+++ b/ext/uri/uriparser/src/UriShorten.c
@@ -41,284 +41,386 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriShorten.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriShorten.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriShorten.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriShorten.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-# include "UriCommon.h"
-# include "UriMemory.h"
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#    include "UriCommon.h"
+#    include "UriMemory.h"
+#  endif
 
 static URI_INLINE UriBool URI_FUNC(AppendSegment)(URI_TYPE(Uri) * uri,
-		const URI_CHAR * first, const URI_CHAR * afterLast,
-		UriMemoryManager * memory) {
-	/* Create segment */
-	URI_TYPE(PathSegment) * segment = memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
-	if (segment == NULL) {
-		return URI_FALSE; /* Raises malloc error */
-	}
-	segment->next = NULL;
-	segment->text.first = first;
-	segment->text.afterLast = afterLast;
+                                                  const URI_CHAR * first,
+                                                  const URI_CHAR * afterLast,
+                                                  UriMemoryManager * memory) {
+    /* Create segment */
+    URI_TYPE(PathSegment) * segment =
+        memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
+    if (segment == NULL) {
+        return URI_FALSE; /* Raises malloc error */
+    }
+    segment->next = NULL;
+    segment->text.first = first;
+    segment->text.afterLast = afterLast;
 
-	/* Put into chain */
-	if (uri->pathTail == NULL) {
-		uri->pathHead = segment;
-	} else {
-		uri->pathTail->next = segment;
-	}
-	uri->pathTail = segment;
+    /* Put into chain */
+    if (uri->pathTail == NULL) {
+        uri->pathHead = segment;
+    } else {
+        uri->pathTail->next = segment;
+    }
+    uri->pathTail = segment;
 
-	return URI_TRUE;
+    return URI_TRUE;
 }
-
-
 
 static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
-		const URI_TYPE(Uri) * second) {
-	/* IPv4 */
-	if (first->hostData.ip4 != NULL) {
-		return ((second->hostData.ip4 != NULL)
-				&& !memcmp(first->hostData.ip4->data,
-					second->hostData.ip4->data, 4)) ? URI_TRUE : URI_FALSE;
-	}
+                                                    const URI_TYPE(Uri) * second) {
+    /* IPv4 */
+    if (first->hostData.ip4 != NULL) {
+        return ((second->hostData.ip4 != NULL)
+                && !memcmp(first->hostData.ip4->data, second->hostData.ip4->data, 4))
+                   ? URI_TRUE
+                   : URI_FALSE;
+    }
 
-	/* IPv6 */
-	if (first->hostData.ip6 != NULL) {
-		return ((second->hostData.ip6 != NULL)
-				&& !memcmp(first->hostData.ip6->data,
-					second->hostData.ip6->data, 16)) ? URI_TRUE : URI_FALSE;
-	}
+    /* IPv6 */
+    if (first->hostData.ip6 != NULL) {
+        return ((second->hostData.ip6 != NULL)
+                && !memcmp(first->hostData.ip6->data, second->hostData.ip6->data, 16))
+                   ? URI_TRUE
+                   : URI_FALSE;
+    }
 
-	/* IPvFuture */
-	if (first->hostData.ipFuture.first != NULL) {
-		return ((second->hostData.ipFuture.first != NULL)
-				&& !URI_FUNC(CompareRange)(&first->hostData.ipFuture,
-					&second->hostData.ipFuture)) ? URI_TRUE : URI_FALSE;
-	}
+    /* IPvFuture */
+    if (first->hostData.ipFuture.first != NULL) {
+        return ((second->hostData.ipFuture.first != NULL)
+                && !URI_FUNC(CompareRange)(&first->hostData.ipFuture,
+                                           &second->hostData.ipFuture))
+                   ? URI_TRUE
+                   : URI_FALSE;
+    }
 
-	return !URI_FUNC(CompareRange)(&first->hostText, &second->hostText)
-			? URI_TRUE : URI_FALSE;
+    return !URI_FUNC(CompareRange)(&first->hostText, &second->hostText) ? URI_TRUE
+                                                                        : URI_FALSE;
 }
-
-
 
 static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * absSource,
-		const URI_TYPE(Uri) * absBase,
-		UriBool domainRootMode, UriMemoryManager * memory) {
-	if (dest == NULL) {
-		return URI_ERROR_NULL;
-	}
-	URI_FUNC(ResetUri)(dest);
+                                       const URI_TYPE(Uri) * absSource,
+                                       const URI_TYPE(Uri) * absBase,
+                                       UriBool domainRootMode,
+                                       UriMemoryManager * memory) {
+    if (dest == NULL) {
+        return URI_ERROR_NULL;
+    }
+    URI_FUNC(ResetUri)(dest);
 
-	if ((absSource == NULL) || (absBase == NULL)) {
-		return URI_ERROR_NULL;
-	}
+    if ((absSource == NULL) || (absBase == NULL)) {
+        return URI_ERROR_NULL;
+    }
 
-	/* absBase absolute? */
-	if (absBase->scheme.first == NULL) {
-		return URI_ERROR_REMOVEBASE_REL_BASE;
-	}
+    /* absBase absolute? */
+    if (absBase->scheme.first == NULL) {
+        return URI_ERROR_REMOVEBASE_REL_BASE;
+    }
 
-	/* absSource absolute? */
-	if (absSource->scheme.first == NULL) {
-		return URI_ERROR_REMOVEBASE_REL_SOURCE;
-	}
+    /* absSource absolute? */
+    if (absSource->scheme.first == NULL) {
+        return URI_ERROR_REMOVEBASE_REL_SOURCE;
+    }
 
-	/* [01/50]	if (A.scheme != Base.scheme) then */
-				if (URI_FUNC(CompareRange)(&absSource->scheme, &absBase->scheme)) {
-	/* [02/50]	   T.scheme    = A.scheme; */
-					dest->scheme = absSource->scheme;
-	/* [03/50]	   T.authority = A.authority; */
-					if (!URI_FUNC(CopyAuthority)(dest, absSource, memory)) {
-						return URI_ERROR_MALLOC;
-					}
-	/* [04/50]	   T.path      = A.path; */
-					if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
-						return URI_ERROR_MALLOC;
-					}
-	/* [05/50]	else */
-				} else {
-	/* [06/50]	   undef(T.scheme); */
-					/* NOOP */
-	/* [07/50]	   if (A.authority != Base.authority) then */
-					if (!URI_FUNC(EqualsAuthority)(absSource, absBase)) {
-	/* [08/50]	      T.authority = A.authority; */
-						if (!URI_FUNC(CopyAuthority)(dest, absSource, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-	/* [09/50]	      T.path      = A.path; */
-						if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
-							return URI_ERROR_MALLOC;
-						}
-	/* [10/50]	   else */
-					} else {
-	/* [11/50]	      if domainRootMode then */
-						if (domainRootMode == URI_TRUE) {
-	/* [12/50]	         undef(T.authority); */
-							/* NOOP */
-	/* [13/50]	         if (first(A.path) == "") then */
-							/* GROUPED */
-	/* [14/50]	            T.path   = "/." + A.path; */
-								/* GROUPED */
-	/* [15/50]	         else */
-								/* GROUPED */
-	/* [16/50]	            T.path   = A.path; */
-								/* GROUPED */
-	/* [17/50]	         endif; */
-							if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
-								return URI_ERROR_MALLOC;
-							}
-							dest->absolutePath = URI_TRUE;
+    /* NOTE: The curly brackets here force deeper indent (and that's all) */
+    {
+        {
+            {
+                /* clang-format off */
+    /* [01/50] if (A.scheme != Base.scheme) then */
+                /* clang-format on */
+                if (URI_FUNC(CompareRange)(&absSource->scheme, &absBase->scheme)) {
+                    /* clang-format off */
+    /* [02/50]    T.scheme    = A.scheme; */
+                    /* clang-format on */
+                    dest->scheme = absSource->scheme;
+                    /* clang-format off */
+    /* [03/50]    T.authority = A.authority; */
+                    /* clang-format on */
+                    if (!URI_FUNC(CopyAuthority)(dest, absSource, memory)) {
+                        return URI_ERROR_MALLOC;
+                    }
+                    /* clang-format off */
+    /* [04/50]    T.path      = A.path; */
+                    /* clang-format on */
+                    if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
+                        return URI_ERROR_MALLOC;
+                    }
+                    /* clang-format off */
+    /* [05/50] else */
+                    /* clang-format on */
+                } else {
+                    /* clang-format off */
+    /* [06/50]    undef(T.scheme); */
+                    /* clang-format on */
+                    /* NOOP */
+                    /* clang-format off */
+    /* [07/50]    if (A.authority != Base.authority) then */
+                    /* clang-format on */
+                    if (!URI_FUNC(EqualsAuthority)(absSource, absBase)) {
+                        /* clang-format off */
+    /* [08/50]       T.authority = A.authority; */
+                        /* clang-format on */
+                        if (!URI_FUNC(CopyAuthority)(dest, absSource, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        /* clang-format off */
+    /* [09/50]       T.path      = A.path; */
+                        /* clang-format on */
+                        if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
+                            return URI_ERROR_MALLOC;
+                        }
+                        /* clang-format off */
+    /* [10/50]    else */
+                        /* clang-format on */
+                    } else {
+                        /* clang-format off */
+    /* [11/50]       if domainRootMode then */
+                        /* clang-format on */
+                        if (domainRootMode == URI_TRUE) {
+                            /* clang-format off */
+    /* [12/50]          undef(T.authority); */
+                            /* clang-format on */
+                            /* NOOP */
+                            /* clang-format off */
+    /* [13/50]          if (first(A.path) == "") then */
+                            /* clang-format on */
+                            /* GROUPED */
+                            /* clang-format off */
+    /* [14/50]             T.path   = "/." + A.path; */
+                            /* clang-format on */
+                            /* GROUPED */
+                            /* clang-format off */
+    /* [15/50]          else */
+                            /* clang-format on */
+                            /* GROUPED */
+                            /* clang-format off */
+    /* [16/50]             T.path   = A.path; */
+                            /* clang-format on */
+                            /* GROUPED */
+                            /* clang-format off */
+    /* [17/50]          endif; */
+                            /* clang-format on */
+                            if (!URI_FUNC(CopyPath)(dest, absSource, memory)) {
+                                return URI_ERROR_MALLOC;
+                            }
+                            dest->absolutePath = URI_TRUE;
 
-							if (!URI_FUNC(FixAmbiguity)(dest, memory)) {
-								return URI_ERROR_MALLOC;
-							}
-	/* [18/50]	      else */
-						} else {
-							const URI_TYPE(PathSegment) * sourceSeg = absSource->pathHead;
-							const URI_TYPE(PathSegment) * baseSeg = absBase->pathHead;
-	/* [19/50]	         bool pathNaked = true; */
-							UriBool pathNaked = URI_TRUE;
-	/* [20/50]	         undef(last(Base.path)); */
-							/* NOOP */
-	/* [21/50]	         T.path = ""; */
-							dest->absolutePath = URI_FALSE;
-	/* [22/50]	         while (first(A.path) == first(Base.path)) do */
-							while ((sourceSeg != NULL) && (baseSeg != NULL)
-									&& !URI_FUNC(CompareRange)(&sourceSeg->text, &baseSeg->text)
-									&& !((sourceSeg->text.first == sourceSeg->text.afterLast)
-										&& ((sourceSeg->next == NULL) != (baseSeg->next == NULL)))) {
-	/* [23/50]	            A.path++; */
-								sourceSeg = sourceSeg->next;
-	/* [24/50]	            Base.path++; */
-								baseSeg = baseSeg->next;
-	/* [25/50]	         endwhile; */
-							}
-	/* [26/50]	         while defined(first(Base.path)) do */
-							while ((baseSeg != NULL) && (baseSeg->next != NULL)) {
-	/* [27/50]	            Base.path++; */
-								baseSeg = baseSeg->next;
-	/* [28/50]	            T.path += "../"; */
-								if (!URI_FUNC(AppendSegment)(dest, URI_FUNC(ConstParent),
-										URI_FUNC(ConstParent) + 2, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-	/* [29/50]	            pathNaked = false; */
-								pathNaked = URI_FALSE;
-	/* [30/50]	         endwhile; */
-							}
-	/* [31/50]	         while defined(first(A.path)) do */
-							while (sourceSeg != NULL) {
-	/* [32/50]	            if pathNaked then */
-								if (pathNaked == URI_TRUE) {
-	/* [33/50]	               if (first(A.path) contains ":") then */
-									UriBool containsColon = URI_FALSE;
-									const URI_CHAR * ch = sourceSeg->text.first;
-									for (; ch < sourceSeg->text.afterLast; ch++) {
-										if (*ch == _UT(':')) {
-											containsColon = URI_TRUE;
-											break;
-										}
-									}
+                            if (!URI_FUNC(FixAmbiguity)(dest, memory)) {
+                                return URI_ERROR_MALLOC;
+                            }
+                            /* clang-format off */
+    /* [18/50]       else */
+                            /* clang-format on */
+                        } else {
+                            const URI_TYPE(PathSegment) * sourceSeg = absSource->pathHead;
+                            const URI_TYPE(PathSegment) * baseSeg = absBase->pathHead;
+                            /* clang-format off */
+    /* [19/50]          bool pathNaked = true; */
+                            /* clang-format on */
+                            UriBool pathNaked = URI_TRUE;
+                            /* clang-format off */
+    /* [20/50]          undef(last(Base.path)); */
+                            /* clang-format on */
+                            /* NOOP */
+                            /* clang-format off */
+    /* [21/50]          T.path = ""; */
+                            /* clang-format on */
+                            dest->absolutePath = URI_FALSE;
+                            /* clang-format off */
+    /* [22/50]          while (first(A.path) == first(Base.path)) do */
+                            /* clang-format on */
+                            while (
+                                (sourceSeg != NULL) && (baseSeg != NULL)
+                                && !URI_FUNC(CompareRange)(&sourceSeg->text,
+                                                           &baseSeg->text)
+                                && !((sourceSeg->text.first == sourceSeg->text.afterLast)
+                                     && ((sourceSeg->next == NULL)
+                                         != (baseSeg->next == NULL)))) {
+                                /* clang-format off */
+    /* [23/50]             A.path++; */
+                                /* clang-format on */
+                                sourceSeg = sourceSeg->next;
+                                /* clang-format off */
+    /* [24/50]             Base.path++; */
+                                /* clang-format on */
+                                baseSeg = baseSeg->next;
+                                /* clang-format off */
+    /* [25/50]          endwhile; */
+                                /* clang-format on */
+                            }
+                            /* clang-format off */
+    /* [26/50]          while defined(first(Base.path)) do */
+                            /* clang-format on */
+                            while ((baseSeg != NULL) && (baseSeg->next != NULL)) {
+                                /* clang-format off */
+    /* [27/50]             Base.path++; */
+                                /* clang-format on */
+                                baseSeg = baseSeg->next;
+                                /* clang-format off */
+    /* [28/50]             T.path += "../"; */
+                                /* clang-format on */
+                                if (!URI_FUNC(AppendSegment)(dest, URI_FUNC(ConstParent),
+                                                             URI_FUNC(ConstParent) + 2,
+                                                             memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                /* clang-format off */
+    /* [29/50]             pathNaked = false; */
+                                /* clang-format on */
+                                pathNaked = URI_FALSE;
+                                /* clang-format off */
+    /* [30/50]          endwhile; */
+                                /* clang-format on */
+                            }
+                            /* clang-format off */
+    /* [31/50]          while defined(first(A.path)) do */
+                            /* clang-format on */
+                            while (sourceSeg != NULL) {
+                                /* clang-format off */
+    /* [32/50]             if pathNaked then */
+                                /* clang-format on */
+                                if (pathNaked == URI_TRUE) {
+                                    /* clang-format off */
+    /* [33/50]                if (first(A.path) contains ":") then */
+                                    /* clang-format on */
+                                    UriBool containsColon = URI_FALSE;
+                                    const URI_CHAR * ch = sourceSeg->text.first;
+                                    for (; ch < sourceSeg->text.afterLast; ch++) {
+                                        if (*ch == _UT(':')) {
+                                            containsColon = URI_TRUE;
+                                            break;
+                                        }
+                                    }
 
-									if (containsColon) {
-	/* [34/50]	                  T.path += "./"; */
-										if (!URI_FUNC(AppendSegment)(dest, URI_FUNC(ConstPwd),
-												URI_FUNC(ConstPwd) + 1, memory)) {
-											return URI_ERROR_MALLOC;
-										}
-	/* [35/50]	               elseif (first(A.path) == "") then */
-									} else if (sourceSeg->text.first == sourceSeg->text.afterLast) {
-	/* [36/50]	                  T.path += "/."; */
-										if (!URI_FUNC(AppendSegment)(dest, URI_FUNC(ConstPwd),
-												URI_FUNC(ConstPwd) + 1, memory)) {
-											return URI_ERROR_MALLOC;
-										}
-	/* [37/50]	               endif; */
-									}
-	/* [38/50]	            endif; */
-								}
-	/* [39/50]	            T.path += first(A.path); */
-								if (!URI_FUNC(AppendSegment)(dest, sourceSeg->text.first,
-										sourceSeg->text.afterLast, memory)) {
-									return URI_ERROR_MALLOC;
-								}
-	/* [40/50]	            pathNaked = false; */
-								pathNaked = URI_FALSE;
-	/* [41/50]	            A.path++; */
-								sourceSeg = sourceSeg->next;
-	/* [42/50]	            if defined(first(A.path)) then */
-								/* NOOP */
-	/* [43/50]	               T.path += + "/"; */
-								/* NOOP */
-	/* [44/50]	            endif; */
-								/* NOOP */
-	/* [45/50]	         endwhile; */
-							}
-	/* [46/50]	      endif; */
-						}
-	/* [47/50]	   endif; */
-					}
-	/* [48/50]	endif; */
-				}
-	/* [49/50]	T.query     = A.query; */
-				dest->query = absSource->query;
-	/* [50/50]	T.fragment  = A.fragment; */
-				dest->fragment = absSource->fragment;
-
-	return URI_SUCCESS;
+                                    if (containsColon) {
+                                        /* clang-format off */
+    /* [34/50]                   T.path += "./"; */
+                                        /* clang-format on */
+                                        if (!URI_FUNC(AppendSegment)(
+                                                dest, URI_FUNC(ConstPwd),
+                                                URI_FUNC(ConstPwd) + 1, memory)) {
+                                            return URI_ERROR_MALLOC;
+                                        }
+                                        /* clang-format off */
+    /* [35/50]                elseif (first(A.path) == "") then */
+                                        /* clang-format on */
+                                    } else if (sourceSeg->text.first
+                                               == sourceSeg->text.afterLast) {
+                                        /* clang-format off */
+    /* [36/50]                   T.path += "/."; */
+                                        /* clang-format on */
+                                        if (!URI_FUNC(AppendSegment)(
+                                                dest, URI_FUNC(ConstPwd),
+                                                URI_FUNC(ConstPwd) + 1, memory)) {
+                                            return URI_ERROR_MALLOC;
+                                        }
+                                        /* clang-format off */
+    /* [37/50]                endif; */
+                                        /* clang-format on */
+                                    }
+                                    /* clang-format off */
+    /* [38/50]             endif; */
+                                    /* clang-format on */
+                                }
+                                /* clang-format off */
+    /* [39/50]             T.path += first(A.path); */
+                                /* clang-format on */
+                                if (!URI_FUNC(AppendSegment)(dest, sourceSeg->text.first,
+                                                             sourceSeg->text.afterLast,
+                                                             memory)) {
+                                    return URI_ERROR_MALLOC;
+                                }
+                                /* clang-format off */
+    /* [40/50]             pathNaked = false; */
+                                /* clang-format on */
+                                pathNaked = URI_FALSE;
+                                /* clang-format off */
+    /* [41/50]             A.path++; */
+                                /* clang-format on */
+                                sourceSeg = sourceSeg->next;
+                                /* clang-format off */
+    /* [42/50]             if defined(first(A.path)) then */
+                                /* clang-format on */
+                                /* NOOP */
+                                /* clang-format off */
+    /* [43/50]                T.path += + "/"; */
+                                /* clang-format on */
+                                /* NOOP */
+                                /* clang-format off */
+    /* [44/50]             endif; */
+                                /* clang-format on */
+                                /* NOOP */
+                                /* clang-format off */
+    /* [45/50]          endwhile; */
+                                /* clang-format on */
+                            }
+                            /* clang-format off */
+    /* [46/50]       endif; */
+                            /* clang-format on */
+                        }
+                        /* clang-format off */
+    /* [47/50]    endif; */
+                        /* clang-format on */
+                    }
+                    /* clang-format off */
+    /* [48/50] endif; */
+                    /* clang-format on */
+                }
+                /* clang-format off */
+    /* [49/50] T.query     = A.query; */
+                /* clang-format on */
+                dest->query = absSource->query;
+                /* clang-format off */
+    /* [50/50] T.fragment  = A.fragment; */
+                /* clang-format on */
+                dest->fragment = absSource->fragment;
+            }
+        }
+    }
+    return URI_SUCCESS;
 }
 
-
-
-int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * absSource,
-		const URI_TYPE(Uri) * absBase,
-		UriBool domainRootMode) {
-	return URI_FUNC(RemoveBaseUriMm)(dest, absSource, absBase,
-			domainRootMode, NULL);
+int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * absSource,
+                            const URI_TYPE(Uri) * absBase, UriBool domainRootMode) {
+    return URI_FUNC(RemoveBaseUriMm)(dest, absSource, absBase, domainRootMode, NULL);
 }
 
+int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * absSource,
+                              const URI_TYPE(Uri) * absBase, UriBool domainRootMode,
+                              UriMemoryManager * memory) {
+    int res;
 
+    URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
-int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * absSource,
-		const URI_TYPE(Uri) * absBase,
-		UriBool domainRootMode, UriMemoryManager * memory) {
-	int res;
-
-	URI_CHECK_MEMORY_MANAGER(memory);  /* may return */
-
-	res = URI_FUNC(RemoveBaseUriImpl)(dest, absSource,
-			absBase, domainRootMode, memory);
-	if ((res != URI_SUCCESS) && (dest != NULL)) {
-		URI_FUNC(FreeUriMembersMm)(dest, memory);
-	}
-	return res;
+    res = URI_FUNC(RemoveBaseUriImpl)(dest, absSource, absBase, domainRootMode, memory);
+    if ((res != URI_SUCCESS) && (dest != NULL)) {
+        URI_FUNC(FreeUriMembersMm)(dest, memory);
+    }
+    return res;
 }
-
-
 
 #endif

--- a/ext/uri/uriparser/src/UriVersion.c
+++ b/ext/uri/uriparser/src/UriVersion.c
@@ -46,42 +46,36 @@
 #include <uriparser/UriDefsConfig.h>
 #if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* Include SELF twice */
-# ifdef URI_ENABLE_ANSI
-#  define URI_PASS_ANSI 1
-#  include "UriVersion.c"
-#  undef URI_PASS_ANSI
-# endif
-# ifdef URI_ENABLE_UNICODE
-#  define URI_PASS_UNICODE 1
-#  include "UriVersion.c"
-#  undef URI_PASS_UNICODE
-# endif
+#  ifdef URI_ENABLE_ANSI
+#    define URI_PASS_ANSI 1
+#    include "UriVersion.c"
+#    undef URI_PASS_ANSI
+#  endif
+#  ifdef URI_ENABLE_UNICODE
+#    define URI_PASS_UNICODE 1
+#    include "UriVersion.c"
+#    undef URI_PASS_UNICODE
+#  endif
 #else
-# ifdef URI_PASS_ANSI
-#  include <uriparser/UriDefsAnsi.h>
-# else
-#  include <uriparser/UriDefsUnicode.h>
-#  include <wchar.h>
-# endif
+#  ifdef URI_PASS_ANSI
+#    include <uriparser/UriDefsAnsi.h>
+#  else
+#    include <uriparser/UriDefsUnicode.h>
+#    include <wchar.h>
+#  endif
 
-
-
-#ifndef URI_DOXYGEN
-# include <uriparser/Uri.h>
-#endif
-
-
+#  ifndef URI_DOXYGEN
+#    include <uriparser/Uri.h>
+#  endif
 
 const URI_CHAR * URI_FUNC(BaseRuntimeVersion)(void) {
-#if defined(URI_PASS_ANSI)
-	return URI_VER_ANSI;
-#elif defined(URI_PASS_UNICODE)
-	return URI_VER_UNICODE;
-#else
-# error Either URI_PASS_ANSI or URI_PASS_UNICODE must be defined
-#endif
+#  if defined(URI_PASS_ANSI)
+    return URI_VER_ANSI;
+#  elif defined(URI_PASS_UNICODE)
+    return URI_VER_UNICODE;
+#  else
+#    error Either URI_PASS_ANSI or URI_PASS_UNICODE must be defined
+#  endif
 }
-
-
 
 #endif


### PR DESCRIPTION
This is specifically to backport uriparser/uriparser#276.

Fixes php/php-src#20431.

----------

Annoyingly this diff contains a large reformatting of the library. To make it easier to review, I did the following:

1. I checked out the previous backport commit uriparser/uriparser@08df3b2 as uriparser.old
2. I ran `clang-format -i src/*` and `clang-format -i include/uriparser/*` with the new clang format configuration.
3. I ran `git diff -w --word-diff` for both `src/` and `include/`.

From what I could see, the fix of this issue is the only functional change and the git log seems to agree:

```
Sebastian Pipping (30):
      CI: Update to Clang 21
      fuzzing.yml: Make use of the expected version of Clang waterproof
      Merge pull request #267 from uriparser/clang-21
      fuzz/ParseFuzzer.cpp: Address warning -Wunused-but-set-variable
      fuzzing.yml: Start specifying CXX and CXXFLAGS also
      Merge pull request #268 from uriparser/fuzzing-ci-cxxflags
      Make CI report on test coverage using LLVM
      Merge pull request #269 from uriparser/coverage-ci
      CMake: Drop support for CMake <3.15.0
      CMake: Remake static CRT approach following libexpat
      Migrate Windows build from AppVeyor to GitHub Actions
      README.md: Sync CMake arguments dump, now in alphabetical order
      ChangeLog: Document pull request 270
      Merge pull request #270 from uriparser/migrate-windows-ci-from-appveyor-to-github-actions
      Merge pull request #266 from TimWolla/mull-mutation
      Drop dead code
      Join two long lines back together
      Initialize .clang-format with default clang-format 21.1.3 config
      .clang-format: Tweak style
      Exclude parts of the code from auto-formatting
      Make "clang-format off" code blend in better
      Replace tabs by four spaces
      Make GitHub Actions enforce clang-format clean code
      Use artificial indent to restore original visual
      Merge pull request #272 from uriparser/clang-format
      Start requiring a C99 compiler
      Remove artificial C89 support scopes
      Merge pull request #273 from uriparser/issue-264-c99
      Merge pull request #274 from uriparser/dependabot/github_actions/actions/upload-artifact-5.0.0
      Merge pull request #276 from TimWolla/set-host-no-path

Tim Düsterhus (5):
      Fully exercise UriParseBase.c in tests
      Add mull.yml configuration
      src/UriMemory.c: Exclude `uriTestMemoryManagerEx()` from mutation testing
      src/UriMemory.c: Exclude mutant without consequence in `uriDecorateRealloc()`
      src/UriSetHostCommon.c: Do not set `absolutePath` for empty paths when removing host

clang-format 21.1.3 (2):
      Mass-apply clang-format 21.1.3
      Mass-apply clang-format 21.1.3

dependabot[bot] (1):
      Actions(deps): Bump actions/upload-artifact from 4.6.2 to 5.0.0
```