### PR TITLE
Provide mechanism for PDO to throw away a persistent connection and get a new one

### DIFF
--- a/ext/pdo/pdo_dbh.stub.php
+++ b/ext/pdo/pdo_dbh.stub.php
@@ -121,6 +121,8 @@ class PDO
     public const int ATTR_DEFAULT_FETCH_MODE = UNKNOWN;
     /** @cvalue LONG_CONST(PDO_ATTR_DEFAULT_STR_PARAM) */
     public const int ATTR_DEFAULT_STR_PARAM = UNKNOWN;
+    /** @cvalue LONG_CONST(PDO_ATTR_PERSISTENT_NEW_CONNECTION) */
+    public const int ATTR_PERSISTENT_NEW_CONNECTION = UNKNOWN;
 
     /** @cvalue LONG_CONST(PDO_ERRMODE_SILENT) */
     public const int ERRMODE_SILENT = UNKNOWN;

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit pdo_dbh.stub.php instead.
- * Stub hash: 006be61b2c519e7d9ca997a7f12135eb3e0f3500 */
+ * Stub hash: 8f155cc3c779acd9e442d92d628ebe802aef2338 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, dsn, IS_STRING, 0)
@@ -450,6 +450,12 @@ static zend_class_entry *register_class_PDO(void)
 	zend_string *const_ATTR_DEFAULT_STR_PARAM_name = zend_string_init_interned("ATTR_DEFAULT_STR_PARAM", sizeof("ATTR_DEFAULT_STR_PARAM") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DEFAULT_STR_PARAM_name, &const_ATTR_DEFAULT_STR_PARAM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ATTR_DEFAULT_STR_PARAM_name, true);
+
+	zval const_ATTR_PERSISTENT_NEW_CONNECTION_value;
+	ZVAL_LONG(&const_ATTR_PERSISTENT_NEW_CONNECTION_value, LONG_CONST(PDO_ATTR_PERSISTENT_NEW_CONNECTION));
+	zend_string *const_ATTR_PERSISTENT_NEW_CONNECTION_name = zend_string_init_interned("ATTR_PERSISTENT_NEW_CONNECTION", sizeof("ATTR_PERSISTENT_NEW_CONNECTION") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_PERSISTENT_NEW_CONNECTION_name, &const_ATTR_PERSISTENT_NEW_CONNECTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release_ex(const_ATTR_PERSISTENT_NEW_CONNECTION_name, true);
 
 	zval const_ERRMODE_SILENT_value;
 	ZVAL_LONG(&const_ERRMODE_SILENT_value, LONG_CONST(PDO_ERRMODE_SILENT));

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -123,6 +123,7 @@ enum pdo_attribute_type {
 	PDO_ATTR_DEFAULT_FETCH_MODE, /* Set the default fetch mode */
 	PDO_ATTR_EMULATE_PREPARES,  /* use query emulation rather than native */
 	PDO_ATTR_DEFAULT_STR_PARAM, /* set the default string parameter type (see the PDO::PARAM_STR_* magic flags) */
+	PDO_ATTR_PERSISTENT_NEW_CONNECTION, /* throw away old persistent connection and make a new one */
 
 	/* this defines the start of the range for driver specific options.
 	 * Drivers should define their own attribute constants beginning with this


### PR DESCRIPTION
The persistent connection may be in a wedged or otherwise undesirable state that the connection liveness check has failed to deal with. (For instance, the ODBC connection dead attribute that PDO_ODBC uses to check isn't perfectly handled by all drivers, or if a persistent connection has bad persistent state, it's easier to just reconnect if so.) If so, provide userland code a way to get rid of a persistent connection and create a new one in its place.

This is prompted by the discussion in GH-15749 and GH-19933. I think adding a notion of disconnected PDO objects is probably unwise, so this provides an alternative that requires very minimal changes in PDO. I'm not entirely pleased with this approach, but perhaps there is a better one. I don't intend to get this merged, without a discussion anyways - I'll bring that up on internals.