### PR TITLE
ext/phar: inject timestamp for flushing

### DIFF
--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -452,7 +452,8 @@ int phar_wrapper_mkdir(php_stream_wrapper *wrapper, const char *url_from, int mo
 		return 0;
 	}
 
-	phar_flush(phar, &error);
+	time_t now = time(NULL);
+	phar_flush(phar, now, &error);
 
 	if (error) {
 		php_stream_wrapper_log_error(wrapper, options, "phar error: cannot create directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry.filename), phar->fname, error);
@@ -573,7 +574,9 @@ int phar_wrapper_rmdir(php_stream_wrapper *wrapper, const char *url, int options
 	} else {
 		entry->is_deleted = 1;
 		entry->is_modified = 1;
-		phar_flush(phar, &error);
+		// TODO: get timestamp from context?
+		time_t now = time(NULL);
+		phar_flush(phar, now, &error);
 
 		if (error) {
 			php_stream_wrapper_log_error(wrapper, options, "phar error: cannot remove directory \"%s\" in phar \"%s\", %s", ZSTR_VAL(entry->filename), phar->fname, error);

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -414,7 +414,7 @@ void phar_entry_delref(phar_entry_data *idata) /* {{{ */
 /**
  * Removes an entry, either by actually removing it or by marking it.
  */
-ZEND_ATTRIBUTE_NONNULL void phar_entry_remove(phar_entry_data *idata, char **error) /* {{{ */
+ZEND_ATTRIBUTE_NONNULL void phar_entry_remove(phar_entry_data *idata, time_t timestamp, char **error) /* {{{ */
 {
 	phar_archive_data *phar;
 
@@ -433,7 +433,7 @@ ZEND_ATTRIBUTE_NONNULL void phar_entry_remove(phar_entry_data *idata, char **err
 	}
 
 	if (!phar->donotflush) {
-		phar_flush(phar, error);
+		phar_flush(phar, timestamp, error);
 	}
 }
 /* }}} */
@@ -1715,7 +1715,8 @@ static zend_result phar_open_from_fp(php_stream* fp, char *fname, size_t fname_l
 
 			if (!memcmp(pos, zip_magic, 4)) {
 				php_stream_seek(fp, 0, SEEK_END);
-				return phar_parse_zipfile(fp, fname, fname_len, alias, alias_len, pphar, error);
+				time_t now = time(NULL);
+				return phar_parse_zipfile(fp, fname, fname_len, alias, alias_len, pphar, now, error);
 			}
 
 			if (got >= 512) {
@@ -2459,8 +2460,8 @@ zend_string *phar_create_default_stub(const zend_string *php_index_str, const ze
 }
 /* }}} */
 
-ZEND_ATTRIBUTE_NONNULL int phar_flush(phar_archive_data *phar, char **error) {
-	return phar_flush_ex(phar, NULL, false, error);
+ZEND_ATTRIBUTE_NONNULL int phar_flush(phar_archive_data *phar, time_t timestamp, char **error) {
+	return phar_flush_ex(phar, NULL, false, timestamp, error);
 }
 
 /**
@@ -2468,7 +2469,7 @@ ZEND_ATTRIBUTE_NONNULL int phar_flush(phar_archive_data *phar, char **error) {
  *
  * if user_stub is NULL the default or existing stub should be used
  */
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, char **error) /* {{{ */
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 5) int phar_flush_ex(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, time_t timestamp, char **error) /* {{{ */
 {
 	static const char halt_stub[] = "__HALT_COMPILER();";
 
@@ -2482,7 +2483,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 	zend_off_t manifest_ftell;
 	zend_long offset;
 	size_t wrote;
-	uint32_t manifest_len, mytime, new_manifest_count;
+	uint32_t manifest_len, new_manifest_count;
 	uint32_t newcrc32;
 	php_stream *file, *oldfile, *newfile;
 	php_stream_filter *filter;
@@ -2507,11 +2508,11 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 	zend_hash_clean(&phar->virtual_dirs);
 
 	if (phar->is_zip) {
-		return phar_zip_flush(phar, user_stub, is_default_stub, error);
+		return phar_zip_flush(phar, user_stub, is_default_stub, timestamp, error);
 	}
 
 	if (phar->is_tar) {
-		return phar_tar_flush(phar, user_stub, is_default_stub, error);
+		return phar_tar_flush(phar, user_stub, is_default_stub, timestamp, error);
 	}
 
 	if (PHAR_G(readonly)) {
@@ -2871,9 +2872,8 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *phar, zen
 			4: metadata-len
 			+: metadata
 		*/
-		mytime = time(NULL);
 		phar_set_32(entry_buffer, entry->uncompressed_filesize);
-		phar_set_32(entry_buffer+4, mytime);
+		phar_set_32(entry_buffer+4, timestamp);
 		phar_set_32(entry_buffer+8, entry->compressed_filesize);
 		phar_set_32(entry_buffer+12, entry->crc32);
 		phar_set_32(entry_buffer+16, entry->flags);

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -446,12 +446,12 @@ zend_result phar_copy_on_write(phar_archive_data **pphar);
 bool phar_is_tar(const char *buf, const char *fname);
 zend_result phar_parse_tarfile(php_stream* fp, char *fname, size_t fname_len, char *alias, size_t alias_len, phar_archive_data** pphar, uint32_t compression, char **error);
 ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_open_or_create_tar(char *fname, size_t fname_len, char *alias, size_t alias_len, bool is_data, uint32_t options, phar_archive_data** pphar, char **error);
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, char **error);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 5) int phar_tar_flush(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, time_t timestamp, char **error);
 
 /* zip functions in zip.c */
-zend_result phar_parse_zipfile(php_stream *fp, char *fname, size_t fname_len, char *alias, size_t alias_len, phar_archive_data** pphar, char **error);
+zend_result phar_parse_zipfile(php_stream *fp, char *fname, size_t fname_len, char *alias, size_t alias_len, phar_archive_data** pphar, time_t timestamp, char **error);
 ZEND_ATTRIBUTE_NONNULL_ARGS(1, 7, 8) zend_result phar_open_or_create_zip(char *fname, size_t fname_len, char *alias, size_t alias_len, bool is_data, uint32_t options, phar_archive_data** pphar, char **error);
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_zip_flush(phar_archive_data *archive, zend_string *user_stub, bool is_default_stub, char **error);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 5) int phar_zip_flush(phar_archive_data *archive, zend_string *user_stub, bool is_default_stub, time_t timestamp, char **error);
 
 #ifdef PHAR_MAIN
 extern const php_stream_wrapper php_stream_phar_wrapper;
@@ -465,10 +465,10 @@ void phar_entry_delref(phar_entry_data *idata);
 
 phar_entry_info *phar_get_entry_info(phar_archive_data *phar, char *path, size_t path_len, char **error, bool security);
 phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, size_t path_len, char dir, char **error, bool security);
-ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, char *path, size_t path_len, const char *mode, char allow_dir, char **error, bool security);
+ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, char *path, size_t path_len, const char *mode, char allow_dir, time_t timestamp, char **error, bool security);
 ZEND_ATTRIBUTE_NONNULL zend_result phar_get_entry_data(phar_entry_data **ret, char *fname, size_t fname_len, char *path, size_t path_len, const char *mode, char allow_dir, char **error, bool security);
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_flush_ex(phar_archive_data *archive, zend_string *user_stub, bool is_default_stub, char **error);
-ZEND_ATTRIBUTE_NONNULL int phar_flush(phar_archive_data *archive, char **error);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 5) int phar_flush_ex(phar_archive_data *archive, zend_string *user_stub, bool is_default_stub, time_t timestamp, char **error);
+ZEND_ATTRIBUTE_NONNULL int phar_flush(phar_archive_data *archive, time_t timestamp, char **error);
 zend_result phar_detect_phar_fname_ext(const char *filename, size_t filename_len, const char **ext_str, size_t *ext_len, int executable, int for_create, bool is_complete);
 zend_result phar_split_fname(const char *filename, size_t filename_len, char **arch, size_t *arch_len, char **entry, size_t *entry_len, int executable, int for_create);
 

