### PR TITLE
Fix GH-20964, GH-20927: fseek() stream seek with PHP_INT_MIN causes undefined behavior

### DIFF
--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -205,7 +205,7 @@ static int php_pdosqlite3_stream_seek(php_stream *stream, zend_off_t offset, int
 	switch(whence) {
 		case SEEK_CUR:
 			if (offset < 0) {
-				if (sqlite3_stream->position < (size_t)(-offset)) {
+				if (sqlite3_stream->position < -(size_t)offset) {
 					sqlite3_stream->position = 0;
 					*newoffs = -1;
 					return -1;
@@ -243,7 +243,7 @@ static int php_pdosqlite3_stream_seek(php_stream *stream, zend_off_t offset, int
 				sqlite3_stream->position = sqlite3_stream->size;
 				*newoffs = -1;
 				return -1;
-			} else if (sqlite3_stream->size < (size_t)(-offset)) {
+			} else if (sqlite3_stream->size < -(size_t)offset) {
 				sqlite3_stream->position = 0;
 				*newoffs = -1;
 				return -1;

--- a/ext/pdo_sqlite/tests/gh20964.phpt
+++ b/ext/pdo_sqlite/tests/gh20964.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-20964 (fseek() on PDO SQLite blob stream with PHP_INT_MIN causes undefined behavior)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = new Pdo\Sqlite('sqlite::memory:');
+
+$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, data BLOB)');
+$db->exec("INSERT INTO test (id, data) VALUES (1, 'hello')");
+
+$stream = $db->openBlob('test', 'data', 1);
+
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_END));
+
+rewind($stream);
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_CUR));
+
+fclose($stream);
+?>
+--EXPECT--
+int(-1)
+int(-1)

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1131,7 +1131,7 @@ static int php_sqlite3_stream_seek(php_stream *stream, zend_off_t offset, int wh
 	switch(whence) {
 		case SEEK_CUR:
 			if (offset < 0) {
-				if (sqlite3_stream->position < (size_t)(-offset)) {
+				if (sqlite3_stream->position < -(size_t)offset) {
 					sqlite3_stream->position = 0;
 					*newoffs = -1;
 					return -1;
@@ -1172,7 +1172,7 @@ static int php_sqlite3_stream_seek(php_stream *stream, zend_off_t offset, int wh
 				sqlite3_stream->position = sqlite3_stream->size;
 				*newoffs = -1;
 				return -1;
-			} else if (sqlite3_stream->size < (size_t)(-offset)) {
+			} else if (sqlite3_stream->size < -(size_t)offset) {
 				sqlite3_stream->position = 0;
 				*newoffs = -1;
 				return -1;

--- a/ext/sqlite3/tests/gh20964.phpt
+++ b/ext/sqlite3/tests/gh20964.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-20964 (fseek() on SQLite3 blob stream with PHP_INT_MIN causes undefined behavior)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+require_once __DIR__ . '/new_db.inc';
+
+$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, data BLOB)');
+$db->exec("INSERT INTO test (id, data) VALUES (1, 'hello')");
+
+$stream = $db->openBlob('test', 'data', 1);
+
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_END));
+
+rewind($stream);
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_CUR));
+
+fclose($stream);
+$db->close();
+?>
+--EXPECT--
+int(-1)
+int(-1)

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -128,7 +128,7 @@ static int php_stream_memory_seek(php_stream *stream, zend_off_t offset, int whe
 	switch(whence) {
 		case SEEK_CUR:
 			if (offset < 0) {
-				if (ms->fpos < (size_t)(-offset)) {
+				if (ms->fpos < -(size_t)offset) {
 					ms->fpos = 0;
 					*newoffs = -1;
 					return -1;
@@ -165,7 +165,7 @@ static int php_stream_memory_seek(php_stream *stream, zend_off_t offset, int whe
 				stream->eof = 0;
 				stream->fatal_error = 0;
 				return 0;
-			} else if (ZSTR_LEN(ms->data) < (size_t)(-offset)) {
+			} else if (ZSTR_LEN(ms->data) < -(size_t)offset) {
 				ms->fpos = 0;
 				*newoffs = -1;
 				return -1;

--- a/tests/basic/gh20964.phpt
+++ b/tests/basic/gh20964.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-20964 (fseek() on php://memory with PHP_INT_MIN causes undefined behavior)
+--FILE--
+<?php
+$stream = fopen('php://memory', 'r+');
+fwrite($stream, 'hello');
+rewind($stream);
+
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_END));
+var_dump(ftell($stream));
+
+rewind($stream);
+var_dump(fseek($stream, PHP_INT_MIN, SEEK_CUR));
+var_dump(ftell($stream));
+
+fclose($stream);
+?>
+--EXPECT--
+int(-1)
+bool(false)
+int(-1)
+bool(false)


### PR DESCRIPTION
## Summary

Stream seek functions in memory, pdo_sqlite, and sqlite3 compute the absolute value of a negative offset using `(size_t)(-offset)`. When `offset == ZEND_LONG_MIN`, the signed negation overflows -- undefined behavior caught by UBSAN.

The fix swaps the cast order: `-(size_t)offset` casts to unsigned first (well-defined), then negates (well-defined unsigned arithmetic). Same result for all values, no behavioral change.

### Files changed

- `main/streams/memory.c` -- php://memory and php://temp stream seek
- `ext/pdo_sqlite/pdo_sqlite.c` -- PDO SQLite blob stream seek
- `ext/sqlite3/sqlite3.c` -- SQLite3 blob stream seek

### Existing PRs

- PR #20965 for GH-20964 uses the same cast-order fix but only covers memory streams
- PR #20928 for GH-20927 uses the same cast-order fix but only covers pdo_sqlite

This patch covers all three affected files.

Fixes #20964
Fixes #20927