### PR TITLE
Use ubuntu-latest for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
       - docs/**
 jobs:
   pages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
No need to keep bumping this build if breakage is unlikely.