### PR TITLE
Remove dead code from zend_declare_typed_property()

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4505,12 +4505,6 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		ce->default_properties_count++;
 		ce->default_properties_table = perealloc(ce->default_properties_table, sizeof(zval) * ce->default_properties_count, ce->type == ZEND_INTERNAL_CLASS);
 
-		/* For user classes this is handled during linking */
-		if (ce->type == ZEND_INTERNAL_CLASS) {
-			ce->properties_info_table = perealloc(ce->properties_info_table, sizeof(zend_property_info *) * ce->default_properties_count, 1);
-			ce->properties_info_table[ce->default_properties_count - 1] = property_info;
-		}
-
 		zval *property_default_ptr = &ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)];
 		ZVAL_COPY_VALUE(property_default_ptr, property);
 		Z_PROP_FLAG_P(property_default_ptr) = Z_ISUNDEF_P(property) ? IS_PROP_UNINIT : 0;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -2585,6 +2585,10 @@ static zend_always_inline bool zend_parse_arg_obj_or_str(
 	return zend_parse_arg_str(arg, destination_string, allow_null, arg_num);
 }
 
+/* Used in arginfo.h files, copied from zend_inheritance.h to avoid its inclusion. */
+void zend_build_properties_info_table(zend_class_entry *ce);
+ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *parent_ce, bool checked);
+
 END_EXTERN_C()
 
 #endif /* ZEND_API_H */

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -158,6 +158,8 @@ static zend_class_entry *register_class_Attribute(void)
 	zend_string_release_ex(attribute_name_Attribute_class_Attribute_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_Attribute_0->args[0].value, ZEND_ATTRIBUTE_TARGET_CLASS);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -172,6 +174,8 @@ static zend_class_entry *register_class_ReturnTypeWillChange(void)
 	zend_attribute *attribute_Attribute_class_ReturnTypeWillChange_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ReturnTypeWillChange_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_ReturnTypeWillChange_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ReturnTypeWillChange_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -188,6 +192,8 @@ static zend_class_entry *register_class_AllowDynamicProperties(void)
 	zend_string_release_ex(attribute_name_Attribute_class_AllowDynamicProperties_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_AllowDynamicProperties_0->args[0].value, ZEND_ATTRIBUTE_TARGET_CLASS);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -203,6 +209,8 @@ static zend_class_entry *register_class_SensitiveParameter(void)
 	zend_string_release_ex(attribute_name_Attribute_class_SensitiveParameter_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_SensitiveParameter_0->args[0].value, ZEND_ATTRIBUTE_TARGET_PARAMETER);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -216,6 +224,8 @@ static zend_class_entry *register_class_SensitiveParameterValue(void)
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_VALUE), &property_value_default_value, ZEND_ACC_PRIVATE|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -231,6 +241,8 @@ static zend_class_entry *register_class_Override(void)
 	zend_attribute *attribute_Attribute_class_Override_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Override_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_Override_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_Override_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_PROPERTY);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -255,6 +267,8 @@ static zend_class_entry *register_class_Deprecated(void)
 	zend_string_release_ex(attribute_name_Attribute_class_Deprecated_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_Deprecated_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION | ZEND_ATTRIBUTE_TARGET_CLASS_CONST | ZEND_ATTRIBUTE_TARGET_CONST | ZEND_ATTRIBUTE_TARGET_CLASS);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -274,6 +288,8 @@ static zend_class_entry *register_class_NoDiscard(void)
 	zend_string_release_ex(attribute_name_Attribute_class_NoDiscard_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_NoDiscard_0->args[0].value, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -288,6 +304,8 @@ static zend_class_entry *register_class_DelayedTargetValidation(void)
 	zend_attribute *attribute_Attribute_class_DelayedTargetValidation_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_DelayedTargetValidation_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_DelayedTargetValidation_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_DelayedTargetValidation_0->args[0].value, ZEND_ATTRIBUTE_TARGET_ALL);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -391,5 +391,7 @@ static zend_class_entry *register_class_stdClass(void)
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_stdClass_0, 0);
 	zend_string_release_ex(attribute_name_AllowDynamicProperties_class_stdClass_0, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/Zend/zend_closures_arginfo.h
+++ b/Zend/zend_closures_arginfo.h
@@ -51,5 +51,7 @@ static zend_class_entry *register_class_Closure(void)
 	INIT_CLASS_ENTRY(ce, "Closure", class_Closure_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/Zend/zend_enum_arginfo.h
+++ b/Zend/zend_enum_arginfo.h
@@ -31,6 +31,8 @@ static zend_class_entry *register_class_UnitEnum(void)
 	INIT_CLASS_ENTRY(ce, "UnitEnum", class_UnitEnum_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -40,6 +42,8 @@ static zend_class_entry *register_class_BackedEnum(zend_class_entry *class_entry
 
 	INIT_CLASS_ENTRY(ce, "BackedEnum", class_BackedEnum_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_UnitEnum);
 
 	return class_entry;

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -148,6 +148,8 @@ static zend_class_entry *register_class_Throwable(zend_class_entry *class_entry_
 
 	INIT_CLASS_ENTRY(ce, "Throwable", class_Throwable_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
@@ -159,7 +161,6 @@ static zend_class_entry *register_class_Exception(zend_class_entry *class_entry_
 
 	INIT_CLASS_ENTRY(ce, "Exception", class_Exception_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_Throwable);
 
 	zval property_message_default_value;
 	ZVAL_EMPTY_STRING(&property_message_default_value);
@@ -190,6 +191,9 @@ static zend_class_entry *register_class_Exception(zend_class_entry *class_entry_
 	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Throwable);
+
 	return class_entry;
 }
 
@@ -198,11 +202,14 @@ static zend_class_entry *register_class_ErrorException(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ErrorException", class_ErrorException_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_severity_default_value;
 	ZVAL_LONG(&property_severity_default_value, E_ERROR);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_SEVERITY), &property_severity_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -213,7 +220,6 @@ static zend_class_entry *register_class_Error(zend_class_entry *class_entry_Thro
 
 	INIT_CLASS_ENTRY(ce, "Error", class_Error_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_Throwable);
 
 	zval property_message_default_value;
 	ZVAL_EMPTY_STRING(&property_message_default_value);
@@ -244,6 +250,9 @@ static zend_class_entry *register_class_Error(zend_class_entry *class_entry_Thro
 	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Throwable);
+
 	return class_entry;
 }
 
@@ -252,7 +261,10 @@ static zend_class_entry *register_class_CompileError(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "CompileError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -262,7 +274,10 @@ static zend_class_entry *register_class_ParseError(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ParseError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_CompileError, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_CompileError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -272,7 +287,10 @@ static zend_class_entry *register_class_TypeError(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "TypeError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -282,7 +300,10 @@ static zend_class_entry *register_class_ArgumentCountError(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ArgumentCountError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_TypeError, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_TypeError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -292,7 +313,10 @@ static zend_class_entry *register_class_ValueError(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ValueError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -302,7 +326,10 @@ static zend_class_entry *register_class_ArithmeticError(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ArithmeticError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -312,7 +339,10 @@ static zend_class_entry *register_class_DivisionByZeroError(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DivisionByZeroError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ArithmeticError, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ArithmeticError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -322,7 +352,10 @@ static zend_class_entry *register_class_UnhandledMatchError(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "UnhandledMatchError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -332,7 +365,10 @@ static zend_class_entry *register_class_RequestParseBodyException(zend_class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RequestParseBodyException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/Zend/zend_fibers_arginfo.h
+++ b/Zend/zend_fibers_arginfo.h
@@ -77,6 +77,8 @@ static zend_class_entry *register_class_Fiber(void)
 	INIT_CLASS_ENTRY(ce, "Fiber", class_Fiber_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -85,7 +87,10 @@ static zend_class_entry *register_class_FiberError(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "FiberError", class_FiberError_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/Zend/zend_generators_arginfo.h
+++ b/Zend/zend_generators_arginfo.h
@@ -56,6 +56,8 @@ static zend_class_entry *register_class_Generator(zend_class_entry *class_entry_
 
 	INIT_CLASS_ENTRY(ce, "Generator", class_Generator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
@@ -66,7 +68,10 @@ static zend_class_entry *register_class_ClosedGeneratorException(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ClosedGeneratorException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/Zend/zend_interfaces_arginfo.h
+++ b/Zend/zend_interfaces_arginfo.h
@@ -124,6 +124,8 @@ static zend_class_entry *register_class_Traversable(void)
 	INIT_CLASS_ENTRY(ce, "Traversable", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -133,6 +135,8 @@ static zend_class_entry *register_class_IteratorAggregate(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "IteratorAggregate", class_IteratorAggregate_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Traversable);
 
 	return class_entry;
@@ -144,6 +148,8 @@ static zend_class_entry *register_class_Iterator(zend_class_entry *class_entry_T
 
 	INIT_CLASS_ENTRY(ce, "Iterator", class_Iterator_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Traversable);
 
 	return class_entry;
@@ -156,6 +162,8 @@ static zend_class_entry *register_class_ArrayAccess(void)
 	INIT_CLASS_ENTRY(ce, "ArrayAccess", class_ArrayAccess_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -165,6 +173,8 @@ static zend_class_entry *register_class_Serializable(void)
 
 	INIT_CLASS_ENTRY(ce, "Serializable", class_Serializable_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -176,6 +186,8 @@ static zend_class_entry *register_class_Countable(void)
 	INIT_CLASS_ENTRY(ce, "Countable", class_Countable_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -186,6 +198,8 @@ static zend_class_entry *register_class_Stringable(void)
 	INIT_CLASS_ENTRY(ce, "Stringable", class_Stringable_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -195,6 +209,8 @@ static zend_class_entry *register_class_InternalIterator(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "InternalIterator", class_InternalIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;

--- a/Zend/zend_weakrefs_arginfo.h
+++ b/Zend/zend_weakrefs_arginfo.h
@@ -68,6 +68,8 @@ static zend_class_entry *register_class_WeakReference(void)
 	INIT_CLASS_ENTRY(ce, "WeakReference", class_WeakReference_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -77,6 +79,8 @@ static zend_class_entry *register_class_WeakMap(zend_class_entry *class_entry_Ar
 
 	INIT_CLASS_ENTRY(ce, "WeakMap", class_WeakMap_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 3, class_entry_ArrayAccess, class_entry_Countable, class_entry_IteratorAggregate);
 
 	return class_entry;

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3568,7 +3568,7 @@ class ClassInfo {
                     $code .= "#if (PHP_VERSION_ID >= " . PHP_84_VERSION_ID . ")\n";
                 }
 
-                $template = "\tclass_entry = zend_register_internal_class_with_flags(&ce, " . (isset($this->extends[0]) ? "class_entry_" . str_replace("\\", "_", $this->extends[0]->toString()) : "NULL") . ", %s);\n";
+                $template = "\tclass_entry = zend_register_internal_class_with_flags(&ce, NULL, %s);\n";
                 $entries = $flags->generateVersionDependentFlagCode($template, $this->phpVersionIdMinimumCompatibility ? max($this->phpVersionIdMinimumCompatibility, PHP_84_VERSION_ID) : null);
                 if ($entries !== '') {
                     $code .= $entries;
@@ -3612,10 +3612,6 @@ class ClassInfo {
             },
             $this->type === "interface" ? $this->extends : $this->implements
         );
-
-        if (!empty($implements)) {
-            $code .= "\tzend_class_implements(class_entry, " . count($implements) . ", " . implode(", ", $implements) . ");\n";
-        }
 
         if ($this->alias) {
             $code .= "\tzend_register_class_alias(\"" . str_replace("\\", "\\\\", $this->alias) . "\", class_entry);\n";
@@ -3677,6 +3673,16 @@ class ClassInfo {
             $code .= $php80CondStart;
             $code .= "\n" . $attributeInitializationCode;
             $code .= $php80CondEnd;
+        }
+
+        if ($this->type === "class" && isset($this->extends[0])) {
+            $parent = "class_entry_" . str_replace("\\", "_", $this->extends[0]->toString());
+            $code .= "\n\tzend_do_inheritance_ex(class_entry, $parent, 0);";
+        }
+        $code .= "\n\tzend_build_properties_info_table(class_entry);\n";
+
+        if (!empty($implements)) {
+            $code .= "\tzend_class_implements(class_entry, " . count($implements) . ", " . implode(", ", $implements) . ");\n";
         }
 
         $code .= "\n\treturn class_entry;\n";

--- a/ext/bcmath/bcmath_arginfo.h
+++ b/ext/bcmath/bcmath_arginfo.h
@@ -200,7 +200,6 @@ static zend_class_entry *register_class_BcMath_Number(zend_class_entry *class_en
 
 	INIT_NS_CLASS_ENTRY(ce, "BcMath", "Number", class_BcMath_Number_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_READONLY_CLASS);
-	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
@@ -211,6 +210,9 @@ static zend_class_entry *register_class_BcMath_Number(zend_class_entry *class_en
 	zend_string *property_scale_name = zend_string_init("scale", sizeof("scale") - 1, true);
 	zend_declare_typed_property(class_entry, property_scale_name, &property_scale_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_scale_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
 }

--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -292,6 +292,8 @@ static zend_class_entry *register_class_variant(void)
 	INIT_CLASS_ENTRY(ce, "variant", class_variant_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -300,7 +302,10 @@ static zend_class_entry *register_class_com(zend_class_entry *class_entry_varian
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "com", class_com_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_variant, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_variant, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -311,7 +316,10 @@ static zend_class_entry *register_class_dotnet(zend_class_entry *class_entry_var
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "dotnet", class_dotnet_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_variant, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_variant, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -324,6 +332,8 @@ static zend_class_entry *register_class_com_safearray_proxy(void)
 	INIT_CLASS_ENTRY(ce, "com_safearray_proxy", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -332,7 +342,10 @@ static zend_class_entry *register_class_com_exception(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "com_exception", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/com_dotnet/com_persist_arginfo.h
+++ b/ext/com_dotnet/com_persist_arginfo.h
@@ -58,5 +58,7 @@ static zend_class_entry *register_class_COMPersistHelper(void)
 	INIT_CLASS_ENTRY(ce, "COMPersistHelper", class_COMPersistHelper_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -1014,6 +1014,8 @@ static zend_class_entry *register_class_CurlHandle(void)
 	INIT_CLASS_ENTRY(ce, "CurlHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1024,6 +1026,8 @@ static zend_class_entry *register_class_CurlMultiHandle(void)
 	INIT_CLASS_ENTRY(ce, "CurlMultiHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1033,6 +1037,8 @@ static zend_class_entry *register_class_CurlShareHandle(void)
 
 	INIT_CLASS_ENTRY(ce, "CurlShareHandle", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1049,6 +1055,8 @@ static zend_class_entry *register_class_CurlSharePersistentHandle(void)
 	zend_string *property_options_name = zend_string_init("options", sizeof("options") - 1, true);
 	zend_declare_typed_property(class_entry, property_options_name, &property_options_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release_ex(property_options_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/curl/curl_file_arginfo.h
+++ b/ext/curl/curl_file_arginfo.h
@@ -74,6 +74,8 @@ static zend_class_entry *register_class_CURLFile(void)
 	zend_declare_typed_property(class_entry, property_postname_name, &property_postname_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_postname_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -101,6 +103,8 @@ static zend_class_entry *register_class_CURLStringFile(void)
 	zend_string *property_mime_name = zend_string_init("mime", sizeof("mime") - 1, true);
 	zend_declare_typed_property(class_entry, property_mime_name, &property_mime_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_mime_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -987,6 +987,8 @@ static zend_class_entry *register_class_DateTimeInterface(void)
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -996,7 +998,6 @@ static zend_class_entry *register_class_DateTime(zend_class_entry *class_entry_D
 
 	INIT_CLASS_ENTRY(ce, "DateTime", class_DateTime_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_DateTimeInterface);
 
 
 	zend_attribute *attribute_Deprecated_func___wakeup_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__wakeup", sizeof("__wakeup") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
@@ -1005,6 +1006,9 @@ static zend_class_entry *register_class_DateTime(zend_class_entry *class_entry_D
 	zend_string *attribute_Deprecated_func___wakeup_0_arg1_str = zend_string_init("this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()", strlen("this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()"), 1);
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_DateTimeInterface);
 
 	return class_entry;
 }
@@ -1015,7 +1019,6 @@ static zend_class_entry *register_class_DateTimeImmutable(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "DateTimeImmutable", class_DateTimeImmutable_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_DateTimeInterface);
 
 
 	zend_attribute *attribute_Deprecated_func___wakeup_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__wakeup", sizeof("__wakeup") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
@@ -1087,6 +1090,9 @@ static zend_class_entry *register_class_DateTimeImmutable(zend_class_entry *clas
 	zend_string *attribute_NoDiscard_func_setmicrosecond_0_arg0_str = zend_string_init("as DateTimeImmutable::setMicrosecond() does not modify the object itself", strlen("as DateTimeImmutable::setMicrosecond() does not modify the object itself"), 1);
 	ZVAL_STR(&attribute_NoDiscard_func_setmicrosecond_0->args[0].value, attribute_NoDiscard_func_setmicrosecond_0_arg0_str);
 	attribute_NoDiscard_func_setmicrosecond_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_DateTimeInterface);
 
 	return class_entry;
 }
@@ -1190,6 +1196,8 @@ static zend_class_entry *register_class_DateTimeZone(void)
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1208,6 +1216,8 @@ static zend_class_entry *register_class_DateInterval(void)
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1217,7 +1227,6 @@ static zend_class_entry *register_class_DatePeriod(zend_class_entry *class_entry
 
 	INIT_CLASS_ENTRY(ce, "DatePeriod", class_DatePeriod_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	zval const_EXCLUDE_START_DATE_value;
 	ZVAL_LONG(&const_EXCLUDE_START_DATE_value, PHP_DATE_PERIOD_EXCLUDE_START_DATE);
@@ -1285,6 +1294,9 @@ static zend_class_entry *register_class_DatePeriod(zend_class_entry *class_entry
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
+
 	return class_entry;
 }
 
@@ -1293,7 +1305,10 @@ static zend_class_entry *register_class_DateError(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1303,7 +1318,10 @@ static zend_class_entry *register_class_DateObjectError(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateObjectError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1313,7 +1331,10 @@ static zend_class_entry *register_class_DateRangeError(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateRangeError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1323,7 +1344,10 @@ static zend_class_entry *register_class_DateException(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1333,7 +1357,10 @@ static zend_class_entry *register_class_DateInvalidTimeZoneException(zend_class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateInvalidTimeZoneException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1343,7 +1370,10 @@ static zend_class_entry *register_class_DateInvalidOperationException(zend_class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateInvalidOperationException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1353,7 +1383,10 @@ static zend_class_entry *register_class_DateMalformedStringException(zend_class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateMalformedStringException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1363,7 +1396,10 @@ static zend_class_entry *register_class_DateMalformedIntervalStringException(zen
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateMalformedIntervalStringException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1373,7 +1409,10 @@ static zend_class_entry *register_class_DateMalformedPeriodStringException(zend_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DateMalformedPeriodStringException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DateException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DateException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/dba/dba_arginfo.h
+++ b/ext/dba/dba_arginfo.h
@@ -110,5 +110,7 @@ static zend_class_entry *register_class_Dba_Connection(void)
 	INIT_NS_CLASS_ENTRY(ce, "Dba", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -45,6 +45,8 @@ static zend_class_entry *register_class_DlTest(void)
 	INIT_CLASS_ENTRY(ce, "DlTest", class_DlTest_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -61,6 +63,8 @@ static zend_class_entry *register_class_DlTestSuperClass(void)
 	zend_declare_typed_property(class_entry, property_a_name, &property_a_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_a_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -69,7 +73,10 @@ static zend_class_entry *register_class_DlTestSubClass(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DlTestSubClass", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DlTestSuperClass, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DlTestSuperClass, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -80,6 +87,8 @@ static zend_class_entry *register_class_DlTestAliasedClass(void)
 
 	INIT_CLASS_ENTRY(ce, "DlTestAliasedClass", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1883,7 +1883,7 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMDocumentType", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
@@ -1921,6 +1921,9 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_internalSubset_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1929,7 +1932,10 @@ static zend_class_entry *register_class_DOMCdataSection(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMCdataSection", class_DOMCdataSection_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMText, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DOMText, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1939,7 +1945,10 @@ static zend_class_entry *register_class_DOMComment(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMComment", class_DOMComment_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMCharacterData, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DOMCharacterData, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1951,6 +1960,8 @@ static zend_class_entry *register_class_DOMParentNode(void)
 	INIT_CLASS_ENTRY(ce, "DOMParentNode", class_DOMParentNode_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1960,6 +1971,8 @@ static zend_class_entry *register_class_DOMChildNode(void)
 
 	INIT_CLASS_ENTRY(ce, "DOMChildNode", class_DOMChildNode_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2124,6 +2137,8 @@ static zend_class_entry *register_class_DOMNode(void)
 	zend_declare_typed_property(class_entry, property_textContent_name, &property_textContent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_textContent_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2197,6 +2212,8 @@ static zend_class_entry *register_class_DOMNameSpaceNode(void)
 	zend_declare_typed_property(class_entry, property_parentElement_name, &property_parentElement_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release_ex(property_parentElement_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2207,6 +2224,8 @@ static zend_class_entry *register_class_DOMImplementation(void)
 	INIT_CLASS_ENTRY(ce, "DOMImplementation", class_DOMImplementation_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2215,8 +2234,7 @@ static zend_class_entry *register_class_DOMDocumentFragment(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMDocumentFragment", class_DOMDocumentFragment_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
-	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
@@ -2238,6 +2256,10 @@ static zend_class_entry *register_class_DOMDocumentFragment(zend_class_entry *cl
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_childElementCount_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
+
 	return class_entry;
 }
 
@@ -2247,13 +2269,15 @@ static zend_class_entry *register_class_DOMNodeList(zend_class_entry *class_entr
 
 	INIT_CLASS_ENTRY(ce, "DOMNodeList", class_DOMNodeList_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2263,8 +2287,7 @@ static zend_class_entry *register_class_DOMCharacterData(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMCharacterData", class_DOMCharacterData_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
-	zend_class_implements(class_entry, 1, class_entry_DOMChildNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
@@ -2292,6 +2315,10 @@ static zend_class_entry *register_class_DOMCharacterData(zend_class_entry *class
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release_ex(property_nextElementSibling_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_DOMChildNode);
+
 	return class_entry;
 }
 
@@ -2300,7 +2327,7 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMAttr", class_DOMAttr_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
@@ -2329,6 +2356,9 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release_ex(property_schemaTypeInfo_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2337,8 +2367,7 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMElement", class_DOMElement_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
-	zend_class_implements(class_entry, 2, class_entry_DOMParentNode, class_entry_DOMChildNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_tagName_default_value;
 	ZVAL_UNDEF(&property_tagName_default_value);
@@ -2398,6 +2427,10 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release_ex(property_nextElementSibling_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_DOMParentNode, class_entry_DOMChildNode);
+
 	return class_entry;
 }
 
@@ -2406,8 +2439,7 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMDocument", class_DOMDocument_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
-	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_doctype_default_value;
 	ZVAL_UNDEF(&property_doctype_default_value);
@@ -2546,6 +2578,10 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_childElementCount_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
+
 	return class_entry;
 }
 
@@ -2554,12 +2590,15 @@ static zend_class_entry *register_class_DOMException(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 	zend_register_class_alias("Dom\\DOMException", class_entry);
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_CODE), &property_code_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2569,13 +2608,16 @@ static zend_class_entry *register_class_DOMText(zend_class_entry *class_entry_DO
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMText", class_DOMText_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMCharacterData, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_wholeText_default_value;
 	ZVAL_UNDEF(&property_wholeText_default_value);
 	zend_string *property_wholeText_name = zend_string_init("wholeText", sizeof("wholeText") - 1, true);
 	zend_declare_typed_property(class_entry, property_wholeText_name, &property_wholeText_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_wholeText_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DOMCharacterData, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2586,13 +2628,15 @@ static zend_class_entry *register_class_DOMNamedNodeMap(zend_class_entry *class_
 
 	INIT_CLASS_ENTRY(ce, "DOMNamedNodeMap", class_DOMNamedNodeMap_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2602,7 +2646,7 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMEntity", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
@@ -2640,6 +2684,9 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_version_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2648,7 +2695,10 @@ static zend_class_entry *register_class_DOMEntityReference(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMEntityReference", class_DOMEntityReference_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2658,7 +2708,7 @@ static zend_class_entry *register_class_DOMNotation(zend_class_entry *class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMNotation", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
@@ -2672,6 +2722,9 @@ static zend_class_entry *register_class_DOMNotation(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_systemId_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2680,7 +2733,7 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMProcessingInstruction", class_DOMProcessingInstruction_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DOMNode, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_target_default_value;
 	ZVAL_UNDEF(&property_target_default_value);
@@ -2693,6 +2746,9 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, true);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_data_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_DOMNode, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2718,6 +2774,8 @@ static zend_class_entry *register_class_DOMXPath(void)
 	zend_declare_typed_property(class_entry, property_registerNodeNamespaces_name, &property_registerNodeNamespaces_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_registerNodeNamespaces_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 #endif
@@ -2729,6 +2787,8 @@ static zend_class_entry *register_class_Dom_ParentNode(void)
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "ParentNode", class_Dom_ParentNode_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2739,6 +2799,8 @@ static zend_class_entry *register_class_Dom_ChildNode(void)
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "ChildNode", class_Dom_ChildNode_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2748,6 +2810,8 @@ static zend_class_entry *register_class_Dom_Implementation(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Implementation", class_Dom_Implementation_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -2887,6 +2951,8 @@ static zend_class_entry *register_class_Dom_Node(void)
 	zend_declare_typed_property(class_entry, property_textContent_name, &property_textContent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_textContent_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2896,13 +2962,15 @@ static zend_class_entry *register_class_Dom_NodeList(zend_class_entry *class_ent
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "NodeList", class_Dom_NodeList_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2913,13 +2981,15 @@ static zend_class_entry *register_class_Dom_NamedNodeMap(zend_class_entry *class
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "NamedNodeMap", class_Dom_NamedNodeMap_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2930,13 +3000,15 @@ static zend_class_entry *register_class_Dom_DtdNamedNodeMap(zend_class_entry *cl
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "DtdNamedNodeMap", class_Dom_DtdNamedNodeMap_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2947,13 +3019,15 @@ static zend_class_entry *register_class_Dom_HTMLCollection(zend_class_entry *cla
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "HTMLCollection", class_Dom_HTMLCollection_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
 	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, true);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -2982,6 +3056,8 @@ static zend_class_entry *register_class_Dom_AdjacentPosition(void)
 	ZVAL_STR(&enum_case_AfterEnd_value, enum_case_AfterEnd_value_str);
 	zend_enum_add_case_cstr(class_entry, "AfterEnd", &enum_case_AfterEnd_value);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -2990,8 +3066,7 @@ static zend_class_entry *register_class_Dom_Element(zend_class_entry *class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Element", class_Dom_Element_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
-	zend_class_implements(class_entry, 2, class_entry_Dom_ParentNode, class_entry_Dom_ChildNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
@@ -3102,6 +3177,10 @@ static zend_class_entry *register_class_Dom_Element(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_substitutedNodeValue_name, &property_substitutedNodeValue_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_substitutedNodeValue_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_Dom_ParentNode, class_entry_Dom_ChildNode);
+
 	return class_entry;
 }
 
@@ -3110,7 +3189,10 @@ static zend_class_entry *register_class_Dom_HTMLElement(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "HTMLElement", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Element, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Element, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3120,7 +3202,7 @@ static zend_class_entry *register_class_Dom_Attr(zend_class_entry *class_entry_D
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Attr", class_Dom_Attr_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
@@ -3161,6 +3243,9 @@ static zend_class_entry *register_class_Dom_Attr(zend_class_entry *class_entry_D
 	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_specified_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3169,8 +3254,7 @@ static zend_class_entry *register_class_Dom_CharacterData(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "CharacterData", class_Dom_CharacterData_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
-	zend_class_implements(class_entry, 1, class_entry_Dom_ChildNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
@@ -3198,6 +3282,10 @@ static zend_class_entry *register_class_Dom_CharacterData(zend_class_entry *clas
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_length_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Dom_ChildNode);
+
 	return class_entry;
 }
 
@@ -3206,13 +3294,16 @@ static zend_class_entry *register_class_Dom_Text(zend_class_entry *class_entry_D
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Text", class_Dom_Text_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_CharacterData, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_wholeText_default_value;
 	ZVAL_UNDEF(&property_wholeText_default_value);
 	zend_string *property_wholeText_name = zend_string_init("wholeText", sizeof("wholeText") - 1, true);
 	zend_declare_typed_property(class_entry, property_wholeText_name, &property_wholeText_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_wholeText_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_CharacterData, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3222,7 +3313,10 @@ static zend_class_entry *register_class_Dom_CDATASection(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "CDATASection", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Text, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Text, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3232,13 +3326,16 @@ static zend_class_entry *register_class_Dom_ProcessingInstruction(zend_class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "ProcessingInstruction", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_CharacterData, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_target_default_value;
 	ZVAL_UNDEF(&property_target_default_value);
 	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, true);
 	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_target_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_CharacterData, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3248,7 +3345,10 @@ static zend_class_entry *register_class_Dom_Comment(zend_class_entry *class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Comment", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_CharacterData, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_CharacterData, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3258,8 +3358,7 @@ static zend_class_entry *register_class_Dom_DocumentType(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "DocumentType", class_Dom_DocumentType_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
-	zend_class_implements(class_entry, 1, class_entry_Dom_ChildNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
@@ -3297,6 +3396,10 @@ static zend_class_entry *register_class_Dom_DocumentType(zend_class_entry *class
 	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_internalSubset_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Dom_ChildNode);
+
 	return class_entry;
 }
 
@@ -3305,8 +3408,7 @@ static zend_class_entry *register_class_Dom_DocumentFragment(zend_class_entry *c
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "DocumentFragment", class_Dom_DocumentFragment_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
-	zend_class_implements(class_entry, 1, class_entry_Dom_ParentNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_children_default_value;
 	ZVAL_UNDEF(&property_children_default_value);
@@ -3335,6 +3437,10 @@ static zend_class_entry *register_class_Dom_DocumentFragment(zend_class_entry *c
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_childElementCount_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Dom_ParentNode);
+
 	return class_entry;
 }
 
@@ -3343,7 +3449,7 @@ static zend_class_entry *register_class_Dom_Entity(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Entity", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
@@ -3363,6 +3469,9 @@ static zend_class_entry *register_class_Dom_Entity(zend_class_entry *class_entry
 	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_notationName_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3371,7 +3480,10 @@ static zend_class_entry *register_class_Dom_EntityReference(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "EntityReference", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3381,7 +3493,7 @@ static zend_class_entry *register_class_Dom_Notation(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Notation", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
@@ -3395,6 +3507,9 @@ static zend_class_entry *register_class_Dom_Notation(zend_class_entry *class_ent
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_systemId_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3403,8 +3518,7 @@ static zend_class_entry *register_class_Dom_Document(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "Document", class_Dom_Document_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Node, ZEND_ACC_ABSTRACT);
-	zend_class_implements(class_entry, 1, class_entry_Dom_ParentNode);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT);
 
 	zval property_children_default_value;
 	ZVAL_UNDEF(&property_children_default_value);
@@ -3504,6 +3618,10 @@ static zend_class_entry *register_class_Dom_Document(zend_class_entry *class_ent
 	zend_declare_typed_property(class_entry, property_title_name, &property_title_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_title_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Node, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Dom_ParentNode);
+
 	return class_entry;
 }
 
@@ -3512,7 +3630,10 @@ static zend_class_entry *register_class_Dom_HTMLDocument(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "HTMLDocument", class_Dom_HTMLDocument_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Document, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Document, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -3522,7 +3643,7 @@ static zend_class_entry *register_class_Dom_XMLDocument(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "XMLDocument", class_Dom_XMLDocument_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Dom_Document, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
 	zval property_xmlEncoding_default_value;
 	ZVAL_UNDEF(&property_xmlEncoding_default_value);
@@ -3548,6 +3669,9 @@ static zend_class_entry *register_class_Dom_XMLDocument(zend_class_entry *class_
 	zend_declare_typed_property(class_entry, property_formatOutput_name, &property_formatOutput_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_formatOutput_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Dom_Document, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3557,7 +3681,6 @@ static zend_class_entry *register_class_Dom_TokenList(zend_class_entry *class_en
 
 	INIT_NS_CLASS_ENTRY(ce, "Dom", "TokenList", class_Dom_TokenList_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
@@ -3568,6 +3691,9 @@ static zend_class_entry *register_class_Dom_TokenList(zend_class_entry *class_en
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_VALUE), &property_value_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;
 }
@@ -3598,6 +3724,8 @@ static zend_class_entry *register_class_Dom_NamespaceInfo(void)
 	zend_declare_typed_property(class_entry, property_element_name, &property_element_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_element_class_Dom_Element, 0, 0));
 	zend_string_release_ex(property_element_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3621,6 +3749,8 @@ static zend_class_entry *register_class_Dom_XPath(void)
 	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", sizeof("registerNodeNamespaces") - 1, true);
 	zend_declare_typed_property(class_entry, property_registerNodeNamespaces_name, &property_registerNodeNamespaces_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_registerNodeNamespaces_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -220,6 +220,8 @@ static zend_class_entry *register_class_EnchantBroker(void)
 	INIT_CLASS_ENTRY(ce, "EnchantBroker", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -229,6 +231,8 @@ static zend_class_entry *register_class_EnchantDictionary(void)
 
 	INIT_CLASS_ENTRY(ce, "EnchantDictionary", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -209,6 +209,8 @@ static zend_class_entry *register_class_FFI(void)
 	zend_declare_typed_class_constant(class_entry, const___BIGGEST_ALIGNMENT___name, &const___BIGGEST_ALIGNMENT___value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const___BIGGEST_ALIGNMENT___name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -218,6 +220,8 @@ static zend_class_entry *register_class_FFI_CData(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "FFI", "CData", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -459,6 +463,8 @@ static zend_class_entry *register_class_FFI_CType(void)
 	zend_declare_typed_class_constant(class_entry, const_ABI_VECTORCALL_name, &const_ABI_VECTORCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ABI_VECTORCALL_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -467,7 +473,10 @@ static zend_class_entry *register_class_FFI_Exception(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "FFI", "Exception", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -477,7 +486,10 @@ static zend_class_entry *register_class_FFI_ParserException(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "FFI", "ParserException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FFI_Exception, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zend_do_inheritance_ex(class_entry, class_entry_FFI_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -113,5 +113,7 @@ static zend_class_entry *register_class_finfo(void)
 	INIT_CLASS_ENTRY(ce, "finfo", class_finfo_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/filter/filter_arginfo.h
+++ b/ext/filter/filter_arginfo.h
@@ -136,7 +136,10 @@ static zend_class_entry *register_class_Filter_FilterException(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Filter", "FilterException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -146,7 +149,10 @@ static zend_class_entry *register_class_Filter_FilterFailedException(zend_class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Filter", "FilterFailedException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Filter_FilterException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Filter_FilterException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -298,5 +298,7 @@ static zend_class_entry *register_class_FTP_Connection(void)
 	INIT_NS_CLASS_ENTRY(ce, "FTP", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -940,6 +940,8 @@ static zend_class_entry *register_class_GdImage(void)
 	INIT_CLASS_ENTRY(ce, "GdImage", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -949,6 +951,8 @@ static zend_class_entry *register_class_GdFont(void)
 
 	INIT_CLASS_ENTRY(ce, "GdFont", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/gmp/gmp_arginfo.h
+++ b/ext/gmp/gmp_arginfo.h
@@ -335,5 +335,7 @@ static zend_class_entry *register_class_GMP(void)
 	INIT_CLASS_ENTRY(ce, "GMP", class_GMP_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -237,5 +237,7 @@ static zend_class_entry *register_class_HashContext(void)
 	INIT_CLASS_ENTRY(ce, "HashContext", class_HashContext_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/breakiterator/breakiterator_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_arginfo.h
@@ -157,7 +157,6 @@ static zend_class_entry *register_class_IntlBreakIterator(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "IntlBreakIterator", class_IntlBreakIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	zval const_DONE_value;
 	ZVAL_LONG(&const_DONE_value, BreakIterator::DONE);
@@ -273,6 +272,9 @@ static zend_class_entry *register_class_IntlBreakIterator(zend_class_entry *clas
 	zend_declare_typed_class_constant(class_entry, const_SENTENCE_SEP_LIMIT_name, &const_SENTENCE_SEP_LIMIT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_SENTENCE_SEP_LIMIT_name, true);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
+
 	return class_entry;
 }
 
@@ -281,7 +283,10 @@ static zend_class_entry *register_class_IntlRuleBasedBreakIterator(zend_class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "IntlRuleBasedBreakIterator", class_IntlRuleBasedBreakIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IntlBreakIterator, ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IntlBreakIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -291,7 +296,10 @@ static zend_class_entry *register_class_IntlCodePointBreakIterator(zend_class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "IntlCodePointBreakIterator", class_IntlCodePointBreakIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IntlBreakIterator, ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IntlBreakIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
@@ -21,7 +21,7 @@ static zend_class_entry *register_class_IntlPartsIterator(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "IntlPartsIterator", class_IntlPartsIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IntlIterator, ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_KEY_SEQUENTIAL_value;
 	ZVAL_LONG(&const_KEY_SEQUENTIAL_value, PARTS_ITERATOR_KEY_SEQUENTIAL);
@@ -40,6 +40,9 @@ static zend_class_entry *register_class_IntlPartsIterator(zend_class_entry *clas
 	zend_string *const_KEY_RIGHT_name = zend_string_init_interned("KEY_RIGHT", sizeof("KEY_RIGHT") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_KEY_RIGHT_name, &const_KEY_RIGHT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_KEY_RIGHT_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IntlIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -561,6 +561,8 @@ static zend_class_entry *register_class_IntlCalendar(void)
 	zend_declare_typed_class_constant(class_entry, const_WALLTIME_NEXT_VALID_name, &const_WALLTIME_NEXT_VALID_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_WALLTIME_NEXT_VALID_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -569,7 +571,10 @@ static zend_class_entry *register_class_IntlGregorianCalendar(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "IntlGregorianCalendar", class_IntlGregorianCalendar_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IntlCalendar, ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IntlCalendar, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/intl/collator/collator_arginfo.h
+++ b/ext/intl/collator/collator_arginfo.h
@@ -245,5 +245,7 @@ static zend_class_entry *register_class_Collator(void)
 	zend_declare_typed_class_constant(class_entry, const_SORT_NUMERIC_name, &const_SORT_NUMERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_SORT_NUMERIC_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/common/common_arginfo.h
+++ b/ext/intl/common/common_arginfo.h
@@ -188,6 +188,8 @@ static zend_class_entry *register_class_IntlIterator(zend_class_entry *class_ent
 
 	INIT_CLASS_ENTRY(ce, "IntlIterator", class_IntlIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;

--- a/ext/intl/converter/converter_arginfo.h
+++ b/ext/intl/converter/converter_arginfo.h
@@ -370,5 +370,7 @@ static zend_class_entry *register_class_UConverter(void)
 	zend_declare_typed_class_constant(class_entry, const_IMAP_MAILBOX_name, &const_IMAP_MAILBOX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_IMAP_MAILBOX_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/dateformat/dateformat_arginfo.h
+++ b/ext/intl/dateformat/dateformat_arginfo.h
@@ -219,5 +219,7 @@ static zend_class_entry *register_class_IntlDateFormatter(void)
 	zend_declare_typed_class_constant(class_entry, const_TRADITIONAL_name, &const_TRADITIONAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_TRADITIONAL_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/dateformat/datepatterngenerator_arginfo.h
+++ b/ext/intl/dateformat/datepatterngenerator_arginfo.h
@@ -31,5 +31,7 @@ static zend_class_entry *register_class_IntlDatePatternGenerator(void)
 	INIT_CLASS_ENTRY(ce, "IntlDatePatternGenerator", class_IntlDatePatternGenerator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/formatter/formatter_arginfo.h
+++ b/ext/intl/formatter/formatter_arginfo.h
@@ -630,5 +630,7 @@ static zend_class_entry *register_class_NumberFormatter(void)
 	ZVAL_STR(&attribute_Deprecated_const_TYPE_CURRENCY_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_3));
 	attribute_Deprecated_const_TYPE_CURRENCY_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/listformatter/listformatter_arginfo.h
+++ b/ext/intl/listformatter/listformatter_arginfo.h
@@ -95,5 +95,7 @@ static zend_class_entry *register_class_IntlListFormatter(void)
 	zend_string_release_ex(const_WIDTH_NARROW_name, true);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/locale/locale_arginfo.h
+++ b/ext/intl/locale/locale_arginfo.h
@@ -193,5 +193,7 @@ static zend_class_entry *register_class_Locale(void)
 	zend_declare_typed_class_constant(class_entry, const_PRIVATE_TAG_name, &const_PRIVATE_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(const_PRIVATE_TAG_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/msgformat/msgformat_arginfo.h
+++ b/ext/intl/msgformat/msgformat_arginfo.h
@@ -80,5 +80,7 @@ static zend_class_entry *register_class_MessageFormatter(void)
 	INIT_CLASS_ENTRY(ce, "MessageFormatter", class_MessageFormatter_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/normalizer/normalizer_arginfo.h
+++ b/ext/intl/normalizer/normalizer_arginfo.h
@@ -94,5 +94,7 @@ static zend_class_entry *register_class_Normalizer(void)
 	zend_declare_typed_class_constant(class_entry, const_NFKC_CF_name, &const_NFKC_CF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_NFKC_CF_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1252,7 +1252,10 @@ static zend_class_entry *register_class_IntlException(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "IntlException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/intl/rangeformatter/rangeformatter_arginfo.h
+++ b/ext/intl/rangeformatter/rangeformatter_arginfo.h
@@ -144,5 +144,7 @@ static zend_class_entry *register_class_IntlNumberRangeFormatter(void)
 	zend_string_release_ex(const_IDENTITY_FALLBACK_RANGE_name, true);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/resourcebundle/resourcebundle_arginfo.h
+++ b/ext/intl/resourcebundle/resourcebundle_arginfo.h
@@ -60,6 +60,8 @@ static zend_class_entry *register_class_ResourceBundle(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "ResourceBundle", class_ResourceBundle_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;

--- a/ext/intl/spoofchecker/spoofchecker_arginfo.h
+++ b/ext/intl/spoofchecker/spoofchecker_arginfo.h
@@ -184,5 +184,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 	zend_string_release_ex(const_SIMPLE_CASE_INSENSITIVE_name, true);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -232,5 +232,7 @@ static zend_class_entry *register_class_IntlTimeZone(void)
 	zend_declare_typed_class_constant(class_entry, const_TYPE_CANONICAL_LOCATION_name, &const_TYPE_CANONICAL_LOCATION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_TYPE_CANONICAL_LOCATION_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -78,5 +78,7 @@ static zend_class_entry *register_class_Transliterator(void)
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_id_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/intl/uchar/uchar_arginfo.h
+++ b/ext/intl/uchar/uchar_arginfo.h
@@ -4307,5 +4307,7 @@ static zend_class_entry *register_class_IntlChar(void)
 	zend_declare_typed_class_constant(class_entry, const_FOLD_CASE_EXCLUDE_SPECIAL_I_name, &const_FOLD_CASE_EXCLUDE_SPECIAL_I_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_FOLD_CASE_EXCLUDE_SPECIAL_I_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -89,6 +89,8 @@ static zend_class_entry *register_class_JsonSerializable(void)
 	INIT_CLASS_ENTRY(ce, "JsonSerializable", class_JsonSerializable_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -97,7 +99,10 @@ static zend_class_entry *register_class_JsonException(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "JsonException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -775,6 +775,8 @@ static zend_class_entry *register_class_LDAP_Connection(void)
 	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -785,6 +787,8 @@ static zend_class_entry *register_class_LDAP_Result(void)
 	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -794,6 +798,8 @@ static zend_class_entry *register_class_LDAP_ResultEntry(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "LDAP", "ResultEntry", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -130,5 +130,7 @@ static zend_class_entry *register_class_LibXMLError(void)
 	ZVAL_UNDEF(&property_line_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_LINE), &property_line_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1325,6 +1325,8 @@ static zend_class_entry *register_class_mysqli_driver(void)
 	zend_declare_typed_property(class_entry, property_report_mode_name, &property_report_mode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_report_mode_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1487,6 +1489,8 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_STR(&attribute_Deprecated_func_refresh_0->args[1].value, attribute_Deprecated_func_refresh_0_arg1_str);
 	attribute_Deprecated_func_refresh_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1496,7 +1500,6 @@ static zend_class_entry *register_class_mysqli_result(zend_class_entry *class_en
 
 	INIT_CLASS_ENTRY(ce, "mysqli_result", class_mysqli_result_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	zval property_current_field_default_value;
 	ZVAL_UNDEF(&property_current_field_default_value);
@@ -1525,6 +1528,9 @@ static zend_class_entry *register_class_mysqli_result(zend_class_entry *class_en
 	zval property_type_default_value;
 	ZVAL_UNDEF(&property_type_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_TYPE), &property_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	return class_entry;
 }
@@ -1596,6 +1602,8 @@ static zend_class_entry *register_class_mysqli_stmt(void)
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_id_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1622,6 +1630,8 @@ static zend_class_entry *register_class_mysqli_warning(void)
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_errno_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1630,7 +1640,7 @@ static zend_class_entry *register_class_mysqli_sql_exception(zend_class_entry *c
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "mysqli_sql_exception", class_mysqli_sql_exception_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, ZEND_ACC_FINAL);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
 	zval property_sqlstate_default_value;
 	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", strlen("00000"), 1);
@@ -1638,6 +1648,9 @@ static zend_class_entry *register_class_mysqli_sql_exception(zend_class_entry *c
 	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, true);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_sqlstate_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -408,6 +408,8 @@ static zend_class_entry *register_class_Odbc_Connection(void)
 	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -417,6 +419,8 @@ static zend_class_entry *register_class_Odbc_Result(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "Odbc", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -758,6 +758,8 @@ static zend_class_entry *register_class_OpenSSLCertificate(void)
 	INIT_CLASS_ENTRY(ce, "OpenSSLCertificate", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -768,6 +770,8 @@ static zend_class_entry *register_class_OpenSSLCertificateSigningRequest(void)
 	INIT_CLASS_ENTRY(ce, "OpenSSLCertificateSigningRequest", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -777,6 +781,8 @@ static zend_class_entry *register_class_OpenSSLAsymmetricKey(void)
 
 	INIT_CLASS_ENTRY(ce, "OpenSSLAsymmetricKey", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pcntl/pcntl_arginfo.h
+++ b/ext/pcntl/pcntl_arginfo.h
@@ -676,5 +676,7 @@ static zend_class_entry *register_class_Pcntl_QosClass(void)
 
 	zend_enum_add_case_cstr(class_entry, "Background", NULL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/pdo/pdo_arginfo.h
+++ b/ext/pdo/pdo_arginfo.h
@@ -16,7 +16,7 @@ static zend_class_entry *register_class_PDOException(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "PDOException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
@@ -27,6 +27,9 @@ static zend_class_entry *register_class_PDOException(zend_class_entry *class_ent
 	zend_string *property_errorInfo_name = zend_string_init("errorInfo", sizeof("errorInfo") - 1, true);
 	zend_declare_typed_property(class_entry, property_errorInfo_name, &property_errorInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release_ex(property_errorInfo_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -565,5 +565,7 @@ static zend_class_entry *register_class_PDO(void)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -138,13 +138,15 @@ static zend_class_entry *register_class_PDOStatement(zend_class_entry *class_ent
 
 	INIT_CLASS_ENTRY(ce, "PDOStatement", class_PDOStatement_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	zval property_queryString_default_value;
 	ZVAL_UNDEF(&property_queryString_default_value);
 	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, true);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_queryString_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	return class_entry;
 }
@@ -161,6 +163,8 @@ static zend_class_entry *register_class_PDORow(void)
 	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, true);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_queryString_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_dblib/pdo_dblib_arginfo.h
+++ b/ext/pdo_dblib/pdo_dblib_arginfo.h
@@ -6,7 +6,7 @@ static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Dblib", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_CONNECTION_TIMEOUT_value;
 	ZVAL_LONG(&const_ATTR_CONNECTION_TIMEOUT_value, PDO_DBLIB_ATTR_CONNECTION_TIMEOUT);
@@ -49,6 +49,9 @@ static zend_class_entry *register_class_Pdo_Dblib(zend_class_entry *class_entry_
 	zend_string *const_ATTR_DATETIME_CONVERT_name = zend_string_init_interned("ATTR_DATETIME_CONVERT", sizeof("ATTR_DATETIME_CONVERT") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_ATTR_DATETIME_CONVERT_name, &const_ATTR_DATETIME_CONVERT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ATTR_DATETIME_CONVERT_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_firebird/pdo_firebird_arginfo.h
+++ b/ext/pdo_firebird/pdo_firebird_arginfo.h
@@ -16,7 +16,7 @@ static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Firebird", class_Pdo_Firebird_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_DATE_FORMAT_value;
 	ZVAL_LONG(&const_ATTR_DATE_FORMAT_value, PDO_FB_ATTR_DATE_FORMAT);
@@ -65,6 +65,9 @@ static zend_class_entry *register_class_Pdo_Firebird(zend_class_entry *class_ent
 	zend_string *const_WRITABLE_TRANSACTION_name = zend_string_init_interned("WRITABLE_TRANSACTION", sizeof("WRITABLE_TRANSACTION") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_WRITABLE_TRANSACTION_name, &const_WRITABLE_TRANSACTION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_WRITABLE_TRANSACTION_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_mysql/pdo_mysql_arginfo.h
+++ b/ext/pdo_mysql/pdo_mysql_arginfo.h
@@ -16,7 +16,7 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Mysql", class_Pdo_Mysql_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_USE_BUFFERED_QUERY_value;
 	ZVAL_LONG(&const_ATTR_USE_BUFFERED_QUERY_value, PDO_MYSQL_ATTR_USE_BUFFERED_QUERY);
@@ -139,6 +139,9 @@ static zend_class_entry *register_class_Pdo_Mysql(zend_class_entry *class_entry_
 	zend_declare_typed_class_constant(class_entry, const_ATTR_LOCAL_INFILE_DIRECTORY_name, &const_ATTR_LOCAL_INFILE_DIRECTORY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ATTR_LOCAL_INFILE_DIRECTORY_name, true);
 #endif
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_odbc/pdo_odbc_arginfo.h
+++ b/ext/pdo_odbc/pdo_odbc_arginfo.h
@@ -11,7 +11,7 @@ static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_P
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Odbc", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_USE_CURSOR_LIBRARY_value;
 	ZVAL_LONG(&const_ATTR_USE_CURSOR_LIBRARY_value, PDO_ODBC_ATTR_USE_CURSOR_LIBRARY);
@@ -42,6 +42,9 @@ static zend_class_entry *register_class_Pdo_Odbc(zend_class_entry *class_entry_P
 	zend_string *const_SQL_USE_ODBC_name = zend_string_init_interned("SQL_USE_ODBC", sizeof("SQL_USE_ODBC") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_SQL_USE_ODBC_name, &const_SQL_USE_ODBC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_SQL_USE_ODBC_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_pgsql/pdo_pgsql_arginfo.h
+++ b/ext/pdo_pgsql/pdo_pgsql_arginfo.h
@@ -86,7 +86,7 @@ static zend_class_entry *register_class_Pdo_Pgsql(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Pgsql", class_Pdo_Pgsql_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	zval const_ATTR_DISABLE_PREPARES_value;
 	ZVAL_LONG(&const_ATTR_DISABLE_PREPARES_value, PDO_PGSQL_ATTR_DISABLE_PREPARES);
@@ -163,6 +163,9 @@ static zend_class_entry *register_class_Pdo_Pgsql(zend_class_entry *class_entry_
 	attribute_Deprecated_const_TRANSACTION_UNKNOWN_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
 	ZVAL_STR_COPY(&attribute_Deprecated_const_TRANSACTION_UNKNOWN_0->args[1].value, attribute_Deprecated_const_TRANSACTION_IDLE_0_arg1_str);
 	attribute_Deprecated_const_TRANSACTION_UNKNOWN_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pdo_sqlite/pdo_sqlite_arginfo.h
+++ b/ext/pdo_sqlite/pdo_sqlite_arginfo.h
@@ -64,7 +64,7 @@ static zend_class_entry *register_class_Pdo_Sqlite(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Pdo", "Sqlite", class_Pdo_Sqlite_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_PDO, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 #if defined(SQLITE_DETERMINISTIC)
 
 	zval const_DETERMINISTIC_value;
@@ -183,6 +183,9 @@ static zend_class_entry *register_class_Pdo_Sqlite(zend_class_entry *class_entry
 	zend_string *const_IGNORE_name = zend_string_init_interned("IGNORE", sizeof("IGNORE") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_IGNORE_name, &const_IGNORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_IGNORE_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_PDO, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1031,6 +1031,8 @@ static zend_class_entry *register_class_PgSql_Connection(void)
 	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Connection", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1041,6 +1043,8 @@ static zend_class_entry *register_class_PgSql_Result(void)
 	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Result", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1050,6 +1054,8 @@ static zend_class_entry *register_class_PgSql_Lob(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "PgSql", "Lob", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -609,7 +609,10 @@ static zend_class_entry *register_class_PharException(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "PharException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -619,8 +622,7 @@ static zend_class_entry *register_class_Phar(zend_class_entry *class_entry_Recur
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "Phar", class_Phar_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RecursiveDirectoryIterator, 0);
-	zend_class_implements(class_entry, 2, class_entry_Countable, class_entry_ArrayAccess);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_BZ2_value;
 	ZVAL_LONG(&const_BZ2_value, PHAR_ENT_COMPRESSED_BZ2);
@@ -718,6 +720,10 @@ static zend_class_entry *register_class_Phar(zend_class_entry *class_entry_Recur
 	zend_declare_typed_class_constant(class_entry, const_SHA512_name, &const_SHA512_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_SHA512_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_RecursiveDirectoryIterator, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_Countable, class_entry_ArrayAccess);
+
 	return class_entry;
 }
 
@@ -726,7 +732,10 @@ static zend_class_entry *register_class_PharData(zend_class_entry *class_entry_R
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "PharData", class_PharData_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RecursiveDirectoryIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RecursiveDirectoryIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 2, class_entry_Countable, class_entry_ArrayAccess);
 
 	return class_entry;
@@ -737,7 +746,10 @@ static zend_class_entry *register_class_PharFileInfo(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "PharFileInfo", class_PharFileInfo_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplFileInfo, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplFileInfo, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -251,6 +251,8 @@ static zend_class_entry *register_class_Random_Engine_Mt19937(zend_class_entry *
 
 	INIT_NS_CLASS_ENTRY(ce, "Random\\Engine", "Mt19937", class_Random_Engine_Mt19937_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Random_Engine);
 
 	return class_entry;
@@ -262,6 +264,8 @@ static zend_class_entry *register_class_Random_Engine_PcgOneseq128XslRr64(zend_c
 
 	INIT_NS_CLASS_ENTRY(ce, "Random\\Engine", "PcgOneseq128XslRr64", class_Random_Engine_PcgOneseq128XslRr64_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Random_Engine);
 
 	return class_entry;
@@ -273,6 +277,8 @@ static zend_class_entry *register_class_Random_Engine_Xoshiro256StarStar(zend_cl
 
 	INIT_NS_CLASS_ENTRY(ce, "Random\\Engine", "Xoshiro256StarStar", class_Random_Engine_Xoshiro256StarStar_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Random_Engine);
 
 	return class_entry;
@@ -284,6 +290,8 @@ static zend_class_entry *register_class_Random_Engine_Secure(zend_class_entry *c
 
 	INIT_NS_CLASS_ENTRY(ce, "Random\\Engine", "Secure", class_Random_Engine_Secure_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Random_CryptoSafeEngine);
 
 	return class_entry;
@@ -296,6 +304,8 @@ static zend_class_entry *register_class_Random_Engine(void)
 	INIT_NS_CLASS_ENTRY(ce, "Random", "Engine", class_Random_Engine_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -305,6 +315,8 @@ static zend_class_entry *register_class_Random_CryptoSafeEngine(zend_class_entry
 
 	INIT_NS_CLASS_ENTRY(ce, "Random", "CryptoSafeEngine", NULL);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Random_Engine);
 
 	return class_entry;
@@ -324,6 +336,8 @@ static zend_class_entry *register_class_Random_Randomizer(void)
 	zend_declare_typed_property(class_entry, property_engine_name, &property_engine_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_engine_class_Random_Engine, 0, 0));
 	zend_string_release_ex(property_engine_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -339,6 +353,8 @@ static zend_class_entry *register_class_Random_IntervalBoundary(void)
 
 	zend_enum_add_case_cstr(class_entry, "OpenOpen", NULL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -347,7 +363,10 @@ static zend_class_entry *register_class_Random_RandomError(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -357,7 +376,10 @@ static zend_class_entry *register_class_Random_BrokenRandomEngineError(zend_clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Random", "BrokenRandomEngineError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Random_RandomError, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Random_RandomError, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -367,7 +389,10 @@ static zend_class_entry *register_class_Random_RandomException(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1387,7 +1387,10 @@ static zend_class_entry *register_class_ReflectionException(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1399,6 +1402,8 @@ static zend_class_entry *register_class_Reflection(void)
 	INIT_CLASS_ENTRY(ce, "Reflection", class_Reflection_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1408,6 +1413,8 @@ static zend_class_entry *register_class_Reflector(zend_class_entry *class_entry_
 
 	INIT_CLASS_ENTRY(ce, "Reflector", NULL);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
@@ -1419,11 +1426,13 @@ static zend_class_entry *register_class_ReflectionFunctionAbstract(zend_class_en
 
 	INIT_CLASS_ENTRY(ce, "ReflectionFunctionAbstract", class_ReflectionFunctionAbstract_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT|ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	return class_entry;
 }
@@ -1433,7 +1442,7 @@ static zend_class_entry *register_class_ReflectionFunction(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionFunction", class_ReflectionFunction_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionFunctionAbstract, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_IS_DEPRECATED_value;
 	ZVAL_LONG(&const_IS_DEPRECATED_value, ZEND_ACC_DEPRECATED);
@@ -1449,6 +1458,9 @@ static zend_class_entry *register_class_ReflectionFunction(zend_class_entry *cla
 	ZVAL_STR(&attribute_Deprecated_func_isdisabled_0->args[1].value, attribute_Deprecated_func_isdisabled_0_arg1_str);
 	attribute_Deprecated_func_isdisabled_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionFunctionAbstract, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1459,6 +1471,8 @@ static zend_class_entry *register_class_ReflectionGenerator(void)
 	INIT_CLASS_ENTRY(ce, "ReflectionGenerator", class_ReflectionGenerator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1467,7 +1481,7 @@ static zend_class_entry *register_class_ReflectionMethod(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionMethod", class_ReflectionMethod_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionFunctionAbstract, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_IS_STATIC_value;
 	ZVAL_LONG(&const_IS_STATIC_value, ZEND_ACC_STATIC);
@@ -1517,6 +1531,9 @@ static zend_class_entry *register_class_ReflectionMethod(zend_class_entry *class
 	ZVAL_STR(&attribute_Deprecated_func_setaccessible_0->args[1].value, attribute_Deprecated_func_setaccessible_0_arg1_str);
 	attribute_Deprecated_func_setaccessible_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionFunctionAbstract, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1526,7 +1543,6 @@ static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_
 
 	INIT_CLASS_ENTRY(ce, "ReflectionClass", class_ReflectionClass_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval const_IS_IMPLICIT_ABSTRACT_value;
 	ZVAL_LONG(&const_IS_IMPLICIT_ABSTRACT_value, ZEND_ACC_IMPLICIT_ABSTRACT_CLASS);
@@ -1568,6 +1584,9 @@ static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
+
 	return class_entry;
 }
 
@@ -1576,7 +1595,10 @@ static zend_class_entry *register_class_ReflectionObject(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionObject", class_ReflectionObject_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionClass, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionClass, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1595,6 +1617,8 @@ static zend_class_entry *register_class_PropertyHookType(void)
 	ZVAL_STR(&enum_case_Set_value, enum_case_Set_value_str);
 	zend_enum_add_case_cstr(class_entry, "Set", &enum_case_Set_value);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1604,7 +1628,6 @@ static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *cla
 
 	INIT_CLASS_ENTRY(ce, "ReflectionProperty", class_ReflectionProperty_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval const_IS_STATIC_value;
 	ZVAL_LONG(&const_IS_STATIC_value, ZEND_ACC_STATIC);
@@ -1682,6 +1705,9 @@ static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *cla
 	ZVAL_STR(&attribute_Deprecated_func_setaccessible_0->args[1].value, attribute_Deprecated_func_setaccessible_0_arg1_str);
 	attribute_Deprecated_func_setaccessible_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
+
 	return class_entry;
 }
 
@@ -1691,7 +1717,6 @@ static zend_class_entry *register_class_ReflectionClassConstant(zend_class_entry
 
 	INIT_CLASS_ENTRY(ce, "ReflectionClassConstant", class_ReflectionClassConstant_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval const_IS_PUBLIC_value;
 	ZVAL_LONG(&const_IS_PUBLIC_value, ZEND_ACC_PUBLIC);
@@ -1725,6 +1750,9 @@ static zend_class_entry *register_class_ReflectionClassConstant(zend_class_entry
 	ZVAL_UNDEF(&property_class_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_CLASS), &property_class_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
+
 	return class_entry;
 }
 
@@ -1734,7 +1762,6 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "ReflectionParameter", class_ReflectionParameter_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
@@ -1760,6 +1787,9 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 	ZVAL_STR_COPY(&attribute_Deprecated_func_iscallable_0->args[1].value, attribute_Deprecated_func_getclass_0_arg1_str);
 	attribute_Deprecated_func_iscallable_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
+
 	return class_entry;
 }
 
@@ -1769,6 +1799,8 @@ static zend_class_entry *register_class_ReflectionType(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "ReflectionType", class_ReflectionType_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
@@ -1779,7 +1811,10 @@ static zend_class_entry *register_class_ReflectionNamedType(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionNamedType", class_ReflectionNamedType_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionType, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionType, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1789,7 +1824,10 @@ static zend_class_entry *register_class_ReflectionUnionType(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionUnionType", class_ReflectionUnionType_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionType, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionType, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1799,7 +1837,10 @@ static zend_class_entry *register_class_ReflectionIntersectionType(zend_class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionIntersectionType", class_ReflectionIntersectionType_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionType, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionType, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1810,11 +1851,13 @@ static zend_class_entry *register_class_ReflectionExtension(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "ReflectionExtension", class_ReflectionExtension_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	return class_entry;
 }
@@ -1825,11 +1868,13 @@ static zend_class_entry *register_class_ReflectionZendExtension(zend_class_entry
 
 	INIT_CLASS_ENTRY(ce, "ReflectionZendExtension", class_ReflectionZendExtension_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	return class_entry;
 }
@@ -1841,6 +1886,8 @@ static zend_class_entry *register_class_ReflectionReference(void)
 	INIT_CLASS_ENTRY(ce, "ReflectionReference", class_ReflectionReference_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1850,7 +1897,6 @@ static zend_class_entry *register_class_ReflectionAttribute(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "ReflectionAttribute", class_ReflectionAttribute_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval const_IS_INSTANCEOF_value;
 	ZVAL_LONG(&const_IS_INSTANCEOF_value, REFLECTION_ATTRIBUTE_IS_INSTANCEOF);
@@ -1862,6 +1908,9 @@ static zend_class_entry *register_class_ReflectionAttribute(zend_class_entry *cl
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
+
 	return class_entry;
 }
 
@@ -1870,7 +1919,10 @@ static zend_class_entry *register_class_ReflectionEnum(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionEnum", class_ReflectionEnum_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionClass, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionClass, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1880,7 +1932,10 @@ static zend_class_entry *register_class_ReflectionEnumUnitCase(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionEnumUnitCase", class_ReflectionEnumUnitCase_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionClassConstant, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionClassConstant, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1890,7 +1945,10 @@ static zend_class_entry *register_class_ReflectionEnumBackedCase(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionEnumBackedCase", class_ReflectionEnumBackedCase_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ReflectionEnumUnitCase, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ReflectionEnumUnitCase, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1902,6 +1960,8 @@ static zend_class_entry *register_class_ReflectionFiber(void)
 	INIT_CLASS_ENTRY(ce, "ReflectionFiber", class_ReflectionFiber_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1911,11 +1971,13 @@ static zend_class_entry *register_class_ReflectionConstant(zend_class_entry *cla
 
 	INIT_CLASS_ENTRY(ce, "ReflectionConstant", class_ReflectionConstant_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	return class_entry;
 }

--- a/ext/session/session_arginfo.h
+++ b/ext/session/session_arginfo.h
@@ -238,6 +238,8 @@ static zend_class_entry *register_class_SessionHandlerInterface(void)
 	INIT_CLASS_ENTRY(ce, "SessionHandlerInterface", class_SessionHandlerInterface_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -247,6 +249,8 @@ static zend_class_entry *register_class_SessionIdInterface(void)
 
 	INIT_CLASS_ENTRY(ce, "SessionIdInterface", class_SessionIdInterface_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -258,6 +262,8 @@ static zend_class_entry *register_class_SessionUpdateTimestampHandlerInterface(v
 	INIT_CLASS_ENTRY(ce, "SessionUpdateTimestampHandlerInterface", class_SessionUpdateTimestampHandlerInterface_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -267,6 +273,8 @@ static zend_class_entry *register_class_SessionHandler(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "SessionHandler", class_SessionHandler_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 2, class_entry_SessionHandlerInterface, class_entry_SessionIdInterface);
 
 	return class_entry;

--- a/ext/shmop/shmop_arginfo.h
+++ b/ext/shmop/shmop_arginfo.h
@@ -67,5 +67,7 @@ static zend_class_entry *register_class_Shmop(void)
 	INIT_CLASS_ENTRY(ce, "Shmop", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/simplexml/simplexml_arginfo.h
+++ b/ext/simplexml/simplexml_arginfo.h
@@ -167,6 +167,8 @@ static zend_class_entry *register_class_SimpleXMLElement(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "SimpleXMLElement", class_SimpleXMLElement_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 3, class_entry_Stringable, class_entry_Countable, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -177,7 +179,10 @@ static zend_class_entry *register_class_SimpleXMLIterator(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SimpleXMLIterator", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SimpleXMLElement, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SimpleXMLElement, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -388,6 +388,8 @@ static zend_class_entry *register_class_SNMP(void)
 	zend_declare_typed_property(class_entry, property_exceptions_enabled_name, &property_exceptions_enabled_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_exceptions_enabled_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -396,7 +398,10 @@ static zend_class_entry *register_class_SNMPException(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SNMPException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -333,6 +333,8 @@ static zend_class_entry *register_class_Soap_Url(void)
 	INIT_NS_CLASS_ENTRY(ce, "Soap", "Url", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -342,6 +344,8 @@ static zend_class_entry *register_class_Soap_Sdl(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "Soap", "Sdl", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -364,6 +368,8 @@ static zend_class_entry *register_class_SoapParam(void)
 	zend_string *property_param_data_name = zend_string_init("param_data", sizeof("param_data") - 1, true);
 	zend_declare_typed_property(class_entry, property_param_data_name, &property_param_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release_ex(property_param_data_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -403,6 +409,8 @@ static zend_class_entry *register_class_SoapHeader(void)
 	zend_declare_typed_property(class_entry, property_actor_name, &property_actor_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release_ex(property_actor_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -411,7 +419,7 @@ static zend_class_entry *register_class_SoapFault(zend_class_entry *class_entry_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SoapFault", class_SoapFault_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_faultstring_default_value;
 	ZVAL_UNDEF(&property_faultstring_default_value);
@@ -461,6 +469,9 @@ static zend_class_entry *register_class_SoapFault(zend_class_entry *class_entry_
 	zend_declare_typed_property(class_entry, property_lang_name, &property_lang_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_lang_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -507,6 +518,8 @@ static zend_class_entry *register_class_SoapVar(void)
 	zend_declare_typed_property(class_entry, property_enc_namens_name, &property_enc_namens_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_enc_namens_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -523,6 +536,8 @@ static zend_class_entry *register_class_SoapServer(void)
 	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", sizeof("SoapFault")-1, 1);
 	zend_declare_typed_property(class_entry, property___soap_fault_name, &property___soap_fault_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property___soap_fault_class_SoapFault, 0, MAY_BE_NULL));
 	zend_string_release_ex(property___soap_fault_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -750,6 +765,8 @@ static zend_class_entry *register_class_SoapClient(void)
 	zend_string *property___last_response_headers_name = zend_string_init("__last_response_headers", sizeof("__last_response_headers") - 1, true);
 	zend_declare_typed_property(class_entry, property___last_response_headers_name, &property___last_response_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property___last_response_headers_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1118,6 +1118,8 @@ static zend_class_entry *register_class_Socket(void)
 	INIT_CLASS_ENTRY(ce, "Socket", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1127,6 +1129,8 @@ static zend_class_entry *register_class_AddressInfo(void)
 
 	INIT_CLASS_ENTRY(ce, "AddressInfo", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -1266,7 +1266,10 @@ static zend_class_entry *register_class_SodiumException(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SodiumException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -260,7 +260,6 @@ static zend_class_entry *register_class_ArrayObject(zend_class_entry *class_entr
 
 	INIT_CLASS_ENTRY(ce, "ArrayObject", class_ArrayObject_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Serializable, class_entry_Countable);
 
 	zval const_STD_PROP_LIST_value;
 	ZVAL_LONG(&const_STD_PROP_LIST_value, SPL_ARRAY_STD_PROP_LIST);
@@ -273,6 +272,9 @@ static zend_class_entry *register_class_ArrayObject(zend_class_entry *class_entr
 	zend_string *const_ARRAY_AS_PROPS_name = zend_string_init_interned("ARRAY_AS_PROPS", sizeof("ARRAY_AS_PROPS") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_ARRAY_AS_PROPS_name, &const_ARRAY_AS_PROPS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ARRAY_AS_PROPS_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Serializable, class_entry_Countable);
 
 	return class_entry;
 }
@@ -283,7 +285,6 @@ static zend_class_entry *register_class_ArrayIterator(zend_class_entry *class_en
 
 	INIT_CLASS_ENTRY(ce, "ArrayIterator", class_ArrayIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 4, class_entry_SeekableIterator, class_entry_ArrayAccess, class_entry_Serializable, class_entry_Countable);
 
 	zval const_STD_PROP_LIST_value;
 	ZVAL_LONG(&const_STD_PROP_LIST_value, SPL_ARRAY_STD_PROP_LIST);
@@ -297,6 +298,9 @@ static zend_class_entry *register_class_ArrayIterator(zend_class_entry *class_en
 	zend_declare_typed_class_constant(class_entry, const_ARRAY_AS_PROPS_name, &const_ARRAY_AS_PROPS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_ARRAY_AS_PROPS_name, true);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 4, class_entry_SeekableIterator, class_entry_ArrayAccess, class_entry_Serializable, class_entry_Countable);
+
 	return class_entry;
 }
 
@@ -305,14 +309,17 @@ static zend_class_entry *register_class_RecursiveArrayIterator(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveArrayIterator", class_RecursiveArrayIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ArrayIterator, 0);
-	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_CHILD_ARRAYS_ONLY_value;
 	ZVAL_LONG(&const_CHILD_ARRAYS_ONLY_value, SPL_ARRAY_CHILD_ARRAYS_ONLY);
 	zend_string *const_CHILD_ARRAYS_ONLY_name = zend_string_init_interned("CHILD_ARRAYS_ONLY", sizeof("CHILD_ARRAYS_ONLY") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_CHILD_ARRAYS_ONLY_name, &const_CHILD_ARRAYS_ONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_CHILD_ARRAYS_ONLY_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ArrayIterator, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
 }

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -478,12 +478,14 @@ static zend_class_entry *register_class_SplFileInfo(zend_class_entry *class_entr
 
 	INIT_CLASS_ENTRY(ce, "SplFileInfo", class_SplFileInfo_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
-	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 
 	zend_attribute *attribute_Deprecated_func__bad_state_ex_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "_bad_state_ex", sizeof("_bad_state_ex") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 1);
 	ZVAL_STR(&attribute_Deprecated_func__bad_state_ex_0->args[0].value, ZSTR_KNOWN(ZEND_STR_8_DOT_2));
 	attribute_Deprecated_func__bad_state_ex_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
 }
@@ -493,7 +495,10 @@ static zend_class_entry *register_class_DirectoryIterator(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DirectoryIterator", class_DirectoryIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplFileInfo, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplFileInfo, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_SeekableIterator);
 
 	return class_entry;
@@ -504,7 +509,7 @@ static zend_class_entry *register_class_FilesystemIterator(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "FilesystemIterator", class_FilesystemIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_DirectoryIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_CURRENT_MODE_MASK_value;
 	ZVAL_LONG(&const_CURRENT_MODE_MASK_value, SPL_FILE_DIR_CURRENT_MODE_MASK);
@@ -578,6 +583,9 @@ static zend_class_entry *register_class_FilesystemIterator(zend_class_entry *cla
 	zend_declare_typed_class_constant(class_entry, const_UNIX_PATHS_name, &const_UNIX_PATHS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_UNIX_PATHS_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_DirectoryIterator, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -586,7 +594,10 @@ static zend_class_entry *register_class_RecursiveDirectoryIterator(zend_class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveDirectoryIterator", class_RecursiveDirectoryIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FilesystemIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_FilesystemIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -597,7 +608,10 @@ static zend_class_entry *register_class_GlobIterator(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "GlobIterator", class_GlobIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FilesystemIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_FilesystemIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Countable);
 
 	return class_entry;
@@ -608,8 +622,7 @@ static zend_class_entry *register_class_SplFileObject(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplFileObject", class_SplFileObject_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplFileInfo, 0);
-	zend_class_implements(class_entry, 2, class_entry_RecursiveIterator, class_entry_SeekableIterator);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_DROP_NEW_LINE_value;
 	ZVAL_LONG(&const_DROP_NEW_LINE_value, SPL_FILE_OBJECT_DROP_NEW_LINE);
@@ -635,6 +648,10 @@ static zend_class_entry *register_class_SplFileObject(zend_class_entry *class_en
 	zend_declare_typed_class_constant(class_entry, const_READ_CSV_name, &const_READ_CSV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_READ_CSV_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_SplFileInfo, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_RecursiveIterator, class_entry_SeekableIterator);
+
 	return class_entry;
 }
 
@@ -643,7 +660,10 @@ static zend_class_entry *register_class_SplTempFileObject(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplTempFileObject", class_SplTempFileObject_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplFileObject, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplFileObject, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_dllist_arginfo.h
+++ b/ext/spl/spl_dllist_arginfo.h
@@ -152,7 +152,6 @@ static zend_class_entry *register_class_SplDoublyLinkedList(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "SplDoublyLinkedList", class_SplDoublyLinkedList_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 4, class_entry_Iterator, class_entry_Countable, class_entry_ArrayAccess, class_entry_Serializable);
 
 	zval const_IT_MODE_LIFO_value;
 	ZVAL_LONG(&const_IT_MODE_LIFO_value, SPL_DLLIST_IT_LIFO);
@@ -178,6 +177,9 @@ static zend_class_entry *register_class_SplDoublyLinkedList(zend_class_entry *cl
 	zend_declare_typed_class_constant(class_entry, const_IT_MODE_KEEP_name, &const_IT_MODE_KEEP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_IT_MODE_KEEP_name, true);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 4, class_entry_Iterator, class_entry_Countable, class_entry_ArrayAccess, class_entry_Serializable);
+
 	return class_entry;
 }
 
@@ -186,7 +188,10 @@ static zend_class_entry *register_class_SplQueue(zend_class_entry *class_entry_S
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplQueue", class_SplQueue_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplDoublyLinkedList, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplDoublyLinkedList, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -196,7 +201,10 @@ static zend_class_entry *register_class_SplStack(zend_class_entry *class_entry_S
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplStack", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplDoublyLinkedList, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplDoublyLinkedList, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_exceptions_arginfo.h
+++ b/ext/spl/spl_exceptions_arginfo.h
@@ -6,7 +6,10 @@ static zend_class_entry *register_class_LogicException(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "LogicException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -16,7 +19,10 @@ static zend_class_entry *register_class_BadFunctionCallException(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "BadFunctionCallException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_LogicException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -26,7 +32,10 @@ static zend_class_entry *register_class_BadMethodCallException(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "BadMethodCallException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_BadFunctionCallException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_BadFunctionCallException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -36,7 +45,10 @@ static zend_class_entry *register_class_DomainException(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DomainException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_LogicException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -46,7 +58,10 @@ static zend_class_entry *register_class_InvalidArgumentException(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "InvalidArgumentException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_LogicException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -56,7 +71,10 @@ static zend_class_entry *register_class_LengthException(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "LengthException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_LogicException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -66,7 +84,10 @@ static zend_class_entry *register_class_OutOfRangeException(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "OutOfRangeException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_LogicException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -76,7 +97,10 @@ static zend_class_entry *register_class_RuntimeException(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RuntimeException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -86,7 +110,10 @@ static zend_class_entry *register_class_OutOfBoundsException(zend_class_entry *c
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "OutOfBoundsException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -96,7 +123,10 @@ static zend_class_entry *register_class_OverflowException(zend_class_entry *clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "OverflowException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -106,7 +136,10 @@ static zend_class_entry *register_class_RangeException(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RangeException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -116,7 +149,10 @@ static zend_class_entry *register_class_UnderflowException(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "UnderflowException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -126,7 +162,10 @@ static zend_class_entry *register_class_UnexpectedValueException(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "UnexpectedValueException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RuntimeException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -94,7 +94,6 @@ static zend_class_entry *register_class_SplFixedArray(zend_class_entry *class_en
 
 	INIT_CLASS_ENTRY(ce, "SplFixedArray", class_SplFixedArray_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Countable, class_entry_JsonSerializable);
 
 
 	zend_attribute *attribute_Deprecated_func___wakeup_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__wakeup", sizeof("__wakeup") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
@@ -103,6 +102,9 @@ static zend_class_entry *register_class_SplFixedArray(zend_class_entry *class_en
 	zend_string *attribute_Deprecated_func___wakeup_0_arg1_str = zend_string_init("this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()", strlen("this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()"), 1);
 	ZVAL_STR(&attribute_Deprecated_func___wakeup_0->args[1].value, attribute_Deprecated_func___wakeup_0_arg1_str);
 	attribute_Deprecated_func___wakeup_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Countable, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/ext/spl/spl_heap_arginfo.h
+++ b/ext/spl/spl_heap_arginfo.h
@@ -180,7 +180,6 @@ static zend_class_entry *register_class_SplPriorityQueue(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "SplPriorityQueue", class_SplPriorityQueue_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 2, class_entry_Iterator, class_entry_Countable);
 
 	zval const_EXTR_BOTH_value;
 	ZVAL_LONG(&const_EXTR_BOTH_value, SPL_PQUEUE_EXTR_BOTH);
@@ -200,6 +199,9 @@ static zend_class_entry *register_class_SplPriorityQueue(zend_class_entry *class
 	zend_declare_typed_class_constant(class_entry, const_EXTR_DATA_name, &const_EXTR_DATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_EXTR_DATA_name, true);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 2, class_entry_Iterator, class_entry_Countable);
+
 	return class_entry;
 }
 
@@ -209,6 +211,8 @@ static zend_class_entry *register_class_SplHeap(zend_class_entry *class_entry_It
 
 	INIT_CLASS_ENTRY(ce, "SplHeap", class_SplHeap_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 2, class_entry_Iterator, class_entry_Countable);
 
 	return class_entry;
@@ -219,7 +223,10 @@ static zend_class_entry *register_class_SplMinHeap(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplMinHeap", class_SplMinHeap_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplHeap, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplHeap, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -229,7 +236,10 @@ static zend_class_entry *register_class_SplMaxHeap(zend_class_entry *class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplMaxHeap", class_SplMaxHeap_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_SplHeap, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_SplHeap, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_iterators_arginfo.h
+++ b/ext/spl/spl_iterators_arginfo.h
@@ -606,6 +606,8 @@ static zend_class_entry *register_class_EmptyIterator(zend_class_entry *class_en
 
 	INIT_CLASS_ENTRY(ce, "EmptyIterator", class_EmptyIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
@@ -616,7 +618,10 @@ static zend_class_entry *register_class_CallbackFilterIterator(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "CallbackFilterIterator", class_CallbackFilterIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FilterIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_FilterIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -626,7 +631,10 @@ static zend_class_entry *register_class_RecursiveCallbackFilterIterator(zend_cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveCallbackFilterIterator", class_RecursiveCallbackFilterIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_CallbackFilterIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_CallbackFilterIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -638,6 +646,8 @@ static zend_class_entry *register_class_RecursiveIterator(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "RecursiveIterator", class_RecursiveIterator_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
@@ -649,7 +659,6 @@ static zend_class_entry *register_class_RecursiveIteratorIterator(zend_class_ent
 
 	INIT_CLASS_ENTRY(ce, "RecursiveIteratorIterator", class_RecursiveIteratorIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_OuterIterator);
 
 	zval const_LEAVES_ONLY_value;
 	ZVAL_LONG(&const_LEAVES_ONLY_value, RIT_LEAVES_ONLY);
@@ -675,6 +684,9 @@ static zend_class_entry *register_class_RecursiveIteratorIterator(zend_class_ent
 	zend_declare_typed_class_constant(class_entry, const_CATCH_GET_CHILD_name, &const_CATCH_GET_CHILD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_CATCH_GET_CHILD_name, true);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_OuterIterator);
+
 	return class_entry;
 }
 
@@ -684,6 +696,8 @@ static zend_class_entry *register_class_OuterIterator(zend_class_entry *class_en
 
 	INIT_CLASS_ENTRY(ce, "OuterIterator", class_OuterIterator_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
@@ -695,6 +709,8 @@ static zend_class_entry *register_class_IteratorIterator(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "IteratorIterator", class_IteratorIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_OuterIterator);
 
 	return class_entry;
@@ -705,7 +721,10 @@ static zend_class_entry *register_class_FilterIterator(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "FilterIterator", class_FilterIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, ZEND_ACC_ABSTRACT);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -715,7 +734,10 @@ static zend_class_entry *register_class_RecursiveFilterIterator(zend_class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveFilterIterator", class_RecursiveFilterIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FilterIterator, ZEND_ACC_ABSTRACT);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT);
+
+	zend_do_inheritance_ex(class_entry, class_entry_FilterIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -726,7 +748,10 @@ static zend_class_entry *register_class_ParentIterator(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ParentIterator", class_ParentIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RecursiveFilterIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RecursiveFilterIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -737,6 +762,8 @@ static zend_class_entry *register_class_SeekableIterator(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "SeekableIterator", class_SeekableIterator_methods);
 	class_entry = zend_register_internal_interface(&ce);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
@@ -747,7 +774,10 @@ static zend_class_entry *register_class_LimitIterator(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "LimitIterator", class_LimitIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -757,8 +787,7 @@ static zend_class_entry *register_class_CachingIterator(zend_class_entry *class_
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "CachingIterator", class_CachingIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, 0);
-	zend_class_implements(class_entry, 3, class_entry_ArrayAccess, class_entry_Countable, class_entry_Stringable);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_CALL_TOSTRING_value;
 	ZVAL_LONG(&const_CALL_TOSTRING_value, CIT_CALL_TOSTRING);
@@ -796,6 +825,10 @@ static zend_class_entry *register_class_CachingIterator(zend_class_entry *class_
 	zend_declare_typed_class_constant(class_entry, const_FULL_CACHE_name, &const_FULL_CACHE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_FULL_CACHE_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 3, class_entry_ArrayAccess, class_entry_Countable, class_entry_Stringable);
+
 	return class_entry;
 }
 
@@ -804,7 +837,10 @@ static zend_class_entry *register_class_RecursiveCachingIterator(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveCachingIterator", class_RecursiveCachingIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_CachingIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_CachingIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -815,7 +851,10 @@ static zend_class_entry *register_class_NoRewindIterator(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "NoRewindIterator", class_NoRewindIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -825,7 +864,10 @@ static zend_class_entry *register_class_AppendIterator(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "AppendIterator", class_AppendIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -835,7 +877,10 @@ static zend_class_entry *register_class_InfiniteIterator(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "InfiniteIterator", class_InfiniteIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_IteratorIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_IteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -845,7 +890,7 @@ static zend_class_entry *register_class_RegexIterator(zend_class_entry *class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RegexIterator", class_RegexIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_FilterIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_USE_KEY_value;
 	ZVAL_LONG(&const_USE_KEY_value, REGIT_USE_KEY);
@@ -895,6 +940,9 @@ static zend_class_entry *register_class_RegexIterator(zend_class_entry *class_en
 	zend_declare_typed_property(class_entry, property_replacement_name, &property_replacement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release_ex(property_replacement_name, true);
 
+	zend_do_inheritance_ex(class_entry, class_entry_FilterIterator, 0);
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -903,7 +951,10 @@ static zend_class_entry *register_class_RecursiveRegexIterator(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveRegexIterator", class_RecursiveRegexIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RegexIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RegexIterator, 0);
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_RecursiveIterator);
 
 	return class_entry;
@@ -914,7 +965,7 @@ static zend_class_entry *register_class_RecursiveTreeIterator(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RecursiveTreeIterator", class_RecursiveTreeIterator_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RecursiveIteratorIterator, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval const_BYPASS_CURRENT_value;
 	ZVAL_LONG(&const_BYPASS_CURRENT_value, RTIT_BYPASS_CURRENT);
@@ -963,6 +1014,9 @@ static zend_class_entry *register_class_RecursiveTreeIterator(zend_class_entry *
 	zend_string *const_PREFIX_RIGHT_name = zend_string_init_interned("PREFIX_RIGHT", sizeof("PREFIX_RIGHT") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_PREFIX_RIGHT_name, &const_PREFIX_RIGHT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_PREFIX_RIGHT_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_RecursiveIteratorIterator, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -237,6 +237,8 @@ static zend_class_entry *register_class_SplObserver(void)
 	INIT_CLASS_ENTRY(ce, "SplObserver", class_SplObserver_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -247,6 +249,8 @@ static zend_class_entry *register_class_SplSubject(void)
 	INIT_CLASS_ENTRY(ce, "SplSubject", class_SplSubject_methods);
 	class_entry = zend_register_internal_interface(&ce);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -256,7 +260,6 @@ static zend_class_entry *register_class_SplObjectStorage(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "SplObjectStorage", class_SplObjectStorage_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 4, class_entry_Countable, class_entry_SeekableIterator, class_entry_Serializable, class_entry_ArrayAccess);
 
 
 	zend_attribute *attribute_Deprecated_func_attach_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "attach", sizeof("attach") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED_CAPITALIZED), 2);
@@ -280,6 +283,9 @@ static zend_class_entry *register_class_SplObjectStorage(zend_class_entry *class
 	ZVAL_STR(&attribute_Deprecated_func_contains_0->args[1].value, attribute_Deprecated_func_contains_0_arg1_str);
 	attribute_Deprecated_func_contains_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 4, class_entry_Countable, class_entry_SeekableIterator, class_entry_Serializable, class_entry_ArrayAccess);
+
 	return class_entry;
 }
 
@@ -289,7 +295,6 @@ static zend_class_entry *register_class_MultipleIterator(zend_class_entry *class
 
 	INIT_CLASS_ENTRY(ce, "MultipleIterator", class_MultipleIterator_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	zval const_MIT_NEED_ANY_value;
 	ZVAL_LONG(&const_MIT_NEED_ANY_value, MIT_NEED_ANY);
@@ -314,6 +319,9 @@ static zend_class_entry *register_class_MultipleIterator(zend_class_entry *class
 	zend_string *const_MIT_KEYS_ASSOC_name = zend_string_init_interned("MIT_KEYS_ASSOC", sizeof("MIT_KEYS_ASSOC") - 1, true);
 	zend_declare_typed_class_constant(class_entry, const_MIT_KEYS_ASSOC_name, &const_MIT_KEYS_ASSOC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(const_MIT_KEYS_ASSOC_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;
 }

--- a/ext/spl/tests/bug75242.phpt
+++ b/ext/spl/tests/bug75242.phpt
@@ -27,10 +27,10 @@ array(2) {
   int(2)
 }
 array(3) {
+  ["CHILD_ARRAYS_ONLY"]=>
+  int(4)
   ["STD_PROP_LIST"]=>
   int(1)
   ["ARRAY_AS_PROPS"]=>
   int(2)
-  ["CHILD_ARRAYS_ONLY"]=>
-  int(4)
 }

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -312,7 +312,10 @@ static zend_class_entry *register_class_SQLite3Exception(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SQLite3Exception", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -548,6 +551,8 @@ static zend_class_entry *register_class_SQLite3(void)
 	zend_string_release_ex(const_RECURSIVE_name, true);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -578,6 +583,8 @@ static zend_class_entry *register_class_SQLite3Stmt(void)
 	zend_string_release_ex(const_EXPLAIN_MODE_EXPLAIN_QUERY_PLAN_name, true);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -587,6 +594,8 @@ static zend_class_entry *register_class_SQLite3Result(void)
 
 	INIT_CLASS_ENTRY(ce, "SQLite3Result", class_SQLite3Result_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -3991,6 +3991,8 @@ static zend_class_entry *register_class___PHP_Incomplete_Class(void)
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0, 0);
 	zend_string_release_ex(attribute_name_AllowDynamicProperties_class___PHP_Incomplete_Class_0, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -3999,7 +4001,10 @@ static zend_class_entry *register_class_AssertionError(zend_class_entry *class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "AssertionError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -4023,6 +4028,8 @@ static zend_class_entry *register_class_RoundingMode(void)
 	zend_enum_add_case_cstr(class_entry, "NegativeInfinity", NULL);
 
 	zend_enum_add_case_cstr(class_entry, "PositiveInfinity", NULL);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/standard/dir_arginfo.h
+++ b/ext/standard/dir_arginfo.h
@@ -70,5 +70,7 @@ static zend_class_entry *register_class_Directory(void)
 	zend_declare_typed_property(class_entry, property_handle_name, &property_handle_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release_ex(property_handle_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -60,6 +60,8 @@ static zend_class_entry *register_class_php_user_filter(void)
 	zend_declare_typed_property(class_entry, property_stream_name, &property_stream_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release_ex(property_stream_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -93,6 +95,8 @@ static zend_class_entry *register_class_StreamBucket(void)
 	zend_string *property_dataLength_name = zend_string_init("dataLength", sizeof("dataLength") - 1, true);
 	zend_declare_typed_property(class_entry, property_dataLength_name, &property_dataLength_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_dataLength_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/sysvmsg/sysvmsg_arginfo.h
+++ b/ext/sysvmsg/sysvmsg_arginfo.h
@@ -78,5 +78,7 @@ static zend_class_entry *register_class_SysvMessageQueue(void)
 	INIT_CLASS_ENTRY(ce, "SysvMessageQueue", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/sysvsem/sysvsem_arginfo.h
+++ b/ext/sysvsem/sysvsem_arginfo.h
@@ -39,5 +39,7 @@ static zend_class_entry *register_class_SysvSemaphore(void)
 	INIT_CLASS_ENTRY(ce, "SysvSemaphore", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/sysvshm/sysvshm_arginfo.h
+++ b/ext/sysvshm/sysvshm_arginfo.h
@@ -59,5 +59,7 @@ static zend_class_entry *register_class_SysvSharedMemory(void)
 	INIT_CLASS_ENTRY(ce, "SysvSharedMemory", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/tidy/tidy_arginfo.h
+++ b/ext/tidy/tidy_arginfo.h
@@ -484,6 +484,8 @@ static zend_class_entry *register_class_tidy(void)
 	ZVAL_NULL(&property_value_default_value);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_VALUE), &property_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -539,6 +541,8 @@ static zend_class_entry *register_class_tidyNode(void)
 	zend_string *property_child_name = zend_string_init("child", sizeof("child") - 1, true);
 	zend_declare_typed_property(class_entry, property_child_name, &property_child_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release_ex(property_child_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/tokenizer/tokenizer_arginfo.h
+++ b/ext/tokenizer/tokenizer_arginfo.h
@@ -68,7 +68,6 @@ static zend_class_entry *register_class_PhpToken(zend_class_entry *class_entry_S
 
 	INIT_CLASS_ENTRY(ce, "PhpToken", class_PhpToken_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
@@ -91,6 +90,9 @@ static zend_class_entry *register_class_PhpToken(zend_class_entry *class_entry_S
 	zend_string *property_pos_name = zend_string_init("pos", sizeof("pos") - 1, true);
 	zend_declare_typed_property(class_entry, property_pos_name, &property_pos_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_pos_name, true);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Stringable);
 
 	return class_entry;
 }

--- a/ext/uri/php_uri_arginfo.h
+++ b/ext/uri/php_uri_arginfo.h
@@ -317,7 +317,10 @@ static zend_class_entry *register_class_Uri_UriException(zend_class_entry *class
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Uri", "UriException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Exception, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -327,7 +330,10 @@ static zend_class_entry *register_class_Uri_UriError(zend_class_entry *class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Uri", "UriError", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Error, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -337,7 +343,10 @@ static zend_class_entry *register_class_Uri_InvalidUriException(zend_class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Uri", "InvalidUriException", NULL);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Uri_UriException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Uri_UriException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -349,6 +358,8 @@ static zend_class_entry *register_class_Uri_UriComparisonMode(void)
 	zend_enum_add_case_cstr(class_entry, "IncludeFragment", NULL);
 
 	zend_enum_add_case_cstr(class_entry, "ExcludeFragment", NULL);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -363,6 +374,8 @@ static zend_class_entry *register_class_Uri_Rfc3986_Uri(void)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "withuserinfo", sizeof("withuserinfo") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -371,13 +384,16 @@ static zend_class_entry *register_class_Uri_WhatWg_InvalidUrlException(zend_clas
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Uri\\WhatWg", "InvalidUrlException", class_Uri_WhatWg_InvalidUrlException_methods);
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Uri_InvalidUriException, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NO_DYNAMIC_PROPERTIES);
 
 	zval property_errors_default_value;
 	ZVAL_UNDEF(&property_errors_default_value);
 	zend_string *property_errors_name = zend_string_init("errors", sizeof("errors") - 1, true);
 	zend_declare_typed_property(class_entry, property_errors_name, &property_errors_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release_ex(property_errors_name, true);
+
+	zend_do_inheritance_ex(class_entry, class_entry_Uri_InvalidUriException, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -444,6 +460,8 @@ static zend_class_entry *register_class_Uri_WhatWg_UrlValidationErrorType(void)
 
 	zend_enum_add_case_cstr(class_entry, "FileInvalidWindowsDriveLetterHost", NULL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -471,6 +489,8 @@ static zend_class_entry *register_class_Uri_WhatWg_UrlValidationError(void)
 	zend_declare_typed_property(class_entry, property_failure_name, &property_failure_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release_ex(property_failure_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -483,6 +503,8 @@ static zend_class_entry *register_class_Uri_WhatWg_Url(void)
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "withpassword", sizeof("withpassword") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -185,5 +185,7 @@ static zend_class_entry *register_class_XMLParser(void)
 	INIT_CLASS_ENTRY(ce, "XMLParser", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/xmlreader/php_xmlreader_arginfo.h
+++ b/ext/xmlreader/php_xmlreader_arginfo.h
@@ -390,5 +390,7 @@ static zend_class_entry *register_class_XMLReader(void)
 	zend_declare_typed_property(class_entry, property_xmlLang_name, &property_xmlLang_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_VIRTUAL, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release_ex(property_xmlLang_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -486,5 +486,7 @@ static zend_class_entry *register_class_XMLWriter(void)
 	INIT_CLASS_ENTRY(ce, "XMLWriter", class_XMLWriter_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -141,5 +141,7 @@ static zend_class_entry *register_class_XSLTProcessor(void)
 	zend_declare_typed_property(class_entry, property_maxTemplateVars_name, &property_maxTemplateVars_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_maxTemplateVars_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/zend_test/fiber_arginfo.h
+++ b/ext/zend_test/fiber_arginfo.h
@@ -41,5 +41,7 @@ static zend_class_entry *register_class__ZendTestFiber(void)
 	INIT_CLASS_ENTRY(ce, "_ZendTestFiber", class__ZendTestFiber_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }

--- a/ext/zend_test/iterators_arginfo.h
+++ b/ext/zend_test/iterators_arginfo.h
@@ -22,6 +22,8 @@ static zend_class_entry *register_class_ZendTest_Iterators_TraversableTest(zend_
 
 	INIT_NS_CLASS_ENTRY(ce, "ZendTest\\Iterators", "TraversableTest", class_ZendTest_Iterators_TraversableTest_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zend_build_properties_info_table(class_entry);
 	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	return class_entry;

--- a/ext/zend_test/object_handlers_arginfo.h
+++ b/ext/zend_test/object_handlers_arginfo.h
@@ -53,6 +53,8 @@ static zend_class_entry *register_class_DoOperationNoCast(void)
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_val_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -68,6 +70,8 @@ static zend_class_entry *register_class_LongCastableNoOperations(void)
 	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, true);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release_ex(property_val_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -85,6 +89,8 @@ static zend_class_entry *register_class_FloatCastableNoOperations(void)
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release_ex(property_val_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -100,6 +106,8 @@ static zend_class_entry *register_class_NumericCastableNoOperations(void)
 	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, true);
 	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_DOUBLE));
 	zend_string_release_ex(property_val_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -158,6 +166,8 @@ static zend_class_entry *register_class_DimensionHandlersNoArrayAccess(void)
 	zend_string *property_offset_name = zend_string_init("offset", sizeof("offset") - 1, true);
 	zend_declare_typed_property(class_entry, property_offset_name, &property_offset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release_ex(property_offset_name, true);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -695,6 +695,8 @@ static zend_class_entry *register_class__ZendTestInterface(void)
 	zend_declare_class_constant_ex(class_entry, const_DUMMY_name, &const_DUMMY_value, ZEND_ACC_PUBLIC, const_DUMMY_comment);
 	zend_string_release_ex(const_DUMMY_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -708,7 +710,6 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 #else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
-	zend_class_implements(class_entry, 1, class_entry__ZendTestInterface);
 	zend_register_class_alias("_ZendTestClassAlias", class_entry);
 
 	zval const_TYPED_CLASS_CONST1_value;
@@ -840,6 +841,9 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 	ZVAL_STR(&attribute_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0->args[0].value, attribute_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0_arg0_str);
 	attribute_Deprecated_const_ZEND_TEST_DEPRECATED_ATTR_0->args[0].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry__ZendTestInterface);
+
 	return class_entry;
 }
 
@@ -853,6 +857,8 @@ static zend_class_entry *register_class__ZendTestMagicCall(void)
 #else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -868,6 +874,8 @@ static zend_class_entry *register_class__ZendTestMagicCallForward(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -877,10 +885,13 @@ static zend_class_entry *register_class__ZendTestChildClass(zend_class_entry *cl
 
 	INIT_CLASS_ENTRY(ce, "_ZendTestChildClass", class__ZendTestChildClass_methods);
 #if (PHP_VERSION_ID >= 80400)
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry__ZendTestClass, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 #else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry__ZendTestClass);
 #endif
+
+	zend_do_inheritance_ex(class_entry, class_entry__ZendTestClass, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -900,6 +911,8 @@ static zend_class_entry *register_class_ZendTestGenStubFlagCompatibilityTest(voi
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 #endif
 #endif
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -952,6 +965,8 @@ static zend_class_entry *register_class_ZendAttributeTest(void)
 	zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "testmethod", sizeof("testmethod") - 1), attribute_name_ZendTestAttribute_func_testmethod_0, 0);
 	zend_string_release_ex(attribute_name_ZendTestAttribute_func_testmethod_0, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -986,6 +1001,8 @@ static zend_class_entry *register_class__ZendTestTrait(void)
 	zend_declare_typed_property(class_entry, property_classUnionProp_name, &property_classUnionProp_default_value, ZEND_ACC_PUBLIC, NULL, property_classUnionProp_type);
 	zend_string_release_ex(property_classUnionProp_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1005,6 +1022,8 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 	zend_attribute *attribute_Attribute_class_ZendTestAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestAttribute_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_ZendTestAttribute_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ZendTestAttribute_0->args[0].value, ZEND_ATTRIBUTE_TARGET_ALL);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1036,6 +1055,8 @@ static zend_class_entry *register_class_ZendTestAttributeWithArguments(void)
 	zend_string_release_ex(attribute_name_Attribute_class_ZendTestAttributeWithArguments_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ZendTestAttributeWithArguments_0->args[0].value, ZEND_ATTRIBUTE_TARGET_ALL);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1055,6 +1076,8 @@ static zend_class_entry *register_class_ZendTestRepeatableAttribute(void)
 	zend_attribute *attribute_Attribute_class_ZendTestRepeatableAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestRepeatableAttribute_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_ZendTestRepeatableAttribute_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ZendTestRepeatableAttribute_0->args[0].value, ZEND_ATTRIBUTE_TARGET_ALL | ZEND_ATTRIBUTE_IS_REPEATABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1081,6 +1104,8 @@ static zend_class_entry *register_class_ZendTestParameterAttribute(void)
 	zend_attribute *attribute_Attribute_class_ZendTestParameterAttribute_0 = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestParameterAttribute_0, 1);
 	zend_string_release_ex(attribute_name_Attribute_class_ZendTestParameterAttribute_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ZendTestParameterAttribute_0->args[0].value, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1112,6 +1137,8 @@ static zend_class_entry *register_class_ZendTestPropertyAttribute(void)
 	zend_string_release_ex(attribute_name_Attribute_class_ZendTestPropertyAttribute_0, true);
 	ZVAL_LONG(&attribute_Attribute_class_ZendTestPropertyAttribute_0->args[0].value, ZEND_ATTRIBUTE_TARGET_PROPERTY);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1139,6 +1166,8 @@ static zend_class_entry *register_class_ZendTestClassWithMethodWithParameterAttr
 	zend_string *attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str = zend_string_init("value3", strlen("value3"), 1);
 	ZVAL_STR(&attribute_ZendTestParameterAttribute_func_override_arg0_0->args[0].value, attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1148,7 +1177,7 @@ static zend_class_entry *register_class_ZendTestChildClassWithMethodWithParamete
 
 	INIT_CLASS_ENTRY(ce, "ZendTestChildClassWithMethodWithParameterAttribute", class_ZendTestChildClassWithMethodWithParameterAttribute_methods);
 #if (PHP_VERSION_ID >= 80400)
-	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ZendTestClassWithMethodWithParameterAttribute, 0);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 #else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_ZendTestClassWithMethodWithParameterAttribute);
 #endif
@@ -1159,6 +1188,9 @@ static zend_class_entry *register_class_ZendTestChildClassWithMethodWithParamete
 	zend_string_release_ex(attribute_name_ZendTestParameterAttribute_func_override_arg0_0, true);
 	zend_string *attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str = zend_string_init("value4", strlen("value4"), 1);
 	ZVAL_STR(&attribute_ZendTestParameterAttribute_func_override_arg0_0->args[0].value, attribute_ZendTestParameterAttribute_func_override_arg0_0_arg0_str);
+
+	zend_do_inheritance_ex(class_entry, class_entry_ZendTestClassWithMethodWithParameterAttribute, 0);
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1185,6 +1217,8 @@ static zend_class_entry *register_class_ZendTestClassWithPropertyAttribute(void)
 	zend_add_property_attribute(class_entry, property_attributed, attribute_name_ZendTestAttribute_property_attributed_0, 0);
 	zend_string_release_ex(attribute_name_ZendTestAttribute_property_attributed_0, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1200,6 +1234,8 @@ static zend_class_entry *register_class_ZendTestForbidDynamicCall(void)
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1211,6 +1247,8 @@ static zend_class_entry *register_class_ZendTestUnitEnum(void)
 	zend_enum_add_case_cstr(class_entry, "Foo", NULL);
 
 	zend_enum_add_case_cstr(class_entry, "Bar", NULL);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1241,6 +1279,8 @@ static zend_class_entry *register_class_ZendTestStringEnum(void)
 	ZVAL_STR(&enum_case_FortyTwo_value, enum_case_FortyTwo_value_str);
 	zend_enum_add_case_cstr(class_entry, "FortyTwo", &enum_case_FortyTwo_value);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 #endif
@@ -1262,6 +1302,8 @@ static zend_class_entry *register_class_ZendTestIntEnum(void)
 	ZVAL_LONG(&enum_case_Baz_value, -1);
 	zend_enum_add_case_cstr(class_entry, "Baz", &enum_case_Baz_value);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 #endif
@@ -1270,11 +1312,13 @@ static zend_class_entry *register_class_ZendTestIntEnum(void)
 static zend_class_entry *register_class_ZendTestEnumWithInterface(zend_class_entry *class_entry__ZendTestInterface)
 {
 	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestEnumWithInterface", IS_UNDEF, NULL);
-	zend_class_implements(class_entry, 1, class_entry__ZendTestInterface);
 
 	zend_enum_add_case_cstr(class_entry, "Foo", NULL);
 
 	zend_enum_add_case_cstr(class_entry, "Bar", NULL);
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry__ZendTestInterface);
 
 	return class_entry;
 }
@@ -1291,6 +1335,8 @@ static zend_class_entry *register_class_ZendTestNS_Foo(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1305,6 +1351,8 @@ static zend_class_entry *register_class_ZendTestNS_UnlikelyCompileError(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1318,6 +1366,8 @@ static zend_class_entry *register_class_ZendTestNS_NotUnlikelyCompileError(void)
 #else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }
@@ -1340,6 +1390,8 @@ static zend_class_entry *register_class_ZendTestNS2_Foo(void)
 	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS2_ZendSubNS_Foo, 0, 0));
 	zend_string_release_ex(property_foo_name, true);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -1353,6 +1405,8 @@ static zend_class_entry *register_class_ZendTestNS2_ZendSubNS_Foo(void)
 #else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 #endif
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -525,7 +525,6 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	INIT_CLASS_ENTRY(ce, "ZipArchive", class_ZipArchive_methods);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
-	zend_class_implements(class_entry, 1, class_entry_Countable);
 
 	zval const_CREATE_value;
 	ZVAL_LONG(&const_CREATE_value, ZIP_CREATE);
@@ -1277,6 +1276,9 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", sizeof("setencryptionindex") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
+
+	zend_build_properties_info_table(class_entry);
+	zend_class_implements(class_entry, 1, class_entry_Countable);
 
 	return class_entry;
 }

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -234,6 +234,8 @@ static zend_class_entry *register_class_InflateContext(void)
 	INIT_CLASS_ENTRY(ce, "InflateContext", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
+	zend_build_properties_info_table(class_entry);
+
 	return class_entry;
 }
 
@@ -243,6 +245,8 @@ static zend_class_entry *register_class_DeflateContext(void)
 
 	INIT_CLASS_ENTRY(ce, "DeflateContext", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
+
+	zend_build_properties_info_table(class_entry);
 
 	return class_entry;
 }


### PR DESCRIPTION
Since GH-15878, trait properties are bound before linking the parent class. Since GH-21358, trait properties don't redeclare locally declared properties. With these two changes, declared properties are never redeclared, and as such we can remove this case from zend_declare_typed_property().