### PR TITLE
Fix memory leaks when php_openssl_dh_pub_from_priv() fails

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -4256,7 +4256,12 @@ static bool php_openssl_pkey_init_legacy_dh(DH *dh, zval *data, bool *is_private
 	OPENSSL_PKEY_SET_BN(data, p);
 	OPENSSL_PKEY_SET_BN(data, q);
 	OPENSSL_PKEY_SET_BN(data, g);
-	if (!p || !g || !DH_set0_pqg(dh, p, q, g)) {
+	if (!p || !q) {
+		BN_free(p);
+		return 0;
+	}
+
+	if (!DH_set0_pqg(dh, p, q, g)) {
 		return 0;
 	}
 

--- a/main/php_version.h
+++ b/main/php_version.h
@@ -2,7 +2,7 @@
 /* edit configure.ac to change version number */
 #define PHP_MAJOR_VERSION 8
 #define PHP_MINOR_VERSION 4
-#define PHP_RELEASE_VERSION 18
+#define PHP_RELEASE_VERSION 19
 #define PHP_EXTRA_VERSION "-dev"
-#define PHP_VERSION "8.4.18-dev"
-#define PHP_VERSION_ID 80418
+#define PHP_VERSION "8.4.19-dev"
+#define PHP_VERSION_ID 80419


### PR DESCRIPTION
Leak report:
```
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f97cf4cb340 in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7f97cef66106 in BN_new bn/bn_lib.c:75
    #2 0x7f97cef6006c in bn_bin2bn_cbs bn/bn_convert.c:151
    #3 0x7f97cef60853 in BN_bin2bn bn/bn_convert.c:206
    #4 0x56229112465b in php_openssl_pkey_init_dh_data /work/php-src/ext/openssl/openssl_backend_v1.c:208
    #5 0x5622911248be in php_openssl_pkey_init_dh /work/php-src/ext/openssl/openssl_backend_v1.c:246
    #6 0x5622910fe1d7 in zif_openssl_pkey_new /work/php-src/ext/openssl/openssl.c:2051
    #7 0x562291eb44e5 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #8 0x5622921dc85a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #9 0x56229233cfa5 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #10 0x562292351ec0 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #11 0x5622924b60cc in zend_execute_script /work/php-src/Zend/zend.c:1980
    #12 0x562291ee8ecb in php_execute_script_ex /work/php-src/main/main.c:2645
    #13 0x562291ee92db in php_execute_script /work/php-src/main/main.c:2685
    #14 0x5622924bbc37 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #15 0x5622924be204 in main /work/php-src/sapi/cli/php_cli.c:1362
    #16 0x7f97ceb301c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #17 0x7f97ceb3028a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #18 0x562291009db4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609db4) (BuildId: 5cc444a6a9fc1a486ea698e72366c16bd5472605)

... etc ...
```

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.