### PR TITLE
cI: re-enabled xdebug in nightly job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -883,7 +883,6 @@ jobs:
           repository: phpredis/phpredis
           path: redis
       - name: git checkout xdebug
-        if: false
         uses: actions/checkout@v6
         with:
           repository: xdebug/xdebug
@@ -947,7 +946,6 @@ jobs:
           ./configure --prefix=/opt/php --with-php-config=/opt/php/bin/php-config
           make -j$(/usr/bin/nproc)
       - name: build xdebug
-        if: false
         run: |
           cd xdebug
           /opt/php/bin/phpize


### PR DESCRIPTION
Re-enabled xdebug extension in the nightly job.

It was disabled 2.5 years ago: https://github.com/php/php-src/commit/349902414a4, then it was re-enabled by me in https://github.com/php/php-src/pull/13192 but backported with disable again in https://github.com/php/php-src/commit/27e8860594d