### PR TITLE
Fix crash in openssl_pkey_export() when BIO_new() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5005,6 +5005,10 @@ PHP_FUNCTION(openssl_pkey_export)
 
 	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
 		bio_out = BIO_new(BIO_s_mem());
+		if (!bio_out) {
+			php_openssl_store_errors();
+			goto out;
+		}
 
 		if (passphrase && req.priv_key_encrypt) {
 			if (req.priv_key_encrypt_cipher) {
@@ -5033,6 +5037,7 @@ PHP_FUNCTION(openssl_pkey_export)
 			php_openssl_store_errors();
 		}
 	}
+out:
 	PHP_SSL_REQ_DISPOSE(&req);
 	EVP_PKEY_free(key);
 	BIO_free(bio_out);


### PR DESCRIPTION
```
==59541==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000058 (pc 0x7f9fafba9b69 bp 0x7ffe3fd87700 sp 0x7ffe3fd876e8 T0)
==59541==The signal is caused by a WRITE memory access.
==59541==Hint: address points to the zero page.
    #0 0x7f9fafba9b69 in BIO_up_ref (/lib/x86_64-linux-gnu/libcrypto.so.3+0xedb69) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x7f9fafbb4ac2  (/lib/x86_64-linux-gnu/libcrypto.so.3+0xf8ac2) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #2 0x7f9fafc886f0  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1cc6f0) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #3 0x7f9fafc88aa6 in OSSL_ENCODER_to_bio (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1ccaa6) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #4 0x7f9fafdaeadf in PEM_write_bio_PrivateKey_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2adf) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #5 0x7f9fafdaebc7 in PEM_write_bio_PrivateKey (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2bc7) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #6 0x555dbe4ff75f in zif_openssl_pkey_export /work/php-src/ext/openssl/openssl.c:2216
    #7 0x555dbf2b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #8 0x555dbf5e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #9 0x555dbf740995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #10 0x555dbf7558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #11 0x555dbf8ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #12 0x555dbf2ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #13 0x555dbf2ecccb in php_execute_script /work/php-src/main/main.c:2685
    #14 0x555dbf8bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #15 0x555dbf8c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #16 0x7f9faf73e1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x7f9faf73e28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #18 0x555dbe409b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.