### PR TITLE
Remove support for HP-UX

### DIFF
--- a/TSRM/threads.m4
+++ b/TSRM/threads.m4
@@ -40,8 +40,6 @@ AC_DEFUN([PTHREADS_FLAGS],[
     PTHREAD_FLAGS=-D_REENTRANT;;
   *aix*)
     PTHREAD_FLAGS=-D_THREAD_SAFE;;
-  *hpux*)
-    PTHREAD_FLAGS=-D_REENTRANT;;
   *sco*)
     PTHREAD_FLAGS=-D_REENTRANT;;
   esac
@@ -91,13 +89,12 @@ dnl  -mthreads         gcc (AIX)
 dnl  -pthread          gcc (Linux, FreeBSD, NetBSD, OpenBSD)
 dnl  -pthreads         gcc (Solaris)
 dnl  -qthreaded        AIX cc V5
-dnl  -threads          gcc (HP-UX)
 dnl
 AC_DEFUN([PTHREADS_CHECK],[
 AC_CACHE_CHECK(for pthreads_cflags,ac_cv_pthreads_cflags,[
 ac_cv_pthreads_cflags=
 if test "$pthreads_working" != "yes"; then
-  for flag in -kthread -pthread -pthreads -mthreads -Kthread -threads -mt -qthreaded; do
+  for flag in -kthread -pthread -pthreads -mthreads -Kthread -mt -qthreaded; do
     ac_save=$CFLAGS
     CFLAGS="$CFLAGS $flag"
     PTHREADS_CHECK_COMPILE

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -91,6 +91,7 @@ PHP 8.6 INTERNALS UPGRADE NOTES
 - Unix build system changes:
   . Symbol HAVE_ST_BLOCKS has been removed from php_config.h (use
     HAVE_STRUCT_STAT_ST_BLOCKS).
+  . Support for HP-UX has been removed.
 
 ========================
 3. Module changes

--- a/Zend/zend_hrtime.c
+++ b/Zend/zend_hrtime.c
@@ -44,7 +44,7 @@ ZEND_API mach_timebase_info_data_t zend_hrtime_timerlib_info = {
 	.denom = 1,
 };
 
-#elif ZEND_HRTIME_PLATFORM_HPUX
+#elif ZEND_HRTIME_PLATFORM_SUNOS
 
 # include <sys/time.h>
 

--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -35,7 +35,7 @@
 #define ZEND_HRTIME_PLATFORM_WINDOWS 0
 #define ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE 0
 #define ZEND_HRTIME_PLATFORM_APPLE_GETTIME_NSEC 0
-#define ZEND_HRTIME_PLATFORM_HPUX    0
+#define ZEND_HRTIME_PLATFORM_SUNOS    0
 #define ZEND_HRTIME_PLATFORM_AIX     0
 
 #if defined(_POSIX_TIMERS) && ((_POSIX_TIMERS > 0) || defined(__OpenBSD__)) && defined(_POSIX_MONOTONIC_CLOCK) && defined(CLOCK_MONOTONIC)
@@ -50,15 +50,15 @@
 #elif defined(__APPLE__)
 # undef  ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE
 # define ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE 1
-#elif (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))
-# undef  ZEND_HRTIME_PLATFORM_HPUX
-# define ZEND_HRTIME_PLATFORM_HPUX 1
+#elif (defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__))
+# undef  ZEND_HRTIME_PLATFORM_SUNOS
+# define ZEND_HRTIME_PLATFORM_SUNOS 1
 #elif defined(_AIX)
 # undef  ZEND_HRTIME_PLATFORM_AIX
 # define ZEND_HRTIME_PLATFORM_AIX 1
 #endif
 
-#define ZEND_HRTIME_AVAILABLE (ZEND_HRTIME_PLATFORM_POSIX || ZEND_HRTIME_PLATFORM_WINDOWS || ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE || ZEND_HRTIME_PLATFORM_APPLE_GETTIME_NSEC || ZEND_HRTIME_PLATFORM_HPUX || ZEND_HRTIME_PLATFORM_AIX)
+#define ZEND_HRTIME_AVAILABLE (ZEND_HRTIME_PLATFORM_POSIX || ZEND_HRTIME_PLATFORM_WINDOWS || ZEND_HRTIME_PLATFORM_APPLE_MACH_ABSOLUTE || ZEND_HRTIME_PLATFORM_APPLE_GETTIME_NSEC || ZEND_HRTIME_PLATFORM_SUNOS || ZEND_HRTIME_PLATFORM_AIX)
 
 BEGIN_EXTERN_C()
 
@@ -98,7 +98,7 @@ static zend_always_inline zend_hrtime_t zend_hrtime(void)
 	struct timespec ts = { .tv_sec = 0, .tv_nsec = 0 };
 	clock_gettime(zend_hrtime_posix_clock_id, &ts);
 	return ((zend_hrtime_t) ts.tv_sec * (zend_hrtime_t)ZEND_NANO_IN_SEC) + ts.tv_nsec;
-#elif ZEND_HRTIME_PLATFORM_HPUX
+#elif ZEND_HRTIME_PLATFORM_SUNOS
 	return (zend_hrtime_t) gethrtime();
 #elif  ZEND_HRTIME_PLATFORM_AIX
 	timebasestruct_t t;

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -229,7 +229,7 @@ char *alloca();
 # endif
 #endif
 
-#if !ZEND_DEBUG && (defined(HAVE_ALLOCA) || (defined (__GNUC__) && __GNUC__ >= 2)) && !(defined(ZTS) && defined(HPUX)) && !defined(__APPLE__)
+#if !ZEND_DEBUG && (defined(HAVE_ALLOCA) || (defined (__GNUC__) && __GNUC__ >= 2)) && !defined(__APPLE__)
 # define ZEND_ALLOCA_MAX_SIZE (32 * 1024)
 # define ALLOCA_FLAG(name) \
 	bool name;
@@ -357,7 +357,7 @@ char *alloca();
 # endif
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__)) || __has_attribute(noreturn)
+#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(_AIX) && !defined(__osf__)) || __has_attribute(noreturn)
 # define HAVE_NORETURN
 # define ZEND_NORETURN __attribute__((noreturn))
 #elif defined(ZEND_WIN32)
@@ -373,7 +373,7 @@ char *alloca();
 # define ZEND_STACK_ALIGNED
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(__hpux) && !defined(_AIX) && !defined(__osf__))
+#if (defined(__GNUC__) && __GNUC__ >= 3 && !defined(__INTEL_COMPILER) && !defined(__APPLE__) && !defined(_AIX) && !defined(__osf__))
 # define HAVE_NORETURN_ALIAS
 # define HAVE_ATTRIBUTE_WEAK
 #endif

--- a/build/php.m4
+++ b/build/php.m4
@@ -1079,28 +1079,11 @@ AC_DEFUN([PHP_CHECK_SIZEOF], [
 dnl
 dnl PHP_TIME_R_TYPE
 dnl
-dnl Check type of reentrant time-related functions. Type can be: irix, hpux or
-dnl POSIX.
+dnl Check type of reentrant time-related functions. Type can be: irix or POSIX.
 dnl
 AC_DEFUN([PHP_TIME_R_TYPE],
 [AC_CACHE_CHECK([for type of reentrant time-related functions],
   [php_cv_time_r_type],
-  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <time.h>
-
-int main(void) {
-char buf[27];
-struct tm t;
-time_t old = 0;
-int r, s;
-
-s = gmtime_r(&old, &t);
-r = (int) asctime_r(&t, buf, 26);
-if (r == s && s == 0) return (0);
-return (1);
-}
-  ]])],
-  [php_cv_time_r_type=hpux],
   [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>
 int main(void) {
@@ -1116,12 +1099,9 @@ int main(void) {
   ]])],
   [php_cv_time_r_type=irix],
   [php_cv_time_r_type=POSIX],
-  [php_cv_time_r_type=POSIX])],
   [php_cv_time_r_type=POSIX])
 ])
 AS_CASE([$php_cv_time_r_type],
-  [hpux], [AC_DEFINE([PHP_HPUX_TIME_R], [1],
-    [Define to 1 if you have HP-UX 10.x.-style reentrant time functions.])],
   [irix], [AC_DEFINE([PHP_IRIX_TIME_R], [1],
     [Define to 1 you have IRIX-style reentrant time functions.])])
 ])
