### PR TITLE
Switch sqlite tests from "" to '' and re-enable for FreeBSD

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -46,7 +46,7 @@ runs:
             pkgconf \
             webp \
             libavif \
-            `#sqlite3` \
+            sqlite3 \
             curl \
             $OPCACHE_TLS_TESTS_DEPS
 
@@ -57,9 +57,7 @@ runs:
             --enable-debug \
             --enable-option-checking=fatal \
             --enable-fpm \
-            `#--with-pdo-sqlite` \
-            --without-sqlite3 \
-            --without-pdo-sqlite \
+            --with-pdo-sqlite \
             --without-pear \
             --with-bz2 \
             --with-avif \

--- a/ext/pdo_sqlite/tests/bug38334.phpt
+++ b/ext/pdo_sqlite/tests/bug38334.phpt
@@ -7,11 +7,11 @@ pdo_sqlite
 
 $db = new PDO('sqlite::memory:');
 $db->exec('CREATE TABLE test_38334 (i INTEGER , f DOUBLE, s VARCHAR(255))');
-$db->exec('INSERT INTO test_38334 VALUES (42, 46.7, "test")');
+$db->exec("INSERT INTO test_38334 VALUES (42, 46.7, 'test')");
 var_dump($db->query('SELECT * FROM test_38334')->fetch(PDO::FETCH_ASSOC));
 
 // Check handling of integers larger than 32-bit.
