### PR TITLE
Fix segfault when preloading constant AST closure

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1154,6 +1154,12 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate_inner(
 		}
 		case ZEND_AST_OP_ARRAY:
 		{
+			// Preloading will attempt to resolve constants but objects can't be stored in shm
+			// Aborting here to store the const AST instead
+			if (CG(in_compilation)) {
+				return FAILURE;
+			}
+
 			zend_function *func = (zend_function *)zend_ast_get_op_array(ast)->op_array;
 
 			zend_create_closure(result, func, scope, scope, NULL);

--- a/ext/opcache/tests/preload_gh21059.inc
+++ b/ext/opcache/tests/preload_gh21059.inc
@@ -1,0 +1,7 @@
+<?php
+
+class Foo {
+    public const C = static function() {
+        echo "Hello world\n";
+    };
+}

--- a/ext/opcache/tests/preload_gh21059.phpt
+++ b/ext/opcache/tests/preload_gh21059.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-21059: Segfault when preloading constant AST closure
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.preload={PWD}/preload_gh21059.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+(Foo::C)();
+?>
+--EXPECT--
+Hello world


### PR DESCRIPTION
Fixes GH-21059

Note: This is anologous to this check during the evaluation of enums:

https://github.com/php/php-src/blob/4d5b651e9003ece86b4146a0d1d12417a07eb3a3/Zend/zend_ast.c#L989-L993