### PR TITLE
Fix GH-21023: CURLOPT_XFERINFOFUNCTION with invalid callback crash.

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -621,6 +621,10 @@ static int curl_fnmatch(void *ctx, const char *pattern, const char *string)
 	zval argv[3];
 	zval retval;
 
+	if (!ZEND_FCC_INITIALIZED(ch->handlers.fnmatch)) {
+		return rval;
+	}
+
 	GC_ADDREF(&ch->std);
 	ZVAL_OBJ(&argv[0], &ch->std);
 	ZVAL_STRING(&argv[1], pattern);

--- a/ext/curl/tests/gh21023.phpt
+++ b/ext/curl/tests/gh21023.phpt
@@ -2,8 +2,6 @@
 GH-21023 (crash with CURLOPT_XFERINFOFUNCTION set with an invalid callback)
 --EXTENSIONS--
 curl
---INI--
-error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 include 'server.inc';
@@ -12,14 +10,18 @@ $url = "{$host}/get.inc";
 $ch = curl_init($url);
 curl_setopt($ch, CURLOPT_NOPROGRESS, 0);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($ch, CURLOPT_XFERINFOFUNCTION, $callback);
+curl_setopt($ch, CURLOPT_XFERINFOFUNCTION, null);
 curl_exec($ch);
 $ch = curl_init($url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($ch, CURLOPT_PROGRESSFUNCTION, $callback);
+curl_setopt($ch, CURLOPT_PROGRESSFUNCTION, null);
 curl_exec($ch);
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_WILDCARDMATCH, 1);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_FNMATCH_FUNCTION, null);
+curl_exec($ch);
+echo "OK", PHP_EOL;
 ?>
---EXPECTF--
-Warning: Undefined variable $callback in %s on line %d
-
-Warning: Undefined variable $callback in %s on line %d
+--EXPECT--
+OK


### PR DESCRIPTION
we check the FCC is properly initialised beforehand.