### PR TITLE
curl: Don't truncate length

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -594,7 +594,7 @@ static size_t curl_write(char *data, size_t size, size_t nmemb, void *ctx)
 			return fwrite(data, size, nmemb, t->fp);
 		case PHP_CURL_RETURN:
 			if (length > 0) {
-				smart_str_appendl(&t->buf, data, (int) length);
+				smart_str_appendl(&t->buf, data, length);
 			}
 			break;
 		case PHP_CURL_USER: {
@@ -876,7 +876,7 @@ static size_t curl_read(char *data, size_t size, size_t nmemb, void *ctx)
 			} else if (!Z_ISUNDEF(retval)) {
 				_php_curl_verify_handlers(ch, /* reporterror */ true);
 				if (Z_TYPE(retval) == IS_STRING) {
-					length = MIN((int) (size * nmemb), Z_STRLEN(retval));
+					length = MIN(size * nmemb, Z_STRLEN(retval));
 					memcpy(data, Z_STRVAL(retval), length);
 				} else if (Z_TYPE(retval) == IS_LONG) {
 					length = Z_LVAL_P(&retval);
@@ -906,7 +906,7 @@ static size_t curl_write_header(char *data, size_t size, size_t nmemb, void *ctx
 			/* Handle special case write when we're returning the entire transfer
 			 */
 			if (ch->handlers.write->method == PHP_CURL_RETURN && length > 0) {
-				smart_str_appendl(&ch->handlers.write->buf, data, (int) length);
+				smart_str_appendl(&ch->handlers.write->buf, data, length);
 			} else {
 				PHPWRITE(data, length);
 			}


### PR DESCRIPTION
Truncating to an int seems dangerous, esp. in combination with a MIN macro. I don't see a reason to truncate the length from size_t to int, and especially no reason to change the signedness.