### PR TITLE
Use `EVP_MD_CTX_destroy()` instead of `EVP_MD_CTX_free()`

### DIFF
--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1905,7 +1905,7 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 
 			if (!EVP_SignInit(md_ctx, mdtype)) {
 				EVP_PKEY_free(key);
-				EVP_MD_CTX_free(md_ctx);
+				EVP_MD_CTX_destroy(md_ctx);
 				efree(sigbuf);
 				if (error) {
 					spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", phar->fname);
@@ -1916,7 +1916,7 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
 				if (!EVP_SignUpdate(md_ctx, buf, sig_len)) {
 					EVP_PKEY_free(key);
-					EVP_MD_CTX_free(md_ctx);
+					EVP_MD_CTX_destroy(md_ctx);
 					efree(sigbuf);
 					if (error) {
 						spprintf(error, 0, "unable to update the openssl signature for phar \"%s\"", phar->fname);
@@ -1927,7 +1927,7 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 
 			if (!EVP_SignFinal (md_ctx, sigbuf, &siglen, key)) {
 				EVP_PKEY_free(key);
-				EVP_MD_CTX_free(md_ctx);
+				EVP_MD_CTX_destroy(md_ctx);
 				efree(sigbuf);
 				if (error) {
 					spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
@@ -1937,7 +1937,7 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 
 			sigbuf[siglen] = '\0';
 			EVP_PKEY_free(key);
-			EVP_MD_CTX_free(md_ctx);
+			EVP_MD_CTX_destroy(md_ctx);
 #else
 			size_t siglen;
 			sigbuf = NULL;


### PR DESCRIPTION
OpenSSL v1.1.0 renamed `EVP_MD_CTX_(create|init|destroy)` to `EVP_MD_CTX_(new|reset|free)` but [full support](https://github.com/openssl/openssl/commit/f8137a62d94c0a5809a4363b7b4aab3adcb8201c) for the old names is present via `#define`s.

Moreover, in the same file and in the openssl extension the older names are still in use.

As this is the **only thing** breaking build of PHP 8.3 branch on legacy systems (since 8.3.26), and as there is no harm in just using the older name, just use them and let people build 😄 
