### PR TITLE
ext/sodium: use correct constants and error messages

### DIFF
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -2374,7 +2374,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult)
 		RETURN_THROWS();
 	}
 	if (p_len != crypto_scalarmult_BYTES) {
-		zend_argument_error(sodium_exception_ce, 2, "must be SODIUM_CRYPTO_SCALARMULT_SCALARBYTES bytes long");
+		zend_argument_error(sodium_exception_ce, 2, "must be SODIUM_CRYPTO_SCALARMULT_BYTES bytes long");
 		RETURN_THROWS();
 	}
 	q = zend_string_alloc(crypto_scalarmult_BYTES, 0);
@@ -2445,7 +2445,7 @@ PHP_FUNCTION(sodium_crypto_scalarmult_ristretto255_base)
 		zend_argument_error(sodium_exception_ce, 1, "must not be zero", 0);
 		RETURN_THROWS();
 	}
-	ZSTR_VAL(q)[crypto_scalarmult_BYTES] = 0;
+	ZSTR_VAL(q)[crypto_scalarmult_ristretto255_BYTES] = 0;
 
 	RETURN_NEW_STR(q);
 }
@@ -2959,7 +2959,7 @@ PHP_FUNCTION(sodium_crypto_kdf_derive_from_key)
 		RETURN_THROWS();
 	}
 	if (key_len != crypto_kdf_KEYBYTES) {
-		zend_argument_error(sodium_exception_ce, 4, "must be SODIUM_CRYPTO_KDF_BYTES_MIN bytes long");
+		zend_argument_error(sodium_exception_ce, 4, "must be SODIUM_CRYPTO_KDF_KEYBYTES bytes long");
 		RETURN_THROWS();
 	}
 	memcpy(ctx_padded, ctx, crypto_kdf_CONTEXTBYTES);


### PR DESCRIPTION
Fix copy-and-paste mistakes in the sodium extension.

`crypto_scalarmult_BYTES` and `crypto_scalarmult_ristretto255_BYTES` have the same value, so behavior is unchanged.