### PR TITLE
Add missing error check on BN_CTX_new()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4395,6 +4395,9 @@ static bool php_openssl_pkey_init_legacy_ec(EC_KEY *eckey, zval *data, bool *is_
 	EC_POINT *point_q = NULL;
 	EC_GROUP *group = NULL;
 	BN_CTX *bctx = BN_CTX_new();
+	if (!bctx) {
+		goto clean_exit;
+	}
 
 	*is_private = false;
 


### PR DESCRIPTION
If this fails, then the big numbers will be allocated outside of the context, leading to leaks.

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.