### PR TITLE
Prefer posix_spawn_file_actions_addchdir() over _np variant when available

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -328,7 +328,7 @@ dnl
 
 PHP_CHECK_FUNC(res_search, resolv, socket)
 
-AC_CHECK_FUNCS([posix_spawn_file_actions_addchdir_np elf_aux_info])
+AC_CHECK_FUNCS([posix_spawn_file_actions_addchdir posix_spawn_file_actions_addchdir_np elf_aux_info])
 
 dnl
 dnl Obsolete check for strptime() declaration. The strptime, where available,

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1394,10 +1394,17 @@ PHP_FUNCTION(proc_open)
 	}
 
 	if (cwd) {
+#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR
+		r = posix_spawn_file_actions_addchdir(&factions, cwd);
+		if (r != 0) {
+			php_error_docref(NULL, E_WARNING, "posix_spawn_file_actions_addchdir() failed: %s", strerror(r));
+		}
+#else
 		r = posix_spawn_file_actions_addchdir_np(&factions, cwd);
 		if (r != 0) {
 			php_error_docref(NULL, E_WARNING, "posix_spawn_file_actions_addchdir_np() failed: %s", strerror(r));
 		}
+#endif
 	}
 
 	if (argv) {


### PR DESCRIPTION
On recent macOS SDKs `posix_spawn_file_actions_addchdir_np()` is declared as deprecated and triggers a -Werror,-Wdeprecated-declarations build failure when compiling `ext/standard/proc_open.c`. The deprecation notice explicitly recommends using the standardized `posix_spawn_file_actions_addchdir()` function instead.

This patch makes `proc_open()` prefer the standard POSIX function when it is available, while keeping the existing _np behavior as a fallback.