### PR TITLE
MSVC: Fix warning C4244 in zend_get_gc_buffer_use

### DIFF
--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -167,7 +167,7 @@ static zend_always_inline void zend_get_gc_buffer_add_ptr(
 static zend_always_inline void zend_get_gc_buffer_use(
 		zend_get_gc_buffer *gc_buffer, zval **table, int *n) {
 	*table = gc_buffer->start;
-	*n = gc_buffer->cur - gc_buffer->start;
+	*n = (int)(gc_buffer->cur - gc_buffer->start);
 }
 
 END_EXTERN_C()


### PR DESCRIPTION
This PR addresses a compilation warning of the form: warning C4244: '=': conversion from '__int64' to 'int', possible loss of data The expression gc_buffer->cur - gc_buffer->start produces a temporary of type ptrdiff_t, which is then assigned to an int. It causes said compilation warning when these types do not match.