### PR TITLE
run-tests.php: Use PHP_SHLIB_SUFFIX

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -859,7 +859,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $exts = get_loaded_extensions();
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
-            if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
+            if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:' . PHP_SHLIB_SUFFIX . ')$/', $file, $matches)) {
                 if (!extension_loaded($matches[1])) {
                     $exts[] = $matches[1];
                 }


### PR DESCRIPTION
Instead of hardcoding the file extensions for shared PHP extensions (which in most cases are '.so', or '.dll'), this uses file extension for the current PHP build as it was defined during the configure/build phase. There can be systems where some other file extension is used for shared modules.