### PR TITLE
Fix GH-20614: SplFixedArray incorrectly handles references in deserialization

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -652,7 +652,7 @@ PHP_METHOD(SplFixedArray, __unserialize)
 		intern->array.size = 0;
 		ZEND_HASH_FOREACH_STR_KEY_VAL(data, key, elem) {
 			if (key == NULL) {
-				ZVAL_COPY(&intern->array.elements[intern->array.size], elem);
+				ZVAL_COPY_DEREF(&intern->array.elements[intern->array.size], elem);
 				intern->array.size++;
 			} else {
 				Z_TRY_ADDREF_P(elem);
@@ -833,7 +833,7 @@ PHP_METHOD(SplFixedArray, offsetGet)
 	value = spl_fixedarray_object_read_dimension_helper(intern, zindex);
 
 	if (value) {
-		RETURN_COPY_DEREF(value);
+		RETURN_COPY(value);
 	} else {
 		RETURN_NULL();
 	}

--- a/ext/spl/tests/gh20614.phpt
+++ b/ext/spl/tests/gh20614.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-20614 (SplFixedArray incorrectly handles references in deserialization)
+--FILE--
+<?php
+
+$fa = new SplFixedArray(0);
+$nr = 1;
+$array = [&$nr];
+$fa->__unserialize($array);
+var_dump($fa);
+unset($fa[0]);
+var_dump($fa);
+
+?>
+--EXPECT--
+object(SplFixedArray)#1 (1) {
+  [0]=>
+  int(1)
+}
+object(SplFixedArray)#1 (1) {
+  [0]=>
+  NULL
+}


### PR DESCRIPTION
All other code caters to dereferencing array elements, except the unserialize handler. This causes references to be present in the fixed array even though this seems not intentional as reference assign is otherwise impossible.
On 8.5+ this causes an assertion failure. On 8.3+ this causes references to be present where they shouldn't be.