### PR TITLE
Fix crash in property existence test in ext/zip

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -977,9 +977,8 @@ static int php_zip_has_property(zend_object *object, zend_string *name, int type
 			} else if (type == 0) {
 				retval = (Z_TYPE(tmp) != IS_NULL);
 			}
+			zval_ptr_dtor(&tmp);
 		}
-
-		zval_ptr_dtor(&tmp);
 	} else {
 		retval = zend_std_has_property(object, name, type, cache_slot);
 	}

--- a/ext/zip/tests/property_existence_test.phpt
+++ b/ext/zip/tests/property_existence_test.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Property existence test can cause a crash
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+$archive = new ZipArchive(__DIR__.'/property_existence.zip');
+var_dump(array_column([$archive], 'lastId'));
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__.'/property_existence.zip');
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(-1)
+}


### PR DESCRIPTION
When type == 2, the zval is not initialized, so zval_ptr_dtor() on it will crash.
Unfortunately couldn't test with property_exists() or Reflection because they have fast paths that go through the property info, but fortunately there are paths that don't implement a fast path (e.g. because it doesn't make sense at that point), like with array_column(). So we use array_column() to trigger the crash.