### PR TITLE
standard: Fix error check for proc_open() command

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -510,7 +510,7 @@ typedef struct _descriptorspec_item {
 } descriptorspec_item;
 
 static zend_string *get_valid_arg_string(zval *zv, int elem_num) {
-	zend_string *str = zval_get_string(zv);
+	zend_string *str = zval_try_get_string(zv);
 	if (!str) {
 		return NULL;
 	}


### PR DESCRIPTION
zval_get_string() can never return NULL, you need to use the try version to get NULL. This is observable because the process will still spawn even if an exception had occurred. To fix this, use the try variant.