### PR TITLE
ext/session: Remove unused source files and headers on Windows

### DIFF
--- a/ext/session/config.w32
+++ b/ext/session/config.w32
@@ -3,10 +3,10 @@
 ARG_ENABLE("session", "session support", "yes");
 
 if (PHP_SESSION == "yes") {
-	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_mm.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_EXTENSION_DEP('session', 'date');
 	// https://bugs.php.net/53141
 	ADD_EXTENSION_DEP('session', 'spl', true);
 	AC_DEFINE("HAVE_PHP_SESSION", 1, "Define to 1 if the PHP extension 'session' is available.");
-	PHP_INSTALL_HEADERS("ext/session", "mod_mm.h php_session.h mod_files.h mod_user.h");
+	PHP_INSTALL_HEADERS("ext/session", "php_session.h mod_files.h mod_user.h");
 }


### PR DESCRIPTION
These are only useful on Unix-like environments when libmm is enabled via configuration option.