### PR TITLE
reflection: Remove `_DO_THROW()` macro

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -106,10 +106,6 @@ PHPAPI zend_class_entry *reflection_fiber_ptr;
 PHPAPI zend_class_entry *reflection_constant_ptr;
 PHPAPI zend_class_entry *reflection_property_hook_type_ptr;
 
-/* Exception throwing macro */
-#define _DO_THROW(msg) \
-	zend_throw_exception(reflection_exception_ptr, msg, 0);
-
 #define GET_REFLECTION_OBJECT() do { \
 	intern = Z_REFLECTION_P(ZEND_THIS); \
 	if (intern->ptr == NULL) { \
@@ -1658,7 +1654,7 @@ static zend_result get_parameter_default(zval *result, parameter_reference *para
 ZEND_METHOD(ReflectionClass, __clone)
 {
 	/* __clone() is private but this is reachable with reflection */
-	_DO_THROW("Cannot clone object using __clone()");
+	zend_throw_exception(reflection_exception_ptr, "Cannot clone object using __clone()", 0);
 }
 /* }}} */
 
@@ -2325,7 +2321,7 @@ ZEND_METHOD(ReflectionGenerator, __construct)
 
 #define REFLECTION_CHECK_VALID_GENERATOR(ex) \
 	if (!ex) { \
-		_DO_THROW("Cannot fetch information from a closed Generator"); \
+		zend_throw_exception(reflection_exception_ptr, "Cannot fetch information from a closed Generator", 0); \
 		RETURN_THROWS(); \
 	}
 
@@ -2505,7 +2501,7 @@ ZEND_METHOD(ReflectionParameter, __construct)
 				if (((classref = zend_hash_index_find(Z_ARRVAL_P(reference), 0)) == NULL)
 					|| ((method = zend_hash_index_find(Z_ARRVAL_P(reference), 1)) == NULL))
 				{
-					_DO_THROW("Expected array($object, $method) or array($classname, $method)");
+					zend_throw_exception(reflection_exception_ptr, "Expected array($object, $method) or array($classname, $method)", 0);
 					RETURN_THROWS();
 				}
 
@@ -2587,7 +2583,7 @@ ZEND_METHOD(ReflectionParameter, __construct)
 			}
 		}
 		if (position == -1) {
-			_DO_THROW("The parameter specified by its name could not be found");
+			zend_throw_exception(reflection_exception_ptr, "The parameter specified by its name could not be found", 0);
 			goto failure;
 		}
 	} else {
@@ -2596,7 +2592,7 @@ ZEND_METHOD(ReflectionParameter, __construct)
 			goto failure;
 		}
 		if (position >= num_args) {
-			_DO_THROW("The parameter specified by its offset could not be found");
+			zend_throw_exception(reflection_exception_ptr, "The parameter specified by its offset could not be found", 0);
 			goto failure;
 		}
 	}
@@ -3370,7 +3366,7 @@ ZEND_METHOD(ReflectionMethod, getClosure)
 		}
 
 		if (!instanceof_function(Z_OBJCE_P(obj), mptr->common.scope)) {
-			_DO_THROW("Given object is not an instance of the class this method was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this method was declared in", 0);
 			RETURN_THROWS();
 		}
 
@@ -3440,7 +3436,7 @@ static void reflection_method_invoke(INTERNAL_FUNCTION_PARAMETERS, int variadic)
 			if (!variadic) {
 				efree(params);
 			}
-			_DO_THROW("Given object is not an instance of the class this method was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this method was declared in", 0);
 			RETURN_THROWS();
 		}
 
@@ -3456,7 +3452,7 @@ static void reflection_method_invoke(INTERNAL_FUNCTION_PARAMETERS, int variadic)
 				if (!variadic) {
 					efree(params);
 				}
-				_DO_THROW("Given Closure is not the same as the reflected Closure");
+				zend_throw_exception(reflection_exception_ptr, "Given Closure is not the same as the reflected Closure", 0);
 				RETURN_THROWS();
 			}
 		}
@@ -5904,7 +5900,7 @@ ZEND_METHOD(ReflectionProperty, getValue)
 
 		/* TODO: Should this always use intern->ce? */
 		if (!instanceof_function(Z_OBJCE_P(object), ref->prop ? ref->prop->ce : intern->ce)) {
-			_DO_THROW("Given object is not an instance of the class this property was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this property was declared in", 0);
 			RETURN_THROWS();
 		}
 
@@ -6012,7 +6008,7 @@ ZEND_METHOD(ReflectionProperty, getRawValue)
 	GET_REFLECTION_OBJECT_PTR(ref);
 
 	if (!instanceof_function(Z_OBJCE_P(object), intern->ce)) {
-		_DO_THROW("Given object is not an instance of the class this property was declared in");
+		zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this property was declared in", 0);
 		RETURN_THROWS();
 	}
 
