### PR TITLE
ci: use MySQL LTS version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     resource_class: arm.medium
     docker:
       - image: cimg/base:current-22.04
-      - image: mysql:8.3
+      - image: mysql:8.4
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_ROOT_PASSWORD: ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,7 +136,7 @@ jobs:
   LINUX_X64:
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:
@@ -278,7 +278,7 @@ jobs:
       PDO_FIREBIRD_TEST_DSN: firebird:dbname=firebird:test.fdb
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:
@@ -413,7 +413,7 @@ jobs:
     if: inputs.branch == 'master'
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:
@@ -661,7 +661,7 @@ jobs:
   OPCACHE_VARIATION:
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,7 @@ jobs:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:
@@ -124,7 +124,7 @@ jobs:
       PDO_MYSQL_TEST_HOST: mysql
     services:
       mysql:
-        image: mysql:8.3
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
### Summary

Update the MySQL version used in CI from **8.3** to **8.4**, the current MySQL LTS release.

### Background

CI has been using MySQL **8.3** due to a MySQL-side bug that caused test failures (see #14112, #14113, #14120).
That issue has now been fixed upstream in MySQL **8.4.8**.

References:

* MySQL 8.4.8 release notes (pluggable authentication fix):
  https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-8.html#mysqld-8-4-8-pluggable-auth
* MySQL bug tracker:
  https://bugs.mysql.com/bug.php?id=114876#c555902
* Docker image availability:
  https://hub.docker.com/_/mysql/tags?name=8.4

### Notes

This change only updates the MySQL version used in CI and does not affect PHP source code or test logic.
