### PR TITLE
Fix GH-19018: php_admin_value disable_functions ignored

### DIFF
--- a/sapi/apache2handler/apache_config.c
+++ b/sapi/apache2handler/apache_config.c
@@ -200,6 +200,9 @@ void apply_config(void *dummy)
 		if (zend_alter_ini_entry_chars(str, data->value, data->value_len, data->status, data->htaccess?PHP_INI_STAGE_HTACCESS:PHP_INI_STAGE_ACTIVATE) == FAILURE) {
 			phpapdebug((stderr, "..FAILED\n"));
 		}
+		if (zend_string_equals_literal(str, "disable_functions") && *data->value) {
+			zend_disable_functions(data->value);
+		}
 	} ZEND_HASH_FOREACH_END();
 }
 


### PR DESCRIPTION
This happens because disable_functions are not explicitly disabled. The fix explicitly calls zend_disable_functions when config is applied.

The WST test for this available here: https://github.com/wstool/wst-php-apache2handler/blob/6573dd55449504e71971c939bf1cca79412197b3/spec/instances/php-admin-value-disable-functions.yaml