### PR TITLE
Fix GH-21029: Add missing cc clobber

### DIFF
--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -292,7 +292,8 @@ static zend_always_inline size_t zend_safe_address(size_t nmemb, size_t size, si
              : "=&r"(res), "=&r"(m_overflow)
              : "r"(nmemb),
                "r"(size),
-               "r"(offset));
+               "r"(offset)
+             : "xer");
 
         if (UNEXPECTED(m_overflow)) {
                 *overflow = 1;


### PR DESCRIPTION
Let the compiler know that the inline assembly in `zend_safe_address()` clobbers the flags register.

We need to add `cc` in the clobber list for aarch64 (`ADDS` affect the condition flags), and `xer` for powerpc64 (`ADDC`, `ADDZE` affect the Fixed point exception register AKA `xer`).

i386, x86_64, and arm were already correct. Other inline assembly blocks seem correct.

I didn't reproduce the issue on powerpc64, but the change was tested at https://github.com/php/php-src/actions/runs/21404066744/job/61623034776.