### PR TITLE
ext/pcntl: Fix signal table updated before php_signal4 succeeds in pc…

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -798,7 +798,7 @@ PHP_FUNCTION(pcntl_signal)
 		RETURN_THROWS();
 	}
 
-	/* we need to register in the OS side first before we update the internal list */
+	/* Register with the OS first so that on failure we don't record a handler that was never installed */
 	if (php_signal4(signo, pcntl_signal_handler, (int) restart_syscalls, 1) == (void *)SIG_ERR) {
 		PCNTL_G(last_error) = errno;
 		php_error_docref(NULL, E_WARNING, "Error assigning signal");


### PR DESCRIPTION
…ntl_signal

Move the signal table update after the php_signal4 call, mirroring what is already done in the SIG_DFL/SIG_IGN (integer) code path. This prevents a stale entry in the table if sigaction fails.