### PR TITLE
Zend: Remove unused parameter from zend_dval_to_lval_cap()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -64,6 +64,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     zend_enum_RoundingMode parameter.
   . Added Z_PARAM_ENUM().
   . Added zend_enum_fetch_case_id().
+  . The zend_dval_to_lval_cap() function no longer takes a second
+    zend_string* parameter.
 
 ========================
 2. Build system changes

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -427,18 +427,14 @@ try_again:
 					 * We use use saturating conversion to emulate strtol()'s
 					 * behaviour.
 					 */
-					if (op_str == NULL) {
-						/* zend_dval_to_lval_cap() can emit a warning so always do the copy here */
-						op_str = zend_string_copy(Z_STR_P(op));
-					}
-					lval = zend_dval_to_lval_cap(dval, op_str);
+					lval = zend_dval_to_lval_cap(dval);
 					if (!zend_is_long_compatible(dval, lval)) {
-						zend_incompatible_string_to_long_error(op_str);
+						zend_incompatible_string_to_long_error(op_str ? op_str : Z_STR_P(op));
 						if (UNEXPECTED(EG(exception))) {
 							*failed = true;
 						}
 					}
-					zend_string_release(op_str);
+					zend_tmp_string_release(op_str);
 					return lval;
 				}
 			}
@@ -994,7 +990,7 @@ try_again:
 					 * behaviour.
 					 */
 					 /* Most usages are expected to not be (int) casts */
-					lval = zend_dval_to_lval_cap(dval, Z_STR_P(op));
+					lval = zend_dval_to_lval_cap(dval);
 					if (UNEXPECTED(is_strict)) {
 						if (!zend_is_long_compatible(dval, lval)) {
 							zend_incompatible_string_to_long_error(Z_STR_P(op));

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -146,7 +146,7 @@ static zend_always_inline zend_long zend_dval_to_lval_silent(double d)
 }
 
 /* Used to convert a string float to integer during an (int) cast */
-static zend_always_inline zend_long zend_dval_to_lval_cap(double d, const zend_string *s)
+static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
 {
 	if (UNEXPECTED(!zend_finite(d))) {
 		return 0;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -2267,7 +2267,7 @@ static bool dom_nodemap_or_nodelist_process_offset_as_named(zval *offset, zend_l
 		if (0 == (is_numeric_string_type = is_numeric_string(Z_STRVAL_P(offset), Z_STRLEN_P(offset), lval, &dval, true))) {
 			return true;
 		} else if (is_numeric_string_type == IS_DOUBLE) {
-			*lval = zend_dval_to_lval_cap(dval, Z_STR_P(offset));
+			*lval = zend_dval_to_lval_cap(dval);
 		}
 	} else {
 		*lval = zval_get_long(offset);

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -757,7 +757,7 @@ static bool php_tidy_set_tidy_opt(TidyDoc doc, const char *optname, zval *value,
 			}
 			uint8_t type = is_numeric_string(ZSTR_VAL(str), ZSTR_LEN(str), &lval, &dval, true);
 			if (type == IS_DOUBLE) {
-				lval = zend_dval_to_lval_cap(dval, str);
+				lval = zend_dval_to_lval_cap(dval);
 				type = IS_LONG;
 			}
 			if (type == IS_LONG) {


### PR DESCRIPTION
The `zend_string *s` parameter became unused after commit f754ffa8b20 (GH-20746) removed the `zend_oob_string_to_long_error()` calls.

This fixes an unused-parameter compiler warning and updates a stale comment in zend_operators.c that incorrectly stated this function can emit warnings.