### PR TITLE
ext/standard: "double" is not deprecated for `settype()`

### DIFF
--- a/ext/standard/type.c
+++ b/ext/standard/type.c
@@ -105,7 +105,7 @@ PHP_FUNCTION(settype)
 		convert_to_long(ptr);
 	} else if (zend_string_equals_ci(type, ZSTR_KNOWN(ZEND_STR_FLOAT))) {
 		convert_to_double(ptr);
-	} else if (zend_string_equals_ci(type, ZSTR_KNOWN(ZEND_STR_DOUBLE))) { /* deprecated */
+	} else if (zend_string_equals_ci(type, ZSTR_KNOWN(ZEND_STR_DOUBLE))) {
 		convert_to_double(ptr);
 	} else if (zend_string_equals_ci(type, ZSTR_KNOWN(ZEND_STR_STRING))) {
 		convert_to_string(ptr);


### PR DESCRIPTION
Remove incorrect inline comment that using "double" as the type is deprecated; this comment was added in 929ae94c64c71fcbed8e4cecdb6d09398d61e079 when support for "float" was included, but the use of "double" was never actually deprecated.

[skip ci]