-$db->exec('INSERT INTO test_38334 VALUES (10000000000, 0.0, "")');
+$db->exec("INSERT INTO test_38334 VALUES (10000000000, 0.0, '')");
 $i = $db->query('SELECT i FROM test_38334 WHERE f = 0.0')->fetchColumn(0);
 if (PHP_INT_SIZE >= 8) {
     var_dump($i === 10000000000);
@@ -20,8 +20,8 @@ if (PHP_INT_SIZE >= 8) {
 }
 
 // Check storing of strings into integer/float columns.
-$db->exec('INSERT INTO test_38334 VALUES ("test", "test", "x")');
-var_dump($db->query('SELECT * FROM test_38334 WHERE s = "x"')->fetch(PDO::FETCH_ASSOC));
+$db->exec("INSERT INTO test_38334 VALUES ('test', 'test', 'x')");
+var_dump($db->query("SELECT * FROM test_38334 WHERE s = 'x'")->fetch(PDO::FETCH_ASSOC));
 
 ?>
 --EXPECT--

--- a/ext/pdo_sqlite/tests/bug_42589.phpt
+++ b/ext/pdo_sqlite/tests/bug_42589.phpt
@@ -15,7 +15,7 @@ if(!in_array('ENABLE_COLUMN_METADATA', $options, true))
 $db = new PDO("sqlite::memory:");
 
 $db->exec('CREATE TABLE test_42589 (field1 VARCHAR(10))');
-$db->exec('INSERT INTO test_42589 VALUES("test")');
+$db->exec("INSERT INTO test_42589 VALUES('test')");
 
 $result = $db->query('SELECT * FROM test_42589 t1 LEFT JOIN test_42589 t2 ON t1.field1 = t2.field1');
 $meta1 = $result->getColumnMeta(0);

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createaggregate.phpt
@@ -9,7 +9,7 @@ $db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE test_pdo_sqlite_createaggregate (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createaggregate VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_createaggregate VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 
 $db->sqliteCreateAggregate('testing', function(&$a, $b) { $a .= $b; return $a; }, function(&$v) { return $v; });
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createcollation.phpt
@@ -10,7 +10,7 @@ $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->query('CREATE TABLE test_pdo_sqlite_createcollation (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createcollation VALUES (NULL, "1"), (NULL, "2"), (NULL, "10")');
+$db->query("INSERT INTO test_pdo_sqlite_createcollation VALUES (NULL, '1'), (NULL, '2'), (NULL, '10')");
 
 $db->sqliteCreateCollation('MYCOLLATE', function($a, $b) { return strnatcmp($a, $b); });
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction.phpt
@@ -9,7 +9,7 @@ $db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE test_pdo_sqlite_createfunction (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createfunction VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_createfunction VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 
 
 $db->sqliteCreateFunction('testing', function($v) { return strtolower($v); });

--- a/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_createfunction_with_flags.phpt
@@ -13,7 +13,7 @@ $db = new PDO('sqlite::memory:');
 
 $db->query('CREATE TABLE test_pdo_sqlite_createfunction_with_flags (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createfunction_with_flags VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_createfunction_with_flags VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 
 
 $db->sqliteCreateFunction('testing', function($v) { return strtolower($v); }, 1, Pdo\Sqlite::DETERMINISTIC);

--- a/ext/pdo_sqlite/tests/pdo_sqlite_dqs.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_dqs.phpt
@@ -1,0 +1,27 @@
+--TEST--
+PDO_sqlite: Testing DQS support
+--EXTENSIONS--
+pdo_sqlite
+--SKIPIF--
+<?php
+$db = new PDO('sqlite::memory:');
+try {
+    $db->exec('SELECT "test"');
+} catch (\PDOException) {
+    die('skip SQLite is lacking DQS');
+}
+?>
+--FILE--
+<?php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE test (s1 VARCHAR(255), s2 VARCHAR(255))');
+$db->exec('INSERT INTO test VALUES (\'test\', "test")');
+var_dump($db->query('SELECT * FROM test')->fetch(PDO::FETCH_ASSOC));
+?>
+--EXPECT--
+array(2) {
+  ["s1"]=>
+  string(4) "test"
+  ["s2"]=>
+  string(4) "test"
+}

--- a/ext/pdo_sqlite/tests/pdo_sqlite_lastinsertid.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_lastinsertid.phpt
@@ -7,7 +7,7 @@ pdo_sqlite
 
 $db = new PDO('sqlite::memory:');
 $db->query('CREATE TABLE test_pdo_sqlite_lastinsertid (id INT AUTO INCREMENT, name TEXT)');
-$db->query('INSERT INTO test_pdo_sqlite_lastinsertid VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_lastinsertid VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 var_dump($db->query('SELECT * FROM test_pdo_sqlite_lastinsertid'));
 var_dump($db->errorInfo());
 var_dump($db->lastInsertId());

--- a/ext/pdo_sqlite/tests/pdo_sqlite_parser.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_parser.phpt
@@ -31,9 +31,8 @@ foreach ($queries as $k => $query) {
 // One parameter
 $queries = [
     "SELECT * FROM {$table} WHERE '1' = ?",
-    "SELECT * FROM {$table} WHERE \"?\" IN (?, \"?\")",
+    "SELECT * FROM {$table} WHERE '?' IN (?, '?')",
     "SELECT * FROM {$table} WHERE `a``?` = ?",
-    "SELECT * FROM {$table} WHERE \"a`?\" = ?",
     "SELECT * FROM {$table} WHERE [a`?] = ?",
 ];
 
@@ -41,6 +40,22 @@ foreach ($queries as $k => $query) {
     $stmt = $db->prepare($query);
     $stmt->execute([1]);
     var_dump($stmt->fetch(PDO::FETCH_NUM) === [0 => 1]);
+}
+
+// Check if DQS are enabled.
+$dqs = true;
+try {
+    $db->exec('SELECT "test"');
+} catch (\PDOException) {
+    $dqs = false;
+}
+
+if ($dqs) {
+    $stmt = $db->prepare("SELECT * FROM {$table} WHERE \"a`?\" = ?");
+    $stmt->execute([1]);
+    var_dump($stmt->fetch(PDO::FETCH_NUM) === [0 => 1]);
+} else {
+    var_dump(true);
 }
 
 ?>

--- a/ext/pdo_sqlite/tests/pdo_sqlite_transaction.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_transaction.phpt
@@ -14,7 +14,7 @@ $db->query('CREATE TABLE test_pdo_sqlite_transaction (id INT AUTO INCREMENT, nam
 $db->commit();
 
 $db->beginTransaction();
-$db->query('INSERT INTO test_pdo_sqlite_transaction VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_transaction VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 $db->rollback();
 
 $r = $db->query('SELECT COUNT(*) FROM test_pdo_sqlite_transaction');

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createafunction_trampoline.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createafunction_trampoline.phpt
@@ -20,11 +20,11 @@ class TrampolineTest {
 
 var_dump($db->createFunction('strtoupper', [new TrampolineTest(), 'strtoupper']));
 
-foreach ($db->query('SELECT strtoupper("test")') as $row) {
+foreach ($db->query("SELECT strtoupper('test')") as $row) {
     var_dump($row);
 }
 
-foreach ($db->query('SELECT strtoupper("test")') as $row) {
+foreach ($db->query("SELECT strtoupper('test')") as $row) {
     var_dump($row);
 }
 
@@ -33,14 +33,14 @@ foreach ($db->query('SELECT strtoupper("test")') as $row) {
 bool(true)
 Trampoline for strtoupper
 array(2) {
-  ["strtoupper("test")"]=>
+  ["strtoupper('test')"]=>
   string(4) "TEST"
   [0]=>
   string(4) "TEST"
 }
 Trampoline for strtoupper
 array(2) {
-  ["strtoupper("test")"]=>
+  ["strtoupper('test')"]=>
   string(4) "TEST"
   [0]=>
   string(4) "TEST"

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createaggregate.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createaggregate.phpt
@@ -10,7 +10,7 @@ $db = new Pdo\Sqlite('sqlite::memory:');
 
 $db->query('CREATE TABLE test_pdo_sqlite_createaggregate (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createaggregate VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_createaggregate VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 
 $db->createAggregate('testing', function(&$a, $b) { $a .= $b; return $a; }, function(&$v) { return $v; });
 

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation.phpt
@@ -11,7 +11,7 @@ $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->query('CREATE TABLE test_pdo_sqlite_createcollation (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO test_pdo_sqlite_createcollation VALUES (NULL, "1"), (NULL, "2"), (NULL, "10")');
+$db->query("INSERT INTO test_pdo_sqlite_createcollation VALUES (NULL, '1'), (NULL, '2'), (NULL, '10')");
 
 $db->createCollation('MYCOLLATE', function($a, $b) { return strnatcmp($a, $b); });
 

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation_trampoline.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createcollation_trampoline.phpt
@@ -9,7 +9,7 @@ $db = new Pdo\Sqlite('sqlite::memory:');
 
 $db->query('CREATE TABLE test_pdo_sqlite_createcollation_trampoline (s VARCHAR(4))');
 
-$stmt = $db->query('INSERT INTO test_pdo_sqlite_createcollation_trampoline VALUES ("a1"), ("a10"), ("a2")');
+$stmt = $db->query("INSERT INTO test_pdo_sqlite_createcollation_trampoline VALUES ('a1'), ('a10'), ('a2')");
 
 class TrampolineTest {
     public function __call(string $name, array $arguments) {

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createfunction_with_flags.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_createfunction_with_flags.phpt
@@ -11,7 +11,7 @@ if (!defined('Pdo\Sqlite::DETERMINISTIC')) die('skip system sqlite is too old');
 // This test was copied from the pdo_sqlite test for sqliteCreateCollation
 $db = new Pdo\Sqlite('sqlite::memory:');
 $db->query('CREATE TABLE test_pdo_sqlite_createfunction_with_flags (id INT AUTO INCREMENT, name TEXT)');
-$db->query('INSERT INTO test_pdo_sqlite_createfunction_with_flags VALUES (NULL, "PHP"), (NULL, "PHP6")');
+$db->query("INSERT INTO test_pdo_sqlite_createfunction_with_flags VALUES (NULL, 'PHP'), (NULL, 'PHP6')");
 
 $db->createFunction('testing', function($v) { return strtolower($v); }, 1, Pdo\Sqlite::DETERMINISTIC);
 

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_getattr_busy.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_getattr_busy.phpt
@@ -8,7 +8,7 @@ pdo_sqlite
 $db = new Pdo\Sqlite('sqlite::memory:');
 
 $db->query('CREATE TABLE test_busy (a string);');
-$db->query('INSERT INTO test_busy VALUES ("interleaved"), ("statements")');
+$db->query("INSERT INTO test_busy VALUES ('interleaved'), ('statements')");
 $st = $db->prepare('SELECT a FROM test_busy');
 var_dump($st->getAttribute(Pdo\Sqlite::ATTR_BUSY_STATEMENT));
 $st->execute();

--- a/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_getsetattr_explain.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdo_sqlite_getsetattr_explain.phpt
@@ -13,7 +13,7 @@ if (!defined('Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN')) die('skip system sqlite does n
 $db = new Pdo\Sqlite('sqlite::memory:');
 
 $db->query('CREATE TABLE test_explain (a string);');
-$stmt = $db->prepare('INSERT INTO test_explain VALUES ("first insert"), ("second_insert")');
+$stmt = $db->prepare("INSERT INTO test_explain VALUES ('first insert'), ('second_insert')");
 $stmt->setAttribute(Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT, Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN);
 var_dump($stmt->getAttribute(Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT) == Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN);
 $r = $stmt->execute();
@@ -24,7 +24,7 @@ var_dump($stmt->getAttribute(Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT) == Pdo\Sqlite::
 $r = $stmts->execute();
 var_dump($stmts->fetchAll(PDO::FETCH_ASSOC));
 
-$stmt = $db->prepare('INSERT INTO test_explain VALUES ("first insert"), ("second_insert")');
+$stmt = $db->prepare("INSERT INTO test_explain VALUES ('first insert'), ('second_insert')");
 $stmt->setAttribute(Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT, Pdo\Sqlite::EXPLAIN_MODE_PREPARED);
 $stmt->execute();
 $stmts->setAttribute(Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT, Pdo\Sqlite::EXPLAIN_MODE_PREPARED);
@@ -88,7 +88,7 @@ array(%d) {
     ["opcode"]=>
     string(13) "InitCoroutine"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(%d)
     ["p3"]=>
@@ -109,7 +109,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(2)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -126,7 +126,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -147,7 +147,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(2)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -164,7 +164,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -183,7 +183,7 @@ array(%d) {
     ["opcode"]=>
     string(12) "EndCoroutine"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -221,7 +221,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(%d)
     ["p3"]=>
@@ -242,7 +242,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(1)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -259,11 +259,11 @@ array(%d) {
     ["opcode"]=>
     string(10) "MakeRecord"
     ["p1"]=>
-    int(2)
+    int(%d)
     ["p2"]=>
     int(1)
     ["p3"]=>
-    int(4)
+    int(%d)
     ["p4"]=>
     string(1) "C"
     ["p5"]=>
@@ -280,9 +280,9 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(4)
+    int(%d)
     ["p3"]=>
-    int(1)
+    int(%d)
     ["p4"]=>
     string(12) "test_explain"
     ["p5"]=>

--- a/ext/pdo_sqlite/tests/subclasses/pdosqlite_001.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdosqlite_001.phpt
@@ -9,8 +9,8 @@ $db = new Pdo\Sqlite('sqlite::memory:');
 
 $db->query('CREATE TABLE pdosqlite_001 (id INT AUTO INCREMENT, name TEXT)');
 
-$db->query('INSERT INTO pdosqlite_001 VALUES (NULL, "PHP")');
-$db->query('INSERT INTO pdosqlite_001 VALUES (NULL, "PHP6")');
+$db->query("INSERT INTO pdosqlite_001 VALUES (NULL, 'PHP')");
+$db->query("INSERT INTO pdosqlite_001 VALUES (NULL, 'PHP6')");
 
 $db->createFunction('testing', function($v) { return strtolower($v); }, 1, Pdo\Sqlite::DETERMINISTIC);
 

--- a/ext/pdo_sqlite/tests/subclasses/pdosqlite_002.phpt
+++ b/ext/pdo_sqlite/tests/subclasses/pdosqlite_002.phpt
@@ -11,8 +11,8 @@ if (!$db instanceof Pdo\Sqlite) {
 }
 
 $db->query('CREATE TABLE pdosqlite_002 (id INT AUTO INCREMENT, name TEXT)');
-$db->query('INSERT INTO pdosqlite_002 VALUES (NULL, "PHP")');
-$db->query('INSERT INTO pdosqlite_002 VALUES (NULL, "PHP6")');
+$db->query("INSERT INTO pdosqlite_002 VALUES (NULL, 'PHP')");
+$db->query("INSERT INTO pdosqlite_002 VALUES (NULL, 'PHP6')");
 
 $db->createFunction('testing', function($v) { return strtolower($v); }, 1, Pdo\Sqlite::DETERMINISTIC);
 

--- a/ext/sqlite3/tests/bug72668.phpt
+++ b/ext/sqlite3/tests/bug72668.phpt
@@ -12,20 +12,20 @@ $db = new SQLite3(':memory:');
 $db->createFunction('my_udf_md5', 'my_udf_md5');
 
 try {
-    $result = $db->query('SELECT my_udf_md5("test")');
+    $result = $db->query("SELECT my_udf_md5('test')");
     var_dump($result);
 }
 catch(\Exception $e) {
     echo "Exception: ".$e->getMessage();
 }
 try {
-    $result = $db->querySingle('SELECT my_udf_md5("test")');
+    $result = $db->querySingle("SELECT my_udf_md5('test')");
     var_dump($result);
 }
 catch(\Exception $e) {
     echo "Exception: ".$e->getMessage();
 }
-$statement = $db->prepare('SELECT my_udf_md5("test")');
+$statement = $db->prepare("SELECT my_udf_md5('test')");
 try {
     $result = $statement->execute();
     var_dump($result);

--- a/ext/sqlite3/tests/sqlite3_29_createfunction.phpt
+++ b/ext/sqlite3/tests/sqlite3_29_createfunction.phpt
@@ -9,14 +9,14 @@ require_once(__DIR__ . '/new_db.inc');
 
 $func = 'strtoupper';
 var_dump($db->createfunction($func, $func));
-var_dump($db->querySingle('SELECT strtoupper("test")'));
+var_dump($db->querySingle("SELECT strtoupper('test')"));
 
 $func2 = 'strtolower';
 var_dump($db->createfunction($func2, $func2));
-var_dump($db->querySingle('SELECT strtolower("TEST")'));
+var_dump($db->querySingle("SELECT strtolower('TEST')"));
 
 var_dump($db->createfunction($func, $func2));
-var_dump($db->querySingle('SELECT strtoupper("tEst")'));
+var_dump($db->querySingle("SELECT strtoupper('tEst')"));
 
 
 ?>

--- a/ext/sqlite3/tests/sqlite3_37_createfunction_flags.phpt
+++ b/ext/sqlite3/tests/sqlite3_37_createfunction_flags.phpt
@@ -13,14 +13,14 @@ require_once(__DIR__ . '/new_db.inc');
 
 $func = 'strtoupper';
 var_dump($db->createfunction($func, $func, 1, SQLITE3_DETERMINISTIC));
-var_dump($db->querySingle('SELECT strtoupper("test")'));
+var_dump($db->querySingle("SELECT strtoupper('test')"));
 
 $func2 = 'strtolower';
 var_dump($db->createfunction($func2, $func2, 1, SQLITE3_DETERMINISTIC));
-var_dump($db->querySingle('SELECT strtolower("TEST")'));
+var_dump($db->querySingle("SELECT strtolower('TEST')"));
 
 var_dump($db->createfunction($func, $func2, 1, SQLITE3_DETERMINISTIC));
-var_dump($db->querySingle('SELECT strtoupper("tEst")'));
+var_dump($db->querySingle("SELECT strtoupper('tEst')"));
 
 
 ?>

--- a/ext/sqlite3/tests/sqlite3_dqs.phpt
+++ b/ext/sqlite3/tests/sqlite3_dqs.phpt
@@ -1,0 +1,28 @@
+--TEST--
+SQLite3 DQS
+--EXTENSIONS--
+sqlite3
+--SKIPIF--
+<?php
+require_once(__DIR__ . '/new_db.inc');
+try {
+    $db->enableExceptions(true);
+    $db->exec('SELECT "test"');
+} catch (\SQLite3Exception) {
+    die('skip SQLite is lacking DQS');
+}
+?>
+--FILE--
+<?php
+require_once(__DIR__ . '/new_db.inc');
+$db->exec('CREATE TABLE test (s1 VARCHAR(255), s2 VARCHAR(255))');
+$db->exec('INSERT INTO test VALUES (\'test\', "test")');
+var_dump($db->prepare('SELECT * FROM test')->execute()->fetchArray(SQLITE3_ASSOC));
+?>
+--EXPECT--
+array(2) {
+  ["s1"]=>
+  string(4) "test"
+  ["s2"]=>
+  string(4) "test"
+}

--- a/ext/sqlite3/tests/sqlite3_explain.phpt
+++ b/ext/sqlite3/tests/sqlite3_explain.phpt
@@ -14,7 +14,7 @@ if ($version <= 3043000) die("skip for sqlite3 < 3.43.0");
 require_once(__DIR__ . '/new_db.inc');
 
 $db->exec('CREATE TABLE test_explain (a string);');
-$stmt = $db->prepare('INSERT INTO test_explain VALUES ("first insert"), ("second_insert")');
+$stmt = $db->prepare("INSERT INTO test_explain VALUES ('first insert'), ('second_insert')");
 $stmt->setExplain(Sqlite3Stmt::EXPLAIN_MODE_EXPLAIN);
 var_dump($stmt->explain() == Sqlite3Stmt::EXPLAIN_MODE_EXPLAIN);
 $r = $stmt->execute();
@@ -28,7 +28,7 @@ $result = [];
 while (($arr = $r->fetchArray(SQLITE3_ASSOC)) !== false) $result[] = $arr;
 var_dump($result);
 
-$stmt = $db->prepare('INSERT INTO test_explain VALUES ("first insert"), ("second_insert")');
+$stmt = $db->prepare("INSERT INTO test_explain VALUES ('first insert'), ('second_insert')");
 $stmt->setExplain(Sqlite3Stmt::EXPLAIN_MODE_PREPARED);
 $stmt->execute();
 $stmts = $db->prepare('SELECT * FROM test_explain');
@@ -81,7 +81,7 @@ array(%d) {
     ["opcode"]=>
     string(%d) "%s"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(%d)
     ["p3"]=>
@@ -102,7 +102,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(2)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -119,7 +119,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -140,7 +140,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(2)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -157,7 +157,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -176,7 +176,7 @@ array(%d) {
     ["opcode"]=>
     string(12) "EndCoroutine"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(0)
     ["p3"]=>
@@ -214,7 +214,7 @@ array(%d) {
     ["opcode"]=>
     string(5) "Yield"
     ["p1"]=>
-    int(3)
+    int(%d)
     ["p2"]=>
     int(%d)
     ["p3"]=>
@@ -235,7 +235,7 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(1)
+    int(%d)
     ["p3"]=>
     int(0)
     ["p4"]=>
@@ -252,11 +252,11 @@ array(%d) {
     ["opcode"]=>
     string(10) "MakeRecord"
     ["p1"]=>
-    int(2)
+    int(%d)
     ["p2"]=>
     int(1)
     ["p3"]=>
-    int(4)
+    int(%d)
     ["p4"]=>
     string(1) "C"
     ["p5"]=>
@@ -273,9 +273,9 @@ array(%d) {
     ["p1"]=>
     int(0)
     ["p2"]=>
-    int(4)
+    int(%d)
     ["p3"]=>
-    int(1)
+    int(%d)
     ["p4"]=>
     string(12) "test_explain"
     ["p5"]=>

--- a/ext/sqlite3/tests/sqlite3_rename_column.phpt
+++ b/ext/sqlite3/tests/sqlite3_rename_column.phpt
@@ -14,7 +14,7 @@ if (SQLite3::version()['versionNumber'] < 3025000) {
 $db = new SQLite3(':memory:');
 
 $db->exec('CREATE TABLE tbl (orig text)');
-$db->exec('insert into tbl values ("one"), ("two")');
+$db->exec("insert into tbl values ('one'), ('two')");
 
 $res1 = $db->prepare('select * from tbl')->execute();
 $res2 = $db->prepare('select * from tbl')->execute();

--- a/ext/sqlite3/tests/sqlite3_stmt_busy.phpt
+++ b/ext/sqlite3/tests/sqlite3_stmt_busy.phpt
@@ -12,7 +12,7 @@ if ($version['versionNumber'] < 3007004) die("skip");
 
 require_once(__DIR__ . '/new_db.inc');
 $db->exec('CREATE TABLE test_busy (a string);');
-$db->exec('INSERT INTO test_busy VALUES ("interleaved"), ("statements")');
+$db->exec("INSERT INTO test_busy VALUES ('interleaved'), ('statements')");
 $st = $db->prepare('SELECT a FROM test_busy');
 var_dump($st->busy());
 $r = $st->execute();

--- a/ext/sqlite3/tests/sqlite3_trampoline_createfunction.phpt
+++ b/ext/sqlite3/tests/sqlite3_trampoline_createfunction.phpt
@@ -16,8 +16,8 @@ class TrampolineTest {
 $o = new TrampolineTest();
 $callback = [$o, 'strtoupper'];
 var_dump($db->createfunction('strtoupper', $callback));
-var_dump($db->querySingle('SELECT strtoupper("test")'));
-var_dump($db->querySingle('SELECT strtoupper("test")'));
+var_dump($db->querySingle("SELECT strtoupper('test')"));
+var_dump($db->querySingle("SELECT strtoupper('test')"));
 
 ?>
 --EXPECT--


### PR DESCRIPTION
FreeBSD builds without DQS (double-quote support). Transform tests so we can re-eanble them for FreeBSD. Add separate tests for DQS.