### PR TITLE
Fix error check on X509_set_subject_name()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3367,7 +3367,10 @@ PHP_FUNCTION(openssl_csr_sign)
 		PHP_OPENSSL_ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);
 	}
 
-	X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr));
+	if (!X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr))) {
+		php_openssl_store_errors();
+		goto cleanup;
+	}
 
 	if (cert == NULL) {
 		cert = new_cert;


### PR DESCRIPTION
This call can fail but this is not checked. The other setter call is checked however.

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.