### PR TITLE
phar: use `SOURCE_DATE_EPOCH` to build PHAR when available

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -2975,7 +2975,7 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 			4: metadata-len
 			+: metadata
 		*/
-		mytime = time(NULL);
+		mytime = source_date_epoch_time(NULL);
 		phar_set_32(entry_buffer, entry->uncompressed_filesize);
 		phar_set_32(entry_buffer+4, mytime);
 		phar_set_32(entry_buffer+8, entry->compressed_filesize);

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -440,6 +440,21 @@ static inline zend_off_t phar_get_fp_offset(phar_entry_info *entry)
 	return PHAR_G(cached_fp)[entry->phar->phar_pos].manifest[entry->manifest_pos].offset;
 }
 
+static inline time_t source_date_epoch_time(time_t *tloc)
+{
+	const char *sde;
+	time_t ts;
+
+	tsrm_env_lock();
+	sde = getenv("SOURCE_DATE_EPOCH");
+	ts = (sde) ? strtoul(sde, NULL, 10) : time(0);
+	tsrm_env_unlock();
+	if (tloc) {
+		*tloc = ts;
+	}
+	return ts;
+}
+
 #define PHAR_MIME_PHP '\0'
 #define PHAR_MIME_PHPS '\1'
 #define PHAR_MIME_OTHER '\2'

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -474,7 +474,7 @@ static int phar_stream_flush(php_stream *stream) /* {{{ */
 	phar_entry_data *data = (phar_entry_data *) stream->abstract;
 
 	if (data->internal_file->is_modified) {
-		data->internal_file->timestamp = time(0);
+		data->internal_file->timestamp = source_date_epoch_time(0);
 		ret = phar_flush(data->phar, 0, 0, 0, &error);
 		if (error) {
 			php_stream_wrapper_log_error(stream->wrapper, REPORT_ERRORS, "%s", error);

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -969,7 +969,7 @@ int phar_tar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 	char halt_stub[] = "__HALT_COMPILER();";
 
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
-	entry.timestamp = time(NULL);
+	entry.timestamp = source_date_epoch_time(NULL);
 	entry.is_modified = 1;
 	entry.is_crc_checked = 1;
 	entry.is_tar = 1;

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -126,7 +126,7 @@ static time_t phar_zip_d2u_time(char *cdtime, char *cddate) /* {{{ */
 	struct tm *tm, tmbuf;
 	time_t now;
 
-	now = time(NULL);
+	now = source_date_epoch_time(NULL);
 	tm = php_localtime_r(&now, &tmbuf);
 
 	tm->tm_year = ((ddate>>9)&127) + 1980 - 1900;
@@ -1221,7 +1221,7 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 
 	pass.error = &temperr;
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
-	entry.timestamp = time(NULL);
+	entry.timestamp = source_date_epoch_time(NULL);
 	entry.is_modified = 1;
 	entry.is_zip = 1;
 	entry.phar = phar;


### PR DESCRIPTION
Hello,

I recently discovered the project https://stagex.tools/ and out of curiosity I checked how the PHP package (https://codeberg.org/stagex/stagex/src/branch/staging/packages/core/php-zts) was built. This is how I discovered those two potential interesting patches (credits to @zeroware) that could easily be merged in the PHP distribution.

I proposed the adoption of those patches to the Nix community as well at https://github.com/NixOS/nixpkgs/pull/463814

I hope the branch `PHP-8.3` is the correct one, let me know if there's anything to change.

Links:
- https://reproducible-builds.org/docs/source-date-epoch/

This PR:

- Use `SOURCE_DATE_EPOCH` (the file datetime) inside the PHAR only when it is available.