### PR TITLE
Fix ip2long in AIX to treat IPs with leading zeros as invalid like LINUX

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -598,6 +598,17 @@ PHP_FUNCTION(ip2long)
 	if (addr_len == 0 || inet_pton(AF_INET, addr, &ip) != 1) {
 		RETURN_FALSE;
 	}
+#ifdef _AIX
+        /*
+        AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
+        192.168.42.42), while Linux don't.
+        For consistency, we convert back the IP to a string and check if it is equal to
+        the original string. If not, the IP should be considered invalid.
+        */
+        if (strcmp(addr, inet_ntoa(ip)) != 0) {
+                RETURN_FALSE;
+       }
+#endif
 	RETURN_LONG(ntohl(ip.s_addr));
 }
 /* }}} */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -598,18 +598,18 @@ PHP_FUNCTION(ip2long)
 	if (addr_len == 0 || inet_pton(AF_INET, addr, &ip) != 1) {
 		RETURN_FALSE;
 	}
-#ifdef _AIX
-        /*
-        AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
-        192.168.42.42), while Linux don't.
-        For consistency, we convert back the IP to a string and check if it is equal to
-        the original string. If not, the IP should be considered invalid.
-        */
-        char str[INET_ADDRSTRLEN];
-        if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
-                RETURN_FALSE;
-       }
-#endif
+	#ifdef _AIX
+		/*
+		AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
+		192.168.42.42), while Linux don't.
+		For consistency, we convert back the IP to a string and check if it is equal to
+		the original string. If not, the IP should be considered invalid.
+		*/
+		char str[INET_ADDRSTRLEN];
+		if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
+			RETURN_FALSE;
+		}
+	#endif
 	RETURN_LONG(ntohl(ip.s_addr));
 }
 /* }}} */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -598,18 +598,18 @@ PHP_FUNCTION(ip2long)
 	if (addr_len == 0 || inet_pton(AF_INET, addr, &ip) != 1) {
 		RETURN_FALSE;
 	}
-	#ifdef _AIX
-		/*
-		AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
-		192.168.42.42), while Linux don't.
-		For consistency, we convert back the IP to a string and check if it is equal to
-		the original string. If not, the IP should be considered invalid.
-		*/
-		char str[INET_ADDRSTRLEN];
-		if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
-			RETURN_FALSE;
-		}
-	#endif
+#ifdef _AIX
+	/*
+	AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
+	192.168.42.42), while Linux don't.
+	For consistency, we convert back the IP to a string and check if it is equal to
+	the original string. If not, the IP should be considered invalid.
+	*/
+	char str[INET_ADDRSTRLEN];
+	if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
+		RETURN_FALSE;
+	}
+#endif
 	RETURN_LONG(ntohl(ip.s_addr));
 }
 /* }}} */

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -605,7 +605,8 @@ PHP_FUNCTION(ip2long)
         For consistency, we convert back the IP to a string and check if it is equal to
         the original string. If not, the IP should be considered invalid.
         */
-        if (strcmp(addr, inet_ntoa(ip)) != 0) {
+        char str[INET_ADDRSTRLEN];
+        if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
                 RETURN_FALSE;
        }
 #endif

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -600,13 +600,15 @@ PHP_FUNCTION(ip2long)
 	}
 #ifdef _AIX
 	/*
-	AIX accepts IP strings with excedentary 0 (192.168.042.42 will be treated as
-	192.168.42.42), while Linux don't.
+	AIX accepts IP strings with extraneous 0 (192.168.042.42 will be treated as
+	192.168.42.42), while Linux doesn't.
 	For consistency, we convert back the IP to a string and check if it is equal to
 	the original string. If not, the IP should be considered invalid.
 	*/
 	char str[INET_ADDRSTRLEN];
-	if (strcmp(addr, inet_ntop(AF_INET, &ip, str, sizeof(str))) != 0) {
+	const char* result = inet_ntop(AF_INET, &ip, str, sizeof(str));
+	ZEND_ASSERT(result != NULL);
+	if (strcmp(addr, result) != 0) {
 		RETURN_FALSE;
 	}
 #endif


### PR DESCRIPTION
Fixes #21295 