### PR TITLE
Fix GH-20695: Assertion failure in normalize_value() when parsing malformed INI input via parse_ini_string()

### DIFF
--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -145,10 +145,10 @@ ZEND_API zend_ini_scanner_globals ini_scanner_globals;
 	if (SCNG(scanner_mode) == ZEND_INI_SCANNER_TYPED &&            \
 		(YYSTATE == STATE(ST_VALUE) || YYSTATE == STATE(ST_RAW))) {\
 		zend_ini_copy_typed_value(ini_lval, type, str, len);       \
-		Z_EXTRA_P(ini_lval) = 0;                                   \
 	} else {                                                       \
 		zend_ini_copy_value(ini_lval, str, len);                   \
 	}                                                              \
+	Z_EXTRA_P(ini_lval) = 0;                                       \
 	return type;                                                   \
 }
 

--- a/ext/standard/tests/gh20695.phpt
+++ b/ext/standard/tests/gh20695.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-20695 (Assertion failure in normalize_value() when parsing malformed INI input via parse_ini_string())
+--FILE--
+<?php
+var_dump(parse_ini_string('8 [[] = !!$]', true, INI_SCANNER_TYPED));
+?>
+--EXPECT--
+array(1) {
+  [8]=>
+  array(1) {
+    ["["]=>
+    int(0)
+  }
+}


### PR DESCRIPTION
I think there's simply a reasoning error about when which scanner state can cause which parser component to invoke later on.