### PR TITLE
Fix crash in openssl_pkey_get_details() when BIO_new() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5145,7 +5145,7 @@ PHP_FUNCTION(openssl_pkey_get_details)
 	EVP_PKEY *pkey = Z_OPENSSL_PKEY_P(key)->pkey;
 
 	BIO *out = BIO_new(BIO_s_mem());
-	if (!PEM_write_bio_PUBKEY(out, pkey)) {
+	if (!out || !PEM_write_bio_PUBKEY(out, pkey)) {
 		BIO_free(out);
 		php_openssl_store_errors();
 		RETURN_FALSE;


### PR DESCRIPTION
PEM_write_bio_PUBKEY() cannot handle a NULL argument:
```
==10779==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000058 (pc 0x7f426f79db69 bp 0x7fff0ec17940 sp 0x7fff0ec17928 T0)
==10779==The signal is caused by a WRITE memory access.
==10779==Hint: address points to the zero page.
    #0 0x7f426f79db69 in BIO_up_ref (/lib/x86_64-linux-gnu/libcrypto.so.3+0xedb69) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x7f426f7a8ac2  (/lib/x86_64-linux-gnu/libcrypto.so.3+0xf8ac2) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #2 0x7f426f87c6f0  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1cc6f0) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #3 0x7f426f87caa6 in OSSL_ENCODER_to_bio (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1ccaa6) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #4 0x7f426f99dc5e in PEM_write_bio_PUBKEY (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2edc5e) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #5 0x5637ebd00530 in zif_openssl_pkey_get_details /work/php-src/ext/openssl/openssl.c:2308
    #6 0x5637ecab7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #7 0x5637ecde024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #8 0x5637ecf40995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #9 0x5637ecf558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #10 0x5637ed0ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #11 0x5637ecaec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #12 0x5637ecaecccb in php_execute_script /work/php-src/main/main.c:2685
    #13 0x5637ed0bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #14 0x5637ed0c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #15 0x7f426f3321c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x7f426f33228a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x5637ebc09b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: eb0a8e6b6d683fbdf45156dfed4d76f9110252b9)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.