### PR TITLE
ext/standard: make php_escape_shell_arg() function private

### DIFF
--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -377,7 +377,7 @@ PHPAPI zend_string *php_escape_shell_cmd(const zend_string *unescaped_cmd)
 /* }}} */
 
 /* {{{ php_escape_shell_arg */
-PHPAPI zend_string *php_escape_shell_arg(const zend_string *unescaped_arg)
+static zend_string *php_escape_shell_arg(const zend_string *unescaped_arg)
 {
 	size_t x, y = 0;
 	zend_string *cmd;

--- a/ext/standard/exec.h
+++ b/ext/standard/exec.h
@@ -21,7 +21,6 @@ PHP_MINIT_FUNCTION(proc_open);
 PHP_MINIT_FUNCTION(exec);
 
 PHPAPI zend_string *php_escape_shell_cmd(const zend_string *unescaped_cmd);
-PHPAPI zend_string *php_escape_shell_arg(const zend_string *unescaped_arg);
 PHPAPI int php_exec(int type, const char *cmd, zval *array, zval *return_value);
 
 #endif /* EXEC_H */


### PR DESCRIPTION
From a quick [SourceGraph search](https://sourcegraph.com/search?q=context:global+php_escape_shell_arg+-f:exec.c+-f:exec.h&patternType=keyword&sm=0) nobody uses this API outside the corresponding PHP function.

