### PR TITLE
openssl: Fix stack leak in php_openssl_load_all_certs_from_file()

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -2330,7 +2330,7 @@ static STACK_OF(X509) *php_openssl_load_all_certs_from_file(
 	ret = stack;
 end:
 	BIO_free(in);
-	sk_X509_INFO_free(sk);
+	sk_X509_INFO_pop_free(sk, X509_INFO_free);
 
 	return ret;
 }


### PR DESCRIPTION
The previous code only freed the stack but not its contents. As reported by
https://github.com/php/php-src/commit/4b9e80eae9485e2eacb894566ab18dae6ce70ec5#r179336568