### PR TITLE
Fix crash in openssl_x509_parse() when i2s_ASN1_INTEGER() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2166,6 +2166,12 @@ PHP_FUNCTION(openssl_x509_parse)
 	}
 
 	str_serial = i2s_ASN1_INTEGER(NULL, asn1_serial);
+	/* Can return NULL on error or memory allocation failure */
+	if (!str_serial) {
+		php_openssl_store_errors();
+		goto err;
+	}
+
 	add_assoc_string(return_value, "serialNumber", str_serial);
 	OPENSSL_free(str_serial);
 


### PR DESCRIPTION
The X509_NAME_oneline() function can return NULL,
which will cause a crash when the string length is computed via add_assoc_string().

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.