### PR TITLE
Fix crash in php_openssl_pkey_init_ec() when EVP_PKEY_CTX_new() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4680,6 +4680,9 @@ static EVP_PKEY *php_openssl_pkey_init_ec(zval *data, bool *is_private) {
 		}
 		EVP_PKEY_CTX_free(ctx);
 		ctx = EVP_PKEY_CTX_new(param_key, NULL);
+		if (!ctx) {
+			goto cleanup;
+		}
 	}
 
 	if (EVP_PKEY_check(ctx) || EVP_PKEY_public_check_quick(ctx)) {


### PR DESCRIPTION
Other locations of EVP_PKEY_CTX_new() pass the pointer into a function that can handle NULL pointer inputs; OR they check for a NULL pointer. EVP_PKEY_check() apparently cannot handle a NULL pointer argument:

```
==3749==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000088 (pc 0x7f6f4550c0fb bp 0x7ffcbff3a9c0 sp 0x7ffcbff3a9b0 T0)
==3749==The signal is caused by a READ memory access.
==3749==Hint: address points to the zero page.
    #0 0x7f6f4550c0fb in EVP_PKEY_pairwise_check (/lib/x86_64-linux-gnu/libcrypto.so.3+0x20f0fb) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x561499d27117 in php_openssl_pkey_init_ec /work/php-src/ext/openssl/openssl_backend_v3.c:459
    #2 0x561499cfe328 in zif_openssl_pkey_new /work/php-src/ext/openssl/openssl.c:2061
    #3 0x56149aab7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #4 0x56149ade024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #5 0x56149af40995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #6 0x56149af558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #7 0x56149b0ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #8 0x56149aaec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #9 0x56149aaecccb in php_execute_script /work/php-src/main/main.c:2685
    #10 0x56149b0bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #11 0x56149b0c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #12 0x7f6f44f7f1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #13 0x7f6f44f7f28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #14 0x561499c09b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: eb0a8e6b6d683fbdf45156dfed4d76f9110252b9)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.