### PR TITLE
Zend/COW invariant violation around $_FILES in debug-assertion builds

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -854,6 +854,9 @@ static bool php_auto_globals_create_files(zend_string *name)
 	zend_hash_update(&EG(symbol_table), name, &PG(http_globals)[TRACK_VARS_FILES]);
 	Z_ADDREF(PG(http_globals)[TRACK_VARS_FILES]);
 
+	/* $_FILES is populated by rfc1867_post_handler() after this point. */
+	HT_ALLOW_COW_VIOLATION(Z_ARRVAL(PG(http_globals)[TRACK_VARS_FILES]));
+
 	return false; /* don't rearm */
 }
 


### PR DESCRIPTION
`rfc1867_post_handler()` registers file metadata into `&PG(http_globals)[TRACK_VARS_FILES]` (i.e. `$_FILES`). See main/rfc1867.c:1153.

`$_FILES` is created as an auto-global and inserted into `EG(symbol_table)` in `php_auto_globals_create_files()` (main/php_variables.c). That means the underlying `HashTable` ends up with `refcount > 1`.

When `php_register_variable_*()` tries to write into that shared `HashTable`, Zend asserts in Zend/zend_hash.c:912 unless the table is marked `HT_ALLOW_COW_VIOLATION` (same mechanism already used for `$_SERVER`).