### PR TITLE
Update ext/{pdo_sqlite,sqlite3} tests

### DIFF
--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
@@ -4,7 +4,7 @@ PDO_sqlite: Testing sqliteCreateFunction() with flags
 pdo_sqlite
 --SKIPIF--
 <?php
-if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip system sqlite is too old');
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
 ?>
 --FILE--
 <?php

--- a/ext/pdo_sqlite/tests/php_8.5_deprecations.phpt
+++ b/ext/pdo_sqlite/tests/php_8.5_deprecations.phpt
@@ -2,6 +2,10 @@
 PDO_sqlite: PHP 8.5 deprecations
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
+?>
 --FILE--
 <?php
 

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_constants.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_constants.phpt
@@ -2,6 +2,10 @@
 PDO_sqlite: Testing constants exist
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
+?>
 --FILE--
 <?php
 

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createfunction_with_flags.phpt
@@ -4,7 +4,7 @@ PDO_sqlite: Testing createFunction() with flags
 pdo_sqlite
 --SKIPIF--
 <?php
-if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip system sqlite is too old');
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
 ?>
 --FILE--
 <?php

--- a/ext/pdo_sqlite/tests/subclasses/pdosqlite_001.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdosqlite_001.phpt
@@ -2,6 +2,10 @@
 Pdo\Sqlite basic
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
+?>
 --FILE--
 <?php
 

--- a/ext/pdo_sqlite/tests/subclasses/pdosqlite_002.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdosqlite_002.phpt
@@ -2,6 +2,10 @@
 Pdo\Sqlite create through PDO::connect and function define.
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php
+if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip Pdo\Sqlite::DETERMINISTIC requires SQLite library >= 3.8.3');
+?>
 --FILE--
 <?php
 

--- a/ext/sqlite3/tests/sqlite3_35_stmt_readonly.phpt
+++ b/ext/sqlite3/tests/sqlite3_35_stmt_readonly.phpt
@@ -2,13 +2,6 @@
 SQLite3_stmt::readOnly check
 --EXTENSIONS--
 sqlite3
---SKIPIF--
-<?php
-$version = SQLite3::version();
-if ($version['versionNumber'] < 3007004) {
-  die("skip");
-}
-?>
 --FILE--
 <?php
 

--- a/ext/sqlite3/tests/sqlite3_37_createfunction_flags.phpt
+++ b/ext/sqlite3/tests/sqlite3_37_createfunction_flags.phpt
@@ -4,7 +4,7 @@ SQLite3::createFunction - Test with flags
 sqlite3
 --SKIPIF--
 <?php
-if (!defined('SQLITE3_DETERMINISTIC')) die('skip system sqlite is too old');
+if (!defined('SQLITE3_DETERMINISTIC')) die('skip SQLITE3_DETERMINISTIC requires SQLite library >= 3.8.3');
 ?>
 --FILE--
 <?php

--- a/ext/sqlite3/tests/sqlite3_stmt_busy.phpt
+++ b/ext/sqlite3/tests/sqlite3_stmt_busy.phpt
@@ -2,11 +2,6 @@
 SQLite3_stmt::busy
 --EXTENSIONS--
 sqlite3
---SKIPIF--
-<?php
-$version = SQLite3::version();
-if ($version['versionNumber'] < 3007004) die("skip");
-?>
 --FILE--
 <?php
 


### PR DESCRIPTION
- Added SKIPIF sections for tests that use Pdo\Sqlite::DETERMINISTIC as it is available since libsqlite 3.8.3.
- Removed outdated SKIPIF sections for libsqlite versions 3.7.4

When using libsqlite 3.7.17 there are two more failing tests due to different warning messages:
- ext/sqlite3/tests/sqlite3_38_extended_error.phpt
- ext/sqlite3/tests/sqlite3_39_toggleExtended.phpt

This fix doesn't address these as minimum required libsqlite will be updated in the future PHP versions anyway at some point and this won't be an issue anymore then.