### PR TITLE
Fix GH-20557: Build make -C ext/* install-modules w/o modules/*

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -47,7 +47,8 @@ install-modules: build-modules
 	$(mkinstalldirs) $(INSTALL_ROOT)$(EXTENSION_DIR)
 	@echo "Installing shared extensions:     $(INSTALL_ROOT)$(EXTENSION_DIR)/"
 	@rm -f modules/*.la >/dev/null 2>&1
-	@$(INSTALL) modules/* $(INSTALL_ROOT)$(EXTENSION_DIR)
+	@test -z "`ls modules/* 2>/dev/null`" || \
+		$(INSTALL) modules/* $(INSTALL_ROOT)$(EXTENSION_DIR)
 
 install-headers:
 	-@if test "$(INSTALL_HEADERS)"; then \


### PR DESCRIPTION
Update the build recipe template as in PHP-8.5 ext/opcache errors on `make -C ext/opcache install` as modules/* does not resolve to actual filenames any longer,
but to `modules/*` verbatim which fails the `install` command yielding the following diagnostics:

    cp: cannot stat 'modules/*': No such file or directory

and exit status 1 (resolved by make as build error 2).

> [!IMPORTANT]  
> Install is a standard target and we keep the invocation unconditional as the user could be currently remaking.

> [!NOTE]  
> ext/opcache is only exemplary, this can be any ext/* that makes use of the install-modules target to install zero modules. (that is the recipe with the fix here)