### PR TITLE
Disable pkg cache for FreeBSD jobs

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -15,6 +15,7 @@ runs:
         release: '13.5'
         usesh: true
         copyback: false
+        disable-cache: true
         # Temporarily disable sqlite, as FreeBSD ships it with disabled double quotes. We'll need to fix our tests.
         # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269889
         prepare: |


### PR DESCRIPTION
These caches can get massive and evict more useful cache, like ccache.