### PR TITLE
Avoid string copy in ZipArchive::addFromString()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -130,3 +130,6 @@ PHP 8.6 UPGRADE NOTES
   . Improved performance of array_walk().
   . Improved performance of intval('+0b...', 2) and intval('0b...', 2).
   . Improved performance of str_split().
+
+- Zip:
+  . Avoid string copies in ZipArchive::addFromString().

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -68,7 +68,7 @@ typedef struct _ze_zip_read_rsrc {
 /* Extends zend object */
 typedef struct _ze_zip_object {
 	struct zip *za;
-	char **buffers;
+	zend_string **buffers;
 	HashTable *prop_handler;
 	char *filename;
 	int filename_len;


### PR DESCRIPTION
Instead of copying the data we increment the refcount of the string.