### PR TITLE
Fix crash in openssl_x509_parse() when X509_NAME_oneline() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2134,6 +2134,11 @@ PHP_FUNCTION(openssl_x509_parse)
 
 	subject_name = X509_get_subject_name(cert);
 	cert_name = X509_NAME_oneline(subject_name, NULL, 0);
+	if (cert_name == NULL) {
+		php_openssl_store_errors();
+		goto err;
+	}
+
 	add_assoc_string(return_value, "name", cert_name);
 	OPENSSL_free(cert_name);
 


### PR DESCRIPTION
The X509_NAME_oneline() function can return NULL, which will cause a crash when the string length is computed via add_assoc_string().

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.