### PR TITLE
Fix GH-20503: Assertion failure with ext/date DateInterval property hash construction

### DIFF
--- a/ext/date/tests/bug-gh20503.phpt
+++ b/ext/date/tests/bug-gh20503.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-20503 (Assertion failure with ext/date DateInterval property hash construction)
+--FILE--
+<?php
+$obj = new DateInterval('P1W');
+$obj->prop3 = $obj;
+
+// Array cast triggers get_properties_for with ARRAY_CAST purpose
+// This would previously cause an assertion failure when modifying
+// a HashTable with refcount > 1
+$props = (array) $obj;
+var_dump(count($props));
+var_dump(isset($props['prop3']));
+var_dump($props['y']);
+?>
+--EXPECTF--
+Deprecated: Creation of dynamic property DateInterval::$prop3 is deprecated in %s on line %d
+int(11)
+bool(true)
+int(0)


### PR DESCRIPTION
When a DateInterval object has a circular reference (e.g., `$obj->prop = $obj`), calling `json_encode()` triggers an assertion failure in debug builds. This happens because the `get_properties` handler modifies the properties HashTable in place, but circular references cause the HashTable to have a refcount > 1, which violates the assertion in `zend_hash_str_update()`.

The fix adds a `get_properties_for` handler for DateInterval that returns a duplicated HashTable. To ensure circular reference detection still works (which relies on HashTable identity), the duplicated HashTable is cached in module globals, keyed by object handle. When we detect a recursive call (cache entry exists with refcount > 1), we return the same cached HashTable so that `GC_IS_RECURSIVE` can properly detect the cycle.

This approach avoids any ABI break by using module globals instead of adding a field to `php_interval_obj`.

Fixes GH-20503