### PR TITLE
zip: Don't truncate return value of zip_fread() with user sizes

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1333,7 +1333,6 @@ PHP_FUNCTION(zip_entry_read)
 	zend_long len = 0;
 	zip_read_rsrc * zr_rsrc;
 	zend_string *buffer;
-	int n = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &zip_entry, &len) == FAILURE) {
 		RETURN_THROWS();
@@ -1349,7 +1348,7 @@ PHP_FUNCTION(zip_entry_read)
 
 	if (zr_rsrc->zf) {
 		buffer = zend_string_safe_alloc(1, len, 0, 0);
-		n = zip_fread(zr_rsrc->zf, ZSTR_VAL(buffer), ZSTR_LEN(buffer));
+		zip_int64_t n = zip_fread(zr_rsrc->zf, ZSTR_VAL(buffer), ZSTR_LEN(buffer));
 		if (n > 0) {
 			ZSTR_VAL(buffer)[n] = '\0';
 			ZSTR_LEN(buffer) = n;
@@ -2911,8 +2910,6 @@ static void php_zip_get_from(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 	zend_string *filename;
 	zend_string *buffer;
 
-	int n = 0;
-
 	if (type == 1) {
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "P|ll", &filename, &len, &flags) == FAILURE) {
 			RETURN_THROWS();
@@ -2949,7 +2946,7 @@ static void php_zip_get_from(INTERNAL_FUNCTION_PARAMETERS, int type) /* {{{ */
 	}
 
 	buffer = zend_string_safe_alloc(1, len, 0, 0);
-	n = zip_fread(zf, ZSTR_VAL(buffer), ZSTR_LEN(buffer));
+	zip_int64_t n = zip_fread(zf, ZSTR_VAL(buffer), ZSTR_LEN(buffer));
 	if (n < 1) {
 		zend_string_efree(buffer);
 		RETURN_EMPTY_STRING();


### PR DESCRIPTION
The return type has been zip_int64_t since 2009, so we shouldn't truncate to an int because the user may have requested a size that won't fit in an int.