### PR TITLE
Fix WSA protocol info cleanup in request shutdown

### DIFF
--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -546,6 +546,10 @@ static PHP_RSHUTDOWN_FUNCTION(sockets)
 		SOCKETS_G(strerror_buf) = NULL;
 	}
 
+#ifdef PHP_WIN32
+	zend_hash_clean(&SOCKETS_G(wsa_info));
+#endif
+
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
```c
PHP_FUNCTION(socket_wsaprotocol_info_export)
{
 .....
        // allocate Request memory here
	seg_name = zend_strpprintf(0, "php_wsa_for_%u", SOCKETS_G(wsa_child_count)++);
	map = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(WSAPROTOCOL_INFO), ZSTR_VAL(seg_name));
	if (NULL != map) {

        // put to persistent memory array
        zend_hash_add_ptr(&(SOCKETS_G(wsa_info)), seg_name, map);

```

Memory allocated for the request is destroyed before the `SOCKETS_G(wsa_info)` array is destructed

If the `socket_wsaprotocol_info_release` method is not called, the application terminates with the message "zend_mm_heap corrupted"

The code proposed in this patch is not ideal, and it may be worth removing the creation of the array in persistent memory. I do not fully understand the reason why it was done this way. Nevertheless, this code works correctly.

P.S. Apparently, this bug is present in all PHP versions.