### PR TITLE
Add str_extend()

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -71,6 +71,7 @@ ZEND_API void   ZEND_FASTCALL _efree(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_
 ZEND_API ZEND_ATTRIBUTE_MALLOC void*  ZEND_FASTCALL _ecalloc(size_t nmemb, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE2(1,2);
 ZEND_API void*  ZEND_FASTCALL _erealloc(void *ptr, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
 ZEND_API void*  ZEND_FASTCALL _erealloc2(void *ptr, size_t size, size_t copy_size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
+ZEND_API void*  ZEND_FASTCALL _erealloc3(void *ptr, size_t size, size_t copy_size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
 ZEND_API void*  ZEND_FASTCALL _safe_erealloc(void *ptr, size_t nmemb, size_t size, size_t offset ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 ZEND_API void*  ZEND_FASTCALL _safe_realloc(void *ptr, size_t nmemb, size_t size, size_t offset);
 ZEND_API ZEND_ATTRIBUTE_MALLOC char*  ZEND_FASTCALL _estrdup(const char *s ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
@@ -158,6 +159,7 @@ ZEND_API void ZEND_FASTCALL _efree_huge(void *, size_t size);
 #define ecalloc(nmemb, size)				_ecalloc((nmemb), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define erealloc(ptr, size)					_erealloc((ptr), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define erealloc2(ptr, size, copy_size)		_erealloc2((ptr), (size), (copy_size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
+#define erealloc3(ptr, size, copy_size)		_erealloc3((ptr), (size), (copy_size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define safe_erealloc(ptr, nmemb, size, offset)	_safe_erealloc((ptr), (nmemb), (size), (offset) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define erealloc_recoverable(ptr, size)		_erealloc((ptr), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define erealloc2_recoverable(ptr, size, copy_size) _erealloc2((ptr), (size), (copy_size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
@@ -200,6 +202,7 @@ ZEND_API ZEND_ATTRIBUTE_MALLOC char * __zend_strdup(const char *s);
 #define pecalloc(nmemb, size, persistent) ((persistent)?__zend_calloc((nmemb), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC):ecalloc((nmemb), (size)))
 #define perealloc(ptr, size, persistent) ((persistent)?__zend_realloc((ptr), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC):erealloc((ptr), (size)))
 #define perealloc2(ptr, size, copy_size, persistent) ((persistent)?__zend_realloc((ptr), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC):erealloc2((ptr), (size), (copy_size)))
+#define perealloc3(ptr, size, copy_size, persistent) ((persistent)?__zend_realloc((ptr), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC):erealloc3((ptr), (size), (copy_size)))
 #define safe_perealloc(ptr, nmemb, size, offset, persistent)	((persistent)?_safe_realloc((ptr), (nmemb), (size), (offset)):safe_erealloc((ptr), (nmemb), (size), (offset)))
 #define perealloc_recoverable(ptr, size, persistent) ((persistent)?realloc((ptr), (size)):erealloc_recoverable((ptr), (size)))
 #define perealloc2_recoverable(ptr, size, persistent) ((persistent)?realloc((ptr), (size)):erealloc2_recoverable((ptr), (size), (copy_size)))

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -261,7 +261,7 @@ static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t
 	ZEND_ASSERT(len >= ZSTR_LEN(s));
 	if (!ZSTR_IS_INTERNED(s)) {
 		if (EXPECTED(GC_REFCOUNT(s) == 1)) {
-			ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
+			ret = (zend_string *)perealloc3(s, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), _ZSTR_STRUCT_SIZE(ZSTR_LEN(s)), persistent);
 			ZSTR_LEN(ret) = len;
 			zend_string_forget_hash_val(ret);
 			return ret;

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2448,6 +2448,11 @@ function substr_replace(array|string $string, array|string $replace, array|int $
  */
 function quotemeta(string $string): string {}
 
+/**
+ * @compile-time-eval
+ */
+function str_extend(string $string, int $size): string {}
+
 /** @compile-time-eval */
 function ord(string $character): int {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f6bf6cdd07080c01d3a0cb08d71409d05b1084f9 */
+ * Stub hash: e5708214c093e9a4ee017b62a55f6b040448b445 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -942,6 +942,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_substr_replace, 0, 3, MAY_BE_STR
 ZEND_END_ARG_INFO()
 
 #define arginfo_quotemeta arginfo_base64_encode
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_extend, 0, 2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, size, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ord, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, character, IS_STRING, 0)
@@ -2551,6 +2556,7 @@ ZEND_FUNCTION(chunk_split);
 ZEND_FUNCTION(substr);
 ZEND_FUNCTION(substr_replace);
 ZEND_FUNCTION(quotemeta);
+ZEND_FUNCTION(str_extend);
 ZEND_FUNCTION(ord);
 ZEND_FUNCTION(chr);
 ZEND_FUNCTION(ucfirst);
@@ -3152,6 +3158,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("substr", zif_substr, arginfo_substr, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_substr, NULL)
 	ZEND_RAW_FENTRY("substr_replace", zif_substr_replace, arginfo_substr_replace, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("quotemeta", zif_quotemeta, arginfo_quotemeta, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
+	ZEND_RAW_FENTRY("str_extend", zif_str_extend, arginfo_str_extend, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("ord", zif_ord, arginfo_ord, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("chr", zif_chr, arginfo_chr, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("ucfirst", zif_ucfirst, arginfo_ucfirst, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2643,6 +2643,28 @@ PHP_FUNCTION(quotemeta)
 }
 /* }}} */
 
+PHP_FUNCTION(str_extend)
+{
+	zend_string *str;
+	zend_long size;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_LONG(size)
+	ZEND_PARSE_PARAMETERS_END();
+
+	size_t len = ZSTR_LEN(str);
+	if (len > size) {
+		zend_argument_value_error(2, "must not be smaller than the input string");
+		RETURN_THROWS();
+	}
+
+	ZVAL_UNDEF(ZEND_CALL_ARG(execute_data, 0)); // avoid copies, so that we may benefit from the RC=1 optimization
+	RETVAL_STR(zend_string_extend(str, size, 0));
+	Z_STRLEN_P(return_value) = len;
+}
+/* }}} */
+
 /* {{{ Returns ASCII value of character
    Warning: This function is special-cased by zend_compile.c and so is bypassed for constant string argument */
 PHP_FUNCTION(ord)

--- a/ext/standard/tests/strings/str_extend.phpt
+++ b/ext/standard/tests/strings/str_extend.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Append to string allocated with str_extend()
+--FILE--
+<?php
+
+$str = str_extend("a", 1 << 22);
+for ($i = 0; $i < 1 << 21; ++$i) {
+	$str .= "a";
+}
+
+var_dump(array_filter(count_chars($str)));
+
+?>
+--EXPECT--
+array(1) {
+  [97]=>
+  int(2097153)
+}


### PR DESCRIPTION
This pre-allocates a large string, for usage with concatenations. Users must take care to keep the refcount to 1, if they desire benefiting from this.

Note that it is generally pointless to call str_extend("", $size) (i.e. extending an empty string), given that e.g. concatenation will special case empty strings, and then use the other string. (Which is why not a str_alloc($size), which would be pointless and thrown away during concat op.)

This has a slight performance improvement on the general case of appending a single byte in a loop (given that zend_string_extend now uses perealloc3) of about 8%. In particular zend_string_extend() will mostly run into the fast path of zend_mm_realloc_heap for huge allocations.

When using str_extend(), appending a single byte in a loop is 33% faster than the old baseline.

The tested loop is:
```php
$str = str_extend("a", 1 << 26);
for ($i = 0; $i < 1 << 25; ++$i) {
        $str .= "a";
}
```

Specifically hyperfine (x.php being the above test script and y.php being the script, but with "a" directly instead of str_extend()):
```
# hyperfine '/root/php-src-X/baseline-php -dmemory_limit=1G y.php'
Benchmark 1: /root/php-src-X/baseline-php -dmemory_limit=1G y.php
  Time (mean ± σ):     495.3 ms ±  10.2 ms    [User: 348.1 ms, System: 137.8 ms]
  Range (min … max):   478.8 ms … 510.5 ms    10 runs

# hyperfine '/root/php-src-X/sapi/cli/php -dmemory_limit=1G y.php'
Benchmark 1: /root/php-src-X/sapi/cli/php -dmemory_limit=1G y.php
  Time (mean ± σ):     456.2 ms ±   8.4 ms    [User: 298.1 ms, System: 152.5 ms]
  Range (min … max):   443.4 ms … 468.5 ms    10 runs

# hyperfine '/root/php-src-X/sapi/cli/php -dmemory_limit=1G x.php'
Benchmark 1: /root/php-src-X/sapi/cli/php -dmemory_limit=1G x.php
  Time (mean ± σ):     325.7 ms ±   7.5 ms    [User: 288.7 ms, System: 29.7 ms]
  Range (min … max):   312.3 ms … 339.1 ms    10 runs
```

I haven't looked at improvements / overhead outside of the synthetic case though (not quite sure what public code to test against) - I could observe some improvements in string processing code though.

Ideally this feature may allow optimizations in JIT eventually whereby lightweight appending can be done with a bare capacity counter for looped string appends, compared against the value initially passed to str_extend(), avoiding repeated string extends.