### PR TITLE
Fix build warning on LibreSSL

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2206,7 +2206,7 @@ PHP_FUNCTION(openssl_x509_parse)
 	for (i = 0; i < X509_PURPOSE_get_count(); i++) {
 		int id, purpset;
 		char * pname;
-		X509_PURPOSE * purp;
+		const X509_PURPOSE * purp;
 		zval subsub;
 
 		array_init(&subsub);


### PR DESCRIPTION
When trying to build on LibreSSL, I encounter the following build warning (this was observed on master, but applies to 8.4 too):
```
/work/php-src/ext/openssl/openssl.c: In function 'zif_openssl_x509_parse':
/work/php-src/ext/openssl/openssl.c:1101:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1101 |                 purp = X509_PURPOSE_get0(i);
      |                      ^
/work/php-src/ext/openssl/openssl.c:1110:23: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1110 |                 pname = useshortnames ? X509_PURPOSE_get0_sname(purp) : X509_PURPOSE_get0_name(purp);

```