### PR TITLE
xml: Use safe_emalloc() correctly

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -111,7 +111,7 @@ _start_element_handler_ns(void *user, const xmlChar *name, const xmlChar *prefix
 
 	if (attributes != NULL) {
 		xmlChar    *qualified_name_attr = NULL;
-		attrs = safe_emalloc((nb_attributes  * 2) + 1, sizeof(int *), 0);
+		attrs = safe_emalloc(nb_attributes, 2 * sizeof(int *), sizeof(int *));
 
 		for (i = 0; i < nb_attributes; i += 1) {
 


### PR DESCRIPTION
Fortunately, libxml won't allow _at this point in time_ to have more than INT_MAX/5 attributes, so this doesn't cause issues right now. However, if this limit is ever raised then it can cause an integer overflow which will cause a heap overflow.
So future-proof this code by properly using safe_emalloc().