### PR TITLE
Add RUN_RESOURCE_HEAVY_TESTS env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,7 @@ jobs:
           name: Test
           no_output_timeout: 30m
           command: |
+            export RUN_RESOURCE_HEAVY_TESTS=1
             sapi/cli/php run-tests.php \
               -d zend_extension=opcache.so \
               -d opcache.enable_cli=1 \

--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -105,6 +105,7 @@ runs:
           export SKIP_IO_CAPTURE_TESTS=1
           export CI_NO_IPV6=1
           export STACK_LIMIT_DEFAULTS_CHECK=1
+          export RUN_RESOURCE_HEAVY_TESTS=1
           sapi/cli/php run-tests.php \
             -P -q -j2 \
             -g FAIL,BORK,LEAK,XLEAK \

--- a/.github/actions/test-gentoo/action.yml
+++ b/.github/actions/test-gentoo/action.yml
@@ -25,6 +25,7 @@ runs:
         # Slow tests criteron is doubled because this runner isn't as fast as others
         export SKIP_IO_CAPTURE_TESTS=1
         export STACK_LIMIT_DEFAULTS_CHECK=1
+        export RUN_RESOURCE_HEAVY_TESTS=1
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -j$(nproc) \
           -g FAIL,BORK,LEAK,XLEAK \

--- a/.github/actions/test-libmysqlclient/action.yml
+++ b/.github/actions/test-libmysqlclient/action.yml
@@ -14,6 +14,7 @@ runs:
         export PDO_MYSQL_TEST_HOST=127.0.0.1
         export PDO_MYSQL_TEST_USER=root
         export PDO_MYSQL_TEST_PASS=root
+        export RUN_RESOURCE_HEAVY_TESTS=1
         sapi/cli/php run-tests.php -P -q \
           -g FAIL,BORK,LEAK,XLEAK \
           --no-progress --offline --show-diff --show-slow 1000 --set-timeout 120 \

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -36,6 +36,7 @@ runs:
           export PDO_PGSQL_TEST_DSN="pgsql:host=localhost port=5432 dbname=test user=postgres password=postgres"
         fi
         export SKIP_IO_CAPTURE_TESTS=1
+        export RUN_RESOURCE_HEAVY_TESTS=1
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -d opcache.jit=${{ inputs.jitType }} \
           -d opcache.jit_buffer_size=16M \

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -14,6 +14,7 @@ runs:
         set -x
         export SKIP_IO_CAPTURE_TESTS=1
         export CI_NO_IPV6=1
+        export RUN_RESOURCE_HEAVY_TESTS=1
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -d opcache.jit=${{ inputs.jitType }} \
           -d opcache.jit_buffer_size=16M \

--- a/Zend/tests/bug55509.phpt
+++ b/Zend/tests/bug55509.phpt
@@ -2,6 +2,7 @@
 Bug #55509 (segfault on x86_64 using more than 2G memory)
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE == 4) {
   die('skip Not for 32-bits OS');
 }

--- a/Zend/tests/bug74093.phpt
+++ b/Zend/tests/bug74093.phpt
@@ -2,6 +2,7 @@
 Bug #74093 (Maximum execution time of n+2 seconds exceed not written in error_log)
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (PHP_ZTS) die("skip only for no-zts build");
 if (substr(PHP_OS, 0, 3) == 'WIN') die("skip not for Windows");

--- a/Zend/tests/bug78010.phpt
+++ b/Zend/tests/bug78010.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Bug #78010: Segmentation fault during GC
+--SKIPIF--
+<?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
+if (getenv("SKIP_SLOW_TESTS")) die('skip slow test');
+?>
 --INI--
 memory_limit=2G
 --FILE--

--- a/ext/gd/tests/bug77270.phpt
+++ b/ext/gd/tests/bug77270.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Bug #77270 (imagecolormatch Out Of Bounds Write on Heap)
---INI--
-memory_limit=-1
 --EXTENSIONS--
 gd
 --SKIPIF--

--- a/ext/gd/tests/bug77272.phpt
+++ b/ext/gd/tests/bug77272.phpt
@@ -6,6 +6,7 @@ memory_limit=-1
 gd
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.5', '<=')) die('skip upstream fix not yet released');
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (substr(PHP_OS, 0, 3) == 'WIN' && PHP_INT_SIZE === 4) die("skip not for Windows x86");

--- a/ext/gd/tests/bug77479.phpt
+++ b/ext/gd/tests/bug77479.phpt
@@ -4,6 +4,7 @@ Bug #77479 (imagewbmp() segfaults with very large image)
 gd
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --INI--

