### PR TITLE
ext/sockets: socket_addrinfo_lookup() allows AF_UNSPEC for ai_family.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,7 +71,9 @@ PHP                                                                        NEWS
 
 - Sockets:
   . Added the TCP_USER_TIMEOUT constant for Linux to set the maximum time in milliseconds
-        transmitted data can remain unacknowledged. (James Lucas)
+    transmitted data can remain unacknowledged. (James Lucas)
+  . Added AF_UNSPEC support for sock_addrinfo_lookup() as a sole umbrella for
+    AF_INET* family only. (David Carlier)
 
 - SPL:
   . DirectoryIterator key can now work better with filesystem supporting larger

--- a/UPGRADING
+++ b/UPGRADING
@@ -107,6 +107,7 @@ PHP 8.6 UPGRADE NOTES
 
 - Sockets:
   . TCP_USER_TIMEOUT (Linux only).
+  . AF_UNSPEC.
 
 ========================================
 11. Changes to INI File Handling

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -19,6 +19,13 @@ const AF_INET = UNKNOWN;
  */
 const AF_INET6 = UNKNOWN;
 #endif
+#ifdef AF_UNSPEC
+/**
+ * @var int
+ * @cvalue AF_UNSPEC
+ */
+const AF_UNSPEC = UNKNOWN;
+#endif
 #ifdef AF_DIVERT
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 038081ca7bb98076d4b559d93b4c9300acc47160 */
+ * Stub hash: a89c4e54ab913728e10baf8f32b45323495d685b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -316,6 +316,9 @@ static void register_sockets_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("AF_INET", AF_INET, CONST_PERSISTENT);
 #if defined(HAVE_IPV6)
 	REGISTER_LONG_CONSTANT("AF_INET6", AF_INET6, CONST_PERSISTENT);
+#endif
+#if defined(AF_UNSPEC)
+	REGISTER_LONG_CONSTANT("AF_UNSPEC", AF_UNSPEC, CONST_PERSISTENT);
 #endif
 #if defined(AF_DIVERT)
 	REGISTER_LONG_CONSTANT("AF_DIVERT", AF_DIVERT, CONST_PERSISTENT);


### PR DESCRIPTION
while still filtering out IPC like addresses and so on.