### PR TITLE
ext/mbstring: Fix deprecation warning

### DIFF
--- a/ext/mbstring/gen_rare_cp_bitvec.php
+++ b/ext/mbstring/gen_rare_cp_bitvec.php
@@ -6,7 +6,7 @@ if ($argc < 2) {
     return;
 }
 
-$bitvec = array_fill(0, (0xFFFF / 32) + 1, 0xFFFFFFFF);
+$bitvec = array_fill(0, intdiv(0xFFFF, 32) + 1, 0xFFFFFFFF);
 
 $input = file_get_contents($argv[1]);
 foreach (explode("\n", $input) as $line) {


### PR DESCRIPTION
This fixes the PHP deprecation warning:

    PHP Deprecated:  Implicit conversion from float 2048.96875 to int
    loses precision in .../ext/mbstring/gen_rare_cp_bitvec.php on line 9