### PR TITLE
[RFC] Allow `#[\Override]` on class constants

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -215,6 +215,8 @@ PHP 8.6 UPGRADE NOTES
     needing to be present beforehand.
   . It is now possible to define the __debugInfo() magic method on enums.
     RFC: https://wiki.php.net/rfc/debugable-enums
+  . #[\Override] can now be applied to class constants, including enum cases.
+    RFC: https://wiki.php.net/rfc/override_constants
 
 - Curl:
   . curl_getinfo() return array now includes a new size_delivered key, which

--- a/Zend/tests/attributes/delayed_target_validation/with_Override_error_constant.phpt
+++ b/Zend/tests/attributes/delayed_target_validation/with_Override_error_constant.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\DelayedTargetValidation] with #[\Override]: non-overrides still error (class constant)
+--FILE--
+<?php
+
+class DemoClass {
+
+	#[DelayedTargetValidation]
+	#[Override] // Does something here
+	public const CLASS_CONSTANT = 'FOO';
+}
+
+?>
+--EXPECTF--
+Fatal error: DemoClass::CLASS_CONSTANT has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/delayed_target_validation/with_Override_error_enum_case.phpt
+++ b/Zend/tests/attributes/delayed_target_validation/with_Override_error_enum_case.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\DelayedTargetValidation] with #[\Override]: non-overrides still error (enum case)
+--FILE--
+<?php
+
+enum DemoEnum {
+
+	#[DelayedTargetValidation]
+	#[Override] // Does something here
+	case MyCase;
+}
+
+?>
+--EXPECTF--
+Fatal error: DemoEnum::MyCase has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/delayed_target_validation/with_Override_okay.phpt
+++ b/Zend/tests/attributes/delayed_target_validation/with_Override_okay.phpt
@@ -12,6 +12,8 @@ class Base {
 		set => $value;
 	}
 
+	public const CLASS_CONST = '';
+
 	public function printVal() {
 		echo __METHOD__ . "\n";
 	}
@@ -34,7 +36,7 @@ class DemoClass extends Base {
 	}
 
 	#[DelayedTargetValidation]
