### PR TITLE
Fix crash in openssl_pkcs12_read() when BIO_new() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2841,7 +2841,7 @@ PHP_FUNCTION(openssl_pkcs12_read)
 
 		if (cert) {
 			bio_out = BIO_new(BIO_s_mem());
-			if (PEM_write_bio_X509(bio_out, cert)) {
+			if (bio_out && PEM_write_bio_X509(bio_out, cert)) {
 				BUF_MEM *bio_buf;
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zcert, bio_buf->data, bio_buf->length);
@@ -2854,7 +2854,7 @@ PHP_FUNCTION(openssl_pkcs12_read)
 
 		if (pkey) {
 			bio_out = BIO_new(BIO_s_mem());
-			if (PEM_write_bio_PrivateKey(bio_out, pkey, NULL, NULL, 0, 0, NULL)) {
+			if (bio_out && PEM_write_bio_PrivateKey(bio_out, pkey, NULL, NULL, 0, 0, NULL)) {
 				BUF_MEM *bio_buf;
 				BIO_get_mem_ptr(bio_out, &bio_buf);
 				ZVAL_STRINGL(&zpkey, bio_buf->data, bio_buf->length);
@@ -2875,7 +2875,7 @@ PHP_FUNCTION(openssl_pkcs12_read)
 				if (!aCA) break;
 
 				bio_out = BIO_new(BIO_s_mem());
-				if (PEM_write_bio_X509(bio_out, aCA)) {
+				if (bio_out && PEM_write_bio_X509(bio_out, aCA)) {
 					BUF_MEM *bio_buf;
 					BIO_get_mem_ptr(bio_out, &bio_buf);
 					ZVAL_STRINGL(&zextracert, bio_buf->data, bio_buf->length);


### PR DESCRIPTION
Example ASAN report:
```
==55442==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000058 (pc 0x7f73a6413b69 bp 0x7ffe666f6010 sp 0x7ffe666f5ff8 T0)
==55442==The signal is caused by a WRITE memory access.
==55442==Hint: address points to the zero page.
    #0 0x7f73a6413b69 in BIO_up_ref (/lib/x86_64-linux-gnu/libcrypto.so.3+0xedb69) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #1 0x7f73a641eac2  (/lib/x86_64-linux-gnu/libcrypto.so.3+0xf8ac2) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #2 0x7f73a64f26f0  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1cc6f0) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #3 0x7f73a64f2aa6 in OSSL_ENCODER_to_bio (/lib/x86_64-linux-gnu/libcrypto.so.3+0x1ccaa6) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #4 0x7f73a6618adf in PEM_write_bio_PrivateKey_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2adf) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #5 0x7f73a6618bc7 in PEM_write_bio_PrivateKey (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2f2bc7) (BuildId: 0698e1ff610cb3c6993dccbd82c1281b1b4c5ade)
    #6 0x559b16af882b in zif_openssl_pkcs12_read /work/php-src/ext/openssl/openssl.c:1520
    #7 0x559b178b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #8 0x559b17be024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #9 0x559b17d40995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #10 0x559b17d558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #11 0x559b17eba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #12 0x559b178ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #13 0x559b178ecccb in php_execute_script /work/php-src/main/main.c:2685
    #14 0x559b17ebfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #15 0x559b17ec21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #16 0x7f73a5fa81c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x7f73a5fa828a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #18 0x559b16a09b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.