### PR TITLE
Fix enabling of opcache in benchmark job in older branches

### DIFF
--- a/.github/matrix.php
+++ b/.github/matrix.php
@@ -73,7 +73,7 @@ function select_jobs($repository, $trigger, $nightly, $labels, $php_version, $re
         && ($all_jobs || !$no_jobs || $test_benchmarking)
         // push trigger is restricted to official repository.
         && ($repository === 'php/php-src' || $trigger === 'pull_request')) {
-        $jobs['BENCHMARKING'] = true;
+        $jobs['BENCHMARKING']['config']['integrated_opcache'] = version_compare($php_version, '8.5', '>=');
     }
     if ($all_jobs || $test_community) {
         $jobs['COMMUNITY']['matrix'] = version_compare($php_version, '8.4', '>=')

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1036,6 +1036,7 @@ jobs:
           sudo mkdir -p /etc/php.d
           sudo chmod 777 /etc/php.d
           echo mysqli.default_socket=/var/run/mysqld/mysqld.sock > /etc/php.d/mysqli.ini
+          ${{ !fromJson(inputs.branch).jobs.BENCHMARKING.config.integrated_opcache && 'echo zend_extension=opcache.so >> /etc/php.d/opcache.ini' || '' }}
           echo opcache.enable=1 >> /etc/php.d/opcache.ini
           echo opcache.enable_cli=1 >> /etc/php.d/opcache.ini
       - name: Setup


### PR DESCRIPTION
8.4 still needs a zend_extension=opcache.so in the ini file.

This will be backported. Targetting 8.4 for testing.