### PR TITLE
ext/spl: Use zend_hash_index_add_new() for missing array keys

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -385,7 +385,7 @@ static zval *spl_array_get_dimension_ptr(bool check_inherited, spl_array_object 
 				case BP_VAR_W: {
 				    zval value;
 					ZVAL_NULL(&value);
-				    retval = zend_hash_index_add_new(ht, key.key, &value);
+				    retval = zend_hash_add_new(ht, key.key, &value);
 				}
 			}
 		}


### PR DESCRIPTION
Previously, `zend_hash_index_update()` was used, which handles both insertion and overwriting.
Since we already check that the key does not exist, `zend_hash_index_add_new()` is more appropriate.

- Avoids unnecessary overwrite logic