### PR TITLE
ext/xml: Use zend_hash_add() for missing array keys

### DIFF
--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -557,7 +557,6 @@ static void xml_add_to_info(xml_parser *parser, zend_string *name)
 	element = zend_hash_lookup(arr, name);
 
 	if (Z_TYPE_P(element) == IS_NULL) {
-		
 		array_init(element);
 	}
 


### PR DESCRIPTION
Use **zend_hash_add** instead of **zend_hash_update** after **zend_hash_find** returns NULL