### PR TITLE
streams/memory: Ensure internal string is NUL terminated

### DIFF
--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -247,8 +247,8 @@ static int php_stream_memory_set_option(php_stream *stream, int option, int valu
 						size_t old_size = ZSTR_LEN(ms->data);
 						ms->data = zend_string_realloc(ms->data, newsize, 0);
 						memset(ZSTR_VAL(ms->data) + old_size, 0, newsize - old_size);
-						ZSTR_VAL(ms->data)[ZSTR_LEN(ms->data)] = '\0';
 					}
+					ZSTR_VAL(ms->data)[ZSTR_LEN(ms->data)] = '\0';
 					return PHP_STREAM_OPTION_RETURN_OK;
 			}
 	}


### PR DESCRIPTION
zend_string_truncate() doesn't put a NUL byte.