### PR TITLE
Add 'multipart_uri_whitelist' INI option to control which URL paths are allowed to submit multipart body

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -199,6 +199,10 @@ SAPI_API void sapi_read_post_data(void)
 	/* now try to find an appropriate POST content handler */
 	if ((post_entry = zend_hash_str_find_ptr(&SG(known_post_content_types), content_type,
 			content_type_length)) != NULL) {
+		if(!SG(allow_multipart_form) && !strcmp(content_type, MULTIPART_CONTENT_TYPE)) {
+			efree(content_type);
+			return;
+		}
 		/* found one, register it for use */
 		SG(request_info).post_entry = post_entry;
 		post_reader_func = post_entry->post_reader;

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -141,7 +141,7 @@ typedef struct _sapi_globals_struct {
 	char *default_charset;
 	HashTable *rfc1867_uploaded_files;
 	zend_long post_max_size;
-	char *multipart_uri_whitelist;
+	bool allow_multipart_form;
 	int options;
 	bool sapi_started;
 	double global_request_time;

--- a/main/main.c
+++ b/main/main.c
@@ -878,7 +878,7 @@ PHP_INI_BEGIN()
 	PHP_INI_ENTRY("disable_functions",			"",			PHP_INI_SYSTEM,		NULL)
 	PHP_INI_ENTRY("max_file_uploads",			"20",			PHP_INI_SYSTEM|PHP_INI_PERDIR,		NULL)
 	PHP_INI_ENTRY("max_multipart_body_parts",	"-1",			PHP_INI_SYSTEM|PHP_INI_PERDIR,		NULL)
-	STD_PHP_INI_ENTRY("multipart_uri_whitelist", NULL,			PHP_INI_PERDIR,		OnUpdateString,		multipart_uri_whitelist, sapi_globals_struct,	sapi_globals)
+	STD_PHP_INI_ENTRY("allow_multipart_form", "1",			PHP_INI_ALL,		OnUpdateBool,		allow_multipart_form, sapi_globals_struct,	sapi_globals)
 
 	STD_PHP_INI_BOOLEAN("allow_url_fopen",		"1",		PHP_INI_SYSTEM,		OnUpdateBool,		allow_url_fopen,		php_core_globals,		core_globals)
 	STD_PHP_INI_BOOLEAN("allow_url_include",	"0",		PHP_INI_SYSTEM,		OnUpdateBool,		allow_url_include,		php_core_globals,		core_globals)

--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -670,7 +670,7 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler)
 	zend_long post_max_size = REQUEST_PARSE_BODY_OPTION_GET(post_max_size, SG(post_max_size));
 	zend_long max_input_vars = REQUEST_PARSE_BODY_OPTION_GET(max_input_vars, PG(max_input_vars));
 	zend_long upload_max_filesize = REQUEST_PARSE_BODY_OPTION_GET(upload_max_filesize, PG(upload_max_filesize));
-	char *multipart_uri_whitelist = SG(multipart_uri_whitelist);
+	bool allow_multipart_form = SG(allow_multipart_form);
 	const zend_encoding *internal_encoding = zend_multibyte_get_internal_encoding();
 	php_rfc1867_getword_t getword;
 	php_rfc1867_getword_conf_t getword_conf;
@@ -695,22 +695,9 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler)
 		_basename = php_ap_basename;
 	}
 
-	if(multipart_uri_whitelist != NULL) {
-		char *uri = strtok(multipart_uri_whitelist, ":");
-		bool find = 0;
-
-		while (uri)
-		{
-			if(strcasecmp(SG(request_info).request_uri, uri) == 0) {
-				find = 1;
-				break;
-			}
-			uri = strtok(NULL, ":");
-		}
-		if(!find) {
-			EMIT_WARNING_OR_ERROR("request uri %s is not allow POST multipart body", SG(request_info).request_uri);
-			return;
-		}
+	if(!allow_multipart_form) {
+		EMIT_WARNING_OR_ERROR("request uri %s is not allow POST multipart body", SG(request_info).request_uri);
+		return;
 	}
 
 	if (post_max_size > 0 && SG(request_info).content_length > post_max_size) {


### PR DESCRIPTION
Currently, in PHP, users can upload files to the server under any circumstances, even if the PHP script does not include file upload handling.
This not only unnecessarily increases server bandwidth usage but also introduces the security risk of arbitrary file uploads to the server. like : hitcon-ctf-2018-one-line-php-challenge.
So  add `allow_multipart_form` PHP_INI_PERDIR ini option.
Changed from `multipart_uri_whitelist` to `allow_multipart_form`.