### PR TITLE
Fix GH-20546: Zend preserve_none attribute config check on macOs issue.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Sync all boost.context files with release 1.86.0. (mvorisek)
   . Fixed bug GH-20435 (SensitiveParameter doesn't work for named argument
     passing to variadic parameter). (ndossche)
+  . Fixed bug GH-20546 (preserve_none attribute configure check on macOs
+    issue). (David Carlier/cho-m)
 
 - Bz2:
   . Fix assertion failures resulting in crashes with stream filter

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -474,7 +474,7 @@ dnl expectations.
 dnl
 AC_DEFUN([ZEND_CHECK_PRESERVE_NONE], [dnl
   AC_CACHE_CHECK([for preserve_none calling convention],
-   [php_cv_preverve_none],
+   [php_cv_preserve_none],
    [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdint.h>
@@ -504,7 +504,11 @@ uintptr_t __attribute__((preserve_none)) test(void) {
 		"movq %2, %%r13\n"
 		"xorq %3, %%r13\n"
 		"xorq %%rax, %%rax\n"
+#if defined(__APPLE__)
+		"call _fun\n"
+#else
 		"call fun\n"
+#endif
 		: "=a" (ret)
 		: "r" (const1), "r" (const2), "r" (key)
 		: "r12", "r13"
@@ -515,7 +519,11 @@ uintptr_t __attribute__((preserve_none)) test(void) {
 		"eor    x20, %1, %3\n"
 		"eor    x21, %2, %3\n"
 		"eor    x0, x0, x0\n"
+#if defined(__APPLE__)
+		"bl     _fun\n"
+#else
 		"bl     fun\n"
+#endif
 		"mov    %0, x0\n"
 		: "=r" (ret)
 		: "r" (const1), "r" (const2), "r" (key)


### PR DESCRIPTION
This attribute fails on macOs due to the inline assembly test. Due to an old Darwin C ABI convention, symbols are prefixed with an underscore so we need to take in account also for x86_64.