### PR TITLE
ext/gd: phpinfo() to be able to display libjpeg 10.0 support.

### DIFF
--- a/ext/gd/libgd/gd_jpeg.c
+++ b/ext/gd/libgd/gd_jpeg.c
@@ -125,6 +125,10 @@ const char * gdJpegGetVersionString()
 			return "9 compatible";
 			break;
 
+		case 100:
+			return "10 compatible";
+			break;
+
 		default:
 			return "unknown";
 	}


### PR DESCRIPTION
Fix #21431

Co-Authored-By: rainerjung