### PR TITLE
Fix by-ref assignment on uninitialized hooked backing value

### DIFF
--- a/Zend/tests/oss-fuzz-471486164-001.phpt
+++ b/Zend/tests/oss-fuzz-471486164-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+OSS-Fuzz #471486164: get_property_ptr_ptr() on uninitialized hooked property
+--FILE--
+<?php
+
+class C {
+    public $a {
+        get => $this->a;
+        set { $this->a = &$value; }
+    }
+    public $x = 1;
+}
+
+$proxy = (new ReflectionClass(C::class))->newLazyProxy(function ($proxy) {
+    $proxy->a = 1;
+    return new C;
+});
+var_dump($proxy->x);
+
+?>
+--EXPECT--
+int(1)

--- a/Zend/tests/oss-fuzz-471486164-002.phpt
+++ b/Zend/tests/oss-fuzz-471486164-002.phpt
@@ -1,0 +1,26 @@
+--TEST--
+OSS-Fuzz #471486164: get_property_ptr_ptr() on uninitialized hooked property
+--FILE--
+<?php
+
+class C {
+    public int $a {
+        get => $this->a;
+        set {
+            global $ref;
+            $this->a = &$ref;
+        }
+    }
+}
+
+$ref = 1;
+$proxy = new C;
+$proxy->a = 1;
+var_dump($proxy->a);
+$ref++;
+var_dump($proxy->a);
+
+?>
+--EXPECT--
+int(1)
+int(2)


### PR DESCRIPTION
Within hooks, the backing value can directly be accessed as if no hooks were present. This was previously handled only in read_property().

zend_fetch_property_address(), which is used for by-ref assignment, will first call get_property_ptr_ptr() and then try read_property(). However, when called on uninitialized backing values, read_property() will return &EG(uninitialized_zval) with an uninitialized property warning. This is problematic for zend_fetch_property_address() because it write to the result of read_property() unless there's an exception.

For untyped properties, this can result in writes to &EG(uninitialized_zval) (see oss-fuzz-471486164-001.phpt). For types properties, it will result in an unexpected "Typed property C::$prop must not be accessed before initialization" exception.

Fixes OSS-Fuzz #471486164