### PR TITLE
ci: remove PHP8.1 from push.yml triggers

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,6 @@ on:
       - .cirrus.yml
       - .circleci/**
     branches:
-      - PHP-8.1
       - PHP-8.2
       - PHP-8.3
       - PHP-8.4


### PR DESCRIPTION
PHP8.1 is EOL, so it may be removed from `push.yml` triggers.