### PR TITLE
Fixed bug GH-20745 ("Casting out of range floats to int" applies to strings)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-20714 (Uncatchable exception thrown in generator). (ilutov)
   . Fixed bug GH-20352 (UAF in php_output_handler_free via re-entrant
     ob_start() during error deactivation). (ndossche)
+  . Fixed bug GH-20745 ("Casting out of range floats to int" applies to
+    strings). (Bob)
 
 - DOM:
   . Fixed bug GH-20722 (Null pointer dereference in DOM namespace node cloning

--- a/UPGRADING
+++ b/UPGRADING
@@ -55,9 +55,8 @@ PHP 8.5 UPGRADE NOTES
   . Destructuring non-array values (other than NULL) using [] or list() now
     emits a warning.
     RFC: https://wiki.php.net/rfc/warnings-php-8-5#destructuring_non-array_values
-  . A warning is now emitted when casting floats (or strings that look like
-    floats) to int if they cannot be represented as one. This affects explicit
-    int casts and implicit int casts.
+  . A warning is now emitted when casting floats to int if they cannot be represented
+    as one. This affects explicit int casts and implicit int casts.
     RFC: https://wiki.php.net/rfc/warnings-php-8-5#casting_out_of_range_floats_to_int
   . A warning is now emitted when casting NAN to other types.
     RFC: https://wiki.php.net/rfc/warnings-php-8-5#coercing_nan_to_other_types

--- a/Zend/tests/type_coercion/float_to_int/explicit_casts_should_not_warn.phpt
+++ b/Zend/tests/type_coercion/float_to_int/explicit_casts_should_not_warn.phpt
@@ -40,10 +40,6 @@ Warning: The float NAN is not representable as an int, cast occurred in %s on li
 int(0)
 int(3)
 int(3)
-
-Warning: The float-string "1.0E+121" is not representable as an int, cast occurred in %s on line %d
 int(9223372036854775807)
-
-Warning: The float-string "1.0E+301" is not representable as an int, cast occurred in %s on line %d
 int(9223372036854775807)
 int(0)

--- a/Zend/tests/type_coercion/float_to_int/explicit_casts_should_not_warn_32bit.phpt
+++ b/Zend/tests/type_coercion/float_to_int/explicit_casts_should_not_warn_32bit.phpt
@@ -40,10 +40,6 @@ Warning: The float NAN is not representable as an int, cast occurred in %s on li
 int(0)
 int(3)
 int(3)
-
-Warning: The float-string "1.0E+121" is not representable as an int, cast occurred in %s on line %d
 int(2147483647)
-
-Warning: The float-string "1.0E+301" is not representable as an int, cast occurred in %s on line %d
 int(2147483647)
 int(0)

--- a/Zend/tests/type_coercion/float_to_int/non-rep-float-as-int-extra1.phpt
+++ b/Zend/tests/type_coercion/float_to_int/non-rep-float-as-int-extra1.phpt
@@ -14,6 +14,5 @@ var_dump($b | 1);
 
 ?>
 --EXPECTF--
-The float-string "1.0E+4%d" is not representable as an int, cast occurred
 Implicit conversion from float-string "1.0E+4%d" to int loses precision
 int(%d)

--- a/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_arrays.phpt
+++ b/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_arrays.phpt
@@ -25,8 +25,6 @@ var_dump($array[$string_float]);
 --EXPECTF--
 Warning: The float 1.0E+121 is not representable as an int, cast occurred in %s on line %d
 int(0)
-
-Warning: The float-string "1.0E+121" is not representable as an int, cast occurred in %s on line %d
 bool(true)
 
 Warning: The float 1.0E+121 is not representable as an int, cast occurred in %s on line %d

--- a/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_strings.phpt
+++ b/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_strings.phpt
@@ -77,8 +77,6 @@ var_dump($string);
 --EXPECTF--
 Warning: The float 1.0E+121 is not representable as an int, cast occurred in %s on line %d
 int(0)
-
-Warning: The float-string "1.0E+121" is not representable as an int, cast occurred in %s on line %d
 int(9223372036854775807)
 Attempt to read
 Float

--- a/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_strings_32bit.phpt
+++ b/Zend/tests/type_coercion/float_to_int/warning_float_does_not_fit_zend_long_strings_32bit.phpt
@@ -77,8 +77,6 @@ var_dump($string);
 --EXPECTF--
 Warning: The float 1.0E+121 is not representable as an int, cast occurred in %s on line %d
 int(0)
-
-Warning: The float-string "1.0E+121" is not representable as an int, cast occurred in %s on line %d
 int(2147483647)
 Attempt to read
 Float

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -149,10 +149,8 @@ static zend_always_inline zend_long zend_dval_to_lval_silent(double d)
 static zend_always_inline zend_long zend_dval_to_lval_cap(double d, const zend_string *s)
 {
 	if (UNEXPECTED(!zend_finite(d))) {
-		zend_oob_string_to_long_error(s);
 		return 0;
 	} else if (!ZEND_DOUBLE_FITS_LONG(d)) {
-		zend_oob_string_to_long_error(s);
 		return (d > 0 ? ZEND_LONG_MAX : ZEND_LONG_MIN);
 	}
 	return (zend_long)d;

--- a/ext/standard/tests/general_functions/gettype_settype_variation2.phpt
+++ b/ext/standard/tests/general_functions/gettype_settype_variation2.phpt
@@ -274,7 +274,6 @@ int(1)
 string(7) "integer"
 -- Iteration 20 --
 string(6) "string"
-2: The float-string "2974394749328742328432" is not representable as an int, cast occurred
 bool(true)
 int(2147483647)
 string(7) "integer"
@@ -305,7 +304,6 @@ int(1)
 string(7) "integer"
 -- Iteration 26 --
 string(6) "string"
-2: The float-string "2974394749328742328432" is not representable as an int, cast occurred
 bool(true)
 int(2147483647)
 string(7) "integer"
@@ -675,7 +673,6 @@ int(1)
 string(7) "integer"
 -- Iteration 20 --
 string(6) "string"
-2: The float-string "2974394749328742328432" is not representable as an int, cast occurred
 bool(true)
 int(2147483647)
 string(7) "integer"
@@ -706,7 +703,6 @@ int(1)
 string(7) "integer"
 -- Iteration 26 --
 string(6) "string"
-2: The float-string "2974394749328742328432" is not representable as an int, cast occurred
 bool(true)
 int(2147483647)
 string(7) "integer"

--- a/ext/standard/tests/general_functions/intval.phpt
+++ b/ext/standard/tests/general_functions/intval.phpt
@@ -221,19 +221,11 @@ int(-2147483648)
 int(2147483647)
 
 *** Testing intval() on non integer types ***
-
-Warning: The float-string "-2147483649" is not representable as an int, cast occurred in %s on line %d
 int(-2147483648)
-
-Warning: The float-string "2147483648" is not representable as an int, cast occurred in %s on line %d
 int(2147483647)
 int(0)
 int(0)
-
-Warning: The float-string "020000000001" is not representable as an int, cast occurred in %s on line %d
 int(2147483647)
-
-Warning: The float-string "-020000000001" is not representable as an int, cast occurred in %s on line %d
 int(-2147483648)
 int(0)
 int(0)

--- a/ext/tidy/tests/gh20374.phpt
+++ b/ext/tidy/tests/gh20374.phpt
@@ -75,8 +75,6 @@ foreach ($values as $key => $value) {
 </body>
 </html>
 --- double overflow ---
-
-Warning: The float-string "1.2089258196146E+24" is not representable as an int, cast occurred in %s on line %d
 <html>
 <head>
 <title></title>


### PR DESCRIPTION
This reverts the warning for float-strings, to whose it never should have been applied in the first place.

@Girgias We did not vote on that. The PR was done after the RFC, and never up for consideration at vote time.
In fact, during discussion time, it was even the topic: https://news-web.php.net/php.internals/128293 - but it was clarified (by someone else) that it's only about floats, not float-strings.

Feel free to propose it again for PHP 8.6 - I personally think it only should apply to implicit casts, in line with https://wiki.php.net/rfc/implicit-float-int-deprecate.

But for PHP 8.5 we should revert this ad-hoc addition to the first PHP 8.5 RC.
From my point of view this is a regression, where nobody agreed on break compatibility here.

With respect to the PR, I retain the zend_oob_string_to_long_error function, as removing it would probably break ABI, but removing all callers should be sufficient.