### PR TITLE
phar: deterministic file order

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -46,7 +46,7 @@ $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/
 	if [ "$(TEST_PHP_EXECUTABLE_RES)" != 1 ]; then \
 		rm -f $(builddir)/phar.phar; \
 		rm -f $(srcdir)/phar.phar; \
-		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -x \\.svn -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)"  $(srcdir)/phar/; \
+		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -x \\.svn -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)" -l 5 `ls -A $(srcdir)/phar/*`; \
 		chmod +x $(builddir)/phar.phar; \
 	else \
 		echo "Skipping phar.phar generating during cross compilation"; \


### PR DESCRIPTION
Hello,

I recently discovered the project https://stagex.tools/ and out of curiosity I checked how the PHP package (https://codeberg.org/stagex/stagex/src/branch/staging/packages/core/php-zts) was built. This is how I discovered those two potential interesting patches (credits to @zeroware) that could easily be merged in the PHP distribution.

I proposed the adoption of those patches to the Nix community as well at https://github.com/NixOS/nixpkgs/pull/463814

I hope the branch `PHP-8.3` is the correct one, let me know if there's anything to change.

This PR:

- Make sure files are listed in deterministic order when building the PHAR