### PR TITLE
[skip ci] Fix Symfony PHP requirements in community build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,9 +38,9 @@ on:
       skip_laravel:
         required: true
         type: boolean
-      skip_symfony:
+      symfony_version:
         required: true
-        type: boolean
+        type: string
       skip_wordpress:
         required: true
         type: boolean
@@ -599,9 +599,9 @@ jobs:
             exit 1
           fi
       - name: Test Symfony
-        if: ${{ !cancelled() && !inputs.skip_symfony }}
+        if: ${{ !cancelled() && inputs.symfony_version != '' }}
         run: |
-          git clone https://github.com/symfony/symfony.git --depth=1
+          git clone https://github.com/symfony/symfony.git --depth=1 --branch="${{ inputs.symfony_version }}"
           cd symfony
           git rev-parse HEAD
           php /usr/bin/composer install --no-progress --ignore-platform-req=php+
@@ -635,7 +635,8 @@ jobs:
             exit 1
           fi
       - name: 'Symfony Preloading'
-        if: ${{ !cancelled() && !inputs.skip_symfony }}
+        # composer create-project will automatically pick the right Symfony version for us.
+        if: ${{ !cancelled() && inputs.symfony_version != '' }}
         run: |
           php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress --ignore-platform-req=php+
           cd symfony_demo

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -57,7 +57,9 @@ jobs:
       windows_version: '2022'
       vs_crt_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) && 'vs17') || 'vs16' }}
       skip_laravel: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
-      skip_symfony: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
+      symfony_version: ${{ (((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9) && '8.1')
+        || ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 2) && '7.4')
+        || '' }}
       skip_wordpress: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
       variation_enable_zend_max_execution_timers: ${{ (matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 3) || matrix.branch.version[0] >= 9 }}
     secrets: inherit


### PR DESCRIPTION
Symfony 8.1 and 8.0 now require PHP 8.4. Use 7.4 for PHP 8.3 and 8.2 builds. PHP 8.1 continues to be skipped. Sadly, this will need to be updated sporadically.

For context: https://github.com/php/php-src/actions/runs/19415664707/job/55543600188