### PR TITLE
Fix error check on X509V3_EXT_print()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2256,7 +2256,7 @@ PHP_FUNCTION(openssl_x509_parse)
 				goto err_subitem;
 			}
 		}
-		else if (X509V3_EXT_print(bio_out, extension, 0, 0)) {
+		else if (X509V3_EXT_print(bio_out, extension, 0, 0) > 0) {
 			BIO_get_mem_ptr(bio_out, &bio_buf);
 			add_assoc_stringl(&subitem, extname, bio_buf->data, bio_buf->length);
 		} else {


### PR DESCRIPTION
The docs I found of this function appear to be wrong, as it can also return -1 on failure.
See also https://github.com/openssl/openssl/pull/29793

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.