### PR TITLE
Fix GH-20882: phar buildFromIterator breaks with missing base directory

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -1397,12 +1397,12 @@ static int phar_build(zend_object_iterator *iter, void *puser) /* {{{ */
 	zval *value;
 	bool close_fp = 1;
 	struct _phar_t *p_obj = (struct _phar_t*) puser;
-	size_t str_key_len, base_len = ZSTR_LEN(p_obj->base);
+	size_t str_key_len, base_len = p_obj->base ? ZSTR_LEN(p_obj->base) : 0;
 	phar_entry_data *data;
 	php_stream *fp;
 	size_t fname_len;
 	size_t contents_len;
-	char *fname, *error = NULL, *base = ZSTR_VAL(p_obj->base), *save = NULL, *temp = NULL;
+	char *fname, *error = NULL, *base = p_obj->base ? ZSTR_VAL(p_obj->base) : NULL, *save = NULL, *temp = NULL;
 	zend_string *opened;
 	char *str_key;
 	zend_class_entry *ce = p_obj->c;

--- a/ext/phar/tests/gh20882.phpt
+++ b/ext/phar/tests/gh20882.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-20882 (phar buildFromIterator breaks with missing base directory)
+--EXTENSIONS--
+phar
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+$phar = new \Phar(__DIR__ . "/test.phar");
+try {
+    $phar->buildFromIterator(
+        new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(__DIR__.'/test79082', FilesystemIterator::SKIP_DOTS)
+        ),
+        null
+    );
+} catch (BadMethodCallException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Iterator RecursiveIteratorIterator returns an SplFileInfo object, so base directory must be specified


### PR DESCRIPTION
Broke in f57526a07a because of changing a char*+size_t pair to zend_string* (which can't handle NULL pointers in its macros).