### PR TITLE
chore: improve errror message when passing named parameter for variadic

### DIFF
--- a/Zend/tests/named_params/internal_variadics.phpt
+++ b/Zend/tests/named_params/internal_variadics.phpt
@@ -15,7 +15,14 @@ try {
     echo $e->getMessage(), "\n";
 }
 
+try {
+    $array = [1, 2];
+    array_push($array, ...['values' => 3]);
+} catch (ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-array_merge() does not accept unknown named parameters
-array_diff_key() does not accept unknown named parameters
+array_merge() does not accept named arguments for variadic parameters
+array_diff_key() does not accept named arguments for variadic parameters
+array_push() does not accept named arguments for variadic parameters

--- a/Zend/tests/named_params/internal_variadics.phpt
+++ b/Zend/tests/named_params/internal_variadics.phpt
@@ -23,6 +23,6 @@ try {
 }
 ?>
 --EXPECT--
-array_merge() does not accept named arguments for variadic parameters
-array_diff_key() does not accept named arguments for variadic parameters
-array_push() does not accept named arguments for variadic parameters
+Internal function array_merge() does not accept named variadic arguments
+Internal function array_diff_key() does not accept named variadic arguments
+Internal function array_push() does not accept named variadic arguments

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -370,7 +370,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void)
 {
 	const char *space;
 	const char *class_name = get_active_class_name(&space);
-	zend_argument_count_error("%s%s%s() does not accept named arguments for variadic parameters",
+	zend_argument_count_error("Internal function %s%s%s() does not accept named variadic arguments",
 		class_name, space, get_active_function_name()
 	);
 }

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -370,8 +370,9 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_unexpected_extra_named_error(void)
 {
 	const char *space;
 	const char *class_name = get_active_class_name(&space);
-	zend_argument_count_error("%s%s%s() does not accept unknown named parameters",
-		class_name, space, get_active_function_name());
+	zend_argument_count_error("%s%s%s() does not accept named arguments for variadic parameters",
+		class_name, space, get_active_function_name()
+	);
 }
 
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_error_variadic(zend_class_entry *error_ce, uint32_t arg_num, const char *format, va_list va) /* {{{ */


### PR DESCRIPTION
I was a bit confused when I encountered the error `does not accept unknown named parameters`.
The issue was that I passed an associative array to a variadic parameter, which made the message misleading.
Because of that, I felt a clearer error message would be more appropriate in this case.

I changed the error message from `<function> does not accept unknown named parameters` to `<function> does not accept named arguments for variadic parameters`.

The discussion about this problem was touched in https://github.com/php/php-src/issues/11026