### PR TITLE
Fix segfault in Tracing JIT with object reference

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -17199,6 +17199,7 @@ static int zend_jit_trace_handler(zend_jit_ctx *jit, const zend_op_array *op_arr
 						SET_STACK_TYPE(stack, EX_VAR_TO_NUM(opline->op2.var), IS_UNKNOWN, 1);
 					}
 					break;
+				case ZEND_FE_RESET_RW:
 				case ZEND_BIND_INIT_STATIC_OR_JMP:
 					if (opline->op1_type == IS_CV) {
 						old_info = STACK_INFO(stack, EX_VAR_TO_NUM(opline->op1.var));
@@ -17223,6 +17224,7 @@ static int zend_jit_trace_handler(zend_jit_ctx *jit, const zend_op_array *op_arr
 						SET_STACK_INFO(stack, EX_VAR_TO_NUM(opline->op2.var), old_info);
 					}
 					break;
+				case ZEND_FE_RESET_RW:
 				case ZEND_BIND_INIT_STATIC_OR_JMP:
 					if (opline->op1_type == IS_CV) {
 						SET_STACK_INFO(stack, EX_VAR_TO_NUM(opline->op1.var), old_info);

--- a/ext/opcache/tests/jit/gh20818.phpt
+++ b/ext/opcache/tests/jit/gh20818.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-20818 (Segfault in Tracing JIT with Object Reference)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=1M
+--FILE--
+<?php
+
+function process($data) {
+    foreach ($data as &$v) {}
+}
+
+$data = [
+    (object) ["" => 1],
+    (object) ["" => 1],
+    (object) [],
+];
+
+for ($i = 0; $i < 200; $i += 1) {
+    foreach ($data as $entry) {
+        process($entry);
+    }
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
Fixes #20818

## Problem

When `FE_RESET_RW` (foreach by-reference) executes, it converts the CV to a `zend_reference` **before** checking if the array/object is empty. However, when the JIT creates exit points for `FE_RESET_RW` in `zend_jit_trace_handler()`, it was not updating the stack type for op1 to reflect this change.

This caused side traces compiled from these exit points to have incorrect type information. The side trace CV cleanup code would see `IS_OBJECT` and generate a direct call to `zend_objects_store_del()`, but the actual value was a `zend_reference*`, causing a segfault.

## Solution

Add `ZEND_FE_RESET_RW` to the list of opcodes that temporarily set their op1 stack type to `IS_UNKNOWN` before creating exit points. This follows the same pattern already used for `ZEND_BIND_INIT_STATIC_OR_JMP` and `ZEND_FE_FETCH_R/RW`.

When `IS_UNKNOWN`, the JIT falls back to SSA type info which correctly includes `MAY_BE_REF` for `FE_RESET_RW` op1_def (see `zend_inference.c:3483-3484`).

## Changes

- `ext/opcache/jit/zend_jit_ir.c`: Add `ZEND_FE_RESET_RW` case to both switch blocks in `zend_jit_trace_handler()` that handle stack type updates around exit point creation
- `ext/opcache/tests/jit/gh20818.phpt`: Test case from the issue

## Testing

- Test passes with `opcache.protect_memory=1`
- All 468 JIT tests pass with no regressions
