### PR TITLE
ext/standard: mark ext/random as a required dependency of ext/standard

### DIFF
--- a/ext/reflection/tests/ReflectionExtension_getDependencies_variation2.phpt
+++ b/ext/reflection/tests/ReflectionExtension_getDependencies_variation2.phpt
@@ -7,10 +7,12 @@ Felix De Vliegher <felix.devliegher@gmail.com>
 $standard = new ReflectionExtension('standard');
 var_dump($standard->getDependencies());
 ?>
---EXPECTF--
-array(%d) {
+--EXPECT--
+array(3) {
+  ["random"]=>
+  string(8) "Required"
   ["uri"]=>
-  %s(8) "Required"
+  string(8) "Required"
   ["session"]=>
-  %s(8) "Optional"
+  string(8) "Optional"
 }

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -140,6 +140,7 @@ static void user_shutdown_function_dtor(zval *zv);
 static void user_tick_function_dtor(user_tick_function_entry *tick_function_entry);
 
 static const zend_module_dep standard_deps[] = { /* {{{ */
+	ZEND_MOD_REQUIRED("random")
 	ZEND_MOD_REQUIRED("uri")
 	ZEND_MOD_OPTIONAL("session")
 	ZEND_MOD_END


### PR DESCRIPTION
As the shuffle() and array_rand() functions use part of the Random API