### PR TITLE
use lexbor version from library

### DIFF
--- a/ext/lexbor/config.m4
+++ b/ext/lexbor/config.m4
@@ -2,7 +2,6 @@ PHP_LEXBOR_CFLAGS="-I@ext_srcdir@/"
 LEXBOR_DIR="lexbor"
 
 AC_DEFINE([HAVE_LEXBOR], [1], [Define to 1 if the PHP extension 'lexbor' is available.])
-AC_DEFINE([LEXBOR_VERSION], ["2.5.0"], [Define the main Lexbor version])
 
 PHP_NEW_EXTENSION([lexbor], m4_normalize([
     php_lexbor.c

--- a/ext/lexbor/config.w32
+++ b/ext/lexbor/config.w32
@@ -24,6 +24,5 @@ ADD_SOURCES("ext/lexbor/lexbor/url", "url.c","lexbor");
 ADD_FLAG("CFLAGS_LEXBOR", "/D LEXBOR_BUILDING /utf-8");
 
 AC_DEFINE("HAVE_LEXBOR", 1, "Define to 1 if the PHP extension 'lexbor' is available.");
-AC_DEFINE("LEXBOR_VERSION", "2.5.0", "Define the main Lexbor version")
 
 PHP_INSTALL_HEADERS("ext/lexbor", "php_lexbor.h lexbor/");

--- a/ext/lexbor/php_lexbor.c
+++ b/ext/lexbor/php_lexbor.c
@@ -22,6 +22,7 @@
 #include "php.h"
 #include "zend_globals.h"
 #include "ext/standard/info.h"
+#include "lexbor/core/base.h"
 #include "lexbor/core/types.h"
 #include "lexbor/core/lexbor.h"
 
@@ -53,7 +54,7 @@ static PHP_MINFO_FUNCTION(lexbor)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Lexbor support", "active");
-	php_info_print_table_row(2, "Lexbor version", LEXBOR_VERSION);
+	php_info_print_table_row(2, "Lexbor version", LEXBOR_VERSION_STRING);
 	php_info_print_table_end();
 }
 


### PR DESCRIPTION
Having the version hardcoded in the config.m4/w32 seems terrible

It seems version is partially updated to 2.6.0, config states 2.5.0, base.h states 2.0.0 :(

This means, the full tree should be updated

This will help later if we are able to build with system library

P.S. AFAIK an update to 2.7.0 will be needed shortly, so full tree welcome