### PR TITLE
Fix PDOStatement::getIterator() not throwing when parameters are provided

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,10 @@ PHP                                                                        NEWS
   . Fixed re-entrancy issue on php_pcre_match_impl, php_pcre_replace_impl,
     php_pcre_split_impl, and php_pcre_grep_impl. (David Carlier)
 
+- PDO:
+  . Fixed PDOStatement::getIterator() not throwing when parameters are
+    provided. (alexandre-daubois)
+
 - Standard:
   . Fixed bug GH-20906 (Assertion failure when messing up output buffers).
     (ndossche)

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2022,9 +2022,7 @@ PHP_METHOD(PDOStatement, debugDumpParams)
 
 PHP_METHOD(PDOStatement, getIterator)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_create_internal_iterator_zval(return_value, ZEND_THIS);
 }


### PR DESCRIPTION
`PDOStatement::getIterator()` silently fails if arguments are provided, which is inconsistent with the rest of the file.