### PR TITLE
Fix dumping function signature with dynamic class const lookup default argument

### DIFF
--- a/Zend/tests/oss-fuzz-465488618.phpt
+++ b/Zend/tests/oss-fuzz-465488618.phpt
@@ -1,0 +1,17 @@
+--TEST--
+OSS-Fuzz #465488618: Dump function signature with dynamic class const lookup default argument
+--FILE--
+<?php
+
+class A {
+    public function test(int $x) {}
+}
+
+class B extends A
+{
+    public function test(string $x = Foo::{C}) {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::test(string $x = <expression>) must be compatible with A::test(int $x) in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -973,7 +973,9 @@ static ZEND_COLD zend_string *zend_get_function_declaration(
 							zend_ast *ast = Z_ASTVAL_P(zv);
 							if (ast->kind == ZEND_AST_CONSTANT) {
 								smart_str_append(&str, zend_ast_get_constant_name(ast));
-							} else if (ast->kind == ZEND_AST_CLASS_CONST) {
+							} else if (ast->kind == ZEND_AST_CLASS_CONST
+							 && ast->child[1]->kind == ZEND_AST_ZVAL
+							 && Z_TYPE_P(zend_ast_get_zval(ast->child[1])) == IS_STRING) {
 								smart_str_append(&str, zend_ast_get_str(ast->child[0]));
 								smart_str_appends(&str, "::");
 								smart_str_append(&str, zend_ast_get_str(ast->child[1]));


### PR DESCRIPTION
Fixes OSS-Fuzz #465488618

Wow, it took a while for fuzzers to find this one. ^^