### PR TITLE
Convert remaining zend_parse_parameters_none() to fast ZPP

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1916,9 +1916,7 @@ PHP_METHOD(PDOStatement, debugDumpParams)
 
 PHP_METHOD(PDOStatement, getIterator)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_create_internal_iterator_zval(return_value, ZEND_THIS);
 }

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1614,9 +1614,7 @@ PHP_METHOD(SimpleXMLElement, getName)
 	xmlNodePtr      node;
 	int             namelen;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	sxe = Z_SXEOBJ_P(ZEND_THIS);
 
@@ -1900,9 +1898,7 @@ static zend_result sxe_object_cast(zend_object *readobj, zval *writeobj, int typ
 /* {{{ Returns the string content */
 PHP_METHOD(SimpleXMLElement, __toString)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_result rv = sxe_object_cast_ex(Z_OBJ_P(ZEND_THIS), return_value, IS_STRING);
 	ZEND_IGNORE_VALUE(rv);
@@ -1950,9 +1946,7 @@ PHP_METHOD(SimpleXMLElement, count)
 {
 	php_sxe_object *sxe = Z_SXEOBJ_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(php_sxe_count_elements_helper(sxe));
 }
@@ -1962,9 +1956,7 @@ PHP_METHOD(SimpleXMLElement, count)
 /* {{{ Rewind to first element */
 PHP_METHOD(SimpleXMLElement, rewind)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	php_sxe_rewind_iterator(Z_SXEOBJ_P(ZEND_THIS));
 }
@@ -1975,9 +1967,7 @@ PHP_METHOD(SimpleXMLElement, valid)
 {
 	php_sxe_object *sxe = Z_SXEOBJ_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_BOOL(!Z_ISUNDEF(sxe->iter.data));
 }
@@ -1988,9 +1978,7 @@ PHP_METHOD(SimpleXMLElement, current)
 {
 	php_sxe_object *sxe = Z_SXEOBJ_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_ISUNDEF(sxe->iter.data)) {
 		zend_throw_error(NULL, "Iterator not initialized or already consumed");
@@ -2008,9 +1996,7 @@ PHP_METHOD(SimpleXMLElement, key)
 	php_sxe_object *intern;
 	php_sxe_object *sxe = Z_SXEOBJ_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_ISUNDEF(sxe->iter.data)) {
 		zend_throw_error(NULL, "Iterator not initialized or already consumed");
@@ -2031,9 +2017,7 @@ PHP_METHOD(SimpleXMLElement, key)
 /* {{{ Move to next element */
 PHP_METHOD(SimpleXMLElement, next)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	php_sxe_move_forward_iterator(Z_SXEOBJ_P(ZEND_THIS));
 }
@@ -2046,9 +2030,7 @@ PHP_METHOD(SimpleXMLElement, hasChildren)
 	php_sxe_object *child;
 	xmlNodePtr      node;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_ISUNDEF(sxe->iter.data) || sxe->iter.type == SXE_ITER_ATTRLIST) {
 		RETURN_FALSE;
@@ -2071,9 +2053,7 @@ PHP_METHOD(SimpleXMLElement, getChildren)
 {
 	php_sxe_object *sxe = Z_SXEOBJ_P(ZEND_THIS);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (Z_ISUNDEF(sxe->iter.data) || sxe->iter.type == SXE_ITER_ATTRLIST) {
 		return; /* return NULL */

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1434,9 +1434,7 @@ PHP_FUNCTION(snmpset)
 /* {{{ Return the current status of quick_print */
 PHP_FUNCTION(snmp_get_quick_print)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_BOOL(netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_QUICK_PRINT));
 }
@@ -1587,9 +1585,7 @@ PHP_FUNCTION(snmp_set_valueretrieval)
 /* {{{ Return the method how the SNMP values will be returned */
 PHP_FUNCTION(snmp_get_valueretrieval)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(SNMP_G(valueretrieval));
 }
