### PR TITLE
gen_stub: Fix compatibility with php 7.4 (in PHP-8.4)

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -84,7 +84,7 @@ function processStubFile(string $stubFile, Context $context, bool $includeOnly =
         }
 
         /* Because exit() and die() are proper token/keywords we need to hack-around */
-        $hasSpecialExitAsFunctionHandling = (basename($stubFile) == 'zend_builtin_functions.stub.php');
+        $hasSpecialExitAsFunctionHandling = basename($stubFile) == 'zend_builtin_functions.stub.php';
         if (!$fileInfo = $context->parsedFiles[$stubFile] ?? null) {
             initPhpParser();
             $stubContent = $stubCode ?? file_get_contents($stubFile);


### PR DESCRIPTION
This PR is for PHP-8.4 only, while #21075 is for PHP-8.5 and up.

The fix required for PHP 8.4 branch is different in the two branches, so I'm not sure what is the right PR procedure in this case...
