### PR TITLE
libxml: Fix input buffer deprecation

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -513,6 +513,7 @@ static int php_libxml_streams_IO_close(void *context)
 	return php_stream_close((php_stream*)context);
 }
 
+/* TODO: This needs to be replaced by context-specific APIs in the future! */
 static xmlParserInputBufferPtr
 php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 {
@@ -591,13 +592,10 @@ php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 	}
 
 	/* Allocate the Input buffer front-end. */
-	ret = xmlAllocParserInputBuffer(enc);
-	if (ret != NULL) {
-		ret->context = context;
-		ret->readcallback = php_libxml_streams_IO_read;
-		ret->closecallback = php_libxml_streams_IO_close;
-	} else
+	ret = xmlParserInputBufferCreateIO(php_libxml_streams_IO_read, php_libxml_streams_IO_close, context, enc);
+	if (ret == NULL) {
 		php_libxml_streams_IO_close(context);
+	}
 
 	return(ret);
 }


### PR DESCRIPTION
While this fixed the last deprecation in ext/libxml, it's not a full fix: The full fix would be to move to the context-specific APIs to override the behaviour. However, that requires API/ABI incompatible changes so that can't be done on a stable branch.