### PR TITLE
zend_portability: Simplify check for `max_align_t`

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -870,8 +870,7 @@ extern "C++" {
 # define ZEND_STATIC_ASSERT(c, m)
 #endif
 
-#if ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) /* C11 */ \
-  || (defined(__cplusplus) && __cplusplus >= 201103L) /* C++11 */) && !defined(ZEND_WIN32)
+#if !defined(ZEND_WIN32)
 typedef max_align_t zend_max_align_t;
 #else
 typedef union {


### PR DESCRIPTION
C11 / C++11 are the baseline requirements, thus we only need to check for Windows.