### PR TITLE
Add tests for strlen() with invalid argument types

### DIFF
--- a/Zend/tests/strlen_enum.phpt
+++ b/Zend/tests/strlen_enum.phpt
@@ -1,0 +1,26 @@
+--TEST--
+strlen() with an enum argument
+--SKIPIF--
+<?php
+//Skip if PHP version < 8.1
+if (PHP_VERSION_ID < 80100) {
+    die("skip enums not supported\n");
+}
+?>
+--FILE--
+<?php
+//Test that passing an enum case to strlen() throws a TypeError
+
+enum E {
+    case A;
+}
+
+try {
+    strlen(E::A);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+strlen(): Argument #1 ($string) must be of type string, %s given

--- a/Zend/tests/strlen_object_without_tostring.phpt
+++ b/Zend/tests/strlen_object_without_tostring.phpt
@@ -1,0 +1,14 @@
+--TEST--
+strlen() with an object without __toString()
+--FILE--
+<?php
+
+try {
+    strlen(new stdClass());
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+strlen(): Argument #1 ($string) must be of type string, %s given

--- a/Zend/tests/strlen_resource.phpt
+++ b/Zend/tests/strlen_resource.phpt
@@ -1,0 +1,16 @@
+--TEST--
+strlen() with a resource argument
+--FILE--
+<?php
+//Test that passing a resource to strlen() throws a TypeError
+
+$fp = fopen(__FILE__, 'r');
+try {
+    strlen($fp);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+fclose($fp);
+?>
+--EXPECTF--
+strlen(): Argument #1 ($string) must be of type string, %s given


### PR DESCRIPTION
This PR adds missing Zend tests for strlen() when called with invalid
argument types that are rejected by the engine before the function
implementation is reached.

Covered cases:
- resource argument
- object without __toString()
- enum case (PHP 8.1+)

All tests assert the user-visible error message and are placed under
Zend/tests/, consistent with existing strlen invalid-type coverage
(e.g. strlen_deprecation_to_exception.phpt).