### PR TITLE
Fix memory leak on failure in openssl_x509_parse()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -1168,6 +1168,7 @@ PHP_FUNCTION(openssl_x509_parse)
 
 err_subitem:
 	zval_ptr_dtor(&subitem);
+	zval_ptr_dtor(&critext);
 err:
 	zend_array_destroy(Z_ARR_P(return_value));
 	if (cert_str) {


### PR DESCRIPTION
Only one of the two arrays (subitem) is destroyed, and critext is not. This leads to a memory leak if the loop bails out:

```
Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f309fe699c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x563b9709ca05 in tracked_malloc /work/php-src/Zend/zend_alloc.c:3018
    #2 0x563b9709b969 in _emalloc /work/php-src/Zend/zend_alloc.c:2780
    #3 0x563b9737dc7b in _zend_new_array /work/php-src/Zend/zend_hash.c:290
    #4 0x563b960f40fc in zif_openssl_x509_parse /work/php-src/ext/openssl/openssl.c:1120
    #5 0x563b96eb7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #6 0x563b971e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #7 0x563b97340995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #8 0x563b973558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #9 0x563b974ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #10 0x563b96eec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #11 0x563b96eecccb in php_execute_script /work/php-src/main/main.c:2685
    #12 0x563b974bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #13 0x563b974c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #14 0x7f309f1641c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #15 0x7f309f16428a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x563b96009b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.