### PR TITLE
Remove obsolete comment in test file

### DIFF
--- a/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
+++ b/ext/pdo/tests/pdo_fetch_class_change_ctor_args_during_fetch2.phpt
@@ -27,7 +27,6 @@ class Test {
     }
 }
 
-// TODO Rename pdo_fetch_class_change_ctor_two table to pdo_fetch_class_change_ctor_two in PHP-8.4
 $db->exec('CREATE TABLE pdo_fetch_class_change_ctor_two(id int NOT NULL PRIMARY KEY, val1 VARCHAR(10), val2 VARCHAR(10))');
 $db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(1, 'A', 'alpha')");
 $db->exec("INSERT INTO pdo_fetch_class_change_ctor_two VALUES(2, 'B', 'beta')");


### PR DESCRIPTION
The table has been renamed, but the comment was still there. Thus the TODO can be safely removed.