### PR TITLE
[ci skip] PHP 8.5 | UPGRADING: document IMAGETYPE_HEIF constant

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -935,6 +935,7 @@ PHP 8.5 UPGRADE NOTES
   . T_PIPE.
 
 - Standard:
+  . IMAGETYPE_HEIF.
   . IMAGETYPE_SVG when libxml is loaded.
 
 ========================================


### PR DESCRIPTION
Refs:
* https://github.com/php/php-src/pull/18940
* https://github.com/php/php-src/commit/dfac2da7fba930570fcda99205cfcf53dbe2e909