### PR TITLE
Remove ext/spl dependency from ext/session

### DIFF
--- a/Zend/zend_autoload.h
+++ b/Zend/zend_autoload.h
@@ -16,6 +16,9 @@
    +----------------------------------------------------------------------+
 */
 
+#ifndef _ZEND_AUTOLOAD_H
+#define _ZEND_AUTOLOAD_H
+
 #include "zend_string.h"
 #include "zend_hash.h"
 #include "zend_API.h"
@@ -28,3 +31,5 @@ ZEND_API void zend_autoload_fcc_map_to_callable_zval_map(zval *return_value);
 /* Only for deprecated strange behaviour of spl_autoload_unregister() */
 ZEND_API void zend_autoload_clean_class_loaders(void);
 void zend_autoload_shutdown(void);
+
+#endif

--- a/ext/session/config.m4
+++ b/ext/session/config.m4
@@ -20,8 +20,6 @@ if test "$PHP_SESSION" != "no"; then
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
   PHP_ADD_EXTENSION_DEP(session, date)
-  dnl https://bugs.php.net/53141
-  PHP_ADD_EXTENSION_DEP(session, spl, true)
 
   PHP_SUBST([SESSION_SHARED_LIBADD])
   PHP_INSTALL_HEADERS([ext/session], [php_session.h mod_files.h mod_user.h])

--- a/ext/session/config.w32
+++ b/ext/session/config.w32
@@ -5,8 +5,6 @@ ARG_ENABLE("session", "session support", "yes");
 if (PHP_SESSION == "yes") {
 	EXTENSION("session", "mod_user_class.c session.c mod_files.c mod_user.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_EXTENSION_DEP('session', 'date');
-	// https://bugs.php.net/53141
-	ADD_EXTENSION_DEP('session', 'spl', true);
 	AC_DEFINE("HAVE_PHP_SESSION", 1, "Define to 1 if the PHP extension 'session' is available.");
 	PHP_INSTALL_HEADERS("ext/session", "php_session.h mod_files.h mod_user.h");
 }

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1527,7 +1527,7 @@ static bool php_can_change_session_setting(const char *setting_name, bool check_
 
 		return false;
 	}
-	
+
 	if (SG(headers_sent) && (!check_cookies || PS(use_cookies))) {
 		char error_msg[256];
 		snprintf(error_msg, sizeof(error_msg), "Session %s cannot be changed after headers have already been sent", setting_name);
@@ -1535,7 +1535,7 @@ static bool php_can_change_session_setting(const char *setting_name, bool check_
 
 		return false;
 	}
-	
+
 	return true;
 }
 
@@ -3055,11 +3055,6 @@ static PHP_MINFO_FUNCTION(session)
 	DISPLAY_INI_ENTRIES();
 }
 
-static const zend_module_dep session_deps[] = {
-	ZEND_MOD_OPTIONAL("spl")
-	ZEND_MOD_END
-};
-
 /* ************************
    * Upload hook handling *
    ************************ */
@@ -3347,7 +3342,7 @@ static zend_result php_session_rfc1867_callback(unsigned int event, void *event_
 zend_module_entry session_module_entry = {
 	STANDARD_MODULE_HEADER_EX,
 	NULL,
-	session_deps,
+	NULL,
 	"session",
 	ext_functions,
 	PHP_MINIT(session), PHP_MSHUTDOWN(session),


### PR DESCRIPTION
This is a follow-up of 668606816f4f7cffe872ed5344f5aa7225ea51e3 (GH-21001).

The SPL extension is no longer needed to be listed among dependencies. The https://bugs.php.net/53141 is tested in
ext/session/tests/bug53141.phpt.

Additionally:
- Added missing inclusion guards to Zend/zend_autoload.h