### PR TITLE
Make brew verbose, limit to 10 minutes

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -13,11 +13,17 @@ runs:
 
         # Some packages exist on x86 but not arm, or vice versa.
         # Install them with reinstall to avoid warnings.
-        brew reinstall autoconf webp tidy-html5 libzip libsodium icu4c
-        brew install \
+        brew reinstall -v \
+          autoconf \
+          webp \
+          tidy-html5 \
+          libzip \
+          libsodium \
+          icu4c
+        brew install -v \
           bison \
           re2c
-        brew install \
+        brew install -v \
           aspell \
           bzip2 \
           enchant \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -367,6 +367,7 @@ jobs:
       - name: Update clang
         uses: ./.github/actions/macos-update-clang
       - name: brew
+        timeout-minutes: 10
         uses: ./.github/actions/brew
       - name: ./configure
         uses: ./.github/actions/configure-macos

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Update clang
         uses: ./.github/actions/macos-update-clang
       - name: brew
+        timeout-minutes: 10
         uses: ./.github/actions/brew
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
This step regularly locks up. Maybe --verbose will provide some insight. Also limit the step to 10 minutes to avoid holding up resources.