### PR TITLE
Fix flagging of partial array containing partial object

### DIFF
--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -965,7 +965,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 					SET_RESULT(op1, &zv);
 				} else if (ct_eval_assign_dim(&zv, data, op2) == SUCCESS) {
 					/* Mark array containing partial array as partial */
-					if (IS_PARTIAL_ARRAY(data)) {
+					if (IS_PARTIAL_ARRAY(data) || IS_PARTIAL_OBJECT(data)) {
 						MAKE_PARTIAL_ARRAY(&zv);
 					}
 					SET_RESULT(result, data);
@@ -1165,7 +1165,7 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 						/* We can't add NEXT element into partial array (skip it) */
 						SET_RESULT(result, &zv);
 					} else if (ct_eval_add_array_elem(&zv, op1, op2) == SUCCESS) {
-						if (IS_PARTIAL_ARRAY(op1)) {
+						if (IS_PARTIAL_ARRAY(op1) || IS_PARTIAL_OBJECT(op1)) {
 							MAKE_PARTIAL_ARRAY(&zv);
 						}
 						SET_RESULT(result, &zv);

--- a/ext/opcache/tests/gh21227.phpt
+++ b/ext/opcache/tests/gh21227.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-21227: Borked partial array propagation
+--CREDITS--
+Daniel Chong (chongwick)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--FILE--
+<?php
+
+function test() {
+    $obj->a = 3;
+    $objs = [];
+    $obj = new stdClass;
+    $objs[] = $obj;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
In SCCP, arrays containing partial objects must be marked as partial so that their values are not accidentally propagated.

Fixes GH-21227