### PR TITLE
gen_stub: Fix php-parser package download

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -5970,9 +5970,10 @@ function installPhpParser(string $version, string $phpParserDir) {
         chdir(__DIR__);
 
         $tarName = "v$version.tar.gz";
-        passthru("wget https://github.com/nikic/PHP-Parser/archive/$tarName", $exit);
+        $downloadUrl = "https://github.com/nikic/PHP-Parser/archive/$tarName";
+        passthru("wget -O $tarName $downloadUrl", $exit);
         if ($exit !== 0) {
-            passthru("curl -LO https://github.com/nikic/PHP-Parser/archive/$tarName", $exit);
+            passthru("curl -LO $downloadUrl", $exit);
         }
         if ($exit !== 0) {
             throw new Exception("Failed to download PHP-Parser tarball");
@@ -5982,6 +5983,7 @@ function installPhpParser(string $version, string $phpParserDir) {
         }
         passthru("tar xvzf $tarName -C PHP-Parser-$version --strip-components 1", $exit);
         if ($exit !== 0) {
+            rmdir($phpParserDir);
             throw new Exception("Failed to extract PHP-Parser tarball");
         }
         unlink(__DIR__ . "/$tarName");


### PR DESCRIPTION
If the system wgetrc has the `content-disposition = on` option, the file is actually saved as `PHP-Parser-5.0.0.tar.gz`, causing a subsequent failure.

Even with `content-disposition = off`, if for any reason the download file already exists and is corrupted, it won't be overwritten, and a new file such as `v5.0.0.tar.gz.1` is saved instead.

We solve both problems by enforcing the name of the downloaded file.

Also, if for any other reason the unpacking should fail, remove the created directory to allow further attempts.