### PR TITLE
Fix skipif for mkfifo usage in gh20582.phpt

### DIFF
--- a/ext/standard/tests/image/gh20582.phpt
+++ b/ext/standard/tests/image/gh20582.phpt
@@ -5,7 +5,9 @@ Nikita Sveshnikov (Positive Technologies)
 ndossche
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY === "Windows") die("skip Only for platforms with FIFO pipes");
+if (!function_exists("posix_mkfifo")) {
+    die("skip no posix_mkfifo()");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Makes it like ext/standard/tests/file/filetype_variation.phpt; it's not just Windows that can have a missing posix_mkfifo, but also a minimal build, like the ones suggested that RMs test with (using --disable-all).