### PR TITLE
Windows build: Add new function CHECK_HEADER()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -92,6 +92,14 @@ PHP 8.6 INTERNALS UPGRADE NOTES
   . Symbol HAVE_ST_BLOCKS has been removed from php_config.h (use
     HAVE_STRUCT_STAT_ST_BLOCKS).
 
+- Windows build system changes:
+  . Function SETUP_OPENSSL() doesn't accept 6th argument anymore and doesn't
+    define the HAVE_OPENSSL_SSL_H preprocessor macro anymore.
+  . Function SETUP_SQLITE3() doesn't define HAVE_SQLITE3_H and HAVE_SQLITE3EXT_H
+    preprocessor macros anymore.
+  . Added a new function CHECK_HEADER() which is intended to be used instead of
+    the CHECK_HEADER_ADD_INCLUDE().
+
 ========================
 3. Module changes
 ========================

--- a/ext/bz2/config.w32
+++ b/ext/bz2/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("bz2", "BZip2", "no");
 
 if (PHP_BZ2 != "no") {
 	if (CHECK_LIB("libbz2_a.lib;libbz2.lib", "bz2", PHP_BZ2) &&
-			CHECK_HEADER_ADD_INCLUDE("bzlib.h", "CFLAGS_BZ2")) {
+			CHECK_HEADER("bzlib.h", "CFLAGS_BZ2")) {
 		EXTENSION("bz2", "bz2.c bz2_filter.c");
 		AC_DEFINE('HAVE_BZ2', 1, "Define to 1 if the PHP extension 'bz2' is available.");
 		// BZ2 extension does this slightly differently from others

--- a/ext/com_dotnet/config.w32
+++ b/ext/com_dotnet/config.w32
@@ -9,6 +9,10 @@ if (PHP_COM_DOTNET == "yes") {
 		com_typeinfo.c com_variant.c com_wrapper.c com_saproxy.c com_persist.c",
 		null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	AC_DEFINE('HAVE_COM_DOTNET', 1, "Define to 1 if the PHP extension 'com_dotnet' is available.");
-	CHECK_HEADER_ADD_INCLUDE('mscoree.h', 'CFLAGS_COM_DOTNET');
+
+	if (CHECK_HEADER('mscoree.h', 'CFLAGS_COM_DOTNET')) {
+		AC_DEFINE('HAVE_MSCOREE_H', 1, 'Define to 1 if you have the <mscoree.h> header file.');
+	}
+
 	ADD_MAKEFILE_FRAGMENT();
 }

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("curl", "cURL support", "no");
 if (PHP_CURL != "no") {
 	var curl_location;
 	if ((curl_location = CHECK_LIB("libcurl_a.lib;libcurl.lib", "curl", PHP_CURL)) &&
-		CHECK_HEADER_ADD_INCLUDE("curl/easy.h", "CFLAGS_CURL") &&
+		CHECK_HEADER("curl/easy.h", "CFLAGS_CURL") &&
 		SETUP_OPENSSL("curl", PHP_CURL) >= 2 &&
 		CHECK_LIB("winmm.lib", "curl", PHP_CURL) &&
 		CHECK_LIB("wldap32.lib", "curl", PHP_CURL) &&

--- a/ext/dba/config.w32
+++ b/ext/dba/config.w32
@@ -15,7 +15,7 @@ if (PHP_DBA != "no") {
 
 	if (PHP_DB != "no") {
 		if (CHECK_LIB("libdb31s.lib;libdb61.lib", "dba", PHP_DBA) &&
-			CHECK_HEADER_ADD_INCLUDE("db.h", "CFLAGS_DBA")) {
+			CHECK_HEADER("db.h", "CFLAGS_DBA")) {
 			ADD_FLAG("CFLAGS_DBA", "/D DB1_VERSION=\"\\\"Berkeley DB 1.85 emulation in DB3\\\"\" /D DB1_INCLUDE_FILE=\"\\\"db_185.h\\\"\" /D DBA_DB3=1 /D DB3_INCLUDE_FILE=\"\\\"db.h\\\"\"");
 		} else {
 			WARNING("dba: db handlers not enabled; libraries and headers not found");
@@ -24,7 +24,7 @@ if (PHP_DBA != "no") {
 
 	if (PHP_QDBM != "no") {
 		if (CHECK_LIB("qdbm_a.lib;qdbm.lib", "dba", PHP_DBA) &&
-			CHECK_HEADER_ADD_INCLUDE("depot.h", "CFLAGS_DBA", PHP_DBA + ";" + PHP_PHP_BUILD + "\\include\\qdbm")) {
+			CHECK_HEADER("depot.h", "CFLAGS_DBA", PHP_DBA + ";" + PHP_PHP_BUILD + "\\include\\qdbm")) {
 			ADD_SOURCES("ext/dba", "dba_qdbm.c", "dba");
 			AC_DEFINE("QDBM_INCLUDE_FILE", "<depot.h>", "The QDBM handler header file.", false);
 			AC_DEFINE("DBA_QDBM", 1, "Define to 1 if the dba extension uses the QDBM handler.");
@@ -35,7 +35,7 @@ if (PHP_DBA != "no") {
 
 	if (PHP_LMDB != "no") {
 		if (CHECK_LIB("liblmdb_a.lib", "dba", PHP_DBA) &&
-			CHECK_HEADER_ADD_INCLUDE("lmdb.h", "CFLAGS_DBA") &&
+			CHECK_HEADER("lmdb.h", "CFLAGS_DBA") &&
 			CHECK_LIB("ntdll.lib", "dba", PHP_DBA)) {
 			ADD_SOURCES("ext/dba", "dba_lmdb.c", "dba");
 			AC_DEFINE("LMDB_INCLUDE_FILE", "<lmdb.h>", "The LMDB handler header file.", false);

--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("dom", "DOM support", "yes");
 if (PHP_DOM == "yes") {
 	if (PHP_LIBXML == "yes" &&
 		ADD_EXTENSION_DEP('dom', 'libxml') &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_DOM", PHP_PHP_BUILD + "\\include\\libxml2")
+		CHECK_HEADER("libxml/parser.h", "CFLAGS_DOM", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("dom", "php_dom.c attr.c document.c infra.c \
 			xml_document.c html_document.c xml_serializer.c html5_serializer.c html5_parser.c namespace_compat.c private_data.c \

--- a/ext/enchant/config.w32
+++ b/ext/enchant/config.w32
@@ -3,8 +3,8 @@
 ARG_WITH("enchant", "Enchant Support", "no");
 
 if (PHP_ENCHANT == "yes") {
-	if (CHECK_HEADER_ADD_INCLUDE("enchant.h", "CFLAGS_ENCHANT", PHP_ENCHANT+ ";" + PHP_PHP_BUILD + "\\include\\enchant") &&
-			CHECK_HEADER_ADD_INCLUDE("glib.h", "CFLAGS_ENCHANT", PHP_ENCHANT+ ";" + PHP_PHP_BUILD + "\\include\\glib-2.0")) {
+	if (CHECK_HEADER("enchant.h", "CFLAGS_ENCHANT", PHP_ENCHANT+ ";" + PHP_PHP_BUILD + "\\include\\enchant") &&
+			CHECK_HEADER("glib.h", "CFLAGS_ENCHANT", PHP_ENCHANT+ ";" + PHP_PHP_BUILD + "\\include\\glib-2.0")) {
 		if (CHECK_LIB("libenchant2.lib", "enchant", PHP_ENCHANT)) {
 			have_enchant = true;
 		} else if (CHECK_LIB("libenchant.lib", "enchant", PHP_ENCHANT)) {

--- a/ext/ffi/config.w32
+++ b/ext/ffi/config.w32
@@ -1,7 +1,7 @@
 ARG_WITH('ffi', 'ffi support', 'no');
 
 if (PHP_FFI != 'no') {
-	if (CHECK_HEADER_ADD_INCLUDE("ffi.h", "CFLAGS_FFI", PHP_FFI+ ";" + PHP_PHP_BUILD + "\\include") &&
+	if (CHECK_HEADER("ffi.h", "CFLAGS_FFI", PHP_FFI+ ";" + PHP_PHP_BUILD + "\\include") &&
 		CHECK_LIB("libffi.lib", "ffi", PHP_FFI)) {
 		AC_DEFINE('HAVE_FFI', 1, "Define to 1 if the PHP extension 'ffi' is available.");
 

--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -8,28 +8,29 @@ if (PHP_GD != "no") {
 	if (
 		CHECK_LIB("libjpeg_a.lib;libjpeg.lib", "gd", PHP_GD) &&
 		CHECK_LIB("freetype_a.lib;freetype.lib", "gd", PHP_GD) &&
-		CHECK_HEADER_ADD_INCLUDE("ft2build.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\freetype2;" + PHP_PHP_BUILD + "\\include\\freetype") &&
+		CHECK_HEADER("ft2build.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\freetype2;" + PHP_PHP_BUILD + "\\include\\freetype") &&
 		CHECK_LIB("libpng_a.lib;libpng.lib", "gd", PHP_GD) &&
-		CHECK_HEADER_ADD_INCLUDE("gd.h", "CFLAGS_GD", PHP_GD + ";ext\\gd\\libgd") &&
-		(CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng16") ||
-		CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng15") ||
-		CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng12")) &&
+		CHECK_HEADER("gd.h", "CFLAGS_GD", PHP_GD + ";ext\\gd\\libgd") &&
+		(CHECK_HEADER("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng16") ||
+		CHECK_HEADER("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng15") ||
+		CHECK_HEADER("png.h", "CFLAGS_GD", PHP_GD +  ";" + PHP_PHP_BUILD + "\\include\\libpng12")) &&
 		(CHECK_LIB("libiconv_a.lib;libiconv.lib", "gd", PHP_GD) || CHECK_LIB("iconv_a.lib;iconv.lib", "gd", PHP_GD)) &&
-		 CHECK_HEADER_ADD_INCLUDE("iconv.h", "CFLAGS_GD", PHP_GD) &&
+		 CHECK_HEADER("iconv.h", "CFLAGS_GD", PHP_GD) &&
 		SETUP_ZLIB_LIB("gd", PHP_GD) &&
-		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
+		CHECK_HEADER("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
 		) {
+			AC_DEFINE('HAVE_ICONV_H', 1, 'Define to 1 if you have the <iconv.h> header');
 
 		if (CHECK_LIB("libXpm_a.lib", "gd", PHP_GD) &&
-			CHECK_HEADER_ADD_INCLUDE("xpm.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\X11")
+			CHECK_HEADER("xpm.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\X11")
 		) {
 			AC_DEFINE('HAVE_XPM', 1, "Define to 1 if you have the xpm library.");
 			AC_DEFINE('HAVE_GD_XPM', 1, "Define to 1 if gd extension has XPM support.");
 		}
 		if (PHP_LIBWEBP != "no") {
 			if ((CHECK_LIB("libwebp_a.lib", "gd", PHP_GD) || CHECK_LIB("libwebp.lib", "gd", PHP_GD)) &&
-				CHECK_HEADER_ADD_INCLUDE("decode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp") &&
-				CHECK_HEADER_ADD_INCLUDE("encode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp")) {
+				CHECK_HEADER("decode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp") &&
+				CHECK_HEADER("encode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp")) {
 				AC_DEFINE("HAVE_LIBWEBP", 1, "Define to 1 if you have the libwebp library.");
 				AC_DEFINE("HAVE_GD_WEBP", 1, "Define to 1 if gd extension has WebP support.");
 			} else {
@@ -39,10 +40,10 @@ if (PHP_GD != "no") {
 		if (PHP_LIBAVIF != "no") {
 			if (CHECK_LIB("avif_a.lib", "gd", PHP_GD) &&
 				CHECK_LIB("aom_a.lib", "gd", PHP_GD) &&
-				CHECK_HEADER_ADD_INCLUDE("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
+				CHECK_HEADER("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
 				ADD_FLAG("CFLAGS_GD", "/D HAVE_LIBAVIF /D HAVE_GD_AVIF");
 			} else if (CHECK_LIB("avif.lib", "gd", PHP_GD) &&
-				CHECK_HEADER_ADD_INCLUDE("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
+				CHECK_HEADER("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
 				ADD_FLAG("CFLAGS_GD", "/D HAVE_LIBAVIF /D HAVE_GD_AVIF");
 			} else {
 				WARNING("libavif not enabled; libraries and headers not found");

--- a/ext/gettext/config.w32
+++ b/ext/gettext/config.w32
@@ -3,7 +3,7 @@
 ARG_WITH("gettext", "gettext support", "no");
 
 if (PHP_GETTEXT != "no") {
-	if (CHECK_LIB("libintl_a.lib;libintl.lib", "gettext", PHP_GETTEXT) && CHECK_HEADER_ADD_INCLUDE("libintl.h", "CFLAGS_GETTEXT")) {
+	if (CHECK_LIB("libintl_a.lib;libintl.lib", "gettext", PHP_GETTEXT) && CHECK_HEADER("libintl.h", "CFLAGS_GETTEXT")) {
 		EXTENSION("gettext", "gettext.c", PHP_GETTEXT_SHARED, "-DHAVE_BIND_TEXTDOMAIN_CODESET=1 -DHAVE_DNGETTEXT=1 -DHAVE_NGETTEXT=1 -DHAVE_LIBINTL=1 -DHAVE_DCNGETTEXT=1");
 	} else {
 		WARNING("gettext not enabled; libraries and headers not found");

--- a/ext/gmp/config.w32
+++ b/ext/gmp/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("gmp", "Include GNU MP support.", "no");
 
 if (PHP_GMP != "no") {
 	if (CHECK_LIB("mpir_a.lib", "gmp", PHP_GMP) &&
-		CHECK_HEADER_ADD_INCLUDE("gmp.h", "CFLAGS_GMP", PHP_GMP +  ";" + PHP_PHP_BUILD + "\\include\\mpir")) {
+		CHECK_HEADER("gmp.h", "CFLAGS_GMP", PHP_GMP +  ";" + PHP_PHP_BUILD + "\\include\\mpir")) {
 		EXTENSION("gmp", "gmp.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		PHP_INSTALL_HEADERS("ext/gmp", "php_gmp_int.h");
 		AC_DEFINE('HAVE_GMP', 1, "Define to 1 if the PHP extension 'gmp' is available.");

--- a/ext/hash/config.w32
+++ b/ext/hash/config.w32
@@ -22,7 +22,7 @@ if(X64) {
 	ADD_SOURCES(hash_sha3_dir, 'KeccakHash.c KeccakSponge.c KeccakP-1600-inplace32BI.c', 'hash');
 }
 
-if (!CHECK_HEADER_ADD_INCLUDE('KeccakHash.h', 'CFLAGS_HASH', hash_sha3_dir)) {
+if (!CHECK_HEADER('KeccakHash.h', 'CFLAGS_HASH', hash_sha3_dir)) {
 	// Should NEVER happen
 	ERROR('Unable to locate SHA3 headers');
 }

--- a/ext/iconv/config.w32
+++ b/ext/iconv/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("iconv", "iconv support", "yes");
 if (PHP_ICONV != "no") {
 	if ((CHECK_LIB("libiconv_a.lib", "iconv", PHP_ICONV) || CHECK_LIB("libiconv.lib", "iconv", PHP_ICONV) ||
 			CHECK_LIB("iconv_a.lib", "iconv", PHP_ICONV) || CHECK_LIB("iconv.lib", "iconv", PHP_ICONV)) &&
-		CHECK_HEADER_ADD_INCLUDE("iconv.h", "CFLAGS_ICONV", PHP_ICONV)) {
+		CHECK_HEADER("iconv.h", "CFLAGS_ICONV", PHP_ICONV)) {
 
 		EXTENSION("iconv", "iconv.c", PHP_ICONV_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 

--- a/ext/intl/config.w32
+++ b/ext/intl/config.w32
@@ -7,7 +7,7 @@ if (PHP_INTL != "no") {
 		CHECK_LIB("icuin.lib", "intl", PHP_INTL) &&
 		CHECK_LIB("icuio.lib", "intl", PHP_INTL) &&
 		CHECK_LIB("icuuc.lib", "intl", PHP_INTL) &&
-					CHECK_HEADER_ADD_INCLUDE("unicode/utf.h", "CFLAGS_INTL")) {
+					CHECK_HEADER("unicode/utf.h", "CFLAGS_INTL")) {
 		// always build as shared - zend_strtod.c/ICU type conflict
 		EXTENSION("intl", "php_intl.c intl_convert.c intl_convertcpp.cpp intl_error.c ", true,
 								"/I \"" + configure_module_dirname + "\" /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
@@ -92,7 +92,7 @@ if (PHP_INTL != "no") {
 				resourcebundle_iterator.cpp",
 				"intl");
 
-		if (CHECK_HEADER_ADD_INCLUDE("unicode/uspoof.h", "CFLAGS_INTL")) {
+		if (CHECK_HEADER("unicode/uspoof.h", "CFLAGS_INTL")) {
 			ADD_SOURCES(configure_module_dirname + "/spoofchecker", "\
 					spoofchecker_class.cpp \
 					spoofchecker_create.cpp \

--- a/ext/ldap/config.w32
+++ b/ext/ldap/config.w32
@@ -4,8 +4,8 @@ ARG_WITH("ldap", "LDAP support", "no");
 
 if (PHP_LDAP != "no") {
 
-	if (CHECK_HEADER_ADD_INCLUDE("ldap.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
-			CHECK_HEADER_ADD_INCLUDE("lber.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
+	if (CHECK_HEADER("ldap.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
+			CHECK_HEADER("lber.h", "CFLAGS_LDAP", PHP_PHP_BUILD + "\\include\\openldap;" + PHP_PHP_BUILD + "\\openldap\\include;" + PHP_LDAP) &&
 			SETUP_OPENSSL("ldap", PHP_LDAP) >= 2 &&
 			CHECK_LIB("oldap32_a.lib", "ldap", PHP_LDAP) &&
 			CHECK_LIB("olber32_a.lib", "ldap", PHP_LDAP)&&

--- a/ext/libxml/config.w32
+++ b/ext/libxml/config.w32
@@ -5,8 +5,8 @@ ARG_WITH("libxml", "LibXML support", "yes");
 if (PHP_LIBXML == "yes") {
 	if (CHECK_LIB("libxml2_a_dll.lib;libxml2_a.lib", "libxml") &&
 			((PHP_ICONV != "no" && !PHP_ICONV_SHARED) || CHECK_LIB("libiconv_a.lib;iconv_a.lib;libiconv.lib;iconv.lib", "libxml")) &&
-			CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
-			CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2")) {
+			CHECK_HEADER("libxml/parser.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2") &&
+			CHECK_HEADER("libxml/tree.h", "CFLAGS_LIBXML", PHP_PHP_BUILD + "\\include\\libxml2")) {
 
 		if (GREP_HEADER("libxml/xmlversion.h", "#define\\s+LIBXML_VERSION\\s+(\\d+)", PHP_PHP_BUILD + "\\include\\libxml2") &&
 				+RegExp.$1 >= 20904) {

--- a/ext/mbstring/config.w32
+++ b/ext/mbstring/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("mbregex", "multibyte regex support", "no");
 
 if (PHP_MBSTRING != "no") {
 
-	if (CHECK_HEADER_ADD_INCLUDE("mbstring.h", "CFLAGS_MBSTRING", PHP_MBSTRING + ";" + PHP_PHP_BUILD + "\\include")) {
+	if (CHECK_HEADER("mbstring.h", "CFLAGS_MBSTRING", PHP_MBSTRING + ";" + PHP_PHP_BUILD + "\\include")) {
 		EXTENSION("mbstring", "mbstring.c php_unicode.c mb_gpc.c", PHP_MBSTRING_SHARED);
 		ADD_EXTENSION_DEP('mbstring', 'pcre');
 
@@ -42,7 +42,7 @@ if (PHP_MBSTRING != "no") {
 		AC_DEFINE('HAVE_MBSTRING', 1, "Define to 1 if the PHP extension 'mbstring' is available.");
 
 		if (PHP_MBREGEX != "no") {
-			if (CHECK_HEADER_ADD_INCLUDE("oniguruma.h", "CFLAGS_MBSTRING", PHP_MBREGEX) &&
+			if (CHECK_HEADER("oniguruma.h", "CFLAGS_MBSTRING", PHP_MBREGEX) &&
 				CHECK_LIB("onig_a.lib;libonig_a.lib", "mbstring", PHP_MBSTRING)) {
 				AC_DEFINE('HAVE_MBREGEX', 1, 'Define to 1 if mbstring has multibyte regex support enabled.');
 

--- a/ext/mysqlnd/config.w32
+++ b/ext/mysqlnd/config.w32
@@ -29,7 +29,7 @@ if (PHP_MYSQLND != "no") {
 			"php_mysqlnd.c ";
 		EXTENSION("mysqlnd", mysqlnd_source, false, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		if (SETUP_ZLIB_LIB("mysqlnd", PHP_MYSQLND) &&
-			CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
+			CHECK_HEADER("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
 		) {
 			AC_DEFINE("MYSQLND_COMPRESSION_ENABLED", 1, "Define to 1 if mysqlnd has compressed protocol support.");
 			AC_DEFINE("MYSQLND_SSL_SUPPORTED", 1, "Define to 1 if mysqlnd core SSL is enabled.");

--- a/ext/odbc/config.w32
+++ b/ext/odbc/config.w32
@@ -4,8 +4,8 @@ ARG_ENABLE("odbc", "ODBC support", "no");
 
 if (PHP_ODBC == "yes") {
 	if (CHECK_LIB("odbc32.lib", "odbc") && CHECK_LIB("odbccp32.lib", "odbc")
-	&& CHECK_HEADER_ADD_INCLUDE("sql.h", "CFLAGS_ODBC")
-	&& CHECK_HEADER_ADD_INCLUDE("sqlext.h", "CFLAGS_ODBC")) {
+	&& CHECK_HEADER("sql.h", "CFLAGS_ODBC")
+	&& CHECK_HEADER("sqlext.h", "CFLAGS_ODBC")) {
 		EXTENSION("odbc", "php_odbc.c odbc_utils.c", PHP_ODBC_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_UODBC", 1, "Define to 1 if the PHP extension 'odbc' is available.");
 	} else {

--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -23,7 +23,7 @@ ADD_EXTENSION_DEP('opcache', 'pcre');
 if (PHP_OPCACHE_JIT == "yes") {
 	if (TARGET_ARCH == 'arm64') {
 		WARNING("JIT not enabled; not yet supported for ARM64");
-	} else if (CHECK_HEADER_ADD_INCLUDE("ir/ir.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
+	} else if (CHECK_HEADER("ir/ir.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
 		var dasm_flags = (X64 ? "-D X64=1" : "") + (X64 ? " -D X64WIN=1" : "") + " -D WIN=1";
 		var ir_target = (X64 ? "IR_TARGET_X64" : "IR_TARGET_X86");
 		var ir_src = "ir_strtab.c ir_cfg.c ir_sccp.c ir_gcm.c ir_ra.c ir_save.c \
@@ -41,7 +41,7 @@ if (PHP_OPCACHE_JIT == "yes") {
 			ADD_FLAG("CFLAGS_OPCACHE", "/D IR_DEBUG");
 		}
 
-		if (CHECK_HEADER_ADD_INCLUDE("capstone\\capstone.h", "CFLAGS_OPCACHE", PHP_OPCACHE+ ";" + PHP_PHP_BUILD + "\\include") &&
+		if (CHECK_HEADER("capstone\\capstone.h", "CFLAGS_OPCACHE", PHP_OPCACHE+ ";" + PHP_PHP_BUILD + "\\include") &&
 			CHECK_LIB("capstone.lib", "opcache", PHP_OPCACHE)) {
 			AC_DEFINE('HAVE_CAPSTONE', 1, 'Define to 1 if Capstone is available.');
 			ir_src += " ir_disasm.c";

--- a/ext/pdo_dblib/config.w32
+++ b/ext/pdo_dblib/config.w32
@@ -7,7 +7,7 @@ if (PHP_PDO_DBLIB != "no") {
 	 * otherwise we'll poke around and look for MSSQL libs */
 
 	if (CHECK_LIB("sybdb.lib", "pdo_dblib", PHP_PDO_DBLIB) &&
-			CHECK_HEADER_ADD_INCLUDE("sybfront.h", "CFLAGS_PDO_DBLIB",
+			CHECK_HEADER("sybfront.h", "CFLAGS_PDO_DBLIB",
 				PHP_PDO_DBLIB, null, null, true))
 	{
 		EXTENSION("pdo_dblib", "pdo_dblib.c dblib_driver.c dblib_stmt.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
@@ -24,7 +24,7 @@ if (PHP_PDO_MSSQL != "no") {
 	PDO_DBLIB_FLAVOUR = 0;
 
 	if (CHECK_LIB("sybdb.lib", "pdo_mssql", PHP_PDO_MSSQL) &&
-			CHECK_HEADER_ADD_INCLUDE("sybfront.h", "CFLAGS_PDO_MSSQL",
+			CHECK_HEADER("sybfront.h", "CFLAGS_PDO_MSSQL",
 			PHP_PDO_MSSQL, null, null, true)) {
 		/* smells like FreeTDS (or maybe native sybase dblib) */
 		PDO_DBLIB_FLAVOUR = "freetds";

--- a/ext/pdo_firebird/config.w32
+++ b/ext/pdo_firebird/config.w32
@@ -5,9 +5,9 @@ ARG_WITH("pdo-firebird", "Firebird support for PDO", "no");
 if (PHP_PDO_FIREBIRD != "no") {
 
 	if (CHECK_LIB("fbclient_ms.lib", "pdo_firebird", PHP_PHP_BUILD + "\\interbase\\lib_ms;" + PHP_PDO_FIREBIRD)
-		&& CHECK_HEADER_ADD_INCLUDE("ibase.h", "CFLAGS_PDO_FIREBIRD",
+		&& CHECK_HEADER("ibase.h", "CFLAGS_PDO_FIREBIRD",
 			PHP_PHP_BUILD + "\\include\\interbase;" + PHP_PHP_BUILD + "\\interbase\\include;" + PHP_PDO_FIREBIRD)
-		&& CHECK_HEADER_ADD_INCLUDE("firebird\\Interface.h", "CFLAGS_PDO_FIREBIRD",
+		&& CHECK_HEADER("firebird\\Interface.h", "CFLAGS_PDO_FIREBIRD",
 			PHP_PHP_BUILD + "\\include\\interbase;" + PHP_PHP_BUILD + "\\interbase\\include;" + PHP_PDO_FIREBIRD)
 	) {
 

--- a/ext/pdo_mysql/config.w32
+++ b/ext/pdo_mysql/config.w32
@@ -12,7 +12,7 @@ if (PHP_PDO_MYSQL != "no") {
 		ADD_MAKEFILE_FRAGMENT();
 	} else {
 		if (CHECK_LIB("libmysql.lib", "pdo_mysql", PHP_PDO_MYSQL) &&
-				CHECK_HEADER_ADD_INCLUDE("mysql.h", "CFLAGS_PDO_MYSQL",
+				CHECK_HEADER("mysql.h", "CFLAGS_PDO_MYSQL",
 					PHP_PDO_MYSQL + "\\include;" +
 					PHP_PHP_BUILD + "\\include\\mysql;" +
 					PHP_PDO_MYSQL)) {

--- a/ext/pdo_odbc/config.w32
+++ b/ext/pdo_odbc/config.w32
@@ -4,11 +4,13 @@ ARG_WITH("pdo-odbc", "ODBC support for PDO", "no");
 
 if (PHP_PDO_ODBC != "no") {
 	if (CHECK_LIB("odbc32.lib", "pdo_odbc") && CHECK_LIB("odbccp32.lib", "pdo_odbc")
-	&& CHECK_HEADER_ADD_INCLUDE('sql.h', 'CFLAGS_PDO_ODBC')
-	&& CHECK_HEADER_ADD_INCLUDE('sqlext.h', 'CFLAGS_PDO_ODBC')) {
+	&& CHECK_HEADER('sql.h', 'CFLAGS_PDO_ODBC')
+	&& CHECK_HEADER('sqlext.h', 'CFLAGS_PDO_ODBC')) {
 
 		EXTENSION("pdo_odbc", "pdo_odbc.c odbc_driver.c odbc_stmt.c");
 		ADD_EXTENSION_DEP('pdo_odbc', 'pdo');
+		AC_DEFINE('HAVE_SQL_H', 1, 'Define to 1 if you have the <sql.h> header.');
+		AC_DEFINE('HAVE_SQLEXT_H', 1, 'Define to 1 if you have the <sqlext.h> header.');
 
 	} else {
 		WARNING("pdo_odbc support can't be enabled, headers or libraries are missing (SDK)")

--- a/ext/pdo_pgsql/config.w32
+++ b/ext/pdo_pgsql/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("pdo-pgsql", "PostgreSQL support for PDO", "no");
 
 if (PHP_PDO_PGSQL != "no") {
 	if (CHECK_LIB("libpq.lib", "pdo_pgsql", PHP_PDO_PGSQL) &&
-			CHECK_HEADER_ADD_INCLUDE("libpq-fe.h", "CFLAGS_PDO_PGSQL", PHP_PDO_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;")) {
+			CHECK_HEADER("libpq-fe.h", "CFLAGS_PDO_PGSQL", PHP_PDO_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;")) {
 		EXTENSION("pdo_pgsql", "pdo_pgsql.c pgsql_driver.c pgsql_statement.c pgsql_sql_parser.c");
 
 		AC_DEFINE('HAVE_PDO_PGSQL', 1, "Define to 1 if the PHP extension 'pdo_pgsql' is available.");

--- a/ext/pgsql/config.w32
+++ b/ext/pgsql/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("pgsql", "PostgreSQL support", "no");
 
 if (PHP_PGSQL != "no") {
 	if (CHECK_LIB("libpq.lib", "pgsql", PHP_PGSQL) &&
-		CHECK_HEADER_ADD_INCLUDE("libpq-fe.h", "CFLAGS_PGSQL", PHP_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;" + PHP_PGSQL)) {
+		CHECK_HEADER("libpq-fe.h", "CFLAGS_PGSQL", PHP_PGSQL + "\\include;" + PHP_PHP_BUILD + "\\include\\pgsql;" + PHP_PHP_BUILD + "\\include\\libpq;" + PHP_PGSQL)) {
 		EXTENSION("pgsql", "pgsql.c", PHP_PGSQL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_PGSQL', 1, "Define to 1 if the PHP extension 'pgsql' is available.");
 		ADD_FLAG("CFLAGS_PGSQL", "/D PGSQL_EXPORTS");

--- a/ext/readline/config.w32
+++ b/ext/readline/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("readline", "Readline support", "yes");
 
 if (PHP_READLINE != "no") {
 	if (CHECK_LIB("edit_a.lib;edit.lib", "readline", PHP_READLINE) &&
-		CHECK_HEADER_ADD_INCLUDE("editline/readline.h", "CFLAGS_READLINE")) {
+		CHECK_HEADER("editline/readline.h", "CFLAGS_READLINE")) {
 		EXTENSION("readline", "readline.c readline_cli.c");
 		ADD_FLAG("CFLAGS_READLINE", "/D HAVE_LIBEDIT");
 		ADD_FLAG("CFLAGS_READLINE", "/D HAVE_RL_COMPLETION_MATCHES");

--- a/ext/simplexml/config.w32
+++ b/ext/simplexml/config.w32
@@ -6,7 +6,7 @@ if (PHP_SIMPLEXML == "yes") {
 	if(PHP_LIBXML == "yes" &&
 		ADD_EXTENSION_DEP('simplexml', 'libxml') &&
 		ADD_EXTENSION_DEP('simplexml', 'spl') &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SIMPLEXML", PHP_PHP_BUILD + "\\include\\libxml2")
+		CHECK_HEADER("libxml/tree.h", "CFLAGS_SIMPLEXML", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("simplexml", "simplexml.c");
 		AC_DEFINE("HAVE_SIMPLEXML", 1, "Define to 1 if the PHP extension 'simplexml' is available.");

--- a/ext/snmp/config.w32
+++ b/ext/snmp/config.w32
@@ -3,7 +3,7 @@
 ARG_WITH("snmp", "SNMP support", "no");
 
 if (PHP_SNMP != "no") {
-	if (CHECK_HEADER_ADD_INCLUDE("snmp.h", "CFLAGS_SNMP", PHP_PHP_BUILD + "\\include\\net-snmp;" + PHP_SNMP) &&
+	if (CHECK_HEADER("snmp.h", "CFLAGS_SNMP", PHP_PHP_BUILD + "\\include\\net-snmp;" + PHP_SNMP) &&
 		SETUP_OPENSSL("snmp", PHP_SNMP) >= 2) {
 		if (CHECK_LIB("netsnmp.lib", "snmp", PHP_SNMP)) {
 			EXTENSION('snmp', 'snmp.c');

--- a/ext/soap/config.w32
+++ b/ext/soap/config.w32
@@ -5,8 +5,8 @@ ARG_ENABLE("soap", "SOAP support", "no");
 if (PHP_SOAP != "no") {
 	if (PHP_LIBXML == "yes" &&
 		ADD_EXTENSION_DEP('soap', 'libxml') &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2") &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2")
+		CHECK_HEADER("libxml/parser.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2") &&
+		CHECK_HEADER("libxml/tree.h", "CFLAGS_SOAP", PHP_PHP_BUILD + "\\include\\libxml2")
 		) {
 		EXTENSION('soap', 'soap.c php_encoding.c php_http.c php_packet_soap.c php_schema.c php_sdl.c php_xml.c', null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE('HAVE_SOAP', 1, "Define to 1 if the PHP extension 'soap' is available.");

--- a/ext/sodium/config.w32
+++ b/ext/sodium/config.w32
@@ -3,7 +3,7 @@
 ARG_WITH("sodium", "for libsodium support", "no");
 
 if (PHP_SODIUM != "no") {
-	if (CHECK_LIB("libsodium.lib", "sodium", PHP_SODIUM) && CHECK_HEADER_ADD_INCLUDE("sodium.h", "CFLAGS_SODIUM")) {
+	if (CHECK_LIB("libsodium.lib", "sodium", PHP_SODIUM) && CHECK_HEADER("sodium.h", "CFLAGS_SODIUM")) {
 		EXTENSION("sodium", "libsodium.c sodium_pwhash.c");
 		AC_DEFINE('HAVE_LIBSODIUMLIB', 1 , "Define to 1 if the PHP extension 'sodium' is available.");
 		PHP_INSTALL_HEADERS("ext/sodium", "php_libsodium.h");

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("password-argon2", "Argon2 support", "no");
 
 if (PHP_PASSWORD_ARGON2 != "no") {
 	if (CHECK_LIB("argon2_a.lib;argon2.lib", null, PHP_PASSWORD_ARGON2)
-	&& CHECK_HEADER_ADD_INCLUDE("argon2.h", "CFLAGS")) {
+	&& CHECK_HEADER("argon2.h", "CFLAGS")) {
 		if (!CHECK_FUNC_IN_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include", "CFLAGS")) {
 			ERROR("Please verify that Argon2 header and libraries >= 20161029 are installed");
 		}
@@ -19,7 +19,7 @@ ARG_WITH("config-file-scan-dir", "Dir to check for additional php ini files", ""
 AC_DEFINE("PHP_CONFIG_FILE_SCAN_DIR", PHP_CONFIG_FILE_SCAN_DIR);
 AC_DEFINE("PHP_USE_PHP_CRYPT_R", 1, "Define to 1 if PHP uses its own crypt_r, and to 0 if using the external crypt library.");
 
-CHECK_HEADER_ADD_INCLUDE("timelib_config.h", "CFLAGS_STANDARD", "ext/date/lib");
+CHECK_HEADER("timelib_config.h", "CFLAGS_STANDARD", "ext/date/lib");
 
 ADD_FLAG("LIBS_STANDARD", "iphlpapi.lib");
 

--- a/ext/tidy/config.w32
+++ b/ext/tidy/config.w32
@@ -7,12 +7,12 @@ if (PHP_TIDY != "no") {
 	if ((CHECK_LIB("libtidy_a.lib;tidy_a.lib", "tidy", PHP_TIDY) && (tidy_static = true) ||
 		CHECK_LIB("libtidy.lib;tidy.lib", "tidy", PHP_TIDY)) &&
 			(
-				CHECK_HEADER_ADD_INCLUDE("tidy.h", "CFLAGS_TIDY") ||
-				CHECK_HEADER_ADD_INCLUDE("tidy/tidy.h", "CFLAGS_TIDY", null, null, true) ||
-				CHECK_HEADER_ADD_INCLUDE("libtidy/tidy.h", "CFLAGS_TIDY", null, null, true)
+				CHECK_HEADER("tidy.h", "CFLAGS_TIDY") ||
+				CHECK_HEADER("tidy/tidy.h", "CFLAGS_TIDY", null, null, true) ||
+				CHECK_HEADER("libtidy/tidy.h", "CFLAGS_TIDY", null, null, true)
 			)) {
 
-		if (CHECK_HEADER_ADD_INCLUDE("tidybuffio.h", "CFLAGS_TIDY")) {
+		if (CHECK_HEADER("tidybuffio.h", "CFLAGS_TIDY")) {
 			AC_DEFINE('HAVE_TIDYBUFFIO_H', 1, 'Define to 1 if you have the <tidybuffio.h> header file.');
 		}
 

--- a/ext/xml/config.w32
+++ b/ext/xml/config.w32
@@ -5,8 +5,8 @@ ARG_WITH("xml", "XML support", "yes");
 if (PHP_XML == "yes") {
 	if (PHP_LIBXML == "yes" &&
 		ADD_EXTENSION_DEP('xml', 'libxml') &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_XML", PHP_PHP_BUILD + "\\include\\libxml2") &&
-		CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_XML", PHP_PHP_BUILD + "\\include\\libxml2")
+		CHECK_HEADER("libxml/parser.h", "CFLAGS_XML", PHP_PHP_BUILD + "\\include\\libxml2") &&
+		CHECK_HEADER("libxml/tree.h", "CFLAGS_XML", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		EXTENSION("xml", "xml.c compat.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_XML", 1, "Define to 1 if the PHP extension 'xml' is available.");

--- a/ext/xmlreader/config.w32
+++ b/ext/xmlreader/config.w32
@@ -4,8 +4,8 @@ ARG_ENABLE("xmlreader", "XMLReader support", "yes");
 
 if (PHP_XMLREADER == "yes" &&
 	PHP_LIBXML == "yes" &&
-	CHECK_HEADER_ADD_INCLUDE("libxml/parser.h", "CFLAGS_XMLREADER", PHP_PHP_BUILD + "\\include\\libxml2") &&
-	CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_XMLREADER", PHP_PHP_BUILD + "\\include\\libxml2")
+	CHECK_HEADER("libxml/parser.h", "CFLAGS_XMLREADER", PHP_PHP_BUILD + "\\include\\libxml2") &&
+	CHECK_HEADER("libxml/tree.h", "CFLAGS_XMLREADER", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 	EXTENSION("xmlreader", "php_xmlreader.c");
 	AC_DEFINE("HAVE_XMLREADER", 1, "Define to 1 if the PHP extension 'xmlreader' is available.");

--- a/ext/xmlwriter/config.w32
+++ b/ext/xmlwriter/config.w32
@@ -3,7 +3,7 @@
 ARG_ENABLE("xmlwriter", "XMLWriter support", "yes");
 
 if (PHP_XMLWRITER == "yes" && PHP_LIBXML == "yes") {
-	if (CHECK_HEADER_ADD_INCLUDE('libxml/xmlwriter.h', 'CFLAGS_XMLWRITER', PHP_XMLWRITER + ";" + PHP_PHP_BUILD + "\\include\\libxml2")) {
+	if (CHECK_HEADER('libxml/xmlwriter.h', 'CFLAGS_XMLWRITER', PHP_XMLWRITER + ";" + PHP_PHP_BUILD + "\\include\\libxml2")) {
 		EXTENSION("xmlwriter", "php_xmlwriter.c");
 		AC_DEFINE("HAVE_XMLWRITER", 1, "Define to 1 if the PHP extension 'xmlwriter' is available.");
 		if (!PHP_XMLWRITER_SHARED) {

--- a/ext/xsl/config.w32
+++ b/ext/xsl/config.w32
@@ -6,7 +6,7 @@ if (PHP_XSL != "no") {
 	if (PHP_DOM == "yes" && PHP_LIBXML == "yes"
 	&& ADD_EXTENSION_DEP('xsl', 'libxml')
 	&& ADD_EXTENSION_DEP('xsl', 'dom')
-	&& CHECK_HEADER_ADD_INCLUDE("libxml/tree.h", "CFLAGS_XSL", PHP_PHP_BUILD + "\\include\\libxml2")
+	&& CHECK_HEADER("libxml/tree.h", "CFLAGS_XSL", PHP_PHP_BUILD + "\\include\\libxml2")
 	) {
 		var ext_xsl_lib_found = false;
 		var ext_exslt_lib_found = false;
@@ -25,9 +25,9 @@ if (PHP_XSL != "no") {
 			}
 		}
 
-		if (ext_xsl_lib_found && CHECK_HEADER_ADD_INCLUDE("libxslt\\xslt.h", "CFLAGS_XSL")) {
+		if (ext_xsl_lib_found && CHECK_HEADER("libxslt\\xslt.h", "CFLAGS_XSL")) {
 			if (ext_exslt_lib_found) {
-				if (CHECK_HEADER_ADD_INCLUDE("libexslt\\exslt.h", "CFLAGS_XSL")) {
+				if (CHECK_HEADER("libexslt\\exslt.h", "CFLAGS_XSL")) {
 					AC_DEFINE("HAVE_XSL_EXSLT", 1, "Define to 1 if the system has the EXSLT extension library for XSLT.");
 				}
 			}

--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -3,8 +3,8 @@
 ARG_ENABLE("zip", "ZIP support", "yes,shared");
 
 if (PHP_ZIP != "no") {
-	if (CHECK_HEADER_ADD_INCLUDE("zip.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\include;" + PHP_EXTRA_INCLUDES) &&
-		CHECK_HEADER_ADD_INCLUDE("zipconf.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\lib\\libzip\\include;" + PHP_EXTRA_LIBS + "\\libzip\\include;" + PHP_ZIP) &&
+	if (CHECK_HEADER("zip.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\include;" + PHP_EXTRA_INCLUDES) &&
+		CHECK_HEADER("zipconf.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\lib\\libzip\\include;" + PHP_EXTRA_LIBS + "\\libzip\\include;" + PHP_ZIP) &&
 		(PHP_ZIP_SHARED && CHECK_LIB("libzip.lib", "zip", PHP_ZIP) ||
 		 CHECK_LIB("libzip_a.lib", "zip", PHP_ZIP) && CHECK_LIB("libbz2_a.lib", "zip", PHP_ZIP) && CHECK_LIB("zlib_a.lib", "zip", PHP_ZIP) && CHECK_LIB("liblzma_a.lib", "zip", PHP_ZIP))
 	) {

--- a/ext/zlib/config.w32
+++ b/ext/zlib/config.w32
@@ -4,7 +4,7 @@ ARG_ENABLE("zlib", "ZLIB support", "yes");
 
 if (PHP_ZLIB == "yes") {
 	if (CHECK_LIB("zlib_a.lib;zlib.lib", "zlib", PHP_ZLIB) &&
-		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)) {
+		CHECK_HEADER("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)) {
 
 		EXTENSION("zlib", "zlib.c zlib_fopen_wrapper.c zlib_filter.c", PHP_ZLIB_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 		AC_DEFINE("HAVE_ZLIB", 1, "Define to 1 if the PHP extension 'zlib' is available.");

--- a/sapi/apache2handler/config.w32
+++ b/sapi/apache2handler/config.w32
@@ -10,7 +10,7 @@ if(PHP_APACHE2_4HANDLER != "no" && PHP_APACHE2HANDLER == "no") {
 if (PHP_APACHE2HANDLER != "no") {
 	if (PHP_ZTS == "no") {
 		WARNING("Apache module requires an --enable-zts build of PHP on windows");
-	} else if (CHECK_HEADER_ADD_INCLUDE("httpd.h", "CFLAGS_APACHE2HANDLER", PHP_PHP_BUILD + "\\include\\apache2_4") &&
+	} else if (CHECK_HEADER("httpd.h", "CFLAGS_APACHE2HANDLER", PHP_PHP_BUILD + "\\include\\apache2_4") &&
 			CHECK_LIB("libhttpd.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
 			CHECK_LIB("libapr-1.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4") &&
 			CHECK_LIB("libaprutil-1.lib", "apache2handler", PHP_PHP_BUILD + "\\lib\\apache2_4")

--- a/sapi/cli/config.w32
+++ b/sapi/cli/config.w32
@@ -12,7 +12,7 @@ if (PHP_CLI == "yes") {
 	PHP_INSTALL_HEADERS("sapi/cli", "cli.h");
 
 	if (CHECK_LIB("edit_a.lib;edit.lib", "cli", PHP_CLI) &&
-		CHECK_HEADER_ADD_INCLUDE("editline/readline.h", "CFLAGS_CLI")) {
+		CHECK_HEADER("editline/readline.h", "CFLAGS_CLI")) {
 		ADD_FLAG("CFLAGS_CLI", "/D HAVE_LIBEDIT");
 	}
 }


### PR DESCRIPTION
The current function `CHECK_HEADER_ADD_INCLUDE()` automatically defines `HAVE_<HEADER_NAME_H>` preprocessor macros, which makes it difficult to sync with other build systems. Specially, if some `HAVE_` macro is used in the code and this function defines this macro but Autotools doesn't.

The new `CHECK_HEADER()` function behaves similar except it doesn't define the `HAVE_<HEADER_NAME_H>` preprocessor macro.

This removes the following unused compile definitions:

HAVE_ARGON2_H
HAVE_AVIF_H
HAVE_BZLIB_H
HAVE_CAPSTONE_CAPSTONE_H
HAVE_CURL_EASY_H
HAVE_DB_H
HAVE_DECODE_H
HAVE_DEPOT_H
HAVE_EDITLINE_READLINE_H
HAVE_ENCHANT_H
HAVE_ENCODE_H
HAVE_FFI_H
HAVE_FIREBIRD_INTERFACE_H
HAVE_FT2BUILD_H
HAVE_GD_H
HAVE_GLIB_H
HAVE_GMP_H
HAVE_HTTPD_H
HAVE_IBASE_H
HAVE_IR_IR_H
HAVE_KECCAKHASH_H
HAVE_LBER_H
HAVE_LDAP_H
HAVE_LIBEXSLT_EXSLT_H
HAVE_LIBINTL_H
HAVE_LIBPQ_FE_H
HAVE_LIBTIDY_TIDY_H
HAVE_LIBXML_PARSER_H
HAVE_LIBXML_TREE_H
HAVE_LIBXML_XMLWRITER_H
HAVE_LIBXSLT_XSLT_H
HAVE_LMDB_H
HAVE_MBSTRING_H
HAVE_MYSQL_H
HAVE_ONIGURUMA_H
HAVE_OPENSSL_SSL_H
HAVE_PNG_H
HAVE_SNMP_H
HAVE_SODIUM_H
HAVE_SQLITE3_H
HAVE_SQLITE3EXT_H
HAVE_SYBFRONT_H
HAVE_TIDY_H
HAVE_TIDY_TIDY_H
HAVE_TIDYBUFFIO_H
HAVE_TIMELIB_CONFIG_H
HAVE_UNICODE_USPOOF_H
HAVE_UNICODE_UTF_H
HAVE_XPM_H
HAVE_ZIP_H
HAVE_ZIPCONF_H
HAVE_ZLIB_H

The following compile definitions are defined explicitly:
- HAVE_ICONV_H
- HAVE_MSCOREE_H
- HAVE_SQL_H
- HAVE_SQLEXT_H

Additionally, the `SETUP_OPENSSL()` function doesn't accept the 6th argument anymore.
