### PR TITLE
zend: Define C23 enum `zend_class_type`

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -144,8 +144,13 @@ struct _zend_inheritance_cache_entry {
 	zend_class_entry             *traits_and_interfaces[1];
 };
 
+C23_ENUM(zend_class_type, uint8_t) {
+	ZEND_INTERNAL_CLASS = 1,
+	ZEND_USER_CLASS = 2,
+};
+
 struct _zend_class_entry {
-	char type;
+	zend_class_type type;
 	zend_string *name;
 	/* class_entry or string depending on ZEND_ACC_LINKED */
 	union {

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4410,8 +4410,7 @@ ZEND_API const char *zend_get_module_version(const char *module_name) /* {{{ */
 /* }}} */
 
 static zend_always_inline bool is_persistent_class(const zend_class_entry *ce) {
-	return (ce->type & ZEND_INTERNAL_CLASS)
-		&& ce->info.internal.module->type == MODULE_PERSISTENT;
+	return ce->type == ZEND_INTERNAL_CLASS && ce->info.internal.module->type == MODULE_PERSISTENT;
 }
 
 ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
@@ -4534,7 +4533,7 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		Z_PROP_FLAG_P(property_default_ptr) = Z_ISUNDEF_P(property) ? IS_PROP_UNINIT : 0;
 	}
 skip_property_storage:
-	if (ce->type & ZEND_INTERNAL_CLASS) {
+	if (ce->type == ZEND_INTERNAL_CLASS) {
 		/* Must be interned to avoid ZTS data races */
 		if (is_persistent_class(ce)) {
 			name = zend_new_interned_string(zend_string_copy(name));
@@ -4753,7 +4752,7 @@ ZEND_API void zend_declare_property_string(zend_class_entry *ce, const char *nam
 {
 	zval property;
 
-	ZVAL_NEW_STR(&property, zend_string_init(value, strlen(value), ce->type & ZEND_INTERNAL_CLASS));
+	ZVAL_NEW_STR(&property, zend_string_init(value, strlen(value), ce->type == ZEND_INTERNAL_CLASS));
 	zend_declare_property(ce, name, name_length, &property, access_type);
 }
 /* }}} */
@@ -4762,7 +4761,7 @@ ZEND_API void zend_declare_property_stringl(zend_class_entry *ce, const char *na
 {
 	zval property;
 
-	ZVAL_NEW_STR(&property, zend_string_init(value, value_len, ce->type & ZEND_INTERNAL_CLASS));
+	ZVAL_NEW_STR(&property, zend_string_init(value, value_len, ce->type == ZEND_INTERNAL_CLASS));
 	zend_declare_property(ce, name, name_length, &property, access_type);
 }
 /* }}} */
@@ -4876,7 +4875,7 @@ ZEND_API void zend_declare_class_constant_stringl(zend_class_entry *ce, const ch
 {
 	zval constant;
 
-	ZVAL_NEW_STR(&constant, zend_string_init(value, value_length, ce->type & ZEND_INTERNAL_CLASS));
+	ZVAL_NEW_STR(&constant, zend_string_init(value, value_length, ce->type == ZEND_INTERNAL_CLASS));
 	zend_declare_class_constant(ce, name, name_length, &constant);
 }
 /* }}} */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1079,9 +1079,6 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 
 #define ZEND_USER_CODE(type)		((type) != ZEND_INTERNAL_FUNCTION)
 
-#define ZEND_INTERNAL_CLASS         1
-#define ZEND_USER_CLASS             2
-
 #define ZEND_EVAL				(1<<0)
 #define ZEND_INCLUDE			(1<<1)
 #define ZEND_INCLUDE_ONCE		(1<<2)

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -100,7 +100,7 @@ static zend_function *zend_duplicate_internal_function(const zend_function *func
 {
 	zend_function *new_function;
 
-	if (UNEXPECTED(ce->type & ZEND_INTERNAL_CLASS)) {
+	if (UNEXPECTED(ce->type == ZEND_INTERNAL_CLASS)) {
 		new_function = (zend_function *)pemalloc(sizeof(zend_internal_function), 1);
 		memcpy(new_function, func, sizeof(zend_internal_function));
 	} else {
@@ -1669,7 +1669,7 @@ static void do_inherit_class_constant(zend_string *name, zend_class_constant *pa
 				Z_CONSTANT_FLAGS(c->value) |= CONST_OWNED;
 			}
 		}
-		if (ce->type & ZEND_INTERNAL_CLASS) {
+		if (ce->type == ZEND_INTERNAL_CLASS) {
 			c = pemalloc(sizeof(zend_class_constant), 1);
 			memcpy(c, parent_const, sizeof(zend_class_constant));
 			parent_const = c;
@@ -2151,7 +2151,7 @@ static void do_inherit_iface_constant(zend_string *name, zend_class_constant *c,
 				Z_CONSTANT_FLAGS(c->value) |= CONST_OWNED;
 			}
 		}
-		if (ce->type & ZEND_INTERNAL_CLASS) {
+		if (ce->type == ZEND_INTERNAL_CLASS) {
 			ct = pemalloc(sizeof(zend_class_constant), 1);
 			memcpy(ct, c, sizeof(zend_class_constant));
 			c = ct;

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -940,7 +940,7 @@ static int php_var_serialize_get_sleep_props(
 
 		priv_name = zend_mangle_property_name(
 			ZSTR_VAL(ce->name), ZSTR_LEN(ce->name),
-			ZSTR_VAL(name), ZSTR_LEN(name), ce->type & ZEND_INTERNAL_CLASS);
+			ZSTR_VAL(name), ZSTR_LEN(name), ce->type == ZEND_INTERNAL_CLASS);
 		if (php_var_serialize_try_add_sleep_prop(ht, props, priv_name, name, struc) == SUCCESS) {
 			zend_tmp_string_release(tmp_name);
 			zend_string_release(priv_name);
@@ -955,7 +955,7 @@ static int php_var_serialize_get_sleep_props(
 		}
 
 		prot_name = zend_mangle_property_name(
-			"*", 1, ZSTR_VAL(name), ZSTR_LEN(name), ce->type & ZEND_INTERNAL_CLASS);
+			"*", 1, ZSTR_VAL(name), ZSTR_LEN(name), ce->type == ZEND_INTERNAL_CLASS);
 		if (php_var_serialize_try_add_sleep_prop(ht, props, prot_name, name, struc) == SUCCESS) {
 			zend_tmp_string_release(tmp_name);
 			zend_string_release(prot_name);


### PR DESCRIPTION
Checked for “binary and” comparisons using Coccinelle:

    @@
    struct _zend_class_entry *e;
    expression x;
    @@

    * (e->type & x)

    @@
    zend_class_entry *e;
    expression x;
    @@

    * (e->type & x)