@@ -1507,19 +1487,14 @@ dnl ----------------------------------------------------------------------------
 dnl
 dnl PHP_SHLIB_SUFFIX_NAMES
 dnl
-dnl Determines link library suffix SHLIB_SUFFIX_NAME which can be: .so, .sl or
+dnl Determines link library suffix SHLIB_SUFFIX_NAME which can be: .so, or
 dnl .dylib
 dnl
-dnl Determines shared library suffix SHLIB_DL_SUFFIX_NAME suffix can be: .so or
-dnl .sl
+dnl Determines shared library suffix SHLIB_DL_SUFFIX_NAME suffix can be: .so.
 dnl
 AC_DEFUN([PHP_SHLIB_SUFFIX_NAMES], [
 AC_REQUIRE([PHP_CANONICAL_HOST_TARGET])dnl
 AS_CASE([$host_alias],
-  [*hpux*], [
-    SHLIB_SUFFIX_NAME=sl
-    SHLIB_DL_SUFFIX_NAME=sl
-  ],
   [*darwin*], [
     SHLIB_SUFFIX_NAME=dylib
     SHLIB_DL_SUFFIX_NAME=so

--- a/configure.ac
+++ b/configure.ac
@@ -226,11 +226,6 @@ case $host_alias in
   *solaris*)
     CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"
     ;;
-  *hpux*)
-    if test "$GCC" = "yes"; then
-      CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE_EXTENDED"
-    fi
-    ;;
 esac
 
 dnl Disable PIC mode by default where it is known to be safe to do so, to avoid

--- a/ext/fileinfo/php_libmagic.h
+++ b/ext/fileinfo/php_libmagic.h
@@ -43,14 +43,6 @@
 #define FINFO_READ_FUNC read
 #endif
 
-#if defined(__hpux) && !defined(HAVE_STRTOULL)
-#if SIZEOF_LONG == 8
-# define strtoull strtoul
-#else
-# define strtoull __strtoull
-#endif
-#endif
-
 #ifndef offsetof
 #define offsetof(STRUCTURE,FIELD) ((int)((char*)&((STRUCTURE*)0)->FIELD))
 #endif

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -816,23 +816,17 @@ const LOG_SYSLOG = UNKNOWN;
  * @cvalue LOG_LPR
  */
 const LOG_LPR = UNKNOWN;
-#ifdef LOG_NEWS
-/* No LOG_NEWS on HP-UX */
 /**
  * usenet new
  * @var int
  * @cvalue LOG_NEWS
  */
 const LOG_NEWS = UNKNOWN;
-#endif
-#ifdef LOG_UUCP
-/* No LOG_UUCP on HP-UX */
 /**
  * @var int
  * @cvalue LOG_UUCP
  */
 const LOG_UUCP = UNKNOWN;
-#endif
 #ifdef LOG_CRON
 /* apparently some systems don't have this one */
 /**

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 8d1c2a735f412f8571675c6b025c3a418b68fb65
+ * Stub hash: 31a5677f7cedf5232f1724c51380e76f4e512776
  * Has decl header: yes */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
@@ -3695,12 +3695,8 @@ static void register_basic_functions_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("LOG_AUTH", LOG_AUTH, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LOG_SYSLOG", LOG_SYSLOG, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("LOG_LPR", LOG_LPR, CONST_PERSISTENT);
-#if defined(LOG_NEWS)
 	REGISTER_LONG_CONSTANT("LOG_NEWS", LOG_NEWS, CONST_PERSISTENT);
-#endif
-#if defined(LOG_UUCP)
 	REGISTER_LONG_CONSTANT("LOG_UUCP", LOG_UUCP, CONST_PERSISTENT);
-#endif
 #if defined(LOG_CRON)
 	REGISTER_LONG_CONSTANT("LOG_CRON", LOG_CRON, CONST_PERSISTENT);
 #endif

--- a/ext/standard/basic_functions_decl.h
+++ b/ext/standard/basic_functions_decl.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit basic_functions.stub.php instead.
- * Stub hash: 8d1c2a735f412f8571675c6b025c3a418b68fb65 */
+ * Stub hash: 31a5677f7cedf5232f1724c51380e76f4e512776 */
 
-#ifndef ZEND_BASIC_FUNCTIONS_DECL_8d1c2a735f412f8571675c6b025c3a418b68fb65_H
-#define ZEND_BASIC_FUNCTIONS_DECL_8d1c2a735f412f8571675c6b025c3a418b68fb65_H
+#ifndef ZEND_BASIC_FUNCTIONS_DECL_31a5677f7cedf5232f1724c51380e76f4e512776_H
+#define ZEND_BASIC_FUNCTIONS_DECL_31a5677f7cedf5232f1724c51380e76f4e512776_H
 
 typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_HalfAwayFromZero = 1,
@@ -15,4 +15,4 @@ typedef enum zend_enum_RoundingMode {
 	ZEND_ENUM_RoundingMode_PositiveInfinity = 8,
 } zend_enum_RoundingMode;
 
-#endif /* ZEND_BASIC_FUNCTIONS_DECL_8d1c2a735f412f8571675c6b025c3a418b68fb65_H */
+#endif /* ZEND_BASIC_FUNCTIONS_DECL_31a5677f7cedf5232f1724c51380e76f4e512776_H */

--- a/main/php_reentrancy.h
+++ b/main/php_reentrancy.h
@@ -38,13 +38,6 @@
 #undef HAVE_CTIME_R
 #endif
 
-#if defined(PHP_HPUX_TIME_R)
-#undef HAVE_LOCALTIME_R
-#undef HAVE_ASCTIME_R
-#undef HAVE_CTIME_R
-#undef HAVE_GMTIME_R
-#endif
-
 BEGIN_EXTERN_C()
 
 #if !defined(HAVE_LOCALTIME_R) && defined(HAVE_LOCALTIME)

--- a/main/reentrancy.c
+++ b/main/reentrancy.c
@@ -68,43 +68,6 @@ PHPAPI char *php_asctime_r(const struct tm *tm, char *buf)
 
 #endif
 
-#if defined(PHP_HPUX_TIME_R)
-
-#define HAVE_LOCALTIME_R 1
-#define HAVE_CTIME_R 1
-#define HAVE_ASCTIME_R 1
-#define HAVE_GMTIME_R 1
-
-PHPAPI struct tm *php_localtime_r(const time_t *const timep, struct tm *p_tm)
-{
-	if (localtime_r(timep, p_tm) == 0)
-		return (p_tm);
-	return (NULL);
-}
-
-PHPAPI char *php_ctime_r(const time_t *clock, char *buf)
-{
-	if (ctime_r(clock, buf, 26) != -1)
-		return (buf);
-	return (NULL);
-}
-
-PHPAPI char *php_asctime_r(const struct tm *tm, char *buf)
-{
-	if (asctime_r(tm, buf, 26) != -1)
-		return (buf);
-	return (NULL);
-}
-
-PHPAPI struct tm *php_gmtime_r(const time_t *const timep, struct tm *p_tm)
-{
-	if (gmtime_r(timep, p_tm) == 0)
-		return (p_tm);
-	return (NULL);
-}
-
-#endif
-
 #if !defined(HAVE_LOCALTIME_R) && defined(HAVE_LOCALTIME)
 
 PHPAPI struct tm *php_localtime_r(const time_t *const timep, struct tm *p_tm)

--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -8,8 +8,6 @@ PHP_ARG_ENABLE([cli],
 if test "$PHP_CLI" != "no"; then
   AC_CHECK_FUNCS([setproctitle])
 
-  AC_CHECK_HEADERS([sys/pstat.h])
-
   AC_CACHE_CHECK([for PS_STRINGS], [php_cv_var_PS_STRINGS],
     [AC_LINK_IFELSE([AC_LANG_PROGRAM([
       #include <machine/vmparam.h>

--- a/sapi/cli/ps_title.c
+++ b/sapi/cli/ps_title.c
@@ -51,9 +51,6 @@ extern char** environ;
 #include <string.h>
 #include <stdlib.h>
 
-#ifdef HAVE_SYS_PSTAT_H
-#include <sys/pstat.h> /* for HP-UX */
-#endif
 #ifdef HAVE_PS_STRINGS
 #include <machine/vmparam.h> /* for old BSD */
 #include <sys/exec.h>
@@ -68,9 +65,6 @@ extern char** environ;
  * PS_USE_SETPROCTITLE
  *         use the function setproctitle(const char *, ...)
  *         (newer BSD systems)
- * PS_USE_PSTAT
- *         use the pstat(PSTAT_SETCMD, )
- *         (HPUX)
  * PS_USE_PS_STRINGS
  *         assign PS_STRINGS->ps_argvstr = "string"
  *         (some BSD systems)
@@ -88,8 +82,6 @@ extern char** environ;
  */
 #if defined(HAVE_SETPROCTITLE)
 #define PS_USE_SETPROCTITLE
-#elif defined(HAVE_SYS_PSTAT_H) && defined(PSTAT_SETCMD)
-#define PS_USE_PSTAT
 #elif defined(HAVE_PS_STRINGS)
 #define PS_USE_PS_STRINGS
 #elif defined(BSD) && !defined(__APPLE__)
@@ -359,15 +351,6 @@ ps_title_status set_ps_title(const char *title, size_t title_len)
 #ifdef PS_USE_SETPROCTITLE
     setproctitle("%s", ps_buffer);
 #endif
-
-#ifdef PS_USE_PSTAT
-    {
-        union pstun pst;
-
-        pst.pst_command = ps_buffer;
-        pstat(PSTAT_SETCMD, pst, ps_buffer_cur_len, 0, 0);
-    }
-#endif /* PS_USE_PSTAT */
 
 #ifdef PS_USE_PS_STRINGS
     PS_STRINGS->ps_nargvstr = 1;

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -2022,15 +2022,6 @@ ssize_t gsendfile( int fdOut, int fdIn, off_t *off, size_t size )
 #define gsendfile sendfile
 #endif
 
-
-#if defined(HPUX)
-ssize_t gsendfile( int fdOut, int fdIn, off_t * off, size_t size )
-{
-    return sendfile( fdOut, fdIn, off, size, NULL, 0 );
-}
-#endif
-
-
 ssize_t LSAPI_sendfile_r( LSAPI_Request * pReq, int fdIn, off_t* off, size_t size )
 {
     struct lsapi_packet_header * pHeader = pReq->m_respPktHeader;


### PR DESCRIPTION
Correct me if this is wrong but I think this is also kind of already suitable for PHP-8.6:

HP-UX is discontinued system since 2026-01-01:
https://userapps.support.sap.com/sap/support/knowledge/en/3629028

Recent compilers also don't work there anymore.

Changes:
- Non-standard '-threads' flag check removed.
- `ZEND_HRTIME_PLATFORM_HPUX` preprocessor macro renamed to `ZEND_HRTIME_PLATFORM_SUNOS` as it is now related to only Solaris/illumos systems.
- Check for HP-UX style reentrant time functions adjusted. This wasn't reproducible on any known system so far.
- `LOG_NEWS` and `LOG_UUCP` conditions removed as all Unix-like systems should have them (Windows build have definitions provided in `win32/syslog.h`).
- Check for `<sys/pstat.h>` header removed as it is relevant only on HP-UX.
- The `.sl` file extension for shared PHP extensions is with this also removed, making extension either `.so` (Unix-like systems), or `.dll` (Windows).