### PR TITLE
ldap: Fix memory leak in ldap_set_options()

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -664,14 +664,15 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				goto failure;
 			}
 
+			zend_string *context_str = NULL;
 			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "context", sizeof("context") - 1)) != NULL) {
-				tmpstring = zval_get_string(tmp);
+				context_str = zval_get_string(tmp);
 				if (EG(exception)) {
 					rc = -1;
 					goto failure;
 				}
-				context.bv_val = ZSTR_VAL(tmpstring);
-				context.bv_len = ZSTR_LEN(tmpstring);
+				context.bv_val = ZSTR_VAL(context_str);
+				context.bv_len = ZSTR_LEN(context_str);
 				vlvInfo.ldvlv_context = &context;
 			} else {
 				vlvInfo.ldvlv_context = NULL;
@@ -682,6 +683,9 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 			rc = ldap_create_vlv_control_value(ld, &vlvInfo, &control_value);
 			if (rc != LDAP_SUCCESS) {
 				php_error_docref(NULL, E_WARNING, "Failed to create VLV control value: %s (%d)", ldap_err2string(rc), rc);
+			}
+			if (context_str) {
+				zend_string_release_ex(context_str, false);
 			}
 		} else {
 			zend_type_error("%s(): Control OID %s cannot be of type array", get_active_function_name(), ZSTR_VAL(control_oid));

--- a/ext/ldap/tests/ldap_set_option_leak_attrvalue_context.phpt
+++ b/ext/ldap/tests/ldap_set_option_leak_attrvalue_context.phpt
@@ -1,0 +1,34 @@
+--TEST--
+ldap_set_option() - Leaks attrvalue and context
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+require "connect.inc";
+
+$link = ldap_connect($uri);
+
+$attrvalue = str_repeat("attrvalue", random_int(1, 1));
+$context = str_repeat("context", random_int(1, 1));
+
+$controls = [
+    ["oid" => "2.16.840.1.113730.3.4.9", "value" => ["attrvalue" => $attrvalue, "context" => $context, "before" => 0, "after" => 0]],
+];
+
+ldap_set_option($link, LDAP_OPT_CLIENT_CONTROLS, $controls);
+ldap_get_option($link, LDAP_OPT_CLIENT_CONTROLS, $controls_out);
+
+var_dump($controls_out);
+?>
+--EXPECTF--
+array(1) {
+  ["2.16.840.1.113730.3.4.9"]=>
+  array(3) {
+    ["oid"]=>
+    string(23) "2.16.840.1.113730.3.4.9"
+    ["iscritical"]=>
+    bool(false)
+    ["value"]=>
+    string(28) "0%0%0Å	attrvaluecontext"
+  }
+}


### PR DESCRIPTION
`tmpstring` is already used for something else, so we can't use it when reading the "context".