### PR TITLE
ext/spl: DirectoryIterator to support modern filesytems.

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -414,7 +414,7 @@ static zend_object *spl_filesystem_object_clone(zend_object *old_object)
 			spl_filesystem_dir_open(intern, source->path);
 			/* read until we hit the position in which we were before */
 			bool skip_dots = SPL_HAS_FLAG(source->flags, SPL_FILE_DIR_SKIPDOTS);
-			int index;
+			zend_long index;
 			for (index = 0; index < source->u.dir.index; ++index) {
 				do {
 					spl_filesystem_dir_read(intern);

--- a/ext/spl/spl_directory.h
+++ b/ext/spl/spl_directory.h
@@ -62,7 +62,7 @@ struct _spl_filesystem_object {
 		struct {
 			php_stream         *dirp;
 			zend_string        *sub_path;
-			int                index;
+			zend_long          index;
 			zend_function      *func_rewind;
 			zend_function      *func_next;
 			zend_function      *func_valid;


### PR DESCRIPTION
With filesystems with builtin large capacity such as ZFS, Btfrs, NTFS
 or even ext4 with large_dir feature enabled, an int to represent an
entry index is falling short, thus risking overflows.

A zend_long however should cover this need without  increasing out internal data structure.