### PR TITLE
Deprecation compliance: null as array offset

### DIFF
--- a/ext/opcache/tests/jit/fetch_dim_r_001.phpt
+++ b/ext/opcache/tests/jit/fetch_dim_r_001.phpt
@@ -18,7 +18,7 @@ function foo() {
     var_dump($a["2"]);
     var_dump($a[false]);
     var_dump($a[true]);
-    var_dump($a[null]);
+    var_dump($a['']);
     var_dump($a["ab"]);
     $x = "a";
     $y = "b";


### PR DESCRIPTION
- Change `$a[null]` to `$a['']` to conform with PHP 8.5 [deprecation](https://www.php.net/manual/en/migration85.deprecated.php).
- Test still passes today; this update future-proofs and aligns with the deprecation.
- No change in expected output; intent made explicit.