### PR TITLE
Fix GH-21496: UAF in dom_objects_free_storage.

### DIFF
--- a/ext/xsl/tests/gh21496.phpt
+++ b/ext/xsl/tests/gh21496.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-21496 (UAF in dom_objects_free_storage when importing non-document node as stylesheet)
+--EXTENSIONS--
+dom
+xsl
+--CREDITS--
+YuanchengJiang
+--FILE--
+<?php
+$comment = new DOMComment("my value");
+$doc = new DOMDocument();
+$doc->loadXML(<<<XML
+<container/>
+XML);
+$doc->documentElement->appendChild($comment);
+unset($doc);
+$proc = new XSLTProcessor();
+var_dump($proc->importStylesheet($comment));
+?>
+--EXPECTF--
+Warning: XSLTProcessor::importStylesheet(): compilation error: file %s line 1 element container in %s on line %d
+
+Warning: XSLTProcessor::importStylesheet(): xsltParseStylesheetProcess : document is not a stylesheet in %s on line %d
+bool(false)

--- a/ext/xsl/tests/gh21496.phpt
+++ b/ext/xsl/tests/gh21496.phpt
@@ -16,9 +16,17 @@ $doc->documentElement->appendChild($comment);
 unset($doc);
 $proc = new XSLTProcessor();
 var_dump($proc->importStylesheet($comment));
+$sxe = simplexml_load_string('<container/>');
+$proc = new XSLTProcessor();
+$proc->importStylesheet($sxe);
 ?>
 --EXPECTF--
 Warning: XSLTProcessor::importStylesheet(): compilation error: file %s line 1 element container in %s on line %d
 
 Warning: XSLTProcessor::importStylesheet(): xsltParseStylesheetProcess : document is not a stylesheet in %s on line %d
 bool(false)
+
+Warning: XSLTProcessor::importStylesheet(): compilation error: element container in %s on line %d
+
+Warning: XSLTProcessor::importStylesheet(): xsltParseStylesheetProcess : document is not a stylesheet in %s on line %d
+

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -196,7 +196,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 			RETURN_THROWS();
 		}
 
-		php_dom_create_object((xmlNodePtr) nodep->doc, &owner_zv, NULL);
+		php_dom_create_object((xmlNodePtr) nodep->doc, &owner_zv, php_dom_obj_from_obj(Z_OBJ_P(docp)));
 		docp = &owner_zv;
 	}
 

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -167,7 +167,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 	xsltStylesheetPtr sheetp;
 	bool clone_docu = false;
 	xmlNode *nodep = NULL;
-	zval *cloneDocu, rv, clone_zv;
+	zval *cloneDocu, rv, clone_zv, owner_zv;
 	zend_string *member;
 
 	id = ZEND_THIS;
@@ -175,10 +175,36 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 		RETURN_THROWS();
 	}
 
+	nodep = php_libxml_import_node(docp);
+	if (nodep == NULL) {
+		zend_argument_type_error(1, "must be a valid XML node");
+		RETURN_THROWS();
+	}
+
+	if (Z_OBJ_HANDLER_P(docp, clone_obj) == NULL) {
+		zend_argument_type_error(1, "must be a cloneable node");
+		RETURN_THROWS();
+	}
+
+	ZVAL_UNDEF(&owner_zv);
+
+	/* For non-document nodes, resolve the ownerDocument and clone that
+	 * instead as xsltParseStylesheetProcess may free nodes in the document. */
+	if (nodep->type != XML_DOCUMENT_NODE && nodep->type != XML_HTML_DOCUMENT_NODE) {
+		if (nodep->doc == NULL) {
+			zend_argument_value_error(1, "must be part of a document");
+			RETURN_THROWS();
+		}
+
+		php_dom_create_object((xmlNodePtr) nodep->doc, &owner_zv, NULL);
+		docp = &owner_zv;
+	}
+
 	/* libxslt uses _private, so we must copy the imported
 	 * stylesheet document otherwise the node proxies will be a mess.
 	 * We will clone the object and detach the libxml internals later. */
 	zend_object *clone = Z_OBJ_HANDLER_P(docp, clone_obj)(Z_OBJ_P(docp));
+	zval_ptr_dtor(&owner_zv);
 	if (!clone) {
 		RETURN_THROWS();
 	}

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -196,7 +196,11 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 			RETURN_THROWS();
 		}
 
-		php_dom_create_object((xmlNodePtr) nodep->doc, &owner_zv, php_dom_obj_from_obj(Z_OBJ_P(docp)));
+		/* See dom_import_simplexml_common */
+
+		dom_object *nodeobj = (dom_object *) ((char *) Z_OBJ_P(docp) - Z_OBJ_HT_P(docp)->offset);
+
+		php_dom_create_object((xmlNodePtr) nodep->doc, &owner_zv, nodeobj);
 		docp = &owner_zv;
 	}
 


### PR DESCRIPTION
Cloning a non-document DOM node creates a copy within the same xmlDoc. importStylesheet then passes that original document to xsltParseStylesheetDoc, which strips and frees nodes (including comment nodes) during processing, invalidating PHP objects still referencing them.

Validate that the imported node is a document node before proceeding with the clone.