### PR TITLE
Windows build: Use GREP_HEADER() instead of CHECK_FUNC_IN_HEADER()

### DIFF
--- a/ext/openssl/config.w32
+++ b/ext/openssl/config.w32
@@ -18,7 +18,7 @@ if (PHP_OPENSSL != "no") {
 		if (PHP_OPENSSL_ARGON2 != "no") {
 			if (PHP_ZTS != "no") {
 				WARNING("OpenSSL argon2 hashing not supported in ZTS mode for now");
-			} else if (!CHECK_FUNC_IN_HEADER("openssl/thread.h", "OSSL_set_max_threads", PHP_PHP_BUILD + "\\include")) {
+			} else if (!GREP_HEADER("openssl/thread.h", "OSSL_set_max_threads", PHP_PHP_BUILD + "\\include")) {
 				WARNING("OpenSSL argon2 hashing requires OpenSSL >= 3.2");
 			} else {
 				AC_DEFINE("HAVE_OPENSSL_ARGON2", 1, "Define to 1 to enable OpenSSL argon2 password hashing.");

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("password-argon2", "Argon2 support", "no");
 if (PHP_PASSWORD_ARGON2 != "no") {
 	if (CHECK_LIB("argon2_a.lib;argon2.lib", null, PHP_PASSWORD_ARGON2)
 	&& CHECK_HEADER("argon2.h", "CFLAGS")) {
-		if (!CHECK_FUNC_IN_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include", "CFLAGS")) {
+		if (!GREP_HEADER("argon2.h", "argon2id_hash_raw", PHP_PHP_BUILD + "\\include")) {
 			ERROR("Please verify that Argon2 header and libraries >= 20161029 are installed");
 		}
 		AC_DEFINE('HAVE_ARGON2LIB', 1, "Define to 1 if the system has the 'libargon2' library.");

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -929,6 +929,11 @@ function OLD_CHECK_LIB(libnames, target, path_to_check)
 
 }
 
+/**
+ * Checks whether function exists in the given header. Same as GREP_HEADER() but
+ * it also defines the 'HAVE_<FUNC_NAME>' preprocessor macro to 1 or 0. In new
+ * code rather use GREP_HEADER() and define the macro explicitly when needed.
+ */
 function CHECK_FUNC_IN_HEADER(header_name, func_name, path_to_check, add_to_flag)
 {
 	var c = false;
@@ -955,6 +960,9 @@ function CHECK_FUNC_IN_HEADER(header_name, func_name, path_to_check, add_to_flag
 	return false;
 }
 
+/**
+ * Checks whether specified regular expression is found in the given header.
+ */
 function GREP_HEADER(header_name, regex, path_to_check)
 {
 	var c = false;


### PR DESCRIPTION
Following https://github.com/php/php-src/pull/21191 this removes the following unused compile definitions:

- HAVE_OSSL_SET_MAX_THREADS
- HAVE_ARGON2ID_HASH_RAW

The `CHECK_FUNC_IN_HEADER()` function defines the 'HAVE_<FUNCTION>' compile definitions to 0 or 1, but these aren't used in the code. Defining such preprocessor macros makes it difficult to track and sync with other build systems.