### PR TITLE
Fix GH-21058: error_log() crash on null destination argument.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -101,6 +101,8 @@ PHP                                                                        NEWS
     while COW violation flag is still set). (alexandre-daubois)
   . Invalid mode values now throw in array_filter() instead of being silently
     defaulted to 0. (Jorg Sowa)
+  . Fixed bug GH-21058 (error_log() crashes with message_type 3 and
+    null destination). (David Carlier)
 
 - Streams:
   . Added so_keepalive, tcp_keepidle, tcp_keepintvl and tcp_keepcnt stream

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1369,7 +1369,7 @@ PHPAPI zend_result _php_error_log(int opt_err, const zend_string *message, const
 			return FAILURE;
 
 		case 3:		/*save to a file */
-			stream = php_stream_open_wrapper(ZSTR_VAL(opt), "a", REPORT_ERRORS, NULL);
+			stream = php_stream_open_wrapper(opt ? ZSTR_VAL(opt) : NULL, "a", REPORT_ERRORS, NULL);
 			if (!stream) {
 				return FAILURE;
 			}

--- a/ext/standard/tests/general_functions/gh21058.phpt
+++ b/ext/standard/tests/general_functions/gh21058.phpt
@@ -1,0 +1,13 @@
+--TEST--
+GH-21058 (error_log() crash with null destination and message type 3)
+--FILE--
+<?php
+
+try {
+	error_log("test", 3, null);
+} catch (\ValueError $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+Path must not be empty


### PR DESCRIPTION
we preserve the lower branches behavior by letting php_stream_open_wrapper_ex handling the null path and propagating the exception.