### PR TITLE
Fix memory leak in check_cert() when X509_STORE_CTX_init() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2342,6 +2342,7 @@ static int check_cert(X509_STORE *ctx, X509 *x, STACK_OF(X509) *untrustedchain, 
 		return 0;
 	}
 	if (!X509_STORE_CTX_init(csc, ctx, x, untrustedchain)) {
+		X509_STORE_CTX_free(csc);
 		php_openssl_store_errors();
 		php_error_docref(NULL, E_WARNING, "Certificate store initialization failed");
 		return 0;


### PR DESCRIPTION
ASAN report:
```
Direct leak of 272 byte(s) in 1 object(s) allocated from:
    #0 0x7f4ce970d9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f4ce8fa97c4 in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2237c4) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #2 0x7f4ce910adbd in X509_STORE_CTX_new_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0x384dbd) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #3 0x563e4a51c26c in php_openssl_check_cert /work/php-src/ext/openssl/openssl_backend_common.c:748
    #4 0x563e4a4f529c in zif_openssl_x509_checkpurpose /work/php-src/ext/openssl/openssl.c:1221
    #5 0x563e4b2b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #6 0x563e4b5e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #7 0x563e4b740995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #8 0x563e4b7558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #9 0x563e4b8ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #10 0x563e4b2ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #11 0x563e4b2ecccb in php_execute_script /work/php-src/main/main.c:2685
    #12 0x563e4b8bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #13 0x563e4b8c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #14 0x7f4ce8a081c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #15 0x7f4ce8a0828a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x563e4a409b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.