### PR TITLE
gen_stub: make use of PHP 8.0 and PHP 8.1 features

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -486,7 +486,7 @@ class Type {
 
     public static function fromNode(Node $node): Type {
         if ($node instanceof Node\UnionType || $node instanceof Node\IntersectionType) {
-            $nestedTypeObjects = array_map(['Type', 'fromNode'], $node->types);
+            $nestedTypeObjects = array_map(Type::fromNode(...), $node->types);
             $types = [];
             foreach ($nestedTypeObjects as $typeObject) {
                 array_push($types, ...$typeObject->types);


### PR DESCRIPTION
PHP 8.1 has been required for the build system since #20933

Each commit can be reviewed independently, and should have no functional changes