### PR TITLE
add path info to slow log

### DIFF
--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -77,6 +77,7 @@ typedef struct {
 
 	char *path_translated;
 	char *request_uri;
+	char *path_info;
 
 	/* Do not use request_body directly, but the php://input stream wrapper instead */
 	struct _php_stream *request_body;

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -987,6 +987,7 @@ static void init_request_info(void)
 	/* initialize the defaults */
 	SG(request_info).path_translated = NULL;
 	SG(request_info).request_method = FCGI_GETENV(request, "REQUEST_METHOD");
+	SG(request_info).path_info = FCGI_GETENV(request, "PATH_INFO");
 	SG(request_info).proto_num = 1000;
 	SG(request_info).query_string = NULL;
 	SG(request_info).request_uri = NULL;

--- a/sapi/fpm/fpm/fpm_php_trace.c
+++ b/sapi/fpm/fpm/fpm_php_trace.c
@@ -34,6 +34,42 @@
 #endif
 
 
+static int dump_request_additional_info(FILE *slowlog){
+	char buffer[1024];
+	long addr;
+
+	if (0 > fpm_trace_get_long((long) &SG(request_info).request_method, &addr)) {
+		return -1;
+	}
+
+	if (0 > fpm_trace_get_strz(buffer, sizeof(buffer), addr)) {
+		return -1;
+	}
+	fprintf(slowlog, "request_method = %s\n", buffer);
+
+	if (0 > fpm_trace_get_long((long) &SG(request_info).path_info, &addr)) {
+
+		return -1;
+	}
+
+	if (0 > fpm_trace_get_strz(buffer, sizeof(buffer), addr)) {
+		return -1;
+	}
+	fprintf(slowlog, "request_path_info = %s\n", buffer);
+
+
+	if (0 > fpm_trace_get_long((long) &SG(request_info).query_string, &addr)) {
+		return -1;
+	}
+
+	if (0 > fpm_trace_get_strz(buffer, sizeof(buffer), addr)) {
+		return -1;
+	}
+	fprintf(slowlog, "request_query_string = %s\n", buffer);
+
+	return 0;
+}
+
 static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ */
 {
 	int callers_limit = child->wp->config->request_slowlog_trace_depth;
@@ -61,6 +97,10 @@ static int fpm_php_trace_dump(struct fpm_child_s *child, FILE *slowlog) /* {{{ *
 	}
 
 	fprintf(slowlog, "script_filename = %s\n", buf);
+
+	if(dump_request_additional_info(slowlog) == -1){
+		return -1;
+	}
 
 	if (0 > fpm_trace_get_long((long) &EG(current_execute_data), &l)) {
 		return -1;


### PR DESCRIPTION
Hi,
I was looking to add to slow logs information about request url. This is useful in case the web server is modifying the url as described here https://github.com/php/php-src/issues/18536

The `sapi_request_info` structure already foresee a `request_uri` variable, 
but it is going to ends up containing the "SCRIPT FILENAME" after  `static void init_request_info(void)` is executed https://github.com/php/php-src/blob/4cc5f0238746704ae683676c0be4b97b7dbc9a11/sapi/fpm/fpm/fpm_main.c#L1334

so I added the `path_info` variable to the `sapi_request_info`, in order to put in it the value of the `PATH_INFO` parameter setted by the web server. 

Then in the slow log the `request_method`, `request_path_info` and `request_query_string` are added

```
[05-Dec-2025 14:20:01]  [pool www] pid 167
script_filename = /var/www/public/index.php
request_method = GET
request_path_info = /lucky/number/4
request_query_string = ciao=hello
[0x00007ffff6215070] sleep() /var/www/public/index.php:3
```


In order to work properly the web server should add the `PATH_INFO` to the request to fpm

ie for nginx
```
    location / {
        # try to serve file directly, fallback to index.php
        try_files $uri /index.php$uri$is_args$args;
    }
    
    ....
     location ~ ^/index\.php(/|$) {
            fastcgi_split_path_info ^(.+\.php)(/.*)$;
            fastcgi_param PATH_INFO $fastcgi_path_info;
            ...
     }
    ..
```

Thanks

