### PR TITLE
ext/session: add mod_user_uses_object_methods_as_handlers global 

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -104,6 +104,9 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 
 - ext/session:
   . php_session_flush() now returns a bool rather than a zend_result.
+  . The mod_user_names global has been removed.
+  . The mod_user_uses_object_methods_as_handlers global has been added,
+    it indicates whether the session handlers are methods of an object or not.
   . Removed session_adapt_url().
   . PS_OPEN_ARGS is now defined as
     `void **mod_data, zend_string *save_path, zend_string *session_name`

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -184,6 +184,7 @@ typedef struct _php_ps_globals {
 
 	bool mod_user_implemented;
 	bool mod_user_is_open;
+	bool mod_user_uses_object_methods_as_handlers;
 	bool use_trans_sid; /* contains the INI value of whether to use trans-sid */
 } php_ps_globals;
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -118,6 +118,7 @@ static inline void php_rinit_session_globals(void)
 	PS(set_handler) = false;
 	PS(mod_data) = NULL;
 	PS(mod_user_is_open) = false;
+	PS(mod_user_uses_object_methods_as_handlers) = false;
 	PS(define_sid) = true;
 	PS(session_vars) = NULL;
 	PS(module_number) = my_module_number;
@@ -2126,6 +2127,7 @@ PHP_FUNCTION(session_set_save_handler)
 		zend_string_release_ex(validate_sid_name, false);
 		zend_string_release_ex(update_timestamp_name, false);
 
+		PS(mod_user_uses_object_methods_as_handlers) = true;
 		if (register_shutdown) {
 			/* create shutdown function */
 			php_shutdown_function_entry shutdown_function_entry = {
@@ -2217,6 +2219,7 @@ PHP_FUNCTION(session_set_save_handler)
 	SESSION_SET_USER_HANDLER_PROCEDURAL_OPTIONAL(ps_validate_sid, validate_id_fci);
 	SESSION_SET_USER_HANDLER_PROCEDURAL_OPTIONAL(ps_update_timestamp, update_timestamp_fci);
 
+	PS(mod_user_uses_object_methods_as_handlers) = false;
 	RETURN_TRUE;
 }
 
@@ -2843,6 +2846,7 @@ static PHP_GINIT_FUNCTION(ps)
 	ps_globals->default_mod = NULL;
 	ps_globals->mod_user_implemented = false;
 	ps_globals->mod_user_is_open = false;
+	ps_globals->mod_user_uses_object_methods_as_handlers = false;
 	ps_globals->session_vars = NULL;
 	ps_globals->set_handler = false;
 	ps_globals->session_started_filename = NULL;


### PR DESCRIPTION
This solves the use case of knowing if the session handlers are methods of an object or individual handlers without relying on the now removed mod_user_names global.