### PR TITLE
remove duplicate no/yes print for preserve_none

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -568,7 +568,6 @@ int main(void) {
     [php_cv_preserve_none=no],
     [php_cv_preserve_none=no])
   ])
-  AC_MSG_RESULT([$php_cv_preserve_none])
   AS_VAR_IF([php_cv_preserve_none], [yes], [
     AC_DEFINE([HAVE_PRESERVE_NONE], [1],
       [Define to 1 if you have preserve_none support.])


### PR DESCRIPTION
fixes https://github.com/php/php-src/pull/20810#issuecomment-3707272411

apparently there was previously a bug that made the variable not print correctly, now with that fixed and the message I added, it prints twice