### PR TITLE
Fix crash in php_openssl_create_sni_server_ctx() when SSL_CTX_new() fails

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1416,6 +1416,10 @@ static SSL_CTX *php_openssl_create_sni_server_ctx(char *cert_path, char *key_pat
 	/* The hello method is not inherited by SSL structs when assigning a new context
 	 * inside the SNI callback, so the just use SSLv23 */
 	SSL_CTX *ctx = SSL_CTX_new(SSLv23_server_method());
+	if (!ctx) {
+		php_error_docref(NULL, E_WARNING, "Failed to create the SSL context");
+		return NULL;
+	}
 
 	if (SSL_CTX_use_certificate_chain_file(ctx, cert_path) != 1) {
 		php_error_docref(NULL, E_WARNING,


### PR DESCRIPTION
```
==41743==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000090 (pc 0x557f134d3acf bp 0x7ffd4d5bc1f0 sp 0x7ffd4d5bb870 T0)
==41743==The signal is caused by a READ memory access.
==41743==Hint: address points to the zero page.
    #0 0x557f134d3acf in php_stream_url_wrap_http_ex /work/php-src/ext/standard/http_fopen_wrapper.c:580
    #1 0x557f134d857e in php_stream_url_wrap_http /work/php-src/ext/standard/http_fopen_wrapper.c:1204
    #2 0x557f1375073d in _php_stream_open_wrapper_ex /work/php-src/main/streams/streams.c:2270
    #3 0x557f13478fa6 in zif_file_get_contents /work/php-src/ext/standard/file.c:409
    #4 0x557f131bfe39 in zif_phar_file_get_contents /work/php-src/ext/phar/func_interceptors.c:226
    #5 0x557f136b7ed2 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #6 0x557f139e024a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #7 0x557f13b40995 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #8 0x557f13b558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #9 0x557f13cba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #10 0x557f136ec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #11 0x557f136ecccb in php_execute_script /work/php-src/main/main.c:2685
    #12 0x557f13cbfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #13 0x557f13cc21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #14 0x7f14599cd1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #15 0x7f14599cd28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 0x557f12809b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.