--- a/ext/gd/tests/gh16322.phpt
+++ b/ext/gd/tests/gh16322.phpt
@@ -2,8 +2,6 @@
 GH-16322 (imageaffine overflow/underflow on affine matrix)
 --EXTENSIONS--
 gd
---INI--
-memory_limit=-1
 --FILE--
 <?php
 $matrix = [INF, 1, 1, 1, 1, 1];

--- a/ext/ldap/tests/GHSA-g665-fm4p-vhff-1.phpt
+++ b/ext/ldap/tests/GHSA-g665-fm4p-vhff-1.phpt
@@ -6,6 +6,7 @@ ldap
 memory_limit=-1
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE !== 4) die("skip only for 32-bit");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>

--- a/ext/ldap/tests/GHSA-g665-fm4p-vhff-2.phpt
+++ b/ext/ldap/tests/GHSA-g665-fm4p-vhff-2.phpt
@@ -6,6 +6,7 @@ ldap
 memory_limit=-1
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE !== 4) die("skip only for 32-bit");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>

--- a/ext/pdo_dblib/tests/GHSA-5hqh-c84r-qjcv.phpt
+++ b/ext/pdo_dblib/tests/GHSA-5hqh-c84r-qjcv.phpt
@@ -4,6 +4,7 @@ GHSA-5hqh-c84r-qjcv (Integer overflow in the dblib quoter causing OOB writes)
 pdo_dblib
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 4) die("skip for 32bit platforms only");
 if (PHP_OS_FAMILY === "Windows") die("skip not for Windows because the virtual address space for application is only 2GiB");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");

--- a/ext/pdo_sqlite/tests/bug81740.phpt
+++ b/ext/pdo_sqlite/tests/bug81740.phpt
@@ -5,6 +5,7 @@ pdo
 pdo_sqlite
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>

--- a/ext/soap/tests/soap_qname_crash.phpt
+++ b/ext/soap/tests/soap_qname_crash.phpt
@@ -4,6 +4,7 @@ Test SoapClient with excessively large QName prefix in SoapVar
 soap
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 8) die("skip: 64-bit only");
 ?>
 --INI--

--- a/ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
+++ b/ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
@@ -2,6 +2,7 @@
 Test file_put_contents() and file_get_contents() functions with 5GB string
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE < 5) {
     // 4=4gb, 5=549gb, 8=9exabytes
     die("skip PHP_INT_SIZE<5 will not fit test string in RAM");

--- a/ext/standard/tests/strings/gh15613.phpt
+++ b/ext/standard/tests/strings/gh15613.phpt
@@ -2,6 +2,7 @@
 GH-15613 overflow on hex strings repeater value
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 8) die("skip this test is for 64 bit platform only");
 ?>
 --INI--

--- a/ext/tidy/tests/parsing_file_too_large.phpt
+++ b/ext/tidy/tests/parsing_file_too_large.phpt
@@ -4,6 +4,7 @@ Trying to parse a file that is too large (over 4GB)
 tidy
 --SKIPIF--
 <?php
+if (!getenv('RUN_RESOURCE_HEAVY_TESTS')) die('skip resource-heavy test');
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (getenv("SKIP_ASAN")) die("skip too big for asan");

--- a/sapi/fpm/tests/bug77023-pm-dynamic-blocking-sigquit.phpt
+++ b/sapi/fpm/tests/bug77023-pm-dynamic-blocking-sigquit.phpt
@@ -6,7 +6,7 @@ pcntl
 <?php
 include "skipif.inc";
 if (!function_exists('pcntl_sigprocmask')) die('skip Requires pcntl_sigprocmask()');
-if (!getenv("FPM_RUN_RESOURCE_HEAVY_TESTS")) die("skip resource heavy test");
+if (!getenv("RUN_RESOURCE_HEAVY_TESTS")) die("skip resource heavy test");
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
 ?>
 --FILE--

--- a/sapi/fpm/tests/proc-idle-timeout.phpt
+++ b/sapi/fpm/tests/proc-idle-timeout.phpt
@@ -3,7 +3,7 @@ FPM: Process manager config pm.process_idle_timeout
 --SKIPIF--
 <?php
 include "skipif.inc";
-if (!getenv("FPM_RUN_RESOURCE_HEAVY_TESTS")) die("skip resource heavy test");
+if (!getenv("RUN_RESOURCE_HEAVY_TESTS")) die("skip resource heavy test");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --FILE--


### PR DESCRIPTION
Disable resource-heavy tests by default (>1GB of memory usage), unless the RUN_RESOURCE_HEAVY_TESTS env variable is set.

Fixes GH-20762

8.3 adds:

- ext/bz2/tests/gh20620.phpt
- ext/standard/tests/strings/gh18976.phpt

Higher branches I'll have to look at still.