### PR TITLE
json: Add test for json_validate() with invalid flags

### DIFF
--- a/ext/json/tests/json_validate_invalid_flag.phpt
+++ b/ext/json/tests/json_validate_invalid_flag.phpt
@@ -1,0 +1,17 @@
+--TEST--
+json_validate() throws with invalid flags
+--EXTENSIONS--
+json
+--FILE--
+<?php
+
+try {
+	json_validate("{}", 512, 9999999);
+	echo "no exception\n";	
+} catch (ValueError $e) {
+	echo "caught\n";
+}
+
+?>
+--EXPECT--
+caught


### PR DESCRIPTION
A test case in json_validate function when flag is invalid should throw a ValueError exception