### PR TITLE
zend_API: Add Z_PARAM_ENUM_NAME()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -54,6 +54,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     ZEND_ACC_USER_ARG_INFO flag was set.
   . Added zend_ast_call_get_args() to fetch the argument node from any call
     node.
+  . Added Z_PARAM_ENUM_NAME().
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -2009,6 +2009,13 @@ ZEND_API ZEND_COLD void zend_class_redeclaration_error_ex(int type, zend_string 
 #define Z_PARAM_OBJ_OF_CLASS_OR_LONG_OR_NULL(dest_obj, _ce, dest_long, is_null) \
 	Z_PARAM_OBJ_OF_CLASS_OR_LONG_EX(dest_obj, _ce, dest_long, is_null, 1)
 
+#define Z_PARAM_ENUM_NAME(dest, _ce) \
+	{ \
+		zend_object *_tmp = NULL; \
+		Z_PARAM_OBJ_OF_CLASS(_tmp, _ce); \
+		dest = Z_STR_P(zend_enum_fetch_case_name(_tmp)); \
+	}
+
 /* old "p" */
 #define Z_PARAM_PATH_EX(dest, dest_len, check_null, deref) \
 		Z_PARAM_PROLOGUE(deref, 0); \

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1680,14 +1680,14 @@ PHP_METHOD(DOMElement, insertAdjacentElement)
 
 PHP_METHOD(Dom_Element, insertAdjacentElement)
 {
-	zval *element_zval, *where_zv;
+	zval *element_zval;
+	const zend_string *where;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_OBJECT_OF_CLASS(where_zv, dom_adjacent_position_class_entry)
+		Z_PARAM_ENUM_NAME(where, dom_adjacent_position_class_entry)
 		Z_PARAM_OBJECT_OF_CLASS(element_zval, dom_modern_element_class_entry)
 	ZEND_PARSE_PARAMETERS_END();
 
-	const zend_string *where = Z_STR_P(zend_enum_fetch_case_name(Z_OBJ_P(where_zv)));
 	dom_element_insert_adjacent_element(INTERNAL_FUNCTION_PARAM_PASSTHRU, where, element_zval);
 }
 /* }}} end DOMElement::insertAdjacentElement */
@@ -1728,15 +1728,14 @@ PHP_METHOD(DOMElement, insertAdjacentText)
 
 PHP_METHOD(Dom_Element, insertAdjacentText)
 {
-	zval *where_zv;
+	const zend_string *where;
 	zend_string *data;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_OBJECT_OF_CLASS(where_zv, dom_adjacent_position_class_entry)
+		Z_PARAM_ENUM_NAME(where, dom_adjacent_position_class_entry)
 		Z_PARAM_STR(data)
 	ZEND_PARSE_PARAMETERS_END();
 
-	const zend_string *where = Z_STR_P(zend_enum_fetch_case_name(Z_OBJ_P(where_zv)));
 	dom_element_insert_adjacent_text(INTERNAL_FUNCTION_PARAM_PASSTHRU, where, data);
 }
 /* }}} end DOMElement::insertAdjacentText */
@@ -1744,7 +1743,7 @@ PHP_METHOD(Dom_Element, insertAdjacentText)
 /* https://html.spec.whatwg.org/#dom-element-insertadjacenthtml */
 PHP_METHOD(Dom_Element, insertAdjacentHTML)
 {
-	zval *where_zv;
+	const zend_string *where;
 	zend_string *string;
 
 	dom_object *this_intern;
@@ -1754,13 +1753,11 @@ PHP_METHOD(Dom_Element, insertAdjacentHTML)
 	bool created_context = false;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
-		Z_PARAM_OBJECT_OF_CLASS(where_zv, dom_adjacent_position_class_entry)
+		Z_PARAM_ENUM_NAME(where, dom_adjacent_position_class_entry)
 		Z_PARAM_STR(string)
 	ZEND_PARSE_PARAMETERS_END();
 
 	DOM_GET_THIS_OBJ(thisp, id, xmlNodePtr, this_intern);
-
-	const zend_string *where = Z_STR_P(zend_enum_fetch_case_name(Z_OBJ_P(where_zv)));
 
 	/* 1. We don't do injection sinks. */
 

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1823,10 +1823,9 @@ PHP_FUNCTION(pcntl_getcpu)
 #endif
 
 #if defined(HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP)
-static qos_class_t qos_zval_to_lval(const zval *qos_obj)
+static qos_class_t qos_zval_to_lval(const zend_string *entry)
 {
 	qos_class_t qos_class = QOS_CLASS_DEFAULT;
-	zend_string *entry = Z_STR_P(zend_enum_fetch_case_name(Z_OBJ_P(qos_obj)));
 
 	if (zend_string_equals_literal(entry, "UserInteractive")) {
 		qos_class = QOS_CLASS_USER_INTERACTIVE;
@@ -1886,13 +1885,13 @@ PHP_FUNCTION(pcntl_getqos_class)
 
 PHP_FUNCTION(pcntl_setqos_class)
 {
-	zval *qos_obj;
+	const zend_string *qos;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJECT_OF_CLASS(qos_obj, QosClass_ce)
+		Z_PARAM_ENUM_NAME(qos, QosClass_ce)
 	ZEND_PARSE_PARAMETERS_END();
 
-	qos_class_t qos_class = qos_zval_to_lval(qos_obj);
+	qos_class_t qos_class = qos_zval_to_lval(qos);
 
 	if (UNEXPECTED(pthread_set_qos_class_self_np((qos_class_t)qos_class, 0) != 0))
 	{

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -131,14 +131,14 @@ PHP_METHOD(Random_Randomizer, getFloat)
 {
 	php_random_randomizer *randomizer = Z_RANDOM_RANDOMIZER_P(ZEND_THIS);
 	double min, max;
-	zend_object *bounds = NULL;
+	const zend_string *bounds = NULL;
 	int bounds_type = 'C' + sizeof("ClosedOpen") - 1;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_DOUBLE(min)
 		Z_PARAM_DOUBLE(max)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS(bounds, random_ce_Random_IntervalBoundary);
+		Z_PARAM_ENUM_NAME(bounds, random_ce_Random_IntervalBoundary);
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!zend_finite(min)) {
@@ -152,10 +152,7 @@ PHP_METHOD(Random_Randomizer, getFloat)
 	}
 
 	if (bounds) {
-		zval *case_name = zend_enum_fetch_case_name(bounds);
-		zend_string *bounds_name = Z_STR_P(case_name);
-
-		bounds_type = ZSTR_VAL(bounds_name)[0] + ZSTR_LEN(bounds_name);
+		bounds_type = ZSTR_VAL(bounds)[0] + ZSTR_LEN(bounds);
 	}
 
 	switch (bounds_type) {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6547,16 +6547,16 @@ ZEND_METHOD(ReflectionProperty, hasHook)
 
 	reflection_object *intern;
 	property_reference *ref;
-	zend_object *type;
+	const zend_string *type;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJ_OF_CLASS(type, reflection_property_hook_type_ptr)
+		Z_PARAM_ENUM_NAME(type, reflection_property_hook_type_ptr)
 	ZEND_PARSE_PARAMETERS_END();
 
 	GET_REFLECTION_OBJECT_PTR(ref);
 
 	zend_property_hook_kind kind;
-	if (zend_string_equals_literal(Z_STR_P(zend_enum_fetch_case_name(type)), "Get")) {
+	if (zend_string_equals_literal(type, "Get")) {
 		kind = ZEND_PROPERTY_HOOK_GET;
 	} else {
 		kind = ZEND_PROPERTY_HOOK_SET;
@@ -6569,10 +6569,10 @@ ZEND_METHOD(ReflectionProperty, getHook)
 {
 	reflection_object *intern;
 	property_reference *ref;
-	zend_object *type;
+	const zend_string *type;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJ_OF_CLASS(type, reflection_property_hook_type_ptr)
+		Z_PARAM_ENUM_NAME(type, reflection_property_hook_type_ptr)
 	ZEND_PARSE_PARAMETERS_END();
 
 	GET_REFLECTION_OBJECT_PTR(ref);
@@ -6583,7 +6583,7 @@ ZEND_METHOD(ReflectionProperty, getHook)
 	}
 
 	zend_function *hook;
-	if (zend_string_equals_literal(Z_STR_P(zend_enum_fetch_case_name(type)), "Get")) {
+	if (zend_string_equals_literal(type, "Get")) {
 		hook = ref->prop->hooks[ZEND_PROPERTY_HOOK_GET];
 	} else {
 		hook = ref->prop->hooks[ZEND_PROPERTY_HOOK_SET];

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -678,7 +678,7 @@ static void throw_cannot_recompose_uri_to_string(php_uri_object *object)
 	zend_throw_exception_ex(php_uri_ce_error, 0, "Cannot recompose %s to a string", ZSTR_VAL(object->std.ce->name));
 }
 
-static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object, zend_object *comparison_mode)
+static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object, const zend_string *comparison_mode)
 {
 	php_uri_object *this_object = Z_URI_OBJECT_P(ZEND_THIS);
 	ZEND_ASSERT(this_object->uri != NULL);
@@ -693,8 +693,7 @@ static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object
 
 	bool exclude_fragment = true;
 	if (comparison_mode) {
-		zval *case_name = zend_enum_fetch_case_name(comparison_mode);
-		exclude_fragment = zend_string_equals_literal(Z_STR_P(case_name), "ExcludeFragment");
+		exclude_fragment = zend_string_equals_literal(comparison_mode, "ExcludeFragment");
 	}
 
 	zend_string *this_str = this_object->parser->to_string(
@@ -721,12 +720,12 @@ static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object
 PHP_METHOD(Uri_Rfc3986_Uri, equals)
 {
 	zend_object *that_object;
-	zend_object *comparison_mode = NULL;
+	const zend_string *comparison_mode = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_rfc3986_uri)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
+		Z_PARAM_ENUM_NAME(comparison_mode, php_uri_ce_comparison_mode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);
@@ -917,12 +916,12 @@ PHP_METHOD(Uri_WhatWg_Url, getFragment)
 PHP_METHOD(Uri_WhatWg_Url, equals)
 {
 	zend_object *that_object;
-	zend_object *comparison_mode = NULL;
+	const zend_string *comparison_mode = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_whatwg_url)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
+		Z_PARAM_ENUM_NAME(comparison_mode, php_uri_ce_comparison_mode)
 	ZEND_PARSE_PARAMETERS_END();
 
 	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);


### PR DESCRIPTION
It is becoming increasingly common to have enum parameters on internal functions. Manually turning the singleton enum object into the case name is verbose, especially for optional parameters.

Add a new `Z_PARAM_ENUM_NAME()` helper to directly retrieve the case name.