### PR TITLE
Zend/Optimizer/dfa_pass.c: refactor zend_dfa_optimize_calls()

### DIFF
--- a/Zend/Optimizer/dfa_pass.c
+++ b/Zend/Optimizer/dfa_pass.c
@@ -409,11 +409,10 @@ static uint32_t zend_dfa_optimize_calls(zend_op_array *op_array, zend_ssa *ssa)
 		do {
 			zend_op *op = call_info->caller_init_opline;
 
-			if (
-				(op->opcode == ZEND_FRAMELESS_ICALL_2 || (op->opcode == ZEND_FRAMELESS_ICALL_3 && (op + 1)->op1_type == IS_CONST))
-				&& call_info->callee_func
-				&& zend_string_equals_literal_ci(call_info->callee_func->common.function_name, "in_array")
-			) {
+			if ((op->opcode == ZEND_FRAMELESS_ICALL_2
+			  || (op->opcode == ZEND_FRAMELESS_ICALL_3 && (op + 1)->op1_type == IS_CONST))
+			 && call_info->callee_func
+			 && zend_string_equals_literal_ci(call_info->callee_func->common.function_name, "in_array")) {
 				bool strict = false;
 				bool has_opdata = op->opcode == ZEND_FRAMELESS_ICALL_3;
 				ZEND_ASSERT(!call_info->is_prototype);


### PR DESCRIPTION
This function is only called within dfa_pass.c, thus make it static

Return a uint32_t as the value can never be negative

Add some const qualifiers

Minor CS adjustment to make if condition easier to read

Noticed this while checking something for #21542 