### PR TITLE
Remove redundant IS_CV != IS_UNUSED check

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -52171,11 +52171,6 @@ assign_dim_error:
 			}
 		}
 	}
-	if (IS_CV != IS_UNUSED) {
-
-
-	}
-
 
 	/* assign_dim has two opcodes! */
 	ZEND_VM_NEXT_OPCODE_EX(1, 2);


### PR DESCRIPTION
Remove redundant IS_CV != IS_UNUSED check.

```diff
-	if (IS_CV != IS_UNUSED) {
-
-
-	}