### PR TITLE
Install missing headers

### DIFF
--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -38,4 +38,5 @@ PHP_INSTALL_HEADERS([ext/random], m4_normalize([
   php_random_csprng.h
   php_random_uint128.h
   php_random.h
+  random_decl.h
 ]))

--- a/ext/random/config.w32
+++ b/ext/random/config.w32
@@ -1,4 +1,4 @@
 EXTENSION("random", "random.c", false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 PHP_RANDOM="yes";
 ADD_SOURCES(configure_module_dirname, "csprng.c engine_mt19937.c engine_pcgoneseq128xslrr64.c engine_xoshiro256starstar.c engine_secure.c engine_user.c gammasection.c randomizer.c zend_utils.c", "random");
-PHP_INSTALL_HEADERS("ext/random", "php_random.h php_random_csprng.h php_random_uint128.h");
+PHP_INSTALL_HEADERS("ext/random", "php_random.h php_random_csprng.h php_random_uint128.h random_decl.h");

--- a/ext/uri/config.m4
+++ b/ext/uri/config.m4
@@ -11,6 +11,7 @@ PHP_ARG_WITH([external-uriparser],
 PHP_INSTALL_HEADERS([ext/uri], m4_normalize([
   php_uri.h
   php_uri_common.h
+  php_uri_decl.h
   uri_parser_rfc3986.h
   uri_parser_whatwg.h
   uri_parser_php_parse_url.h

--- a/ext/uri/config.w32
+++ b/ext/uri/config.w32
@@ -9,4 +9,4 @@ ADD_SOURCES("ext/uri/uriparser/src", "UriCommon.c UriCompare.c UriCopy.c UriEsca
     UriMemory.c UriNormalize.c UriNormalizeBase.c UriParse.c UriParseBase.c UriQuery.c UriRecompose.c UriResolve.c \
     UriSetFragment.c UriSetHostAuto.c UriSetHostCommon.c UriSetHostIp4.c UriSetHostIp6.c UriSetHostIpFuture.c UriSetHostRegName.c \
     UriSetPath.c UriSetPort.c UriSetQuery.c UriSetScheme.c UriSetUserInfo.c UriShorten.c UriVersion.c", "uri");
-PHP_INSTALL_HEADERS("ext/uri", "php_uri.h php_uri_common.h uri_parser_rfc3986.h uri_parser_whatwg.h uri_parser_php_parse_url.h uriparser/src uriparser/include");
+PHP_INSTALL_HEADERS("ext/uri", "php_uri.h php_uri_common.h php_uri_decl.h uri_parser_rfc3986.h uri_parser_whatwg.h uri_parser_php_parse_url.h uriparser/src uriparser/include");


### PR DESCRIPTION
These are included in public headers and should therefore be also installed.

Follow-up of d16e6f52a432cc70fa8d54a3cd0c635ff403ec07