### PR TITLE
Add missing error check on SSL_set_ex_data()

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1806,7 +1806,8 @@ static zend_result php_openssl_setup_crypto(php_stream *stream,
 
 	sslsock->ssl_handle = SSL_new(sslsock->ctx);
 
-	if (sslsock->ssl_handle == NULL) {
+	if (sslsock->ssl_handle == NULL
+	 || !SSL_set_ex_data(sslsock->ssl_handle, php_openssl_get_ssl_stream_data_index(), stream)) {
 		php_error_docref(NULL, E_WARNING, "SSL handle creation failure");
 		SSL_CTX_free(sslsock->ctx);
 		sslsock->ctx = NULL;
@@ -1817,8 +1818,6 @@ static zend_result php_openssl_setup_crypto(php_stream *stream,
 		}
 #endif
 		return FAILURE;
-	} else {
-		SSL_set_ex_data(sslsock->ssl_handle, php_openssl_get_ssl_stream_data_index(), stream);
 	}
 
 	if (!SSL_set_fd(sslsock->ssl_handle, sslsock->s.socket)) {


### PR DESCRIPTION
This can actually fail because internally this function does stack management in internal data structures.
Can cause a crash later, e.g.:

```
==239255==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x5652d8f2fe68 bp 0x7ffc99ee8fc0 sp 0x7ffc99ee8ec0 T0)
==239255==The signal is caused by a READ memory access.
==239255==Hint: address points to the zero page.
    #0 0x5652d8f2fe68 in php_openssl_limit_handshake_reneg /work/php-src/ext/openssl/xp_ssl.c:1080
    #1 0x5652d8f306e2 in php_openssl_info_callback /work/php-src/ext/openssl/xp_ssl.c:1137
    #2 0x7f45057b84e5  (/lib/x86_64-linux-gnu/libssl.so.3+0x694e5) (BuildId: 5f3b12d47114f9fbdc7765266cd0bb8f1b5ee8fc)
    #3 0x5652d8f351d9 in php_openssl_enable_crypto /work/php-src/ext/openssl/xp_ssl.c:1850
    #4 0x5652d8f39c86 in php_openssl_sockop_set_option /work/php-src/ext/openssl/xp_ssl.c:2516
    #5 0x5652d9d4c610 in _php_stream_set_option /work/php-src/main/streams/streams.c:1466
    #6 0x5652d9d557c1 in php_stream_xport_crypto_enable /work/php-src/main/streams/transports.c:387
    #7 0x5652d8f387be in php_openssl_tcp_sockop_accept /work/php-src/ext/openssl/xp_ssl.c:2279
    #8 0x5652d8f39fcd in php_openssl_sockop_set_option /work/php-src/ext/openssl/xp_ssl.c:2551
    #9 0x5652d9d4c610 in _php_stream_set_option /work/php-src/main/streams/streams.c:1466
    #10 0x5652d9d54d3a in php_stream_xport_accept /work/php-src/main/streams/transports.c:307
    #11 0x5652d9b50161 in zif_stream_socket_accept /work/php-src/ext/standard/streamsfuncs.c:298
    #12 0x5652d9fdacfb in ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER /work/php-src/Zend/zend_vm_execute.h:1355
    #13 0x5652da140689 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116469
    #14 0x5652da1558b0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #15 0x5652da2ba0ab in zend_execute_script /work/php-src/Zend/zend.c:1980
    #16 0x5652d9cec8bb in php_execute_script_ex /work/php-src/main/main.c:2645
    #17 0x5652d9cecccb in php_execute_script /work/php-src/main/main.c:2685
    #18 0x5652da2bfc16 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #19 0x5652da2c21e3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #20 0x7f4504ebc1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #21 0x7f4504ebc28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #22 0x5652d8e09b34 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609b34) (BuildId: aa149f943514fff0c491e1f199e30fed0e977f7c)
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.