### PR TITLE
Fix mb_ereg_search_getregs() NULL pointer dereference

### DIFF
--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -1535,7 +1535,7 @@ PHP_FUNCTION(mb_ereg_search_getregs)
 				add_index_bool(return_value, i, 0);
 			}
 		}
-		if (onig_number_of_names(MBREX(search_re)) > 0) {
+		if (MBREX(search_re) != NULL && onig_number_of_names(MBREX(search_re)) > 0) {
 			mb_regex_groups_iter_args args = {
 				return_value,
 				Z_STRVAL(MBREX(search_str)),

--- a/ext/mbstring/tests/gh21036_mb_ereg_search_getregs_null.phpt
+++ b/ext/mbstring/tests/gh21036_mb_ereg_search_getregs_null.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-21036 (mb_ereg_search_getregs() crash after mb_eregi() invalidates search_re)
+--CREDITS--
+vi3tL0u1s
+--EXTENSIONS--
+mbstring
+--SKIPIF--
+<?php
+if (!function_exists("mb_ereg_search_init")) die("skip mb_ereg_search_init() not available");
+?>
+--FILE--
+<?php
+// mb_eregi() can invalidate MBREX(search_re) via regex cache eviction
+// while MBREX(search_regs) remains valid, causing NULL pointer dereference
+
+mb_ereg_search_init("a", "a");
+mb_ereg_search_pos();
+mb_eregi("a", "a");  // This invalidates search_re
+$result = mb_ereg_search_getregs();  // Should not crash
+var_dump($result);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(1) "a"
+}


### PR DESCRIPTION
Add NULL check for `MBREX(search_re)` before calling `onig_number_of_names()` in `mb_ereg_search_getregs()` to prevent crash when `mb_eregi()` invalidates the regex cache.

Fixes GH-21036