### PR TITLE
Fix crash in openssl_digest() when EVP_MD_CTX_create() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7625,7 +7625,8 @@ PHP_FUNCTION(openssl_digest)
 	sigbuf = zend_string_alloc(siglen, 0);
 
 	md_ctx = EVP_MD_CTX_create();
-	if (EVP_DigestInit(md_ctx, mdtype) &&
+	if (md_ctx &&
+			EVP_DigestInit(md_ctx, mdtype) &&
 			EVP_DigestUpdate(md_ctx, (unsigned char *)data, data_len) &&
 			EVP_DigestFinal (md_ctx, (unsigned char *)ZSTR_VAL(sigbuf), &siglen)) {
 		if (raw_output) {


### PR DESCRIPTION
EVP_DigestInit() cannot handle a NULL argument:

```
==8028==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000028 (pc 0x7fade0826b2d bp 0x7ffcae8236f0 sp 0x7ffcae8236c0 T0)
==8028==The signal is caused by a READ memory access.
==8028==Hint: address points to the zero page.
    #0 0x7fade0826b2d  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1e3b2d) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x5584fb314601 in zif_openssl_digest /work/php-src/ext/openssl/openssl.c:4459
    #2 0x5584fc0b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #3 0x5584fc3e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #4 0x5584fc540995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #5 0x5584fc5558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #6 0x5584fc6ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #7 0x5584fc0ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #8 0x5584fc0ecccb in php_execute_script /work/php-src/main/main.c:2685
    #9 0x5584fc6bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #10 0x5584fc6c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #11 0x7fade02c51c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #12 0x7fade02c528a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #13 0x5584fb209b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.