### PR TITLE
Avoid huge output in gh20840.phpt

### DIFF
--- a/ext/standard/tests/general_functions/gh20840.phpt
+++ b/ext/standard/tests/general_functions/gh20840.phpt
@@ -28,11 +28,20 @@ for ($i = 0; $i < 50000; $i++) {
     $node = $newNode;
 }
 
+$buffer = '';
+ob_start(function ($chunk) use (&$buffer) {
+    $buffer .= $chunk;
+    $buffer = preg_replace('(\s*object\(Node\)#\d+ \(\d+\) \{\s*)', '', $buffer);
+    $buffer = preg_replace('(\s*\["next"\]=>\s*)', '', $buffer);
+    $buffer = preg_replace('(\s*\}\s*)', '', $buffer);
+});
 var_dump($firstNode);
+ob_end_flush();
+echo $buffer;
 
 while ($next = $firstNode->next) {
     $firstNode->next = $next->next;
 }
 ?>
---EXPECTREGEX--
-^object\(Node\)#\d+ \(\d+\).*(nesting level too deep|["\s}]*)$
+--EXPECT--
+nesting level too deep


### PR DESCRIPTION
This can trigger the memory limit in run-tests.php, which buffers the tests output. Instead, only output "nesting level too deep" and discard the rest.

See https://github.com/php/php-src/actions/runs/21016506933/job/60422676108.