### PR TITLE
/ext/soap/*: various typo fixs

### DIFF
--- a/ext/soap/php_packet_soap.c
+++ b/ext/soap/php_packet_soap.c
@@ -31,7 +31,7 @@ bool parse_packet_soap(zval *this_ptr, char *buffer, int buffer_size, sdlFunctio
 
 	ZVAL_NULL(return_value);
 
-	/* Response for one-way opearation */
+	/* Response for one-way operation */
 	if (buffer_size == 0) {
 		return true;
 	}

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -3362,7 +3362,7 @@ cache_in_memory:
 
 			zend_hash_str_update_mem(SOAP_GLOBAL(mem_cache), uri,
 											uri_len, &p, sizeof(sdl_cache_bucket));
-			/* remove non-persitent sdl structure */
+			/* remove non-persistent sdl structure */
 			delete_sdl_impl(sdl);
 			/* and replace it with persistent one */
 			sdl = psdl;

--- a/ext/soap/php_sdl.h
+++ b/ext/soap/php_sdl.h
@@ -166,7 +166,7 @@ struct _sdlContentModel {
 	union {
 		sdlTypePtr          element;      /* pointer to element */
 		sdlTypePtr          group;        /* pointer to group */
-		HashTable          *content;      /* array of sdlContentModel for sequnce,all,choice*/
+		HashTable          *content;      /* array of sdlContentModel for sequence,all,choice*/
 		char               *group_ref;    /* reference to group */
 	} u;
 };

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1951,7 +1951,7 @@ static zend_never_inline ZEND_COLD void soap_real_error_handler(int error_num, z
 			} else {
 				buffer = zend_string_copy(message);
 
-				/* Get output buffer and send as fault detials */
+				/* Get output buffer and send as fault details */
 				zval outbuflen;
 				if (php_output_get_length(&outbuflen) != FAILURE && Z_LVAL(outbuflen) != 0) {
 					php_output_get_contents(&outbuf);
@@ -2834,7 +2834,7 @@ PHP_METHOD(SoapClient, __doRequest)
 }
 /* }}} */
 
-/* {{{ Sets cookie thet will sent with SOAP request.
+/* {{{ Sets cookie that will sent with SOAP request.
    The call to this function will effect all following calls of SOAP methods.
    If value is not specified cookie is removed. */
 PHP_METHOD(SoapClient, __setCookie)


### PR DESCRIPTION
There are still bunch of typos in the codebase (sapi, ext, tests...). I think maybe I could use some linting script to fix the majority of them in the future.
[skip ci]