### PR TITLE
ext/reflection: Add ReflectionConstant::inNamespace() method

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -81,6 +81,7 @@ PHP                                                                        NEWS
 - Reflection:
   . Fixed bug GH-20217 (ReflectionClass::isIterable() incorrectly returns true
     for classes with property hooks). (alexandre-daubois)
+  . Added ReflectionConstant::inNamespace(). (Khaled Alam)
 
 - Soap:
   . Soap::__setCookie() when cookie name is a digit is now not stored and represented

--- a/UPGRADING
+++ b/UPGRADING
@@ -95,6 +95,9 @@ PHP 8.6 UPGRADE NOTES
 6. New Functions
 ========================================
 
+- Reflection:
+  . ReflectionConstant::inNamespace()
+
 - Standard:
   . `clamp()` returns the given value if in range, else return the nearest bound.
     RFC: https://wiki.php.net/rfc/clamp_v2

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -7714,6 +7714,20 @@ ZEND_METHOD(ReflectionConstant, getName)
 	RETURN_STR_COPY(const_->name);
 }
 
+ZEND_METHOD(ReflectionConstant, inNamespace)
+{
+	reflection_object *intern;
+	zend_constant *const_;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	GET_REFLECTION_OBJECT_PTR(const_);
+
+	const char *backslash = zend_memrchr(ZSTR_VAL(const_->name), '\\', ZSTR_LEN(const_->name));
+	RETURN_BOOL(backslash);
+}
+/* }}} */
+
 ZEND_METHOD(ReflectionConstant, getNamespaceName)
 {
 	reflection_object *intern;

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -915,6 +915,8 @@ class ReflectionConstant implements Reflector
 
     public function getName(): string {}
 
+    public function inNamespace(): bool {}
+
     public function getNamespaceName(): string {}
 
     public function getShortName(): string {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit php_reflection.stub.php instead.
- * Stub hash: dba3ec692c7c90d59d67f6e5323dc31997fc92e0
+ * Stub hash: b09497083efa7035dab6047f6d845ceaec81579e
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
@@ -703,6 +703,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionConstant_getName arginfo_class_ReflectionFunction___toString
 
+#define arginfo_class_ReflectionConstant_inNamespace arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
+
 #define arginfo_class_ReflectionConstant_getNamespaceName arginfo_class_ReflectionFunction___toString
 
 #define arginfo_class_ReflectionConstant_getShortName arginfo_class_ReflectionFunction___toString
@@ -985,6 +987,7 @@ ZEND_METHOD(ReflectionFiber, getCallable);
 ZEND_METHOD(ReflectionFiber, getTrace);
 ZEND_METHOD(ReflectionConstant, __construct);
 ZEND_METHOD(ReflectionConstant, getName);
+ZEND_METHOD(ReflectionConstant, inNamespace);
 ZEND_METHOD(ReflectionConstant, getNamespaceName);
 ZEND_METHOD(ReflectionConstant, getShortName);
 ZEND_METHOD(ReflectionConstant, getValue);
@@ -1355,6 +1358,7 @@ static const zend_function_entry class_ReflectionFiber_methods[] = {
 static const zend_function_entry class_ReflectionConstant_methods[] = {
 	ZEND_ME(ReflectionConstant, __construct, arginfo_class_ReflectionConstant___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionConstant, getName, arginfo_class_ReflectionConstant_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionConstant, inNamespace, arginfo_class_ReflectionConstant_inNamespace, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionConstant, getNamespaceName, arginfo_class_ReflectionConstant_getNamespaceName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionConstant, getShortName, arginfo_class_ReflectionConstant_getShortName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionConstant, getValue, arginfo_class_ReflectionConstant_getValue, ZEND_ACC_PUBLIC)

--- a/ext/reflection/php_reflection_decl.h
+++ b/ext/reflection/php_reflection_decl.h
@@ -1,12 +1,12 @@
 /* This is a generated file, edit php_reflection.stub.php instead.
- * Stub hash: dba3ec692c7c90d59d67f6e5323dc31997fc92e0 */
+ * Stub hash: b09497083efa7035dab6047f6d845ceaec81579e */
 
-#ifndef ZEND_PHP_REFLECTION_DECL_dba3ec692c7c90d59d67f6e5323dc31997fc92e0_H
-#define ZEND_PHP_REFLECTION_DECL_dba3ec692c7c90d59d67f6e5323dc31997fc92e0_H
+#ifndef ZEND_PHP_REFLECTION_DECL_b09497083efa7035dab6047f6d845ceaec81579e_H
+#define ZEND_PHP_REFLECTION_DECL_b09497083efa7035dab6047f6d845ceaec81579e_H
 
 typedef enum zend_enum_PropertyHookType {
 	ZEND_ENUM_PropertyHookType_Get = 1,
 	ZEND_ENUM_PropertyHookType_Set = 2,
 } zend_enum_PropertyHookType;
 
-#endif /* ZEND_PHP_REFLECTION_DECL_dba3ec692c7c90d59d67f6e5323dc31997fc92e0_H */
+#endif /* ZEND_PHP_REFLECTION_DECL_b09497083efa7035dab6047f6d845ceaec81579e_H */

--- a/ext/reflection/tests/ReflectionConstant_inNamespace.phpt
+++ b/ext/reflection/tests/ReflectionConstant_inNamespace.phpt
@@ -1,0 +1,39 @@
+--TEST--
+ReflectionConstant::inNamespace()
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    const NAMESPACED_CONST = 'in namespace';
+}
+
+namespace {
+    const GLOBAL_CONST = 'global';
+
+    $rc1 = new ReflectionConstant('GLOBAL_CONST');
+    var_dump($rc1->inNamespace());
+    var_dump($rc1->getNamespaceName());
+    var_dump($rc1->getShortName());
+
+    $rc2 = new ReflectionConstant('Foo\Bar\NAMESPACED_CONST');
+    var_dump($rc2->inNamespace());
+    var_dump($rc2->getNamespaceName());
+    var_dump($rc2->getShortName());
+
+    $rc3 = new ReflectionConstant('E_ERROR');
+    var_dump($rc3->inNamespace());
+    var_dump($rc3->getNamespaceName());
+    var_dump($rc3->getShortName());
+}
+
+?>
+--EXPECT--
+bool(false)
+string(0) ""
+string(12) "GLOBAL_CONST"
+bool(true)
+string(7) "Foo\Bar"
+string(16) "NAMESPACED_CONST"
+bool(false)
+string(0) ""
+string(7) "E_ERROR"

--- a/ext/reflection/tests/ReflectionConstant_ns.phpt
+++ b/ext/reflection/tests/ReflectionConstant_ns.phpt
@@ -14,6 +14,10 @@ namespace {
     var_dump(new \ReflectionConstant('\\C'));
     var_dump(new \ReflectionConstant('Foo\\C'));
     var_dump(new \ReflectionConstant('\\Foo\\C'));
+    var_dump((new \ReflectionConstant('C'))->inNamespace());
+    var_dump((new \ReflectionConstant('\\C'))->inNamespace());
+    var_dump((new \ReflectionConstant('Foo\\C'))->inNamespace());
+    var_dump((new \ReflectionConstant('\\Foo\\C'))->inNamespace());
     var_dump((new \ReflectionConstant('C'))->getNamespaceName());
     var_dump((new \ReflectionConstant('\\C'))->getNamespaceName());
     var_dump((new \ReflectionConstant('Foo\\C'))->getNamespaceName());
@@ -42,6 +46,10 @@ object(ReflectionConstant)#1 (1) {
   ["name"]=>
   string(6) "\Foo\C"
 }
+bool(false)
+bool(false)
+bool(true)
+bool(true)
 string(0) ""
 string(0) ""
 string(3) "Foo"


### PR DESCRIPTION
## Description

Fix #19557

This PR adds the missing `inNamespace()` method to `ReflectionConstant` to achieve full parity with `ReflectionClass` and `ReflectionFunctionAbstract` for API consistency.

## Background

`ReflectionConstant` already has:
- [x] `getShortName()` - returns the short name without namespace
- [x] `getNamespaceName()` - returns the namespace name

But was missing:
- [ ] `inNamespace()` - returns boolean indicating if in a namespace

