### PR TITLE
Add snmp_init_mib function to allow MIB tree to be reset using environment variables

### DIFF
--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -89,6 +89,8 @@ typedef struct snmp_session php_snmp_session;
 	} \
 }
 
+static int mib_needs_reset;
+
 ZEND_DECLARE_MODULE_GLOBALS(snmp)
 static PHP_GINIT_FUNCTION(snmp);
 
@@ -1629,12 +1631,34 @@ PHP_FUNCTION(snmp_read_mib)
 		RETURN_THROWS();
 	}
 
+	mib_needs_reset = 1;
 	if (!read_mib(filename)) {
 		char *error = strerror(errno);
 		php_error_docref(NULL, E_WARNING, "Error while reading MIB file '%s': %s", filename, error);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ Resets the MIB tree and set the mib directories to the provided mibdirs. */
+PHP_FUNCTION(snmp_init_mib)
+{
+	zend_string *mibdirs = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(mibdirs)
+	ZEND_PARSE_PARAMETERS_END();
+
+	// If the mibdirs has been changed, we need to reset the MIB tree at the end of the request
+	if (mibdirs != NULL) {
+		mib_needs_reset = 1;
+	}
+
+	shutdown_mib();
+	netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, ZSTR_VAL(mibdirs));
+	init_mib();
 }
 /* }}} */
 
@@ -2172,6 +2196,19 @@ PHP_MSHUTDOWN_FUNCTION(snmp)
 }
 /* }}} */
 
+/* {{{ PHP_RSHUTDOWN_FUNCTION */
+static PHP_RSHUTDOWN_FUNCTION(snmp)
+{
+	if (mib_needs_reset) {
+		shutdown_mib();
+		netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, NULL);
+		init_mib();
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ PHP_MINFO_FUNCTION */
 PHP_MINFO_FUNCTION(snmp)
 {
@@ -2199,7 +2236,7 @@ zend_module_entry snmp_module_entry = {
 	PHP_MINIT(snmp),
 	PHP_MSHUTDOWN(snmp),
 	NULL,
-	NULL,
+	PHP_RSHUTDOWN(snmp),
 	PHP_MINFO(snmp),
 	PHP_SNMP_VERSION,
 	PHP_MODULE_GLOBALS(snmp),

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -89,6 +89,8 @@ typedef struct snmp_session php_snmp_session;
 	} \
 }
 
+static int mib_needs_reset;
+
 ZEND_DECLARE_MODULE_GLOBALS(snmp)
 static PHP_GINIT_FUNCTION(snmp);
 
@@ -1658,12 +1660,34 @@ PHP_FUNCTION(snmp_read_mib)
 		RETURN_THROWS();
 	}
 
+	mib_needs_reset = 1;
 	if (!read_mib(filename)) {
 		char *error = strerror(errno);
 		php_error_docref(NULL, E_WARNING, "Error while reading MIB file '%s': %s", filename, error);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ Resets the MIB tree and set the mib directories to the provided mibdirs. */
+PHP_FUNCTION(snmp_init_mib)
+{
+	zend_string *mibdirs = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(mibdirs)
+	ZEND_PARSE_PARAMETERS_END();
+
+	// If the mibdirs has been changed, we need to reset the MIB tree at the end of the request
+	if (mibdirs != NULL) {
+		mib_needs_reset = 1;
+	}
+
+	shutdown_mib();
+	netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, ZSTR_VAL(mibdirs));
+	init_mib();
 }
 /* }}} */
 
@@ -2201,6 +2225,19 @@ PHP_MSHUTDOWN_FUNCTION(snmp)
 }
 /* }}} */
 
