### PR TITLE
Fix lazy proxy bailing __clone assertion

### DIFF
--- a/Zend/tests/lazy_objects/gh20905.phpt
+++ b/Zend/tests/lazy_objects/gh20905.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-20905: Lazy proxy bailing __clone assertion
+--FILE--
+<?php
+
+function test() {
+    function f() {}
+}
+
+class A {
+    public $_;
+    public function __clone() {
+        test();
+    }
+}
+
+test();
+clone (new ReflectionClass(A::class))->newLazyProxy(fn() => new A);
+
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare function f() (previously declared in %s:%d) in %s on line %d

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -744,12 +744,11 @@ zend_object *zend_lazy_object_clone(zend_object *old_obj)
 		}
 	}
 
-	OBJ_EXTRA_FLAGS(new_proxy) = OBJ_EXTRA_FLAGS(old_obj);
-
 	zend_lazy_object_info *new_info = emalloc(sizeof(*info));
 	*new_info = *info;
 	new_info->u.instance = zend_objects_clone_obj(info->u.instance);
 
+	OBJ_EXTRA_FLAGS(new_proxy) = OBJ_EXTRA_FLAGS(old_obj);
 	zend_lazy_object_set_info(new_proxy, new_info);
 
 	return new_proxy;


### PR DESCRIPTION
When __clone of the underlying object fails with a bailout, ZEND_ASSERT(res == SUCCESS) in zend_lazy_object_del_info() will fail because the info has not been registered yet.

Only copy OBJ_EXTRA_FLAGS once the info has been successfully registered.

Fixes GH-20905