### PR TITLE
ext/standard: Math: Throw ValueError for log() when base is 1

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -721,8 +721,10 @@ PHP_FUNCTION(log)
 		RETURN_DOUBLE(log10(num));
 	}
 
+	
 	if (base == 1.0) {
-		RETURN_DOUBLE(ZEND_NAN);
+		zend_argument_value_error(2, "must not be equal to 1");
+		RETURN_THROWS();
 	}
 
 	if (base <= 0.0) {

--- a/ext/standard/tests/math/log_base_validation.phpt
+++ b/ext/standard/tests/math/log_base_validation.phpt
@@ -1,0 +1,33 @@
+--TEST--
+log(): Throw ValueError for invalid base values
+--FILE--
+<?php
+
+try {
+    log(10, 1);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    log(10, 0);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+try {
+    log(10, -2);
+} catch (ValueError $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo log(8, 2), PHP_EOL;
+echo log(100, 10), PHP_EOL;
+
+?>
+--EXPECT--
+log(): Argument #2 ($base) must not be equal to 1
+log(): Argument #2 ($base) must be greater than 0
+log(): Argument #2 ($base) must be greater than 0
+3
+2


### PR DESCRIPTION
Throw `ValueError` for `log()` with `base = 1` instead of returning `NAN`