### PR TITLE
Fix GH-19520: php_admin_value[extension] in FPM unsafely runs RINIT

### DIFF
--- a/ext/standard/dl.h
+++ b/ext/standard/dl.h
@@ -19,8 +19,12 @@
 #ifndef DL_H
 #define DL_H
 
-PHPAPI int php_load_extension(const char *filename, int type, int start_now);
-PHPAPI void php_dl(const char *file, int type, zval *return_value, int start_now);
+#define PHP_DL_START_NONE    0
+#define PHP_DL_START_REQUEST 1
+#define PHP_DL_START_MODULE  2
+
+PHPAPI int php_load_extension(const char *filename, int type, int start_mode);
+PHPAPI void php_dl(const char *file, int type, zval *return_value, int start_mode);
 PHPAPI void *php_load_shlib(const char *path, char **errp);
 
 /* dynamic loading functions */

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -313,7 +313,7 @@ static void php_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callback_t
 static void php_load_php_extension_cb(void *arg)
 {
 #ifdef HAVE_LIBDL
-	php_load_extension(*((char **) arg), MODULE_PERSISTENT, 0);
+	php_load_extension(*((char **) arg), MODULE_PERSISTENT, PHP_DL_START_NONE);
 #endif
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -75,7 +75,7 @@ int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode) /* {{{ */
 		zend_rc_debug = false;
 #endif
 
-		php_dl(value, MODULE_PERSISTENT, &zv, 1);
+		php_dl(value, MODULE_PERSISTENT, &zv, PHP_DL_START_MODULE);
 
 #if ZEND_RC_DEBUG
 		zend_rc_debug = orig_rc_debug;


### PR DESCRIPTION
This redifines start_now param to start_mode in php_dl / php_load_extension to allow selection of start hooks to run. And for php-fpm it uses just starting of module.