### PR TITLE
Fix GH-20771: Assertion failure when getUnicodeHost() returns empty string

### DIFF
--- a/ext/uri/tests/whatwg/getters/gh20771.phpt
+++ b/ext/uri/tests/whatwg/getters/gh20771.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-20771 (Assertion failure when getUnicodeHost() returns empty string)
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse('test://');
+
+var_dump($url->getUnicodeHost());
+
+?>
+--EXPECT--
+string(0) ""

--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -365,7 +365,7 @@ static zend_result php_uri_parser_whatwg_host_read(void *uri, php_uri_component_
 				lxb_url_serialize_host_unicode(&lexbor_idna, &lexbor_uri->host, serialize_to_smart_str_callback, &host_str);
 				lxb_unicode_idna_clean(&lexbor_idna);
 
-				ZVAL_NEW_STR(retval, smart_str_extract(&host_str));
+				ZVAL_STR(retval, smart_str_extract(&host_str));
 				break;
 			}
 			case PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII:


### PR DESCRIPTION
If nothing was added to a smart_str, the interned empty string is returned, and therefore ZVAL_NEW_STR is wrong as it'll set the REFCOUNTED flag.