### PR TITLE
ext/bcmath: Fix bc_str2num accepting strings with embedded null bytes

### DIFF
--- a/ext/bcmath/libbcmath/src/str2num.c
+++ b/ext/bcmath/libbcmath/src/str2num.c
@@ -131,7 +131,7 @@ bool bc_str2num(bc_num *num, const char *str, const char *end, size_t scale, siz
 	const char *decimal_point = (*ptr == '.') ? ptr : NULL;
 
 	/* If a non-digit and non-decimal-point indicator is in the string, i.e. an invalid character */
-	if (UNEXPECTED(!decimal_point && *ptr != '\0')) {
+	if (UNEXPECTED(!decimal_point && ptr != end)) {
 		goto fail;
 	}
 
@@ -140,7 +140,7 @@ bool bc_str2num(bc_num *num, const char *str, const char *end, size_t scale, siz
 		/* search */
 		fractional_ptr = fractional_end = decimal_point + 1;
 		/* For strings that end with a decimal point, such as "012." */
-		if (UNEXPECTED(*fractional_ptr == '\0')) {
+		if (UNEXPECTED(fractional_ptr == end)) {
 			if (full_scale) {
 				*full_scale = 0;
 			}
@@ -149,7 +149,7 @@ bool bc_str2num(bc_num *num, const char *str, const char *end, size_t scale, siz
 
 		/* validate */
 		fractional_end = bc_count_digits(fractional_ptr, end);
-		if (UNEXPECTED(*fractional_end != '\0')) {
+		if (UNEXPECTED(fractional_end != end)) {
 			/* invalid num */
 			goto fail;
 		}

--- a/ext/bcmath/tests/sec_embedded_null_truncation.phpt
+++ b/ext/bcmath/tests/sec_embedded_null_truncation.phpt
@@ -1,0 +1,59 @@
+--TEST--
+bcmath strings with embedded null bytes must be rejected as not well-formed
+--EXTENSIONS--
+bcmath
+--FILE--
+<?php
+$cases = [
+    "100\x005",
+    "1.2\x003",
+    "\x00123",
+];
+
+$calls = [
+    fn($s) => bcadd($s, "0"),
+    fn($s) => bcsub($s, "0"),
+    fn($s) => bcmul($s, "1"),
+    fn($s) => bcdiv($s, "1"),
+    fn($s) => bcmod($s, "7"),
+    fn($s) => bcpow($s, "1"),
+    fn($s) => bccomp($s, "0"),
+    fn($s) => bcsqrt($s),
+];
+
+foreach ($cases as $s) {
+    foreach ($calls as $fn) {
+        try {
+            $fn($s);
+            echo "FAIL: accepted\n";
+        } catch (\ValueError $e) {
+            echo $e->getMessage() . "\n";
+        }
+    }
+}
+?>
+--EXPECT--
+bcadd(): Argument #1 ($num1) is not well-formed
+bcsub(): Argument #1 ($num1) is not well-formed
+bcmul(): Argument #1 ($num1) is not well-formed
+bcdiv(): Argument #1 ($num1) is not well-formed
+bcmod(): Argument #1 ($num1) is not well-formed
+bcpow(): Argument #1 ($num) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bcsqrt(): Argument #1 ($num) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcsub(): Argument #1 ($num1) is not well-formed
+bcmul(): Argument #1 ($num1) is not well-formed
+bcdiv(): Argument #1 ($num1) is not well-formed
+bcmod(): Argument #1 ($num1) is not well-formed
+bcpow(): Argument #1 ($num) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bcsqrt(): Argument #1 ($num) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcsub(): Argument #1 ($num1) is not well-formed
+bcmul(): Argument #1 ($num1) is not well-formed
+bcdiv(): Argument #1 ($num1) is not well-formed
+bcmod(): Argument #1 ($num1) is not well-formed
+bcpow(): Argument #1 ($num) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bcsqrt(): Argument #1 ($num) is not well-formed


### PR DESCRIPTION
`bc_str2num` accepts an explicit end boundary pointer but validated input using null-terminator checks (*ptr != '\0'). This caused strings with embedded null bytes to be silently truncated rather than rejected.

`"100\x005"` was parsed as `"100"` while `"100a5"` correctly threw a ValueError.