### PR TITLE
Add `php.github.io/php-src` to  CONTRIBUTING.md Technical Resources list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ scattered across different websites, and often outdated. Nonetheless, they can
 provide a good starting point for learning about the fundamentals of the code
 base.
 
+* https://php.github.io/php-src/
 * https://www.phpinternalsbook.com/
 * https://www.npopov.com/
   * [Internal value representation](https://www.npopov.com/2015/05/05/Internal-value-representation-in-PHP-7-part-1.html), [part 2](https://www.npopov.com/2015/06/19/Internal-value-representation-in-PHP-7-part-2.html)


### PR DESCRIPTION
https://php.github.io/php-src/ is missing in the [CONTRIBUTING.md#technical-resources](https://github.com/php/php-src/blob/1ee8dfd6fcf02ce7cc3662381e4cfa76de47ec3b/CONTRIBUTING.md#technical-resources) list.

IMO it is explain technical things like how to write tests, run tests, how PHP works. It can be added in the list. WDYT ?