### PR TITLE
Fix GH-21557: jewishtojd returns 0 for years >= 6000.

### DIFF
--- a/ext/calendar/jewish.c
+++ b/ext/calendar/jewish.c
@@ -710,7 +710,7 @@ zend_long JewishToSdn(
 	int yearLength;
 	int lengthOfAdarIAndII;
 
-	if (year <= 0 || year >= 6000 || day <= 0 || day > 30) {
+	if (year <= 0 || year >= INT_MAX - 1 || day <= 0 || day > 30) {
 		return (0);
 	}
 	switch (month) {

--- a/ext/calendar/tests/gh21557.phpt
+++ b/ext/calendar/tests/gh21557.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-21557 jewishtojd returns 0 for years >= 6000
+--CREDITS--
+oleibman
+--EXTENSIONS--
+calendar
+--FILE--
+<?php
+for ($yh = 5995; $yh < 6005; ++$yh) {
+    $rh = jewishtojd(1, 1, $yh);
+    echo "yh=$yh rh=$rh\n";
+}
+?>
+--EXPECT--
+yh=5995 rh=2537279
+yh=5996 rh=2537633
+yh=5997 rh=2538016
+yh=5998 rh=2538371
+yh=5999 rh=2538725
+yh=6000 rh=2539110
+yh=6001 rh=2539463
+yh=6002 rh=2539818
+yh=6003 rh=2540202
+yh=6004 rh=2540557


### PR DESCRIPTION
The year >= 6000 upper bound introduced in GH-18849 was too restrictive as it is a valid year in the Jewish calendar. The overflow protection in MoladOfMetonicCycle already handles large values, the only guard needed is to prevent year + 1 from wrapping around INT_MAX.