### PR TITLE
Require Autoconf 2.71 or newer

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -99,6 +99,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
     . --with-pic is now --enable-pic. The old flag will result in an error.
   . Symbol HAVE_ST_BLOCKS has been removed from php_config.h (use
     HAVE_STRUCT_STAT_ST_BLOCKS).
+  . Autoconf minimum required version upgraded to 2.71.
 
 - Windows build system changes:
   . Function SETUP_OPENSSL() doesn't accept 6th argument anymore and doesn't

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -133,13 +133,13 @@ dnl
 AC_DEFUN([ZEND_INIT], [dnl
 AC_REQUIRE([AC_PROG_CC])
 
-AC_CHECK_HEADERS(m4_normalize([
+AC_CHECK_HEADERS([
   cpuid.h
   libproc.h
-]))
+])
 
 dnl Check for library functions.
-AC_CHECK_FUNCS(m4_normalize([
+AC_CHECK_FUNCS([
   getpid
   gettid
   kill
@@ -150,7 +150,7 @@ AC_CHECK_FUNCS(m4_normalize([
   pthread_getattr_np
   pthread_stackseg_np
   strnlen
-]))
+])
 
 AC_CHECK_DECL([clock_gettime_nsec_np],
   [AC_DEFINE([HAVE_CLOCK_GETTIME_NSEC_NP], [1],

--- a/configure.ac
+++ b/configure.ac
@@ -22,10 +22,10 @@ m4_include([Zend/Zend.m4])
 dnl Basic autoconf initialization, generation of config.nice.
 dnl ----------------------------------------------------------------------------
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.71])
 AC_INIT([PHP],[8.6.0-dev],[https://github.com/php/php-src/issues],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([main/php_version.h])
-AC_CONFIG_MACRO_DIR([build])
+AC_CONFIG_MACRO_DIRS([build])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER
 
@@ -120,11 +120,14 @@ dnl ----------------------------------------------------------------------------
 
 PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
+
+dnl Check if C compiler accepts C11.
+AS_CASE([$ac_prog_cc_stdc], [c99|c89|no],
+  [AC_MSG_ERROR([C compiler would not accept C11 code.])])
+
 PHP_DETECT_ICC
 PHP_DETECT_SUNCC
 
-dnl AC_PROG_CC_C99 is obsolete with autoconf >= 2.70 yet necessary for <= 2.69.
-m4_version_prereq([2.70],,[AC_PROG_CC_C99])
 AC_PROG_CPP
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_LN_S
@@ -134,17 +137,6 @@ AS_VAR_IF([cross_compiling], [yes],
     AC_MSG_CHECKING([for native build C compiler])
     AC_MSG_RESULT([$BUILD_CC])],
   [BUILD_CC=$CC])
-
-dnl The macro AC_PROG_CC_C99 sets the shell variable ac_cv_prog_cc_c99 to 'no'
-dnl if the compiler does not support C99.i.e. does not support any of _Bool,
-dnl flexible arrays, inline, long long int, mixed code and declarations,
-dnl named initialization of structs, restrict, varargs macros, variable
-dnl declarations in for loops and variable length arrays.
-dnl
-dnl https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/C-Compiler.html
-if test "$ac_cv_prog_cc_c99" = no; then
-  AC_MSG_ERROR([C compiler would not accept C99 code])
-fi
 
 dnl Support systems with system libraries in e.g. /usr/lib64.
 PHP_ARG_WITH([libdir],
@@ -377,7 +369,7 @@ dnl Then headers.
 dnl ----------------------------------------------------------------------------
 
 dnl QNX requires unix.h to allow functions in libunix to work properly.
-AC_CHECK_HEADERS(m4_normalize([
+AC_CHECK_HEADERS([
   dirent.h
   sys/param.h
   sys/types.h
@@ -425,7 +417,7 @@ AC_CHECK_HEADERS(m4_normalize([
   nmmintrin.h
   wmmintrin.h
   immintrin.h
-]),,, [dnl
+],,, [dnl
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -448,8 +440,6 @@ PHP_BROKEN_GETCWD
 AS_VAR_IF([GCC], [yes], [PHP_BROKEN_GCC_STRLEN_OPT])
 
 dnl Detect the headers required to use makedev, major, and minor.
-dnl Autoconf <= 2.69 didn't check glibc 2.25 deprecated macros in sys/types.h.
-m4_version_prereq([2.70],,[ac_cv_header_sys_types_h_makedev=no])
 AC_HEADER_MAJOR
 
 dnl Checks for typedefs, structures, and compiler characteristics.
@@ -542,7 +532,7 @@ PHP_CHECK_VARIABLE_ATTRIBUTE([aligned])
 dnl Checks for library functions.
 dnl ----------------------------------------------------------------------------
 
-AC_CHECK_FUNCS(m4_normalize([
+AC_CHECK_FUNCS([
   alphasort
   asctime_r
   asprintf
@@ -603,7 +593,7 @@ AC_CHECK_FUNCS(m4_normalize([
   usleep
   utime
   vasprintf
-]))
+])
 
 PHP_ARG_ENABLE([system-glob],
   [whether to use the system glob function],

--- a/ext/ldap/config.m4
+++ b/ext/ldap/config.m4
@@ -132,7 +132,7 @@ if test "$PHP_LDAP" != "no"; then
 
   dnl Solaris 2.8 claims to be 2004 API, but doesn't have ldap_parse_reference()
   dnl nor ldap_start_tls_s()
-  AC_CHECK_FUNCS(m4_normalize([
+  AC_CHECK_FUNCS([
     ldap_control_find
     ldap_extended_operation
     ldap_extended_operation_s
@@ -143,7 +143,7 @@ if test "$PHP_LDAP" != "no"; then
     ldap_refresh_s
     ldap_start_tls_s
     ldap_whoami_s
-  ]))
+  ])
 
   dnl Sanity check
   AC_CHECK_FUNC([ldap_sasl_bind_s],,

--- a/ext/pcntl/config.m4
+++ b/ext/pcntl/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_PCNTL" != "no"; then
       [AC_MSG_FAILURE([ext/pcntl: required function $function() not found.])])
   done
 
-  AC_CHECK_FUNCS(m4_normalize([
+  AC_CHECK_FUNCS([
     forkx
     getcpuid
     getpriority
@@ -26,7 +26,7 @@ if test "$PHP_PCNTL" != "no"; then
     waitid
     wait6
     syscall
-  ]))
+  ])
 
   AC_CHECK_FUNCS([WIFCONTINUED],,
     [AC_CHECK_DECL([WIFCONTINUED], [AC_DEFINE([HAVE_WIFCONTINUED], [1])],,

--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -12,7 +12,7 @@ if test "$PHP_POSIX" = "yes"; then
     [$ext_shared],,
     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 
-  AC_CHECK_FUNCS(m4_normalize([
+  AC_CHECK_FUNCS([
     ctermid
     eaccess
     getgrgid_r
@@ -28,7 +28,7 @@ if test "$PHP_POSIX" = "yes"; then
     seteuid
     setrlimit
     setsid
-  ]))
+  ])
 
   dnl Check for makedev. If it's defined as a macro, AC_CHECK_FUNCS won't work.
   dnl Required headers are included by the AC_HEADER_MAJOR logic.

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -15,7 +15,7 @@ m4_include([build/php_cxx_compile_stdcxx.m4])
 m4_include([build/php.m4])
 m4_include([build/pkg.m4])
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.71])
 AC_INIT
 AC_CONFIG_SRCDIR([config.m4])
 AC_CONFIG_AUX_DIR([build])
@@ -36,6 +36,11 @@ PHP_INIT_BUILD_SYSTEM
 
 PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
+
+dnl Check if C compiler accepts C11.
+AS_CASE([$ac_prog_cc_stdc], [c99|c89|no],
+  [AC_MSG_ERROR([C compiler would not accept C11 code.])])
+
 PHP_DETECT_ICC
 PHP_DETECT_SUNCC
 


### PR DESCRIPTION
This updates the minimum required Autoconf version to 2.71.

- Autoconf versions 2.70 started supporting C11 standards.
- Autoconf 2.71 was released soon after 2.70 providing some bugfixes.

Changes:
- Removed obsolete AC_PROG_CC_C99 macro. In Autoconf 2.70 and later this is done by the AC_PROG_CC macro.
- m4_normalize is not needed for AC_CHECK_HEADERS and AC_CHECK_FUNCTIONS macros anymore, as the argument is normalized internally by Autoconf in these newer versions.
- Adjusted C11 check in configure.ac and added check also in phpize
  mode. Extensions using PHP headers should be also built with some
  C11-compliant compiler.
- Removed ac_cv_header_sys_types_h_makedev hack for AC_HEADER_MAJOR macro when using Autoconf versions prior to 2.70.
- Replaced AC_CONFIG_MACRO_DIR with preferred AC_CONFIG_MACRO_DIRS.

This also enables using --runstatedir configure option in the future.

Current known target systems with Autoconf versions <= 2.69:

* AIX (Autoconf 2.69)
* RHEL 8, RHEL 9, AlmaLinux 8, RockyLinux 8: Autoconf 2.69 (some has Autoconf 2.71provided as a separate package or EPEL repository).  
* Solaris 10: Autoconf 2.69 via OpenCSW
* Solaris 11.4: Autoconf 2.69 (updated 2.71 available as of 11.4.81 update)

Autoconf versions can be also observed at:
* https://repology.org/project/autoconf/versions 
* https://pkgs.org/search/?q=autoconf
 
