### PR TITLE
MSVC: Add include guards to config.w32.h to prevent macro redefinition warnings

### DIFF
--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -2,6 +2,9 @@
 	Build Configuration Template for Win32.
 */
 
+#ifndef PHP_WIN32_CONFIG_W32_H
+#define PHP_WIN32_CONFIG_W32_H
+
 /* Define the minimum supported version */
 #undef _WIN32_WINNT
 #undef NTDDI_VERSION
@@ -141,3 +144,5 @@
 #endif
 
 #define HAVE_GETADDRINFO 1
+
+#endif /* PHP_WIN32_CONFIG_W32_H */


### PR DESCRIPTION
This PR adds standard include guards to win32/build/config.w32.h.in (which generates config.w32.h). This prevents multiple inclusions in the same translation unit, avoiding C4005 warnings for macros redefined by config.pickle.h, arisen due to subsequent inclusion of config.w32.h.