### PR TITLE
Fix TypeError message of `setlocale()`

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4957,7 +4957,7 @@ PHP_FUNCTION(setlocale)
 
 	for (uint32_t i = 0; i < num_args; i++) {
 		if (UNEXPECTED(Z_TYPE(args[i]) != IS_ARRAY && !zend_parse_arg_str(&args[i], &strings[i], true, i + 2))) {
-			zend_wrong_parameter_type_error(i + 2, Z_EXPECTED_ARRAY_OR_STRING, &args[i]);
+			zend_wrong_parameter_type_error(i + 2, Z_EXPECTED_ARRAY_OR_STRING_OR_NULL, &args[i]);
 			goto out;
 		}
 	}

--- a/ext/standard/tests/strings/gh18823_strict.phpt
+++ b/ext/standard/tests/strings/gh18823_strict.phpt
@@ -15,5 +15,5 @@ try {
 }
 ?>
 --EXPECT--
-setlocale(): Argument #2 ($locales) must be of type array|string, int given
-setlocale(): Argument #3 must be of type array|string, int given
+setlocale(): Argument #2 ($locales) must be of type array|string|null, int given
+setlocale(): Argument #3 must be of type array|string|null, int given


### PR DESCRIPTION
#19071 allowed `setlocale($typs, null)`, but the error message of TypeError was not changed.
This PR fixes the error message.