### PR TITLE
Performance: Empty string early return for strip_tags

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5123,6 +5123,11 @@ PHPAPI size_t php_strip_tags_ex(char *rbuf, size_t len, const char *allow, size_
 	char *allow_free = NULL;
 	char is_xml = 0;
 
+	if (len == 0) {
+		*rbuf = '\0';
+		return 0;
+	}
+
 	buf = estrndup(rbuf, len);
 	end = buf + len;
 	lc = '\0';


### PR DESCRIPTION
We were commenting in the WordPress repository about a strange condition: when running an empty string check vs. an empty string with `strip_tags` the underperforming difference was significant, so I decided to take a look into the code to find that there was no early return for this condition. 

So I believe this could be a  nice little upgrade to the function.