@@ -6031,7 +6027,7 @@ ZEND_METHOD(ReflectionProperty, getRawValue)
 			intern->ce, Z_OBJ_P(object));
 
 	if (UNEXPECTED(prop && (prop->flags & ZEND_ACC_STATIC))) {
-		_DO_THROW("May not use getRawValue on static properties");
+		zend_throw_exception(reflection_exception_ptr, "May not use getRawValue on static properties", 0);
 		RETURN_THROWS();
 	}
 
@@ -6091,7 +6087,7 @@ ZEND_METHOD(ReflectionProperty, setRawValue)
 			intern->ce, Z_OBJ_P(object));
 
 	if (UNEXPECTED(prop && (prop->flags & ZEND_ACC_STATIC))) {
-		_DO_THROW("May not use setRawValue on static properties");
+		zend_throw_exception(reflection_exception_ptr, "May not use setRawValue on static properties", 0);
 		RETURN_THROWS();
 	}
 
@@ -6295,7 +6291,7 @@ ZEND_METHOD(ReflectionProperty, isInitialized)
 
 		/* TODO: Should this always use intern->ce? */
 		if (!instanceof_function(Z_OBJCE_P(object), ref->prop ? ref->prop->ce : intern->ce)) {
-			_DO_THROW("Given object is not an instance of the class this property was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this property was declared in", 0);
 			RETURN_THROWS();
 		}
 
@@ -6683,11 +6679,11 @@ ZEND_METHOD(ReflectionProperty, isReadable)
 	zend_property_info *prop = ref->prop;
 	if (prop && obj) {
 		if (prop->flags & ZEND_ACC_STATIC) {
-			_DO_THROW("null is expected as object argument for static properties");
+			zend_throw_exception(reflection_exception_ptr, "null is expected as object argument for static properties", 0);
 			RETURN_THROWS();
 		}
 		if (!instanceof_function(obj->ce, prop->ce)) {
-			_DO_THROW("Given object is not an instance of the class this property was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this property was declared in", 0);
 			RETURN_THROWS();
 		}
 		prop = reflection_property_get_effective_prop(ref, intern->ce, obj);
@@ -6789,11 +6785,11 @@ ZEND_METHOD(ReflectionProperty, isWritable)
 	zend_property_info *prop = ref->prop;
 	if (prop && obj) {
 		if (prop->flags & ZEND_ACC_STATIC) {
-			_DO_THROW("null is expected as object argument for static properties");
+			zend_throw_exception(reflection_exception_ptr, "null is expected as object argument for static properties", 0);
 			RETURN_THROWS();
 		}
 		if (!instanceof_function(obj->ce, prop->ce)) {
-			_DO_THROW("Given object is not an instance of the class this property was declared in");
+			zend_throw_exception(reflection_exception_ptr, "Given object is not an instance of the class this property was declared in", 0);
 			RETURN_THROWS();
 		}
 		prop = reflection_property_get_effective_prop(ref, intern->ce, obj);
@@ -7293,10 +7289,9 @@ ZEND_METHOD(ReflectionZendExtension, getCopyright)
 /* {{{     Dummy constructor -- always throws ReflectionExceptions. */
 ZEND_METHOD(ReflectionReference, __construct)
 {
-	_DO_THROW(
+	zend_throw_exception(reflection_exception_ptr,
 		"Cannot directly instantiate ReflectionReference. "
-		"Use ReflectionReference::fromArrayElement() instead"
-	);
+		"Use ReflectionReference::fromArrayElement() instead", 0);
 }
 /* }}} */
 
@@ -7331,7 +7326,7 @@ ZEND_METHOD(ReflectionReference, fromArrayElement)
 	}
 
 	if (!item) {
-		_DO_THROW("Array key not found");
+		zend_throw_exception(reflection_exception_ptr, "Array key not found", 0);
 		RETURN_THROWS();
 	}
 
@@ -7358,7 +7353,7 @@ ZEND_METHOD(ReflectionReference, getId)
 
 	intern = Z_REFLECTION_P(ZEND_THIS);
 	if (Z_TYPE(intern->obj) != IS_REFERENCE) {
-		_DO_THROW("Corrupted ReflectionReference object");
+		zend_throw_exception(reflection_exception_ptr, "Corrupted ReflectionReference object", 0);
 		RETURN_THROWS();
 	}
 
@@ -7382,13 +7377,13 @@ ZEND_METHOD(ReflectionReference, getId)
 
 ZEND_METHOD(ReflectionAttribute, __construct)
 {
-	_DO_THROW("Cannot directly instantiate ReflectionAttribute");
+	zend_throw_exception(reflection_exception_ptr, "Cannot directly instantiate ReflectionAttribute", 0);
 }
 
 ZEND_METHOD(ReflectionAttribute, __clone)
 {
 	/* __clone() is private but this is reachable with reflection */
-	_DO_THROW("Cannot clone object using __clone()");
+	zend_throw_exception(reflection_exception_ptr, "Cannot clone object using __clone()", 0);
 }
 
 /* {{{ Returns a string representation */


### PR DESCRIPTION
This is an unnecessary layer of indirection that hides the exception type and does not exist elsewhere (in a similar way).