### PR TITLE
Avoid segmented shared_alloc_shm.c allocation to support OPcache JIT on Solaris

### DIFF
--- a/ext/opcache/shared_alloc_shm.c
+++ b/ext/opcache/shared_alloc_shm.c
@@ -66,7 +66,7 @@ static int create_segments(size_t requested_size, zend_shared_segment_shm ***sha
 	first_segment_id = shmget(first_segment_key, seg_allocate_size, shmget_flags);
 	if (UNEXPECTED(first_segment_id == -1)) {
 		/* Search for biggest n^2 < requested_size. */
-		seg_allocate_size = 1024 * 1024;
+		seg_allocate_size = SEG_ALLOC_SIZE_MIN;
 		while (seg_allocate_size < requested_size / 2) {
 			seg_allocate_size *= 2;
 		}


### PR DESCRIPTION
The SysV shared memory allocator in OPcache hardcodes a maximum segment size of 32MB (SEG_ALLOC_SIZE_MAX). With JIT enabled, OPcache reserves 64MB (ZEND_JIT_DEFAULT_BUFFER_SIZE) from the last segment, causing startup to fail with "Insufficient shared memory!".

Try to allocate the entire buffer at once, and fall back to segmentation only if the allocation fails.

Fixes #20718.