### PR TITLE
Autotools: Add -fvisibility=hidden also in phpize

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -91,6 +91,8 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 - Unix build system changes:
   . Symbol HAVE_ST_BLOCKS has been removed from php_config.h (use
     HAVE_STRUCT_STAT_ST_BLOCKS).
+  . When using phpize, extensions are now built with -fvisibility=hidden compile
+    option (when building inside php-src this was already enabled previously).
 
 ========================
 3. Module changes

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -127,6 +127,9 @@ AS_VAR_IF([PHP_DEBUG], [yes], [
 dnl Always shared.
 PHP_BUILD_SHARED
 
+AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
+  [CFLAGS="$CFLAGS -fvisibility=hidden"])
+
 PHP_HELP_SEPARATOR([Extension:])
 PHP_CONFIGURE_PART([Configuring extension])
 


### PR DESCRIPTION
This builds shared extensions in php-src and through phpize with the same visibility preset.

Otherwise, I'm not sure if this is of any importance but IMHO it isn't good producing two different modules when building in php-src or via phpize.

For example:
```sh
./buildconf
./configure --enable-calendar=shared
make
readelf --dyn-syms modules/calendar.so
``` 

vs.

```sh
cd ext/calendar
phpize
./configure
make
readelf --dyn-syms modules/calendar.so
```