### PR TITLE
Add support for draft SNMPv3 AES192 and AES 256 (and Cisco variant) security protocols

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1098,7 +1098,7 @@ zend_value_error("Security protocol must be one of "
 # endif
  "\"AES128\", or \"AES\""
 );
-#elifndef NETSNMP_DISABLE_DES
+#elif !defined(NETSNMP_DISABLE_DES)
 	zend_value_error("Security protocol must be \"DES\"");
 #else
 	zend_value_error("No security protocol supported");

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1096,7 +1096,7 @@ zend_value_error("Security protocol must be one of "
 # ifdef NETSNMP_DRAFT_BLUMENTHAL_AES_04
  "\"AES256\", \"AES256C\", \"AES192\", \"AES192C\", "
 # endif
- \"AES128\", or \"AES\""
+ "\"AES128\", or \"AES\""
 );
 #elifndef NETSNMP_DISABLE_DES
 	zend_value_error("Security protocol must be \"DES\"");

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1089,25 +1089,19 @@ static ZEND_ATTRIBUTE_NONNULL bool snmp_session_set_sec_protocol(struct snmp_ses
 #endif
 
 #ifdef HAVE_AES
+zend_value_error("Security protocol must be one of "
+#  ifndef NETSNMP_DISABLE_DES
+    "\"DES\", "
+#  endif
 # ifdef NETSNMP_DRAFT_BLUMENTHAL_AES_04
-#  ifndef NETSNMP_DISABLE_DES
-	zend_value_error("Security protocol must be one of \"AES256\", \"AES256C\", \"AES192\", \"AES192C\", \"AES128\", \"AES\", or \"DES\"");
-#  else
-	zend_value_error("Security protocol must be one of \"AES256\", \"AES256C\", \"AES192\", \"AES192C\", \"AES128\", or \"AES\"");
-#  endif
-# else
-#  ifndef NETSNMP_DISABLE_DES
-	zend_value_error("Security protocol must be one of \"AES128\", \"AES\", or \"DES\"");
-#  else
-	zend_value_error("Security protocol must be one of \"AES128\", or \"AES\"");
-#  endif
+ "\"AES256\", \"AES256C\", \"AES192\", \"AES192C\", "
 # endif
-#else
-# ifndef NETSNMP_DISABLE_DES
+ \"AES128\", or \"AES\""
+);
+#elifndef NETSNMP_DISABLE_DES
 	zend_value_error("Security protocol must be \"DES\"");
-# else
+#else
 	zend_value_error("No security protocol supported");
-# endif
 #endif
 	return false;
 }

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1060,13 +1060,47 @@ static ZEND_ATTRIBUTE_NONNULL bool snmp_session_set_sec_protocol(struct snmp_ses
 		s->securityPrivProtoLen = USM_PRIV_PROTO_AES_LEN;
 		return true;
 	}
+
+# ifdef NETSNMP_DRAFT_BLUMENTHAL_AES_04
+	if (zend_string_equals_literal_ci(prot, "AES192")) {
+		s->securityPrivProto = usmAES192PrivProtocol;
+		s->securityPrivProtoLen = OID_LENGTH(usmAES192PrivProtocol);
+		return true;
+	}
+
+	if (zend_string_equals_literal_ci(prot, "AES256")) {
+		s->securityPrivProto = usmAES256PrivProtocol;
+		s->securityPrivProtoLen = OID_LENGTH(usmAES256PrivProtocol);
+		return true;
+	}
+
+	if (zend_string_equals_literal_ci(prot, "AES192C")) {
+		s->securityPrivProto = usmAES192CiscoPrivProtocol;
+		s->securityPrivProtoLen = OID_LENGTH(usmAES192CiscoPrivProtocol);
+		return true;
+	}
+
+	if (zend_string_equals_literal_ci(prot, "AES256C")) {
+		s->securityPrivProto = usmAES256CiscoPrivProtocol;
+		s->securityPrivProtoLen = OID_LENGTH(usmAES256CiscoPrivProtocol);
+		return true;
+	}
+# endif
 #endif
 
 #ifdef HAVE_AES
-# ifndef NETSNMP_DISABLE_DES
-	zend_value_error("Security protocol must be one of \"DES\", \"AES128\", or \"AES\"");
+# ifdef NETSNMP_DRAFT_BLUMENTHAL_AES_04
+#  ifndef NETSNMP_DISABLE_DES
+	zend_value_error("Security protocol must be one of \"AES256\", \"AES256C\", \"AES192\", \"AES192C\", \"AES128\", \"AES\", or \"DES\"");
+#  else
+	zend_value_error("Security protocol must be one of \"AES256\", \"AES256C\", \"AES192\", \"AES192C\", \"AES128\", or \"AES\"");
+#  endif
 # else
+#  ifndef NETSNMP_DISABLE_DES
+	zend_value_error("Security protocol must be one of \"AES128\", \"AES\", or \"DES\"");
+#  else
 	zend_value_error("Security protocol must be one of \"AES128\", or \"AES\"");
+#  endif
 # endif
 #else
 # ifndef NETSNMP_DISABLE_DES

--- a/ext/snmp/tests/snmp-object-setSecurity_error.phpt
+++ b/ext/snmp/tests/snmp-object-setSecurity_error.phpt
@@ -72,8 +72,8 @@ bool(false)
 
 Warning: SNMP::setSecurity(): Error generating a key for authentication pass phrase 'te': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)
-Security protocol must be one of "DES", "AES128", or "AES"
-Security protocol must be one of "DES", "AES128", or "AES"
+Security protocol must be one of %s
+Security protocol must be one of %s
 
 Warning: SNMP::setSecurity(): Error generating a key for privacy pass phrase '': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -68,7 +68,7 @@ bool(false)
 
 Warning: snmp3_get(): Error generating a key for authentication pass phrase 'te': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)
-Security protocol must be one of "DES", "AES128", or "AES"
+Security protocol must be one of %s
 
 Warning: snmp3_get(): Error generating a key for privacy pass phrase '': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -68,7 +68,7 @@ bool(false)
 
 Warning: snmp3_get(): Error generating a key for authentication pass phrase 'te': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)
-Security protocol must be one of %s
+Security protocol must be one of %s "AES128", or "AES"
 
 Warning: snmp3_get(): Error generating a key for privacy pass phrase '': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/snmp_improvements_2026

This adds support for missing SNMPv3 security protocols that are supported by the net-snmp library.