### PR TITLE
Fix run-tests.php -s flag

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -697,7 +697,8 @@ function main(): void
     write_information($user_tests, $phpdbg);
 
     if ($test_cnt) {
-        putenv('NO_INTERACTION=1');
+        $exts_tested = [];
+        $exts_skipped = [];
         usort($test_files, "test_sort");
         $start_timestamp = time();
         $start_time = hrtime(true);
@@ -777,7 +778,7 @@ function main(): void
         show_end($start_timestamp, $start_time, $end_time);
         show_summary();
 
-        save_results($output_file, /* prompt_to_save_results: */ true);
+        save_results($output_file, /* prompt_to_save_results: */ !$just_save_results);
     }
 
     $junit->saveXML();
@@ -920,7 +921,7 @@ function save_results(string $output_file, bool $prompt_to_save_results): void
 {
     global $sum_results, $failed_test_summary, $PHP_FAILED_TESTS, $php;
 
-    if (getenv('NO_INTERACTION')) {
+    if (getenv('NO_INTERACTION') && $prompt_to_save_results) {
         return;
     }
 


### PR DESCRIPTION
- Remove unnedded `putenv('NO_INTERACTION=1')` when executing individual tests.
- Fix undefined variable errors when executing individual tests.
- Fix `-s` when `NO_INTERACTION=1` is set, given we don't need to prompt anyway.

Fixes GH-20961