### PR TITLE
quote variable in libtool.m4 path test

### DIFF
--- a/build/libtool.m4
+++ b/build/libtool.m4
@@ -472,7 +472,7 @@ else
   lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
   for dir in $PATH /usr/ucb; do
     IFS="$lt_save_ifs"
-    if (test -f $dir/echo || test -f $dir/echo$ac_exeext) &&
+    if (test -f "$dir/echo" || test -f "$dir/echo$ac_exeext") &&
        test "X`($dir/echo '\t') 2>/dev/null`" = 'X\t' &&
        echo_testing_string=`($dir/echo "$echo_test_string") 2>/dev/null` &&
        test "X$echo_testing_string" = "X$echo_test_string"; then


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/17310 by escaping the directories that are in the $PATH environment.