-	#[Override] // Does nothing here
+	#[Override] // Does something here
 	public const CLASS_CONST = 'FOO';
 
 	public function __construct(

--- a/Zend/tests/attributes/override/constants/anon_failure.phpt
+++ b/Zend/tests/attributes/override/constants/anon_failure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - anonymous class, no interface or parent class
+--FILE--
+<?php
+
+new class () {
+    #[\Override]
+    public const C = 'C';
+};
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: class@anonymous::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/anon_interface.phpt
+++ b/Zend/tests/attributes/override/constants/anon_interface.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - anonymous class overrides interface
+--FILE--
+<?php
+
+interface IFace {
+    public const I = 'I';
+}
+
+new class () implements IFace {
+    #[\Override]
+    public const I = 'Changed';
+};
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/anon_parent.phpt
+++ b/Zend/tests/attributes/override/constants/anon_parent.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - anonymous class overrides parent class
+--FILE--
+<?php
+
+class Base {
+    public const C = 'C';
+}
+
+new class () extends Base {
+    #[\Override]
+    public const C = 'Changed';
+};
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/basic.phpt
+++ b/Zend/tests/attributes/override/constants/basic.phpt
@@ -1,0 +1,39 @@
+--TEST--
+#[\Override]: Constants - basic
+--FILE--
+<?php
+
+interface I {
+    public const I = 'I';
+}
+
+interface II extends I {
+    #[\Override]
+    public const I = 'I';
+}
+
+class P {
+    public const C1 = 'C1';
+    public const C2 = 'C2';
+}
+
+class PP extends P {
+    #[\Override]
+    public const C1 = 'C1';
+    public const C2 = 'C2';
+}
+
+class C extends PP implements I {
+    #[\Override]
+    public const I = 'I';
+    #[\Override]
+    public const C1 = 'C1';
+    public const C2 = 'C2';
+    public const C = 'C';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/basic.phpt
+++ b/Zend/tests/attributes/override/constants/basic.phpt
@@ -37,6 +37,11 @@ enum E implements I {
     public const I = 'I';
 }
 
+enum WithCase implements I {
+    #[\Override]
+    case I;
+}
+
 echo "Done";
 
 ?>

--- a/Zend/tests/attributes/override/constants/basic.phpt
+++ b/Zend/tests/attributes/override/constants/basic.phpt
@@ -32,6 +32,11 @@ class C extends PP implements I {
     public const C = 'C';
 }
 
+enum E implements I {
+    #[\Override]
+    public const I = 'I';
+}
+
 echo "Done";
 
 ?>

--- a/Zend/tests/attributes/override/constants/basic.phpt
+++ b/Zend/tests/attributes/override/constants/basic.phpt
@@ -15,12 +15,16 @@ interface II extends I {
 class P {
     public const C1 = 'C1';
     public const C2 = 'C2';
+    public const C3 = 'C3';
+    public const C4 = 'C4';
 }
 
 class PP extends P {
     #[\Override]
     public const C1 = 'C1';
     public const C2 = 'C2';
+    #[\Override]
+    public const C3 = 'C3';
 }
 
 class C extends PP implements I {
@@ -28,7 +32,11 @@ class C extends PP implements I {
     public const I = 'I';
     #[\Override]
     public const C1 = 'C1';
+    #[\Override]
     public const C2 = 'C2';
+    public const C3 = 'C3';
+    #[\Override]
+    public const C4 = 'C4';
     public const C = 'C';
 }
 

--- a/Zend/tests/attributes/override/constants/enum_failure.phpt
+++ b/Zend/tests/attributes/override/constants/enum_failure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - no interface for enum
+--FILE--
+<?php
+
+enum Demo {
+    #[\Override]
+    public const C = 'C';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: Demo::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/enum_failure.phpt
+++ b/Zend/tests/attributes/override/constants/enum_failure.phpt
@@ -1,5 +1,5 @@
 --TEST--
-#[\Override]: Constants - no interface for enum
+#[\Override]: Constants - no interface for enum constant
 --FILE--
 <?php
 

--- a/Zend/tests/attributes/override/constants/enum_failure_case.phpt
+++ b/Zend/tests/attributes/override/constants/enum_failure_case.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - no interface for enum
+--FILE--
+<?php
+
+enum Demo {
+    #[\Override]
+    case C;
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: Demo::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/enum_failure_case.phpt
+++ b/Zend/tests/attributes/override/constants/enum_failure_case.phpt
@@ -1,5 +1,5 @@
 --TEST--
-#[\Override]: Constants - no interface for enum
+#[\Override]: Constants - no interface for enum case
 --FILE--
 <?php
 

--- a/Zend/tests/attributes/override/constants/failure.phpt
+++ b/Zend/tests/attributes/override/constants/failure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - no interface or parent class
+--FILE--
+<?php
+
+class Demo {
+    #[\Override]
+    public const C = 'C';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: Demo::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/interface_failure.phpt
+++ b/Zend/tests/attributes/override/constants/interface_failure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - no parent interface
+--FILE--
+<?php
+
+interface IFace {
+    #[\Override]
+    public const I = 'I';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: IFace::I has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/trait_failure.phpt
+++ b/Zend/tests/attributes/override/constants/trait_failure.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - on a trait, no interface or parent class
+--FILE--
+<?php
+
+trait DemoTrait {
+    #[\Override]
+    public const T = 'T';
+}
+
+class UsesTrait {
+    use DemoTrait;
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: UsesTrait::T has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/trait_interface.phpt
+++ b/Zend/tests/attributes/override/constants/trait_interface.phpt
@@ -1,0 +1,23 @@
+--TEST--
+#[\Override]: Constants - on a trait, overrides interface
+--FILE--
+<?php
+
+trait DemoTrait {
+    #[\Override]
+    public const C = 'Changed';
+}
+
+interface IFace {
+    public const C = 'C';
+}
+
+class UsesTrait implements IFace {
+    use DemoTrait;
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/trait_parent.phpt
+++ b/Zend/tests/attributes/override/constants/trait_parent.phpt
@@ -1,0 +1,23 @@
+--TEST--
+#[\Override]: Constants - on a trait, overrides parent class
+--FILE--
+<?php
+
+trait DemoTrait {
+    #[\Override]
+    public const C = 'Changed';
+}
+
+class Base {
+    public const C = 'C';
+}
+
+class UsesTrait extends Base {
+    use DemoTrait;
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/trait_redeclared.phpt
+++ b/Zend/tests/attributes/override/constants/trait_redeclared.phpt
@@ -1,0 +1,21 @@
+--TEST--
+#[\Override]: Constants - trait constant redeclared, not overridden
+--FILE--
+<?php
+
+trait DemoTrait {
+    public const T = 'T';
+}
+
+class UsesTrait {
+    use DemoTrait;
+
+    #[\Override]
+    public const T = 'T';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: UsesTrait::T has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/trait_redeclared_interface.phpt
+++ b/Zend/tests/attributes/override/constants/trait_redeclared_interface.phpt
@@ -1,0 +1,25 @@
+--TEST--
+#[\Override]: Constants - trait constant redeclared, overrides interface
+--FILE--
+<?php
+
+interface IFace {
+    public const I = 'I';
+}
+
+trait DemoTrait {
+    public const I = 'I';
+}
+
+class UsesTrait implements IFace {
+    use DemoTrait;
+
+    #[\Override]
+    public const I = 'I';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/trait_redeclared_parent.phpt
+++ b/Zend/tests/attributes/override/constants/trait_redeclared_parent.phpt
@@ -1,0 +1,25 @@
+--TEST--
+#[\Override]: Constants - trait constant redeclared, overrides parent class
+--FILE--
+<?php
+
+class Base {
+    public const I = 'I';
+}
+
+trait DemoTrait {
+    public const I = 'I';
+}
+
+class UsesTrait extends Base {
+    use DemoTrait;
+
+    #[\Override]
+    public const I = 'I';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/trait_unused.phpt
+++ b/Zend/tests/attributes/override/constants/trait_unused.phpt
@@ -1,0 +1,15 @@
+--TEST--
+#[\Override]: Constants - on a trait, unused
+--FILE--
+<?php
+
+trait Demo {
+    #[\Override]
+    public const T = 'T';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/visibility_01.phpt
+++ b/Zend/tests/attributes/override/constants/visibility_01.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - private constant not overridden (by public constant)
+--FILE--
+<?php
+
+class Base {
+    private const C = 'C';
+}
+
+class Child extends Base {
+    #[\Override]
+    public const C = 'Changed';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: Child::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/visibility_02.phpt
+++ b/Zend/tests/attributes/override/constants/visibility_02.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - private constant not overridden (by private constant)
+--FILE--
+<?php
+
+class Base {
+    private const C = 'C';
+}
+
+class Child extends Base {
+    #[\Override]
+    private const C = 'Changed';
+}
+
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: Child::C has #[\Override] attribute, but no matching parent constant exists in %s on line %d

--- a/Zend/tests/attributes/override/constants/visibility_03.phpt
+++ b/Zend/tests/attributes/override/constants/visibility_03.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - protected constant is overridden (by public constant)
+--FILE--
+<?php
+
+class Base {
+    protected const C = 'C';
+}
+
+class Child extends Base {
+    #[\Override]
+    public const C = 'Changed';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/constants/visibility_04.phpt
+++ b/Zend/tests/attributes/override/constants/visibility_04.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#[\Override]: Constants - protected constant is overridden (by protected constant)
+--FILE--
+<?php
+
+class Base {
+    protected const C = 'C';
+}
+
+class Child extends Base {
+    #[\Override]
+    protected const C = 'Changed';
+}
+
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/zend_attributes.stub.php
+++ b/Zend/zend_attributes.stub.php
@@ -68,7 +68,7 @@ final class SensitiveParameterValue
 /**
  * @strict-properties
  */
-#[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_PROPERTY|Attribute::TARGET_CLASS_CONSTANT)]
 final class Override
 {
     public function __construct() {}

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit zend_attributes.stub.php instead.
- * Stub hash: b868cb33f41d9442f42d0cec84e33fcc09f5d88c */
+ * Stub hash: bae42fcb945360f90a1e2762c6c22177f25efb9e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Attribute___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "Attribute::TARGET_ALL")
@@ -230,7 +230,7 @@ static zend_class_entry *register_class_Override(void)
 	zend_string *attribute_name_Attribute_class_Override_0 = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, true);
 	zend_attribute *attribute_Attribute_class_Override_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Override_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_Override_0, true);
-	ZVAL_LONG(&attribute_Attribute_class_Override_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_PROPERTY);
+	ZVAL_LONG(&attribute_Attribute_class_Override_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_PROPERTY | ZEND_ATTRIBUTE_TARGET_CLASS_CONST);
 
 	return class_entry;
 }

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9374,7 +9374,8 @@ static void zend_compile_class_const_decl(zend_ast *ast, uint32_t flags, zend_as
 			const zend_attribute *override = zend_get_attribute_str(c->attributes, "override", sizeof("override") - 1);
 			if (override) {
 				ZEND_CLASS_CONST_FLAGS(c) |= ZEND_ACC_OVERRIDE;
-				/* We need to be able to remove the flag */
+				/* We need to be able to remove the flag once the override is
+				 * resolved. See ZEND_ACC_DEPRECATED above. */
 				ce->ce_flags |= ZEND_ACC_HAS_AST_CONSTANTS;
 				ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 			}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9837,6 +9837,14 @@ static void zend_compile_enum_case(zend_ast *ast)
 		if (deprecated) {
 			ZEND_CLASS_CONST_FLAGS(c) |= ZEND_ACC_DEPRECATED;
 		}
+
+		const zend_attribute *override = zend_get_attribute_str(c->attributes, "override", sizeof("override") - 1);
+		if (override) {
+			ZEND_CLASS_CONST_FLAGS(c) |= ZEND_ACC_OVERRIDE;
+			/* We need to be able to remove the flag */
+			enum_class->ce_flags |= ZEND_ACC_HAS_AST_CONSTANTS;
+			enum_class->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
+		}
 	}
 }
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9370,6 +9370,14 @@ static void zend_compile_class_const_decl(zend_ast *ast, uint32_t flags, zend_as
 				ce->ce_flags |= ZEND_ACC_HAS_AST_CONSTANTS;
 				ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 			}
+
+			const zend_attribute *override = zend_get_attribute_str(c->attributes, "override", sizeof("override") - 1);
+			if (override) {
+				ZEND_CLASS_CONST_FLAGS(c) |= ZEND_ACC_OVERRIDE;
+				/* We need to be able to remove the flag */
+				ce->ce_flags |= ZEND_ACC_HAS_AST_CONSTANTS;
+				ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
+			}
 		}
 	}
 }

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9842,7 +9842,9 @@ static void zend_compile_enum_case(zend_ast *ast)
 		const zend_attribute *override = zend_get_attribute_str(c->attributes, "override", sizeof("override") - 1);
 		if (override) {
 			ZEND_CLASS_CONST_FLAGS(c) |= ZEND_ACC_OVERRIDE;
-			/* We need to be able to remove the flag */
+			/* We need to be able to remove the flag once the override is
+			 * resolved. See ZEND_ACC_DEPRECATED handling in
+			 * zend_compile_class_const_decl(). */
 			enum_class->ce_flags |= ZEND_ACC_HAS_AST_CONSTANTS;
 			enum_class->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
 		}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2116,7 +2116,9 @@ static bool do_inherit_constant_check(
 	}
 
 	if (!(ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_PRIVATE)) {
-		ZEND_CLASS_CONST_FLAGS(child_constant) &= ~ZEND_ACC_OVERRIDE;
+		if (child_constant->ce == ce) {
+			ZEND_CLASS_CONST_FLAGS(child_constant) &= ~ZEND_ACC_OVERRIDE;
+		}
 	}
 
 	if (!(ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_PRIVATE) && ZEND_TYPE_IS_SET(parent_constant->type)) {

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2115,6 +2115,10 @@ static bool do_inherit_constant_check(
 		);
 	}
 
+	if (!(ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_PRIVATE)) {
+		ZEND_CLASS_CONST_FLAGS(child_constant) &= ~ZEND_ACC_OVERRIDE;
+	}
+
 	if (!(ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_PRIVATE) && ZEND_TYPE_IS_SET(parent_constant->type)) {
 		inheritance_status status = class_constant_types_compatible(parent_constant, child_constant);
 		if (status == INHERITANCE_ERROR) {
@@ -2314,6 +2318,15 @@ void zend_inheritance_check_override(const zend_class_entry *ce)
 				E_COMPILE_ERROR, f->op_array.filename, f->op_array.line_start,
 				"%s::%s() has #[\\Override] attribute, but no matching parent method exists",
 				ZEND_FN_SCOPE_NAME(f), ZSTR_VAL(f->common.function_name));
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	ZEND_HASH_MAP_FOREACH_STR_KEY_PTR(&ce->constants_table, zend_string *name, zend_class_constant *c) {
+		if (ZEND_CLASS_CONST_FLAGS(c) & ZEND_ACC_OVERRIDE) {
+			zend_error_noreturn(
+				E_COMPILE_ERROR,
+				"%s::%s has #[\\Override] attribute, but no matching parent constant exists",
+				ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
 	} ZEND_HASH_FOREACH_END();
 


### PR DESCRIPTION
https://wiki.php.net/rfc/override_constants