### PR TITLE
ext/snmp: fix infinite loop in snprint_value retry when val_len is zero

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -243,6 +243,15 @@ static void php_snmp_getvalue(struct variable_list *vars, zval *snmpval, int val
 
 	/* use emalloc() for large values, use static array otherwise */
 
+	/* Ensure val_len is at least sizeof(sbuf) so doubling will grow beyond
+	 * the initial stack buffer. Without this, a zero val_len would cause
+	 * val_len *= 2 to remain zero indefinitely, never reaching the 512k
+	 * break condition.
+	 */
+	if (val_len < (int)sizeof(sbuf)) {
+		val_len = sizeof(sbuf);
+	}
+
 	/* There is no way to know the size of buffer snprint_value() needs in order to print a value there.
 	 * So we are forced to probe it
 	 */


### PR DESCRIPTION
When an SNMP variable has `val_len == 0` (valid for empty octet strings),
the `snprint_value` retry loop doubles `val_len` on each iteration
(`val_len *= 2`). Since `0 * 2 == 0`, `val_len` never grows, the
allocated buffer stays at 1 byte, and the `512k` break condition is
never reached. This causes an infinite loop consuming CPU.

Fix by clamping `val_len` to at least `sizeof(sbuf)` before the loop,
ensuring the doubling produces meaningful growth past the initial stack
buffer size.