### PR TITLE
Fix bug #74154: Phar extractTo creates empty files

### DIFF
--- a/ext/phar/tests/bug74154.phpt
+++ b/ext/phar/tests/bug74154.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #74154 (Phar extractTo creates empty files)
+--EXTENSIONS--
+phar
+--FILE--
+<?php
+
+$dir = __DIR__.'/bug74154';
+mkdir($dir);
+file_put_contents("$dir/1.txt", str_repeat('h', 64));
+file_put_contents("$dir/2.txt", str_repeat('i', 64));
+$phar = new PharData(__DIR__.'/bug74154.tar');
+$phar->buildFromDirectory($dir);
+
+$compPhar = $phar->compress(Phar::GZ);
+unset($phar); //make sure that test.tar is closed
+unlink(__DIR__.'/bug74154.tar');
+unset($compPhar); //make sure that test.tar.gz is closed
+$extractingPhar = new PharData(__DIR__.'/bug74154.tar.gz');
+$extractingPhar->extractTo($dir.'_out');
+
+var_dump(file_get_contents($dir.'_out/1.txt'));
+var_dump(file_get_contents($dir.'_out/2.txt'));
+
+?>
+--CLEAN--
+<?php
+$dir = __DIR__.'/bug74154';
+@unlink("$dir/1.txt");
+@unlink("$dir/2.txt");
+@rmdir($dir);
+@unlink($dir.'_out/1.txt');
+@unlink($dir.'_out/2.txt');
+@rmdir($dir.'_out');
+@unlink(__DIR__.'/bug74154.tar');
+@unlink(__DIR__.'/bug74154.tar.gz');
+?>
+--EXPECT--
+string(64) "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh"
+string(64) "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"

--- a/ext/phar/tests/tar/bug70417.phpt
+++ b/ext/phar/tests/tar/bug70417.phpt
@@ -10,10 +10,11 @@ $filename = __DIR__ . '/bug70417.tar';
 $resBefore = count(get_resources());
 $arch = new PharData($filename);
 $arch->addFromString('foo', 'bar');
+$arch->addFromString('foo2', 'baz');
 $arch->compress(Phar::GZ);
 unset($arch);
 $resAfter = count(get_resources());
-var_dump($resBefore === $resAfter);
+var_dump($resAfter - $resBefore);
 ?>
 --CLEAN--
 <?php
@@ -22,4 +23,4 @@ $filename = __DIR__ . '/bug70417.tar';
 @unlink("$filename.gz");
 ?>
 --EXPECT--
-bool(true)
+int(0)


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=74154

The current code causes the phar entry to remain in the fname cache. This would be fine for uncompressed phars, but is a problem for compressed phars when they try to reopen the file pointer. The reopen code will try to use the compressed file pointer as if it were an uncompressed file pointer. In that case, for the given test, the file offsets are out of bounds for the compressed file pointer because they are the uncompressed offsets. This results in empty files. In other cases, it's possible to read compressed parts of the file that don't belong to that particular file.
To solve this, we simply remove the phar entry from the fname cache if the file pointer was closed but the phar is compressed. This will make sure that reopening the phar will not go through the cache and instead opens up a fresh file pointer with the right decompression settings.

Targeting 8.4 because 8.3 is almost out of bugfix support and I don't want to risk regressions.