### PR TITLE
Fix -Wdefault-const-init-field-unsafe with clang 21

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -3465,12 +3465,14 @@ ZEND_API zend_mm_heap *zend_mm_startup(void)
 ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void *data, size_t data_size)
 {
 #if ZEND_MM_STORAGE
-	zend_mm_storage tmp_storage, *storage;
+	zend_mm_storage *storage;
+	zend_mm_storage tmp_storage = {
+		.handlers = *handlers,
+		.data = data,
+	};
 	zend_mm_chunk *chunk;
 	zend_mm_heap *heap;
 
-	memcpy((zend_mm_handlers*)&tmp_storage.handlers, handlers, sizeof(zend_mm_handlers));
-	tmp_storage.data = data;
 	chunk = (zend_mm_chunk*)handlers->chunk_alloc(&tmp_storage, ZEND_MM_CHUNK_SIZE, ZEND_MM_CHUNK_SIZE);
 	if (UNEXPECTED(chunk == NULL)) {
 #if ZEND_MM_ERROR


### PR DESCRIPTION
```
Zend/zend_alloc.c:3469:18: error: default initialization of an object of type 'zend_mm_storage' (aka 'struct _zend_mm_storage') with const member leaves the object uninitialized [-Werror,-Wdefault-const-init-field-unsafe]
 3469 |         zend_mm_storage tmp_storage, *storage;
      |                         ^
Zend/zend_alloc.h:313:25: note: member 'handlers' declared 'const' here
  313 |         const zend_mm_handlers handlers;
      |                                ^
```