### PR TITLE
ci: add fork protection on workflow verify-bundled-files

### DIFF
--- a/.github/workflows/verify-bundled-files.yml
+++ b/.github/workflows/verify-bundled-files.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   VERIFY_BUNDLED_FILES:
+    if: github.repository == 'php/php-src' || github.event_name == 'workflow_dispatch'
     name: Verify Bundled Files
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Adds fork protection to the `verify-bundled-files` workflow. Running this workflow on forks is an unnecessary waste of resources.