### PR TITLE
opcache: Remove unused sys/ipc.h include from ZendAccelerator.c

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -89,7 +89,6 @@ typedef int gid_t;
 #ifndef ZEND_WIN32
 # include <sys/types.h>
 # include <sys/wait.h>
-# include <sys/ipc.h>
 # include <pwd.h>
 # include <grp.h>
 #endif


### PR DESCRIPTION
As far as I can tell that's been there since the initial open source release (commit 528006a). The header defines ftok() and a handful of IPC_* constants, none of which are used here.

System V IPC is increasingly being replaced by POSIX IPC and may therefore not be implemented on new and/or hobbyist operating systems such as SerenityOS[1]. In the past that wasn't an issue as the OPCache could be disabled, which is no longer possible as of PHP 8.5[2].

I was able to build with the include patched out, but we would prefer this to be addressed upstream.

1: https://github.com/SerenityOS/serenity/pull/26465
2: https://github.com/php/php-src/pull/18961