### PR TITLE
Fix hooked object properties overflow

### DIFF
--- a/Zend/tests/property_hooks/gh20479.phpt
+++ b/Zend/tests/property_hooks/gh20479.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-20479: Hooked object properties overflow
+--CREDITS--
+Viet Hoang Luu (@vi3tL0u1s)
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class Trigger {
+    public $a = 'x';
+    public $b = 'x';
+    public $c = 'x';
+    public $d = 'x';
+    public $e = 'x';
+    public $f = 'x';
+    public string $trigger {
+      get {
+        return 'trigger';
+      }
+    }
+}
+
+$obj = new Trigger();
+// Add 2 dynamic props
+$obj->g = $obj->h = 'x';
+var_export($obj);
+
+?>
+--EXPECT--
+\Trigger::__set_state(array(
+   'a' => 'x',
+   'b' => 'x',
+   'c' => 'x',
+   'd' => 'x',
+   'e' => 'x',
+   'f' => 'x',
+   'trigger' => 'trigger',
+   'h' => 'x',
+   'g' => 'x',
+))

--- a/Zend/zend_property_hooks.c
+++ b/Zend/zend_property_hooks.c
@@ -121,7 +121,7 @@ skip_property:
 			if (Z_TYPE_P(prop_value) == IS_INDIRECT) {
 				continue;
 			}
-			zval *tmp = _zend_hash_append(properties, prop_name, prop_value);
+			zval *tmp = zend_hash_add_new(properties, prop_name, prop_value);
 			Z_TRY_ADDREF_P(tmp);
 		} ZEND_HASH_FOREACH_END();
 	}


### PR DESCRIPTION
The computed number of properties using zend_hash_num_elements(zobj->properties) is incorrect when the object contains virtual properties. We don't have a trivial way to find the number of properties virtual properties that need to be added to this number, so just append with zend_hash_add_new() instead.

Fixes GH-20479