### PR TITLE
Remove unused config.h inclusion in SAPIs

### DIFF
--- a/sapi/cli/php_cli_process_title.c
+++ b/sapi/cli/php_cli_process_title.c
@@ -14,10 +14,6 @@
   +----------------------------------------------------------------------+
 */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "php.h"
 #include "php_cli_process_title.h"
 #include "ps_title.h"

--- a/sapi/phpdbg/phpdbg_io.c
+++ b/sapi/phpdbg/phpdbg_io.c
@@ -14,10 +14,6 @@
    +----------------------------------------------------------------------+
 */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "phpdbg_io.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(phpdbg)


### PR DESCRIPTION
Current PHP SAPIs aren't built outside of php-src and neither is anywhere described how such configuration header is supposed to be used.