### PR TITLE
Fix GH-20856: heap-use-after-free in SplDoublyLinkedList iterator when modifying during iteration

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -764,11 +764,10 @@ PHP_METHOD(SplDoublyLinkedList, offsetUnset)
 	element = spl_ptr_llist_offset(intern->llist, index, intern->flags & SPL_DLLIST_IT_LIFO);
 
 	if (element != NULL) {
-		/* connect the neightbors */
+		/* disconnect the neighbours */
 		if (element->prev) {
 			element->prev->next = element->next;
 		}
-
 		if (element->next) {
 			element->next->prev = element->prev;
 		}
@@ -781,6 +780,10 @@ PHP_METHOD(SplDoublyLinkedList, offsetUnset)
 		if (element == llist->tail) {
 			llist->tail = element->prev;
 		}
+
+		/* Keep consistency if element is kept alive. */
+		element->prev = NULL;
+		element->next = NULL;
 
 		/* finally, delete the element */
 		llist->count--;

--- a/ext/spl/tests/gh20856.phpt
+++ b/ext/spl/tests/gh20856.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-20856 (heap-use-after-free in SplDoublyLinkedList iterator when modifying during iteration)
+--CREDITS--
+vi3tL0u1s
+iluuu1994
+--FILE--
+<?php
+$m = new SplStack;
+$m[] = new stdClass;
+$m[] = new stdClass;
+
+foreach ($m as $l) {
+    unset($m[0]);
+    unset($m[0]);
+}
+
+var_dump($m);
+?>
+--EXPECTF--
+object(SplStack)#%d (%d) {
+  ["flags":"SplDoublyLinkedList":private]=>
+  int(6)
+  ["dllist":"SplDoublyLinkedList":private]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
The element may be still in use in other places, so the linking pointers should be kept consistent. If not consistent, the "move forward" code in the sample test will read a stale, dangling pointer.