### PR TITLE
Windows: Allow OpenSSL Argon2 password hashing on ZTS

### DIFF
--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -16,9 +16,7 @@ if (PHP_OPENSSL != "no") {
 			AC_DEFINE("LOAD_OPENSSL_LEGACY_PROVIDER", 1, "Define to 1 to load the OpenSSL legacy algorithm provider in addition to the default provider.");
 		}
 		if (PHP_OPENSSL_ARGON2 != "no") {
-			if (PHP_ZTS != "no") {
-				WARNING("OpenSSL argon2 hashing not supported in ZTS mode for now");
-			} else if (!GREP_HEADER("openssl/thread.h", "OSSL_set_max_threads", PHP_PHP_BUILD + "\\include")) {
+			if (!GREP_HEADER("openssl/thread.h", "OSSL_set_max_threads", PHP_PHP_BUILD + "\\include")) {
 				WARNING("OpenSSL argon2 hashing requires OpenSSL >= 3.2");
 			} else {
 				AC_DEFINE("HAVE_OPENSSL_ARGON2", 1, "Define to 1 to enable OpenSSL argon2 password hashing.");


### PR DESCRIPTION
This is a follow-up of ce6e7a278694bb065f8adcd11beb42c353787f18 (GH-19236).