### PR TITLE
ext/session: Fix memory leak

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -41,6 +41,7 @@
 #include "ext/standard/url_scanner_ex.h"
 #include "ext/standard/info.h"
 #include "zend_smart_str.h"
+#include "zend_exceptions.h"
 #include "ext/standard/url.h"
 #include "ext/standard/basic_functions.h"
 #include "ext/standard/head.h"
@@ -1723,14 +1724,27 @@ PHPAPI php_session_status php_get_session_status(void)
 
 static bool php_session_abort(void)
 {
-	if (PS(session_status) == php_session_active) {
-		if (PS(mod_data) || PS(mod_user_implemented)) {
-			PS(mod)->s_close(&PS(mod_data));
-		}
-		PS(session_status) = php_session_none;
-		return true;
-	}
-	return false;
+    if (PS(session_status) == php_session_active) {
+
+        if ((PS(mod_data) || PS(mod_user_implemented)) && PS(mod)->s_close) {
+
+            zend_object *old_exception = EG(exception);
+            EG(exception) = NULL;
+
+            PS(mod)->s_close(&PS(mod_data));
+
+            if (!EG(exception)) {
+                EG(exception) = old_exception;
+            } else if (old_exception) {
+                zend_exception_set_previous(EG(exception), old_exception);
+            }
+        }
+
+        PS(session_status) = php_session_none;
+        return true;
+    }
+
+    return false;
 }
 
 static bool php_session_reset(void)

--- a/ext/session/tests/sessionhandler_validateid_return_type.phpt
+++ b/ext/session/tests/sessionhandler_validateid_return_type.phpt
@@ -1,0 +1,35 @@
+--TEST--
+SessionHandler::validateId must return bool
+--INI--
+session.use_strict_mode=1
+--EXTENSIONS--
+session
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+class MySession extends SessionHandler {
+    public function validateId($key) {
+        return null;
+    }
+}
+
+$handler = new MySession();
+
+try {
+    session_set_save_handler($handler);
+    session_start();
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+session_write_close();
+
+try {
+    session_start();
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Session id must be a string

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
@@ -43,6 +43,8 @@ var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i
 --EXPECTF--
 *** Testing session_set_save_handler() : incorrect arguments for existing handler open ***
 Open:
+
+Warning: SessionHandler::close(): Parent session handler is not open in %s on line %d
 SessionHandler::open() expects exactly 2 arguments, 0 given
 
 Warning: Undefined global variable $_SESSION in %s on line %d


### PR DESCRIPTION
Fix the memory leak.

```php

class MySession extends SessionHandler {
    public function validateId($key) {
        return null; //memory leak here
    }
}

$handler = new MySession();

try {
    session_set_save_handler($handler);
    session_start();
} catch (TypeError $e) {
   echo $e->getMessage(), "\n";
}

session_write_close();

try {
    session_start();
} catch (Throwable $e) {
   echo $e->getMessage(), "\n";
}
```