### PR TITLE
ext/pgsql: fix GH-21165 unit test.

### DIFF
--- a/ext/pgsql/tests/gh21162.phpt
+++ b/ext/pgsql/tests/gh21162.phpt
@@ -2,12 +2,6 @@
 GH-21162 (pg_connect() on error memory leak)
 --EXTENSIONS--
 pgsql
---SKIPIF--
-<?php
-if(substr(PHP_OS, 0, 3) == 'WIN' ) {
-    die('skip not for windows');
-}
-?>
 --FILE--
 <?php
 
@@ -15,7 +9,7 @@ set_error_handler(function (int $errno, string $errstr) {
     echo "Warning caught\n";
 });
 
-pg_connect('');
+pg_connect('host=blablahost.');
 
 echo "Done\n";
 ?>


### PR DESCRIPTION
skipping on windows as the error handler does not seem to trigger.