### PR TITLE
Fix incorrect zend_hash_find_ptr() on non-ptr in ReflectionProperty::isReadable()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6676,7 +6676,7 @@ ZEND_METHOD(ReflectionProperty, isReadable)
 
 	zend_class_entry *ce = obj ? obj->ce : intern->ce;
 	if (!prop) {
-		if (obj && obj->properties && zend_hash_find_ptr(obj->properties, ref->unmangled_name)) {
+		if (obj && obj->properties && zend_hash_find(obj->properties, ref->unmangled_name)) {
 			RETURN_TRUE;
 		}
 handle_magic_get:
@@ -6701,7 +6701,7 @@ handle_magic_get:
 			if (!obj) {
 				RETURN_THROWS();
 			}
-			if (obj->properties && zend_hash_find_ptr(obj->properties, ref->unmangled_name)) {
+			if (obj->properties && zend_hash_find(obj->properties, ref->unmangled_name)) {
 				RETURN_TRUE;
 			}
 		}

--- a/ext/reflection/tests/oss-fuzz-489355368.phpt
+++ b/ext/reflection/tests/oss-fuzz-489355368.phpt
@@ -1,0 +1,17 @@
+--TEST--
+OSS-Fuzz #489355368: Incorrect assumption Z_PTR_P assumption
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+class A {}
+
+$obj = new A;
+$obj->prop = 0;
+
+$rp = new ReflectionProperty($obj, 'prop');
+var_dump($rp->isReadable(null, $obj));
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Fixes OSS-Fuzz #489355368