### PR TITLE
Fix Laravel build for PHP 8.2

### DIFF
--- a/.github/matrix.php
+++ b/.github/matrix.php
@@ -80,8 +80,14 @@ function select_jobs($repository, $trigger, $nightly, $labels, $php_version, $re
         $jobs['COMMUNITY']['matrix'] = version_compare($php_version, '8.4', '>=')
             ? ['type' => ['asan', 'verify_type_inference']]
             : ['type' => ['asan']];
-        $jobs['COMMUNITY']['config']['symfony_version'] = version_compare($php_version, '8.4', '>=') ? '8.1' : '7.4';
-        $jobs['COMMUNITY']['config']['laravel_version'] = version_compare($php_version, '8.3', '>=') ? '13.x' : '12.x';
+        $jobs['COMMUNITY']['config']['symfony_version'] = match (true) {
+            version_compare($php_version, '8.3', '<=') => '7.4',
+            default => '',
+        };
+        $jobs['COMMUNITY']['config']['laravel_version'] = match (true) {
+            version_compare($php_version, '8.2', '<=') => '12.x',
+            default => '',
+        };
     }
     if (($all_jobs && $ref === 'master') || $test_coverage) {
         $jobs['COVERAGE'] = true;

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -506,7 +506,8 @@ jobs:
       - name: Test Laravel
         if: ${{ !cancelled() }}
         run: |
-          git clone https://github.com/laravel/framework.git --depth=1 --branch="${{ fromJson(inputs.branch).jobs.COMMUNITY.config.laravel_version }}"
+          branch=${{ fromJson(inputs.branch).jobs.COMMUNITY.config.laravel_version }}
+          git clone https://github.com/laravel/framework.git --depth=1 ${branch:+--branch="$branch"}
           cd framework
           git rev-parse HEAD
           php /usr/bin/composer install --no-progress --ignore-platform-req=php+
@@ -551,7 +552,8 @@ jobs:
       - name: Test Symfony
         if: ${{ !cancelled() }}
         run: |
-          git clone https://github.com/symfony/symfony.git --depth=1 --branch="${{ fromJson(inputs.branch).jobs.COMMUNITY.config.symfony_version }}"
+          branch=${{ fromJson(inputs.branch).jobs.COMMUNITY.config.symfony_version }}
+          git clone https://github.com/symfony/symfony.git --depth=1 ${branch:+--branch="$branch"}
           cd symfony
           git rev-parse HEAD
           php /usr/bin/composer install --no-progress --ignore-platform-req=php+


### PR DESCRIPTION
Laravel 13.x dropped support for PHP 8.2. Fall back to 12.x for 8.2.