### PR TITLE
pdo_pgsql: Reset persistent session state on disconnect-equivalent processing

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1340,6 +1340,20 @@ static const zend_function_entry *pdo_pgsql_get_driver_methods(pdo_dbh_t *dbh, i
 	}
 }
 
+static void pdo_pgsql_request_shutdown(pdo_dbh_t *dbh)
+{
+	PGresult *res;
+	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
+
+	if(H->server) {
+		res = PQexec(H->server, "DISCARD ALL");
+
+		if(res) {
+			PQclear(res);
+		}
+	}
+}
+
 static bool pdo_pgsql_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	bool bval;
@@ -1383,7 +1397,7 @@ static const struct pdo_dbh_methods pgsql_methods = {
 	pdo_pgsql_get_attribute,
 	pdo_pgsql_check_liveness,	/* check_liveness */
 	pdo_pgsql_get_driver_methods,  /* get_driver_methods */
-	NULL,
+	pdo_pgsql_request_shutdown,
 	pgsql_handle_in_transaction,
 	NULL, /* get_gc */
 	pdo_pgsql_scanner

--- a/ext/pdo_pgsql/tests/session_state_reset.phpt
+++ b/ext/pdo_pgsql/tests/session_state_reset.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Persistent connections: session state reset when performing disconnect-equivalent processing (general case)
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+putenv('PDOTEST_ATTR='.serialize([PDO::ATTR_PERSISTENT => true]));
+
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+
+$pdo1 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid1 = (int)$pdo1
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+$defaultValue = (int)$pdo1
+    ->query('show log_min_duration_statement;')
+    ->fetchColumn(0);
+
+$setValue = $defaultValue + 1;
+
+$pdo1->exec("set log_min_duration_statement = {$setValue};");
+
+$pdo1 = null;
+
+$pdo2 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid2 = (int)$pdo2
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+assert($pid1 === $pid2);
+
+$expectedValue = (int)$pdo2
+    ->query('show log_min_duration_statement;')
+    ->fetchColumn(0);
+
+echo "defaultValue: {$defaultValue}\n";
+echo "setValue: {$setValue}\n";
+echo "expectedValue: {$expectedValue}\n";
+echo "expected value should be reset to default: " . (($expectedValue === $defaultValue) ? 'success' : 'failure') . "\n";
+
+?>
+--EXPECTF--
+defaultValue: %i
+setValue: %d
+expectedValue: %i
+expected value should be reset to default: success

--- a/ext/pdo_pgsql/tests/session_state_reset_advisory_lock.phpt
+++ b/ext/pdo_pgsql/tests/session_state_reset_advisory_lock.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Persistent connections: session state reset when performing disconnect-equivalent processing (advisory lock case)
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+putenv('PDOTEST_ATTR='.serialize([PDO::ATTR_PERSISTENT => true]));
+
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+
+$pdo1 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid1 = (int)$pdo1
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+$lockResult1 = (bool)$pdo1
+    ->query('select pg_try_advisory_lock(42)::int;')
+    ->fetchColumn(0);
+
+$pdo1 = null;
+
+$dsn = getenv('PDO_PGSQL_TEST_DSN');
+$dsn .= ';';
+putenv('PDO_PGSQL_TEST_DSN='.$dsn);
+
+$pdo2 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid2 = (int)$pdo2
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+assert($pid1 !== $pid2);
+
+$lockResult2 = (bool)$pdo2
+    ->query('select pg_try_advisory_lock(42)::int;')
+    ->fetchColumn(0);
+
+echo "lock1: " . ($lockResult1 ? 'success' : 'failure') . "\n";
+echo "lock2: " . ($lockResult2 ? 'success' : 'failure') . "\n";
+
+?>
+--EXPECT--
+lock1: success
+lock2: success

--- a/ext/pdo_pgsql/tests/session_state_reset_after_interrupted.phpt
+++ b/ext/pdo_pgsql/tests/session_state_reset_after_interrupted.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Persistent connections: session state reset after backend termination (interrupted case)
+--EXTENSIONS--
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+putenv('PDOTEST_ATTR='.serialize([PDO::ATTR_PERSISTENT => true]));
+
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+
+$pdo1 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid1 = (int)$pdo1
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+$pid1 = (int)$pdo1
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+$dsn = getenv('PDO_PGSQL_TEST_DSN');
+$dsn .= ';';
+putenv('PDO_PGSQL_TEST_DSN='.$dsn);
+
+$pdo2 = PDOTest::test_factory(__DIR__ . '/common.phpt');
+
+$pid2 = (int)$pdo2
+    ->query('select pg_backend_pid()::int;')
+    ->fetchColumn(0);
+
+assert($pid1 !== $pid2);
+
+$terminateResult = (bool)$pdo2
+    ->query("select pg_terminate_backend({$pid1})::int")
+    ->fetchColumn(0);
+
+// Disconnect after being terminated by another connection
+$pdo1 = null;
+
+echo 'pid of pdo1: ' . $pid1 . "\n";
+echo 'terminate result of pdo1 by pdo2: ' . ($terminateResult ? 'success' : 'failure') . "\n";
+
+?>
+--EXPECTF--
+pid of pdo1: %d
+terminate result of pdo1 by pdo2: success


### PR DESCRIPTION
This patch makes `ext/pdo_pgsql` clear session-local state when performing disconnect-equivalent processing by issuing a single `DISCARD ALL` on the `libpq` connection.

## Why

Persistent PDO connections could carry session-scoped state across disconnect-equivalent lifecycles, causing surprising behavior for users (changed session settings, leftover temporary objects or prepared statements, or stuck advisory locks).

Clearing the session on disconnect-equivalent processing prevents these surprises.
**`ext/pgsql` already performs a session reset using `RESET ALL`**; `DISCARD ALL` is more comprehensive (it also releases advisory locks and removes temporary objects), so pdo_pgsql uses `DISCARD ALL` for broader cleanup.

## Risk / Benefit

The change runs only during disconnect-equivalent cleanup and does not affect active connections. The small runtime cost of the `DISCARD ALL` call is outweighed by reducing hard-to-diagnose bugs caused by stale session state.

## Ref

* [PostgreSQL: Documentation: 18: 13.3. Explicit Locking - Advisory Locks](https://www.postgresql.org/docs/18/explicit-locking.html#ADVISORY-LOCKS)
* [PostgreSQL: Documentation: 18: SET](https://www.postgresql.org/docs/18/sql-set.html)
* [PostgreSQL: Documentation: 18: RESET](https://www.postgresql.org/docs/18/sql-reset.html)
* [PostgreSQL: Documentation: 18: DISCARD](https://www.postgresql.org/docs/18/sql-discard.html)
* [`ext/pgsql`s `RESET ALL`](https://github.com/php/php-src/blob/ca914ee3891f674ae6dfadd9c0e231e4bc41dee3/ext/pgsql/pgsql.c#L757-L760)