### PR TITLE
ext/session: fix PS_FUNCS() macro expansion

### DIFF
--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -70,7 +70,7 @@ typedef struct ps_module_struct {
 	PS_WRITE_FUNC(x); \
 	PS_DESTROY_FUNC(x); \
 	PS_GC_FUNC(x);	\
-	PS_CREATE_SID_FUNC(x) \
+	PS_CREATE_SID_FUNC(x); \
 	PS_VALIDATE_SID_FUNC(x);
 
 #define PS_MOD(x) \


### PR DESCRIPTION
Added the missing trailing `;` after `PS_CREATE_SID_FUNC(x)` so `PS_FUNCS(x)` expands to valid prototypes.