### PR TITLE
win32/sendmail.c: Various refactorings (part 2)

### DIFF
--- a/win32/php_win32_globals.h
+++ b/win32/php_win32_globals.h
@@ -42,7 +42,6 @@ struct _php_win32_core_globals {
 
 	char   mail_buffer[MAIL_BUFFER_SIZE];
 	SOCKET mail_socket;
-	char   mail_local_host[HOST_NAME_LEN];
 };
 
 void php_win32_core_globals_ctor(void *vg);


### PR DESCRIPTION
Follow-up from #20781 

Commits should be reviewed in order.

The main objective here is to get rid of some of the globals as it makes it, IMHO, unintuitive how the code flows.