### PR TITLE
uri: Preinitialize `errors` array with the correct size in `fill_errors()`

### DIFF
--- a/ext/uri/uri_parser_whatwg.c
+++ b/ext/uri/uri_parser_whatwg.c
@@ -62,12 +62,13 @@ static zend_always_inline void zval_long_or_null_to_lexbor_str(zval *value, lexb
  */
 static const char *fill_errors(zval *errors)
 {
-	if (lexbor_parser.log == NULL || lexbor_plog_length(lexbor_parser.log) == 0) {
+	size_t log_len;
+	if (lexbor_parser.log == NULL || (log_len = lexbor_plog_length(lexbor_parser.log)) == 0) {
 		ZVAL_EMPTY_ARRAY(errors);
 		return NULL;
 	}
 
-	array_init(errors);
+	array_init_size(errors, log_len);
 	const char *result = NULL;
 
 	lexbor_plog_entry_t *lxb_error;


### PR DESCRIPTION
Since we already could get length from `lexbor_plog_length(lexbor_parser.log)`, we could directly use `array_init_size(errors, len)` instead of `array_init(errors)` 