### PR TITLE
Fix GH-13989: Allow opcache.file_cache_only=1 without source files

### DIFF
--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_autoload.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_autoload.phpt
@@ -1,0 +1,141 @@
+--TEST--
+GH-13989: file_cache_only should serve autoloaded classes without source files (classmap autoloading)
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache6', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache6"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+$php = PHP_BINARY;
+$baseDir = __DIR__ . '/gh13989_autoload';
+$cacheDir = __DIR__ . '/gh13989_cache6';
+
+// Create project structure
+@mkdir($baseDir . '/vendor/composer', 0777, true);
+@mkdir($baseDir . '/src/Models', 0777, true);
+@mkdir($baseDir . '/src/Services', 0777, true);
+
+// Class files
+file_put_contents($baseDir . '/src/Models/User.php', <<<'PHP'
+<?php
+namespace App\Models;
+class User {
+    public function __construct(private string $name) {}
+    public function getName(): string { return $this->name; }
+}
+PHP);
+
+file_put_contents($baseDir . '/src/Services/Greeter.php', <<<'PHP'
+<?php
+namespace App\Services;
+use App\Models\User;
+class Greeter {
+    public function greet(User $user): string {
+        return "Hello, " . $user->getName() . "!";
+    }
+}
+PHP);
+
+// Classmap autoloader (like composer dump-autoload -o)
+file_put_contents($baseDir . '/vendor/composer/autoload_classmap.php',
+    '<?php return array(' .
+    "'App\\\\Models\\\\User' => dirname(__DIR__, 2) . '/src/Models/User.php'," .
+    "'App\\\\Services\\\\Greeter' => dirname(__DIR__, 2) . '/src/Services/Greeter.php'," .
+    ');'
+);
+
+file_put_contents($baseDir . '/vendor/autoload.php', <<<'PHP'
+<?php
+$classMap = require __DIR__ . '/composer/autoload_classmap.php';
+spl_autoload_register(function ($class) use ($classMap) {
+    if (isset($classMap[$class])) {
+        require $classMap[$class];
+    }
+});
+PHP);
+
+// Main script
+file_put_contents($baseDir . '/index.php', <<<'PHP'
+<?php
+require __DIR__ . '/vendor/autoload.php';
+$user = new \App\Models\User('World');
+$greeter = new \App\Services\Greeter();
+echo $greeter->greet($user) . "\n";
+PHP);
+
+$opcacheArgs = implode(' ', [
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.jit=disable',
+    '-dopcache.file_cache=' . escapeshellarg($cacheDir),
+    '-dopcache.file_cache_only=1',
+    '-dopcache.file_cache_consistency_checks=0',
+    '-dopcache.file_update_protection=0',
+    '-dopcache.validate_timestamps=0',
+    '-dopcache.validate_permission=0',
+    '-dopcache.validate_root=0',
+]);
+
+$script = $baseDir . '/index.php';
+
+// Step 1: Run to warm cache
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 1: " . trim($out) . "\n";
+
+// Step 2: Delete class source files (keep autoloader and main script)
+unlink($baseDir . '/src/Models/User.php');
+unlink($baseDir . '/src/Services/Greeter.php');
+
+// Step 3: Run again — autoloader will require files served from cache
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 2: " . trim($out) . "\n";
+
+// Step 4: Also delete the main script and autoloader files
+unlink($baseDir . '/index.php');
+unlink($baseDir . '/vendor/autoload.php');
+unlink($baseDir . '/vendor/composer/autoload_classmap.php');
+
+// Step 5: Run with all source deleted
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 3: " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache6');
+removeDirRecursive(__DIR__ . '/gh13989_autoload');
+?>
+--EXPECT--
+Step 1: Hello, World!
+Step 2: Hello, World!
+Step 3: Hello, World!
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_cli_missing_no_cache.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_cli_missing_no_cache.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-13989: CLI should show "Could not open input file" when file_cache_only is not enabled
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$script = __DIR__ . '/gh13989_nonexistent_script.php';
+
+// Without file_cache_only: missing file must produce the original error
+$out = shell_exec("$php -n $script 2>&1");
+echo "Without opcache: " . trim($out) . "\n";
+
+// With opcache loaded but file_cache_only=0: same original error
+$out = shell_exec("$php -n -dopcache.enable=1 -dopcache.enable_cli=1 -dopcache.file_cache_only=0 $script 2>&1");
+echo "With opcache, file_cache_only=0: " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--EXPECTF--
+Without opcache: Could not open input file: %sgh13989_nonexistent_script.php
+With opcache, file_cache_only=0: Could not open input file: %sgh13989_nonexistent_script.php
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_cli_primary.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_cli_primary.phpt
@@ -1,0 +1,74 @@
+--TEST--
+GH-13989: CLI should execute primary script from file_cache_only without source
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache3', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache3"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+$php = PHP_BINARY;
+$script = __DIR__ . '/gh13989_primary_test.php';
+$cacheDir = __DIR__ . '/gh13989_cache3';
+
+$opcacheArgs = implode(' ', [
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.jit=disable',
+    '-dopcache.file_cache=' . escapeshellarg($cacheDir),
+    '-dopcache.file_cache_only=1',
+    '-dopcache.file_cache_consistency_checks=0',
+    '-dopcache.file_update_protection=0',
+    '-dopcache.validate_timestamps=0',
+    '-dopcache.validate_permission=0',
+    '-dopcache.validate_root=0',
+]);
+
+// Step 1: Create script and run to populate cache
+file_put_contents($script, '<?php echo "primary cached\n";');
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 1: " . trim($out) . "\n";
+
+// Step 2: Remove source and run again — should serve from cache
+unlink($script);
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 2: " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache3');
+@unlink(__DIR__ . '/gh13989_primary_test.php');
+?>
+--EXPECT--
+Step 1: primary cached
+Step 2: primary cached
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_docker.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_docker.phpt
@@ -1,0 +1,144 @@
+--TEST--
+GH-13989: file_cache_only Docker deployment — ship image with only opcache binary cache, no source
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== 'Linux') {
+    die('skip Docker test requires Linux host');
+}
+exec('docker info 2>&1', $output, $exitCode);
+if ($exitCode !== 0) {
+    die('skip Docker is not available or not running');
+}
+$opcacheSo = ini_get('extension_dir') . '/opcache.so';
+if (!file_exists($opcacheSo)) {
+    die('skip opcache.so not found');
+}
+?>
+--INI--
+opcache.enable=0
+--FILE--
+<?php
+$phpBin = PHP_BINARY;
+$opcacheSo = ini_get('extension_dir') . '/opcache.so';
+
+// Collect shared library directories from ldd so the host PHP binary
+// can run inside the container without installing build dependencies.
+$libDirs = [];
+foreach ([$phpBin, $opcacheSo] as $binary) {
+    $lines = [];
+    exec('ldd ' . escapeshellarg($binary) . ' 2>/dev/null', $lines);
+    foreach ($lines as $line) {
+        if (preg_match('#=>\s+(/\S+)#', $line, $m) && file_exists($m[1])) {
+            $libDirs[dirname($m[1])] = true;
+        }
+    }
+}
+
+// Mount each host library directory at /opt/hostlibs/N in the container
+$mounts = '';
+$ldPaths = [];
+$idx = 0;
+foreach (array_keys($libDirs) as $dir) {
+    $target = '/opt/hostlibs/' . $idx;
+    $mounts .= sprintf(' -v %s:%s:ro', escapeshellarg($dir), $target);
+    $ldPaths[] = $target;
+    $idx++;
+}
+$ldPathStr = implode(':', $ldPaths);
+
+$bashScript = <<<'BASH'
+#!/bin/bash
+set -e
+export LD_LIBRARY_PATH="%%LD_LIBRARY_PATH%%"
+
+PHP=/opt/php
+OPTS="-n -dzend_extension=/opt/opcache.so -dopcache.enable=1 -dopcache.enable_cli=1 -dopcache.jit=disable"
+OPTS="$OPTS -dopcache.file_cache=/app/cache -dopcache.file_cache_only=1"
+OPTS="$OPTS -dopcache.file_update_protection=0 -dopcache.validate_timestamps=0"
+
+# ── Create a Composer-like app with classmap autoloader ────────
+mkdir -p /app/{cache,src/Models,src/Services,vendor/composer}
+
+cat > /app/src/Models/User.php << 'PHP_SRC'
+<?php
+namespace App\Models;
+class User {
+    public function __construct(private string $name) {}
+    public function getName(): string { return $this->name; }
+}
+PHP_SRC
+
+cat > /app/src/Services/Greeter.php << 'PHP_SRC'
+<?php
+namespace App\Services;
+use App\Models\User;
+class Greeter {
+    public function greet(User $u): string {
+        return "Hello, " . $u->getName() . "!";
+    }
+}
+PHP_SRC
+
+cat > /app/vendor/composer/autoload_classmap.php << 'PHP_SRC'
+<?php return array(
+    'App\\Models\\User' => '/app/src/Models/User.php',
+    'App\\Services\\Greeter' => '/app/src/Services/Greeter.php',
+);
+PHP_SRC
+
+cat > /app/vendor/autoload.php << 'PHP_SRC'
+<?php
+$classMap = require __DIR__ . '/composer/autoload_classmap.php';
+spl_autoload_register(function ($class) use ($classMap) {
+    if (isset($classMap[$class])) {
+        require $classMap[$class];
+    }
+});
+PHP_SRC
+
+cat > /app/index.php << 'PHP_SRC'
+<?php
+require __DIR__ . '/vendor/autoload.php';
+$user = new \App\Models\User('Docker');
+$greeter = new \App\Services\Greeter();
+echo $greeter->greet($user) . "\n";
+PHP_SRC
+
+# ── Step 1: Warm the file cache ───────────────────────────────
+$PHP $OPTS /app/index.php
+
+# ── Step 2: Remove class source files (simulate stripped deploy)
+rm /app/src/Models/User.php /app/src/Services/Greeter.php
+
+# ── Step 3: Run from cache — class files served by opcache ────
+$PHP $OPTS /app/index.php
+
+# ── Step 4: Remove ALL source files ───────────────────────────
+rm /app/index.php /app/vendor/autoload.php /app/vendor/composer/autoload_classmap.php
+
+# ── Step 5: Run from cache — everything served by opcache ─────
+$PHP $OPTS /app/index.php
+BASH;
+
+$bashScript = str_replace('%%LD_LIBRARY_PATH%%', $ldPathStr, $bashScript);
+
+$scriptFile = tempnam(sys_get_temp_dir(), 'gh13989_docker_');
+file_put_contents($scriptFile, $bashScript);
+
+$cmd = sprintf(
+    'docker run --rm%s -v %s:/opt/php:ro -v %s:/opt/opcache.so:ro -v %s:/test.sh:ro debian:bookworm-slim bash /test.sh 2>/dev/null',
+    $mounts,
+    escapeshellarg($phpBin),
+    escapeshellarg($opcacheSo),
+    escapeshellarg($scriptFile)
+);
+
+$out = shell_exec($cmd);
+@unlink($scriptFile);
+
+echo $out;
+?>
+--EXPECT--
+Hello, Docker!
+Hello, Docker!
+Hello, Docker!

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_no_source.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_no_source.phpt
@@ -1,0 +1,63 @@
+--TEST--
+GH-13989: file_cache_only should serve scripts without source files on disk
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+// Create a temporary PHP file
+$file = __DIR__ . '/gh13989_test_script.php';
+file_put_contents($file, '<?php echo "cached output\n";');
+
+// Compile it to populate file cache
+opcache_compile_file($file);
+
+// Include it once to verify it works
+include $file;
+
+// Now remove the source file
+unlink($file);
+
+// Include again — should serve from file cache without source
+include $file;
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache');
+@unlink(__DIR__ . '/gh13989_test_script.php');
+?>
+--EXPECT--
+cached output
+cached output
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_no_source_require.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_no_source_require.phpt
@@ -1,0 +1,59 @@
+--TEST--
+GH-13989: file_cache_only should serve included files without source on disk
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache2', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache2"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+$lib = __DIR__ . '/gh13989_lib.php';
+file_put_contents($lib, '<?php echo "from lib\n";');
+
+// Include to populate cache
+include $lib;
+
+// Remove source
+unlink($lib);
+
+// Include again without source — should serve from file cache
+include $lib;
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache2');
+@unlink(__DIR__ . '/gh13989_lib.php');
+?>
+--EXPECT--
+from lib
+from lib
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_phar.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_phar.phpt
@@ -1,0 +1,98 @@
+--TEST--
+GH-13989: file_cache_only should serve scripts from PHAR when source inside PHAR is stripped
+--SKIPIF--
+<?php
+if (!extension_loaded('phar')) die('skip phar extension not available');
+@mkdir(__DIR__ . '/gh13989_cache5', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache5"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+phar.readonly=0
+--EXTENSIONS--
+opcache
+phar
+--FILE--
+<?php
+$php = PHP_BINARY;
+$pharFile = __DIR__ . '/gh13989_app.phar';
+$cacheDir = __DIR__ . '/gh13989_cache5';
+
+$opcacheArgs = implode(' ', [
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.jit=disable',
+    '-dopcache.file_cache=' . escapeshellarg($cacheDir),
+    '-dopcache.file_cache_only=1',
+    '-dopcache.file_cache_consistency_checks=0',
+    '-dopcache.file_update_protection=0',
+    '-dopcache.validate_timestamps=0',
+    '-dopcache.validate_permission=0',
+    '-dopcache.validate_root=0',
+    '-dphar.readonly=1',
+]);
+
+// Step 1: Create PHAR with real source and warm cache
+$p = new Phar($pharFile);
+$p['index.php'] = '<?php echo "from phar cache\n"; require __DIR__ . "/lib.php";';
+$p['lib.php'] = '<?php echo "lib from phar\n";';
+$p->setStub('<?php __HALT_COMPILER(); ?>');
+unset($p);
+
+$pharScript = 'phar://' . $pharFile . '/index.php';
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($pharScript) . " 2>&1");
+echo "Step 1: " . trim($out) . "\n";
+
+// Step 2: Replace PHAR with stripped source (no real code inside)
+$p = new Phar($pharFile);
+$p['index.php'] = '<?php /* stripped */ ?>';
+$p['lib.php'] = '<?php /* stripped */ ?>';
+$p->setStub('<?php __HALT_COMPILER(); ?>');
+unset($p);
+
+// Step 3: Run again — should serve original compiled output from file cache
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($pharScript) . " 2>&1");
+echo "Step 2: " . trim($out) . "\n";
+
+// Step 4: Run a third time to ensure cache was not invalidated
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($pharScript) . " 2>&1");
+echo "Step 3: " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache5');
+@unlink(__DIR__ . '/gh13989_app.phar');
+?>
+--EXPECT--
+Step 1: from phar cache
+lib from phar
+Step 2: from phar cache
+lib from phar
+Step 3: from phar cache
+lib from phar
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_relative_path.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_relative_path.phpt
@@ -1,0 +1,99 @@
+--TEST--
+GH-13989: file_cache_only should resolve relative paths with . and .. when source is missing
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache7', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache7"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=0
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+$php = PHP_BINARY;
+$baseDir = __DIR__ . '/gh13989_relpath';
+$subDir = $baseDir . '/sub';
+$cacheDir = __DIR__ . '/gh13989_cache7';
+
+@mkdir($subDir, 0777, true);
+
+// Create a script in the base directory
+file_put_contents($baseDir . '/target.php', '<?php echo "from relative path\n";');
+
+$opcacheArgs = implode(' ', [
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.jit=disable',
+    '-dopcache.file_cache=' . escapeshellarg($cacheDir),
+    '-dopcache.file_cache_only=1',
+    '-dopcache.file_cache_consistency_checks=0',
+    '-dopcache.file_update_protection=0',
+    '-dopcache.validate_timestamps=0',
+    '-dopcache.validate_permission=0',
+    '-dopcache.validate_root=0',
+]);
+
+// Step 1: Warm cache using a path with ./
+$script1 = $baseDir . '/./target.php';
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($script1) . " 2>&1");
+echo "Step 1 (./): " . trim($out) . "\n";
+
+// Step 2: Warm cache using a path with sub/../
+$script2 = $baseDir . '/sub/../target.php';
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($script2) . " 2>&1");
+echo "Step 2 (sub/../): " . trim($out) . "\n";
+
+// Step 3: Remove source file
+unlink($baseDir . '/target.php');
+
+// Step 4: Run with ./ path — should serve from cache
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($script1) . " 2>&1");
+echo "Step 3 (./ no source): " . trim($out) . "\n";
+
+// Step 5: Run with sub/../ path — should serve from same cache entry
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($script2) . " 2>&1");
+echo "Step 4 (sub/../ no source): " . trim($out) . "\n";
+
+// Step 6: Run with canonical absolute path — should serve from same cache entry
+$script3 = $baseDir . '/target.php';
+$out = shell_exec("$php $opcacheArgs " . escapeshellarg($script3) . " 2>&1");
+echo "Step 5 (absolute no source): " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache7');
+removeDirRecursive(__DIR__ . '/gh13989_relpath');
+?>
+--EXPECT--
+Step 1 (./): from relative path
+Step 2 (sub/../): from relative path
+Step 3 (./ no source): from relative path
+Step 4 (sub/../ no source): from relative path
+Step 5 (absolute no source): from relative path
+done