@@ -1666,9 +1662,7 @@ PHP_METHOD(SNMP, close)
 
 	snmp_object = Z_SNMP_P(object);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	snmp_session_free(&(snmp_object->session));
 
@@ -1737,9 +1731,7 @@ PHP_METHOD(SNMP, getErrno)
 
 	snmp_object = Z_SNMP_P(object);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(snmp_object->snmp_errno);
 }
@@ -1753,9 +1745,7 @@ PHP_METHOD(SNMP, getError)
 
 	snmp_object = Z_SNMP_P(object);
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_STRING(snmp_object->snmp_errstr);
 }

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -730,9 +730,7 @@ PHP_METHOD(SoapFault, __toString)
 	zend_string *faultcode_val, *faultstring_val, *file_val;
 	zend_long line_val;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	this_ptr = ZEND_THIS;
 	faultcode = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultcode", sizeof("faultcode")-1, 1, &rv1);
@@ -1134,9 +1132,7 @@ PHP_METHOD(SoapServer, getFunctions)
 	soapServicePtr  service;
 	HashTable      *ft = NULL;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	FETCH_THIS_SERVICE_NO_BAILOUT(service);
 
@@ -2692,9 +2688,7 @@ PHP_METHOD(SoapClient, __soapCall)
 /* {{{ Returns list of SOAP functions */
 PHP_METHOD(SoapClient, __getFunctions)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	sdl *sdl;
 	FETCH_THIS_SDL(sdl);
@@ -2717,9 +2711,7 @@ PHP_METHOD(SoapClient, __getFunctions)
 /* {{{ Returns list of SOAP types */
 PHP_METHOD(SoapClient, __getTypes)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	sdl *sdl;
 	FETCH_THIS_SDL(sdl);
@@ -2744,9 +2736,7 @@ PHP_METHOD(SoapClient, __getTypes)
 /* {{{ Returns last SOAP request */
 PHP_METHOD(SoapClient, __getLastRequest)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_COPY(Z_CLIENT_LAST_REQUEST_P(ZEND_THIS));
 }
@@ -2756,9 +2746,7 @@ PHP_METHOD(SoapClient, __getLastRequest)
 /* {{{ Returns last SOAP response */
 PHP_METHOD(SoapClient, __getLastResponse)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_COPY(Z_CLIENT_LAST_RESPONSE_P(ZEND_THIS));
 }
@@ -2768,9 +2756,7 @@ PHP_METHOD(SoapClient, __getLastResponse)
 /* {{{ Returns last SOAP request headers */
 PHP_METHOD(SoapClient, __getLastRequestHeaders)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_COPY(Z_CLIENT_LAST_REQUEST_HEADERS_P(ZEND_THIS));
 }
@@ -2780,9 +2766,7 @@ PHP_METHOD(SoapClient, __getLastRequestHeaders)
 /* {{{ Returns last SOAP response headers */
 PHP_METHOD(SoapClient, __getLastResponseHeaders)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_COPY(Z_CLIENT_LAST_RESPONSE_HEADERS_P(ZEND_THIS));
 }
