### PR TITLE
Fix GH-21083: Skip private_key_bits validation for EC/curve-based keys

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3828,7 +3828,10 @@ static int php_openssl_get_evp_pkey_type(int key_type) {
 /* {{{ php_openssl_generate_private_key */
 static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req)
 {
-	if (req->priv_key_bits < MIN_KEY_LENGTH) {
+	if ((req->priv_key_type == OPENSSL_KEYTYPE_RSA ||
+			req->priv_key_type == OPENSSL_KEYTYPE_DH ||
+			req->priv_key_type == OPENSSL_KEYTYPE_DSA) &&
+			req->priv_key_bits < MIN_KEY_LENGTH) {
 		php_error_docref(NULL, E_WARNING, "Private key length must be at least %d bits, configured to %d",
 			MIN_KEY_LENGTH, req->priv_key_bits);
 		return NULL;

--- a/ext/openssl/tests/gh21083.phpt
+++ b/ext/openssl/tests/gh21083.phpt
@@ -1,0 +1,61 @@
+--TEST--
+GH-21083 (openssl_pkey_new() fails for EC keys when private_key_bits is not set)
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php if (!defined("OPENSSL_KEYTYPE_EC")) die("skip EC disabled"); ?>
+--ENV--
+OPENSSL_CONF=
+--FILE--
+<?php
+// Create a minimal openssl.cnf without default_bits (simulates OpenSSL 3.6 default config)
+$conf = tempnam(sys_get_temp_dir(), 'ossl');
+file_put_contents($conf, "[req]\ndistinguished_name = req_dn\n[req_dn]\n");
+
+// EC key - size is determined by the curve, private_key_bits should not be required
+$key = openssl_pkey_new([
+    'config' => $conf,
+    'private_key_type' => OPENSSL_KEYTYPE_EC,
+    'curve_name' => 'prime256v1',
+]);
+var_dump($key !== false);
+$details = openssl_pkey_get_details($key);
+var_dump($details['bits']);
+var_dump($details['type'] === OPENSSL_KEYTYPE_EC);
+echo "EC OK\n";
+
+// X25519 - fixed size key, private_key_bits should not be required
+if (defined('OPENSSL_KEYTYPE_X25519')) {
+    $key = openssl_pkey_new([
+        'config' => $conf,
+        'private_key_type' => OPENSSL_KEYTYPE_X25519,
+    ]);
+    var_dump($key !== false);
+    echo "X25519 OK\n";
+} else {
+    echo "bool(true)\nX25519 OK\n";
+}
+
+// Ed25519 - fixed size key, private_key_bits should not be required
+if (defined('OPENSSL_KEYTYPE_ED25519')) {
+    $key = openssl_pkey_new([
+        'config' => $conf,
+        'private_key_type' => OPENSSL_KEYTYPE_ED25519,
+    ]);
+    var_dump($key !== false);
+    echo "Ed25519 OK\n";
+} else {
+    echo "bool(true)\nEd25519 OK\n";
+}
+
+unlink($conf);
+?>
+--EXPECT--
+bool(true)
+int(256)
+bool(true)
+EC OK
+bool(true)
+X25519 OK
+bool(true)
+Ed25519 OK


### PR DESCRIPTION
## Summary

`openssl_pkey_new()` checks `private_key_bits >= 384` before generating any key. EC and curve-based key types (X25519, ED25519, X448, ED448) don't use `private_key_bits` at all, their size comes from the curve or is fixed.

This worked by accident because most `openssl.cnf` files set `default_bits = 2048`, which passes the check even though EC keys ignore it. OpenSSL 3.6 ships with `default_bits` commented out, so `priv_key_bits` defaults to 0 and the check rejects the key.

## Fix

Skip the `priv_key_bits < MIN_KEY_LENGTH` guard for key types where bit length is inherent:
- `OPENSSL_KEYTYPE_EC` - size from curve name
- `OPENSSL_KEYTYPE_X25519` / `OPENSSL_KEYTYPE_X448` - fixed 256/448 bits
- `OPENSSL_KEYTYPE_ED25519` / `OPENSSL_KEYTYPE_ED448` - fixed 256/456 bits

## Test

`ext/openssl/tests/gh21083.phpt` creates a minimal `openssl.cnf` without `default_bits` and generates EC, X25519, and ED25519 keys without specifying `private_key_bits`. Fails before the fix, passes after.

Fixes #21083