--- a/ext/opcache/tests/gh13989/gh13989_file_cache_only_validate_timestamps.phpt
+++ b/ext/opcache/tests/gh13989/gh13989_file_cache_only_validate_timestamps.phpt
@@ -1,0 +1,80 @@
+--TEST--
+GH-13989: file_cache_only with validate_timestamps=1 should serve cached scripts when source is deleted
+--SKIPIF--
+<?php
+@mkdir(__DIR__ . '/gh13989_cache4', 0777, true);
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.file_cache="{PWD}/gh13989_cache4"
+opcache.file_cache_only=1
+opcache.file_cache_consistency_checks=0
+opcache.file_update_protection=0
+opcache.validate_timestamps=1
+opcache.validate_permission=0
+opcache.validate_root=0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+$php = PHP_BINARY;
+$script = __DIR__ . '/gh13989_validate_ts_test.php';
+$cacheDir = __DIR__ . '/gh13989_cache4';
+
+$opcacheArgs = implode(' ', [
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.jit=disable',
+    '-dopcache.file_cache=' . escapeshellarg($cacheDir),
+    '-dopcache.file_cache_only=1',
+    '-dopcache.file_cache_consistency_checks=0',
+    '-dopcache.file_update_protection=0',
+    '-dopcache.validate_timestamps=1',
+    '-dopcache.validate_permission=0',
+    '-dopcache.validate_root=0',
+]);
+
+// Step 1: Create script and run to populate cache
+file_put_contents($script, '<?php echo "cached with timestamps\n";');
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 1: " . trim($out) . "\n";
+
+// Step 2: Remove source and run again — should serve from cache
+// even with validate_timestamps=1, because source is missing
+unlink($script);
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 2: " . trim($out) . "\n";
+
+// Step 3: Run a third time to ensure cache file was not deleted
+$out = shell_exec("$php $opcacheArgs $script 2>&1");
+echo "Step 3: " . trim($out) . "\n";
+
+echo "done\n";
+?>
+--CLEAN--
+<?php
+function removeDirRecursive($dir) {
+    if (!is_dir($dir)) return;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $fileinfo) {
+        if ($fileinfo->isDir()) {
+            @rmdir($fileinfo->getRealPath());
+        } else {
+            @unlink($fileinfo->getRealPath());
+        }
+    }
+    @rmdir($dir);
+}
+removeDirRecursive(__DIR__ . '/gh13989_cache4');
+@unlink(__DIR__ . '/gh13989_validate_ts_test.php');
+?>
+--EXPECT--
+Step 1: cached with timestamps
+Step 2: cached with timestamps
+Step 3: cached with timestamps
+done

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -565,6 +565,11 @@ static zend_result cli_seek_file_begin(zend_file_handle *file_handle, char *scri
 {
 	FILE *fp = VCWD_FOPEN(script_file, "rb");
 	if (!fp) {
+		if (INI_INT("opcache.file_cache_only")) {
+			zend_stream_init_filename(file_handle, script_file);
+			file_handle->primary_script = 1;
+			return SUCCESS;
+		}
 		fprintf(stderr, "Could not open input file: %s\n", script_file);
 		return FAILURE;
 	}


### PR DESCRIPTION
When `opcache.file_cache_only=1` is enabled and the file cache is warm, PHP currently requires source files to exist on disk even though it serves compiled opcodes from cache. This prevents legitimate deployment workflows where source code is stripped from the final image (e.g., Docker, PHAR, WASM).

This PR makes PHP fall back to the file cache when source files are missing, instead of failing with "Could not open input file" or "Failed opening required".

  Changes

 `sapi/cli/php_cli.c` -- When `opcache.file_cache_only=1` is set and the script file doesn't exist, defer to opcache instead of immediately failing. The original "Could not open input file" error is preserved when opcache is not involved.
  `ext/opcache/ZendAccelerator.c` -- Two changes:
  - `file_cache_compile_file()`: Try loading from file cache before attempting to open the source file. Paths are canonicalized via `expand_filepath_with_mode(CWD_EXPAND)` so that `./foo.php`, `bar/../foo.php`, and `/app/foo.php` all resolve to the same cache entry.
  - `persistent_zend_resolve_path()`: In `file_cache_only` mode, when the original resolver fails (file missing), return the canonicalized path so the file cache can look it up.  

`ext/opcache/zend_file_cache.c` -- When `validate_timestamps=1` and the source file is missing (timestamp 0), serve from cache instead of invalidating it.

  Limitations

  - CLI only for the primary script. FPM/CGI SAPIs check file existence before opcache can intercept, so the entry point script must still exist on disk (can be empty). Included/required files work in all SAPIs.
  - Requires absolute paths or CWD-resolvable paths. Include-path-based resolution needs the source file for initial path discovery. Composer classmap autoloaders (which use absolute paths) work fully.

  Test plan

  - gh13989_file_cache_only_no_source — basic include from cache after source deletion
  - gh13989_file_cache_only_no_source_require — same with require
  - gh13989_file_cache_only_cli_primary — CLI primary script from cache
  - gh13989_file_cache_only_autoload — Composer-style classmap autoloading
  - gh13989_file_cache_only_phar — PHAR with stripped source
  - gh13989_file_cache_only_validate_timestamps — validate_timestamps=1 with missing source
  - gh13989_file_cache_only_relative_path — ./ and ../ path canonicalization
  - gh13989_file_cache_only_cli_missing_no_cache — preserves "Could not open input file" without opcache
  - gh13989_file_cache_only_docker — end-to-end Docker deployment scenario (Linux only)

  Closes GH-13989.