### PR TITLE
ci: cache for freebsd job

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -25,6 +25,7 @@ runs:
 
           kldload accf_http
           pkg install -y \
+            ccache \
             autoconf \
             bison \
             gmake \
@@ -50,8 +51,13 @@ runs:
             curl \
             $OPCACHE_TLS_TESTS_DEPS
 
+          export CCACHE_DIR=$GITHUB_WORKSPACE/.ccache
+          ccache --set-config=max_size=256M
+          ccache --set-config=compression=true
+          ccache -z
+
           ./buildconf -f
-          CC=clang CXX=clang++ \
+          CC="ccache clang" CXX="ccache clang++" \
           ./configure \
             --prefix=/usr/local \
             --enable-debug \

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -975,6 +975,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJson(inputs.branch).ref }}
+      - name: ccache
+        uses: ./.github/actions/ccache
+        with:
+          name: "${{ github.job }}"
       - name: FreeBSD
         uses: ./.github/actions/freebsd
         with:


### PR DESCRIPTION
Adds ccache step for FreeBSD job. Ccache is already used in the other jobs in `push.yaml`. Reduces the time of the whole job by about ~3 minutes when cache hits.