### PR TITLE
Fix header for uriBaseRuntimeVersionA prototype

### DIFF
--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -30,7 +30,7 @@
 #include "uri_parser_rfc3986.h"
 #include "uri_parser_php_parse_url.h"
 #include "php_uri_arginfo.h"
-#include "uriparser/UriBase.h"
+#include "uriparser/Uri.h"
 
 zend_class_entry *php_uri_ce_rfc3986_uri;
 zend_class_entry *php_uri_ce_whatwg_url;


### PR DESCRIPTION
When building using `--with-external-uriparser`

```
/work/build/php85/ext/uri/php_uri.c: Dans la fonction « zm_info_uri »:
/work/build/php85/ext/uri/php_uri.c:1128:65: erreur: déclaration implicite de la fonction « uriBaseRuntimeVersionA » [-Wimplicit-function-declaration]
 1128 |         php_info_print_table_row(2, "uriparser loaded version", uriBaseRuntimeVersionA());
      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~

```

Notice: `Uri.h` includes `UriBase.h`