@@ -2848,9 +2832,7 @@ PHP_METHOD(SoapClient, __setCookie)
 /* {{{ Returns list of cookies */
 PHP_METHOD(SoapClient, __getCookies)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_COPY(Z_CLIENT_COOKIES_P(ZEND_THIS));
 }

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -571,9 +571,8 @@ PHP_FUNCTION(sodium_crypto_box_keypair)
 	zend_string *keypair;
 	size_t       keypair_len;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	keypair_len = crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES;
 	keypair = zend_string_alloc(keypair_len, 0);
 	if (crypto_box_keypair((unsigned char *) ZSTR_VAL(keypair) +
@@ -891,9 +890,8 @@ PHP_FUNCTION(sodium_crypto_sign_keypair)
 	zend_string *keypair;
 	size_t       keypair_len;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	keypair_len = crypto_sign_SECRETKEYBYTES + crypto_sign_PUBLICKEYBYTES;
 	keypair = zend_string_alloc(keypair_len, 0);
 	if (crypto_sign_keypair((unsigned char *) ZSTR_VAL(keypair) +
@@ -1733,9 +1731,7 @@ PHP_FUNCTION(sodium_crypto_pwhash_scryptsalsa208sha256_str_verify)
 
 PHP_FUNCTION(sodium_crypto_aead_aes256gcm_is_available)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 #ifdef HAVE_AESGCM
 	RETURN_BOOL(crypto_aead_aes256gcm_is_available());
 #else
@@ -2719,9 +2715,8 @@ PHP_FUNCTION(sodium_crypto_kx_keypair)
 	unsigned char *pk;
 	zend_string   *keypair;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	keypair = zend_string_alloc(crypto_kx_SECRETKEYBYTES + crypto_kx_PUBLICKEYBYTES, 0);
 	sk = (unsigned char *) ZSTR_VAL(keypair);
 	pk = sk + crypto_kx_SECRETKEYBYTES;
@@ -3028,9 +3023,8 @@ PHP_FUNCTION(sodium_crypto_aead_aes256gcm_keygen)
 {
 	unsigned char key[crypto_aead_aes256gcm_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3041,9 +3035,8 @@ PHP_FUNCTION(sodium_crypto_aead_aegis128l_keygen)
 {
 	unsigned char key[crypto_aead_aegis128l_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	crypto_aead_aegis128l_keygen(key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3054,9 +3047,8 @@ PHP_FUNCTION(sodium_crypto_aead_aegis256_keygen)
 {
 	unsigned char key[crypto_aead_aegis256_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	crypto_aead_aegis256_keygen(key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3066,9 +3058,8 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_keygen)
 {
 	unsigned char key[crypto_aead_chacha20poly1305_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3077,9 +3068,8 @@ PHP_FUNCTION(sodium_crypto_aead_chacha20poly1305_ietf_keygen)
 {
 	unsigned char key[crypto_aead_chacha20poly1305_IETF_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3089,9 +3079,8 @@ PHP_FUNCTION(sodium_crypto_aead_xchacha20poly1305_ietf_keygen)
 {
 	unsigned char key[crypto_aead_xchacha20poly1305_IETF_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3101,9 +3090,8 @@ PHP_FUNCTION(sodium_crypto_auth_keygen)
 {
 	unsigned char key[crypto_auth_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3112,9 +3100,8 @@ PHP_FUNCTION(sodium_crypto_generichash_keygen)
 {
 	unsigned char key[crypto_generichash_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3123,9 +3110,8 @@ PHP_FUNCTION(sodium_crypto_kdf_keygen)
 {
 	unsigned char key[crypto_kdf_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3134,9 +3120,8 @@ PHP_FUNCTION(sodium_crypto_secretbox_keygen)
 {
 	unsigned char key[crypto_secretbox_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3145,9 +3130,8 @@ PHP_FUNCTION(sodium_crypto_shorthash_keygen)
 {
 	unsigned char key[crypto_shorthash_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3156,9 +3140,8 @@ PHP_FUNCTION(sodium_crypto_stream_keygen)
 {
 	unsigned char key[crypto_stream_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3167,9 +3150,8 @@ PHP_FUNCTION(sodium_crypto_stream_xchacha20_keygen)
 {
 	unsigned char key[crypto_stream_xchacha20_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		return;
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3391,9 +3373,8 @@ PHP_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_keygen)
 {
 	unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3679,9 +3660,8 @@ PHP_FUNCTION(sodium_crypto_core_ristretto255_random)
 {
 	zend_string   *r;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	r = zend_string_alloc(crypto_core_ristretto255_BYTES, 0);
 	crypto_core_ristretto255_random((unsigned char *) ZSTR_VAL(r));
 	ZSTR_VAL(r)[crypto_core_ristretto255_BYTES] = 0;
@@ -3820,9 +3800,8 @@ PHP_FUNCTION(sodium_crypto_core_ristretto255_scalar_random)
 {
 	zend_string   *r;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	};
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	r = zend_string_alloc(crypto_core_ristretto255_SCALARBYTES, 0);
 	crypto_core_ristretto255_scalar_random((unsigned char *) ZSTR_VAL(r));
 	ZSTR_VAL(r)[crypto_core_ristretto255_SCALARBYTES] = 0;
@@ -3919,9 +3898,8 @@ PHP_FUNCTION(sodium_crypto_ipcrypt_keygen)
 {
 	unsigned char key[crypto_ipcrypt_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	crypto_ipcrypt_keygen(key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -3992,9 +3970,8 @@ PHP_FUNCTION(sodium_crypto_ipcrypt_nd_keygen)
 {
 	unsigned char key[crypto_ipcrypt_ND_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	randombytes_buf(key, sizeof key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -4069,9 +4046,8 @@ PHP_FUNCTION(sodium_crypto_ipcrypt_ndx_keygen)
 {
 	unsigned char key[crypto_ipcrypt_NDX_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	crypto_ipcrypt_ndx_keygen(key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }
@@ -4146,9 +4122,8 @@ PHP_FUNCTION(sodium_crypto_ipcrypt_pfx_keygen)
 {
 	unsigned char key[crypto_ipcrypt_PFX_KEYBYTES];
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
+
 	crypto_ipcrypt_pfx_keygen(key);
 	RETURN_STRINGL((const char *) key, sizeof key);
 }

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -471,9 +471,7 @@ static void php_xmlreader_no_arg(INTERNAL_FUNCTION_PARAMETERS, xmlreader_read_in
 	int retval;
 	xmlreader_object *intern;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	id = ZEND_THIS;
 
@@ -495,9 +493,7 @@ static void php_xmlreader_no_arg_string(INTERNAL_FUNCTION_PARAMETERS, xmlreader_
 	char *retchar = NULL;
 	xmlreader_object *intern;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	id = ZEND_THIS;
 
@@ -575,9 +571,7 @@ PHP_METHOD(XMLReader, close)
 	zval *id;
 	xmlreader_object *intern;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	id = ZEND_THIS;
 	intern = Z_XMLREADER_P(id);
@@ -827,9 +821,7 @@ PHP_METHOD(XMLReader, read)
 	int retval;
 	xmlreader_object *intern;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	id = ZEND_THIS;
 	intern = Z_XMLREADER_P(id);

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1518,9 +1518,7 @@ PHP_METHOD(ZipArchive, close)
 	ze_zip_object *ze_obj;
 	int err;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ZIP_FROM_OBJECT(intern, self);
 
@@ -1561,9 +1559,7 @@ PHP_METHOD(ZipArchive, count)
 	zval *self = ZEND_THIS;
 	zip_int64_t num;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ZIP_FROM_OBJECT(intern, self);
 
@@ -1578,9 +1574,7 @@ PHP_METHOD(ZipArchive, clearError)
 	zval *self = ZEND_THIS;
 	ze_zip_object *ze_obj;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ze_obj = Z_ZIP_P(self); /* not ZIP_FROM_OBJECT as we can use saved error after close */
 	if (ze_obj->za) {
@@ -1598,9 +1592,7 @@ PHP_METHOD(ZipArchive, getStatusString)
 	zval *self = ZEND_THIS;
 	ze_zip_object *ze_obj;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ze_obj = Z_ZIP_P(self); /* not ZIP_FROM_OBJECT as we can use saved error after close */
 
@@ -2653,9 +2645,7 @@ PHP_METHOD(ZipArchive, unchangeAll)
 	struct zip *intern;
 	zval *self = ZEND_THIS;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ZIP_FROM_OBJECT(intern, self);
 
@@ -2669,9 +2659,7 @@ PHP_METHOD(ZipArchive, unchangeArchive)
 	struct zip *intern;
 	zval *self = ZEND_THIS;
 
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	ZIP_FROM_OBJECT(intern, self);
 

--- a/main/output.c
+++ b/main/output.c
@@ -1393,9 +1393,7 @@ PHP_FUNCTION(ob_start)
 /* {{{ Flush (send) contents of the output buffer. The last buffer content is sent to next buffer */
 PHP_FUNCTION(ob_flush)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (!OG(active)) {
 		php_error_docref("ref.outcontrol", E_NOTICE, "Failed to flush buffer. No buffer to flush");
@@ -1413,9 +1411,7 @@ PHP_FUNCTION(ob_flush)
 /* {{{ Clean (delete) the current output buffer */
 PHP_FUNCTION(ob_clean)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (!OG(active)) {
 		php_error_docref("ref.outcontrol", E_NOTICE, "Failed to delete buffer. No buffer to delete");
@@ -1433,9 +1429,7 @@ PHP_FUNCTION(ob_clean)
 /* {{{ Flush (send) the output buffer, and delete current output buffer */
 PHP_FUNCTION(ob_end_flush)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (!OG(active)) {
 		php_error_docref("ref.outcontrol", E_NOTICE, "Failed to delete and flush buffer. No buffer to delete or flush");
@@ -1449,9 +1443,7 @@ PHP_FUNCTION(ob_end_flush)
 /* {{{ Clean the output buffer, and delete current output buffer */
 PHP_FUNCTION(ob_end_clean)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (!OG(active)) {
 		php_error_docref("ref.outcontrol", E_NOTICE, "Failed to delete buffer. No buffer to delete");
@@ -1465,9 +1457,7 @@ PHP_FUNCTION(ob_end_clean)
 /* {{{ Get current buffer contents, flush (send) the output buffer, and delete current output buffer */
 PHP_FUNCTION(ob_get_flush)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_output_get_contents(return_value) == FAILURE) {
 		php_error_docref("ref.outcontrol", E_NOTICE, "Failed to delete and flush buffer. No buffer to delete or flush");
@@ -1483,9 +1473,7 @@ PHP_FUNCTION(ob_get_flush)
 /* {{{ Get current buffer contents and delete current output buffer */
 PHP_FUNCTION(ob_get_clean)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if(!OG(active)) {
 		RETURN_FALSE;
@@ -1505,9 +1493,7 @@ PHP_FUNCTION(ob_get_clean)
 /* {{{ Return the contents of the output buffer */
 PHP_FUNCTION(ob_get_contents)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_output_get_contents(return_value) == FAILURE) {
 		RETURN_FALSE;
@@ -1518,9 +1504,7 @@ PHP_FUNCTION(ob_get_contents)
 /* {{{ Return the nesting level of the output buffer */
 PHP_FUNCTION(ob_get_level)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	RETURN_LONG(php_output_get_level());
 }
@@ -1529,9 +1513,7 @@ PHP_FUNCTION(ob_get_level)
 /* {{{ Return the length of the output buffer */
 PHP_FUNCTION(ob_get_length)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_output_get_length(return_value) == FAILURE) {
 		RETURN_FALSE;
@@ -1542,9 +1524,7 @@ PHP_FUNCTION(ob_get_length)
 /* {{{ List all output_buffers in an array */
 PHP_FUNCTION(ob_list_handlers)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	array_init(return_value);
 
@@ -1595,9 +1575,7 @@ PHP_FUNCTION(ob_implicit_flush)
 /* {{{ Reset(clear) URL rewriter values */
 PHP_FUNCTION(output_reset_rewrite_vars)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
-		RETURN_THROWS();
-	}
+	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (php_url_scanner_reset_vars() == SUCCESS) {
 		RETURN_TRUE;


### PR DESCRIPTION
Final round. There are 2 remaining, but I'm not aware of a way to update them (because they goto or return NULL explicitly)