### PR TITLE
Fix negative-size-param crash when OBJ_obj2txt() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2317,8 +2317,13 @@ PHP_FUNCTION(openssl_pkey_get_details)
 	add_assoc_stringl(return_value, "key", pbio, pbio_len);
 	
 	zend_long ktype = php_openssl_pkey_get_details(return_value, pkey);
-
-	add_assoc_long(return_value, "type", ktype);
+	if (ktype != -2) {
+		add_assoc_long(return_value, "type", ktype);
+	} else {
+		php_openssl_store_errors();
+		zval_ptr_dtor(return_value);
+		RETVAL_FALSE;
+	}
 
 	BIO_free(out);
 }

--- a/ext/openssl/openssl_backend_v1.c
+++ b/ext/openssl/openssl_backend_v1.c
@@ -531,8 +531,14 @@ zend_long php_openssl_pkey_get_details(zval *return_value, EVP_PKEY *pkey)
 					obj = OBJ_nid2obj(nid);
 					if (obj != NULL) {
 						int oir_len = OBJ_obj2txt(oir_buf, sizeof(oir_buf), obj, 1);
-						add_assoc_stringl(&ec, "curve_oid", (char*) oir_buf, oir_len);
-						ASN1_OBJECT_free(obj);
+						if (oir_len < 0) {
+							ktype = -2;
+							ASN1_OBJECT_free(obj);
+							break;
+						} else {
+							add_assoc_stringl(&ec, "curve_oid", (char*) oir_buf, oir_len);
+							ASN1_OBJECT_free(obj);
+						}
 					}
 				}
 

--- a/ext/openssl/openssl_backend_v3.c
+++ b/ext/openssl/openssl_backend_v3.c
@@ -668,8 +668,14 @@ zend_long php_openssl_pkey_get_details(zval *return_value, EVP_PKEY *pkey)
 						// OpenSSL recommends a buffer length of 80.
 						char oir_buf[80];
 						int oir_len = OBJ_obj2txt(oir_buf, sizeof(oir_buf), obj, 1);
-						add_assoc_stringl(&ary, "curve_oid", oir_buf, oir_len);
-						ASN1_OBJECT_free(obj);
+						if (oir_len < 0) {
+							ktype = -2;
+							ASN1_OBJECT_free(obj);
+							break;
+						} else {
+							add_assoc_stringl(&ary, "curve_oid", oir_buf, oir_len);
+							ASN1_OBJECT_free(obj);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When the function returns -1, the length passed to the string constructor is negative:

```
==188567==ERROR: AddressSanitizer: negative-size-param: (size=-1)
    #0 0x7f36ea0305bd in memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x559c568a05b3 in zend_string_init /work/php-src/Zend/zend_string.h:191
    #2 0x559c568b3cb7 in add_assoc_stringl_ex /work/php-src/Zend/zend_API.c:1986
    #3 0x559c559234a2 in add_assoc_stringl /work/php-src/Zend/zend_API.h:579
    #4 0x559c55928b3e in php_openssl_pkey_get_details /work/php-src/ext/openssl/openssl_backend_v3.c:671
    #5 0x559c559006d4 in zif_openssl_pkey_get_details /work/php-src/ext/openssl/openssl.c:2319
    #6 0x559c566b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #7 0x559c569e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #8 0x559c56b40995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #9 0x559c56b558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #10 0x559c56cba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #11 0x559c566ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #12 0x559c566ecccb in php_execute_script /work/php-src/main/main.c:2685
    #13 0x559c56cbfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #14 0x559c56cc21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #15 0x7f36e932d1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x7f36e932d28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x559c55809b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.