### PR TITLE
ext/pcntl: Bump num_signals to uint16_t

### DIFF
--- a/ext/pcntl/php_pcntl.h
+++ b/ext/pcntl/php_pcntl.h
@@ -46,7 +46,8 @@ ZEND_BEGIN_MODULE_GLOBALS(pcntl)
 	bool processing_signal_queue;
 	volatile bool pending_signals;
 	bool async_signals;
-	uint8_t num_signals;
+	/* some OSes define NSIG to be > UINT8_MAX */
+	uint16_t num_signals;
 	int last_error;
 	struct php_pcntl_pending_signal *head, *tail, *spares;
 ZEND_END_MODULE_GLOBALS(pcntl)


### PR DESCRIPTION
On AIX, NSIG is def'd as SIGMAX64+1, and SIGMAX64 itself is def'd as 255:

```
$ grep -Rw SIGMAX64 /QOpenSys/usr/include/
/QOpenSys/usr/include/sys/signal.h:#define SIGMAX64 255
/QOpenSys/usr/include/sys/signal.h:#define SIGMAX SIGMAX64
/QOpenSys/usr/include/sys/signal.h:#define NSIG64               (SIGMAX64+1)
```

...this causes an overflow when we set num_signals from the value of NSIG, per GCC:

```
/rpmbuild/BUILD/php-8.5.3/ext/pcntl/pcntl.c:216:25: warning: large integer implicitly truncated to unsigned type [-Woverflow]
  PCNTL_G(num_signals) = NSIG;
                         ^~~~
```

...when we try to use pcntl to i.e. install a signal handler, we get an error from pcntl:

```
Fatal error: Uncaught ValueError: pcntl_signal(): Argument #1 ($signal) must be less than 0 in phar:///QOpenSys/pkgs/bin/composer/vendor/seld/signal-handler/src/SignalHandler.php:491
```

The easiest way to deal with this silly AIX behaviour is to just promote the storage size.