### PR TITLE
standard: Remove nonsensical dtor of return value in fread()

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1555,7 +1555,6 @@ PHPAPI PHP_FUNCTION(fread)
 
 	str = php_stream_read_to_str(stream, len);
 	if (!str) {
-		zval_ptr_dtor_str(return_value);
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
It was never set to a string at this point, so why dtor it?