### PR TITLE
Fix GH-20905: assertion in zend_lazy_object_del_info during unclean s…

### DIFF
--- a/Zend/tests/clone_clone_method_declares_function.phpt.php
+++ b/Zend/tests/clone_clone_method_declares_function.phpt.php
@@ -1,0 +1,33 @@
+--TEST--
+Lazy objects: clone does not assert when __clone() declares a function causing a fatal error
+--FILE--
+<?php
+
+// Regression test for GH-20905:
+// When __clone() declares a function that was already declared (triggering E_ERROR
+// and bailout), del_info() was called during shutdown on an object whose info entry
+// had already been removed, causing an assertion failure in debug builds.
+
+function f() {}
+
+class A {
+    public stdClass $p;
+
+    public function __construct()
+    {
+        $this->p = new stdClass;
+    }
+
+    public function __clone()
+    {
+        // Redeclaring an already-declared function triggers E_ERROR -> bailout.
+        // The lazy object machinery must not assert during the resulting shutdown.
+        function f() {}
+    }
+}
+
+$r = new ReflectionClass(A::class);
+clone $r->newLazyProxy(fn() => new A);
+?>
+--EXPECTF--
+Fatal error: Cannot redeclare function f() (previously declared in %s:%d) in %s on line %d

--- a/Zend/zend_lazy_objects.c
+++ b/Zend/zend_lazy_objects.c
@@ -162,7 +162,7 @@ zend_lazy_object_flags_t zend_lazy_object_get_flags(const zend_object *obj)
 void zend_lazy_object_del_info(const zend_object *obj)
 {
 	zend_result res = zend_hash_index_del(&EG(lazy_objects_store).infos, obj->handle);
-	ZEND_ASSERT(res == SUCCESS);
+	ZEND_ASSERT(res == SUCCESS || CG(unclean_shutdown));
 }
 
 bool zend_lazy_object_decr_lazy_props(const zend_object *obj)


### PR DESCRIPTION
…hutdown
Fixes an assertion failure (Assertion 'res == SUCCESS' failed) in zend_lazy_object_del_info() that occurs in debug builds when a lazy object's
__clone() method triggers a fatal error (E_ERROR) leading to zend_bailout().
Closes #20905
