### PR TITLE
ext/posix: (Further) fix groups array creation on macos.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-20732 (Phar::LoadPhar undefined behavior when reading fails).
     (ndossche)
 
+- POSIX:
+  . Fixed crash on posix groups to php array creation on macos.
+    (David Carlier)
+
 - SPL:
   . Fixed bug GH-20678 (resource created by GlobIterator crashes with fclose()).
     (David Carlier)

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -678,7 +678,8 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
 	for (count = 0;; count++) {
 		/* gr_mem entries may be misaligned on macos. */
 		char *gr_mem;
-		memcpy(&gr_mem, &g->gr_mem[count], sizeof(char *));
+		char *entry = (char *)g->gr_mem + (count * sizeof (char *));
+		memcpy(&gr_mem, entry, sizeof(char *));
 		if (!gr_mem) {
 			break;
 		}


### PR DESCRIPTION
With macos Tahoe and clang "17.0.0" (Xcode) the ext/posix/tests/posix_getgrgid_macosx.phpt test crashes as follow:

ext/posix/posix.c:681:19: runtime error: load of misaligned address 0x60800000e972 for type 'char **', which requires 8 byte alignment 0x60800000e972: note: pointer points here
70 00  2a 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 seems memcpy had been translated to a load instruction ? anyhow, we force to copy a "proper" char * source.