### PR TITLE
Fix property_info sizing for locally shadowed trait properties

### DIFF
--- a/Zend/tests/gh20672.phpt
+++ b/Zend/tests/gh20672.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-20672: Incorrect property_info sizing for locally shadowed trait properties
+--CREDITS--
+Jonne Ransijn (yyny)
+--FILE--
+<?php
+
+trait T {
+    public static $a;
+    public static $b;
+    public static $c;
+}
+
+class Base {
+    public $x;
+    public $y;
+}
+
+class Child extends Base {
+    public static $a;
+    public static $b;
+    public static $c;
+    public static $d;
+
+    use T;
+}
+
+?>
+--EXPECT--

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2933,9 +2933,7 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 								ZSTR_VAL(prop_name),
 								ZSTR_VAL(ce->name));
 					}
-					if (!(flags & ZEND_ACC_STATIC)) {
-						continue;
-					}
+					continue;
 				}
 			}
 


### PR DESCRIPTION
Previously, static trait properties would always redeclare locally declared static properties to make sure an inherited static property stops sharing a common slot with the parent. This would leave holes in property_info, creating issues for this code:

    zend_hash_extend(&ce->properties_info,
        zend_hash_num_elements(&ce->properties_info) +
        zend_hash_num_elements(&parent_ce->properties_info), 0);

where `zend_hash_num_elements(&ce->properties_info) + zend_hash_num_elements(&parent_ce->properties_info)` is supposed to extend the hash table enough to hold all additional properties coming from parent. However, if `ce->properties_info` contains holes this might not be enough, given all parent properties are appended at nNumUsed.

This could be fixed by further extending the hash table, but we can also avoid the holes in properties_info completely. This is now possible because traits are bound before performing parent class inheritance, declaring the static property and avoiding the defensive copying of these properties.

Fixes GH-20672