### PR TITLE
Zend: mark zend_free_internal_arg_info() static

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -976,7 +976,6 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void);
 		} \
 	} while (0)
 
-void zend_free_internal_arg_info(zend_internal_function *function);
 ZEND_API void destroy_zend_function(zend_function *function);
 ZEND_API void zend_function_dtor(zval *zv);
 ZEND_API void destroy_zend_class(zval *zv);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -124,7 +124,7 @@ ZEND_API void zend_type_release(zend_type type, bool persistent) {
 	}
 }
 
-void zend_free_internal_arg_info(zend_internal_function *function) {
+static void zend_free_internal_arg_info(zend_internal_function *function) {
 	if ((function->fn_flags & (ZEND_ACC_HAS_RETURN_TYPE|ZEND_ACC_HAS_TYPE_HINTS)) &&
 		function->arg_info) {
 


### PR DESCRIPTION
Previously it was used by the disable_classes INI, as this no longer exists there is no need to expose it.