### PR TITLE
Fix GH-19961: Static analysis arrayIndexThenCheck warning in firebird

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -632,7 +632,7 @@ static zend_long firebird_handle_doer(pdo_dbh_t *dbh, const zend_string *sql) /*
 			ret = -1;
 			goto free_statement;
 		}
-		while (result[i] != isc_info_end && i < result_size) {
+		while (i < result_size && result[i] != isc_info_end) {
 			short len = (short)isc_vax_integer(&result[i+1],2);
 			/* bail out on bad len */
 			if (len != 1 && len != 2 && len != 4) {


### PR DESCRIPTION
Static analysis reports that the bounds check comes after reading the byte from the buffer.
In practice, this is tagged data that loops until the end tag is found and therefore there isn't really a bug. The extra length check is only there for extra hardening.
So we simply silence the static analysers and improve the hardening.

See also https://docwiki.embarcadero.com/InterBase/15/en/Isc_dsql_sql_info()