### PR TITLE
Remove PHP_HAVE_STREAMS

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -48,6 +48,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . The WRONG_PARAM_COUNT and ZEND_WRONG_PARAM_COUNT() macros have been
     removed. Call zend_wrong_param_count(); followed by RETURN_THROWS();
     instead.
+  . PHP_HAVE_STREAMS macro removed from <php.h>.
 
 ========================
 2. Build system changes

--- a/main/php.h
+++ b/main/php.h
@@ -23,7 +23,6 @@
 #endif
 
 #define PHP_API_VERSION 20250926
-#define PHP_HAVE_STREAMS
 #define YYDEBUG 0
 #define PHP_DEFAULT_CHARSET "UTF-8"
 


### PR DESCRIPTION
This was once an indicator for PHP extensions whether PHP 4.3.0 or later is used. Today, this is redundant.