### PR TITLE
gen_stub: Update the arginfo file timestamp when generation is skipped

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -78,7 +78,8 @@ function processStubFile(string $stubFile, Context $context, bool $includeOnly =
             $stubHash = computeStubHash($stubCode);
             $oldStubHash = extractStubHash($arginfoFile);
             if ($stubHash === $oldStubHash && !$context->forceParse) {
-                /* Stub file did not change, do not regenerate. */
+                /* Stub file did not change, do not regenerate, but update the timestamp */
+                touch($arginfoFile);
                 return null;
             }
         }


### PR DESCRIPTION
In case the script is started by the Makefile, the timestamp of the product
needs to be updated even if no changes are needed, otherwise it will be
started over and over without any effect.