+/* {{{ PHP_RSHUTDOWN_FUNCTION */
+static PHP_RSHUTDOWN_FUNCTION(snmp)
+{
+	if (mib_needs_reset) {
+		shutdown_mib();
+		netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, NULL);
+		init_mib();
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ PHP_MINFO_FUNCTION */
 PHP_MINFO_FUNCTION(snmp)
 {
@@ -2228,7 +2265,7 @@ zend_module_entry snmp_module_entry = {
 	PHP_MINIT(snmp),
 	PHP_MSHUTDOWN(snmp),
 	NULL,
-	NULL,
+	PHP_RSHUTDOWN(snmp),
 	PHP_MINFO(snmp),
 	PHP_SNMP_VERSION,
 	PHP_MODULE_GLOBALS(snmp),

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -1677,7 +1677,7 @@ PHP_FUNCTION(snmp_init_mib)
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_STR_OR_NULL(mibdirs)
+		Z_PARAM_PATH_STR_OR_NULL(mibdirs)
 	ZEND_PARSE_PARAMETERS_END();
 
 	// If the mibdirs has been changed, we need to reset the MIB tree at the end of the request

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -89,7 +89,7 @@ typedef struct snmp_session php_snmp_session;
 	} \
 }
 
-static int mib_needs_reset;
+static bool mib_needs_reset;
 
 ZEND_DECLARE_MODULE_GLOBALS(snmp)
 static PHP_GINIT_FUNCTION(snmp);

--- a/ext/snmp/snmp.stub.php
+++ b/ext/snmp/snmp.stub.php
@@ -181,6 +181,8 @@ function snmp_get_valueretrieval(): int {}
 
 function snmp_read_mib(string $filename): bool {}
 
+function snmp_init_mib(?string $mibdirs): void {}
+
 class SNMP
 {
     /** @cvalue SNMP_VERSION_1 */

--- a/ext/snmp/snmp.stub.php
+++ b/ext/snmp/snmp.stub.php
@@ -181,6 +181,8 @@ function snmp_get_valueretrieval(): int {}
 
 function snmp_read_mib(string $filename): bool {}
 
+function snmp_init_mib(?string $mibdirs): void {}
+
 /** @not-serializable */
 class SNMP
 {

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit snmp.stub.php instead.
- * Stub hash: e2451ac3ea0fa5eb1158e8b7252e61c6794d514f */
+ * Stub hash: 68dd2791d2ed4c931d99e012f6dc2d5d6f5e23b4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
@@ -114,6 +114,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmp_read_mib, 0, 1, _IS_BOOL, 0
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmp_init_mib, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, mibdirs, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SNMP___construct, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, version, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
@@ -185,6 +189,7 @@ ZEND_FUNCTION(snmp3_set);
 ZEND_FUNCTION(snmp_set_valueretrieval);
 ZEND_FUNCTION(snmp_get_valueretrieval);
 ZEND_FUNCTION(snmp_read_mib);
+ZEND_FUNCTION(snmp_init_mib);
 ZEND_METHOD(SNMP, __construct);
 ZEND_METHOD(SNMP, close);
 ZEND_METHOD(SNMP, setSecurity);
@@ -220,6 +225,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(snmp_set_valueretrieval, arginfo_snmp_set_valueretrieval)
 	ZEND_FE(snmp_get_valueretrieval, arginfo_snmp_get_valueretrieval)
 	ZEND_FE(snmp_read_mib, arginfo_snmp_read_mib)
+	ZEND_FE(snmp_init_mib, arginfo_snmp_init_mib)
 	ZEND_FE_END
 };
 

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit snmp.stub.php instead.
- * Stub hash: 20039fa88cb9f8a861bf3bf3e2e5e291e50c6a12 */
+ * Stub hash: 68dd2791d2ed4c931d99e012f6dc2d5d6f5e23b4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
@@ -114,6 +114,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmp_read_mib, 0, 1, _IS_BOOL, 0
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmp_init_mib, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, mibdirs, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SNMP___construct, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, version, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
@@ -185,6 +189,7 @@ ZEND_FUNCTION(snmp3_set);
 ZEND_FUNCTION(snmp_set_valueretrieval);
 ZEND_FUNCTION(snmp_get_valueretrieval);
 ZEND_FUNCTION(snmp_read_mib);
+ZEND_FUNCTION(snmp_init_mib);
 ZEND_METHOD(SNMP, __construct);
 ZEND_METHOD(SNMP, close);
 ZEND_METHOD(SNMP, setSecurity);
@@ -220,6 +225,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(snmp_set_valueretrieval, arginfo_snmp_set_valueretrieval)
 	ZEND_FE(snmp_get_valueretrieval, arginfo_snmp_get_valueretrieval)
 	ZEND_FE(snmp_read_mib, arginfo_snmp_read_mib)
+	ZEND_FE(snmp_init_mib, arginfo_snmp_init_mib)
 	ZEND_FE_END
 };
 

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit snmp.stub.php instead.
- * Stub hash: 68dd2791d2ed4c931d99e012f6dc2d5d6f5e23b4 */
+ * Stub hash: 18e6ffa1acd3c1b6d1c962be97f36e9a46a317a2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/snmp_improvements_2026

I have been trying to use the PHP SNMP extension in LibreNMS to replace calls to external snmp* programs.  One issue I have come across is that there is no way to clear the MIB tree in the PHP SNMP extension.  It becomes even worse with PHP-FPM where the MIB tree is persistent across different requests.

The above causes issues when a script wants to do multiple SNMP queries against incompatible MIBs because there is currently no way to clear the MIB tree and start again.

This PR add a new snmp_init_mib() function that frees up the existing MIB tree and then calls init_mib(), which will:
 - Set the MIB directories according to the `MIBDIRS` environment variable
 - Load MIBs according to the `MIBS` environment variable (plus any IMPORTs)
 - Load MIB files according to the `MIBFILES` variable

I have chosen to only expose the one function above because the other functions like shutdown_mib(), init_mib_internals() netsnmp_read_module() require understanding how the net-snmp internals work to ensure everything is initialised properly.  The proposed function can be used to clear the MIB tree back to the default state if the environment variables are not changed, or to reset to a known state if the environment variables are updated.

It's marked as draft until I have tested that it works.
