### PR TITLE
Fix GH-20936: DatePeriod::__set_state() cannot handle null start

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5811,7 +5811,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 			php_date_obj *date_obj;
 			date_obj = Z_PHPDATE_P(ht_entry);
 
-			if (!date_obj->time) {
+			if (!date_obj->time || !period_obj->start_ce) {
 				return 0;
 			}
 
@@ -5832,7 +5832,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 			php_date_obj *date_obj;
 			date_obj = Z_PHPDATE_P(ht_entry);
 
-			if (!date_obj->time) {
+			if (!date_obj->time || !period_obj->start_ce) {
 				return 0;
 			}
 

--- a/ext/date/tests/gh20936.phpt
+++ b/ext/date/tests/gh20936.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-20936 (DatePeriod::__set_state() cannot handle null start)
+--FILE--
+<?php
+$end = new DateTime('2022-07-16', new DateTimeZone('UTC'));
+$interval = new DateInterval('P2D');
+try {
+    DatePeriod::__set_state(['start' => null, 'end' => $end, 'current' => null, 'interval' => $interval, 'recurrences' => 2, 'include_start_date' => false, 'include_end_date' => true]);
+} catch (Throwable $e) {
+    echo $e::class, ": ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Error: Invalid serialization data for DatePeriod object


### PR DESCRIPTION
The "current" and "end" field also rely on start_ce, which is set by "start". Therefore, if "current" or "end" are provided, so must "start" be provided.