### PR TITLE
ext/pcntl: Fix cpuset leak in pcntl_setcpuaffinity on out-of-range CPU ID

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1733,6 +1733,7 @@ PHP_FUNCTION(pcntl_setcpuaffinity)
 
 		if (cpu < 0 || cpu >= maxcpus) {
 			zend_argument_value_error(2, "cpu id must be between 0 and " ZEND_ULONG_FMT " (" ZEND_LONG_FMT ")", maxcpus, cpu);
+			PCNTL_CPU_DESTROY(mask);
 			RETURN_THROWS();
 		}
 


### PR DESCRIPTION
Add missing PCNTL_CPU_DESTROY(mask) call before RETURN_THROWS() when the cpu id is out of range, matching the cleanup on other error paths.