--- a/ext/phar/stream.h
+++ b/ext/phar/stream.h
@@ -21,7 +21,7 @@ BEGIN_EXTERN_C()
 #include "ext/standard/url.h"
 
 php_url* phar_parse_url(php_stream_wrapper *wrapper, const char *filename, const char *mode, int options);
-ZEND_ATTRIBUTE_NONNULL void phar_entry_remove(phar_entry_data *idata, char **error);
+ZEND_ATTRIBUTE_NONNULL void phar_entry_remove(phar_entry_data *idata, time_t timestamp, char **error);
 
 static php_stream* phar_wrapper_open_url(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
 static int phar_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from, const char *url_to, int options, php_stream_context *context);

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -960,7 +960,7 @@ ZEND_ATTRIBUTE_NONNULL static int phar_tar_setupmetadata(zval *zv, void *argumen
 }
 /* }}} */
 
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, char **error) /* {{{ */
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 5) int phar_tar_flush(phar_archive_data *phar, zend_string *user_stub, bool is_default_stub, time_t timestamp, char **error) /* {{{ */
 {
 	static const char newstub[] = "<?php // tar-based phar archive stub file\n__HALT_COMPILER();";
 	static const char halt_stub[] = "__HALT_COMPILER();";
@@ -973,7 +973,7 @@ ZEND_ATTRIBUTE_NONNULL_ARGS(1, 4) int phar_tar_flush(phar_archive_data *phar, ze
 	char *buf, *signature, sigbuf[8];
 
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
-	entry.timestamp = time(NULL);
+	entry.timestamp = timestamp;
 	entry.is_modified = 1;
 	entry.is_crc_checked = 1;
 	entry.is_tar = 1;

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -606,7 +606,7 @@ really_get_entry:
 /**
  * Create a new dummy file slot within a writeable phar for a newly created file
  */
-ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, char *path, size_t path_len, const char *mode, char allow_dir, char **error, bool security) /* {{{ */
+ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, char *path, size_t path_len, const char *mode, char allow_dir, time_t timestamp, char **error, bool security) /* {{{ */
 {
 	phar_archive_data *phar;
 	phar_entry_info *entry, etemp;
@@ -668,7 +668,7 @@ ZEND_ATTRIBUTE_NONNULL phar_entry_data *phar_get_or_create_entry_data(char *fnam
 
 	phar_add_virtual_dirs(phar, path, path_len);
 	etemp.is_modified = 1;
-	etemp.timestamp = time(0);
+	etemp.timestamp = timestamp;
 	etemp.is_crc_checked = 1;
 	etemp.phar = phar;
 	etemp.filename = zend_string_init(path, path_len, false);


### PR DESCRIPTION
The objective of this is to potentially allow userland to set the timestamp to allow building reproducible phars.

People this might interest in the long run:
- @theofidry
- @drupol 
- @Ocramius 