### PR TITLE
Fix compile warnings under GCC 15.2.1

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -169,7 +169,7 @@ static zend_always_inline void zend_hash_real_init_mixed_ex(HashTable *ht)
 	void *data;
 	uint32_t nSize = ht->nTableSize;
 
-	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize) != 0);
 
 	if (UNEXPECTED(GC_FLAGS(ht) & IS_ARRAY_PERSISTENT)) {
 		data = pemalloc(HT_SIZE_EX(nSize, HT_SIZE_TO_MASK(nSize)), 1);
@@ -351,7 +351,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_packed_to_hash(HashTable *ht)
 	uint32_t i;
 	uint32_t nSize = ht->nTableSize;
 
-	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize) != 0);
 
 	HT_ASSERT_RC1(ht);
 	// Alloc before assign to avoid inconsistencies on OOM
@@ -399,7 +399,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_extend(HashTable *ht, uint32_t nSize, bool
 
 	if (nSize == 0) return;
 
-	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize) != 0);
 
 	if (UNEXPECTED(HT_FLAGS(ht) & HASH_FLAG_UNINITIALIZED)) {
 		if (nSize > ht->nTableSize) {
@@ -1318,7 +1318,7 @@ static void ZEND_FASTCALL zend_hash_do_resize(HashTable *ht)
 		uint32_t nSize = ht->nTableSize + ht->nTableSize;
 		Bucket *old_buckets = ht->arData;
 
-		ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+		ZEND_ASSERT(HT_SIZE_TO_MASK(nSize) != 0);
 
 		new_data = pemalloc(HT_SIZE_EX(nSize, HT_SIZE_TO_MASK(nSize)), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
 		ht->nTableSize = nSize;

--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -723,7 +723,7 @@ void php_filter_validate_email(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 }
 /* }}} */
 
-static int _php_filter_validate_ipv4(char *str, size_t str_len, int *ip) /* {{{ */
+static int _php_filter_validate_ipv4(const char *str, size_t str_len, int *ip) /* {{{ */
 {
 	const char *end = str + str_len;
 	int num, m;
@@ -764,7 +764,7 @@ static int _php_filter_validate_ipv6(const char *str, size_t str_len, int ip[8])
 	int blocks = 0;
 	unsigned int num, n;
 	int i;
-	char *ipv4;
+	const char *ipv4;
 	const char *end;
 	int ip4elm[4];
 	const char *s = str;

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -320,7 +320,7 @@ static zend_result php_iconv_output_handler(void **nothing, php_output_context *
 
 		if (mimetype != NULL && (!(output_context->op & PHP_OUTPUT_HANDLER_CLEAN) || ((output_context->op & PHP_OUTPUT_HANDLER_START) && !(output_context->op & PHP_OUTPUT_HANDLER_FINAL)))) {
 			size_t len;
-			char *p = strstr(get_output_encoding(), "//");
+			const char *p = strstr(get_output_encoding(), "//");
 
 			if (p) {
 				len = spprintf(&content_type, 0, "Content-Type:%.*s; charset=%.*s", mimetype_len ? mimetype_len : (int) strlen(mimetype), mimetype, (int) (p - get_output_encoding()), get_output_encoding());
@@ -2577,7 +2577,7 @@ static php_stream_filter *php_iconv_stream_filter_factory_create(const char *nam
 {
 	php_stream_filter *retval = NULL;
 	php_iconv_stream_filter *inst;
-	char *from_charset = NULL, *to_charset = NULL;
+	const char *from_charset = NULL, *to_charset = NULL;
 	size_t from_charset_len, to_charset_len;
 
 	if ((from_charset = strchr(name, '.')) == NULL) {

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -282,7 +282,7 @@ PHPAPI zend_string *php_escape_shell_cmd(const zend_string *unescaped_cmd)
 	size_t x, y;
 	zend_string *cmd;
 #ifndef PHP_WIN32
-	char *p = NULL;
+	const char *p = NULL;
 #endif
 
 	ZEND_ASSERT(ZSTR_LEN(unescaped_cmd) == strlen(ZSTR_VAL(unescaped_cmd)) && "Must be a binary safe string");

--- a/ext/standard/filters.c
+++ b/ext/standard/filters.c
@@ -1559,7 +1559,7 @@ static php_stream_filter *strfilter_convert_create(const char *filtername, zval 
 	php_convert_filter *inst;
 	php_stream_filter *retval = NULL;
 
-	char *dot;
+	const char *dot;
 	int conv_mode = 0;
 
 	if (filterparams != NULL && Z_TYPE_P(filterparams) != IS_ARRAY) {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -259,8 +259,8 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 	len = strlen(filtername);
 
 	/* determine the classname/class entry */
-	if (NULL == (fdat = zend_hash_str_find_ptr(BG(user_filter_map), (char*)filtername, len))) {
-		char *period;
+	if (NULL == (fdat = zend_hash_str_find_ptr(BG(user_filter_map), filtername, len))) {
+		const char *period;
 
 		/* Userspace Filters using ambiguous wildcards could cause problems.
            i.e.: myfilter.foo.bar will always call into myfilter.foo.*
@@ -272,16 +272,16 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 
 			/* Search for wildcard matches instead */
 			memcpy(wildcard, filtername, len + 1); /* copy \0 */
-			period = wildcard + (period - filtername);
-			while (period) {
-				ZEND_ASSERT(period[0] == '.');
-				period[1] = '*';
-				period[2] = '\0';
+			char *new_period = wildcard + (period - filtername);
+			while (new_period) {
+				ZEND_ASSERT(new_period[0] == '.');
+				new_period[1] = '*';
+				new_period[2] = '\0';
 				if (NULL != (fdat = zend_hash_str_find_ptr(BG(user_filter_map), wildcard, strlen(wildcard)))) {
-					period = NULL;
+					new_period = NULL;
 				} else {
-					*period = '\0';
-					period = strrchr(wildcard, '.');
+					*new_period = '\0';
+					new_period = strrchr(wildcard, '.');
 				}
 			}
 			efree(wildcard);
@@ -311,7 +311,7 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 	}
 
 	/* filtername */
-	add_property_string(&obj, "filtername", (char*)filtername);
+	add_property_string(&obj, "filtername", filtername);
 
 	/* and the parameters, if any */
 	if (filterparams) {

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -641,7 +641,7 @@ static int is_port_number(const char *bindpath)
 
 int fcgi_listen(const char *path, int backlog)
 {
-	char     *s;
+	const char *s;
 	int       tcp = 0;
 	char      host[MAXPATHLEN];
 	short     port = 0;

--- a/main/main.c
+++ b/main/main.c
@@ -995,7 +995,7 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 {
 	zend_string *replace_origin = NULL;
 	char *docref_buf = NULL, *target = NULL;
-	char *docref_target = "", *docref_root = "";
+	const char *docref_target = "", *docref_root = "";
 	char *p;
 	const char *space = "";
 	const char *class_name = "";

--- a/main/network.c
+++ b/main/network.c
@@ -553,7 +553,7 @@ bound:
 
 PHPAPI zend_result php_network_parse_network_address_with_port(const char *addr, size_t addrlen, struct sockaddr *sa, socklen_t *sl)
 {
-	char *colon;
+	const char *colon;
 	char *tmp;
 	zend_result ret = FAILURE;
 	short port;

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -224,7 +224,7 @@ PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval 
 	const php_stream_filter_factory *factory = NULL;
 	php_stream_filter *filter = NULL;
 	size_t n;
-	char *period;
+	const char *period;
 
 	n = strlen(filtername);
 
@@ -236,17 +236,17 @@ PHPAPI php_stream_filter *php_stream_filter_create(const char *filtername, zval 
 
 		wildname = safe_emalloc(1, n, 3);
 		memcpy(wildname, filtername, n+1);
-		period = wildname + (period - filtername);
-		while (period && !filter) {
-			ZEND_ASSERT(period[0] == '.');
-			period[1] = '*';
-			period[2] = '\0';
+		char *new_period = wildname + (period - filtername);
+		while (new_period && !filter) {
+			ZEND_ASSERT(new_period[0] == '.');
+			new_period[1] = '*';
+			new_period[2] = '\0';
 			if (NULL != (factory = zend_hash_str_find_ptr(filter_hash, wildname, strlen(wildname)))) {
 				filter = factory->create_filter(filtername, filterparams, persistent);
 			}
 
-			*period = '\0';
-			period = strrchr(wildname, '.');
+			*new_period = '\0';
+			new_period = strrchr(wildname, '.');
 		}
 		efree(wildname);
 	}

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -615,7 +615,8 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 {
 	php_stream *stream;
 	php_stream_temp_data *ts;
-	char *comma, *semi, *sep;
+	char *comma;
+	const char *semi, *sep;
 	size_t mlen, dlen, plen, vlen, ilen;
 	zend_off_t newoffs;
 	zval meta;
@@ -637,7 +638,7 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 		path += 2;
 	}
 
-	if ((comma = memchr(path, ',', dlen)) == NULL) {
+	if ((comma = (char *) memchr(path, ',', dlen)) == NULL) {
 		php_stream_wrapper_log_error(wrapper, options, "rfc2397: no comma in URL");
 		return NULL;
 	}

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1775,7 +1775,7 @@ not_relative_path:
 	ptr = pathbuf;
 
 	while (ptr && *ptr) {
-		end = strchr(ptr, DEFAULT_DIR_SEPARATOR);
+		end = (char *) strchr(ptr, DEFAULT_DIR_SEPARATOR);
 		if (end != NULL) {
 			*end = '\0';
 			end++;

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -617,7 +617,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
 
 static inline char *parse_ip_address_ex(const char *str, size_t str_len, int *portno, int get_err, zend_string **err)
 {
-	char *colon;
+	const char *colon;
 	char *host = NULL;
 
 	if (memchr(str, '\0', str_len)) {
@@ -628,7 +628,7 @@ static inline char *parse_ip_address_ex(const char *str, size_t str_len, int *po
 #ifdef HAVE_IPV6
 	if (*(str) == '[' && str_len > 1) {
 		/* IPV6 notation to specify raw address with port (i.e. [fe80::1]:80) */
-		char *p = memchr(str + 1, ']', str_len - 2);
+		const char *p = memchr(str + 1, ']', str_len - 2);
 		if (!p || *(p + 1) != ':') {
 			if (get_err) {
 				*err = strpprintf(0, "Failed to parse IPv6 address \"%s\"", str);

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -111,7 +111,7 @@ PHPDBG_API int phpdbg_is_addr(const char *str) /* {{{ */
 
 PHPDBG_API int phpdbg_is_class_method(const char *str, size_t len, char **class, char **method) /* {{{ */
 {
-	char *sep = NULL;
+	const char *sep = NULL;
 
 	if (strstr(str, "#") != NULL)
 		return 0;


### PR DESCRIPTION
The compiler now infers constness through string functions. Adhere to that.
It also now warns about using multiplications in conditions.