### PR TITLE
fastcgi: Fix compile warning wrt safe_read()

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -944,7 +944,7 @@ static inline ssize_t safe_write(fcgi_request *req, const void *buf, size_t coun
 	return n;
 }
 
-static inline ssize_t safe_read(fcgi_request *req, const void *buf, size_t count)
+static inline ssize_t safe_read(fcgi_request *req, void *buf, size_t count)
 {
 	int    ret;
 	size_t n = 0;


### PR DESCRIPTION
This shouldn't be const. Fixes the following warning:
```
warning: variable 'hdr' is uninitialized when passed as a const pointer argument here
      [-Wuninitialized-const-pointer]
 1054 |         if (safe_read(req, &hdr, sizeof(fcgi_header)) != sizeof(fcgi_header) ||
      |                             ^~~
```