### PR TITLE
Fix NUL byte truncation in sqlite3 TEXT column handling

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -648,7 +648,7 @@ static void sqlite_value_to_zval(sqlite3_stmt *stmt, int column, zval *data) /* 
 			break;
 
 		case SQLITE3_TEXT:
-			ZVAL_STRING(data, (char*)sqlite3_column_text(stmt, column));
+			ZVAL_STRINGL(data, (const char *) sqlite3_column_text(stmt, column), sqlite3_column_bytes(stmt, column));
 			break;
 
 		case SQLITE_BLOB:

--- a/ext/sqlite3/tests/text_column_NUL_bytes.phpt
+++ b/ext/sqlite3/tests/text_column_NUL_bytes.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Text column with NUL bytes
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+
+$db->exec(
+    'CREATE TABLE messages (
+        content TEXT
+    )'
+);
+
+$insert = $db->prepare(
+    'INSERT INTO messages (content) VALUES (:content)'
+);
+
+$insert->bindValue(':content', "with\0null", SQLITE3_TEXT);
+$insert->execute();
+$insert->bindValue(':content', "\0", SQLITE3_TEXT);
+$insert->execute();
+
+$result = $db->query('SELECT * FROM messages');
+while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+    var_dump($row);
+}
+
+?>
+--EXPECTF--
+array(1) {
+  ["content"]=>
+  string(9) "with%0null"
+}
+array(1) {
+  ["content"]=>
+  string(1) "%0"
+}


### PR DESCRIPTION
As a bonus, this should probably also be a tad faster.