### PR TITLE
Fix SKIPIF of openssl_password.phpt

### DIFF
--- a/ext/openssl/tests/openssl_password.phpt
+++ b/ext/openssl/tests/openssl_password.phpt
@@ -5,7 +5,10 @@ openssl
 --SKIPIF--
 <?php
 if (!function_exists('openssl_password_hash')) {
-    echo "skip - No openssl_password_hash";
+    die("skip No openssl_password_hash");
+}
+if (!defined('PASSWORD_ARGON2_PROVIDER')) {
+    die("skip No openssl argon2 support");
 }
 ?>
 --FILE--


### PR DESCRIPTION
It's possible there is no argon2 provider at all.