### PR TITLE
Fix GH-20214: PDO::FETCH_DEFAULT unexpected behavior with setFetchMode

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1731,11 +1731,11 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 
 	stmt->default_fetch_type = PDO_FETCH_BOTH;
 
-	if ((mode & ~PDO_FETCH_FLAGS) == PDO_FETCH_USE_DEFAULT) {
-		mode = stmt->dbh->default_fetch_type;
-	}
-
 	flags = mode & PDO_FETCH_FLAGS;
+
+	if ((mode & ~PDO_FETCH_FLAGS) == PDO_FETCH_USE_DEFAULT) {
+		mode = stmt->dbh->default_fetch_type | flags;
+	}
 
 	if (!pdo_stmt_verify_mode(stmt, mode, mode_arg_num, false)) {
 		return false;

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1731,6 +1731,10 @@ bool pdo_stmt_setup_fetch_mode(pdo_stmt_t *stmt, zend_long mode, uint32_t mode_a
 
 	stmt->default_fetch_type = PDO_FETCH_BOTH;
 
+	if ((mode & ~PDO_FETCH_FLAGS) == PDO_FETCH_USE_DEFAULT) {
+		mode = stmt->dbh->default_fetch_type;
+	}
+
 	flags = mode & PDO_FETCH_FLAGS;
 
 	if (!pdo_stmt_verify_mode(stmt, mode, mode_arg_num, false)) {

--- a/ext/pdo/tests/gh20214.phpt
+++ b/ext/pdo/tests/gh20214.phpt
@@ -14,48 +14,50 @@ PDOTest::skip();
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
+
+$db->exec('CREATE TABLE gh20214 (c1 VARCHAR(10), c2 VARCHAR(10))');
+$db->exec("INSERT INTO gh20214 VALUES ('v1', 'v2')");
+
 $db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
 
 // setFetchMode with FETCH_DEFAULT should use connection default (FETCH_OBJ)
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt = $db->query('SELECT c1, c2 FROM gh20214');
 $stmt->setFetchMode(PDO::FETCH_DEFAULT);
 $row = $stmt->fetch();
 var_dump($row instanceof stdClass);
 var_dump($row->c1);
 
 // fetch with FETCH_DEFAULT should also use connection default
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt = $db->query('SELECT c1, c2 FROM gh20214');
 $row = $stmt->fetch(PDO::FETCH_DEFAULT);
 var_dump($row instanceof stdClass);
 
 // fetchAll with FETCH_DEFAULT should also use connection default
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt = $db->query('SELECT c1, c2 FROM gh20214');
 $rows = $stmt->fetchAll(PDO::FETCH_DEFAULT);
 var_dump($rows[0] instanceof stdClass);
 
 // setFetchMode then fetch without argument
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt = $db->query('SELECT c1, c2 FROM gh20214');
 $stmt->setFetchMode(PDO::FETCH_DEFAULT);
 $row = $stmt->fetch();
 var_dump($row instanceof stdClass);
 
 // query() with FETCH_DEFAULT as second argument
 $db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_NUM);
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2", PDO::FETCH_DEFAULT);
+$stmt = $db->query('SELECT c1, c2 FROM gh20214', PDO::FETCH_DEFAULT);
 $row = $stmt->fetch();
 var_dump(is_array($row) && isset($row[0]));
-
-// FETCH_DEFAULT with flags should preserve the flags
-$db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
-$stmt->setFetchMode(PDO::FETCH_DEFAULT | PDO::FETCH_GROUP);
-$rows = $stmt->fetchAll();
-var_dump(is_array($rows) && array_key_exists('v1', $rows));
+?>
+--CLEAN--
+<?php
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+PDOTest::dropTableIfExists($db, "gh20214");
 ?>
 --EXPECT--
 bool(true)
 string(2) "v1"
-bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/ext/pdo/tests/gh20214.phpt
+++ b/ext/pdo/tests/gh20214.phpt
@@ -1,10 +1,19 @@
 --TEST--
 GH-20214 (PDO::FETCH_DEFAULT unexpected behavior with PDOStatement::setFetchMode)
 --EXTENSIONS--
-pdo_sqlite
+pdo
+--SKIPIF--
+<?php
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
 --FILE--
 <?php
-$db = new PDO("sqlite::memory:");
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
 $db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
 
 // setFetchMode with FETCH_DEFAULT should use connection default (FETCH_OBJ)
@@ -29,10 +38,25 @@ $stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
 $stmt->setFetchMode(PDO::FETCH_DEFAULT);
 $row = $stmt->fetch();
 var_dump($row instanceof stdClass);
+
+// query() with FETCH_DEFAULT as second argument
+$db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_NUM);
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2", PDO::FETCH_DEFAULT);
+$row = $stmt->fetch();
+var_dump(is_array($row) && isset($row[0]));
+
+// FETCH_DEFAULT with flags should preserve the flags
+$db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt->setFetchMode(PDO::FETCH_DEFAULT | PDO::FETCH_GROUP);
+$rows = $stmt->fetchAll();
+var_dump(is_array($rows) && array_key_exists('v1', $rows));
 ?>
 --EXPECT--
 bool(true)
 string(2) "v1"
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/ext/pdo_sqlite/tests/gh20214.phpt
+++ b/ext/pdo_sqlite/tests/gh20214.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-20214 (PDO::FETCH_DEFAULT unexpected behavior with PDOStatement::setFetchMode)
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+$db = new PDO("sqlite::memory:");
+$db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
+
+// setFetchMode with FETCH_DEFAULT should use connection default (FETCH_OBJ)
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt->setFetchMode(PDO::FETCH_DEFAULT);
+$row = $stmt->fetch();
+var_dump($row instanceof stdClass);
+var_dump($row->c1);
+
+// fetch with FETCH_DEFAULT should also use connection default
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$row = $stmt->fetch(PDO::FETCH_DEFAULT);
+var_dump($row instanceof stdClass);
+
+// fetchAll with FETCH_DEFAULT should also use connection default
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$rows = $stmt->fetchAll(PDO::FETCH_DEFAULT);
+var_dump($rows[0] instanceof stdClass);
+
+// setFetchMode then fetch without argument
+$stmt = $db->query("SELECT 'v1' AS c1, 'v2' AS c2");
+$stmt->setFetchMode(PDO::FETCH_DEFAULT);
+$row = $stmt->fetch();
+var_dump($row instanceof stdClass);
+?>
+--EXPECT--
+bool(true)
+string(2) "v1"
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
When `setFetchMode(PDO::FETCH_DEFAULT)` is called, `pdo_stmt_setup_fetch_mode()` stores `PDO_FETCH_USE_DEFAULT` (0) as the statement's default fetch type. Later, `do_fetch()` tries to resolve `PDO_FETCH_USE_DEFAULT` by reading `stmt->default_fetch_type` — which is also 0, creating a circular reference. On 8.4 this silently fell through to `FETCH_BOTH`; on master it throws a `ValueError`.

The fix resolves `PDO_FETCH_USE_DEFAULT` to the connection-level default (`stmt->dbh->default_fetch_type`) early in `pdo_stmt_setup_fetch_mode()`, before flags extraction and the mode switch. The connection default is guaranteed to never be `PDO_FETCH_USE_DEFAULT` (enforced by `PDO::setAttribute`), so no circular resolution is possible.

Not sure if this should be rebased to the PHP-8.4 branch since the bug affects 8.4 as well (silently returns wrong fetch mode there).

Fixes #20214