### PR TITLE
Remove pointless EG(exception) checks when parsing coercive string argument

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -592,9 +592,6 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_long_weak(const zval *arg, zend_long 
 				return 0;
 			}
 		}
-		if (UNEXPECTED(EG(exception))) {
-			return 0;
-		}
 	} else if (EXPECTED(Z_TYPE_P(arg) < IS_TRUE)) {
 		if (UNEXPECTED(Z_TYPE_P(arg) == IS_NULL) && !zend_null_arg_deprecated("int", arg_num)) {
 			return 0;
@@ -640,9 +637,6 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_double_weak(const zval *arg, double *
 			} else {
 				return 0;
 			}
-		}
-		if (UNEXPECTED(EG(exception))) {
-			return 0;
 		}
 	} else if (EXPECTED(Z_TYPE_P(arg) < IS_TRUE)) {
 		if (UNEXPECTED(Z_TYPE_P(arg) == IS_NULL) && !zend_null_arg_deprecated("float", arg_num)) {


### PR DESCRIPTION
The is_numeric_str_function() family cannot throw. This used to be necessary in the past, see https://github.com/php/php-src/commit/21148679d1dfb614404c09a918d9d2b74f120640