### PR TITLE
sapi/phpdbg: use 'h' ZPP specifier instead of 'H'

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -491,7 +491,7 @@ PHP_FUNCTION(phpdbg_get_executable)
 	HashTable *files = &PHPDBG_G(file_sources);
 	HashTable files_tmp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|H", &options) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|h", &options) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -585,7 +585,7 @@ PHP_FUNCTION(phpdbg_end_oplog)
 	bool by_function = 0;
 	bool by_opcode = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|H", &options) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|h", &options) == FAILURE) {
 		RETURN_THROWS();
 	}
 


### PR DESCRIPTION
The stubs say array so in debug mode we get a ZPP violation assertion and even by fixing the stubs the behaviour is not identical due to missing indirect handling.

This indicates using objects was never done, thus use the correct ZPP specifier