### PR TITLE
Fix build in strict mode

### DIFF
--- a/main/debug_gdb_scripts.c
+++ b/main/debug_gdb_scripts.c
@@ -6,7 +6,7 @@
  *
  * See https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
  */
-asm(
+__asm__(
     ".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
     ".byte 4 /* Python Text */\n"
     ".ascii \"gdb.inlined-script\\n\"\n"

--- a/scripts/gdb/debug_gdb_scripts_gen.php
+++ b/scripts/gdb/debug_gdb_scripts_gen.php
@@ -27,7 +27,7 @@ $ccode = sprintf(
      *
      * See https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
      */
-    asm(
+    __asm__(
         ".pushsection \".debug_gdb_scripts\", \"MS\",%%progbits,1\n"
         ".byte 4 /* Python Text */\n"
         ".ascii \"gdb.inlined-script\\n\"\n"


### PR DESCRIPTION
When building in strict mode (e.g. `-std=c11`), compilation of `main/debug_gdb_scripts.c` fails because `asm()` is not a standard top level statement. `__asm__()` however can be reserved by the compiler even in strict mode.

IR will need a similar fix (https://github.com/dstogov/ir/pull/128).

Partially fixes GH-21215.