### PR TITLE
Fix curl_setopt_ssl test for curl 8.19.0

### DIFF
--- a/ext/curl/tests/curl_setopt_ssl.phpt
+++ b/ext/curl/tests/curl_setopt_ssl.phpt
@@ -37,6 +37,7 @@ function check_response($response, $clientCertSubject) {
 }
 
 $clientCertSubject = "Subject: C=US, ST=TX, L=Clientlocation, O=Clientcompany, CN=clientname/emailAddress=test@example.com";
+$rejectsZeroLengthBlobs = curl_version()['version_number'] >= 0x081300;
 
 // load server cert
 $serverCertPath = __DIR__ . DIRECTORY_SEPARATOR . 'curl_setopt_ssl_servercert.pem';
@@ -91,7 +92,7 @@ try {
     echo "\n";
     echo "case 2: empty client cert and key from string\n";
     $ch = curl_init("https://127.0.0.1:$port/");
-    var_dump(curl_setopt($ch, CURLOPT_SSLCERT_BLOB, ''));
+    var_dump(curl_setopt($ch, CURLOPT_SSLCERT_BLOB, '') === !$rejectsZeroLengthBlobs);
     var_dump(curl_setopt($ch, CURLOPT_SSLKEY_BLOB, $clientKey));
     var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false));
     var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false));
@@ -99,14 +100,14 @@ try {
 
     $response = curl_exec($ch);
     check_response($response, $clientCertSubject);
-    check_error($ch);
+    check_error($ch, $rejectsZeroLengthBlobs ? 56 : 58);
     curl_close($ch);
 
     echo "\n";
     echo "case 3: client cert and empty key from string\n";
     $ch = curl_init("https://127.0.0.1:$port/");
     var_dump(curl_setopt($ch, CURLOPT_SSLCERT_BLOB, $clientCert));
-    var_dump(curl_setopt($ch, CURLOPT_SSLKEY_BLOB, ''));
+    var_dump(curl_setopt($ch, CURLOPT_SSLKEY_BLOB, '') === !$rejectsZeroLengthBlobs);
     var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false));
     var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -166,7 +167,7 @@ try {
     echo "case 7: empty issuer cert from string\n";
     $ch = curl_init("https://127.0.0.1:$port/");
     var_dump(curl_setopt($ch, CURLOPT_CAINFO, $serverCertPath));
-    var_dump(curl_setopt($ch, CURLOPT_ISSUERCERT_BLOB, ''));
+    var_dump(curl_setopt($ch, CURLOPT_ISSUERCERT_BLOB, '') === !$rejectsZeroLengthBlobs);
     var_dump(curl_setopt($ch, CURLOPT_SSLCERT, $clientCertPath));
     var_dump(curl_setopt($ch, CURLOPT_SSLKEY, $clientKeyPath));
     var_dump(curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true));
@@ -174,8 +175,8 @@ try {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
     $response = curl_exec($ch);
-    check_response($response, $clientCertSubject);
-    check_error($ch);
+    var_dump((is_string($response) && strpos($response, $clientCertSubject) !== false) === $rejectsZeroLengthBlobs);
+    var_dump(curl_errno($ch) === ($rejectsZeroLengthBlobs ? 0 : 83));
     curl_close($ch);
 
 } finally {
@@ -199,7 +200,7 @@ bool(true)
 bool(true)
 bool(true)
 client cert subject not in response
-CURL ERROR: 58
+CURL ERROR: EXPECTED
 
 case 3: client cert and empty key from string
 bool(true)
@@ -241,5 +242,5 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-client cert subject not in response
-CURL ERROR: 83
+bool(true)
+bool(true)


### PR DESCRIPTION
This updates `curl_setopt_ssl.phpt` for libcurl 8.19.0 and fixes #21515.

Ref: https://github.com/curl/curl/pull/20705
