### PR TITLE
VM: Reuse result variable in ICALL_0 implementation

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -9800,7 +9800,7 @@ ZEND_VM_HANDLER(204, ZEND_FRAMELESS_ICALL_0, UNUSED, UNUSED, SPEC(OBSERVER))
 #endif
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
-		function(EX_VAR(opline->result.var));
+		function(result);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -39304,7 +39304,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FRAMELESS_ICA
 #endif
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
-		function(EX_VAR(opline->result.var));
+		function(result);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -39324,7 +39324,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_FUNC_CCONV ZEND_FRAMELESS_ICA
 #endif
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
-		function(EX_VAR(opline->result.var));
+		function(result);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -94770,7 +94770,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FRAMELESS_ICALL_0_
 #endif
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
-		function(EX_VAR(opline->result.var));
+		function(result);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -94790,7 +94790,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_OPCODE_HANDLER_CCONV ZEND_FRAMELESS_ICALL_0_
 #endif
 	{
 		zend_frameless_function_0 function = (zend_frameless_function_0)ZEND_FLF_HANDLER(opline);
-		function(EX_VAR(opline->result.var));
+		function(result);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }


### PR DESCRIPTION
This reduces the assembly size of e.g. `ZEND_FRAMELESS_ICALL_0_SPEC_UNUSED_UNUSED_HANDLER` from 52 to 46 bytes on x86-64 with GCC 15.2.1, strangely. Removes a redundant load.

Before:
```
<+0>:	sub    $0x8,%rsp
<+4>:	movslq 0x10(%r15),%rax
<+8>:	movslq 0x10(%r15),%rdi
<+12>:	mov    %r15,(%r14)
<+15>:	mov    0x14(%r15),%edx
<+19>:	movl   $0x1,0x8(%r14,%rax,1)
<+28>:	mov    0x140695d(%rip),%rax        # 0x1addfe0 <zend_flf_handlers>
<+35>:	add    %r14,%rdi
<+38>:	call   *(%rax,%rdx,8)
<+41>:	mov    (%r14),%r15
<+44>:	add    $0x8,%rsp
<+48>:	add    $0x20,%r15
<+52>:	ret
```

After:
```
<+0>:	sub    $0x8,%rsp
<+4>:	movslq 0x10(%r15),%rdi
<+8>:	mov    0x14(%r15),%edx
<+12>:	mov    %r15,(%r14)
<+15>:	mov    0xace58a(%rip),%rax        # 0x10d9840 <zend_flf_handlers>
<+22>:	add    %r14,%rdi
<+25>:	movl   $0x1,0x8(%rdi)
<+32>:	call   *(%rax,%rdx,8)
<+35>:	mov    (%r14),%r15
<+38>:	add    $0x8,%rsp
<+42>:	add    $0x20,%r15
<+46>:	ret
```