### PR TITLE
Fix crash in mb_substr with MacJapanese encoding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,8 @@ PHP                                                                        NEWS
   . Added GB18030-2022 to default encoding list for zh-CN. (HeRaNO)
   . Fixed bug GH-20836 (Stack overflow in mb_convert_variables with
     recursive array references). (alexandre-daubois)
+  . Fixed bug GH-20832 (assertion failure in mb_wchar_to_sjismac with
+    MacJapanese encoding). (Alex Dowad)
 
 - Opcache:
   . Fixed bug GH-20051 (apache2 shutdowns when restart is requested during

--- a/ext/mbstring/tests/gh20832.phpt
+++ b/ext/mbstring/tests/gh20832.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Ensure mb_substr does not crash with MacJapanese input, when codepoints to skip are more than number of bytes in input string
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+var_dump(mb_substr("\x85\xAC", -1, encoding: 'MacJapanese'));
+?>
+--EXPECT--
+string(1) "V"


### PR DESCRIPTION
Thanks to the GitHub user @vi3tL0u1s (Viet Hoang Luu) for reporting this issue.

The MacJapanese legacy text encoding has a very unusual property; it is possible for a string to encode more codepoints than it has bytes. In some corner cases, this resulted in a situation where the implementation code for mb_substr() would allocate a buffer of size -1. As you can probably imagine, that doesn't end well.

Fixes GH-20832.

@youkidearitai @ndossche @cmb69 