### PR TITLE
uri: Fix RFC3986 to_string implementation with ExcludeFragment returning non-terminated strings

### DIFF
--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -595,6 +595,7 @@ ZEND_ATTRIBUTE_NONNULL static zend_string *php_uri_parser_rfc3986_to_string(void
 		const char *pos = zend_memrchr(ZSTR_VAL(uri_string), '#', ZSTR_LEN(uri_string));
 		if (pos != NULL) {
 			uri_string = zend_string_truncate(uri_string, (pos - ZSTR_VAL(uri_string)), false);
+			ZSTR_VAL(uri_string)[ZSTR_LEN(uri_string)] = '\0';
 		}
 	}
 


### PR DESCRIPTION
zend_string_truncate() doesn't put a NUL byte.
Right now this doesn't matter as this code path is only hittable via the equals() method, but if other extension (or future other code) starts using this code path, then it can be problematic as all user-exposed zend_strings need to end with a NUL byte.