### PR TITLE
Fix memory leaks when sk_X509_new_null() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2552,6 +2552,9 @@ static STACK_OF(X509) *php_array_to_X509_sk(zval * zcerts, uint32_t arg_num, con
 	bool free_cert;
 
 	sk = sk_X509_new_null();
+	if (sk == NULL) {
+		goto clean_exit;
+	}
 
 	/* get certs */
 	if (Z_TYPE_P(zcerts) == IS_ARRAY) {
@@ -5797,6 +5800,9 @@ PHP_FUNCTION(openssl_pkcs7_encrypt)
 	}
 
 	recipcerts = sk_X509_new_null();
+	if (recipcerts == NULL) {
+		goto clean_exit;
+	}
 
 	/* get certs */
 	if (Z_TYPE_P(zrecipcerts) == IS_ARRAY) {
@@ -6404,6 +6410,9 @@ PHP_FUNCTION(openssl_cms_encrypt)
 	}
 
 	recipcerts = sk_X509_new_null();
+	if (recipcerts == NULL) {
+		goto clean_exit;
+	}
 
 	/* get certs */
 	if (Z_TYPE_P(zrecipcerts) == IS_ARRAY) {


### PR DESCRIPTION
In a lot of places the return value is not checked, and when the function fails the code continues execution. However, this means that operations on the stack fail and will cause memory leaks on the objects that weren't pushed.
On LibreSSL, this will also cause crashes due to a NULL deref.

We also notice an inconsistency in how these failures are handled. For example, in one place we explicitly have a fatal error `php_error_docref(NULL, E_ERROR, "Memory allocation failure");` but this is the only place to do so.

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.