### PR TITLE
Fix NPD when i2d_PKCS12_bio is called on NULL bio

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2762,7 +2762,7 @@ PHP_FUNCTION(openssl_pkcs12_export)
 
 	if (p12 != NULL) {
 		bio_out = BIO_new(BIO_s_mem());
-		if (i2d_PKCS12_bio(bio_out, p12)) {
+		if (bio_out && i2d_PKCS12_bio(bio_out, p12)) {
 			BUF_MEM *bio_buf;
 
 			BIO_get_mem_ptr(bio_out, &bio_buf);


### PR DESCRIPTION
Most functions in OpenSSL can handle NULL arguments, but apparently i2d_PKCS12_bio not. Prevent crashes by adding a NULL check.

ASAN trace:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==132158==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000058 (pc 0x7fc646e33b69 bp 0x7fff7fe53d30 sp 0x7fff7fe53d18 T0)
==132158==The signal is caused by a WRITE memory access.
==132158==Hint: address points to the zero page.
    #0 0x7fc646e33b69 in BIO_up_ref (/lib/x86_64-linux-gnu/libcrypto.so.3+0xedb69) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x7fc646e3eac2  (/lib/x86_64-linux-gnu/libcrypto.so.3+0xf8ac2) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #2 0x7fc646f126f0  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1cc6f0) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #3 0x7fc646f12aa6 in OSSL_ENCODER_to_bio (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1ccaa6) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #4 0x7fc647038adf in PEM_write_bio_PrivateKey_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2adf) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #5 0x7fc647038bc7 in PEM_write_bio_PrivateKey (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2bc7) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #6 0x55ed204f881e in zif_openssl_pkcs12_read /work/php-src/ext/openssl/openssl.c:1520
    #7 0x55ed215aa81b in ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER /work/php-src/Zend/zend_vm_execute.h:1355
    #8 0x55ed217101a9 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116469
    #9 0x55ed217253d0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #10 0x55ed21889bcb in zend_execute_script /work/php-src/Zend/zend.c:1980
    #11 0x55ed212bc3db in php_execute_script_ex /work/php-src/main/main.c:2645
    #12 0x55ed212bc7eb in php_execute_script /work/php-src/main/main.c:2685
    #13 0x55ed2188f736 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #14 0x55ed21891d03 in main /work/php-src/sapi/cli/php_cli.c:1362
    #15 0x7fc6469c61c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x7fc6469c628a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x55ed20409b54 in _start (/work/php-src/sapi/cli/php+0x609b54) (BuildId: 7ce2ce63d1ea0b60b6ee6599e1c6b5160f97af1e)
```

----

May be more of these exist, but I'm just going through the reports. This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.