### PR TITLE
Fix(sqlite3): avoid UB when fseek(PHP_INT_MIN) on BLOB streams

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1149,7 +1149,7 @@ static int php_sqlite3_stream_seek(php_stream *stream, zend_off_t offset, int wh
 	switch(whence) {
 		case SEEK_CUR:
 			if (offset < 0) {
-				if (sqlite3_stream->position < (size_t)(-offset)) {
+				if (sqlite3_stream->position < -(size_t)offset) {
 					sqlite3_stream->position = 0;
 					*newoffs = -1;
 					return -1;
@@ -1190,7 +1190,7 @@ static int php_sqlite3_stream_seek(php_stream *stream, zend_off_t offset, int wh
 				sqlite3_stream->position = sqlite3_stream->size;
 				*newoffs = -1;
 				return -1;
-			} else if (sqlite3_stream->size < (size_t)(-offset)) {
+			} else if (sqlite3_stream->size < -(size_t)offset) {
 				sqlite3_stream->position = 0;
 				*newoffs = -1;
 				return -1;

--- a/ext/sqlite3/tests/bug20962.phpt
+++ b/ext/sqlite3/tests/bug20962.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #20962 SQLite3 BLOB stream fseek with PHP_INT_MIN (non-PDO)
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+
+$db->exec('CREATE TABLE test (id TEXT, data BLOB)');
+
+$stmt = $db->prepare('INSERT INTO test (id, data) VALUES (:id, :data)');
+$stmt->bindValue(':id', 'a', SQLITE3_TEXT);
+$stmt->bindValue(':data', 'TEST TEST', SQLITE3_BLOB);
+$stmt->execute();
+
+$row = $db->querySingle("SELECT data FROM test WHERE id='a'", true);
+
+$stream = $db->openBlob('test', 'data', 1); 
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_END));
+?>
+--EXPECT--
+int(-1)


### PR DESCRIPTION
[#20962 ](https://github.com/php/php-src/issues/20962)