### PR TITLE
ext/dba/tests/dba_db4_018.phpt: fix typo

### DIFF
--- a/ext/dba/tests/dba_db4_018.phpt
+++ b/ext/dba/tests/dba_db4_018.phpt
@@ -28,7 +28,7 @@ $db_file2 = dba_popen($db_filename, 'n', 'flatfile');
 if ($db_file1 === $db_file2) {
     echo "objects are the same\n";
 } else {
-    echo "object are different\n";
+    echo "objects are different\n";
 }
 
 


### PR DESCRIPTION
We expect "objects" but print "object".

Gentoo-bug: https://bugs.gentoo.org/968656