### PR TITLE
Fix gen_stub.php --verify-manual subcommand

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -154,81 +154,97 @@ namespace
     /**
      * @var int
      * @cvalue INDEX_SIZE_ERR
+     * @link constant.-dom-index-size-err
      */
     const DOM_INDEX_SIZE_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue DOMSTRING_SIZE_ERR
+     * @link constant.-domstring-size-err
      */
     const DOMSTRING_SIZE_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue HIERARCHY_REQUEST_ERR
+     * @link constant.-dom-hierarchy-request-err
      */
     const DOM_HIERARCHY_REQUEST_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue WRONG_DOCUMENT_ERR
+     * @link constant.-dom-wrong-document-err
      */
     const DOM_WRONG_DOCUMENT_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue INVALID_CHARACTER_ERR
+     * @link constant.-dom-invalid-character-err
      */
     const DOM_INVALID_CHARACTER_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue NO_DATA_ALLOWED_ERR
+     * @link constant.-dom-no-data-allowed-err
      */
     const DOM_NO_DATA_ALLOWED_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue NO_MODIFICATION_ALLOWED_ERR
+     * @link constant.-dom-no-modification-allowed-err
      */
     const DOM_NO_MODIFICATION_ALLOWED_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue NOT_FOUND_ERR
+     * @link constant.-dom-not-found-err
      */
     const DOM_NOT_FOUND_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue NOT_SUPPORTED_ERR
+     * @link constant.-dom-not-supported-err
      */
     const DOM_NOT_SUPPORTED_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue INUSE_ATTRIBUTE_ERR
+     * @link constant.-dom-inuse-attribute-err
      */
     const DOM_INUSE_ATTRIBUTE_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue INVALID_STATE_ERR
+     * @link constant.-dom-invalid-state-err
      */
     const DOM_INVALID_STATE_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue SYNTAX_ERR
+     * @link constant.-dom-syntax-err
      */
     const DOM_SYNTAX_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue INVALID_MODIFICATION_ERR
+     * @link constant.-dom-invalid-modification-err
      */
     const DOM_INVALID_MODIFICATION_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue NAMESPACE_ERR
+     * @link constant.-dom-namespace-err
      */
     const DOM_NAMESPACE_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue INVALID_ACCESS_ERR
+     * @link constant.-dom-invalid-access-err
      */
     const DOM_INVALID_ACCESS_ERR = UNKNOWN;
     /**
      * @var int
      * @cvalue VALIDATION_ERR
+     * @link constant.-dom-validation-err
      */
     const DOM_VALIDATION_ERR = UNKNOWN;
 

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 757889c0ca89cc8e9905ba465e0621fe89b6e716 */
+ * Stub hash: 477c0583a27e45491b0a592a4fc51c3429213817 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dom_import_simplexml, 0, 1, DOMAttr|DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)

--- a/ext/dom/php_dom_decl.h
+++ b/ext/dom/php_dom_decl.h
@@ -1,0 +1,14 @@
+/* This is a generated file, edit php_dom.stub.php instead.
+ * Stub hash: 4e27e7ae25f7070428de588aebbc8d37b76576ce */
+
+#ifndef ZEND_PHP_DOM_DECL_4e27e7ae25f7070428de588aebbc8d37b76576ce_H
+#define ZEND_PHP_DOM_DECL_4e27e7ae25f7070428de588aebbc8d37b76576ce_H
+
+typedef enum zend_enum_Dom_AdjacentPosition {
+	ZEND_ENUM_Dom_AdjacentPosition_BeforeBegin = 1,
+	ZEND_ENUM_Dom_AdjacentPosition_AfterBegin = 2,
+	ZEND_ENUM_Dom_AdjacentPosition_BeforeEnd = 3,
+	ZEND_ENUM_Dom_AdjacentPosition_AfterEnd = 4,
+} zend_enum_Dom_AdjacentPosition;
+
+#endif /* ZEND_PHP_DOM_DECL_4e27e7ae25f7070428de588aebbc8d37b76576ce_H */


### PR DESCRIPTION
Before these changes, the command used to fail with an exception due to ext/DOM constants being wrongly formatted: the old and new constant counterparts were documented in the same row (e.g. <constant>DOM_VALIDATION_ERR</constant> / <constant>Dom\VALIDATION_ERR</constant>) which format cannot be recognized by gen_stub.php. Instead, let's document each constant on its own row.