### PR TITLE
Drop unnecessary parameter in mysqlnd_auth

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -74,6 +74,10 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 - ext/mbstring:
   . Added GB18030-2022 to default encoding list for zh-CN.
 
+- ext/mysqlnd:
+  . Dropped session_options parameter from all methods in mysqlnd_auth.
+    The same information is present in conn->options and should be used instead.
+
 - ext/standard:
   . _php_error_log() now has a formal return type of zend_result.
   . _php_error_log() now accepts zend_string* values instead of char*.

--- a/ext/mysqlnd/mysqlnd_auth.h
+++ b/ext/mysqlnd/mysqlnd_auth.h
@@ -24,7 +24,6 @@ mysqlnd_auth_handshake(MYSQLND_CONN_DATA * conn,
 						const size_t passwd_len,
 						const char * const db,
 						const size_t db_len,
-						const MYSQLND_SESSION_OPTIONS * const session_options,
 						const zend_ulong mysql_flags,
 						const unsigned int server_charset_no,
 						const bool use_full_blown_auth_packet,
@@ -75,7 +74,6 @@ mysqlnd_connect_run_authentication(
 			const char * const authentication_protocol,
 			const unsigned int charset_no,
 			const size_t server_capabilities,
-			const MYSQLND_SESSION_OPTIONS * const session_options,
 			const zend_ulong mysql_flags
 			);
 
@@ -90,7 +88,6 @@ mysqlnd_run_authentication(
 			const MYSQLND_STRING auth_plugin_data,
 			const char * const auth_protocol,
 			const unsigned int charset_no,
-			const MYSQLND_SESSION_OPTIONS * const session_options,
 			const zend_ulong mysql_flags,
 			const bool silent,
 			const bool is_change_user

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -623,8 +623,7 @@ MYSQLND_METHOD(mysqlnd_command, handshake)(MYSQLND_CONN_DATA * const conn, const
 
 	if (FAIL == mysqlnd_connect_run_authentication(conn, user, passwd, db, db_len, (size_t) passwd_len,
 												   greet_packet.authentication_plugin_data, greet_packet.auth_protocol,
-												   greet_packet.charset_no, greet_packet.server_capabilities,
-												   conn->options, mysql_flags))
+												   greet_packet.charset_no, greet_packet.server_capabilities, mysql_flags))
 	{
 		goto err;
 	}

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1386,7 +1386,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, change_user)(MYSQLND_CONN_DATA * const conn,
 	/* XXX: passwords that have \0 inside work during auth, but in this case won't work with change user */
 	ret = mysqlnd_run_authentication(conn, user, passwd, passwd_len, db, strlen(db),
 									 conn->authentication_plugin_data, conn->options->auth_protocol,
-									0 /*charset not used*/, conn->options, conn->server_capabilities, silent, TRUE/*is_change*/);
+									0 /*charset not used*/, conn->server_capabilities, silent, TRUE/*is_change*/);
 
 	/*
 	  Here we should close all statements. Unbuffered queries should not be a

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -1323,7 +1323,6 @@ typedef zend_uchar * (*func_auth_plugin__get_auth_data)(struct st_mysqlnd_authen
 														size_t * auth_data_len,
 														MYSQLND_CONN_DATA * conn, const char * const user, const char * const passwd,
 														const size_t passwd_len, zend_uchar * auth_plugin_data, size_t auth_plugin_data_len,
-														const MYSQLND_SESSION_OPTIONS * const session_options,
 														const MYSQLND_PFC_DATA * const pfc_data, const zend_ulong mysql_flags
 														);
 


### PR DESCRIPTION
The PR changes the signatures of methods in mysqlnd_auth to remove the `session_options` parameter which is just a shortcut for `conn->options`. Since `conn` is available in all of these method signatures, it doesn't make much sense to duplicate the information. 
