### PR TITLE
ext/gd: Enable HAVE_GD_GET_INTERPOLATION

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -265,6 +265,10 @@ if test "$PHP_GD" != "no"; then
     AC_DEFINE([HAVE_GD_BUNDLED], [1],
       [Define to 1 if gd extension uses GD library bundled in PHP.])
 
+    AC_DEFINE([HAVE_GD_GET_INTERPOLATION], [1],
+      [Define to 1 if GD library has the 'gdImageGetInterpolationMethod'
+      function.])
+
 dnl Various checks for GD features
     PHP_SETUP_ZLIB([GD_SHARED_LIBADD])
     PHP_GD_PNG


### PR DESCRIPTION
Bundled libgd has gdImageGetInterpolationMethod() function. It is available as of libgd 2.1.1.

The gdImageGetInterpolationMethod() declaration was added in PHP-8.4+.

This was hanging for a while on my local Git branch but I think this is correct.