### PR TITLE
Fix GH-20491: SLES15 compile error with mbstring oniguruma

### DIFF
--- a/ext/mbstring/php_onig_compat.h
+++ b/ext/mbstring/php_onig_compat.h
@@ -5,4 +5,10 @@
 #define regex_t                     php_mb_regex_t
 #define re_registers                php_mb_re_registers
 
+/* Required for some distros that conditionally override PV_.
+ * As we're in C99 this header is always available. */
+#ifndef HAVE_STDARG_H
+# define HAVE_STDARG_H
+#endif
+
 #endif /* _PHP_ONIG_COMPAT_H */


### PR DESCRIPTION
The issue is specific to SLES15.
Arguably this should be reported to them as it seems to me they meddled with the oniguruma source code.

The definition in oniguruma.h on that platform looks like this (same as upstream):
```c
ONIG_EXTERN
int onig_error_code_to_str PV_((OnigUChar* s, int err_code, ...));
```

Where `PV_` is defined as (differs):
```c
#ifndef PV_
#ifdef HAVE_STDARG_PROTOTYPES
# define PV_(args) args
#else
# define PV_(args) ()
#endif
#endif
```

So that means that `HAVE_STDARG_PROTOTYPES` is unset. This can be set if we define `HAVE_STDARG_H`,
which we can do because PHP requires at least C99 in which the header is always available.
We could also use an autoconf check, but this isn't really necessary as it will always succeed.