### PR TITLE
Fix duplicated CONNECTION_SSL_STARTUP in a switch case (pdo_pgsql)

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -509,7 +509,7 @@ static int pdo_pgsql_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return_
 					break;
 #endif
 #ifdef CONNECTION_GSS_STARTUP
-				case CONNECTION_SSL_STARTUP:
+				case CONNECTION_GSS_STARTUP:
 					ZVAL_STRINGL(return_value, "Negotiating GSSAPI.", strlen("Negotiating GSSAPI."));
 					break;
 #endif


### PR DESCRIPTION
Fix issue https://github.com/php/php-src/issues/21055

(Follow up of https://github.com/php/php-src/pull/21056 - requested to target PHP-8.4 branch instead of master)