### PR TITLE
ext/session/mod_mm.c: add a few missing ZSTR macros

### DIFF
--- a/ext/session/mod_mm.c
+++ b/ext/session/mod_mm.c
@@ -264,7 +264,7 @@ static void ps_mm_destroy(ps_mm *data)
 
 PHP_MINIT_FUNCTION(ps_mm)
 {
-	size_t save_path_len = strlen(PS(save_path));
+	size_t save_path_len = ZSTR_LEN(PS(save_path));
 	size_t mod_name_len = strlen(sapi_module.name);
 	size_t euid_len;
 	char *ps_mm_path, euid[30];
@@ -284,8 +284,8 @@ PHP_MINIT_FUNCTION(ps_mm)
 	/* Directory + '/' + File + Module Name + Effective UID + \0 */
 	ps_mm_path = emalloc(save_path_len + 1 + (sizeof(PS_MM_FILE) - 1) + mod_name_len + euid_len + 1);
 
-	memcpy(ps_mm_path, PS(save_path), save_path_len);
-	if (save_path_len && PS(save_path)[save_path_len - 1] != DEFAULT_SLASH) {
+	memcpy(ps_mm_path, ZSTR_VAL(PS(save_path)), save_path_len);
+	if (save_path_len && ZSTR_VAL(PS(save_path))[save_path_len - 1] != DEFAULT_SLASH) {
 		ps_mm_path[save_path_len] = DEFAULT_SLASH;
 		save_path_len++;
 	}


### PR DESCRIPTION
In https://github.com/php/php-src/commits/eaee504c4d4f337df11b56c251aaeec032b1ea51 the session's `save_path` global was changed to a `zend_string` pointer, but there are a few direct char-pointer accesses in `ext/session/mod_mm.c` that slipped through the cracks. GCC-15 notices them and fails to build due to the incompatible pointer types. Three `ZSTR_*` wrappers are all that is needed.

Gentoo-Bug: https://bugs.gentoo.org/967862