### PR TITLE
Fix GH-21161: socket_set_option() crash with array 'addr' entry as null.

### DIFF
--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -611,7 +611,7 @@ static void from_zval_write_sin6_addr(const zval *zaddr_str, char *addr6, ser_co
 	} else {
 		/* error already emitted, but let's emit another more relevant */
 		do_from_zval_err(ctx, "could not resolve address '%s' to get an AF_INET6 "
-				"address", Z_STRVAL_P(zaddr_str));
+				"address", ZSTR_VAL(addr_str));
 	}
 
 	zend_tmp_string_release(tmp_addr_str);


### PR DESCRIPTION
in the ipv6 address creation helper we need to use, for the error message, the converted data rather than assuming the original is a proper zend_string().